### PR TITLE
Reader: turn off flyout menus and remove 'Streams' heading

### DIFF
--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -55,6 +55,7 @@ export const ExpandableSidebarMenu = ( {
 	materialIconStyle,
 	customIcon,
 	children,
+	disableFlyout,
 	...props
 } ) => {
 	let { expanded } = props;
@@ -79,7 +80,7 @@ export const ExpandableSidebarMenu = ( {
 	} );
 
 	const onEnter = () => {
-		if ( expanded || isTouch || ! config.isEnabled( 'nav-unification' ) ) {
+		if ( disableFlyout || expanded || isTouch || ! config.isEnabled( 'nav-unification' ) ) {
 			return;
 		}
 
@@ -87,6 +88,7 @@ export const ExpandableSidebarMenu = ( {
 	};
 
 	const onLeave = () => {
+		// Remove "hovered" state even if menu is expanded.
 		if ( isTouch || ! config.isEnabled( 'nav-unification' ) ) {
 			return;
 		}
@@ -151,6 +153,7 @@ ExpandableSidebarMenu.propTypes = {
 	materialIcon: PropTypes.string,
 	materialIconStyle: PropTypes.string,
 	expanded: PropTypes.bool,
+	disableFlyout: PropTypes.bool,
 };
 
 export default ExpandableSidebarMenu;

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -20,7 +20,6 @@ import QueryReaderLists from 'calypso/components/data/query-reader-lists';
 import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
 import Sidebar from 'calypso/layout/sidebar';
 import SidebarFooter from 'calypso/layout/sidebar/footer';
-import SidebarHeading from 'calypso/layout/sidebar/heading';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
 import SidebarRegion from 'calypso/layout/sidebar/region';
@@ -155,7 +154,6 @@ export class ReaderSidebar extends React.Component {
 		const { path, translate } = this.props;
 		return (
 			<SidebarMenu>
-				<SidebarHeading>{ translate( 'Streams' ) }</SidebarHeading>
 				<QueryReaderLists />
 				<QueryReaderTeams />
 				<QueryReaderOrganizations />

--- a/client/reader/sidebar/reader-sidebar-followed-sites/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-followed-sites/index.jsx
@@ -80,6 +80,7 @@ export class ReaderSidebarFollowedSites extends Component {
 				title={ translate( 'Followed Sites' ) }
 				onClick={ this.props.toggleReaderSidebarFollowing }
 				materialIcon="check_circle"
+				disableFlyout={ true }
 			>
 				{ this.renderAll() }
 				{ this.renderSites() }

--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -41,6 +41,7 @@ export class ReaderSidebarLists extends Component {
 					title={ translate( 'Lists' ) }
 					onClick={ onClick }
 					materialIcon={ 'list' }
+					disableFlyout={ true }
 				>
 					<li>
 						<ReaderSidebarListsList { ...passedProps } />

--- a/client/reader/sidebar/reader-sidebar-organizations/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list.jsx
@@ -92,6 +92,7 @@ export class ReaderSidebarOrganizationsList extends Component {
 				title={ organization.title }
 				onClick={ this.handleClick }
 				customIcon={ this.renderIcon() }
+				disableFlyout={ true }
 			>
 				{ this.renderAll() }
 				{ this.renderSites() }

--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -63,6 +63,7 @@ export class ReaderSidebarTags extends Component {
 					title={ translate( 'Tags' ) }
 					onClick={ onClick }
 					materialIcon="local_offer"
+					disableFlyout={ true }
 				>
 					<ReaderSidebarTagsList { ...this.props } />
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes stale "Streams" heading.
![](https://cln.sh/WIwnho+)
Since we are going to remove [errant heading from "Me" section](https://github.com/Automattic/wp-calypso/issues/49178), let's remove this one too. It actually doesn't appear for a12s at all. 
* Adds `disableFlyout` property and uses it to reader expandable menus.
 
#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/read`.
* Make sure no menu shows a flyout while hovered.

Fixes #48211
