### PR TITLE
Social Previews: Fix the white screen for the SEO device.

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -290,13 +290,16 @@ class ReaderPostCard extends React.Component {
 
 export default connect(
 	( state, ownProps ) => ( {
-		isFollowingItem: isFollowing( state, {
-			blogId: ownProps.postKey.blogId,
-			feedId: ownProps.postKey.feedId,
-		} ),
+		isFollowingItem:
+			ownProps.postKey &&
+			isFollowing( state, {
+				blogId: ownProps.postKey.blogId,
+				feedId: ownProps.postKey.feedId,
+			} ),
 		isWPForTeamsItem:
-			isSiteWPForTeams( state, ownProps.postKey.blogId ) ||
-			isFeedWPForTeams( state, ownProps.postKey.feedId ),
+			ownProps.postKey &&
+			( isSiteWPForTeams( state, ownProps.postKey.blogId ) ||
+				isFeedWPForTeams( state, ownProps.postKey.feedId ) ),
 		teams: getReaderTeams( state ),
 		isExpanded: isReaderCardExpanded( state, ownProps.postKey ),
 	} ),


### PR DESCRIPTION
In #48972, it was reported that the application would crash if the
Search & Social device was selected in the post preview.

The cause was related to some changes that were made to
`reader-post-card` which is being used to generate the preview. Those
changes assumed that there would be a `postKey` prop, which in the case
of the social previews, isn't there.

#### Changes proposed in this Pull Request

As the prop is used to set some boolean flags, this change adds some
logic to check for its existence and default those flags to `false` if
not.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

As described in #48972, create a post,  or edit an existing one, on a site with a  business plan.
Select 'Search & Social' from the device dropdown in the preview window. 

Without this change, the app will crash, and with it, you should be presented with the social previews as usual.

Fixes #48972
