### PR TITLE
Deduplicate is-callable

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15043,12 +15043,7 @@ is-buffer@^2.0.0, is-buffer@~2.0.3:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
-is-callable@^1.1.4, is-callable@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
-  integrity sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==
-
-is-callable@^1.2.2:
+is-callable@^1.1.4, is-callable@^1.1.5, is-callable@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
   integrity sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `is-callable` (done automatically with `npx yarn-deduplicate --packages is-callable`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> is-callable@1.1.5
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> is-callable@1.1.5
< wp-calypso@0.17.0 -> @wordpress/components@12.0.1 -> ... -> is-callable@1.1.5
< wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> is-callable@1.1.5
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> is-callable@1.1.5
< wp-calypso@0.17.0 -> enzyme-adapter-react-16@1.15.1 -> ... -> is-callable@1.1.5
< wp-calypso@0.17.0 -> enzyme@3.11.0 -> ... -> is-callable@1.1.5
< wp-calypso@0.17.0 -> eslint-plugin-import@2.22.1 -> ... -> is-callable@1.1.5
< wp-calypso@0.17.0 -> eslint-plugin-jsx-a11y@6.4.0 -> ... -> is-callable@1.1.5
< wp-calypso@0.17.0 -> eslint-plugin-react@7.21.5 -> ... -> is-callable@1.1.5
< wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> is-callable@1.1.5
< wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> is-callable@1.1.5
< wp-calypso@0.17.0 -> npm-run-all@4.1.5 -> ... -> is-callable@1.1.5
< wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> is-callable@1.1.5
> wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> is-callable@1.2.2
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> is-callable@1.2.2
> wp-calypso@0.17.0 -> @wordpress/components@12.0.1 -> ... -> is-callable@1.2.2
> wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> is-callable@1.2.2
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> is-callable@1.2.2
> wp-calypso@0.17.0 -> enzyme-adapter-react-16@1.15.1 -> ... -> is-callable@1.2.2
> wp-calypso@0.17.0 -> enzyme@3.11.0 -> ... -> is-callable@1.2.2
> wp-calypso@0.17.0 -> eslint-plugin-import@2.22.1 -> ... -> is-callable@1.2.2
> wp-calypso@0.17.0 -> eslint-plugin-jsx-a11y@6.4.0 -> ... -> is-callable@1.2.2
> wp-calypso@0.17.0 -> eslint-plugin-react@7.21.5 -> ... -> is-callable@1.2.2
> wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> is-callable@1.2.2
> wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> is-callable@1.2.2
> wp-calypso@0.17.0 -> npm-run-all@4.1.5 -> ... -> is-callable@1.2.2
> wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> is-callable@1.2.2
```