### PR TITLE
Store|Woo: Add new single calypso_woocommerce_nav_item_click Tracks event

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -665,9 +665,27 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
-	trackStoreClick = () => {
-		this.trackMenuItemClick( 'store' );
-		this.props.recordTracksEvent( 'calypso_woocommerce_store_nav_item_click' );
+	trackWooCommerceNavItemClick = ( menuItemName, experience, plan ) => {
+		// Log the general Tracks event
+		this.trackMenuItemClick( menuItemName );
+
+		// Log a single Tracks event for Store/WooCommerce nav item clicks,
+		// so that easy comparisons can be made between them.
+		this.props.recordTracksEvent( 'calypso_woocommerce_nav_item_click', {
+			nav_item: menuItemName,
+			experience,
+			plan,
+			nav_item_experience_plan_combo: `${ menuItemName }__${ experience }__${ plan }`,
+		} );
+
+		// Continue to log the old individual Tracks events so that existing analysis
+		// using them still function.
+		if ( menuItemName === 'store' ) {
+			this.props.recordTracksEvent( 'calypso_woocommerce_store_nav_item_click' );
+		} else if ( menuItemName === 'woocommerce' ) {
+			this.props.recordTracksEvent( 'calypso_woocommerce_store_woo_core_item_click' );
+		}
+
 		this.onNavigate();
 	};
 
@@ -684,12 +702,14 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
+		let experience = 'calypso-store';
 		let storeLink = '/store' + siteSuffix;
 		if ( isEcommerce( site.plan ) && canUserUseWooCommerceCoreStore ) {
 			// Eventually, the plan is to have the WooCommerce Core menu item labelled the same
 			// for both Business and eCommerce users. But, for now, we want to continue to
 			// use the "Store" label for eCommerce users because that is what they are used to.
 			// So, we'll just continue to change the link here as we have been doing.
+			experience = 'wpadmin-woocommerce-core';
 			storeLink = site.options.admin_url + 'admin.php?page=wc-admin';
 		} else if ( ! canUserUseCalypsoStore ) {
 			return null;
@@ -715,7 +735,12 @@ export class MySitesSidebar extends Component {
 			<SidebarItem
 				label={ translate( 'Store' ) }
 				link={ storeLink }
-				onNavigate={ this.trackStoreClick }
+				onNavigate={ this.trackWooCommerceNavItemClick.bind(
+					this,
+					'store',
+					experience,
+					site.plan.product_slug
+				) }
 				materialIcon="shopping_cart"
 				forceInternalLink
 				className="sidebar__store"
@@ -732,12 +757,6 @@ export class MySitesSidebar extends Component {
 			</SidebarItem>
 		);
 	}
-
-	trackWooCommerceClick = () => {
-		this.trackMenuItemClick( 'woocommerce' );
-		this.props.recordTracksEvent( 'calypso_woocommerce_store_woo_core_item_click' );
-		this.onNavigate();
-	};
 
 	woocommerce() {
 		const { site, canUserUseWooCommerceCoreStore, siteSuffix, isSiteWpcomStore } = this.props;
@@ -770,7 +789,12 @@ export class MySitesSidebar extends Component {
 			<SidebarItem
 				label="WooCommerce"
 				link={ storeLink }
-				onNavigate={ this.trackWooCommerceClick }
+				onNavigate={ this.trackWooCommerceNavItemClick.bind(
+					this,
+					'woocommerce',
+					'wpadmin-woocommerce-core',
+					site.plan.product_slug
+				) }
 				materialIcon="shopping_cart"
 			/>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* A new `calypso_woocommerce_nav_item_click` Tracks event has been added. It will be logged when the "Store" or "WooCommerce" menu items are clicked. The following custom properties are logged, letting us easily do comparisons to see how Sunset Store is performing (and do other similar analysis if future changes are made to how these menu items function).
    * `nav_item`: "store" or "woocommerce"
    * `experience`: "calypso-store" (the deprecated Store experience) or "wpadmin-woocommerce-core' (the full WooCommerce Core experience)
    * `plan`: "business-bundle" or "ecommerce-bundle"
    * `nav_item_experience_plan_combo`: a single combination of all the above properties, making it simple to quickly understand how things are performing:
        * "store__calypso-store__business-bundle": This will be logged for Business plan sites using the deprecated Store from the "Store" menu
        * "store__wpadmin_woocommerce-core__ecommerce-bundle": This will be logged for eCommerce plan sites using WooCommerce Core from the "Store" menu
        * "woocommerce__wpadmin_woocommerce-core__business-bundle": This will be logged for Business plan sites using  WooCommerce Core from the "WooCommerce" menu

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run branch
* Enable debugging of analytics in dev console:

```
localStorage.setItem( 'debug', 'calypso:analytics*' )
```

* With a Business and eCommerce plan sites, as a non-A8C user (so that you do not have the Nav Unification sidebar), click on "Store" and "WooCommerce" menu items and make sure that Tracks events are logged as expected.
    * `calypso_woocommerce_nav_item_click` should be logged for all "Store" and "WooCommerce" menu item clicks, with the custom properties described above set appropriately
    * `calypso_woocommerce_store_nav_item_click` should continue to be logged for all "Store" menu item clicks
    * `calypso_woocommerce_store_woo_core_item_click` should continue to be logged for all "WooCommerce" menu item clicks
