### PR TITLE
On mouse leave do not return early for expanded menus.

### DIFF
--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -87,7 +87,7 @@ export const ExpandableSidebarMenu = ( {
 	};
 
 	const onLeave = () => {
-		if ( expanded || isTouch || ! config.isEnabled( 'nav-unification' ) ) {
+		if ( isTouch || ! config.isEnabled( 'nav-unification' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Do not return early for "onLeave" event of expanded menus so that they don't keep hovering after navigating to another menu.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Before**
* Click any Calypso submenu (like Themes, Marketing, All Posts)
* Click "My Home"
* The menu from step (1) will appear hovered

https://user-images.githubusercontent.com/13387217/105375214-623c5600-5bbd-11eb-8269-83844745264c.mov

**After**
* Click any Calypso submenu (like Themes, Marketing, All Posts)
* Click "My Home"
* The menu from step (1) will **NOT** appear hovered

Fixes #49110
