### PR TITLE
Editing Toolkit: update to 2.16

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.15
+ * Version: 2.16
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.15' );
+define( 'PLUGIN_VERSION', '2.16' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.5
 Tested up to: 5.6
-Stable tag: 2.15
+Stable tag: 2.16
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,10 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.16 =
+* Fix Global Styles Panel Font Change Update (https://github.com/Automattic/wp-calypso/pull/49216)
+* Welcome Tour: combine existing and variant tour plugins (https://github.com/Automattic/wp-calypso/pull/49296)
 
 = 2.15 =
 * Add plugin to transform i18n imports to local variables (https://github.com/Automattic/wp-calypso/pull/49341)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -43,6 +43,11 @@ This plugin is experimental, so we don't provide any support for it outside of w
 = 2.16 =
 * Fix Global Styles Panel Font Change Update (https://github.com/Automattic/wp-calypso/pull/49216)
 * Welcome Tour: combine existing and variant tour plugins (https://github.com/Automattic/wp-calypso/pull/49296)
+* Launch: Fix launch button translations not loaded. (https://github.com/Automattic/wp-calypso/pull/49456)
+* Gutenboarding: Fix eCommerce plan not being recommended (https://github.com/Automattic/wp-calypso/pull/49426)
+* Gutenboarding: Fix "Choose a domain I own" layout on mobile (https://github.com/Automattic/wp-calypso/pull/49249)
+* Domain Picker: Prevent instant error on domain step during editor launch flow (https://github.com/Automattic/wp-calypso/pull/48399)
+* Focused Launch: Highlight selected plan in Focused Launch - Detailed Plans. (https://github.com/Automattic/wp-calypso/pull/48622)
 
 = 2.15 =
 * Add plugin to transform i18n imports to local variables (https://github.com/Automattic/wp-calypso/pull/49341)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.15.0",
+	"version": "2.16.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Editing Toolkit version bump to 2.16

### [Editing Toolkit changes included in this release](https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit)
- [x]  Fix Global Styles Panel Font Change Update (https://github.com/Automattic/wp-calypso/pull/49216)
- [x] Welcome Tour: combine existing and variant tour plugins (https://github.com/Automattic/wp-calypso/pull/49296)
   - This release marks MVP launch for the Welcome Tour.
- [x] Launch: Fix launch button translations not loaded. (#49456)
- [x] Gutenboarding: Fix eCommerce plan not being recommended (#49426) 

### Other [changes](https://github.com/Automattic/wp-calypso/commits/trunk/packages) included from the [imported @automattic packages](https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/tsconfig.json#L37-L46) and their imports

- [x] Gutenboarding: Fix "Choose a domain I own" layout on mobile (#49249)
- [x] Domain Picker: Prevent instant error on domain step during editor launch flow (#48399)
- [x] Focused Launch: Highlight selected plan in Focused Launch - Detailed Plans. (https://github.com/Automattic/wp-calypso/pull/48622)

### Testing instructions

1. Load the diff on your sandbox (D56172-code ) and confirm that the above changes work correctly
2. When each of the changes listed above have been validated, please mark it as checked
3. Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.
    - [x] Tested on atomic