### PR TITLE
Plugins: Add wp.org plugins query component and selectors

### DIFF
--- a/client/components/data/query-wporg-plugins/README.md
+++ b/client/components/data/query-wporg-plugins/README.md
@@ -1,0 +1,64 @@
+# Query Wporg Plugins
+
+`<QueryWporgPlugins />` is a React component used in managing network requests for retrieving and storing WordAds settings.
+
+## Usage
+
+Render the component, passing `category` or `searchTerm`, and optionally `page`.
+
+WP.org plugins can be filtered either by `category` or `searchTerm`, so only one of those props should be specified.
+Pagination is currently supported only for category queries in the API, so you can use `page` only together with `category`.
+
+It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+```jsx
+import React from 'react';
+import QueryWporgPlugins from 'calypso/components/data/query-wporg-plugins';
+import { getPluginsListByCategory } from 'calypso/state/plugins/wporg/selectors';
+
+export default function MyPlugins() {
+	const category = 'popular';
+	const plugins = useSelector( ( state ) => getPluginsListByCategory( state, category ) );
+
+	return (
+		<div>
+			<QueryWporgPlugins category={ category } />
+
+			{ plugin.map( ( plugin ) => (
+				<div key={ plugin.slug }>
+					{ plugin.slug }: { plugin.name }
+				</div>
+			) ) }
+		</div>
+	);
+}
+```
+
+## Props
+
+### `category`
+
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+Category for which to request plugins from. Can be one of "featured", "popular", "new", "beta" or "recommended".
+
+### `page`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+Page number. Pagination is currently supported only for category queries in the API, so you can use `page` only together with the `category` prop.
+
+### `searchTerm`
+
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+Search term to query plugins by. Can accept any open values, for example "security" or "enhancement".

--- a/client/components/data/query-wporg-plugins/index.js
+++ b/client/components/data/query-wporg-plugins/index.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { fetchPluginsList } from 'calypso/state/plugins/wporg/actions';
+
+export default function QueryWporgPlugins( { category, page, searchTerm } ) {
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		dispatch( fetchPluginsList( category, page, searchTerm ) );
+	}, [ dispatch, category, page, searchTerm ] );
+
+	return null;
+}
+
+QueryWporgPlugins.propTypes = {
+	category: PropTypes.string,
+	page: PropTypes.number,
+	searchTerm: PropTypes.string,
+};

--- a/client/state/plugins/wporg/selectors.js
+++ b/client/state/plugins/wporg/selectors.js
@@ -21,6 +21,14 @@ export function isFetched( state, pluginSlug ) {
 	return plugin ? !! plugin.fetched : false;
 }
 
+export function getPluginsListByCategory( state, category ) {
+	return state.plugins.wporg.lists.category?.[ category ] ?? [];
+}
+
+export function getPluginsListBySearchTerm( state, searchTerm ) {
+	return state.plugins.wporg.lists.search?.[ searchTerm ] ?? [];
+}
+
 /**
  * WP.org plugins can be filtered either by category or search term.
  * So we can either be fetching by category or by search term.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Introduce a `QueryWporgPlugins` query component
* Introduce selectors to retrieve plugins by category or search term with tests.

Part of #24180.

#### Testing instructions

* Verify test pass.
* Drop the query component somewhere and verify it works well by observing `state.plugins.wporg.lists`.
