### PR TITLE
Store|Woo: Enable Store deprecation in production

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -347,7 +347,7 @@ export const TYPE_SECURITY_REALTIME = 'TYPE_SECURITY_REALTIME';
 export const TYPE_ALL = 'TYPE_ALL';
 export const TYPE_P2_PLUS = 'TYPE_P2_PLUS';
 
-export const STORE_DEPRECATION_START_DATE = new Date( '2021-01-15T16:00:00+00:00' );
+export const STORE_DEPRECATION_START_DATE = new Date( '2021-01-19T19:30:00+00:00' );
 
 export function isMonthly( plan ) {
 	return WPCOM_MONTHLY_PLANS.includes( plan ) || JETPACK_MONTHLY_PLANS.includes( plan );

--- a/config/production.json
+++ b/config/production.json
@@ -168,7 +168,7 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
-		"woocommerce/store-deprecated": false,
+		"woocommerce/store-deprecated": true,
 		"woocommerce/store-removed": false,
 		"wpcom-user-bootstrap": true
 	},


### PR DESCRIPTION
** DO NOT MERGE THIS, UNLESS YOU ARE ON MOTHRA, AS YOU WILL BE LAUNCHING TO PRODUCTION! **

Part of the "Sunset Store on WordPress.com" epic (https://github.com/woocommerce/woocommerce-admin/issues/5816) -- see that for more context.

#### Changes proposed in this Pull Request

* The `woocommerce/store-deprecated` feature flag has been enabled in `production`, launching it to customers
* The `STORE_DEPRECATION_START_DATE` has been updated to a timestamp that is a little bit before this PR was created, which will allow for sites with Business plan subscriptions added before the deprecation started to continue using the deprecated Store for now

#### Testing instructions

Make sure that feature flag enabling looks okay.

Partially addresses #48939
