### PR TITLE
Update sunset store support doc link

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
@@ -48,7 +48,7 @@ class StoreMoveNoticeView extends Component {
 							'We’re rolling your favorite Store features into WooCommerce in February. {{link}}Learn more{{/link}} about this streamlined, commerce-focused navigation experience, designed to help you save time and access your favorite extensions faster.',
 							{
 								components: {
-									link: <a href="https://wordpress.com/support/store/" />,
+									link: <a href="https://wordpress.com/support/?page_id=177856" />,
 								},
 							}
 						) }
@@ -57,7 +57,7 @@ class StoreMoveNoticeView extends Component {
 							'We’ve rolled your favorite Store functions into WooCommerce. {{link}}Learn more{{/link}} about how this streamlined, commerce-focused navigation experience can help you save time and access your favorite extensions faster.',
 							{
 								components: {
-									link: <a href="https://wordpress.com/support/store/" />,
+									link: <a href="https://wordpress.com/support/?page_id=177856" />,
 								},
 							}
 						) }

--- a/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
@@ -48,7 +48,9 @@ class StoreMoveNoticeView extends Component {
 							'We’re rolling your favorite Store features into WooCommerce in February. {{link}}Learn more{{/link}} about this streamlined, commerce-focused navigation experience, designed to help you save time and access your favorite extensions faster.',
 							{
 								components: {
-									link: <a href="https://wordpress.com/support/?page_id=177856" />,
+									link: (
+										<a href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/" />
+									),
 								},
 							}
 						) }
@@ -57,7 +59,9 @@ class StoreMoveNoticeView extends Component {
 							'We’ve rolled your favorite Store functions into WooCommerce. {{link}}Learn more{{/link}} about how this streamlined, commerce-focused navigation experience can help you save time and access your favorite extensions faster.',
 							{
 								components: {
-									link: <a href="https://wordpress.com/support/?page_id=177856" />,
+									link: (
+										<a href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/" />
+									),
 								},
 							}
 						) }

--- a/client/extensions/woocommerce/components/store-deprecated-notice/index.js
+++ b/client/extensions/woocommerce/components/store-deprecated-notice/index.js
@@ -22,7 +22,7 @@ class StoreDeprecatedNotice extends Component {
 				) }
 				showDismiss={ false }
 			>
-				<NoticeAction href="https://wordpress.com/support/?page_id=177856">
+				<NoticeAction href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/">
 					{ translate( 'Learn more' ) }
 				</NoticeAction>
 			</Notice>

--- a/client/extensions/woocommerce/components/store-deprecated-notice/index.js
+++ b/client/extensions/woocommerce/components/store-deprecated-notice/index.js
@@ -22,7 +22,7 @@ class StoreDeprecatedNotice extends Component {
 				) }
 				showDismiss={ false }
 			>
-				<NoticeAction href="https://wordpress.com/support/store/">
+				<NoticeAction href="https://wordpress.com/support/?page_id=177856">
 					{ translate( 'Learn more' ) }
 				</NoticeAction>
 			</Notice>

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -690,7 +690,13 @@ export class MySitesSidebar extends Component {
 			'Your favorite Store functions will become part of WooCommerce menus in February. {{link}}Learn more{{/link}}.',
 			{
 				components: {
-					link: <a href="https://wordpress.com/support/store/" rel="noreferrer" target="_blank" />,
+					link: (
+						<a
+							href="https://wordpress.com/support/?page_id=177856"
+							rel="noreferrer"
+							target="_blank"
+						/>
+					),
 				},
 			}
 		);

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -692,7 +692,7 @@ export class MySitesSidebar extends Component {
 				components: {
 					link: (
 						<a
-							href="https://wordpress.com/support/?page_id=177856"
+							href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/"
 							rel="noreferrer"
 							target="_blank"
 						/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #48981

* Update sunset store support link to https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/
#### Testing instructions

Testing `store-deprecated`
1. Start Calypso locally
2. Navigate to your store and click one of the sidebar menus.
3. You should see "Your favorite Store functions will become part of WooCommerce menus in February." notice. Confirm the "Learn more" link is https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/

Testing `store-removed`
1. Start Calypso locally
2. Navigate to your store dashboard
3. Check "learn more" link is linked to https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/