### PR TITLE
Signup: Make sure the password field does not have extra margin

### DIFF
--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -5,7 +5,8 @@
 	transition: none;
 
 	&.is-error,
-	&[type='password'] {
+	&[type='password'],
+	&[name='password'] {
 		margin-bottom: 0;
 	}
 


### PR DESCRIPTION
When you toggle the password field to show the password, it jumps because regular fields have extra bottom margin.


https://user-images.githubusercontent.com/3392497/106271713-d7480500-6227-11eb-8568-78ff2a843252.mov

#### Testing instructions
Go to https://wordpress.com/start/user

Toggle the visibility of the password field - the form should not "jump", no margin should be added on the bottom. See the above video.