### PR TITLE
Adds missing dependencies

### DIFF
--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -46,6 +46,7 @@
 		"jquery": "^1.12.3",
 		"lodash": "^4.17.15",
 		"react": "^16.12.0",
+		"react-dom": "^16.12.0",
 		"tinymce": "^4.9.6"
 	},
 	"devDependencies": {

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -32,6 +32,7 @@
 		"use-subscription": "^1.2.0"
 	},
 	"devDependencies": {
+		"react": "^16.12.0",
 		"react-dom": "^16.12.0",
 		"react-test-renderer": "^16.12.0"
 	},

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -29,6 +29,8 @@
 	"devDependencies": {
 		"@testing-library/jest-dom": "^5.11.6",
 		"@testing-library/react": "^11.2.0",
-		"@testing-library/react-hooks": "^3.4.2"
+		"@testing-library/react-hooks": "^3.4.2",
+		"react-dom": "^16.12.0",
+		"react-test-renderer": "^16.12.0"
 	}
 }

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -48,9 +48,11 @@
 	},
 	"devDependencies": {
 		"@automattic/typography": "^1.0.0",
+		"@testing-library/react": "^10.0.5",
 		"@wordpress/base-styles": "^2.0.1",
 		"copyfiles": "^2.3.0",
-		"@testing-library/react": "^10.0.5"
+		"react": "^16.12.0",
+		"react-dom": "^16.12.0"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^4.22.3",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -43,7 +43,9 @@
 		"@testing-library/react": "^10.0.5",
 		"@wordpress/base-styles": "^2.0.1",
 		"copyfiles": "^2.3.0",
-		"history": "^5.0.0"
+		"history": "^5.0.0",
+		"react": "^16.12.0",
+		"react-dom": "^16.12.0"
 	},
 	"peerDependencies": {
 		"react": "^16.8"

--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -45,6 +45,7 @@
 		"@testing-library/jest-dom": "^5.9.0",
 		"@testing-library/react": "^10.0.5",
 		"cache-loader": "^4.1.0",
+		"react-dom": "^16.12.0",
 		"webpack": "^4.44.2"
 	},
 	"private": true

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -49,7 +49,9 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-build": "^6.1.0",
-		"enzyme": "^3.11.0"
+		"enzyme": "^3.11.0",
+		"react": "^16.12.0",
+		"react-dom": "^16.12.0"
 	},
 	"peerDependencies": {
 		"react": "^16.12.0"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes the following errors reported by `@yarnpkg/doctor`

```
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/social-previews/package.json:51:32: Unmet transitive peer dependency on react@^16.0.0, via @automattic/calypso-build@^6.1.0
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/social-previews/package.json:51:32: Unmet transitive peer dependency on react-dom@^16.0.0, via @automattic/calypso-build@^6.1.0
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/apps/wpcom-block-editor/package.json:52:32: Unmet transitive peer dependency on react-dom@^16.0.0, via @automattic/calypso-build@^6.1.0
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/i18n-calypso/package.json:35:16: Unmet transitive peer dependency on react@^16.14.0, via react-dom@^16.12.0
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/i18n-calypso/package.json:36:26: Unmet transitive peer dependency on react@^16.14.0, via react-test-renderer@^16.12.0
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/i18n-utils/package.json:31:29: Unmet transitive peer dependency on react-dom@*, via @testing-library/react@^11.2.0
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/i18n-utils/package.json:32:35: Unmet transitive peer dependency on react-test-renderer@>=16.9.0, via @testing-library/react-hooks@^3.4.2
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/launch/package.json:53:29: Unmet transitive peer dependency on react@*, via @testing-library/react@^10.0.5
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/launch/package.json:53:29: Unmet transitive peer dependency on react-dom@*, via @testing-library/react@^10.0.5
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/onboarding/package.json:43:29: Unmet transitive peer dependency on react@*, via @testing-library/react@^10.0.5
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/onboarding/package.json:43:29: Unmet transitive peer dependency on react-dom@*, via @testing-library/react@^10.0.5
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/shopping-cart/package.json:46:29: Unmet transitive peer dependency on react-dom@*, via @testing-library/react@^10.0.5
```

#### Testing instructions

* Checkout the branch, run `yarn` and then run `yarn run effective-module-tree -o list`. Do the same with `trunk` and diff the outputs. There should be no differences, meaning the dependency tree has not changed.