### PR TITLE
Ensure that EmailManagement (re)fetches site domains before rendering

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -22,7 +22,6 @@ import {
 	isSiteRedirect,
 	isTitanMail,
 } from 'calypso/lib/products-values';
-import { isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
 import {
 	isGSuiteExtraLicenseProductSlug,
 	isGSuiteOrGoogleWorkspaceProductSlug,
@@ -42,7 +41,6 @@ import { Button } from '@automattic/components';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { downloadTrafficGuide } from 'calypso/my-sites/marketing/ultimate-traffic-guide';
 import { emailManagementEdit } from 'calypso/my-sites/email/paths';
-import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 
 export class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
@@ -541,19 +539,8 @@ export class CheckoutThankYouHeader extends PureComponent {
 	}
 
 	render() {
-		const {
-			isDataLoaded,
-			isPendingDomainUpdateForTitan,
-			isSimplified,
-			hasFailedPurchases,
-			primaryPurchase,
-			selectedSite,
-		} = this.props;
-		const classes = {
-			'is-placeholder':
-				! isDataLoaded ||
-				( primaryPurchase && isTitanMail( primaryPurchase ) && isPendingDomainUpdateForTitan ),
-		};
+		const { isDataLoaded, isSimplified, hasFailedPurchases, primaryPurchase } = this.props;
+		const classes = { 'is-placeholder': ! isDataLoaded };
 
 		let svg = 'thank-you.svg';
 		if ( hasFailedPurchases ) {
@@ -582,9 +569,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 						) : (
 							<h2 className="checkout-thank-you__header-text">{ this.getText() }</h2>
 						) }
-						{ primaryPurchase && selectedSite?.ID && isTitanMail( primaryPurchase ) && (
-							<QuerySiteDomains siteId={ selectedSite.ID } />
-						) }
+
 						{ this.props.children }
 
 						{ this.getButtons() }
@@ -633,22 +618,11 @@ export class CheckoutThankYouHeader extends PureComponent {
 }
 
 export default connect(
-	( state, ownProps ) => {
-		let isPendingDomainUpdateForTitan = false;
-		if (
-			ownProps.primaryPurchase &&
-			ownProps.selectedSite?.ID &&
-			isTitanMail( ownProps.primaryPurchase )
-		) {
-			isPendingDomainUpdateForTitan = isRequestingSiteDomains( state, ownProps.selectedSite.ID );
-		}
-		return {
-			upgradeIntent: ownProps.upgradeIntent || getCheckoutUpgradeIntent( state ),
-			isAtomic: isAtomicSite( state, ownProps.selectedSite?.ID ),
-			isPendingDomainUpdateForTitan,
-			siteAdminUrl: getSiteAdminUrl( state, ownProps.selectedSite?.ID ),
-		};
-	},
+	( state, ownProps ) => ( {
+		upgradeIntent: ownProps.upgradeIntent || getCheckoutUpgradeIntent( state ),
+		isAtomic: isAtomicSite( state, ownProps.selectedSite?.ID ),
+		siteAdminUrl: getSiteAdminUrl( state, ownProps.selectedSite?.ID ),
+	} ),
 	{
 		recordStartTransferClickInThankYou,
 		recordTracksEvent,

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -25,7 +25,11 @@ import { getEligibleEmailForwardingDomain } from 'calypso/lib/domains/email-forw
 import getGSuiteUsers from 'calypso/state/selectors/get-gsuite-users';
 import hasLoadedGSuiteUsers from 'calypso/state/selectors/has-loaded-gsuite-users';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
-import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
+import {
+	getDomainsBySiteId,
+	hasLoadedSiteDomains,
+	isRequestingSiteDomains,
+} from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import GSuitePurchaseCta from 'calypso/my-sites/email/gsuite-purchase-cta';
 import GSuiteUsersCard from 'calypso/my-sites/email/email-management/gsuite-users-card';
@@ -132,9 +136,15 @@ class EmailManagement extends React.Component {
 	}
 
 	content() {
-		const { domains, hasGSuiteUsersLoaded, hasSiteDomainsLoaded, selectedDomainName } = this.props;
+		const {
+			domains,
+			hasGSuiteUsersLoaded,
+			hasSiteDomainsLoaded,
+			isFetchingSiteDomains,
+			selectedDomainName,
+		} = this.props;
 
-		if ( ! hasGSuiteUsersLoaded || ! hasSiteDomainsLoaded ) {
+		if ( ! hasGSuiteUsersLoaded || ! hasSiteDomainsLoaded || isFetchingSiteDomains ) {
 			return <Placeholder />;
 		}
 
@@ -301,6 +311,7 @@ export default connect(
 			gsuiteUsers: getGSuiteUsers( state, selectedSiteId ),
 			hasGSuiteUsersLoaded: hasLoadedGSuiteUsers( state, selectedSiteId ),
 			hasSiteDomainsLoaded: hasLoadedSiteDomains( state, selectedSiteId ),
+			isFetchingSiteDomains: isRequestingSiteDomains( state, selectedSiteId ),
 			previousRoute: getPreviousRoute( state ),
 			selectedSiteId,
 			selectedSiteSlug: getSelectedSiteSlug( state ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR ensures that when we load the Email Management UI, we re-fetch all the domains for the site before we render.This ensures that we get updated Titan and G Suite subscription data for the target domain before we try to display the page.

#### Testing instructions

Given that this is a timing bug, testing it is tricky.

As a starting point, you need access to a system with Store Sandbox enabled.

For testing, you _could_ try many Titan purchases, and simply click on the post-checkout "Manage Email" button, but you won't be able to tell whether my fix definitively worked just because it doesn't fail while you're trying. As a result, I came up with a simulated way to force a bad/stale client state without requiring a new purchase.

* Disable Store Sandbox mode.
* Navigate to Manage -> Domains -> [your_domain] -> Manage email accounts, and verify that you see the Add Email UI.
* Re-enable Store Sandbox, and navigate to the same URL.
* Verify that you see the management UI for the domain after a short period of showing a placeholder.

If you want to verify that the steps above would trigger the problem without the fix, change the logic in `EmailManagement` that shows a placeholder when `isFetchingSiteDomains` is true (i.e. you can just remove it from the condition). Then repeat the steps starting from "Disable Store Sandbox mode", except this time the final step should result in you still seeing the "Add Email" page, at least temporarily.

A massive hat-tip to @stephanethomas for making sure I actually fixed this the right way (which will also take care of G Suite! ;) )