### PR TITLE
Checkout: add window.location redirect fallback after payment complete

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -261,7 +261,7 @@ function displayRenewalSuccessNotice(
 						},
 					}
 				),
-				{ persistent: true }
+				{ displayOnNextPage: true }
 			)
 		);
 		return;
@@ -282,7 +282,7 @@ function displayRenewalSuccessNotice(
 					},
 				}
 			),
-			{ persistent: true }
+			{ displayOnNextPage: true }
 		)
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import page from 'page';
 import React, { useCallback } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch, useStore } from 'react-redux';
@@ -176,7 +175,7 @@ export default function useCreatePaymentCompleteCallback( {
 					fetchSitesAndUser(
 						domainName,
 						() => {
-							page.redirect( url );
+							window.location.href = url;
 						},
 						reduxStore
 					);

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -238,7 +238,7 @@ function performRedirect( url: string ): void {
 
 function displayRenewalSuccessNotice(
 	responseCart: ResponseCart,
-	purchases: Record< number, Purchase >,
+	purchases: Record< number, Purchase[] >,
 	translate: ReturnType< typeof useTranslate >,
 	moment: ReturnType< typeof useLocalizedMoment >,
 	reduxDispatch: ReturnType< typeof useDispatch >
@@ -246,7 +246,7 @@ function displayRenewalSuccessNotice(
 	const renewalItem = getRenewalItems( responseCart )[ 0 ];
 	// group all purchases into an array
 	const purchasedProducts = Object.values( purchases ?? {} ).reduce(
-		( result: Purchase[], value: Purchase ) => [ ...result, value ],
+		( result: Purchase[], value: Purchase[] ) => [ ...result, ...value ],
 		[]
 	);
 	// and take the first product which matches the product id of the renewalItem

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -191,15 +191,12 @@ export default function useCreatePaymentCompleteCallback( {
 				try {
 					window.localStorage.removeItem( 'shoppingCart' );
 					window.localStorage.removeItem( 'siteParams' );
-				} catch ( err ) {}
-
-				// We use window.location instead of page.redirect() so that the cookies are detected on fresh page load.
-				// Using page.redirect() will take to the log in page which we don't want.
-				window.location.href = url;
-				return;
+				} catch ( err ) {
+					debug( 'error while clearing localStorage cart' );
+				}
 			}
 
-			page.redirect( url );
+			window.location.href = url;
 		},
 		[
 			previousRoute,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import page from 'page';
 import React, { useCallback } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch, useStore } from 'react-redux';
@@ -175,7 +176,7 @@ export default function useCreatePaymentCompleteCallback( {
 					fetchSitesAndUser(
 						domainName,
 						() => {
-							window.location.href = url;
+							performRedirect( url );
 						},
 						reduxStore
 					);
@@ -193,9 +194,14 @@ export default function useCreatePaymentCompleteCallback( {
 				} catch ( err ) {
 					debug( 'error while clearing localStorage cart' );
 				}
+
+				// We use window.location instead of page.redirect() so that the cookies are detected on fresh page load.
+				// Using page.redirect() will take to the log in page which we don't want.
+				window.location.href = url;
+				return;
 			}
 
-			window.location.href = url;
+			performRedirect( url );
 		},
 		[
 			previousRoute,
@@ -220,6 +226,14 @@ export default function useCreatePaymentCompleteCallback( {
 			createUserAndSiteBeforeTransaction,
 		]
 	);
+}
+
+function performRedirect( url: string ): void {
+	try {
+		page( url );
+	} catch ( err ) {
+		window.location.href = url;
+	}
 }
 
 function displayRenewalSuccessNotice(

--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -900,8 +900,8 @@ export type WpcomStoreState = {
 type PurchaseSiteId = number;
 
 export interface TransactionResponse {
-	failed_purchases?: Record< PurchaseSiteId, Purchase >;
-	purchases?: Record< PurchaseSiteId, Purchase >;
+	failed_purchases?: Record< PurchaseSiteId, Purchase[] >;
+	purchases?: Record< PurchaseSiteId, Purchase[] >;
 	receipt_id?: number;
 	order_id?: number;
 	redirect_url?: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The checkout thank-you URL can be many different things, and occasionally it's not a wordpress.com URL at all (eg: for a Jetpack site). Currently, `useCreatePaymentCompleteCallback` uses `page.redirect(url)` to redirect after checkout completes, but it appears that `page.redirect()` uses `History.replaceState()` which cannot be used for cross-origin changes. In fact, we don't really want to use `History.replaceState()` anyway because there's really no need to remove checkout from the browser history.

This PR changes `useCreatePaymentCompleteCallback` to use `page()` instead, which still has a similar issue because it uses `History.pushState()`, so it adds a fallback to use `window.location.href = url` instead if `page()` fails. The reason we need to use `page()` in the first place is that there are several notices that may be displayed when checkout completes, and `page()` redirects to calypso without reloading the page, allowing those notices to persist to the next page. Of course, it's fine if they don't persist if the redirect URL is not in calypso, but we want to give them a chance.

Note that the post-checkout notices were actually broken because of mistyped data from the endpoint. This PR also fixes them. For example, if you renew a purchase:

<img width="744" alt="Screen Shot 2021-01-27 at 5 18 52 PM" src="https://user-images.githubusercontent.com/2036909/106062518-e19dbe00-60c4-11eb-85c3-c34221bd4b58.png">


#### Testing instructions

- Complete checkout with any flow and verify that you are successfully redirected to a new page afterward.
