### PR TITLE
Starter page templates: Prevent links and buttons from being clicked within the layout preview

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -170,6 +170,13 @@ const BlockFramePreview = ( {
 			 */
 			iframeRef.current.contentDocument.head.innerHTML +=
 				'<style>.editor-post-title .editor-post-title__input { height: auto !important; }</style>';
+
+			// Prevent links and buttons from being clicked. This is applied within
+			// the iframe, because if we targeted the iframe itself it would prevent
+			// scrolling the iframe in Firefox.
+			iframeRef.current.contentDocument.head.innerHTML +=
+				'<style>a, button { pointer-events: none; }</style>';
+
 			rescale();
 		}, 0 );
 	}, [ setTimeout, bodyClassName, rescale ] );

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -175,7 +175,7 @@ const BlockFramePreview = ( {
 			// the iframe, because if we targeted the iframe itself it would prevent
 			// scrolling the iframe in Firefox.
 			iframeRef.current.contentDocument.head.innerHTML +=
-				'<style>a, button { pointer-events: none; }</style>';
+				'<style>a, button, .wp-block-button, .wp-block-button__link { pointer-events: none; cursor: default; }</style>';
 
 			rescale();
 		}, 0 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Pass in `pointer-events: none` to links and buttons in the iframe preview used by the starter page templates (the page layout picker when you got to add a new page)

#### Screenshot

This is a quick demo in Chrome of selecting page layouts and attempting to click the featured blog post. Note that the clicks do not do anything, and we avoid the layoutception reported in #49020.

![page-layout-picker-disarm-links](https://user-images.githubusercontent.com/14988353/104994378-6dd23480-5a78-11eb-9250-8a78f79f4fed.gif)
 
#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox the diff associated with this PR and your test site
* Go to add a new page
* Select the Blog layout that has the picture of the pancakes
* Attempt to click on the main link to the featured post: the link should not work
* Test on Firefox and make sure that the preview iframe can still be scrolled with the mouse

Fixes #49020
