### PR TITLE
Fix: Coerce `unseen_count` in subscriptions to number to avoid display glitch.

### DIFF
--- a/client/reader/sidebar/reader-sidebar-followed-sites/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-followed-sites/index.jsx
@@ -41,11 +41,7 @@ export class ReaderSidebarFollowedSites extends Component {
 
 	renderAll() {
 		const { path, translate, sites } = this.props;
-		// have a selector
-		const sum = sites.reduce( ( acc, item ) => {
-			acc = acc + item.unseen_count;
-			return acc;
-		}, 0 );
+		const sum = sites.reduce( ( acc, { unseen_count } ) => acc + ( unseen_count | 0 ), 0 );
 		return (
 			<SidebarItem
 				className={ ReaderSidebarHelper.itemLinkClass( '/read', path, {


### PR DESCRIPTION
Type error strikes again. A subscription from `/read/following/mine` returned
a string value of "0", which when used in `ReaderSidebarFollowedSites` was
showing a value of "4.6000000002e+42K" unseen posts. The devtools showed a type
error for the `<Count>` component, expecting number but getting a string.

By coercing the value to a number with `| 0` this properly turns into a count
that can be displayed. The API work should be examined to fix the type error.

![Screen Shot 2021-01-18 at 7 29 10 PM](https://user-images.githubusercontent.com/5431237/104983497-1d9c9900-59ca-11eb-91a4-c62cbe2a7b48.png)