### PR TITLE
Partner Portal: Introduce the license details toggle UI

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import {
+	STATE_ATTACHED,
+	STATE_DETACHED,
+	STATE_REVOKED,
+	getLicenseState,
+} from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import { Button, Card } from '@automattic/components';
+import ClipboardButton from 'calypso/components/forms/clipboard-button';
+import Gridicon from 'calypso/components/gridicon';
+import FormattedDate from 'calypso/components/formatted-date';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	licenseKey: string;
+	issuedOn: string;
+	attachedOn: string;
+	revokedOn: string;
+	username: string;
+	blogId: number;
+}
+
+export default function LicenseDetails( {
+	licenseKey,
+	issuedOn,
+	attachedOn,
+	revokedOn,
+	username,
+	blogId,
+}: Props ) {
+	const translate = useTranslate();
+	const licenseState = getLicenseState( attachedOn, revokedOn );
+
+	return (
+		<Card className="license-details">
+			<ul className="license-details__list">
+				<li className="license-details__list-item license-details__list-item--wide">
+					<h4 className="license-details__label">{ translate( 'License code' ) }</h4>
+
+					<div className="license-details__license-key-row">
+						<code className="license-details__license-key">{ licenseKey }</code>
+
+						<ClipboardButton
+							text={ licenseKey }
+							className="license-details__clipboard-button"
+							borderless
+							compact
+						>
+							<Gridicon icon="clipboard" />
+						</ClipboardButton>
+					</div>
+				</li>
+
+				<li className="license-details__list-item">
+					<h4 className="license-details__label">{ translate( 'Issued on' ) }</h4>
+					<FormattedDate date={ issuedOn } format="LLL" />
+				</li>
+
+				{ licenseState === STATE_ATTACHED && (
+					<li className="license-details__list-item">
+						<h4 className="license-details__label">{ translate( 'Attached on' ) }</h4>
+						<FormattedDate date={ attachedOn } format="LLL" />
+					</li>
+				) }
+
+				{ licenseState === STATE_DETACHED && (
+					<li className="license-details__list-item">
+						<h4 className="license-details__label">{ translate( 'Attached on' ) }</h4>
+						<Gridicon icon="minus" />
+					</li>
+				) }
+
+				{ licenseState === STATE_REVOKED && (
+					<li className="license-details__list-item">
+						<h4 className="license-details__label">{ translate( 'Revoked on' ) }</h4>
+						<FormattedDate date={ revokedOn } format="LLL" />
+					</li>
+				) }
+
+				<li className="license-details__list-item">
+					<h4 className="license-details__label">{ translate( "Owner's User ID" ) }</h4>
+					<span>{ username }</span>
+				</li>
+
+				<li className="license-details__list-item">
+					<h4 className="license-details__label">{ translate( 'Blog ID' ) }</h4>
+					<span>{ blogId }</span>
+				</li>
+			</ul>
+			<div className="license-details__actions">
+				<Button scary>{ translate( 'Revoke License' ) }</Button>
+			</div>
+		</Card>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
@@ -1,0 +1,63 @@
+@import '~@wordpress/base-styles/_breakpoints.scss';
+@import '~@wordpress/base-styles/_mixins.scss';
+
+.license-details {
+	margin: 0;
+
+	&__list {
+		display: grid;
+		grid-template-columns: repeat( 2, 1fr );
+		grid-column-gap: 32px;
+		grid-row-gap: 32px;
+		padding: 0;
+		margin: 0;
+		list-style-type: none;
+	}
+
+	&__list-item {
+		font-size: 1rem;
+
+		&--wide {
+			grid-column-start: span 2;
+			white-space: nowrap;
+		}
+	}
+
+	&__license-key-row {
+		display: flex;
+	}
+
+	&__license-key {
+		flex: 0 1 auto;
+		padding: 6px;
+		font-size: 0.875rem;
+		background: var( --studio-gray-0 );
+		color: var( --studio-gray-70 );
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	&__clipboard-button {
+		flex: 0 0 auto;
+		position: relative;
+		top: -1px;
+		margin-left: 8px;
+
+		// Overpower specificity of the button component styles.
+		&.button.button {
+			color: var( --studio-gray-70 );
+		}
+	}
+
+	&__label {
+		margin-bottom: 8px;
+		font-size: 1rem;
+		font-weight: bold;
+	}
+
+	&__actions {
+		margin-top: 42px;
+		display: flex;
+		justify-content: flex-end;
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -19,6 +19,7 @@ import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import Gridicon from 'calypso/components/gridicon';
 import FormattedDate from 'calypso/components/formatted-date';
 import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
+import LicenseDetails from 'calypso/jetpack-cloud/sections/partner-portal/license-details';
 
 /**
  * Style dependencies
@@ -32,6 +33,8 @@ interface Props {
 	issuedOn: string;
 	attachedOn: string;
 	revokedOn: string;
+	username: string;
+	blogId: number;
 }
 
 export default function LicensePreview( {
@@ -41,6 +44,8 @@ export default function LicensePreview( {
 	issuedOn,
 	attachedOn,
 	revokedOn,
+	username,
+	blogId,
 }: Props ) {
 	const translate = useTranslate();
 	const [ isOpen, setOpen ] = useState( false );
@@ -138,6 +143,17 @@ export default function LicensePreview( {
 					</Button>
 				</div>
 			</LicenseListItem>
+
+			{ isOpen && (
+				<LicenseDetails
+					licenseKey={ licenseKey }
+					issuedOn={ issuedOn }
+					attachedOn={ attachedOn }
+					revokedOn={ revokedOn }
+					username={ username }
+					blogId={ blogId }
+				/>
+			) }
 		</div>
 	);
 }


### PR DESCRIPTION
Context:
* Project thread: pbtFPC-Um-p2
* i4 designs: pbtFPC-103-p2

#### Changes proposed in this Pull Request

* (re)Introduce the LicenseDetails component which renders the details of a license to match designs.

#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key, if prompted.
* Expand a license via the chevron button on the right and confirm the details UI you are presented with matches designs.

![license-details](https://user-images.githubusercontent.com/22746396/106746352-195bb700-662b-11eb-928b-80b77516746c.png)
The license code visible in the screenshot is fake.