### PR TITLE
Store|Woo: Updates on e2e for store removal

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -759,6 +759,7 @@ export class MySitesSidebar extends Component {
 
 		return (
 			<SidebarItem
+				className="sidebar__woocommerce-menu-item"
 				label="WooCommerce"
 				link={ storeLink }
 				onNavigate={ this.trackWooCommerceClick }

--- a/config/development.json
+++ b/config/development.json
@@ -216,8 +216,8 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
-		"woocommerce/store-deprecated": true,
-		"woocommerce/store-removed": false,
+		"woocommerce/store-deprecated": false,
+		"woocommerce/store-removed": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false
 	}

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -185,8 +185,8 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
-		"woocommerce/store-deprecated": true,
-		"woocommerce/store-removed": false,
+		"woocommerce/store-deprecated": false,
+		"woocommerce/store-removed": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true
 	},

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -14,6 +14,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.sidebar' ) );
 		this.storeSelector = By.css( '.menu-link-text[data-e2e-sidebar="Store"]' );
+		this.woocommerceSelector = By.css( '.sidebar__woocommerce-menu-item > a.sidebar__menu-link' );
 	}
 	async _postInit() {
 		return await this.ensureSidebarMenuVisible();
@@ -125,12 +126,23 @@ export default class SidebarComponent extends AsyncBaseContainer {
 		return await this._scrollToAndClickMenuItem( 'side-menu-comments' );
 	}
 
-	async selectStoreOption() {
-		return await driverHelper.clickWhenClickable( this.driver, this.storeSelector );
+	async storeOptionRemoved() {
+		return await driverHelper.elementIsNotPresent( this.driver, this.storeSelector );
 	}
 
-	async storeOptionDisplayed() {
-		return await driverHelper.isEventuallyPresentAndDisplayed( this.driver, this.storeSelector );
+	async woocommerceOptionDisplayed() {
+		return await driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			this.woocommerceSelector
+		);
+	}
+
+	async woocommerceOptionLinksToWoocommerce() {
+		return await driverHelper.elementContainsLinkTo(
+			this.driver,
+			this.woocommerceSelector,
+			/:\/\/.*\/wp-admin\/admin.php\?page=wc-admin/
+		);
 	}
 
 	async settingsOptionExists( click = false ) {

--- a/test/e2e/lib/components/store-sidebar-component.js
+++ b/test/e2e/lib/components/store-sidebar-component.js
@@ -16,6 +16,8 @@ export default class StoreSidebarComponent extends AsyncBaseContainer {
 		this.productsLinkSelector = By.css( 'li.products a' );
 		this.ordersLinkSelector = By.css( 'li.orders a' );
 		this.settingsLinkSelector = By.css( 'li.settings a' );
+		this.promotionsLinkSelector = By.css( 'li.promotions a' );
+		this.reviewsLinkSelector = By.css( 'li.reviews a' );
 	}
 
 	async _postInit() {
@@ -42,24 +44,55 @@ export default class StoreSidebarComponent extends AsyncBaseContainer {
 		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, this.ordersLinkSelector );
 	}
 
-	selectProducts() {
-		return driverHelper.clickWhenClickable( this.driver, this.productsLinkSelector );
-	}
-
-	selectOrders() {
-		return driverHelper.clickWhenClickable( this.driver, this.ordersLinkSelector );
-	}
-
-	addProduct() {
-		this.selectProducts();
-		return driverHelper.selectElementByText( this.driver, By.css( '.button' ), 'Add a product' );
-	}
-
 	settingsLinkDisplayed() {
 		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, this.settingsLinkSelector );
 	}
 
-	selectSettings() {
-		return driverHelper.clickWhenClickable( this.driver, this.settingsLinkSelector );
+	promotionsLinkDisplayed() {
+		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, this.promotionsLinkSelector );
+	}
+
+	reviewsLinkDisplayed() {
+		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, this.reviewsLinkSelector );
+	}
+
+	async productsLinksToWoocommerce() {
+		return await driverHelper.elementContainsLinkTo(
+			this.driver,
+			this.productsLinkSelector,
+			/:\/\/.*\/wp-admin\/edit.php\?post_type=product/
+		);
+	}
+
+	async ordersLinksToWoocommerce() {
+		return await driverHelper.elementContainsLinkTo(
+			this.driver,
+			this.ordersLinkSelector,
+			/:\/\/.*\/wp-admin\/edit.php\?post_type=shop_order/
+		);
+	}
+
+	async settingsLinksToWoocommerce() {
+		return await driverHelper.elementContainsLinkTo(
+			this.driver,
+			this.settingsLinkSelector,
+			/:\/\/.*\/wp-admin\/admin.php\?page=wc-settings/
+		);
+	}
+
+	async promotionsLinksToWoocommerce() {
+		return await driverHelper.elementContainsLinkTo(
+			this.driver,
+			this.promotionsLinkSelector,
+			/:\/\/.*\/wp-admin\/edit.php\?post_type=shop_coupon/
+		);
+	}
+
+	async reviewsLinksToWoocommerce() {
+		return await driverHelper.elementContainsLinkTo(
+			this.driver,
+			this.reviewsLinkSelector,
+			/:\/\/.*\/wp-admin\/edit-comments.php/
+		);
 	}
 }

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -611,3 +611,29 @@ export async function waitTillTextPresent( driver, selector, text, waitOverride 
 		`Timed out waiting for element with ${ selector.using } of '${ selector.value }' to be present and displayed with text '${ text }'`
 	);
 }
+
+/**
+ * Matches a selector's href attribute with a regex
+ *
+ * @param {object} driver - Browser context in which to search
+ * @param {object} selector - Element to search for
+ * @param {object} hrefRegex - Regex argument
+ * @returns {Promise} - Promise of a Boolean value
+ */
+export function elementContainsLinkTo( driver, selector, hrefRegex ) {
+	return driver.findElement( selector ).then(
+		function ( element ) {
+			return element.getAttribute( 'href' ).then(
+				function ( href ) {
+					return href && href.match( hrefRegex ) !== null;
+				},
+				function () {
+					return false;
+				}
+			);
+		},
+		function () {
+			return false;
+		}
+	);
+}

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -259,6 +259,14 @@ export default class LoginFlow {
 		return await StoreDashboardPage.Expect( this.driver );
 	}
 
+	async loginAndAccessStoreDirectly() {
+		await this.loginAndSelectMySite();
+		const siteURL = ( await this.driver.getCurrentUrl() ).split( 'home/' )[ 1 ];
+		this.sideBarComponent = await SidebarComponent.Expect( this.driver );
+		await this.driver.get( dataHelper.getCalypsoURL( `store/${ siteURL }` ) );
+		return await StoreDashboardPage.Expect( this.driver );
+	}
+
 	async loginAndSelectWPAdmin() {
 		await this.loginAndSelectMySite();
 		this.sideBarComponent = await SidebarComponent.Expect( this.driver );

--- a/test/e2e/lib/pages/woocommerce/store-dashboard-page.js
+++ b/test/e2e/lib/pages/woocommerce/store-dashboard-page.js
@@ -7,9 +7,15 @@ import { By as by } from 'selenium-webdriver';
  * Internal dependencies
  */
 import AsyncBaseContainer from '../../async-base-container';
+import * as driverHelper from '../../driver-helper.js';
 
 export default class StoreDashboardPage extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, by.css( '.woocommerce .dashboard.main' ) );
+		this.storeMoveNoticeCardSelector = by.css( '.dashboard__store-move-notice' );
+	}
+
+	async storeMoveNoticeCardDisplayed() {
+		return await driverHelper.isElementPresent( this.driver, this.storeMoveNoticeCardSelector );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR changes existing e2e tests for Store UI removal from calypso.

- Sets `woocommerce/store-removed` to true for `wpcalypso` and `development` environments

Fixes #48588.


#### Testing instructions

* If your local has not set up yet, follow the instructions here: https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/docs/running-tests.md

