### PR TITLE
Calypso Build: preserve translator comments in build

### DIFF
--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## trunk
 
+- Do not remove translator comments from build.
+
 ## 6.5.0
 
 - Added `corejs`, `debug`, and `useBuiltIns` options to the `babel/default` preset.

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -104,6 +104,9 @@ function getWebpackConfig(
 					ecma: 5,
 					safari10: true,
 					mangle: { reserved: [ '__', '_n', '_nx', '_x' ] },
+					format: {
+						comments: /translators:/i,
+					},
 				},
 			} ),
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

External services like translate.wordpress.org rely on translator comments to display additional context for translators, when used alongside translation functions.

Let's keep those comments in our builds.

Internal reference: p1610626123006500-slack-C7YPUHBB2

#### Testing instructions

I'm not quite sure how to go about testing this. I think it would involve using `yarn link` and then building a production build of Jetpack but I can't seem to get this to work on my end for some reason.

In the end, in the production build we should still translator comments like those:

<img width="882" alt="Screenshot 2021-01-14 at 12 41 01" src="https://user-images.githubusercontent.com/426388/104589378-12fc9f80-566a-11eb-9b2b-3d22fad34bbe.png">
<img width="906" alt="Screenshot 2021-01-14 at 12 40 41" src="https://user-images.githubusercontent.com/426388/104589385-142dcc80-566a-11eb-9601-d41dbc30c9f6.png">

Fixes https://github.com/Automattic/jetpack/issues/16549