### PR TITLE
Show a confirmation message when disabling autorenew for G Suite

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -12,8 +12,14 @@ import { localize } from 'i18n-calypso';
 import { Button, Dialog } from '@automattic/components';
 import CancelAutoRenewalForm from 'calypso/components/marketing-survey/cancel-auto-renewal-form';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
-import { isDomainRegistration, isPlan, isTitanMail } from 'calypso/lib/products-values';
+import {
+	isDomainRegistration,
+	isGoogleApps,
+	isPlan,
+	isTitanMail,
+} from 'calypso/lib/products-values';
 import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSite } from 'calypso/state/sites/selectors';
 import './style.scss';
@@ -53,7 +59,7 @@ class AutoRenewDisablingDialog extends Component {
 			return 'plan';
 		}
 
-		if ( isTitanMail( purchase ) ) {
+		if ( isGoogleApps( purchase ) || isTitanMail( purchase ) ) {
 			return 'email';
 		}
 
@@ -125,7 +131,9 @@ class AutoRenewDisablingDialog extends Component {
 					{
 						args: {
 							domainName: purchase.meta,
-							emailProductName: getTitanProductName(),
+							emailProductName: isTitanMail( purchase )
+								? getTitanProductName()
+								: getGoogleMailServiceFamily(),
 							expiryDate,
 						},
 						comment:

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -12,8 +12,6 @@ import { localize } from 'i18n-calypso';
 import { Button, Dialog } from '@automattic/components';
 import CancelAutoRenewalForm from 'calypso/components/marketing-survey/cancel-auto-renewal-form';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
-import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
 import {
 	isDomainRegistration,
 	isGoogleApps,
@@ -131,9 +129,8 @@ class AutoRenewDisablingDialog extends Component {
 					{
 						args: {
 							domainName: purchase.meta,
-							emailProductName: isTitanMail( purchase )
-								? getTitanProductName()
-								: getGoogleMailServiceFamily(),
+							// Use the purchased product name to make sure it's correct
+							emailProductName: purchase.productName,
 							expiryDate,
 						},
 						comment:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR is a slight modification to the logic for PR #48961, which ensures that we show a clear confirmation message when disabling autorenew for a Titan subscription. The main change here is that instead of showing the current UI-level name for G Suite/Google Workspace or Titan/Email, we always use the product name from the purchase.

#### Testing instructions

* Make sure that you have a G Suite subscription and an Email subscription. (If you don't have either, please purchase them, preferably with a credit card, as autorenew needs to be enabled).
* Manage each of your subscriptions and confirm that if you disable autorenew for the subscription you see a confirmation dialog with the following wording:
> ### Before you go...
> By canceling auto-renewal, your <product_name> subscription for example.com will expire on 25 March 2021. After it expires, you will not be able to send and receive emails for this domain. To avoid that, turn auto-renewal back on or manually renew your subscription before the expiration date.