### PR TITLE
reduxify user-settings in `/me/account`

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -9,7 +9,7 @@ import CSSTransition from 'react-transition-group/CSSTransition';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
 import emailValidator from 'email-validator';
-import { debounce, flowRight as compose, get, has, map, size, update } from 'lodash';
+import { debounce, flowRight as compose, get, has, map, size } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -162,14 +162,9 @@ const Account = createReactClass( {
 	},
 
 	updateColorScheme( colorScheme ) {
-		// Set a fallback color scheme if no default value is provided by the API.
-		// This is a workaround that allows us to use userSettings.updateSetting() without an
-		// existing value. Without this workaround the save button wouldn't become active.
-		// TODO: the API should provide a default value, which would make this line obsolete
-		update( this.props.userSettings.settings, colorSchemeKey, ( value ) => value || 'default' );
-
 		this.props.recordTracksEvent( 'calypso_color_schemes_select', { color_scheme: colorScheme } );
 		this.props.recordGoogleEvent( 'Me', 'Selected Color Scheme', 'scheme', colorScheme );
+
 		this.updateUserSetting( colorSchemeKey, colorScheme );
 	},
 

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -123,23 +123,14 @@ class Account extends React.Component {
 	}
 
 	getUserSetting( settingName ) {
-		// @TODO make it so we can handle nested values as well like
-		// `settingName = [ 'calypso_preferences', 'colorScheme' ] for
-		// `userSettings.calypso_preferences.colorScheme`
 		return this.props.unsavedUserSettings[ settingName ] ?? this.props.userSettings[ settingName ];
 	}
 
 	getUserOriginalSetting( settingName ) {
-		// @TODO make it so we can handle nested values as well like
-		// `settingName = [ 'calypso_preferences', 'colorScheme' ] for
-		// `userSettings.calypso_preferences.colorScheme`
 		return this.props.userSettings[ settingName ];
 	}
 
 	hasUnsavedUserSetting( settingName ) {
-		// @TODO make it so we can handle nested values as well like
-		// `settingName = [ 'calypso_preferences', 'colorScheme' ] for
-		// `userSettings.calypso_preferences.colorScheme`
 		return !! this.props.unsavedUserSettings[ settingName ];
 	}
 

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -528,7 +528,7 @@ class Account extends React.Component {
 	submitForm = ( event ) => {
 		event.preventDefault();
 
-		this.props.saveUserSettings();
+		this.props.saveUserSettings( null, this.state.redirect );
 	};
 
 	renderPendingEmailChange() {

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
 import CSSTransition from 'react-transition-group/CSSTransition';
 import { localize } from 'i18n-calypso';
@@ -83,58 +82,56 @@ const debug = debugFactory( 'calypso:me:account' );
 const ALLOWED_USERNAME_CHARACTERS_REGEX = /^[a-z0-9]+$/;
 const USERNAME_MIN_LENGTH = 4;
 
-/* eslint-disable react/prefer-es6-class */
-const Account = createReactClass( {
-	displayName: 'Account',
-
-	propTypes: {
+class Account extends React.Component {
+	static propTypes = {
 		userSettings: PropTypes.object.isRequired,
 		showNoticeInitially: PropTypes.bool,
-	},
+	};
 
-	UNSAFE_componentWillMount() {
-		// Clear any username changes that were previously made
-		this.clearUsernameValidation();
+	constructor( props ) {
+		super( props );
+
 		this.props.clearUnsavedUserSettings( 'user_login' );
-	},
+	}
+
+	state = {
+		validationResult: false,
+	};
 
 	componentDidMount() {
 		debug( this.constructor.displayName + ' component is mounted.' );
 		this.debouncedUsernameValidate = debounce( this.validateUsername, 600 );
-	},
+	}
 
 	componentWillUnmount() {
 		debug( this.constructor.displayName + ' component is unmounting.' );
-	},
+		this.props.clearUnsavedUserSettings();
+	}
 
 	getUserSetting( settingName ) {
 		return this.props.getSetting( settingName );
-	},
+	}
 
 	getUserOriginalSetting( settingName ) {
 		return this.props.getOriginalSetting( settingName );
-	},
+	}
 
 	updateUserSetting( settingName, value ) {
 		this.props.setUserSetting( settingName, value );
-	},
+	}
 
-	updateUserSettingInput( event ) {
+	updateUserSettingInput = ( event ) => {
 		this.updateUserSetting( event.target.name, event.target.value );
-	},
+	};
 
-	updateUserSettingCheckbox( event ) {
-		this.updateUserSetting( event.target.name, event.target.checked );
-	},
-
-	updateCommunityTranslatorSetting( event ) {
+	updateCommunityTranslatorSetting = ( event ) => {
 		const { name, checked } = event.target;
 		this.updateUserSetting( name, checked );
 		const redirect = '/me/account';
 		this.setState( { redirect } );
-	},
+	};
 
-	updateLanguage( event ) {
+	updateLanguage = ( event ) => {
 		const { value, empathyMode, useFallbackForIncompleteLanguages } = event.target;
 		this.updateUserSetting( 'language', value );
 
@@ -159,32 +156,32 @@ const Account = createReactClass( {
 		// store any selected locale variant so we can test it against those with no GP translation sets
 		const localeVariantSelected = isLocaleVariant( value ) ? value : '';
 		this.setState( { redirect, localeVariantSelected } );
-	},
+	};
 
-	updateColorScheme( colorScheme ) {
+	updateColorScheme = ( colorScheme ) => {
 		this.props.recordTracksEvent( 'calypso_color_schemes_select', { color_scheme: colorScheme } );
 		this.props.recordGoogleEvent( 'Me', 'Selected Color Scheme', 'scheme', colorScheme );
 
 		this.updateUserSetting( colorSchemeKey, colorScheme );
-	},
+	};
 
 	getEmailAddress() {
 		return this.hasPendingEmailChange()
 			? this.getUserSetting( 'new_user_email' )
 			: this.getUserSetting( 'user_email' );
-	},
+	}
 
-	updateEmailAddress( event ) {
+	updateEmailAddress = ( event ) => {
 		const { value } = event.target;
 		const emailValidationError =
 			( '' === value && 'empty' ) || ( ! emailValidator.validate( value ) && 'invalid' ) || false;
 		this.setState( { emailValidationError } );
 		this.updateUserSetting( 'user_email', value );
-	},
+	};
 
 	updateUserLoginConfirm( event ) {
 		this.setState( { userLoginConfirm: event.target.value } );
-	},
+	}
 
 	async validateUsername() {
 		const { translate } = this.props;
@@ -229,11 +226,11 @@ const Account = createReactClass( {
 		} catch ( error ) {
 			this.setState( { validationResult: error } );
 		}
-	},
+	}
 
 	hasEmailValidationError() {
 		return !! this.state.emailValidationError;
-	},
+	}
 
 	shouldDisplayCommunityTranslator() {
 		const locale = this.getUserSetting( 'language' );
@@ -260,7 +257,7 @@ const Account = createReactClass( {
 		}
 
 		return true;
-	},
+	}
 
 	communityTranslator() {
 		if ( ! this.shouldDisplayCommunityTranslator() ) {
@@ -296,7 +293,7 @@ const Account = createReactClass( {
 				</FormLabel>
 			</FormFieldset>
 		);
-	},
+	}
 
 	thankTranslationContributors() {
 		if ( ! this.shouldDisplayCommunityTranslator() ) {
@@ -325,9 +322,9 @@ const Account = createReactClass( {
 				) }
 			</FormSettingExplanation>
 		);
-	},
+	}
 
-	cancelEmailChange() {
+	cancelEmailChange = () => {
 		// @TODO handle email change in user settings redux data layer
 		this.props.cancelPendingEmailChange(/*( error, response ) => {
 			if ( error ) {
@@ -340,14 +337,14 @@ const Account = createReactClass( {
 				this.props.successNotice( translate( 'The email change has been successfully canceled.' ) );
 			}
 		}*/);
-	},
+	};
 
 	handleRadioChange( event ) {
 		const { name, value } = event.currentTarget;
 		this.setState( { [ name ]: value } );
-	},
+	}
 
-	handleSubmitButtonClick() {
+	handleSubmitButtonClick = () => {
 		const { unsavedSettings } = this.props.userSettings;
 		this.recordClickEvent( 'Save Account Settings Button' );
 		if ( has( unsavedSettings, colorSchemeKey ) ) {
@@ -368,7 +365,7 @@ const Account = createReactClass( {
 				country_code: this.props.countryCode,
 			} );
 		}
-	},
+	};
 
 	/**
 	 * We handle the username (user_login) change manually through an onChange handler
@@ -376,15 +373,15 @@ const Account = createReactClass( {
 	 *
 	 * @param {object} event Event from onChange of user_login input
 	 */
-	handleUsernameChange( event ) {
+	handleUsernameChange = ( event ) => {
 		this.debouncedUsernameValidate();
 		this.updateUserSetting( 'user_login', event.currentTarget.value );
 		this.setState( { usernameAction: null } );
-	},
+	};
 
 	recordClickEvent( action ) {
 		this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
-	},
+	}
 
 	getClickHandler( action, callback ) {
 		return () => {
@@ -394,11 +391,11 @@ const Account = createReactClass( {
 				callback();
 			}
 		};
-	},
+	}
 
 	getFocusHandler( action ) {
 		return () => this.props.recordGoogleEvent( 'Me', 'Focused on ' + action );
-	},
+	}
 
 	getCheckboxHandler( checkboxName ) {
 		return ( event ) => {
@@ -407,7 +404,7 @@ const Account = createReactClass( {
 
 			this.props.recordGoogleEvent( 'Me', action, 'checked', value );
 		};
-	},
+	}
 
 	handleUsernameChangeBlogRadio( event ) {
 		this.props.recordGoogleEvent(
@@ -416,9 +413,9 @@ const Account = createReactClass( {
 			'checked',
 			event.target.value
 		);
-	},
+	}
 
-	cancelUsernameChange() {
+	cancelUsernameChange = () => {
 		this.setState( {
 			userLoginConfirm: null,
 			usernameAction: null,
@@ -430,7 +427,7 @@ const Account = createReactClass( {
 		if ( ! this.props.hasUnsavedUserSettings ) {
 			this.props.markSaved();
 		}
-	},
+	};
 
 	async submitUsernameForm() {
 		const username = this.getUserSetting( 'user_login' );
@@ -451,33 +448,35 @@ const Account = createReactClass( {
 			this.setState( { submittingForm: false, validationResult: error } );
 			this.props.errorNotice( error.message );
 		}
-	},
+	}
 
 	isUsernameValid() {
 		return this.state.validationResult?.success === true;
-	},
+	}
 
 	getUsernameValidationFailureMessage() {
 		return this.state.validationResult?.message ?? null;
-	},
+	}
 
 	getAllowedActions() {
 		return this.state.validationResult?.allowed_actions ?? {};
-	},
+	}
 
 	getValidatedUsername() {
 		return this.state.validationResult?.validatedUsername ?? null;
-	},
+	}
 
 	clearUsernameValidation() {
 		this.setState( { validationResult: false } );
-	},
+	}
 
-	onSiteSelect( siteId ) {
-		if ( siteId ) {
-			this.updateUserSetting( 'primary_site_ID', siteId );
+	onSiteSelect = ( siteId ) => {
+		if ( ! siteId ) {
+			return;
 		}
-	},
+
+		this.updateUserSetting( 'primary_site_ID', siteId );
+	};
 
 	renderJoinDate() {
 		const { currentUserDate, translate, moment } = this.props;
@@ -493,11 +492,11 @@ const Account = createReactClass( {
 				} ) }
 			</span>
 		);
-	},
+	}
 
 	hasPendingEmailChange() {
 		return this.props.isPendingEmailChange;
-	},
+	}
 
 	renderPendingEmailChange() {
 		const { translate } = this.props;
@@ -522,7 +521,7 @@ const Account = createReactClass( {
 				<NoticeAction onClick={ this.cancelEmailChange }>{ translate( 'Cancel' ) }</NoticeAction>
 			</Notice>
 		);
-	},
+	}
 
 	renderUsernameValidation() {
 		const { translate } = this.props;
@@ -552,7 +551,7 @@ const Account = createReactClass( {
 				/>
 			);
 		}
-	},
+	}
 
 	renderUsernameConfirmNotice() {
 		const { translate } = this.props;
@@ -567,7 +566,7 @@ const Account = createReactClass( {
 		}
 
 		return <Notice showDismiss={ false } status={ status } text={ text } />;
-	},
+	}
 
 	renderPrimarySite() {
 		const { onboardingUrl, requestingMissingSites, translate, visibleSiteCount } = this.props;
@@ -593,7 +592,7 @@ const Account = createReactClass( {
 				onSiteSelect={ this.onSiteSelect }
 			/>
 		);
-	},
+	}
 
 	renderEmailValidation() {
 		const { translate } = this.props;
@@ -618,7 +617,7 @@ const Account = createReactClass( {
 		}
 
 		return <FormTextValidation isError={ true } text={ notice } />;
-	},
+	}
 
 	/*
 	 * These form fields are displayed when there is not a username change in progress.
@@ -727,7 +726,7 @@ const Account = createReactClass( {
 				</FormButton>
 			</div>
 		);
-	},
+	}
 
 	renderBlogActionFields() {
 		const { translate } = this.props;
@@ -761,7 +760,7 @@ const Account = createReactClass( {
 				}
 			</FormFieldset>
 		);
-	},
+	}
 
 	/*
 	 * These form fields are displayed when a username change is in progress.
@@ -873,7 +872,7 @@ const Account = createReactClass( {
 				</FormButtonsBar>
 			</div>
 		);
-	},
+	}
 
 	render() {
 		const { markChanged, translate } = this.props;
@@ -926,8 +925,8 @@ const Account = createReactClass( {
 				{ config.isEnabled( 'me/account-close' ) && <AccountSettingsCloseLink /> }
 			</Main>
 		);
-	},
-} );
+	}
+}
 
 export default compose(
 	connect(

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -343,18 +343,7 @@ class Account extends React.Component {
 	}
 
 	cancelEmailChange = () => {
-		// @TODO handle email change in user settings redux data layer
-		this.props.cancelPendingEmailChange(/*( error, response ) => {
-			if ( error ) {
-				debug( 'Error canceling email change: ' + JSON.stringify( error ) );
-				this.props.errorNotice(
-					translate( 'There was a problem canceling the email change. Please, try again.' )
-				);
-			} else {
-				debug( JSON.stringify( 'Email change canceled successfully' + response ) );
-				this.props.successNotice( translate( 'The email change has been successfully canceled.' ) );
-			}
-		}*/);
+		this.props.cancelPendingEmailChange();
 	};
 
 	handleRadioChange( event ) {

--- a/client/me/form-base/with-form-base.jsx
+++ b/client/me/form-base/with-form-base.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -45,10 +44,6 @@ const withFormBase = ( WrappedComponent ) => {
 			return unsavedUserSettings[ settingName ] ?? userSettings[ settingName ] ?? '';
 		};
 
-		getOriginalSetting = ( settingName ) => {
-			return this.props.userSettings[ settingName ];
-		};
-
 		toggleSetting = ( event ) => {
 			const { name } = event.currentTarget;
 			this.props.setUserSetting( name, ! this.getSetting( name ) );
@@ -57,10 +52,6 @@ const withFormBase = ( WrappedComponent ) => {
 		updateSetting = ( event ) => {
 			const { name, value } = event.currentTarget;
 			this.props.setUserSetting( name, value );
-		};
-
-		hasUnsavedUserSetting = ( settingName ) => {
-			return has( this.props.unsavedUserSettings, settingName );
 		};
 
 		submitForm = ( event ) => {
@@ -72,11 +63,9 @@ const withFormBase = ( WrappedComponent ) => {
 		getFormBaseProps = () => ( {
 			getDisabledState: this.getDisabledState,
 			getSetting: this.getSetting,
-			getOriginalSetting: this.getOriginalSetting,
 			toggleSetting: this.toggleSetting,
 			updateSetting: this.updateSetting,
 			submitForm: this.submitForm,
-			hasUnsavedUserSetting: this.hasUnsavedUserSetting,
 			hasUnsavedUserSettings: this.props.hasUnsavedUserSettings,
 			isUpdatingUserSettings: this.props.isUpdatingUserSettings,
 		} );

--- a/client/me/form-base/with-form-base.jsx
+++ b/client/me/form-base/with-form-base.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -44,6 +45,10 @@ const withFormBase = ( WrappedComponent ) => {
 			return unsavedUserSettings[ settingName ] ?? userSettings[ settingName ] ?? '';
 		};
 
+		getOriginalSetting = ( settingName ) => {
+			return this.props.userSettings[ settingName ];
+		};
+
 		toggleSetting = ( event ) => {
 			const { name } = event.currentTarget;
 			this.props.setUserSetting( name, ! this.getSetting( name ) );
@@ -52,6 +57,10 @@ const withFormBase = ( WrappedComponent ) => {
 		updateSetting = ( event ) => {
 			const { name, value } = event.currentTarget;
 			this.props.setUserSetting( name, value );
+		};
+
+		hasUnsavedUserSetting = ( settingName ) => {
+			return has( this.props.unsavedUserSettings, settingName );
 		};
 
 		submitForm = ( event ) => {
@@ -63,9 +72,11 @@ const withFormBase = ( WrappedComponent ) => {
 		getFormBaseProps = () => ( {
 			getDisabledState: this.getDisabledState,
 			getSetting: this.getSetting,
+			getOriginalSetting: this.getOriginalSetting,
 			toggleSetting: this.toggleSetting,
 			updateSetting: this.updateSetting,
 			submitForm: this.submitForm,
+			hasUnsavedUserSetting: this.hasUnsavedUserSetting,
 			hasUnsavedUserSettings: this.props.hasUnsavedUserSettings,
 			isUpdatingUserSettings: this.props.isUpdatingUserSettings,
 		} );

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -89,6 +89,15 @@ export function userSettingsSaveFailure( { settingsOverride }, error ) {
 		];
 	}
 
+	if ( false === settingsOverride?.user_email_change_pending ) {
+		return [
+			errorNotice(
+				translate( 'There was a problem canceling the email change. Please, try again.' )
+			),
+			saveUserSettingsFailure( settingsOverride, error ),
+		];
+	}
+
 	return [
 		errorNotice( error.message || translate( 'There was a problem saving your changes.' ), {
 			id: 'save-user-settings',
@@ -113,6 +122,8 @@ export const userSettingsSaveSuccess = ( { settingsOverride, redirectTo }, data 
 		return;
 	}
 
+	// The require() trick is used to avoid excessive mocking in unit tests.
+	// TODO: Replace it with standard 'import' when the `lib/user` module is Reduxized
 	const userLibModule = require( 'calypso/lib/user' );
 	const userLib = userLibModule.default ? userLibModule.default : userLibModule; // TODO: delete line after removing add-module-exports.
 
@@ -121,10 +132,14 @@ export const userSettingsSaveSuccess = ( { settingsOverride, redirectTo }, data 
 		window.location = window.location.pathname + '?updated=success';
 		return;
 	}
+
 	// Refetch the user data after saving user settings
-	// The require() trick is used to avoid excessive mocking in unit tests.
-	// TODO: Replace it with standard 'import' when the `lib/user` module is Reduxized
 	userLib().fetch();
+
+	if ( false === settingsOverride?.user_email_change_pending ) {
+		dispatch( successNotice( translate( 'The email change has been successfully canceled.' ) ) );
+		return;
+	}
 
 	dispatch(
 		successNotice( translate( 'Settings saved successfully!' ), {

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -101,7 +101,9 @@ export function userSettingsSaveFailure( { settingsOverride }, error ) {
  * After settings were successfully saved, update the settings stored in the Redux state,
  * clear the unsaved settings list, and re-fetch info about the user.
  */
-export const userSettingsSaveSuccess = ( { settingsOverride }, data ) => ( dispatch ) => {
+export const userSettingsSaveSuccess = ( { settingsOverride, redirectTo }, data ) => async (
+	dispatch
+) => {
 	dispatch( saveUserSettingsSuccess( fromApi( data ) ) );
 	dispatch( clearUnsavedUserSettings( settingsOverride ? Object.keys( settingsOverride ) : null ) );
 
@@ -110,11 +112,18 @@ export const userSettingsSaveSuccess = ( { settingsOverride }, data ) => ( dispa
 		window.location = window.location.pathname + '?updated=password';
 		return;
 	}
+
+	const userLibModule = require( 'calypso/lib/user' );
+	const userLib = userLibModule.default ? userLibModule.default : userLibModule; // TODO: delete line after removing add-module-exports.
+
+	if ( redirectTo ) {
+		await userLib().clear();
+		window.location = window.location.pathname + '?updated=success';
+		return;
+	}
 	// Refetch the user data after saving user settings
 	// The require() trick is used to avoid excessive mocking in unit tests.
 	// TODO: Replace it with standard 'import' when the `lib/user` module is Reduxized
-	const userLibModule = require( 'calypso/lib/user' );
-	const userLib = userLibModule.default ? userLibModule.default : userLibModule; // TODO: delete line after removing add-module-exports.
 	userLib().fetch();
 
 	dispatch(

--- a/client/state/user-settings/actions.js
+++ b/client/state/user-settings/actions.js
@@ -116,8 +116,10 @@ export const removeUnsavedUserSetting = ( settingName ) => ( {
 export function setUserSetting( settingName, value ) {
 	return ( dispatch, getState ) => {
 		const settings = getUserSettings( getState() );
+		const settingKey = Array.isArray( settingName ) ? settingName : settingName.split( '.' );
+		const originalSetting = get( settings, settingKey );
 
-		if ( get( settings, settingName ) === undefined ) {
+		if ( originalSetting === undefined ) {
 			debug( settingName + ' does not exist in user-settings data module.' );
 			return false;
 		}
@@ -127,11 +129,11 @@ export function setUserSetting( settingName, value ) {
 		 * user_login is a special case since the logic for validating and saving a username
 		 * is more complicated.
 		 */
-		if ( settings[ settingName ] === value && 'user_login' !== settingName ) {
-			debug( 'Removing ' + settingName + ' from changed settings.' );
-			dispatch( removeUnsavedUserSetting( settingName ) );
+		if ( originalSetting === value && 'user_login' !== settingKey ) {
+			debug( 'Removing ' + settingKey + ' from changed settings.' );
+			dispatch( removeUnsavedUserSetting( settingKey ) );
 		} else {
-			dispatch( setUnsavedUserSetting( settingName, value ) );
+			dispatch( setUnsavedUserSetting( settingKey, value ) );
 		}
 
 		return true;

--- a/client/state/user-settings/actions.js
+++ b/client/state/user-settings/actions.js
@@ -60,11 +60,13 @@ export const fetchUserSettingsSuccess = ( settingValues ) => ( {
  * Post settings to WordPress.com API at /me/settings endpoint
  *
  * @param {object} settingsOverride - default settings object
+ * @param {string} redirectTo - Redirect target after successful save
  * @returns {object} Action object
  */
-export const saveUserSettings = ( settingsOverride ) => ( {
+export const saveUserSettings = ( settingsOverride, redirectTo ) => ( {
 	type: USER_SETTINGS_SAVE,
 	settingsOverride,
+	redirectTo,
 } );
 
 /**

--- a/client/state/user-settings/actions.js
+++ b/client/state/user-settings/actions.js
@@ -119,7 +119,13 @@ export function setUserSetting( settingName, value ) {
 		const settingKey = Array.isArray( settingName ) ? settingName : settingName.split( '.' );
 		const originalSetting = get( settings, settingKey );
 
-		if ( originalSetting === undefined ) {
+		/*
+		 * Exclude `colorScheme` from this condition.
+		 * This is a workaround that allows us to use `setUserSetting()` without an
+		 * existing value. Without this workaround the save button wouldn't become active.
+		 * @TODO: the API should provide a default value, which would make this line obsolete
+		 */
+		if ( originalSetting === undefined && settingName !== 'calypso_preferences.colorScheme' ) {
 			debug( settingName + ' does not exist in user-settings data module.' );
 			return false;
 		}

--- a/client/state/user-settings/actions.js
+++ b/client/state/user-settings/actions.js
@@ -155,8 +155,10 @@ export function setUserSetting( settingName, value ) {
 
 		/*
 		 * If the two match, we don't consider the setting "changed".
-		 * user_login is a special case since the logic for validating and saving a username
-		 * is more complicated.
+		 * `user_login` is a special case since the logic for validating and saving a username
+		 * is more complicated. `language` is a special case since we have to check for changes
+		 * to locale_variant this might be easier if we tracked the lang_id instead as we do in
+		 * client/my-sites/site-settings/form-general.jsx
 		 */
 		if (
 			( originalSetting === value && 'user_login' !== settingKey && 'language' !== settingKey ) ||
@@ -167,7 +169,5 @@ export function setUserSetting( settingName, value ) {
 		} else {
 			dispatch( setUnsavedUserSetting( settingKey, value ) );
 		}
-
-		return true;
 	};
 }

--- a/client/state/user-settings/helpers.js
+++ b/client/state/user-settings/helpers.js
@@ -1,0 +1,45 @@
+/**
+ * Set a (nested) value in an object. Will create keys if they're not existent.
+ *
+ * @param {object} obj Object to operate on
+ * @param {string | Array} path Key to set. Can be an array to represent nested values
+ * @param {string} value Value which key should be set to
+ */
+export function setValue( obj, path, value ) {
+	if ( ! Array.isArray( path ) ) {
+		path = [ path ];
+	}
+	function doSet( o = {}, i ) {
+		return {
+			...o,
+			[ path[ i ] ]: i === path.length - 1 ? value : doSet( o[ path[ i ] ], i + 1 ),
+		};
+	}
+	return doSet( obj, 0 );
+}
+
+/**
+ * Remove a (nested) value from an object. It will clean up empty objects in the tree.
+ *
+ * @param {object} obj Object to operate on
+ * @param {string | Array} path Key to remove. Can be an array to represent nested values
+ */
+export function removeValue( obj, path ) {
+	if ( ! Array.isArray( path ) ) {
+		path = [ path ];
+	}
+	function doRemove( o, i ) {
+		if ( ! o ) {
+			return {};
+		}
+		if ( i < path.length - 1 ) {
+			const r = doRemove( o[ path[ i ] ], i + 1 );
+			if ( Object.keys( r ).length > 0 ) {
+				return { ...o, [ path[ i ] ]: r };
+			}
+		}
+		const { [ path[ i ] ]: r, ...or } = o;
+		return or;
+	}
+	return doRemove( obj, 0 );
+}

--- a/client/state/user-settings/reducer.js
+++ b/client/state/user-settings/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { omit } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,6 +19,7 @@ import {
 	USER_SETTINGS_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
 import { combineReducers } from 'calypso/state/utils';
+import { setValue, removeValue } from './helpers';
 
 export const settings = ( state = {}, { type, settingValues } ) => {
 	switch ( type ) {
@@ -32,26 +33,30 @@ export const settings = ( state = {}, { type, settingValues } ) => {
 
 export const unsavedSettings = ( state = {}, action ) => {
 	switch ( action.type ) {
-		case USER_SETTINGS_UNSAVED_CLEAR:
-			// After a successful save, remove the saved settings (either all of them,
-			// or a subset) from the `unsavedSettings`.
-			if ( ! action.settingNames ) {
+		case USER_SETTINGS_UNSAVED_CLEAR: {
+			const settingNames = action.settingNames;
+
+			if ( ! settingNames ) {
 				return {};
 			}
-			return omit( state, action.settingNames );
 
-		case USER_SETTINGS_UNSAVED_SET:
-			if ( state[ action.settingName ] === action.value ) {
+			if ( Array.isArray( settingNames ) ) {
+				return settingNames.reduce( removeValue, state );
+			}
+
+			return removeValue( state, settingNames );
+		}
+		case USER_SETTINGS_UNSAVED_SET: {
+			if ( get( state, action.settingName ) === action.value ) {
 				return state;
 			}
-			return { ...state, [ action.settingName ]: action.value };
-
-		case USER_SETTINGS_UNSAVED_REMOVE:
-			return omit( state, action.settingName );
-
-		default:
-			return state;
+			return setValue( state, action.settingName, action.value );
+		}
+		case USER_SETTINGS_UNSAVED_REMOVE: {
+			return removeValue( state, action.settingName );
+		}
 	}
+	return state;
 };
 
 export const fetching = ( state = false, action ) => {

--- a/client/state/user-settings/test/actions.js
+++ b/client/state/user-settings/test/actions.js
@@ -29,7 +29,7 @@ describe( 'actions', () => {
 			expect( result ).to.be.true;
 			expect( dispatch ).to.have.been.calledWith( {
 				type: USER_SETTINGS_UNSAVED_SET,
-				settingName: 'foo',
+				settingName: [ 'foo' ],
 				value: 'qix',
 			} );
 		} );
@@ -48,7 +48,7 @@ describe( 'actions', () => {
 			expect( result ).to.be.true;
 			expect( dispatch ).to.have.been.calledWith( {
 				type: USER_SETTINGS_UNSAVED_REMOVE,
-				settingName: 'foo',
+				settingName: [ 'foo' ],
 			} );
 		} );
 

--- a/client/state/user-settings/test/actions.js
+++ b/client/state/user-settings/test/actions.js
@@ -24,9 +24,8 @@ describe( 'actions', () => {
 				},
 			} );
 
-			const result = setUserSetting( 'foo', 'qix' )( dispatch, getState );
+			setUserSetting( 'foo', 'qix' )( dispatch, getState );
 
-			expect( result ).to.be.true;
 			expect( dispatch ).to.have.been.calledWith( {
 				type: USER_SETTINGS_UNSAVED_SET,
 				settingName: [ 'foo' ],
@@ -43,9 +42,8 @@ describe( 'actions', () => {
 				},
 			} );
 
-			const result = setUserSetting( 'foo', 'bar' )( dispatch, getState );
+			setUserSetting( 'foo', 'bar' )( dispatch, getState );
 
-			expect( result ).to.be.true;
 			expect( dispatch ).to.have.been.calledWith( {
 				type: USER_SETTINGS_UNSAVED_REMOVE,
 				settingName: [ 'foo' ],

--- a/client/state/user-settings/test/helpers.js
+++ b/client/state/user-settings/test/helpers.js
@@ -1,0 +1,174 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { setValue, removeValue } from '../helpers';
+
+describe( 'setValue()', () => {
+	test( 'should set simple key to value in obj and return a new object', () => {
+		const state = deepFreeze( {} );
+
+		const result = setValue( state, 'foo', 'bar' );
+		expect( result ).toEqual( { foo: 'bar' } );
+	} );
+
+	test( 'should set simple key to value in obj and keep existing values', () => {
+		const state = deepFreeze( { baz: 'qux' } );
+
+		const result = setValue( state, 'foo', 'bar' );
+		expect( result ).toEqual( { foo: 'bar', baz: 'qux' } );
+	} );
+
+	test( 'should set simple key to value in obj and keep existing nested values', () => {
+		const state = deepFreeze( { foo: { bar: 'baz' } } );
+
+		const result = setValue( state, 'qux', 'quz' );
+		expect( result ).toEqual( { foo: { bar: 'baz' }, qux: 'quz' } );
+	} );
+
+	test( 'should set nested key to value in obj and return a new object', () => {
+		const state = deepFreeze( {} );
+
+		const result = setValue( state, [ 'foo', 'bar' ], 'baz' );
+		expect( result ).toEqual( { foo: { bar: 'baz' } } );
+	} );
+
+	test( 'should set nested key to value in obj and keep existing value', () => {
+		const state = deepFreeze( { foo: 'bar' } );
+
+		const result = setValue( state, [ 'baz', 'qux' ], 'quz' );
+		expect( result ).toEqual( { foo: 'bar', baz: { qux: 'quz' } } );
+	} );
+
+	test( 'should set nested key to value in obj and keep existing (other) nested values', () => {
+		const state = deepFreeze( { foo: { bar: 'baz' } } );
+
+		const result = setValue( state, [ 'foo', 'qux' ], 'quz' );
+		expect( result ).toEqual( { foo: { bar: 'baz', qux: 'quz' } } );
+	} );
+
+	test( 'should set nested key to value in obj and overwrite if key is already set', () => {
+		const state = deepFreeze( { foo: { bar: 'baz' } } );
+
+		const result = setValue( state, [ 'foo', 'bar' ], 'qux' );
+		expect( result ).toEqual( { foo: { bar: 'qux' } } );
+	} );
+
+	test( 'should set deeply nested key to value in obj', () => {
+		const state = deepFreeze( {} );
+
+		const result = setValue( state, [ 'foo', 'bar', 'baz' ], 'qux' );
+		expect( result ).toEqual( { foo: { bar: { baz: 'qux' } } } );
+	} );
+
+	test( 'should set deeply nested key to value in obj and keep others', () => {
+		const state = deepFreeze( { abc: 'def' } );
+
+		const result = setValue( state, [ 'foo', 'bar', 'baz' ], 'qux' );
+		expect( result ).toEqual( { foo: { bar: { baz: 'qux' } }, abc: 'def' } );
+	} );
+
+	test( 'should set deeply nested key to value in obj and keep other nested ones', () => {
+		const state = deepFreeze( { foo: { bar: 'baz' } } );
+
+		const result = setValue( state, [ 'foo', 'abc', 'def' ], 'qux' );
+		expect( result ).toEqual( { foo: { bar: 'baz', abc: { def: 'qux' } } } );
+	} );
+
+	test( 'should overwrite existing keys if value is already set (not null)', () => {
+		const state = deepFreeze( { foo: 1 } );
+
+		const result = setValue( state, [ 'foo', 'bar' ], 'baz' );
+		expect( result ).toEqual( { foo: { bar: 'baz' } } );
+	} );
+
+	test( 'should overwrite existing keys if value is set to `null`', () => {
+		const state = deepFreeze( { foo: null } );
+
+		const result = setValue( state, [ 'foo', 'bar' ], 'baz' );
+		expect( result ).toEqual( { foo: { bar: 'baz' } } );
+	} );
+
+	test( 'should overwrite existing keys if value is set to `undefined`', () => {
+		const state = deepFreeze( { foo: undefined } );
+
+		const result = setValue( state, [ 'foo', 'bar' ], 'baz' );
+		expect( result ).toEqual( { foo: { bar: 'baz' } } );
+	} );
+} );
+
+describe( 'removeValue()', () => {
+	test( 'should remove simple value from obj', () => {
+		const state = deepFreeze( { foo: 'bar' } );
+
+		const result = removeValue( state, 'foo' );
+		expect( result ).toEqual( {} );
+	} );
+
+	test( 'should remove simple value from obj but keep others', () => {
+		const state = deepFreeze( { foo: 'bar', baz: 'qux' } );
+
+		const result = removeValue( state, 'foo' );
+		expect( result ).toEqual( { baz: 'qux' } );
+	} );
+
+	test( 'should remove simple value from obj but keep nested others', () => {
+		const state = deepFreeze( { foo: 'bar', baz: { qux: 'quz' } } );
+
+		const result = removeValue( state, 'foo' );
+		expect( result ).toEqual( { baz: { qux: 'quz' } } );
+	} );
+
+	test( 'should remove nested value from obj', () => {
+		const state = deepFreeze( { foo: { bar: 'baz' } } );
+
+		const result = removeValue( state, [ 'foo', 'bar' ] );
+		expect( result ).toEqual( {} );
+	} );
+
+	test( 'should remove nested value from obj but keep other simple attributes', () => {
+		const state = deepFreeze( { foo: { bar: 'baz' }, qux: 'quz' } );
+
+		const result = removeValue( state, [ 'foo', 'bar' ] );
+		expect( result ).toEqual( { qux: 'quz' } );
+	} );
+
+	test( 'should remove nested value from obj but keep key if it contains more attributes', () => {
+		const state = deepFreeze( { foo: { bar: 'baz', qux: 'quz' } } );
+
+		const result = removeValue( state, [ 'foo', 'bar' ] );
+		expect( result ).toEqual( { foo: { qux: 'quz' } } );
+	} );
+
+	test( 'should remove deeply nested value from obj', () => {
+		const state = deepFreeze( { foo: { bar: { baz: 'qux' } } } );
+
+		const result = removeValue( state, [ 'foo', 'bar', 'baz' ] );
+		expect( result ).toEqual( {} );
+	} );
+
+	test( 'should remove deeply nested value from obj and keep others', () => {
+		const state = deepFreeze( { foo: { bar: { baz: 'qux' } }, abc: 'def' } );
+
+		const result = removeValue( state, [ 'foo', 'bar', 'baz' ] );
+		expect( result ).toEqual( { abc: 'def' } );
+	} );
+
+	test( 'should remove deeply nested value from obj and keep other nested ones', () => {
+		const state = deepFreeze( { foo: { bar: { baz: 'qux' }, abc: 'def' } } );
+
+		const result = removeValue( state, [ 'foo', 'bar', 'baz' ] );
+		expect( result ).toEqual( { foo: { abc: 'def' } } );
+	} );
+
+	test( 'should ignore values which are not set', () => {
+		const state = deepFreeze( { foo: { bar: 'baz' } } );
+
+		const result = removeValue( state, [ 'foo', 'qux' ] );
+		expect( result ).toEqual( { foo: { bar: 'baz' } } );
+	} );
+} );

--- a/client/state/user-settings/test/reducer.js
+++ b/client/state/user-settings/test/reducer.js
@@ -89,6 +89,20 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		test( 'should store a nexted user setting', () => {
+			const state = unsavedSettings( undefined, {
+				type: USER_SETTINGS_UNSAVED_SET,
+				settingName: [ 'foo', 'bar' ],
+				value: 'baz',
+			} );
+
+			expect( state ).toEqual( {
+				foo: {
+					bar: 'baz',
+				},
+			} );
+		} );
+
 		test( 'should store additional user setting after it is set', () => {
 			const original = deepFreeze( {
 				foo: 'bar',
@@ -106,6 +120,25 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		test( 'should store additional nested user setting after it is set', () => {
+			const original = deepFreeze( {
+				foo: 'bar',
+			} );
+
+			const state = unsavedSettings( original, {
+				type: USER_SETTINGS_UNSAVED_SET,
+				settingName: [ 'baz', 'bar' ],
+				value: 'qux',
+			} );
+
+			expect( state ).toEqual( {
+				foo: 'bar',
+				baz: {
+					bar: 'qux',
+				},
+			} );
+		} );
+
 		test( 'should remove a user setting', () => {
 			const original = deepFreeze( {
 				foo: 'bar',
@@ -119,6 +152,46 @@ describe( 'reducer', () => {
 
 			expect( state ).toEqual( {
 				foo: 'bar',
+			} );
+		} );
+
+		test( 'should remove a nested user setting', () => {
+			const original = deepFreeze( {
+				foo: 'bar',
+				baz: {
+					bar: 'qux',
+				},
+			} );
+
+			const state = unsavedSettings( original, {
+				type: USER_SETTINGS_UNSAVED_REMOVE,
+				settingName: [ 'baz', 'bar' ],
+			} );
+
+			expect( state ).toEqual( {
+				foo: 'bar',
+			} );
+		} );
+
+		test( 'should keep non-empty top level setting keys', () => {
+			const original = deepFreeze( {
+				foo: 'bar',
+				baz: {
+					qux: 'bar',
+					bar: 'qux',
+				},
+			} );
+
+			const state = unsavedSettings( original, {
+				type: USER_SETTINGS_UNSAVED_REMOVE,
+				settingName: [ 'baz', 'bar' ],
+			} );
+
+			expect( state ).toEqual( {
+				foo: 'bar',
+				baz: {
+					qux: 'bar',
+				},
 			} );
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reduxify `user-settings` in `/me/account`
* Drop `form-base` mixin from `<Account />` (and use Redux actions directly instead of introducing `withFormBase` hoc)
* Refactor `<Account />` to a class component (drop `createReactClass`)
* Add support for nested objects in `state/user-settings` reducer

#### Testing instructions

*

part of #24162 
