### PR TITLE
ABTest, Plans: Convert some product constants into functions that get evaluated on demand

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -69,7 +69,7 @@ export default {
 		allowExistingUsers: false,
 	},
 	jetpackSimplifyPricingPage: {
-		datestamp: '20210122',
+		datestamp: '20210125',
 		variations: {
 			test: 50,
 			control: 50,

--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -110,48 +110,72 @@ export const PRODUCTS_WITH_OPTIONS = [
 ] as const;
 
 // Jetpack Security
-export const OPTION_PLAN_SECURITY: ( variation: string ) => SelectorProduct = ( variation ) => ( {
-	productSlug: OPTIONS_JETPACK_SECURITY,
-	annualOptionSlug: OPTIONS_JETPACK_SECURITY,
-	monthlyOptionSlug: OPTIONS_JETPACK_SECURITY_MONTHLY,
-	term: TERM_ANNUALLY,
-	type: ITEM_TYPE_BUNDLE,
-	subtypes: [ PLAN_JETPACK_SECURITY_DAILY, PLAN_JETPACK_SECURITY_REALTIME ],
-	costProductSlug: PLAN_JETPACK_SECURITY_DAILY,
-	monthlyProductSlug: PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
-	iconSlug: 'jetpack_security_v2',
-	displayName: translate( 'Jetpack Security' ),
-	shortName: translate( 'Security', {
-		comment: 'Short name of the Jetpack Security generic plan',
-	} ),
-	tagline: translate( 'Comprehensive WordPress protection' ),
-	description: translate(
-		'Enjoy the peace of mind of complete site security. ' +
-			'Easy-to-use, powerful security tools guard your site, so you can focus on your business.'
-	),
-	features: {
-		items: buildCardFeaturesFromItem(
-			{
-				[ FEATURE_CATEGORY_SECURITY ]: [
-					FEATURE_PRODUCT_BACKUP_V2,
-					FEATURE_PRODUCT_SCAN_V2,
-					FEATURE_PRODUCT_ANTISPAM_V2,
-					FEATURE_ACTIVITY_LOG_V2,
-				],
-				[ FEATURE_CATEGORY_OTHER ]: [
-					FEATURE_VIDEO_HOSTING_V2,
-					FEATURE_SOCIAL_MEDIA_POSTING_V2,
-					FEATURE_COLLECT_PAYMENTS_V2,
-					FEATURE_SITE_MONETIZATION_V2,
-					FEATURE_PRIORITY_SUPPORT_V2,
-				],
-			},
-			undefined,
-			variation
+export const OPTION_PLAN_SECURITY: ( variation: string ) => SelectorProduct = ( variation ) => {
+	const plan = {
+		productSlug: OPTIONS_JETPACK_SECURITY,
+		annualOptionSlug: OPTIONS_JETPACK_SECURITY,
+		monthlyOptionSlug: OPTIONS_JETPACK_SECURITY_MONTHLY,
+		term: TERM_ANNUALLY,
+		type: ITEM_TYPE_BUNDLE,
+		subtypes: [ PLAN_JETPACK_SECURITY_DAILY, PLAN_JETPACK_SECURITY_REALTIME ],
+		costProductSlug: PLAN_JETPACK_SECURITY_DAILY,
+		monthlyProductSlug: PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+		iconSlug: 'jetpack_security_v2',
+		displayName: translate( 'Jetpack Security' ),
+		shortName: translate( 'Security', {
+			comment: 'Short name of the Jetpack Security generic plan',
+		} ),
+		tagline: translate( 'Comprehensive WordPress protection' ),
+		description: translate(
+			'Enjoy the peace of mind of complete site security. ' +
+				'Easy-to-use, powerful security tools guard your site, so you can focus on your business.'
 		),
-		more: MORE_FEATURES_LINK,
-	},
-} );
+		features: {
+			items: buildCardFeaturesFromItem(
+				{
+					[ FEATURE_CATEGORY_SECURITY ]: [
+						FEATURE_PRODUCT_BACKUP_V2,
+						FEATURE_PRODUCT_SCAN_V2,
+						FEATURE_PRODUCT_ANTISPAM_V2,
+						FEATURE_ACTIVITY_LOG_V2,
+					],
+					[ FEATURE_CATEGORY_OTHER ]: [
+						FEATURE_VIDEO_HOSTING_V2,
+						FEATURE_SOCIAL_MEDIA_POSTING_V2,
+						FEATURE_COLLECT_PAYMENTS_V2,
+						FEATURE_SITE_MONETIZATION_V2,
+						FEATURE_PRIORITY_SUPPORT_V2,
+					],
+				},
+				undefined,
+				variation
+			),
+			more: MORE_FEATURES_LINK,
+		},
+	};
+
+	Object.defineProperties( plan, {
+		displayName: {
+			get: () => translate( 'Jetpack Security' ),
+		},
+		shortName: {
+			get: () =>
+				translate( 'Security', {
+					comment: 'Short name of the Jetpack Security generic plan',
+				} ),
+		},
+		tagline: { get: () => translate( 'Comprehensive WordPress protection' ) },
+		description: {
+			get: () =>
+				translate(
+					'Enjoy the peace of mind of complete site security. ' +
+						'Easy-to-use, powerful security tools guard your site, so you can focus on your business.'
+				),
+		},
+	} );
+
+	return plan;
+};
 export const OPTION_PLAN_SECURITY_MONTHLY: ( variation: string ) => SelectorProduct = (
 	variation
 ) => ( {
@@ -163,37 +187,58 @@ export const OPTION_PLAN_SECURITY_MONTHLY: ( variation: string ) => SelectorProd
 } );
 
 // Jetpack Backup
-export const OPTION_PRODUCT_BACKUP: ( variation: string ) => SelectorProduct = ( variation ) => ( {
-	productSlug: OPTIONS_JETPACK_BACKUP,
-	annualOptionSlug: OPTIONS_JETPACK_BACKUP,
-	monthlyOptionSlug: OPTIONS_JETPACK_BACKUP_MONTHLY,
-	term: TERM_ANNUALLY,
-	type: ITEM_TYPE_PRODUCT,
-	subtypes: [ PRODUCT_JETPACK_BACKUP_DAILY, PRODUCT_JETPACK_BACKUP_REALTIME ],
-	costProductSlug: PRODUCT_JETPACK_BACKUP_DAILY,
-	monthlyProductSlug: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
-	iconSlug: 'jetpack_backup_v2',
-	displayName: translate( 'Jetpack Backup' ),
-	shortName: translate( 'Backup', {
-		comment: 'Short name of the Jetpack Backup generic product',
-	} ),
-	tagline: translate( 'Recommended for all sites' ),
-	description: translate( 'Never lose a word, image, page, or time worrying about your site.' ),
-	buttonLabel: translate( 'Get Backup' ),
-	features: {
-		items: buildCardFeaturesFromItem(
-			[
-				FEATURE_BACKUP_V2,
-				FEATURE_ONE_CLICK_RESTORE_V2,
-				FEATURE_SECURE_STORAGE_V2,
-				FEATURE_ACTIVITY_LOG_V2,
-				FEATURE_PRIORITY_SUPPORT_V2,
-			],
-			{ withoutDescription: true, withoutIcon: true },
-			variation
-		),
-	},
-} );
+export const OPTION_PRODUCT_BACKUP: ( variation: string ) => SelectorProduct = ( variation ) => {
+	const plan = {
+		productSlug: OPTIONS_JETPACK_BACKUP,
+		annualOptionSlug: OPTIONS_JETPACK_BACKUP,
+		monthlyOptionSlug: OPTIONS_JETPACK_BACKUP_MONTHLY,
+		term: TERM_ANNUALLY,
+		type: ITEM_TYPE_PRODUCT,
+		subtypes: [ PRODUCT_JETPACK_BACKUP_DAILY, PRODUCT_JETPACK_BACKUP_REALTIME ],
+		costProductSlug: PRODUCT_JETPACK_BACKUP_DAILY,
+		monthlyProductSlug: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
+		iconSlug: 'jetpack_backup_v2',
+		displayName: translate( 'Jetpack Backup' ),
+		shortName: translate( 'Backup', {
+			comment: 'Short name of the Jetpack Backup generic product',
+		} ),
+		tagline: translate( 'Recommended for all sites' ),
+		description: translate( 'Never lose a word, image, page, or time worrying about your site.' ),
+		buttonLabel: translate( 'Get Backup' ),
+		features: {
+			items: buildCardFeaturesFromItem(
+				[
+					FEATURE_BACKUP_V2,
+					FEATURE_ONE_CLICK_RESTORE_V2,
+					FEATURE_SECURE_STORAGE_V2,
+					FEATURE_ACTIVITY_LOG_V2,
+					FEATURE_PRIORITY_SUPPORT_V2,
+				],
+				{ withoutDescription: true, withoutIcon: true },
+				variation
+			),
+		},
+	};
+
+	Object.defineProperties( plan, {
+		displayName: {
+			get: () => translate( 'Jetpack Backup' ),
+		},
+		shortName: {
+			get: () =>
+				translate( 'Backup', {
+					comment: 'Short name of the Jetpack Backup generic product',
+				} ),
+		},
+		tagline: { get: () => translate( 'Recommended for all sites' ) },
+		description: {
+			get: () => translate( 'Never lose a word, image, page, or time worrying about your site.' ),
+		},
+		buttonLabel: { get: () => translate( 'Get Backup' ) },
+	} );
+
+	return plan;
+};
 
 export const OPTION_PRODUCT_BACKUP_MONTHLY: ( variation: string ) => SelectorProduct = (
 	variation

--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -59,7 +59,6 @@ import {
 	FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 	FEATURE_ACTIVITY_LOG,
 } from 'calypso/lib/plans/constants';
-import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans/jetpack-plans/abtest';
 import { buildCardFeaturesFromItem } from './utils';
 
 /**
@@ -111,7 +110,7 @@ export const PRODUCTS_WITH_OPTIONS = [
 ] as const;
 
 // Jetpack Security
-export const OPTION_PLAN_SECURITY: SelectorProduct = {
+export const OPTION_PLAN_SECURITY: ( variation: string ) => SelectorProduct = ( variation ) => ( {
 	productSlug: OPTIONS_JETPACK_SECURITY,
 	annualOptionSlug: OPTIONS_JETPACK_SECURITY,
 	monthlyOptionSlug: OPTIONS_JETPACK_SECURITY_MONTHLY,
@@ -148,46 +147,23 @@ export const OPTION_PLAN_SECURITY: SelectorProduct = {
 				],
 			},
 			undefined,
-			getJetpackCROActiveVersion()
+			variation
 		),
 		more: MORE_FEATURES_LINK,
 	},
-};
-export const OPTION_PLAN_SECURITY_MONTHLY: SelectorProduct = {
-	...OPTION_PLAN_SECURITY,
+} );
+export const OPTION_PLAN_SECURITY_MONTHLY: ( variation: string ) => SelectorProduct = (
+	variation
+) => ( {
+	...OPTION_PLAN_SECURITY( variation ),
 	productSlug: OPTIONS_JETPACK_SECURITY_MONTHLY,
 	term: TERM_MONTHLY,
 	subtypes: [ PLAN_JETPACK_SECURITY_DAILY_MONTHLY, PLAN_JETPACK_SECURITY_REALTIME_MONTHLY ],
 	costProductSlug: PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
-};
-
-/**
- * Define properties with translatable strings getters.
- */
-[ OPTION_PLAN_SECURITY, OPTION_PLAN_SECURITY_MONTHLY ].forEach( ( target ) => {
-	Object.defineProperties( target, {
-		displayName: {
-			get: () => translate( 'Jetpack Security' ),
-		},
-		shortName: {
-			get: () =>
-				translate( 'Security', {
-					comment: 'Short name of the Jetpack Security generic plan',
-				} ),
-		},
-		tagline: { get: () => translate( 'Comprehensive WordPress protection' ) },
-		description: {
-			get: () =>
-				translate(
-					'Enjoy the peace of mind of complete site security. ' +
-						'Easy-to-use, powerful security tools guard your site, so you can focus on your business.'
-				),
-		},
-	} );
 } );
 
 // Jetpack Backup
-export const OPTION_PRODUCT_BACKUP: SelectorProduct = {
+export const OPTION_PRODUCT_BACKUP: ( variation: string ) => SelectorProduct = ( variation ) => ( {
 	productSlug: OPTIONS_JETPACK_BACKUP,
 	annualOptionSlug: OPTIONS_JETPACK_BACKUP,
 	monthlyOptionSlug: OPTIONS_JETPACK_BACKUP_MONTHLY,
@@ -214,39 +190,19 @@ export const OPTION_PRODUCT_BACKUP: SelectorProduct = {
 				FEATURE_PRIORITY_SUPPORT_V2,
 			],
 			{ withoutDescription: true, withoutIcon: true },
-			getJetpackCROActiveVersion()
+			variation
 		),
 	},
-};
+} );
 
-export const OPTION_PRODUCT_BACKUP_MONTHLY: SelectorProduct = {
-	...OPTION_PRODUCT_BACKUP,
+export const OPTION_PRODUCT_BACKUP_MONTHLY: ( variation: string ) => SelectorProduct = (
+	variation
+) => ( {
+	...OPTION_PRODUCT_BACKUP( variation ),
 	productSlug: OPTIONS_JETPACK_BACKUP_MONTHLY,
 	term: TERM_MONTHLY,
 	subtypes: [ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY, PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ],
 	costProductSlug: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
-};
-
-/**
- * Define properties with translatable strings getters.
- */
-[ OPTION_PRODUCT_BACKUP, OPTION_PRODUCT_BACKUP_MONTHLY ].forEach( ( target ) => {
-	Object.defineProperties( target, {
-		displayName: {
-			get: () => translate( 'Jetpack Backup' ),
-		},
-		shortName: {
-			get: () =>
-				translate( 'Backup', {
-					comment: 'Short name of the Jetpack Backup generic product',
-				} ),
-		},
-		tagline: { get: () => translate( 'Recommended for all sites' ) },
-		description: {
-			get: () => translate( 'Never lose a word, image, page, or time worrying about your site.' ),
-		},
-		buttonLabel: { get: () => translate( 'Get Backup' ) },
-	} );
 } );
 
 // Jetpack CRM
@@ -254,16 +210,14 @@ export const OPTION_PRODUCT_BACKUP_MONTHLY: SelectorProduct = {
 const CRM_ENTREPRENEUR_PRICE = 17;
 const CRM_ENTREPRENEUR_CURRENCY = 'USD';
 
-export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
+export const EXTERNAL_PRODUCT_CRM: ( variation: string ) => SelectorProduct = ( variation ) => ( {
 	productSlug: PRODUCT_JETPACK_CRM,
 	term: TERM_ANNUALLY,
 	type: ITEM_TYPE_PRODUCT,
 	subtypes: [],
 	costProductSlug: PRODUCT_JETPACK_CRM,
 	monthlyProductSlug: PRODUCT_JETPACK_CRM,
-	iconSlug: [ 'v1', 'v2' ].includes( getJetpackCROActiveVersion() )
-		? 'jetpack_crm_dark'
-		: 'jetpack_crm',
+	iconSlug: [ 'v1', 'v2' ].includes( variation ) ? 'jetpack_crm_dark' : 'jetpack_crm',
 	displayName:
 		{
 			v2: translate( 'Jetpack CRM {{em}}Entrepreneur{{/em}}', {
@@ -272,13 +226,13 @@ export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
 				},
 			} ),
 			i5: translate( 'CRM Entrepreneur' ),
-		}[ getJetpackCROActiveVersion() ] || translate( 'Jetpack CRM' ),
+		}[ variation ] || translate( 'Jetpack CRM' ),
 
 	shortName:
 		{
 			v2: translate( 'Jetpack CRM ' ),
 			i5: translate( 'CRM Entrepreneur' ),
-		}[ getJetpackCROActiveVersion() ] ||
+		}[ variation ] ||
 		translate( 'CRM', {
 			comment: 'Short name of the Jetpack CRM',
 		} ),
@@ -286,13 +240,12 @@ export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
 	// Jetpack CRM isn't considered as a product like others for the time being (and therefore not
 	// available via the API). Rather like a third-party product.
 	// See pricing in https://jetpackcrm.com/pricing/ (only available in USD)
-	displayPrice: getJetpackCROActiveVersion() === 'v1' ? undefined : CRM_ENTREPRENEUR_PRICE,
-	displayCurrency: getJetpackCROActiveVersion() === 'v1' ? undefined : CRM_ENTREPRENEUR_CURRENCY,
+	displayPrice: variation === 'v1' ? undefined : CRM_ENTREPRENEUR_PRICE,
+	displayCurrency: variation === 'v1' ? undefined : CRM_ENTREPRENEUR_CURRENCY,
 	description: translate(
 		'The most simple and powerful WordPress CRM. Improve customer relationships and increase profits.'
 	),
-	buttonLabel:
-		getJetpackCROActiveVersion() === 'v1' ? translate( 'Get Jetpack CRM' ) : translate( 'Get CRM' ),
+	buttonLabel: variation === 'v1' ? translate( 'Get Jetpack CRM' ) : translate( 'Get CRM' ),
 	features: {
 		items: buildCardFeaturesFromItem(
 			[
@@ -303,24 +256,29 @@ export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
 				FEATURE_CRM_PRIORITY_SUPPORT,
 			],
 			{ withoutDescription: true, withoutIcon: true },
-			getJetpackCROActiveVersion()
+			variation
 		),
 	},
 	hidePrice: true,
 	externalUrl: 'https://jetpackcrm.com/pricing/',
-};
+} );
 
-export const EXTERNAL_PRODUCT_CRM_MONTHLY: SelectorProduct = {
-	...EXTERNAL_PRODUCT_CRM,
+export const EXTERNAL_PRODUCT_CRM_MONTHLY: ( variation: string ) => SelectorProduct = (
+	variation
+) => ( {
+	...EXTERNAL_PRODUCT_CRM( variation ),
 	productSlug: PRODUCT_JETPACK_CRM_MONTHLY,
 	term: TERM_MONTHLY,
 	displayTerm: TERM_ANNUALLY,
 	subtypes: [],
 	costProductSlug: PRODUCT_JETPACK_CRM_MONTHLY,
-};
+} );
 
 // Map slug to objects.
-export const OPTIONS_SLUG_MAP: Record< SelectorProductSlug, SelectorProduct > = {
+export const OPTIONS_SLUG_MAP: Record<
+	SelectorProductSlug,
+	( variation: string ) => SelectorProduct
+> = {
 	[ OPTIONS_JETPACK_SECURITY ]: OPTION_PLAN_SECURITY,
 	[ OPTIONS_JETPACK_SECURITY_MONTHLY ]: OPTION_PLAN_SECURITY_MONTHLY,
 	[ OPTIONS_JETPACK_BACKUP ]: OPTION_PRODUCT_BACKUP,
@@ -331,7 +289,10 @@ export const OPTIONS_SLUG_MAP: Record< SelectorProductSlug, SelectorProduct > = 
 export const EXTERNAL_PRODUCTS_LIST = [ PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM_MONTHLY ];
 
 // External Product slugs to SelectorProduct.
-export const EXTERNAL_PRODUCTS_SLUG_MAP: Record< string, SelectorProduct > = {
+export const EXTERNAL_PRODUCTS_SLUG_MAP: Record<
+	string,
+	( variation: string ) => SelectorProduct
+> = {
 	[ PRODUCT_JETPACK_CRM ]: EXTERNAL_PRODUCT_CRM,
 	[ PRODUCT_JETPACK_CRM_MONTHLY ]: EXTERNAL_PRODUCT_CRM_MONTHLY,
 };

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -407,10 +407,12 @@ function slugIsJetpackPlanSlug( slug: string ): slug is JetpackPlanSlugs {
  */
 
 export function slugToItem( slug: string ): Plan | Product | SelectorProduct | null {
+	const iteration = getJetpackCROActiveVersion();
+
 	if ( slugIsSelectorProductSlug( slug ) ) {
-		return OPTIONS_SLUG_MAP[ slug ];
+		return OPTIONS_SLUG_MAP[ slug ]( iteration );
 	} else if ( EXTERNAL_PRODUCTS_LIST.includes( slug ) ) {
-		return EXTERNAL_PRODUCTS_SLUG_MAP[ slug ];
+		return EXTERNAL_PRODUCTS_SLUG_MAP[ slug ]( iteration );
 	} else if ( slugIsJetpackProductSlug( slug ) ) {
 		return JETPACK_PRODUCTS_LIST[ slug ];
 	} else if ( slugIsJetpackPlanSlug( slug ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In `my-sites/plans/jetpack-plans/constants.ts`, de-couple the active CRO iteration by converting several product descriptions from literal objects to functions that accept the current iteration as an argument, thereby preventing unintentional A/B test info loading and extra `calypso_abtest_start` events.

#### Testing instructions

**Prerequisite:** When you build this PR locally, make sure to add `DISABLE_FEATURES="dev/test-helper"` at the beginning of your command, to disable the AB test helper.

**Regression testing:** Explore Calypso Blue, Green, and Jetpack Connect flows to ensure that all pages load correctly (with correct copy, icons, product grid order, etc.) without console errors.

##### Setup option 1: the do-it-yourself way

1. Load Calypso Blue and start going through the Jetpack Connect flow. Before you get too far in the process, set a breakpoint in your browser's dev tools on the file `my-sites/plans/jetpack-plans/abtest.ts` on the first line of `getJetpackCROActiveVersion` (this should be line 18). This will alert us to any attempts to get the current CRO test iteration, which should only happen on pages where product information needs to be loaded.

##### Setup option 2: the ready-made way

**WARNING:** If you choose this method, do **not** approve the OAuth authorization prompt when the page loads, if one appears.

1. Load the Track analytics dashboard and select Live View, filtering by the event name `calypso_abtest_start`. Look through the results to find an example in which the `browserdocumentlocation` contains the path `/jetpack/connect/authorize`.
2. Open an incognito window, paste this URL into the address bar (substituting wordpress.com for your testing environment's domain), and go there.
3. In your browser's dev tools, set a breakpoint as in **Setup option 1** above to catch all calls to `getJetpackCROActiveVersion`, then hard-reload the page. (On Mac, this is ⌘+⇧+R.)

##### Verifying behavior

1. When the `/jetpack/connect/authorize` page loads, verify that your breakpoint is *not* activated, meaning that no calls to `getJetpackCROActiveVersion` have been made on this page.

#### Reference screenshots

<img width="600" alt="image" src="https://user-images.githubusercontent.com/670067/105758835-54683700-5f15-11eb-80d3-5f242be37ba1.png">

![image](https://user-images.githubusercontent.com/670067/105758467-eae82880-5f14-11eb-845e-c80cd91a4425.png)