### PR TITLE
Add description for Email product in the purchases page

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -71,7 +71,7 @@ function createPurchaseObject( purchase ) {
 		tagLine: purchase.tag_line,
 		taxAmount: purchase.tax_amount,
 		taxText: purchase.tax_text,
-		titanMaximumMailboxCount: purchase.titan_maximum_mailbox_count || null,
+		purchaseRenewalQuantity: purchase.renewal_price_tier_usage_quantity || null,
 		userId: Number( purchase.user_id ),
 	};
 

--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -71,6 +71,7 @@ function createPurchaseObject( purchase ) {
 		tagLine: purchase.tag_line,
 		taxAmount: purchase.tax_amount,
 		taxText: purchase.tax_text,
+		titanMaximumMailboxCount: purchase.titan_maximum_mailbox_count || null,
 		userId: Number( purchase.user_id ),
 	};
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -523,14 +523,14 @@ class ManagePurchase extends Component {
 				},
 			} );
 
-			if ( purchase.titanMaximumMailboxCount ) {
+			if ( purchase.purchaseRenewalQuantity ) {
 				description = translate(
 					'%(mailboxCount)d mailbox for %(domain)s',
 					'%(mailboxCount)d mailboxes for %(domain)s',
 					{
-						count: purchase.titanMaximumMailboxCount,
+						count: purchase.purchaseRenewalQuantity,
 						args: {
-							mailboxCount: purchase.titanMaximumMailboxCount,
+							mailboxCount: purchase.purchaseRenewalQuantity,
 							domain: purchase.meta,
 						},
 					}

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -516,6 +516,26 @@ class ManagePurchase extends Component {
 				'Transfers an existing domain from another provider to WordPress.com, ' +
 					'helping you manage your site and domain in one place.'
 			);
+		} else if ( isTitanMail( purchase ) ) {
+			description = translate( 'Email for %(domain)s', {
+				args: {
+					domain: purchase.meta,
+				},
+			} );
+
+			if ( purchase.titanMaximumMailboxCount ) {
+				description = translate(
+					'%(mailboxCount)d mailbox for %(domain)s',
+					'%(mailboxCount)d mailboxes for %(domain)s',
+					{
+						count: purchase.titanMaximumMailboxCount,
+						args: {
+							mailboxCount: purchase.titanMaximumMailboxCount,
+							domain: purchase.meta,
+						},
+					}
+				);
+			}
 		}
 
 		const registrationAgreementUrl = getDomainRegistrationAgreementUrl( purchase );

--- a/client/me/purchases/product-link/index.jsx
+++ b/client/me/purchases/product-link/index.jsx
@@ -20,6 +20,7 @@ import {
 	isPlan,
 	isSiteRedirect,
 	isTheme,
+	isTitanMail,
 } from 'calypso/lib/products-values';
 
 const ProductLink = ( { productUrl, purchase, selectedSite } ) => {
@@ -41,7 +42,7 @@ const ProductLink = ( { productUrl, purchase, selectedSite } ) => {
 		text = i18n.translate( 'Domain Settings' );
 	}
 
-	if ( isGoogleApps( purchase ) ) {
+	if ( isGoogleApps( purchase ) || isTitanMail( purchase ) ) {
 		url = emailManagement( selectedSite.slug, purchase.meta );
 		text = i18n.translate( 'Email Settings' );
 	}

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -121,6 +121,7 @@ describe( 'selectors', () => {
 				tagLine: undefined,
 				taxAmount: undefined,
 				taxText: undefined,
+				titanMaximumMailboxCount: null,
 				userId: NaN,
 			} );
 		} );

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -121,7 +121,7 @@ describe( 'selectors', () => {
 				tagLine: undefined,
 				taxAmount: undefined,
 				taxText: undefined,
-				titanMaximumMailboxCount: null,
+				purchaseRenewalQuantity: null,
 				userId: NaN,
 			} );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show the number of mailboxes when you open the purchases page for the Email product
* Also add link to the Email settings page

Looks like this:
<img width="1078" alt="Screenshot 2021-01-14 at 16 15 26" src="https://user-images.githubusercontent.com/1355045/104602161-c756ef80-5683-11eb-8f56-d56bb3ce3c88.png">


#### Testing instructions

* Open the purchase page for Email purchase and verify that the number of mailboxes is shown and the "Email Settings" link is there and points to the proper section
