### PR TITLE
Checkout: Display Ebanx processing errors

### DIFF
--- a/client/lib/checkout/processor-specific.js
+++ b/client/lib/checkout/processor-specific.js
@@ -140,19 +140,20 @@ export function countrySpecificFieldRules( country ) {
 }
 
 export function translatedEbanxError( error ) {
-	let errorMessage = i18n.translate(
-		'Your payment was not processed this time due to an error, please try to submit it again.'
-	);
-
+	// It's unclear if this property still exists
 	switch ( error.status_code ) {
 		case 'BP-DR-55':
-			errorMessage = { message: { cvv: i18n.translate( 'Invalid credit card CVV number' ) } };
-			break;
+			return i18n.translate( 'Invalid credit card CVV number' );
 		case 'BP-DR-51':
 		case 'BP-DR-95':
-			errorMessage = { message: { name: i18n.translate( 'Please enter your name.' ) } };
-			break;
+			return i18n.translate( 'Please enter your name.' );
 	}
 
-	return errorMessage;
+	if ( error.message ) {
+		return error.message;
+	}
+
+	return i18n.translate(
+		'Your payment was not processed this time due to an error, please try to submit it again.'
+	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After clicking to pay with an Ebanx credit card, before we submit the transaction to our transactions endpoint, it sends the card data directly to Ebanx and gets a token. If the token creation fails, we get an error message. There are two bugs in checkout which prevent that error message from being logged or displayed to the user, who instead just sees a generic error message. This PR fixes those bugs.

The first bug is when the token creation fails. The error data is passed through `translatedEbanxError()`, which checks the data for a `status_code` string (eg: `BP-DR-55`) and transforms that into a localized message (eg: `Invalid credit card CVV number`). If the error has no `status_code` or if the code is unknown, it returns a generic message that reads `Your payment was not processed this time due to an error, please try to submit it again.`. In my testing, if I try to submit an invalid field, I instead get a type of error object that has no `status_code`; instead it has a `field` property that specifies the invalid field and a `message` property that has a Portuguese error message. In fact, even if the code was present and recognized, the response of `translatedEbanxError()` was an object rather than a string, and probably would not be displayed or logged correctly.

In this PR we change `translatedEbanxError()` to always return a string and if the code is not present or recognized, to check for a `message` property and return that before defaulting to the generic message. Note that this means we are displaying to the customer the exact message returned by Ebanx, which I imagine will always be in Portuguese. If we like, we could use the `field` property instead to recognize and display our own error messages for each invalid field. Because there are about 12 different fields in the Ebanx form, and because preparing translations for new strings is a slow process, I decided for this PR to pass through the raw message, but we could improve this in a later PR.

The second bug is that the `createEbanxToken()` function, despite having the `async` keyword, has several levels of callbacks and promises and somewhere in all that the error message is lost. The result is that the payment processor system reports an error, but no error message, so even the generic message returned by `translatedEbanxError()` is lost and replaced by an even more generic message `An error occurred during the transaction`.

In this PR we refactor `createEbanxToken()` to use `await` for all its async functions (promisifying those that use callbacks), which hopefully makes the code easier to follow and also makes sure that if any part of the process has an error it will result in the error message making its way to the payment processor error handler. From there, the message will be logged and displayed in checkout.

Before:

<img width="881" alt="Screen Shot 2021-01-15 at 5 45 09 PM" src="https://user-images.githubusercontent.com/2036909/104786904-4f102d00-575c-11eb-9d44-d311c5e83cec.png">

After:

<img width="806" alt="Screen Shot 2021-01-15 at 5 40 28 PM" src="https://user-images.githubusercontent.com/2036909/104786913-52a3b400-575c-11eb-8eb1-62dd18e2f371.png">


#### Testing instructions

- If you plan to use test Ebanx data, you'll need to sandbox the store and the API.
- Set your currency to BRL.
- Visit checkout with a product in the cart.
- In the contact information step, choose "Brazil" for the country.
- In the final step, choose "Credit or debit card".
- Verify that the form asks for all the Ebanx fields in addition to the credit card fields (Taxpayer Identification Number, Phone, etc.)
- Use an [ebanx test card](https://developer.ebanx.com/docs/resources/testCreditCards/) and [test customer info](https://developer.ebanx.com/docs/resources/testCustomerData/) to fill in the form, _except_ do not correctly set the cardholder name. Instead, write something totally different in that field.
- Submit the form.
- Verify that you see an error message in Portuguese that explains the problem (eg: `Ei, faltou uma informação aqui! Preencha com o nome que aparece em seu cartão.`).
- Correctly set the cardholder name field to match the test data and submit the form again.
- Verify that the transaction is successful and that you are redirected away from checkout.