### PR TITLE
Gutenboarding: Collapse launch button + plugin icons on mobile

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-header-buttons/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-header-buttons/index.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * File for various functionality which needs to be added to Simple and Atomic
+ * sites. The code in this file is always loaded in the block editor.
+ *
+ * Currently, this module may not be the best place if you need to load
+ * front-end assets, but you could always add a separate action for that.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE\EditorHeaderButtons;
+
+/**
+ * Enqueue assets
+ */
+function enqueue_script_and_style() {
+	// Avoid loading assets if possible.
+	if ( ! \A8C\FSE\Common\is_block_editor_screen() ) {
+		return;
+	}
+
+	$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/editor-header-buttons.asset.php';
+	$script_dependencies = isset( $asset_file['dependencies'] ) ? $asset_file['dependencies'] : array();
+	$script_version      = isset( $asset_file['version'] ) ? $asset_file['version'] : filemtime( plugin_dir_path( __FILE__ ) . 'dist/editor-header-buttons.js' );
+	$style_version       = isset( $asset_file['version'] ) ? $asset_file['version'] : filemtime( plugin_dir_path( __FILE__ ) . 'dist/editor-header-buttons.css' );
+
+	wp_enqueue_script(
+		'a8c-fse-editor-header-buttons-script',
+		plugins_url( 'dist/editor-header-buttons.js', __FILE__ ),
+		$script_dependencies,
+		$script_version,
+		true
+	);
+
+	wp_set_script_translations( 'a8c-fse-editor-header-buttons-script', 'full-site-editing' );
+
+	wp_localize_script(
+		'a8c-fse-editor-header-buttons-script',
+		'wpcomEditorSiteLaunch',
+		array(
+			'locale' => determine_locale(),
+		)
+	);
+
+	$style_file = is_rtl()
+		? 'editor-header-buttons.rtl.css'
+		: 'editor-header-buttons.css';
+
+	wp_enqueue_style(
+		'a8c-fse-editor-header-buttons-style',
+		plugins_url( 'dist/' . $style_file, __FILE__ ),
+		array(),
+		$style_version
+	);
+}
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_script_and_style' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-header-buttons/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-header-buttons/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './src';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-header-buttons/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-header-buttons/src/index.tsx
@@ -2,14 +2,62 @@
  * External Dependencies
  */
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import domReady from '@wordpress/dom-ready';
-
+import { PostPreviewButton, PostPublishButton, PostSavedState } from '@wordpress/editor';
+import { Button, Dropdown } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 /**
  * Internal Dependencies
  */
 
 import './styles.scss';
+
+const PostEditorButtonMenu: React.FunctionComponent = () => {
+	const editPostStore = 'core/edit-post';
+
+	const { hasActiveMetaboxes, isPublishSidebarOpened, isSaving } = useSelect(
+		( select ) => ( {
+			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
+			isPublishSidebarOpened: select( editPostStore ).isPublishSidebarOpened(),
+			isSaving: select( editPostStore ).isSavingMetaBoxes(),
+			showIconLabels: select( editPostStore ).isFeatureActive( 'showIconLabels' ),
+			hasReducedUI: select( editPostStore ).isFeatureActive( 'reducedUI' ),
+			isEditingTemplate: select( editPostStore ).isEditingTemplate(),
+		} ),
+		[]
+	);
+
+	// These buttons may require props that exist for their usages in Gutenberg here; gutenberg-repo/packages/edit-post/src/components/header/index.js
+	return (
+		<div className="dropdown-container">
+			<Dropdown
+				className="my-container-class-name"
+				contentClassName="my-popover-content-classname"
+				position="bottom center"
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<Button isPrimary onClick={ onToggle } aria-expanded={ isOpen }>
+						Update
+					</Button>
+				) }
+				renderContent={ () => (
+					<div className="dropdown-content">
+						{ ! isPublishSidebarOpened && (
+							// This button isn't completely hidden by the publish sidebar.
+							// We can't hide the whole toolbar when the publish sidebar is open because
+							// we want to prevent mounting/unmounting the PostPublishButtonOrToggle DOM node.
+							// We track that DOM node to return focus to the PostPublishButtonOrToggle
+							// when the publish sidebar has been closed.
+							<PostSavedState forceIsDirty={ hasActiveMetaboxes } forceIsSaving={ isSaving } />
+						) }
+						<PostPreviewButton forceIsAutosaveable={ hasActiveMetaboxes } />
+						<PostPublishButton />
+					</div>
+				) }
+			/>
+		</div>
+	);
+};
 
 domReady( () => {
 	const editorHeaderButtonsInception = setInterval( () => {
@@ -26,8 +74,6 @@ domReady( () => {
 		componentsToolbar.className = 'editor-header-buttons';
 		toolbar.prepend( componentsToolbar );
 
-		const DummyComponent: React.FunctionComponent = () => <>hello world</>;
-
-		ReactDOM.render( <DummyComponent />, componentsToolbar );
+		ReactDOM.render( <PostEditorButtonMenu />, componentsToolbar );
 	} );
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-header-buttons/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-header-buttons/src/index.tsx
@@ -1,0 +1,33 @@
+/**
+ * External Dependencies
+ */
+import * as React from 'react';
+import ReactDOM from 'react-dom';
+import domReady from '@wordpress/dom-ready';
+
+/**
+ * Internal Dependencies
+ */
+
+import './styles.scss';
+
+domReady( () => {
+	const editorHeaderButtonsInception = setInterval( () => {
+		// Cycle through interval until header toolbar is found.
+		const toolbar = document.querySelector( '.edit-post-header__settings' );
+
+		if ( ! toolbar ) {
+			return;
+		}
+		clearInterval( editorHeaderButtonsInception );
+
+		// Add components toolbar with override class name (original will be hidden in ./style.scss).
+		const componentsToolbar = document.createElement( 'div' );
+		componentsToolbar.className = 'editor-header-buttons';
+		toolbar.prepend( componentsToolbar );
+
+		const DummyComponent: React.FunctionComponent = () => <>hello world</>;
+
+		ReactDOM.render( <DummyComponent />, componentsToolbar );
+	} );
+} );

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-header-buttons/src/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-header-buttons/src/styles.scss
@@ -7,3 +7,15 @@
 		display: none;
 	}
 }
+
+.interface-pinned-items > button:not(:first-child) {
+	@media ( max-width: $break-medium ) {
+		display: none;
+	}
+}
+
+.edit-post-header__settings > *:not(.editor-header-buttons, .interface-pinned-items, .components-dropdown-menu) {
+	@media ( max-width: $break-medium ) {
+		display: none;
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-header-buttons/src/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-header-buttons/src/styles.scss
@@ -1,0 +1,9 @@
+@import '~@wordpress/base-styles/mixins';
+@import '~@wordpress/base-styles/variables';
+@import '~@wordpress/base-styles/breakpoints';
+
+.editor-header-buttons {
+	@include break-medium {
+		display: none;
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -141,6 +141,15 @@ function load_common_module() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_common_module' );
 
 /**
+ *  Sigh: load_header_buttons
+ */
+function load_header_buttons() {
+	require_once __DIR__ . '/editor-header-buttons/index.php';
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_header_buttons' );
+
+
+/**
  * Sigh: load_editor_site_launch
  */
 function load_editor_site_launch() {

--- a/apps/editing-toolkit/package.json.orig
+++ b/apps/editing-toolkit/package.json.orig
@@ -28,7 +28,7 @@
 		"editor-gutenboarding-launch": "calypso-build --env source='editor-gutenboarding-launch'",
 		"dev:editor-gutenboarding-launch": "yarn run editor-gutenboarding-launch",
 		"build:editor-gutenboarding-launch": "NODE_ENV=production yarn run editor-gutenboarding-launch",
-		"editor-header-buttons": "calypso-build --env source='editor-header-buttons'",
+		"editor-header-buttons": "calypso-build --env --source='editor-header-buttons'",
 		"build:editor-header-buttons": "NODE_ENV=production yarn run editor-header-buttons",
 		"dev:editor-header-buttons": "yarn run editor-header-buttons",
 		"editor-site-launch": "calypso-build --env source='editor-site-launch'",
@@ -129,6 +129,10 @@
 		"@wordpress/html-entities": "*",
 		"@wordpress/i18n": "*",
 		"@wordpress/icons": "*",
+<<<<<<< HEAD
+=======
+		"@wordpress/interface": "^1.0.0",
+>>>>>>> Hide desktop icons and show mobile alternatives within the editors header
 		"@wordpress/keycodes": "*",
 		"@wordpress/nux": "^3.24.1",
 		"@wordpress/plugins": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5092,7 +5092,16 @@
     turbo-combine-reducers "^1.0.2"
     use-memo-one "^1.1.1"
 
-"@wordpress/date@*", "@wordpress/date@^3.13.0", "@wordpress/date@^3.7.0":
+"@wordpress/date@*", "@wordpress/date@^3.7.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/date/-/date-3.9.0.tgz#d2034952512363d38d4191c3786695905f4b67b1"
+  integrity sha512-V4+k6Ipkm/JX1TzRcwo96v0Lk1m1NGAHwO9JsnUCCXlG1Qxgl+MxRkWpgmUwgdCDjVvevS/4bU+LvndDWQIzVA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    moment "^2.22.1"
+    moment-timezone "^0.5.16"
+
+"@wordpress/date@^3.13.0":
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/@wordpress/date/-/date-3.13.0.tgz#47e601aadb1645f47b427fb6940de21767de4b42"
   integrity sha512-mNN+0NVn1EQtpSk/3fyhuo9cDSrPBsTBdCtmiS3kN8ybkBhqXNTY+HInj0No3ZZ/xii1Hr8xYKm0YijtNtUs9g==
@@ -5295,12 +5304,19 @@
     terminal-link "^2.0.0"
     yargs "^14.0.0"
 
-"@wordpress/escape-html@^1.11.0", "@wordpress/escape-html@^1.8.0":
+"@wordpress/escape-html@^1.11.0":
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-1.11.0.tgz#6e33fc4ab6d36940f62be4f6e58959ee69d301d8"
   integrity sha512-f/jk3SpYRUp04+LzdonNWBpH8jlm8RXGjK2TimfLz+wRFzFFdF7i2dI9GX+4gea/UuV+WtXAWkfARyV0HVDXwQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
+
+"@wordpress/escape-html@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-1.8.0.tgz#07234fc8914c1edb408e194dd19c981f4dcb1117"
+  integrity sha512-z7z+57nm9Dv3Hau0u3+17dJCbpWnh853VBF6JPID7rKnLPw2AOoRJtNHf4gLeBJTrG6M4cC8EG8Flarsuoxb2w==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 "@wordpress/eslint-plugin@^7.3.0":
   version "7.3.0"
@@ -5368,7 +5384,16 @@
     sprintf-js "^1.1.1"
     tannin "^1.2.0"
 
-"@wordpress/icons@*", "@wordpress/icons@^2.9.0":
+"@wordpress/icons@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/icons/-/icons-2.0.0.tgz#9a27deb0a629fbe51b5d108de63b21fdd731f205"
+  integrity sha512-+clpVHv6ABqxjTzXinuVfUlQubJ4FbNFkh8mX6KQHVn+i4nLq/3Qy8ktYNGB2fs1ck0c17tfAKG+FEz+E5AF4g==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@wordpress/element" "^2.14.0"
+    "@wordpress/primitives" "^1.5.0"
+
+"@wordpress/icons@^2.9.0":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@wordpress/icons/-/icons-2.9.0.tgz#6a4fb2e0f6a67a836f79050bfcc32489b747b4eb"
   integrity sha512-eQJQIaCLdmdo8iTjequNkB14Fzx3qLRbjzZTk26fnggG41L+uGRblIeheZDcHY/jPKDd2H4+v9c9/0LqfjuPCA==
@@ -5528,6 +5553,15 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@wordpress/element" "^2.19.0"
+    classnames "^2.2.5"
+
+"@wordpress/primitives@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/primitives/-/primitives-1.5.0.tgz#e4ef2b886ab516ca9a4a54468c8243a24aecc5b9"
+  integrity sha512-SHP95z2AwRHN5egYzUdyvefdvescYTpDNHhp2klTPUNLIme3yNCdL43rihYb+cUEZCgVKEod8Y9EIE7xB9g5YQ==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@wordpress/element" "^2.14.0"
     classnames "^2.2.5"
 
 "@wordpress/priority-queue@^1.10.0":
@@ -18872,6 +18906,13 @@ moment-timezone-data-webpack-plugin@^1.3.0:
   dependencies:
     find-cache-dir "^3.0.0"
     make-dir "^3.0.0"
+
+moment-timezone@^0.5.16:
+  version "0.5.32"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.32.tgz#db7677cc3cc680fd30303ebd90b0da1ca0dfecc2"
+  integrity sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==
+  dependencies:
+    moment ">= 2.9.0"
 
 moment-timezone@^0.5.31:
   version "0.5.31"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Tidy up the icons in the header on mobile viewport widths and collapse relevant actions.

#### Testing instructions

* Checkout this branch
* Ensure your site is sandboxed and you're logged in to your sandbox environment
* Navigate to `apps/editing-toolkit` and run `yarn dev --sync`
* Open a post or page on your chosen site to go to the editor
* Shrink your viewport down to mobile size and observe the collapsed menu in the editor

**Before**
![Screenshot 2021-01-22 at 10 38 46](https://user-images.githubusercontent.com/8639742/105481389-e31f4e80-5c9e-11eb-9849-70fe4079aeb2.png)

**After**
![Screenshot 2021-01-22 at 10 38 55](https://user-images.githubusercontent.com/8639742/105481401-e74b6c00-5c9e-11eb-878d-b68a2450fdfd.png)

Video: https://www.loom.com/share/2709f1194d5a4e48b2fe154179089051

Fixes #48337 
