### PR TITLE
Add some unit tests to main controller module

### DIFF
--- a/client/jetpack-cloud/controller.ts
+++ b/client/jetpack-cloud/controller.ts
@@ -138,11 +138,11 @@ const siteSelectionWithoutFragment = ( context: PageJS.Context, next: () => void
  * @param {PageJS.Context} context Route context
  * @param {Function} next Next middleware function
  */
-const siteSelectionWithFragment = (
+const siteSelectionWithFragment = async (
 	siteFragment: string,
 	context: PageJS.Context,
 	next: () => void
-): void => {
+): Promise< void > => {
 	const { getState } = context.store;
 	const siteId = getSiteId( getState(), siteFragment );
 
@@ -151,19 +151,19 @@ const siteSelectionWithFragment = (
 		selectSite( context, siteId );
 		next();
 	} else {
-		fetchSite( context, siteFragment ).then( ( { id } ) => {
-			if ( id ) {
-				selectSite( context, id );
-				next();
-			} else {
-				const allSitesPath = addQueryArgs(
-					{ site: siteFragment },
-					sectionify( context.path, siteFragment )
-				);
+		const { id } = await fetchSite( context, siteFragment );
 
-				page.redirect( allSitesPath );
-			}
-		} );
+		if ( id ) {
+			selectSite( context, id );
+			next();
+		} else {
+			const allSitesPath = addQueryArgs(
+				{ site: siteFragment },
+				sectionify( context.path, siteFragment )
+			);
+
+			page.redirect( allSitesPath );
+		}
 	}
 };
 

--- a/client/jetpack-cloud/controller.ts
+++ b/client/jetpack-cloud/controller.ts
@@ -10,6 +10,8 @@ import { addQueryArgs, getSiteFragment, sectionify } from 'calypso/lib/route';
 import {
 	redirectToPrimary,
 	updateRecentSitesPreferences,
+	renderEmptySites,
+	renderNoVisibleSites,
 	recordNoSitesPageView,
 	recordNoVisibleSitesPageView,
 	showMissingPrimaryError,
@@ -180,13 +182,15 @@ export function noSite(
 	const currentUser = getCurrentUser( getState() ) as UserData;
 
 	if ( 0 === currentUser?.jetpack_site_count ) {
-		// TODO: render no sites screen
+		// TODO: render no Jetpack sites screen instead
+		renderEmptySites( context );
 		recordNoSitesPageView( context, siteFragment );
 		return true;
 	}
 
 	if ( 0 === currentUser?.jetpack_visible_site_count ) {
-		// TODO: render no visible sites screen
+		// TODO: render no Jetpack visible sites screen instead
+		renderNoVisibleSites( context );
 		recordNoVisibleSitesPageView( context, siteFragment );
 		return true;
 	}

--- a/client/jetpack-cloud/controller.ts
+++ b/client/jetpack-cloud/controller.ts
@@ -181,15 +181,15 @@ export function noSite(
 	const { getState } = context.store;
 	const currentUser = getCurrentUser( getState() ) as UserData;
 
-	if ( 0 === currentUser?.jetpack_site_count ) {
-		// TODO: render no Jetpack sites screen instead
+	if ( 0 === currentUser?.site_count ) {
+		// TODO: use jetpack_site_count and render no Jetpack sites screen instead
 		renderEmptySites( context );
 		recordNoSitesPageView( context, siteFragment );
 		return true;
 	}
 
-	if ( 0 === currentUser?.jetpack_visible_site_count ) {
-		// TODO: render no Jetpack visible sites screen instead
+	if ( 0 === currentUser?.visible_site_count ) {
+		// TODO: use jetpack_visible_site_count and render no Jetpack visible sites screen instead
 		renderNoVisibleSites( context );
 		recordNoVisibleSitesPageView( context, siteFragment );
 		return true;

--- a/client/jetpack-cloud/controller.ts
+++ b/client/jetpack-cloud/controller.ts
@@ -19,7 +19,15 @@ import { setSelectedSiteId, setAllSitesSelected } from 'calypso/state/ui/actions
  * Type dependencies
  */
 import type { UserData } from 'calypso/lib/user/user';
+import type PageJS from 'page';
 
+/**
+ * Parse site slug from path. If no slug is detected but a `site` query parameter
+ * exists, a redirection to `/:path/:site/` occurs.
+ *
+ * @param {PageJS.Context} context Route context
+ * @returns {string} Site slug
+ */
 const parseSiteFragment = ( context: PageJS.Context ): string | undefined => {
 	const siteFragment = context.params.site || getSiteFragment( context.path );
 
@@ -43,6 +51,13 @@ const parseSiteFragment = ( context: PageJS.Context ): string | undefined => {
 	}
 };
 
+/**
+ * Fetch site data.
+ *
+ * @param {PageJS.Context} context Route context
+ * @param {number|string} siteId Site id
+ * @returns {Promise} Promise that resolves with the site id and slug
+ */
 const fetchSite = (
 	context: PageJS.Context,
 	siteId: number | string
@@ -55,6 +70,12 @@ const fetchSite = (
 	} ) );
 };
 
+/**
+ * Store site id in state, and add site to the list of most recent sites.
+ *
+ * @param {PageJS.Context} context Route context
+ * @param {number|string} siteId Site id
+ */
 const selectSite = ( context: PageJS.Context, siteId: number ): void => {
 	const { dispatch } = context.store;
 
@@ -62,6 +83,14 @@ const selectSite = ( context: PageJS.Context, siteId: number ): void => {
 	updateRecentSitesPreferences( context );
 };
 
+/**
+ * Handle case when path contains no site slug. If the current user has only
+ * one site, we try to use this site for context. Otherwise, the user must
+ * select one of their sites.
+ *
+ * @param {PageJS.Context} context Route context
+ * @param {Function} next Next middleware function
+ */
 const siteSelectionWithoutFragment = ( context: PageJS.Context, next: () => void ): void => {
 	const { getState, dispatch } = context.store;
 	const currentUser = getCurrentUser( getState() ) as UserData;
@@ -93,6 +122,13 @@ const siteSelectionWithoutFragment = ( context: PageJS.Context, next: () => void
 	}
 };
 
+/**
+ * Select site when path contains a site slug.
+ *
+ * @param {string} siteFragment Parsed site slug
+ * @param {PageJS.Context} context Route context
+ * @param {Function} next Next middleware function
+ */
 const siteSelectionWithFragment = (
 	siteFragment: string,
 	context: PageJS.Context,
@@ -122,6 +158,12 @@ const siteSelectionWithFragment = (
 	}
 };
 
+/**
+ * Parse site slug from path and call the proper middleware.
+ *
+ * @param {PageJS.Context} context Route context
+ * @param {Function} next Next middleware function
+ */
 export function cloudSiteSelection( context: PageJS.Context, next: () => void ): void {
 	const siteFragment = parseSiteFragment( context );
 

--- a/client/jetpack-cloud/controller.ts
+++ b/client/jetpack-cloud/controller.ts
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { addQueryArgs, getSiteFragment, sectionify } from 'calypso/lib/route';
+import { redirectToPrimary, updateRecentSitesPreferences } from 'calypso/my-sites/controller';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import getSiteId from 'calypso/state/selectors/get-site-id';
+import { requestSite } from 'calypso/state/sites/actions';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { setSelectedSiteId, setAllSitesSelected } from 'calypso/state/ui/actions';
+
+/**
+ * Type dependencies
+ */
+import type { UserData } from 'calypso/lib/user/user';
+
+const parseSiteFragment = ( context: PageJS.Context ): string | undefined => {
+	const siteFragment = context.params.site || getSiteFragment( context.path );
+
+	if ( siteFragment ) {
+		return siteFragment;
+	}
+
+	const { query: queryParams, pathname } = context;
+	const { site: siteQuery } = queryParams;
+
+	if ( siteQuery ) {
+		page.redirect(
+			addQueryArgs(
+				{
+					...queryParams,
+					site: undefined,
+				},
+				`${ pathname }/${ siteQuery }`
+			)
+		);
+	}
+};
+
+const fetchSite = (
+	context: PageJS.Context,
+	siteId: number | string
+): Promise< { id: number | undefined; slug: string | undefined } > => {
+	const { getState, dispatch } = context.store;
+
+	return dispatch( requestSite( siteId ) ).then( () => ( {
+		id: getSiteId( getState(), siteId ),
+		slug: getSiteSlug( getState(), siteId ),
+	} ) );
+};
+
+const selectSite = ( context: PageJS.Context, siteId: number ): void => {
+	const { dispatch } = context.store;
+
+	dispatch( setSelectedSiteId( siteId ) );
+	updateRecentSitesPreferences( context );
+};
+
+const siteSelectionWithoutFragment = ( context: PageJS.Context, next: () => void ): void => {
+	const { getState, dispatch } = context.store;
+	const currentUser = getCurrentUser( getState() ) as UserData;
+	const hasOneSite = currentUser?.visible_site_count === 1;
+
+	// User has only one site
+	if ( hasOneSite ) {
+		const primarySiteId = getPrimarySiteId( getState() ) as NonNullable< number >;
+		const primarySiteSlug = getSiteSlug( getState(), primarySiteId );
+
+		// Site is already available in state
+		if ( primarySiteSlug ) {
+			// Redirect to the single site context
+			redirectToPrimary( context, primarySiteSlug );
+		} else {
+			fetchSite( context, primarySiteId ).then( ( { slug } ) => {
+				if ( slug ) {
+					// Redirect to the single site context
+					redirectToPrimary( context, slug );
+				} else {
+					// TODO: display error
+				}
+			} );
+		}
+	} else {
+		// Show all sites
+		dispatch( setAllSitesSelected() );
+		next();
+	}
+};
+
+const siteSelectionWithFragment = (
+	siteFragment: string,
+	context: PageJS.Context,
+	next: () => void
+): void => {
+	const { getState } = context.store;
+	const siteId = getSiteId( getState(), siteFragment );
+
+	// Site is already available in state
+	if ( siteId ) {
+		selectSite( context, siteId );
+		next();
+	} else {
+		fetchSite( context, siteFragment ).then( ( { id } ) => {
+			if ( id ) {
+				selectSite( context, id );
+				next();
+			} else {
+				const allSitesPath = addQueryArgs(
+					{ site: siteFragment },
+					sectionify( context.path, siteFragment )
+				);
+
+				page.redirect( allSitesPath );
+			}
+		} );
+	}
+};
+
+export function cloudSiteSelection( context: PageJS.Context, next: () => void ): void {
+	const siteFragment = parseSiteFragment( context );
+
+	// TODO: handle no Jetpack site
+	// TODO: handle no visible Jetpack site
+
+	if ( siteFragment ) {
+		siteSelectionWithFragment( siteFragment, context, next );
+	} else {
+		siteSelectionWithoutFragment( context, next );
+	}
+}

--- a/client/jetpack-cloud/controller.ts
+++ b/client/jetpack-cloud/controller.ts
@@ -63,18 +63,18 @@ const parseSiteFragment = ( context: PageJS.Context ): string | undefined => {
  * Fetch site data.
  *
  * @param {PageJS.Context} context Route context
- * @param {number|string} siteId Site id
+ * @param {number|string} siteIdOrSlug Site id or slug
  * @returns {Promise} Promise that resolves with the site id and slug
  */
 const fetchSite = (
 	context: PageJS.Context,
-	siteId: number | string
+	siteIdOrSlug: number | string
 ): Promise< { id: number | undefined; slug: string | undefined } > => {
 	const { getState, dispatch } = context.store;
 
-	return dispatch( requestSite( siteId ) ).then( () => ( {
-		id: getSiteId( getState(), siteId ),
-		slug: getSiteSlug( getState(), siteId ),
+	return dispatch( requestSite( siteIdOrSlug ) ).then( () => ( {
+		id: getSiteId( getState(), siteIdOrSlug ),
+		slug: getSiteSlug( getState(), siteIdOrSlug ),
 	} ) );
 };
 

--- a/client/jetpack-cloud/index.js
+++ b/client/jetpack-cloud/index.js
@@ -10,8 +10,7 @@ import React from 'react';
  */
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { cloudSiteSelection } from 'calypso/jetpack-cloud/controller';
-import { sites } from 'calypso/my-sites/controller';
+import { sites, siteSelection } from 'calypso/my-sites/controller';
 import { startJetpackCloudOAuthOverride } from 'calypso/lib/jetpack/oauth-override';
 import { translate } from 'i18n-calypso';
 import Landing from './sections/landing';
@@ -54,8 +53,8 @@ export const handleOAuthOverride = () => {
 };
 
 export default function () {
-	page( '/landing/:site', cloudSiteSelection, landingController, makeLayout, clientRender );
-	page( '/landing', cloudSiteSelection, selectionPrompt, sites, makeLayout, clientRender );
+	page( '/landing/:site', siteSelection, landingController, makeLayout, clientRender );
+	page( '/landing', siteSelection, selectionPrompt, sites, makeLayout, clientRender );
 	page( '/oauth-override', handleOAuthOverride );
 	page( '/', redirectToPrimarySiteLanding );
 }

--- a/client/jetpack-cloud/index.js
+++ b/client/jetpack-cloud/index.js
@@ -10,7 +10,8 @@ import React from 'react';
  */
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { siteSelection, sites } from 'calypso/my-sites/controller';
+import { cloudSiteSelection } from 'calypso/jetpack-cloud/controller';
+import { sites } from 'calypso/my-sites/controller';
 import { startJetpackCloudOAuthOverride } from 'calypso/lib/jetpack/oauth-override';
 import { translate } from 'i18n-calypso';
 import Landing from './sections/landing';
@@ -53,8 +54,8 @@ export const handleOAuthOverride = () => {
 };
 
 export default function () {
-	page( '/landing/:site', siteSelection, landingController, makeLayout, clientRender );
-	page( '/landing', siteSelection, selectionPrompt, sites, makeLayout, clientRender );
+	page( '/landing/:site', cloudSiteSelection, landingController, makeLayout, clientRender );
+	page( '/landing', cloudSiteSelection, selectionPrompt, sites, makeLayout, clientRender );
 	page( '/oauth-override', handleOAuthOverride );
 	page( '/', redirectToPrimarySiteLanding );
 }

--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -4,7 +4,7 @@
 import { jetpackPricingContext } from './controller';
 import config from '@automattic/calypso-config';
 import userFactory from 'calypso/lib/user';
-import { siteSelection } from 'calypso/my-sites/controller';
+import { cloudSiteSelection } from 'calypso/jetpack-cloud/controller';
 import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
 
 /**
@@ -25,10 +25,10 @@ export default function (): void {
 			jetpackPlans( `/plans`, jetpackPricingContext );
 		}
 	} else {
-		jetpackPlans( `/pricing/:site?`, siteSelection, jetpackPricingContext );
+		jetpackPlans( `/pricing/:site?`, cloudSiteSelection, jetpackPricingContext );
 
 		if ( config.isEnabled( 'jetpack-cloud/connect' ) ) {
-			jetpackPlans( `/plans/:site?`, siteSelection, jetpackPricingContext );
+			jetpackPlans( `/plans/:site?`, cloudSiteSelection, jetpackPricingContext );
 		}
 	}
 }

--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -4,7 +4,7 @@
 import { jetpackPricingContext } from './controller';
 import config from '@automattic/calypso-config';
 import userFactory from 'calypso/lib/user';
-import { cloudSiteSelection } from 'calypso/jetpack-cloud/controller';
+import { siteSelection } from 'calypso/my-sites/controller';
 import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
 
 /**
@@ -25,10 +25,10 @@ export default function (): void {
 			jetpackPlans( `/plans`, jetpackPricingContext );
 		}
 	} else {
-		jetpackPlans( `/pricing/:site?`, cloudSiteSelection, jetpackPricingContext );
+		jetpackPlans( `/pricing/:site?`, siteSelection, jetpackPricingContext );
 
 		if ( config.isEnabled( 'jetpack-cloud/connect' ) ) {
-			jetpackPlans( `/plans/:site?`, cloudSiteSelection, jetpackPricingContext );
+			jetpackPlans( `/plans/:site?`, siteSelection, jetpackPricingContext );
 		}
 	}
 }

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -70,9 +70,11 @@ export type OptionalUserData = {
 	primary_blog_is_jetpack: boolean;
 	primary_blog_url: string;
 	site_count: number;
+	jetpack_site_count?: number;
 	social_login_connections: unknown;
 	user_ip_country_code: string;
 	user_URL: string;
 	username: string;
 	visible_site_count: number;
+	jetpack_visible_site_count?: number;
 };

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -101,7 +101,7 @@ function createNavigation( context ) {
 	);
 }
 
-function renderEmptySites( context ) {
+export function renderEmptySites( context ) {
 	setSectionMiddleware( { group: 'sites' } )( context );
 
 	context.primary = React.createElement( NoSitesMessage );
@@ -110,7 +110,7 @@ function renderEmptySites( context ) {
 	clientRender( context );
 }
 
-function renderNoVisibleSites( context ) {
+export function renderNoVisibleSites( context ) {
 	const { getState } = getStore( context );
 	const state = getState();
 	const currentUser = getCurrentUser( state );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -262,7 +262,7 @@ export function updateRecentSitesPreferences( context ) {
 	const state = context.store.getState();
 
 	if ( hasReceivedRemotePreferences( state ) ) {
-		const siteId = getSelectedSite( state )?.ID;
+		const siteId = getSelectedSiteId( state );
 		const recentSites = getPreference( state, 'recentSites' );
 
 		if ( siteId && siteId !== recentSites[ 0 ] ) {

--- a/client/my-sites/test/controller.js
+++ b/client/my-sites/test/controller.js
@@ -1,0 +1,209 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+/**
+ * Internal dependencies
+ */
+import {
+	updateRecentSitesPreferences,
+	recordNoSitesPageView,
+	recordNoVisibleSitesPageView,
+	redirectToPrimary,
+} from '../controller';
+import * as pageView from 'calypso/lib/analytics/page-view';
+import { PREFERENCES_SET } from 'calypso/state/action-types';
+
+const middlewares = [ thunk ];
+const mockStore = configureStore( middlewares );
+
+describe( 'updateRecentSitesPreferences', () => {
+	it( 'should do nothing if remote preferences are not available', () => {
+		const initialState = {
+			preferences: {
+				remoteValues: null,
+			},
+		};
+		const store = mockStore( initialState );
+
+		updateRecentSitesPreferences( { store } );
+
+		expect( store.getActions() ).toHaveLength( 0 );
+	} );
+
+	it( 'should not nothing if no site is selected', () => {
+		const initialState = {
+			preferences: {
+				remoteValues: {},
+			},
+			ui: {
+				selectedSiteId: null,
+			},
+		};
+		const store = mockStore( initialState );
+
+		updateRecentSitesPreferences( { store } );
+
+		expect( store.getActions() ).toHaveLength( 0 );
+	} );
+
+	it( 'should not nothing if selected site is the most recent', () => {
+		const selectedSiteId = 1;
+		const initialState = {
+			preferences: {
+				remoteValues: {
+					recentSites: [ selectedSiteId ],
+				},
+			},
+			ui: {
+				selectedSiteId,
+			},
+		};
+		const store = mockStore( initialState );
+
+		updateRecentSitesPreferences( { store } );
+
+		expect( store.getActions() ).toHaveLength( 0 );
+	} );
+
+	it( 'should save the selected site as the most recent', () => {
+		const selectedSiteId = 1;
+		const initialState = {
+			preferences: {
+				remoteValues: {
+					recentSites: [ selectedSiteId + 1 ],
+				},
+			},
+			sites: {
+				items: {
+					[ selectedSiteId ]: {},
+					[ selectedSiteId + 1 ]: {},
+				},
+			},
+			ui: {
+				selectedSiteId,
+			},
+		};
+		const store = mockStore( initialState );
+
+		updateRecentSitesPreferences( { store } );
+
+		expect(
+			store.getActions().find( ( { type } ) => type === PREFERENCES_SET )?.value[ 0 ]
+		).toEqual( selectedSiteId );
+	} );
+
+	it( 'should limit the number of recent sites to 5', () => {
+		const initialState = {
+			preferences: {
+				remoteValues: {
+					recentSites: [ 2, 3, 4, 5, 6 ],
+				},
+			},
+			sites: {
+				items: {
+					1: {},
+					2: {},
+					3: {},
+					4: {},
+					5: {},
+					6: {},
+				},
+			},
+			ui: {
+				selectedSiteId: 1,
+			},
+		};
+		const store = mockStore( initialState );
+
+		updateRecentSitesPreferences( { store } );
+
+		expect(
+			store.getActions().find( ( { type } ) => type === PREFERENCES_SET )?.value
+		).toHaveLength( 5 );
+	} );
+
+	it( 'should not save sites that are not available locally', () => {
+		const selectedSiteId = 1;
+		const initialState = {
+			preferences: {
+				remoteValues: {
+					recentSites: [ selectedSiteId + 1 ],
+				},
+			},
+			sites: {
+				items: {
+					[ selectedSiteId ]: {},
+				},
+			},
+			ui: {
+				selectedSiteId,
+			},
+		};
+		const store = mockStore( initialState );
+
+		updateRecentSitesPreferences( { store } );
+
+		expect(
+			store.getActions().find( ( { type } ) => type === PREFERENCES_SET )?.value
+		).toHaveLength( 1 );
+	} );
+} );
+
+describe( 'recordNoVisibleSitesPageView', () => {
+	it( 'should record the page view', () => {
+		const path = '/path';
+		const siteFragment = 'site';
+		const title = 'Title';
+
+		pageView.recordPageView = jest.fn();
+
+		recordNoVisibleSitesPageView( { path: `${ path }/${ siteFragment }` }, siteFragment, title );
+
+		expect( pageView.recordPageView ).toHaveBeenCalledWith(
+			`/no-sites`,
+			expect.stringMatching( 'All Sites Hidden' ),
+			{ base_path: path }
+		);
+
+		pageView.recordPageView.mockRestore();
+	} );
+} );
+
+describe( 'recordNoSitesPageView', () => {
+	it( 'should record the page view', () => {
+		const path = '/path';
+		const siteFragment = 'site';
+
+		pageView.recordPageView = jest.fn();
+
+		recordNoSitesPageView( { path: `${ path }/${ siteFragment }` }, siteFragment );
+
+		expect( pageView.recordPageView ).toHaveBeenCalledWith(
+			`/no-sites`,
+			expect.stringMatching( 'No Sites' ),
+			{ base_path: path }
+		);
+
+		pageView.recordPageView.mockRestore();
+	} );
+} );
+
+describe( 'redirectToPrimary', () => {
+	it( 'should redirect to section with the specified site', () => {
+		const path = '/path';
+		const siteFragment = 'site';
+		const query = 'a=b';
+
+		page.redirect = jest.fn();
+
+		redirectToPrimary( { pathname: `${ path }/no-site`, querystring: query }, siteFragment );
+
+		expect( page.redirect ).toHaveBeenCalledWith( `${ path }/site?${ query }` );
+
+		page.redirect.mockRestore();
+	} );
+} );

--- a/client/state/selectors/get-site-id.js
+++ b/client/state/selectors/get-site-id.js
@@ -16,8 +16,8 @@ import { getSite } from 'calypso/state/sites/selectors';
  * const numericID = getSiteId( state, siteIdentifierOfUnknownFormat );
  *
  * @param  {object}  state       Global state tree
- * @param  {number|string|null}  siteIdOrSlug Site ID
- * @returns {?number}             Site object
+ * @param  {number|string|null}  siteIdOrSlug Site ID or slug
+ * @returns {?number}            Site ID
  */
 export default function getSiteId( state, siteIdOrSlug ) {
 	if ( ! siteIdOrSlug ) {

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -113,7 +113,7 @@ export function requestSites() {
  * Returns a function which, when invoked, triggers a network request to fetch
  * a site.
  *
- * @param {number} siteFragment Site ID or slug
+ * @param {number|string} siteFragment Site ID or slug
  * @param {boolean} forceWpcom explicitly get info from WPCOM vs Jetpack site
  * @returns {Function}              Action thunk
  */

--- a/package.json
+++ b/package.json
@@ -314,6 +314,8 @@
 	"devDependencies": {
 		"bunyan": "^1.8.14",
 		"chokidar": "^2.1.8",
-		"eslint-nibble": "^6.0.0"
+		"eslint-nibble": "^6.0.0",
+		"redux-mock-store": "^1.5.4",
+		"redux-thunk": "^2.3.0"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23290,6 +23290,13 @@ redux-dynamic-middlewares@^2.0.0:
   resolved "https://registry.yarnpkg.com/redux-dynamic-middlewares/-/redux-dynamic-middlewares-2.0.0.tgz#bb34e42d22deb5fe8d5e6af8af66d0739d26e8b1"
   integrity sha512-Wqr76OhNkT+HqDumK9crfa/ZSR06wR29mB8DkTjR+Z/aTv9UmNv2zQKpjUBk4YiD7z2oXbPiWuycK4DB/jEQnQ==
 
+redux-mock-store@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.4.tgz#90d02495fd918ddbaa96b83aef626287c9ab5872"
+  integrity sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==
+  dependencies:
+    lodash.isplainobject "^4.0.6"
+
 redux-multi@^0.1.12:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/redux-multi/-/redux-multi-0.1.12.tgz#28e1fe5e49672cbc5bd8a07f0b2aeaf0ef8355c2"


### PR DESCRIPTION
### Changes proposed in this Pull Request

#47936 extracted some logic in `siteSelection` to their own functions, for reuse. This PR adds unit tests for these newly created functions.

### Testing instructions

- Review changes
- Check that the tests pass in this PR
- Alternatively, download the PR and run `yarn test-client:watch client/my-sites/test/controller.js`