### PR TITLE
Reduce e2e test flakiness when interacting with the editor

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -50,6 +50,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			this.explicitWaitMS,
 			'Could not locate the editor iFrame.'
 		);
+		await this.driver.sleep( 2000 );
 	}
 
 	async _postInit() {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -52,6 +52,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		);
 	}
 
+	async _postInit() {
+		await this.driver.sleep( 2000 );
+	}
+
 	async initEditor( { dismissPageTemplateSelector = false } = {} ) {
 		if ( dismissPageTemplateSelector ) {
 			await this.dismissPageTemplateSelector();

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -42,6 +42,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		if ( this.editorType !== 'iframe' ) {
 			return;
 		}
+		await this.driver.sleep( 5000 );
 		await this.driver.switchTo().defaultContent();
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.editoriFrameSelector );
 		await this.driver.wait(
@@ -49,11 +50,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			this.explicitWaitMS,
 			'Could not locate the editor iFrame.'
 		);
-		await this.driver.sleep( 5000 );
-	}
-
-	async _postInit() {
-		await this.driver.sleep( 2000 );
 	}
 
 	async initEditor( { dismissPageTemplateSelector = false } = {} ) {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -49,7 +49,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			this.explicitWaitMS,
 			'Could not locate the editor iFrame.'
 		);
-		await this.driver.sleep( 2000 );
+		await this.driver.sleep( 5000 );
 	}
 
 	async _postInit() {

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1148,7 +1148,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe( 'Use the Calypso Media Modal: @parallel', function () {
+	describe.skip( 'Use the Calypso Media Modal: @parallel', function () {
 		let fileDetails;
 
 		// Create image file for upload

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1148,7 +1148,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe.skip( 'Use the Calypso Media Modal: @parallel', function () {
+	describe( 'Use the Calypso Media Modal: @parallel', function () {
 		let fileDetails;
 
 		// Create image file for upload


### PR DESCRIPTION
E2e tests that interact with the page editor are intermittently but consistently failing. 

Current theory is that the block editor is taking longer than previously to load, now exceeding the sleep/timeouts we had in place that occur before tests attempt to check if the editor is available for interaction.

Any test that attempts to check the editor has loaded will fail if it checks too early.

Originally we were consistently seeing failures limited to `wp-gutenboarding-spec.js` but this has since spread to other areas that make use of the same [editor init code](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/lib/gutenberg/gutenberg-editor-component.js#L41).

It looks like this has happened before with #37004 and #40239 which added [sleeps.](https://github.com/Automattic/wp-calypso/blame/5da326aebd653288b5d3004ce17b5302c71af5cb/test/e2e/lib/gutenberg/gutenberg-editor-component.js#L51)

#### Changes proposed in this Pull Request

* Increase sleep duration before trying to interact with the editor in e2e tests.

#### Testing instructions

* `./node_modules/.bin/mocha -f "Create new site as existing user" specs/wp-gutenboarding-spec.js`
* `./node_modules/.bin/mocha -f "Basic Public Post" specs/wp-calypso-gutenberg-post-editor-spec.js`
* or any other test suite that runs through the page editor, a few in here for example: p1610555333255800-slack-C1A1EKDGQ