### PR TITLE
Navigation sidebar: use sentence case for headings

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -417,8 +417,8 @@ class CalypsoifyIframe extends Component<
 					post: translate( 'Add new post' ),
 				},
 				listHeadings: {
-					page: translate( 'Recent Pages' ),
-					post: translate( 'Recent Posts' ),
+					page: translate( 'Recent pages' ),
+					post: translate( 'Recent posts' ),
 				},
 			} );
 		}

--- a/client/state/selectors/get-editor-close-config.js
+++ b/client/state/selectors/get-editor-close-config.js
@@ -60,9 +60,9 @@ export default function getEditorCloseConfig( state, siteId, postType, fseParent
 
 	let label = translate( 'Back' );
 	if ( postType === 'post' ) {
-		label = translate( 'View Posts' );
+		label = translate( 'View posts' );
 	} else if ( postType === 'page' ) {
-		label = translate( 'View Pages' );
+		label = translate( 'View pages' );
 	}
 
 	return {


### PR DESCRIPTION
### Changes proposed in this Pull Request

[Sentence case](https://github.com/WordPress/gutenberg/search?q=sentence+capitalization) is the trend in Gutenberg so let's make things consistent.


### Testing instructions

Run this branch and open a post from the posts list page (http://calypso.localhost:3000/posts/[YOUR_SITE])

Check that the back link in the sidebar says "View posts"

Check that the heading says "Recent posts" 

<img width="447" alt="Screen Shot 2021-02-01 at 12 30 56 pm" src="https://user-images.githubusercontent.com/6458278/106405212-918a7700-6489-11eb-90e7-7244298bb1a8.png">

Open a page from the pages list page (http://calypso.localhost:3000/pages/[YOUR_SITE])

Check that the back link in the sidebar says "View pages"

Check that the heading says "Recent pages" 

<img width="306" alt="Screen Shot 2021-02-01 at 12 27 52 pm" src="https://user-images.githubusercontent.com/6458278/106405211-8df6f000-6489-11eb-80b1-74d6505a7ba1.png">



Related to #47846
