### PR TITLE
Store|Woo: Update Store deprecation message

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
@@ -45,7 +45,7 @@ class StoreMoveNoticeView extends Component {
 				<p>
 					{ isStoreDeprecated &&
 						translate(
-							'We’re rolling your favorite Store features into WooCommerce in February. {{link}}Learn more{{/link}} about this streamlined, commerce-focused navigation experience, designed to help you save time and access your favorite extensions faster.',
+							'We’re rolling your favorite Store features into WooCommerce. In addition to Products and Orders, you’ll have top-level access for managing your Analytics, Marketing, and Customers. {{link}}Learn more{{/link}} about what to expect in February.',
 							{
 								components: {
 									link: (
@@ -56,7 +56,7 @@ class StoreMoveNoticeView extends Component {
 						) }
 					{ isStoreRemoved &&
 						translate(
-							'We’ve rolled your favorite Store functions into WooCommerce. {{link}}Learn more{{/link}} about how this streamlined, commerce-focused navigation experience can help you save time and access your favorite extensions faster.',
+							'We’ve rolled your favorite Store features into WooCommerce. In addition to Products and Orders, you have top-level access for managing your Analytics, Marketing, and Customers. {{link}}Learn more{{/link}} about what has changed.',
 							{
 								components: {
 									link: (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the message shown on `/store` when Store is deprecated

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that Store deprecation message shown when navigating to `/store` has been updated.

Before:

<img width="887" alt="screen-shot-2021-01-15-at-18 16 34" src="https://user-images.githubusercontent.com/2098816/105226131-9405dc00-5b2d-11eb-8f5e-b4ffda520ccb.png">

After:

<img width="868" alt="Screen Shot 2021-01-20 at 14 37 38" src="https://user-images.githubusercontent.com/2098816/105226153-9bc58080-5b2d-11eb-916d-622a166ce4ce.png">

