### PR TITLE
i18n: Re-enable translation chunks for production and stage

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -147,7 +147,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-component": false,
-		"use-translation-chunks": false,
+		"use-translation-chunks": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -154,7 +154,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-component": false,
-		"use-translation-chunks": false,
+		"use-translation-chunks": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,


### PR DESCRIPTION
After fixing `build-languages` script in https://github.com/Automattic/wp-calypso/pull/49259, it should be safe to re-enable translation chunks

#### Changes proposed in this Pull Request

* Re-enable translation chunks for `production` and `stage` environments.

#### Testing instructions

Test Translation Chunks on staging / production with https://wordpress.com/?flags=use-translation-chunks and verify that they are used using the Network Monitor of your dev tools.

Ref. p1611555347006200-slack-i18n
