### PR TITLE
Anchor Gutenboarding: use-on-signup: Fix lint warnings

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-signup.ts
+++ b/client/landing/gutenboarding/hooks/use-on-signup.ts
@@ -18,7 +18,7 @@ import { useIsAnchorFm, useAnchorFmParams } from '../path';
  * After signup a site is automatically created using the username and bearerToken
  **/
 
-export default function useOnSignup() {
+export default function useOnSignup(): void {
 	const locale = useLocale();
 	const { createSite } = useDispatch( ONBOARD_STORE );
 
@@ -40,7 +40,7 @@ export default function useOnSignup() {
 				anchorFmSpotifyUrl,
 			} );
 		},
-		[ createSite, locale, anchorFmPodcastId, anchorFmEpisodeId ]
+		[ createSite, locale, anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyUrl ]
 	);
 
 	React.useEffect( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix two basic lint warnings in client/landing/gutenboarding/hooks/use-on-signup.ts

#### Testing instructions

* You should still be able to visit http://calypso.localhost:3000/new?&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q and create a new site.
