### PR TITLE
Add some unit tests to the base controller module

### DIFF
--- a/client/my-sites/test/controller.js
+++ b/client/my-sites/test/controller.js
@@ -1,4 +1,8 @@
 /**
+ * @jest-environment jsdom
+ */
+
+/**
  * External dependencies
  */
 import page from 'page';
@@ -158,18 +162,15 @@ describe( 'recordNoVisibleSitesPageView', () => {
 		const path = '/path';
 		const siteFragment = 'site';
 		const title = 'Title';
-
-		pageView.recordPageView = jest.fn();
+		const spy = jest.spyOn( pageView, 'recordPageView' );
 
 		recordNoVisibleSitesPageView( { path: `${ path }/${ siteFragment }` }, siteFragment, title );
 
-		expect( pageView.recordPageView ).toHaveBeenCalledWith(
-			`/no-sites`,
-			expect.stringMatching( 'All Sites Hidden' ),
-			{ base_path: path }
-		);
+		expect( spy ).toHaveBeenCalledWith( `/no-sites`, expect.stringMatching( 'All Sites Hidden' ), {
+			base_path: path,
+		} );
 
-		pageView.recordPageView.mockRestore();
+		spy.mockRestore();
 	} );
 } );
 
@@ -177,18 +178,15 @@ describe( 'recordNoSitesPageView', () => {
 	it( 'should record the page view', () => {
 		const path = '/path';
 		const siteFragment = 'site';
-
-		pageView.recordPageView = jest.fn();
+		const spy = jest.spyOn( pageView, 'recordPageView' );
 
 		recordNoSitesPageView( { path: `${ path }/${ siteFragment }` }, siteFragment );
 
-		expect( pageView.recordPageView ).toHaveBeenCalledWith(
-			`/no-sites`,
-			expect.stringMatching( 'No Sites' ),
-			{ base_path: path }
-		);
+		expect( spy ).toHaveBeenCalledWith( `/no-sites`, expect.stringMatching( 'No Sites' ), {
+			base_path: path,
+		} );
 
-		pageView.recordPageView.mockRestore();
+		spy.mockRestore();
 	} );
 } );
 
@@ -197,13 +195,12 @@ describe( 'redirectToPrimary', () => {
 		const path = '/path';
 		const siteFragment = 'site';
 		const query = 'a=b';
-
-		page.redirect = jest.fn();
+		const spy = jest.spyOn( page, 'redirect' );
 
 		redirectToPrimary( { pathname: `${ path }/no-site`, querystring: query }, siteFragment );
 
-		expect( page.redirect ).toHaveBeenCalledWith( `${ path }/site?${ query }` );
+		expect( spy ).toHaveBeenCalledWith( `${ path }/site?${ query }` );
 
-		page.redirect.mockRestore();
+		spy.mockRestore();
 	} );
 } );

--- a/client/my-sites/test/controller.js
+++ b/client/my-sites/test/controller.js
@@ -1,0 +1,209 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+/**
+ * Internal dependencies
+ */
+import {
+	updateRecentSitesPreferences,
+	recordNoSitesPageView,
+	recordNoVisibleSitesPageView,
+	redirectToPrimary,
+} from '../controller';
+import * as pageView from 'calypso/lib/analytics/page-view';
+import { PREFERENCES_SET } from 'calypso/state/action-types';
+
+const middlewares = [ thunk ];
+const mockStore = configureStore( middlewares );
+
+describe( 'updateRecentSitesPreferences', () => {
+	it( 'should do nothing if remote preferences are not available', () => {
+		const initialState = {
+			preferences: {
+				remoteValues: null,
+			},
+		};
+		const store = mockStore( initialState );
+
+		updateRecentSitesPreferences( { store } );
+
+		expect( store.getActions() ).toHaveLength( 0 );
+	} );
+
+	it( 'should not nothing if no site is selected', () => {
+		const initialState = {
+			preferences: {
+				remoteValues: {},
+			},
+			ui: {
+				selectedSiteId: null,
+			},
+		};
+		const store = mockStore( initialState );
+
+		updateRecentSitesPreferences( { store } );
+
+		expect( store.getActions() ).toHaveLength( 0 );
+	} );
+
+	it( 'should not nothing if selected site is the most recent', () => {
+		const selectedSiteId = 1;
+		const initialState = {
+			preferences: {
+				remoteValues: {
+					recentSites: [ selectedSiteId ],
+				},
+			},
+			ui: {
+				selectedSiteId,
+			},
+		};
+		const store = mockStore( initialState );
+
+		updateRecentSitesPreferences( { store } );
+
+		expect( store.getActions() ).toHaveLength( 0 );
+	} );
+
+	it( 'should save the selected site as the most recent', () => {
+		const selectedSiteId = 1;
+		const initialState = {
+			preferences: {
+				remoteValues: {
+					recentSites: [ selectedSiteId + 1 ],
+				},
+			},
+			sites: {
+				items: {
+					[ selectedSiteId ]: {},
+					[ selectedSiteId + 1 ]: {},
+				},
+			},
+			ui: {
+				selectedSiteId,
+			},
+		};
+		const store = mockStore( initialState );
+
+		updateRecentSitesPreferences( { store } );
+
+		expect(
+			store.getActions().find( ( { type } ) => type === PREFERENCES_SET )?.value[ 0 ]
+		).toEqual( selectedSiteId );
+	} );
+
+	it( 'should limit the number of recent sites to 5', () => {
+		const initialState = {
+			preferences: {
+				remoteValues: {
+					recentSites: [ 2, 3, 4, 5, 6 ],
+				},
+			},
+			sites: {
+				items: {
+					1: {},
+					2: {},
+					3: {},
+					4: {},
+					5: {},
+					6: {},
+				},
+			},
+			ui: {
+				selectedSiteId: 1,
+			},
+		};
+		const store = mockStore( initialState );
+
+		updateRecentSitesPreferences( { store } );
+
+		expect(
+			store.getActions().find( ( { type } ) => type === PREFERENCES_SET )?.value
+		).toHaveLength( 5 );
+	} );
+
+	it( 'should not save sites that are not available locally', () => {
+		const selectedSiteId = 1;
+		const initialState = {
+			preferences: {
+				remoteValues: {
+					recentSites: [ selectedSiteId + 1 ],
+				},
+			},
+			sites: {
+				items: {
+					[ selectedSiteId ]: {},
+				},
+			},
+			ui: {
+				selectedSiteId,
+			},
+		};
+		const store = mockStore( initialState );
+
+		updateRecentSitesPreferences( { store } );
+
+		expect(
+			store.getActions().find( ( { type } ) => type === PREFERENCES_SET )?.value
+		).toHaveLength( 1 );
+	} );
+} );
+
+describe( 'recordNoVisibleSitesPageView', () => {
+	it( 'should record the page view', () => {
+		const path = '/path';
+		const siteFragment = 'site';
+		const title = 'Title';
+
+		pageView.recordPageView = jest.fn();
+
+		recordNoVisibleSitesPageView( { path: `${ path }/${ siteFragment }` }, siteFragment, title );
+
+		expect( pageView.recordPageView ).toHaveBeenCalledWith(
+			`/no-sites`,
+			expect.stringMatching( 'All Sites Hidden' ),
+			{ base_path: path }
+		);
+
+		pageView.recordPageView.mockRestore();
+	} );
+} );
+
+describe( 'recordNoSitesPageView', () => {
+	it( 'should record the page view', () => {
+		const path = '/path';
+		const siteFragment = 'site';
+
+		pageView.recordPageView = jest.fn();
+
+		recordNoSitesPageView( { path: `${ path }/${ siteFragment }` }, siteFragment );
+
+		expect( pageView.recordPageView ).toHaveBeenCalledWith(
+			`/no-sites`,
+			expect.stringMatching( 'No Sites' ),
+			{ base_path: path }
+		);
+
+		pageView.recordPageView.mockRestore();
+	} );
+} );
+
+describe( 'redirectToPrimary', () => {
+	it( 'should redirect to section with the specified site', () => {
+		const path = '/path';
+		const siteFragment = 'site';
+		const query = 'a=b';
+
+		page.redirect = jest.fn();
+
+		redirectToPrimary( { pathname: `${ path }/no-site`, querystring: query }, siteFragment );
+
+		expect( page.redirect ).toHaveBeenCalledWith( `${ path }/site?${ query }` );
+
+		page.redirect.mockRestore();
+	} );
+} );

--- a/client/my-sites/test/controller.js
+++ b/client/my-sites/test/controller.js
@@ -38,7 +38,7 @@ describe( 'updateRecentSitesPreferences', () => {
 		expect( store.getActions() ).toHaveLength( 0 );
 	} );
 
-	it( 'should not nothing if no site is selected', () => {
+	it( 'should do nothing if no site is selected', () => {
 		const initialState = {
 			preferences: {
 				remoteValues: {},
@@ -54,7 +54,7 @@ describe( 'updateRecentSitesPreferences', () => {
 		expect( store.getActions() ).toHaveLength( 0 );
 	} );
 
-	it( 'should not nothing if selected site is the most recent', () => {
+	it( 'should do nothing if selected site is the most recent', () => {
 		const selectedSiteId = 1;
 		const initialState = {
 			preferences: {

--- a/client/package.json
+++ b/client/package.json
@@ -228,6 +228,7 @@
 		"component-event": "^0.1.4",
 		"component-query": "^0.0.3",
 		"pkg-dir": "^5.0.0",
-		"postcss-custom-properties": "^9.1.1"
+		"postcss-custom-properties": "^9.1.1",
+		"redux-mock-store": "^1.5.4"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -314,6 +314,8 @@
 	"devDependencies": {
 		"bunyan": "^1.8.14",
 		"chokidar": "^2.1.8",
-		"eslint-nibble": "^6.0.0"
+		"eslint-nibble": "^6.0.0",
+		"redux-mock-store": "^1.5.4",
+		"redux-thunk": "^2.3.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -314,8 +314,6 @@
 	"devDependencies": {
 		"bunyan": "^1.8.14",
 		"chokidar": "^2.1.8",
-		"eslint-nibble": "^6.0.0",
-		"redux-mock-store": "^1.5.4",
-		"redux-thunk": "^2.3.0"
+		"eslint-nibble": "^6.0.0"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23256,6 +23256,13 @@ redux-dynamic-middlewares@^2.0.0:
   resolved "https://registry.yarnpkg.com/redux-dynamic-middlewares/-/redux-dynamic-middlewares-2.0.0.tgz#bb34e42d22deb5fe8d5e6af8af66d0739d26e8b1"
   integrity sha512-Wqr76OhNkT+HqDumK9crfa/ZSR06wR29mB8DkTjR+Z/aTv9UmNv2zQKpjUBk4YiD7z2oXbPiWuycK4DB/jEQnQ==
 
+redux-mock-store@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.4.tgz#90d02495fd918ddbaa96b83aef626287c9ab5872"
+  integrity sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==
+  dependencies:
+    lodash.isplainobject "^4.0.6"
+
 redux-multi@^0.1.12:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/redux-multi/-/redux-multi-0.1.12.tgz#28e1fe5e49672cbc5bd8a07f0b2aeaf0ef8355c2"


### PR DESCRIPTION
### Changes proposed in this Pull Request

#47936 extracted some logic in `siteSelection` to their own functions, for reuse. This PR adds unit tests for these newly created functions.

### Testing instructions

- Review changes
- Check that the tests pass in this PR
- Alternatively, download the PR and run `yarn test-client:watch client/my-sites/test/controller.js`