### PR TITLE
Domains: Use Banner component for the free domain explainer

### DIFF
--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -8,7 +8,7 @@ import { omit } from 'lodash';
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
+import Banner from 'calypso/components/banner';
 
 /**
  * Style dependencies
@@ -44,39 +44,45 @@ class FreeDomainExplainer extends React.Component {
 		);
 	}
 
-	render() {
-		const { translate, isReskinned, locale } = this.props;
+	getDescription() {
+		const { translate, locale } = this.props;
 		const { TextWrapper } = this;
+		return (
+			<>
+				<TextWrapper className="free-domain-explainer__subtitle">
+					{ locale === 'en'
+						? translate(
+								"We'll pay the registration fees for your new domain when you choose an annual plan during the next step."
+						  )
+						: translate(
+								"We'll pay the registration fees for your new domain when you choose a paid plan during the next step."
+						  ) }
+				</TextWrapper>
+				<TextWrapper className="free-domain-explainer__subtitle">
+					{ translate( "You can claim your free custom domain later if you aren't ready yet." ) }
+				</TextWrapper>
+			</>
+		);
+	}
+
+	render() {
+		const { translate, locale } = this.props;
+		const title =
+			locale === 'en'
+				? translate( 'Get a free one-year domain registration with any paid annual plan.' )
+				: translate( 'Get a free one-year domain registration with any paid plan.' );
 
 		return (
-			<div className="free-domain-explainer card is-compact">
-				<header>
-					<h1 className="free-domain-explainer__title">
-						{ locale === 'en'
-							? translate( 'Get a free one-year domain registration with any paid annual plan.' )
-							: translate( 'Get a free one-year domain registration with any paid plan.' ) }
-					</h1>
-					<TextWrapper className="free-domain-explainer__subtitle">
-						{ locale === 'en'
-							? translate(
-									"We'll pay the registration fees for your new domain when you choose an annual plan during the next step."
-							  )
-							: translate(
-									"We'll pay the registration fees for your new domain when you choose a paid plan during the next step."
-							  ) }
-					</TextWrapper>
-					<TextWrapper className="free-domain-explainer__subtitle">
-						{ translate( "You can claim your free custom domain later if you aren't ready yet." ) }
-						<Button
-							borderless
-							className="free-domain-explainer__subtitle-link"
-							onClick={ this.handleClick }
-						>
-							{ translate( 'Review our plans to get started' ) } { ! isReskinned && <>&raquo;</> }
-						</Button>
-					</TextWrapper>
-				</header>
-			</div>
+			<Banner
+				callToAction={ translate( 'Review our plans to get started' ) }
+				description={ this.getDescription() }
+				dismissPreferenceName="free-domain-explainer"
+				dismissTemporary
+				horizontal
+				title={ title }
+				primaryButton={ false }
+				onClick={ this.handleClick }
+			/>
 		);
 	}
 }

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -74,6 +74,7 @@ class FreeDomainExplainer extends React.Component {
 
 		return (
 			<Banner
+				className="free-domain-explainer"
 				callToAction={ translate( 'Review our plans to get started' ) }
 				description={ this.getDescription() }
 				dismissPreferenceName="free-domain-explainer"

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -14,20 +14,8 @@
 .free-domain-explainer__subtitle {
     color: var( --color-text );
     font-weight: 400;
-    font-size: $font-body;
     margin: 0;
     margin-bottom: 0.3em;
-
-    & .button,
-    & .button:hover,
-    & .button:focus {
-        color: var( --color-link );
-        display: inline;
-        font-size: $font-body;
-        margin-left: 0.3em;
-        text-decoration: underline;
-        vertical-align: baseline;
-    }
 }
 
 body.is-section-signup.is-white-signup {
@@ -38,12 +26,11 @@ body.is-section-signup.is-white-signup {
 
         .free-domain-explainer__subtitle {
             color: var( --color-neutral-60 );
-            font-size: 1rem;
             margin-bottom: 0;
 
             &::after {
                 content: ' ';
-                
+
                 @include break-mobile {
                     content: '\a';
                     white-space: pre;

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -1,8 +1,17 @@
 @import '~@wordpress/base-styles/breakpoints';
 @import '~@wordpress/base-styles/mixins';
 
-.free-domain-explainer__title {
+.free-domain-explainer {
+	.banner__description {
+		display: none;
 
+		@include break-mobile {
+			display: block;
+		}
+	}
+}
+
+.free-domain-explainer__title {
     color: var( --color-text );
     font-weight: 400;
     font-size: $font-title-small;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -134,7 +134,7 @@ body.is-section-signup .layout.gravatar {
 	}
 
 	@include breakpoint-deprecated( '<660px' ) {
-		button {
+		button:not( .is-compact ) {
 			font-size: $font-body;
 			padding-top: 12px;
 			padding-bottom: 14px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I was going through our signup flow with fresh mind and the "free domain explainer" stood out to me. While it's providing helpful context (confirmed by a very successful A/B test), I feel like it can be overly annoying if you just want to search for domains. It stays on top of results always, you cannot dismiss it and on mobile it takes up almost all view:

<img width="377" alt="Screenshot 2021-01-29 at 13 26 31" src="https://user-images.githubusercontent.com/3392497/106289265-fb641000-6240-11eb-99a2-a478ff1f6711.png">

I've switched it to use one of our components/blocks. I was debating whether to use [`UpsellNudge`](https://wpcalypso.wordpress.com/devdocs/blocks/upsell-nudge) or [`Banner`](https://wpcalypso.wordpress.com/devdocs/design/banner), but I'm not sure if UpsellNudge is applicable here since we don't have a site?

Either, now it's more consistent with our other messaging like this. And most importantly, it's dismissable (but shows up again on refresh). Takes up less space both on mobile and desktop. And has a proper button support.

@niranjan-uma-shankar (or someone else from @Automattic/martech), I'd especially love your opinion here as this change came from your A/B test and I don't want to undo it - just iterate on it. Link to internal discussion: p99Zz8-1BJ-p2#comment-4821

#### Testing instructions

Probably best to test this in a private window with a fresh user. Or at least start from `/start` to force the old signup flow if you're using existing user.

Previously:

<img width="985" alt="Screenshot 2021-01-29 at 14 50 24" src="https://user-images.githubusercontent.com/3392497/106289587-55fd6c00-6241-11eb-8ee9-82fb30ebc183.png">

Now:

<img width="986" alt="Screenshot 2021-01-29 at 14 38 39" src="https://user-images.githubusercontent.com/3392497/106289593-5ac22000-6241-11eb-9811-b081cfe88ab1.png">

Now (in reskinned signup -> force the `reskinSignupFlow` A/B test to `reskinned` variation):

<img width="1006" alt="Screenshot 2021-01-29 at 14 38 18" src="https://user-images.githubusercontent.com/3392497/106289696-804f2980-6241-11eb-9b17-edcc2c6a80c9.png">

Aaand mobile - note that the description is hidden to keep it concise, as recommended here: p99Zz8-1BJ-p2#comment-4827):

![Screen Shot 2021-02-17 at 16 12 33](https://user-images.githubusercontent.com/3392497/108232884-20aab680-713b-11eb-8aaa-2a47c8fe9927.png)

