### PR TITLE
Editing toolkit: clean out contributors list in readme

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -1,5 +1,5 @@
 === WordPress.com Editing Toolkit ===
-Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons, dmsnell, get_dave, glendaviesnz, gwwar, iamtakashi, iandstewart, jeryj, Joen, jonsurrell, kwight, marekhrabe, mattwiebe, mkaz, mmtr86, mppfeiffer, noahtallen, nosolosw, nrqsnchz, obenland, okenobi, owolski, philipmjackson, vindl
+Contributors: automattic
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.5
 Tested up to: 5.6


### PR DESCRIPTION
Since this plugin isn't really for public consumption, nor the list affects any permissions, let's just remove it. It's hassle to maintain, and can confuse people they need to be added to the list to have access.

