### PR TITLE
Plugins: Hide recommended plugins when empty

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -236,12 +236,17 @@ export class PluginsBrowser extends Component {
 	}
 
 	getRecommendedPluginListView() {
+		const { recommendedPlugins } = this.props;
+		if ( recommendedPlugins && recommendedPlugins.length === 0 ) {
+			return;
+		}
+
 		return (
 			<PluginsBrowserList
 				currentSites={ this.props.sites }
 				expandedListLink={ false }
 				listName="recommended"
-				plugins={ this.props.recommendedPlugins }
+				plugins={ recommendedPlugins }
 				showPlaceholders={ this.props.isRequestingRecommendedPlugins }
 				site={ this.props.siteSlug }
 				size={ SHORT_LIST_LENGTH }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR hides recommended plugins when the list is empty.

Related to #24180. 

Discovered by @flootr while testing #49198.

#### Testing instructions

* Go to `/plugins/:site` where `:site` is a Jetpack site.
* Manually set the prop `recommendedPlugins` of `PluginsBrowser` to an empty array if it isn't empty.
* Verify that an empty "Recommended" section doesn't appear in that use case.

Note: This is testable only on development and wpcalypso (calypso.live) environments, as the feature is disabled on staging / production.
