### PR TITLE
[WIP] experimental: expose desktop ipc handlers in webapp

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -381,9 +381,7 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 		setupGlobalKeyboardShortcuts();
 	}
 
-	if ( config.isEnabled( 'desktop' ) ) {
-		require( 'calypso/lib/desktop' ).default.init();
-	}
+	require( 'calypso/lib/desktop' ).default.init();
 
 	if (
 		config.isEnabled( 'dev/test-helper' ) &&


### PR DESCRIPTION
### Description

We recently deprecated `electron` from being directly required in the Renderer (Chrome) process of the Desktop app by using `send/receive` functions on the `window.electron` object (see PR #47513 for more details). Not only is this aligned with recommended Electron security best practices, but potentially provides the opportunity to deprecate the Calypso server from the Desktop app entirely while retaining the ability to communicate between the Electron Main process and the Calypso webapp (!).

### Context

By loading the Calypso web app, we can expect that things should "just work" as they do in the browser proper and eliminate a whole host of bugs and broken features in the Desktop app. We would also still retain the benefits of native features like notifications (via Pinghub) and spellchecking. We could drastically simplify the Calypso codebase (by excising most, if not all, `desktop`-related conditionals, and make maintenance a lot easier going forward. Some communication between the webapp and Electron will be necessary in order to implement things like in-app purchases (for submission to the Mac App Store).

### Proof-of-Concept

As a proof-of-concept ([in another experimental branch](https://github.com/Automattic/wp-calypso/compare/desktop/simplified-architecture)), I was able to load an ([https-enabled](PCYsg-5YE-p2)) local instance of Calypso in a simplified wp-desktop/Electron shell. Further, I was able to verify that the Desktop app can still indeed communicate with Calypso webapp (emphasis: this communication is possible [even if loading the webapp directly](https://github.com/Automattic/wp-calypso/compare/desktop/simplified-architecture#diff-506da09367cb6b743c4b58e0975249eae62e72d2d852fd1b7faf6db4a5d8df2eR34)):

In Calypso:

```
// We can gate this by checking for the presence of window.electron:
// if (typeof window.electron === 'object' ) { ... }
window.electron?.receive( 'say-hello', () => {
		window.electron?.send( 'said-hello' ); // eslint-disable-line
	} );
```

In Desktop app (Main process):

```
ipc.on( 'said-hello', () => {
		log.info( 'Renderer process said hello' );
	} );
```

Output:

```
[2021-01-20 12:17:19.673] [desktop:menu:help] [info] User selected 'say hello'...
[2021-01-20 12:17:19.679] [desktop:runapp] [info] Renderer process said hello
```

The above is very promising, as it demonstrates that we might be able to drastically simplify the Desktop app while retaining the ability to communicate with the Calypso webapp, if and where necessary. These IPC events are reflected in `calypso/lib/desktop` and comprise purely of methods on a window object with no references to the Electron module.

My next step is to experiment with exposing all of the existing desktop IPC events (emphasis: this is not necessarily the final implementation, just some rough experimentation to verify the approach). However, making it so `require( 'calypso/lib/desktop' ).default.init();` is _unconditionally_ imported in `desktop/init leads to an error, and I'm not sure why.

I've boiled down the offending code change and steps to reproduce in this branch.

### Steps

1. Check out this branch
2. `yarn run start`
3. Navigate to `http://calypso.localhost:3000`

**Expect**: Calypso webapp to load successfully
**Instead**: Calypso fails to load, with the error message `default.init is not a function`

![calypso_boot_error](https://user-images.githubusercontent.com/8979548/105254723-6f1a6480-5b3f-11eb-938f-38091958ac66.png)

Not sure why this is the case?