### PR TITLE
fix: Add calypso-config to client dependencies

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@automattic/calypso-build": "^7.0.0",
 		"@automattic/calypso-color-schemes": "^2.1.1",
+		"@automattic/calypso-config": "^1.0.0-alpha.0",
 		"@automattic/calypso-polyfills": "^1.0.0",
 		"@automattic/calypso-stripe": "^1.0.0",
 		"@automattic/color-studio": "^2.3.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `@automattic/calypso-config` to `client` dependencies.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Lint a file that imports `@automattic/calypso-config` and ensure that the warning is gone.

Fixes https://github.com/Automattic/wp-calypso/pull/49414#issuecomment-769355742
