### PR TITLE
eslint i18n fixes (gutenboarding and packages/plans-grid)

### DIFF
--- a/client/landing/gutenboarding/components/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans-button/index.tsx
@@ -40,7 +40,7 @@ const PlansButton: React.FunctionComponent = () => {
 		<>
 			<Link
 				to={ makePath( Step.PlansModal ) }
-				label={ __( planLabel ) }
+				label={ planLabel }
 				className={ classnames( 'plans-button', { 'is-highlighted': !! plan } ) }
 			>
 				{ isDesktop && planLabel }

--- a/packages/plans-grid/src/plans-table/plan-item.tsx
+++ b/packages/plans-grid/src/plans-table/plan-item.tsx
@@ -182,11 +182,7 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 									isPrimary
 									disabled={ !! disabledLabel }
 								>
-									<span>
-										{ disabledLabel
-											? __( disabledLabel, __i18n_text_domain__ )
-											: __( 'Choose', __i18n_text_domain__ ) }
-									</span>
+									<span>{ disabledLabel ?? __( 'Choose', __i18n_text_domain__ ) }</span>
 								</Button>
 							) : (
 								<Button
@@ -200,9 +196,7 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 									<span>
 										{
 											/* translators: %s is a WordPress.com plan name (eg: Free, Personal) */
-											disabledLabel
-												? __( disabledLabel, __i18n_text_domain__ )
-												: sprintf( __( 'Select %s', __i18n_text_domain__ ), name )
+											disabledLabel ?? sprintf( __( 'Select %s', __i18n_text_domain__ ), name )
 										}
 									</span>
 								</Button>
@@ -216,6 +210,7 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 							onPickDomain={ onPickDomainClick }
 							disabledLabel={
 								disabledLabel &&
+								// Translators: %s is the domain name (e.g. "example.com is not included")
 								sprintf( __( '%s is not included', __i18n_text_domain__ ), domain?.domain_name )
 							}
 							billingPeriod={ billingPeriod }


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Refactor code so that it doesn't cause eslint i18n linting errors
* The main fix has been to make sure that a string is not wrapped in the `__()` function twice

## Testing instructions

### Setup
- prepare your sandbox
- in two separate terminal windows, run:
  - `yarn start` 
  - `cd apps/editing-toolkit && yarn dev --sync`

### Focused Launch

1. Add an _unlaunched_ site created through `/start`to your sandbox
2. Visit `wordpress.com/page/SITE_ID.wordpress.com/home?flags=create/focused-launch-flow`
3. Press "Launch" button, Focused Launch summary view should appear
4. Pick a custom domain in the summary view
5. Click "View all plans"
    - [x] Check that the plans grid loads and works as expected, especially the label for the disabled button in the free plan
    - [x] Check that the disable button label is translated correctly (if that's already happening in production)
6. **In short, things should keep working as they are in production**

### Gutenboarding

1. Visit `/new
2. As you go through the steps, check if the "plans button" in the top right appears correctly (as it does in production)
    - [x] Check that the button's label is translated correctly
3. **In short, things should keep working as they are in production**

Related to #49312
