### PR TITLE
Jetpack FAQ: update refund FAQ to account for monthly and yearly plans

### DIFF
--- a/client/my-sites/plans-features-main/jetpack-faq-i5/index.tsx
+++ b/client/my-sites/plans-features-main/jetpack-faq-i5/index.tsx
@@ -48,15 +48,13 @@ const JetpackFAQi5: React.FC = () => {
 
 				<FoldableFAQ
 					id="faq-1"
-					question={ translate( 'What is the cancellation policy?' ) }
+					question={ translate( 'What is your cancellation policy?' ) }
 					onToggle={ onFaqToggle }
 				>
 					{ translate(
-						'We want to make sure Jetpack is exactly what you need, so you can request a cancellation' +
-							' within %(days)d days of purchase and receive a full refund. If there’s something you’d like' +
-							' to see changed in Jetpack to better suit your needs, {{helpLink}}please let us know{{/helpLink}}!',
+						'If you are dissatisfied for any reason, we offer full refunds within %(annualDays)d days for yearly plans, and within %(monthlyDays)d days for monthly plans. If you have a question about our paid plans, {{helpLink}}please let us know{{/helpLink}}!',
 						{
-							args: { days: 14 },
+							args: { annualDays: 14, monthlyDays: 7 },
 							components: { helpLink: getHelpLink( 'cancellation' ) },
 						}
 					) }

--- a/client/my-sites/plans-features-main/jetpack-faq.jsx
+++ b/client/my-sites/plans-features-main/jetpack-faq.jsx
@@ -35,13 +35,11 @@ const JetpackFAQ = () => {
 	return (
 		<FAQ>
 			<FAQItem
-				question={ translate( 'What is the cancellation policy?' ) }
+				question={ translate( 'What is your cancellation policy?' ) }
 				answer={ translate(
-					'We want to make sure Jetpack is exactly what you need, so you can request a cancellation' +
-						' within %(days)d days of purchase and receive a full refund. If there’s something you’d like' +
-						' to see changed in Jetpack to better suit your needs, {{helpLink}}please let us know{{/helpLink}}!',
+					'If you are dissatisfied for any reason, we offer full refunds within %(annualDays)d days for yearly plans, and within %(monthlyDays)d days for monthly plans. If you have a question about our paid plans, {{helpLink}}please let us know{{/helpLink}}!',
 					{
-						args: { days: 14 },
+						args: { annualDays: 14, monthlyDays: 7 },
 						components: { helpLink: getHelpLink( 'cancellation' ) },
 					}
 				) }


### PR DESCRIPTION
This is a follow-up to the changes requested in https://github.com/Automattic/wp-calypso/pull/48872#issuecomment-765478320.

<img width="857" alt="Screen Shot 2021-01-22 at 12 34 52 PM" src="https://user-images.githubusercontent.com/942359/105524860-3ea50880-5cae-11eb-9a5f-39f43e99b090.png">

**To Test:**
- for a Jetpack site, visit the Plans screen
- verify the copy :)