### PR TITLE
P2 signup: Small tweaks to paddings and copy

### DIFF
--- a/client/signup/p2-step-wrapper/style.scss
+++ b/client/signup/p2-step-wrapper/style.scss
@@ -13,8 +13,16 @@
 	line-height: 1.8;
 
 	@include break-mobile {
-		padding: 80px 20px 0;
+		padding: 48px 20px 0;
 		max-width: 400px;
+	}
+
+	@include break-medium {
+		padding: 64px 20px 0;
+	}
+
+	@include break-huge {
+		padding: 80px 20px 0;
 	}
 
 	input,
@@ -37,8 +45,9 @@
 
 .p2-step-wrapper__header {
 	margin-bottom: 40px;
-	@include break-mobile {
-		margin-bottom: 80px;
+
+	@include break-huge {
+		margin-bottom: 56px;
 	}
 }
 
@@ -81,7 +90,7 @@
 	background-color: var( --p2-color-button );
 	color: var( --p2-color-text );
 	border: none;
-	border-radius: 40px;
+	border-radius: 40px; /* stylelint-disable-line scales/radii */
 	font-weight: normal;
 	font-size: var( --p2-font-size-form );
 	transition: background 0.2s ease;

--- a/client/signup/steps/p2-details/index.jsx
+++ b/client/signup/steps/p2-details/index.jsx
@@ -78,7 +78,7 @@ function P2Details( {
 				</div>
 				<div className="p2-details__description">
 					{ translate(
-						'P2 is powered by WordPress.com: log in with your account (or create a new one) ' +
+						'P2 is powered by WordPress.com: log in to your account (or create a new one) ' +
 							'to continue.'
 					) }
 				</div>
@@ -94,7 +94,7 @@ function P2Details( {
 							page( getLoginLink( { flowName, locale } ) );
 						} }
 					>
-						{ translate( 'Log in with WordPress.com' ) }
+						{ translate( 'Log in to WordPress.com' ) }
 					</Button>
 					<Button
 						onClick={ () => {


### PR DESCRIPTION
This PR introduces a couple of very small changes to the P2 signup flow:

- Tweaks to the paddings in different breakpoints, so the form is better proportioned in smaller screens.
- Small change to the copy in the second step (when logged out) so it's consistent with the log in screen P2.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/820374/106289396-25b5cd80-6241-11eb-83ac-5755027a7f16.png)|![image](https://user-images.githubusercontent.com/820374/106289220-e8e9d680-6240-11eb-91eb-6dea861592c7.png)|

## Testing instructions
Navigate to `/start/p2` while logged out, and make sure that the form looks as expected in different screen sizes, and the copy of the second step is as shown in the screenshot above.