### PR TITLE
Editing Toolkit: Update to 2.13

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.12
+ * Version: 2.13
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.12' );
+define( 'PLUGIN_VERSION', '2.13' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -46,6 +46,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Editing toolkit: clean out contributors list in readme (https://github.com/Automattic/wp-calypso/pull/49182)
 * Fix untranslated text in Domain Picker (https://github.com/Automattic/wp-calypso/pull/49168)
 * Use @automattic/format-currency package to format prices in Plan Store (https://github.com/Automattic/wp-calypso/pull/49293)
+* Patterns and SPT: Add pattern_meta is_web param to calls to the ptk/patterns endpoint (https://github.com/Automattic/wp-calypso/pull/49166)
 
 = 2.12 =
 * Starter page templates: remove sidebar component (#48948)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.5
 Tested up to: 5.6
-Stable tag: 2.12
+Stable tag: 2.13
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,13 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.13 =
+* New Onboarding Launch: fix plans data-store integration (https://github.com/Automattic/wp-calypso/pull/49304)
+* Refunds: update copy to reflect 14-day refunds (https://github.com/Automattic/wp-calypso/pull/48872)
+* Editing toolkit: clean out contributors list in readme (https://github.com/Automattic/wp-calypso/pull/49182)
+* Fix untranslated text in Domain Picker (https://github.com/Automattic/wp-calypso/pull/49168)
+* Use @automattic/format-currency package to format prices in Plan Store (https://github.com/Automattic/wp-calypso/pull/49293)
 
 = 2.12 =
 * Starter page templates: remove sidebar component (#48948)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -47,6 +47,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Fix untranslated text in Domain Picker (https://github.com/Automattic/wp-calypso/pull/49168)
 * Use @automattic/format-currency package to format prices in Plan Store (https://github.com/Automattic/wp-calypso/pull/49293)
 * Patterns and SPT: Add pattern_meta is_web param to calls to the ptk/patterns endpoint (https://github.com/Automattic/wp-calypso/pull/49166)
+* Switch on block pattern modifications (https://github.com/Automattic/wp-calypso/pull/48848)
 
 = 2.12 =
 * Starter page templates: remove sidebar component (#48948)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.12.0",
+	"version": "2.13.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Bumps version of Editing Toolkit to 2.13

### [Editing Toolkit changes included in this release](https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit)

- [x] New Onboarding Launch: fix plans data-store integration (#49304)
- [x] Refunds: update copy to reflect 14-day refunds (#48872)
- [x] Editing toolkit: clean out contributors list in readme (#49182)
- [x] Patterns and SPT: Add pattern_meta is_web param to calls to the ptk/patterns endpoint (#49166)
- [x] Switch on ETK block pattern modifications (#48848)

### Other [changes](https://github.com/Automattic/wp-calypso/commits/trunk/packages) included from the [imported @automattic packages](https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/tsconfig.json#L37-L46) and their imports

- [x] Fix untranslated text in Domain Picker (#49168) (checked with [caveat](https://github.com/Automattic/wp-calypso/pull/49319#issuecomment-767773378) )
- [x] Use `@automattic/format-currency` package to format prices in Plan Store (#49293)

### Testing instructions

1. Load the diff on your sandbox (D56032-code) and confirm that the above changes work correctly
2. When a change has been tested to work correctly, please mark it as checked in the list above
3. Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.
    - [x] Tested on atomic 