### PR TITLE
Upsell nudge: Redirect to signup destination if eligible

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -155,8 +155,9 @@ export default function getThankYouPageUrl( {
 	// nudge opened by a direct link to /offer-support-session.
 	const isCartEmpty = cart && getAllCartItems( cart ).length === 0;
 	if ( ':receiptId' === pendingOrReceiptId && isCartEmpty ) {
-		debug( 'cart is empty or receipt ID is pending, so returning', fallbackUrl );
-		return fallbackUrl;
+		const emptyCartUrl = urlFromCookie || fallbackUrl;
+		debug( 'cart is empty or receipt ID is pending, so returning', emptyCartUrl );
+		return emptyCartUrl;
 	}
 
 	// Domain only flow
@@ -237,6 +238,11 @@ function getFallbackDestination( {
 	const isCartEmpty = cart ? getAllCartItems( cart ).length === 0 : true;
 	const isReceiptEmpty = ':receiptId' === pendingOrReceiptId;
 
+	if ( 'noPreviousPurchase' === pendingOrReceiptId ) {
+		debug( 'fallback is just root' );
+		return '/';
+	}
+
 	// We will show the Thank You page if there's a site slug and either one of the following is true:
 	// - has a receipt number
 	// - does not have a receipt number but has an item in cart(as in the case of paying with a redirect payment type)
@@ -280,13 +286,10 @@ function getFallbackDestination( {
 				? `/checkout/thank-you/features/${ feature }/${ siteSlug }/${ pendingOrReceiptId }`
 				: `/checkout/thank-you/${ siteSlug }/${ pendingOrReceiptId }`;
 		debug( 'site with receipt or cart; feature is', feature );
+
 		return siteWithReceiptOrCartUrl;
 	}
 
-	if ( siteSlug && ! isCartEmpty ) {
-		debug( 'just site slug', siteSlug );
-		return `/checkout/thank-you/${ siteSlug }`;
-	}
 	debug( 'fallback is just root' );
 	return '/';
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -290,6 +290,11 @@ function getFallbackDestination( {
 		return siteWithReceiptOrCartUrl;
 	}
 
+	if ( siteSlug ) {
+		debug( 'just site slug', siteSlug );
+		return `/checkout/thank-you/${ siteSlug }`;
+	}
+
 	debug( 'fallback is just root' );
 	return '/';
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -121,6 +121,14 @@ export default function getThankYouPageUrl( {
 	} );
 	debug( 'fallbackUrl is', fallbackUrl );
 
+	// If receipt ID is 'noPreviousPurchase', then send the user to a generic page (not post-purchase related).
+	// For example, this case arises when a Skip button is clicked on a concierge upsell
+	// nudge opened by a direct link to /checkout/offer-support-session.
+	if ( 'noPreviousPurchase' === pendingOrReceiptId ) {
+		debug( 'receipt ID is "noPreviousPurchase", so returning: ', fallbackUrl );
+		return fallbackUrl;
+	}
+
 	saveUrlToCookieIfEcomm( saveUrlToCookie, cart, fallbackUrl );
 
 	// If the user is making a purchase/upgrading within the editor,
@@ -148,16 +156,6 @@ export default function getThankYouPageUrl( {
 			managePurchaseUrl
 		);
 		return managePurchaseUrl;
-	}
-
-	// If cart is empty, then send the user to a generic page (not post-purchase related).
-	// For example, this case arises when a Skip button is clicked on a concierge upsell
-	// nudge opened by a direct link to /offer-support-session.
-	const isCartEmpty = cart && getAllCartItems( cart ).length === 0;
-	if ( ':receiptId' === pendingOrReceiptId && isCartEmpty ) {
-		const emptyCartUrl = urlFromCookie || fallbackUrl;
-		debug( 'cart is empty or receipt ID is pending, so returning', emptyCartUrl );
-		return emptyCartUrl;
 	}
 
 	// Domain only flow

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -284,7 +284,7 @@ function getFallbackDestination( {
 		return siteWithReceiptOrCartUrl;
 	}
 
-	if ( siteSlug ) {
+	if ( siteSlug && ! isCartEmpty ) {
 		debug( 'just site slug', siteSlug );
 		return `/checkout/thank-you/${ siteSlug }`;
 	}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -155,9 +155,8 @@ export default function getThankYouPageUrl( {
 	// nudge opened by a direct link to /offer-support-session.
 	const isCartEmpty = cart && getAllCartItems( cart ).length === 0;
 	if ( ':receiptId' === pendingOrReceiptId && isCartEmpty ) {
-		const emptyCartUrl = urlFromCookie || fallbackUrl;
-		debug( 'cart is empty or receipt ID is pending, so returning', emptyCartUrl );
-		return emptyCartUrl;
+		debug( 'cart is empty or receipt ID is pending, so returning', fallbackUrl );
+		return fallbackUrl;
 	}
 
 	// Domain only flow

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -457,21 +457,6 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/cookie' );
 	} );
 
-	it( 'redirects to url from cookie if cart is empty and no receipt is set', () => {
-		const getUrlFromCookie = jest.fn( () => '/cookie' );
-		const cart = {
-			products: [],
-		};
-		const url = getThankYouPageUrl( {
-			...defaultArgs,
-			siteSlug: 'foo.bar',
-			cart,
-			getUrlFromCookie,
-			isEligibleForSignupDestination: true,
-		} );
-		expect( url ).toBe( '/cookie' );
-	} );
-
 	it( 'Should store the current URL in the redirect cookie when called from the editor', () => {
 		const saveUrlToCookie = jest.fn();
 		const cart = {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -437,7 +437,7 @@ describe( 'getThankYouPageUrl', () => {
 			receiptId: 'noPreviousPurchase',
 			cart,
 			getUrlFromCookie,
-			isEligibleForSignupDestination: false,
+			isEligibleForSignupDestinationResult: false,
 		} );
 		expect( url ).toBe( '/' );
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -426,7 +426,7 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/:receiptId' );
 	} );
 
-	it( 'Redirects to thank-you page without a receipt ID if isEligibleForSignupDestination is false', () => {
+	it( 'Redirects to root if previous receipt is "noPreviousPurchase" and isEligibleForSignupDestination is false', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
 			products: [ { product_slug: 'foo' } ],
@@ -434,23 +434,7 @@ describe( 'getThankYouPageUrl', () => {
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
-			receiptId: ':receiptId',
-			cart,
-			getUrlFromCookie,
-			isEligibleForSignupDestination: false,
-		} );
-		expect( url ).toBe( '/checkout/thank-you/foo.bar' );
-	} );
-
-	it( 'Redirects to root if isEligibleForSignupDestination is false, no receiptId, and cart is empty', () => {
-		const getUrlFromCookie = jest.fn( () => '/cookie' );
-		const cart = {
-			products: [],
-		};
-		const url = getThankYouPageUrl( {
-			...defaultArgs,
-			siteSlug: 'foo.bar',
-			receiptId: ':receiptId',
+			receiptId: 'noPreviousPurchase',
 			cart,
 			getUrlFromCookie,
 			isEligibleForSignupDestination: false,

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -426,6 +426,38 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/:receiptId' );
 	} );
 
+	it( 'Redirects to thank-you page without a receipt ID if isEligibleForSignupDestination is false', () => {
+		const getUrlFromCookie = jest.fn( () => '/cookie' );
+		const cart = {
+			products: [ { product_slug: 'foo' } ],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			receiptId: ':receiptId',
+			cart,
+			getUrlFromCookie,
+			isEligibleForSignupDestination: false,
+		} );
+		expect( url ).toBe( '/checkout/thank-you/foo.bar' );
+	} );
+
+	it( 'Redirects to root if isEligibleForSignupDestination is false, no receiptId, and cart is empty', () => {
+		const getUrlFromCookie = jest.fn( () => '/cookie' );
+		const cart = {
+			products: [],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			receiptId: ':receiptId',
+			cart,
+			getUrlFromCookie,
+			isEligibleForSignupDestination: false,
+		} );
+		expect( url ).toBe( '/' );
+	} );
+
 	it( 'redirects to url from cookie if isEligibleForSignupDestination is set', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -50,6 +50,10 @@ import getThankYouPageUrl from 'calypso/my-sites/checkout/composite-checkout/hoo
 import { extractStoredCardMetaValue } from './purchase-modal/util';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import isEligibleForSignupDestination from 'calypso/state/selectors/is-eligible-for-signup-destination';
+import {
+	retrieveSignupDestination,
+	clearSignupDestinationCookie,
+} from 'calypso/signup/storageUtils';
 
 /**
  * Style dependencies
@@ -245,6 +249,14 @@ export class UpsellNudge extends React.Component {
 			isEligibleForSignupDestinationResult: this.props.isEligibleForSignupDestinationResult,
 		};
 		const url = getThankYouPageUrl( getThankYouPageUrlArguments );
+
+		// Removes the destination cookie only if redirecting to the signup destination.
+		// (e.g. if the destination is an upsell nudge, it does not remove the cookie).
+		const destinationFromCookie = retrieveSignupDestination();
+		if ( url.includes( destinationFromCookie ) ) {
+			clearSignupDestinationCookie();
+		}
+
 		page.redirect( url );
 	};
 

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -49,6 +49,7 @@ import { isFetchingStoredCards, getStoredCards } from 'calypso/state/stored-card
 import getThankYouPageUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url';
 import { extractStoredCardMetaValue } from './purchase-modal/util';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
+import isEligibleForSignupDestination from 'calypso/state/selectors/is-eligible-for-signup-destination';
 
 /**
  * Style dependencies
@@ -241,6 +242,7 @@ export class UpsellNudge extends React.Component {
 			receiptId: this.props.receiptId,
 			cart: this.props.cart,
 			hideNudge: shouldHideUpsellNudges,
+			isEligibleForSignupDestinationResult: this.props.isEligibleForSignupDestinationResult,
 		};
 		const url = getThankYouPageUrl( getThankYouPageUrlArguments );
 		page.redirect( url );
@@ -394,6 +396,7 @@ export default connect(
 			siteSlug,
 			selectedSiteId,
 			hasSevenDayRefundPeriod: isMonthly( planSlug ),
+			isEligibleForSignupDestinationResult: isEligibleForSignupDestination( props.cart ),
 		};
 	},
 	{

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -243,7 +243,7 @@ export class UpsellNudge extends React.Component {
 		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
 		const getThankYouPageUrlArguments = {
 			siteSlug: this.props.siteSlug,
-			receiptId: this.props.receiptId,
+			receiptId: this.props.receiptId || 'noPreviousPurchase',
 			cart: this.props.cart,
 			hideNudge: shouldHideUpsellNudges,
 			isEligibleForSignupDestinationResult: this.props.isEligibleForSignupDestinationResult,

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@automattic/calypso-build": "^7.0.0",
 		"@automattic/calypso-color-schemes": "^2.1.1",
+		"@automattic/calypso-config": "^1.0.0-alpha.0",
 		"@automattic/calypso-polyfills": "^1.0.0",
 		"@automattic/calypso-stripe": "^1.0.0",
 		"@automattic/color-studio": "^2.3.0",

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,6 @@
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@automattic/calypso-build": "^7.0.0",
 		"@automattic/calypso-color-schemes": "^2.1.1",
-		"@automattic/calypso-config": "^1.0.0-alpha.0",
 		"@automattic/calypso-polyfills": "^1.0.0",
 		"@automattic/calypso-stripe": "^1.0.0",
 		"@automattic/color-studio": "^2.3.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* On post puchase upsell offer, clicking the Decline button should lead to the following:
    - Take to signup destination if eligible
    - Delete the signup destination cookie
* After opening an upsell offer using a direct link, like `/checkout/offer-quickstart-session`, clicking Decline should take to Customer Home

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow at /start and purchase a Premium plan.
* On the post purchase upsell nudge, click on the "decline" button. You should be taken to Customer Home. The existing behaviour is that it would take to a "Thank You" page.
* On an existing account, open an upsell offer using the direct link, such as `/checkout/offer-quickstart-session`. Confirm that clicking the decline button will take root location `/`. 
* On an account having two sites, open `/checkout/offer-quickstart-session`. Clicking the decline button should take to root location `/`.
* On an existing account, upgrade to a higher plan. Verify that clicking the decline button on the post checkout upsell will take you to a Thank You page for the plan purchase.
* On an existing account, add an eCommerce plan to cart, exit checkout, and then navigate to `/checkout/offer-quickstart-session/{siteSlug}`. Clicking the decline button should take to root location `/` and no new cookies should be set. In production, there's a bug that with an eCommerce plan in cart, clicking decline will take to a thank-you page and then create a new `wpcom_signup_complete_destination` cookie.

