### PR TITLE
Checkout: Add translators comments to payment methods and related code

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
@@ -104,6 +104,7 @@ function ButtonContents( { formStatus, total, activeButtonText = undefined } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
+		/* translators: %s is the total to be paid in localized currency */
 		return activeButtonText || sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
@@ -329,6 +329,7 @@ function ButtonContents( { formStatus, total } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
+		/* translators: %s is the total to be paid in localized currency */
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.js
@@ -63,6 +63,7 @@ function ButtonContents( { formStatus, total } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
+		/* translators: %s is the total to be paid in localized currency */
 		return sprintf( __( 'Pay %s with credits' ), total );
 	}
 	return __( 'Please wait…' );
@@ -75,9 +76,12 @@ function WordPressCreditsLabel() {
 	return (
 		<React.Fragment>
 			<div>
-				{ sprintf( __( 'WordPress.com Credits: %(amount)s available' ), {
-					amount: responseCart.credits_display,
-				} ) }
+				{
+					/* translators: %(amount)s is the total amount of credits available in localized currency */
+					sprintf( __( 'WordPress.com Credits: %(amount)s available' ), {
+						amount: responseCart.credits_display,
+					} )
+				}
 			</div>
 			<WordPressLogo />
 		</React.Fragment>

--- a/client/my-sites/checkout/composite-checkout/payment-methods/id-wallet.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/id-wallet.js
@@ -255,6 +255,7 @@ function ButtonContents( { formStatus, total } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === 'ready' ) {
+		/* translators: %s is the total to be paid in localized currency */
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
@@ -256,6 +256,7 @@ function ButtonContents( { formStatus, total } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
+		/* translators: %s is the total to be paid in localized currency */
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/wechat/index.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/wechat/index.js
@@ -217,6 +217,7 @@ function ButtonContents( { formStatus, total } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
+		/* translators: %s is the total to be paid in localized currency */
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -96,6 +96,7 @@ export default function CheckoutPaymentMethods( {
 					<CheckoutErrorBoundary
 						key={ method.id }
 						errorMessage={ sprintf(
+							/* translators: %s is the payment method name that has an error, like "PayPal" */
 							__( 'There was a problem with the payment method: %s' ),
 							method.id
 						) }

--- a/packages/composite-checkout/src/lib/payment-methods/alipay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/alipay.js
@@ -160,6 +160,7 @@ function ButtonContents( { formStatus, total } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
+		/* translators: %s is the total to be paid in localized currency */
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/bancontact.js
+++ b/packages/composite-checkout/src/lib/payment-methods/bancontact.js
@@ -162,6 +162,7 @@ function ButtonContents( { formStatus, total } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
+		/* translators: %s is the total to be paid in localized currency */
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/eps.js
+++ b/packages/composite-checkout/src/lib/payment-methods/eps.js
@@ -156,6 +156,7 @@ function ButtonContents( { formStatus, total } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
+		/* translators: %s is the total to be paid in localized currency */
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -81,6 +81,7 @@ function formatDate( cardExpiry ) {
 export function ExistingCardLabel( { last4, cardExpiry, cardholderName, brand } ) {
 	const { __, _x } = useI18n();
 
+	/* translators: %s is the last 4 digits of the credit card number */
 	const maskedCardDetails = sprintf( _x( '**** %s', 'Masked credit card number' ), last4 );
 
 	return (
@@ -147,6 +148,7 @@ function ButtonContents( { formStatus, total, activeButtonText = undefined } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
+		/* translators: %s is the total to be paid in localized currency */
 		return activeButtonText || sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );
@@ -155,6 +157,7 @@ function ButtonContents( { formStatus, total, activeButtonText = undefined } ) {
 function ExistingCardSummary( { cardholderName, cardExpiry, brand, last4 } ) {
 	const { __, _x } = useI18n();
 
+	/* translators: %s is the last 4 digits of the credit card number */
 	const maskedCardDetails = sprintf( _x( '**** %s', 'Masked credit card number' ), last4 );
 
 	return (

--- a/packages/composite-checkout/src/lib/payment-methods/giropay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/giropay.js
@@ -160,6 +160,7 @@ function ButtonContents( { formStatus, total } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
+		/* translators: %s is the total to be paid in localized currency */
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/ideal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/ideal.js
@@ -233,6 +233,7 @@ function ButtonContents( { formStatus, total } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
+		/* translators: %s is the total to be paid in localized currency */
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/p24.js
+++ b/packages/composite-checkout/src/lib/payment-methods/p24.js
@@ -179,6 +179,7 @@ function ButtonContents( { formStatus, total } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
+		/* translators: %s is the total to be paid in localized currency */
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/sofort.js
+++ b/packages/composite-checkout/src/lib/payment-methods/sofort.js
@@ -160,6 +160,7 @@ function ButtonContents( { formStatus, total } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
+		/* translators: %s is the total to be paid in localized currency */
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -403,6 +403,7 @@ function ButtonContents( { formStatus, total } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
+		/* translators: %s is the total to be paid in localized currency */
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes the `@wordpress/i18n-translator-comments` errors in various checkout files by adding `translators:` comments to each translation function that uses placeholder text.

#### Testing instructions

Verify that checkout loads. This should not cause any changes.