### PR TITLE
i18n Disable translation chunks in staging and production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -147,7 +147,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-component": false,
-		"use-translation-chunks": true,
+		"use-translation-chunks": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -154,7 +154,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-component": false,
-		"use-translation-chunks": true,
+		"use-translation-chunks": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,


### PR DESCRIPTION
Looks like the Webpack 5 upgrade broke this. This brings back translations.