### PR TITLE
Fix: Per-user coupon is always declined

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-coupon-field-state.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-coupon-field-state.ts
@@ -64,6 +64,8 @@ export default function useCouponFieldState(
 }
 
 function isCouponValid( coupon: string ) {
-	// TODO: figure out some basic validation here
-	return coupon.match( /^[a-zA-Z0-9_-]+$/ );
+	// Coupon code is case-insensitive and started with an alphabet.
+	// Underscores and hyphens can be included in the coupon code.
+	// Per-user coupons can have a dot followed by 5-6 letter checksum for verification.
+	return coupon.match( /^[a-z][a-z\d_-]+(\.[a-z\d]+)?$/i );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the bug that per-user coupon is always delined.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create get your own code for the coupon code `COMEBACK.230L000` by the instruction(pau2Xa-2Cr-p2).
* Try to buy either Jetpack Backup, Jetpack Secutiry, or Jetpack Complete.
* The coupon should work.
  <img width="571" alt="Checkout_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/105484434-a4b18000-5cee-11eb-8e97-5d31a2786977.png">
