### PR TITLE
Author Selector: Use new search component

### DIFF
--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -16,7 +16,7 @@ import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import UserItem from 'calypso/components/user';
 import InfiniteList from 'calypso/components/infinite-list';
 import { fetchUsers } from 'calypso/lib/users/actions';
-import Search from 'calypso/components/search';
+import Search from '@automattic/search';
 import { hasTouch } from 'calypso/lib/touch-detect';
 
 /**

--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { createRef } from 'react';
 import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
@@ -42,6 +42,10 @@ class AuthorSwitcherShell extends React.Component {
 		showAuthorMenu: false,
 	};
 
+	authorSelectorSearchRef = createRef();
+	authorSelectorToggleRef = createRef();
+	authorSelectorChevronRef = createRef();
+
 	UNSAFE_componentWillMount() {
 		this.instance = instance;
 		instance++;
@@ -62,7 +66,7 @@ class AuthorSwitcherShell extends React.Component {
 		}
 
 		if ( ! prevState.showAuthorMenu && this.props.users.length > 10 && ! hasTouch() ) {
-			setTimeout( () => this.refs.authorSelectorSearch.focus(), 0 );
+			setTimeout( () => this.authorSelectorSearchRef.current?.focus(), 0 );
 		}
 	}
 
@@ -79,17 +83,19 @@ class AuthorSwitcherShell extends React.Component {
 				<span
 					className="author-selector__author-toggle"
 					onClick={ this.toggleShowAuthor }
+					onKeyDown={ this.toggleShowAuthor }
+					role="button"
 					tabIndex={ -1 }
-					ref="author-selector-toggle"
+					ref={ this.authorSelectorToggleRef }
 				>
 					{ this.props.children }
-					<Gridicon ref="authorSelectorChevron" icon="chevron-down" size={ 16 } />
+					<Gridicon ref={ this.authorSelectorChevronRef } icon="chevron-down" size={ 18 } />
 				</span>
 				<Popover
 					isVisible={ this.state.showAuthorMenu }
 					onClose={ this.onClose }
 					position={ this.props.popoverPosition }
-					context={ this.refs && this.refs.authorSelectorChevron }
+					context={ this.authorSelectorChevronRef.current }
 					onKeyDown={ this.onKeyDown }
 					className="author-selector__popover popover"
 					ignoreContext={ this.props.ignoreContext }
@@ -100,7 +106,7 @@ class AuthorSwitcherShell extends React.Component {
 							onSearch={ this.onSearch }
 							placeholder={ this.props.translate( 'Find Author…', { context: 'search label' } ) }
 							delaySearch={ true }
-							ref="authorSelectorSearch"
+							ref={ this.authorSelectorSearchRef }
 						/>
 					) }
 					{ this.props.fetchInitialized &&
@@ -166,7 +172,7 @@ class AuthorSwitcherShell extends React.Component {
 	};
 
 	onClose = ( event ) => {
-		const toggleElement = ReactDom.findDOMNode( this.refs[ 'author-selector-toggle' ] );
+		const toggleElement = ReactDom.findDOMNode( this.authorSelectorToggleRef.current );
 
 		if ( event && toggleElement.contains( event.target ) ) {
 			// let toggleShowAuthor() handle this case

--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -5,18 +5,18 @@ import React, { createRef } from 'react';
 import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
 import debugModule from 'debug';
 
 /**
  * Internal dependencies
  */
+import AsyncLoad from 'calypso/components/async-load';
+import Gridicon from 'calypso/components/gridicon';
 import Popover from 'calypso/components/popover';
 import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import UserItem from 'calypso/components/user';
 import InfiniteList from 'calypso/components/infinite-list';
 import { fetchUsers } from 'calypso/lib/users/actions';
-import Search from '@automattic/search';
 import { hasTouch } from 'calypso/lib/touch-detect';
 
 /**
@@ -101,7 +101,8 @@ class AuthorSwitcherShell extends React.Component {
 					ignoreContext={ this.props.ignoreContext }
 				>
 					{ ( this.props.fetchOptions.search || users.length > 10 ) && (
-						<Search
+						<AsyncLoad
+							require="@automattic/search"
 							compact
 							onSearch={ this.onSearch }
 							placeholder={ this.props.translate( 'Find Author…', { context: 'search label' } ) }

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -12,7 +12,6 @@ $input-z-index: 20;
 	border-radius: 2px;
 	display: flex;
 	flex: 1 1 auto;
-	margin-bottom: 24px;
 	width: 60px;
 	height: 51px;
 	position: relative;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use the new search component for the author selector
* Remove deprecated string refs
* Fix a11y issues
* Address an ESLint error about normalized Gridicon sizes

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get a site with more than 10 authors (otherwise you'll have to force some things) and navigate to `/people/edit/:site/:user` and scroll to the bottom. Select the deletion option to attribute posts to another user and click the "choose a new user" button. This will open a popover that includes the search.

If you don't want to create a site with more than 10 authors (this can be really time consuming) you can checkout the branch locally and force the search to appear by modifying the code in `blocks/author-selector/switcher-shell`.

<img width="346" alt="Captura de Tela 2021-01-22 às 08 42 14" src="https://user-images.githubusercontent.com/24264157/105525367-d9451d80-5c95-11eb-9829-a26abc079a49.png">