### PR TITLE
Plans: Remove duplicate FAQ section on Jetpack plans pages

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
@@ -10,7 +10,6 @@ import { useTranslate } from 'i18n-calypso';
 import ExternalLink from 'calypso/components/external-link';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import SocialLogo from 'calypso/components/social-logo';
-import StoreFooter from 'calypso/jetpack-connect/store-footer';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 /**
@@ -52,7 +51,6 @@ const JetpackComFooter = () => {
 
 	return (
 		<>
-			<StoreFooter />
 			<hr className="jpcom-footer__separator" />
 			<footer className="jpcom-footer">
 				<div className="jpcom-footer__col jpcom-footer__col--logo">

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -141,7 +141,7 @@ export function offerResetContext( context, next ) {
 	debug( 'controller: offerResetContext', context.params );
 	context.header = <StoreHeader urlQueryArgs={ context.query } />;
 
-	if ( getJetpackCROActiveVersion() !== Iterations.I5 ) {
+	if ( ! [ Iterations.I5, Iterations.SPP ].includes( getJetpackCROActiveVersion() ) ) {
 		context.footer = <StoreFooter />;
 	}
 

--- a/client/my-sites/plans/jetpack-plans/products-grid-i5/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/products-grid-i5/index.tsx
@@ -199,7 +199,7 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 					) }
 				</div>
 			</section>
-			{ ! isJetpackCloud() && <StoreFooter /> }
+			<StoreFooter />
 		</Experiment>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/spp/products-grid-spp/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/spp/products-grid-spp/index.tsx
@@ -216,7 +216,7 @@ const ProductsGridSpp: React.FC< ProductsGridProps > = ( {
 					/>
 				</div>
 			</section>
-			{ ! isJetpackCloud() && <StoreFooter /> }
+			<StoreFooter />
 		</Experiment>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Suppresses the `StoreFooter` in the Jetpack Connect flow for the SPP design iteration, bringing it into line with the I5 iteration.

#### Testing instructions

* Ensure that you are currently assigned to the `test` variation of the `jetpackSimplifyPricingPage` A/B test.
* Go through the Jetpack connect flow, and/or visit `/jetpack/connect/store` in Calypso Blue, and verify that the FAQ section appears only once at the bottom of the page.
* Verify that the Jetpack FAQ section is correctly displayed on all the pages it's supposed to be displayed, in both Calypso Blue and Green (e.g., plans and pricing pages).
* Assign yourself to the `control` variation of the A/B test and repeat these test instructions.

#### Reference screenshot

<img width="729" alt="image" src="https://user-images.githubusercontent.com/670067/105519602-3abdba00-5c9f-11eb-8af6-2041a722e7ab.png">