### PR TITLE
Nav-Unification: Adjusts margins for the nudge collapsed state.

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -364,6 +364,10 @@ $font-size: rem( 14px );
 		}
 
 		// client/blocks/upsell-nudge/style.scss
+		.upsell-nudge.banner.card.is-compact {
+			margin: 8px 3px 7px;
+		}
+
 		.current-site__notices > a::before {
 			content: '\f534';
 			font-family: 'dashicons';


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This is a regression fix after some nudges UI changes that weren't also adjusted for the sidebar collapsed state.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* enable nav-unification (paYJgx-1af-p2).
* load `http://calypso.localhost:3000/home` on a site that has an upsell nudge (eg "Free domain with a plan").
* collapse the sidebar by clicking "Collapse menu" on the bottom of the sidebar.

Before | After
-------|------
![](https://cln.sh/ZfgMDj+) | ![](https://cln.sh/SMnylm+)