### PR TITLE
Jetpack Search: Query purchases if not already been fetched

### DIFF
--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -48,7 +48,7 @@ export default function JetpackSearchMain(): ReactElement {
 	const onSettingsClick = useTrackCallback( undefined, 'calypso_jetpack_search_settings' );
 
 	if ( ! hasLoadedSitePurchases ) {
-		return <JetpackSearchPlaceholder />;
+		return <JetpackSearchPlaceholder siteId={ siteId } />;
 	}
 
 	if ( ! hasSearchProduct ) {

--- a/client/my-sites/jetpack-search/placeholder.tsx
+++ b/client/my-sites/jetpack-search/placeholder.tsx
@@ -13,6 +13,7 @@ import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import FormattedHeader from 'calypso/components/formatted-header';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 
 /**
  * Style dependencies
@@ -24,9 +25,14 @@ import './style.scss';
  */
 import JetpackSearchSVG from 'calypso/assets/images/illustrations/jetpack-search.svg';
 
-export default function JetpackSearchPlaceholder(): ReactElement {
+interface Props {
+	siteId: number;
+}
+
+export default function JetpackSearchPlaceholder( { siteId }: Props ): ReactElement {
 	return (
 		<Main className="jetpack-search__placeholder">
+			<QuerySitePurchases siteId={ siteId } />
 			<DocumentHead title="Jetpack Search" />
 			<SidebarNavigation />
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the `/jetpack-search/:site` page was added to Calypso, purchases had always been queried by the time the user hit the page. This doesn't now seem to be the case and the page can get stuck on the placeholder.

This PR adds a `QuerySitePurchases` so we know we have the information we need to display an upsell or the user's plan details.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*Go to `/jetpack-search` and select a site that is subscribed to Jetpack Search (either directly or via JP Professional). Make sure the 'active on your site' page is displayed:

<img width="815" alt="Screen Shot 2021-01-28 at 16 01 36" src="https://user-images.githubusercontent.com/17325/106083911-26d3f580-6182-11eb-8663-ce9c95574321.png">

*Go to `/jetpack-search` and select a site that is _not_ subscribed to Jetpack Search. Make sure the upsell page is displayed:

<img width="810" alt="Screen Shot 2021-01-28 at 16 02 52" src="https://user-images.githubusercontent.com/17325/106083987-49660e80-6182-11eb-858d-41df4ea41d1f.png">

