### PR TITLE
Plugins: Move code to selector or helper function territory

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
-import { capitalize, find, flow, isEmpty, some } from 'lodash';
+import { capitalize, find, flow, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -31,6 +31,7 @@ import NoPermissionsError from './no-permissions-error';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import canCurrentUserManagePlugins from 'calypso/state/selectors/can-current-user-manage-plugins';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
+import getUpdateableJetpackSites from 'calypso/state/selectors/get-updateable-jetpack-sites';
 import hasJetpackSites from 'calypso/state/selectors/has-jetpack-sites';
 import {
 	canJetpackSiteUpdateFiles,
@@ -244,19 +245,13 @@ export class PluginsMain extends Component {
 	}
 
 	getUpdatesTabVisibility() {
-		const { selectedSite } = this.props;
+		const { selectedSite, updateableJetpackSites } = this.props;
 
 		if ( selectedSite ) {
 			return this.props.selectedSiteIsJetpack && this.props.canSelectedJetpackSiteUpdateFiles;
 		}
 
-		return some(
-			this.props.sites,
-			( site ) =>
-				site &&
-				this.props.isJetpackSite( site.ID ) &&
-				this.props.canJetpackSiteUpdateFiles( site.ID )
-		);
+		return updateableJetpackSites.length > 0;
 	}
 
 	shouldShowPluginListPlaceholders() {
@@ -477,17 +472,13 @@ export default flow(
 				siteIds,
 				canSelectedJetpackSiteUpdateFiles:
 					selectedSite && canJetpackSiteUpdateFiles( state, selectedSiteId ),
-				/* eslint-disable wpcalypso/redux-no-bound-selectors */
-				// @TODO: follow up with fixing these functions
-				canJetpackSiteUpdateFiles: ( siteId ) => canJetpackSiteUpdateFiles( state, siteId ),
-				isJetpackSite: ( siteId ) => isJetpackSite( state, siteId ),
-				/* eslint-enable wpcalypso/redux-no-bound-selectors */
 				wporgPlugins: getAllWporgPlugins( state ),
 				isRequestingSites: isRequestingSites( state ),
 				currentPlugins: getPlugins( state, siteIds, filter ),
 				currentPluginsOnVisibleSites: getPlugins( state, visibleSiteIds, filter ),
 				pluginUpdateCount: pluginsWithUpdates && pluginsWithUpdates.length,
 				requestingPluginsForSites: isRequestingForSites( state, siteIds ),
+				updateableJetpackSites: getUpdateableJetpackSites( state ),
 				userCanManagePlugins: selectedSiteId
 					? canCurrentUser( state, selectedSiteId, 'manage_options' )
 					: canCurrentUserManagePlugins( state ),

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -45,6 +45,7 @@ import {
 import { getPlugins, isRequestingForSites } from 'calypso/state/plugins/installed/selectors';
 import { Button } from '@automattic/components';
 import { isEnabled } from 'calypso/config';
+import { getVisibleSites, siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 
 /**
  * Style dependencies
@@ -462,10 +463,8 @@ export default flow(
 			const sites = getSelectedOrAllSitesWithPlugins( state );
 			const selectedSite = getSelectedSite( state );
 			const selectedSiteId = getSelectedSiteId( state );
-			/* eslint-disable wpcalypso/redux-no-bound-selectors */
-			const visibleSiteIds =
-				sites?.filter( ( site ) => site.visible )?.map( ( site ) => site.ID ) ?? [];
-			const siteIds = sites?.map( ( site ) => site.ID ) ?? [];
+			const visibleSiteIds = siteObjectsToSiteIds( getVisibleSites( sites ) ) ?? [];
+			const siteIds = siteObjectsToSiteIds( sites ) ?? [];
 			const pluginsWithUpdates = getPlugins( state, siteIds, 'updates' );
 
 			return {

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -27,6 +27,7 @@ import {
 	UPDATE_PLUGIN,
 } from 'calypso/lib/plugins/constants';
 import { getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
+import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 
 /**
@@ -328,8 +329,7 @@ class PluginItem extends Component {
 }
 
 export default connect( ( state, { plugin, sites } ) => {
-	// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
-	const siteIds = sites?.map( ( site ) => site.ID );
+	const siteIds = siteObjectsToSiteIds( sites );
 
 	return {
 		pluginsOnSites: getPluginOnSites( state, siteIds, plugin?.slug ),

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -31,7 +31,7 @@ import PluginRemoveButton from 'calypso/my-sites/plugins/plugin-remove-button';
 import PluginInformation from 'calypso/my-sites/plugins/plugin-information';
 import WpcomPluginInstallButton from 'calypso/my-sites/plugins/plugin-install-button-wpcom';
 import PluginAutomatedTransfer from 'calypso/my-sites/plugins/plugin-automated-transfer';
-import { getExtensionSettingsPath } from 'calypso/my-sites/plugins/utils';
+import { getExtensionSettingsPath, siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { userCan } from 'calypso/lib/site/utils';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { FEATURE_UPLOAD_PLUGINS, TYPE_BUSINESS } from 'calypso/lib/plans/constants';
@@ -617,8 +617,7 @@ export class PluginMeta extends Component {
 const mapStateToProps = ( state, { plugin, sites } ) => {
 	const siteId = getSelectedSiteId( state );
 	const selectedSite = getSelectedSite( state );
-	// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
-	const siteIds = sites.map( ( site ) => site.ID );
+	const siteIds = siteObjectsToSiteIds( sites );
 
 	return {
 		disabledActivation: isPluginActionInProgress(

--- a/client/my-sites/plugins/plugin-site-list/index.jsx
+++ b/client/my-sites/plugins/plugin-site-list/index.jsx
@@ -18,6 +18,7 @@ import {
 	getPluginOnSites,
 	getSiteObjectsWithPlugin,
 } from 'calypso/state/plugins/installed/selectors';
+import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 
 /**
  * Style dependencies
@@ -81,8 +82,7 @@ function getSitesWithSecondarySites( state, sites ) {
 }
 
 export default connect( ( state, { plugin, sites } ) => {
-	// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
-	const siteIds = sites.map( ( site ) => site.ID );
+	const siteIds = siteObjectsToSiteIds( sites );
 
 	return {
 		sitesWithPlugin: getSiteObjectsWithPlugin( state, siteIds, plugin.slug ),

--- a/client/my-sites/plugins/plugin-site-network/index.jsx
+++ b/client/my-sites/plugins/plugin-site-network/index.jsx
@@ -24,6 +24,7 @@ import {
 	isPluginActionInProgress,
 } from 'calypso/state/plugins/installed/selectors';
 import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
+import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 
 /**
  * Style dependencies
@@ -164,8 +165,7 @@ class PluginSiteNetwork extends React.Component {
 }
 
 export default connect( ( state, { plugin, secondarySites, site } ) => {
-	// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
-	const secondarySiteIds = secondarySites.map( ( secSite ) => secSite.ID );
+	const secondarySiteIds = siteObjectsToSiteIds( secondarySites );
 
 	return {
 		pluginOnSite: getPluginOnSite( state, site.ID, plugin.slug ),

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -48,6 +48,7 @@ import {
 	isRequestingForSites,
 } from 'calypso/state/plugins/installed/selectors';
 import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
+import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 
 function goBack() {
 	window.history.back();
@@ -313,9 +314,7 @@ export default connect(
 	( state, props ) => {
 		const selectedSiteId = getSelectedSiteId( state );
 		const sites = getSelectedOrAllSitesWithPlugins( state );
-
-		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
-		const siteIds = uniq( sites.map( ( site ) => site.ID ) );
+		const siteIds = uniq( siteObjectsToSiteIds( sites ) );
 
 		return {
 			plugin: getPluginOnSites( state, siteIds, props.pluginSlug ),

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -17,6 +17,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSitesWithPlugin } from 'calypso/state/plugins/installed/selectors';
+import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 
 /**
  * Style dependencies
@@ -140,12 +141,7 @@ export default compose(
 
 		const sitesWithPlugin =
 			site && currentSites
-				? getSitesWithPlugin(
-						state,
-						// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
-						currentSites.map( ( currentSite ) => currentSite.ID ),
-						plugin.slug
-				  )
+				? getSitesWithPlugin( state, siteObjectsToSiteIds( currentSites ), plugin.slug )
 				: [];
 
 		return {

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -32,7 +32,7 @@ import {
 } from 'calypso/state/plugins/installed/actions';
 import getSites from 'calypso/state/selectors/get-sites';
 import {
-	getPluginOnSites,
+	getPluginsOnSites,
 	getPluginStatusesByType,
 } from 'calypso/state/plugins/installed/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
@@ -591,17 +591,9 @@ export default connect(
 	( state, { plugins } ) => {
 		const selectedSite = getSelectedSite( state );
 
-		/* eslint-disable wpcalypso/redux-no-bound-selectors */
-		const pluginsOnSites = Object.values( plugins ).reduce( ( acc, plugin ) => {
-			const siteIds = Object.keys( plugin.sites );
-			acc[ plugin.slug ] = getPluginOnSites( state, siteIds, plugin.slug );
-			return acc;
-		}, {} );
-		/* eslint-enable wpcalypso/redux-no-bound-selectors */
-
 		return {
 			allSites: getSites( state ),
-			pluginsOnSites,
+			pluginsOnSites: getPluginsOnSites( state, plugins ),
 			selectedSite,
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 			inProgressStatuses: getPluginStatusesByType( state, 'inProgress' ),

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -26,3 +26,7 @@ export function getExtensionSettingsPath( plugin ) {
 export function siteObjectsToSiteIds( sites ) {
 	return sites?.map( ( site ) => site.ID ) ?? [];
 }
+
+export function getVisibleSites( sites ) {
+	return sites?.filter( ( site ) => site.visible );
+}

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -22,3 +22,7 @@ export function getExtensionSettingsPath( plugin ) {
 
 	return get( section, 'settings_path' );
 }
+
+export function siteObjectsToSiteIds( sites ) {
+	return sites?.map( ( site ) => site.ID ) ?? [];
+}

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -100,6 +100,14 @@ export function getPluginsWithUpdates( state, siteIds ) {
 	} ) );
 }
 
+export function getPluginsOnSites( state, plugins ) {
+	return Object.values( plugins ).reduce( ( acc, plugin ) => {
+		const siteIds = Object.keys( plugin.sites );
+		acc[ plugin.slug ] = getPluginOnSites( state, siteIds, plugin.slug );
+		return acc;
+	}, {} );
+}
+
 export function getPluginOnSites( state, siteIds, pluginSlug ) {
 	return getPlugins( state, siteIds ).find( ( plugin ) => plugin.slug === pluginSlug );
 }

--- a/client/state/selectors/get-updateable-jetpack-sites.js
+++ b/client/state/selectors/get-updateable-jetpack-sites.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
+import { canJetpackSiteUpdateFiles } from 'calypso/state/sites/selectors';
+
+/**
+ * Retrieves all Jetpack sites that are allowed to be updated.
+ *
+ * @param   {object} state Global state tree
+ * @returns {Array}        Array of updateable Jetpack sites
+ */
+export default function getUpdateableJetpackSites( state ) {
+	const sites = getSelectedOrAllSitesWithPlugins( state );
+	return sites.filter( ( site ) => canJetpackSiteUpdateFiles( state, site.ID ) );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the process of reduxifying plugins, we introduced some functions that we define in `mapStateToProps`, and we also have some bound ones. This PR moves code to selector or helper function territory, depending on where it really belongs.

Some instances we're refactoring here were reported in https://github.com/Automattic/wp-calypso/pull/48053/files#r537320099 and https://github.com/Automattic/wp-calypso/pull/48453/files#r545141583 by @flootr.

Related to #24180.

#### Testing instructions

* Get several Jetpack sites (including multisite with subsites) with some plugins for testing. 
* Test the following scenarios with and without an empty Redux store.
* Thoroughly test lists of plugins in all plugin scenarios; compare against production and verify that they still work the same way when updating, installing, or removing plugins, as well as toggling auto-updates and activating/deactivating plugins:
  * `/plugins`
  * `/plugins/manage`
  * `/plugins/manage` - for multiple selected plugins (bulk actions are enabled by clicking the "Edit All" button)
  * `/plugins/manage/:site` - for a single plugin
  * `/plugins/manage/:site` - for multiple selected plugins (bulk actions are enabled by clicking the "Edit All" button)
* Specifically try uploading an old version of a plugin and verify everything behaves the same way before, during, and after the upload.
* Specifically test updating an old plugin and verify everything behaves the same way before, during, and after the update.
* Test filtering of plugins specifically.
* While on one of the above pages, try switching between sites, between all sites and a single site, and the other way around and verify plugins are always loaded accordingly.
* Verify all tests pass.

