### PR TITLE
Disable Titan Mail as an email option

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -243,7 +243,7 @@ class EmailProvidersComparison extends React.Component {
 		);
 	}
 
-	renderGSuiteDetails() {
+	renderGSuiteDetails( className ) {
 		const { currencyCode, gSuiteProduct, translate } = this.props;
 
 		let title = translate( 'G Suite by Google' );
@@ -298,20 +298,25 @@ class EmailProvidersComparison extends React.Component {
 				}
 				buttonLabel={ buttonLabel }
 				onButtonClick={ this.goToAddGSuite }
+				className={ className }
 			/>
 		);
 	}
 
 	render() {
 		const { isGSuiteSupported } = this.props;
-		const cardClassName = isGSuiteSupported ? null : 'no-gsuite';
+		const isTitanSupported = config.isEnabled( 'titan/phase-2' );
+		const cardClassName = classNames( [
+			isGSuiteSupported ? null : 'no-gsuite',
+			isTitanSupported ? null : 'no-titan',
+		] );
 		return (
 			<>
 				{ this.renderHeaderSection() }
 				<div className="email-providers-comparison__providers">
 					{ this.renderForwardingDetails( cardClassName ) }
-					{ this.renderTitanDetails( cardClassName ) }
-					{ isGSuiteSupported && this.renderGSuiteDetails() }
+					{ isTitanSupported && this.renderTitanDetails( cardClassName ) }
+					{ isGSuiteSupported && this.renderGSuiteDetails( cardClassName ) }
 					<TrackComponentView
 						eventName="calypso_email_providers_comparison_page_view"
 						eventProperties={ { is_gsuite_supported: isGSuiteSupported } }

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -15,6 +15,9 @@
 		&.no-gsuite {
 			width: calc( 50% - 0.5em );
 		}
+		&.no-titan {
+			width: calc( 50% - 0.5em );
+		}
 
 		&.titan {
 			.promo-card__title-badge {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the Email launch, we want to remove Titan Mail as a purchase option. To achieve that, this PR does the following:
* Display of the Email option is now controlled by the `titan/phase-2` feature flag -- when the flag is disabled, we don't show the current Titan Mail product, and when it is enabled, we'll show the new Email product.
   - This will simplify undoing this change -- all we need to do to launch Email is enable the `titan/phase-2` feature flag in production
* When the Titan card is hidden, we will widen the Email Forwarding and G Suite cards to just under 50% each.
* When both the Titan card and the G Suite cards are hidden, we still keep the Email Forwarding card at 50% of the width and left aligned.
   - I am 100% open to changing this, but when I played with making it full-width or centre-aligned, it looked even worse than having a single card taking up the left half of the screen!

#### Testing instructions

This PR only affects the display of the page accessible the "Add" button in the Email column on the Domains listing page (either via Manage -> Domains, or via Upgrades -> Domains). We need to view the page with the following situations:
* The `titan/phase-2` flag is enabled and the domain supports buying G Suite. (You can force the `isGSuiteSupported` flag to true in `client/my-sites/email/email-providers-comparison/index.jsx` if you need to and are testing locally.)
   - In this case, all three options should be shown including the new Email option, and they should each take up about a third of the horizontal screen space.
* The `titan/phase-2` flag is enabled and the domain doesn't support buying G Suite. (As above, you can toggle the `isGSuiteSupported` flag manually.)
   - In this case, only Email Forwarding and the new Email option should be shown, and each should take up half the horizontal screen space.
* The `titan/phase-2` flag is disabled and the domain supports buying G Suite. (As above re the `isGSuiteSupported` flag.)
   - In this case, only Email Forwarding and G Suite should be shown, and each should take up half the horizontal screen space.
* The `titan/phase-2` flag is disabled and the domain doesn't support buying G Suite. (As above re the `isGSuiteSupported` flag.)
   - In this case, only Email Forwarding should be shown, and it should take up the left half of the screen.