### PR TITLE
Add plugin to transform i18n imports to local variables

### DIFF
--- a/apps/editing-toolkit/webpack.config.js
+++ b/apps/editing-toolkit/webpack.config.js
@@ -70,6 +70,11 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 			path: outputPath,
 			filename: '[name].js', // dynamic filename
 		},
+		optimization: {
+			...webpackConfig.optimization,
+			// disable module concatenation so that instances of `__()` are not renamed
+			concatenateModules: false,
+		},
 		plugins: [
 			...webpackConfig.plugins.filter(
 				( plugin ) => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'

--- a/apps/wpcom-block-editor/webpack.config.js
+++ b/apps/wpcom-block-editor/webpack.config.js
@@ -55,6 +55,11 @@ function getWebpackConfig(
 	return {
 		...webpackConfig,
 		devtool: isDevelopment ? 'inline-cheap-source-map' : false,
+		optimization: {
+			...webpackConfig.optimization,
+			// disable module concatenation so that instances of `__()` are not renamed
+			concatenateModules: false,
+		},
 		plugins: [
 			...webpackConfig.plugins.filter(
 				( plugin ) => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'

--- a/packages/calypso-build/babel/babel-plugin-optimize-i18n.js
+++ b/packages/calypso-build/babel/babel-plugin-optimize-i18n.js
@@ -1,0 +1,58 @@
+const i18nImports = new Set( [ '__', '_n', '_nx', '_x' ] );
+
+module.exports = function ( babel ) {
+	const { types: t } = babel;
+
+	// Collects named imports from the "@wordpress/i18n" package
+	function collectAllImportsAndAliasThem( path ) {
+		const node = path.node;
+		const aliases = [];
+		if ( t.isStringLiteral( node.source ) && node.source.value === '@wordpress/i18n' ) {
+			const specifiers = path.get( 'specifiers' );
+
+			for ( const specifier of specifiers ) {
+				if ( t.isImportSpecifier( specifier ) ) {
+					const importedNode = specifier.node.imported;
+					const localNode = specifier.node.local;
+
+					if ( t.isIdentifier( importedNode ) && t.isIdentifier( localNode ) ) {
+						if ( i18nImports.has( importedNode.name ) ) {
+							aliases.push( {
+								original: localNode.name,
+								aliased: 'alias' + localNode.name,
+							} );
+							specifier.replaceWith(
+								t.importSpecifier(
+									t.identifier( 'alias' + localNode.name ),
+									t.identifier( importedNode.name )
+								)
+							);
+							path.scope.removeBinding( localNode.name );
+						}
+					}
+				}
+			}
+			path.scope.registerDeclaration( path );
+		}
+		return aliases;
+	}
+
+	return {
+		name: 'babel-plugin-optimize-i18n',
+		visitor: {
+			ImportDeclaration( path ) {
+				const aliases = collectAllImportsAndAliasThem( path );
+				if ( aliases.length > 0 ) {
+					const declarations = aliases.map( ( { original, aliased } ) =>
+						t.variableDeclarator( t.identifier( original ), t.identifier( aliased ) )
+					);
+					const aliasDeclarationNode = t.variableDeclaration( 'const', declarations );
+					path.insertAfter( aliasDeclarationNode );
+
+					const aliasDeclarationPath = path.getNextSibling();
+					path.scope.registerDeclaration( aliasDeclarationPath );
+				}
+			},
+		},
+	};
+};

--- a/packages/calypso-build/babel/default.js
+++ b/packages/calypso-build/babel/default.js
@@ -41,5 +41,6 @@ module.exports = ( api, opts ) => ( {
 				version: require( '@babel/helpers/package.json' ).version,
 			},
 		],
+		require.resolve( './babel-plugin-optimize-i18n' ),
 	],
 } );


### PR DESCRIPTION
Babel plugin that transforms this:
```js
import { __, _x } from '@wordpress/i18n';

__( 'Hello' );
_x( 'World' );
```
to this:
```js
import { __ as alias__, _x as alias_x } from '@wordpress/i18n';
const __ = alias__,
      _x = alias_x;

__('Hello');
_x('World');
```

Inspired by [babel-plugin-optimize-react](https://www.npmjs.com/package/babel-plugin-optimize-react) that does similar transforms for React imports.

The transform ensures that the `__('Hello')` syntax remains intact in the output bundle (and even after minification if Terser uses the `mangle.reserved` option and can be extracted by WP i18n tools.

I had to disable webpack module concatenation to preserve the `__` names. Because module concatenation will rename the `__` local variables if it's merging two modules that each define the variable.