### PR TITLE
Checkout: Strip products from url after checkout loads

### DIFF
--- a/client/layout/masterbar/checkout.jsx
+++ b/client/layout/masterbar/checkout.jsx
@@ -20,8 +20,6 @@ class CheckoutMasterbar extends React.Component {
 		const { previousPath, siteSlug } = this.props;
 		let closeUrl = siteSlug ? '/plans/' + siteSlug : '/start';
 		this.props.recordTracksEvent( 'calypso_masterbar_close_clicked' );
-		const searchParams = new URLSearchParams( window.location.search );
-		searchParams.has( 'signup' ) && clearSignupDestinationCookie();
 
 		if (
 			previousPath &&
@@ -30,6 +28,17 @@ class CheckoutMasterbar extends React.Component {
 			! previousPath.includes( '/checkout/' )
 		) {
 			closeUrl = previousPath;
+		}
+
+		try {
+			const searchParams = new URLSearchParams( window.location.search );
+			searchParams.has( 'signup' ) && clearSignupDestinationCookie();
+			if ( searchParams.has( 'redirect_to' ) ) {
+				closeUrl = searchParams.get( 'redirect_to' );
+			}
+		} catch ( error ) {
+			// Silently ignore query string errors (eg: which may occur in IE since it doesn't support URLSearchParams).
+			console.error( 'Error getting query string in close button' ); // eslint-disable-line no-console
 		}
 
 		window.location = closeUrl;

--- a/client/layout/masterbar/checkout.jsx
+++ b/client/layout/masterbar/checkout.jsx
@@ -27,7 +27,7 @@ class CheckoutMasterbar extends React.Component {
 			previousPath &&
 			'' !== previousPath &&
 			previousPath !== window.location.href &&
-			! previousPath.includes( '/checkout/no-site' )
+			! previousPath.includes( '/checkout/' )
 		) {
 			closeUrl = previousPath;
 		}

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -221,6 +221,7 @@ export default function CompositeCheckout( {
 		purchaseId,
 		isJetpackNotAtomic,
 		isPrivate,
+		siteSlug,
 	} );
 
 	const {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -62,22 +62,6 @@ export default function useAddProductsFromUrl( {
 		couponCodeFromUrl,
 	] );
 
-	// If we have made requests to update the cart, and the cart has finished
-	// updating, mark this hook complete.
-	useEffect( () => {
-		if ( ! isLoading ) {
-			return;
-		}
-		if ( ! hasRequestedInitialProducts.current ) {
-			return;
-		}
-		if ( ! isCartPendingUpdate && ! isLoadingCart ) {
-			debug( 'initial cart requests have been completed' );
-			setIsLoading( false );
-			return;
-		}
-	}, [ isLoading, isCartPendingUpdate, isLoadingCart ] );
-
 	// If we have products or a coupon to add, and we have not requested they be
 	// added, and nothing is loading, request that the shopping cart add those
 	// products.
@@ -89,13 +73,18 @@ export default function useAddProductsFromUrl( {
 			return;
 		}
 		debug( 'adding initial products to cart', productsForCart );
+		const cartPromises = [];
 		if ( productsForCart.length > 0 ) {
-			addProductsToCart( productsForCart );
+			cartPromises.push( addProductsToCart( productsForCart ) );
 		}
 		debug( 'adding initial coupon to cart', couponCodeFromUrl );
 		if ( couponCodeFromUrl ) {
-			applyCoupon( couponCodeFromUrl );
+			cartPromises.push( applyCoupon( couponCodeFromUrl ) );
 		}
+		Promise.all( cartPromises ).then( () => {
+			debug( 'initial cart requests have completed' );
+			setIsLoading( false );
+		} );
 		hasRequestedInitialProducts.current = true;
 	}, [
 		isLoading,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -43,11 +43,13 @@ export default function usePrepareProductsForCart( {
 	purchaseId: originalPurchaseId,
 	isJetpackNotAtomic,
 	isPrivate,
+	siteSlug,
 }: {
 	productAliasFromUrl: string | null | undefined;
 	purchaseId: string | number | null | undefined;
 	isJetpackNotAtomic: boolean;
 	isPrivate: boolean;
+	siteSlug: string | undefined;
 } ): PreparedProductsForCart {
 	const initializePreparedProductsState = (
 		initialState: PreparedProductsForCart
@@ -91,7 +93,34 @@ export default function usePrepareProductsForCart( {
 		addHandler,
 	} );
 
+	useStripProductsFromUrl( siteSlug, state.isLoading );
+
 	return state;
+}
+
+function useStripProductsFromUrl( siteSlug: string | undefined, isLoading: boolean ): void {
+	useEffect( () => {
+		// Only run this when the url has been processed already
+		if ( ! isLoading ) {
+			return;
+		}
+
+		try {
+			// Replace the pathname with /checkout/example.com, which otherwise may
+			// include new products (eg /checkout/example.com/personal) or renewals
+			// (eg /checkout/value_bundle/11111111/example.com). That way loading the
+			// page later will not add those products to the cart again.
+			const newUrl =
+				window.location.protocol + '//' + window.location.host + '/checkout/' + siteSlug ??
+				'' + window.location.search + window.location.hash;
+			debug( 'changing the url to strip the products to', newUrl );
+			window.history.replaceState( null, '', newUrl );
+		} catch ( error ) {
+			// Fail silently; this isn't that important to do
+			debug( 'changing the url to strip the products failed', error );
+			return;
+		}
+	}, [ isLoading, siteSlug ] );
 }
 
 type PreparedProductsAction =

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -108,8 +108,8 @@ function useStripProductsFromUrl( siteSlug: string | undefined, isLoading: boole
 		try {
 			// Replace the pathname with /checkout/example.com, which otherwise may
 			// include new products (eg /checkout/example.com/personal) or renewals
-			// (eg /checkout/value_bundle/11111111/example.com). That way loading the
-			// page later will not add those products to the cart again.
+			// (eg /checkout/value_bundle/renew/11111111/example.com). That way
+			// loading the page later will not add those products to the cart again.
 			const newUrl =
 				window.location.protocol + '//' + window.location.host + '/checkout/' + siteSlug ??
 				'no-site' + window.location.search + window.location.hash;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -112,7 +112,7 @@ function useStripProductsFromUrl( siteSlug: string | undefined, isLoading: boole
 			// page later will not add those products to the cart again.
 			const newUrl =
 				window.location.protocol + '//' + window.location.host + '/checkout/' + siteSlug ??
-				'' + window.location.search + window.location.hash;
+				'no-site' + window.location.search + window.location.hash;
 			debug( 'changing the url to strip the products to', newUrl );
 			window.history.replaceState( null, '', newUrl );
 		} catch ( error ) {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -108,11 +108,14 @@ function useStripProductsFromUrl( siteSlug: string | undefined, isLoading: boole
 		try {
 			// Replace the pathname with /checkout/example.com, which otherwise may
 			// include new products (eg /checkout/example.com/personal) or renewals
-			// (eg /checkout/value_bundle/renew/11111111/example.com). That way
-			// loading the page later will not add those products to the cart again.
+			// (eg /checkout/value_bundle/renew/11111111/example.com) or coupons (eg
+			// /checkout/example.com?coupon=FOOBAR). That way loading the page later
+			// will not add those products to the cart again.
+			const queryString = window.location.search;
+			const alteredQueryString = queryString.replace( /&?coupon=[^&]+&?/, '' );
 			const newUrl =
 				window.location.protocol + '//' + window.location.host + '/checkout/' + siteSlug ??
-				'no-site' + window.location.search + window.location.hash;
+				'no-site' + alteredQueryString + window.location.hash;
 			debug( 'changing the url to strip the products to', newUrl );
 			window.history.replaceState( null, '', newUrl );
 		} catch ( error ) {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -23,6 +23,7 @@ import { getPlanByPathSlug } from 'calypso/lib/plans';
 import { getProductsList, isProductsListFetching } from 'calypso/state/products-list/selectors';
 import useFetchProductsIfNotLoaded from './use-fetch-products-if-not-loaded';
 import doesValueExist from '../lib/does-value-exist';
+import useStripProductsFromUrl from './use-strip-products-from-url';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-prepare-products-for-cart' );
 
@@ -96,34 +97,6 @@ export default function usePrepareProductsForCart( {
 	useStripProductsFromUrl( siteSlug, state.isLoading );
 
 	return state;
-}
-
-function useStripProductsFromUrl( siteSlug: string | undefined, isLoading: boolean ): void {
-	useEffect( () => {
-		// Only run this when the url has been processed already
-		if ( ! isLoading ) {
-			return;
-		}
-
-		try {
-			// Replace the pathname with /checkout/example.com, which otherwise may
-			// include new products (eg /checkout/example.com/personal) or renewals
-			// (eg /checkout/value_bundle/renew/11111111/example.com) or coupons (eg
-			// /checkout/example.com?coupon=FOOBAR). That way loading the page later
-			// will not add those products to the cart again.
-			const queryString = window.location.search;
-			const alteredQueryString = queryString.replace( /&?coupon=[^&]+&?/, '' );
-			const newUrl =
-				window.location.protocol + '//' + window.location.host + '/checkout/' + siteSlug ??
-				'no-site' + alteredQueryString + window.location.hash;
-			debug( 'changing the url to strip the products to', newUrl );
-			window.history.replaceState( null, '', newUrl );
-		} catch ( error ) {
-			// Fail silently; this isn't that important to do
-			debug( 'changing the url to strip the products failed', error );
-			return;
-		}
-	}, [ isLoading, siteSlug ] );
 }
 
 type PreparedProductsAction =

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -94,7 +94,9 @@ export default function usePrepareProductsForCart( {
 		addHandler,
 	} );
 
-	useStripProductsFromUrl( siteSlug, state.isLoading );
+	// Do not strip products from url until the URL has been parsed
+	const areProductsRetrievedFromUrl = ! state.isLoading;
+	useStripProductsFromUrl( siteSlug, ! areProductsRetrievedFromUrl );
 
 	return state;
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-strip-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-strip-products-from-url.ts
@@ -24,9 +24,15 @@ export default function useStripProductsFromUrl(
 			// will not add those products to the cart again.
 			const queryString = window.location.search;
 			const alteredQueryString = queryString.replace( /&?coupon=[^&]+&?/, '' );
+			const finalSiteSlug = siteSlug ?? 'no-site';
 			const newUrl =
-				window.location.protocol + '//' + window.location.host + '/checkout/' + siteSlug ??
-				'no-site' + alteredQueryString + window.location.hash;
+				window.location.protocol +
+				'//' +
+				window.location.host +
+				'/checkout/' +
+				finalSiteSlug +
+				alteredQueryString +
+				window.location.hash;
 			debug( 'changing the url to strip the products to', newUrl );
 			window.history.replaceState( null, '', newUrl );
 		} catch ( error ) {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-strip-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-strip-products-from-url.ts
@@ -8,11 +8,11 @@ const debug = debugFactory( 'calypso:composite-checkout:use-strip-products-from-
 
 export default function useStripProductsFromUrl(
 	siteSlug: string | undefined,
-	isLoading: boolean
+	doNotRun: boolean
 ): void {
 	useEffect( () => {
-		// Only run this when the url has been processed already
-		if ( ! isLoading ) {
+		// Only run this when the url has been processed for products already
+		if ( doNotRun ) {
 			return;
 		}
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-strip-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-strip-products-from-url.ts
@@ -19,11 +19,12 @@ export default function useStripProductsFromUrl(
 		try {
 			// Replace the pathname with /checkout/example.com, which otherwise may
 			// include new products (eg /checkout/example.com/personal) or renewals
-			// (eg /checkout/value_bundle/renew/11111111/example.com) or coupons (eg
-			// /checkout/example.com?coupon=FOOBAR). That way loading the page later
-			// will not add those products to the cart again.
+			// (eg /checkout/value_bundle/renew/11111111/example.com). That way
+			// loading the page later will not add those products to the cart again.
+			// This does not strip data from the query string, including coupons.
+			// Coupons are parsed out of the URL in a different place than the
+			// products, and removing them here may cause them not to be applied.
 			const queryString = window.location.search;
-			const alteredQueryString = queryString.replace( /&?coupon=[^&]+/, '' );
 			const finalSiteSlug = siteSlug ?? 'no-site';
 			const newUrl =
 				window.location.protocol +
@@ -31,7 +32,7 @@ export default function useStripProductsFromUrl(
 				window.location.host +
 				'/checkout/' +
 				finalSiteSlug +
-				alteredQueryString +
+				queryString +
 				window.location.hash;
 			debug( 'changing the url to strip the products to', newUrl );
 			window.history.replaceState( null, '', newUrl );
@@ -40,5 +41,5 @@ export default function useStripProductsFromUrl(
 			debug( 'changing the url to strip the products failed', error );
 			return;
 		}
-	}, [ isLoading, siteSlug ] );
+	}, [ doNotRun, siteSlug ] );
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-strip-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-strip-products-from-url.ts
@@ -23,7 +23,7 @@ export default function useStripProductsFromUrl(
 			// /checkout/example.com?coupon=FOOBAR). That way loading the page later
 			// will not add those products to the cart again.
 			const queryString = window.location.search;
-			const alteredQueryString = queryString.replace( /&?coupon=[^&]+&?/, '' );
+			const alteredQueryString = queryString.replace( /&?coupon=[^&]+/, '' );
 			const finalSiteSlug = siteSlug ?? 'no-site';
 			const newUrl =
 				window.location.protocol +

--- a/client/my-sites/checkout/composite-checkout/hooks/use-strip-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-strip-products-from-url.ts
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'calypso:composite-checkout:use-strip-products-from-url' );
+
+export default function useStripProductsFromUrl(
+	siteSlug: string | undefined,
+	isLoading: boolean
+): void {
+	useEffect( () => {
+		// Only run this when the url has been processed already
+		if ( ! isLoading ) {
+			return;
+		}
+
+		try {
+			// Replace the pathname with /checkout/example.com, which otherwise may
+			// include new products (eg /checkout/example.com/personal) or renewals
+			// (eg /checkout/value_bundle/renew/11111111/example.com) or coupons (eg
+			// /checkout/example.com?coupon=FOOBAR). That way loading the page later
+			// will not add those products to the cart again.
+			const queryString = window.location.search;
+			const alteredQueryString = queryString.replace( /&?coupon=[^&]+&?/, '' );
+			const newUrl =
+				window.location.protocol + '//' + window.location.host + '/checkout/' + siteSlug ??
+				'no-site' + alteredQueryString + window.location.hash;
+			debug( 'changing the url to strip the products to', newUrl );
+			window.history.replaceState( null, '', newUrl );
+		} catch ( error ) {
+			// Fail silently; this isn't that important to do
+			debug( 'changing the url to strip the products failed', error );
+			return;
+		}
+	}, [ isLoading, siteSlug ] );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There are specific URLs which will add products to the cart when loading checkout. For example, something like `/checkout/example.com/premium` will add the Premium plan to the cart and `/checkout/value_bundle/renew/10000001/example.com` will add a Premium plan renewal to the cart. However, keeping these URLs in the browser history has risks; if a user returns to this URL accidentally (for example, by using the browser's "Back" button) they would end up with the same products in their cart once again. This can result in duplicate purchases or unintended renewals.

This PR modifies checkout so that after the URL is parsed for products, it replaces the URL in the browser history with `/checkout/example.com`.

Some care is needed here due to the declarative nature of React. When the URL is modified, it changes the props passed in to the checkout components. If the URL is modified too soon, the products won't be added correctly to the cart. There may be other unintended effects.

Fixes https://github.com/Automattic/wp-calypso/issues/49368

#### Testing instructions

- Visit checkout with a URL like `/checkout/example.com/premium`
- Verify that the URL becomes `/checkout/example.com`
- Verify that the cart loads correctly with the product included.
- Repeat the above example with a renewal (it's easiest to use the "Renew now" button on the product page).

Consider other possible issues this may cause.