### PR TITLE
Plugins: Fix getPlugins selector for plugins with updates

### DIFF
--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -35,7 +35,7 @@ const _filters = {
 	},
 	updates: function ( plugin ) {
 		return some( plugin.sites, function ( site ) {
-			return site.update;
+			return site.update && ! site.update.recentlyUpdated;
 		} );
 	},
 	isEqual: function ( pluginSlug, plugin ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the `getPlugins` selector for plugins with updates. Usually, the plugin's site `update` property holds data for plugins on sites that have newer versions, but there is an edge case where we hold the `recentlyUpdated` prop in there, for the instance when a plugin has just been updated. This edge case wasn't considered when retrieving the plugins with updates, and this PR fixes that.

#### Testing instructions

* Get a connected Jetpack site with one or several outdated plugins.
* Go to `/plugins/manage/:site`
* Click on `Update x plugin(s)` (top right)
* Verify the `Update plugin(s)` button disappears after plugins have been updated.

Fixes #49340
