### PR TITLE
Remove FEATURE_MEMBERSHIPS from blogger plan feature list

### DIFF
--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -74,7 +74,6 @@ const getPlanBloggerDetails = () => ( {
 		constants.FEATURE_BASIC_DESIGN,
 		constants.FEATURE_6GB_STORAGE,
 		constants.FEATURE_NO_ADS,
-		constants.FEATURE_MEMBERSHIPS,
 		constants.FEATURE_PREMIUM_CONTENT_BLOCK,
 	],
 	getSignupFeatures: () => [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes the "Payments" line from the list of features of the Blogger plan in the plans comparison page since that plan does not offer that feature. See pNPgK-5ju-p2

#### Testing instructions

View the plans comparison page and verify that "Payments" is not listed under the Blogger plan. This will require having an account that can see the (deprecated) Blogger plan. It may work to just add the Blogger plan directly to a site on the back-end and then view `/plans` on the front-end for that site.