### PR TITLE
Security2faSMSSettings: clean up `verifyByApp` class prop

### DIFF
--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -60,8 +60,6 @@ class Security2faSMSSettings extends React.Component {
 		};
 	}
 
-	verifyByApp = null;
-
 	getSubmitDisabled() {
 		if ( this.props.isUpdatingUserSettings ) {
 			return true;
@@ -81,17 +79,16 @@ class Security2faSMSSettings extends React.Component {
 
 	onVerifyByApp = ( event ) => {
 		event.preventDefault();
-		this.verifyByApp = true;
-		this.submitSMSSettings();
+		this.submitSMSSettings( true );
 	};
 
 	onVerifyBySMS = ( event ) => {
 		event.preventDefault();
-		this.verifyByApp = false;
 		this.submitSMSSettings();
 	};
 
-	async submitSMSSettings() {
+	async submitSMSSettings( verifyByApp = false ) {
+		const { onVerifyByApp, onVerifyBySMS } = this.props;
 		const phoneNumber = this.state.phoneNumber;
 
 		if ( ! phoneNumber.isValid ) {
@@ -103,15 +100,15 @@ class Security2faSMSSettings extends React.Component {
 			phoneNumber.countryCode === this.props.userSettings.two_step_sms_country &&
 			phoneNumber.phoneNumber === this.props.userSettings.two_step_sms_phone_number
 		) {
-			this.handleSubmitResponse();
+			verifyByApp ? onVerifyByApp() : onVerifyBySMS();
 			return;
 		}
 
 		try {
 			await this.props.saveTwoStepSMSSettings( phoneNumber.countryCode, phoneNumber.phoneNumber );
-			this.handleSubmitResponse();
+			verifyByApp ? onVerifyByApp() : onVerifyBySMS();
 		} catch ( error ) {
-			this.handleSubmitResponse( error );
+			this.setState( { lastError: error } );
 		}
 	}
 
@@ -125,17 +122,6 @@ class Security2faSMSSettings extends React.Component {
 			},
 		} );
 	};
-
-	handleSubmitResponse( error ) {
-		if ( error ) {
-			this.setState( { lastError: error } );
-			return;
-		}
-
-		const { onVerifyByApp, onVerifyBySMS } = this.props;
-
-		this.verifyByApp ? onVerifyByApp() : onVerifyBySMS();
-	}
 
 	clearLastError = () => {
 		this.setState( { lastError: false } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `verifyByApp` class prop from `<Security2faSMSSettings />`

#### Testing instructions

Get a WP.com account which doesn't have 2fa set up.

* Go to `/me/security/two-step` and hit _Get started_
* Type in a (valid) phone number and hit _Verify by App_, then hit _Cancel_
* Your phone number should still be there, hit _Verify by SMS_ (you should receive a text with a verification code)
* Hit _Cancel_ again and try both while blocking the network request, do you get an error?
* Do all flows work exactly like on prod?

follow up from #49000
