### PR TITLE
Gutenboarding: implement refund window copy changes in the plans page

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -102,15 +102,23 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 			<div>
 				<Title>{ __( 'Select a plan' ) }</Title>
 				<SubTitle>
-					{ sprintf(
-						/* translators: number of days */
-						__(
-							'Pick a plan that’s right for you. There’s no risk, you can cancel for a full refund within %1$d days.'
-						),
-						// Only show a 7-days refund window if billing period is
-						// defined AND is set to monthl (its value starts as undefined)
-						billingPeriod === 'MONTHLY' ? 7 : 14
-					) }
+					{ billingPeriod === 'MONTHLY'
+						? sprintf(
+								/* translators: %1$d is number of days */
+								__(
+									'Pick a plan that’s right for you. There is no risk, you can cancel your monthly plan for a full refund within %1$d days.'
+								),
+								// Monthly-billed plans have a 7-day refund window
+								7
+						  )
+						: sprintf(
+								/* translators: %1$d is number of days */
+								__(
+									'Pick a plan that’s right for you. There is no risk, you can cancel your annual plan for a full refund within %1$d days.'
+								),
+								// Annually-billed plans have a 14-day refund window
+								14
+						  ) }
 				</SubTitle>
 			</div>
 			<ActionButtons>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change copy at the top of the plans page in Gutenboarding to highlight the difference between monthly-billed and annually-billed plans

#### Testing instructions

* Visit `/new` on the [calypso.live link](https://calypso.live/?branch=feat/monthly-plans-gutenboarding-copy-changes)
* Navigate to the plans step
* Make sure that A/C described in #49252 are met
* Once translations are in, check that all required locales display the translated text correctly

#### Screenshots

For translators: 

<img width="1792" alt="Screenshot 2021-01-25 at 20 36 23" src="https://user-images.githubusercontent.com/1083581/105756580-1555d800-5f4d-11eb-8a96-d63715150b07.png">

<img width="1792" alt="Screenshot 2021-01-25 at 20 36 13" src="https://user-images.githubusercontent.com/1083581/105756573-125ae780-5f4d-11eb-8e56-c2340bcd34dc.png">


Fixes #49252
Relates to #47576