### PR TITLE
Show the activity log for all purchased jetpack plans

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -42,7 +42,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import SuccessBanner from '../activity-log-banner/success-banner';
 import RewindUnavailabilityNotice from './rewind-unavailability-notice';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { siteHasBackupProductPurchase } from 'calypso/state/purchases/selectors';
+import { siteHasJetpackProductPurchase } from 'calypso/state/purchases/selectors';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug, getSiteTitle, isJetpackSite } from 'calypso/state/sites/selectors';
 import {
@@ -565,7 +565,7 @@ export default connect(
 		const siteIsOnFreePlan =
 			isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) ) &&
 			! isVipSite( state, siteId );
-		const siteHasNoLog = siteIsOnFreePlan && ! siteHasBackupProductPurchase( state, siteId );
+		const siteHasNoLog = siteIsOnFreePlan && ! siteHasJetpackProductPurchase( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
 
 		return {

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -42,7 +42,10 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import SuccessBanner from '../activity-log-banner/success-banner';
 import RewindUnavailabilityNotice from './rewind-unavailability-notice';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { siteHasJetpackProductPurchase } from 'calypso/state/purchases/selectors';
+import {
+	siteHasBackupProductPurchase,
+	siteHasScanProductPurchase,
+} from 'calypso/state/purchases/selectors';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug, getSiteTitle, isJetpackSite } from 'calypso/state/sites/selectors';
 import {
@@ -565,7 +568,10 @@ export default connect(
 		const siteIsOnFreePlan =
 			isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) ) &&
 			! isVipSite( state, siteId );
-		const siteHasNoLog = siteIsOnFreePlan && ! siteHasJetpackProductPurchase( state, siteId );
+		const siteHasNoLog =
+			siteIsOnFreePlan &&
+			! siteHasBackupProductPurchase( state, siteId ) &&
+			! siteHasScanProductPurchase( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
 
 		return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the Activity Log for Scan add-ons to include the same level of access that we give to the Backup add-on. Discussion can be found [here](https://wp.me/pbuNQi-Pp).

#### Testing instructions

* Use a test site with a **paid scan plan**
* Run Calypso from wordpress.com
* Navigate to the Activity Log for the test site - notice the lack of filter options and the prompt to upgrade
* Switch to this branch and run Calypso locally ( or from the Test Live )
* Navigate to the Activity Log for the test site - notice the filter options now available and the lack of prompt for upgrade
* Switch to a test site with **no paid plans**
* Navigate to the Activity Log for the test site - notice the lack of filter options and the prompt to upgrade
