### PR TITLE
Cloudflare - allow updating Cloudflare tracking ID as a site setting

### DIFF
--- a/client/my-sites/site-settings/cloudflare-analytics/index.js
+++ b/client/my-sites/site-settings/cloudflare-analytics/index.js
@@ -29,7 +29,7 @@ import cloudflareIllustration from 'calypso/assets/images/illustrations/cloudfla
  */
 import './style.scss';
 
-const validateTrackingId = ( code ) => ! code || code.match( /^(UA-\d+-\d+)|(G-[A-Z0-9]+)$/i ); // @TODO: how are cloudflare tracking IDs formatted?
+const validateTrackingId = ( code ) => ! code || code.match( /^[a-fA-F0-9]+$/i );
 
 export function CloudflareAnalyticsSettings( {
 	fields,
@@ -51,12 +51,11 @@ export function CloudflareAnalyticsSettings( {
 	);
 	const isSubmitButtonDisabled =
 		isRequestingSettings || isSavingSettings || ! isCodeValid || ! enableForm;
-
 	const handleFieldChange = ( key, value ) => {
 		const updatedCloudflareFields = Object.assign( {}, fields.cloudflare || {}, {
 			[ key ]: value,
 		} );
-		updateFields( { cloudflare: updatedCloudflareFields } );
+		updateFields( { cloudflare_analytics: updatedCloudflareFields } );
 	};
 
 	const handleCodeChange = ( event ) => {
@@ -117,7 +116,7 @@ export function CloudflareAnalyticsSettings( {
 						<FormTextInput
 							name="cloudflareCode"
 							id="cloudflareCode"
-							value={ fields.cloudflare ? fields.cloudflare.code : '' }
+							value={ fields.cloudflare_analytics ? fields.cloudflare_analytics.code : '' }
 							onChange={ handleCodeChange }
 							placeholder={ placeholderText }
 							disabled={ isRequestingSettings || ! enableForm }
@@ -181,7 +180,7 @@ const mapDispatchToProps = {
 
 const connectComponent = connect( mapStateToProps, mapDispatchToProps, null, { pure: false } );
 
-const getFormSettings = partialRight( pick, [ 'cloudflare' ] );
+const getFormSettings = partialRight( pick, [ 'cloudflare_analytics' ] );
 
 export default flowRight(
 	connectComponent,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This diff (along with D55521-code) updates the code introduced in https://github.com/Automattic/wp-calypso/pull/48895 so that a user can enter a Cloudflare analytics tracking ID and have the value saved as a new site setting.

(Note that this will probably not be the final state of this interface; as discussed in p1610647688001200-slack-C01HV13S295, Cloudflare provides users with a full code snippet but not the token as a standalone, easily copyable value. However, this implementation establishes the basic logic necessary to manage this new site setting.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch to your local Calypso environment. (This will ensure the `cloudflare` feature flag is enabled.)
* Check out D55521-code to your sandbox and ensure that the API is sandboxed in your hosts file.
* Ensure the site you're configuring is on a Premium, Business, or eCommerce plan.
* Navigate to http://calypso.localhost:3000/marketing/traffic/{siteUrl} and verify that you can enter a hexadecimal string value into the Cloudflare card's "Tracking ID" field and then save the value, and that it is persisted on a page reload.
* Navigate to the actual site itself, and use dev tools to verify that the token you entered is populated into the site header in a Cloudflare code snippet, which should look like this:

```
<!-- Cloudflare Web Analytics -->
<script defer 
    src='https://static.cloudflareinsights.com/beacon.min.js' 
</script>
```

Fixes 406-gh-Automattic/dotcom-manage (partially)