### PR TITLE
Add/block tour on starterpagelayout

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -26,16 +26,14 @@ import previewImage from './images/preview.svg';
 import privateImage from './images/private.svg';
 
 function WpcomNux() {
-	const { isWpcomNuxEnabled, isSPTOpen, site } = useSelect( ( select ) => ( {
+	const { isWpcomNuxEnabled, isSPTOpen, site, isGuideManuallyOpened } = useSelect( ( select ) => ( {
 		isWpcomNuxEnabled: select( 'automattic/nux' ).isWpcomNuxEnabled(),
 		isSPTOpen:
 			select( 'automattic/starter-page-layouts' ) && // Handle the case where SPT is not initalized.
 			select( 'automattic/starter-page-layouts' ).isOpen(),
 		site: select( 'automattic/site' ).getSite( window._currentSiteId ),
+		isGuideManuallyOpened: select( 'automattic/nux' ).isGuideManuallyOpened(),
 	} ) );
-	const isGuideManuallyOpened = useSelect( ( select ) =>
-		select( 'automattic/nux' ).isGuideManuallyOpened()
-	);
 
 	const { closeGeneralSidebar } = useDispatch( 'core/edit-post' );
 	const { setWpcomNuxStatus, setGuideOpenStatus } = useDispatch( 'automattic/nux' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-launch.js
@@ -23,17 +23,16 @@ import { __ } from '@wordpress/i18n';
 
 function LaunchWpcomWelcomeTour() {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
-	const { isWpcomNuxEnabled, isSPTOpen } = useSelect( ( select ) => ( {
+	const { isWpcomNuxEnabled, isSPTOpen, isTourManuallyOpened } = useSelect( ( select ) => ( {
 		isWpcomNuxEnabled: select( 'automattic/nux' ).isWpcomNuxEnabled(),
 		// Handle the case where SPT is initialized and open
 		isSPTOpen:
 			select( 'automattic/starter-page-layouts' ) &&
 			select( 'automattic/starter-page-layouts' ).isOpen(),
+		isTourManuallyOpened: select( 'automattic/nux' ).isTourManuallyOpened(),
 	} ) );
+
 	const { closeGeneralSidebar } = useDispatch( 'core/edit-post' );
-	const isTourManuallyOpened = useSelect( ( select ) =>
-		select( 'automattic/nux' ).isTourManuallyOpened()
-	);
 	const { setWpcomNuxStatus } = useDispatch( 'automattic/nux' );
 
 	// Preload first card image (others preloaded after NUX status confirmed)

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-launch.js
@@ -23,9 +23,13 @@ import { __ } from '@wordpress/i18n';
 
 function LaunchWpcomWelcomeTour() {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
-	const isWpcomNuxEnabled = useSelect( ( select ) =>
-		select( 'automattic/nux' ).isWpcomNuxEnabled()
-	);
+	const { isWpcomNuxEnabled, isSPTOpen } = useSelect( ( select ) => ( {
+		isWpcomNuxEnabled: select( 'automattic/nux' ).isWpcomNuxEnabled(),
+		// Handle the case where SPT is initialized and open
+		isSPTOpen:
+			select( 'automattic/starter-page-layouts' ) &&
+			select( 'automattic/starter-page-layouts' ).isOpen(),
+	} ) );
 	const { closeGeneralSidebar } = useDispatch( 'core/edit-post' );
 	const isTourManuallyOpened = useSelect( ( select ) =>
 		select( 'automattic/nux' ).isTourManuallyOpened()
@@ -54,12 +58,13 @@ function LaunchWpcomWelcomeTour() {
 	}, [ closeGeneralSidebar, isWpcomNuxEnabled ] );
 
 	useEffect( () => {
-		if ( ! isWpcomNuxEnabled ) {
+		if ( ! isWpcomNuxEnabled && ! isSPTOpen ) {
 			return;
 		}
 		portalParent.classList.add( 'wpcom-editor-welcome-tour-portal-parent' );
 		document.body.appendChild( portalParent );
 
+		// Track opening of the Welcome Guide
 		recordTracksEvent( 'calypso_editor_wpcom_tour_open', {
 			is_gutenboarding: window.calypsoifyGutenberg?.isGutenboarding,
 			is_manually_opened: isTourManuallyOpened,
@@ -67,9 +72,9 @@ function LaunchWpcomWelcomeTour() {
 		return () => {
 			document.body.removeChild( portalParent );
 		};
-	}, [ isTourManuallyOpened, isWpcomNuxEnabled, portalParent ] );
+	}, [ isSPTOpen, isTourManuallyOpened, isWpcomNuxEnabled, portalParent ] );
 
-	if ( ! isWpcomNuxEnabled ) {
+	if ( ! isWpcomNuxEnabled || isSPTOpen ) {
 		return null;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add check for starter page template: if a user is on the start page template page, do not show the Welcome Tour (same [behavior as existing NUX](https://github.com/Automattic/wp-calypso/blob/b69abaa128396c32511ae7cae59906402f80eba3/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js#L31)

#### Testing instructions
If testing on local standalone WP:
Pull down this branch
Add define( 'SHOW_WELCOME_TOUR', true ); to wp-config.php

If testing on sandbox:

Pull down this branch and sync to sandbox yarn dev --sync
Add define( 'SHOW_WELCOME_TOUR', true ); to your /home/wpcom/public_html/wp-content/mu-plugins/0-sandbox.php file. This will force the Welcome Tour to show every time the editor loads.

❗ In dev tools Application tab you must clear the site's local storage to ensure the @automattic/nux store is reset. 

* Go to your test site's `https://wordpress.com/pages/{test-site}
* Click Add new page
* On the Starter Page Layout page, the Welcome Tour should _not show_
* Select any layout
* When editor opens after selection, the Welcome Tour _should show_


Fixes: oversight in not duplicating this behavior from NUX.
