### PR TITLE
Do not restrict `evergreen` definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
 			"unreleased Firefox versions",
 			"unreleased FirefoxAndroid versions",
 			"unreleased Edge versions",
-			"unreleased Opera versions",
-			"safari 13"
+			"unreleased Opera versions"
 		],
 		"server": [
 			"current node"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Don't restrict `evergreen` to include `safari 13` browsers.

#### Testing instructions

* Smoke test the live branch in Chrome and IE11
