### PR TITLE
Email: Show correct billing period for Titan Mail

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -51,6 +51,7 @@ import { canEditPaymentDetails } from '../utils';
 import { TERM_BIENNIALLY, TERM_MONTHLY, JETPACK_LEGACY_PLANS } from 'calypso/lib/plans/constants';
 import { getCurrentUser, getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
 
 export default function PurchaseMeta( {
 	purchaseId = false,
@@ -289,6 +290,10 @@ function PurchaseMetaPrice( { purchase, translate } ) {
 				period = translate( 'month' );
 				break;
 		}
+	}
+
+	if ( productSlug === TITAN_MAIL_MONTHLY_SLUG ) {
+		period = translate( 'month' );
 	}
 
 	return translate( '%(priceText)s %(currencyCode)s {{period}}/ %(period)s{{/period}}', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the billing period shown on the purchases page for Titan Mail.

<img width="254" alt="Screenshot 2021-01-18 at 2 33 44 PM" src="https://user-images.githubusercontent.com/13062352/104921853-2d03ee00-599a-11eb-8a2c-82816059b84d.png">


#### Testing instructions

- Go to site domains
- Click on a domain with Titan (or purchase one through Store Sandbox)
- choose Manage your email accounts
- Click on Update your billing and payment settings
- Verify that price is shown per month, and not per year (like the screenshot above)
