### PR TITLE
Mark Titan control panel link as external

### DIFF
--- a/client/my-sites/email/email-management/titan-management-nav/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-nav/index.jsx
@@ -88,7 +88,11 @@ class TitanManagementNav extends React.Component {
 		if ( ! externalManagementUrl || isFetchingExternalManagementUrl ) {
 			return <VerticalNavItem isPlaceholder={ true } />;
 		}
-		return <VerticalNavItem path={ externalManagementUrl }>{ linkTitle }</VerticalNavItem>;
+		return (
+			<VerticalNavItem path={ externalManagementUrl } external={ true }>
+				{ linkTitle }
+			</VerticalNavItem>
+		);
 	};
 
 	renderPurchaseManagementLink = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change clearly flags the link to the full-window Titan control panel as external

#### Testing instructions

It's easiest to test this against a sandboxed public API with Store Sandbox enabled.

* Navigate to Manage -> Domains and click on a domain that already has an Email subscription.
* Click on the "Manage your email accounts" menu item.
* Verify that the "Manage your email settings and accounts" menu item has an external link icon on the right hand side instead of a chevron (i.e. `>`)
  - Note that you need to ensure the `titan/iframe-control-panel` feature flag is disabled if you test this via your local dev environment.
