### PR TITLE
New Onboarding: fix header not being fixed on desktop

### DIFF
--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -6,7 +6,7 @@ $margin-left--gutenboarding__header-section-item: 13px; // matches design
 $padding--gutenboarding__header: $grid-unit-10;
 
 // Copied from https://github.com/WordPress/gutenberg/blob/8c0c7b7267473b5c197dd3052e9707f75f4e6448/packages/edit-widgets/src/components/header/style.scss
-[role=region].gutenboarding__header {
+.gutenboarding__layout .gutenboarding__header {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -6,7 +6,7 @@ $margin-left--gutenboarding__header-section-item: 13px; // matches design
 $padding--gutenboarding__header: $grid-unit-10;
 
 // Copied from https://github.com/WordPress/gutenberg/blob/8c0c7b7267473b5c197dd3052e9707f75f4e6448/packages/edit-widgets/src/components/header/style.scss
-.gutenboarding__header {
+[role=region].gutenboarding__header {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make CSS more specific after change in Gutenberg to reduce the spacing at the top and make the header sticky

#### Testing instructions

* Go to https://wordpress.com/new/design on desktop
* Go to `/new/design` on this branch: https://calypso.live/new/design?branch=fix/gutenboarding-header-not-fixed
* Scroll a bit down on both

#### Screenshots
* **Before:**
<img width="1121" alt="Screenshot 2021-01-22 at 17 14 45" src="https://user-images.githubusercontent.com/14192054/105509303-0a454280-5cd6-11eb-9678-71d92ca9a020.png">
<img width="1145" alt="Screenshot 2021-01-22 at 17 13 59" src="https://user-images.githubusercontent.com/14192054/105509338-103b2380-5cd6-11eb-89cc-1d283b5ef534.png">

* **After:**
<img width="1121" alt="Screenshot 2021-01-22 at 17 16 11" src="https://user-images.githubusercontent.com/14192054/105509367-17fac800-5cd6-11eb-9c6f-e7e320ae9a95.png">
<img width="1119" alt="Screenshot 2021-01-22 at 17 15 50" src="https://user-images.githubusercontent.com/14192054/105509392-1d581280-5cd6-11eb-83cb-5ca5ac3d81bd.png">