### PR TITLE
Show renewal-aware warnings when renewals are removed from the cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -24,6 +24,7 @@ import {
 	getCouponLineItemFromCart,
 	getTaxLineItemFromCart,
 	getCreditsLineItemFromCart,
+	isWpComProductRenewal,
 } from '@automattic/wpcom-checkout';
 import {
 	isPlan,
@@ -60,7 +61,6 @@ import {
 	getProductPriceTierList,
 } from 'calypso/state/products-list/selectors';
 import { getPriceTierForUnits } from 'calypso/my-sites/plans/jetpack-plans/utils';
-import isWpComProductRenewal from 'calypso/my-sites/checkout/composite-checkout/lib/is-wpcom-product-renewal';
 
 const WPOrderReviewList = styled.ul< { theme?: Theme } >`
 	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
@@ -482,7 +482,13 @@ function returnModalCopyForProduct(
 	const productType =
 		isPlan( product ) && hasDomainsInCart ? 'plan with dependencies' : product.product_slug;
 	const isRenewal = isWpComProductRenewal( product );
-	return returnModalCopy( productType, translate, createUserAndSiteBeforeTransaction, isPwpoUser, isRenewal );
+	return returnModalCopy(
+		productType,
+		translate,
+		createUserAndSiteBeforeTransaction,
+		isPwpoUser,
+		isRenewal
+	);
 }
 
 function returnModalCopy(
@@ -490,16 +496,18 @@ function returnModalCopy(
 	translate: ReturnType< typeof useTranslate >,
 	createUserAndSiteBeforeTransaction: boolean,
 	isPwpoUser: boolean,
-	isRenewal: boolean = false,
+	isRenewal = false
 ): ModalCopy {
 	switch ( productType ) {
 		case 'plan with dependencies': {
 			if ( isRenewal ) {
 				return {
 					title: String( translate( 'You are about to remove your plan renewal from the cart' ) ),
-					description: String( translate(
-						'When you press Continue, we will remove your plan renewal from the cart and your plan will keep its current expiry date.'
-					) ),
+					description: String(
+						translate(
+							'When you press Continue, we will remove your plan renewal from the cart and your plan will keep its current expiry date.'
+						)
+					),
 				};
 			}
 			const title = String( translate( 'You are about to remove your plan from the cart' ) );
@@ -528,9 +536,11 @@ function returnModalCopy(
 			if ( isRenewal ) {
 				return {
 					title: String( translate( 'You are about to remove your plan renewal from the cart' ) ),
-					description: String( translate(
-						'When you press Continue, we will remove your plan renewal from the cart and your plan will keep its current expiry date. We will then take you back to your site.'
-					) ),
+					description: String(
+						translate(
+							'When you press Continue, we will remove your plan renewal from the cart and your plan will keep its current expiry date. We will then take you back to your site.'
+						)
+					),
 				};
 			}
 
@@ -548,9 +558,11 @@ function returnModalCopy(
 			if ( isRenewal ) {
 				return {
 					title: String( translate( 'You are about to remove your domain renewal from the cart' ) ),
-					description: String( translate(
-						'When you press Continue, we will remove your domain renewal from the cart and your domain will keep its current expiry date.'
-					) ),
+					description: String(
+						translate(
+							'When you press Continue, we will remove your domain renewal from the cart and your domain will keep its current expiry date.'
+						)
+					),
 				};
 			}
 
@@ -573,9 +585,11 @@ function returnModalCopy(
 			if ( isRenewal ) {
 				return {
 					title: String( translate( 'You are about to remove your renewal from the cart' ) ),
-					description: String( translate(
-						'When you press Continue, we will remove your renewal from the cart and your product will keep its current expiry date.'
-					) ),
+					description: String(
+						translate(
+							'When you press Continue, we will remove your renewal from the cart and your product will keep its current expiry date.'
+						)
+					),
 				};
 			}
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -27,6 +27,7 @@ import {
 	isWpComProductRenewal,
 } from '@automattic/wpcom-checkout';
 import {
+	isDomainRegistration,
 	isPlan,
 	isMonthlyProduct,
 	isYearly,
@@ -479,8 +480,7 @@ function returnModalCopyForProduct(
 	createUserAndSiteBeforeTransaction: boolean,
 	isPwpoUser: boolean
 ): ModalCopy {
-	const productType =
-		isPlan( product ) && hasDomainsInCart ? 'plan with dependencies' : product.product_slug;
+	const productType = getProductTypeForModalCopy( product, hasDomainsInCart );
 	const isRenewal = isWpComProductRenewal( product );
 	return returnModalCopy(
 		productType,
@@ -489,6 +489,24 @@ function returnModalCopyForProduct(
 		isPwpoUser,
 		isRenewal
 	);
+}
+
+function getProductTypeForModalCopy(
+	product: ResponseCartProduct,
+	hasDomainsInCart: boolean
+): string {
+	if ( isPlan( product ) ) {
+		if ( hasDomainsInCart ) {
+			return 'plan with dependencies';
+		}
+		return 'plan';
+	}
+
+	if ( isDomainRegistration( product ) ) {
+		return 'domain';
+	}
+
+	return product.product_slug;
 }
 
 function returnModalCopy(

--- a/client/my-sites/checkout/composite-checkout/lib/is-wpcom-product-renewal.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/is-wpcom-product-renewal.ts
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
+
+export default function isWpComProductRenewal( product: ResponseCartProduct ): boolean {
+	return product?.extra?.purchaseType === 'renewal';
+}

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -14,3 +14,4 @@ export { default as styled } from './styled';
 export * from './payment-methods/bancontact';
 export * from './use-is-web-payment-available';
 export * from './payment-methods/google-pay';
+export { isWpComProductRenewal } from './is-wpcom-product-renewal';

--- a/packages/wpcom-checkout/src/is-wpcom-product-renewal.ts
+++ b/packages/wpcom-checkout/src/is-wpcom-product-renewal.ts
@@ -3,6 +3,6 @@
  */
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
-export default function isWpComProductRenewal( product: ResponseCartProduct ): boolean {
+export function isWpComProductRenewal( product: ResponseCartProduct ): boolean {
 	return product?.extra?.purchaseType === 'renewal';
 }

--- a/packages/wpcom-checkout/src/is-wpcom-product-renewal.ts
+++ b/packages/wpcom-checkout/src/is-wpcom-product-renewal.ts
@@ -4,5 +4,5 @@
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 export function isWpComProductRenewal( product: ResponseCartProduct ): boolean {
-	return product?.extra?.purchaseType === 'renewal';
+	return product.extra?.purchaseType === 'renewal';
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the warnings shown when a user attempts to remove either a renewal from the cart so that it's clearer that you keep your current expiration date when you do so. The previous language made it sounds like really bad things would happen.
* This PR also updates the logic to make sure that we show more specific language for domain registrations and plans (when no domains are in the cart), for both new purchases and renewals.

#### Testing instructions

For each of the following product types (or items), follow the steps below:
 * A plan
 * A domain registration
 * A plan and a domain registration in the same cart
 * Any other product of your choice that is not a plan or a domain registration

_You will already need a subscription for each of these items._

1. Initiate a renewal of the product, but don't complete checkout.
2. From within checkout, edit your cart and remove the product.
3. Verify that you get an appropriate warning about the renewal being removed.
   - In the case of domains and plans, verify that the language identifies the type of the item being removed.

In addition to the above, verify that adding a new domain and a new plan to the cart and then removing them also shows appropriate warnings that specify the product type.

Also verify that you can add and remove a valid coupon, with the removal confirmation dialog including coupon-specific wording.

#### Screenshots

##### Removing a plan renewal

<img width="426" alt="remove_plan_renewal" src="https://user-images.githubusercontent.com/3376401/117721879-b147de80-b1e0-11eb-9c75-cbc913beacec.png">

##### Removing a domain renewal

<img width="426" alt="remove_domain_renewal" src="https://user-images.githubusercontent.com/3376401/117721911-bc027380-b1e0-11eb-9ef6-bcf111e901f5.png">

##### Removing any other product renewal

<img width="426" alt="remove_other_renewal" src="https://user-images.githubusercontent.com/3376401/117721954-c91f6280-b1e0-11eb-880b-845b7dcef84f.png">