### PR TITLE
Should enable mark as seen only if feed is followed

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -27,6 +27,7 @@ import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions'
 import { getReaderTeams } from 'calypso/state/reader/teams/selectors';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
+import { isFollowing } from 'calypso/state/reader/follows/selectors';
 
 /**
  * Style dependencies
@@ -45,6 +46,9 @@ class ReaderCombinedCardComponent extends React.Component {
 		showFollowButton: PropTypes.bool,
 		followSource: PropTypes.string,
 		blockedSites: PropTypes.array,
+		teams: PropTypes.array,
+		isFollowingItem: PropTypes.bool,
+		isWPForTeamsItem: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -89,6 +93,9 @@ class ReaderCombinedCardComponent extends React.Component {
 			isDiscover,
 			blockedSites,
 			translate,
+			teams,
+			isFollowingItem,
+			isWPForTeamsItem,
 		} = this.props;
 		const feedId = postKey.feedId;
 		const siteId = postKey.blogId;
@@ -148,6 +155,9 @@ class ReaderCombinedCardComponent extends React.Component {
 							isDiscover={ isDiscover }
 							isSelected={ isSelectedPost( post ) }
 							showFeaturedAsset={ mediaCount > 0 }
+							teams={ teams }
+							isFollowingItem={ isFollowingItem }
+							isWPForTeamsItem={ isWPForTeamsItem }
 						/>
 					) ) }
 				</ul>
@@ -206,7 +216,11 @@ function mapStateToProps( st, ownProps ) {
 		const postKeys = combinedCardPostKeyToKeys( ownProps.postKey, memoized );
 
 		return {
-			isWPForTeams:
+			isFollowingItem: isFollowing( state, {
+				blogId: ownProps.postKey.blogId,
+				feedId: ownProps.postKey.feedId,
+			} ),
+			isWPForTeamsItem:
 				isFeedWPForTeams( state, ownProps.postKey.feedId ) ||
 				isSiteWPForTeams( state, ownProps.postKey.blogId ),
 			teams: getReaderTeams( state ),

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -28,7 +28,8 @@ import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
 
 class ReaderCombinedCardPost extends React.Component {
 	static propTypes = {
-		isWPForTeams: PropTypes.bool,
+		isFollowingItem: PropTypes.bool,
+		isWPForTeamsItem: PropTypes.bool,
 		teams: PropTypes.array,
 		post: PropTypes.object,
 		streamUrl: PropTypes.string,
@@ -80,7 +81,16 @@ class ReaderCombinedCardPost extends React.Component {
 	};
 
 	render() {
-		const { post, streamUrl, isDiscover, isSelected, postKey, teams, isWPForTeams } = this.props;
+		const {
+			post,
+			streamUrl,
+			isDiscover,
+			isSelected,
+			postKey,
+			teams,
+			isFollowingItem,
+			isWPForTeamsItem,
+		} = this.props;
 		const isLoading = ! post || post._state === 'pending' || post._state === 'minimal';
 
 		if ( isLoading ) {
@@ -116,7 +126,8 @@ class ReaderCombinedCardPost extends React.Component {
 			recordPermalinkClick( 'timestamp_combined_card', post );
 		};
 
-		const isSeen = isEligibleForUnseen( teams, isWPForTeams ) && !! post.is_seen;
+		const isSeen =
+			isEligibleForUnseen( { teams, isFollowingItem, isWPForTeamsItem } ) && !! post.is_seen;
 		const classes = classnames( {
 			'reader-combined-card__post': true,
 			'is-selected': isSelected,

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -46,6 +46,9 @@ class FeedHeader extends Component {
 		feed: PropTypes.object,
 		showBack: PropTypes.bool,
 		streamKey: PropTypes.string,
+		isFollowingItem: PropTypes.bool,
+		isWPForTeamsItem: PropTypes.bool,
+		teams: PropTypes.array,
 	};
 
 	getFollowerCount = ( feed, site ) => {
@@ -79,7 +82,8 @@ class FeedHeader extends Component {
 			following,
 			isEmailBlocked,
 			teams,
-			isWPForTeams,
+			isFollowingItem,
+			isWPForTeamsItem,
 		} = this.props;
 		const followerCount = this.getFollowerCount( feed, site );
 		const ownerDisplayName = site && ! site.is_multi_author && site.owner && site.owner.name;
@@ -123,7 +127,7 @@ class FeedHeader extends Component {
 								</div>
 							) }
 
-							{ isEligibleForUnseen( teams, isWPForTeams ) && feed && (
+							{ isEligibleForUnseen( { teams, isFollowingItem, isWPForTeamsItem } ) && feed && (
 								<button
 									onClick={ this.markAllAsSeen }
 									className="reader-feed-header__seen-button"
@@ -173,7 +177,11 @@ class FeedHeader extends Component {
 
 export default connect(
 	( state, ownProps ) => ( {
-		isWPForTeams:
+		isFollowingItem: isFollowing( state, {
+			blogId: ownProps.site && ownProps.site.ID,
+			feedId: ownProps.feed && ownProps.feed.feed_ID,
+		} ),
+		isWPForTeamsItem:
 			isSiteWPForTeams( state, ownProps.site && ownProps.site.ID ) ||
 			isFeedWPForTeams( state, ownProps.feed && ownProps.feed.feed_ID ),
 		teams: getReaderTeams( state ),

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -88,6 +88,7 @@ import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
  * Style dependencies
  */
 import './style.scss';
+import { isFollowing } from 'calypso/state/reader/follows/selectors';
 
 export class FullPostView extends React.Component {
 	static propTypes = {
@@ -95,6 +96,9 @@ export class FullPostView extends React.Component {
 		onClose: PropTypes.func.isRequired,
 		referralPost: PropTypes.object,
 		referralStream: PropTypes.string,
+		isFollowingItem: PropTypes.bool,
+		isWPForTeamsItem: PropTypes.bool,
+		teams: PropTypes.array,
 	};
 
 	hasScrolledToCommentAnchor = false;
@@ -259,7 +263,7 @@ export class FullPostView extends React.Component {
 	};
 
 	attemptToSendPageView = () => {
-		const { post, site, teams, isWPForTeams } = this.props;
+		const { post, site, teams, isWPForTeamsItem, isFollowingItem } = this.props;
 
 		if (
 			post &&
@@ -277,7 +281,7 @@ export class FullPostView extends React.Component {
 		}
 
 		if ( ! this.hasLoaded && post && post._state !== 'pending' ) {
-			if ( isEligibleForUnseen( teams, isWPForTeams ) ) {
+			if ( isEligibleForUnseen( { teams, isFollowingItem, isWPForTeamsItem } ) ) {
 				this.markAsSeen();
 			}
 
@@ -378,7 +382,8 @@ export class FullPostView extends React.Component {
 			feedId,
 			postId,
 			teams,
-			isWPForTeams,
+			isWPForTeamsItem,
+			isFollowingItem,
 		} = this.props;
 
 		if ( post.is_error ) {
@@ -479,7 +484,8 @@ export class FullPostView extends React.Component {
 								/>
 							) }
 
-							{ isEligibleForUnseen( teams, isWPForTeams ) && this.renderMarkAsSenButton() }
+							{ isEligibleForUnseen( { teams, isFollowingItem, isWPForTeamsItem } ) &&
+								this.renderMarkAsSenButton() }
 						</div>
 					</div>
 					<Emojify>
@@ -592,7 +598,8 @@ export default connect(
 		const { site_ID: siteId, is_external: isExternal } = post;
 
 		const props = {
-			isWPForTeams: isSiteWPForTeams( state, blogId ) || isFeedWPForTeams( state, feedId ),
+			isFollowingItem: isFollowing( state, { blogId, feedId } ),
+			isWPForTeamsItem: isSiteWPForTeams( state, blogId ) || isFeedWPForTeams( state, feedId ),
 			teams: getReaderTeams( state ),
 			post,
 			liked: isLikedPost( state, siteId, post.ID ),

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -83,12 +83,12 @@ import { getReaderTeams } from 'calypso/state/reader/teams/selectors';
 import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
+import { isFollowing } from 'calypso/state/reader/follows/selectors';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-import { isFollowing } from 'calypso/state/reader/follows/selectors';
 
 export class FullPostView extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -40,6 +40,7 @@ import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import { getReaderTeams } from 'calypso/state/reader/teams/selectors';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
+import { isFollowing } from 'calypso/state/reader/follows/selectors';
 
 class ReaderPostCard extends React.Component {
 	static propTypes = {
@@ -57,6 +58,9 @@ class ReaderPostCard extends React.Component {
 		isDiscoverStream: PropTypes.bool,
 		postKey: PropTypes.object,
 		compact: PropTypes.bool,
+		isFollowingItem: PropTypes.bool,
+		isWPForTeamsItem: PropTypes.bool,
+		teams: PropTypes.array,
 	};
 
 	static defaultProps = {
@@ -134,10 +138,12 @@ class ReaderPostCard extends React.Component {
 			expandCard,
 			compact,
 			teams,
-			isWPForTeams,
+			isWPForTeamsItem,
+			isFollowingItem,
 		} = this.props;
 
-		const isSeen = isEligibleForUnseen( teams, isWPForTeams ) && !! post.is_seen;
+		const isSeen =
+			isEligibleForUnseen( { teams, isFollowingItem, isWPForTeamsItem } ) && !! post.is_seen;
 		const isPhotoPost = !! ( post.display_type & DisplayTypes.PHOTO_ONLY ) && ! compact;
 		const isGalleryPost = !! ( post.display_type & DisplayTypes.GALLERY ) && ! compact;
 		const isVideo = !! ( post.display_type & DisplayTypes.FEATURED_VIDEO ) && ! compact;
@@ -284,7 +290,11 @@ class ReaderPostCard extends React.Component {
 
 export default connect(
 	( state, ownProps ) => ( {
-		isWPForTeams:
+		isFollowingItem: isFollowing( state, {
+			blogId: ownProps.postKey.blogId,
+			feedId: ownProps.postKey.feedId,
+		} ),
+		isWPForTeamsItem:
 			isSiteWPForTeams( state, ownProps.postKey.blogId ) ||
 			isFeedWPForTeams( state, ownProps.postKey.feedId ),
 		teams: getReaderTeams( state ),

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -40,12 +40,12 @@ import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions'
 import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
+import { isFollowing } from 'calypso/state/reader/follows/selectors';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-import { isFollowing } from 'calypso/state/reader/follows/selectors';
 
 class ReaderPostOptionsMenu extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -45,6 +45,7 @@ import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
  * Style dependencies
  */
 import './style.scss';
+import { isFollowing } from 'calypso/state/reader/follows/selectors';
 
 class ReaderPostOptionsMenu extends React.Component {
 	static propTypes = {
@@ -59,6 +60,9 @@ class ReaderPostOptionsMenu extends React.Component {
 		showReportSite: PropTypes.bool,
 		position: PropTypes.string,
 		posts: PropTypes.array,
+		isWPForTeamsItem: PropTypes.bool,
+		isFollowingItem: PropTypes.bool,
+		teams: PropTypes.array,
 	};
 
 	static defaultProps = {
@@ -247,7 +251,17 @@ class ReaderPostOptionsMenu extends React.Component {
 	};
 
 	render() {
-		const { post, site, feed, teams, translate, position, posts, isWPForTeams } = this.props;
+		const {
+			post,
+			site,
+			feed,
+			teams,
+			translate,
+			position,
+			posts,
+			isWPForTeamsItem,
+			isFollowingItem,
+		} = this.props;
 
 		if ( ! post ) {
 			return null;
@@ -309,14 +323,14 @@ class ReaderPostOptionsMenu extends React.Component {
 						/>
 					) }
 
-					{ isEligibleForUnseen( teams, isWPForTeams ) && post.is_seen && (
+					{ isEligibleForUnseen( { teams, isFollowingItem, isWPForTeamsItem } ) && post.is_seen && (
 						<PopoverMenuItem onClick={ this.markAsUnSeen } icon="not-visible" itemComponent={ 'a' }>
 							{ size( posts ) > 0 && translate( 'Mark all as unseen' ) }
 							{ size( posts ) === 0 && translate( 'Mark as unseen' ) }
 						</PopoverMenuItem>
 					) }
 
-					{ isEligibleForUnseen( teams, isWPForTeams ) && ! post.is_seen && (
+					{ isEligibleForUnseen( { teams, isFollowingItem, isWPForTeamsItem } ) && ! post.is_seen && (
 						<PopoverMenuItem onClick={ this.markAsSeen } icon="visible">
 							{ size( posts ) > 0 && translate( 'Mark all as seen' ) }
 							{ size( posts ) === 0 && translate( 'Mark as seen' ) }
@@ -368,7 +382,8 @@ export default connect(
 		const siteId = is_external ? null : site_ID;
 
 		return Object.assign(
-			{ isWPForTeams: isSiteWPForTeams( state, siteId ) || isFeedWPForTeams( state, feedId ) },
+			{ isFollowingItem: isFollowing( state, { blogId: siteId, feedId } ) },
+			{ isWPForTeamsItem: isSiteWPForTeams( state, siteId ) || isFeedWPForTeams( state, feedId ) },
 			{ teams: getReaderTeams( state ) },
 			feedId > 0 && { feed: getFeed( state, feedId ) },
 			siteId > 0 && { site: getSite( state, siteId ) }

--- a/client/reader/a8c/main.jsx
+++ b/client/reader/a8c/main.jsx
@@ -32,7 +32,7 @@ const A8CFollowing = ( props ) => {
 	return (
 		<Stream { ...props } shouldCombineCards={ false }>
 			<SectionHeader label={ translate( 'Followed A8C Sites' ) }>
-				{ isEligibleForUnseen( teams ) && (
+				{ isEligibleForUnseen( { teams, isFollowingItem: true } ) && (
 					<Button
 						compact
 						onClick={ () => markAllAsSeen( props.feedsInfo ) }

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -72,7 +72,7 @@ const FollowingStream = ( props ) => {
 			</CompactCard>
 			<BlankSuggestions suggestions={ suggestionList } />
 			<SectionHeader label={ translate( 'Followed Sites' ) }>
-				{ isEligibleForUnseen( teams ) && (
+				{ isEligibleForUnseen( { teams, isFollowingItem: true } ) && (
 					<Button
 						compact
 						onClick={ () => markAllAsSeen( props.feedsInfo ) }

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -98,21 +98,29 @@ export const getSiteAuthorName = ( site ) => {
 /**
  * Check if user is eligible to use seen posts feature (unseen counts and mark as seen)
  *
- * @param {Array} teams list of reader teams
- * @param {boolean} isWPForTeams id if exists
+ * @param {object} flags eligibility data
+ * @param {Array} flags.teams list of reader teams
+ * @param {boolean} flags.isFollowingItem wether or not is following a blog id
+ * @param {boolean} flags.isWPForTeamsItem id if exists
  *
  * @returns {boolean} whether or not the user can use the feature for the given site
  */
-export const isEligibleForUnseen = ( teams, isWPForTeams = false ) => {
+export const isEligibleForUnseen = ( {
+	teams,
+	isFollowingItem = false,
+	isWPForTeamsItem = false,
+} ) => {
 	if ( ! config.isEnabled( 'reader/seen-posts' ) ) {
+		return false;
+	}
+
+	if ( ! isFollowingItem ) {
 		return false;
 	}
 
 	if ( isAutomatticTeamMember( teams ) ) {
 		return true;
-	} else if ( isWPForTeams ) {
-		return true;
 	}
 
-	return false;
+	return isWPForTeamsItem;
 };

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -25,6 +25,7 @@ import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import { getReaderTeams } from 'calypso/state/reader/teams/selectors';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
+import { isFollowing } from 'calypso/state/reader/follows/selectors';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 class CrossPost extends PureComponent {
@@ -38,6 +39,9 @@ class CrossPost extends PureComponent {
 		postKey: PropTypes.object,
 		site: PropTypes.object,
 		feed: PropTypes.object,
+		isFollowingItem: PropTypes.bool,
+		isWPForTeamsItem: PropTypes.bool,
+		teams: PropTypes.array,
 	};
 
 	handleTitleClick = ( event ) => {
@@ -165,12 +169,22 @@ class CrossPost extends PureComponent {
 	};
 
 	render() {
-		const { post, postKey, site, feed, translate, teams, isWPForTeams } = this.props;
+		const {
+			post,
+			postKey,
+			site,
+			feed,
+			translate,
+			teams,
+			isWPForTeamsItem,
+			isFollowingItem,
+		} = this.props;
 		const { blogId: siteId, feedId } = postKey;
 		const siteIcon = get( site, 'icon.img' );
 		const feedIcon = get( feed, 'image' );
 
-		const isSeen = isEligibleForUnseen( teams, isWPForTeams ) && !! post.is_seen;
+		const isSeen =
+			isEligibleForUnseen( { teams, isFollowingItem, isWPForTeamsItem } ) && !! post.is_seen;
 		const articleClasses = classnames( {
 			reader__card: true,
 			'is-x-post': true,
@@ -232,7 +246,8 @@ export default connect( ( state, ownProps ) => {
 		feed = site && site.feed_ID ? getFeed( state, site.feed_ID ) : undefined;
 	}
 	return {
-		isWPForTeams: isSiteWPForTeams( state, blogId ) || isFeedWPForTeams( state, feedId ),
+		isFollowingItem: isFollowing( state, { feedId, blogId } ),
+		isWPForTeamsItem: isSiteWPForTeams( state, blogId ) || isFeedWPForTeams( state, feedId ),
 		teams: getReaderTeams( state ),
 		feed,
 		site,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Check if feed is followed when showing "Mark as seen" buttons, context: p1611017256098300-slack-C010KDAPG49

#### Testing instructions
- When using Reader search or tags, only posts from feed you follow should have the mark as seen option
- Mark as seen works for a12s on all their sites
- Mark as seen is visible for regular users only for P2 sites