### PR TITLE
Store|Woo: Hide deprecated Store menu item for sites with Business plan subscriptions after Store was deprecated

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -346,6 +346,8 @@ export const TYPE_SECURITY_REALTIME = 'TYPE_SECURITY_REALTIME';
 export const TYPE_ALL = 'TYPE_ALL';
 export const TYPE_P2_PLUS = 'TYPE_P2_PLUS';
 
+export const STORE_DEPRECATION_START_DATE = new Date( '2021-01-18T00:00:00+00:00' );
+
 export function isMonthly( plan ) {
 	return WPCOM_MONTHLY_PLANS.includes( plan ) || JETPACK_MONTHLY_PLANS.includes( plan );
 }

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -53,8 +53,8 @@ import {
 	getSite,
 	isJetpackSite,
 	canCurrentUserUseEarn,
-	canCurrentUserUseStore,
 	getSiteOption,
+	canCurrentUserUseCalypsoStore,
 } from 'calypso/state/sites/selectors';
 import getSiteChecklist from 'calypso/state/selectors/get-site-checklist';
 import getSiteTaskList from 'calypso/state/selectors/get-site-task-list';
@@ -662,19 +662,11 @@ export class MySitesSidebar extends Component {
 	};
 
 	store() {
-		const { translate, site, siteSuffix, canUserUseStore } = this.props;
+		const { translate, site, siteSuffix, canUserUseCalypsoStore } = this.props;
 		const isCalypsoStoreDeprecatedOrRemoved =
 			isEnabled( 'woocommerce/store-deprecated' ) || isEnabled( 'woocommerce/store-removed' );
 
-		if ( ! isEnabled( 'woocommerce/extension-dashboard' ) || ! site ) {
-			return null;
-		}
-
-		if ( ! canUserUseStore ) {
-			return null;
-		}
-
-		if ( ! isEnabled( 'woocommerce/extension-dashboard' ) || ! site ) {
+		if ( ! isEnabled( 'woocommerce/extension-dashboard' ) || ! site || ! canUserUseCalypsoStore ) {
 			return null;
 		}
 
@@ -717,17 +709,16 @@ export class MySitesSidebar extends Component {
 	};
 
 	woocommerce() {
-		const { site, canUserUseStore, siteSuffix, isSiteWpcomStore } = this.props;
+		const { site, canUserUseWooCommerceCoreStore, siteSuffix, isSiteWpcomStore } = this.props;
 
 		const isCalypsoStoreDeprecatedOrRemoved =
 			isEnabled( 'woocommerce/store-deprecated' ) || isEnabled( 'woocommerce/store-removed' );
 
 		if (
-			! isEnabled( 'woocommerce/extension-dashboard' ) ||
 			! isCalypsoStoreDeprecatedOrRemoved ||
 			! site ||
 			! isBusiness( site.plan ) ||
-			! canUserUseStore
+			! canUserUseWooCommerceCoreStore
 		) {
 			return null;
 		}
@@ -1112,7 +1103,7 @@ function mapStateToProps( state ) {
 		canUserPublishPosts: canCurrentUser( state, siteId, 'publish_posts' ),
 		canUserViewStats: canCurrentUser( state, siteId, 'view_stats' ),
 		canUserManagePlugins: canCurrentUserManagePlugins( state ),
-		canUserUseStore: canCurrentUserUseStore( state, siteId ),
+		canUserUseCalypsoStore: canCurrentUserUseCalypsoStore( state, siteId ),
 		canUserUseEarn: canCurrentUserUseEarn( state, siteId ),
 		canUserUseCustomerHome: canCurrentUserUseCustomerHome( state, siteId ),
 		currentUser,

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -55,6 +55,7 @@ import {
 	canCurrentUserUseEarn,
 	getSiteOption,
 	canCurrentUserUseCalypsoStore,
+	canCurrentUserUseWooCommerceCoreStore,
 } from 'calypso/state/sites/selectors';
 import getSiteChecklist from 'calypso/state/selectors/get-site-checklist';
 import getSiteTaskList from 'calypso/state/selectors/get-site-task-list';
@@ -662,17 +663,27 @@ export class MySitesSidebar extends Component {
 	};
 
 	store() {
-		const { translate, site, siteSuffix, canUserUseCalypsoStore } = this.props;
-		const isCalypsoStoreDeprecatedOrRemoved =
-			isEnabled( 'woocommerce/store-deprecated' ) || isEnabled( 'woocommerce/store-removed' );
+		const {
+			translate,
+			site,
+			siteSuffix,
+			canUserUseCalypsoStore,
+			canUserUseWooCommerceCoreStore,
+		} = this.props;
 
-		if ( ! site || ! canUserUseCalypsoStore ) {
+		if ( ! site ) {
 			return null;
 		}
 
 		let storeLink = '/store' + siteSuffix;
-		if ( isEcommerce( site.plan ) ) {
+		if ( isEcommerce( site.plan ) && canUserUseWooCommerceCoreStore ) {
+			// Eventually, the plan is to have the WooCommerce Core menu item labelled the same
+			// for both Business and eCommerce users. But, for now, we want to continue to
+			// use the "Store" label for eCommerce users because that is what they are used to.
+			// So, we'll just continue to change the link here as we have been doing.
 			storeLink = site.options.admin_url + 'admin.php?page=wc-admin';
+		} else if ( ! canUserUseCalypsoStore ) {
+			return null;
 		}
 
 		const infoCopy = translate(
@@ -683,6 +694,7 @@ export class MySitesSidebar extends Component {
 				},
 			}
 		);
+		const isCalypsoStoreDeprecated = isEnabled( 'woocommerce/store-deprecated' );
 
 		return (
 			<SidebarItem
@@ -693,7 +705,7 @@ export class MySitesSidebar extends Component {
 				forceInternalLink
 				className="sidebar__store"
 			>
-				{ isCalypsoStoreDeprecatedOrRemoved && isBusiness( site.plan ) && (
+				{ isCalypsoStoreDeprecated && isBusiness( site.plan ) && (
 					<InfoPopover className="sidebar__store-tooltip" position="bottom right">
 						{ infoCopy }
 					</InfoPopover>
@@ -711,15 +723,21 @@ export class MySitesSidebar extends Component {
 	woocommerce() {
 		const { site, canUserUseWooCommerceCoreStore, siteSuffix, isSiteWpcomStore } = this.props;
 
+		if ( ! site ) {
+			return null;
+		}
+
 		const isCalypsoStoreDeprecatedOrRemoved =
 			isEnabled( 'woocommerce/store-deprecated' ) || isEnabled( 'woocommerce/store-removed' );
 
 		if (
 			! isCalypsoStoreDeprecatedOrRemoved ||
-			! site ||
 			! isBusiness( site.plan ) ||
 			! canUserUseWooCommerceCoreStore
 		) {
+			// Right now, we only use the "WooCommerce" label for Business plan sites.
+			// eCommerce sites continue to use the "Store" label for now
+			// (see handling in `store()` above.
 			return null;
 		}
 
@@ -1104,6 +1122,7 @@ function mapStateToProps( state ) {
 		canUserViewStats: canCurrentUser( state, siteId, 'view_stats' ),
 		canUserManagePlugins: canCurrentUserManagePlugins( state ),
 		canUserUseCalypsoStore: canCurrentUserUseCalypsoStore( state, siteId ),
+		canUserUseWooCommerceCoreStore: canCurrentUserUseWooCommerceCoreStore( state, siteId ),
 		canUserUseEarn: canCurrentUserUseEarn( state, siteId ),
 		canUserUseCustomerHome: canCurrentUserUseCustomerHome( state, siteId ),
 		currentUser,

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -666,7 +666,7 @@ export class MySitesSidebar extends Component {
 		const isCalypsoStoreDeprecatedOrRemoved =
 			isEnabled( 'woocommerce/store-deprecated' ) || isEnabled( 'woocommerce/store-removed' );
 
-		if ( ! isEnabled( 'woocommerce/extension-dashboard' ) || ! site || ! canUserUseCalypsoStore ) {
+		if ( ! site || ! canUserUseCalypsoStore ) {
 			return null;
 		}
 

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -57,6 +57,11 @@ describe( 'MySitesSidebar', () => {
 				isSiteAutomatedTransfer: false,
 				canUserUpgradeSite: true,
 				...defaultProps,
+				site: {
+					plan: {
+						product_slug: 'business-bundle',
+					},
+				},
 			} );
 			const Store = () => Sidebar.store();
 
@@ -83,6 +88,7 @@ describe( 'MySitesSidebar', () => {
 		test( 'Should return Calypsoified store menu item if user can use store on this site and the site is an ecommerce plan', () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseCalypsoStore: true,
+				canUserUseWooCommerceCoreStore: true,
 				...defaultProps,
 				site: {
 					options: {
@@ -105,6 +111,11 @@ describe( 'MySitesSidebar', () => {
 				canUserUseCalypsoStore: false,
 				canUserUpgradeSite: true,
 				...defaultProps,
+				site: {
+					plan: {
+						product_slug: 'business-bundle',
+					},
+				},
 			} );
 			const Store = () => Sidebar.store();
 
@@ -112,12 +123,17 @@ describe( 'MySitesSidebar', () => {
 			expect( wrapper.html() ).toEqual( null );
 		} );
 
-		test( "Should return null if user who can't upgrade  user can not use store on this site (control a/b group)", () => {
+		test( "Should return null if user who can't upgrade user can not use store on this site (control a/b group)", () => {
 			abtest.mockImplementation( () => 'control' );
 			const Sidebar = new MySitesSidebar( {
 				canUserUseCalypsoStore: false,
 				canUserUpgradeSite: true,
 				...defaultProps,
+				site: {
+					plan: {
+						product_slug: 'business-bundle',
+					},
+				},
 			} );
 			const Store = () => Sidebar.store();
 
@@ -161,6 +177,7 @@ describe( 'MySitesSidebar', () => {
 
 		test( 'Should return null item if site has Personal plan', () => {
 			const Sidebar = new MySitesSidebar( {
+				canUserUseWooCommerceCoreStore: false,
 				...defaultProps,
 				site: {
 					plan: {

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -66,7 +66,7 @@ describe( 'MySitesSidebar', () => {
 
 		test( 'Should return store menu item if user can use store on this site', () => {
 			const Sidebar = new MySitesSidebar( {
-				canUserUseStore: true,
+				canUserUseCalypsoStore: true,
 				...defaultProps,
 				site: {
 					plan: {
@@ -82,7 +82,7 @@ describe( 'MySitesSidebar', () => {
 
 		test( 'Should return Calypsoified store menu item if user can use store on this site and the site is an ecommerce plan', () => {
 			const Sidebar = new MySitesSidebar( {
-				canUserUseStore: true,
+				canUserUseCalypsoStore: true,
 				...defaultProps,
 				site: {
 					options: {
@@ -102,7 +102,7 @@ describe( 'MySitesSidebar', () => {
 		test( 'Should return null item if user who can upgrade can not use store on this site (control a/b group)', () => {
 			abtest.mockImplementation( () => 'control' );
 			const Sidebar = new MySitesSidebar( {
-				canUserUseStore: false,
+				canUserUseCalypsoStore: false,
 				canUserUpgradeSite: true,
 				...defaultProps,
 			} );
@@ -115,7 +115,7 @@ describe( 'MySitesSidebar', () => {
 		test( "Should return null if user who can't upgrade  user can not use store on this site (control a/b group)", () => {
 			abtest.mockImplementation( () => 'control' );
 			const Sidebar = new MySitesSidebar( {
-				canUserUseStore: false,
+				canUserUseCalypsoStore: false,
 				canUserUpgradeSite: true,
 				...defaultProps,
 			} );
@@ -137,12 +137,15 @@ describe( 'MySitesSidebar', () => {
 			config.isEnabled.mockImplementation( () => true );
 		} );
 
-		test( 'Should return null item if woocommerce/store-deprecated is disabled', () => {
-			config.isEnabled.mockImplementation(
-				( feature ) => feature !== 'woocommerce/store-deprecated' // Only disable this one feature
-			);
+		test( 'Should return null item if woocommerce/store-deprecated and woocommerce/store-removed is disabled', () => {
+			// Enable all features except for store deprecation and removal
+			config.isEnabled.mockImplementation( ( feature ) => {
+				return (
+					feature !== 'woocommerce/store-deprecated' && feature !== 'woocommerce/store-removed'
+				);
+			} );
 			const Sidebar = new MySitesSidebar( {
-				canUserUserStore: true,
+				canUserUseWooCommerceCoreStore: true,
 				...defaultProps,
 				site: {
 					plan: {
@@ -173,7 +176,7 @@ describe( 'MySitesSidebar', () => {
 
 		test( 'Should return null item if site has eCommerce plan', () => {
 			const Sidebar = new MySitesSidebar( {
-				canUserUseStore: true,
+				canUserUseWooCommerceCoreStore: true,
 				...defaultProps,
 				site: {
 					plan: {
@@ -189,7 +192,7 @@ describe( 'MySitesSidebar', () => {
 
 		test( 'Should return null item if site has Business plan and user cannot use store', () => {
 			const Sidebar = new MySitesSidebar( {
-				canUserUseStore: false,
+				canUserUseWooCommerceCoreStore: false,
 				...defaultProps,
 				site: {
 					plan: {
@@ -205,7 +208,7 @@ describe( 'MySitesSidebar', () => {
 
 		test( 'Should return WooCommerce menu item redirecting to WooCommerce if site has Business plan and user can use store', () => {
 			const Sidebar = new MySitesSidebar( {
-				canUserUseStore: true,
+				canUserUseWooCommerceCoreStore: true,
 				...defaultProps,
 				site: {
 					options: {
@@ -228,7 +231,7 @@ describe( 'MySitesSidebar', () => {
 
 		test( 'Should return WooCommerce menu item linking to Store UI dashboard if site has Business plan, WooCommerce plugin not installed yet, and user can use store', () => {
 			const Sidebar = new MySitesSidebar( {
-				canUserUseStore: true,
+				canUserUseWooCommerceCoreStore: true,
 				...defaultProps,
 				site: {
 					options: {

--- a/client/state/sites/selectors/can-current-user-use-any-woocommerce-based-store.js
+++ b/client/state/sites/selectors/can-current-user-use-any-woocommerce-based-store.js
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies
+ */
+import config from 'calypso/config';
+import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
+import hasSitePendingAutomatedTransfer from 'calypso/state/selectors/has-site-pending-automated-transfer';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+/**
+ * Returns true if current user can use any WooCommerce-based store
+ *
+ * @param  {object}   state  Global state tree
+ * @param  {number}   siteId Site ID
+ * @returns {?boolean}        Whether current user can use any WooCommerce-based store
+ */
+export default function canCurrentUserUseAnyWooCommerceBasedStore( state, siteId = null ) {
+	if ( ! siteId ) {
+		siteId = getSelectedSiteId( state );
+	}
+
+	const canUserManageOptions = canCurrentUser( state, siteId, 'manage_options' );
+	const isSiteAT = !! isSiteAutomatedTransfer( state, siteId );
+
+	const hasSitePendingAT = hasSitePendingAutomatedTransfer( state, siteId );
+	const transferStatus = getAutomatedTransferStatus( state, siteId );
+	const siteHasBackgroundTransfer = hasSitePendingAT && transferStatus !== transferStates.ERROR;
+
+	return (
+		( canUserManageOptions && isSiteAT ) ||
+		( config.isEnabled( 'signup/atomic-store-flow' ) && siteHasBackgroundTransfer )
+	);
+}

--- a/client/state/sites/selectors/can-current-user-use-calypso-store.js
+++ b/client/state/sites/selectors/can-current-user-use-calypso-store.js
@@ -17,7 +17,10 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
  * @returns {?boolean}        Whether site is previewable
  */
 export default function canCurrentUserUseCalypsoStore( state, siteId = null ) {
-	if ( ! config.isEnabled( 'woocommerce/extension-dashboard' ) ) {
+	if (
+		config.isEnabled( 'woocommerce/store-removed' ) ||
+		! config.isEnabled( 'woocommerce/extension-dashboard' )
+	) {
 		return false;
 	}
 

--- a/client/state/sites/selectors/can-current-user-use-calypso-store.js
+++ b/client/state/sites/selectors/can-current-user-use-calypso-store.js
@@ -10,13 +10,13 @@ import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 /**
- * Returns true if current user can see and use Store option in menu
+ * Returns true if current user can see and use the Calypso-based Store option in menu
  *
  * @param  {object}   state  Global state tree
  * @param  {number}   siteId Site ID
  * @returns {?boolean}        Whether site is previewable
  */
-export default function canCurrentUserUseStore( state, siteId = null ) {
+export default function canCurrentUserUseCalypsoStore( state, siteId = null ) {
 	if ( ! siteId ) {
 		siteId = getSelectedSiteId( state );
 	}

--- a/client/state/sites/selectors/can-current-user-use-calypso-store.js
+++ b/client/state/sites/selectors/can-current-user-use-calypso-store.js
@@ -27,6 +27,11 @@ export default function canCurrentUserUseCalypsoStore( state, siteId = null ) {
 	}
 
 	const currentPlan = getCurrentPlan( state, siteId );
+
+	if ( ! currentPlan ) {
+		return false;
+	}
+
 	const subscribedDate = new Date( currentPlan.subscribedDate );
 	const subscribedBeforeDeprecation = subscribedDate < STORE_DEPRECATION_START_DATE;
 

--- a/client/state/sites/selectors/can-current-user-use-calypso-store.js
+++ b/client/state/sites/selectors/can-current-user-use-calypso-store.js
@@ -14,7 +14,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
  *
  * @param  {object}   state  Global state tree
  * @param  {number}   siteId Site ID
- * @returns {?boolean}        Whether site is previewable
+ * @returns {?boolean}        Whether current user can use the Calypso-based Store
  */
 export default function canCurrentUserUseCalypsoStore( state, siteId = null ) {
 	if (

--- a/client/state/sites/selectors/can-current-user-use-calypso-store.js
+++ b/client/state/sites/selectors/can-current-user-use-calypso-store.js
@@ -2,12 +2,7 @@
  * Internal dependencies
  */
 import config from 'calypso/config';
-import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
-import { transferStates } from 'calypso/state/automated-transfer/constants';
-import hasSitePendingAutomatedTransfer from 'calypso/state/selectors/has-site-pending-automated-transfer';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import canCurrentUserUseAnyWooCommerceBasedStore from 'calypso/state/sites/selectors/can-current-user-use-any-woocommerce-based-store';
 
 /**
  * Returns true if current user can see and use the Calypso-based Store option in menu
@@ -24,18 +19,5 @@ export default function canCurrentUserUseCalypsoStore( state, siteId = null ) {
 		return false;
 	}
 
-	if ( ! siteId ) {
-		siteId = getSelectedSiteId( state );
-	}
-	const canUserManageOptions = canCurrentUser( state, siteId, 'manage_options' );
-	const isSiteAT = !! isSiteAutomatedTransfer( state, siteId );
-
-	const hasSitePendingAT = hasSitePendingAutomatedTransfer( state, siteId );
-	const transferStatus = getAutomatedTransferStatus( state, siteId );
-	const siteHasBackgroundTransfer = hasSitePendingAT && transferStatus !== transferStates.ERROR;
-
-	return (
-		( canUserManageOptions && isSiteAT ) ||
-		( config.isEnabled( 'signup/atomic-store-flow' ) && siteHasBackgroundTransfer )
-	);
+	return canCurrentUserUseAnyWooCommerceBasedStore( state, siteId );
 }

--- a/client/state/sites/selectors/can-current-user-use-calypso-store.js
+++ b/client/state/sites/selectors/can-current-user-use-calypso-store.js
@@ -17,6 +17,10 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
  * @returns {?boolean}        Whether site is previewable
  */
 export default function canCurrentUserUseCalypsoStore( state, siteId = null ) {
+	if ( ! config.isEnabled( 'woocommerce/extension-dashboard' ) ) {
+		return false;
+	}
+
 	if ( ! siteId ) {
 		siteId = getSelectedSiteId( state );
 	}

--- a/client/state/sites/selectors/can-current-user-use-calypso-store.js
+++ b/client/state/sites/selectors/can-current-user-use-calypso-store.js
@@ -3,6 +3,9 @@
  */
 import config from 'calypso/config';
 import canCurrentUserUseAnyWooCommerceBasedStore from 'calypso/state/sites/selectors/can-current-user-use-any-woocommerce-based-store';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { STORE_DEPRECATION_START_DATE } from 'calypso/lib/plans/constants';
 
 /**
  * Returns true if current user can see and use the Calypso-based Store option in menu
@@ -19,5 +22,16 @@ export default function canCurrentUserUseCalypsoStore( state, siteId = null ) {
 		return false;
 	}
 
-	return canCurrentUserUseAnyWooCommerceBasedStore( state, siteId );
+	if ( ! siteId ) {
+		siteId = getSelectedSiteId( state );
+	}
+
+	const currentPlan = getCurrentPlan( state, siteId );
+	const subscribedDate = new Date( currentPlan.subscribedDate );
+	const subscribedBeforeDeprecation = subscribedDate < STORE_DEPRECATION_START_DATE;
+
+	return (
+		canCurrentUserUseAnyWooCommerceBasedStore( state, siteId ) &&
+		( config.isEnabled( 'woocommerce/store-deprecated' ) ? subscribedBeforeDeprecation : true )
+	);
 }

--- a/client/state/sites/selectors/can-current-user-use-woocommerce-core-store.js
+++ b/client/state/sites/selectors/can-current-user-use-woocommerce-core-store.js
@@ -25,10 +25,13 @@ export default function canCurrentUserUseWooCommerceCoreStore( state, siteId = n
 		return false;
 	}
 
+	const isCalypsoStoreDeprecatedOrRemoved =
+		config.isEnabled( 'woocommerce/store-deprecated' ) ||
+		config.isEnabled( 'woocommerce/store-removed' );
+
 	return (
 		canCurrentUserUseAnyWooCommerceBasedStore( state, siteId ) &&
 		( isEcommercePlan( currentPlan.productSlug ) ||
-			( isBusinessPlan( currentPlan.productSlug ) &&
-				config.isEnabled( 'woocommerce/store-deprecated' ) ) )
+			( isBusinessPlan( currentPlan.productSlug ) && isCalypsoStoreDeprecatedOrRemoved ) )
 	);
 }

--- a/client/state/sites/selectors/can-current-user-use-woocommerce-core-store.js
+++ b/client/state/sites/selectors/can-current-user-use-woocommerce-core-store.js
@@ -1,0 +1,30 @@
+/**
+ * Internal dependencies
+ */
+import config from 'calypso/config';
+import canCurrentUserUseAnyWooCommerceBasedStore from 'calypso/state/sites/selectors/can-current-user-use-any-woocommerce-based-store';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { isBusinessPlan, isEcommercePlan } from 'calypso/lib/plans';
+
+/**
+ * Returns true if current user can see and use the WooCommerce Core-based option in menu
+ *
+ * @param  {object}   state  Global state tree
+ * @param  {number}   siteId Site ID
+ * @returns {?boolean}        Whether current user can use WooCommerce
+ */
+export default function canCurrentUserUseWooCommerceCoreStore( state, siteId = null ) {
+	if ( ! siteId ) {
+		siteId = getSelectedSiteId( state );
+	}
+
+	const currentPlan = getCurrentPlan( state, siteId );
+
+	return (
+		canCurrentUserUseAnyWooCommerceBasedStore( state, siteId ) &&
+		( isEcommercePlan( currentPlan.productSlug ) ||
+			( isBusinessPlan( currentPlan.productSlug ) &&
+				config.isEnabled( 'woocommerce/store-deprecated' ) ) )
+	);
+}

--- a/client/state/sites/selectors/can-current-user-use-woocommerce-core-store.js
+++ b/client/state/sites/selectors/can-current-user-use-woocommerce-core-store.js
@@ -21,6 +21,10 @@ export default function canCurrentUserUseWooCommerceCoreStore( state, siteId = n
 
 	const currentPlan = getCurrentPlan( state, siteId );
 
+	if ( ! currentPlan ) {
+		return false;
+	}
+
 	return (
 		canCurrentUserUseAnyWooCommerceBasedStore( state, siteId ) &&
 		( isEcommercePlan( currentPlan.productSlug ) ||

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -4,6 +4,7 @@ export { default as canCurrentUserUpgradeSite } from './can-current-user-upgrade
 export { default as canCurrentUserUseAds } from './can-current-user-use-ads';
 export { default as canCurrentUserUseCustomerHome } from './can-current-user-use-customer-home';
 export { default as canCurrentUserUseEarn } from './can-current-user-use-earn';
+export { default as canCurrentUserUseAnyWooCommerceBasedStore } from './can-current-user-use-any-woocommerce-based-store';
 export { default as canCurrentUserUseCalypsoStore } from './can-current-user-use-calypso-store';
 export { default as canJetpackSiteAutoUpdateCore } from './can-jetpack-site-auto-update-core';
 export { default as canJetpackSiteAutoUpdateFiles } from './can-jetpack-site-auto-update-files';

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -4,7 +4,7 @@ export { default as canCurrentUserUpgradeSite } from './can-current-user-upgrade
 export { default as canCurrentUserUseAds } from './can-current-user-use-ads';
 export { default as canCurrentUserUseCustomerHome } from './can-current-user-use-customer-home';
 export { default as canCurrentUserUseEarn } from './can-current-user-use-earn';
-export { default as canCurrentUserUseStore } from './can-current-user-use-store';
+export { default as canCurrentUserUseCalypsoStore } from './can-current-user-use-calypso-store';
 export { default as canJetpackSiteAutoUpdateCore } from './can-jetpack-site-auto-update-core';
 export { default as canJetpackSiteAutoUpdateFiles } from './can-jetpack-site-auto-update-files';
 export { default as canJetpackSiteUpdateFiles } from './can-jetpack-site-update-files';

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -6,6 +6,7 @@ export { default as canCurrentUserUseCustomerHome } from './can-current-user-use
 export { default as canCurrentUserUseEarn } from './can-current-user-use-earn';
 export { default as canCurrentUserUseAnyWooCommerceBasedStore } from './can-current-user-use-any-woocommerce-based-store';
 export { default as canCurrentUserUseCalypsoStore } from './can-current-user-use-calypso-store';
+export { default as canCurrentUserUseWooCommerceCoreStore } from './can-current-user-use-woocommerce-core-store';
 export { default as canJetpackSiteAutoUpdateCore } from './can-jetpack-site-auto-update-core';
 export { default as canJetpackSiteAutoUpdateFiles } from './can-jetpack-site-auto-update-files';
 export { default as canJetpackSiteUpdateFiles } from './can-jetpack-site-update-files';

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -3539,6 +3539,7 @@ describe( 'selectors', () => {
 		} );
 
 		beforeEach( () => {
+			// TODO: disable store removed
 			config.isEnabled.mockImplementation( () => true );
 		} );
 
@@ -3564,6 +3565,17 @@ describe( 'selectors', () => {
 
 			expect( canCurrentUserUseCalypsoStore( createState( false, false, true ) ) ).toBe( false );
 		} );
+
+		test( 'should return false if extension dashboard is not enabled', () => {
+			// Enable all features except for the extension dashboard
+			config.isEnabled.mockImplementation(
+				( feature ) => feature !== 'woocommerce/extension-dashboard'
+			);
+
+			expect( canCurrentUserUseCalypsoStore( createState( true, true, false ) ) ).toBe( false );
+		} );
+
+		// TODO: test if store removed
 	} );
 
 	describe( 'canCurrentUserUseAds()', () => {

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -56,6 +56,19 @@ import {
 import config from 'calypso/config';
 import { userState } from 'calypso/state/selectors/test/fixtures/user-state';
 
+jest.mock( 'calypso/config', () => {
+	const configMock = () => '';
+	configMock.isEnabled = jest.fn( () => true );
+	return configMock;
+} );
+
+jest.mock( 'calypso/sections-filter', () => {
+	const mock = () => '';
+	mock.isSectionEnabled = jest.fn( () => true );
+	mock.isSectionNameEnabled = jest.fn( () => true );
+	return mock;
+} );
+
 describe( 'selectors', () => {
 	const createStateWithItems = ( items ) =>
 		deepFreeze( {
@@ -3525,6 +3538,10 @@ describe( 'selectors', () => {
 			},
 		} );
 
+		beforeEach( () => {
+			config.isEnabled.mockImplementation( () => true );
+		} );
+
 		test( 'should return true if site is AT and user can manage it', () => {
 			expect( canCurrentUserUseCalypsoStore( createState( true, true, false ) ) ).toBe( true );
 		} );
@@ -3538,13 +3555,13 @@ describe( 'selectors', () => {
 		} );
 
 		test( "should return true if user can't manage a site, but it has background transfer and atomic store flow is enabled", () => {
-			const oldEnabled = config.isEnabled;
-			config.isEnabled = () => true;
 			expect( canCurrentUserUseCalypsoStore( createState( false, false, true ) ) ).toBe( true );
-			config.isEnabled = oldEnabled;
 		} );
 
 		test( "should return false if user can't manage a site, but it has background transfer and atomic store flow is disabled", () => {
+			// Enable all features except for the atomic store flow
+			config.isEnabled.mockImplementation( ( feature ) => feature !== 'signup/atomic-store-flow' );
+
 			expect( canCurrentUserUseCalypsoStore( createState( false, false, true ) ) ).toBe( false );
 		} );
 	} );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -37,6 +37,7 @@ import {
 	hasStaticFrontPage,
 	canCurrentUserUseAds,
 	canCurrentUserUseCustomerHome,
+	canCurrentUserUseAnyWooCommerceBasedStore,
 	canCurrentUserUseCalypsoStore,
 	canJetpackSiteUpdateFiles,
 	canJetpackSiteAutoUpdateFiles,
@@ -3507,6 +3508,68 @@ describe( 'selectors', () => {
 				wpcom_url: 'unmapped-url.wordpress.com',
 				URL: 'https://unmapped-url.wordpress.com',
 			} );
+		} );
+	} );
+
+	describe( 'canCurrentUserUseAnyWooCommerceBasedStore()', () => {
+		const createState = (
+			manage_options,
+			is_automated_transfer,
+			has_pending_automated_transfer
+		) => ( {
+			ui: {
+				selectedSiteId: 1,
+			},
+			currentUser: {
+				capabilities: {
+					1: {
+						manage_options,
+					},
+				},
+			},
+			sites: {
+				items: {
+					1: {
+						options: {
+							is_automated_transfer,
+							has_pending_automated_transfer,
+						},
+					},
+				},
+			},
+		} );
+
+		test( 'should return true if site is AT and user can manage it', () => {
+			expect( canCurrentUserUseAnyWooCommerceBasedStore( createState( true, true, false ) ) ).toBe(
+				true
+			);
+		} );
+
+		test( 'should return false if site is not AT and user can manage it', () => {
+			expect( canCurrentUserUseAnyWooCommerceBasedStore( createState( true, false, false ) ) ).toBe(
+				false
+			);
+		} );
+
+		test( "should return false if site is AT and user can't manage it", () => {
+			expect( canCurrentUserUseAnyWooCommerceBasedStore( createState( false, true, false ) ) ).toBe(
+				false
+			);
+		} );
+
+		test( "should return true if user can't manage a site, but it has background transfer and atomic store flow is enabled", () => {
+			expect( canCurrentUserUseAnyWooCommerceBasedStore( createState( false, false, true ) ) ).toBe(
+				true
+			);
+		} );
+
+		test( "should return false if user can't manage a site, but it has background transfer and atomic store flow is disabled", () => {
+			// Enable all features except for the atomic store flow
+			config.isEnabled.mockImplementation( ( feature ) => feature !== 'signup/atomic-store-flow' );
+
+			expect( canCurrentUserUseAnyWooCommerceBasedStore( createState( false, false, true ) ) ).toBe(
+				false
+			);
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -3777,18 +3777,34 @@ describe( 'selectors', () => {
 			).toBe( false );
 		} );
 
-		test( 'should return false if site is Business and Store is not deprecated', () => {
+		test( 'should return false if site is Business and Store is not deprecated or removed', () => {
 			// Enable all features except for store deprecation
-			config.isEnabled.mockImplementation(
-				( feature ) => feature !== 'woocommerce/store-deprecated'
-			);
+			config.isEnabled.mockImplementation( ( feature ) => {
+				return (
+					feature !== 'woocommerce/store-deprecated' && feature !== 'woocommerce/store-removed'
+				);
+			} );
 
 			expect(
 				canCurrentUserUseWooCommerceCoreStore( createState( true, true, false, PLAN_BUSINESS ) )
 			).toBe( false );
 		} );
 
-		test( 'should return true if site is Business and Store is deprecated', () => {
+		test( 'should return true if site is Business and Store is deprecated but not removed', () => {
+			// Enable all features except for store removal
+			config.isEnabled.mockImplementation( ( feature ) => feature !== 'woocommerce/store-removed' );
+
+			expect(
+				canCurrentUserUseWooCommerceCoreStore( createState( true, true, false, PLAN_BUSINESS ) )
+			).toBe( true );
+		} );
+
+		test( 'should return true if site is Business and Store is not deprecated but is removed', () => {
+			// Enable all features except for store deprecation
+			config.isEnabled.mockImplementation(
+				( feature ) => feature !== 'woocommerce/store-deprecated'
+			);
+
 			expect(
 				canCurrentUserUseWooCommerceCoreStore( createState( true, true, false, PLAN_BUSINESS ) )
 			).toBe( true );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -3539,8 +3539,8 @@ describe( 'selectors', () => {
 		} );
 
 		beforeEach( () => {
-			// TODO: disable store removed
-			config.isEnabled.mockImplementation( () => true );
+			// Enable all features except for store removal
+			config.isEnabled.mockImplementation( ( feature ) => feature !== 'woocommerce/store-removed' );
 		} );
 
 		test( 'should return true if site is AT and user can manage it', () => {
@@ -3575,7 +3575,12 @@ describe( 'selectors', () => {
 			expect( canCurrentUserUseCalypsoStore( createState( true, true, false ) ) ).toBe( false );
 		} );
 
-		// TODO: test if store removed
+		test( 'should return false if store is removed', () => {
+			// Enable all features, including store removal
+			config.isEnabled.mockImplementation( () => true );
+
+			expect( canCurrentUserUseCalypsoStore( createState( true, true, false ) ) ).toBe( false );
+		} );
 	} );
 
 	describe( 'canCurrentUserUseAds()', () => {

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -37,7 +37,7 @@ import {
 	hasStaticFrontPage,
 	canCurrentUserUseAds,
 	canCurrentUserUseCustomerHome,
-	canCurrentUserUseStore,
+	canCurrentUserUseCalypsoStore,
 	canJetpackSiteUpdateFiles,
 	canJetpackSiteAutoUpdateFiles,
 	canJetpackSiteAutoUpdateCore,
@@ -3497,7 +3497,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'canCurrentUserUseStore()', () => {
+	describe( 'canCurrentUserUseCalypsoStore()', () => {
 		const createState = (
 			manage_options,
 			is_automated_transfer,
@@ -3526,26 +3526,26 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'should return true if site is AT and user can manage it', () => {
-			expect( canCurrentUserUseStore( createState( true, true, false ) ) ).toBe( true );
+			expect( canCurrentUserUseCalypsoStore( createState( true, true, false ) ) ).toBe( true );
 		} );
 
 		test( 'should return false if site is not AT and user can manage it', () => {
-			expect( canCurrentUserUseStore( createState( true, false, false ) ) ).toBe( false );
+			expect( canCurrentUserUseCalypsoStore( createState( true, false, false ) ) ).toBe( false );
 		} );
 
 		test( "should return false if site is AT and user can't manage it", () => {
-			expect( canCurrentUserUseStore( createState( false, true, false ) ) ).toBe( false );
+			expect( canCurrentUserUseCalypsoStore( createState( false, true, false ) ) ).toBe( false );
 		} );
 
 		test( "should return true if user can't manage a site, but it has background transfer and atomic store flow is enabled", () => {
 			const oldEnabled = config.isEnabled;
 			config.isEnabled = () => true;
-			expect( canCurrentUserUseStore( createState( false, false, true ) ) ).toBe( true );
+			expect( canCurrentUserUseCalypsoStore( createState( false, false, true ) ) ).toBe( true );
 			config.isEnabled = oldEnabled;
 		} );
 
 		test( "should return false if user can't manage a site, but it has background transfer and atomic store flow is disabled", () => {
-			expect( canCurrentUserUseStore( createState( false, false, true ) ) ).toBe( false );
+			expect( canCurrentUserUseCalypsoStore( createState( false, false, true ) ) ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
Part of the "Sunset Store on WordPress.com" epic (https://github.com/woocommerce/woocommerce-admin/issues/5816) -- see that for more context.

#### Changes proposed in this Pull Request

* Updates to `canCurrentUserUseCalypsoStore` (was `canCurrentUserUseStore`) and `canCurrentUserUseWooCommerceCoreStore` (new) selectors
* Updates My Sites sidebar to hide "Store" menu item for sites with Business plan subscriptions started after Store was deprecated

#### Testing instructions

##### Automated testing

- Check out branch
- Verify that all automated tests for selectors pass:

```
yarn run test-client client/state/sites/test/selectors.js
yarn run test-client client/my-sites/sidebar/test/sidebar.js
```

##### Manual testing

_Note: to change the deprecation start date when testing, in `client/lib/plans/constants.js`, edit the `STORE_DEPRECATION_START_DATE` constant. (I don't like giving manual testing instructions that involve editing code, but this is the easiest way. There might also be a way to change the subscription date in the database/state tree.)_

- Check out branch

###### Verify that "Store" and "WooCommerce" menu items appear correctly for sites when Store is deprecated:

```
ENABLE_FEATURES=woocommerce/store-deprecated yarn start
```

- "Store" available for sites with Business plan subscriptions started before Store was deprecated
- "Store" not available for sites with Business plan subscriptions started after Store was deprecated
- "Store" (linking to WooCommerce Core) available for sites with eCommerce plan subscriptions
- "WooCommerce" available for sites with Business plan subscriptions

###### Verify that "Store" and "WooCommerce" menu items appear correctly for sites when Store is removed:

```
ENABLE_FEATURES=woocommerce/store-removed yarn start
```

- "Store" not available for sites with Business plan subscriptions
- "Store" (linking to WooCommerce Core) available for sites with eCommerce plan subscriptions
- "WooCommerce" available for sites with Business plan subscriptions

Fixes #48424
