### PR TITLE
Show more details in the Email quantity selection UI

### DIFF
--- a/client/lib/titan/get-configured-titan-mailbox-count.js
+++ b/client/lib/titan/get-configured-titan-mailbox-count.js
@@ -1,0 +1,3 @@
+export function getConfiguredTitanMailboxCount( domain ) {
+	return domain.titanMailSubscription?.numberOfMailboxes ?? 0;
+}

--- a/client/lib/titan/index.js
+++ b/client/lib/titan/index.js
@@ -1,3 +1,4 @@
 export { getTitanMailOrderId } from './get-titan-mail-order-id';
+export { getConfiguredTitanMailboxCount } from './get-configured-titan-mailbox-count';
 export { getMaxTitanMailboxCount } from './get-max-titan-mailbox-count';
 export { hasTitanMailWithUs } from './has-titan-mail-with-us';

--- a/client/my-sites/email/titan-mail-quantity-selection/index.jsx
+++ b/client/my-sites/email/titan-mail-quantity-selection/index.jsx
@@ -31,7 +31,11 @@ import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import Notice from 'calypso/components/notice';
 import AddEmailAddressesCardPlaceholder from 'calypso/my-sites/email/gsuite-add-users/add-users-placeholder';
 import { getSelectedDomain } from 'calypso/lib/domains';
-import { hasTitanMailWithUs, getMaxTitanMailboxCount } from 'calypso/lib/titan';
+import {
+	getConfiguredTitanMailboxCount,
+	getMaxTitanMailboxCount,
+	hasTitanMailWithUs,
+} from 'calypso/lib/titan';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
@@ -137,8 +141,74 @@ class TitanMailQuantitySelection extends React.Component {
 		) : null;
 	}
 
+	renderCurrentMailboxCounts() {
+		const { selectedDomain, translate } = this.props;
+		if ( ! hasTitanMailWithUs( selectedDomain ) ) {
+			return null;
+		}
+
+		const purchasedMailboxCount = getMaxTitanMailboxCount( selectedDomain );
+		if ( purchasedMailboxCount < 1 ) {
+			return null;
+		}
+
+		const configuredMailboxCount = getConfiguredTitanMailboxCount( selectedDomain );
+		if ( configuredMailboxCount >= purchasedMailboxCount ) {
+			return (
+				<span>
+					{ translate(
+						'You currently have %(mailboxCount)d mailbox for this domain',
+						'You currently have %(mailboxCount)d mailboxes for this domain',
+						{
+							args: {
+								mailboxCount: configuredMailboxCount,
+							},
+							count: configuredMailboxCount,
+							comment:
+								'%(mailboxCount)d is the number of email mailboxes the user has for a domain name',
+						}
+					) }
+				</span>
+			);
+		}
+
+		const unusedMailboxCount = purchasedMailboxCount - configuredMailboxCount;
+		return (
+			<React.Fragment>
+				<span>
+					{ translate(
+						'You have already bought %(mailboxCount)d mailbox for this domain',
+						'You have already bought %(mailboxCount)d mailboxes for this domain',
+						{
+							args: {
+								mailboxCount: purchasedMailboxCount,
+							},
+							count: purchasedMailboxCount,
+							comment:
+								'%(mailboxCount)d is the number of email mailboxes the user has bought for the domain',
+						}
+					) }
+				</span>
+				<span>
+					{ translate(
+						'You still have %(unusedMailboxCount)d unused mailbox',
+						'You still have %(unusedMailboxCount)d unused mailboxes',
+						{
+							args: {
+								unusedMailboxCount,
+							},
+							count: unusedMailboxCount,
+							comment:
+								'%(unusedMailboxCount)d is the number of unused mailboxes that the user has paid for but is not using',
+						}
+					) }
+				</span>
+			</React.Fragment>
+		);
+	}
+
 	renderForm() {
-		const { isLoadingDomains, translate } = this.props;
+		const { isLoadingDomains, selectedDomainName, translate } = this.props;
 
 		if ( isLoadingDomains ) {
 			return <AddEmailAddressesCardPlaceholder />;
@@ -149,6 +219,20 @@ class TitanMailQuantitySelection extends React.Component {
 				<SectionHeader label={ translate( 'Choose Mailbox Quantity' ) } />
 
 				<Card>
+					<div className="titan-mail-quantity-selection__domain-info">
+						{ translate( "You're adding mailboxes for {{strong}}%(domainName)s{{/strong}}", {
+							args: {
+								domainName: selectedDomainName,
+							},
+							components: {
+								strong: <strong />,
+							},
+							comment: '%(domainName)s is a domain name',
+						} ) }
+					</div>
+					<div className="titan-mail-quantity-selection__mailbox-info">
+						{ this.renderCurrentMailboxCounts() }
+					</div>
 					<div>
 						<FormLabel>{ translate( 'Number of new mailboxes to add' ) }</FormLabel>
 						<FormTextInput
@@ -180,6 +264,7 @@ class TitanMailQuantitySelection extends React.Component {
 			selectedSite,
 			isSelectedDomainNameValid,
 			isLoadingDomains,
+			translate,
 		} = this.props;
 
 		if ( ! isLoadingDomains && ! isSelectedDomainNameValid ) {
@@ -195,7 +280,14 @@ class TitanMailQuantitySelection extends React.Component {
 						onClick={ this.goToEmail }
 						selectedDomainName={ selectedDomainName }
 					>
-						{ getTitanProductName() }
+						{ translate( '%(productName)s: %(domainName)s', {
+							args: {
+								domainName: selectedDomainName,
+								productName: getTitanProductName(),
+							},
+							comment:
+								'%(productName)s is the name of the product, either "Email" or "Titan Mail"; %(domainName)s is the name of a domain',
+						} ) }
 					</DomainManagementHeader>
 
 					{ this.renderForwardsNotice() }
@@ -218,6 +310,7 @@ export default connect(
 			selectedDomainName: ownProps.selectedDomainName,
 		} );
 		return {
+			selectedDomain,
 			selectedSite,
 			isLoadingDomains,
 			currentRoute: getCurrentRoute( state ),

--- a/client/my-sites/email/titan-mail-quantity-selection/style.scss
+++ b/client/my-sites/email/titan-mail-quantity-selection/style.scss
@@ -10,3 +10,16 @@
 .titan-mail-quantity-selection__divider {
 	margin-top: 1.5em;
 }
+.titan-mail-quantity-selection__domain-info {
+	margin-bottom: 1em;
+}
+.titan-mail-quantity-selection__mailbox-info {
+	span {
+		display: block;
+		font-size: $font-body-small;
+
+		&:last-child {
+			margin-bottom: 1em;
+		}
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change adds more details to the quantity selection UI to give users clearer context. Those changes are:
* Always show which domain we're working with, both in the header bar and in the main page body.
* If you have already bought mailboxes for the domain, and you have all those mailboxes set up, we show a message that simply describes the number of mailboxes you already have: `You currently have 2 mailboxes for this domain`
<img width="741" alt="Existing mailboxes all configured" src="https://user-images.githubusercontent.com/3376401/104650697-43baf400-56bf-11eb-9ebb-87aab13b7ea0.png">

* If you have already bought mailboxes for the domain, but you haven't configured all the mailboxes yet, we show two messages:
   - `You have already bought 3 mailboxes for this domain`
   - `You still have 1 unused mailbox`
<img width="744" alt="Screenshot 2021-01-14 at 23 09 45" src="https://user-images.githubusercontent.com/3376401/104650786-6baa5780-56bf-11eb-9e3f-13bb008874b2.png">


#### Testing instructions

Ensure that you have Store Sandbox enabled and that the `titan/phase-2` feature flag is enabled.

Then check the following cases to make sure things look good:
* Start the process of adding Email to a domain that doesn't have it yet. The only changes should be showing the domain in the header bar and the card body.
* Try to add mailboxes to a domain that has purchased Email, but not all mailboxes are configured. Ensure that you see both the message about the total number of mailboxes and the number of unused mailboxes.
* Try to add mailboxes to a domain that has purchased Email, and all of the mailboxes are configured. Ensure that you only see the message about the number of mailboxes.
