### PR TITLE
Help: Reduxify notices in HelpUnverifiedWarning

### DIFF
--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import user from 'calypso/lib/user';
 
@@ -10,7 +11,7 @@ import user from 'calypso/lib/user';
  */
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import notices from 'calypso/notices';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 /**
  * Style dependencies
@@ -63,13 +64,13 @@ class HelpUnverifiedWarning extends Component {
 					const nextResendState = RESEND_SUCCESS;
 
 					this.setState( { resendState: nextResendState } );
-					notices.success( resendStateToMessage( nextResendState ) );
+					this.props.successNotice( resendStateToMessage( nextResendState ) );
 				} )
 				.catch( () => {
 					const nextResendState = RESEND_ERROR;
 
 					this.setState( { resendState: nextResendState } );
-					notices.error( resendStateToMessage( nextResendState ) );
+					this.props.errorNotice( resendStateToMessage( nextResendState ) );
 				} );
 		};
 
@@ -91,4 +92,7 @@ class HelpUnverifiedWarning extends Component {
 	}
 }
 
-export default localize( HelpUnverifiedWarning );
+export default connect( null, {
+	errorNotice,
+	successNotice,
+} )( localize( HelpUnverifiedWarning ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Help: Reduxify notices in `HelpUnverifiedWarning`

Part of #48408.

#### Testing instructions

* Create a new account in WP.com. Do not verify your email. Log in as that user if you haven't.
* Go to `/help`
* You'll see a warning to resend activation email. Click the "Resend Email" button.
* Verify you see a success message.
* Visit `/help` again.
* Go offline (in the Network tab of your dev tools for example).
* Click the "Resend Email" button.
* Verify you can see the error notice.
