### PR TITLE
Deduplicate esrecurse

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11861,21 +11861,14 @@ esquery@^1.0.1, esquery@^1.2.0:
   dependencies:
     estraverse "^5.1.0"
 
-esrecurse@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
-  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
-  dependencies:
-    estraverse "^4.1.0"
-
-esrecurse@^4.3.0:
+esrecurse@^4.1.0, esrecurse@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `esrecurse` (done automatically with `npx yarn-deduplicate --packages esrecurse`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @automattic/calypso-build@6.5.0 -> ... -> esrecurse@4.2.1
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> esrecurse@4.2.1
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> esrecurse@4.2.1
< wp-calypso@0.17.0 -> webpack@4.44.2 -> ... -> esrecurse@4.2.1
> wp-calypso@0.17.0 -> @automattic/calypso-build@6.5.0 -> ... -> esrecurse@4.3.0
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> esrecurse@4.3.0
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> esrecurse@4.3.0
> wp-calypso@0.17.0 -> webpack@4.44.2 -> ... -> esrecurse@4.3.0
```