### PR TITLE
Domains: Fix positioning of the example domain

### DIFF
--- a/client/components/domains/example-domain-browser/index.jsx
+++ b/client/components/domains/example-domain-browser/index.jsx
@@ -17,15 +17,9 @@ export default function ExampleDomainBrowser( { className } ) {
 				<g fill="none" fillRule="evenodd">
 					<path fill="#D8D8D8" d="M10 0h285v50H0V10C0 4.477 4.477 0 10 0z" />
 					<path fill="#FFF" d="M0 50h295v50H0zM94 9h201v30H94a4 4 0 0 1-4-4V13a4 4 0 0 1 4-4z" />
-					<text className="example-domain-browser__protocol">
-						<tspan x="99" y="29">
-							https://
-						</tspan>
-					</text>
-					<text className="example-domain-browser__domain">
-						<tspan x="148" y="29">
-							example.com
-						</tspan>
+					<text x="99" y="29">
+						<tspan className="example-domain-browser__protocol">https://</tspan>
+						<tspan className="example-domain-browser__domain">example.com</tspan>
 					</text>
 					<rect width="30" height="30" x="10" y="10" fill="#FFF" rx="4" />
 					<rect width="30" height="30" x="50" y="10" fill="#FFF" rx="4" />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The way the example domain is built is causing alignment issues - let's simplify the markup and let the browser do the positioning of the parts of the URL.

Before:
<img width="320" alt="Screenshot 2021-01-29 at 11 55 09" src="https://user-images.githubusercontent.com/3392497/106273692-001dc980-622b-11eb-9ac3-26ae0f8a1daa.png">

After:
<img width="321" alt="Screenshot 2021-01-29 at 12 07 01" src="https://user-images.githubusercontent.com/3392497/106273730-0d3ab880-622b-11eb-8a54-49b312fe2325.png">

#### Testing instructions

Go to https://wordpress.com/start/domain/domain-only in a private window, make sure the example domain SVG is looking proper now.