### PR TITLE
DomainPicker: Fix untranslated text

### DIFF
--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -118,7 +118,7 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 	const paidIncludedDomainLabel =
 		type === ITEM_TYPE_INDIVIDUAL_ITEM
 			? firstYearIncludedInPaid
-			: __( isMobile ? 'Free' : 'Included in plans', __i18n_text_domain__ );
+			: __( isMobile ? 'Free' : 'Included with annual plans', __i18n_text_domain__ );
 
 	React.useEffect( () => {
 		// Only record TrainTracks render event when the domain name and railcarId change.

--- a/packages/domain-picker/src/domain-picker/use-your-domain-item.tsx
+++ b/packages/domain-picker/src/domain-picker/use-your-domain-item.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import * as React from 'react';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { ArrowButton } from '@automattic/onboarding';
 
 /**
@@ -22,12 +22,20 @@ const UseYourDomainItem: React.FunctionComponent< Props > = ( { onClick } ) => {
 				</span>
 				<div>
 					<span className="domain-picker__item-tip">
-						{ __( "You can use it as your site's address", __i18n_text_domain__ ) }
+						{ _x(
+							"You can use it as your site's address.",
+							'Upgrades: Register domain description',
+							__i18n_text_domain__
+						) }
 					</span>
 				</div>
 			</div>
 			<ArrowButton arrow="right" onClick={ onClick }>
-				{ __( 'Use a domain I own', __i18n_text_domain__ ) }
+				{ _x(
+					'Use a domain I own',
+					'Domain transfer or mapping suggestion button',
+					__i18n_text_domain__
+				) }
 			</ArrowButton>
 		</label>
 	);

--- a/packages/domain-picker/test/use-your-domain-item.tsx
+++ b/packages/domain-picker/test/use-your-domain-item.tsx
@@ -21,7 +21,7 @@ describe( '<UseYourDomainItem />', () => {
 		render( <UseYourDomainItem onClick={ onClick } /> );
 
 		expect( screen.getByText( 'Already own a domain?' ) ).toBeTruthy();
-		expect( screen.getByText( "You can use it as your site's address" ) ).toBeTruthy();
+		expect( screen.getByText( "You can use it as your site's address." ) ).toBeTruthy();
 	} );
 
 	test( 'Component fires onClick callback onClick', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use context when needed for UseYourDomainItem text to match the entries in GlotPress
* Use already translated string "Included with annual plans"

#### Testing instructions
* As an existing user, go to `/new/domains/fr` and check for all text to be translated


#### Screenshots
* **Before:**
<img width="988" alt="Screenshot 2021-01-22 at 08 48 09" src="https://user-images.githubusercontent.com/14192054/105459325-bebd7500-5c92-11eb-86d3-8c1e5cde65c3.png">

* **After:**
<img width="944" alt="Screenshot 2021-01-22 at 09 12 23" src="https://user-images.githubusercontent.com/14192054/105459344-c54bec80-5c92-11eb-9202-76ee47f5ba53.png">
