### PR TITLE
Deduplicate function.prototype.name

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12955,16 +12955,7 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
-function.prototype.name@^1.1.0, function.prototype.name@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.2.tgz#5cdf79d7c05db401591dfde83e3b70c5123e9a45"
-  integrity sha512-C8A+LlHBJjB2AdcRPorc5JvJ5VUoWlXdEHLOJdCI7kjHEtGTpHQUiqMvCIKUwIsGwZX2jZJy761AXsn356bJQg==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    functions-have-names "^1.2.0"
-
-function.prototype.name@^1.1.3:
+function.prototype.name@^1.1.0, function.prototype.name@^1.1.2, function.prototype.name@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.3.tgz#0bb034bb308e7682826f215eb6b2ae64918847fe"
   integrity sha512-H51qkbNSp8mtkJt+nyW1gyStBiKZxfRqySNUR99ylq6BPXHKI4SEvIlTKp4odLfjRKJV04DFWMU3G/YRlQOsag==
@@ -12978,11 +12969,6 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
-
-functions-have-names@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.1.tgz#a981ac397fa0c9964551402cdc5533d7a4d52f91"
-  integrity sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA==
 
 functions-have-names@^1.2.1:
   version "1.2.2"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `function.prototype.name` (done automatically with `npx yarn-deduplicate --packages function.prototype.name`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> function.prototype.name@1.1.2
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> function.prototype.name@1.1.2
< wp-calypso@0.17.0 -> @wordpress/components@12.0.1 -> ... -> function.prototype.name@1.1.2
< wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> function.prototype.name@1.1.2
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> function.prototype.name@1.1.2
< wp-calypso@0.17.0 -> enzyme-adapter-react-16@1.15.1 -> ... -> function.prototype.name@1.1.2
< wp-calypso@0.17.0 -> enzyme@3.11.0 -> ... -> function.prototype.name@1.1.2
> wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> function.prototype.name@1.1.3
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> function.prototype.name@1.1.3
> wp-calypso@0.17.0 -> @wordpress/components@12.0.1 -> ... -> function.prototype.name@1.1.3
> wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> function.prototype.name@1.1.3
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> function.prototype.name@1.1.3
> wp-calypso@0.17.0 -> enzyme-adapter-react-16@1.15.1 -> ... -> function.prototype.name@1.1.3
> wp-calypso@0.17.0 -> enzyme@3.11.0 -> ... -> function.prototype.name@1.1.3
```