### PR TITLE
WIP: Billing Timeframe Experiment

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -33,6 +33,7 @@ import { getPlanBySlug } from 'calypso/state/plans/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { planLevelsMatch } from 'calypso/lib/plans/index';
+import { getVariationForUser } from 'calypso/state/experiments/selectors';
 
 export class PlanFeaturesHeader extends Component {
 	render() {
@@ -219,6 +220,7 @@ export class PlanFeaturesHeader extends Component {
 			annualPricePerMonth,
 			isInSignup,
 			isMonthlyPlan,
+			isBillingTimeframeVariation,
 		} = this.props;
 
 		if ( isInSignup && isMonthlyPlan && annualPricePerMonth < rawPrice ) {
@@ -236,10 +238,12 @@ export class PlanFeaturesHeader extends Component {
 				! isMonthlyPlan &&
 				planMatches( planType, { group: GROUP_WPCOM, term: TERM_ANNUALLY } )
 			) {
-				const price = formatCurrency( fullRawPrice, currencyCode, { stripZeros: true } );
-				return translate( 'Per month, %(price)s billed yearly', {
-					args: { price: price },
-				} );
+				if ( isBillingTimeframeVariation ) {
+					const price = formatCurrency( fullRawPrice, currencyCode, { stripZeros: true } );
+					return translate( 'Per month, %(price)s billed yearly', {
+						args: { price: price },
+					} );
+				}
 			}
 			return null;
 		}
@@ -515,6 +519,8 @@ export default connect( ( state, { planType, relatedMonthlyPlan } ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const currentSitePlan = getCurrentPlan( state, selectedSiteId );
 	const isYearly = !! relatedMonthlyPlan;
+	const isBillingTimeframeVariation =
+		'treatment' === getVariationForUser( state, 'detailed_billing_timeframe_en' );
 
 	return {
 		currentSitePlan,
@@ -522,5 +528,6 @@ export default connect( ( state, { planType, relatedMonthlyPlan } ) => {
 		isYearly,
 		relatedYearlyPlan: isYearly ? null : getPlanBySlug( state, getYearlyPlanByMonthly( planType ) ),
 		siteSlug: getSiteSlug( state, selectedSiteId ),
+		isBillingTimeframeVariation,
 	};
 } )( localize( PlanFeaturesHeader ) );

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -223,31 +223,31 @@ export class PlanFeaturesHeader extends Component {
 			isBillingTimeframeVariation,
 		} = this.props;
 
+		const isAnnualWpcomPlan = planMatches( planType, { group: GROUP_WPCOM, term: TERM_ANNUALLY } );
 		if ( isInSignup && isMonthlyPlan && annualPricePerMonth < rawPrice ) {
 			const discountRate = Math.round( ( 100 * ( rawPrice - annualPricePerMonth ) ) / rawPrice );
 			return translate( `Save %(discountRate)s%% by paying annually`, { args: { discountRate } } );
 		}
 
+		const fullPrice = formatCurrency( fullRawPrice, currencyCode, { stripZeros: true } );
 		if ( isInSignup && ! isMonthlyPlan ) {
+			if ( isAnnualWpcomPlan && isBillingTimeframeVariation ) {
+				return translate( '%(fullPrice)s billed annually', {
+					args: { fullPrice },
+				} );
+			}
 			return translate( 'billed annually' );
 		}
 
 		if ( typeof discountPrice !== 'number' || typeof rawPrice !== 'number' ) {
-			if (
-				! isInSignup &&
-				! isMonthlyPlan &&
-				planMatches( planType, { group: GROUP_WPCOM, term: TERM_ANNUALLY } )
-			) {
-				if ( isBillingTimeframeVariation ) {
-					const price = formatCurrency( fullRawPrice, currencyCode, { stripZeros: true } );
-					return translate( 'Per month, %(price)s billed yearly', {
-						args: { price: price },
-					} );
-				}
+			if ( isAnnualWpcomPlan && isBillingTimeframeVariation ) {
+				return translate( 'Per month, %(fullPrice)s billed yearly', {
+					args: { fullPrice },
+				} );
 			}
 			return null;
 		}
-		if ( ! planMatches( planType, { group: GROUP_WPCOM, term: TERM_ANNUALLY } ) ) {
+		if ( ! isAnnualWpcomPlan ) {
 			return null;
 		}
 		if ( ! currentSitePlan || ! isFreePlan( currentSitePlan.productSlug ) ) {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -210,7 +210,9 @@ export class PlanFeaturesHeader extends Component {
 	getPerMonthDescription() {
 		const {
 			discountPrice,
+			fullRawPrice,
 			rawPrice,
+			currencyCode,
 			translate,
 			planType,
 			currentSitePlan,
@@ -229,6 +231,16 @@ export class PlanFeaturesHeader extends Component {
 		}
 
 		if ( typeof discountPrice !== 'number' || typeof rawPrice !== 'number' ) {
+			if (
+				! isInSignup &&
+				! isMonthlyPlan &&
+				planMatches( planType, { group: GROUP_WPCOM, term: TERM_ANNUALLY } )
+			) {
+				const price = formatCurrency( fullRawPrice, currencyCode, { stripZeros: true } );
+				return translate( 'Per month, %(price)s billed yearly', {
+					args: { price: price },
+				} );
+			}
 			return null;
 		}
 		if ( ! planMatches( planType, { group: GROUP_WPCOM, term: TERM_ANNUALLY } ) ) {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -81,6 +81,7 @@ import {
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import PlanFeaturesScroller from './scroller';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
+import Experiment from 'calypso/components/experiment';
 
 /**
  * Style dependencies
@@ -119,6 +120,7 @@ export class PlanFeatures extends Component {
 		return (
 			<div className={ planWrapperClasses }>
 				<QueryActivePromotions />
+				<Experiment name="detailed_billing_timeframe_en" />
 				<div className={ planClasses }>
 					{ this.renderNotice() }
 					<div ref={ this.contentRef } className="plan-features__content">

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -318,9 +318,13 @@ export class PlanFeatures extends Component {
 				primaryUpgrade,
 				isPlaceholder,
 				hideMonthly,
+				rawPrice,
+				fullRawPrice,
+				discountPrice,
+				annualPricePerMonth,
+				isMonthlyPlan,
 			} = properties;
-			const { rawPrice, discountPrice } = properties;
-			const { annualPricePerMonth, isMonthlyPlan } = properties;
+
 			return (
 				<div className="plan-features__mobile-plan" key={ planName }>
 					<PlanFeaturesHeader
@@ -334,6 +338,7 @@ export class PlanFeatures extends Component {
 						title={ planConstantObj.getTitle() }
 						planType={ planName }
 						rawPrice={ rawPrice }
+						fullRawPrice={ fullRawPrice }
 						discountPrice={ discountPrice }
 						billingTimeFrame={ planConstantObj.getBillingTimeFrame() }
 						hideMonthly={ hideMonthly }
@@ -406,6 +411,7 @@ export class PlanFeatures extends Component {
 				isPlaceholder,
 				hideMonthly,
 				rawPrice,
+				fullRawPrice,
 			} = properties;
 			let { discountPrice } = properties;
 			const classes = classNames( 'plan-features__table-item', 'has-border-top' );
@@ -450,6 +456,7 @@ export class PlanFeatures extends Component {
 						current={ current }
 						currencyCode={ currencyCode }
 						discountPrice={ discountPrice }
+						fullRawPrice={ fullRawPrice }
 						hideMonthly={ hideMonthly }
 						isInSignup={ isInSignup }
 						isJetpack={ isJetpack }
@@ -934,6 +941,9 @@ export default connect(
 				const discountPrice = siteId
 					? getPlanDiscountedRawPrice( state, selectedSiteId, plan, isMonthlyObj )
 					: getDiscountedRawPrice( state, planProductId, showMonthlyPrice );
+				const fullRawPrice = siteId
+					? getSitePlanRawPrice( state, selectedSiteId, plan )
+					: getPlanRawPrice( state, planProductId );
 
 				let annualPricePerMonth = rawPrice;
 				const isMonthlyPlan = isMonthly( plan );
@@ -977,6 +987,7 @@ export default connect(
 					current: isCurrentSitePlan( state, selectedSiteId, planProductId ),
 					discountPrice,
 					features: planFeatures,
+					fullRawPrice,
 					isLandingPage,
 					isPlaceholder,
 					planConstantObj,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Display a more detailed billing timeframe for annual plans in the non-Gutenboarding signup, /plans, and launch flows as an experiment.

#### Testing instructions

**Signup**
1. Assign yourself to the `control` variation of the experiment in the ExPlat experiment dashboard.
2. Start a new site with /start/user and stop at the plans page. The plans component should look like this:
<img width="1288" alt="Screenshot 2021-01-20 at 15 00 57" src="https://user-images.githubusercontent.com/82778/105195368-3f6d5b80-5b43-11eb-8d33-dc9d5cccdd95.png">
3. Do not complete the signup, assign yourself to `treatment` and start over
4. Plans should look like this:
<img width="1288" alt="Screenshot 2021-01-20 at 14 58 17" src="https://user-images.githubusercontent.com/82778/105195605-75aadb00-5b43-11eb-94b2-d5428d70ca43.png">

**Plans**
1. Log in with a test free site
2. Go to /plans
3. Control should look like this:

4. Treatment should look like this:
<img width="996" alt="Screenshot 2021-01-20 at 14 52 25" src="https://user-images.githubusercontent.com/82778/105195912-c3bfde80-5b43-11eb-9e12-61dd5087c8b7.png">
<img width="996" alt="Screenshot 2021-01-20 at 14 53 50" src="https://user-images.githubusercontent.com/82778/105195919-c6bacf00-5b43-11eb-97f9-4ecba59b6eba.png">
