### PR TITLE
Updates fallback data slug so that they are unique.

### DIFF
--- a/client/my-sites/sidebar-unified/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar-unified/static-data/fallback-menu.js
@@ -64,21 +64,21 @@ export default function buildFallbackResponse( {
 			children: [
 				{
 					parent: 'upgrades',
-					slug: 'upgrades',
+					slug: 'Plans',
 					title: translate( 'Plans' ),
 					type: 'submenu-item',
 					url: `/plans/${ siteDomain }`,
 				},
 				{
 					parent: 'upgrades',
-					slug: 'upgrades',
+					slug: 'Purchases',
 					title: translate( 'Purchases' ),
 					type: 'submenu-item',
 					url: `/purchases/subscriptions/${ siteDomain }`,
 				},
 				{
 					parent: 'upgrades',
-					slug: 'upgrades',
+					slug: 'Domains',
 					title: translate( 'Domains' ),
 					type: 'submenu-item',
 					url: `/domains/manage/${ siteDomain }`,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes duplicate keys in fallback data

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go here `/my-sites/sidebar-unified/use-site-menu-items.js:68` and change `return menuItems ?? buildFallbackResponse( fallbackDataOverides );` to `return buildFallbackResponse( fallbackDataOverides );` 

**Before**
*  There would be a console warning about "upgrades" duplicate keys

**After**
*  There shouldn't be a console warning about "upgrades" duplicate keys

Fixes #49196