### PR TITLE
warn: Extract into package

### DIFF
--- a/client/components/domains/registrant-extra-info/with-contact-details-validation.jsx
+++ b/client/components/domains/registrant-extra-info/with-contact-details-validation.jsx
@@ -16,7 +16,7 @@ const debug = debugFactory( 'calypso:domains:with-contact-details-validation' );
  */
 import getValidationSchemas from 'calypso/state/selectors/get-validation-schemas';
 import { bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
-import warn from 'calypso/lib/warn';
+import warn from '@automattic/warn';
 
 export function disableSubmitButton( children ) {
 	if ( isEmpty( children ) ) {

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -42,7 +42,7 @@ import RequiredPluginsInstallView from './required-plugins-install-view';
 import SetupTasksView from './setup';
 import StoreLocationSetupView from './setup/store-location';
 import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
-import warn from 'calypso/lib/warn';
+import warn from '@automattic/warn';
 import StoreMoveNoticeView from './store-move-notice-view';
 import config from '@automattic/calypso-config';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';

--- a/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
+++ b/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { sortBy } from 'lodash';
-import warn from 'calypso/lib/warn';
+import warn from '@automattic/warn';
 import formatCurrency from '@automattic/format-currency';
 
 /**

--- a/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/index.js
+++ b/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/index.js
@@ -13,7 +13,7 @@ import FormField from '../form-field';
 import FormSelect from 'calypso/components/forms/form-select';
 import AppliesToFilteredList from './applies-to-filtered-list';
 import ProductSearch from 'woocommerce/components/product-search';
-import warn from 'calypso/lib/warn';
+import warn from '@automattic/warn';
 
 class PromotionAppliesToField extends React.Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/app/promotions/promotion-form.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form.js
@@ -5,7 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { uniqueId, get, find } from 'lodash';
-import warn from 'calypso/lib/warn';
+import warn from '@automattic/warn';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/state/data-layer/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/index.js
@@ -4,7 +4,7 @@
 import debugFactory from 'debug';
 import { isUndefined, mapValues, omitBy } from 'lodash';
 import { stringify } from 'qs';
-import warn from 'calypso/lib/warn';
+import warn from '@automattic/warn';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/state/data-layer/products/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/test/index.js
@@ -4,7 +4,7 @@
 import { expect } from 'chai';
 import { spy, match } from 'sinon';
 
-jest.mock( 'calypso/lib/warn', () => () => {} );
+jest.mock( '@automattic/warn', () => () => {} );
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/state/sites/coupons/handlers.js
+++ b/client/extensions/woocommerce/state/sites/coupons/handlers.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { trim, isFunction } from 'lodash';
-import warn from 'calypso/lib/warn';
+import warn from '@automattic/warn';
 import debugFactory from 'debug';
 
 /**

--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -7,7 +7,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 /**
  * Internal dependencies
  */
-import warn from 'calypso/lib/warn';
+import warn from '@automattic/warn';
 
 /**
  * Constants

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import AsyncLoad from 'calypso/components/async-load';
-import warn from 'calypso/lib/warn';
+import warn from '@automattic/warn';
 import PlanFeatures from 'calypso/my-sites/plan-features';
 import {
 	JETPACK_PLANS,

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -22,11 +22,13 @@ jest.mock( 'calypso/components/data/cart', () => 'CartData' );
 jest.mock( 'calypso/my-sites/plan-features', () => 'PlanFeatures' );
 jest.mock( 'calypso/my-sites/plans-features-main/wpcom-faq', () => 'WpcomFAQ' );
 jest.mock( 'calypso/my-sites/plans-features-main/jetpack-faq', () => 'JetpackFAQ' );
+jest.mock( '@automattic/warn', () => jest.fn() );
 
 /**
  * External dependencies
  */
 import { shallow } from 'enzyme';
+import warn from '@automattic/warn';
 
 /**
  * Internal dependencies
@@ -327,7 +329,6 @@ describe( 'PlansFeaturesMain.getPlansFromProps', () => {
 	} );
 
 	test( 'Should filter out invalid plan types and print a warning in the console', () => {
-		global.console.warn = jest.fn();
 		const NOT_A_PLAN = 'not-a-plan';
 		const instance = new PlansFeaturesMain( {
 			...props,
@@ -336,7 +337,7 @@ describe( 'PlansFeaturesMain.getPlansFromProps', () => {
 		const plans = instance.getPlansFromProps( group, term );
 
 		expect( plans ).toEqual( [ PLAN_BUSINESS, PLAN_ECOMMERCE ] );
-		expect( global.console.warn ).toHaveBeenCalledWith(
+		expect( warn ).toHaveBeenCalledWith(
 			`Invalid plan type, \`${ NOT_A_PLAN }\`, provided to \`PlansFeaturesMain\` component. See plans constants for valid plan types.`
 		);
 	} );

--- a/client/package.json
+++ b/client/package.json
@@ -44,6 +44,7 @@
 		"@automattic/tree-select": "^1.0.3",
 		"@automattic/viewport": "^1.0.0",
 		"@automattic/viewport-react": "^1.0.0",
+		"@automattic/warn": "^1.0.0-alpha.0",
 		"@automattic/webpack-config-flag-plugin": "^1.0.0",
 		"@automattic/webpack-extensive-lodash-replacement-plugin": "^0.0.2",
 		"@automattic/webpack-inline-constant-exports-plugin": "^1.0.0",

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -8,7 +8,7 @@ import { get, identity, merge, noop } from 'lodash';
  * Internal dependencies
  */
 import { keyedReducer } from 'calypso/state/utils';
-import warn from 'calypso/lib/warn';
+import warn from '@automattic/warn';
 
 /**
  * Returns response data from an HTTP request success action if available

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -8,7 +8,7 @@ import { random, map, includes, get, noop } from 'lodash';
  */
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
-import warn from 'calypso/lib/warn';
+import warn from '@automattic/warn';
 import { READER_STREAMS_PAGE_REQUEST } from 'calypso/state/reader/action-types';
 import { receivePage, receiveUpdates } from 'calypso/state/reader/streams/actions';
 import { receivePosts } from 'calypso/state/reader/posts/actions';

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -20,7 +20,7 @@ jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 
 jest.mock( 'calypso/lib/wp' );
 jest.mock( 'calypso/reader/stats', () => ( { recordTrack: () => {} } ) );
-jest.mock( 'calypso/lib/warn', () => () => {} );
+jest.mock( '@automattic/warn', () => () => {} );
 
 describe( 'streams', () => {
 	const action = deepfreeze( requestPageAction( { streamKey: 'following', page: 2 } ) );

--- a/client/state/happychat/ui/test/index.js
+++ b/client/state/happychat/ui/test/index.js
@@ -15,7 +15,7 @@ import {
 	HAPPYCHAT_SET_CURRENT_MESSAGE,
 } from 'calypso/state/action-types';
 import { lostFocusAt, currentMessage } from '../reducer';
-jest.mock( 'calypso/lib/warn', () => () => {} );
+jest.mock( '@automattic/warn', () => () => {} );
 
 // Simulate the time Feb 27, 2017 05:25 UTC
 const NOW = 1488173100125;

--- a/client/state/reader/streams/test/reducer.js
+++ b/client/state/reader/streams/test/reducer.js
@@ -26,7 +26,7 @@ import {
 	PENDING_ITEMS_DEFAULT,
 } from '../reducer';
 
-jest.mock( 'calypso/lib/warn', () => () => {} );
+jest.mock( '@automattic/warn', () => () => {} );
 jest.mock( 'calypso/lib/user', () => () => {} );
 
 const TIME1 = '2018-01-01T00:00:00.000Z';

--- a/client/state/reader/watermarks/test/reducer.js
+++ b/client/state/reader/watermarks/test/reducer.js
@@ -5,7 +5,7 @@ import { viewStream } from '../actions';
 import { watermarks } from '../reducer';
 import { DESERIALIZE, SERIALIZE } from 'calypso/state/action-types';
 
-jest.mock( 'calypso/lib/warn', () => () => {} );
+jest.mock( '@automattic/warn', () => () => {} );
 
 const streamKey = 'special-chicken-stream';
 const mark = Date.now();

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -17,9 +17,9 @@ import {
 	withEnhancers,
 	withStorageKey,
 } from 'calypso/state/utils';
-import warn from 'calypso/lib/warn';
+import warn from '@automattic/warn';
 
-jest.mock( 'calypso/lib/warn', () => jest.fn() );
+jest.mock( '@automattic/warn', () => jest.fn() );
 
 describe( 'utils', () => {
 	beforeEach( () => warn.mockReset() );

--- a/client/state/utils/schema-utils.js
+++ b/client/state/utils/schema-utils.js
@@ -9,7 +9,7 @@ import { forEach, get, isEmpty, isEqual } from 'lodash';
  */
 import { DESERIALIZE, SERIALIZE } from 'calypso/state/action-types';
 import { getInitialState } from './get-initial-state';
-import warn from 'calypso/lib/warn';
+import warn from '@automattic/warn';
 
 export function isValidStateWithSchema( state, schema, debugInfo ) {
 	const validate = validator( schema, {

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -20,6 +20,7 @@
 		{ "path": "./plans-grid" },
 		{ "path": "./react-i18n" },
 		{ "path": "./search" },
-		{ "path": "./shopping-cart" }
+		{ "path": "./shopping-cart" },
+		{ "path": "./warn" }
 	]
 }

--- a/packages/warn/CHANGELOG.md
+++ b/packages/warn/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0-alpha.0
+
+Extracted from `lib/warn` and transformed to TypeScript.

--- a/packages/warn/README.md
+++ b/packages/warn/README.md
@@ -7,5 +7,5 @@ If you'd like to hide output within a test,
 add this line to the top of your test file:
 
 ```javascript
-jest.mock( 'lib/warn', () => () => {} );
+jest.mock( '@automattic/warn', () => () => {} );
 ```

--- a/packages/warn/package.json
+++ b/packages/warn/package.json
@@ -1,11 +1,11 @@
 {
 	"name": "@automattic/warn",
 	"version": "1.0.0-alpha.0",
-	"description": "Creates the calypso configuration api.",
+	"description": "A tiny utility function that wraps the browsers `console.warn` so that it does not emit in production.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic Inc.",
-	"sideEffects": true,
+	"sideEffects": false,
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
 	"calypso:src": "src/index.ts",
@@ -30,6 +30,5 @@
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
-	},
-	"dependencies": {}
+	}
 }

--- a/packages/warn/package.json
+++ b/packages/warn/package.json
@@ -1,0 +1,35 @@
+{
+	"name": "@automattic/warn",
+	"version": "1.0.0-alpha.0",
+	"description": "Creates the calypso configuration api.",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"sideEffects": true,
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.ts",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/warn"
+	},
+	"files": [
+		"dist",
+		"src"
+	],
+	"types": "dist/types",
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": {
+		"url": "https://github.com/Automattic/wp-calypso/issues"
+	},
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch"
+	},
+	"dependencies": {}
+}

--- a/packages/warn/src/index.ts
+++ b/packages/warn/src/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-console, @typescript-eslint/no-empty-function */
+/* eslint-disable no-console */
 
 /*
  * Wraps console.warn to only emit in development and test environments.
@@ -7,11 +7,13 @@
  * For example: stats warns when any tracks events aren't properly formatted (@see lib/analytics)
  */
 
-let warn: typeof console.warn;
+let warn: ( ...data: any[] ) => void;
 if ( process.env.NODE_ENV === 'production' || 'function' !== typeof console.warn ) {
-	warn = (): void => {};
+	warn = (): void => {
+		/* don't log in production */
+	};
 } else {
-	warn = ( ...args: Parameters< typeof console.warn > ): void => console.warn( ...args );
+	warn = console.warn;
 }
 
 export default warn;

--- a/packages/warn/src/index.ts
+++ b/packages/warn/src/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, @typescript-eslint/no-empty-function */
 
 /*
  * Wraps console.warn to only emit in development and test environments.
@@ -7,11 +7,11 @@
  * For example: stats warns when any tracks events aren't properly formatted (@see lib/analytics)
  */
 
-let warn;
+let warn: typeof console.warn;
 if ( process.env.NODE_ENV === 'production' || 'function' !== typeof console.warn ) {
-	warn = () => {};
+	warn = (): void => {};
 } else {
-	warn = ( ...args ) => console.warn( ...args );
+	warn = ( ...args: Parameters< typeof console.warn > ): void => console.warn( ...args );
 }
 
 export default warn;

--- a/packages/warn/tsconfig-cjs.json
+++ b/packages/warn/tsconfig-cjs.json
@@ -1,0 +1,11 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"declaration": false,
+		"declarationDir": null,
+		"outDir": "dist/cjs",
+		"composite": false,
+		"incremental": true
+	}
+}

--- a/packages/warn/tsconfig.json
+++ b/packages/warn/tsconfig.json
@@ -1,0 +1,35 @@
+{
+	"compilerOptions": {
+		"target": "ES5",
+		"lib": [ "DOM", "DOM.Iterable", "ESNext" ],
+		"baseUrl": ".",
+		"module": "esnext",
+		"allowJs": false,
+		"jsx": "react",
+		"declaration": true,
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src",
+
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+
+		"moduleResolution": "node",
+		"esModuleInterop": true,
+
+		"forceConsistentCasingInFileNames": true,
+
+		"typeRoots": [ "../../node_modules/@types" ],
+		"types": [ "node" ],
+
+		"noEmitHelpers": true,
+		"importHelpers": true,
+
+		"composite": true
+	},
+	"include": [ "src" ],
+	"exclude": [ "**/docs/*", "**/test/*" ]
+}

--- a/packages/warn/tsconfig.json
+++ b/packages/warn/tsconfig.json
@@ -1,11 +1,9 @@
 {
 	"compilerOptions": {
 		"target": "ES5",
-		"lib": [ "DOM", "DOM.Iterable", "ESNext" ],
 		"baseUrl": ".",
 		"module": "esnext",
 		"allowJs": false,
-		"jsx": "react",
 		"declaration": true,
 		"declarationDir": "dist/types",
 		"outDir": "dist/esm",
@@ -14,8 +12,6 @@
 		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"noImplicitReturns": true,
-		"noFallthroughCasesInSwitch": true,
 
 		"moduleResolution": "node",
 		"esModuleInterop": true,
@@ -30,6 +26,5 @@
 
 		"composite": true
 	},
-	"include": [ "src" ],
-	"exclude": [ "**/docs/*", "**/test/*" ]
+	"include": [ "src" ]
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Extracts warn into a package and turns it into TypeScript.

Note: I'm doing this one mostly so that `create-selector` can be extracted into a package, this is the only internal dependency of that package.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure build passes
* Ensure unit tests pass
* Ensure warnings are emitted (easiest way to do this I found is to checkout this branch and add a call to `warn` somewhere and verify it that it's warning still).