### PR TITLE
Deduplicate inquirer

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -14759,7 +14759,7 @@ inline-source-map@~0.6.0:
   dependencies:
     source-map "~0.5.3"
 
-"inquirer@7.0.1 - 7.2.0":
+"inquirer@7.0.1 - 7.2.0", inquirer@^7.0.0, inquirer@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.2.0.tgz#63ce99d823090de7eb420e4bb05e6f3449aa389a"
   integrity sha512-E0c4rPwr9ByePfNlTIB8z51kK1s2n6jrHuJeEHENl/sbq2G/S1auvibgEwNR4uSyiU+PiYHqSwsgGiXjG8p5ZQ==
@@ -14778,7 +14778,7 @@ inline-source-map@~0.6.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
-inquirer@7.0.4, inquirer@^7.0.0:
+inquirer@7.0.4:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.0.4.tgz#99af5bde47153abca23f5c7fc30db247f39da703"
   integrity sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==
@@ -14814,25 +14814,6 @@ inquirer@^6.2.0:
     rxjs "^6.4.0"
     string-width "^2.1.0"
     strip-ansi "^5.1.0"
-    through "^2.3.6"
-
-inquirer@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.1.0.tgz#1298a01859883e17c7264b82870ae1034f92dd29"
-  integrity sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    chalk "^3.0.0"
-    cli-cursor "^3.1.0"
-    cli-width "^2.0.0"
-    external-editor "^3.0.3"
-    figures "^3.0.0"
-    lodash "^4.17.15"
-    mute-stream "0.0.8"
-    run-async "^2.4.0"
-    rxjs "^6.5.3"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
     through "^2.3.6"
 
 insert-module-globals@^7.0.0:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `inquirer` (done automatically with `npx yarn-deduplicate --packages inquirer`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> inquirer@7.0.4
< wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> inquirer@7.0.4
< wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> inquirer@7.0.4
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> inquirer@7.2.0
> wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> inquirer@7.2.0
> wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> inquirer@7.2.0
```