### PR TITLE
Gutenboarding: update tt-blocks theme slug

### DIFF
--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -16,9 +16,9 @@
 		},
 		{
 			"title": "Twenty Twenty One",
-			"slug": "twentytwentyone-blocks",
-			"template": "twentytwentyone-blocks",
-			"theme": "twentytwentyone-blocks",
+			"slug": "tt1-blocks",
+			"template": "tt1-blocks",
+			"theme": "tt1-blocks",
 			"fonts": {
 				"headings": "Playfair Display",
 				"base": "Fira Sans"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Twenty Twenty-One Blocks was renamed to TT1 Blocks along with its theme slug. This PR updates the Gutenboarding config to point to the updated theme.

pNEWy-dAs-p2

#### Testing instructions

* Go through the `/new` flow with the gutenboarding feature flags enabled and verify that the TT1 theme shows up in the design step.