### PR TITLE
Remove old block patterns function check

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -261,10 +261,6 @@ function load_block_patterns_from_api( $current_screen ) {
 		return;
 	}
 
-	if ( ! function_exists( '\gutenberg_load_block_pattern' ) ) {
-		return;
-	}
-
 	if ( ! $current_screen->is_block_editor ) {
 		return;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This function was removed in the latest Gutenberg version, which caused our block patterns to not work any longer. It was added in WP 5.5, which is now supported on all platforms, so we can remove it.

#### Testing instructions
1. Load ETK onto your sandbox.
2. Sandbox public API and a test site
3. You should see Automattic patterns, not just the default ones.