### PR TITLE
Update target URLs for e2e tests after subdir upgrade

### DIFF
--- a/test/e2e/localization-data.json
+++ b/test/e2e/localization-data.json
@@ -4,7 +4,7 @@
 		"currency_symbol": "$",
 		"nux_landing_page_string": "خطوة",
 		"wpcom_landing_page_string": "دخول",
-		"wpcom_base_url": "ar.wordpress.com",
+		"wpcom_base_url": "wordpress.com/ar",
 
 		"google_searches": [
 			{
@@ -197,7 +197,7 @@
 		"currency_symbol": "$",
 		"nux_landing_page_string": "Etapa",
 		"wpcom_landing_page_string": "Fazer login",
-		"wpcom_base_url": "br.wordpress.com",
+		"wpcom_base_url": "wordpress.com/pt-br",
 
 		"google_searches": [
 			{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* e2e tests fail for Arabic and Brazilian Portuguese after they were migrated to test dirs

#### Testing instructions

* run e2e tests via `run.sh -I` in the `test/e2e` directory. Follow the instructions on https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/docs/running-tests.md
