### PR TITLE
Purchases: Reduxify notices in cancel button

### DIFF
--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -24,10 +24,10 @@ import {
 	isSubscription,
 } from 'calypso/lib/purchases';
 import { isDomainRegistration } from 'calypso/lib/products-values';
-import notices from 'calypso/notices';
 import { confirmCancelDomain, purchasesRoot } from 'calypso/me/purchases/paths';
 import { refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { cancellationEffectDetail, cancellationEffectHeadline } from './cancellation-effect';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getDowngradePlanFromPurchase } from 'calypso/state/purchases/selectors';
 
 class CancelPurchaseButton extends Component {
@@ -102,7 +102,7 @@ class CancelPurchaseButton extends Component {
 			this.props.clearPurchases();
 
 			if ( success ) {
-				notices.success(
+				this.props.successNotice(
 					translate(
 						'%(purchaseName)s was successfully cancelled. It will be available ' +
 							'for use until it expires on %(subscriptionEndDate)s.',
@@ -113,12 +113,12 @@ class CancelPurchaseButton extends Component {
 							},
 						}
 					),
-					{ persistent: true }
+					{ displayOnNextPage: true }
 				);
 
 				page( this.props.purchaseListUrl );
 			} else {
-				notices.error(
+				this.props.errorNotice(
 					translate(
 						'There was a problem canceling %(purchaseName)s. ' +
 							'Please try again later or contact support.',
@@ -143,14 +143,14 @@ class CancelPurchaseButton extends Component {
 
 	handleSubmit = ( error, response ) => {
 		if ( error ) {
-			notices.error( error.message );
+			this.props.errorNotice( error.message );
 
 			this.cancellationFailed();
 
 			return;
 		}
 
-		notices.success( response.message, { persistent: true } );
+		this.props.successNotice( response.message, { displayOnNextPage: true } );
 
 		this.props.refreshSitePlans( this.props.purchase.siteId );
 
@@ -171,14 +171,14 @@ class CancelPurchaseButton extends Component {
 				this.setDisabled( false );
 
 				if ( error ) {
-					notices.error( error.message );
+					this.props.errorNotice( error.message );
 
 					this.cancellationFailed();
 
 					return;
 				}
 
-				notices.success( response.message, { persistent: true } );
+				this.props.successNotice( response.message, { displayOnNextPage: true } );
 
 				this.props.refreshSitePlans( purchase.siteId );
 
@@ -206,14 +206,14 @@ class CancelPurchaseButton extends Component {
 				this.setDisabled( false );
 
 				if ( error ) {
-					notices.error( error.message );
+					this.props.errorNotice( error.message );
 
 					this.cancellationFailed();
 
 					return;
 				}
 
-				notices.success( response.message, { persistent: true } );
+				this.props.successNotice( response.message, { displayOnNextPage: true } );
 
 				this.props.refreshSitePlans( purchase.siteId );
 
@@ -320,5 +320,7 @@ class CancelPurchaseButton extends Component {
 
 export default connect( null, {
 	clearPurchases,
+	errorNotice,
+	successNotice,
 	refreshSitePlans,
 } )( localize( CancelPurchaseButton ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reduxifies the notices in the cancel purchase button.

Part of #48408.

#### Testing instructions

* Go to `/me/purchases`.
* Pick some purchases and verify cancelation continues to produce the same notices as before.
* Make sure to test both success and error cases with purchases with the following scenarios:
  * A domain within the refund window.
  * A domain outside the refund window.
  * A plan within the refund window.
  * A plan outside the refund window.
  * A one-off purchase (for example, a premium theme)
