### PR TITLE
Purchases: remove currency code from price meta

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -264,13 +264,13 @@ function renderPaymentInfo( { purchase, translate, moment } ) {
 }
 
 function PurchaseMetaPrice( { purchase, translate } ) {
-	const { priceText, currencyCode, productSlug } = purchase;
+	const { priceText, productSlug } = purchase;
 	const plan = getPlan( productSlug ) || getProductFromSlug( productSlug );
 	let period = translate( 'year' );
 
 	if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
-		return translate( '%(priceText)s %(currencyCode)s {{period}}(one-time){{/period}}', {
-			args: { priceText, currencyCode },
+		return translate( '%(priceText)s {{period}}(one-time){{/period}}', {
+			args: { priceText },
 			components: {
 				period: <span className="manage-purchase__time-period" />,
 			},
@@ -297,12 +297,8 @@ function PurchaseMetaPrice( { purchase, translate } ) {
 		period = translate( 'month' );
 	}
 
-	return translate( '%(priceText)s %(currencyCode)s {{period}}/ %(period)s{{/period}}', {
-		args: {
-			priceText,
-			currencyCode,
-			period,
-		},
+	return translate( '%(priceText)s {{period}}/ %(period)s{{/period}}', {
+		args: { priceText, period },
 		components: {
 			period: <span className="manage-purchase__time-period" />,
 		},

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -269,6 +269,7 @@ function PurchaseMetaPrice( { purchase, translate } ) {
 	let period = translate( 'year' );
 
 	if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
+		// translators: %(priceText)s is the price of the purchase with localized currency (i.e. "C$10")
 		return translate( '%(priceText)s {{period}}(one-time){{/period}}', {
 			args: { priceText },
 			components: {
@@ -297,6 +298,7 @@ function PurchaseMetaPrice( { purchase, translate } ) {
 		period = translate( 'month' );
 	}
 
+	// translators: %(priceText)s is the price of the purchase with localized currency (i.e. "C$10"), %(period)s is how long the plan is active (i.e. "year")
 	return translate( '%(priceText)s {{period}}/ %(period)s{{/period}}', {
 		args: { priceText, period },
 		components: {


### PR DESCRIPTION
I believe `currencyCode` was added to `priceText` in the purchase price meta in order to address the confusion for users that live in an area without a supported currency, but where their local currency uses the `$` (see #46205). The problem with that approach is that for non-USD currencies that we support, `priceText` already includes the currency identifier, and sometimes we've opted to use the currency code instead of a currency symbol (i.e. PLN and DKR). This causes a duplicate currency code, depending on the left/right localization of `priceText` (i.e. `168 PLN PLN` or `C$10 CAD`).

In D52530-code, we fixed the unsupported `$` currency issue on the backend, so this PR removes the redundant currency code on the front-end. This is a partial fix, because we should ultimately be more consistent about using a localized return value from the endpoint (see: Automattic/payments-shilling/79#issuecomment-752669323).

**Before (PLN):**
![Screen Shot 2021-01-18 at 10 50 28 AM](https://user-images.githubusercontent.com/942359/104941920-bc50d780-5981-11eb-9111-ee6e560922d0.png)

**After (PLN):**
<img width="970" alt="Screen Shot 2021-01-18 at 10 52 59 AM" src="https://user-images.githubusercontent.com/942359/104942080-f7530b00-5981-11eb-873a-5aae237551db.png">

**After (PLN - one time purchase):**
<img width="970" alt="Screen Shot 2021-01-18 at 10 54 00 AM" src="https://user-images.githubusercontent.com/942359/104942150-0e91f880-5982-11eb-8c91-1649535a73e2.png">

**After (USD, non-US geo - one time purchase):**
<img width="970" alt="Screen Shot 2021-01-18 at 10 55 36 AM" src="https://user-images.githubusercontent.com/942359/104942209-249fb900-5982-11eb-914b-2a8fb6ccf882.png">

**To test:**
- Switch currency to `PLN` or `DKR`
- Visit a purchase's management page
- Verify that the currency code isn't duplicated
- Switch currency to `CAD`
- Verify that the purchase price meta reads `$C{amount} / year`
- Switch to `USD` with a US geo
- Verify that the purchase price meta reads `${amount} / year`
- Keep `USD` and use a VPN to change your geo to outside of the US
- Verify that the purchase price meta reads `US${amount} / year`