### PR TITLE
Nav Unification: address color schemes Beta feedback

### DIFF
--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -166,3 +166,17 @@
 		}
 	}
 }
+
+/**
+ * Color scheme specific styles
+ *
+ * Nav unification introduces changes that require modifications to existing color schemes.
+ */
+
+// Ensure sidebar is visually separate from the content in the Contrast color scheme
+// client/layout/style.scss
+.theme-default.is-contrast .is-nav-unification {
+	.layout__secondary {
+		outline: 1px solid var( --color-sidebar-border );
+	}
+}

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -157,24 +157,31 @@ $font-size: rem( 14px );
 			opacity: 0.6;
 		}
 
-		.sidebar__menu-item-parent {
-			&.selected {
-				.sidebar__menu-link {
-					background: var( --color-sidebar-menu-selected-background );
-					color: var( --color-sidebar-menu-selected-text );
+		.selected .sidebar__menu-link {
+			background: var( --color-sidebar-menu-selected-background );
+			color: var( --color-sidebar-menu-selected-text );
 
-					.sidebar__menu-icon {
-						color: var( --color-sidebar-menu-selected-text );
-					}
+			&::after {
+				display: block;
+			}
+		}
 
-					img.sidebar__menu-icon {
-						opacity: 1;
-					}
+		.sidebar__menu--selected .selected .sidebar__menu-link::after,
+		.sidebar__expandable-content .selected .sidebar__menu-link::after {
+			display: none;
+		}
 
-					&::after {
-						display: block;
-					}
-				}
+		.sidebar__menu-item-parent.selected .sidebar__menu-link {
+			.sidebar__menu-icon {
+				color: var( --color-sidebar-menu-selected-text );
+			}
+
+			img.sidebar__menu-icon {
+				opacity: 1;
+			}
+
+			&::after {
+				display: block;
 			}
 		}
 
@@ -454,6 +461,41 @@ $font-size: rem( 14px );
 		width: 80px;
 		height: 21px;
 		margin-right: 8px;
+	}
+
+	// Reader specific styles
+	// client/reader/sidebar/style.scss
+	.is-section-reader & {
+		.sidebar__menu .count {
+			background: transparent;
+			color: var( --color-sidebar-menu-text );
+			border-color: var( --color-sidebar-menu-text );
+		}
+
+		.sidebar__menu-link:hover .count {
+			color: var( --color-sidebar-submenu-hover-text );
+			border-color: var( --color-sidebar-submenu-hover-text );
+		}
+
+		.selected .sidebar__menu-link .count {
+			color: var( --color-sidebar-submenu-selected-text );
+			border-color: var( --color-sidebar-submenu-selected-text );
+		}
+
+		.sidebar__menu.is-toggle-open {
+			.sidebar__heading {
+				background: var( --color-sidebar-menu-selected-background );
+				color: var( --color-sidebar-menu-selected-text );
+
+				&::after {
+					display: block;
+				}
+
+				.sidebar__menu-icon {
+					fill: var( --color-sidebar-menu-selected-text );
+				}
+			}
+		}
 	}
 
 	/*

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
@@ -141,6 +141,6 @@ Used studio-blue for the primary+accent.
 	--color-sidebar-submenu-background: var( --theme-submenu-background-color );
 	--color-sidebar-submenu-text: var( --theme-submenu-text-color );
 	--color-sidebar-submenu-hover-background: transparent;
-	--color-sidebar-submenu-hover-text: var( --theme-highlight-color );
+	--color-sidebar-submenu-hover-text: var( --theme-text-color );
 }
 

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
@@ -32,6 +32,7 @@ Well use studio-orange for both the primary and accent colors
 	--theme-base-color-rgb: 207, 73, 68; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
 	--theme-submenu-text-color: #f1c8c7; /* mix( $base-color, $text-color, 30% ) */
 	--theme-submenu-background-color: #be3631; /* darken( $base-color, 7% ), computed: http://scg.ar-ch.org/ */
+	--theme-submenu-hover-text-color: #f7e3d3; /* Direct from wp-admin */
 	--theme-icon-color: #f3f1f1; /* Direct from wp-admin */
 	--theme-highlight-color: #dd823b; /* Direct from wp-admin */
 	--theme-highlight-color-rgb: 221, 130, 59; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
@@ -143,6 +144,6 @@ Well use studio-orange for both the primary and accent colors
 	--color-sidebar-submenu-background: var( --theme-submenu-background-color );
 	--color-sidebar-submenu-text: var( --theme-submenu-text-color );
 	--color-sidebar-submenu-hover-background: transparent;
-	--color-sidebar-submenu-hover-text: var( --theme-highlight-color );
+	--color-sidebar-submenu-hover-text: var( --theme-submenu-hover-text-color );
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR aims to address a collection of issues related to color schemes reported in the Beta feedback.

In various color schemes this PR:
- fixes the selected state of menu items in Calypso /me/account
- fixes the selected state of menu items in the Reader
- fixes the unread normal/hover/selected states in the Reader
- fixes the hover color of submenu items in Calypso for Blue and Sunrise color schemes
- adds a visual divider between sidebar and content in the Contrast color scheme

Related issue https://github.com/Automattic/wp-calypso/issues/48009

### Testing instructions

#### General testing instructions

The before/after changes should be tested in specific themes as outlined below. That said, please also double check that the rest of the color schemes and interface still looks as expected.

When testing locally there's a know issue where the /me/account screen doesn't work in Chrome. You can use Firefox to switch your color scheme in /me/account locally.

#### Shared testing instructions

- Check out and run branch locally or use the calypso.live link
- Log in as an A11n and ensure you're seeing the Nav Unification interface

#### Testing fixed selected state of menu items in Calypso /me/account

|Before|After|
|-|-|
|<img width="268" alt="101065707-77a0e680-3563-11eb-9b4b-9ee0cdcb6b3d" src="https://user-images.githubusercontent.com/1562646/106147958-c4c2c280-6178-11eb-9b64-f691f6e09bba.png">|<img width="295" alt="Screenshot 2021-01-28 at 14 59 31" src="https://user-images.githubusercontent.com/1562646/106148551-76fa8a00-6179-11eb-9adc-62d6c741df75.png">|

- Navigate to /me/account
- Ensure that the After state compares to the screenshot above 
- Confirm the result is as expected for the following color schemes: 
  - [ ] Light
  - [ ] Classic Blue
  - [ ] Contrast
  - [ ] Aquatic
 
#### Testing fixes in the Reader

|Before|After|
|-|-|
|<img width="282" alt="Screenshot 2021-01-28 at 15 15 26" src="https://user-images.githubusercontent.com/1562646/106150462-aca07280-617b-11eb-861b-15192f58bfc1.png">|<img width="288" alt="Screenshot 2021-01-28 at 15 10 36" src="https://user-images.githubusercontent.com/1562646/106149895-0e141180-617b-11eb-9fc6-07b8210f8917.png">|

- Navigate to /read
- Ensure that the After states compare to the screenshots above for:
  - [ ] the selected state of menu items in the Reader
  - [ ] the unread normal/hover/selected states in the Reader
  - [ ] the hover color of submenu items in the Reader
- Confirm the results are as expected for the following color schemes: 
  - [ ] Aquatic
  - [ ] Contrast
  - [ ] Blue
  - [ ] Sunrise

#### Testing the addition of a visual divider in the Contrast color scheme

|Before|After|
|-|-|
|<img width="404" alt="Screenshot 2021-01-28 at 15 08 05" src="https://user-images.githubusercontent.com/1562646/106149539-abbb1100-617a-11eb-8d4e-a845a72c4efc.png">|<img width="414" alt="Screenshot 2021-01-28 at 15 07 34" src="https://user-images.githubusercontent.com/1562646/106149545-ad84d480-617a-11eb-9a60-8195b48becfb.png">|

- select the Contrast color scheme
- confirm there is now a visual divider between the sidebar and the content
