### PR TITLE
Fix broken plans page when a mouse is connected

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -10,6 +10,12 @@ $plan-features-sidebar-width: 272px;
 	// If experiment succeeds the following styles
 	// need to be moved to the corresponding selectors
 
+	.plans-features-main__group.is-wpcom {
+		overflow: auto;
+		max-height: calc( 100vh - 115px );
+		margin-top: 14px;
+	}
+
 	// To be moved to line 651 approximately
 	.plan-features--signup {
 		.plan-features__table {
@@ -609,9 +615,6 @@ $plan-features-sidebar-width: 272px;
 
 .plans-features-main__group.is-wpcom {
 	padding-top: 19px;
-	overflow: scroll;
-	max-height: calc( 100vh - 115px );
-	margin-top: 14px;
 }
 
 // This is the customer type buttons that let


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Fixes the broken plans page which is visible when an external mouse is connected
![image](https://user-images.githubusercontent.com/3422709/106268931-cad8a200-6251-11eb-930b-f1f8f24a8402.png)
- Bug introduced by change #48728
- The change moves the CSS change inside the experiment completely removing the impact on control
- Once the change is activated the scroll is fixed by introducing overflow:auto

#### Testing instructions

- Connect an external mouse
- Assign yourself to ExPlat experiment introduced here pcbrnV-XN-p2
- Go to the plans page via any signup flow
- Check if the above bug is fixed
- Switch to mobile and check if scroll works fine

Fixes #49457
