### PR TITLE
Patterns and SPT calls to ptk/patterns: Add pattern_meta is_web param to calls

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -124,6 +124,8 @@ class Block_Patterns_From_API {
 				add_query_arg(
 					array(
 						'site' => $override_source_site,
+						'tags' => 'pattern',
+						'pattern_meta' => 'is_web',
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->get_block_patterns_locale()
 				)
@@ -151,6 +153,7 @@ class Block_Patterns_From_API {
 				add_query_arg(
 					array(
 						'tags' => 'pattern',
+						'pattern_meta' => 'is_web',
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->get_block_patterns_locale()
 				)

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -123,8 +123,8 @@ class Block_Patterns_From_API {
 			$request_url = esc_url_raw(
 				add_query_arg(
 					array(
-						'site' => $override_source_site,
-						'tags' => 'pattern',
+						'site'         => $override_source_site,
+						'tags'         => 'pattern',
 						'pattern_meta' => 'is_web',
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->get_block_patterns_locale()
@@ -152,7 +152,7 @@ class Block_Patterns_From_API {
 			$request_url = esc_url_raw(
 				add_query_arg(
 					array(
-						'tags' => 'pattern',
+						'tags'         => 'pattern',
 						'pattern_meta' => 'is_web',
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->get_block_patterns_locale()

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -212,8 +212,8 @@ class Starter_Page_Templates {
 			$request_url = esc_url_raw(
 				add_query_arg(
 					array(
-						'site' => $override_source_site,
-						'tags' => 'layout',
+						'site'         => $override_source_site,
+						'tags'         => 'layout',
 						'pattern_meta' => 'is_web',
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->get_verticals_locale()

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -204,15 +204,17 @@ class Starter_Page_Templates {
 	public function get_page_templates() {
 		$page_template_data = get_transient( $this->templates_cache_key );
 
+		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
+
 		// Load fresh data if we don't have any or vertical_id doesn't match.
-		if ( false === $page_template_data || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ) {
-			$override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
+		if ( false === $page_template_data || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || false !== $override_source_site ) {
 
 			$request_url = esc_url_raw(
 				add_query_arg(
 					array(
 						'site' => $override_source_site,
 						'tags' => 'layout',
+						'pattern_meta' => 'is_web',
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->get_verticals_locale()
 				)
@@ -231,7 +233,11 @@ class Starter_Page_Templates {
 			}
 
 			$page_template_data = json_decode( wp_remote_retrieve_body( $response ), true );
-			set_transient( $this->templates_cache_key, $page_template_data, DAY_IN_SECONDS );
+
+			// Only save to cache if we have not overridden the source site.
+			if ( false === $override_source_site ) {
+				set_transient( $this->templates_cache_key, $page_template_data, DAY_IN_SECONDS );
+			}
 
 			return $page_template_data;
 		}


### PR DESCRIPTION
To support @enejb's recent change to the ptk/patterns API to add in a pattern_meta param, this change updates the calls to that endpoint with the `'pattern_meta' => 'is_web'` param to grab just those patterns flagged to be used in the web-based editor.

This change also tweaks the behaviour in starter page templates when using the `a8c_override_patterns_source_site` override so that it doesn't accidentally pollute the cache if you have a non dotcompatterns source site set.

#### Changes proposed in this Pull Request

* Add `'pattern_meta' => 'is_web'` param to each call to the ptk/patterns API endpoint
* Update caching approach for `a8c_override_patterns_source_site` in starter page templates to avoid cache pollution when using a non dotcompatterns source site

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this diff in your sandbox before updating your `0-sandbox.php` file, to avoid cache pollution
* Add to your `0-sandbox.php` file the following to ensure that you skip caching to test this change:

```
add_filter( 'a8c_override_patterns_source_site', function () { return 'dotcompatterns.<domain>'; } );
```

(Replace `<domain>` in the string below with the real domain for dotcompatterns)

* Sandbox your test site, and go to create a new page. You should see all of the page layouts just as you would without this change.
* In a page or post, go to add Patterns, and you should see the full list of patterns available in the inserter just as you would without this change.
* Remove the line you added to `0-sandbox.php` before finishing testing, just to be sure.
* Take a look over the change to the caching — does it look okay? The objective is that when using a source site override, we skip storing a transient with the results of the API call, so that we can more quickly test changes to patterns when using a custom source site (even when that source site is set to the same as the real one).

This change helps address the proposal in: pb3aDo-IK-p2