### PR TITLE
Deduplicate js-yaml

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -16643,7 +16643,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@3.14.0, js-yaml@^3.14.0:
+js-yaml@3.14.0, js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.6.1:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
@@ -16651,7 +16651,7 @@ js-yaml@3.14.0, js-yaml@^3.14.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.13.1, js-yaml@^3.6.1, js-yaml@~3.13.1:
+js-yaml@~3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `js-yaml` (done automatically with `npx yarn-deduplicate --packages js-yaml`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> js-yaml@3.13.1
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> js-yaml@3.13.1
< wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> js-yaml@3.13.1
< wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> js-yaml@3.13.1
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> js-yaml@3.13.1
< wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> js-yaml@3.13.1
< wp-calypso@0.17.0 -> eslint@7.12.0 -> ... -> js-yaml@3.13.1
< wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> js-yaml@3.13.1
< wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> js-yaml@3.13.1
< wp-calypso@0.17.0 -> postcss-cli@6.1.3 -> ... -> js-yaml@3.13.1
> wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> js-yaml@3.14.0
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> js-yaml@3.14.0
> wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> js-yaml@3.14.0
> wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> js-yaml@3.14.0
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> js-yaml@3.14.0
> wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> js-yaml@3.14.0
> wp-calypso@0.17.0 -> eslint@7.12.0 -> ... -> js-yaml@3.14.0
> wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> js-yaml@3.14.0
> wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> js-yaml@3.14.0
> wp-calypso@0.17.0 -> postcss-cli@6.1.3 -> ... -> js-yaml@3.14.0
```