### PR TITLE
Login: improve autofill detection on iOS & Safari

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -531,7 +531,6 @@ export class LoginForm extends Component {
 							autoCapitalize="off"
 							autoCorrect="off"
 							spellCheck="false"
-							type="email"
 							autoComplete="username"
 							className={ classNames( {
 								'is-error': requestError && requestError.field === 'usernameOrEmail',
@@ -567,7 +566,6 @@ export class LoginForm extends Component {
 
 							<FormPasswordInput
 								autoCapitalize="off"
-								type="password"
 								autoComplete="current-password"
 								className={ classNames( {
 									'is-error': requestError && requestError.field === 'password',

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -510,7 +510,6 @@ export class LoginForm extends Component {
 								) }
 							</p>
 						) }
-
 						<FormLabel htmlFor="usernameOrEmail">
 							{ this.isPasswordView() ? (
 								<button
@@ -532,6 +531,8 @@ export class LoginForm extends Component {
 							autoCapitalize="off"
 							autoCorrect="off"
 							spellCheck="false"
+							type="email"
+							autoComplete="username"
 							className={ classNames( {
 								'is-error': requestError && requestError.field === 'usernameOrEmail',
 							} ) }
@@ -566,7 +567,8 @@ export class LoginForm extends Component {
 
 							<FormPasswordInput
 								autoCapitalize="off"
-								autoComplete="off"
+								type="password"
+								autoComplete="current-password"
 								className={ classNames( {
 									'is-error': requestError && requestError.field === 'password',
 								} ) }


### PR DESCRIPTION
Login forms are on multiple pages and we can help autofill detect correct inputs with autocomplete="current-password" and autocomplete="username".

#### Changes proposed in this Pull Request
* Added type "email" and "password" + autocomplete attributes "current-password" and "username" in accordance with [Apple docs](https://developer.apple.com/documentation/security/password_autofill/enabling_password_autofill_on_an_html_input_element
) to allow detection by Password Autofill's heuristics on multiple login pages.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in with multiple browsers, observe saved passwords correctly load into the fields provided.

Fixes #47089