### PR TITLE
Change DIFM CTA href to string- no curly braces needed.

### DIFF
--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -83,7 +83,7 @@ class UpworkBanner extends PureComponent {
 				role="button"
 				style={ { backgroundColor: '#DAF5FC' } }
 				onClick={ this.onStartNowClick }
-				href={ 'https://wordpress.com/built-by-wordpress-com/' }
+				href="https://wordpress.com/built-by-wordpress-com/"
 			>
 				<QueryPreferences />
 				<h1 className="upwork-banner__title">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adjusts the `href` attribute on the DIFM banner link to remove the curly braces, since the value is only a string.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Head to My Site > Design Themes https://wordpress.com/themes.
- Click on "Show all themes".
- Click on the "Find your expert" button under the "Let our WordPress experts build your site" banner.
- Confirm the browser navigates to https://wordpress.com/built-by-wordpress-com/.

Fixes #48947