### PR TITLE
New Onboarding: fix /new/free flow

### DIFF
--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -18,7 +18,7 @@ export type { State };
 export type { Plan, PlanSlug, PlanProduct } from './types';
 export type { PlanPath } from './types';
 
-// plansPaths is used to construct the route that accepts plan slugs like (/beginner, /business, etc..)
+// plansPaths is used to construct the route that accepts plan slugs like (/free, /business, etc..)
 export {
 	PLAN_FREE,
 	PLAN_PERSONAL,

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -16,6 +16,7 @@ import type {
 	Feature,
 } from './types';
 import {
+	PLAN_FREE,
 	TIMELESS_PLAN_FREE,
 	TIMELESS_PLAN_PREMIUM,
 	plansProductSlugs,
@@ -110,7 +111,7 @@ function normalizePlanProducts(
 			periodAgnosticSlug: periodAgnosticPlan.periodAgnosticSlug,
 			storeSlug: planProduct.product_slug,
 			rawPrice: planProduct.raw_price,
-			pathSlug: planProduct.product_slug === 'free_plan' ? 'free' : planProduct.path_slug,
+			pathSlug: planProduct.product_slug === PLAN_FREE ? 'free' : planProduct.path_slug,
 			price:
 				planProduct?.bill_period === MONTHLY_PLAN_BILLING_PERIOD || planProduct.raw_price === 0
 					? getFormattedPrice( planProduct )

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -110,7 +110,7 @@ function normalizePlanProducts(
 			periodAgnosticSlug: periodAgnosticPlan.periodAgnosticSlug,
 			storeSlug: planProduct.product_slug,
 			rawPrice: planProduct.raw_price,
-			pathSlug: planProduct.path_slug,
+			pathSlug: planProduct.product_slug === 'free_plan' ? 'free' : planProduct.path_slug,
 			price:
 				planProduct?.bill_period === MONTHLY_PLAN_BILLING_PERIOD || planProduct.raw_price === 0
 					? getFormattedPrice( planProduct )

--- a/packages/data-stores/src/plans/test/resolvers.ts
+++ b/packages/data-stores/src/plans/test/resolvers.ts
@@ -116,7 +116,7 @@ describe( 'getSupportedPlans', () => {
 				{
 					annualPrice: '₹0',
 					billingPeriod: 'ANNUALLY',
-					pathSlug: undefined,
+					pathSlug: 'free',
 					periodAgnosticSlug: undefined,
 					price: '₹0',
 					productId: 1,

--- a/packages/data-stores/src/plans/test/resolvers.ts
+++ b/packages/data-stores/src/plans/test/resolvers.ts
@@ -25,6 +25,7 @@ describe( 'getSupportedPlans', () => {
 				// premium plan, billed annually
 				currency_code: 'INR',
 				product_slug: PLAN_PREMIUM,
+				path_slug: 'premium',
 				raw_price: 12,
 				product_id: 2,
 			},
@@ -112,6 +113,7 @@ describe( 'getSupportedPlans', () => {
 
 		// setPlanProducts call
 		expect( iter.next().value ).toEqual( {
+			type: 'SET_PLAN_PRODUCTS',
 			products: [
 				{
 					annualPrice: '₹0',
@@ -127,7 +129,7 @@ describe( 'getSupportedPlans', () => {
 					annualDiscount: 92,
 					annualPrice: '₹12',
 					billingPeriod: 'ANNUALLY',
-					pathSlug: undefined,
+					pathSlug: 'premium',
 					periodAgnosticSlug: undefined,
 					price: '₹1',
 					productId: 2,
@@ -146,7 +148,6 @@ describe( 'getSupportedPlans', () => {
 					storeSlug: 'value_bundle_monthly',
 				},
 			],
-			type: 'SET_PLAN_PRODUCTS',
 		} );
 
 		expect( iter.next().value ).toEqual( {

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -117,11 +117,9 @@ export interface APIPlanDetail {
 	support_priority: number;
 	support_name: string;
 	groups: string[];
-	products: [
-		{
-			plan_id: number;
-		}
-	];
+	products: {
+		plan_id: number;
+	}[];
 	name: string;
 	short_name: string;
 	nonlocalized_short_name: PlanSlug;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When Plans data-store was refactored, `getPlanByPath` selector was also [modified](https://github.com/Automattic/wp-calypso/pull/48790/files#diff-fe3f8145013cbb4868d1e345357357b4f1564e6c1c194ad20eec492fa402bb34R111-R125) and now it uses path slugs returned from the API. Since there is no slug in the API response for Free plan, we can return `'free'` in the resolver.

#### Testing instructions

* Go to /new/free
* Advance through the flow. Free plan should be displayed as selected in top-right corner and Plans step shouldn't be mandatory if you pick a free domain and skip Features step. See more details in #48115

Fixes #49391
