### PR TITLE
Clear selection when navigating between steps in new onboarding

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -48,11 +48,21 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 	const currentStep = useCurrentStep();
 	const previousStep = usePrevious( currentStep );
 
-	const { pathname, state: locationState = {} } = useLocation< GutenLocationStateType >();
+	const { state: locationState = {} } = useLocation< GutenLocationStateType >();
 
-	React.useEffect( () => {
-		setTimeout( () => window.scrollTo( 0, 0 ), 0 );
-	}, [ pathname ] );
+	React.useLayoutEffect( () => {
+		// Runs some navigation related side-effects when the step changes
+		// We only want to run when a real transition happens:
+		// - not on first load when `previousStep === undefined` and,
+		// - during an intermediate state when `previousStep === currentStep`
+		if ( previousStep && previousStep !== currentStep ) {
+			setTimeout( () => window.scrollTo( 0, 0 ), 0 );
+
+			if ( window.getSelection && window.getSelection()?.empty ) {
+				window.getSelection()?.empty();
+			}
+		}
+	}, [ currentStep, previousStep ] );
 
 	// makePathWithState( path: StepType ) - A wrapper around makePath() that preserves location state.
 	// This uses makePath() to generate a string path, then transforms that


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Clear selection when navigating between steps in new onboarding
* Moves the "scroll to top" action so that it's in the same call to `useLayoutEffect`

This fixes a bug that only happens on Chrome where if all text in an `<input>` is selected when advancing to the next step, then all the DOM elements will be highlighted (as if a text selection has been made) after landing on the next step.

See the buggy behaviour below. Note: I'm using command+a) to select all the text in the `<input>`, it only seems to bug out when you select all this way (as opposed to double-clicking or something)
![Jan-15-2021 17-48-47](https://user-images.githubusercontent.com/1500769/104682638-05bede00-575a-11eb-8ad6-98661c79b067.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new` in Chrome (or Edge, something Chrome based)
* Find a text box in the new onboarding flow
* Type in the text box, select all using command+a, and proceed to the next step
* The next step shouldn't have all the DOM selected (see the above gif)
* The window should still scroll to the top when navigation happens

This does have the side effect that if some text outside the onboarding block is selected (e.g. the user has selected **View plans** or something) then that selection will be cleared during navigation.
