### PR TITLE
Fix business sub without WC showing both Store and WooCommerce

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -669,6 +669,7 @@ export class MySitesSidebar extends Component {
 			siteSuffix,
 			canUserUseCalypsoStore,
 			canUserUseWooCommerceCoreStore,
+			isSiteWpcomStore,
 		} = this.props;
 
 		if ( ! site ) {
@@ -686,6 +687,12 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
+		const isCalypsoStoreDeprecated = isEnabled( 'woocommerce/store-deprecated' );
+
+		if ( ! isSiteWpcomStore && isCalypsoStoreDeprecated && isBusiness( site.plan ) ) {
+			return null;
+		}
+
 		const infoCopy = translate(
 			'Your favorite Store functions will become part of WooCommerce menus in February. {{link}}Learn more{{/link}}.',
 			{
@@ -700,7 +707,6 @@ export class MySitesSidebar extends Component {
 				},
 			}
 		);
-		const isCalypsoStoreDeprecated = isEnabled( 'woocommerce/store-deprecated' );
 
 		return (
 			<SidebarItem
@@ -711,15 +717,13 @@ export class MySitesSidebar extends Component {
 				forceInternalLink
 				className="sidebar__store"
 			>
-				{ isCalypsoStoreDeprecated && isBusiness( site.plan ) && (
-					<InfoPopover
-						className="sidebar__store-tooltip"
-						position="bottom right"
-						showOnHover={ true }
-					>
-						{ infoCopy }
-					</InfoPopover>
-				) }
+				<InfoPopover
+					className="sidebar__store-tooltip"
+					position="bottom right"
+					showOnHover={ true }
+				>
+					{ infoCopy }
+				</InfoPopover>
 			</SidebarItem>
 		);
 	}

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -72,6 +72,7 @@ describe( 'MySitesSidebar', () => {
 		test( 'Should return store menu item if user can use store on this site', () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseCalypsoStore: true,
+				isSiteWpcomStore: true,
 				...defaultProps,
 				site: {
 					plan: {
@@ -89,6 +90,7 @@ describe( 'MySitesSidebar', () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseCalypsoStore: true,
 				canUserUseWooCommerceCoreStore: true,
+				isSiteWpcomStore: true,
 				...defaultProps,
 				site: {
 					options: {
@@ -103,6 +105,27 @@ describe( 'MySitesSidebar', () => {
 
 			const wrapper = shallow( <Store /> );
 			expect( wrapper.props().link ).toEqual( 'http://test.com/wp-admin/admin.php?page=wc-admin' );
+		} );
+
+		test( 'Should not return store menu item if a business site does not have the store installed', () => {
+			const Sidebar = new MySitesSidebar( {
+				canUserUseCalypsoStore: true,
+				canUserUseWooCommerceCoreStore: true,
+				isSiteWpcomStore: false,
+				...defaultProps,
+				site: {
+					options: {
+						admin_url: 'http://test.com/wp-admin/',
+					},
+					plan: {
+						product_slug: 'business-bundle',
+					},
+				},
+			} );
+			const Store = () => Sidebar.store();
+
+			const wrapper = shallow( <Store /> );
+			expect( wrapper ).toEqual( {} );
 		} );
 
 		test( 'Should return null item if user who can upgrade can not use store on this site (control a/b group)', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This changes the logic such that the Store menu item will not be displayed on Business stores without WooCommerce installed

#### Testing instructions

* Take a site with Business plan with WooCommerce installed (an Atomic site)
* remove WooCommerce
* Refresh a page showing the menu. The Store menu item should not be displayed, however the WooCommerce menu item should (without the external link icon and leading to `http://calypso.localhost:3000/store/{__________}.wpcomstaging.com?redirect_after_install`)

Fixes #49088
