### PR TITLE
Onboarding: remove Edison design's premium badge

### DIFF
--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -51,7 +51,7 @@
 				"base": "Open Sans"
 			},
 			"categories": [ "featured", "blog" ],
-			"is_premium": true,
+			"is_premium": false,
 			"features": []
 		},
 		{

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -146,7 +146,11 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 		} );
 	} );
 
-	describe( 'Skip first step in Gutenboarding, select paid design and see Domains page after Style preview @parallel', function () {
+	/**
+	 * Paid "premium" designs are temporarily disabled in the flow.
+	 * See https://github.com/Automattic/wp-calypso/pull/49251
+	 */
+	describe.skip( 'Skip first step in Gutenboarding, select paid design and see Domains page after Style preview @parallel', function () {
 		before( async function () {
 			await driverManager.ensureNotLoggedIn( driver );
 			await NewPage.Visit( driver );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove Edison design's premium badge

#### Testing instructions

`/new/design` shouldn't have any designs with "premium" left:

<img width="580" alt="Screenshot 2021-01-25 at 12 51 37" src="https://user-images.githubusercontent.com/87168/105696538-26322980-5f0c-11eb-95cc-3c8446708d01.png">
