### PR TITLE
Add Titan terms of service to checkout

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -841,6 +841,10 @@ export function hasGoogleApps( cart ) {
 	return some( getAllCartItems( cart ), isGoogleApps );
 }
 
+export function hasTitanMail( cart ) {
+	return some( getAllCartItems( cart ), isTitanMail );
+}
+
 export function customDesignItem() {
 	return {
 		product_slug: 'custom-design',

--- a/client/my-sites/checkout/composite-checkout/components/checkout-terms.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-terms.jsx
@@ -14,6 +14,7 @@ import DomainRegistrationAgreement from './domain-registration-agreement';
 import DomainRegistrationHsts from './domain-registration-hsts';
 import ConciergeRefundPolicy from './concierge-refund-policy';
 import BundledDomainNotice from './bundled-domain-notice';
+import TitanTermsOfService from './titan-terms-of-service';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -36,6 +37,7 @@ class CheckoutTerms extends React.Component {
 				<DomainRefundPolicy cart={ cart } />
 				<ConciergeRefundPolicy cart={ cart } />
 				<BundledDomainNotice cart={ cart } />
+				<TitanTermsOfService cart={ cart } />
 			</Fragment>
 		);
 	}

--- a/client/my-sites/checkout/composite-checkout/components/titan-terms-of-service.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/titan-terms-of-service.jsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { hasTitanMail } from 'calypso/lib/cart-values/cart-items';
+import Gridicon from 'calypso/components/gridicon';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+class TitanTermsOfService extends React.Component {
+	render() {
+		const { cart, translate } = this.props;
+		if ( ! hasTitanMail( cart ) ) {
+			return null;
+		}
+
+		const titanTerms = translate(
+			"You understand that your Email service will be powered by Titan and is subject to Titan's {{titanCustomerTos}}Customer Terms of Service{{/titanCustomerTos}}, {{titanAup}}Acceptable Use Policy{{/titanAup}}, and {{titanPrivacy}}Privacy Policy{{/titanPrivacy}}.",
+			{
+				components: {
+					titanCustomerTos: (
+						<a
+							href="https://support.titan.email/hc/en-us/articles/360038024254-Titan-Customer-Terms-of-Use"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+					titanAup: (
+						<a
+							href="https://support.titan.email/hc/en-us/articles/900000775226-Titan-Acceptable-Use-Policy"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+					titanPrivacy: (
+						<a
+							href="https://support.titan.email/hc/en-us/articles/360038535773-Titan-Privacy-Policy"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+			}
+		);
+
+		return (
+			<div className="checkout__titan-terms-of-service">
+				<Gridicon icon="info-outline" size={ 18 } />
+				<p>{ titanTerms }</p>
+			</div>
+		);
+	}
+}
+
+export default localize( TitanTermsOfService );

--- a/client/my-sites/checkout/composite-checkout/components/titan-terms-of-service.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/titan-terms-of-service.jsx
@@ -12,49 +12,46 @@ import Gridicon from 'calypso/components/gridicon';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-class TitanTermsOfService extends React.Component {
-	render() {
-		const { cart, translate } = this.props;
-		if ( ! hasTitanMail( cart ) ) {
-			return null;
-		}
-
-		const titanTerms = translate(
-			"You understand that your Email service will be powered by Titan and is subject to Titan's {{titanCustomerTos}}Customer Terms of Service{{/titanCustomerTos}}, {{titanAup}}Acceptable Use Policy{{/titanAup}}, and {{titanPrivacy}}Privacy Policy{{/titanPrivacy}}.",
-			{
-				components: {
-					titanCustomerTos: (
-						<a
-							href="https://support.titan.email/hc/en-us/articles/360038024254-Titan-Customer-Terms-of-Use"
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
-					titanAup: (
-						<a
-							href="https://support.titan.email/hc/en-us/articles/900000775226-Titan-Acceptable-Use-Policy"
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
-					titanPrivacy: (
-						<a
-							href="https://support.titan.email/hc/en-us/articles/360038535773-Titan-Privacy-Policy"
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
-				},
-			}
-		);
-
-		return (
-			<div className="checkout__titan-terms-of-service">
-				<Gridicon icon="info-outline" size={ 18 } />
-				<p>{ titanTerms }</p>
-			</div>
-		);
+function TitanTermsOfService( { cart, translate } ) {
+	if ( ! hasTitanMail( cart ) ) {
+		return null;
 	}
+
+	const titanTerms = translate(
+		"You understand that your Email service will be powered by Titan and is subject to Titan's {{titanCustomerTos}}Customer Terms of Service{{/titanCustomerTos}}, {{titanAup}}Acceptable Use Policy{{/titanAup}}, and {{titanPrivacy}}Privacy Policy{{/titanPrivacy}}.",
+		{
+			components: {
+				titanCustomerTos: (
+					<a
+						href="https://support.titan.email/hc/en-us/articles/360038024254-Titan-Customer-Terms-of-Use"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+				titanAup: (
+					<a
+						href="https://support.titan.email/hc/en-us/articles/900000775226-Titan-Acceptable-Use-Policy"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+				titanPrivacy: (
+					<a
+						href="https://support.titan.email/hc/en-us/articles/360038535773-Titan-Privacy-Policy"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			},
+		}
+	);
+
+	return (
+		<div className="checkout__titan-terms-of-service">
+			<Gridicon icon="info-outline" size={ 18 } />
+			<p>{ titanTerms }</p>
+		</div>
+	);
 }
 
 export default localize( TitanTermsOfService );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds the collective Titan terms of service that users need to agree to whenever a Titan product is present in the cart/checkout.

#### Testing instructions

* Ensure that you're running your back end with Store Sandbox enabled.
* Ensure that you're running Calypso with the `titan/phase-2` feature flag enabled.
* Add some number of Email mailboxes to your cart (try with a new subscription and with additional mailboxes; also try with other products).
* Verify that the checkout page shows the following text when one or more Titan mailboxes are being purchased:
> You understand that your Email service will be powered by Titan and is subject to Titan's [Customer Terms of Service](https://support.titan.email/hc/en-us/articles/360038024254-Titan-Customer-Terms-of-Use), [Acceptable Use Policy](https://support.titan.email/hc/en-us/articles/900000775226-Titan-Acceptable-Use-Policy), and [Privacy Policy](https://support.titan.email/hc/en-us/articles/360038535773-Titan-Privacy-Policy).
* Ensure that the links work and open the correct documents in a new window.

<img width="586" alt="checkout_titan_terms" src="https://user-images.githubusercontent.com/3376401/105339270-2ae19f80-5be5-11eb-8f7c-a9a4f8a1f6cb.png">

I am still confirming whether the documents are available in any other languages. (Confirmed: they are only available in English.)