### PR TITLE
Deduplicate duplexer

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10857,12 +10857,7 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
-duplexer@^0.1.1, duplexer@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
-  integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
-
-duplexer@^0.1.2:
+duplexer@^0.1.1, duplexer@^0.1.2, duplexer@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `duplexer` (done automatically with `npx yarn-deduplicate --packages duplexer`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> duplexer@0.1.1
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> duplexer@0.1.1
< wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> duplexer@0.1.1
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> duplexer@0.1.2
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> duplexer@0.1.2
> wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> duplexer@0.1.2
```