### PR TITLE
DomainPicker: update price formatting

### DIFF
--- a/packages/data-stores/src/domain-suggestions/resolvers.ts
+++ b/packages/data-stores/src/domain-suggestions/resolvers.ts
@@ -15,8 +15,11 @@ import {
 	receiveDomainAvailability,
 } from './actions';
 import { fetchAndParse, wpcomRequest } from '../wpcom-request-controls';
+import { getFormattedPrice } from './utils';
+
 import type { Selectors } from './selectors';
 import type { TailParameters } from '../mapped-types';
+import type { DomainSuggestion } from './types';
 
 export const isAvailable = function* isAvailable(
 	domainName: TailParameters< Selectors[ 'isAvailable' ] >[ 0 ]
@@ -79,5 +82,13 @@ export function* __internalGetDomainSuggestions(
 		);
 	}
 
-	return receiveDomainSuggestionsSuccess( queryObject, suggestions );
+	const processedSuggestions = suggestions.map( ( suggestion: DomainSuggestion ) => ( {
+		...suggestion,
+		...( suggestion.raw_price &&
+			suggestion.currency_code && {
+				cost: getFormattedPrice( suggestion.raw_price, suggestion.currency_code ),
+			} ),
+	} ) );
+
+	return receiveDomainSuggestionsSuccess( queryObject, processedSuggestions );
 }

--- a/packages/data-stores/src/domain-suggestions/test/reducer.ts
+++ b/packages/data-stores/src/domain-suggestions/test/reducer.ts
@@ -72,6 +72,8 @@ describe( 'domainSuggestions', () => {
 				product_id: 78,
 				product_slug: 'dotsite_domain',
 				cost: '$25.00',
+				raw_price: 25,
+				currency_code: 'USD',
 			},
 			{
 				domain_name: 'hot-test-site.com',
@@ -82,6 +84,8 @@ describe( 'domainSuggestions', () => {
 				product_id: 6,
 				product_slug: 'domain_reg',
 				cost: '$18.00',
+				raw_price: 18,
+				currency_code: 'USD',
 			},
 		];
 		const now = Date.now();

--- a/packages/data-stores/src/domain-suggestions/types.ts
+++ b/packages/data-stores/src/domain-suggestions/types.ts
@@ -77,21 +77,42 @@ export interface DomainSuggestion {
 	domain_name: DomainName;
 
 	/**
+	 * Rendered formatted cost
+	 *
+	 * @example "Free" or "€15.00"
+	 */
+	cost: string;
+
+	/**
+	 * Raw price
+	 *
+	 * @example 40
+	 */
+	raw_price?: number;
+
+	/**
+	 * Currency code
+	 *
+	 * @example USD
+	 */
+	currency_code?: string;
+
+	/**
 	 * Relevance as a percent: 0 <= relevance <= 1
 	 *
 	 * @example 0.9
 	 */
-	relevance: number;
+	relevance?: number;
 
 	/**
 	 * Whether the domain supports privacy
 	 */
-	supports_privacy: boolean;
+	supports_privacy?: boolean;
 
 	/**
 	 * The domain vendor
 	 */
-	vendor: string;
+	vendor?: string;
 
 	/**
 	 * Reasons for suggestion the domain
@@ -101,21 +122,14 @@ export interface DomainSuggestion {
 	match_reasons?: readonly string[];
 
 	/**
-	 * Rendered cost with currency
-	 *
-	 * @example "€15.00"
-	 */
-	cost: string;
-
-	/**
 	 * The product ID
 	 */
-	product_id: number;
+	product_id?: number;
 
 	/**
 	 * The product slug
 	 */
-	product_slug: string;
+	product_slug?: string;
 
 	/**
 	 * Whether the domain is free

--- a/packages/data-stores/src/domain-suggestions/utils.ts
+++ b/packages/data-stores/src/domain-suggestions/utils.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import deterministicStringify from 'fast-json-stable-stringify';
+import formatCurrency from '@automattic/format-currency';
 
 /**
  * Internal dependencies
@@ -16,3 +17,16 @@ import type { DomainSuggestionQuery } from './types';
 export const stringifyDomainQueryObject: (
 	q: DomainSuggestionQuery
 ) => string = deterministicStringify;
+
+/**
+ * Formats the domain suggestion price according to 'format-currency' package rules
+ * We use this for consistency in prices formats across plans and domains
+ *
+ * @param price the domain suggestion raw price
+ * @param currencyCode the currency code to be used when formatting price
+ */
+export function getFormattedPrice( price: number, currencyCode: string ): string {
+	return formatCurrency( price, currencyCode, {
+		stripZeros: true,
+	} ) as string;
+}

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { stringify } from 'qs';
+import formatCurrency from '@automattic/format-currency';
 
 /**
  * Internal dependencies
@@ -27,7 +28,6 @@ import {
 	FEATURE_IDS_THAT_REQUIRE_ANNUALLY_BILLED_PLAN,
 } from './constants';
 import { fetchAndParse, wpcomRequest } from '../wpcom-request-controls';
-import formatCurrency from '@automattic/format-currency';
 
 const MONTHLY_PLAN_BILLING_PERIOD = 31;
 

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -60,7 +60,7 @@ interface Props {
 	isUnavailable?: boolean;
 	domain: string;
 	isLoading?: boolean;
-	cost: string;
+	cost?: string;
 	hstsRequired?: boolean;
 	isFree?: boolean;
 	isExistingSubdomain?: boolean;

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -40,8 +40,8 @@ export type DomainProduct = {
 	meta: string;
 	product_id: number;
 	extra: {
-		privacy_available: boolean;
-		privacy: boolean;
+		privacy_available?: boolean;
+		privacy?: boolean;
 		source: string;
 	};
 };
@@ -49,15 +49,20 @@ export type DomainProduct = {
 export const getDomainProduct = (
 	domain: DomainSuggestions.DomainSuggestion,
 	flow: string
-): DomainProduct => ( {
-	meta: domain?.domain_name,
-	product_id: domain?.product_id,
-	extra: {
-		privacy_available: domain?.supports_privacy,
-		privacy: domain?.supports_privacy,
-		source: flow,
-	},
-} );
+): DomainProduct | undefined => {
+	if ( ! domain?.product_id ) {
+		return;
+	}
+	return {
+		meta: domain?.domain_name,
+		product_id: domain?.product_id,
+		extra: {
+			privacy_available: domain?.supports_privacy,
+			privacy: domain?.supports_privacy,
+			source: flow,
+		},
+	};
+};
 
 export const isDomainProduct = ( item: ResponseCartProduct ): boolean => {
 	return !! item.is_domain_registration;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use newly introduced properties from D56060-code to format domain suggestion price on client

#### Testing instructions

* Go to /new as a non-US user having USD currency set for your account
* Open DomainPicker and PlansGrid and price formatting should match
* Check in one of the launch flows
* Check with other currency (see guide on PCYsg-2xJ-p2)

#### Screenshots
* **Before**
<img width="1066" alt="Screenshot 2021-01-29 at 13 56 15" src="https://user-images.githubusercontent.com/14192054/106280864-1df92780-6247-11eb-90c8-bb1a5fac4d08.png">

* **After**
<img width="1069" alt="Screenshot 2021-01-29 at 13 55 59" src="https://user-images.githubusercontent.com/14192054/106280839-19cd0a00-6247-11eb-9601-68adece3d0ae.png">

Fixes #49410