### PR TITLE
Fix: hide validation error when field untouched

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -76,6 +76,11 @@ const resetAnalyticsData = () => {
 };
 
 class SignupForm extends Component {
+	constructor( props ) {
+		super( props );
+		this.emailRef = React.createRef();
+	}
+
 	static propTypes = {
 		className: PropTypes.string,
 		disableEmailExplanation: PropTypes.string,
@@ -122,11 +127,17 @@ class SignupForm extends Component {
 
 	state = {
 		submitting: false,
-		focusPassword: false,
-		focusUsername: false,
 		form: null,
 		signedUp: false,
 		validationInitialized: false,
+		isAnyFieldChanged: false,
+		isFieldTouchedStates: {
+			firstName: false,
+			lastName: false,
+			username: false,
+			password: false,
+			email: false,
+		},
 	};
 
 	getInitialFields() {
@@ -151,6 +162,15 @@ class SignupForm extends Component {
 	recordBackLinkClick = () => {
 		recordTracksEvent( 'calypso_signup_back_link_click' );
 	};
+
+	componentDidUpdate() {
+		if ( this.emailRef.current && ! this.state.emailFocussed ) {
+			// eslint-disable-next-line react/no-did-update-set-state
+			this.setState( { emailFocussed: true }, () => {
+				this.emailRef.current.focus();
+			} );
+		}
+	}
 
 	UNSAFE_componentWillMount() {
 		debug( 'Mounting the SignupForm React component.' );
@@ -238,10 +258,11 @@ class SignupForm extends Component {
 	};
 
 	validate = ( fields, onComplete ) => {
+		const { isFieldTouchedStates } = this.state;
 		const fieldsForValidation = filter( [
-			'email',
-			'password',
-			this.props.displayUsernameInput && 'username',
+			isFieldTouchedStates.email && 'email',
+			isFieldTouchedStates.password && 'password',
+			isFieldTouchedStates.username && this.props.displayUsernameInput && 'username',
 			this.props.displayNameInput && 'firstName',
 			this.props.displayNameInput && 'lastName',
 		] );
@@ -330,25 +351,50 @@ class SignupForm extends Component {
 		const name = event.target.name;
 		const value = event.target.value;
 
+		const { isFieldTouchedStates, isAnyFieldChanged } = this.state;
+
+		if ( ! isAnyFieldChanged ) {
+			this.setState( { isAnyFieldChanged: true } );
+		}
+
+		const isFieldPreviouslyTouched = isFieldTouchedStates[ name ];
+		if ( ! isFieldPreviouslyTouched ) {
+			this.setState( { isFieldTouchedStates: { ...isFieldTouchedStates, [ name ]: true } } );
+		}
+
 		this.formStateController.handleFieldChange( {
 			name: name,
 			value: value,
 		} );
 	};
 
+	isEmptyForm = () => {
+		const data = this.getUserData();
+
+		if ( data.username.length === 0 && data.password.length === 0 && data.email.length === 0 ) {
+			return true;
+		}
+		return false;
+	};
+
 	handleBlur = ( event ) => {
-		const fieldId = event.target.id;
-		// Ensure that username and password field validation does not trigger prematurely
-		if ( fieldId === 'password' ) {
-			this.setState( { focusPassword: true }, () => {
-				this.validateAndSaveForm();
-			} );
+		// Form remains untouched until at least one input is keyed in
+		// When a user moves away from the signup form without having entered anything do not show error messages, think going to click log in.
+		// However if any value is keyed in which means at least one field "changes" then we assume that the user means to interact with the signup form
+		// Here if a value was keyed and deleted later we still run the validations even though the form is technically empty
+		if ( ! this.state.isAnyFieldChanged && this.isEmptyForm() ) {
 			return;
 		}
-		if ( fieldId === 'username' ) {
-			this.setState( { focusUsername: true }, () => {
-				this.validateAndSaveForm();
-			} );
+
+		const fieldId = event.target.id;
+		// Ensure that username and password field validation does not trigger prematurely
+		if ( [ 'email', 'username', 'password' ].includes( fieldId ) ) {
+			this.setState(
+				{ isFieldTouchedStates: { ...this.state.isFieldTouchedStates, [ fieldId ]: true } },
+				() => {
+					this.validateAndSaveForm();
+				}
+			);
 			return;
 		}
 
@@ -356,26 +402,50 @@ class SignupForm extends Component {
 	};
 
 	validateAndSaveForm = () => {
-		const data = this.getUserData();
-		// When a user moves away from the signup form without having entered
-		// anything do not show error messages, think going to click log in.
-		if ( data.username.length === 0 && data.password.length === 0 && data.email.length === 0 ) {
-			return;
-		}
-
 		this.formStateController.sanitize();
 		this.formStateController.validate();
 		this.props.save && this.props.save( this.state.form );
 	};
 
+	touchAllFieldsAndValidate = () => {
+		this.setState(
+			{
+				isAnyFieldChanged: true,
+				isFieldTouchedStates: {
+					firstName: true,
+					lastName: true,
+					username: true,
+					password: true,
+					email: true,
+				},
+			},
+			() => {
+				this.validateAndSaveForm();
+			}
+		);
+	};
+
 	handleSubmit = ( event ) => {
 		event.preventDefault();
+
+		if ( this.isEmptyForm() ) {
+			this.touchAllFieldsAndValidate();
+		}
 
 		if ( this.state.submitting ) {
 			return;
 		}
 
-		this.setState( { submitting: true } );
+		this.setState( {
+			submitting: true,
+			isFieldTouchedStates: {
+				firstName: true,
+				lastName: true,
+				username: true,
+				password: true,
+				email: true,
+			},
+		} );
 
 		if ( this.props.submitting ) {
 			resetAnalyticsData();
@@ -566,6 +636,7 @@ class SignupForm extends Component {
 					isValid={ this.state.validationInitialized && isEmailValid }
 					onBlur={ this.handleBlur }
 					onChange={ this.handleChangeEvent }
+					inputRef={ this.emailRef }
 				/>
 				{ this.emailDisableExplanation() }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
Fixes calypso signup UX bug for validation errors showing too early, as mentioned below by @aneeshd16 in his review, this behaviour has some history which needs to be taken to account before diving into this change. Some use cases and scenarios and test cases that I have taken into account, given the history ( #31149, #34247,  #36172 ) 

Discussion here : p9Jlb4-2cE-p2

#### Key Assumptions
- "On mount", focus input on the email field by default.
- If the form is completely empty and the the "Submit" button is clicked, it will not trigger the submit callback and all fields will become "touched", which means all validation errors will now be visible.

- If all fields are empty, any of the fields will not be "touched" even when tabbed.
  - This is to accommodate for the scenario where a user moves away from the signup form without having entered anything. When this happens we should not show any error messages, think when trying to click on log in.
  - However this breaks the behaviour mentioned here [In this comment at #31149](https://github.com/Automattic/wp-calypso/pull/31149#pullrequestreview-210550087) by @jsnajdr where tabbing on fields of and fresh, empty signup form should show errors.
  - Nevertheless if any value whatsoever is keyed in ( at least one field "changes" ) then we assume that the user's intent is to interact with the signup form, NOT redirecting to somewhere else. Hence, even if all value are deleted after an initial key in, we still run the validations even though the form is technically empty.

 
<br/>

- Once at least one field has a "change", any field can now become touched.  "onBlur" of a given field fields that were "touched" will be validated and errors will be shown for any such touched fields.


-----

#### Related Use Cases, further explaining this change

##### Errors should not be shown if all fields are empty and there have been no values keyed in, even if we tab through the fields
1. Open an incognito window
2. Go to /start (Calypso Signup)
3. Enter an email address
4. Tab to other fields
5. Users errors should not be shown to any  fields if all fields are empty

##### Errors should be shown for touched fields (on blur triggered) fields with at least one field triggering a "change"
1. Open an incognito window
2. Go to /start 
3. Enter a random string that is not an email in the email field
5. Tab to next field
6. An "invalid email error" should be shown for email field (Others should not show any errors)
7. Tab to next field
8. An "empty username error" should be shown for username field (Others should not show any errors)
9. Click on tab
10. An "empty password error" should be shown for password field (Others should not show any errors)

##### Are errors shown for all fields when submitting an empty form?
1. Open an incognito window
2. Go to /start 
3. Submit signup form without filling up anything
4. All field errors should be shown
(Form is not submitted if empty, are there any tracks implications here?)

Fixes #38030



> Tagging historical stakeholders involved with this change 
> @davemart-in @jsnajdr @GeoJunkie @p-jackson @niranjan-uma-shankar @simison