### PR TITLE
eslint: Add @wordpress/eslint-plugin/i18n ruleset

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
 		'plugin:prettier/recommended',
 		'prettier/react',
 		'plugin:md/prettier',
+		'plugin:@wordpress/eslint-plugin/i18n',
 	],
 	overrides: [
 		{
@@ -385,5 +386,8 @@ module.exports = {
 				'@wordpress/components': [ '__experimentalNavigationBackButton' ],
 			},
 		],
+
+		// Disabled, because in packages we are using globally defined `__i18n_text_domain__` constant at compile time
+		'@wordpress/i18n-text-domain': 'off',
 	},
 };

--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
 		"@wordpress/base-styles": "^3.3.0",
 		"@wordpress/components": "^12.0.1",
 		"@wordpress/element": "^2.19.0",
+		"@wordpress/eslint-plugin": "^7.3.0",
 		"@wordpress/i18n": "^3.17.0",
 		"@wordpress/icons": "^2.9.0",
 		"@wordpress/jest-preset-default": "^6.5.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `@wordpress/eslint-plugin/i18n` ruleset to root eslint config
* Disable `@wordpress/i18n-text-domain` rule, because we use `__i18n_text_domain__` global constant in packages instead of string literals.

#### Testing instructions

* Checkout the branch locally and `yarn install`
* Run `yarn eslint` on a file that is known not to fulfil the rules from `@wordpress/eslint-plugin/i18n` and confirm it's reporting the lint errors, e.g. `packages/domain-picker/src/domain-picker/suggestion-item.tsx`

