### PR TITLE
Plugins Browser: Use new search component

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import FormattedHeader from 'calypso/components/formatted-header';
 import DocumentHead from 'calypso/components/data/document-head';
-import Search from 'calypso/components/search';
+import Search from '@automattic/search';
 import SectionNav from 'calypso/components/section-nav';
 import MainComponent from 'calypso/components/main';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -46,6 +46,7 @@ import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { isEnabled } from 'calypso/config';
 import wpcomFeaturesAsPlugins from './wpcom-features-as-plugins';
 import QuerySiteRecommendedPlugins from 'calypso/components/data/query-site-recommended-plugins';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 
 /**
  * Style dependencies
@@ -357,7 +358,7 @@ export class PluginsBrowser extends Component {
 				initialValue={ this.props.search }
 				placeholder={ this.props.translate( 'Search Plugins' ) }
 				delaySearch={ true }
-				analyticsGroup="PluginsBrowser"
+				recordEvent={ ( eventName ) => gaRecordEvent( 'PluginsBrowser', eventName ) }
 			/>
 		);
 	}

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -46,7 +46,6 @@ import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { isEnabled } from 'calypso/config';
 import wpcomFeaturesAsPlugins from './wpcom-features-as-plugins';
 import QuerySiteRecommendedPlugins from 'calypso/components/data/query-site-recommended-plugins';
-import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 
 /**
  * Style dependencies
@@ -347,6 +346,8 @@ export class PluginsBrowser extends Component {
 		);
 	}
 
+	recordSearchEvent = ( eventName ) => this.props.recordGoogleEvent( 'PluginsBrowser', eventName );
+
 	getSearchBox() {
 		const { WrappedSearch } = this;
 
@@ -358,7 +359,7 @@ export class PluginsBrowser extends Component {
 				initialValue={ this.props.search }
 				placeholder={ this.props.translate( 'Search Plugins' ) }
 				delaySearch={ true }
-				recordEvent={ ( eventName ) => gaRecordEvent( 'PluginsBrowser', eventName ) }
+				recordEvent={ this.recordSearchEvent }
 			/>
 		);
 	}

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -79,6 +79,7 @@ type Props = {
 	overlayStyling?: ( search: string ) => React.ReactNode;
 	placeholder?: string;
 	pinned?: boolean;
+	recordEvent?: ( eventName: string ) => void;
 	searching?: boolean;
 	value?: string;
 };
@@ -113,6 +114,7 @@ export class Search extends React.Component< Props, State > {
 		//disable overlay scrolling calculation when no overlay is provided.
 		overlayStyling: undefined,
 		pinned: false,
+		recordEvent: noop,
 		searching: false,
 	};
 
@@ -150,6 +152,7 @@ export class Search extends React.Component< Props, State > {
 		this.props.onSearchOpen?.( event );
 		// prevent outlines around the open icon after being clicked
 		this.openIcon.current?.blur();
+		this.props.recordEvent?.( 'Clicked Open Search' );
 	};
 
 	closeSearch = (
@@ -180,6 +183,8 @@ export class Search extends React.Component< Props, State > {
 		}
 
 		this.props.onSearchClose?.( event );
+
+		this.props.recordEvent?.( 'Clicked Close Search' );
 	};
 
 	closeListener = keyListener( this.closeSearch );
@@ -398,6 +403,8 @@ export class Search extends React.Component< Props, State > {
 				aria-label={ this.props.__( 'Open Search', __i18n_text_domain__ ) }
 			>
 				{ ! this.props.hideOpenIcon && (
+					// `className` is accepted for some reason the intrisic attributes for SVG won't allow it (but it does work)
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 					/* @ts-ignore */
 					<Icon icon={ search } className="search-component__open-icon" />
 				) }
@@ -427,6 +434,8 @@ export class Search extends React.Component< Props, State > {
 					aria-controls={ 'search-component-' + this.instanceId }
 					aria-label={ this.props.__( 'Close Search', __i18n_text_domain__ ) }
 				>
+					{ /* `className` is accepted for some reason the intrisic attributes for SVG won't allow it (but it does work) */ }
+					{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
 					{ /* @ts-ignore */ }
 					<Icon icon={ close } className="search-component__close-icon" />
 				</Button>

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -195,6 +195,7 @@ $input-z-index: 20;
 		}
 	
 		input.search-component__input[type='search'] {
+			font-size: inherit;
 			display: block;
 		}
 	


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use the new search component for the plugins browser

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/plugins` and ensure that search still works and appears correctly

Note: There is one big difference in that the search icon is facing the opposite direction than before. This is because we're using the `@wordpress/icon` component rather than Gridicons in the new search component so it is expected as there are minor differences. This doesn't affect the functionality of the component.
