### PR TITLE
G Suite: Rename Account Information section in checkout for Google Workspace

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -49,6 +49,7 @@ import {
 import { login } from 'calypso/lib/paths';
 import config from 'calypso/config';
 import getContactDetailsType from '../lib/get-contact-details-type';
+import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import {
 	hasGoogleApps,
 	hasDomainRegistration,
@@ -71,11 +72,23 @@ const ContactFormTitle = () => {
 			? translate( 'Contact information' )
 			: translate( 'Enter your contact information' );
 	}
+
 	if ( contactDetailsType === 'gsuite' ) {
 		return ! isActive && isComplete
-			? translate( 'G Suite account information' )
-			: translate( 'Enter your G Suite account information' );
+			? translate( '%(googleMailService)s account information', {
+					args: {
+						googleMailService: getGoogleMailServiceFamily(),
+					},
+					comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+			  } )
+			: translate( 'Enter your %(googleMailService)s account information', {
+					args: {
+						googleMailService: getGoogleMailServiceFamily(),
+					},
+					comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+			  } );
 	}
+
 	return ! isActive && isComplete
 		? translate( 'Billing information' )
 		: translate( 'Enter your billing information' );
@@ -138,7 +151,8 @@ export default function WPCheckout( {
 		const redirectTo = '/checkout/no-site?cart=no-user';
 		const isNative = config.isEnabled( 'login/native-login-links' );
 		const loginUrl = login( { redirectTo, emailAddress, isNative } );
-		const loginRedirectMessage = translate(
+
+		return translate(
 			'That email address is already in use. If you have an existing account, {{a}}please log in{{/a}}.',
 			{
 				components: {
@@ -146,7 +160,6 @@ export default function WPCheckout( {
 				},
 			}
 		);
-		return loginRedirectMessage;
 	};
 
 	const validateContactDetailsAndDisplayErrors = async () => {

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -298,7 +298,7 @@ class EmailProvidersComparison extends React.Component {
 				}
 				buttonLabel={ buttonLabel }
 				onButtonClick={ this.goToAddGSuite }
-				className={ className }
+				className={ classNames( className, 'gsuite' ) }
 			/>
 		);
 	}

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -15,11 +15,16 @@
 		&.no-gsuite {
 			width: calc( 50% - 0.5em );
 		}
+
 		&.no-titan {
 			width: calc( 50% - 0.5em );
 		}
 
-		&.titan {
+		&.gsuite .action-panel__figure img {
+			max-width: 24px;
+		}
+
+			&.titan {
 			.promo-card__title-badge {
 				background: none;
 				padding: 0;


### PR DESCRIPTION
This pull request updates the checkout to show the right product name in the account information section if Google Workspace is enabled:

![screenshot](https://user-images.githubusercontent.com/594356/105859774-30782480-5fed-11eb-825b-3642ce1861cd.png)

It also fixes a [small display issue](https://github.com/Automattic/wp-calypso/pull/49247#pullrequestreview-575227085) with the Google Workspace icon on the `Email Comparison` page on mobile views.

#### Testing instructions

1. Run `git checkout update/account-information-google-workspace` and start your server, or open a [live branch](https://calypso.live/?branch=update/account-information-google-workspace)
2. Log into a WordPress.com account with a site with a domain
3. Open the [`Domains` page](http://calypso.localhost:3000/domains/manage)
4. Click the `Add` button in front of your domain to access the `Email Comparison` page
5. Assert that the Google Workspace icon is displayed correctly even on small viewports
6. Click the `Add Google Workspace` button
7. Fill in and submit the form
8. Assert that `Enter your Google Workspace account information` is displayed for section 1
9. Fill in account information, and click the `Continue` button
10. Assert that `Google Workspace account information` is displayed now
