### PR TITLE
Editing Toolkit: Update to 2.15

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.14
+ * Version: 2.15
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.14' );
+define( 'PLUGIN_VERSION', '2.15' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.5
 Tested up to: 5.6
-Stable tag: 2.14
+Stable tag: 2.15
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,11 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.15 =
+* Add plugin to transform i18n imports to local variables (https://github.com/Automattic/wp-calypso/pull/49341)
+* Plans Grid: add monthly pricing option (https://github.com/Automattic/wp-calypso/pull/48963)
+* Gutenboarding: Calypso-Free Launch Button Injection (https://github.com/Automattic/wp-calypso/pull/49004)
 
 = 2.14 =
 * Hide plugin buttons in header on mobile layouts (https://github.com/Automattic/wp-calypso/pull/49329)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.14.0",
+	"version": "2.15.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Bumps version of Editing Toolkit to 2.15

### [Editing Toolkit changes included in this release](https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit)

- [x] Add plugin to transform i18n imports to local variables (#49341)
- [x] Plans Grid: add monthly pricing option (#48963)
- [x] Gutenboarding: Calypso-Free Launch Button Injection (#49004)
- [x] eslint i18n fixes (gutenboarding and packages/plans-grid) (#49400)

### Other [changes](https://github.com/Automattic/wp-calypso/commits/trunk/packages) included from the [imported @automattic packages](https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/tsconfig.json#L37-L46) and their imports

- [x] New Onboarding: fix /new/free flow (#49392)
- [x] localizeUrl: Update to new WordPress.com subdir structure (#49395)

### Testing instructions

1. Load the diff on your sandbox (D56142-code) and confirm that the above changes work correctly
2. When a change has been tested to work correctly, please mark it as checked in the list above
3. Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.
    - [x] Tested on atomic 