### PR TITLE
Welcome Tour: bumping the z-index value for the welcome tour 

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/style-tour.scss
@@ -10,6 +10,7 @@
 	display: inline;
 	left: 16px;
 	position: fixed;
+	z-index: 9999;
 }
 
 .welcome-tour-card__heading {


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Bumping the z-index value for the welcome tour so that it floats above the nav in Atomic sites where the editor is NOT in full screen mode

**Before**
<img width="490" alt="Screen Shot 2021-01-15 at 3 32 17 pm" src="https://user-images.githubusercontent.com/6458278/104682304-75c46880-5748-11eb-9b72-c6bc7e4bfbbb.png">


**After**

<img width="523" alt="Screen Shot 2021-01-15 at 3 32 10 pm" src="https://user-images.githubusercontent.com/6458278/104682308-7826c280-5748-11eb-8ea8-4289e2c49b7f.png">


#### Testing instructions
Test on an ephemeral Atomic site by following the instructions on PCYsg-ly5-p2

The long and short of it:

Create an ephemeral site

Checkout this branch and build the plugin by running:

```
cd apps/editing-toolkit
yarn build
```
Make sure to activate Gutenberg and remove any current Editing Toolkit plugins

Then `cd editing-toolkit-plugin` and sync the plugin to your new site from your local files. 

Activate the plugin and create a new page

Turn off Fullscreen mode
<img width="350" alt="Screen Shot 2021-01-15 at 3 32 22 pm" src="https://user-images.githubusercontent.com/6458278/104682285-6c3b0080-5748-11eb-9a80-de64e94ed4bb.png">

The Welcome tour should appear above the nav

For good measure, make sure it still works on simple sites by running `yarn dev --sync` and testing on a sandboxed simple site too!

Fixes #48942
