### PR TITLE
Adds a monthly label next to the Titan product label

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -92,7 +92,7 @@ function WPLineItem( {
 			data-product-type={ item.type }
 		>
 			<LineItemTitle id={ itemSpanId } isSummary={ isSummary }>
-				{ item.label } { isTitanMail && <>(Monthly)</> }
+				{ item.label }
 			</LineItemTitle>
 			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
 				<LineItemPrice item={ item } isSummary={ isSummary } />

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -92,7 +92,7 @@ function WPLineItem( {
 			data-product-type={ item.type }
 		>
 			<LineItemTitle id={ itemSpanId } isSummary={ isSummary }>
-				{ item.label }
+				{ item.label } { isTitanMail && <>(Monthly)</> }
 			</LineItemTitle>
 			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
 				<LineItemPrice item={ item } isSummary={ isSummary } />

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -419,7 +419,7 @@ function getSublabel( serverCartItem: ResponseCartProduct ): i18nCalypso.Transla
 	const isRenewalItem = isRenewal( serverCartItem );
 	const { meta, product_name: productName } = serverCartItem;
 
-	if ( isDotComPlan( serverCartItem ) || isTitanMail( serverCartItem ) ) {
+	if ( isDotComPlan( serverCartItem ) || ( ! isRenewalItem && isTitanMail( serverCartItem ) ) ) {
 		if ( isRenewalItem ) {
 			return translate( 'Plan Renewal' );
 		}

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -24,6 +24,7 @@ import {
 	isDomainTransferProduct,
 	isDomainProduct,
 	isDotComPlan,
+	isTitanMail,
 } from 'calypso/lib/products-values';
 import { isRenewal } from 'calypso/lib/cart-values/cart-items';
 import doesValueExist from './does-value-exist';
@@ -418,7 +419,7 @@ function getSublabel( serverCartItem: ResponseCartProduct ): i18nCalypso.Transla
 	const isRenewalItem = isRenewal( serverCartItem );
 	const { meta, product_name: productName } = serverCartItem;
 
-	if ( isDotComPlan( serverCartItem ) ) {
+	if ( isDotComPlan( serverCartItem ) || isTitanMail( serverCartItem ) ) {
 		if ( isRenewalItem ) {
 			return translate( 'Plan Renewal' );
 		}


### PR DESCRIPTION
This PR enables the sub label below the Product title for Titan. This is needed to show the billing interval that is associated with the purchase.

It was previously shown for certain existing products and plans.


