### PR TITLE
Jetpack Cloud: send action to enable oauth2 implicit authorization

### DIFF
--- a/client/jetpack-cloud/sections/auth/controller.tsx
+++ b/client/jetpack-cloud/sections/auth/controller.tsx
@@ -22,6 +22,14 @@ import { authTokenRedirectPath } from './paths';
 const WP_AUTHORIZE_ENDPOINT = 'https://public-api.wordpress.com/oauth2/authorize';
 const debug = debugFactory( 'calypso:jetpack-cloud-connect' );
 
+interface OAuth2Params {
+	response_type: 'token';
+	client_id: string;
+	redirect_uri: string;
+	scope: 'global';
+	action?: string;
+}
+
 export const connect: PageJS.Callback = ( context, next ) => {
 	if ( config.isEnabled( 'oauth' ) && config( 'oauth_client_id' ) ) {
 		const protocol = window.location.protocol;
@@ -31,13 +39,16 @@ export const connect: PageJS.Callback = ( context, next ) => {
 			? `${ protocol }//${ host }:${ port }${ authTokenRedirectPath() }`
 			: `${ protocol }//${ host }${ authTokenRedirectPath() }`;
 
-		const params = {
+		const params: OAuth2Params = {
 			response_type: 'token',
 			client_id: config( 'oauth_client_id' ),
 			redirect_uri: redirectUri,
 			scope: 'global',
-			action: 'oauth2-auth',
 		};
+
+		if ( config.isEnabled( 'oauth_implicit_authorization' ) ) {
+			params.action = 'oauth2-auth';
+		}
 
 		const authUrl = `${ WP_AUTHORIZE_ENDPOINT }?${ stringify( params ) }`;
 		debug( `authUrl: ${ authUrl }` );

--- a/client/jetpack-cloud/sections/auth/controller.tsx
+++ b/client/jetpack-cloud/sections/auth/controller.tsx
@@ -36,6 +36,7 @@ export const connect: PageJS.Callback = ( context, next ) => {
 			client_id: config( 'oauth_client_id' ),
 			redirect_uri: redirectUri,
 			scope: 'global',
+			action: 'oauth2-auth',
 		};
 
 		const authUrl = `${ WP_AUTHORIZE_ENDPOINT }?${ stringify( params ) }`;

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -51,6 +51,7 @@
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
 		"oauth": true,
+		"oauth_implicit_authorization": true,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -46,6 +46,7 @@
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
 		"oauth": true,
+		"oauth_implicit_authorization": false,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -49,6 +49,7 @@
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
 		"oauth": true,
+		"oauth_implicit_authorization": true,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,


### PR DESCRIPTION
#### Motivation

We want to experiment with a smoother authentication flow on cloud.jetpack.com. For that purpose, we enabled on `D55375-code` implicit authorization for Jetpack cloud clients, and only if the `action` parameter is sent. 

#### Changes proposed in this Pull Request

* Include the `action` parameter to enable implicit authorization.

#### Testing instructions

* Follow `D55375-code` instructions.