### PR TITLE
Deduplicate fast-glob

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13308,19 +13308,7 @@ fast-glob@^2.0.2, fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.0.3, fast-glob@^3.1.1:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.2.tgz#ade1a9d91148965d4bf7c51f72e1ca662d32e63d"
-  integrity sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.0"
-    merge2 "^1.3.0"
-    micromatch "^4.0.2"
-    picomatch "^2.2.1"
-
-fast-glob@^3.2.4:
+fast-glob@^3.0.3, fast-glob@^3.1.1, fast-glob@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
   integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `fast-glob` (done automatically with `npx yarn-deduplicate --packages fast-glob`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @typescript-eslint/eslint-plugin@4.12.0 -> ... -> fast-glob@3.2.2
< wp-calypso@0.17.0 -> @typescript-eslint/parser@4.12.0 -> ... -> fast-glob@3.2.2
< wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> fast-glob@3.2.2
< wp-calypso@0.17.0 -> globby@10.0.1 -> ... -> fast-glob@3.2.2
< wp-calypso@0.17.0 -> i18n-calypso-cli@1.0.0 -> ... -> fast-glob@3.2.2
< wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> fast-glob@3.2.2
> wp-calypso@0.17.0 -> @typescript-eslint/eslint-plugin@4.12.0 -> ... -> fast-glob@3.2.4
> wp-calypso@0.17.0 -> @typescript-eslint/parser@4.12.0 -> ... -> fast-glob@3.2.4
> wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> fast-glob@3.2.4
> wp-calypso@0.17.0 -> globby@10.0.1 -> ... -> fast-glob@3.2.4
> wp-calypso@0.17.0 -> i18n-calypso-cli@1.0.0 -> ... -> fast-glob@3.2.4
> wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> fast-glob@3.2.4
```