### PR TITLE
State: Move publicize and keyring notices out of notices middleware

### DIFF
--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -32,19 +32,11 @@ import {
 	INVITE_RESEND_REQUEST_FAILURE,
 	INVITES_DELETE_REQUEST_SUCCESS,
 	INVITES_DELETE_REQUEST_FAILURE,
-	KEYRING_CONNECTION_DELETE,
-	KEYRING_CONNECTION_DELETE_FAILURE,
 	POST_DELETE_FAILURE,
 	POST_DELETE_SUCCESS,
 	POST_RESTORE_FAILURE,
 	POST_RESTORE_SUCCESS,
 	POST_SAVE_SUCCESS,
-	PUBLICIZE_CONNECTION_CREATE,
-	PUBLICIZE_CONNECTION_CREATE_FAILURE,
-	PUBLICIZE_CONNECTION_DELETE,
-	PUBLICIZE_CONNECTION_DELETE_FAILURE,
-	PUBLICIZE_CONNECTION_UPDATE,
-	PUBLICIZE_CONNECTION_UPDATE_FAILURE,
 	SITE_DELETE,
 	SITE_DELETE_FAILURE,
 	SITE_DELETE_RECEIVE,
@@ -168,60 +160,6 @@ export const onPostSaveSuccess = ( { post, savedPost } ) => ( dispatch ) => {
 	}
 };
 
-export const onPublicizeConnectionCreate = ( { connection } ) =>
-	successNotice(
-		translate( 'The %(service)s account was successfully connected.', {
-			args: { service: connection.label },
-			context: 'Sharing: Publicize connection confirmation',
-		} ),
-		{ id: 'publicize' }
-	);
-
-export const onPublicizeConnectionCreateFailure = ( { error } ) =>
-	errorNotice(
-		error.message ||
-			translate( 'An error occurred while connecting the account.', {
-				context: 'Sharing: Publicize connection confirmation',
-			} ),
-		{ id: 'publicize' }
-	);
-
-export const onPublicizeConnectionDelete = ( { connection } ) =>
-	successNotice(
-		translate( 'The %(service)s account was successfully disconnected.', {
-			args: { service: connection.label },
-			context: 'Sharing: Publicize connection confirmation',
-		} ),
-		{ id: 'publicize' }
-	);
-
-export const onPublicizeConnectionDeleteFailure = ( { error } ) =>
-	errorNotice(
-		translate( 'The %(service)s account was unable to be disconnected.', {
-			args: { service: error.label },
-			context: 'Sharing: Publicize connection confirmation',
-		} ),
-		{ id: 'publicize' }
-	);
-
-export const onPublicizeConnectionUpdate = ( { connection } ) =>
-	successNotice(
-		translate( 'The %(service)s account was successfully updated.', {
-			args: { service: connection.label },
-			context: 'Sharing: Publicize connection confirmation',
-		} ),
-		{ id: 'publicize' }
-	);
-
-export const onPublicizeConnectionUpdateFailure = ( { error } ) =>
-	errorNotice(
-		translate( 'The %(service)s account was unable to be updated.', {
-			args: { service: error.label },
-			context: 'Sharing: Publicize reconnection confirmation',
-		} ),
-		{ id: 'publicize' }
-	);
-
 const onGuidedTransferHostDetailsSaveSuccess = () =>
 	successNotice( translate( 'Thanks for confirming those details!' ) );
 
@@ -313,19 +251,11 @@ export const handlers = {
 	[ INVITES_DELETE_REQUEST_SUCCESS ]: onDeleteInvitesSuccess,
 	[ INVITES_DELETE_REQUEST_FAILURE ]: onDeleteInvitesFailure,
 	[ INVITE_RESEND_REQUEST_FAILURE ]: onInviteResendRequestFailure,
-	[ KEYRING_CONNECTION_DELETE ]: onPublicizeConnectionDelete,
-	[ KEYRING_CONNECTION_DELETE_FAILURE ]: onPublicizeConnectionDeleteFailure,
 	[ POST_DELETE_FAILURE ]: onPostDeleteFailure,
 	[ POST_DELETE_SUCCESS ]: onPostDeleteSuccess,
 	[ POST_RESTORE_FAILURE ]: onPostRestoreFailure,
 	[ POST_RESTORE_SUCCESS ]: onPostRestoreSuccess,
 	[ POST_SAVE_SUCCESS ]: onPostSaveSuccess,
-	[ PUBLICIZE_CONNECTION_CREATE ]: onPublicizeConnectionCreate,
-	[ PUBLICIZE_CONNECTION_CREATE_FAILURE ]: onPublicizeConnectionCreateFailure,
-	[ PUBLICIZE_CONNECTION_DELETE ]: onPublicizeConnectionDelete,
-	[ PUBLICIZE_CONNECTION_DELETE_FAILURE ]: onPublicizeConnectionDeleteFailure,
-	[ PUBLICIZE_CONNECTION_UPDATE ]: onPublicizeConnectionUpdate,
-	[ PUBLICIZE_CONNECTION_UPDATE_FAILURE ]: onPublicizeConnectionUpdateFailure,
 	[ GUIDED_TRANSFER_HOST_DETAILS_SAVE_SUCCESS ]: onGuidedTransferHostDetailsSaveSuccess,
 	[ SITE_DELETE ]: onSiteDelete,
 	[ SITE_DELETE_FAILURE ]: onSiteDeleteFailure,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As we've previously discussed in other PRs, the notices middleware isn't as useful as it looks like. It adds some weight that is loaded on all pages on the main entry point but is still used far too seldom to make sense to always be loaded.

This PR removes the publicize / keyring module notices away from the notices middleware and moves them into the corresponding action creators / thunks.

#### Testing instructions

* Checkout this branch.
* Go to `/marketing/connections/:site` where `:site` is a WP.com site.
* Verify connecting and disconnecting a service still works well and produces the same notices as in production. Please make sure to force failures, too.
* Verify tests pass.
