### PR TITLE
Adds alternative styles to OAuth login screen for Jetpack Cloud

### DIFF
--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import store from 'store';
 import debugFactory from 'debug';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -22,6 +23,7 @@ import LostPassword from './lost-password';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import SelfHostedInstructions from './self-hosted-instructions';
+import JetpackLogo from 'calypso/components/jetpack-logo';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -133,10 +135,15 @@ export class Auth extends Component {
 		const { translate } = this.props;
 		const { requires2fa, inProgress, errorMessage, errorLevel, showInstructions } = this.state;
 
+		const bodyClasses = classNames( {
+			auth: true,
+			'is-jetpack-cloud': isJetpackCloud(),
+		} );
+
 		return (
-			<Main className="auth">
+			<Main className={ bodyClasses }>
 				<div className="auth__content">
-					<WordPressLogo />
+					{ isJetpackCloud() ? <JetpackLogo size={ 72 } /> : <WordPressLogo /> }
 					<form className="auth__form" onSubmit={ this.submitForm }>
 						<FormFieldset>
 							<div className="auth__input-wrapper">
@@ -208,7 +215,9 @@ export class Auth extends Component {
 						<button onClick={ this.toggleSelfHostedInstructions }>
 							{ translate( 'Add self-hosted site' ) }
 						</button>
-						<a href={ config( 'signup_url' ) }>{ translate( 'Create account' ) }</a>
+						{ config( 'signup_url' ) && (
+							<a href={ config( 'signup_url' ) }>{ translate( 'Create account' ) }</a>
+						) }
 					</div>
 					{ showInstructions && (
 						<SelfHostedInstructions onClickClose={ this.toggleSelfHostedInstructions } />

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import store from 'store';
 import debugFactory from 'debug';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -135,13 +134,8 @@ export class Auth extends Component {
 		const { translate } = this.props;
 		const { requires2fa, inProgress, errorMessage, errorLevel, showInstructions } = this.state;
 
-		const bodyClasses = classNames( {
-			auth: true,
-			'is-jetpack-cloud': isJetpackCloud(),
-		} );
-
 		return (
-			<Main className={ bodyClasses }>
+			<Main className="auth">
 				<div className="auth__content">
 					{ isJetpackCloud() ? <JetpackLogo size={ 72 } /> : <WordPressLogo /> }
 					<form className="auth__form" onSubmit={ this.submitForm }>

--- a/client/auth/style.scss
+++ b/client/auth/style.scss
@@ -36,6 +36,10 @@
 	justify-content: center;
 	align-content: center;
 	max-width: 100%;
+
+	&.is-jetpack-cloud {
+		background: var( --color-surface-backdrop );
+	}
 }
 
 .auth__content {
@@ -136,6 +140,15 @@
 
 .auth__lost-password a {
 	color: var( --color-neutral-10 );
+
+	.is-jetpack-cloud & {
+		color: var( --color-neutral-50 );
+
+		&:hover,
+		&:active {
+			color: var( --color-accent );
+		}
+	}
 }
 
 .auth__help,
@@ -168,10 +181,21 @@
 	}
 }
 
+.is-jetpack-cloud .auth__links {
+	a, button {
+		color: var( --color-neutral-50 );
+
+		&:hover,
+		&:focus {
+			color: var( --color-accent );
+		}
+	}
+}
+
 .auth__self-hosted-instructions {
 	color: #fff;
 	background: var( --color-primary-dark );
-	border-radius: 8px;
+	border-radius: ( 2px * 4 );
 	padding: 40px;
 	position: absolute;
 	z-index: z-index( 'root', '.auth__self-hosted-instructions' );

--- a/client/auth/style.scss
+++ b/client/auth/style.scss
@@ -37,7 +37,8 @@
 	align-content: center;
 	max-width: 100%;
 
-	&.is-jetpack-cloud {
+	.theme-jetpack-cloud & {
+		// Use a plain background color for Jetpack.com logins.
 		background: var( --color-surface-backdrop );
 	}
 }
@@ -46,9 +47,17 @@
 	margin: 0 auto;
 	text-align: center;
 
+	.jetpack-logo {
+		margin-bottom: 20px;
+	}
+
 	.notice {
 		width: calc( 100% - 20px );
 		margin: 20px auto 0;
+	}
+
+	.theme-jetpack-cloud & .notice {
+		width: 100%;
 	}
 
 	.notice.is-info {
@@ -92,6 +101,10 @@
 		float: none;
 		margin: 0;
 		width: calc( 100% - 20px );
+
+		.theme-jetpack-cloud & {
+			width: 100%;
+		}
 	}
 
 	.form-buttons-bar .button.is-primary[disabled],
@@ -141,7 +154,7 @@
 .auth__lost-password a {
 	color: var( --color-neutral-10 );
 
-	.is-jetpack-cloud & {
+	.theme-jetpack-cloud & {
 		color: var( --color-neutral-50 );
 
 		&:hover,
@@ -181,7 +194,7 @@
 	}
 }
 
-.is-jetpack-cloud .auth__links {
+.theme-jetpack-cloud .auth__links {
 	a, button {
 		color: var( --color-neutral-50 );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Styles OAuth login page to mimic look of Jetpack Cloud login.
* Changes it so if create account URL is not set, don't show a button.

#### Screenshots

<img width="300" alt="Screen Shot 2021-01-27 at 11 50 52 AM" src="https://user-images.githubusercontent.com/1760168/106024777-1c3c3200-6096-11eb-8a09-a7282799a69b.png">
<img width="300" alt="Screen Shot 2021-01-27 at 11 51 25 AM" src="https://user-images.githubusercontent.com/1760168/106024775-1c3c3200-6096-11eb-8aa4-cf7410679988.png">
<img width="300" alt="Screen Shot 2021-01-27 at 11 51 34 AM" src="https://user-images.githubusercontent.com/1760168/106024772-1ba39b80-6096-11eb-9cfc-ac1e1bbfe487.png">
<img width="300" alt="Screen Shot 2021-01-26 at 3 00 20 PM" src="https://user-images.githubusercontent.com/1760168/105898566-982b7100-5fe7-11eb-8c43-55aac87b7155.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See #49138 for how to set up this PR. This is primarily visual.
* Verify styles are as expected.

Fixes 1143508703416848-as-1199670278480655.