### PR TITLE
Marketing: Reduxify notices

### DIFF
--- a/client/my-sites/marketing/controller.js
+++ b/client/my-sites/marketing/controller.js
@@ -10,7 +10,6 @@ import { translate } from 'i18n-calypso';
  */
 import MarketingTools from './tools';
 import MarketingBusinessTools from './business-tools';
-import notices from 'calypso/notices';
 import Sharing from './main';
 import SharingButtons from './buttons/buttons';
 import SharingConnections from './connections/connections';
@@ -23,6 +22,7 @@ import {
 	isJetpackModuleActive,
 	getSiteOption,
 } from 'calypso/state/sites/selectors';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { fetchPreferences } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
@@ -87,8 +87,8 @@ export const connections = ( context, next ) => {
 	const siteId = getSelectedSiteId( state );
 
 	if ( siteId && ! canCurrentUser( state, siteId, 'publish_posts' ) ) {
-		notices.error(
-			translate( 'You are not authorized to manage sharing settings for this site.' )
+		dispatch(
+			errorNotice( translate( 'You are not authorized to manage sharing settings for this site.' ) )
 		);
 	}
 
@@ -115,8 +115,8 @@ export const sharingButtons = ( context, next ) => {
 	const siteId = getSelectedSiteId( state );
 
 	if ( siteId && ! canCurrentUser( state, siteId, 'manage_options' ) ) {
-		notices.error(
-			translate( 'You are not authorized to manage sharing settings for this site.' )
+		store.dispatch(
+			errorNotice( translate( 'You are not authorized to manage sharing settings for this site.' ) )
 		);
 	}
 
@@ -128,9 +128,11 @@ export const sharingButtons = ( context, next ) => {
 		( ! isJetpackModuleActive( state, siteId, 'sharedaddy' ) ||
 			versionCompare( siteJetpackVersion, '3.4-dev', '<' ) )
 	) {
-		notices.error(
-			translate(
-				'This page is only available to Jetpack sites running version 3.4 or higher with the Sharing module activated.'
+		store.dispatch(
+			errorNotice(
+				translate(
+					'This page is only available to Jetpack sites running version 3.4 or higher with the Sharing module activated.'
+				)
 			)
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reduxifies notices in the Marketing section.

Part of #48408.

#### Testing instructions

* Log in as a user with the "Contributor" role in a site.
* Go to `/marketing/connections/:site`.
* Verify you get an error notice that you are not authorized to manage these settings.
* Go to `/marketing/sharing-buttons/:site`.
* Verify you get an error notice that you are not authorized to manage these settings.
* Create a Jetpack site, connect it to WP.cokm and disable the `Sharing` (AKA `sharedaddy` module (you can do that from the "hidden menu" in `/wp-admin/admin.php?page=jetpack_modules` or with WP CLI by the `wp jetpack module deactivate sharedaddy` command).
* Go to `/marketing/sharing-buttons/:site` as an admin user.
* Verify you get an error notice that sharing settings are available only when the module is enabled.
