### PR TITLE
Editor: Hide plugin buttons in header on mobile layouts

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/hide-plugin-buttons-mobile.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/hide-plugin-buttons-mobile.js
@@ -1,0 +1,5 @@
+/**
+ * Internal dependencies
+ */
+
+import './hide-plugin-buttons-mobile.scss';

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/hide-plugin-buttons-mobile.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/hide-plugin-buttons-mobile.scss
@@ -1,0 +1,9 @@
+@import '~@wordpress/base-styles/mixins';
+@import '~@wordpress/base-styles/variables';
+@import '~@wordpress/base-styles/breakpoints';
+
+.interface-pinned-items > button:not( :first-child ) {
+	@media ( max-width: $break-medium ) {
+		display: none;
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
@@ -177,3 +177,24 @@ function get_iso_639_locale( $language ) {
 
 	return $language;
 }
+
+/**
+ * Hides plugin buttons that appear in the header on mobile devices
+ * (because there's not enough room).
+ *
+ * Can be disabled with the `a8c_fse_enqueue_hide_plugin_buttons_mobile_style` filter.
+ */
+function enqueue_hide_plugin_buttons_mobile_style() {
+	if ( apply_filters( 'a8c_fse_enqueue_hide_plugin_buttons_mobile_style', true ) ) {
+		$style_file = is_rtl()
+			? 'hide-plugin-buttons-mobile.rtl.css'
+			: 'hide-plugin-buttons-mobile.css';
+		wp_enqueue_style(
+			'a8c-fse-hide-plugin-buttons-mobile',
+			plugins_url( 'dist/' . $style_file, __FILE__ ),
+			array(),
+			filemtime( plugin_dir_path( __FILE__ ) . 'dist/' . $style_file )
+		);
+	}
+}
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_hide_plugin_buttons_mobile_style' );

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -22,7 +22,7 @@
 		"posts-list-block": "calypso-build --env source='posts-list-block'",
 		"dev:posts-list-block": "yarn run posts-list-block",
 		"build:posts-list-block": "NODE_ENV=production yarn run posts-list-block",
-		"common": "calypso-build --env source='common','common/data-stores'",
+		"common": "calypso-build --env source='common','common/data-stores','common/hide-plugin-buttons-mobile'",
 		"dev:common": "yarn run common",
 		"build:common": "NODE_ENV=production yarn run common",
 		"editor-gutenboarding-launch": "calypso-build --env source='editor-gutenboarding-launch'",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Tidy up the icons in the header on mobile viewport widths.
* Added a filter in case we want to disable this in a hurry.

This is a stripped down version of the original PR that also collapsed the publish/save/update buttons #49079

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch, sandbox a test site, and run `yarn dev --sync`
* Open a post or page in the block editor
* Shrink viewport down to mobile size and observe the plugin buttons disappear (they should still be available in the more menu)

Fixes #48337
