### PR TITLE
Deduplicate ignore

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -14567,12 +14567,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.0.0, ignore@^5.1.1, ignore@^5.1.4, ignore@~5.1.4:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
-  integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
-
-ignore@^5.1.8:
+ignore@^5.0.0, ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8, ignore@~5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `ignore` (done automatically with `npx yarn-deduplicate --packages ignore`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @typescript-eslint/eslint-plugin@4.12.0 -> ... -> ignore@5.1.4
< wp-calypso@0.17.0 -> @typescript-eslint/parser@4.12.0 -> ... -> ignore@5.1.4
< wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> ignore@5.1.4
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> ignore@5.1.4
< wp-calypso@0.17.0 -> globby@10.0.1 -> ... -> ignore@5.1.4
< wp-calypso@0.17.0 -> i18n-calypso-cli@1.0.0 -> ... -> ignore@5.1.4
< wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> ignore@5.1.4
> wp-calypso@0.17.0 -> @typescript-eslint/eslint-plugin@4.12.0 -> ... -> ignore@5.1.8
> wp-calypso@0.17.0 -> @typescript-eslint/parser@4.12.0 -> ... -> ignore@5.1.8
> wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> ignore@5.1.8
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> ignore@5.1.8
> wp-calypso@0.17.0 -> globby@10.0.1 -> ... -> ignore@5.1.8
> wp-calypso@0.17.0 -> i18n-calypso-cli@1.0.0 -> ... -> ignore@5.1.8
> wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> ignore@5.1.8
```