### PR TITLE
Checkout: Remove absolute position on CheckoutSummaryHelpButton/PaymentChatButton

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/payment-chat-button.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-chat-button.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
+import styled from '@emotion/styled';
 
 /**
  * Internal dependencies
@@ -12,6 +13,10 @@ import Gridicon from 'calypso/components/gridicon';
 import HappychatButton from 'calypso/components/happychat/button';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSupportLevel from 'calypso/state/selectors/get-support-level';
+
+const PaymentChatButtonText = styled.span`
+	padding-left: 4px;
+`;
 
 export default function PaymentChatButton( { plan }: { plan: string | undefined } ): JSX.Element {
 	const reduxDispatch = useDispatch();
@@ -30,7 +35,7 @@ export default function PaymentChatButton( { plan }: { plan: string | undefined 
 	return (
 		<HappychatButton className="payment-chat-button" onClick={ chatButtonClicked }>
 			<Gridicon icon="chat" className="payment-chat-button__icon" />
-			{ translate( 'Need help? Chat with us' ) }
+			<PaymentChatButtonText>{ translate( 'Need help? Chat with us' ) }</PaymentChatButtonText>
 		</HappychatButton>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -425,7 +425,6 @@ const CheckoutSummaryFeaturesListWrapper = styled.ul`
 `;
 
 const CheckoutSummaryHelpButton = styled.button`
-	margin-top: 16px;
 	text-align: left;
 
 	.rtl & {
@@ -444,16 +443,7 @@ const CheckoutSummaryHelpButton = styled.button`
 `;
 
 const CheckoutSummaryHelpWrapper = styled.div`
-	position: absolute;
-
-	@media screen and ( max-width: 960px ) {
-		position: static;
-		padding: 0 20px 20px;
-
-		> button {
-			margin-top: 0;
-		}
-	}
+	padding: 0 20px 20px;
 `;
 
 const WPCheckoutCheckIcon = styled( CheckoutCheckIcon )`

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -395,21 +395,6 @@ const CheckoutSummaryFeatures = styled.div`
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		padding: 20px;
 	}
-
-	.payment-chat-button.is-borderless {
-		color: ${ ( props ) => props.theme.colors.textColor };
-		padding: 0;
-
-		svg {
-			margin-right: 4px;
-			width: 20px;
-
-			.rtl & {
-				margin-right: 0;
-				margin-left: 4px;
-			}
-		}
-	}
 `;
 
 const CheckoutSummaryFeaturesTitle = styled.h3`


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes the position of the `CheckoutSummaryHelpButton` and `PaymentChatButton` in the checkout sidebar so that other nearby elements do not overlap it. It does this by removing the absolute position on the parent of these elements. 

The visual effect of this change is of moving the buttons inside the top sidebar block. This may not be the ideal place for the buttons, but it's much better than the buttons being overlapped by other elements. In the future, we could move the buttons outside of the box instead of trying to position them outside the box, but this should at least make things behave sensibly until then.

Before, with `CheckoutSummaryHelpButton`:

<img width="343" alt="Screen Shot 2021-01-26 at 6 00 38 PM" src="https://user-images.githubusercontent.com/2036909/105917539-6f63a580-6000-11eb-8f5a-5c4b5c08ceb0.png">

After, with  `CheckoutSummaryHelpButton`:

<img width="343" alt="Screen Shot 2021-01-26 at 5 56 25 PM" src="https://user-images.githubusercontent.com/2036909/105917436-4cd18c80-6000-11eb-9176-8b1a1b03b6d8.png">

Before, with `PaymentChatButton`:

<img width="345" alt="Screen Shot 2021-01-26 at 6 47 29 PM" src="https://user-images.githubusercontent.com/2036909/105921570-f9af0800-6006-11eb-99fd-4b9fb88ed130.png">

After, with `PaymentChatButton`:

<img width="342" alt="Screen Shot 2021-01-26 at 6 38 14 PM" src="https://user-images.githubusercontent.com/2036909/105920622-b56f3800-6005-11eb-902b-44a5c9cd67d4.png">

Fixes https://github.com/Automattic/wp-calypso/issues/49150

#### Testing instructions

First test the `CheckoutSummaryHelpButton`:

- Start with a site that does not have a plan.
- Add a custom domain to your cart and visit checkout.
- Verify that the "Questions? Ask a Happiness Engineer" link on the sidebar at wide (desktop) width is clearly visible.
- Verify that the link is still clearly visible at small (mobile) width.

Testing the `PaymentChatButton` is a little more difficult. You must force `PaymentChatButton` to be displayed. You can do this by applying the following patch:

<details>

```
diff --git a/client/components/happychat/button.jsx b/client/components/happychat/button.jsx
index 3023283bec..98eb527d0d 100644
--- a/client/components/happychat/button.jsx
+++ b/client/components/happychat/button.jsx
@@ -107,7 +107,7 @@ export default connect(
 	( state ) => ( {
 		hasUnread: hasUnreadMessages( state ),
 		getAuth: getHappychatAuth( state ),
-		isChatAvailable: isHappychatAvailable( state ),
+		isChatAvailable: true,
 		isChatActive: hasActiveHappychatSession( state ),
 		isConnectionUninitialized: isHappychatConnectionUninitialized( state ),
 	} ),
diff --git a/client/jetpack-connect/happychat-button.jsx b/client/jetpack-connect/happychat-button.jsx
index 1cbfd8bbb3..2e859b0dd1 100644
--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -61,7 +61,7 @@ JetpackConnectHappychatButton.propTypes = {
 };
 
 export default connect( ( state ) => ( {
-	isChatAvailable: isHappychatAvailable( state ),
+	isChatAvailable: true,
 	isChatActive: hasActiveHappychatSession( state ),
 	isLoggedIn: Boolean( getCurrentUserId( state ) ),
 } ) )( localize( JetpackConnectHappychatButton ) );
diff --git a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
index 11c97b85fd..63f6e93050 100644
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -322,10 +322,7 @@ export function CheckoutSummaryHelp() {
 	const supportVariationDetermined = useSelector( isSupportVariationDetermined );
 	const supportVariation = useSelector( getSupportVariation );
 
-	const happyChatAvailable = useSelector( isHappychatAvailable );
-	const presalesChatAvailable = useSelector( isPresalesChatAvailable );
 	const presalesEligiblePlanLabel = getHighestWpComPlanLabel( plans );
-	const isPresalesChatEligible = presalesChatAvailable && presalesEligiblePlanLabel;
 
 	const onEvent = useEvents();
 	const handleHelpButtonClicked = () => {
@@ -334,8 +331,7 @@ export function CheckoutSummaryHelp() {
 	};
 
 	// If chat is available and the cart has a pre-sales plan or is already eligible for chat.
-	const shouldRenderPaymentChatButton =
-		happyChatAvailable && ( isPresalesChatEligible || supportVariation === SUPPORT_HAPPYCHAT );
+	const shouldRenderPaymentChatButton = true;
 
 	const hasDirectSupport =
 		supportVariation !== SUPPORT_DIRECTLY && supportVariation !== SUPPORT_FORUM;
```

</details>

- Repeat the above steps after forcing the `PaymentChatButton` to be displayed.