### PR TITLE
Store|Woo: Enable Store deprecation in development and staging environments

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -346,7 +346,7 @@ export const TYPE_SECURITY_REALTIME = 'TYPE_SECURITY_REALTIME';
 export const TYPE_ALL = 'TYPE_ALL';
 export const TYPE_P2_PLUS = 'TYPE_P2_PLUS';
 
-export const STORE_DEPRECATION_START_DATE = new Date( '2021-01-18T00:00:00+00:00' );
+export const STORE_DEPRECATION_START_DATE = new Date( '2021-01-15T16:00:00+00:00' );
 
 export function isMonthly( plan ) {
 	return WPCOM_MONTHLY_PLANS.includes( plan ) || JETPACK_MONTHLY_PLANS.includes( plan );

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -154,6 +154,8 @@
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
+		"woocommerce/store-deprecated": true,
+		"woocommerce/store-removed": false,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -216,7 +216,7 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
-		"woocommerce/store-deprecated": false,
+		"woocommerce/store-deprecated": true,
 		"woocommerce/store-removed": false,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false

--- a/config/stage.json
+++ b/config/stage.json
@@ -175,6 +175,8 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
+		"woocommerce/store-deprecated": true,
+		"woocommerce/store-removed": false,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true
 	},

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -185,6 +185,8 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
+		"woocommerce/store-deprecated": true,
+		"woocommerce/store-removed": false,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true
 	},


### PR DESCRIPTION
Part of the "Sunset Store on WordPress.com" epic (https://github.com/woocommerce/woocommerce-admin/issues/5816) -- see that for more context.

#### Changes proposed in this Pull Request

* The `woocommerce/store-deprecated` feature flag has been enabled in `desktop-development`, `development`, `stage`, and `wpcalypso`, to allow for final testing before Store deprecation is launched in production
* The `STORE_DEPRECATION_START_DATE` has been updated to a timestamp that is a little bit before this PR was created, which will allow for easy testing of the scenario where a site has a Business plan subscription added after the deprecation started

#### Testing instructions

Make sure that feature flag enabling looks okay for all environments.

Verify that the feature flag is enabled locally in Calypso development env:

- "Store" available for (Atomic) sites with Business plan subscriptions started before Store was deprecated
- "Store" not available for (Atomic) sites with Business plan subscriptions started after Store was deprecated (after you create a new site with a Business plan subscription, install the "Hello Dolly" plugin to trigger Automated Transfer to Atomic)
- "Store" (linking to WooCommerce Core) available for sites with eCommerce plan subscriptions
- "WooCommerce" available for (Atomic) sites with Business plan subscriptions


Partially addresses #48939
