### PR TITLE
Fix Global Styles Panel Font Change Update

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/dom-updater.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/dom-updater.js
@@ -58,7 +58,7 @@ export default ( options, getOptionValue ) => {
 			Object.keys( currentOptions ).forEach( ( key ) => {
 				declarationList += `${ cssVariables[ key ] }:${ currentOptions[ key ] };`;
 			} );
-			styleElement.textContent = `.edit-post-visual-editor.editor-styles-wrapper{${ declarationList }}`;
+			styleElement.textContent = `.edit-post-visual-editor .editor-styles-wrapper{${ declarationList }}`;
 		} );
 	} );
 };


### PR DESCRIPTION
This appears to only reproduce when in production (or with some other
dependency I'm unable to reproduce).  When running this editing-toolkit
locally this works as expected.

Note that when running locally the edited content resides in the
element:
```
<div tabindex="-1" class="edit-post-visual-editor
editor-styles-wrapper">
```

However on wpcom I see that it's actually in:
```
<div class="edit-post-visual-editor">
  <div class="popover-slot"/>
  <div class="editor-styles-wrapper">
```

Therefore the selector `.edit-post-visual-editor.editor-styles-wrapper`
does not reflect the values being written.

Changing this selector is still the most specific selector defining the
variables so those are what are displayed.

#### Changes proposed in this Pull Request

* relax selector assigning font CSS variables

#### Testing instructions

* Tested with Varia
* With the change the contents should render with the selected font immediately upon selection.

This addresses a bug opened against themes: https://github.com/Automattic/themes/issues/2989

