### PR TITLE
Purchases: Reduxify survey notice

### DIFF
--- a/client/lib/purchases/actions.js
+++ b/client/lib/purchases/actions.js
@@ -7,7 +7,8 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import wpcom from 'calypso/lib/wp';
-import notices from 'calypso/notices';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { reduxDispatch } from 'calypso/lib/redux-bridge';
 
 const debug = debugFactory( 'calypso:purchases:actions' );
 
@@ -35,7 +36,7 @@ export function submitSurvey( surveyName, siteID, surveyData ) {
 		.then( ( res ) => {
 			debug( 'Survey submit response', res );
 			if ( ! res.success ) {
-				notices.error( res.err );
+				reduxDispatch( errorNotice( res.err ) );
 			}
 		} )
 		.catch( ( err ) => debug( err ) ); // shouldn't get here


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Reduxify survey submission notice.

Part of #48408.

#### Testing instructions

* Add the following lines before the code on [this line](https://github.com/Automattic/wp-calypso/blob/reduxify/purchase-actions/client/lib/purchases/actions.js#L38):
```
res.success = false;
res.err = 'An error has occurred.';
```
* Add a `return;` on [this line](https://github.com/Automattic/wp-calypso/blob/reduxify/purchase-actions/client/blocks/disconnect-jetpack/index.jsx#L174) to prevent from actual disconnection (optional).
* Go to `/settings/disconnect-site/confirm/:site?reason=slow` where `:site` is a Jetpack site.
* Click the "Disconnect" button.
* Verify you get the error notice you used in `res.err`.
