### PR TITLE
Domains picker: update copy to reflect monthly vs annual plans difference

### DIFF
--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -406,6 +406,10 @@ $accent-blue: #117ac9;
 	@include break-small {
 		display: inline;
 	}
+
+	strong {
+		font-weight: 700;
+	}
 }
 
 .domain-picker__price-renewal {

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -76,41 +76,23 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 	const [ previousDomain, setPreviousDomain ] = React.useState< string | undefined >();
 	const [ previousRailcarId, setPreviousRailcarId ] = React.useState< string | undefined >();
 
+	// translators: 'Default' will be shown next to the standard, free domain
 	const freeDomainLabelDefault = __( 'Default', __i18n_text_domain__ );
 	const freeDomainLabelFree = __( 'Free', __i18n_text_domain__ );
-
-	const firstYearLabel = __( 'Included in paid plans', __i18n_text_domain__ );
-	const firstYearLabelAlt = __( 'Included with annual plans', __i18n_text_domain__ );
-	// translators: text in between the <strong></strong> marks is styled as bold text
-	const firstYearLabelFormatted = __(
-		'<strong>First year included</strong> in paid plans',
-		__i18n_text_domain__
-	);
-
 	const freeDomainLabel =
 		type === ITEM_TYPE_INDIVIDUAL_ITEM ? freeDomainLabelDefault : freeDomainLabelFree;
 
-	const firstYearIncludedInPaidLabel = isMobile
+	const firstYearLabel = __( 'Included in annual plans', __i18n_text_domain__ );
+	// translators: text in between the <strong></strong> marks is styled as bold text
+	const firstYearLabelFormatted = __(
+		'<strong>First year included</strong> in annual plans',
+		__i18n_text_domain__
+	);
+	const paidIncludedDomainLabel = isMobile
 		? firstYearLabel
 		: createInterpolateElement( firstYearLabelFormatted, {
 				strong: <strong />,
 		  } );
-
-	/**
-	 *  IIFE executes immediately after creation, hence it returns the translated values immediately.
-	 * The great advantage is that:
-	 * 1. We don't have to execute it during rendering.
-	 * 2. We don't have to use nested ternaries (which is not allowed by the linter).
-	 * 3. It improves the readability of our code
-	 */
-	const paidIncludedDomainLabel = ( () => {
-		if ( type === ITEM_TYPE_INDIVIDUAL_ITEM ) {
-			return firstYearIncludedInPaidLabel;
-		} else if ( isMobile ) {
-			return freeDomainLabelFree;
-		}
-		return firstYearLabelAlt;
-	} )();
 
 	React.useEffect( () => {
 		// Only record TrainTracks render event when the domain name and railcarId change.

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -82,15 +82,15 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 	const freeDomainLabel =
 		type === ITEM_TYPE_INDIVIDUAL_ITEM ? freeDomainLabelDefault : freeDomainLabelFree;
 
-	const firstYearLabel = __( 'Included in annual plans', __i18n_text_domain__ );
+	const includedLabel = __( 'Included in annual plans', __i18n_text_domain__ );
 	// translators: text in between the <strong></strong> marks is styled as bold text
-	const firstYearLabelFormatted = __(
+	const includedLabelFormatted = __(
 		'<strong>First year included</strong> in annual plans',
 		__i18n_text_domain__
 	);
 	const paidIncludedDomainLabel = isMobile
-		? firstYearLabel
-		: createInterpolateElement( firstYearLabelFormatted, {
+		? includedLabel
+		: createInterpolateElement( includedLabelFormatted, {
 				strong: <strong />,
 		  } );
 

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -67,7 +67,7 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 	const { __ } = useI18n();
 	const localizeUrl = useLocalizeUrl();
 
-	const isMobile = useViewportMatch( 'small', '<' );
+	const isMobile = ! useViewportMatch( 'small', '>=' );
 
 	const dotPos = domain.indexOf( '.' );
 	const domainName = domain.slice( 0, dotPos );

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -4,6 +4,7 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import { useI18n } from '@automattic/react-i18n';
+import { useLocale } from '@automattic/i18n-utils';
 import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
 
@@ -64,7 +65,8 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 	type = ITEM_TYPE_RADIO,
 	buttonRef,
 } ) => {
-	const { __ } = useI18n();
+	const { __, hasTranslation } = useI18n();
+	const locale = useLocale();
 	const localizeUrl = useLocalizeUrl();
 
 	const isMobile = ! useViewportMatch( 'small', '>=' );
@@ -82,12 +84,28 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 	const freeDomainLabel =
 		type === ITEM_TYPE_INDIVIDUAL_ITEM ? freeDomainLabelDefault : freeDomainLabelFree;
 
-	const includedLabel = __( 'Included in annual plans', __i18n_text_domain__ );
+	const fallbackIncludedLabel = __( 'Included with annual plans', __i18n_text_domain__ );
+	const newIncludedLabel = __( 'Included in annual plans', __i18n_text_domain__ );
+	const includedLabel =
+		locale === 'en' || hasTranslation?.( 'Included in annual plans', __i18n_text_domain__ )
+			? newIncludedLabel
+			: fallbackIncludedLabel;
+
 	// translators: text in between the <strong></strong> marks is styled as bold text
-	const includedLabelFormatted = __(
+	const fallbackIncludedLabelFormatted = __(
+		'<strong>First year included</strong> in paid plans',
+		__i18n_text_domain__
+	);
+	// translators: text in between the <strong></strong> marks is styled as bold text
+	const newIncludedLabelFormatted = __(
 		'<strong>First year included</strong> in annual plans',
 		__i18n_text_domain__
 	);
+	const includedLabelFormatted =
+		locale === 'en' ||
+		hasTranslation?.( '<strong>First year included</strong> in annual plans', __i18n_text_domain__ )
+			? newIncludedLabelFormatted
+			: fallbackIncludedLabelFormatted;
 	const paidIncludedDomainLabel = isMobile
 		? includedLabel
 		: createInterpolateElement( includedLabelFormatted, {

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -87,7 +87,7 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 	const fallbackIncludedLabel = __( 'Included with annual plans', __i18n_text_domain__ );
 	const newIncludedLabel = __( 'Included in annual plans', __i18n_text_domain__ );
 	const includedLabel =
-		locale === 'en' || hasTranslation?.( 'Included in annual plans', __i18n_text_domain__ )
+		locale === 'en' || hasTranslation?.( 'Included in annual plans' )
 			? newIncludedLabel
 			: fallbackIncludedLabel;
 
@@ -102,8 +102,7 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 		__i18n_text_domain__
 	);
 	const includedLabelFormatted =
-		locale === 'en' ||
-		hasTranslation?.( '<strong>First year included</strong> in annual plans', __i18n_text_domain__ )
+		locale === 'en' || hasTranslation?.( '<strong>First year included</strong> in annual plans' )
 			? newIncludedLabelFormatted
 			: fallbackIncludedLabelFormatted;
 	const paidIncludedDomainLabel = isMobile


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Update copy in domain picker package, showing that custom domains are included with _annual_ plans
* The same copy is now shared across all flows (gutenboarding, step by step launch, focused launch)
* Fix viewport `isMobile` check, so that there isn't a 1px overlap between CSS and JS

Do not merge this PR until all translations have been completed!

## Testing instructions

### Setup
- prepare your sandbox
- in two separate terminal windows, run:
  - `yarn start` 
  - `cd apps/editing-toolkit && yarn dev --sync`

### Focused Launch

1. Assign yourself to the "treatment" group in the `focused_launch_flow_v2` A/B test (id `20106`)
2. Add an _unlaunched_ site created through `/start`to your sandbox
3. Open the block editor (e.g. by visiting `calyspo.localhost:3000/page/UNLAUNCHED_SITE_CREATED_WITH_START.wordpress.com/home`)`
4. Press "Launch" button, Focused Launch summary view should appear
    - [x] Verify that the new copy is correct in the domain picker step (both mobile and desktop), according to A/C in #49256
    - [x] These copy changes are not expected to affect non-english locales for the purpose of this PR (but it's important that the previous _translated_ fallback text is used)

### Step by Step Launch

1. Add an _unlaunched_ site on a _free_ plan created through `/new` to your sandbox
2. Visit `wordpress.com/page/SITE_ID.wordpress.com/home`
3. Press "Launch" button, Step by Step Launch modal should appear. Navigate to domain step
    - [x] Verify that the new copy is correct in the domain picker step (both mobile and desktop), according to A/C in #49256
    - [x] These copy changes are not expected to affect non-english locales for the purpose of this PR (but it's important that the previous _translated_ fallback text is used)

### Gutenboarding

1. Visit `/new` and navigate to the domain picker
2. Verify that the new copy is correct in the domain picker step (both mobile and desktop), according to A/C in #49256

## Screenshots

Context for translators:

<img width="602" alt="focused-launch-mobile-big-new" src="https://user-images.githubusercontent.com/1083581/105831373-e9773880-5fc6-11eb-8cbb-cf445f1d0c95.png">


### Visual comparison of Gutenboarding changes

<details>
  <summary>Click to expand</summary>

  |     | Before | After |
  |---|---|---|
  | Mobile | <img width="448" alt="gutenboarding-mobile-old" src="https://user-images.githubusercontent.com/1083581/105831785-715d4280-5fc7-11eb-9ad3-5789462be107.png"> | <img width="449" alt="gutenboarding-mobile-new" src="https://user-images.githubusercontent.com/1083581/105831806-76ba8d00-5fc7-11eb-8149-e7724c6ae090.png"> | 
  | Mobile big |  <img width="610" alt="gutenboarding-mobile-big-old" src="https://user-images.githubusercontent.com/1083581/105831838-82a64f00-5fc7-11eb-8d11-6e99a58b2676.png"> | <img width="610" alt="gutenboarding-mobile-big-new" src="https://user-images.githubusercontent.com/1083581/107504529-bbcfe900-6b9b-11eb-9b0c-a986b4e60104.png"> | 
  | Desktop | <img width="1242" alt="gutenboarding-desktop-old" src="https://user-images.githubusercontent.com/1083581/105832091-d022bc00-5fc7-11eb-90ea-5191c12304e4.png"> | <img width="1242" alt="gutenboarding-desktop-new" src="https://user-images.githubusercontent.com/1083581/107504423-8f1bd180-6b9b-11eb-8e60-cc0a637a3de0.png"> | 
</details>


### Visual comparison of Focused Launch changes

<details>
  <summary>Click to expand</summary>
  
  |     | Before | After |
  |---|---|---|
  | Mobile | <img width="361" alt="focused-launch-mobile-old" src="https://user-images.githubusercontent.com/1083581/105832085-cf8a2580-5fc7-11eb-88b2-8d6e3f2d85dd.png"> | <img width="361" alt="focused-launch-mobile-new" src="https://user-images.githubusercontent.com/1083581/105832084-cef18f00-5fc7-11eb-86bf-5956266c9992.png"> | 
  | Mobile big | <img width="601" alt="focused-launch-mobile-big-old" src="https://user-images.githubusercontent.com/1083581/105832082-ce58f880-5fc7-11eb-9213-050ef0d0b9a9.png"> | <img width="602" alt="focused-launch-mobile-big-new" src="https://user-images.githubusercontent.com/1083581/105832080-cdc06200-5fc7-11eb-81a4-25e1e19b29fc.png"> | 
  | Desktop | <img width="1242" alt="focused-launch-desktop-old" src="https://user-images.githubusercontent.com/1083581/105832077-cc8f3500-5fc7-11eb-8e27-a1b5254fae65.png"> | <img width="1239" alt="focused-launch-desktop-new" src="https://user-images.githubusercontent.com/1083581/105832072-ca2cdb00-5fc7-11eb-881e-bb64b50a95eb.png"> | 
</details>


### Visual comparison of Step by Step launch changes

<details>
  <summary>Click to expand</summary>
  
  |     | Before | After|
  |---|---|---|
  | Mobile | <img width="361" alt="step-by-step-mobile-old" src="https://user-images.githubusercontent.com/1083581/105832106-d31dac80-5fc7-11eb-886d-e7215dd83f38.png"> | <img width="360" alt="step-by-step-mobile-new" src="https://user-images.githubusercontent.com/1083581/105832101-d2851600-5fc7-11eb-9b56-0c97a2fd373d.png"> | 
  | Mobile big | <img width="602" alt="step-by-step-mobile-big-old" src="https://user-images.githubusercontent.com/1083581/105832098-d2851600-5fc7-11eb-9e73-212aea549393.png"> | <img width="601" alt="step-by-step-mobile-big-new" src="https://user-images.githubusercontent.com/1083581/105832096-d1ec7f80-5fc7-11eb-84b6-24a7716ac90f.png"> | 
  | Desktop | <img width="1241" alt="step-by-step-desktop-old" src="https://user-images.githubusercontent.com/1083581/105832095-d153e900-5fc7-11eb-869e-d642d3fb79e2.png"> | <img width="1241" alt="step-by-step-desktop-new" src="https://user-images.githubusercontent.com/1083581/105832092-d0bb5280-5fc7-11eb-8d0e-6ba3b360bf2a.png"> | 
</details>

Fixes #49256
Relates to #47576