### PR TITLE
Jetpack Search: update upsell links to go directly to checkout.

### DIFF
--- a/client/my-sites/jetpack-search/upsell.tsx
+++ b/client/my-sites/jetpack-search/upsell.tsx
@@ -57,8 +57,9 @@ export default function JetpackSearchUpsell(): ReactElement {
 						text: translate( 'Upgrade to Jetpack Search' ),
 						action: {
 							url:
-								'https://jetpack.com/upgrade/search/?utm_campaign=my-sites-jetpack-search&utm_source=calypso&site=' +
-								siteSlug,
+								'/checkout/' +
+								siteSlug +
+								'/jetpack_search_monthly?utm_campaign=my-sites-jetpack-search&utm_source=calypso',
 							onClick: onUpgradeClick,
 							selfTarget: true,
 						},

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -233,8 +233,9 @@ export default connect( ( state, { isRequestingSettings } ) => {
 		( site && site.plan && ( hasBusinessPlan( site.plan ) || isVipPlan( site.plan ) ) ) ||
 		!! hasSearchProduct;
 	const upgradeLink =
-		'https://jetpack.com/upgrade/search/?utm_campaign=site-settings&utm_source=calypso&site=' +
-		getSelectedSiteSlug( state );
+		'/checkout/' +
+		getSelectedSiteSlug( state ) +
+		'/jetpack_search_monthly?utm_campaign=site-settings&utm_source=calypso';
 
 	return {
 		activatingSearchModule:


### PR DESCRIPTION
Going direct seems to be a better UX.

#### Testing instructions

There are two places these links show up for sites that don't have a JPS subscription:
* The Jetpack>Search page
* The Settings>Performance page

There is a bug in the nav unification that makes testing the Jetpack>Search page tough: https://github.com/Automattic/wp-calypso/issues/49345