### PR TITLE
Login: improve password fields on iOS

### DIFF
--- a/client/components/forms/form-password-input/index.jsx
+++ b/client/components/forms/form-password-input/index.jsx
@@ -52,8 +52,8 @@ class FormPasswordInput extends React.Component {
 		return (
 			<div className="form-password-input">
 				<FormTextInput
-					{ ...omit( this.props, 'hideToggle', 'submitting', 'isBreakpointActive' ) }
 					autoComplete="off"
+					{ ...omit( this.props, 'hideToggle', 'submitting', 'isBreakpointActive' ) }
 					ref={ this.textFieldRef }
 					type={ this.hidden() ? 'password' : 'text' }
 				/>

--- a/client/components/forms/form-password-input/index.jsx
+++ b/client/components/forms/form-password-input/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { omit } from 'lodash';
-import { withMobileBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import React from 'react';
@@ -24,7 +23,7 @@ class FormPasswordInput extends React.Component {
 
 	constructor( props ) {
 		super( props );
-		this.state = { hidePassword: ! props.isBreakpointActive };
+		this.state = { hidePassword: true };
 	}
 
 	togglePasswordVisibility = () => {
@@ -53,7 +52,7 @@ class FormPasswordInput extends React.Component {
 			<div className="form-password-input">
 				<FormTextInput
 					autoComplete="off"
-					{ ...omit( this.props, 'hideToggle', 'submitting', 'isBreakpointActive' ) }
+					{ ...omit( this.props, 'hideToggle', 'submitting' ) }
 					ref={ this.textFieldRef }
 					type={ this.hidden() ? 'password' : 'text' }
 				/>
@@ -66,4 +65,4 @@ class FormPasswordInput extends React.Component {
 	}
 }
 
-export default withMobileBreakpoint( FormPasswordInput );
+export default FormPasswordInput;


### PR DESCRIPTION
Context: when I talk about password visibility I mean this feature
![Image from iOS-2](https://user-images.githubusercontent.com/1500769/106416094-864d4080-64b5-11eb-8ebd-0066b26d79cc.jpg)

#### Changes proposed in this Pull Request

* Mobile devices no longer default to showing the password as the user types
* Allow the `autoComplete` prop on `<FormPasswordInput>` can be overridden

The password autofill on iOS wasn't kicking in by default because the password field was defaulting to visible. iOS doesn't seem to offer password autofill in this situation. It is a nice feature to show the password by default because typing a password on an on-screen keyboard can be tricky. However I'd argue that a password manager is even more useful, or at least, we should be encouraging the use of password managers.

The other change is to allow the `autoComplete` prop to be overridden. The login form was switched to using `autoComplete="current-password"` in #48976. This is important because [Apple document this as a way to hint that password autofill can be used](https://developer.apple.com/documentation/security/password_autofill/enabling_password_autofill_on_an_html_input_element). However the change wasn't being reflected in the DOM because `<FormPasswordInput>` wouldn't allow `autoComplete` to be set. We attempt to set the `autoComplete` prop here: https://github.com/Automattic/wp-calypso/blob/2b955fe7a8021f6ea9cd118cbadaa1ff9d1c1ee5/client/blocks/login/login-form.jsx#L569
But it's not having any impact on the DOM as observed here: https://github.com/Automattic/wp-calypso/issues/47089#issuecomment-769459945

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test using https://calypso.live/log-in?branch=update/form-password-input-autocomplete-can-be-overridden to make testing on a mobile device easier
* Check auto fill on mobile safari works ([this guide might be helpful if you've disabled keychain on your phone for something like 1password](https://9to5mac.com/2019/05/02/password-autofill-iphone-ipad/))
* On a desktop, log in with multiple browsers at `/log-in`, observe saved passwords correctly load into the fields provided.
* Check in DOM inspector tools that the password field has the `autocomplete="current-password"` attribute.
* Test on android too (I haven't got one to test on)