### PR TITLE
Plans: Make most copy for 'simplify pricing page' test the same as i5

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -281,7 +281,6 @@ export const FEATURE_PRODUCT_SCAN_V2_NO_SLIDEOUT = 'product-scan-v2-no-slideout'
 export const FEATURE_PRODUCT_SCAN_DAILY_V2 = 'product-scan-daily-v2';
 export const FEATURE_PRODUCT_SCAN_REALTIME_V2 = 'product-scan-realtime-v2';
 export const FEATURE_ANTISPAM_V2 = 'antispam-v2';
-export const FEATURE_AUTOMATED_SPAM_PROTECTION_V2 = 'automated-spam-protection-v2';
 export const FEATURE_PRODUCT_ANTISPAM_V2 = 'product-antispam-v2';
 export const FEATURE_ACTIVITY_LOG_V2 = 'activity-log-v2';
 export const FEATURE_ACTIVITY_LOG_1_YEAR_V2 = 'activity-log-1-year-v2';

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1269,11 +1269,6 @@ export const FEATURES_LIST = {
 			}[ getJetpackCROActiveVersion() ] || i18n.translate( 'Automated spam protection' ) ),
 	},
 
-	[ constants.FEATURE_AUTOMATED_SPAM_PROTECTION_V2 ]: {
-		getSlug: () => constants.FEATURE_AUTOMATED_SPAM_PROTECTION_V2,
-		getTitle: () => i18n.translate( 'Automated spam protection' ),
-	},
-
 	[ constants.FEATURE_PRODUCT_ANTISPAM_V2 ]: {
 		getSlug: () => constants.FEATURE_PRODUCT_ANTISPAM_V2,
 		getIcon: () => 'bug',
@@ -1392,7 +1387,6 @@ export const FEATURES_LIST = {
 						strong: <strong />,
 					},
 				} ),
-				spp: i18n.translate( 'CRM: Entrepreneur' ),
 			}[ getJetpackCROActiveVersion() ] || i18n.translate( 'CRM: Entrepreneur bundle' ) ),
 		getDescription: () =>
 			i18n.translate(

--- a/client/lib/products-values/products-list.ts
+++ b/client/lib/products-values/products-list.ts
@@ -24,7 +24,6 @@ import {
 	FEATURE_INSTANT_EMAIL_V2,
 	FEATURE_SEARCH_V2,
 	FEATURE_ANTISPAM_V2,
-	FEATURE_AUTOMATED_SPAM_PROTECTION_V2,
 	FEATURE_AKISMET_V2,
 	FEATURE_SPAM_BLOCK_V2,
 	FEATURE_ADVANCED_STATS_V2,
@@ -109,15 +108,12 @@ export const JETPACK_PRODUCTS_LIST: Record< JetpackProductSlug, Product > = {
 		type: constants.PRODUCT_JETPACK_SCAN,
 		term: TERM_ANNUALLY,
 		bill_period: PLAN_ANNUAL_PERIOD,
-		getFeatures: ( variant: string ): string[] =>
-			( {
-				spp: [ FEATURE_SCAN_V2, FEATURE_ONE_CLICK_FIX_V2, FEATURE_INSTANT_EMAIL_V2 ],
-			}[ variant ] || [
-				FEATURE_SCAN_V2,
-				FEATURE_ONE_CLICK_FIX_V2,
-				FEATURE_INSTANT_EMAIL_V2,
-				FEATURE_PRIORITY_SUPPORT_V2,
-			] ),
+		getFeatures: (): string[] => [
+			FEATURE_SCAN_V2,
+			FEATURE_ONE_CLICK_FIX_V2,
+			FEATURE_INSTANT_EMAIL_V2,
+			FEATURE_PRIORITY_SUPPORT_V2,
+		],
 	},
 	[ constants.PRODUCT_JETPACK_SCAN_MONTHLY ]: {
 		product_name: PRODUCT_SHORT_NAMES[ constants.PRODUCT_JETPACK_SCAN_MONTHLY ],
@@ -125,15 +121,12 @@ export const JETPACK_PRODUCTS_LIST: Record< JetpackProductSlug, Product > = {
 		type: constants.PRODUCT_JETPACK_SCAN,
 		term: TERM_MONTHLY,
 		bill_period: PLAN_MONTHLY_PERIOD,
-		getFeatures: ( variant: string ): string[] =>
-			( {
-				spp: [ FEATURE_SCAN_V2, FEATURE_ONE_CLICK_FIX_V2, FEATURE_INSTANT_EMAIL_V2 ],
-			}[ variant ] || [
-				FEATURE_SCAN_V2,
-				FEATURE_ONE_CLICK_FIX_V2,
-				FEATURE_INSTANT_EMAIL_V2,
-				FEATURE_PRIORITY_SUPPORT_V2,
-			] ),
+		getFeatures: (): string[] => [
+			FEATURE_SCAN_V2,
+			FEATURE_ONE_CLICK_FIX_V2,
+			FEATURE_INSTANT_EMAIL_V2,
+			FEATURE_PRIORITY_SUPPORT_V2,
+		],
 	},
 	[ constants.PRODUCT_JETPACK_SEARCH ]: {
 		product_name: PRODUCT_SHORT_NAMES[ constants.PRODUCT_JETPACK_SEARCH ],
@@ -141,16 +134,13 @@ export const JETPACK_PRODUCTS_LIST: Record< JetpackProductSlug, Product > = {
 		type: constants.PRODUCT_JETPACK_SEARCH,
 		term: TERM_ANNUALLY,
 		bill_period: PLAN_ANNUAL_PERIOD,
-		getFeatures: ( variant: string ): string[] =>
-			( {
-				spp: [ FEATURE_SEARCH_V2, FEATURE_FILTERING_V2, FEATURE_LANGUAGE_SUPPORT_V2 ],
-			}[ variant ] || [
-				FEATURE_SEARCH_V2,
-				FEATURE_FILTERING_V2,
-				FEATURE_LANGUAGE_SUPPORT_V2,
-				FEATURE_SPELLING_CORRECTION_V2,
-				FEATURE_PRIORITY_SUPPORT_V2,
-			] ),
+		getFeatures: (): string[] => [
+			FEATURE_SEARCH_V2,
+			FEATURE_FILTERING_V2,
+			FEATURE_LANGUAGE_SUPPORT_V2,
+			FEATURE_SPELLING_CORRECTION_V2,
+			FEATURE_PRIORITY_SUPPORT_V2,
+		],
 	},
 	[ constants.PRODUCT_JETPACK_SEARCH_MONTHLY ]: {
 		product_name: PRODUCT_SHORT_NAMES[ constants.PRODUCT_JETPACK_SEARCH_MONTHLY ],
@@ -158,16 +148,13 @@ export const JETPACK_PRODUCTS_LIST: Record< JetpackProductSlug, Product > = {
 		type: constants.PRODUCT_JETPACK_SEARCH,
 		term: TERM_MONTHLY,
 		bill_period: PLAN_MONTHLY_PERIOD,
-		getFeatures: ( variant: string ): string[] =>
-			( {
-				spp: [ FEATURE_SEARCH_V2, FEATURE_FILTERING_V2, FEATURE_LANGUAGE_SUPPORT_V2 ],
-			}[ variant ] || [
-				FEATURE_SEARCH_V2,
-				FEATURE_FILTERING_V2,
-				FEATURE_LANGUAGE_SUPPORT_V2,
-				FEATURE_SPELLING_CORRECTION_V2,
-				FEATURE_PRIORITY_SUPPORT_V2,
-			] ),
+		getFeatures: (): string[] => [
+			FEATURE_SEARCH_V2,
+			FEATURE_FILTERING_V2,
+			FEATURE_LANGUAGE_SUPPORT_V2,
+			FEATURE_SPELLING_CORRECTION_V2,
+			FEATURE_PRIORITY_SUPPORT_V2,
+		],
 	},
 	[ constants.PRODUCT_JETPACK_ANTI_SPAM ]: {
 		product_name: PRODUCT_SHORT_NAMES[ constants.PRODUCT_JETPACK_ANTI_SPAM ],
@@ -175,16 +162,13 @@ export const JETPACK_PRODUCTS_LIST: Record< JetpackProductSlug, Product > = {
 		type: constants.PRODUCT_JETPACK_ANTI_SPAM,
 		term: TERM_ANNUALLY,
 		bill_period: PLAN_ANNUAL_PERIOD,
-		getFeatures: ( variant: string ): string[] =>
-			( {
-				spp: [ FEATURE_AUTOMATED_SPAM_PROTECTION_V2, FEATURE_AKISMET_V2, FEATURE_SPAM_BLOCK_V2 ],
-			}[ variant ] || [
-				FEATURE_ANTISPAM_V2,
-				FEATURE_AKISMET_V2,
-				FEATURE_SPAM_BLOCK_V2,
-				FEATURE_ADVANCED_STATS_V2,
-				FEATURE_PRIORITY_SUPPORT_V2,
-			] ),
+		getFeatures: (): string[] => [
+			FEATURE_ANTISPAM_V2,
+			FEATURE_AKISMET_V2,
+			FEATURE_SPAM_BLOCK_V2,
+			FEATURE_ADVANCED_STATS_V2,
+			FEATURE_PRIORITY_SUPPORT_V2,
+		],
 	},
 	[ constants.PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: {
 		product_name: PRODUCT_SHORT_NAMES[ constants.PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ],
@@ -192,16 +176,13 @@ export const JETPACK_PRODUCTS_LIST: Record< JetpackProductSlug, Product > = {
 		type: constants.PRODUCT_JETPACK_ANTI_SPAM,
 		term: TERM_MONTHLY,
 		bill_period: PLAN_MONTHLY_PERIOD,
-		getFeatures: ( variant: string ): string[] =>
-			( {
-				spp: [ FEATURE_AUTOMATED_SPAM_PROTECTION_V2, FEATURE_AKISMET_V2, FEATURE_SPAM_BLOCK_V2 ],
-			}[ variant ] || [
-				FEATURE_ANTISPAM_V2,
-				FEATURE_AKISMET_V2,
-				FEATURE_SPAM_BLOCK_V2,
-				FEATURE_ADVANCED_STATS_V2,
-				FEATURE_PRIORITY_SUPPORT_V2,
-			] ),
+		getFeatures: (): string[] => [
+			FEATURE_ANTISPAM_V2,
+			FEATURE_AKISMET_V2,
+			FEATURE_SPAM_BLOCK_V2,
+			FEATURE_ADVANCED_STATS_V2,
+			FEATURE_PRIORITY_SUPPORT_V2,
+		],
 	},
 };
 

--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -245,6 +245,9 @@ export const getJetpackProductsDescriptions = () => {
 			i5: translate(
 				'Help your site visitors find answers instantly so they keep reading and buying. Great for sites with a lot of content.'
 			),
+			spp: translate(
+				'Help your site visitors find answers instantly so they keep reading and buying. Great for sites with a lot of content.'
+			),
 		}[ getJetpackCROActiveVersion() ] ||
 		translate( 'Help your site visitors find answers instantly so they keep reading and buying.' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Revert bullet-point copy for product cards to be the same as the i5 iteration, except for references to Backup Daily (replaced with "Jetpack Backup") and Security Daily (replaced with "Jetpack Security").

**Question for Design:** *Do we want to keep all six of the existing bullet points for Jetpack Free in the 'control' experience, or should it still be constrained to three items to match CRM Free?*

#### Testing instructions

Same testing instructions as #48934 (relevant sections copied here for easy access), but the only thing we're testing here is that the copy for all product feature bullet points look the same as the 'control' variant.

-----

**Tip:** In addition to toggling your A/B test assignment, you can also manually toggle between variants by appending `cloud-pricing-page=<variant>` to your URL as a query parameter, where `<variant>` is the variant name (e.g., "i5", "spp").

##### All interfaces

In all experiences (Calypso Blue's **Plans** page, Calypso Green's **Pricing** page, Jetpack Connect's store/plans page):

* In the A/B test dev panel in the lower right of Calypso Blue, select the `jetpackSimplifyPricingPage` test and either the `control` or `test` radio button, depending on what you'd like to test.
* Verify that for both variants, copy for the product feature bullet points is roughly identical (see: "Changes proposed in this Pull Request").
* Resize your browser's viewport to simulate both mobile and desktop screen widths. Verify that product grid items (especially Jetpack CRM Free) render correctly with no unexpected visual abnormalities.