### PR TITLE
Deduplicate eslint-visitor-keys

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12749,12 +12749,7 @@ eslint-utils@^2.1.0:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
-  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
-
-eslint-visitor-keys@^1.3.0:
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `eslint-visitor-keys` (done automatically with `npx yarn-deduplicate --packages eslint-visitor-keys`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @typescript-eslint/eslint-plugin@4.12.0 -> ... -> eslint-visitor-keys@1.1.0
< wp-calypso@0.17.0 -> babel-eslint@10.1.0 -> ... -> eslint-visitor-keys@1.1.0
< wp-calypso@0.17.0 -> eslint-plugin-jest@23.20.0 -> ... -> eslint-visitor-keys@1.1.0
< wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> eslint-visitor-keys@1.1.0
< wp-calypso@0.17.0 -> eslint@7.12.0 -> ... -> eslint-visitor-keys@1.1.0
> wp-calypso@0.17.0 -> @typescript-eslint/eslint-plugin@4.12.0 -> ... -> eslint-visitor-keys@1.3.0
> wp-calypso@0.17.0 -> babel-eslint@10.1.0 -> ... -> eslint-visitor-keys@1.3.0
> wp-calypso@0.17.0 -> eslint-plugin-jest@23.20.0 -> ... -> eslint-visitor-keys@1.3.0
> wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> eslint-visitor-keys@1.3.0
> wp-calypso@0.17.0 -> eslint@7.12.0 -> ... -> eslint-visitor-keys@1.3.0
```