### PR TITLE
Anchor.fm: Rename spotify_show_url -> spotify_url

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -79,7 +79,7 @@ interface Props {
 	anchorFmData: {
 		anchor_podcast: string | undefined;
 		anchor_episode: string | undefined;
-		spotify_show_url: string | undefined;
+		spotify_url: string | undefined;
 	};
 	siteAdminUrl: T.URL | null;
 	fseParentPageId: T.PostId;

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -199,8 +199,8 @@ function getPressThisData( query ) {
 }
 
 function getAnchorFmData( query ) {
-	const { anchor_podcast, anchor_episode, spotify_show_url } = query;
-	return { anchor_podcast, anchor_episode, spotify_show_url };
+	const { anchor_podcast, anchor_episode, spotify_url } = query;
+	return { anchor_podcast, anchor_episode, spotify_url };
 }
 
 export const post = ( context, next ) => {

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -174,7 +174,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 		const queryParts = {
 			anchor_podcast: anchorFmPodcastId,
 			anchor_episode: anchorFmEpisodeId,
-			spotify_show_url: anchorFmSpotifyShowUrl,
+			spotify_url: anchorFmSpotifyShowUrl,
 		};
 		for ( const [ k, v ] of Object.entries( queryParts ) ) {
 			if ( v ) {

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -50,7 +50,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 	const makePath = usePath();
 	const currentStep = useCurrentStep();
 	const isMobile = useViewportMatch( 'small', '<' );
-	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyShowUrl } = useAnchorFmParams();
+	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyUrl } = useAnchorFmParams();
 	const isAnchorFmSignup = useIsAnchorFm();
 
 	const closeModal = () => {
@@ -174,7 +174,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 		const queryParts = {
 			anchor_podcast: anchorFmPodcastId,
 			anchor_episode: anchorFmEpisodeId,
-			spotify_url: anchorFmSpotifyShowUrl,
+			spotify_url: anchorFmSpotifyUrl,
 		};
 		for ( const [ k, v ] of Object.entries( queryParts ) ) {
 			if ( v ) {

--- a/client/landing/gutenboarding/hooks/use-on-login.ts
+++ b/client/landing/gutenboarding/hooks/use-on-login.ts
@@ -44,7 +44,7 @@ export default function useOnLogin(): void {
 				visibility,
 				anchorFmPodcastId: null,
 				anchorFmEpisodeId: null,
-				anchorFmSpotifyShowUrl: null,
+				anchorFmSpotifyUrl: null,
 			} );
 		}
 	}, [

--- a/client/landing/gutenboarding/hooks/use-on-signup.ts
+++ b/client/landing/gutenboarding/hooks/use-on-signup.ts
@@ -26,7 +26,7 @@ export default function useOnSignup() {
 	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
 	const visibility = useNewSiteVisibility();
 	const isAnchorFmSignup = useIsAnchorFm();
-	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyShowUrl } = useAnchorFmParams();
+	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyUrl } = useAnchorFmParams();
 
 	const handleCreateSite = React.useCallback(
 		( username: string, isPublicSite: number, bearerToken?: string ) => {
@@ -37,7 +37,7 @@ export default function useOnSignup() {
 				visibility: isPublicSite,
 				anchorFmPodcastId,
 				anchorFmEpisodeId,
-				anchorFmSpotifyShowUrl,
+				anchorFmSpotifyUrl,
 			} );
 		},
 		[ createSite, locale, anchorFmPodcastId, anchorFmEpisodeId ]

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -74,7 +74,7 @@ export default function useOnSiteCreation(): void {
 
 	const isAnchorFmSignup = useIsAnchorFm();
 	const flow = useOnboardingFlow();
-	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyShowUrl } = useAnchorFmParams();
+	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyUrl } = useAnchorFmParams();
 
 	const { resetOnboardStore, setIsRedirecting, setSelectedSite } = useDispatch( ONBOARD_STORE );
 	const flowCompleteTrackingParams = {
@@ -148,7 +148,7 @@ export default function useOnSiteCreation(): void {
 				const params = {
 					anchor_podcast: anchorFmPodcastId,
 					anchor_episode: anchorFmEpisodeId,
-					spotify_url: anchorFmSpotifyShowUrl,
+					spotify_url: anchorFmSpotifyUrl,
 				};
 				const queryString = Object.keys( params )
 					.filter( ( key ) => params[ key as keyof typeof params ] != null )
@@ -175,6 +175,6 @@ export default function useOnSiteCreation(): void {
 		isAnchorFmSignup,
 		anchorFmPodcastId,
 		anchorFmEpisodeId,
-		anchorFmSpotifyShowUrl,
+		anchorFmSpotifyUrl,
 	] );
 }

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -148,7 +148,7 @@ export default function useOnSiteCreation(): void {
 				const params = {
 					anchor_podcast: anchorFmPodcastId,
 					anchor_episode: anchorFmEpisodeId,
-					spotify_show_url: anchorFmSpotifyShowUrl,
+					spotify_url: anchorFmSpotifyShowUrl,
 				};
 				const queryString = Object.keys( params )
 					.filter( ( key ) => params[ key as keyof typeof params ] != null )

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -35,7 +35,7 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	// @TODO: move site creation to a separate hook or an action on the ONBOARD store
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );
-	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyShowUrl } = useAnchorFmParams();
+	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyUrl } = useAnchorFmParams();
 
 	const { createSite } = useDispatch( ONBOARD_STORE );
 	const newSiteVisibility = useNewSiteVisibility();
@@ -49,7 +49,7 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 				visibility: newSiteVisibility,
 				anchorFmPodcastId,
 				anchorFmEpisodeId,
-				anchorFmSpotifyShowUrl,
+				anchorFmSpotifyUrl,
 			} );
 		}
 		// Adding a newUser check works for Anchor.fm flow.  Without it, we ask for login twice.
@@ -61,7 +61,7 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 				visibility: newSiteVisibility,
 				anchorFmPodcastId,
 				anchorFmEpisodeId,
-				anchorFmSpotifyShowUrl,
+				anchorFmSpotifyUrl,
 			} );
 		}
 		return onSignupDialogOpen();
@@ -86,8 +86,8 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	if ( anchorFmEpisodeId ) {
 		locationState.anchorFmEpisodeId = anchorFmEpisodeId;
 	}
-	if ( anchorFmSpotifyShowUrl ) {
-		locationState.anchorFmSpotifyShowUrl = anchorFmSpotifyShowUrl;
+	if ( anchorFmSpotifyUrl ) {
+		locationState.anchorFmSpotifyUrl = anchorFmSpotifyUrl;
 	}
 
 	const handleBack = () => history.push( previousStepPath, locationState );

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -152,7 +152,7 @@ export function useAnchorFmParams(): AnchorFmParams {
 	const sanitizeShowUrl = ( id: string ) =>
 		id.replace( /[^A-Za-z0-9_.\-~%!*'();:@&=+$,/?#[\]]/g, '' );
 	const anchorFmSpotifyShowUrl = useAnchorParameter( {
-		queryParamName: 'spotify_show_url',
+		queryParamName: 'spotify_url',
 		locationStateParamName: 'anchorFmSpotifyShowUrl',
 		sanitize: sanitizeShowUrl,
 	} );

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -53,7 +53,7 @@ export type StepNameType = keyof typeof Step;
 export interface GutenLocationStateType {
 	anchorFmPodcastId?: string;
 	anchorFmEpisodeId?: string;
-	anchorFmSpotifyShowUrl?: string;
+	anchorFmSpotifyUrl?: string;
 }
 export type GutenLocationStateKeyType = keyof GutenLocationStateType;
 
@@ -126,7 +126,7 @@ export function useOnboardingFlow(): string {
 export interface AnchorFmParams {
 	anchorFmPodcastId: string | null;
 	anchorFmEpisodeId: string | null;
-	anchorFmSpotifyShowUrl: string | null;
+	anchorFmSpotifyUrl: string | null;
 }
 export function useAnchorFmParams(): AnchorFmParams {
 	const sanitizePodcast = ( id: string ) => id.replace( /[^a-zA-Z0-9]/g, '' );
@@ -151,16 +151,16 @@ export function useAnchorFmParams(): AnchorFmParams {
 	// Unreserved: A-Za-z0-9_.~-    (possibly % as a part of percent-encoding)
 	const sanitizeShowUrl = ( id: string ) =>
 		id.replace( /[^A-Za-z0-9_.\-~%!*'();:@&=+$,/?#[\]]/g, '' );
-	const anchorFmSpotifyShowUrl = useAnchorParameter( {
+	const anchorFmSpotifyUrl = useAnchorParameter( {
 		queryParamName: 'spotify_url',
-		locationStateParamName: 'anchorFmSpotifyShowUrl',
+		locationStateParamName: 'anchorFmSpotifyUrl',
 		sanitize: sanitizeShowUrl,
 	} );
 
 	return {
 		anchorFmPodcastId,
 		anchorFmEpisodeId,
-		anchorFmSpotifyShowUrl,
+		anchorFmSpotifyUrl,
 	};
 }
 

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -41,7 +41,7 @@ export interface CreateSiteActionParameters {
 	visibility: number;
 	anchorFmPodcastId: string | null;
 	anchorFmEpisodeId: string | null;
-	anchorFmSpotifyShowUrl: string | null;
+	anchorFmSpotifyUrl: string | null;
 }
 
 export function* createSite( {
@@ -51,7 +51,7 @@ export function* createSite( {
 	visibility = Site.Visibility.PublicNotIndexed,
 	anchorFmPodcastId = null,
 	anchorFmEpisodeId = null,
-	anchorFmSpotifyShowUrl = null,
+	anchorFmSpotifyUrl = null,
 }: CreateSiteActionParameters ) {
 	const {
 		domain,
@@ -102,8 +102,8 @@ export function* createSite( {
 			...( anchorFmEpisodeId && {
 				anchor_fm_episode_id: anchorFmEpisodeId,
 			} ),
-			...( anchorFmSpotifyShowUrl && {
-				anchor_fm_spotify_url: anchorFmSpotifyShowUrl,
+			...( anchorFmSpotifyUrl && {
+				anchor_fm_spotify_url: anchorFmSpotifyUrl,
 			} ),
 		},
 		...( bearerToken && { authToken: bearerToken } ),

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -103,7 +103,7 @@ export function* createSite( {
 				anchor_fm_episode_id: anchorFmEpisodeId,
 			} ),
 			...( anchorFmSpotifyShowUrl && {
-				anchor_fm_spotify_show_url: anchorFmSpotifyShowUrl,
+				anchor_fm_spotify_url: anchorFmSpotifyShowUrl,
 			} ),
 		},
 		...( bearerToken && { authToken: bearerToken } ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rename variables:
  * `spotify_show_url` -> `spotify_url`
  * `SpotifyShowUrl` -> `SpotifyUrl`

#### Testing instructions

* Apply D55959-code
* Go through a regular anchor gutenboarding process
  * Visit, http://calypso.localhost:3000/new?&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q , create a new site, land in editor with anchor info added.

Fixes # 427-gh-Automattic/dotcom-manage