### PR TITLE
Ensure that we support autorenew management for Titan subscriptions

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -12,7 +12,14 @@ import { localize } from 'i18n-calypso';
 import { Button, Dialog } from '@automattic/components';
 import CancelAutoRenewalForm from 'calypso/components/marketing-survey/cancel-auto-renewal-form';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import { isDomainRegistration, isPlan } from 'calypso/lib/products-values';
+import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
+import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
+import {
+	isDomainRegistration,
+	isGoogleApps,
+	isPlan,
+	isTitanMail,
+} from 'calypso/lib/products-values';
 import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSite } from 'calypso/state/sites/selectors';
 import './style.scss';
@@ -50,6 +57,10 @@ class AutoRenewDisablingDialog extends Component {
 
 		if ( isPlan( purchase ) ) {
 			return 'plan';
+		}
+
+		if ( isTitanMail( purchase ) || isGoogleApps( purchase ) ) {
+			return 'email';
 		}
 
 		return null;
@@ -109,6 +120,25 @@ class AutoRenewDisablingDialog extends Component {
 						comment:
 							'%(planName)s is the name of a WordPress.com plan, e.g. Personal, Premium, Business. ' +
 							'%(siteDomain)s is a domain name, e.g. example.com, example.wordpress.com. ' +
+							'%(expiryDate)s is a date string, e.g. May 14, 2020',
+					}
+				);
+			case 'email':
+				return translate(
+					'By canceling auto-renewal, your %(emailProductName)s subscription for %(domainName)s will expire on %(expiryDate)s. ' +
+						'After it expires, you will not be able to send and receive emails for this domain. ' +
+						'To avoid that, turn auto-renewal back on or manually renew your subscription before the expiration date.',
+					{
+						args: {
+							domainName: purchase.meta,
+							emailProductName: isTitanMail( purchase )
+								? getTitanProductName()
+								: getGoogleMailServiceFamily(),
+							expiryDate,
+						},
+						comment:
+							'%(emailProductName)s is the name of an email product, e.g. Email, Titan Mail, Google Workspace. ' +
+							'%(domainName)s is a domain name, e.g. example.com. ' +
 							'%(expiryDate)s is a date string, e.g. May 14, 2020',
 					}
 				);

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -12,14 +12,8 @@ import { localize } from 'i18n-calypso';
 import { Button, Dialog } from '@automattic/components';
 import CancelAutoRenewalForm from 'calypso/components/marketing-survey/cancel-auto-renewal-form';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
-import {
-	isDomainRegistration,
-	isGoogleApps,
-	isPlan,
-	isTitanMail,
-} from 'calypso/lib/products-values';
+import { isDomainRegistration, isPlan, isTitanMail } from 'calypso/lib/products-values';
 import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSite } from 'calypso/state/sites/selectors';
 import './style.scss';
@@ -59,7 +53,7 @@ class AutoRenewDisablingDialog extends Component {
 			return 'plan';
 		}
 
-		if ( isTitanMail( purchase ) || isGoogleApps( purchase ) ) {
+		if ( isTitanMail( purchase ) ) {
 			return 'email';
 		}
 
@@ -131,9 +125,7 @@ class AutoRenewDisablingDialog extends Component {
 					{
 						args: {
 							domainName: purchase.meta,
-							emailProductName: isTitanMail( purchase )
-								? getTitanProductName()
-								: getGoogleMailServiceFamily(),
+							emailProductName: getTitanProductName(),
 							expiryDate,
 						},
 						comment:

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -36,6 +36,7 @@ import {
 	isJetpackPlan,
 	isJetpackProduct,
 	isPlan,
+	isTitanMail,
 	getProductFromSlug,
 } from 'calypso/lib/products-values';
 import { getPlan } from 'calypso/lib/plans';
@@ -422,7 +423,10 @@ function PurchaseMetaExpiration( {
 	}
 
 	if (
-		( isDomainRegistration( purchase ) || isPlan( purchase ) || isGoogleApps( purchase ) ) &&
+		( isDomainRegistration( purchase ) ||
+			isPlan( purchase ) ||
+			isGoogleApps( purchase ) ||
+			isTitanMail( purchase ) ) &&
 		! isExpired( purchase )
 	) {
 		const dateSpan = <span className="manage-purchase__detail-date-span" />;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds a check that ensures we show auto-renew management for Titan subscriptions in the purchase/subscription management page, and show the following confirmation dialog when disabling auto-renew
<img width="451" alt="email_disable_auto_renew_dialog" src="https://user-images.githubusercontent.com/3376401/104904652-12297d80-598a-11eb-83c3-df6505b1f632.png">

#### Testing instructions

* In terms of setup, make sure you have the following:
   - You have Store Sandbox mode enabled
   - You have a valid Titan (aka Email) subscription
* Navigate to the purchase management page for your subscription (either via Plans -> Billing -> <your purchase> or via Manage -> Domains -> <your domain> -> Manage your email accounts -> Update your billing and payment settings, where the latter path is only accessible if the `titan/phase-2` feature flag is enabled)
* Verify that you can see an autorenew toggle for the subscription
* Confirm that you can enable and disable autorenew via the UI
