### PR TITLE
WordAds: Remove unused notices

### DIFF
--- a/client/my-sites/stats/wordads/earnings.jsx
+++ b/client/my-sites/stats/wordads/earnings.jsx
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
-import notices from 'calypso/notices';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -30,14 +28,6 @@ class WordAdsEarnings extends Component {
 		showSponsoredInfo: false,
 		showAdjustmentInfo: false,
 	};
-
-	componentDidUpdate() {
-		if ( this.state.error && this.state.error.message ) {
-			notices.error( this.state.error.message );
-		} else {
-			notices.clearNotices( 'notices' );
-		}
-	}
 
 	handleEarningsNoticeToggle = ( event ) => {
 		event.preventDefault();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `error` component state hasn't been used since we reduxified WordAds in #25819. This PR removes it together with the notices code that relies on it. 

Part of #48408.

#### Testing instructions

* Go to `/earn/ads-earnings/:site` where `:site` is a site with WordAds enabled.
* Verify the page still works well.
