### PR TITLE
Notices: Refactor away from and remove notices.getStatusHelper

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -40,7 +40,6 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormButton from 'calypso/components/forms/form-button';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import notices from 'calypso/notices';
 import Notice from 'calypso/components/notice';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import { login } from 'calypso/lib/paths';
@@ -443,12 +442,12 @@ class SignupForm extends Component {
 		return notice.message;
 	}
 
-	globalNotice( notice ) {
+	globalNotice( notice, status ) {
 		return (
 			<Notice
 				className="signup-form__notice"
 				showDismiss={ false }
-				status={ notices.getStatusHelper( notice ) }
+				status={ status }
 				text={ this.getNoticeMessageWithLogin( notice ) }
 			/>
 		);
@@ -771,17 +770,20 @@ class SignupForm extends Component {
 
 	getNotice() {
 		if ( this.props.step && 'invalid' === this.props.step.status ) {
-			return this.globalNotice( this.props.step.errors[ 0 ] );
+			return this.globalNotice( this.props.step.errors[ 0 ], 'is-error' );
 		}
 		if ( this.userCreationComplete() ) {
 			return (
 				<TrackRender eventName="calypso_signup_account_already_created_show">
-					{ this.globalNotice( {
-						info: true,
-						message: this.props.translate(
-							'Your account has already been created. You can change your email, username, and password later.'
-						),
-					} ) }
+					{ this.globalNotice(
+						{
+							info: true,
+							message: this.props.translate(
+								'Your account has already been created. You can change your email, username, and password later.'
+							),
+						},
+						'is-info'
+					) }
 				</TrackRender>
 			);
 		}

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -122,7 +122,6 @@ class SignupForm extends Component {
 	};
 
 	state = {
-		notice: null,
 		submitting: false,
 		focusPassword: false,
 		focusUsername: false,
@@ -331,8 +330,6 @@ class SignupForm extends Component {
 	handleChangeEvent = ( event ) => {
 		const name = event.target.name;
 		const value = event.target.value;
-
-		this.setState( { notice: null } );
 
 		this.formStateController.handleFieldChange( {
 			name: name,
@@ -670,7 +667,6 @@ class SignupForm extends Component {
 					value={ formState.getFieldValue( this.state.form, 'email' ) }
 					onBlur={ this.handleBlur }
 					onChange={ ( value ) => {
-						this.setState( { notice: null } );
 						this.formStateController.handleFieldChange( {
 							name: 'email',
 							value,
@@ -693,7 +689,6 @@ class SignupForm extends Component {
 							value={ formState.getFieldValue( this.state.form, 'username' ) }
 							onBlur={ this.handleBlur }
 							onChange={ ( value ) => {
-								this.setState( { notice: null } );
 								this.formStateController.handleFieldChange( {
 									name: 'username',
 									value,
@@ -777,9 +772,6 @@ class SignupForm extends Component {
 	getNotice() {
 		if ( this.props.step && 'invalid' === this.props.step.status ) {
 			return this.globalNotice( this.props.step.errors[ 0 ] );
-		}
-		if ( this.state.notice ) {
-			return this.globalNotice( this.state.notice );
 		}
 		if ( this.userCreationComplete() ) {
 			return (

--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -18,7 +18,6 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
-import notices from 'calypso/notices';
 import {
 	domainManagementSiteRedirect,
 	domainManagementRedirectSettings,
@@ -109,6 +108,16 @@ class SiteRedirect extends React.Component {
 		this.props.recordLocationFocus( this.props.selectedDomainName );
 	};
 
+	getNoticeStatus( notice ) {
+		if ( notice?.error ) {
+			return 'is-error';
+		}
+		if ( notice?.success ) {
+			return 'is-success';
+		}
+		return 'is-info';
+	}
+
 	render() {
 		const { location, translate } = this.props;
 		const { isUpdating, notice } = location;
@@ -126,7 +135,7 @@ class SiteRedirect extends React.Component {
 					{ notice && (
 						<Notice
 							onDismissClick={ this.closeRedirectNotice }
-							status={ notices.getStatusHelper( notice ) }
+							status={ this.getNoticeStatus( notice ) }
 							text={ notice.text }
 						/>
 					) }

--- a/client/notices/index.js
+++ b/client/notices/index.js
@@ -205,24 +205,6 @@ const notices = {
 		list[ container ] = [];
 		list.emit( 'change' );
 	},
-
-	getStatusHelper: function ( noticeObject ) {
-		if ( noticeObject.error ) {
-			return 'is-error';
-		}
-
-		if ( noticeObject.warning ) {
-			return 'is-warning';
-		}
-
-		if ( noticeObject.info ) {
-			return 'is-info';
-		}
-
-		if ( noticeObject.success ) {
-			return 'is-success';
-		}
-	},
 };
 
 export default notices;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes any usages of `notices.getStatusHelper` and removes that method altogether as part of the notices reduxification effort.

We refactor the 2 remaining usages of `notices.getStatusHelper`:

* `SignupForm`:
  *  Remove the unnecessary `notice` component state because it's not used at all.
  * Pass the notice status manually to the local `globalNotice()` method.
* `SiteRedirect`:
  * Move the notice status logic inline

And afterwards, when `notices.getStatusHelper` is not used anymore, we're removing it.

Part of #48408.

#### Testing instructions

* Creating an account should still work well. Most of the relevant changes to `SignupForm` were introduced in #36441. Could I ask for a review and test @p-jackson?
* Successful and unsuccessful save of a redirect should still yield the relevant notices like it did before, could I ask for a review someone from @Automattic/cobalt? 


