### PR TITLE
Editing Toolkit Update to  2.11

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.5
 Tested up to: 5.6
-Stable tag: 2.10
+Stable tag: 2.11
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,11 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.11 =
+* Welcome Guide (Tour & NUX modal): add flag to track if guide is opened manually via MoreMenu
+* Welcome Tour: adjust z-index to show above editor side nav
+* Welcome Tour: prevent showing on Start Page Layout selection page
 
 = 2.10 =
 * Fix issue where block patterns did not load.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- [x]  Welcome Guide (Tour & NUX modal): add flag to track if guide is opened manually via MoreMenu https://github.com/Automattic/wp-calypso/pull/48846
- [x] Welcome Tour: adjust z-index to show above editor side nav https://github.com/Automattic/wp-calypso/pull/48945
- [x] Welcome Tour: prevent showing on Start Page Layout selection page https://github.com/Automattic/wp-calypso/pull/48979

#### Testing instructions

* Load the diff on your sandbox (D54935-code) and confirm that the above changes work correctly
* When a change has been tested to work correctly, please mark it as checked in the list above
* Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.
    - [ ] Tested on atomic

**Note**: this PR was missing version updates in two files.  A subsequent PR was made for the missing files https://github.com/Automattic/wp-calypso/pull/48987