### PR TITLE
Premium Content: Fix bug where premium content popover preview in block transformations menu would freeze the editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useEffect, useState, useRef } from '@wordpress/element';
-import { Placeholder, Spinner, ToolbarGroup, ToolbarButton } from '@wordpress/components';
+import { Disabled, Placeholder, Spinner, ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { BlockControls } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
@@ -454,6 +454,29 @@ function getConnectUrl( props, connectURL ) {
 	return addQueryArgs( connectURL, { state: window.btoa( JSON.stringify( decodedState ) ) } );
 }
 
+function MaybeDisabledEdit( props ) {
+	// The block transformations menu renders a block preview popover using real blocks
+	// for transformation. The block previews do not play nicely with useEffect and
+	// updating content after a resolved API call. To disarm the block preview, we can
+	// check to see if the block is being rendered within a Disabled context, and set
+	// the isPreview flag accordingly.
+	return (
+		<Disabled.Consumer>
+			{ ( isDisabled ) => {
+				return (
+					<Edit
+						{ ...props }
+						attributes={ {
+							...props.attributes,
+							isPreview: isDisabled || props.attributes?.isPreview,
+						} }
+					/>
+				);
+			} }
+		</Disabled.Consumer>
+	);
+}
+
 export default compose( [
 	withSelect( ( select ) => {
 		const { getCurrentPostId } = select( 'core/editor' );
@@ -479,4 +502,4 @@ export default compose( [
 			createSuccessNotice: notices.createSuccessNotice,
 		};
 	} ),
-] )( Edit );
+] )( MaybeDisabledEdit );


### PR DESCRIPTION
As reported in #48984, the block preview in the block transformations menu caused the editor to freeze due to the block trying to perform an API request and update its state within the context of the preview. This change detects whether or not the block's Edit component is running within that block transformation preview by checking the current Disabled context, and if so, it sets `isPreview` to `true`, to disarm the block within the preview.

#### Changes proposed in this Pull Request

* Wrap the Premium Content block's Edit component in a check for the Disabled context

#### Screenshot

A video of the editor freezing can be found in the reported issue (#48984)

Here is a demo of hovering over the Premium Content block in the block transformations menu. Note that it's displaying the preview content, the editor isn't freezing, and after insertion, the original content (the paragraph block) can be found in the Subscriber View.

![premium-content-block-transformation-small](https://user-images.githubusercontent.com/14988353/104876256-6abd4280-59ab-11eb-9ebe-48e0bfe7eef7.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the diff associated with this PR in your sandbox
* Add a paragraph or heading to a post or page
* Hover over the block and click the block's icon to open the block transformation menu. Hover over each of the different block names, and you should see the correct preview (in this case a hard-coded preview for Premium Content), and the editor shouldn't freeze
* Convert the block to Premium Content, and double-check that the block is working correctly
* Check that the block still works as expected from the block inserter

Note: if this approach looks okay, I can update https://github.com/Automattic/jetpack/pull/17907 to include this change, too.

Fixes #48984 
