### PR TITLE
Deduplicate enzyme-shallow-equal

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11154,12 +11154,12 @@ enzyme-matchers@^7.1.2:
     deep-equal-ident "^1.1.1"
 
 enzyme-shallow-equal@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.1.tgz#7afe03db3801c9b76de8440694096412a8d9d49e"
-  integrity sha512-hGA3i1so8OrYOZSM9whlkNmVHOicJpsjgTzC+wn2JMJXhq1oO4kA4bJ5MsfzSIcC71aLDKzJ6gZpIxrqt3QTAQ==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.4.tgz#b9256cb25a5f430f9bfe073a84808c1d74fced2e"
+  integrity sha512-MttIwB8kKxypwHvRynuC3ahyNc+cFbR8mjVIltnmzQ0uKGqmsfO4bfBuLxb0beLNPhjblUEYvEbsg+VSygvF1Q==
   dependencies:
     has "^1.0.3"
-    object-is "^1.0.2"
+    object-is "^1.1.2"
 
 enzyme-to-json@^3.3.0, enzyme-to-json@^3.4.3, enzyme-to-json@^3.4.4:
   version "3.4.4"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `enzyme-shallow-equal` (done automatically with `npx yarn-deduplicate --packages enzyme-shallow-equal`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> enzyme-shallow-equal@1.0.1
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> enzyme-shallow-equal@1.0.1
< wp-calypso@0.17.0 -> enzyme@3.11.0 -> ... -> enzyme-shallow-equal@1.0.1
> wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> enzyme-shallow-equal@1.0.4
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> enzyme-shallow-equal@1.0.4
> wp-calypso@0.17.0 -> enzyme@3.11.0 -> ... -> enzyme-shallow-equal@1.0.4
```