### PR TITLE
Data Layer: Move the home settings import to sites

### DIFF
--- a/client/state/site-settings/actions.js
+++ b/client/state/site-settings/actions.js
@@ -14,7 +14,6 @@ import {
 } from 'calypso/state/action-types';
 import { normalizeSettings } from './utils';
 
-import 'calypso/state/data-layer/wpcom/sites/homepage';
 import 'calypso/state/site-settings/init';
 import 'calypso/state/ui/init';
 

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -29,6 +29,8 @@ import {
 } from 'calypso/state/action-types';
 import { SITE_REQUEST_FIELDS, SITE_REQUEST_OPTIONS } from 'calypso/state/sites/constants';
 
+import 'calypso/state/data-layer/wpcom/sites/homepage';
+
 /**
  * Returns an action object to be used in signalling that a site has been
  * deleted.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the site's homepage settings data layer import from `site-settings` to `sites`.

The site's homepage settings are handled by `sites` state, but their data layer was imported into `site-settings`.
This was causing some hard-to-notice issues where the page used for the homepage was saved in the Redux state but never in the database.

#### Testing instructions

* Open `/pages/{ site }` on a site with several pages, and set to show a page as front page.
* Open the browser dev tools' Network tab and filter by `homepage` and XHR.
* Click on any page's ellipsis menu, and either "Set as Homepage" or "Set as Posts Page".
* Observe the Network tab, and make sure a `sites/{ site }/homepage` request is dispatched.
* Reload the page, and make sure the options are persisted correctly. (Wait a few seconds for the fresh data from the server to replace the locally persisted state)

Fixes #46114
