### PR TITLE
G Suite: Update Add New Users page for Google Workspace

### DIFF
--- a/client/components/gsuite/gsuite-new-user-list/style.scss
+++ b/client/components/gsuite/gsuite-new-user-list/style.scss
@@ -6,6 +6,7 @@
 
 .gsuite-new-user-list__new-user-remove-user-button {
 	display: none; // TODO: Fix button displayed in the middle of form (see 1165571745647867-as-1198174007918339)
+	overflow: unset; // Prevents ellipsis from appearing because of a right margin applied on the gridicon
 
 	@include breakpoint-deprecated( '>800px' ) {
 		display: block;

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -23,7 +23,11 @@ import {
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import { getDomainsBySiteId, isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getDomainsWithForwards } from 'calypso/state/selectors/get-email-forwards';
-import { getEligibleGSuiteDomain, getGSuiteSupportedDomains } from 'calypso/lib/gsuite';
+import {
+	getEligibleGSuiteDomain,
+	getGoogleMailServiceFamily,
+	getGSuiteSupportedDomains,
+} from 'calypso/lib/gsuite';
 import {
 	areAllUsersValid,
 	getItemsForCart,
@@ -199,7 +203,11 @@ class GSuiteAddUsers extends React.Component {
 				{ domainsWithForwards.length ? (
 					<Notice showDismiss={ false } status="is-warning">
 						{ translate(
-							'Please note that email forwards are not compatible with G Suite, and will be disabled once G Suite is added to this domain. The following domains have forwards:'
+							'Please note that email forwards are not compatible with %(productFamily)s, and will be disabled once %(productFamily)s is added to this domain. The following domains have forwards:',
+							{
+								args: { productFamily: getGoogleMailServiceFamily() },
+								comment: '%(productFamily)s can be either "G Suite" or "Google Workspace"',
+							}
 						) }
 						<ul>
 							{ domainsWithForwards.map( ( domainName ) => {
@@ -261,11 +269,14 @@ class GSuiteAddUsers extends React.Component {
 						onClick={ this.goToEmail }
 						selectedDomainName={ selectedDomainName }
 					>
-						{ translate( 'G Suite' ) }
+						{ getGoogleMailServiceFamily() }
 					</DomainManagementHeader>
 
 					<EmailVerificationGate
-						noticeText={ translate( 'You must verify your email to purchase G Suite.' ) }
+						noticeText={ translate( 'You must verify your email to purchase %(productFamily)s.', {
+							args: { productFamily: getGoogleMailServiceFamily() },
+							comment: '%(productFamily)s can be either "G Suite" or "Google Workspace"',
+						} ) }
 						noticeStatus="is-info"
 					>
 						{ this.renderAddGSuite() }


### PR DESCRIPTION
This pull request updates the title as well as the header of the `Add New Users` page for Google Workspace:

![screenshot](https://user-images.githubusercontent.com/594356/105205681-ce7b7300-5b45-11eb-89c2-5cfaaa409161.png)

#### Testing instructions

1. Run `git checkout update/add-new-users-for-google-workspace` and start your server, or open a [live branch](https://calypso.live/?branch=update/add-new-users-for-google-workspace)
2. Log into a WordPress.com account with a domain
3. Open the [`Email Comparison` page](http://calypso.localhost:3000/email)
4. Click the `Add Google Workspace` button
5. Assert that you see `Google Workspace` in the header
6. Assert that you see `Google Workspace` in the page title
