### PR TITLE
Editing Toolkit Update to 2.12

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.11
+ * Version: 2.12
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.11' );
+define( 'PLUGIN_VERSION', '2.12' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -46,6 +46,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Fix bug where premium content popover preview in block transformations menu would freeze the editor (https://github.com/Automattic/wp-calypso/pull/48988)
 * Focused-Launch: fix styling for disabled Free plan card (https://github.com/Automattic/wp-calypso/pull/47796)
 * Update type definitions (https://github.com/Automattic/wp-calypso/pull/46728)
+* Add a basic README.md for the Welcome Tour (https://github.com/Automattic/wp-calypso/pull/48785)
 
 = 2.11 =
 * Welcome Guide (Tour & NUX modal): add flag to track if guide is opened manually via MoreMenu

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.5
 Tested up to: 5.6
-Stable tag: 2.11
+Stable tag: 2.12
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,13 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.12 =
+* Starter page templates: remove sidebar component (#48948)
+* Starter page templates: Prevent links and buttons from being clicked within the layout preview (https://github.com/Automattic/wp-calypso/pull/49024)
+* Fix bug where premium content popover preview in block transformations menu would freeze the editor (https://github.com/Automattic/wp-calypso/pull/48988)
+* Focused-Launch: fix styling for disabled Free plan card (https://github.com/Automattic/wp-calypso/pull/47796)
+* Update type definitions (https://github.com/Automattic/wp-calypso/pull/46728)
 
 = 2.11 =
 * Welcome Guide (Tour & NUX modal): add flag to track if guide is opened manually via MoreMenu

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.11.0",
+	"version": "2.12.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- [x] Starter page templates: remove sidebar component (#48948)
- [x] Starter page templates: Prevent links and buttons from being clicked within the layout preview (https://github.com/Automattic/wp-calypso/pull/49024)
- [x] Fix bug where premium content popover preview in block transformations menu would freeze the editor (https://github.com/Automattic/wp-calypso/pull/48988)
- [x] Focused-Launch: fix styling for disabled Free plan card (https://github.com/Automattic/wp-calypso/pull/47796)

#### Testing instructions

* Load the Editing Toolkit diff generated by this PR (D55733-code) on your sandbox and confirm that the above changes work correctly
* When a change has been tested to work correctly, please mark it as checked in the list above
* Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.
    - [x] Tested on atomic
