### PR TITLE
Color Scheme Picker: update default selection

### DIFF
--- a/client/blocks/color-scheme-picker/README.md
+++ b/client/blocks/color-scheme-picker/README.md
@@ -23,6 +23,15 @@ function render() {
 
 The following props can be passed to the ColorSchemePicker component:
 
+### `defaultSelection`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+Provide a default selection for when no color scheme has been selected yet. If no other default is provided, the first item in the color scheme array will be selected.
+
 ### `temporarySelection`
 
 <table>

--- a/client/blocks/color-scheme-picker/index.jsx
+++ b/client/blocks/color-scheme-picker/index.jsx
@@ -23,6 +23,7 @@ import './style.scss';
 
 class ColorSchemePicker extends PureComponent {
 	static propTypes = {
+		defaultSelection: PropTypes.string,
 		temporarySelection: PropTypes.bool,
 		onSelection: PropTypes.func,
 		// Connected props
@@ -41,12 +42,13 @@ class ColorSchemePicker extends PureComponent {
 
 	render() {
 		const colorSchemesData = getColorSchemesData( translate );
+		const defaultColorScheme = this.props.defaultSelection || colorSchemesData[ 0 ].value;
 		const checkedColorScheme = find( colorSchemesData, [
 			'value',
 			this.props.colorSchemePreference,
 		] )
 			? this.props.colorSchemePreference
-			: colorSchemesData[ 0 ].value;
+			: defaultColorScheme;
 		return (
 			<div className="color-scheme-picker">
 				<QueryPreferences />

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -19,7 +19,7 @@ import LanguagePicker from 'calypso/components/language-picker';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import { protectForm } from 'calypso/lib/protect-form';
 import formBase from 'calypso/me/form-base';
-import config from 'calypso/config';
+import config, { isEnabled } from 'calypso/config';
 import languages from '@automattic/languages';
 import { supportsCssCustomProperties } from 'calypso/lib/feature-detection';
 import { Card, Button } from '@automattic/components';
@@ -709,7 +709,13 @@ const Account = createReactClass( {
 						<FormLabel id="account__color_scheme" htmlFor="color_scheme">
 							{ translate( 'Dashboard color scheme' ) }
 						</FormLabel>
-						<ColorSchemePicker temporarySelection onSelection={ this.updateColorScheme } />
+						<ColorSchemePicker
+							temporarySelection
+							defaultSelection={
+								isEnabled( 'nav-unification' ) ? 'classic-dark' : 'classic-bright'
+							}
+							onSelection={ this.updateColorScheme }
+						/>
 					</FormFieldset>
 				) }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

**Context:**
While answering a question from @mmtr on Color Scheme selection in Nav Unification, I had the idea of showing the Classic Dark color scheme as selected for users that have never changed their color scheme. The default used to be Classic Bright, which in the Context of Nav Unification would be confusing to the user.

To verify my hypothesis, I logged in as a new user. At this point I noticed a regression in the `ColorSchemePicker`: I would've expected the Classic Bright color scheme to be selected. Instead the Aquatic color scheme was selected. The cause for this regression turned out to be us reordering the color schemes to be alphabetical. Classic Bright used to be the first item in the list, now it's Aquatic. 

This PR addresses the regression as well as adding the new selection for Nav Unification:

**Changes:**
* Show Classic Bright color scheme as selected default again in Calypso

|Before|After|
|-|-|
|<img width="1000" alt="Screenshot 2021-01-14 at 16 59 48" src="https://user-images.githubusercontent.com/1562646/104615861-efe1e800-5689-11eb-8f4d-8a77aefa3cf1.png">|<img width="990" alt="Screenshot 2021-01-14 at 16 58 22" src="https://user-images.githubusercontent.com/1562646/104615770-d771cd80-5689-11eb-92ab-6585d41477fa.png">|

* Show Classic Dark as selected default when Nav Unification is active

|Calypso|Nav Unification|
|-|-|
|<img width="990" alt="Screenshot 2021-01-14 at 16 58 22" src="https://user-images.githubusercontent.com/1562646/104615731-cd4fcf00-5689-11eb-8360-72ce5fa09748.png">|<img width="1003" alt="Screenshot 2021-01-14 at 16 57 34" src="https://user-images.githubusercontent.com/1562646/104615753-d2148300-5689-11eb-8bfb-1fb8ff6dd48d.png">|



### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new user
* Visit /me/account
* Verify that Classic Bright shows as selected default
* Enable nav-unification (paYJgx-1af-p2)
* Verify that Classic Dark shows as selected default

