### PR TITLE
e2e: Fix some tests and re-enable one test

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -43,6 +43,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			return;
 		}
 		await this.driver.switchTo().defaultContent();
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.editoriFrameSelector );
 		await this.driver.wait(
 			until.ableToSwitchToFrame( this.editoriFrameSelector ),
 			this.explicitWaitMS,

--- a/test/e2e/lib/pages/domain-map-checkout-page.js
+++ b/test/e2e/lib/pages/domain-map-checkout-page.js
@@ -7,7 +7,7 @@ import { By } from 'selenium-webdriver';
  * Internal dependencies
  */
 import AsyncBaseContainer from '../async-base-container';
-import * as driverHelper from "../driver-helper";
+import * as driverHelper from '../driver-helper';
 
 export default class MapADomainCheckoutPage extends AsyncBaseContainer {
 	constructor( driver ) {

--- a/test/e2e/lib/pages/domain-map-checkout-page.js
+++ b/test/e2e/lib/pages/domain-map-checkout-page.js
@@ -7,9 +7,15 @@ import { By } from 'selenium-webdriver';
  * Internal dependencies
  */
 import AsyncBaseContainer from '../async-base-container';
+import * as driverHelper from "../driver-helper";
 
 export default class MapADomainCheckoutPage extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.checkout__payment-box-container,.composite-checkout' ) );
+	}
+
+	async _postInit() {
+		const completeCheckoutSelector = By.css( '.checkout-submit-button .checkout-button' );
+		return await driverHelper.waitTillPresentAndDisplayed( this.driver, completeCheckoutSelector );
 	}
 }

--- a/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
+++ b/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
@@ -18,10 +18,9 @@ export default class AcquireIntentPage extends AsyncBaseContainer {
 	async enterSiteTitle( siteTitle ) {
 		const siteTitleSelector = By.css( '.acquire-intent-text-input__input' );
 		return await driverHelper.setWhenSettable(
-			this.driver,
-			siteTitleSelector,
-			siteTitle,
-			{ pauseBetweenKeysMS: 10 }
+			this.driver, siteTitleSelector, siteTitle, {
+				pauseBetweenKeysMS: 10,
+			}
 		);
 	}
 

--- a/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
+++ b/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
@@ -17,7 +17,7 @@ export default class AcquireIntentPage extends AsyncBaseContainer {
 
 	async enterSiteTitle( siteTitle ) {
 		const siteTitleSelector = By.css( '.acquire-intent-text-input__input' );
-		return await driverHelper.setWhenSettable( this.driver, siteTitleSelector, siteTitle );
+		return await driverHelper.setWhenSettable( this.driver, siteTitleSelector, siteTitle, { pauseBetweenKeysMS: 10 } );
 	}
 
 	async goToNextStep() {

--- a/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
+++ b/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
@@ -17,11 +17,9 @@ export default class AcquireIntentPage extends AsyncBaseContainer {
 
 	async enterSiteTitle( siteTitle ) {
 		const siteTitleSelector = By.css( '.acquire-intent-text-input__input' );
-		return await driverHelper.setWhenSettable(
-			this.driver, siteTitleSelector, siteTitle, {
-				pauseBetweenKeysMS: 10,
-			}
-		);
+		return await driverHelper.setWhenSettable( this.driver, siteTitleSelector, siteTitle, {
+			pauseBetweenKeysMS: 10,
+		} );
 	}
 
 	async goToNextStep() {

--- a/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
+++ b/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
@@ -17,7 +17,12 @@ export default class AcquireIntentPage extends AsyncBaseContainer {
 
 	async enterSiteTitle( siteTitle ) {
 		const siteTitleSelector = By.css( '.acquire-intent-text-input__input' );
-		return await driverHelper.setWhenSettable( this.driver, siteTitleSelector, siteTitle, { pauseBetweenKeysMS: 10 } );
+		return await driverHelper.setWhenSettable(
+			this.driver,
+			siteTitleSelector,
+			siteTitle,
+			{ pauseBetweenKeysMS: 10 }
+		);
 	}
 
 	async goToNextStep() {

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -34,7 +34,7 @@ before( async function () {
 	driver = await driverManager.startBrowser();
 } );
 
-describe.skip( 'Gutenboarding: (' + screenSize + ')', function () {
+describe( 'Gutenboarding: (' + screenSize + ')', function () {
 	this.timeout( mochaTimeOut );
 	describe( 'Create new site as existing user @parallel @canary', function () {
 		const siteTitle = dataHelper.randomPhrase();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes some issues with some tests that have been failing lately. It also fixes and re-enables the `Gutenboarding: Create new site as existing user @parallel @canary` test that was disabled in https://github.com/Automattic/wp-calypso/pull/48729

I left comments on the changes to detail what they are fixing

#### Testing instructions
* Ensure the the tests `Gutenboarding: Create new site as existing user @parallel @canary` and `'Map a domain to an existing site @parallel` pass in CI

