### PR TITLE
Domains: Reduxify ICANN verification notices

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-out/icann-verification.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/icann-verification.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -10,8 +10,8 @@ import { localize } from 'i18n-calypso';
  */
 import { Card, Button } from '@automattic/components';
 import { resendIcannVerification } from 'calypso/lib/domains';
-import notices from 'calypso/notices';
 import { TRANSFER_DOMAIN_REGISTRATION } from 'calypso/lib/url/support';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 class IcannVerification extends React.Component {
 	state = {
@@ -23,9 +23,9 @@ class IcannVerification extends React.Component {
 
 		resendIcannVerification( this.props.selectedDomainName, ( error ) => {
 			if ( error ) {
-				notices.error( error.message );
+				this.props.errorNotice( error.message );
 			} else {
-				notices.success(
+				this.props.successNotice(
 					this.props.translate(
 						'We sent the ICANN verification email to your ' +
 							'email address. Please check your inbox and click the link in the email.'
@@ -74,4 +74,7 @@ class IcannVerification extends React.Component {
 	}
 }
 
-export default localize( IcannVerification );
+export default connect( null, {
+	errorNotice,
+	successNotice,
+} )( localize( IcannVerification ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reduxifies notices in the ICANN verification screen.

Part of #48408.

#### Testing instructions

* Purchase a domain (or use one) with a user with an unverified email.
* Attempt to transfer the domain to another registrar.
* You'll see a card with a "You must verify your email address before you can transfer this domain" message.
* Click the "Resend Verification Email" button. 
* Verify you get a success notice in a bit.
* Disable network connection or make `wpcom.undocumented().resendIcannVerification` throw an error.
* Verify you still get an error notice. 