### PR TITLE
Domain Picker: Fix i18n for "Included with annual plans" copy

### DIFF
--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -106,7 +106,7 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 			? __( 'Default', __i18n_text_domain__ )
 			: __( 'Free', __i18n_text_domain__ );
 
-	const firstYearIncludedInPaid = isMobile
+	const firstYearIncludedInPaidLabel = isMobile
 		? __( 'Included in paid plans', __i18n_text_domain__ )
 		: createInterpolateElement(
 				__( '<strong>First year included</strong> in paid plans', __i18n_text_domain__ ),
@@ -115,10 +115,21 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 				}
 		  );
 
-	const paidIncludedDomainLabel =
-		type === ITEM_TYPE_INDIVIDUAL_ITEM
-			? firstYearIncludedInPaid
-			: __( isMobile ? 'Free' : 'Included with annual plans', __i18n_text_domain__ );
+	/**
+	 *  IIFE executes immediately after creation, hence it returns the translated values immediately.
+	 * The great advantage is that:
+	 * 1. We don't have to execute it during rendering.
+	 * 2. We don't have to use nested ternaries (which is not allowed by the linter).
+	 * 3. It improves the readibility of our code
+	 */
+	const paidIncludedDomainLabel = ( () => {
+		if ( type === ITEM_TYPE_INDIVIDUAL_ITEM ) {
+			return firstYearIncludedInPaidLabel;
+		} else if ( isMobile ) {
+			return __( 'Free', __i18n_text_domain__ );
+		}
+		return __( 'Included with annual plans', __i18n_text_domain__ );
+	} )();
 
 	React.useEffect( () => {
 		// Only record TrainTracks render event when the domain name and railcarId change.


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The `__()` method needs to be parsable by static analysis, hence only string literals are allowed. In this PR, the ternary is removed from `__()` and an `IIFE` is introduced to render translated strings correctly.

#### Technical changes
* remove ternary from inside the `__()` method.
* add `IIFE` to handle the logic and return a translated string immediately after its creation. 

#### Testing instructions

**Focused Launch**
1. Switch to a language other than English (e.g. French or Dutch).
2. Go to `/page/[UNLAUNCHED_SITE_ID].wordpress.com/home?flags=create/focused-launch-flow`.
3. Click "Launch" to open the Focused Launch flow.
4. Click on "View All Domains" 
5. Check that:
    * [ ] All labels are correctly translated

**Gutenboarding - Regression testing**
1. Go to `/new`.
2. Enter a site name. Go to the next step which should be the domain step.
3. Open DevTools and switch to the mobile layout (e.g. iPhone X)
4. Check that:
    * [ ] No unexpected changes have appeared.

**Editing Toolkit Step-by-Step Launch - Regression testing**
1. Check out this branch and run `yarn dev --sync` from `/apps/editing-toolkit` ensuring you're also logged into your sandbox environment.
2. Go to `/new` and go through the process to create a new site, you will land in the editing experience.
3. Sandbox your newly created site in your host file.
4. Flush your cache & DNS and then refresh your site made in step 1 and ensure that you're using the dev version of the Editing Toolkit.
5. Click "Launch". This should open the launch modal. 
6. Open DevTools and switch to the mobile layout (e.g. iPhone X).
7. Proceed to the step "Select a domain" and confirm that: 
    * [ ] No unexpected changes have appeared.

Fixes #49305
