### PR TITLE
Update WooCommerce setup link in thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -111,7 +111,7 @@ class AtomicStoreThankYouCard extends Component {
 			<div className="checkout-thank-you__atomic-store-action-buttons">
 				<a
 					className={ classNames( 'button', 'thank-you-card__button' ) }
-					href={ site.URL + '/wp-admin/admin.php?page=wc-setup' }
+					href={ site.URL + '/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard' }
 				>
 					{ translate( 'Create your store!' ) }
 				</a>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the thank you card button after eCommerce plan purchase.

Fixes https://github.com/Automattic/wp-calypso/issues/49064

#### Testing instructions

1. Check out this branch, run `yarn start`
2. Open up calypso in local http://calypso.localhost:3000/
1. Purchase a new site with eCommerce plan
2. Wait for the thank you page to load
3. Click on 'Create your store' button
4. Setup store page in WooCommerce loads

#### Screenshot 
![image](https://user-images.githubusercontent.com/3747241/105133298-76357880-5b27-11eb-8889-887618b3924f.png)

