### PR TITLE
Revert "Use deterministic chunkIds"

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -192,7 +192,7 @@ const webpackConfig = {
 		},
 		runtimeChunk: isDesktop ? false : { name: 'runtime' },
 		moduleIds: 'named',
-		chunkIds: isDevelopment || shouldEmitStats ? 'named' : 'deterministic',
+		chunkIds: isDevelopment || shouldEmitStats ? 'named' : 'natural',
 		minimize: shouldMinify,
 		minimizer: Minify( {
 			// Desktop: number of workers should *not* exceed # of vCPUs available.


### PR DESCRIPTION
Reverts Automattic/wp-calypso#49245, which was unexpectedly causing issues you can reproduce with these instructions from @atanas-dev:

1. Checkout and pull trunk.
2. Run yarn.
3. Run yarn start-jetpack-cloud.
4. Open http://jetpack.cloud.localhost:3000/pricing - you should see the pricing page.
5. Make any change to a rendered component file (e.g. edit client/jetpack-cloud/sections/pricing/header/index.tsx and remove line 56 <NewYear2021SaleBanner urlQueryArgs={ urlQueryArgs } />) and save.
6. Switch back to the browser - you should see a [webpack] hot update failed: ReferenceError: __webpack_require__ is not defined error in Chrome’s console.
7. Refresh - the error should appear again.
The only way to get rid of the error (which breaks any further automatic builds) is to manually restart the build.

We'll re-open the switch to `deterministic` once this is sorted out.

