### PR TITLE
Welcome tour: minimize when the inserter opens

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -43,6 +43,10 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 	&.components-button {
 		height: 44px;
 	}
+
+	.wpcom-editor-welcome-tour__maximize-icon path {
+		fill: white;
+	}
 }
 
 .wpcom-editor-welcome-tour-card-frame {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
@@ -66,9 +66,8 @@ function WelcomeTourFrame() {
 	const [ isMinimized, setIsMinimized ] = useState( false );
 	const [ currentCardIndex, setCurrentCardIndex ] = useState( 0 );
 	const [ justMaximized, setJustMaximized ] = useState( false );
-
 	const { setWpcomNuxStatus, setTourOpenStatus } = useDispatch( 'automattic/nux' );
-
+	const isInserterOpened = useSelect( ( select ) => select( 'core/edit-post' ).isInserterOpened() );
 	const dismissWpcomNuxTour = ( source ) => {
 		recordTracksEvent( 'calypso_editor_wpcom_tour_dismiss', {
 			is_gutenboarding: window.calypsoifyGutenberg?.isGutenboarding,
@@ -78,6 +77,12 @@ function WelcomeTourFrame() {
 		setWpcomNuxStatus( { isNuxEnabled: false } );
 		setTourOpenStatus( { isTourManuallyOpened: false } );
 	};
+
+	useEffect( () => {
+		if ( isInserterOpened && ! isMinimized ) {
+			setIsMinimized( true );
+		}
+	}, [ isInserterOpened ] );
 
 	// Preload card images
 	cardContent.forEach( ( card ) => ( new window.Image().src = card.imgSrc ) );
@@ -118,10 +123,13 @@ function WelcomeTourMinimized( { onMaximize, setJustMaximized, slideNumber } ) {
 	};
 
 	return (
-		<Button onClick={ handleOnMaximize } className="wpcom-editor-welcome-tour__resume-btn">
+		<Button
+			onClick={ handleOnMaximize }
+			className="wpcom-editor-welcome-tour__resume-btn components-button is-primary"
+		>
 			<Flex gap={ 13 }>
 				<p>{ __( 'Click to resume tutorial', 'full-site-editing' ) }</p>
-				<Icon icon={ maximize } size={ 24 } />
+				<Icon className="wpcom-editor-welcome-tour__maximize-icon" icon={ maximize } size={ 24 } />
 			</Flex>
 		</Button>
 	);


### PR DESCRIPTION
## Changes proposed in this Pull Request

This commit minimizes the welcome tour when we detect that the block inserter opens.

We're also changing the colour of the minimized button to match the primary button styles

The reason behind this changes is to make sure the inserter isn't hidden by the welcome tour. Also, we minimize the tour because any focus outside the inserter closes the inserter.  

**Before**
![Feb-01-2021 14-42-42](https://user-images.githubusercontent.com/6458278/106412401-d15a5a00-649b-11eb-9ac5-6eec81669ec9.gif)

**After**
![Feb-01-2021 14-34-43](https://user-images.githubusercontent.com/6458278/106412238-58f39900-649b-11eb-8e61-b90b117e29a9.gif)

## Testing instructions

Sync these changes to your sandbox and enable the welcome tour by adding `define( 'SHOW_WELCOME_TOUR', true );` to your 0-sandbox.php

Open the Welcome Guide from the options menu.

Click on the + block inserter

The tour should minimize.

At this stage any event outside the block inserter container will cause the inserter to close, therefore maximizing the tour will also do this.




