### PR TITLE
Deduplicate is-core-module

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15084,14 +15084,7 @@ is-color@^0.2.0:
     rgb-regex "^1.0.1"
     rgba-regex "^1.0.0"
 
-is-core-module@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.0.0.tgz#58531b70aed1db7c0e8d4eb1a0a2d1ddd64bd12d"
-  integrity sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==
-  dependencies:
-    has "^1.0.3"
-
-is-core-module@^2.1.0:
+is-core-module@^2.0.0, is-core-module@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
   integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `is-core-module` (done automatically with `npx yarn-deduplicate --packages is-core-module`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> @automattic/wp-babel-makepot@1.0.2 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> @babel/core@7.12.9 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> @storybook/addon-actions@6.1.10 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> @wordpress/components@12.0.1 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> babel-eslint@10.1.0 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> concurrently@5.1.0 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> eslint-plugin-import@2.22.1 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> eslint-plugin-react@7.21.5 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> node-sass-package-importer@5.3.2 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> node-sass@4.13.0 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> npm-run-all@4.1.5 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> is-core-module@2.0.0
< wp-calypso@0.17.0 -> whybundled@1.4.2 -> ... -> is-core-module@2.0.0
> wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> @automattic/wp-babel-makepot@1.0.2 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> @babel/core@7.12.9 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> @storybook/addon-actions@6.1.10 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> @wordpress/components@12.0.1 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> babel-eslint@10.1.0 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> concurrently@5.1.0 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> eslint-plugin-import@2.22.1 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> eslint-plugin-react@7.21.5 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> node-sass-package-importer@5.3.2 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> node-sass@4.13.0 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> npm-run-all@4.1.5 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> is-core-module@2.2.0
> wp-calypso@0.17.0 -> whybundled@1.4.2 -> ... -> is-core-module@2.2.0
```