### PR TITLE
Deduplicate events

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11941,12 +11941,7 @@ events@^2.0.0:
   resolved "https://registry.yarnpkg.com/events/-/events-2.1.0.tgz#2a9a1e18e6106e0e812aa9ebd4a819b3c29c0ba5"
   integrity sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==
 
-events@^3.0.0, events@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/events/-/events-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
-  integrity sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==
-
-events@^3.2.0:
+events@^3.0.0, events@^3.1.0, events@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
   integrity sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `events` (done automatically with `npx yarn-deduplicate --packages events`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @automattic/calypso-build@6.5.0 -> ... -> events@3.1.0
< wp-calypso@0.17.0 -> @automattic/data-stores@1.0.0-alpha.1 -> ... -> events@3.1.0
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> events@3.1.0
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> events@3.1.0
< wp-calypso@0.17.0 -> i18n-calypso@5.0.0 -> ... -> events@3.1.0
< wp-calypso@0.17.0 -> webpack@4.44.2 -> ... -> events@3.1.0
> wp-calypso@0.17.0 -> @automattic/calypso-build@6.5.0 -> ... -> events@3.2.0
> wp-calypso@0.17.0 -> @automattic/data-stores@1.0.0-alpha.1 -> ... -> events@3.2.0
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> events@3.2.0
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> events@3.2.0
> wp-calypso@0.17.0 -> i18n-calypso@5.0.0 -> ... -> events@3.2.0
> wp-calypso@0.17.0 -> webpack@4.44.2 -> ... -> events@3.2.0
```