### PR TITLE
Add margin to store deprecated notice

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -154,7 +154,7 @@
 .dashboard__store-move-notice {
 	font-size: $font-body-small;
 	text-align: center;
-	margin-bottom: 60px;
+	margin-bottom: 80px;
 
 	a {
 		margin-top: 20px;

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -152,24 +152,25 @@
 }
 
 .dashboard__store-move-notice {
-    font-size: $font-body-small;
-    text-align: center;
+	font-size: $font-body-small;
+	text-align: center;
+	margin-bottom: 60px;
 
-    a {
-        margin-top: 20px;
-    }
+	a {
+		margin-top: 20px;
+	}
 
-    h1 {
-        font-weight: bold;
-        margin: 17px;
-    }
+	h1 {
+		font-weight: bold;
+		margin: 17px;
+	}
 
-    p {
-        max-width: 50%;
-        margin: auto;
-    }
+	p {
+		max-width: 50%;
+		margin: auto;
+	}
 
-    &.store-removed {
-        margin-top: 40px;
-    }
+	&.store-removed {
+		margin-top: 40px;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds bottom margin to store deprecated notice. This PR also lints the scss file.

Fixes #48983 

#### Testing instructions

- Enable `woocommerce/store-deprecated` config flag
- With a business plan site, click on `Store` menu and view dashboard
- See that there's a gap between the deprecated store notice and the rest of dashboard's contents 

#### Screenshot
![image](https://user-images.githubusercontent.com/3747241/104868872-801c7780-597f-11eb-983e-76cd74eaa6ba.png)
