### PR TITLE
Language picker: Fix region underline color for themes

### DIFF
--- a/packages/language-picker/src/style.scss
+++ b/packages/language-picker/src/style.scss
@@ -96,7 +96,7 @@
 		padding-bottom: 4px;
 		&.is-selected {
 			padding-bottom: 2px;
-			border-bottom: 2px solid #3582c4;
+			border-bottom: 2px solid var( --color-primary );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the language picker selected region underline color

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the language picker at `/me/account` and test it with several different themes ensuring that the selected region's underline color matches the theme correctly.

Fixes #49135 
