### PR TITLE
Show the Email domain in the cancellation screen

### DIFF
--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -16,6 +16,7 @@ import CancelPurchaseLoadingPlaceholder from 'calypso/me/purchases/cancel-purcha
 import CancelPurchaseRefundInformation from './refund-information';
 import {
 	getName,
+	purchaseType,
 	hasAmountAvailableToRefund,
 	isCancelable,
 	isOneTimePurchase,
@@ -38,6 +39,7 @@ import ProductLink from 'calypso/me/purchases/product-link';
 import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import PurchaseSiteHeader from 'calypso/me/purchases/purchases-site/header';
 
 /**
  * Style dependencies
@@ -167,7 +169,7 @@ class CancelPurchase extends React.Component {
 
 		const { purchase } = this.props;
 		const purchaseName = getName( purchase );
-		const { siteName, domain: siteDomain } = purchase;
+		const { siteName, domain: siteDomain, siteId } = purchase;
 
 		let heading;
 
@@ -211,9 +213,10 @@ class CancelPurchase extends React.Component {
 					/>
 				</Card>
 
+				<PurchaseSiteHeader siteId={ siteId } name={ siteName } domain={ siteDomain } />
 				<CompactCard className="cancel-purchase__product-information">
 					<div className="cancel-purchase__purchase-name">{ purchaseName }</div>
-					<div className="cancel-purchase__site-title">{ siteName || siteDomain }</div>
+					<div className="cancel-purchase__description">{ purchaseType( purchase ) }</div>
 					<ProductLink purchase={ purchase } selectedSite={ this.props.site } />
 				</CompactCard>
 				<CompactCard className="cancel-purchase__footer">


### PR DESCRIPTION
We want to show the relevant Email domain in the subscription cancellation screen. In order to do that I think it's best if we update the cancellation screen to better match the purchase management screen so I suggest we reuse the `PurchaseSiteHeader` component and then show the product name and product type below each other (similarly to how we show those in the purchase management screen). This will affect all purchases but I believe it's better than what we have now.

#### Changes proposed in this Pull Request

* Show the product type in the cancel screen
* Display the `PurchaseSiteHeader` above the cancellation card so it's consistent between the management and the cancellation screen

Here's how the cancellation screen looks with the new design:

<img width="1062" alt="Screenshot 2021-01-20 at 14 52 57" src="https://user-images.githubusercontent.com/1355045/105178049-3626c380-5b30-11eb-9821-dcba2f59d4fb.png">

And for comparison - the purchase management screen:

<img width="1067" alt="Screenshot 2021-01-20 at 14 56 10" src="https://user-images.githubusercontent.com/1355045/105178073-3c1ca480-5b30-11eb-86de-b6781366776a.png">

#### Testing instructions

* Open any purchase management page and click on the cancel nav item and verify that the site header is shown above the cancellation box. Also verify that the relevant domain is shown for Email subscriptions
