### PR TITLE
New Onboarding: Disable mshot design previews

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -75,7 +75,7 @@
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,
 		"gutenboarding/show-vertical-input": false,
-		"gutenboarding/mshot-preview": true,
+		"gutenboarding/mshot-preview": false,
 		"gutenboarding/landscape-preview": true,
 		"help": true,
 		"home/layout-dev": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -47,7 +47,7 @@
 		"gutenboarding/language-picker": true,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,
-		"gutenboarding/mshot-preview": true,
+		"gutenboarding/mshot-preview": false,
 		"gutenboarding/landscape-preview": true,
 		"happychat": false,
 		"help": true,

--- a/config/production.json
+++ b/config/production.json
@@ -44,7 +44,7 @@
 		"google-my-business": true,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,
-		"gutenboarding/mshot-preview": true,
+		"gutenboarding/mshot-preview": false,
 		"gutenboarding/landscape-preview": true,
 		"happychat": true,
 		"help": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -45,7 +45,7 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": false,
 		"google-my-business": true,
-		"gutenboarding/mshot-preview": true,
+		"gutenboarding/mshot-preview": false,
 		"gutenboarding/landscape-preview": true,
 		"gutenboarding/language-picker": false,
 		"gutenboarding/feature-picker": true,

--- a/config/test.json
+++ b/config/test.json
@@ -44,7 +44,7 @@
 		"google-my-business": false,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,
-		"gutenboarding/mshot-preview": true,
+		"gutenboarding/mshot-preview": false,
 		"gutenboarding/landscape-preview": true,
 		"help": true,
 		"inline-help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -52,7 +52,7 @@
 		"gdpr-banner": true,
 		"google-my-business": true,
 		"google-workspace-migration": true,
-		"gutenboarding/mshot-preview": true,
+		"gutenboarding/mshot-preview": false,
 		"gutenboarding/landscape-preview": true,
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/language-picker": false,


### PR DESCRIPTION
PR just in case we need to disable mShots.

#### Changes proposed in this Pull Request

* Turns off mshot design previews enabled in #49170, this reverts previews
back to calypso hosted screenshots.

#### Testing instructions

* Check signup no longer displays mshot images (check network tab) http://calypso.localhost:3000/new/design
* Check localized signup no longer displays translated design preview content and instead reverts to the original english only screenshots http://calypso.localhost:3000/new/design/ja
