### PR TITLE
AnchorFM Signup Required Params

### DIFF
--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -112,8 +112,13 @@ export function useNewQueryParam() {
 }
 
 export function useIsAnchorFm(): boolean {
-	const { anchorFmPodcastId } = useAnchorFmParams();
-	return Boolean( anchorFmPodcastId && anchorFmPodcastId.match( /^[0-9a-f]{7,8}$/i ) );
+	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyShowUrl } = useAnchorFmParams();
+	return Boolean(
+		anchorFmPodcastId &&
+			anchorFmPodcastId.match( /^[0-9a-f]{7,8}$/i ) &&
+			anchorFmEpisodeId &&
+			anchorFmSpotifyShowUrl
+	);
 }
 
 export function useOnboardingFlow(): string {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Makes the Spotify Show URL and Podcast Episode params required on signup

Note: This is just a proposal PR to experiment with this updated experience

#### Testing instructions
- Use the Calypso Live branch or pull down this branch
- Go to http://calypso.localhost:3000/new?anchor_podcast=22b6608
- Going through this sign-up flow should not have an Anchor-specific content
- Go through http://calypso.localhost:3000/new?&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_show_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q
- Going through this sign-up flow should be Anchor-specific


#### GIFs
![2021-01-19 23 05 50](https://user-images.githubusercontent.com/66652282/105139284-1c4f9700-5ac4-11eb-9c25-f0e358077f20.gif)


Fixes #419-gh-Automattic/dotcom-manage