### PR TITLE
Checkout: Modify useCreateExistingCards to only rememoize only when ids change

### DIFF
--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useMemo } from 'react';
+import { useMemo, useRef, useEffect } from 'react';
 import {
 	createPayPalMethod,
 	createAlipayMethod,
@@ -288,22 +288,56 @@ function useCreateApplePay( {
 	return applePayMethod;
 }
 
+// See https://usehooks.com/useMemoCompare/
+function useMemoCompare( next, compare ) {
+	// Ref for storing previous value
+	const previousRef = useRef();
+	const previous = previousRef.current;
+
+	// Pass previous and next value to compare function
+	// to determine whether to consider them equal.
+	const isEqual = compare( previous, next );
+
+	// If not equal update previousRef to next value.
+	// We only update if not equal so that this hook continues to return
+	// the same old value if compare keeps returning true.
+	useEffect( () => {
+		if ( ! isEqual ) {
+			previousRef.current = next;
+		}
+	} );
+
+	// Finally, if equal then return the previous value
+	return isEqual ? previous : next;
+}
+
 export function useCreateExistingCards( { storedCards, activePayButtonText = undefined } ) {
-	const existingCardMethods = useMemo( () => {
-		return storedCards.map( ( storedDetails ) =>
-			createExistingCardMethod( {
-				id: `existingCard-${ storedDetails.stored_details_id }`,
-				cardholderName: storedDetails.name,
-				cardExpiry: storedDetails.expiry,
-				brand: storedDetails.card_type,
-				last4: storedDetails.card,
-				storedDetailsId: storedDetails.stored_details_id,
-				paymentMethodToken: storedDetails.mp_ref,
-				paymentPartnerProcessorId: storedDetails.payment_partner,
-				activePayButtonText,
-			} )
+	// Memoize the cards by comparing their stored_details_id values, in case the
+	// objects are recreated on each render.
+	const memoizedStoredCards = useMemoCompare( storedCards, ( prev, next ) => {
+		const prevIds = prev?.map( ( card ) => card.stored_details_id ) ?? [];
+		const nextIds = next?.map( ( card ) => card.stored_details_id ) ?? [];
+		return (
+			prevIds.length === nextIds.length && prevIds.every( ( id, index ) => id === nextIds[ index ] )
 		);
-	}, [ storedCards, activePayButtonText ] );
+	} );
+	const existingCardMethods = useMemo( () => {
+		return (
+			memoizedStoredCards?.map( ( storedDetails ) =>
+				createExistingCardMethod( {
+					id: `existingCard-${ storedDetails.stored_details_id }`,
+					cardholderName: storedDetails.name,
+					cardExpiry: storedDetails.expiry,
+					brand: storedDetails.card_type,
+					last4: storedDetails.card,
+					storedDetailsId: storedDetails.stored_details_id,
+					paymentMethodToken: storedDetails.mp_ref,
+					paymentPartnerProcessorId: storedDetails.payment_partner,
+					activePayButtonText,
+				} )
+			) ?? []
+		);
+	}, [ memoizedStoredCards, activePayButtonText ] );
 	return existingCardMethods;
 }
 


### PR DESCRIPTION
The `useCreateExistingCards` hook creates composite-checkout payment method objects and has a dependency on an array of objects from the stored cards endpoint. Previously, the payment methods were recreated any time the stored cards array changed. Since the array is an object, this is an referential equality check.

Here, we change the hook such that it will only recreate the payment methods if the ids of the stored cards change. Since the ids are numbers or strings, this is a primitive value check.

This will make it easier to call the hook without recreating the payment methods each time since the stored card data typically comes from the `getStoredCards` selector which always returns a new array.

This is part of https://github.com/Automattic/wp-calypso/issues/48966

#### Testing instructions

- Visit checkout when you have no stored cards and be sure that there are no errors.
- Visit checkout with some stored cards and be sure there are no errors and that your stored cards show up as payment methods.