### PR TITLE
Display a "purchase success" notice in Customer Home

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -530,7 +530,7 @@ function LineItemSublabelAndPrice( { item } ) {
 		isGSuiteOrExtraLicenseProductSlug( productSlug ) || isGoogleWorkspaceProductSlug( productSlug );
 
 	if ( item.type === 'plan' && item.wpcom_meta?.months_per_bill_period > 1 ) {
-		return translate( '%(sublabel)s: %(monthlyPrice)s /month × %(monthsPerBillPeriod)s', {
+		return translate( '%(sublabel)s: %(monthlyPrice)s / month × %(monthsPerBillPeriod)s', {
 			args: {
 				sublabel: item.sublabel,
 				monthlyPrice: item.wpcom_meta.item_subtotal_monthly_cost_display,

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -530,13 +530,13 @@ function LineItemSublabelAndPrice( { item } ) {
 		isGSuiteOrExtraLicenseProductSlug( productSlug ) || isGoogleWorkspaceProductSlug( productSlug );
 
 	if ( item.type === 'plan' && item.wpcom_meta?.months_per_bill_period > 1 ) {
-		return translate( '%(sublabel)s: %(monthlyPrice)s / month × %(monthsPerBillPeriod)s', {
+		return translate( '%(sublabel)s: %(monthlyPrice)s/month × %(monthsPerBillPeriod)s', {
 			args: {
 				sublabel: item.sublabel,
 				monthlyPrice: item.wpcom_meta.item_subtotal_monthly_cost_display,
 				monthsPerBillPeriod: item.wpcom_meta.months_per_bill_period,
 			},
-			comment: 'product type and monthly breakdown of total cost, separated by a colon',
+			comment: 'product type and monthly breakdown of total cost, separated by a colon. For "/month", there is no space before and after the "/" but please add a space if it makes sense in other languages.',
 		} );
 	}
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -390,9 +390,15 @@ function getDisplayModeParamFromCart( cart: ResponseCart | undefined ): Record< 
 	if ( cart && hasConciergeSession( cart ) ) {
 		return { d: 'concierge' };
 	}
+
 	if ( cart && hasTrafficGuide( cart ) ) {
 		return { d: 'traffic-guide' };
 	}
+
+	if ( cart ) {
+		return { d: 'purchase-success' };
+	}
+
 	return {};
 }
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -196,6 +196,8 @@ export default function getThankYouPageUrl( {
 
 	if ( isEligibleForSignupDestinationResult && urlFromCookie ) {
 		debug( 'is eligible for signup destination', urlFromCookie );
+		const noticeType = getNoticeType( cart );
+		const queryParams = { ...displayModeParam, ...noticeType };
 		return getUrlWithQueryParam( urlFromCookie, displayModeParam );
 	}
 	debug( 'returning fallback url', fallbackUrl );
@@ -395,8 +397,12 @@ function getDisplayModeParamFromCart( cart: ResponseCart | undefined ): Record< 
 		return { d: 'traffic-guide' };
 	}
 
+	return {};
+}
+
+function getNoticeType( cart: ResponseCart | undefined ): Record< string, string > {
 	if ( cart ) {
-		return { d: 'purchase-success' };
+		return { notice: 'purchase-success' };
 	}
 
 	return {};

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -196,8 +196,6 @@ export default function getThankYouPageUrl( {
 
 	if ( isEligibleForSignupDestinationResult && urlFromCookie ) {
 		debug( 'is eligible for signup destination', urlFromCookie );
-		const noticeType = getNoticeType( cart );
-		const queryParams = { ...displayModeParam, ...noticeType };
 		return getUrlWithQueryParam( urlFromCookie, displayModeParam );
 	}
 	debug( 'returning fallback url', fallbackUrl );
@@ -395,14 +393,6 @@ function getDisplayModeParamFromCart( cart: ResponseCart | undefined ): Record< 
 
 	if ( cart && hasTrafficGuide( cart ) ) {
 		return { d: 'traffic-guide' };
-	}
-
-	return {};
-}
-
-function getNoticeType( cart: ResponseCart | undefined ): Record< string, string > {
-	if ( cart ) {
-		return { notice: 'purchase-success' };
 	}
 
 	return {};

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -739,7 +739,7 @@ describe( 'getThankYouPageUrl', () => {
 			receiptId: '1234abcd',
 			hideNudge: true,
 		} );
-		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
+		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd?d=purchase-success' );
 	} );
 
 	it( 'redirects to thank you page (with traffic guide display mode) if traffic guide is in cart', () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -739,7 +739,7 @@ describe( 'getThankYouPageUrl', () => {
 			receiptId: '1234abcd',
 			hideNudge: true,
 		} );
-		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd?d=purchase-success' );
+		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );
 
 	it( 'redirects to thank you page (with traffic guide display mode) if traffic guide is in cart', () => {

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -18,12 +18,22 @@ export default async function ( context, next ) {
 	const isDev = context.query.dev === 'true';
 	const forcedView = context.query.view;
 
+	// Fetch display mode
+	const displayMode = context.query.d;
+
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {
 		window.scrollTo( 0, 0 );
 	}
 
-	context.primary = <CustomerHome key={ siteId } isDev={ isDev } forcedView={ forcedView } />;
+	context.primary = (
+		<CustomerHome
+			key={ siteId }
+			isDev={ isDev }
+			forcedView={ forcedView }
+			displayMode={ displayMode }
+		/>
+	);
 
 	next();
 }

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -19,7 +19,7 @@ export default async function ( context, next ) {
 	const forcedView = context.query.view;
 
 	// Fetch display mode
-	const displayMode = context.query.d;
+	const noticeType = context.query.notice;
 
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -29,6 +29,7 @@ import { getHomeLayout } from 'calypso/state/selectors/get-home-layout';
 import Primary from 'calypso/my-sites/customer-home/locations/primary';
 import Secondary from 'calypso/my-sites/customer-home/locations/secondary';
 import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
+import notices from 'calypso/notices';
 
 /**
  * Style dependencies
@@ -43,6 +44,7 @@ const Home = ( {
 	site,
 	siteId,
 	trackViewSiteAction,
+	displayMode,
 } ) => {
 	const translate = useTranslate();
 
@@ -54,6 +56,13 @@ const Home = ( {
 				illustration="/calypso/images/illustrations/error.svg"
 			/>
 		);
+	}
+
+	if ( 'purchase_success' === displayMode ) {
+		const successMessage = translate( 'Your purchase has been completed!' );
+		notices.success( successMessage, {
+			persistent: true,
+		} );
 	}
 
 	const header = (

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -58,7 +58,7 @@ const Home = ( {
 		);
 	}
 
-	if ( 'purchase_success' === displayMode ) {
+	if ( 'purchase-success' === displayMode ) {
 		const successMessage = translate( 'Your purchase has been completed!' );
 		notices.success( successMessage, {
 			persistent: true,

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -44,7 +44,7 @@ const Home = ( {
 	site,
 	siteId,
 	trackViewSiteAction,
-	displayMode,
+	noticeType,
 } ) => {
 	const translate = useTranslate();
 
@@ -58,7 +58,7 @@ const Home = ( {
 		);
 	}
 
-	if ( 'purchase-success' === displayMode ) {
+	if ( 'purchase-success' === noticeType ) {
 		const successMessage = translate( 'Your purchase has been completed!' );
 		notices.success( successMessage, {
 			persistent: true,


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* When a new user lands in Customer Home after successfully purchasing a plan, show a success notice. Otherwise there's no indication that the transaction was successful.

**New signup -> Checkout -> Customer Home**

<img width="1250" alt="Screenshot 2021-01-29 at 1 04 03 PM" src="https://user-images.githubusercontent.com/1269602/106245475-825dbc00-6232-11eb-833b-276453d86ee0.png">

**Launch flow -> Checkout -> Customer Home**

<img width="1235" alt="Screenshot 2021-01-29 at 12 45 55 PM" src="https://user-images.githubusercontent.com/1269602/106245519-92759b80-6232-11eb-8f33-7ad8865936a2.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Signup as a new user, purchase a plan, decline any upsell offers. Verify that you are taken to Customer Home with a success notice as shown in the screenshots above.
* Enter the site launch flow, purchase a plan, and verify that you are taken to Customer Home with a success notice.
* Signup as a new user, select a free plan, and confirm that you _do not see_ any notices when on Customer Home.
* Repeat step 1 with a non-EN language and verify that the success notice appears translated:
<img width="1264" alt="Screenshot 2021-01-29 at 12 58 21 PM" src="https://user-images.githubusercontent.com/1269602/106245375-5b06ef00-6232-11eb-890e-47f04a696624.png">




