### PR TITLE
Checkout: Add Jetpack Redirect after Jetpack Cloud Checkout[Revised]

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -16,6 +16,8 @@ import {
 	PRODUCT_JETPACK_CRM_MONTHLY,
 } from 'calypso/lib/products-values/constants';
 
+export const JETPACK_REDIRECT_URL = 'https://jetpack.com/redirect/';
+
 // plans constants
 export const PLAN_BUSINESS_MONTHLY = 'business-bundle-monthly';
 export const PLAN_BUSINESS = 'business-bundle';

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -12,6 +12,7 @@ const debug = debugFactory( 'calypso:composite-checkout:get-thank-you-page-url' 
  */
 import { isExternal } from 'calypso/lib/url';
 import config from '@automattic/calypso-config';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
 	hasRenewalItem,
 	getAllCartItems,
@@ -29,7 +30,7 @@ import {
 import { managePurchase } from 'calypso/me/purchases/paths';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
 import { JETPACK_PRODUCTS_LIST } from 'calypso/lib/products-values/constants';
-import { JETPACK_RESET_PLANS } from 'calypso/lib/plans/constants';
+import { JETPACK_RESET_PLANS, JETPACK_REDIRECT_URL } from 'calypso/lib/plans/constants';
 import { persistSignupDestination, retrieveSignupDestination } from 'calypso/signup/storageUtils';
 import { abtest } from 'calypso/lib/abtest';
 
@@ -259,6 +260,13 @@ function getFallbackDestination( {
 			);
 		if ( isJetpackNotAtomic && purchasedProduct ) {
 			debug( 'the site is jetpack and bought a jetpack product', siteSlug, purchasedProduct );
+
+			if ( isJetpackCloud() ) {
+				debug( 'checkout is Jetpack Cloud, returning Jetpack Redirect API url' );
+				return `${ JETPACK_REDIRECT_URL }?source=jetpack-checkout-thankyou&site=${ siteSlug }&query=${ encodeURIComponent(
+					`product=${ purchasedProduct }&thank-you=true`
+				) }`;
+			}
 			return `/plans/my-plan/${ siteSlug }?thank-you=true&product=${ purchasedProduct }`;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR sets the post checkout redirect location to an explicit Jetpack Redirect API source if we're checking out on Jetpack Cloud and it's a Jetpack product. Using the Jetpack Redirect API allows us to gracefully update the post purchase redirect location when needed.

This PR is another approach to #49425 and in my opinion is a much simpler and optimal solution.

### Testing instructions

- Checkout and run this PR in Jetpack Cloud  (`yarn start-jetpack-cloud`)
- Select a Jetpack site and go to the pricing page: `jetpack.cloud.localhost:3000/pricing/:site`
- Purchase any Jetpack product.
- Verify you are redirected to `https://cloud.jetpack.com/landing/:site?product=:productSlug&thank-you=true`
    - note: /landing redirects to /backup (which is expected for now)
- Bonus for testing various products.
- Run unit tests and verify they pass.
    -  `yarn test-client client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js`

Fixes: 1199409969959876-as-1199670278480660
