### PR TITLE
Post purchase upsell: DIFM offer

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2669,4 +2669,16 @@ Undocumented.prototype.getMatchingAnchorSite = function (
 	);
 };
 
+/**
+ * Records the interest of the user for the DIFM upsell offer if they click Accept on the offer page. Check pcbrnV-Y3-p2.
+ * 
+ * @returns {Promise} A promise
+ */
+Undocumented.prototype.saveDifmInterestForUser = function () {
+	return this.wpcom.req.get( {
+		apiNamespace: 'wpcom/v2',
+		path: '/difm/interested',
+	} );
+};
+
 export default Undocumented;

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2671,7 +2671,7 @@ Undocumented.prototype.getMatchingAnchorSite = function (
 
 /**
  * Records the interest of the user for the DIFM upsell offer if they click Accept on the offer page. Check pcbrnV-Y3-p2.
- * 
+ *
  * @returns {Promise} A promise
  */
 Undocumented.prototype.saveDifmInterestForUser = function () {

--- a/client/me/difm-intake/controller.js
+++ b/client/me/difm-intake/controller.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import DifmIntake from './main';
+
+const intake = ( context, next ) => {
+	context.primary = <DifmIntake />;
+	next();
+};
+
+export default {
+	intake,
+};

--- a/client/me/difm-intake/index.js
+++ b/client/me/difm-intake/index.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import controller from './controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+
+export default () => {
+	page( '/me/difm-intake', controller.intake, makeLayout, clientRender );
+};

--- a/client/me/difm-intake/main.js
+++ b/client/me/difm-intake/main.js
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import React, { Component, Fragment } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'calypso/components/main';
+import { localize } from 'i18n-calypso';
+import { Card } from '@automattic/components';
+import FormattedHeader from 'calypso/components/formatted-header';
+import ExternalLink from 'calypso/components/external-link';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class DifmIntake extends Component {
+	renderHeader() {
+		const { translate } = this.props;
+
+		return (
+			<Fragment>
+				<Card>
+					<img
+						className="difm-intake__info-illustration"
+						alt="support session signup form header"
+						src={ '/calypso/images/illustrations/illustration-start.svg' }
+					/>
+					<FormattedHeader
+						headerText={ translate( 'WordPress.com "Built for you" application form' ) }
+						subHeaderText={ translate(
+							'Fill out the form below to apply for your "Built for you" program.'
+						) }
+					/>
+					<ExternalLink
+						className="difm-intake__info-link"
+						icon={ false }
+						href={ 'https://wordpress.com/built-by-wordpress-com/' }
+						target="_blank"
+					>
+						{ translate( 'Learn more' ) }
+					</ExternalLink>
+				</Card>
+			</Fragment>
+		);
+	}
+
+	renderSurvey() {
+		return (
+			<div class="difm-intake__survey">
+				<iframe
+					title="DIFM intake survey"
+					scrolling="auto"
+					width="100%"
+					allowtransparency="true"
+					src="https://automattic.survey.fm/site-builder-intake-survey-upsell-version?iframe=1"
+				>
+					<a href="https://automattic.survey.fm/site-builder-intake-survey-upsell-version">
+						View Survey
+					</a>
+				</iframe>
+			</div>
+		);
+	}
+
+	render() {
+		return (
+			<Main>
+				<div>
+					{ this.renderHeader() }
+					{ this.renderSurvey() }
+				</div>
+			</Main>
+		);
+	}
+}
+
+export default localize( DifmIntake );

--- a/client/me/difm-intake/main.js
+++ b/client/me/difm-intake/main.js
@@ -8,7 +8,7 @@ import React, { Component, Fragment } from 'react';
  */
 import Main from 'calypso/components/main';
 import { localize } from 'i18n-calypso';
-import { Card } from '@automattic/components';
+import { Card, CompactCard } from '@automattic/components';
 import FormattedHeader from 'calypso/components/formatted-header';
 import ExternalLink from 'calypso/components/external-link';
 
@@ -18,6 +18,10 @@ import ExternalLink from 'calypso/components/external-link';
 import './style.scss';
 
 class DifmIntake extends Component {
+	state = {
+		showPlaceholders: true,
+	};
+
 	renderHeader() {
 		const { translate } = this.props;
 
@@ -48,14 +52,44 @@ class DifmIntake extends Component {
 		);
 	}
 
+	setLoadingComplete = () => {
+		this.setState( { showPlaceholders: false } );
+	};
+
+	renderPlaceholders() {
+		return (
+			<CompactCard>
+				<div className="difm-intake__header">
+					<div className="difm-intake__placeholders">
+						<div className="difm-intake__placeholder-row is-placeholder" />
+						<div className="difm-intake__placeholder-row is-placeholder" />
+						<div className="difm-intake__placeholder-row is-placeholder" />
+					</div>
+					<div className="difm-intake__placeholders">
+						<div className="difm-intake__placeholder-row is-placeholder" />
+						<div className="difm-intake__placeholder-row is-placeholder" />
+						<div className="difm-intake__placeholder-row is-placeholder" />
+					</div>
+					<div className="difm-intake__placeholders">
+						<div className="difm-intake__placeholder-row is-placeholder" />
+						<div className="difm-intake__placeholder-row is-placeholder" />
+						<div className="difm-intake__placeholder-row is-placeholder" />
+					</div>
+				</div>
+			</CompactCard>
+		);
+	}
+
 	renderSurvey() {
 		return (
 			<div className="difm-intake__survey">
+				{ this.state.showPlaceholders && this.renderPlaceholders() }
 				<iframe
 					title="DIFM intake survey"
 					scrolling="auto"
 					width="100%"
 					allowtransparency="true"
+					onLoad={ this.setLoadingComplete }
 					src="https://automattic.survey.fm/site-builder-intake-survey-upsell-version?iframe=1"
 				>
 					<a href="https://automattic.survey.fm/site-builder-intake-survey-upsell-version">

--- a/client/me/difm-intake/main.js
+++ b/client/me/difm-intake/main.js
@@ -50,7 +50,7 @@ class DifmIntake extends Component {
 
 	renderSurvey() {
 		return (
-			<div class="difm-intake__survey">
+			<div className="difm-intake__survey">
 				<iframe
 					title="DIFM intake survey"
 					scrolling="auto"

--- a/client/me/difm-intake/main.js
+++ b/client/me/difm-intake/main.js
@@ -36,7 +36,10 @@ class DifmIntake extends Component {
 					<FormattedHeader
 						headerText={ translate( 'WordPress.com "Built for you" application form' ) }
 						subHeaderText={ translate(
-							'Fill out the form below to apply for your "Built for you" program.'
+							`Fill out the form below to apply for your "Built for you" program.{{br/}}We'll get back to you in 2-3 business days.`,
+							{
+								components: { br: <br /> },
+							}
 						) }
 					/>
 					<ExternalLink

--- a/client/me/difm-intake/style.scss
+++ b/client/me/difm-intake/style.scss
@@ -1,0 +1,21 @@
+.difm-intake__info-illustration {
+	display: block;
+	margin: 0 auto 20px;
+	max-width: 300px;
+}
+.difm-intake__info-link {
+	display: block;
+	margin: 0 auto;
+	width: auto;
+	text-align: center;
+}
+
+.difm-intake__survey {
+    iframe {
+        height: 1500px;
+
+        @include breakpoint-deprecated ( '<480px' ) {
+            height: 1600px;
+        }
+    }
+}

--- a/client/me/difm-intake/style.scss
+++ b/client/me/difm-intake/style.scss
@@ -19,3 +19,34 @@
         }
     }
 }
+
+.difm-intake__placeholders {
+	display: flex;
+	flex-direction: column;
+	margin-bottom: 25px;
+
+	.is-placeholder {
+		animation: pulse-light 800ms ease-in-out infinite;
+		background: var( --color-neutral-10 );
+	}
+}
+
+.difm-intake__placeholder-row {
+	height: 20px;
+	margin-bottom: 25px;
+}
+
+.difm-intake__placeholder-button {
+	height: 50px;
+	width: 100%;
+
+	@include breakpoint-deprecated( '>480px' ) {
+		width: 80px;
+		height: 40px;
+	}
+}
+
+.difm-intake__placeholder-button-container {
+	display: flex;
+	justify-content: space-between;
+}

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -93,6 +93,9 @@ import { getActiveTheme } from 'calypso/state/themes/selectors';
 import getCustomizeOrEditFrontPageUrl from 'calypso/state/selectors/get-customize-or-edit-front-page-url';
 import getCheckoutUpgradeIntent from 'calypso/state/selectors/get-checkout-upgrade-intent';
 import { isProductsListFetching } from 'calypso/state/products-list/selectors';
+import { isTreatmentDifmUpsellTest } from 'calypso/state/marketing/selectors';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
+
 /**
  * Style dependencies
  */
@@ -388,7 +391,13 @@ export class CheckoutThankYou extends React.Component {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const {
+			translate,
+			selectedSiteSlug,
+			receiptId,
+			shouldShowDifmUpsell,
+			previousRoute,
+		} = this.props;
 		let purchases = [];
 		let failedPurchases = [];
 		let wasJetpackPlanPurchased = false;
@@ -436,6 +445,14 @@ export class CheckoutThankYou extends React.Component {
 				return (
 					<TransferPending orderId={ this.props.receiptId } siteId={ this.props.selectedSite.ID } />
 				);
+			}
+
+			if (
+				shouldShowDifmUpsell &&
+				! previousRoute.includes( `/checkout/${ selectedSiteSlug }/offer-difm/${ receiptId }` )
+			) {
+				recordTracksEvent( 'calypso_eligible_difm_upsell' );
+				page( `/checkout/${ selectedSiteSlug }/offer-difm/${ receiptId }?isEcommerce=1` );
 			}
 
 			return (
@@ -675,6 +692,8 @@ export default connect(
 			selectedSiteSlug: getSiteSlug( state, siteId ),
 			siteHomeUrl: getSiteHomeUrl( state, siteId ),
 			customizeUrl: getCustomizeOrEditFrontPageUrl( state, activeTheme, siteId ),
+			shouldShowDifmUpsell: isTreatmentDifmUpsellTest( state ),
+			previousRoute: getPreviousRoute( state ),
 		};
 	},
 	( dispatch ) => {

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -447,11 +447,12 @@ export class CheckoutThankYou extends React.Component {
 				);
 			}
 
+			// This is for the DIFM upsell A/B test. Check https://wp.me/pcbrnV-Y3.
+			recordTracksEvent( 'calypso_eligible_difm_upsell' );
 			if (
 				shouldShowDifmUpsell &&
 				! previousRoute.includes( `/checkout/${ selectedSiteSlug }/offer-difm/${ receiptId }` )
 			) {
-				recordTracksEvent( 'calypso_eligible_difm_upsell' );
 				page( `/checkout/${ selectedSiteSlug }/offer-difm/${ receiptId }?isEcommerce=1` );
 			}
 

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -447,7 +447,7 @@ export class CheckoutThankYou extends React.Component {
 				);
 			}
 
-			// This is for the DIFM upsell A/B test. Check https://wp.me/pcbrnV-Y3.
+			// This is for the DIFM upsell A/B test. Check pcbrnV-Y3-p2.
 			recordTracksEvent( 'calypso_eligible_difm_upsell' );
 			if (
 				shouldShowDifmUpsell &&

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -453,7 +453,7 @@ export class CheckoutThankYou extends React.Component {
 				shouldShowDifmUpsell &&
 				! previousRoute.includes( `/checkout/${ selectedSiteSlug }/offer-difm/${ receiptId }` )
 			) {
-				page( `/checkout/${ selectedSiteSlug }/offer-difm/${ receiptId }?isEcommerce=1` );
+				page( `/checkout/${ selectedSiteSlug }/offer-difm/${ receiptId }` );
 			}
 
 			return (

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -45,7 +45,10 @@ import {
 import isEligibleForSignupDestination from 'calypso/state/selectors/is-eligible-for-signup-destination';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import { isTreatmentOneClickTest } from 'calypso/state/marketing/selectors';
+import {
+	isTreatmentOneClickTest,
+	isTreatmentDifmUpsellTest,
+} from 'calypso/state/marketing/selectors';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import { recordCompositeCheckoutErrorDuringAnalytics } from '../lib/analytics';
 
@@ -80,6 +83,7 @@ export default function useCreatePaymentCompleteCallback( {
 	const adminUrl = selectedSiteData?.options?.admin_url;
 	const isEligibleForSignupDestinationResult = isEligibleForSignupDestination( responseCart );
 	const shouldShowOneClickTreatment = useSelector( ( state ) => isTreatmentOneClickTest( state ) );
+	const shouldShowDifmUpsell = useSelector( ( state ) => isTreatmentDifmUpsellTest( state ) );
 	const previousRoute = useSelector( ( state ) => getPreviousRoute( state ) );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const isJetpackNotAtomic =
@@ -104,6 +108,7 @@ export default function useCreatePaymentCompleteCallback( {
 				productAliasFromUrl,
 				isEligibleForSignupDestinationResult,
 				shouldShowOneClickTreatment,
+				shouldShowDifmUpsell,
 				hideNudge: isComingFromUpsell,
 				isInEditor,
 				previousRoute,
@@ -207,6 +212,7 @@ export default function useCreatePaymentCompleteCallback( {
 		[
 			previousRoute,
 			shouldShowOneClickTreatment,
+			shouldShowDifmUpsell,
 			siteSlug,
 			adminUrl,
 			redirectTo,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -386,7 +386,7 @@ function getRedirectUrlForConciergeNudge( {
 			return upgradePath;
 		}
 
-		// This is for the DIFM upsell A/B test. Check https://wp.me/pcbrnV-Y3.
+		// This is for the DIFM upsell A/B test. Check pcbrnV-Y3-p2.
 		if ( hasBusinessPlan( cart ) ) {
 			recordTracksEvent( 'calypso_eligible_difm_upsell' );
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -398,14 +398,20 @@ function getRedirectUrlForConciergeNudge( {
 			}
 
 			if ( hasBusinessPlan( cart ) ) {
-				recordTracksEvent( 'calypso_eligible_difm_upsell' );
-
 				if ( shouldShowDifmUpsell ) {
+					recordTracksEvent( 'calypso_eligible_difm_upsell' );
 					return `/checkout/${ siteSlug }/offer-difm/${ pendingOrReceiptId }`;
 				}
 			}
 
 			return getQuickstartUrl( { pendingOrReceiptId, siteSlug, orderId } );
+		}
+
+		if ( hasBusinessPlan( cart ) ) {
+			if ( shouldShowDifmUpsell ) {
+				recordTracksEvent( 'calypso_eligible_difm_upsell' );
+				return `/checkout/${ siteSlug }/offer-difm/${ pendingOrReceiptId }`;
+			}
 		}
 	}
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -386,6 +386,15 @@ function getRedirectUrlForConciergeNudge( {
 			return upgradePath;
 		}
 
+		// This is for the DIFM upsell A/B test. Check https://wp.me/pcbrnV-Y3.
+		if ( hasBusinessPlan( cart ) ) {
+			recordTracksEvent( 'calypso_eligible_difm_upsell' );
+
+			if ( shouldShowDifmUpsell ) {
+				return `/checkout/${ siteSlug }/offer-difm/${ pendingOrReceiptId }`;
+			}
+		}
+
 		// The conciergeUpsellDial test is used when we need to quickly dial back the volume of concierge sessions
 		// being offered and so sold, to be inline with HE availability.
 		// To dial back, uncomment the condition below and modify the test config.
@@ -397,21 +406,7 @@ function getRedirectUrlForConciergeNudge( {
 				}
 			}
 
-			if ( hasBusinessPlan( cart ) ) {
-				if ( shouldShowDifmUpsell ) {
-					recordTracksEvent( 'calypso_eligible_difm_upsell' );
-					return `/checkout/${ siteSlug }/offer-difm/${ pendingOrReceiptId }`;
-				}
-			}
-
 			return getQuickstartUrl( { pendingOrReceiptId, siteSlug, orderId } );
-		}
-
-		if ( hasBusinessPlan( cart ) ) {
-			if ( shouldShowDifmUpsell ) {
-				recordTracksEvent( 'calypso_eligible_difm_upsell' );
-				return `/checkout/${ siteSlug }/offer-difm/${ pendingOrReceiptId }`;
-			}
 		}
 	}
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
@@ -13,7 +13,10 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import isEligibleForSignupDestination from 'calypso/state/selectors/is-eligible-for-signup-destination';
 import getThankYouPageUrl from './get-thank-you-page-url';
 import type { TransactionResponse } from '../../types/wpcom-store-state';
-import { isTreatmentOneClickTest } from 'calypso/state/marketing/selectors';
+import {
+	isTreatmentOneClickTest,
+	isTreatmentDifmUpsellTest,
+} from 'calypso/state/marketing/selectors';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-get-thank-you-url' );
@@ -34,6 +37,7 @@ export default function useGetThankYouUrl( {
 }: GetThankYouUrlProps ): GetThankYouUrl {
 	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
 	const shouldShowOneClickTreatment = useSelector( ( state ) => isTreatmentOneClickTest( state ) );
+	const shouldShowDifmUpsell = useSelector( ( state ) => isTreatmentDifmUpsellTest( state ) );
 	const previousRoute = useSelector( ( state ) => getPreviousRoute( state ) );
 
 	const adminUrl = selectedSiteData?.options?.admin_url;
@@ -57,6 +61,7 @@ export default function useGetThankYouUrl( {
 			productAliasFromUrl,
 			isEligibleForSignupDestinationResult,
 			shouldShowOneClickTreatment,
+			shouldShowDifmUpsell,
 			hideNudge,
 			isInEditor,
 			previousRoute,
@@ -70,6 +75,7 @@ export default function useGetThankYouUrl( {
 		transactionResult,
 		isEligibleForSignupDestinationResult,
 		shouldShowOneClickTreatment,
+		shouldShowDifmUpsell,
 		siteSlug,
 		adminUrl,
 		isJetpackNotAtomic,

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -10,6 +10,7 @@
 import getThankYouPageUrl from '../hooks/use-get-thank-you-url/get-thank-you-page-url';
 import { isEnabled } from '@automattic/calypso-config';
 import {
+	PLAN_BUSINESS,
 	PLAN_ECOMMERCE,
 	JETPACK_REDIRECT_URL,
 	redirectCloudCheckoutToWpAdmin,
@@ -158,6 +159,26 @@ describe( 'getThankYouPageUrl', () => {
 			shouldShowOneClickTreatment,
 		} );
 		expect( url ).toBe( '/checkout/foo.bar/offer-plan-upgrade/premium/:receiptId' );
+	} );
+
+	// This test is for the A/B test defined in https://wp.me/pcbrnV-12W.
+	it( 'redirects to the DIFM offer page when a site but no orderId is set and the cart contains the business plan', () => {
+		const cart = {
+			products: [
+				{
+					product_slug: PLAN_BUSINESS,
+				},
+			],
+		};
+		// Note: This requires the user to be assigned to the treatment of the premium bump A/B test
+		const shouldShowDifmUpsell = true;
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+			shouldShowDifmUpsell,
+		} );
+		expect( url ).toBe( '/checkout/foo.bar/offer-difm' );
 	} );
 
 	it( 'redirects to the thank-you page with a placeholder receiptId with a site when the cart is not empty but there is no receipt id', () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -17,7 +17,6 @@ import {
 } from 'calypso/lib/plans/constants';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
-
 let mockGSuiteCountryIsValid = true;
 jest.mock( 'calypso/lib/user', () =>
 	jest.fn( () => ( {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -141,7 +141,7 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/foo.bar/offer-plan-upgrade/business/:receiptId' );
 	} );
 
-	// This test is for the A/B test defined in https://wp.me/pbxNRc-B0.
+	// This test is for the A/B test defined in pbxNRc-B0-p2.
 	it( 'redirects to the premium plan bump offer page with a placeholder receipt id when a site but no orderId is set and the cart contains the personal plan', () => {
 		const cart = {
 			products: [

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -179,7 +179,7 @@ describe( 'getThankYouPageUrl', () => {
 			cart,
 			shouldShowDifmUpsell,
 		} );
-		expect( url ).toBe( '/checkout/foo.bar/offer-difm' );
+		expect( url ).toBe( '/checkout/foo.bar/offer-difm/:receiptId' );
 	} );
 
 	it( 'redirects to the thank-you page with a placeholder receiptId with a site when the cart is not empty but there is no receipt id', () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -17,6 +17,7 @@ import {
 } from 'calypso/lib/plans/constants';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
+
 let mockGSuiteCountryIsValid = true;
 jest.mock( 'calypso/lib/user', () =>
 	jest.fn( () => ( {

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -193,6 +193,7 @@ export function upsellNudge( context, next ) {
 
 	let upsellType;
 	let upgradeItem;
+	let addnlProps;
 
 	if ( context.path.includes( 'offer-quickstart-session' ) ) {
 		upsellType = CONCIERGE_QUICKSTART_SESSION;
@@ -217,6 +218,8 @@ export function upsellNudge( context, next ) {
 		}
 	} else if ( context.path.includes( 'offer-difm' ) ) {
 		upsellType = DIFM_UPSELL;
+		const isFromEcommercePurchase = context.query?.isEcommerce === '1';
+		addnlProps = { isFromEcommercePurchase };
 	}
 
 	setSectionMiddleware( { name: upsellType } )( context );
@@ -228,6 +231,7 @@ export function upsellNudge( context, next ) {
 				receiptId={ Number( receiptId ) }
 				upsellType={ upsellType }
 				upgradeItem={ upgradeItem }
+				addnlProps={ addnlProps }
 			/>
 		</CalypsoShoppingCartProvider>
 	);

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -33,6 +33,7 @@ import UpsellNudge, {
 	BUSINESS_PLAN_UPGRADE_UPSELL,
 	CONCIERGE_SUPPORT_SESSION,
 	CONCIERGE_QUICKSTART_SESSION,
+	DIFM_UPSELL,
 } from './upsell-nudge';
 
 export function checkout( context, next ) {
@@ -214,6 +215,8 @@ export function upsellNudge( context, next ) {
 			default:
 				upsellType = BUSINESS_PLAN_UPGRADE_UPSELL;
 		}
+	} else if ( context.path.includes( 'offer-difm' ) ) {
+		upsellType = DIFM_UPSELL;
 	}
 
 	setSectionMiddleware( { name: upsellType } )( context );

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -193,7 +193,6 @@ export function upsellNudge( context, next ) {
 
 	let upsellType;
 	let upgradeItem;
-	let addnlProps;
 
 	if ( context.path.includes( 'offer-quickstart-session' ) ) {
 		upsellType = CONCIERGE_QUICKSTART_SESSION;
@@ -218,8 +217,6 @@ export function upsellNudge( context, next ) {
 		}
 	} else if ( context.path.includes( 'offer-difm' ) ) {
 		upsellType = DIFM_UPSELL;
-		const isFromEcommercePurchase = context.query?.isEcommerce === '1';
-		addnlProps = { isFromEcommercePurchase };
 	}
 
 	setSectionMiddleware( { name: upsellType } )( context );
@@ -231,7 +228,6 @@ export function upsellNudge( context, next ) {
 				receiptId={ Number( receiptId ) }
 				upsellType={ upsellType }
 				upgradeItem={ upgradeItem }
-				addnlProps={ addnlProps }
 			/>
 		</CalypsoShoppingCartProvider>
 	);

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -132,6 +132,14 @@ export default function () {
 		);
 	}
 
+	page(
+		'/checkout/:site/offer-difm/:receiptId?',
+		siteSelection,
+		upsellNudge,
+		makeLayout,
+		clientRender
+	);
+
 	page( '/checkout/:domainOrProduct', siteSelection, checkout, makeLayout, clientRender );
 
 	page( '/checkout/:product/:domainOrProduct', siteSelection, checkout, makeLayout, clientRender );

--- a/client/my-sites/checkout/upsell-nudge/difm-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/difm-upsell/index.jsx
@@ -1,0 +1,166 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import Gridicon from 'calypso/components/gridicon';
+
+/**
+ * Internal dependencies
+ */
+import { CompactCard, Button } from '@automattic/components';
+import DocumentHead from 'calypso/components/data/document-head';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+/**
+ * Image dependencies
+ */
+import premiumThemesImage from 'calypso/assets/images/illustrations/themes.svg';
+
+export class DifmUpsell extends PureComponent {
+	render() {
+		const { receiptId, translate } = this.props;
+
+		const title = translate( 'Checkout ‹ Plan Upgrade', {
+			comment: '"Checkout" is the part of the site where a user is preparing to make a purchase.',
+		} );
+
+		return (
+			<>
+				<PageViewTracker path="/checkout/:site/offer-difm/:receipt_id" title={ title } />
+				<DocumentHead title={ title } />
+				{ receiptId ? (
+					<CompactCard className="difm-upsell__card-header">{ this.header() }</CompactCard>
+				) : (
+					''
+				) }
+				<CompactCard className="difm-upsell__card-body">{ this.body() }</CompactCard>
+				<CompactCard className="difm-upsell__card-footer">{ this.footer() }</CompactCard>
+			</>
+		);
+	}
+
+	header() {
+		const { translate } = this.props;
+
+		return (
+			<header className="difm-upsell__small-header">
+				<h2 className="difm-upsell__title">
+					{ translate( "Hold tight, we're getting your site ready." ) }
+				</h2>
+			</header>
+		);
+	}
+
+	body() {
+		const { translate } = this.props;
+		return (
+			<>
+				<h2 className="difm-upsell__header">
+					{ translate(
+						'Skip to the launch line: {{br/}} Let our experts build your dream website',
+						{
+							components: { br: <br /> },
+						}
+					) }
+				</h2>
+
+				<div className="difm-upsell__column-pane">
+					<div className="difm-upsell__column-content">
+						<p>
+							<b>
+								{ translate(
+									'Stand out online with a beautiful, functional, secure website designed and built by WordPress experts just for you.'
+								) }
+							</b>
+						</p>
+						<p>
+							{ translate(
+								'If you’re familiar with WordPress plugins, you know why that’s exciting. Installing plugins on your site is like downloading an app on your phone. Except, instead of getting a new game or productivity tool, you get new features and functionality for your site.'
+							) }
+						</p>
+						<p>
+							{ translate(
+								'There are more than 50,000 WordPress plugins available to help turn your site into any powerful platform you imagine.'
+							) }
+						</p>
+						<p>{ translate( 'Our premium website building service is perfect for:' ) }</p>
+						<ul className="difm-upsell__checklist">
+							<li className="difm-upsell__checklist-item">
+								<Gridicon icon="checkmark" className="difm-upsell__checklist-item-icon" />
+								<span className="difm-upsell__checklist-item-text">
+									{ translate( 'Online stores', {
+										comment: "This is a benefit listed on a 'Upgrade your plan' page",
+									} ) }
+								</span>
+							</li>
+							<li className="difm-upsell__checklist-item">
+								<Gridicon icon="checkmark" className="difm-upsell__checklist-item-icon" />
+								<span className="difm-upsell__checklist-item-text">
+									{ translate( 'Educational websites', {
+										comment: "This is a benefit listed on a 'Upgrade your plan' page",
+									} ) }
+								</span>
+							</li>
+							<li className="difm-upsell__checklist-item">
+								<Gridicon icon="checkmark" className="difm-upsell__checklist-item-icon" />
+								<span className="difm-upsell__checklist-item-text">
+									{ translate( 'Professional services', {
+										comment: "This is a benefit listed on a 'Upgrade your plan' page",
+									} ) }
+								</span>
+							</li>
+							<li className="difm-upsell__checklist-item">
+								<Gridicon icon="checkmark" className="difm-upsell__checklist-item-icon" />
+								<span className="difm-upsell__checklist-item-text">
+									{ translate( 'Advanced tailored solutions', {
+										comment: "This is a benefit listed on a 'Upgrade your plan' page",
+									} ) }
+								</span>
+							</li>
+						</ul>
+
+						<p>
+							{ translate( '{{b}}Custom websites starting at $4,900{{/b}}', {
+								components: { b: <b /> },
+							} ) }
+						</p>
+					</div>
+					<div className="difm-upsell__column-doodle">
+						<img
+							className="difm-upsell__doodle"
+							alt="Website expert offering a support session"
+							src={ premiumThemesImage }
+						/>
+					</div>
+				</div>
+			</>
+		);
+	}
+
+	footer() {
+		const { translate, handleClickAccept, handleClickDecline } = this.props;
+		return (
+			<footer className="difm-upsell__footer">
+				<Button
+					data-e2e-button="decline"
+					className="difm-upsell__decline-offer-button"
+					onClick={ handleClickDecline }
+				>
+					{ translate( 'No thanks' ) }
+				</Button>
+				<Button
+					primary
+					className="difm-upsell__accept-offer-button"
+					onClick={ () => handleClickAccept( 'accept' ) }
+				>
+					{ translate( 'I’m interested' ) }
+				</Button>
+			</footer>
+		);
+	}
+}

--- a/client/my-sites/checkout/upsell-nudge/difm-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/difm-upsell/index.jsx
@@ -68,7 +68,7 @@ export class DifmUpsell extends PureComponent {
 			<>
 				<h2 className="difm-upsell__header">
 					{ translate(
-						'Skip to the launch line: {{br/}} Let our experts build your dream website',
+						'Skip to the launch line: {{br/}} Let our WordPress experts build your website',
 						{
 							components: { br: <br /> },
 						}
@@ -78,20 +78,18 @@ export class DifmUpsell extends PureComponent {
 				<div className="difm-upsell__column-pane">
 					<div className="difm-upsell__column-content">
 						<p>
-							<b>
-								{ translate(
-									'Stand out online with a beautiful, functional, secure website designed and built by WordPress experts just for you.'
-								) }
-							</b>
-						</p>
-						<p>
 							{ translate(
-								'If you’re familiar with WordPress plugins, you know why that’s exciting. Installing plugins on your site is like downloading an app on your phone. Except, instead of getting a new game or productivity tool, you get new features and functionality for your site.'
+								'Get up and running quickly by letting our WordPress experts build and design your website from scratch.'
 							) }
 						</p>
 						<p>
 							{ translate(
-								'There are more than 50,000 WordPress plugins available to help turn your site into any powerful platform you imagine.'
+								'Whether you’re launching a store, a business, or even online courses, we’ll help you stand out online with a beautiful, functional, secure website that’s built just for you.'
+							) }
+						</p>
+						<p>
+							{ translate(
+								'You’ll work with a dedicated engagement manager throughout the entire project, ensuring that your vision is carried through from start to finish. All for a one-time fee.'
 							) }
 						</p>
 						<p>{ translate( 'Our premium website building service is perfect for:' ) }</p>
@@ -100,7 +98,8 @@ export class DifmUpsell extends PureComponent {
 								<Gridicon icon="checkmark" className="difm-upsell__checklist-item-icon" />
 								<span className="difm-upsell__checklist-item-text">
 									{ translate( 'Online stores', {
-										comment: "This is a benefit listed on a 'Upgrade your plan' page",
+										comment:
+											"This is a type of business listed on the 'Website building service' offer page",
 									} ) }
 								</span>
 							</li>
@@ -108,7 +107,8 @@ export class DifmUpsell extends PureComponent {
 								<Gridicon icon="checkmark" className="difm-upsell__checklist-item-icon" />
 								<span className="difm-upsell__checklist-item-text">
 									{ translate( 'Educational websites', {
-										comment: "This is a benefit listed on a 'Upgrade your plan' page",
+										comment:
+											"This is a type of business listed on the 'Website building service' offer page",
 									} ) }
 								</span>
 							</li>
@@ -116,7 +116,8 @@ export class DifmUpsell extends PureComponent {
 								<Gridicon icon="checkmark" className="difm-upsell__checklist-item-icon" />
 								<span className="difm-upsell__checklist-item-text">
 									{ translate( 'Professional services', {
-										comment: "This is a benefit listed on a 'Upgrade your plan' page",
+										comment:
+											"This is a type of business listed on the 'Website building service' offer page",
 									} ) }
 								</span>
 							</li>
@@ -124,11 +125,18 @@ export class DifmUpsell extends PureComponent {
 								<Gridicon icon="checkmark" className="difm-upsell__checklist-item-icon" />
 								<span className="difm-upsell__checklist-item-text">
 									{ translate( 'Advanced tailored solutions', {
-										comment: "This is a benefit listed on a 'Upgrade your plan' page",
+										comment:
+											"This is a type of business listed on the 'Website building service' offer page",
 									} ) }
 								</span>
 							</li>
 						</ul>
+
+						<p>
+							{ translate(
+								'Simply tell us a little bit more about your website, and we’ll get back to you in 2-3 business days.'
+							) }
+						</p>
 
 						<p>
 							{ translate( '{{b}}Custom websites starting at $4,900{{/b}}', {
@@ -164,7 +172,7 @@ export class DifmUpsell extends PureComponent {
 					className="difm-upsell__accept-offer-button"
 					onClick={ () => handleClickAccept( 'accept' ) }
 				>
-					{ translate( 'I’m interested' ) }
+					{ translate( 'Yes, I want to apply now and get my site built' ) }
 				</Button>
 			</footer>
 		);

--- a/client/my-sites/checkout/upsell-nudge/difm-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/difm-upsell/index.jsx
@@ -25,7 +25,7 @@ export class DifmUpsell extends PureComponent {
 	render() {
 		const { receiptId, translate } = this.props;
 
-		const title = translate( 'Checkout ‹ Plan Upgrade', {
+		const title = translate( 'Checkout ‹ "Built For You" offer', {
 			comment: '"Checkout" is the part of the site where a user is preparing to make a purchase.',
 		} );
 

--- a/client/my-sites/checkout/upsell-nudge/difm-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/difm-upsell/index.jsx
@@ -49,9 +49,15 @@ export class DifmUpsell extends PureComponent {
 
 		return (
 			<header className="difm-upsell__small-header">
-				<h2 className="difm-upsell__title">
-					{ translate( "Hold tight, we're getting your site ready." ) }
-				</h2>
+				<Gridicon icon="checkmark-circle" className="difm-upsell__purchase-success-icon" />
+				<div className="difm-upsell__title">
+					<h2 className="difm-upsell__title-heading">
+						{ translate( 'Congratulations on your purchase!' ) }
+					</h2>
+					<div className="difm-upsell__subtitle">
+						{ translate( 'You will receive an email confirmation shortly.' ) }
+					</div>
+				</div>
 			</header>
 		);
 	}

--- a/client/my-sites/checkout/upsell-nudge/difm-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/difm-upsell/index.jsx
@@ -10,6 +10,7 @@ import Gridicon from 'calypso/components/gridicon';
 import { CompactCard, Button } from '@automattic/components';
 import DocumentHead from 'calypso/components/data/document-head';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import wpcom from 'calypso/lib/wp';
 
 /**
  * Style dependencies
@@ -156,8 +157,14 @@ export class DifmUpsell extends PureComponent {
 		);
 	}
 
+	handleDifmAccept = () => {
+		wpcom.undocumented().saveDifmInterestForUser();
+
+		this.props.handleClickAccept( 'accept' );
+	};
+
 	footer() {
-		const { translate, handleClickAccept, handleClickDecline } = this.props;
+		const { translate, handleClickDecline } = this.props;
 		return (
 			<footer className="difm-upsell__footer">
 				<Button
@@ -170,7 +177,7 @@ export class DifmUpsell extends PureComponent {
 				<Button
 					primary
 					className="difm-upsell__accept-offer-button"
-					onClick={ () => handleClickAccept( 'accept' ) }
+					onClick={ () => this.handleDifmAccept() }
 				>
 					{ translate( 'Yes, I want to apply now and get my site built' ) }
 				</Button>

--- a/client/my-sites/checkout/upsell-nudge/difm-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/difm-upsell/style.scss
@@ -48,7 +48,11 @@ main.difm-upsell.main {
 	&__card-header,
 	&__card-footer {
 		width: 100%;
-	}
+    }
+    
+    .card.difm-upsell__card-header {
+        margin-bottom: 30px;
+    }
 
 	&__card-body {
 		overflow: auto;
@@ -77,11 +81,11 @@ main.difm-upsell.main {
 
 	&__doodle {
 		margin-top: 85px;
-	}
+    }
 
 	&__small-header {
-		font-style: italic;
-		text-align: center;
+		display: flex;
+		align-items: center;
 	}
 
 	&__header {
@@ -155,5 +159,19 @@ main.difm-upsell.main {
 		@include breakpoint-deprecated( '>480px' ) {
 			float: right;
 		}
+    }
+    
+    &__purchase-success-icon {
+        width: 30px;
+		margin-right: 10px;
+		fill: var( --studio-green-50 );
+    }
+
+	&__title-heading {
+		font-weight: 600;;
+	}
+
+	&__subtitle {
+		font-size: 0.875rem;
 	}
 }

--- a/client/my-sites/checkout/upsell-nudge/difm-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/difm-upsell/style.scss
@@ -1,0 +1,159 @@
+main.difm-upsell.main {
+	margin: auto;
+}
+
+.difm-upsell {
+	display: flex;
+	flex-direction: column;
+
+	b {
+		font-weight: 700;
+	}
+
+	.card {
+		width: 100%;
+	}
+
+	&__placeholders {
+		display: flex;
+		flex-direction: column;
+
+		.is-placeholder {
+			animation: pulse-light 800ms ease-in-out infinite;
+			background: var( --color-neutral-10 );
+		}
+	}
+
+	&__placeholder-row {
+		height: 40px;
+		flex: 0 0 100%;
+		margin-bottom: 15px;
+	}
+
+	&__placeholder-button {
+		height: 50px;
+		width: 100%;
+
+		@include breakpoint-deprecated( '>480px' ) {
+			width: 80px;
+			height: 40px;
+		}
+	}
+
+	&__placeholder-button-container {
+		display: flex;
+		justify-content: space-between;
+	}
+
+	&__card-header,
+	&__card-footer {
+		width: 100%;
+	}
+
+	&__card-body {
+		overflow: auto;
+		flex: 1;
+	}
+
+	&__column-pane {
+		display: flex;
+		flex-flow: row;
+	}
+
+	&__column-content {
+		padding-right: 10px;
+		@include breakpoint-deprecated( '<480px' ) {
+			padding-right: 0;
+		}
+	}
+
+	&__column-doodle {
+		width: 120px;
+		flex-shrink: 0;
+		@include breakpoint-deprecated( '<480px' ) {
+			display: none;
+		}
+	}
+
+	&__doodle {
+		margin-top: 85px;
+	}
+
+	&__small-header {
+		font-style: italic;
+		text-align: center;
+	}
+
+	&__header {
+		font-size: $font-title-medium;
+		font-weight: 600;
+		text-align: center;
+		line-height: 1.4;
+		margin-top: 0.7em;
+		margin-bottom: 1em;
+
+		@include breakpoint-deprecated( '<660px' ) {
+			font-size: $font-title-small;
+		}
+	}
+	&__sub-header {
+		font-size: $font-title-small;
+		font-weight: normal;
+		text-align: center;
+		line-height: 1.4;
+		margin-top: 5px;
+		margin-bottom: 1.6em;
+
+		@include breakpoint-deprecated( '<660px' ) {
+			font-size: $font-body;
+		}
+	}
+
+	&__checklist {
+		margin: 0 0 0.75em;
+
+		&-item {
+			display: flex;
+			width: 100%;
+			align-items: flex-start;
+			margin-bottom: 1.2em;
+
+			@include breakpoint-deprecated( '<660px' ) {
+				align-items: flex-start;
+			}
+		}
+
+		&-item-icon {
+			width: 18px;
+			fill: var( --studio-jetpack-green-30 );
+			margin-right: 5px;
+		}
+
+		&-item-text {
+			flex: 1;
+		}
+	}
+
+	&__footer &__decline-offer-button {
+		color: var( --color-primary );
+
+		@include breakpoint-deprecated( '<480px' ) {
+			width: 100%;
+		}
+
+		@include breakpoint-deprecated( '>480px' ) {
+			float: left;
+		}
+	}
+
+	&__footer &__accept-offer-button {
+		@include breakpoint-deprecated( '<480px' ) {
+			width: 100%;
+			margin-top: 10px;
+		}
+
+		@include breakpoint-deprecated( '>480px' ) {
+			float: right;
+		}
+	}
+}

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -40,6 +40,7 @@ import { ConciergeQuickstartSession } from './concierge-quickstart-session';
 import { ConciergeSupportSession } from './concierge-support-session';
 import { BusinessPlanUpgradeUpsell } from './business-plan-upgrade-upsell';
 import { PremiumPlanUpgradeUpsell } from './premium-plan-upgrade-upsell';
+import { DifmUpsell } from './difm-upsell';
 import getUpgradePlanSlugFromPath from 'calypso/state/selectors/get-upgrade-plan-slug-from-path';
 import PurchaseModal from './purchase-modal';
 import Gridicon from 'calypso/components/gridicon';
@@ -67,6 +68,7 @@ export const CONCIERGE_QUICKSTART_SESSION = 'concierge-quickstart-session';
 export const CONCIERGE_SUPPORT_SESSION = 'concierge-support-session';
 export const PREMIUM_PLAN_UPGRADE_UPSELL = 'premium-plan-upgrade-upsell';
 export const BUSINESS_PLAN_UPGRADE_UPSELL = 'business-plan-upgrade-upsell';
+export const DIFM_UPSELL = 'difm-upsell';
 
 export class UpsellNudge extends React.Component {
 	static propTypes = {
@@ -234,6 +236,19 @@ export class UpsellNudge extends React.Component {
 						handleClickDecline={ this.handleClickDecline }
 					/>
 				);
+
+			case DIFM_UPSELL:
+				return (
+					<DifmUpsell
+						currencyCode={ currencyCode }
+						planRawPrice={ planRawPrice }
+						planDiscountedRawPrice={ planDiscountedRawPrice }
+						receiptId={ receiptId }
+						translate={ translate }
+						handleClickAccept={ this.handleClickAccept }
+						handleClickDecline={ this.handleClickDecline }
+					/>
+				);
 		}
 	}
 
@@ -281,6 +296,10 @@ export class UpsellNudge extends React.Component {
 			} );
 			this.props.shoppingCartManager.replaceProductsInCart( [ this.props.product ] );
 			return;
+		}
+
+		if ( DIFM_UPSELL === upsellType ) {
+			return '/me/difm-intake';
 		}
 
 		return siteSlug

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -256,6 +256,7 @@ export class UpsellNudge extends React.Component {
 		const { trackUpsellButtonClick, upsellType } = this.props;
 
 		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
+
 		const getThankYouPageUrlArguments = {
 			siteSlug: this.props.siteSlug,
 			receiptId: this.props.receiptId || 'noPreviousPurchase',

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -299,7 +299,8 @@ export class UpsellNudge extends React.Component {
 		}
 
 		if ( DIFM_UPSELL === upsellType ) {
-			return '/me/difm-intake';
+			page( '/me/difm-intake' );
+			return;
 		}
 
 		return siteSlug

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -17,13 +17,21 @@ export default async function ( context, next ) {
 
 	const isDev = context.query.dev === 'true';
 	const forcedView = context.query.view;
+	const noticeType = context.query.notice;
 
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {
 		window.scrollTo( 0, 0 );
 	}
 
-	context.primary = <CustomerHome key={ siteId } isDev={ isDev } forcedView={ forcedView } />;
+	context.primary = (
+		<CustomerHome
+			key={ siteId }
+			isDev={ isDev }
+			forcedView={ forcedView }
+			noticeType={ noticeType }
+		/>
+	);
 
 	next();
 }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -29,6 +29,7 @@ import { getHomeLayout } from 'calypso/state/selectors/get-home-layout';
 import Primary from 'calypso/my-sites/customer-home/locations/primary';
 import Secondary from 'calypso/my-sites/customer-home/locations/secondary';
 import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
+import notices from 'calypso/notices';
 
 /**
  * Style dependencies
@@ -43,6 +44,7 @@ const Home = ( {
 	site,
 	siteId,
 	trackViewSiteAction,
+	noticeType,
 } ) => {
 	const translate = useTranslate();
 
@@ -54,6 +56,13 @@ const Home = ( {
 				illustration="/calypso/images/illustrations/error.svg"
 			/>
 		);
+	}
+
+	if ( 'difm_success' === noticeType ) {
+		const successMessage = translate( 'Your application has been sent!' );
+		notices.success( successMessage, {
+			persistent: true,
+		} );
 	}
 
 	const header = (

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React from 'react';
-import { connect } from 'react-redux';
+import React, { useEffect } from 'react';
+import { connect, useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 
@@ -29,7 +29,7 @@ import { getHomeLayout } from 'calypso/state/selectors/get-home-layout';
 import Primary from 'calypso/my-sites/customer-home/locations/primary';
 import Secondary from 'calypso/my-sites/customer-home/locations/secondary';
 import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
-import notices from 'calypso/notices';
+import { successNotice } from 'calypso/state/notices/actions';
 
 /**
  * Style dependencies
@@ -47,6 +47,24 @@ const Home = ( {
 	noticeType,
 } ) => {
 	const translate = useTranslate();
+	const reduxDispatch = useDispatch();
+
+	useEffect( () => {
+		if ( ! canUserUseCustomerHome || ! layout || ! noticeType ) {
+			return;
+		}
+
+		if ( noticeType === 'difm-success' ) {
+			const successMessage = translate( 'Your application has been sent!' );
+			reduxDispatch(
+				successNotice( successMessage, {
+					isPersistent: true,
+				} )
+			);
+		}
+
+		return;
+	}, [ noticeType, layout, reduxDispatch, translate ] );
 
 	if ( ! canUserUseCustomerHome ) {
 		const title = translate( 'This page is not available on this site.' );
@@ -56,13 +74,6 @@ const Home = ( {
 				illustration="/calypso/images/illustrations/error.svg"
 			/>
 		);
-	}
-
-	if ( 'difm_success' === noticeType ) {
-		const successMessage = translate( 'Your application has been sent!' );
-		notices.success( successMessage, {
-			persistent: true,
-		} );
 	}
 
 	const header = (

--- a/client/sections.js
+++ b/client/sections.js
@@ -91,6 +91,12 @@ const sections = [
 		group: 'me',
 	},
 	{
+		name: 'difm',
+		paths: [ '/me/difm-intake' ],
+		module: 'calypso/me/difm-intake',
+		group: 'me',
+	},
+	{
 		name: 'media',
 		paths: [ '/media' ],
 		module: 'calypso/my-sites/media',

--- a/client/state/marketing/selectors.ts
+++ b/client/state/marketing/selectors.ts
@@ -12,3 +12,7 @@ export function isTreatmentOneClickTest( state: AppState ): boolean {
 export function isTreatmentPlansReorderTest( state: AppState ): boolean {
 	return 'treatment' === getCurrentUser( state )?.meta.plans_reorder_abtest_variation;
 }
+
+export function isTreatmentDifmUpsellTest( state: AppState ): boolean {
+	return 'treatment' === getVariationForUser( state, 'post_purchase_difm_upsell' );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Implementation of the DIFM upsell offer A/B test. For more context, check pcbrnV-12W-p2.

A quick summary of changes:

* A/B test the DIFM upsell offer copy for users who purchase a Business or eCommerce plan. Check this [Figma](https://www.figma.com/file/b6jGfIqCpucVeNHlx82LA3/DIFM-post-purchase-offer-flow?node-id=106%3A9) for the design.
* Business plan users who decline the upsell will be taken to Customer Home. Those who Accept the offer, they will be taken to an intake form page which displays embedded the Crowdsignal DIFM survey. Successful completion of the survey will take the user to Customer Home.
* eCommerce users who decline the upsell will be taken to the Atomic Thank You page. Those who Accept the offer will be taken to an intake form page which displays embedded the Crowdsignal DIFM survey. Successful completion of the survey will take the user to Customer Home.

**DIFM Upsell offer**

<img width="1675" alt="Screenshot 2021-01-28 at 12 05 18 AM" src="https://user-images.githubusercontent.com/1269602/106037368-98696080-60fc-11eb-80f9-03b877ed375a.png">

**DIFM intake form**

<img width="1677" alt="Screenshot 2021-01-28 at 12 04 36 AM" src="https://user-images.githubusercontent.com/1269602/106037400-a0c19b80-60fc-11eb-9891-c366af756187.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Apply patch D56268-code**

**Scenario 1**

* Assign yourself to the treatment of the `post_purchase_difm_upsell` experiment.
* Go through the signup flow and purchase a Business plan. Verify that you see the DIFM upsell offer.
    - Declining the offer should take to thank you page.
    - Accepting the offer should take to a DIFM intake survey. Successful completion of the survey should take to Customer Home with a [notice indicating successful form submission](https://d.pr/i/ZsR2rv). Note that the form redirects to wordpress.com on successful submission, so replace the domain with calypso url to see the success notice.
    - You should receive an email with a link to the DIFM intake page on accepting the upsell offer. 
* Go through the signup flow and purchase an eCommerce plan. Verify that you see the DIFM upsell offer.
    - Declining the offer should take to the [atomic Thank You page](https://d.pr/i/BoQqLk)
    - Accepting the offer should take to a DIFM intake survey. Successful completion of the survey should take to [atomic Thank You page](https://d.pr/i/BoQqLk).
    - You should receive an email with a link to the DIFM intake page on accepting the upsell offer.
    
**Scenario 2**

* Assign yourself to `control` of the `post_purchase_difm_upsell` experiment.
* Verify that control experience is unchanged for Business purchase, After purchasing a Business plan, you're either taken to Customer Home or shown a Quick Start upsell, depending on which variant you get assigned on the Quick Start offer test.
* Verify that control experience is unchanged for eCommerce purchase. After purchasing an eCommerce plan, you should be taken to the atomic Thank You page. 