### PR TITLE
Plans: Add 'you own this product' marker to cards owned on the selected site

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-i5/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-i5/index.tsx
@@ -112,30 +112,40 @@ const JetpackProductCardAlt2: React.FC< Props > = ( {
 					<>{ preventWidows( productName ) }</>
 				) }
 				<p className="jetpack-product-card-i5__description">{ description }</p>
-				<div className="jetpack-product-card-i5__price">
-					{ currencyCode && originalPrice ? (
-						<>
-							{ displayFrom && <span className="jetpack-product-card-i5__price-from">from</span> }
-							<span className="jetpack-product-card-i5__raw-price">
-								<PlanPrice
-									rawPrice={ ( isDiscounted ? discountedPrice : originalPrice ) as number }
-									currencyCode={ currencyCode }
+				{ isOwned && (
+					<p className="jetpack-product-card-i5__you-own-this">
+						{ translate( 'You own this product' ) }
+					</p>
+				) }
+				{ ! isOwned && (
+					<div className="jetpack-product-card-i5__price">
+						{ currencyCode && originalPrice ? (
+							<>
+								{ displayFrom && <span className="jetpack-product-card-i5__price-from">from</span> }
+								<span className="jetpack-product-card-i5__raw-price">
+									<PlanPrice
+										rawPrice={ ( isDiscounted ? discountedPrice : originalPrice ) as number }
+										currencyCode={ currencyCode }
+									/>
+								</span>
+								<JetpackProductCardTimeFrame
+									expiryDate={ expiryDate }
+									billingTerm={ billingTerm }
 								/>
-							</span>
-							<JetpackProductCardTimeFrame expiryDate={ expiryDate } billingTerm={ billingTerm } />
-							{ tooltipText && (
-								<InfoPopover position="top" className="jetpack-product-card-i5__price-tooltip">
-									{ tooltipText }
-								</InfoPopover>
-							) }
-						</>
-					) : (
-						<>
-							<div className="jetpack-product-card-i5__price-placeholder" />
-							<div className="jetpack-product-card-i5__time-frame-placeholder" />
-						</>
-					) }
-				</div>
+								{ tooltipText && (
+									<InfoPopover position="top" className="jetpack-product-card-i5__price-tooltip">
+										{ tooltipText }
+									</InfoPopover>
+								) }
+							</>
+						) : (
+							<>
+								<div className="jetpack-product-card-i5__price-placeholder" />
+								<div className="jetpack-product-card-i5__time-frame-placeholder" />
+							</>
+						) }
+					</div>
+				) }
 				{ aboveButtonText && (
 					<p className="jetpack-product-card-i5__above-button">{ aboveButtonText }</p>
 				) }

--- a/client/components/jetpack/card/jetpack-product-card-i5/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-i5/index.tsx
@@ -44,6 +44,7 @@ type OwnProps = {
 	expiryDate?: Moment;
 	isFeatured?: boolean;
 	isOwned?: boolean;
+	isIncludedInPlan?: boolean;
 	isDeprecated?: boolean;
 	isAligned?: boolean;
 	isDisabled?: boolean;
@@ -71,6 +72,7 @@ const JetpackProductCardAlt2: React.FC< Props > = ( {
 	expiryDate,
 	isFeatured,
 	isOwned,
+	isIncludedInPlan,
 	isDeprecated,
 	isAligned,
 	features,
@@ -117,7 +119,12 @@ const JetpackProductCardAlt2: React.FC< Props > = ( {
 						{ translate( 'You own this product' ) }
 					</p>
 				) }
-				{ ! isOwned && (
+				{ isIncludedInPlan && (
+					<p className="jetpack-product-card-i5__you-own-this">
+						{ translate( 'Part of your current plan' ) }
+					</p>
+				) }
+				{ ! isOwned && ! isIncludedInPlan && (
 					<div className="jetpack-product-card-i5__price">
 						{ currencyCode && originalPrice ? (
 							<>

--- a/client/components/jetpack/card/jetpack-product-card-i5/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-i5/style.scss
@@ -100,6 +100,19 @@
 	}
 }
 
+.jetpack-product-card-i5__you-own-this {
+	margin-top: -18px;
+	margin-bottom: 31px;
+
+	padding-top: 6px;
+	padding-bottom: 6px;
+
+	border-radius: 4px;
+
+	text-align: center;
+	background-color: rgba( var( --color-success-10-rgb ), 0.1 );
+}
+
 .jetpack-product-card-i5__price {
 	display: flex;
 	align-items: center;

--- a/client/my-sites/plans/jetpack-plans/product-card-i5/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card-i5/index.tsx
@@ -69,7 +69,6 @@ const ProductCardI5: React.FC< ProductCardProps > = ( {
 		}
 		return false;
 	}, [ item.productSlug, sitePlan, siteProducts ] );
-
 	// Calculate the product price.
 	const { originalPrice, discountedPrice, priceTiers } = useItemPrice(
 		siteId,
@@ -120,12 +119,13 @@ const ProductCardI5: React.FC< ProductCardProps > = ( {
 			expiryDate={ showExpiryNotice && purchase ? moment( purchase.expiryDate ) : undefined }
 			isFeatured={ featuredPlans && featuredPlans.includes( item.productSlug ) }
 			isOwned={ isOwned }
+			isIncludedInPlan={ ! isOwned && isItemPlanFeature }
 			isDeprecated={ item.legacy }
 			isAligned={ isAligned }
 			features={ item.features }
 			displayFrom={ ! siteId && priceTiers !== null }
 			tooltipText={ priceTiers && productTooltip( item, priceTiers ) }
-			aboveButtonText={ productAboveButtonText( item, siteProduct ) }
+			aboveButtonText={ productAboveButtonText( item, siteProduct, isOwned, isItemPlanFeature ) }
 			{ ...disabledProps }
 		/>
 	);

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -375,9 +375,16 @@ export function productTooltip(
 
 export function productAboveButtonText(
 	product: SelectorProduct,
-	siteProduct?: SiteProduct
+	siteProduct?: SiteProduct,
+	isOwned?: boolean,
+	isIncludedInPlan?: boolean
 ): TranslateResult | null {
-	if ( siteProduct && JETPACK_SEARCH_PRODUCTS.includes( product.productSlug ) ) {
+	if (
+		! isOwned &&
+		! isIncludedInPlan &&
+		siteProduct &&
+		JETPACK_SEARCH_PRODUCTS.includes( product.productSlug )
+	) {
 		return translate( '*estimated price based off of %(records)s records', {
 			args: {
 				records: numberFormat( siteProduct.tierUsage, 0 ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Partially fixes `1196341175636977-as-1199527862646253`.

* Add a 'You own this product' descriptor in place of the price for products the selected site currently owns.

#### Testing instructions

##### Calypso Blue

* Select a site that owns no products and visit the **Plans** page.
* Verify that all prices are displayed as they currently are in production.
* Select a site that owns at least one product listed on the **Plans** page.
* Verify that for each owned product, that product's price is replaced with a line that says "You own this product." See reference mock-up (attached below) to verify the appearance is as expected.

##### Calypso Green

* Follow the same steps as for Calypso Blue, but for scenarios that require a selected site, do the following:
  * Log in with your Jetpack account.
  * Go to `/pricing/:site_slug?site=:site_slug`, where `:site_slug` is your site's URL-safe slug.

#### Screenshot

<img width="353" alt="image" src="https://user-images.githubusercontent.com/670067/104648822-590d2f80-5679-11eb-934b-59bd008977fd.png">

#### Reference mock-up

<img width="229" alt="image" src="https://user-images.githubusercontent.com/670067/104649261-1861e600-567a-11eb-895a-85962990eac6.png">