### PR TITLE
Site Settings: Enable Jetpack Search configuration for P2+

### DIFF
--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -38,6 +38,7 @@ import {
 	isEcommerce,
 	isJetpackSearch,
 } from 'calypso/lib/products-values';
+import { isP2Plus } from 'calypso/lib/products-values/is-p2-plus';
 import { planHasJetpackSearch } from 'calypso/lib/plans';
 import { FEATURE_SEARCH } from 'calypso/lib/plans/constants';
 import {
@@ -220,7 +221,8 @@ class Search extends Component {
 }
 
 const hasBusinessPlan = overSome( isJetpackBusiness, isBusiness, isEnterprise, isEcommerce );
-const checkForSearchProduct = ( purchase ) => purchase.active && isJetpackSearch( purchase );
+const checkForSearchProduct = ( purchase ) =>
+	purchase.active && ( isJetpackSearch( purchase ) || isP2Plus( purchase ) );
 export default connect( ( state, { isRequestingSettings } ) => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enables P2+ sites to change Jetpack Search settings via the Performance Site Settings page.

#### Testing instructions

* Navigate to `/settings/performance/` for a site with a P2+ plan.
* Ensure that Jetpack Search and Instant Search settings become toggleable.


#### Visual Changes
Before:
<img width="737" alt="Screen Shot 2021-01-18 at 1 24 33 PM" src="https://user-images.githubusercontent.com/4044428/104960129-de058b00-5990-11eb-9821-1628a3e8375d.png">


After:
<img width="737" alt="Screen Shot 2021-01-18 at 1 24 40 PM" src="https://user-images.githubusercontent.com/4044428/104960135-e1007b80-5990-11eb-8420-68c697da950e.png">
