### PR TITLE
ABTest, Plans: Eliminate extraneous loading of jetpackSimplifyPricingPage test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -69,7 +69,7 @@ export default {
 		allowExistingUsers: false,
 	},
 	jetpackSimplifyPricingPage: {
-		datestamp: '20210118',
+		datestamp: '20210121',
 		variations: {
 			test: 50,
 			control: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -69,7 +69,7 @@ export default {
 		allowExistingUsers: false,
 	},
 	jetpackSimplifyPricingPage: {
-		datestamp: '20210121',
+		datestamp: '20210122',
 		variations: {
 			test: 50,
 			control: 50,

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -13,7 +13,6 @@ import MaterialIcon from 'calypso/components/material-icon';
 import ExternalLink from 'calypso/components/external-link';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from 'calypso/lib/url/support';
-import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans/jetpack-plans/abtest';
 
 export const FEATURE_CATEGORIES = {
 	[ constants.FEATURE_CATEGORY_SECURITY ]: {
@@ -1021,10 +1020,10 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_PLAN_SECURITY_DAILY ]: {
 		getSlug: () => constants.FEATURE_PLAN_SECURITY_DAILY,
 		getIcon: () => 'lock',
-		getTitle: () =>
+		getTitle: ( variation ) =>
 			( {
 				spp: i18n.translate( 'All Jetpack Security features' ),
-			}[ getJetpackCROActiveVersion() ] || i18n.translate( 'All Security Daily features' ) ),
+			}[ variation ] || i18n.translate( 'All Security Daily features' ) ),
 		isPlan: true,
 	},
 
@@ -1075,11 +1074,11 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_BACKUP_REALTIME_V2 ]: {
 		getSlug: () => constants.FEATURE_BACKUP_REALTIME_V2,
-		getTitle: () =>
+		getTitle: ( variation ) =>
 			( {
 				i5: i18n.translate( 'Backup (real-time, off-site)' ),
 				spp: i18n.translate( 'Backup (real-time, off-site)' ),
-			}[ getJetpackCROActiveVersion() ] || i18n.translate( 'Automated real-time site backups' ) ),
+			}[ variation ] || i18n.translate( 'Automated real-time site backups' ) ),
 	},
 
 	[ constants.FEATURE_PRODUCT_BACKUP_V2 ]: {
@@ -1095,13 +1094,13 @@ export const FEATURES_LIST = {
 					},
 				}
 			),
-		isProduct: getJetpackCROActiveVersion() === 'v2',
+		isProduct: ( variation ) => variation === 'v2',
 	},
 
 	[ constants.FEATURE_PRODUCT_BACKUP_DAILY_V2 ]: {
 		getSlug: () => constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
 		getIcon: () => 'cloud-upload',
-		getTitle: () =>
+		getTitle: ( variation ) =>
 			( {
 				v2: i18n.translate( 'Backup {{strong}}{{em}}Daily{{/em}}{{/strong}}', {
 					components: {
@@ -1111,7 +1110,7 @@ export const FEATURES_LIST = {
 				} ),
 				i5: i18n.translate( 'All Backup Daily features' ),
 				spp: i18n.translate( 'All Jetpack Backup features' ),
-			}[ getJetpackCROActiveVersion() ] ||
+			}[ variation ] ||
 			i18n.translate( 'Backup {{em}}Daily{{/em}}', {
 				components: {
 					em: <em />,
@@ -1126,13 +1125,13 @@ export const FEATURES_LIST = {
 					},
 				}
 			),
-		isProduct: getJetpackCROActiveVersion() === 'v2',
+		isProduct: ( variation ) => variation === 'v2',
 	},
 
 	[ constants.FEATURE_PRODUCT_BACKUP_REALTIME_V2 ]: {
 		getSlug: () => constants.FEATURE_PRODUCT_BACKUP_REALTIME_V2,
 		getIcon: () => 'cloud-upload',
-		getTitle: () =>
+		getTitle: ( variation ) =>
 			( {
 				v2: i18n.translate( 'Backup {{strong}}{{em}}Real{{nbh/}}time{{/em}}{{/strong}}', {
 					components: {
@@ -1143,7 +1142,7 @@ export const FEATURES_LIST = {
 					comment: '{{nbh}} represents a non breakable hyphen',
 				} ),
 				i5: i18n.translate( 'Backup Real-time (off-site)' ),
-			}[ getJetpackCROActiveVersion() ] ||
+			}[ variation ] ||
 			i18n.translate( 'Backup {{em}}Real-time{{/em}}', {
 				components: {
 					em: <em />,
@@ -1158,7 +1157,7 @@ export const FEATURES_LIST = {
 					},
 				}
 			),
-		isProduct: getJetpackCROActiveVersion() === 'v2',
+		isProduct: ( variation ) => variation === 'v2',
 	},
 
 	[ constants.FEATURE_SCAN_V2 ]: {
@@ -1179,7 +1178,7 @@ export const FEATURES_LIST = {
 					},
 				}
 			),
-		isProduct: getJetpackCROActiveVersion() === 'v2',
+		isProduct: ( variation ) => variation === 'v2',
 	},
 
 	/**
@@ -1199,7 +1198,7 @@ export const FEATURES_LIST = {
 					},
 				}
 			),
-		isProduct: getJetpackCROActiveVersion() === 'v2',
+		isProduct: ( variation ) => variation === 'v2',
 	},
 
 	// * Scan Daily *
@@ -1209,11 +1208,11 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_PRODUCT_SCAN_DAILY_V2 ]: {
 		getSlug: () => constants.FEATURE_PRODUCT_SCAN_DAILY_V2,
 		getIcon: () => ( { icon: 'security', component: MaterialIcon } ),
-		getTitle: () =>
+		getTitle: ( variation ) =>
 			( {
 				i5: i18n.translate( 'Scan (daily, automated)' ),
 				spp: i18n.translate( 'Scan (daily, automated)' ),
-			}[ getJetpackCROActiveVersion() ] ||
+			}[ variation ] ||
 			i18n.translate( 'Scan {{em}}Daily{{/em}}', {
 				components: {
 					em: <em />,
@@ -1228,7 +1227,7 @@ export const FEATURES_LIST = {
 					},
 				}
 			),
-		isProduct: getJetpackCROActiveVersion() === 'v2',
+		isProduct: ( variation ) => variation === 'v2',
 	},
 
 	// * Scan Real-time *
@@ -1238,11 +1237,11 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_PRODUCT_SCAN_REALTIME_V2 ]: {
 		getSlug: () => constants.FEATURE_PRODUCT_SCAN_REALTIME_V2,
 		getIcon: () => ( { icon: 'security', component: MaterialIcon } ),
-		getTitle: () =>
+		getTitle: ( variation ) =>
 			( {
 				i5: i18n.translate( 'Scan (real-time, automated)' ),
 				spp: i18n.translate( 'Scan (real-time, automated)' ),
-			}[ getJetpackCROActiveVersion() ] ||
+			}[ variation ] ||
 			i18n.translate( 'Scan {{em}}Real-time{{/em}}', {
 				components: {
 					em: <em />,
@@ -1257,16 +1256,16 @@ export const FEATURES_LIST = {
 					},
 				}
 			),
-		isProduct: getJetpackCROActiveVersion() === 'v2',
+		isProduct: ( variation ) => variation === 'v2',
 	},
 
 	[ constants.FEATURE_ANTISPAM_V2 ]: {
 		getSlug: () => constants.FEATURE_ANTISPAM_V2,
-		getTitle: () =>
+		getTitle: ( variation ) =>
 			( {
 				i5: i18n.translate( 'Anti-spam ' ),
 				spp: i18n.translate( 'Anti-spam' ),
-			}[ getJetpackCROActiveVersion() ] || i18n.translate( 'Automated spam protection' ) ),
+			}[ variation ] || i18n.translate( 'Automated spam protection' ) ),
 	},
 
 	[ constants.FEATURE_PRODUCT_ANTISPAM_V2 ]: {
@@ -1282,7 +1281,7 @@ export const FEATURES_LIST = {
 					},
 				}
 			),
-		isProduct: getJetpackCROActiveVersion() === 'v2',
+		isProduct: ( variation ) => variation === 'v2',
 	},
 
 	[ constants.FEATURE_ACTIVITY_LOG_V2 ]: {
@@ -1337,8 +1336,8 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_PRODUCT_SEARCH_V2 ]: {
 		getSlug: () => constants.FEATURE_PRODUCT_SEARCH_V2,
-		getIcon: () => ( getJetpackCROActiveVersion() === 'v2' ? 'search' : null ),
-		getTitle: () =>
+		getIcon: ( variation ) => ( variation === 'v2' ? 'search' : null ),
+		getTitle: ( variation ) =>
 			( {
 				v2: i18n.translate( 'Jetpack Search {{strong}}{{em}}Up to 100k records{{/em}}{{/strong}}', {
 					components: {
@@ -1348,7 +1347,7 @@ export const FEATURES_LIST = {
 				} ),
 				i5: i18n.translate( 'Site Search: up to 100k records' ),
 				spp: i18n.translate( 'Site Search: up to 100k records' ),
-			}[ getJetpackCROActiveVersion() ] || i18n.translate( 'Search: up to 100k records' ) ),
+			}[ variation ] || i18n.translate( 'Search: up to 100k records' ) ),
 
 		getDescription: () =>
 			i18n.translate(
@@ -1359,7 +1358,7 @@ export const FEATURES_LIST = {
 					},
 				}
 			),
-		isProduct: getJetpackCROActiveVersion() === 'v2',
+		isProduct: ( variation ) => variation === 'v2',
 	},
 
 	[ constants.FEATURE_VIDEO_HOSTING_V2 ]: {
@@ -1378,8 +1377,8 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_CRM_V2 ]: {
 		getSlug: () => constants.FEATURE_CRM_V2,
-		getIcon: () => ( getJetpackCROActiveVersion() === 'v2' ? 'multiple-users' : null ),
-		getTitle: () =>
+		getIcon: ( variation ) => ( variation === 'v2' ? 'multiple-users' : null ),
+		getTitle: ( variation ) =>
 			( {
 				v2: i18n.translate( 'Jetpack CRM {{strong}}{{em}}Entrepreneur{{/em}}{{/strong}}', {
 					components: {
@@ -1387,7 +1386,7 @@ export const FEATURES_LIST = {
 						strong: <strong />,
 					},
 				} ),
-			}[ getJetpackCROActiveVersion() ] || i18n.translate( 'CRM: Entrepreneur bundle' ) ),
+			}[ variation ] || i18n.translate( 'CRM: Entrepreneur bundle' ) ),
 		getDescription: () =>
 			i18n.translate(
 				'The most simple and powerful WordPress CRM. Improve customer relationships and increase profits. {{link}}Learn more{{/link}}.',
@@ -1397,7 +1396,7 @@ export const FEATURES_LIST = {
 					},
 				}
 			),
-		isProduct: getJetpackCROActiveVersion() === 'v2',
+		isProduct: ( variation ) => variation === 'v2',
 	},
 
 	[ constants.FEATURE_CRM_LEADS_AND_FUNNEL ]: {
@@ -1517,12 +1516,11 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_ONE_CLICK_RESTORE_V2 ]: {
 		getSlug: () => constants.FEATURE_ONE_CLICK_RESTORE_V2,
-		getTitle: () =>
+		getTitle: ( variation ) =>
 			( {
 				i5: i18n.translate( 'One-click restores' ),
 				spp: i18n.translate( 'One-click restores' ),
-			}[ getJetpackCROActiveVersion() ] ||
-			i18n.translate( 'One-click restores from desktop or mobile' ) ),
+			}[ variation ] || i18n.translate( 'One-click restores from desktop or mobile' ) ),
 	},
 
 	[ constants.FEATURE_ONE_CLICK_FIX_V2 ]: {

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -9,7 +9,6 @@ import i18n, { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { isEnabled } from 'calypso/config';
-import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans/jetpack-plans/abtest';
 import * as constants from './constants';
 
 const WPComGetBillingTimeframe = () => i18n.translate( 'per month, billed annually' );
@@ -392,21 +391,20 @@ const getPlanBusinessDetails = () => ( {
 const getPlanJetpackSecurityDailyDetails = () => ( {
 	group: constants.GROUP_JETPACK,
 	type: constants.TYPE_SECURITY_DAILY,
-	getTitle: () =>
+	getTitle: ( variation ) =>
 		( {
 			v2: translate( 'Jetpack Security {{em}}Daily{{/em}}', { components: { em: <em /> } } ),
 			spp: translate( 'Jetpack Security' ),
-		}[ getJetpackCROActiveVersion() ] ||
-		translate( 'Security {{em}}Daily{{/em}}', { components: { em: <em /> } } ) ),
-	getButtonLabel: () =>
+		}[ variation ] || translate( 'Security {{em}}Daily{{/em}}', { components: { em: <em /> } } ) ),
+	getButtonLabel: ( variation ) =>
 		( {
 			v2: translate( 'Get Security {{em}}Daily{{/em}}', { components: { em: <em /> } } ),
 			spp: translate( 'Get Jetpack Security' ),
-		}[ getJetpackCROActiveVersion() ] || undefined ),
+		}[ variation ] || undefined ),
 	getAudience: () => translate(),
 	availableFor: ( plan ) =>
 		[ constants.PLAN_JETPACK_FREE, ...constants.JETPACK_LEGACY_PLANS ].includes( plan ),
-	getDescription: () =>
+	getDescription: ( variation ) =>
 		( {
 			v2: translate(
 				'All of the essential Jetpack Security features in one package including Backup, Scan, Anti-spam and more.'
@@ -417,25 +415,19 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 			spp: translate(
 				'All of the essential Jetpack Security features in one package including Backup, Scan, Anti-spam and more.'
 			),
-		}[ getJetpackCROActiveVersion() ] ||
+		}[ variation ] ||
 		translate(
 			'Enjoy the peace of mind of complete site protection. ' +
 				'Great for brochure sites, restaurants, blogs, and resume sites.'
 		) ),
 
-	getTagline: () => {
-		if ( getJetpackCROActiveVersion() === 'v1' ) {
-			return translate( 'Backup, Scan, and Anti-spam in one package' );
-		}
-
-		if ( getJetpackCROActiveVersion() === 'v2' ) {
-			return translate( 'Essential WordPress protection' );
-		}
-
-		return translate( 'Best for sites with occasional updates' );
-	},
+	getTagline: ( variation ) =>
+		( {
+			v1: translate( 'Backup, Scan, and Anti-spam in one package' ),
+			v2: translate( 'Essential WordPress protection' ),
+		}[ variation ] || translate( 'Best for sites with occasional updates' ) ),
 	getPlanCompareFeatures: () => [],
-	getPlanCardFeatures: () =>
+	getPlanCardFeatures: ( variation ) =>
 		( {
 			v2: [
 				constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
@@ -458,7 +450,7 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 				constants.FEATURE_ANTISPAM_V2,
 				constants.FEATURE_VIDEO_HOSTING_V2,
 			],
-		}[ getJetpackCROActiveVersion() ] || {
+		}[ variation ] || {
 			[ constants.FEATURE_CATEGORY_SECURITY ]: [
 				constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
 				constants.FEATURE_PRODUCT_SCAN_V2,
@@ -496,14 +488,15 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 const getPlanJetpackSecurityRealtimeDetails = () => ( {
 	group: constants.GROUP_JETPACK,
 	type: constants.TYPE_SECURITY_REALTIME,
-	getTitle: () =>
-		getJetpackCROActiveVersion() === 'v2'
-			? translate( 'Jetpack Security {{em}}Real-time{{/em}}', { components: { em: <em /> } } )
-			: translate( 'Security {{em}}Real-time{{/em}}', { components: { em: <em /> } } ),
-	getButtonLabel: () =>
-		getJetpackCROActiveVersion() === 'v2'
-			? translate( 'Get Security {{em}}Real-time{{/em}}', { components: { em: <em /> } } )
-			: undefined,
+	getTitle: ( variation ) =>
+		( {
+			v2: translate( 'Jetpack Security {{em}}Real-time{{/em}}', { components: { em: <em /> } } ),
+		}[ variation ] ||
+		translate( 'Security {{em}}Real-time{{/em}}', { components: { em: <em /> } } ) ),
+	getButtonLabel: ( variation ) =>
+		( { v2: translate( 'Get Security {{em}}Real-time{{/em}}', { components: { em: <em /> } } ) }[
+			variation
+		] || undefined ),
 	getAudience: () => translate(),
 	availableFor: ( plan ) =>
 		[
@@ -512,7 +505,7 @@ const getPlanJetpackSecurityRealtimeDetails = () => ( {
 			constants.PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 			...constants.JETPACK_LEGACY_PLANS,
 		].includes( plan ),
-	getDescription: () =>
+	getDescription: ( variation ) =>
 		( {
 			v2: translate(
 				'Get next level protection. Includes all essential security tools, but with on-demand scan, real time backup & more.'
@@ -520,17 +513,17 @@ const getPlanJetpackSecurityRealtimeDetails = () => ( {
 			i5: translate(
 				'Get next-level protection with real-time backups, real-time scan and all essential security tools.'
 			),
-		}[ getJetpackCROActiveVersion() ] ||
+		}[ variation ] ||
 		translate(
 			'Additional security for sites with 24/7 activity. ' +
 				'Recommended for eCommerce stores, news organizations, and online forums.'
 		) ),
-	getTagline: () =>
-		getJetpackCROActiveVersion() === 'v2'
-			? translate( 'Always on protection, backs up as you edit' )
-			: translate( 'Best for sites with frequent updates' ),
+	getTagline: ( variation ) =>
+		( {
+			v2: translate( 'Always on protection, backs up as you edit' ),
+		}[ variation ] || translate( 'Best for sites with frequent updates' ) ),
 	getPlanCompareFeatures: () => [],
-	getPlanCardFeatures: () =>
+	getPlanCardFeatures: ( variation ) =>
 		( {
 			v2: [
 				constants.FEATURE_PLAN_SECURITY_DAILY,
@@ -545,7 +538,7 @@ const getPlanJetpackSecurityRealtimeDetails = () => ( {
 				constants.FEATURE_PRODUCT_SCAN_REALTIME_V2,
 				constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
 			],
-		}[ getJetpackCROActiveVersion() ] || {
+		}[ variation ] || {
 			[ constants.FEATURE_CATEGORY_SECURITY ]: [
 				constants.FEATURE_PRODUCT_BACKUP_REALTIME_V2,
 				constants.FEATURE_PRODUCT_SCAN_V2,
@@ -590,10 +583,8 @@ const getPlanJetpackSecurityRealtimeDetails = () => ( {
 const getPlanJetpackCompleteDetails = () => ( {
 	group: constants.GROUP_JETPACK,
 	type: constants.TYPE_ALL,
-	getTitle: () =>
-		getJetpackCROActiveVersion() === 'i5'
-			? translate( 'Complete' )
-			: translate( 'Jetpack Complete' ),
+	getTitle: ( variation ) =>
+		( { i5: translate( 'Complete' ) }[ variation ] || translate( 'Jetpack Complete' ) ),
 	getAudience: () => translate(),
 	availableFor: ( plan ) =>
 		[
@@ -607,7 +598,7 @@ const getPlanJetpackCompleteDetails = () => ( {
 		),
 	getTagline: () => translate( 'For best-in-class WordPress sites' ),
 	getPlanCompareFeatures: () => [],
-	getPlanCardFeatures: () =>
+	getPlanCardFeatures: ( variation ) =>
 		( {
 			v2: [
 				constants.FEATURE_PLAN_SECURITY_REALTIME,
@@ -628,7 +619,7 @@ const getPlanJetpackCompleteDetails = () => ( {
 				constants.FEATURE_CRM_V2,
 				constants.FEATURE_PRODUCT_SEARCH_V2,
 			],
-		}[ getJetpackCROActiveVersion() ] || {
+		}[ variation ] || {
 			[ constants.FEATURE_CATEGORY_SECURITY ]: [
 				[
 					constants.FEATURE_SECURITY_REALTIME_V2,

--- a/client/lib/plans/types.ts
+++ b/client/lib/plans/types.ts
@@ -37,10 +37,10 @@ export type Plan = {
 		| typeof constants.TERM_BIENNIALLY
 		| typeof constants.TERM_MONTHLY;
 	getBillingTimeFrame: () => TranslateResult;
-	getTitle: () => TranslateResult;
-	getDescription: () => TranslateResult;
-	getTagline?: ( features?: string[] ) => TranslateResult;
-	getButtonLabel?: () => TranslateResult;
+	getTitle: ( variation?: string ) => TranslateResult;
+	getDescription: ( variation?: string ) => TranslateResult;
+	getTagline?: ( featuresOrCROVariation?: string[] | string ) => TranslateResult;
+	getButtonLabel?: ( variation?: string ) => TranslateResult;
 	getAnnualSlug?: () => JetpackPlanSlugs | string;
 	getMonthlySlug?: () => JetpackPlanSlugs | string;
 	getAudience?: () => TranslateResult;

--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -104,7 +104,7 @@ export const getJetpackProductsDisplayNames = () => {
 	const antiSpam = {
 		i5: translate( 'Anti-spam' ),
 		spp: translate( 'Anti-Spam' ),
-	}[ getJetpackCROActiveVersion() ] || <>{ translate( 'Jetpack Anti-spam' ) }</>;
+	}[ currentCROvariant ] || <>{ translate( 'Jetpack Anti-spam' ) }</>;
 
 	return {
 		[ CONSTANTS.PRODUCT_JETPACK_BACKUP_DAILY ]: backupDaily,
@@ -227,6 +227,8 @@ export const getJetpackProductsTaglines = () => {
 };
 
 export const getJetpackProductsDescriptions = () => {
+	const currentCROvariant = getJetpackCROActiveVersion();
+
 	const backupDailyDescription =
 		{
 			i5: translate(
@@ -235,7 +237,7 @@ export const getJetpackProductsDescriptions = () => {
 			spp: translate(
 				'Never lose a word, image, page, or time worrying about your site with automated backups & one-click restores.'
 			),
-		}[ getJetpackCROActiveVersion() ] ||
+		}[ currentCROvariant ] ||
 		translate( 'Never lose a word, image, page, or time worrying about your site.' );
 	const backupRealtimeDescription = translate(
 		'Real-time backups save every change and one-click restores get you back online quickly.'
@@ -248,7 +250,7 @@ export const getJetpackProductsDescriptions = () => {
 			spp: translate(
 				'Help your site visitors find answers instantly so they keep reading and buying. Great for sites with a lot of content.'
 			),
-		}[ getJetpackCROActiveVersion() ] ||
+		}[ currentCROvariant ] ||
 		translate( 'Help your site visitors find answers instantly so they keep reading and buying.' );
 
 	const scanDescription = translate(
@@ -262,7 +264,7 @@ export const getJetpackProductsDescriptions = () => {
 			spp: translate(
 				'Save time, get more responses, and give your visitors a better experience, by automatically blocking spam.'
 			),
-		}[ getJetpackCROActiveVersion() ] ||
+		}[ currentCROvariant ] ||
 		translate(
 			'Automated spam protection for comments and forms. Save time, get more responses, and give your visitors a better experience.'
 		);

--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -131,21 +131,25 @@ export const OPTION_PLAN_SECURITY: SelectorProduct = {
 			'Easy-to-use, powerful security tools guard your site, so you can focus on your business.'
 	),
 	features: {
-		items: buildCardFeaturesFromItem( {
-			[ FEATURE_CATEGORY_SECURITY ]: [
-				FEATURE_PRODUCT_BACKUP_V2,
-				FEATURE_PRODUCT_SCAN_V2,
-				FEATURE_PRODUCT_ANTISPAM_V2,
-				FEATURE_ACTIVITY_LOG_V2,
-			],
-			[ FEATURE_CATEGORY_OTHER ]: [
-				FEATURE_VIDEO_HOSTING_V2,
-				FEATURE_SOCIAL_MEDIA_POSTING_V2,
-				FEATURE_COLLECT_PAYMENTS_V2,
-				FEATURE_SITE_MONETIZATION_V2,
-				FEATURE_PRIORITY_SUPPORT_V2,
-			],
-		} ),
+		items: buildCardFeaturesFromItem(
+			{
+				[ FEATURE_CATEGORY_SECURITY ]: [
+					FEATURE_PRODUCT_BACKUP_V2,
+					FEATURE_PRODUCT_SCAN_V2,
+					FEATURE_PRODUCT_ANTISPAM_V2,
+					FEATURE_ACTIVITY_LOG_V2,
+				],
+				[ FEATURE_CATEGORY_OTHER ]: [
+					FEATURE_VIDEO_HOSTING_V2,
+					FEATURE_SOCIAL_MEDIA_POSTING_V2,
+					FEATURE_COLLECT_PAYMENTS_V2,
+					FEATURE_SITE_MONETIZATION_V2,
+					FEATURE_PRIORITY_SUPPORT_V2,
+				],
+			},
+			undefined,
+			getJetpackCROActiveVersion()
+		),
 		more: MORE_FEATURES_LINK,
 	},
 };
@@ -209,7 +213,8 @@ export const OPTION_PRODUCT_BACKUP: SelectorProduct = {
 				FEATURE_ACTIVITY_LOG_V2,
 				FEATURE_PRIORITY_SUPPORT_V2,
 			],
-			{ withoutDescription: true, withoutIcon: true }
+			{ withoutDescription: true, withoutIcon: true },
+			getJetpackCROActiveVersion()
 		),
 	},
 };
@@ -297,7 +302,8 @@ export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
 				FEATURE_CRM_NO_CONTACT_LIMITS,
 				FEATURE_CRM_PRIORITY_SUPPORT,
 			],
-			{ withoutDescription: true, withoutIcon: true }
+			{ withoutDescription: true, withoutIcon: true },
+			getJetpackCROActiveVersion()
 		),
 	},
 	hidePrice: true,

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -495,13 +495,19 @@ export function itemToSelectorProduct(
 			term: item.term,
 			hidePrice: JETPACK_SEARCH_PRODUCTS.includes( item.product_slug ),
 			features: {
-				items: buildCardFeaturesFromItem( item, {
-					withoutDescription: true,
-					withoutIcon: true,
-				} ),
+				items: buildCardFeaturesFromItem(
+					item,
+					{
+						withoutDescription: true,
+						withoutIcon: true,
+					},
+					currentCROvariant
+				),
 			},
 		};
 	} else if ( objectIsPlan( item ) ) {
+		const currentCROvariant = getJetpackCROActiveVersion();
+
 		const productSlug = item.getStoreSlug();
 		let monthlyProductSlug;
 		let yearlyProductSlug;
@@ -517,17 +523,17 @@ export function itemToSelectorProduct(
 			productSlug,
 			// Using the same slug for any duration helps prevent unnecessary DOM updates
 			iconSlug: ( yearlyProductSlug || productSlug ) + iconAppend,
-			displayName: item.getTitle(),
-			buttonLabel: item.getButtonLabel?.(),
+			displayName: item.getTitle( currentCROvariant ),
+			buttonLabel: item.getButtonLabel?.( currentCROvariant ),
 			type,
 			subtypes: [],
-			shortName: item.getTitle(),
-			tagline: get( item, 'getTagline', () => '' )(),
-			description: item.getDescription(),
+			shortName: item.getTitle( currentCROvariant ),
+			tagline: get( item, 'getTagline', () => '' )( currentCROvariant ),
+			description: item.getDescription( currentCROvariant ),
 			monthlyProductSlug,
 			term: item.term === TERM_BIENNIALLY ? TERM_ANNUALLY : item.term,
 			features: {
-				items: buildCardFeaturesFromItem( item ),
+				items: buildCardFeaturesFromItem( item, undefined, currentCROvariant ),
 				more: MORE_FEATURES_LINK,
 			},
 			legacy: ! isResetPlan,
@@ -570,15 +576,17 @@ export function buildCardFeatureItemFromFeatureKey(
 	if ( feature ) {
 		return {
 			slug: feature.getSlug(),
-			icon: options?.withoutIcon ? undefined : feature.getIcon?.(),
+			icon: options?.withoutIcon ? undefined : feature.getIcon?.( variation ),
 			text: feature.getTitle( variation ),
 			description: options?.withoutDescription ? undefined : feature.getDescription?.(),
 			subitems: subFeaturesKeys
 				? compact(
-						subFeaturesKeys.map( ( f ) => buildCardFeatureItemFromFeatureKey( f, options ) )
+						subFeaturesKeys.map( ( f ) =>
+							buildCardFeatureItemFromFeatureKey( f, options, variation )
+						)
 				  )
 				: undefined,
-			isHighlighted: feature.isProduct || feature.isPlan,
+			isHighlighted: feature.isProduct?.( variation ) || feature.isPlan,
 		};
 	}
 }
@@ -632,27 +640,29 @@ export function buildCardFeaturesFromFeatureKeys(
  *
  * @param {Plan | Product | object} item Product, plan, or object
  * @param {object?} options Options
+ * @param {string?} variation The current A/B test variation
  * @returns {SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[]} Features
  */
 export function buildCardFeaturesFromItem(
 	item: Plan | Product | Record< string, unknown >,
-	options?: Record< string, unknown >
+	options?: Record< string, unknown >,
+	variation?: string
 ): SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[] {
 	if ( objectIsPlan( item ) ) {
-		const features = item.getPlanCardFeatures?.();
+		const features = item.getPlanCardFeatures?.( variation );
 
 		if ( features ) {
-			return buildCardFeaturesFromFeatureKeys( features, options );
+			return buildCardFeaturesFromFeatureKeys( features, options, variation );
 		}
 	} else if ( isFunction( item.getFeatures ) ) {
-		const features = item.getFeatures( getJetpackCROActiveVersion() );
+		const features = item.getFeatures( variation );
 
 		if ( features ) {
-			return buildCardFeaturesFromFeatureKeys( features, options );
+			return buildCardFeaturesFromFeatureKeys( features, options, variation );
 		}
 	}
 
-	return buildCardFeaturesFromFeatureKeys( item, options );
+	return buildCardFeaturesFromFeatureKeys( item, options, variation );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In `features-list.ts`, `plans-list.js`, and `products-values/translations.js`, convert direct calls to `getJetpackCROActiveVersion` into parameterized functions, where the active CRO version is passed in by the caller.
* Convert types in `lib/plans/types.ts` to match changes from the aforementioned bullet point.
* Add the current CRO variation as an argument to relevant function calls in `jetpack-plans/constants.ts` and `jetpack-plans/utils.ts`.
* Reset the `jetpackSimplifyPricingPage` test's datestamp to "restart" our test and ignore noisy data from before this PR.

#### Testing instructions

**Important:** These instructions should be executed _in order_, to avoid loading A/B test data before we're ready for it.

##### Preparation

* Check out this PR branch and build, making sure to include `DISABLE_FEATURES="dev/test-helper"` in your build command. This will disable the A/B test helper, which eagerly loads all A/B test information on every page.
* **Sign out** of any authenticated WordPress.com sessions you may have open.
* Visit the root of your testing environment (e.g., `calypso.localhost:3000/`) and clear out all local storage. Then, add analytics debugging. You can accomplish both of these tasks by executing the following command in the console: `localStorage.clear(); localStorage.debug = 'calypso:analytics';`.
* Ensure that **Debug**-level logging is enabled in your browser's console. Other log levels can be safely ignored for the following test scenarios.

##### Test not loaded on irrelevant pages for logged-out users

* **Important:** Clear your browser's local storage again: `localStorage.clear(); localStorage.debug = 'calypso:analytics';`
* With your browser's console open, visit a page not related to the `jetpackSimplifyPricingPage` test (e.g., `/start/domains/en`). Verify that in all the console messages that are logged, none of them includes references to `calypso_abtest_start` and `jetpackSimplifyPricingPlan`.
* Verify that the test's date stamp in the console correctly reads `20210121`, indicating today's date, January 21.

##### Test correctly loaded on pricing pages for logged-out users

* Still unauthenticated, and with your browser's console open, visit an unauthenticated pricing page (e.g., `/jetpack/connect/store`. Verify that you see at least one reference to `calypso_abtest_start` and `jetpackSimplifyPricingPlan` in the console's backlog, indicating that the test was correctly loaded.

#### Reference screenshots

##### No A/B test info loaded

<img width="667" alt="image" src="https://user-images.githubusercontent.com/670067/105366265-c0206c00-5bc4-11eb-812f-163f9fee6cfc.png">

##### A/B test info correctly loaded

![image](https://user-images.githubusercontent.com/670067/105367311-edb9e500-5bc5-11eb-94b2-a5aee54f57d7.png)