### PR TITLE
Checkout: Reduxify notices in composite checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -24,7 +24,6 @@ import { useStripe } from '@automattic/calypso-stripe';
  * Internal dependencies
  */
 import wp from 'calypso/lib/wp';
-import notices from 'calypso/notices';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
@@ -33,6 +32,7 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { StateSelect } from 'calypso/my-sites/domains/components/form';
 import { getPlan } from 'calypso/lib/plans';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { errorNotice, infoNotice, successNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import QueryContactDetailsCache from 'calypso/components/data/query-contact-details-cache';
@@ -152,31 +152,41 @@ export default function CompositeCheckout( {
 		( error ) => {
 			debug( 'error', error );
 			const message = error && error.toString ? error.toString() : error;
-			notices.error( message || translate( 'An error occurred during your purchase.' ) );
+			reduxDispatch(
+				errorNotice( message || translate( 'An error occurred during your purchase.' ) )
+			);
 		},
-		[ translate ]
+		[ reduxDispatch, translate ]
 	);
 
 	const showErrorMessageBriefly = useCallback(
 		( error ) => {
 			debug( 'error', error );
 			const message = error && error.toString ? error.toString() : error;
-			notices.error( message || translate( 'An error occurred during your purchase.' ), {
-				duration: 5000,
-			} );
+			reduxDispatch(
+				errorNotice( message || translate( 'An error occurred during your purchase.' ), {
+					duration: 5000,
+				} )
+			);
 		},
-		[ translate ]
+		[ reduxDispatch, translate ]
 	);
 
-	const showInfoMessage = useCallback( ( message ) => {
-		debug( 'info', message );
-		notices.info( message );
-	}, [] );
+	const showInfoMessage = useCallback(
+		( message ) => {
+			debug( 'info', message );
+			reduxDispatch( infoNotice( message ) );
+		},
+		[ reduxDispatch ]
+	);
 
-	const showSuccessMessage = useCallback( ( message ) => {
-		debug( 'success', message );
-		notices.success( message );
-	}, [] );
+	const showSuccessMessage = useCallback(
+		( message ) => {
+			debug( 'success', message );
+			reduxDispatch( successNotice( message ) );
+		},
+		[ reduxDispatch ]
+	);
 
 	const countriesList = useCountryList( overrideCountryList || [] );
 
@@ -279,7 +289,7 @@ export default function CompositeCheckout( {
 	} );
 
 	// Display errors. Note that we display all errors if any of them change,
-	// because notices.error() otherwise will remove the previously displayed
+	// because errorNotice() otherwise will remove the previously displayed
 	// errors.
 	const errorsToDisplay = [
 		cartLoadingError,
@@ -287,7 +297,9 @@ export default function CompositeCheckout( {
 		cartProductPrepError,
 	].filter( doesValueExist );
 	useActOnceOnStrings( errorsToDisplay, () => {
-		notices.error( errorsToDisplay.map( ( message ) => <p key={ message }>{ message }</p> ) );
+		reduxDispatch(
+			errorNotice( errorsToDisplay.map( ( message ) => <p key={ message }>{ message }</p> ) )
+		);
 	} );
 
 	const isFullCredits =

--- a/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
@@ -16,11 +16,12 @@ import {
 	useDispatch,
 } from '@automattic/composite-checkout';
 import { camelCase } from 'lodash';
+import { useDispatch as useReduxDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import notices from 'calypso/notices';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { validatePaymentDetails } from 'calypso/lib/checkout/validation';
 import useCountryList from 'calypso/my-sites/checkout/composite-checkout/hooks/use-country-list';
 import Field from 'calypso/my-sites/checkout/composite-checkout/components/field';
@@ -295,12 +296,13 @@ function EbanxTefPayButton( { disabled, onClick, store } ) {
 	const contactCountryCode = useSelect(
 		( select ) => select( 'wpcom' )?.getContactInfo().countryCode?.value
 	);
+	const reduxDispatch = useReduxDispatch();
 
 	return (
 		<Button
 			disabled={ disabled }
 			onClick={ () => {
-				if ( isFormValid( store, contactCountryCode, __ ) ) {
+				if ( isFormValid( store, contactCountryCode, __, reduxDispatch ) ) {
 					debug( 'submitting ebanx-tef payment' );
 					onClick( 'ebanx-tef', {
 						...massagedFields,
@@ -344,7 +346,7 @@ function EbanxTefSummary() {
 	);
 }
 
-function isFormValid( store, contactCountryCode, __ ) {
+function isFormValid( store, contactCountryCode, __, reduxDispatch ) {
 	// Touch fields so that we show errors
 	store.dispatch( store.actions.touchAllFields() );
 	let isValid = true;
@@ -388,7 +390,9 @@ function isFormValid( store, contactCountryCode, __ ) {
 
 	if ( validationResults.errors?.country?.length > 0 ) {
 		const countryErrorMessage = validationResults.errors.country[ 0 ];
-		notices.error( countryErrorMessage || __( 'An error occurred during your purchase.' ) );
+		reduxDispatch(
+			errorNotice( countryErrorMessage || __( 'An error occurred during your purchase.' ) )
+		);
 	}
 	return isValid;
 }

--- a/client/my-sites/checkout/composite-checkout/payment-methods/id-wallet.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/id-wallet.js
@@ -15,11 +15,12 @@ import {
 	useDispatch,
 } from '@automattic/composite-checkout';
 import { camelCase } from 'lodash';
+import { useDispatch as useReduxDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import notices from 'calypso/notices';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { validatePaymentDetails } from 'calypso/lib/checkout/validation';
 import useCountryList from 'calypso/my-sites/checkout/composite-checkout/hooks/use-country-list';
 import Field from 'calypso/my-sites/checkout/composite-checkout/components/field';
@@ -222,12 +223,13 @@ function IdWalletPayButton( { disabled, onClick, store } ) {
 	const contactCountryCode = useSelect(
 		( select ) => select( 'wpcom' )?.getContactInfo().countryCode?.value
 	);
+	const reduxDispatch = useReduxDispatch();
 
 	return (
 		<Button
 			disabled={ disabled }
 			onClick={ () => {
-				if ( isFormValid( store, contactCountryCode, __ ) ) {
+				if ( isFormValid( store, contactCountryCode, __, reduxDispatch ) ) {
 					debug( 'submitting id wallet payment' );
 					onClick( 'id_wallet', {
 						...massagedFields,
@@ -268,7 +270,7 @@ function IdWalletSummary() {
 	);
 }
 
-function isFormValid( store, contactCountryCode, __ ) {
+function isFormValid( store, contactCountryCode, __, reduxDispatch ) {
 	// Touch fields so that we show errors
 	store.dispatch( store.actions.touchAllFields() );
 	let isValid = true;
@@ -305,7 +307,9 @@ function isFormValid( store, contactCountryCode, __ ) {
 
 	if ( validationResults.errors?.country?.length > 0 ) {
 		const countryErrorMessage = validationResults.errors.country[ 0 ];
-		notices.error( countryErrorMessage || __( 'An error occurred during your purchase.' ) );
+		reduxDispatch(
+			errorNotice( countryErrorMessage || __( 'An error occurred during your purchase.' ) )
+		);
 	}
 	return isValid;
 }

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
@@ -16,11 +16,12 @@ import {
 	useDispatch,
 } from '@automattic/composite-checkout';
 import { camelCase } from 'lodash';
+import { useDispatch as useReduxDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import notices from 'calypso/notices';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { validatePaymentDetails } from 'calypso/lib/checkout/validation';
 import useCountryList from 'calypso/my-sites/checkout/composite-checkout/hooks/use-country-list';
 import Field from 'calypso/my-sites/checkout/composite-checkout/components/field';
@@ -223,12 +224,13 @@ function NetBankingPayButton( { disabled, onClick, store } ) {
 	const contactCountryCode = useSelect(
 		( select ) => select( 'wpcom' )?.getContactInfo().countryCode?.value
 	);
+	const reduxDispatch = useReduxDispatch();
 
 	return (
 		<Button
 			disabled={ disabled }
 			onClick={ () => {
-				if ( isFormValid( store, contactCountryCode, __ ) ) {
+				if ( isFormValid( store, contactCountryCode, __, reduxDispatch ) ) {
 					debug( 'submitting netbanking payment' );
 					onClick( 'netbanking', {
 						...massagedFields,
@@ -269,7 +271,7 @@ function NetBankingSummary() {
 	);
 }
 
-function isFormValid( store, contactCountryCode, __ ) {
+function isFormValid( store, contactCountryCode, __, reduxDispatch ) {
 	// Touch fields so that we show errors
 	store.dispatch( store.actions.touchAllFields() );
 	let isValid = true;
@@ -306,7 +308,9 @@ function isFormValid( store, contactCountryCode, __ ) {
 
 	if ( validationResults.errors?.country?.length > 0 ) {
 		const countryErrorMessage = validationResults.errors.country[ 0 ];
-		notices.error( countryErrorMessage || __( 'An error occurred during your purchase.' ) );
+		reduxDispatch(
+			errorNotice( countryErrorMessage || __( 'An error occurred during your purchase.' ) )
+		);
 	}
 	return isValid;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reduxifies the notices in composite checkout components and payment methods.

Part of #48408.

#### Testing instructions

* I'm not 100% sure how to test all affected flows. I'd love the help of @sirbrillig or anyone else from @Automattic/shilling or @Automattic/payments to fully test this.

