### PR TITLE
Remove redirection from `?site` to `/:site/` in cloud

### DIFF
--- a/client/jetpack-cloud/controller.ts
+++ b/client/jetpack-cloud/controller.ts
@@ -30,33 +30,13 @@ import type { UserData } from 'calypso/lib/user/user';
 import type PageJS from 'page';
 
 /**
- * Parse site slug from path. If no slug is detected but a `site` query parameter
- * exists, a redirection to `/:path/:site/` occurs.
+ * Parse site slug from path.
  *
  * @param {PageJS.Context} context Route context
  * @returns {string} Site slug
  */
 const parseSiteFragment = ( context: PageJS.Context ): string | undefined => {
-	const siteFragment = context.params.site || getSiteFragment( context.path );
-
-	if ( siteFragment ) {
-		return siteFragment;
-	}
-
-	const { query: queryParams, pathname } = context;
-	const { site: siteQuery } = queryParams;
-
-	if ( siteQuery ) {
-		page.redirect(
-			addQueryArgs(
-				{
-					...queryParams,
-					site: undefined,
-				},
-				`${ pathname }/${ siteQuery }`
-			)
-		);
-	}
+	return context.params.site || getSiteFragment( context.path ) || undefined;
 };
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request

#47936 introduced a redirection from `/:section?site=:site` to `/:section/:site/` in Jetpack cloud. This redirection was implemented to fix the checkout screen not loading properly in cloud (see #47870). However, it was rightly pointed that such a global redirection isn't future-proof, as all URLs may not follow the pattern of having the site slug as the last segment.

The fix should be applied locally instead, i.e. for the `/pricing` route. It turns out that this have already been implemented in https://github.com/Automattic/wp-calypso/blob/trunk/client/jetpack-cloud/sections/pricing/controller.tsx#L27, so this PR just removes the global redirect.

### Testing instructions

- Run the PR in cloud
- Check that `/pricing?site=:site` redirects to `/pricing/site?site=:site`