### PR TITLE
Onboarding: Hide language picker label on small screens

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -56,7 +56,9 @@ const Header: React.FunctionComponent = () => {
 			return (
 				<div className="gutenboarding__header-section-item gutenboarding__header-language-section">
 					<Link to={ makePath( Step.LanguageModal ) }>
-						<span>{ __( 'Site Language' ) } </span>
+						<span className="gutenboarding__header-site-language-label">
+							{ __( 'Site Language' ) }
+						</span>
 						<span className="gutenboarding__header-site-language-badge">{ locale }</span>
 					</Link>
 				</div>

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -28,7 +28,19 @@ $padding--gutenboarding__header: $grid-unit-10;
 }
 
 .gutenboarding__header-language-section {
-	margin-right: 15px;
+	margin-right: auto;
+
+	@include break-small {
+		margin-right: 15px;
+	}
+}
+
+.gutenboarding__header-site-language-label {
+	display: none;
+
+	@include break-small {
+		display: inline;
+	}
 }
 
 .gutenboarding__header-site-language-badge {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide the language picker label on small screens to prevent it breaking out of the layout.

| Before | After |
| - | - |
| <img width="564" alt="Screenshot 2021-01-21 at 11 23 50" src="https://user-images.githubusercontent.com/2070010/105344925-8149e080-5bdb-11eb-8a04-333c6964a988.png"> | <img width="561" alt="Screenshot 2021-01-21 at 11 23 57" src="https://user-images.githubusercontent.com/2070010/105344935-84dd6780-5bdb-11eb-911b-9bb74569d39a.png"> |

#### Testing instructions

* Open http://calypso.localhost:3000/new/design/ja
* Resize the window to a small width.
* Make sure the language picker label is hidden on small screens.
* Try if different languages all look appropriately.

Fixes #49061
