### PR TITLE
Add 404 handling for titan section

### DIFF
--- a/client/my-sites/email/titan-redirector/controller.js
+++ b/client/my-sites/email/titan-redirector/controller.js
@@ -2,11 +2,13 @@
  * External dependencies
  */
 import React from 'react';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import TitanRedirector from 'calypso/my-sites/email/titan-redirector/titan-redirector';
+import EmptyContent from 'calypso/components/empty-content';
 
 export default {
 	emailTitanAddMailboxes( pageContext, next ) {
@@ -15,6 +17,19 @@ export default {
 				mode={ pageContext.params.mode }
 				jwt={ pageContext.query.jwt }
 				redirectUrl={ pageContext.query.redirect_url }
+			/>
+		);
+
+		next();
+	},
+	emailTitanNotFound( pageContext, next ) {
+		pageContext.primary = (
+			<EmptyContent
+				illustration="/calypso/images/illustrations/illustration-404.svg"
+				title={ translate( 'Uh oh. Page not found.' ) }
+				line={ translate(
+					"Sorry, the page you were looking for doesn't exist or has been moved."
+				) }
 			/>
 		);
 

--- a/client/my-sites/email/titan-redirector/index.js
+++ b/client/my-sites/email/titan-redirector/index.js
@@ -17,4 +17,6 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+	page( '/titan', controller.emailTitanNotFound, makeLayout, clientRender );
+	page( '/titan/*', controller.emailTitanNotFound, makeLayout, clientRender );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We need to handle not found pages under /titan and show a not found screen

Here's how it looks:
<img width="791" alt="Screenshot 2021-01-22 at 17 24 27" src="https://user-images.githubusercontent.com/1355045/105509923-b8e98300-5cd6-11eb-97e0-f9da80cb4de0.png">

#### Testing instructions

* Open up `/titan/something/somethingelse` or `/titan` - it should show a regular not found page
