### PR TITLE
i18n: Throttle i18n.addTranslations calls

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -570,8 +570,6 @@ const _addTranslationsBatch = throttle( function ( userTranslations ) {
 /**
  * Adds new translations to the existing locale data.
  *
-
- *
  * @param {Object} translations       Translations data
  * @param {Object} [userTranslations] User translations data that will override chunk translations
  */

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -556,26 +556,24 @@ const _translationsBatch = [];
 /**
  * A throttle wrapper around i18n.addTranslations.
  *
- * This function also saves the duration of the call as a performance measure
- *
  * @param {Object} userTranslations User translations data that will override chunk translations
  */
 const _addTranslationsBatch = throttle( function ( userTranslations ) {
-	window.performance?.mark( 'add_translations_start' );
 	i18n.addTranslations( Object.assign( {}, ..._translationsBatch.splice( 0 ), userTranslations ) );
-	window.performance?.measure( 'add_translations', 'add_translations_start' );
-	window.performance?.clearMarks( 'add_translations_start' );
 }, 100 );
 
 /**
  * Adds new translations to the existing locale data.
  *
-
+ * This function also saves the duration of the call as a performance measure
  *
  * @param {Object} translations       Translations data
  * @param {Object} [userTranslations] User translations data that will override chunk translations
  */
 function addTranslations( translations, userTranslations ) {
+	window.performance?.mark( 'add_translations_start' );
 	_translationsBatch.push( translations );
 	_addTranslationsBatch( userTranslations );
+	window.performance?.measure( 'add_translations', 'add_translations_start' );
+	window.performance?.clearMarks( 'add_translations_start' );
 }

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -556,24 +556,26 @@ const _translationsBatch = [];
 /**
  * A throttle wrapper around i18n.addTranslations.
  *
+ * This function also saves the duration of the call as a performance measure
+ *
  * @param {Object} userTranslations User translations data that will override chunk translations
  */
 const _addTranslationsBatch = throttle( function ( userTranslations ) {
+	window.performance?.mark( 'add_translations_start' );
 	i18n.addTranslations( Object.assign( {}, ..._translationsBatch.splice( 0 ), userTranslations ) );
+	window.performance?.measure( 'add_translations', 'add_translations_start' );
+	window.performance?.clearMarks( 'add_translations_start' );
 }, 100 );
 
 /**
  * Adds new translations to the existing locale data.
  *
- * This function also saves the duration of the call as a performance measure
+
  *
  * @param {Object} translations       Translations data
  * @param {Object} [userTranslations] User translations data that will override chunk translations
  */
 function addTranslations( translations, userTranslations ) {
-	window.performance?.mark( 'add_translations_start' );
 	_translationsBatch.push( translations );
 	_addTranslationsBatch( userTranslations );
-	window.performance?.measure( 'add_translations', 'add_translations_start' );
-	window.performance?.clearMarks( 'add_translations_start' );
 }

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -3,7 +3,7 @@
  */
 import i18n from 'i18n-calypso';
 import debugFactory from 'debug';
-import { forEach, includes } from 'lodash';
+import { forEach, includes, throttle } from 'lodash';
 
 /**
  * Internal dependencies
@@ -294,7 +294,7 @@ function addRequireChunkTranslationsHandler(
 			localeSlug,
 			targetBuild
 		).then( ( translations ) => {
-			addTranslations( { ...translations, ...userTranslations } );
+			addTranslations( translations, userTranslations );
 			loadedTranslationChunks[ chunkId ] = true;
 		} );
 
@@ -547,15 +547,35 @@ function loadCSS( cssUrl, currentLink ) {
 }
 
 /**
- * Add translations.
+ * Translation data batch strore.
+ *
+ * @type {Array}
+ */
+const _translationsBatch = [];
+
+/**
+ * A throttle wrapper around i18n.addTranslations.
  *
  * This function also saves the duration of the call as a performance measure
  *
- * @param translations translations to add
+ * @param {Object} userTranslations User translations data that will override chunk translations
  */
-function addTranslations( translations ) {
+const _addTranslationsBatch = throttle( function ( userTranslations ) {
 	window.performance?.mark( 'add_translations_start' );
-	i18n.addTranslations( translations );
+	i18n.addTranslations( Object.assign( {}, ..._translationsBatch.splice( 0 ), userTranslations ) );
 	window.performance?.measure( 'add_translations', 'add_translations_start' );
 	window.performance?.clearMarks( 'add_translations_start' );
+}, 1000 / 60 );
+
+/**
+ * Adds new translations to the existing locale data.
+ *
+
+ *
+ * @param {Object} translations       Translations data
+ * @param {Object} [userTranslations] User translations data that will override chunk translations
+ */
+function addTranslations( translations, userTranslations ) {
+	_translationsBatch.push( translations );
+	_addTranslationsBatch( userTranslations );
 }

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -565,7 +565,7 @@ const _addTranslationsBatch = throttle( function ( userTranslations ) {
 	i18n.addTranslations( Object.assign( {}, ..._translationsBatch.splice( 0 ), userTranslations ) );
 	window.performance?.measure( 'add_translations', 'add_translations_start' );
 	window.performance?.clearMarks( 'add_translations_start' );
-}, 1000 / 60 );
+}, 100 );
 
 /**
  * Adds new translations to the existing locale data.

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -565,7 +565,7 @@ const _addTranslationsBatch = throttle( function ( userTranslations ) {
 	i18n.addTranslations( Object.assign( {}, ..._translationsBatch.splice( 0 ), userTranslations ) );
 	window.performance?.measure( 'add_translations', 'add_translations_start' );
 	window.performance?.clearMarks( 'add_translations_start' );
-}, 100 );
+}, 50 );
 
 /**
  * Adds new translations to the existing locale data.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Throttle `i18n.addTranslations` calls in translation chunks related callbacks to reduce the total amount of calls and improve performance.

#### Testing instructions

* Change Calypso UI to a non-English language, preferably to a Mag-16 language
* Go to `calypso.live` build and add `?flags=use-translation-chunks` to the URL
* Confirm the initial and async loaded translation chunks are rendering properly by navigating through different sections of Calypso.
* Additionally, go to `{calypso.live}/post/{site}/{postId}?flags=use-translation-chunks` and inspect the logstash network request. `properties.translationsChunksDuration` is expected to be lower compared to the current wordpress.com build. 

Ref. p1611841947138800-slack-calypso-performance
