### PR TITLE
ci(teamcity): Run e2e tests in TeamCity

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -857,7 +857,9 @@ object RunCanaryE2eTests : BuildType({
 
 				export LIVEBRANCHES=true
 				export NODE_CONFIG_ENV=test
-				export MAGELLANDEBUG=false
+
+				## Uncomment to debug Magellan
+				#export MAGELLANDEBUG=true
 
 				IMAGE_URL="https://calypso.live?image=registry.a8c.com/calypso/app:build-${BuildDockerImage.depParamRefs.buildNumber}";
 				MAX_LOOP=10

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -956,6 +956,7 @@ object RunCanaryE2eTests : BuildType({
 
 	failureConditions {
 		executionTimeoutMin = 20
+		supportTestRetry = true
 	}
 
 	dependencies {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -910,10 +910,10 @@ object RunCanaryE2eTests : BuildType({
 
 				# Collect results
 				mkdir -p reports
-				find test/e2e/temp -path '*/reports/*' -print0 | xargs -0 mv -t reports
+				find test/e2e/temp -path '*/reports/*' -print0 | xargs -r -0 mv -t reports
 
 				mkdir -p screenshots
-				find test/e2e/temp -path '*/screenshots/*' -print0 | xargs -0 mv -t screenshots
+				find test/e2e/temp -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
 
 				mkdir -p logs
 				find test/e2e -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
@@ -922,6 +922,12 @@ object RunCanaryE2eTests : BuildType({
 			dockerImage = "%docker_image_e2e%"
 			dockerRunParameters = "-u %env.UID%"
 		}
+	}
+
+	feature {
+		type = "xml-report-plugin"
+		param("xmlReportParsing.reportType", "junit")
+		param("xmlReportParsing.reportDirs", "test/e2e/reports/*.xml")
 	}
 
 	failureConditions {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -928,7 +928,7 @@ object RunCanaryE2eTests : BuildType({
 		feature {
 			type = "xml-report-plugin"
 			param("xmlReportParsing.reportType", "junit")
-			param("xmlReportParsing.reportDirs", "test/e2e/reports/*.xml")
+			param("xmlReportParsing.reportDirs", "reports/*.xml")
 		}
 		perfmon {
 		}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -924,10 +924,32 @@ object RunCanaryE2eTests : BuildType({
 		}
 	}
 
-	feature {
-		type = "xml-report-plugin"
-		param("xmlReportParsing.reportType", "junit")
-		param("xmlReportParsing.reportDirs", "test/e2e/reports/*.xml")
+	features {
+		feature {
+			type = "xml-report-plugin"
+			param("xmlReportParsing.reportType", "junit")
+			param("xmlReportParsing.reportDirs", "test/e2e/reports/*.xml")
+		}
+		perfmon {
+		}
+		pullRequests {
+			vcsRootExtId = "${WpCalypso.id}"
+			provider = github {
+				authType = token {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
+			}
+		}
+		commitStatusPublisher {
+			vcsRootExtId = "${WpCalypso.id}"
+			publisher = github {
+				githubUrl = "https://api.github.com"
+				authType = personalToken {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+			}
+		}
 	}
 
 	failureConditions {

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -142,6 +142,8 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 				} );
 				options.setProxy( getProxyType() );
 				options.addArguments( '--no-first-run' );
+				options.addArguments( '--disable-dev-shm-usage' );
+				options.addArguments( '--verbose' );
 
 				if ( useCustomUA ) {
 					options.addArguments( userAgent );
@@ -162,7 +164,11 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 
 				options.addArguments( '--app=https://www.wordpress.com' );
 
-				const service = new chrome.ServiceBuilder( chromedriver.path ).build(); // eslint-disable-line no-case-declarations
+				// eslint-disable-next-line no-case-declarations
+				const service = new chrome.ServiceBuilder( chromedriver.path )
+					.loggingTo( './chrome.' + Math.random() + '.log' )
+					.enableVerboseLogging()
+					.build();
 				chrome.setDefaultService( service );
 
 				builder = new webdriver.Builder();

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -143,7 +143,7 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 				options.setProxy( getProxyType() );
 				options.addArguments( '--no-first-run' );
 				options.addArguments( '--disable-dev-shm-usage' );
-				options.addArguments( '--verbose' );
+				options.addArguments( '--no-sandbox' );
 
 				if ( useCustomUA ) {
 					options.addArguments( userAgent );
@@ -166,7 +166,7 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 
 				// eslint-disable-next-line no-case-declarations
 				const service = new chrome.ServiceBuilder( chromedriver.path )
-					.loggingTo( './chrome.' + Math.random() + '.log' )
+					.loggingTo( './chromedriver.' + Math.random() + '.log' )
 					.enableVerboseLogging()
 					.build();
 				chrome.setDefaultService( service );

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -x
+
 MAGELLAN=./node_modules/.bin/magellan
 MOCHA_ARGS=""
 WORKERS=6


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Creates a build to run e2e tests.

For now this build is manual: it doesn't run automatically and it doesn't notify GitHub with the results. The idea is to keep this build manual for testing, comparing results with CircleCI and iterate its capabilities until we are ready to make the final transition.

#### How it works

When a build for "Canary e2e tests" is enqueued, TeamCity will first run the build "Build docker image" for that branch. Once the docker image is built it will be pushed to the registry. Then "Canary e2e tests" can start.

The first thing it does is query `http://calypso.live?image=<image-name>` with the docker image built in the previous step. This instructs `calypso.live` to fetch that image and spin up a container. It then responds with a HTTP 302 redirect to the container, something like `http://<container-name>.calypso.live/`.

The build uses `test/e2e/run.sh` to spin up a few Chrome instances that run some webdriver tests against `http://<container-name>.calypso.live/`. A last step collects the results, logs and screenshots of all tests and save them as build artifacts so they can be inspected by a human.

#### Testing instructions

Go to TeamCity and trigger the build "Canary e2e tests" for this branch.