### PR TITLE
G Suite: Pass quantity when adding Google Workspace to shopping cart

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -765,9 +765,12 @@ export function googleApps( properties ) {
 			? GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
 			: GSUITE_BASIC_SLUG );
 
-	const item = domainItem( productSlug, properties.meta ? properties.meta : properties.domain );
-
-	return assign( item, { extra: { google_apps_users: properties.users } } );
+	return assign( domainItem( productSlug, properties.meta ?? properties.domain ), {
+		extra: { google_apps_users: properties.users },
+		...( productSlug === GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
+			? { quantity: properties.quantity }
+			: {} ),
+	} );
 }
 
 export function googleAppsExtraLicenses( properties ) {


### PR DESCRIPTION
This pull request makes sure we pass a `quantity` property when adding Google Workspace Business Starter to the shopping cart. Products [such as Titan](https://github.com/Automattic/wp-calypso/blob/5634099706f0b926a1674d48e628ad6e57c2a006/client/lib/cart-values/cart-items.js#L789) indeed expects that property to correctly handle the number of licenses.

#### Testing instructions

1. Run `git checkout fix/google-workspace-quantity` and start your server, or open a [live branch](https://calypso.live/?branch=fix/google-workspace-quantity)
2. Point `public-api.wordpress.com` to your sandbox
3. Open the `Store_Product_Google_Workspace_Business_Starter_Yearly::modify_cart_after_adding_product()` method
4. Add a debug statement for `$cart`
5. Log into a WordPress.com account with a domain
6. Open the [`Email Comparison` page](http://calypso.localhost:3000/email)
7. Click the `Add Google Workspace` button
8. Enter several users, and click the `Continue` button
9. Assert that you see the right price in the checkout
10. Assert that you see the right number of licenses in the PHP error logs

