### PR TITLE
Revert "Gutenboarding: use granular selectors from onboarding store"

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -26,12 +26,9 @@ const DomainPickerButton: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const locale = useLocale();
 	const makePath = usePath();
-	const { domain, selectedDesign, siteTitle, siteVertical } = useSelect( ( select ) => ( {
-		domain: select( ONBOARD_STORE ).getSelectedDomain(),
-		selectedDesign: select( ONBOARD_STORE ).getSelectedDesign(),
-		siteTitle: select( ONBOARD_STORE ).getSelectedSiteTitle(),
-		siteVertical: select( ONBOARD_STORE ).getSelectedVertical(),
-	} ) );
+	const { domain, selectedDesign, siteTitle, siteVertical } = useSelect( ( select ) =>
+		select( ONBOARD_STORE ).getState()
+	);
 
 	// Use site title or vertical as search query for a domain suggestion
 	const suggestionQuery = siteTitle || siteVertical?.label || '';

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -30,7 +30,7 @@ const Header: React.FunctionComponent = () => {
 	const isAnchorFmSignup = useIsAnchorFm();
 	const makePath = usePath();
 
-	const siteTitle = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedSiteTitle() );
+	const { siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 
 	// steps (including modals) where we show Domains button
 	const showDomainsButton =

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -45,10 +45,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 	const { createAccount, clearErrors } = useDispatch( USER_STORE );
 	const isFetchingNewUser = useSelect( ( select ) => select( USER_STORE ).isFetchingNewUser() );
 	const newUserError = useSelect( ( select ) => select( USER_STORE ).getNewUserError() );
-	const { siteTitle, siteVertical } = useSelect( ( select ) => ( {
-		siteTitle: select( ONBOARD_STORE ).getSelectedSiteTitle(),
-		siteVertical: select( ONBOARD_STORE ).getSelectedVertical(),
-	} ) );
+	const { siteTitle, siteVertical } = useSelect( ( select ) => select( ONBOARD_STORE ) ).getState();
 	const langParam = useLangRouteParam();
 	const makePath = usePath();
 	const currentStep = useCurrentStep();

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -57,7 +57,7 @@ interface Cart {
  **/
 
 export default function useOnSiteCreation(): void {
-	const domain = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDomain() );
+	const { domain } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const isRedirecting = useSelect( ( select ) => select( ONBOARD_STORE ).getIsRedirecting() );
 	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
 	const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );

--- a/client/landing/gutenboarding/hooks/use-signup.ts
+++ b/client/landing/gutenboarding/hooks/use-signup.ts
@@ -25,7 +25,7 @@ import { useIsAnchorFm } from '../path';
  */
 
 export default function useSignup() {
-	const showSignupDialog = useSelect( ( select ) => select( ONBOARD_STORE ).showSignupDialog() );
+	const { showSignupDialog } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const { setShowSignupDialog } = useDispatch( ONBOARD_STORE );
 	const isAnchorFmSignup = useIsAnchorFm();
 	const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );

--- a/client/landing/gutenboarding/hooks/use-steps.ts
+++ b/client/landing/gutenboarding/hooks/use-steps.ts
@@ -42,11 +42,9 @@ export default function useSteps(): Array< StepType > {
 
 	// Logic necessary to skip Domains or Plans steps
 	// General rule: if a step has been used already, don't remove it.
-	const { domain, hasUsedDomainsStep, hasUsedPlansStep } = useSelect( ( select ) => ( {
-		domain: select( ONBOARD_STORE ).getSelectedDomain(),
-		hasUsedDomainsStep: select( ONBOARD_STORE ).hasUsedDomainsStep(),
-		hasUsedPlansStep: select( ONBOARD_STORE ).hasUsedPlansStep(),
-	} ) );
+	const { domain, hasUsedDomainsStep, hasUsedPlansStep } = useSelect( ( select ) =>
+		select( ONBOARD_STORE ).getState()
+	);
 	const plan = useSelect( ( select ) => select( ONBOARD_STORE ).getPlan() );
 	const hasPlanFromPath = !! usePlanFromPath();
 

--- a/client/landing/gutenboarding/hooks/use-track-onboarding-start.ts
+++ b/client/landing/gutenboarding/hooks/use-track-onboarding-start.ts
@@ -18,9 +18,7 @@ import { useOnboardingFlow } from '../path';
 
 export default function useTrackOnboardingStart() {
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
-	const hasOnboardingStarted = useSelect( ( select ) =>
-		select( ONBOARD_STORE ).hasOnboardingStarted()
-	);
+	const { hasOnboardingStarted } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const { startOnboarding } = useDispatch( ONBOARD_STORE );
 	const flow = useOnboardingFlow();
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/acquire-intent-text-input/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/acquire-intent-text-input/index.tsx
@@ -71,6 +71,7 @@ const AcquireIntentTextInput: React.FunctionComponent< Props > = ( {
 	return (
 		<div className="acquire-intent-text-input__wrapper">
 			<input
+				key="acquire-intent__input"
 				className={ classnames( 'acquire-intent-text-input__input', {
 					'is-empty': ! ( value as string ).length,
 				} ) }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -27,12 +27,12 @@ import './style.scss';
 
 const AcquireIntent: React.FunctionComponent = () => {
 	const { __ } = useI18n();
-	const { siteVertical, siteTitle, wasVerticalSkipped, hasSiteTitle } = useSelect( ( select ) => ( {
-		siteVertical: select( STORE_KEY ).getSelectedVertical(),
-		siteTitle: select( STORE_KEY ).getSelectedSiteTitle(),
-		wasVerticalSkipped: select( STORE_KEY ).wasVerticalSkipped(),
-		hasSiteTitle: select( STORE_KEY ).hasSiteTitle(),
-	} ) );
+	const {
+		getSelectedVertical,
+		getSelectedSiteTitle,
+		wasVerticalSkipped,
+		hasSiteTitle,
+	} = useSelect( ( select ) => select( STORE_KEY ) );
 
 	const siteTitleRef = React.useRef< HTMLInputElement >();
 
@@ -44,12 +44,16 @@ const AcquireIntent: React.FunctionComponent = () => {
 
 	const { goNext } = useStepNavigation();
 
-	const showSiteTitleAndNext = !! ( siteVertical || hasSiteTitle || wasVerticalSkipped );
+	const showSiteTitleAndNext = !! (
+		getSelectedVertical() ||
+		hasSiteTitle() ||
+		wasVerticalSkipped()
+	);
 
 	useTrackStep( 'IntentGathering', () => ( {
-		selected_vertical_slug: siteVertical?.slug,
-		selected_vertical_label: siteVertical?.label,
-		has_selected_site_title: hasSiteTitle,
+		selected_vertical_slug: getSelectedVertical()?.slug,
+		selected_vertical_label: getSelectedVertical()?.label,
+		has_selected_site_title: hasSiteTitle(),
 	} ) );
 
 	const handleSkip = () => {
@@ -67,8 +71,8 @@ const AcquireIntent: React.FunctionComponent = () => {
 	};
 
 	const handleSiteTitleSubmit = () => {
-		if ( hasSiteTitle && isGoodDefaultDomainQuery( siteTitle ) ) {
-			setDomainSearch( siteTitle );
+		if ( hasSiteTitle() && isGoodDefaultDomainQuery( getSelectedSiteTitle() ) ) {
+			setDomainSearch( getSelectedSiteTitle() );
 		}
 		goNext();
 	};
@@ -84,7 +88,7 @@ const AcquireIntent: React.FunctionComponent = () => {
 	const siteTitleInput = showSiteTitleAndNext && (
 		<SiteTitle inputRef={ siteTitleRef } onSubmit={ handleSiteTitleSubmit } />
 	);
-	const nextStepButton = hasSiteTitle ? (
+	const nextStepButton = hasSiteTitle() ? (
 		<NextButton onClick={ handleSiteTitleSubmit }>{ __( 'Continue' ) }</NextButton>
 	) : (
 		<SkipButton onClick={ handleSiteTitleSkip }>{ __( 'Skip for now' ) }</SkipButton>
@@ -95,6 +99,8 @@ const AcquireIntent: React.FunctionComponent = () => {
 			{ __( 'I donʼt know' ) }
 		</SkipButton>
 	);
+
+	const siteVertical = getSelectedVertical();
 
 	const showVerticalInput = config.isEnabled( 'gutenboarding/show-vertical-input' );
 
@@ -119,7 +125,7 @@ const AcquireIntent: React.FunctionComponent = () => {
 						) ) }
 					{ ! isMobile && (
 						<>
-							{ ! wasVerticalSkipped && verticalSelect }
+							{ ! wasVerticalSkipped() && verticalSelect }
 							{ siteTitleInput }
 						</>
 					) }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -26,7 +26,7 @@ interface Props {
 
 const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) => {
 	const { __, _x } = useI18n();
-	const siteTitle = useSelect( ( select ) => select( STORE_KEY ).getSelectedSiteTitle() );
+	const { siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
 	const isAnchorFmSignup = useIsAnchorFm();
 	const { setSiteTitle } = useDispatch( STORE_KEY );
 	const [ isTouched, setIsTouched ] = React.useState( false );
@@ -112,15 +112,20 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) =
 				{ inputLabel }
 			</label>
 			<div className="site-title__input-wrapper">
+				{ /* Adding key makes it more performant
+					because without it the element is recreated
+					for every letter in the typing animation
+					*/ }
 				<AcquireIntentTextInput
 					ref={ inputRef as React.MutableRefObject< HTMLInputElement | null > }
+					key="site-title__input"
 					onChange={ setSiteTitle }
 					onFocus={ handleFocus }
 					onBlur={ handleBlur }
 					value={ siteTitle }
 					autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 					placeholder={ placeHolder }
-				/>
+				></AcquireIntentTextInput>
 				<p className="site-title__input-hint">
 					<Icon icon={ tip } size={ 18 } />
 					{ /* translators: The "it" here refers to the site title. */ }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -60,7 +60,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 			} ) )
 	);
 
-	const siteVertical = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedVertical() );
+	const { siteVertical } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const { setSiteVertical, resetSiteVertical } = useDispatch( ONBOARD_STORE );
 	const isMobile = useViewportMatch( 'small', '<' );
 

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -32,16 +32,14 @@ const DesignSelector: React.FunctionComponent = () => {
 	const { goBack, goNext } = useStepNavigation();
 
 	const { setSelectedDesign, setFonts } = useDispatch( ONBOARD_STORE );
-	const { selectedDesign, hasPaidDesign, randomizedDesigns } = useSelect( ( select ) => ( {
-		selectedDesign: select( ONBOARD_STORE ).getSelectedDesign(),
-		hasPaidDesign: select( ONBOARD_STORE ).hasPaidDesign(),
-		randomizedDesigns: select( ONBOARD_STORE ).getRandomizedDesigns(),
-	} ) );
+	const { getSelectedDesign, hasPaidDesign, getRandomizedDesigns } = useSelect( ( select ) =>
+		select( ONBOARD_STORE )
+	);
 	const isAnchorFmSignup = useIsAnchorFm();
 
 	useTrackStep( 'DesignSelection', () => ( {
-		selected_design: selectedDesign?.slug,
-		is_selected_design_premium: hasPaidDesign,
+		selected_design: getSelectedDesign()?.slug,
+		is_selected_design_premium: hasPaidDesign(),
 	} ) );
 
 	return (
@@ -65,8 +63,8 @@ const DesignSelector: React.FunctionComponent = () => {
 				<div
 					className={ isAnchorFmSignup ? 'design-selector__grid-minimal' : 'design-selector__grid' }
 				>
-					{ randomizedDesigns.featured
-						.filter(
+					{ getRandomizedDesigns()
+						.featured.filter(
 							( design ) =>
 								// TODO Add finalized design templates to client/landing/gutenboarding/available-designs-config.json
 								// along with is_anchorfm prop

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -37,10 +37,7 @@ import './colors.scss';
 import './style.scss';
 
 const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = () => {
-	const { selectedDesign, siteTitle } = useSelect( ( select ) => ( {
-		selectedDesign: select( STORE_KEY ).getSelectedDesign(),
-		siteTitle: select( STORE_KEY ).getSelectedSiteTitle(),
-	} ) );
+	const { selectedDesign, siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
 	const isRedirecting = useSelect( ( select ) => select( STORE_KEY ).getIsRedirecting() );
 	const isCreatingSite = useSelect( ( select ) => select( SITE_STORE ).isFetchingSite() );
 	const newSiteError = useSelect( ( select ) => select( SITE_STORE ).getNewSiteError() );

--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -18,16 +18,15 @@ import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 
 const FontSelect: React.FunctionComponent = () => {
 	const { __ } = useI18n();
-	const { selectedDesign, selectedFonts, randomizedDesigns } = useSelect( ( select ) => ( {
-		selectedDesign: select( ONBOARD_STORE ).getSelectedDesign(),
-		selectedFonts: select( ONBOARD_STORE ).getSelectedFonts(),
-		randomizedDesigns: select( ONBOARD_STORE ).getRandomizedDesigns(),
-	} ) );
+	const { selectedDesign, selectedFonts } = useSelect( ( select ) =>
+		select( ONBOARD_STORE ).getState()
+	);
+	const { getRandomizedDesigns } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 	const { setFonts } = useDispatch( ONBOARD_STORE );
 	const [ isOpen, setIsOpen ] = React.useState( false );
 
 	// TODO: Add font loading for unknown fonts
-	const selectedDesignDefaultFonts = randomizedDesigns.featured.find(
+	const selectedDesignDefaultFonts = getRandomizedDesigns().featured.find(
 		( design ) => design.slug === selectedDesign?.slug
 	)?.fonts;
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -58,11 +58,9 @@ interface Props {
 const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 	const language = useLocale();
 	const [ previewHtml, setPreviewHtml ] = React.useState< string >();
-	const { selectedDesign, selectedFonts, siteTitle } = useSelect( ( select ) => ( {
-		selectedDesign: select( STORE_KEY ).getSelectedDesign(),
-		selectedFonts: select( STORE_KEY ).getSelectedFonts(),
-		siteTitle: select( STORE_KEY ).getSelectedSiteTitle(),
-	} ) );
+	const { selectedDesign, selectedFonts, siteTitle } = useSelect( ( select ) =>
+		select( STORE_KEY ).getState()
+	);
 
 	const iframe = React.useRef< HTMLIFrameElement >( null );
 	const effectiveFontPairings = useFontPairings();

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -14,6 +14,7 @@ export const getSelectedFonts = ( state: State ) => state.selectedFonts;
 export const getSelectedSite = ( state: State ) => state.selectedSite;
 export const getSelectedSiteTitle = ( state: State ) => state.siteTitle;
 export const getSelectedVertical = ( state: State ) => state.siteVertical;
+export const getState = ( state: State ) => state;
 export const hasPaidDesign = ( state: State ): boolean => {
 	if ( ! state.selectedDesign ) {
 		return false;
@@ -26,11 +27,7 @@ export const hasPaidDomain = ( state: State ): boolean => {
 	}
 	return ! state.domain.is_free;
 };
-export const hasOnboardingStarted = ( state: State ) => state.hasOnboardingStarted;
 export const hasSiteTitle = ( state: State ) => state.siteTitle.trim().length > 1; // for valid domain results, we need at least 2 characters
-export const hasUsedPlansStep = ( state: State ) => state.hasUsedPlansStep;
-export const hasUsedDomainsStep = ( state: State ) => state.hasUsedDomainsStep;
-export const showSignupDialog = ( state: State ) => state.showSignupDialog;
 export const wasVerticalSkipped = ( state: State ): boolean => state.wasVerticalSkipped;
 
 // Selectors dependent on other selectors (cannot be put in alphabetical order)


### PR DESCRIPTION
This reverts commit 8671c92af06a5f8e841ce107d2638b66befa55db merged in #48729.

This commit was an experimental attempt at fixing Gutenboarding e2e test. I wanted to revert it before merging, but didn't do so 😢 

**How to test:**
This patch caused JS crashes in Gutenboarding when selecting a plan (clicking "Select"):

<img width="1003" alt="Screenshot 2021-01-21 at 10 39 53" src="https://user-images.githubusercontent.com/664258/105332545-08e02100-5bd5-11eb-8871-181b67e855de.png">

Verify that the error is gone and Gutenboarding works again.