### PR TITLE
Gutenboarding: Fix "Choose a domain I own" layout on mobile

### DIFF
--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -109,6 +109,16 @@ $accent-blue: #117ac9;
 		}
 	}
 
+	&.type-link {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+
+		@include break-medium {
+			flex-direction: initial;
+		}
+	}
+
 	&.placeholder {
 		cursor: default;
 	}

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -115,7 +115,7 @@ $accent-blue: #117ac9;
 		align-items: flex-start;
 
 		@include break-medium {
-			flex-direction: initial;
+			flex-direction: row;
 			align-items: center;
 		}
 	}

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -116,6 +116,7 @@ $accent-blue: #117ac9;
 
 		@include break-medium {
 			flex-direction: initial;
+			align-items: center;
 		}
 	}
 

--- a/packages/domain-picker/src/domain-picker/suggestion-item-wrapper.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item-wrapper.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import type { SUGGESTION_ITEM_TYPE } from 'src';
+
+// to avoid nesting buttons, wrap the item with a div instead of button in button mode
+// (button mode means there is a Select button, not the whole item being a button)
+
+interface WrappingComponentAdditionalProps {
+	type: SUGGESTION_ITEM_TYPE;
+	disabled?: boolean;
+}
+type WrappingComponentProps = WrappingComponentAdditionalProps &
+	( React.HTMLAttributes< HTMLDivElement > | React.ButtonHTMLAttributes< HTMLButtonElement > );
+
+const WrappingComponent = React.forwardRef< HTMLButtonElement, WrappingComponentProps >(
+	( { type, disabled, ...props }, ref ) => {
+		if ( type === 'button' ) {
+			return <div { ...( props as React.HTMLAttributes< HTMLDivElement > ) } />;
+		}
+		return (
+			<button
+				ref={ ref }
+				disabled={ disabled }
+				{ ...( props as React.ButtonHTMLAttributes< HTMLButtonElement > ) }
+			/>
+		);
+	}
+);
+
+export default WrappingComponent;

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -20,6 +20,7 @@ import { sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import InfoTooltip from '../info-tooltip';
+import WrappingComponent from './suggestion-item-wrapper';
 // TODO: remove when all needed core types are available
 /*#__PURE__*/ import '../types-patch';
 
@@ -30,32 +31,6 @@ export type SUGGESTION_ITEM_TYPE =
 	| typeof ITEM_TYPE_RADIO
 	| typeof ITEM_TYPE_BUTTON
 	| typeof ITEM_TYPE_INDIVIDUAL_ITEM;
-
-// to avoid nesting buttons, wrap the item with a div instead of button in button mode
-// (button mode means there is a Select button, not the whole item being a button)
-
-interface WrappingComponentAdditionalProps {
-	type: SUGGESTION_ITEM_TYPE;
-	disabled?: boolean;
-}
-type WrappingComponentProps = WrappingComponentAdditionalProps &
-	( React.HTMLAttributes< HTMLDivElement > | React.ButtonHTMLAttributes< HTMLButtonElement > );
-
-const WrappingComponent = React.forwardRef< HTMLButtonElement, WrappingComponentProps >(
-	( { type, disabled, ...props }, ref ) => {
-		if ( type === 'button' ) {
-			return <div { ...( props as React.HTMLAttributes< HTMLDivElement > ) } />;
-		}
-		return (
-			<button
-				ref={ ref }
-				disabled={ disabled }
-				{ ...( props as React.ButtonHTMLAttributes< HTMLButtonElement > ) }
-			/>
-		);
-	}
-);
-
 interface Props {
 	isUnavailable?: boolean;
 	domain: string;

--- a/packages/domain-picker/src/domain-picker/use-your-domain-item.tsx
+++ b/packages/domain-picker/src/domain-picker/use-your-domain-item.tsx
@@ -8,16 +8,22 @@ import { ArrowButton } from '@automattic/onboarding';
 /**
  * Internal dependencies
  */
+import WrappingComponent from './suggestion-item-wrapper';
 
 interface Props {
 	onClick: () => void;
 }
 
 const UseYourDomainItem: React.FunctionComponent< Props > = ( { onClick } ) => {
+	const useYourOwnDomainItemRef = React.createRef< any >();
+
 	return (
-		/* eslint-disable jsx-a11y/click-events-have-key-events */
-		/* eslint-disable jsx-a11y/interactive-supports-focus */
-		<div role="button" className="domain-picker__suggestion-item type-link" onClick={ onClick }>
+		<WrappingComponent
+			type="button"
+			className="domain-picker__suggestion-item type-link"
+			ref={ useYourOwnDomainItemRef }
+			onClick={ onClick }
+		>
 			<div className="domain-picker__suggestion-item-name">
 				<span className="domain-picker__domain-wrapper with-margin with-bold-text">
 					{ __( 'Already own a domain?', __i18n_text_domain__ ) }
@@ -39,7 +45,7 @@ const UseYourDomainItem: React.FunctionComponent< Props > = ( { onClick } ) => {
 					__i18n_text_domain__
 				) }
 			</ArrowButton>
-		</div>
+		</WrappingComponent>
 	);
 };
 

--- a/packages/domain-picker/src/domain-picker/use-your-domain-item.tsx
+++ b/packages/domain-picker/src/domain-picker/use-your-domain-item.tsx
@@ -15,7 +15,9 @@ interface Props {
 
 const UseYourDomainItem: React.FunctionComponent< Props > = ( { onClick } ) => {
 	return (
-		<label className="domain-picker__suggestion-item contains-link">
+		/* eslint-disable jsx-a11y/click-events-have-key-events */
+		/* eslint-disable jsx-a11y/interactive-supports-focus */
+		<div role="button" className="domain-picker__suggestion-item type-link" onClick={ onClick }>
 			<div className="domain-picker__suggestion-item-name">
 				<span className="domain-picker__domain-wrapper with-margin with-bold-text">
 					{ __( 'Already own a domain?', __i18n_text_domain__ ) }
@@ -37,7 +39,7 @@ const UseYourDomainItem: React.FunctionComponent< Props > = ( { onClick } ) => {
 					__i18n_text_domain__
 				) }
 			</ArrowButton>
-		</label>
+		</div>
 	);
 };
 

--- a/packages/domain-picker/src/domain-picker/use-your-domain-item.tsx
+++ b/packages/domain-picker/src/domain-picker/use-your-domain-item.tsx
@@ -15,13 +15,10 @@ interface Props {
 }
 
 const UseYourDomainItem: React.FunctionComponent< Props > = ( { onClick } ) => {
-	const useYourOwnDomainItemRef = React.createRef< any >();
-
 	return (
 		<WrappingComponent
 			type="button"
 			className="domain-picker__suggestion-item type-link"
-			ref={ useYourOwnDomainItemRef }
 			onClick={ onClick }
 		>
 			<div className="domain-picker__suggestion-item-name">

--- a/packages/onboarding/src/action-buttons/style.scss
+++ b/packages/onboarding/src/action-buttons/style.scss
@@ -87,7 +87,7 @@ button.action_buttons__button.components-button {
 	}
 
 	&.action-buttons__arrow {
-		justify-content: flex-end;
+		justify-content: flex-start;
 
 		text-decoration: underline;
 		// stylelint-disable-next-line scales/font-weight
@@ -97,6 +97,10 @@ button.action_buttons__button.components-button {
 		// @TODO: We have to revisit the ArrowButton's padding when we pick up #48568 (https://github.com/Automattic/wp-calypso/issues/48568)
 		padding: 0;
 		margin-right: 0;
+
+		@include break-medium {
+			justify-content: flex-end;
+		}
 
 		svg {
 			// The viewbox has a 5px margin and we have to crop it to align it with the ArrowButton's copy properly.

--- a/packages/onboarding/src/action-buttons/style.scss
+++ b/packages/onboarding/src/action-buttons/style.scss
@@ -92,6 +92,9 @@ button.action_buttons__button.components-button {
 		font-weight: 500;
 		color: var( --mainColor );
 
+		// @TODO: We have to revisit the ArrowButton's padding when we pick up #48568 (https://github.com/Automattic/wp-calypso/issues/48568)
+		padding-left: 0;
+
 		svg {
 			// the svg has 5 empty pixels on the left
 			margin-left: -5px;

--- a/packages/onboarding/src/action-buttons/style.scss
+++ b/packages/onboarding/src/action-buttons/style.scss
@@ -87,17 +87,20 @@ button.action_buttons__button.components-button {
 	}
 
 	&.action-buttons__arrow {
+		justify-content: flex-end;
+
 		text-decoration: underline;
 		// stylelint-disable-next-line scales/font-weight
 		font-weight: 500;
 		color: var( --mainColor );
 
 		// @TODO: We have to revisit the ArrowButton's padding when we pick up #48568 (https://github.com/Automattic/wp-calypso/issues/48568)
-		padding-left: 0;
+		padding: 0;
+		margin-right: 0;
 
 		svg {
-			// the svg has 5 empty pixels on the left
-			margin-left: -5px;
+			// The viewbox has a 5px margin and we have to crop it to align it with the ArrowButton's copy properly.
+			margin: 0 -5px -4px;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The copy of the "Choose a domain I own" row on the Domain Picker is unreadable on mobile devices because the CTA-link is on the same row. This PR contains a fix that stacks (i.e. placed on separate rows) both on mobile viewports.

#### Technical changes

* Update HTML semantics (i.e. from `<label/>` to `<div/>`) to align with the solution provided in the `/start` flow.
* Update flexbox alignment (mobile-first approach).
* Overrule flexbox alignment on larger-than-mobile-viewports.
* Update padding for `<ArrowButton/>`. We have to revisit this while working on #48568.

#### Expected Result
**Mobile**
<img width="381" alt="Screenshot 2021-01-25 at 14 07 32" src="https://user-images.githubusercontent.com/12104589/105717896-f17c9d00-5f20-11eb-95de-4f5ada32a6c7.png">

**Desktop**

<img width="778" alt="Screenshot 2021-01-25 at 15 22 13" src="https://user-images.githubusercontent.com/12104589/105718040-1e30b480-5f21-11eb-9dab-487ed21450c8.png">

#### Testing instructions 

#### Gutenboarding

1. Go to `/new/domains-modal`
2. Confirm that:
    * [x] Both copy & CTA-link are on the same row
    * [x] The complete row is clickable and clicking redirects you to the domain's transfer/mapping view
    * [x] Clicking the CTA-link redirects you to the domain's transfer/mapping view.
3. Open DevTools and switch to a mobile viewport (e.g. `iPhone X`).
4. Revisit `/new/domains-modal`.
5. Confirm that:
    * [x] Copy & CTA-link are stacked and readable
    * [x] The complete row is clickable and clicking redirects you to the domain's transfer/mapping view.
    * [x] Clicking the CTA-link redirects you to the domain's transfer/mapping view
6. Switch from English to a more verbose language (e.g French) and repeat steps 1-6.

#### Focused Launch
1. Go to `/page/[UNLAUNCHED_SITE_ID].wordpress.com/home?flags=create/focused-launch-flow`.
2. Click "Launch" to open the Focused Launch flow.
3. Click on "View All Domains".
4. Confirm that:
    * [x] Both copy & CTA-link are on the same row
    * [x] The complete row is clickable and clicking redirects you to the domain's transfer/mapping view.
    * [x] Clicking the CTA-link redirects you to the domain's transfer/mapping view.
5. Open DevTools and switch to a mobile viewport (e.g. `iPhone X`).
6. Revisit `/page/[UNLAUNCHED_SITE_ID].wordpress.com/home?flags=create/focused-launch-flow`.
7. Confirm that:
    * [x] Copy & CTA-link are stacked and readable
    * [x] The complete row is clickable and clicking redirects you to the domain's transfer/mapping view
    * [x] Clicking the CTA-link redirects you to the domain's transfer/mapping view.
8. Switch from English to a more verbose language (e.g French) and repeat steps 1-7.

Fixes #49171
