### PR TITLE
Inline extracted manifest

### DIFF
--- a/build-tools/webpack/extract-manifest-plugin.js
+++ b/build-tools/webpack/extract-manifest-plugin.js
@@ -15,11 +15,7 @@ class ExtractManifestModule extends webpack.RuntimeModule {
 
 		return `${ namespace }.__extracted_manifest = ${ runtimeTemplate.basicFunction(
 			'',
-			template.indent( [
-				'const manifest=new Map();',
-				...this.manifestContent,
-				'return manifest;',
-			] )
+			template.indent( [ 'var manifest=new Map();', ...this.manifestContent, 'return manifest;' ] )
 		) }`;
 	}
 }

--- a/build-tools/webpack/extract-manifest-plugin.js
+++ b/build-tools/webpack/extract-manifest-plugin.js
@@ -21,8 +21,6 @@ class ExtractManifestModule extends webpack.RuntimeModule {
 }
 
 class ExtractManifestPlugin {
-	constructor() {}
-
 	apply( compiler ) {
 		// Tapping into compiler.make allow us to come after the regular TemplatedPathPlugin
 		compiler.hooks.compilation.tap( PLUGIN_NAME, ( compilation ) => {

--- a/build-tools/webpack/extract-manifest-plugin.js
+++ b/build-tools/webpack/extract-manifest-plugin.js
@@ -1,24 +1,40 @@
 const PLUGIN_NAME = 'ExtractManifestPlugin';
-const { ConcatSource } = require( 'webpack' ).sources;
+const webpack = require( 'webpack' );
+
+class ExtractManifestModule extends webpack.RuntimeModule {
+	constructor( manifestContent = [] ) {
+		super( 'extract manifest' );
+		this.manifestContent = manifestContent;
+	}
+
+	generate() {
+		const { compilation } = this;
+		const { runtimeTemplate } = compilation;
+		const namespace = webpack.RuntimeGlobals.require;
+		const template = webpack.Template;
+
+		return `${ namespace }.__extracted_manifest = ${ runtimeTemplate.basicFunction(
+			'',
+			template.indent( [
+				'const manifest=new Map();',
+				...this.manifestContent,
+				'return manifest;',
+			] )
+		) }`;
+	}
+}
 
 class ExtractManifestPlugin {
-	constructor( options = {} ) {
-		this.options = {
-			manifestName: 'manifest',
-			runtimeChunk: 'runtime',
-			globalManifest: 'window.__WEBPACK_MANIFEST',
-			...options,
-		};
-	}
+	constructor() {}
 
 	apply( compiler ) {
 		// Tapping into compiler.make allow us to come after the regular TemplatedPathPlugin
 		compiler.hooks.compilation.tap( PLUGIN_NAME, ( compilation ) => {
-			const globalManifest = this.options.globalManifest;
-			const manifestContent = [ `${ globalManifest }=new Map();` ];
+			const manifestContent = [];
 			const quoteRegex = new RegExp( /^(['"])/ );
 			const variableRegex = new RegExp( /\[(.*?)\]/gi );
 			const variablesProcessed = new Set();
+			const namespace = webpack.RuntimeGlobals.require;
 
 			// This method is called on different ocasions to generate the name of an asset. Sometimes the result of this method
 			// will be used as the actual filename of the asset, but sometimes it will used as a JS expression to compute the
@@ -92,12 +108,12 @@ class ExtractManifestPlugin {
 						// `nameExpression` is an expression that assumes `chunkId` exists in the scope (like `({1:'chunk1', 2:'chunk2'}[chunkId])`).
 						// Transform it to a function and add it to the manifest.
 						manifestContent.push(
-							`${ globalManifest }.set('${ variable }', function(chunkId){return ${ nameExpression };});`
+							`manifest.set('${ variable }', function(chunkId){return ${ nameExpression };});`
 						);
 						variablesProcessed.add( variable );
 					}
 					// Create an expression that calls the generated manifest function with the chunkId
-					return `${ quote }+${ globalManifest }.get('${ variable }')(chunkId)+${ quote }`;
+					return `${ quote }+${ namespace }.__extracted_manifest().get('${ variable }')(chunkId)+${ quote }`;
 				} );
 			} );
 
@@ -105,29 +121,35 @@ class ExtractManifestPlugin {
 			// template and hash for both files (eg: it will generate `runtime.<hash>.js` and `manifest.<hash>.js` and both <hash> will be the same).
 			//
 			// The logic has been copied from webpack/lib/javascript/JavascriptModulesPlugin.js
-			compilation.hooks.renderManifest.tap( PLUGIN_NAME, ( result, options ) => {
-				const { chunk, outputOptions } = options;
+			// compilation.hooks.renderManifest.tap( PLUGIN_NAME, ( result, options ) => {
+			// 	const { chunk, outputOptions } = options;
 
-				if ( chunk.name === this.options.runtimeChunk ) {
-					// Using unshift so the manifest comes before the runtime, so when the runtime runs, all globals are already in place.
-					result.unshift( {
-						render: () => new ConcatSource( ...manifestContent ),
-						filenameTemplate: chunk.filenameTemplate || outputOptions.filename,
-						pathOptions: {
-							hash: options.hash,
-							runtime: chunk.runtime,
-							contentHashType: 'javascript',
-							chunk: {
-								...chunk,
-								name: this.options.manifestName,
-							},
-						},
-						identifier: `chunk${ chunk.id }-manifest`,
-						hash: chunk.contentHash.javascript,
-					} );
-				}
-				return result;
-			} );
+			// 	if ( chunk.name === this.options.runtimeChunk ) {
+			// 		// Using unshift so the manifest comes before the runtime, so when the runtime runs, all globals are already in place.
+			// 		result.unshift( {
+			// 			render: () => new ConcatSource( ...manifestContent ),
+			// 			filenameTemplate: chunk.filenameTemplate || outputOptions.filename,
+			// 			pathOptions: {
+			// 				hash: options.hash,
+			// 				runtime: chunk.runtime,
+			// 				contentHashType: 'javascript',
+			// 				chunk: {
+			// 					...chunk,
+			// 					name: this.options.manifestName,
+			// 				},
+			// 			},
+			// 			identifier: `chunk${ chunk.id }-manifest`,
+			// 			hash: chunk.contentHash.javascript,
+			// 		} );
+			// 	}
+			// 	return result;
+			// } );
+
+			compilation.hooks.runtimeRequirementInTree
+				.for( webpack.RuntimeGlobals.ensureChunkHandlers )
+				.tap( PLUGIN_NAME, ( chunk ) => {
+					compilation.addRuntimeModule( chunk, new ExtractManifestModule( manifestContent ) );
+				} );
 		} );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

Instead of rendering the manifest in separate file, it inlines it in the runtime file. This allows the variable replacement functions to have access to `__webpack_require__` (see #49333 for more info).

This joins the existing `manifest` and `runtime` into one single file again. However, because it adds a new level of indirection it still solves the original issue (#42979) : the manifest is not duplicated by mini-css plugin.

Note that we didn't see any benefit in RUM data when we extracted the manifest to a separate file anyway.

### How it works:

It generate a function like:

```
/******/ 	/* webpack/runtime/extract manifest */
/******/ 	(() => {
/******/ 		__webpack_require__.__extracted_manifest = () => {
/******/ 				var manifest=new Map();
/******/ 				manifest.set('name', function(chunkId){return "" + ({"65":"moment-locale-fy", /*...*/})
/******/ 				manifest.set('chunkhash', function(chunkId){return "" + ({"65":"708829d14d55f070bcd4", /*...*/})
/******/				return maifest;
******/ 		}
/******/ 	})();
```

This function is "inside" the webpack runtime and therefore any of the replacements has access to `__webpack_require__`. Then the function to compute the name of an asset (either JS or CSS) is:

```
/******/ 	/* webpack/runtime/get javascript chunk filename */
/******/ 	(() => {
/******/ 		// This function allow to reference async chunks
/******/ 		__webpack_require__.u = (chunkId) => {
/******/ 			// return url for filenames based on template
/******/ 			return ""+__webpack_require__.__extracted_manifest().get('name')(chunkId)+"."+__webpack_require__.__extracted_manifest().get('chunkhash')(chunkId)+".min.js";
/******/ 		};
/******/ 	})();
/******/ 	
/******/ 	/* webpack/runtime/get mini-css chunk filename */
/******/ 	(() => {
/******/ 		// This function allow to reference all chunks
/******/ 		__webpack_require__.miniCssF = (chunkId) => {
/******/ 			// return url for filenames based on template
/******/ 			return ""+__webpack_require__.__extracted_manifest().get('name')(chunkId)+"."+__webpack_require__.__extracted_manifest().get('chunkhash')(chunkId)+".min.css";
/******/ 		};
/******/ 	})();
```




### Testing instructions

* Smoke test the live branch, including the `fallback` build.
