### PR TITLE
Deduplicate is-regex

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15451,14 +15451,7 @@ is-property@^1.0.0, is-property@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
   integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
 
-is-regex@^1.0.4, is-regex@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
-  integrity sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
-  dependencies:
-    has "^1.0.3"
-
-is-regex@^1.1.0, is-regex@^1.1.1:
+is-regex@^1.0.4, is-regex@^1.0.5, is-regex@^1.1.0, is-regex@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
   integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `is-regex` (done automatically with `npx yarn-deduplicate --packages is-regex`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> is-regex@1.0.5
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> is-regex@1.0.5
< wp-calypso@0.17.0 -> enzyme@3.11.0 -> ... -> is-regex@1.0.5
< wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> is-regex@1.0.5
> wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> is-regex@1.1.1
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> is-regex@1.1.1
> wp-calypso@0.17.0 -> enzyme@3.11.0 -> ... -> is-regex@1.1.1
> wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> is-regex@1.1.1
```