### PR TITLE
Fix case where uninstall of WC then going to WC install page would cause redirect to WP Core with access denied

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -197,12 +197,8 @@ class Dashboard extends Component {
 		) {
 			// Redirect to Core UI setup after finish installation if store is
 			// installed on this site. This check is needed because of an edge
-			// case where on a site where WooCommerce was installed then
-			// removed, then shouldRedirectAfterInstall is always true because
-			// the site option still includes WooCommerce - it isn't removed on
-			// plugin removal. See
-			// /client/extensions/woocommerce/state/sites/setup-choices/selectors.js
-			// in getFinishedInstallOfRequiredPlugins().
+			// case where, if WooCommerce was installed then removed, then
+			// shouldRedirectAfterInstall is always true
 			if ( isSiteWpcomStore ) {
 				this.redirectToWoocommerceSetup( selectedSite );
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds a check that the store is actually installed before allowing the redirect on the store install page
* This is needed because of an edge case where on a Business, atomic site with WooCommerce installed, then WooCommerce is uninstalled, the page to install the store would immediately redirect to a core page for WC (showing an access denied message) because the site thought that WooCommerce was still installed (because that check is done using site options, which don't seem to be updated on plugin uninstall (and it would be difficult to update them since plugin uninstall happens on another site).

#### Testing instructions

* Start a business plan site with WooCommerce installed
* Uninstall WooCommerce
* Navigate to the Store page
* It should show the install page and not redirect to a core "access denied" page


