### PR TITLE
Checkout: Adds an error message for multisite purchases

### DIFF
--- a/client/my-sites/checkout/cart/cart-messages.jsx
+++ b/client/my-sites/checkout/cart/cart-messages.jsx
@@ -11,6 +11,7 @@ import { useTranslate } from 'i18n-calypso';
 import notices from 'calypso/notices';
 import { getNewMessages } from 'calypso/lib/cart-values';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { JETPACK_SUPPORT } from 'calypso/lib/url/support';
 
 export default function CartMessages( { cart, isLoadingCart } ) {
 	const previousCart = useRef( null );
@@ -66,6 +67,21 @@ function getBlockedPurchaseErrorMessage( { translate, selectedSiteSlug } ) {
 	);
 }
 
+function getInvalidMultisitePurchaseErrorMessage( { translate, message } ) {
+	return (
+		<>
+			{ message }&nbsp;
+			<a
+				href={ JETPACK_SUPPORT + 'backup/#does-jetpack-backup-support-multisite' }
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				{ translate( 'More info' ) }
+			</a>
+		</>
+	);
+}
+
 function getPrettyErrorMessages( messages, { translate, selectedSiteSlug } ) {
 	if ( ! messages ) {
 		return [];
@@ -81,6 +97,11 @@ function getPrettyErrorMessages( messages, { translate, selectedSiteSlug } ) {
 			case 'blocked':
 				return Object.assign( error, {
 					message: getBlockedPurchaseErrorMessage( { translate, selectedSiteSlug } ),
+				} );
+
+			case 'invalid-product-multisite':
+				return Object.assign( error, {
+					message: getInvalidMultisitePurchaseErrorMessage( { translate, ...error } ),
 				} );
 
 			default:

--- a/client/my-sites/checkout/cart/cart-messages.jsx
+++ b/client/my-sites/checkout/cart/cart-messages.jsx
@@ -101,7 +101,7 @@ function getPrettyErrorMessages( messages, { translate, selectedSiteSlug } ) {
 
 			case 'invalid-product-multisite':
 				return Object.assign( error, {
-					message: getInvalidMultisitePurchaseErrorMessage( { translate, ...error } ),
+					message: getInvalidMultisitePurchaseErrorMessage( { translate, message: error.message } ),
 				} );
 
 			default:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a "more info" link to the error message shown when people try to buy a Backup/Scan product for a multi-site. 

See accompanying diff: D55385-code

#### Screenshots

Single error:
<img width="882" alt="Screen Shot 2021-01-14 at 4 15 56 PM" src="https://user-images.githubusercontent.com/1760168/104650742-a9d65580-5684-11eb-8334-a05f5f0f60f8.png">

Multiple errors:
<img width="925" alt="Screen Shot 2021-01-14 at 4 15 31 PM" src="https://user-images.githubusercontent.com/1760168/104650743-a9d65580-5684-11eb-861d-c47796d2aef7.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR, either Green or Blue.
* Load diff: D55385-code.
* Add a Jetpack product to a multisite that would be incompatible.
* Verify error has link to more information.

Fixes 1164141197617539-as-1199554500149266.