### PR TITLE
Remove tagline in latest version of pricing page

### DIFF
--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -38,15 +38,6 @@ const Header: React.FC< Props > = ( { urlQueryArgs } ) => {
 				'Security, performance, and marketing tools made for WordPress'
 			),
 		}[ iteration ] ?? translate( 'Security, performance, and marketing tools for WordPress' );
-	const tagline =
-		{
-			[ Iterations.V1 ]: '',
-			[ Iterations.V2 ]: '',
-			[ Iterations.I5 ]: '',
-		}[ iteration ] ??
-		translate(
-			'Get everything your site needs, in one package — so you can focus on your business.'
-		);
 
 	return (
 		<>
@@ -61,7 +52,6 @@ const Header: React.FC< Props > = ( { urlQueryArgs } ) => {
 					headerText={ preventWidows( title ) }
 					align="center"
 				/>
-				{ tagline && <p>{ tagline }</p> }
 			</div>
 		</>
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR removes the tagline in the pricing page, for the SPP variation (matching previous variations).

### Testing instructions

- Run the PR in cloud
- Select the `test` variation of the `jetpackSimplifyPricingPage` experiment
- Check that there's no tagline

### Screenshots

#### Before
<img width="1076" alt="Screen Shot 2021-01-29 at 4 23 18 PM" src="https://user-images.githubusercontent.com/1620183/106328680-3ae52900-624e-11eb-9112-72f92e25db7e.png">


#### After
<img width="1066" alt="Screen Shot 2021-01-29 at 4 23 13 PM" src="https://user-images.githubusercontent.com/1620183/106328693-3fa9dd00-624e-11eb-97ce-191d5a002177.png">
