### PR TITLE
Plugins: Disable other actions while performing one in PluginMeta

### DIFF
--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -164,7 +164,7 @@ class PluginRemoveButton extends React.Component {
 
 	renderButton = () => {
 		const disabledInfo = this.getDisabledInfo();
-		const disabled = !! disabledInfo;
+		const disabled = !! disabledInfo || this.props.disabled;
 		const label = disabled
 			? this.props.translate( 'Removal Disabled', {
 					context:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, on the plugin page for a site (`/plugins/:plugin/:site`) we have 3 actions at the top:

* activation/deactivating
* autoupdate toggling
* removal

As @flootr reported in p1607502043005400-slack-C7YPUHBB2 when attempting one of them, we don't disable the other ones, and that might cause race conditions and put the UI in an unpredictable state. This has been like that since this section was created and isn't related to the reduxification work.

This PR updates those to be disabled if one of the actions is being performed. When the action is complete, the actions get enabled again. 

Related to #24180.

#### Testing instructions

* Keep an eye on the console for errors.
* Go to `/plugins/:plugin/:site`
* Try activating/deactivating the plugin, enabling/disabling auto-update and removing a plugin, and verify that while doing any of those, controls for all 3 actions are disabled, and they reenable again when the action is finished.
* Verify all tests still pass.