### PR TITLE
Domains: Fix primary domain indicator

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -65,6 +65,7 @@ class DomainItem extends PureComponent {
 		isLoadingDomainDetails: PropTypes.bool,
 		selectionIndex: PropTypes.number,
 		enableSelection: PropTypes.bool,
+		isChecked: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -74,6 +75,7 @@ class DomainItem extends PureComponent {
 		onToggle: null,
 		isLoadingDomainDetails: false,
 		isBusy: false,
+		isChecked: false,
 	};
 
 	handleClick = ( e ) => {
@@ -430,7 +432,14 @@ class DomainItem extends PureComponent {
 	}
 
 	render() {
-		const { domain, domainDetails, isManagingAllSites, showCheckbox, enableSelection } = this.props;
+		const {
+			domain,
+			domainDetails,
+			isChecked,
+			isManagingAllSites,
+			showCheckbox,
+			enableSelection,
+		} = this.props;
 		const { listStatusText, listStatusClass } = resolveDomainStatus( domainDetails || domain );
 
 		const rowClasses = classNames( 'domain-item', `domain-item__status-${ listStatusClass }`, {
@@ -450,7 +459,11 @@ class DomainItem extends PureComponent {
 					/>
 				) }
 				{ enableSelection && (
-					<FormRadio className="domain-item__checkbox" onClick={ this.onSelect } />
+					<FormRadio
+						className="domain-item__checkbox"
+						checked={ isChecked }
+						onClick={ this.onSelect }
+					/>
 				) }
 				<div className="list__domain-link">
 					<div className="domain-item__status">

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -432,6 +432,8 @@ export class List extends React.Component {
 			hasSingleSite,
 		} = this.props;
 
+		const { changePrimaryDomainModeEnabled, primaryDomainIndex, settingPrimaryDomain } = this.state;
+
 		const domains =
 			selectedSite.jetpack || ( renderAllSites && isDomainOnly )
 				? this.filterOutWpcomDomains( this.props.domains )
@@ -445,13 +447,14 @@ export class List extends React.Component {
 				domainDetails={ domain }
 				site={ selectedSite }
 				isManagingAllSites={ false }
-				onClick={ this.state.settingPrimaryDomain ? noop : this.goToEditDomainRoot }
-				isBusy={ this.state.settingPrimaryDomain && index === this.state.primaryDomainIndex }
+				onClick={ settingPrimaryDomain ? noop : this.goToEditDomainRoot }
+				isBusy={ settingPrimaryDomain && index === primaryDomainIndex }
+				isChecked={ changePrimaryDomainModeEnabled && index === primaryDomainIndex }
 				busyMessage={ this.props.translate( 'Setting Primary Domain…', {
 					context: 'Shows up when the primary domain is changing and the user is waiting',
 				} ) }
-				disabled={ this.state.settingPrimaryDomain || this.state.changePrimaryDomainModeEnabled }
-				enableSelection={ this.state.changePrimaryDomainModeEnabled && domain.canSetAsPrimary }
+				disabled={ settingPrimaryDomain || changePrimaryDomainModeEnabled }
+				enableSelection={ changePrimaryDomainModeEnabled && domain.canSetAsPrimary }
 				selectionIndex={ index }
 				onMakePrimaryClick={ this.handleUpdatePrimaryDomainOptionClick }
 				onSelect={ this.handleUpdatePrimaryDomain }

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -133,43 +133,6 @@
 	}
 }
 
-.domain-management-list-item__content {
-	display: flex;
-	justify-content: space-between;
-
-	@include breakpoint-deprecated( '<960px' ) {
-		justify-content: flex-start;
-		flex-direction: column;
-	}
-}
-
-input[type='radio'].domain-management-list-item__radio {
-	margin-left: -8px;
-	margin-right: 12px;
-	margin-top: 19px;
-}
-
-.domain-management-list-item__spinner {
-	float: right;
-	margin-top: 12px;
-}
-
-.domain-management-list-item__busy-message {
-	text-transform: uppercase;
-	color: var( --color-neutral-50 );
-	font-weight: 600;
-	font-size: $font-body-extra-small;
-	text-overflow: ellipsis;
-	overflow: hidden;
-	margin-top: 5px;
-
-	@include breakpoint-deprecated( '>480px' ) {
-		float: right;
-		margin-top: -11px;
-		margin-right: 15px;
-	}
-}
-
 .list-all__container .list-all__site {
 	margin-bottom: 10px;
 }
@@ -362,6 +325,7 @@ input[type='radio'].domain-management-list-item__radio {
 	.domain-item__busy-message {
 		font-size: $font-body-small;
 		margin-left: auto;
+		margin-right: 5px;
 	}
 
 	.domain-item__upsell {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This has been bothering me for a while - seems that when we introduced the new components, some regressions crept in:
 - We don't preselect the currently primary domain.
 - The loading indicator has no padding/margin.

Example of the first issue:
<img width="1066" alt="Screenshot 2021-01-14 at 15 25 42" src="https://user-images.githubusercontent.com/3392497/104611209-c9698000-567c-11eb-9d61-93cd033452b2.png">


#### Testing instructions
Go to Manage -> Domains and click Change primary domain. The currently primary domain should have the radio box next to it checked:
<img width="1064" alt="Screenshot 2021-01-14 at 15 20 25" src="https://user-images.githubusercontent.com/3392497/104611402-f9188800-567c-11eb-94b1-f4a58ada3c88.png">


Change it to a different one (or select the same one - this should just revert to normal mode). Make sure the radio button gets updated and there's space now for the loading indicator:

<img width="1059" alt="Screenshot 2021-01-14 at 15 20 32" src="https://user-images.githubusercontent.com/3392497/104611375-f0c04d00-567c-11eb-943a-dcbf8c806e67.png">

