### PR TITLE
Plugins: Remove notices clearing

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -9,7 +9,6 @@ import { includes, some } from 'lodash';
  * Internal Dependencies
  */
 import { getSiteFragment, sectionify } from 'calypso/lib/route';
-import notices from 'calypso/notices';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import PlanSetup from './jetpack-plugins-setup';
 import PluginEligibility from './plugin-eligibility';
@@ -125,15 +124,12 @@ export function plugins( context, next ) {
 	const basePath = sectionify( context.path ).replace( '/' + filter, '' );
 
 	context.params.pluginFilter = filter;
-	notices.clearNotices( 'notices' );
 	renderPluginList( context, basePath );
 	next();
 }
 
 function plugin( context, next ) {
 	const siteUrl = getSiteFragment( context.path );
-
-	notices.clearNotices( 'notices' );
 	renderSinglePlugin( context, siteUrl );
 	next();
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the unnecessary clearing of notices when the user lands on the plugins or single plugin screens. The initial reason for implementing those is no longer there: 1606-gh-Automattic/calypso-pre-oss. Furthermore, the notices are being cleared on the `ROUTE_SET` action anyway, so removing them manually when the route is changed is not necessary anymore. 

Part of #48408.

#### Testing instructions

* Go to `/marketing/tools/:site` where `:site` is a Jetpack site.
* Type `dispatch( { type: 'NOTICE_CREATE', notice: { status: 'is-error', text: 'An error occurred while accepting the domain transfer.' } } )` in the browser console.
* Click "Plugins" in the sidebar navigation and verify notice still disappears like it did before.
