### PR TITLE
Handle the upgradePlan action from incoming Titan redirects

### DIFF
--- a/client/my-sites/email/titan-redirector/index.jsx
+++ b/client/my-sites/email/titan-redirector/index.jsx
@@ -131,6 +131,7 @@ class TitanRedirector extends Component {
 		switch ( action ) {
 			case 'renewOrder':
 			case 'billing':
+			case 'upgradePlan':
 				redirectURL = getManagePurchaseUrlFor( siteSlug, subscriptionId );
 				break;
 			case 'buyMoreAccounts':


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR simply adds support for the incoming `upgradePlan` action in redirects from Titan

#### Testing instructions

* Verify that if you click on the Billing and Upgrade menu item in the Titan Control Panel left nav, you are correctly redirected to manage your Email subscription.
