### PR TITLE
Disable ExtractManifestPlugin in development

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -392,7 +392,7 @@ const webpackConfig = {
 		 */
 		new ExtensiveLodashReplacementPlugin(),
 
-		! isDesktop && new ExtractManifestPlugin(),
+		! isDesktop && ! isDevelopment && new ExtractManifestPlugin(),
 	].filter( Boolean ),
 	externals: [ 'keytar' ],
 };


### PR DESCRIPTION
The `ExtractManifestPlugin` is not compatible with `webpack-hot-middleware` and probably with webpack dev mode in general.

The extracted manifest in dev mode with HMR looks like this:

<img width="439" alt="Screenshot 2021-01-27 at 9 44 01" src="https://user-images.githubusercontent.com/664258/105968022-d75ccf00-6086-11eb-8bfa-0361ebdff9cd.png">

And because `__webpack_require__` is not in scope in this file (it would be in the original location before extracting), Calypso in dev mode fails with exception after HMR downloads the new manifest.