### PR TITLE
Launch: Fix launch button translations not loaded.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
@@ -39,6 +39,8 @@ function enqueue_launch_button_script_and_style( $site_launch_options ) {
 		$style_version
 	);
 
+	wp_set_script_translations( 'a8c-fse-editor-site-launch-button-script', 'full-site-editing' );
+
 	// Prepare site launch options.
 	$options = array(
 		'siteSlug'   => $site_launch_options['site_slug'],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR is just to fix the "Launch" string on the launch button not being translated.

#### Testing instructions

* Can't really be tested as languages are deployed after a new ETK version is deployed.

* What can be tested if whether or not the language string is extracted, you could run:
   * Run `yarn dev` on `apps/editing-toolkit`
   * Go to `apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/dist`.
   * Run `wp i18n make-pot . test.pot --domain=full-site-editing`
   * Then run `cat test.pot | grep "Launch"` to see if the "Launch" string is extracted.

![image](https://user-images.githubusercontent.com/1287077/106255001-14a99400-6222-11eb-9a4b-3be8aab3a0c5.png)

