### PR TITLE
Anchor Gutenboarding: Use-signup hook has new and current user as deps

### DIFF
--- a/client/landing/gutenboarding/hooks/use-signup.ts
+++ b/client/landing/gutenboarding/hooks/use-signup.ts
@@ -28,8 +28,8 @@ export default function useSignup() {
 	const { showSignupDialog } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const { setShowSignupDialog } = useDispatch( ONBOARD_STORE );
 	const isAnchorFmSignup = useIsAnchorFm();
-	const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );
-	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
+	const hasNewUser = useSelect( ( select ) => !! select( USER_STORE ).getNewUser() );
+	const hasCurrentUser = useSelect( ( select ) => !! select( USER_STORE ).getCurrentUser() );
 
 	const {
 		location: { pathname, search },
@@ -43,7 +43,7 @@ export default function useSignup() {
 		// we don't have a user yet.
 		if (
 			new URLSearchParams( search ).has( 'signup' ) ||
-			( isAnchorFmSignup && ! newUser && ! currentUser )
+			( isAnchorFmSignup && ! hasNewUser && ! hasCurrentUser )
 		) {
 			setShowSignupDialog( true );
 		} else {
@@ -53,7 +53,7 @@ export default function useSignup() {
 			// explicitly hide the dialog.
 			setShowSignupDialog( false );
 		}
-	}, [ pathname ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [ pathname, isAnchorFmSignup, hasNewUser, hasCurrentUser ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return {
 		showSignupDialog,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `currentUser` and `newUser` are changed to boolean versions
  * We only care about the boolean value of the user, and I want to limit recomputation to when the boolean value changes, not whenever a simple comparison of the user is different (which might be always, even if the user is the same)
*  The use-signup hook which checks `hasCurrentUser` and `hasNewUser` now has those values added to the dependency array.
* This is an attempt to solve Anchor Gutenboarding asking you to log in when you're already logged in in production.  However, the problem doesn't happen in development.

#### Testing instructions

* Visit http://calypso.localhost:3000/new?&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q 
  * While logged out: Should prompt you to log in
  * While logged in: Should not prompt you to log in

Possibly Fixes 436-gh-Automattic/dotcom-manage