### PR TITLE
Focused Launch - Summary View: Update the plan's prices with monthly/annual toggle

### DIFF
--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -327,10 +327,12 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 		? [ defaultPaidPlan, nonDefaultPaidPlan, defaultFreePlan ]
 		: [ defaultPaidPlan, defaultFreePlan ];
 
-	const allAvailablePlansProducts = useSelect( ( select ) =>
-		allAvailablePlans.map( ( plan ) =>
-			select( PLANS_STORE ).getPlanProduct( plan?.periodAgnosticSlug, selectedPlanBillingPeriod )
-		)
+	const allAvailablePlansProducts = useSelect(
+		( select ) =>
+			allAvailablePlans.map( ( plan ) =>
+				select( PLANS_STORE ).getPlanProduct( plan?.periodAgnosticSlug, selectedPlanBillingPeriod )
+			),
+		[ allAvailablePlans, selectedPlanBillingPeriod ]
 	);
 
 	return (

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -403,7 +403,8 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 						</p>
 						<div>
 							{ allAvailablePlans.map( ( plan, index ) =>
-								! plan ? (
+								typeof plan === 'undefined' ||
+								typeof allAvailablePlansProducts?.[ index ] === 'undefined' ? (
 									<FocusedLaunchSummaryItem key={ index } isLoading />
 								) : (
 									<FocusedLaunchSummaryItem

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -298,8 +298,8 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 		return {
 			selectedPlan: plansStore.getPlanByProductId( selectedPlanProductId, locale ),
 			selectedPaidPlan: plansStore.getPlanByProductId( selectedPaidPlanProductId, locale ),
-			selectedPlanBillingPeriod: plansStore.getPlanProductById( selectedPlanProductId )
-				?.billingPeriod,
+			selectedPlanBillingPeriod:
+				plansStore.getPlanProductById( selectedPlanProductId )?.billingPeriod || 'ANNUALLY',
 		};
 	} );
 

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -284,30 +284,46 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 
 	const { setPlanProductId } = useDispatch( LAUNCH_STORE );
 
-	const selectedPlanProductId = useSelect( ( select ) =>
-		select( LAUNCH_STORE ).getSelectedPlanProductId()
-	);
+	const { selectedPlanProductId } = useSelect( ( select ) => {
+		const launchStore = select( LAUNCH_STORE );
 
-	const selectedPaidPlanProductId = useSelect( ( select ) =>
-		select( LAUNCH_STORE ).getPaidPlanProductId()
-	);
-
-	const selectedPlan = useSelect( ( select ) =>
-		select( PLANS_STORE ).getPlanByProductId( selectedPlanProductId, locale )
-	);
-
-	const selectedPaidPlan = useSelect( ( select ) =>
-		select( PLANS_STORE ).getPlanByProductId( selectedPaidPlanProductId, locale )
-	);
-
-	const { selectedPlanProduct } = useSelect( ( select ) => {
-		const plansStore = select( PLANS_STORE );
 		return {
-			selectedPlanProduct: plansStore.getPlanProductById( selectedPlanProductId ),
+			selectedPlanProductId: launchStore.getSelectedPlanProductId(),
 		};
 	} );
 
-	const billingPeriod = selectedPlanProduct?.billingPeriod;
+	const { selectedPaidPlanProductId } = useSelect( ( select ) => {
+		const launchStore = select( LAUNCH_STORE );
+
+		return {
+			selectedPaidPlanProductId: launchStore.getPaidPlanProductId(),
+		};
+	} );
+
+	const { selectedPlan } = useSelect( ( select ) => {
+		const plansStore = select( PLANS_STORE );
+
+		return {
+			selectedPlan: plansStore.getPlanByProductId( selectedPlanProductId, locale ),
+		};
+	} );
+
+	const { selectedPaidPlan } = useSelect( ( select ) => {
+		const plansStore = select( PLANS_STORE );
+
+		return {
+			selectedPaidPlan: plansStore.getPlanByProductId( selectedPaidPlanProductId, locale ),
+		};
+	} );
+
+	const { selectedPlanBillingPeriod } = useSelect( ( select ) => {
+		const plansStore = select( PLANS_STORE );
+
+		return {
+			selectedPlanBillingPeriod: plansStore.getPlanProductById( selectedPlanProductId )
+				?.billingPeriod,
+		};
+	} );
 
 	const { defaultPaidPlan, defaultFreePlan } = usePlans();
 
@@ -333,10 +349,14 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 		? [ defaultPaidPlan, nonDefaultPaidPlan, defaultFreePlan ]
 		: [ defaultPaidPlan, defaultFreePlan ];
 
-	const allAvailablePlansProducts = useSelect( ( select ) => {
-		return allAvailablePlans.map( ( plan ) =>
-			select( PLANS_STORE ).getPlanProduct( plan?.periodAgnosticSlug, billingPeriod )
-		);
+	const { allAvailablePlansProducts } = useSelect( ( select ) => {
+		const plansStore = select( PLANS_STORE );
+
+		return {
+			allAvailablePlansProducts: allAvailablePlans.map( ( plan ) =>
+				plansStore.getPlanProduct( plan?.periodAgnosticSlug, selectedPlanBillingPeriod )
+			),
+		};
 	} );
 
 	return (
@@ -515,19 +535,19 @@ const Summary: React.FunctionComponent = () => {
 		selectedDomain,
 		selectedPlanProductId,
 	] = useSelect( ( select ) => {
-		const { isSiteTitleStepVisible, domain, planProductId } = select( LAUNCH_STORE ).getState();
+		const launchStore = select( LAUNCH_STORE );
+		const { isSiteTitleStepVisible, domain, planProductId } = launchStore.getState();
 
-		return [
-			select( LAUNCH_STORE ).hasSelectedDomain(),
-			isSiteTitleStepVisible,
-			domain,
-			planProductId,
-		];
+		return [ launchStore.hasSelectedDomain(), isSiteTitleStepVisible, domain, planProductId ];
 	} );
 
-	const isSelectedPlanFree = useSelect( ( select ) =>
-		select( PLANS_STORE ).isPlanProductFree( selectedPlanProductId )
-	);
+	const { isSelectedPlanFree } = useSelect( ( select ) => {
+		const plansStore = select( PLANS_STORE );
+
+		return {
+			isSelectedPlanFree: plansStore.isPlanProductFree( selectedPlanProductId ),
+		};
+	} );
 
 	const { launchSite } = useDispatch( SITE_STORE );
 	const { setModalDismissible, showModalTitle, showSiteTitleStep } = useDispatch( LAUNCH_STORE );

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -292,13 +292,13 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 		select( LAUNCH_STORE ).getPaidPlanProductId()
 	);
 
-	const { selectedPlan, selectedPaidPlan, selectedPlanBillingPeriod } = useSelect( ( select ) => {
+	const { selectedPlan, selectedPaidPlan, billingPeriod } = useSelect( ( select ) => {
 		const plansStore = select( PLANS_STORE );
 
 		return {
 			selectedPlan: plansStore.getPlanByProductId( selectedPlanProductId, locale ),
 			selectedPaidPlan: plansStore.getPlanByProductId( selectedPaidPlanProductId, locale ),
-			selectedPlanBillingPeriod:
+			billingPeriod:
 				plansStore.getPlanProductById( selectedPlanProductId )?.billingPeriod || 'ANNUALLY',
 		};
 	} );
@@ -330,9 +330,9 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 	const allAvailablePlansProducts = useSelect(
 		( select ) =>
 			allAvailablePlans.map( ( plan ) =>
-				select( PLANS_STORE ).getPlanProduct( plan?.periodAgnosticSlug, selectedPlanBillingPeriod )
+				select( PLANS_STORE ).getPlanProduct( plan?.periodAgnosticSlug, billingPeriod )
 			),
-		[ allAvailablePlans, selectedPlanBillingPeriod ]
+		[ allAvailablePlans, billingPeriod ]
 	);
 
 	return (

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -410,7 +410,6 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 									<FocusedLaunchSummaryItem
 										key={ plan.periodAgnosticSlug }
 										isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
-										/* this must be fixed. the first product id represents the annual version of the plan */
 										onClick={ () =>
 											setPlanProductId( allAvailablePlansProducts[ index ]?.productId )
 										}

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -284,42 +284,20 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 
 	const { setPlanProductId } = useDispatch( LAUNCH_STORE );
 
-	const { selectedPlanProductId } = useSelect( ( select ) => {
-		const launchStore = select( LAUNCH_STORE );
+	const selectedPlanProductId = useSelect( ( select ) =>
+		select( LAUNCH_STORE ).getSelectedPlanProductId()
+	);
 
-		return {
-			selectedPlanProductId: launchStore.getSelectedPlanProductId(),
-		};
-	} );
+	const selectedPaidPlanProductId = useSelect( ( select ) =>
+		select( LAUNCH_STORE ).getPaidPlanProductId()
+	);
 
-	const { selectedPaidPlanProductId } = useSelect( ( select ) => {
-		const launchStore = select( LAUNCH_STORE );
-
-		return {
-			selectedPaidPlanProductId: launchStore.getPaidPlanProductId(),
-		};
-	} );
-
-	const { selectedPlan } = useSelect( ( select ) => {
+	const { selectedPlan, selectedPaidPlan, selectedPlanBillingPeriod } = useSelect( ( select ) => {
 		const plansStore = select( PLANS_STORE );
 
 		return {
 			selectedPlan: plansStore.getPlanByProductId( selectedPlanProductId, locale ),
-		};
-	} );
-
-	const { selectedPaidPlan } = useSelect( ( select ) => {
-		const plansStore = select( PLANS_STORE );
-
-		return {
 			selectedPaidPlan: plansStore.getPlanByProductId( selectedPaidPlanProductId, locale ),
-		};
-	} );
-
-	const { selectedPlanBillingPeriod } = useSelect( ( select ) => {
-		const plansStore = select( PLANS_STORE );
-
-		return {
 			selectedPlanBillingPeriod: plansStore.getPlanProductById( selectedPlanProductId )
 				?.billingPeriod,
 		};
@@ -349,15 +327,11 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 		? [ defaultPaidPlan, nonDefaultPaidPlan, defaultFreePlan ]
 		: [ defaultPaidPlan, defaultFreePlan ];
 
-	const { allAvailablePlansProducts } = useSelect( ( select ) => {
-		const plansStore = select( PLANS_STORE );
-
-		return {
-			allAvailablePlansProducts: allAvailablePlans.map( ( plan ) =>
-				plansStore.getPlanProduct( plan?.periodAgnosticSlug, selectedPlanBillingPeriod )
-			),
-		};
-	} );
+	const allAvailablePlansProducts = useSelect( ( select ) =>
+		allAvailablePlans.map( ( plan ) =>
+			select( PLANS_STORE ).getPlanProduct( plan?.periodAgnosticSlug, selectedPlanBillingPeriod )
+		)
+	);
 
 	return (
 		<SummaryStep

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -284,8 +284,6 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 
 	const { setPlanProductId } = useDispatch( LAUNCH_STORE );
 
-	const billingPeriod = 'ANNUALLY';
-
 	const selectedPlanProductId = useSelect( ( select ) =>
 		select( LAUNCH_STORE ).getSelectedPlanProductId()
 	);
@@ -301,6 +299,15 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 	const selectedPaidPlan = useSelect( ( select ) =>
 		select( PLANS_STORE ).getPlanByProductId( selectedPaidPlanProductId, locale )
 	);
+
+	const { selectedPlanProduct } = useSelect( ( select ) => {
+		const plansStore = select( PLANS_STORE );
+		return {
+			selectedPlanProduct: plansStore.getPlanProductById( selectedPlanProductId ),
+		};
+	} );
+
+	const billingPeriod = selectedPlanProduct?.billingPeriod;
 
 	const { defaultPaidPlan, defaultFreePlan } = usePlans();
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, the billing period is fixed to "ANNUALLY" and the summary view only shows the available yearly plans but we want to make it dynamic and therefore we need to align the state with the state from the billing period toggle in the plans-overview. 

The proposed way to achieve this is to retrieve the `billingPeriod` from the currently selected PlanProduct because this is selected by the user in the plans-overview by using the toggle. It allows us to this parameter to retrieve all other plans. 

#### Technical changes

* Add `selectedPlanProduct` selector to retrieve the selected PlanProduct.
* Hook the `billingPeriod` variable to the selector to make it dynamic.

#### Testing instructions

#### Focused Launch

1. Go to `/page/[UNLAUNCHED_SITE_ID].wordpress.com/home?flags=create/focused-launch-flow`.
2. Click "Launch" to open the Focused Launch flow. 
3. Click on "View All Plans".
4. Switch to "Monthly" and take note of the price of each premium plan when billed monthly.
5. Select any premium billed plan, you will be automatically taken back to the summary view.
6. Ensure that:
    * [ ] The correct prices are displayed in the summary view.
7. Click "Launch your site" and ensure that:
    * [ ] You are redirected to the checkout.
    * [ ] The correct plan (i.e. **MONTHLY**) is added.
    * [ ] The correct price is charged.

Fixes #49257
