### PR TITLE
Jetpack cloud: fix broken link to manage site purchase

### DIFF
--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import page from 'page';
 import React, { useState, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -107,7 +106,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 					duration: currentDuration,
 				} )
 			);
-			page( manageSitePurchase( siteSlug, purchase.id ) );
+			manageSitePurchase( siteSlug, purchase.id );
 			return;
 		}
 

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -11,14 +11,13 @@ import { useDispatch, useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import PlansFilterBar from 'calypso/my-sites/plans/jetpack-plans/plans-filter-bar';
 import { EXTERNAL_PRODUCTS_LIST } from 'calypso/my-sites/plans/jetpack-plans/constants';
-import { checkout } from 'calypso/my-sites/plans/jetpack-plans/utils';
+import { checkout, manageSitePurchase } from 'calypso/my-sites/plans/jetpack-plans/utils';
 import QueryProducts from 'calypso/my-sites/plans/jetpack-plans/query-products';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getYearlyPlanByMonthly } from 'calypso/lib/plans';
 import { getProductYearlyVariant, isJetpackPlan } from 'calypso/lib/products-values';
 import { TERM_ANNUALLY } from 'calypso/lib/plans/constants';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { managePurchase } from 'calypso/me/purchases/paths';
 import Main from 'calypso/components/main';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QuerySites from 'calypso/components/data/query-sites';
@@ -108,7 +107,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 					duration: currentDuration,
 				} )
 			);
-			page( managePurchase( siteSlug, purchase.id ) );
+			page( manageSitePurchase( siteSlug, purchase.id ) );
 			return;
 		}
 

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -717,12 +717,13 @@ export function checkout(
  * @param {string} siteSlug Selected site
  * @param {number} purchaseId Id of a purchase
  */
-export function manageSitePurchase( siteSlug: string, purchaseId: number ): string {
+export function manageSitePurchase( siteSlug: string, purchaseId: number ): void {
 	const relativePath = managePurchase( siteSlug, purchaseId );
 	if ( isJetpackCloud() ) {
-		return `https://wordpress.com${ relativePath }`;
+		window.location.href = `https://wordpress.com${ relativePath }`;
+	} else {
+		page.redirect( relativePath );
 	}
-	return relativePath;
 }
 
 /**

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -59,6 +59,7 @@ import { getJetpackProductCallToAction } from 'calypso/lib/products-values/get-j
 import { getJetpackProductDescription } from 'calypso/lib/products-values/get-jetpack-product-description';
 import { getJetpackProductShortName } from 'calypso/lib/products-values/get-jetpack-product-short-name';
 import config from 'calypso/config';
+import { managePurchase } from 'calypso/me/purchases/paths';
 import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans/jetpack-plans/abtest';
 import { MORE_FEATURES_LINK } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { addQueryArgs } from 'calypso/lib/route';
@@ -706,6 +707,22 @@ export function checkout(
 	} else {
 		page.redirect( addQueryArgs( urlQueryArgs, path ) );
 	}
+}
+
+/**
+ * Returns an absolute or relative URL to manage a site purchase.
+ * On cloud.jetpack.com, the URL will point to wordpress.com. In any other case,
+ * it will return a relative path to the site purchase.
+ *
+ * @param {string} siteSlug Selected site
+ * @param {number} purchaseId Id of a purchase
+ */
+export function manageSitePurchase( siteSlug: string, purchaseId: number ): string {
+	const relativePath = managePurchase( siteSlug, purchaseId );
+	if ( isJetpackCloud() ) {
+		return `https://wordpress.com${ relativePath }`;
+	}
+	return relativePath;
 }
 
 /**

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -710,9 +710,9 @@ export function checkout(
 }
 
 /**
- * Returns an absolute or relative URL to manage a site purchase.
+ * Redirects users to the appropriate URL to manage a site purchase.
  * On cloud.jetpack.com, the URL will point to wordpress.com. In any other case,
- * it will return a relative path to the site purchase.
+ * it will point to a relative path to the site purchase.
  *
  * @param {string} siteSlug Selected site
  * @param {number} purchaseId Id of a purchase


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes 1164141197617539-as-1199616761686040

* On Jetpack cloud, redirect users to wordpress.com to manage a site purchase.

#### Testing instructions

Prerequisite: Jetpack site with a paid plan/purchase.

* Download this PR.
* Run both Calypso Blue and Calypso Green with `yarn start` and `yarn start-jetpack-cloud-p`.

Calypso Blue
* Visit `http://calypso.localhost:3000/plans/:site`.
* Click on the CTA of the plan/product owned by your site.
* Verify that you are redirected to `http://calypso.localhost:3000/me/purchases/:siteUrl/:purchaseId`.
* Verify that no error appears in the console.

Calypso Green

* Visit `http://jetpack.cloud.localhost:3001/pricing/:site?source=jetpack-plans`.
* Click on the CTA of the plan/product owned by your site.
* Verify that you are redirected to `https://wordpress.com/me/purchases/:siteUrl/:purchaseId`.
* Verify that no error appears in the console.
* Verify that the back button takes you back to the Pricing page.
 
#### Demo Calypso Blue (no changes here)
![WPCOMManagePurchase](https://user-images.githubusercontent.com/3418513/105097525-7e3ddb80-5a87-11eb-9f4c-3625515abbaf.gif)

#### Demo Calypso Green (the bug is no longer present)
![JCloudManagePurchase](https://user-images.githubusercontent.com/3418513/105097551-8e55bb00-5a87-11eb-91b4-29b03604af22.gif)

