### PR TITLE
Added AL access for sites with purchased Scan Product

### DIFF
--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -14,7 +14,10 @@ import { isFreePlan } from 'calypso/lib/plans';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getHttpData } from 'calypso/state/data-layer/http-data';
 import { requestActivityLogs, getRequestActivityLogsId } from 'calypso/state/data-getters';
-import { siteHasBackupProductPurchase } from 'calypso/state/purchases/selectors';
+import {
+	siteHasBackupProductPurchase,
+	siteHasScanProductPurchase,
+} from 'calypso/state/purchases/selectors';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import ActivityCardList from 'calypso/components/activity-card-list';
@@ -54,9 +57,12 @@ const ActivityLogV2: FunctionComponent = () => {
 	const siteHasBackupPurchase = useSelector(
 		( state ) => siteId && siteHasBackupProductPurchase( state, siteId )
 	);
+	const siteHasScanPurchase = useSelector(
+		( state ) => siteId && siteHasScanProductPurchase( state, siteId )
+	);
 	const settingsUrl = useSelector( ( state ) => getSettingsUrl( state, siteId, 'general' ) );
 
-	const showUpgrade = siteIsOnFreePlan && ! siteHasBackupPurchase;
+	const showUpgrade = siteIsOnFreePlan && ! siteHasBackupPurchase && ! siteHasScanPurchase;
 	const showFilter = ! showUpgrade;
 
 	const jetpackCloudHeader = showUpgrade ? (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the Activity Log for Scan add-ons to include the same level of access that we give to the Backup add-on. Discussion can be found [here](https://wp.me/pbuNQi-Pp).
* This PR updates Jetpack Cloud and is related to [PR #49327](https://github.com/Automattic/wp-calypso/pull/49327) which only updated Calypso on wordpress.com 

#### Testing instructions

* Use a test site with a **paid scan plan**
* Run Calypso from cloud.jetpack.com
* Navigate to the Activity Log for the test site - notice the lack of filter options and the prompt to upgrade
* Switch to this branch and run Jetpack Cloud locally ( or from the Test Live )
* Navigate to the Activity Log for the test site - notice the filter options now available and the lack of prompt for upgrade
* Switch to a test site with **no paid plans**
* Navigate to the Activity Log for the test site - notice the lack of filter options and the prompt to upgrade