### PR TITLE
Launch Email on WordPress.com

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -129,6 +129,7 @@
 		"signup/wpforteams": true,
 		"site-indicator": true,
 		"support-user": true,
+		"titan/phase-2": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -97,6 +97,7 @@
 		"signup/wpcc": true,
 		"signup/wpforteams": true,
 		"site-indicator": true,
+		"titan/phase-2": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -128,6 +128,7 @@
 		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,
+		"titan/phase-2": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,

--- a/config/production.json
+++ b/config/production.json
@@ -136,6 +136,7 @@
 		"memberships": true,
 		"ssr/sample-log-cache-misses": true,
 		"support-user": true,
+		"titan/phase-2": true,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -143,6 +143,7 @@
 		"signup/wpforteams": true,
 		"site-indicator": true,
 		"support-user": true,
+		"titan/phase-2": true,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change launches Email on WordPress.com by enabling the `titan/phase-2` feature flag.

#### Testing instructions

* This one is tricky to verify because it only affects environments outside of WPCalypso and development. We've been testing this fairly extensively with and without the feature flag, so I don't believe this needs specific testing.