### PR TITLE
E2E: Fix gutenboarding canary

### DIFF
--- a/test/e2e/lib/pages/gutenboarding/plans-page.js
+++ b/test/e2e/lib/pages/gutenboarding/plans-page.js
@@ -22,6 +22,7 @@ export default class PlansPage extends AsyncBaseContainer {
 	}
 	async expandAllPlans() {
 		const toggleAllPlansSelector = By.css( 'button.plans-accordion__toggle-all-button' );
+		await driverHelper.scrollIntoView( this.driver, toggleAllPlansSelector );
 		return await driverHelper.clickWhenClickable( this.driver, toggleAllPlansSelector );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR scrolls the plan expansion button into view before trying to click it. It was failing intermittently because it couldn't find the right button

#### Testing instructions

* Run `Create new site as existing user @parallel @canary` test locally and ensure it passes
* Ensure that test passes in CI.

