### PR TITLE
Fix how we handle invalid-quantity errors for Titan mailboxes

### DIFF
--- a/client/my-sites/email/titan-mail-quantity-selection/index.jsx
+++ b/client/my-sites/email/titan-mail-quantity-selection/index.jsx
@@ -103,7 +103,18 @@ class TitanMailQuantitySelection extends React.Component {
 			.addProductsToCart( [
 				fillInSingleCartItemAttributes( this.getCartItem(), this.props.productsList ),
 			] )
-			.then( () => this.isMounted && page( '/checkout/' + selectedSite.slug ) );
+			.then( () => {
+				const { errors } = this.props?.cart?.messages;
+				if (
+					errors &&
+					errors.length &&
+					errors.filter( ( error ) => error.code === 'invalid-quantity' ).length
+				) {
+					// Stay on the page as there's an invalid quantity error
+					return;
+				}
+				return this.isMounted && page( '/checkout/' + selectedSite.slug );
+			} );
 	};
 
 	onQuantityChange = ( e ) => {

--- a/client/my-sites/email/titan-mail-quantity-selection/index.jsx
+++ b/client/my-sites/email/titan-mail-quantity-selection/index.jsx
@@ -250,6 +250,8 @@ class TitanMailQuantitySelection extends React.Component {
 							name="quantity"
 							type="number"
 							min="1"
+							max="50"
+							step="1"
 							placeholder={ translate( 'Number of new mailboxes' ) }
 							value={ this.state.quantity }
 							onChange={ this.onQuantityChange }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We want to limit the maximum number of mailboxes you can purchase. The change happens in the backend but we need to also properly handle how the frontend treats the `invalid-quantity` errors from the shopping cart.

Here's what the error looks like:
<img width="891" alt="Screenshot 2021-01-22 at 14 15 46" src="https://user-images.githubusercontent.com/1355045/105489720-613e1e00-5cbc-11eb-9d5a-43a4935765b7.png">

Depends on D55828-code

#### Testing instructions

* Apply D55828-code and then try to add more than 500 Titan mailboxes - you should see the above error and not be redirected to the shopping cart
