### PR TITLE
Add pricing and proration details to Email quantity selection UI

### DIFF
--- a/client/lib/titan/get-titan-expiry-date.js
+++ b/client/lib/titan/get-titan-expiry-date.js
@@ -1,0 +1,3 @@
+export function getTitanExpiryDate( domain ) {
+	return domain.titanMailSubscription?.expiryDate;
+}

--- a/client/lib/titan/get-titan-mailbox-purchase-cost.js
+++ b/client/lib/titan/get-titan-mailbox-purchase-cost.js
@@ -1,0 +1,3 @@
+export function getTitanMailboxPurchaseCost( domain ) {
+	return domain.titanMailSubscription?.purchaseCostPerMailbox;
+}

--- a/client/lib/titan/get-titan-mailbox-renewal-cost.js
+++ b/client/lib/titan/get-titan-mailbox-renewal-cost.js
@@ -1,0 +1,3 @@
+export function getTitanMailboxRenewalCost( domain ) {
+	return domain.titanMailSubscription?.renewalCostPerMailbox;
+}

--- a/client/lib/titan/index.js
+++ b/client/lib/titan/index.js
@@ -1,4 +1,7 @@
-export { getTitanMailOrderId } from './get-titan-mail-order-id';
 export { getConfiguredTitanMailboxCount } from './get-configured-titan-mailbox-count';
 export { getMaxTitanMailboxCount } from './get-max-titan-mailbox-count';
+export { getTitanExpiryDate } from './get-titan-expiry-date';
+export { getTitanMailboxPurchaseCost } from './get-titan-mailbox-purchase-cost';
+export { getTitanMailboxRenewalCost } from './get-titan-mailbox-renewal-cost';
+export { getTitanMailOrderId } from './get-titan-mail-order-id';
 export { hasTitanMailWithUs } from './has-titan-mail-with-us';

--- a/client/my-sites/email/titan-mail-quantity-selection/index.jsx
+++ b/client/my-sites/email/titan-mail-quantity-selection/index.jsx
@@ -227,7 +227,7 @@ class TitanMailQuantitySelection extends React.Component {
 		}
 		return (
 			costPerAdditionalMailbox.amount === titanMonthlyProduct.cost &&
-			costPerAdditionalMailbox.currency_code === titanMonthlyProduct.currency_code
+			costPerAdditionalMailbox.currency === titanMonthlyProduct.currency_code
 		);
 	}
 

--- a/client/my-sites/email/titan-mail-quantity-selection/index.jsx
+++ b/client/my-sites/email/titan-mail-quantity-selection/index.jsx
@@ -14,6 +14,7 @@ import { Button, Card } from '@automattic/components';
 import DomainManagementHeader from 'calypso/my-sites/domains/domain-management/components/header';
 import Main from 'calypso/components/main';
 import SectionHeader from 'calypso/components/section-header';
+import formatCurrency from '@automattic/format-currency';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { emailManagement } from 'calypso/my-sites/email/paths';
@@ -37,8 +38,9 @@ import {
 	hasTitanMailWithUs,
 } from 'calypso/lib/titan';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
-import { getProductsList } from 'calypso/state/products-list/selectors';
+import { getProductBySlug, getProductsList } from 'calypso/state/products-list/selectors';
 import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
+import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
 
 /**
  * Style dependencies
@@ -207,6 +209,32 @@ class TitanMailQuantitySelection extends React.Component {
 		);
 	}
 
+	renderPricingDetails() {
+		const { selectedDomain, titanMonthlyProduct, translate } = this.props;
+		if ( ! hasTitanMailWithUs( selectedDomain ) ) {
+			return (
+				<React.Fragment>
+					<span>
+						{ translate( 'Each mailbox costs {{strong}}%(mailboxPrice)s/month{{/strong}}', {
+							args: {
+								mailboxPrice: formatCurrency(
+									titanMonthlyProduct.cost,
+									titanMonthlyProduct.currency_code
+								),
+							},
+							components: {
+								strong: <strong />,
+							},
+							comment:
+								'%(mailboxPrice)s is a formatted price for each mailbox, e.g. $3.50 or €3.75',
+						} ) }
+					</span>
+				</React.Fragment>
+			);
+		}
+		return null;
+	}
+
 	renderForm() {
 		const { isLoadingDomains, selectedDomainName, translate } = this.props;
 
@@ -232,6 +260,9 @@ class TitanMailQuantitySelection extends React.Component {
 					</div>
 					<div className="titan-mail-quantity-selection__mailbox-info">
 						{ this.renderCurrentMailboxCounts() }
+					</div>
+					<div className="titan-mail-quantity-selection__pricing-info">
+						{ this.renderPricingDetails() }
 					</div>
 					<div>
 						<FormLabel>{ translate( 'Number of new mailboxes to add' ) }</FormLabel>
@@ -319,6 +350,7 @@ export default connect(
 			maxTitanMailboxCount: hasTitanMailWithUs( selectedDomain )
 				? getMaxTitanMailboxCount( selectedDomain )
 				: 0,
+			titanMonthlyProduct: getProductBySlug( state, TITAN_MAIL_MONTHLY_SLUG ),
 			isSelectedDomainNameValid: !! selectedDomain,
 		};
 	},

--- a/client/my-sites/email/titan-mail-quantity-selection/style.scss
+++ b/client/my-sites/email/titan-mail-quantity-selection/style.scss
@@ -6,23 +6,52 @@
 		margin-right: 10px;
 	}
 }
-
 .titan-mail-quantity-selection__divider {
 	margin-top: 1.5em;
+
+	&.titan-mail-quantity-selection__divider-pricing {
+		margin-bottom: 1em;
+	}
 }
 .titan-mail-quantity-selection__domain-info {
 	margin-bottom: 1em;
 }
 .titan-mail-quantity-selection__mailbox-info {
+	margin-bottom: 1em;
+
 	span {
 		display: block;
 		font-size: $font-body-small;
-
-		&:last-child {
-			margin-bottom: 1em;
-		}
 	}
 }
 .titan-mail-quantity-selection__pricing-info {
 	margin-bottom: 1em;
+
+	h3 {
+		font-size: $font-title-small;
+	}
+
+	>span {
+		display: block;
+		margin: 0.25em 0;
+	}
+
+	.titan-mail-quantity-selection__prorating-details {
+		align-items: center;
+		display: flex;
+		font-size: $font-body-small;
+		margin: 0.5em 0;
+
+		&.card {
+			padding: 16px;
+		}
+
+		.gridicon {
+			flex: 36px;
+		}
+
+		span {
+			margin-left: 0.5em;
+		}
+	}
 }

--- a/client/my-sites/email/titan-mail-quantity-selection/style.scss
+++ b/client/my-sites/email/titan-mail-quantity-selection/style.scss
@@ -23,3 +23,6 @@
 		}
 	}
 }
+.titan-mail-quantity-selection__pricing-info {
+	margin-bottom: 1em;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The core goal of this PR is to add pricing and proration details to the Email quantity selection UI, as both pieces of information were missing.

Before diving into the approach, it's worth describing the four possible situations we can have (though two are effectively the same):
1. The user doesn't have an Email subscription yet.
2. The user bought an Email subscription earlier that day.
3. The user bought an Email subscription within the last month.
4. The user bought an Email subscription and manually renewed it.

The first two situations are effectively the same: the user is going to see the standard monthly price.

Situation 3 is slightly different: the user will see a lower price, because any additional subscription(s) they buy will be prorated to cover the remainder of the billing month, so the price will be reduced.

Situation 4 is also different: the user will see a higher price, because any additional subscription(s) they buy will be prorated to cover the remainder of the current billing month _plus_ any months needed to share the same expiry date.

##### The core change
This PR introduces a new "Pricing" section that displays the pricing to the user.
* If the user sees only a "standard" price, we simply show the monthly price per mailbox.
* If the user sees a lower prorated price, we show the prorated price, the standard renewal price and when it will go into effect (i.e. on the expiration/renewal date), and an explanation about why those two prices are different.
* If the user sees a higher prorated price, we show the prorated price, the standard renewal price and when it will go into effect (i.e. on the expiration/renewal date), and an explanation about why those two prices are different.

**Note:** The current implementation relies on server-side price formatting logic.

##### Minor UI improvements
Just to try and tidy things up, I added some `CompactCard` elements to avoid having a flat wall of text. We can still improve from here (a _lot_) but this means we're less bad after this iteration.

#### Testing instructions

**Note:** This PR depends on D55887-code for additional values from the server.

We need to test the display for all of the core cases mentioned above:
1. Buying an Email mailbox for a domain that doesn't have Email set up at all.
2. Buying additional Email mailboxes for a domain on the same day as the first mailbox was bought.
3. Buying additional Email mailboxes for a domain at least one day after first buying an Email mailbox, and less then a month later.
4. Buying additional Email mailboxes for a domain after manually renewing the Email subscription for that domain.

For all of the above test cases, verify all of the following:
* You can see a valid price for the mailboxes you want to buy
* If there is an existing subscription and proration should occur, verify that the pricing information is accurate and correctly formatted, including the renewal/expiry date.
* Verify that the information we're presenting in this page makes sense and is not too dense.
* Verify that if you click the "Continue" button, the prorated price that was mentioned is also used by checkout.

If you want a bonus test case, you can also set up a user with an Email subscription in currency A. Then change the user's default currency to currency B.  For this case, the _original_ currency and amounts should continue to be used.

#### Screenshots

1. Case 1: New purchase
<img width="741" alt="email_purchase_new" src="https://user-images.githubusercontent.com/3376401/105561066-6f248b00-5d1e-11eb-98dd-b33affbcfb23.png">

2. Case 2: Additional purchase on same day
<img width="744" alt="email_purchase_additional_same_day" src="https://user-images.githubusercontent.com/3376401/105561092-85324b80-5d1e-11eb-8b59-b16ba295c065.png">

3. Case 3: Additional purchase with lower proration
<img width="746" alt="email_purchase_lower_proration" src="https://user-images.githubusercontent.com/3376401/105561139-a2671a00-5d1e-11eb-9173-fcfecd7b7cf0.png">

4. Case 4: Additional purchase with higher proration
<img width="747" alt="email_purchase_higher_proration" src="https://user-images.githubusercontent.com/3376401/105561215-ce829b00-5d1e-11eb-93dd-805df8ac6360.png">
