### PR TITLE
Checkout: Add Jetpack Redirect after Jetpack Cloud Checkout

### DIFF
--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -37,6 +37,8 @@ import {
 	SITE_BLOCKED,
 	WORDPRESS_DOT_COM,
 } from './connection-notice-types';
+import { JETPACK_REDIRECT_URL } from 'calypso/lib/plans/constants';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
 const debug = debugModule( 'calypso:jetpack-connect:main' );
 
@@ -87,7 +89,15 @@ const jetpackConnection = ( WrappedComponent ) => {
 				clearPlan();
 				if ( currentPlan ) {
 					debug( `Redirecting to checkout with ${ currentPlan } plan retrieved from cookies` );
-					this.redirect( 'checkout', url, currentPlan, queryArgs );
+					const urlQueryArgs = {
+						...queryArgs,
+						// If isJetpackCloud(), add the `redirect_to` url query arg to
+						// tell checkout to redirect to a Jetpack Redirect url after checkout complete.
+						...( isJetpackCloud() && {
+							redirect_to: `${ JETPACK_REDIRECT_URL }?source=jetpack-checkout-thankyou`,
+						} ),
+					};
+					this.redirect( 'checkout', url, currentPlan, urlQueryArgs );
 				} else {
 					debug( 'Redirecting to plans_selection' );
 					this.redirect( 'plans_selection', url );

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -16,6 +16,8 @@ import {
 	PRODUCT_JETPACK_CRM_MONTHLY,
 } from 'calypso/lib/products-values/constants';
 
+export const JETPACK_REDIRECT_URL = `https://jetpack.com/redirect/`;
+
 // plans constants
 export const PLAN_BUSINESS_MONTHLY = 'business-bundle-monthly';
 export const PLAN_BUSINESS = 'business-bundle';

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -9,7 +9,7 @@
  */
 import getThankYouPageUrl from '../hooks/use-get-thank-you-url/get-thank-you-page-url';
 import { isEnabled } from '@automattic/calypso-config';
-import { PLAN_ECOMMERCE } from '../../../../lib/plans/constants';
+import { PLAN_ECOMMERCE, JETPACK_REDIRECT_URL } from '../../../../lib/plans/constants';
 
 let mockGSuiteCountryIsValid = true;
 jest.mock( 'calypso/lib/user', () =>
@@ -319,6 +319,20 @@ describe( 'getThankYouPageUrl', () => {
 		const redirectTo = adminUrl + 'post.php?post=515';
 		const url = getThankYouPageUrl( { ...defaultArgs, siteSlug: 'foo.bar', adminUrl, redirectTo } );
 		expect( url ).toBe( redirectTo + '&action=edit&plan_upgraded=1' );
+	} );
+
+	it( 'redirects to a "Jetpack Redirect" url if "Jetpack Redirect" url and "source" query arg are provided and is Jetpack site.', () => {
+		// "Jetpack Redirect URL's: https://mc.a8c.com/jetpack-crew/redirects/"
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			redirectTo: `${ JETPACK_REDIRECT_URL }?source=jetpack-connect-thankyou`,
+			isJetpackNotAtomic: true,
+			productAliasFromUrl: 'jetpack_backup_daily',
+		} );
+		expect( url ).toBe(
+			`${ JETPACK_REDIRECT_URL }?source=jetpack-connect-thankyou&site=foo.bar&query=product%3Djetpack_backup_daily%26thank-you%3Dtrue`
+		);
 	} );
 
 	it( 'redirects to manage purchase page if there is a renewal', () => {

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -28,6 +28,7 @@ import {
 import RecordsDetails from './records-details';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
+	JETPACK_REDIRECT_URL,
 	TERM_ANNUALLY,
 	TERM_MONTHLY,
 	TERM_BIENNIALLY,
@@ -721,10 +722,20 @@ export function checkout(
 		? `/checkout/${ siteSlug }/${ productsString }`
 		: `/jetpack/connect/${ productsString }`;
 
+	const queryArgs = {
+		...urlQueryArgs,
+		// If we're on the /checkout path and isJetpackCloud(), add the `redirect_to` query arg to
+		// tell checkout to redirect to a Jetpack Redirect url after checkout complete.
+		...( siteSlug &&
+			isJetpackCloud() && {
+				redirect_to: `${ JETPACK_REDIRECT_URL }?source=jetpack-checkout-thankyou`,
+			} ),
+	};
+
 	if ( isJetpackCloud() && ! config.isEnabled( 'jetpack-cloud/connect' ) ) {
-		window.location.href = addQueryArgs( urlQueryArgs, `https://wordpress.com${ path }` );
+		window.location.href = addQueryArgs( queryArgs, `https://wordpress.com${ path }` );
 	} else {
-		page.redirect( addQueryArgs( urlQueryArgs, path ) );
+		page.redirect( addQueryArgs( queryArgs, path ) );
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR allows us to add a "Jetpack Redirect" link to the `redirect_to` query param of the checkout route so that we can gracefully update the post purchase redirect location for Jetpack Cloud.

For example, adding the url query:
`?redirect_to=https://jetpack.com/redirect/?source=jetpack-checkout-thankyou`
to the Jetpack product checkout route will then redirect to the `jetpack-checkout-thankyou` target defined in the Jetpack Redirect API.

### Testing instructions

- Checkout and run this PR in Jetpack Cloud  (`yarn start-jetpack-cloud`)
- Select a Jetpack site and go to the pricing page: `jetpack.cloud.localhost:3000/pricing/:site`
- Purchase any Jetpack product.
- Verify you are redirected to `https://cloud.jetpack.com/landing/:site?product=:productSlug&thank-you=true`
    - note: /landing redirects to /backup
- Run unit tests and verify they pass.
    -  `yarn test-client client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js`


Fixes 1199409969959876-as-1199670278480660