### PR TITLE
Nav-unification: navigating on mobile:

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import qs from 'qs';
+import { parse } from 'qs';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -56,7 +56,7 @@ class MasterbarLoggedIn extends React.Component {
 
 	componentDidMount() {
 		// Give a chance to direct URLs to open the sidebar on page load ( eg by clicking 'me' in wp-admin ).
-		const qryString = qs.parse( document.location.search.replace( /^\?/, '' ) );
+		const qryString = parse( document.location.search.replace( /^\?/, '' ) );
 		if ( qryString?.openSidebar === 'true' ) {
 			this.props.setNextLayoutFocus( 'sidebar' );
 		}

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import qs from 'qs';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -53,6 +54,14 @@ class MasterbarLoggedIn extends React.Component {
 		hasUnseen: PropTypes.bool,
 	};
 
+	componentDidMount() {
+		// Give a chance to direct URLs to open the sidebar on page load ( eg by clicking 'me' in wp-admin ).
+		const qryString = qs.parse( document.location.search.replace( /^\?/, '' ) );
+		if ( qryString?.openSidebar === 'true' ) {
+			this.props.setNextLayoutFocus( 'sidebar' );
+		}
+	}
+
 	clickMySites = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_my_sites_clicked' );
 		if ( ! config.isEnabled( 'nav-unification' ) ) {
@@ -60,6 +69,7 @@ class MasterbarLoggedIn extends React.Component {
 		} else if ( 'sites' !== this.props.section || 'sidebar' === this.props.currentLayoutFocus ) {
 			// when my-sites is not focused or sidebar is open, focus to my-sites' content. Else, open my-sites' sidebar.
 			this.props.setNextLayoutFocus( 'content' );
+			this.props.setNextLayoutFocus( 'sidebar' );
 		} else {
 			this.props.setNextLayoutFocus( 'sidebar' );
 		}
@@ -107,6 +117,7 @@ class MasterbarLoggedIn extends React.Component {
 		} else if ( 'reader' !== this.props.section || 'sidebar' === this.props.currentLayoutFocus ) {
 			// when reader is not focused or sidebar is open, focus to reader's content. Else, open reader's sidebar.
 			this.props.setNextLayoutFocus( 'content' );
+			this.props.setNextLayoutFocus( 'sidebar' );
 		} else {
 			this.props.setNextLayoutFocus( 'sidebar' );
 		}
@@ -118,6 +129,7 @@ class MasterbarLoggedIn extends React.Component {
 			if ( 'me' !== this.props.section || 'sidebar' === this.props.currentLayoutFocus ) {
 				// when me is not focused or sidebar is open, focus to me's content. Else, open me's sidebar.
 				this.props.setNextLayoutFocus( 'content' );
+				this.props.setNextLayoutFocus( 'sidebar' );
 			} else {
 				this.props.setNextLayoutFocus( 'sidebar' );
 			}

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -54,6 +54,20 @@ class MasterbarLoggedIn extends React.Component {
 		hasUnseen: PropTypes.bool,
 	};
 
+	handleLayoutFocus = ( currentSection ) => {
+		if ( ! config.isEnabled( 'nav-unification' ) ) {
+			this.props.setNextLayoutFocus( 'sidebar' );
+		} else if ( currentSection !== this.props.section ) {
+			// When current section is not focused then open the sidebar.
+			this.props.setNextLayoutFocus( 'sidebar' );
+		} else {
+			// When current section is focused then open or close the sidebar depending on current state.
+			'sidebar' === this.props.currentLayoutFocus
+				? this.props.setNextLayoutFocus( 'content' )
+				: this.props.setNextLayoutFocus( 'sidebar' );
+		}
+	};
+
 	componentDidMount() {
 		// Give a chance to direct URLs to open the sidebar on page load ( eg by clicking 'me' in wp-admin ).
 		const qryString = parse( document.location.search.replace( /^\?/, '' ) );
@@ -64,15 +78,7 @@ class MasterbarLoggedIn extends React.Component {
 
 	clickMySites = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_my_sites_clicked' );
-		if ( ! config.isEnabled( 'nav-unification' ) ) {
-			this.props.setNextLayoutFocus( 'sidebar' );
-		} else if ( 'sites' !== this.props.section || 'sidebar' === this.props.currentLayoutFocus ) {
-			// when my-sites is not focused or sidebar is open, focus to my-sites' content. Else, open my-sites' sidebar.
-			this.props.setNextLayoutFocus( 'content' );
-			this.props.setNextLayoutFocus( 'sidebar' );
-		} else {
-			this.props.setNextLayoutFocus( 'sidebar' );
-		}
+		this.handleLayoutFocus( 'sites' );
 
 		/**
 		 * Site Migration: Reset a failed migration when clicking on My Sites
@@ -112,28 +118,12 @@ class MasterbarLoggedIn extends React.Component {
 
 	clickReader = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_reader_clicked' );
-		if ( ! config.isEnabled( 'nav-unification' ) ) {
-			this.props.setNextLayoutFocus( 'content' );
-		} else if ( 'reader' !== this.props.section || 'sidebar' === this.props.currentLayoutFocus ) {
-			// when reader is not focused or sidebar is open, focus to reader's content. Else, open reader's sidebar.
-			this.props.setNextLayoutFocus( 'content' );
-			this.props.setNextLayoutFocus( 'sidebar' );
-		} else {
-			this.props.setNextLayoutFocus( 'sidebar' );
-		}
+		this.handleLayoutFocus( 'reader' );
 	};
 
 	clickMe = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_me_clicked' );
-		if ( config.isEnabled( 'nav-unification' ) ) {
-			if ( 'me' !== this.props.section || 'sidebar' === this.props.currentLayoutFocus ) {
-				// when me is not focused or sidebar is open, focus to me's content. Else, open me's sidebar.
-				this.props.setNextLayoutFocus( 'content' );
-				this.props.setNextLayoutFocus( 'sidebar' );
-			} else {
-				this.props.setNextLayoutFocus( 'sidebar' );
-			}
-		}
+		this.handleLayoutFocus( 'me' );
 	};
 
 	preloadMySites = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* when switching to a section, also open and focus on the sidebar.
* support having the sidebar open when having `openSidebar=true` in the querystring.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- enable nav-unification ( paYJgx-1af-p2#testing-simple-sites) 
 
Case 1
* switch to a breakpoint `<660px`
* clicking either "My Sites", "Reader", or "Me" should redirect to that section with the sidebar opened

Case 2
* switch to a breakpoint `<660px`
  * load `http://calypso.localhost:3000/home/[DOMAIN]?openSidebar=true` or `http://calypso.localhost:3000/read?openSidebar=true` or `http://calypso.localhost:3000/me?openSidebar=true`. The correct section should load, with the sidebar opened.
  * load `http://calypso.localhost:3000/home/[DOMAIN]?openSidebar`. The My Sites section should open with sidebar closed.
  * load `http://calypso.localhost:3000/home/[DOMAIN]?test=test&openSidebar=true`. The My Sites section should open with sidebar opened.
* no console errors should appear throughout the tests.

Fixes #48182 partially. There will be a Jetpack PR that will append `?openSidebar=true` to "Reader" and "Me" links in the masterbar.