### PR TITLE
Plugins: Fix and use isFetching wporg selector

### DIFF
--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -124,7 +124,7 @@ class SinglePlugin extends React.Component {
 	}
 
 	pluginExists( plugin ) {
-		if ( this.isFetching() ) {
+		if ( this.isFetching() || ! this.isFetched() ) {
 			return 'unknown';
 		}
 		if ( plugin && plugin.fetched ) {

--- a/client/state/plugins/wporg/actions.js
+++ b/client/state/plugins/wporg/actions.js
@@ -1,11 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:wporg-data:actions' );
-
-/**
  * Internal dependencies
  */
 import Dispatcher from 'calypso/dispatcher';
@@ -23,17 +16,13 @@ import {
 } from 'calypso/state/action-types';
 import {
 	getNextPluginsListPage,
+	isFetching,
 	isFetchingPluginsList,
 } from 'calypso/state/plugins/wporg/selectors';
 
 import 'calypso/state/plugins/init';
 
 const PLUGINS_LIST_DEFAULT_SIZE = 24;
-
-// TODO: fix the selector in `selectors.js` to not return `true` by default
-function isFetching( state, pluginSlug ) {
-	return get( state, [ 'plugins', 'wporg', 'fetchingItems', pluginSlug ], false );
-}
 
 export function fetchPluginData( pluginSlug ) {
 	return async ( dispatch, getState ) => {
@@ -49,14 +38,12 @@ export function fetchPluginData( pluginSlug ) {
 		try {
 			const data = await fetchPluginInformation( pluginSlug );
 
-			debug( 'plugin details fetched from .org', pluginSlug, data );
 			dispatch( {
 				type: PLUGINS_WPORG_PLUGIN_RECEIVE,
 				pluginSlug,
 				data: normalizePluginData( { detailsFetched: Date.now() }, data ),
 			} );
 		} catch ( error ) {
-			debug( 'plugin details failed to fetch from .org', pluginSlug, error );
 			dispatch( {
 				type: PLUGINS_WPORG_PLUGIN_RECEIVE,
 				pluginSlug,

--- a/client/state/plugins/wporg/selectors.js
+++ b/client/state/plugins/wporg/selectors.js
@@ -13,16 +13,11 @@ export function getPlugin( state, pluginSlug ) {
 }
 
 export function isFetching( state, pluginSlug ) {
-	// if the `isFetching` attribute doesn't exist yet,
-	// we assume we are still launching the fetch action, so it's true
-	const status = state?.plugins.wporg.fetchingItems[ pluginSlug ];
-	return status === undefined ? true : status;
+	return state?.plugins.wporg.fetchingItems[ pluginSlug ] ?? false;
 }
 
 export function isFetched( state, pluginSlug ) {
 	const plugin = getPlugin( state, pluginSlug );
-	// if the plugin or the `isFetching` attribute doesn't exist yet,
-	// we assume we are still launching the fetch action, so it's true
 	return plugin ? !! plugin.fetched : false;
 }
 

--- a/client/state/plugins/wporg/test/selectors.js
+++ b/client/state/plugins/wporg/test/selectors.js
@@ -75,8 +75,8 @@ describe( 'WPorg Selectors', () => {
 	} );
 
 	describe( 'isFetching', () => {
-		test( 'Should get `true` if the requested plugin is not in the current state', () => {
-			expect( isFetching( state, 'no.test' ) ).toBe( true );
+		test( 'Should get `false` if the requested plugin is not in the current state', () => {
+			expect( isFetching( state, 'no.test' ) ).toBe( false );
 		} );
 
 		test( 'Should get `false` if the requested plugin is not being fetched', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, we're using a working copy of the `isFetching` wporg plugins selector in the `fetchPluginData` action creator. This PR fixes the actual selector and updates the code to use it.

We also use the opportunity to remove the unnecessary debugging code.

Related to #24180.

#### Testing instructions

* Start with a clean Redux store.
* Make sure you have several Jetpack sites connected, among which a multisite with subsites.
* Go to `/plugins/:plugin` where `:plugin` is a WP.org plugin.
* Verify the plugin loads correctly and loading order (placeholder before data is loaded) still makes sense.
