### PR TITLE
Checkout: Allow server to remove a previously applied coupon when cart changes

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/coupon.js
+++ b/client/my-sites/checkout/composite-checkout/components/coupon.js
@@ -25,12 +25,6 @@ export default function Coupon( { id, className, disabled, couponStatus, couponF
 		handleCouponSubmit,
 	} = couponFieldStateProps;
 
-	if ( couponStatus === 'applied' ) {
-		// Clear the field value when the coupon is applied
-		setCouponFieldValue( '' );
-		return null;
-	}
-
 	const hasCouponError = couponStatus === 'invalid' || couponStatus === 'rejected';
 	const isPending = couponStatus === 'pending';
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { FormStatus, useLineItems, useFormStatus } from '@automattic/composite-checkout';
@@ -92,6 +92,14 @@ function CouponFieldArea( {
 } ) {
 	const { formStatus } = useFormStatus();
 	const translate = useTranslate();
+	const { setCouponFieldValue } = couponFieldStateProps;
+
+	useEffect( () => {
+		if ( couponStatus === 'applied' ) {
+			// Clear the field value when the coupon is applied
+			setCouponFieldValue( '' );
+		}
+	}, [ couponStatus, setCouponFieldValue ] );
 
 	if ( isPurchaseFree || couponStatus === 'applied' ) {
 		return null;

--- a/packages/shopping-cart/src/use-shopping-cart-reducer.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-reducer.ts
@@ -260,26 +260,21 @@ function removeItemFromLocalStorage( productSlugsInCart: string[] ) {
 	}
 }
 
-function getUpdatedCouponStatus( currentCouponStatus: CouponStatus, responseCart: ResponseCart ) {
+function getUpdatedCouponStatus(
+	currentCouponStatus: CouponStatus,
+	responseCart: ResponseCart
+): CouponStatus {
 	const isCouponApplied = responseCart.is_coupon_applied;
 	const couponDiscounts = responseCart.coupon_discounts_integer.length;
 
-	switch ( currentCouponStatus ) {
-		case 'fresh':
-			return isCouponApplied ? 'applied' : currentCouponStatus;
-		case 'pending': {
-			if ( isCouponApplied ) {
-				return 'applied';
-			}
-			if ( ! isCouponApplied && couponDiscounts <= 0 ) {
-				return 'invalid';
-			}
-			if ( ! isCouponApplied && couponDiscounts > 0 ) {
-				return 'rejected';
-			}
-			return 'error';
-		}
-		default:
-			return currentCouponStatus;
+	if ( isCouponApplied ) {
+		return 'applied';
 	}
+	if ( currentCouponStatus === 'pending' && couponDiscounts <= 0 ) {
+		return 'invalid';
+	}
+	if ( currentCouponStatus === 'pending' && couponDiscounts > 0 ) {
+		return 'rejected';
+	}
+	return 'fresh';
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The workings of the shopping-cart endpoint are mysterious, and we must be aware of them. If a coupon is applied to an active shopping cart and then the cart changes such that the coupon no longer applies, the shopping-cart endpoint will remove that coupon. At the same time, the `@automattic/shopping-cart` package keeps its own state to determine if a coupon is applied because it needs to be able to recognize when a coupon attempt occurred and the coupon has failed to apply so that it can highlight the coupon field. Keeping this state up-to-date is the responsibility of a function called `getUpdatedCouponStatus()`. 

However, due to the way the shopping-cart state evolved, that function was not built in such a way that it would allow the coupon state to go from "applied" to "fresh" (unapplied) directly. The result is that the internal state would still think a coupon was applied even if it had been removed after being applied.

In this PR we refactor the function to have clearer logic and to generally respect the response of the shopping-cart endpoint.

Fixes the bug described here: https://github.com/Automattic/wp-calypso/pull/47716#pullrequestreview-577144051

We also fix a small bug wherein the coupon field was not being cleared when a coupon was successfully applied.

#### Testing instructions

- Add an annual plan to the cart and visit checkout.
- Click "Edit" on the "Your order" section at the top, then click "Add a coupon code".
- Enter an invalid coupon and press "Apply".
- Verify that an error message is displayed, that the invalid coupon text remains in the field, and that the field is highlighted.
- Enter a valid coupon that only applies to an annual plan and press "Apply".
- Verify that a success message is displayed as well as a "Coupon:" line item.
- Click to change the plan length to monthly.
- Verify that the plan price changes and that the coupon field appears again, this time empty.
