### PR TITLE
Plans: Remove duplicate entries for some sites on the Plans/Pricing pages

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
@@ -81,7 +81,8 @@ export const getProductsToDisplay = ( {
 	purchasedProducts: ( SelectorProduct | null )[];
 	includedInPlanProducts: ( SelectorProduct | null )[];
 } ): SelectorProduct[] => {
-	const purchasedSlugs = purchasedProducts?.map( ( p ) => p?.productSlug ) || [];
+	const purchasedSlugs =
+		purchasedProducts?.map( ( p ) => p?.productSlug )?.filter( ( slug ) => slug ) || [];
 
 	// Products that have not been directly purchased must honor the current filter
 	// selection since they exist in both monthly and yearly version.

--- a/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
@@ -90,7 +90,11 @@ export const getProductsToDisplay = ( {
 		.filter( ( product ): product is SelectorProduct => product?.term === duration )
 		// Remove duplicates (only happens if the site somehow has the same product
 		// both purchased and included in a plan, very unlikely)
-		.filter( ( product ) => ! purchasedSlugs.includes( product.productSlug ) );
+		.filter(
+			( product ) =>
+				! purchasedSlugs.includes( product.productSlug ) &&
+				! purchasedSlugs.includes( product.monthlyProductSlug )
+		);
 	return (
 		[ ...purchasedProducts, ...filteredProducts ]
 			// Make sure we don't allow any null or invalid products

--- a/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
@@ -91,11 +91,17 @@ export const getProductsToDisplay = ( {
 		.filter( ( product ): product is SelectorProduct => product?.term === duration )
 		// Remove duplicates (only happens if the site somehow has the same product
 		// both purchased and included in a plan, very unlikely)
-		.filter(
-			( product ) =>
-				! purchasedSlugs.includes( product.productSlug ) &&
-				! purchasedSlugs.includes( product.monthlyProductSlug )
-		);
+		.filter( ( product ) => {
+			if ( product.productSlug && purchasedSlugs.includes( product.productSlug ) ) {
+				return false;
+			}
+
+			if ( product.monthlyProductSlug && purchasedSlugs.includes( product.monthlyProductSlug ) ) {
+				return false;
+			}
+
+			return true;
+		} );
 	return (
 		[ ...purchasedProducts, ...filteredProducts ]
 			// Make sure we don't allow any null or invalid products


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove entries from the list of available/included-in-plan products whose product slug also exists in the list of purchased products, thereby eliminating the possibility of duplicate cards for sites where a product has both (a) been purchased and (b) is included as part of a purchased plan.

#### Testing instructions

**NOTE:** This behavior seems to occur with all design iterations.

* Select a Jetpack site and purchase a bundle or plan (e.g., Security Daily). Then, purchase an individual product included in that plan. (Added complexity scenario: purchase the two items using two different billing terms.)
* Verify that in staging/production, the **Plans** (Calypso Blue) and **Pricing** (Calypso Green, logged in) pages show the overlapping product(s) more than once.
* Verify that when this PR is applied to your testing environment, no duplicate card is present and all cards still function as expected.

#### Reference screenshot

![image](https://user-images.githubusercontent.com/670067/104959542-13fa3d80-5998-11eb-96fc-d8d7bfd9a141.png)
