### PR TITLE
Monthly Plans: Escape percent sign correctly

### DIFF
--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -126,7 +126,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 					<span ref={ ( ref ) => ref && setSpanRef( ref ) }>{ translate( 'Pay annually' ) }</span>
 					<PopupMessages context={ spanRef } isVisible={ popupIsVisible }>
 						{ translate(
-							'Save up to %(maxDiscount)d% by paying annually and get a free domain for one year',
+							'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',
 							{
 								args: { maxDiscount },
 								comment: 'Will be like "Save up to 30% by paying annually..."',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Escape `%` (percent) sign correctly 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch your WordPress.com account's language to something different than english (e.g. French)
* Open the calypso.live link, visit `/start` and navigate to plans grid
* Click on "Pay monthly" on the monthly vs annually toggle
* The text in the tooltip should be translated (see screenshot):
![image](https://user-images.githubusercontent.com/1083581/106134451-d7340080-6166-11eb-9d03-4ec46b4e5214.png)


Fixes issue discussed in p1611831922171600/1611740503.105000-slack-C0KDTA48Y