### PR TITLE
Deduplicate jest-worker

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -16578,28 +16578,10 @@ jest-worker@^25.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest-worker@^26.1.0:
-  version "26.2.1"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.2.1.tgz#5d630ab93f666b53f911615bc13e662b382bd513"
-  integrity sha512-+XcGMMJDTeEGncRb5M5Zq9P7K4sQ1sirhjdOxsN1462h6lFo9w59bl2LVQmdGEEeU3m+maZCkS2Tcc9SfCHO4A==
-  dependencies:
-    "@types/node" "*"
-    merge-stream "^2.0.0"
-    supports-color "^7.0.0"
-
-jest-worker@^26.2.1, jest-worker@^26.6.2:
+jest-worker@^26.1.0, jest-worker@^26.2.1, jest-worker@^26.3.0, jest-worker@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
   integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
-  dependencies:
-    "@types/node" "*"
-    merge-stream "^2.0.0"
-    supports-color "^7.0.0"
-
-jest-worker@^26.3.0:
-  version "26.3.0"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.3.0.tgz#7c8a97e4f4364b4f05ed8bca8ca0c24de091871f"
-  integrity sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==
   dependencies:
     "@types/node" "*"
     merge-stream "^2.0.0"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `jest-worker` (done automatically with `npx yarn-deduplicate --packages jest-worker`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> jest-worker@26.3.0
< wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> jest-worker@26.3.0
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> jest-worker@26.3.0
< wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> jest-worker@26.3.0
> wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> jest-worker@26.6.2
> wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> jest-worker@26.6.2
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> jest-worker@26.6.2
> wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> jest-worker@26.6.2
```