### PR TITLE
[TeamCity] - Experimental build to test and build ETK

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -42,6 +42,7 @@ project {
 
 	vcsRoot(WpCalypso)
 	subProject(WpDesktop)
+	subProject(WPComPlugins)
 	buildType(RunAllUnitTests)
 	buildType(BuildBaseImages)
 	buildType(CheckCodeStyle)
@@ -440,33 +441,6 @@ object RunAllUnitTests : BuildType({
 
 				# Run build-tools tests
 				JEST_JUNIT_OUTPUT_DIR="./test_results/build-tools" yarn test-build-tools --maxWorkers=${'$'}JEST_MAX_WORKERS --ci --reporters=default --reporters=jest-junit --silent
-			""".trimIndent()
-			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
-			dockerPull = true
-			dockerImage = "%docker_image%"
-			dockerRunParameters = "-u %env.UID%"
-		}
-		script {
-			name = "Run unit tests for Editing Toolkit"
-			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
-			scriptContent = """
-				#!/bin/bash
-
-				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
-				nvm install
-
-				set -o errexit
-				set -o nounset
-				set -o pipefail
-
-				export JEST_JUNIT_OUTPUT_NAME="results.xml"
-				unset NODE_ENV
-				unset CALYPSO_ENV
-
-				# Run Editing Toolkit tests
-				cd apps/editing-toolkit
-				JEST_JUNIT_OUTPUT_DIR="../../test_results/editing-toolkit" yarn test:js --reporters=default --reporters=jest-junit  --maxWorkers=${'$'}JEST_MAX_WORKERS
 			""".trimIndent()
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 			dockerPull = true
@@ -1088,3 +1062,100 @@ object WpDesktop_DesktopE2ETests : BuildType({
 	}
 })
 
+object WPComPlugins : Project({
+    name = "WPCom Plugins"
+    buildType(WPComPlugins_EditorToolKit)
+    params {
+        text("docker_image_wpcom", "registry.a8c.com/calypso/ci-wpcom:latest", label = "Docker image", description = "Docker image to use for the run", allowEmpty = true)
+    }
+})
+
+object WPComPlugins_EditorToolKit : BuildType({
+    name = "Editor ToolKit"
+
+    artifactRules = "editing-toolkit.zip"
+
+    vcs {
+        root(WpCalypso)
+        cleanCheckout = true
+    }
+
+    steps {
+        script {
+            name = "Prepare environment"
+            scriptContent = """
+                #!/bin/bash
+
+                # Update node
+                . "${'$'}NVM_DIR/nvm.sh" --no-use
+                nvm install
+
+                set -o errexit
+                set -o nounset
+                set -o pipefail
+
+                # Update composer
+                composer install
+
+                # Install modules
+                yarn install
+            """.trimIndent()
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
+            dockerPull = true
+            dockerImage = "%docker_image_wpcom%"
+            dockerRunParameters = "-u %env.UID%"
+        }
+        script {
+            name = "Run tests"
+            executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+            scriptContent = """
+                #!/bin/bash
+
+                # Update node
+                . "${'$'}NVM_DIR/nvm.sh" --no-use
+                nvm install
+
+                set -o errexit
+                set -o nounset
+                set -o pipefail
+
+                export JEST_JUNIT_OUTPUT_NAME="results.xml"
+                export JEST_JUNIT_OUTPUT_DIR="../../test_results/editing-toolkit"
+
+                cd apps/editing-toolkit
+                yarn test:js --reporters=default --reporters=jest-junit --maxWorkers=${'$'}JEST_MAX_WORKERS
+            """.trimIndent()
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
+            dockerPull = true
+            dockerImage = "%docker_image_wpcom%"
+            dockerRunParameters = "-u %env.UID%"
+        }
+        script {
+            name = "Build artifacts"
+            executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+            scriptContent = """
+                #!/bin/bash
+
+                # Update node
+                . "${'$'}NVM_DIR/nvm.sh" --no-use
+                nvm install
+
+                set -o errexit
+                set -o nounset
+                set -o pipefail
+
+                export NODE_ENV="production"
+
+                cd apps/editing-toolkit
+                yarn build
+
+                cd editing-toolkit-plugin/
+                zip -r ../../../editing-toolkit.zip .
+            """.trimIndent()
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
+            dockerPull = true
+            dockerImage = "%docker_image_wpcom%"
+            dockerRunParameters = "-u %env.UID%"
+        }
+    }
+})


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Creates a new subproject "WPCom Plugins" in TeamCity to build and test wpcom plugins in the repo.
* Creates an experimental build to test and pack ETK

The new build doesn't run automatically and doesn't post the status to GitHub, so existing branches won't be affected.

Depends on #49160

#### Testing instructions

Can't be tested until it is merged. The Kotlin spec has been craeted by configuring the build manually in TeamCity and exporting it.


