### PR TITLE
Deduplicate graceful-fs

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13679,12 +13679,7 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
-  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
-
-graceful-fs@^4.2.4:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `graceful-fs` (done automatically with `npx yarn-deduplicate --packages graceful-fs`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> graceful-fs@4.2.3
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> graceful-fs@4.2.3
< wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> graceful-fs@4.2.3
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> graceful-fs@4.2.3
< wp-calypso@0.17.0 -> eslint-plugin-import@2.22.1 -> ... -> graceful-fs@4.2.3
< wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> graceful-fs@4.2.3
< wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> graceful-fs@4.2.3
< wp-calypso@0.17.0 -> node-sass@4.13.0 -> ... -> graceful-fs@4.2.3
< wp-calypso@0.17.0 -> npm-run-all@4.1.5 -> ... -> graceful-fs@4.2.3
< wp-calypso@0.17.0 -> postcss-cli@6.1.3 -> ... -> graceful-fs@4.2.3
< wp-calypso@0.17.0 -> recursive-copy@2.0.10 -> ... -> graceful-fs@4.2.3
< wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> graceful-fs@4.2.3
< wp-calypso@0.17.0 -> webpack@5.13.0 -> ... -> graceful-fs@4.2.3
< wp-calypso@0.17.0 -> whybundled@1.4.2 -> ... -> graceful-fs@4.2.3
> wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> graceful-fs@4.2.4
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> graceful-fs@4.2.4
> wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> graceful-fs@4.2.4
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> graceful-fs@4.2.4
> wp-calypso@0.17.0 -> eslint-plugin-import@2.22.1 -> ... -> graceful-fs@4.2.4
> wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> graceful-fs@4.2.4
> wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> graceful-fs@4.2.4
> wp-calypso@0.17.0 -> node-sass@4.13.0 -> ... -> graceful-fs@4.2.4
> wp-calypso@0.17.0 -> npm-run-all@4.1.5 -> ... -> graceful-fs@4.2.4
> wp-calypso@0.17.0 -> postcss-cli@6.1.3 -> ... -> graceful-fs@4.2.4
> wp-calypso@0.17.0 -> recursive-copy@2.0.10 -> ... -> graceful-fs@4.2.4
> wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> graceful-fs@4.2.4
> wp-calypso@0.17.0 -> webpack@5.13.0 -> ... -> graceful-fs@4.2.4
> wp-calypso@0.17.0 -> whybundled@1.4.2 -> ... -> graceful-fs@4.2.4
```