### PR TITLE
Show Email mailbox count in domain list views

### DIFF
--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -43,7 +43,7 @@ import { withoutHttp } from 'calypso/lib/url';
 import RemovePurchase from 'calypso/me/purchases/remove-purchase';
 import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'calypso/lib/gsuite';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
+import { getMaxTitanMailboxCount } from 'calypso/lib/titan';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils';
 import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -113,7 +113,18 @@ class DomainManagementNavigationEnhanced extends React.Component {
 				}
 			);
 		} else if ( hasTitanMailWithUs( domain ) ) {
-			navigationDescription = getTitanProductName();
+			const titanMailboxCount = getMaxTitanMailboxCount( domain );
+			navigationDescription = translate(
+				'%(titanMailboxCount)d mailbox',
+				'%(titanMailboxCount)d mailboxes',
+				{
+					args: {
+						titanMailboxCount,
+					},
+					count: titanMailboxCount,
+					comment: '%(titanMailboxCount)d is the number of mailboxes for the current domain',
+				}
+			);
 		} else if ( emailForwardsCount > 0 ) {
 			navigationDescription = translate(
 				'%(emailForwardsCount)d forward',

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -41,7 +41,7 @@ import {
 import Spinner from 'calypso/components/spinner';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
+import { getMaxTitanMailboxCount } from 'calypso/lib/titan/get-max-titan-mailbox-count';
 import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
 
 class DomainItem extends PureComponent {
@@ -302,7 +302,14 @@ class DomainItem extends PureComponent {
 		}
 
 		if ( hasTitanMailWithUs( domainDetails ) ) {
-			return getTitanProductName();
+			const titanMailboxCount = getMaxTitanMailboxCount( domainDetails );
+			return translate( '%(titanMailboxCount)d mailbox', '%(titanMailboxCount)d mailboxes', {
+				args: {
+					titanMailboxCount,
+				},
+				count: titanMailboxCount,
+				comment: '%(titanMailboxCount)d is the number of mailboxes for the current domain',
+			} );
 		}
 
 		if ( domainDetails?.emailForwardsCount > 0 ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the domain listing view and domain management menu to show the total number of available Email mailboxes
<img width="1053" alt="Domain listing view" title="Domain listing view" src="https://user-images.githubusercontent.com/3376401/104592602-1ea29300-5677-11eb-9925-d7f3e5c64036.png">
<img width="734" alt="Domain management menu" title="Domain management menu" src="https://user-images.githubusercontent.com/3376401/104592634-2e21dc00-5677-11eb-81ce-b807c8cd2b40.png">


#### Testing instructions

* Navigate to the All Domains view or Manage -> Domains for a site where one or more domains have Email subscriptions.
* Verify that we show the total number of mailboxes that the user has paid for.
