### PR TITLE
Deduplicate make-dir

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -17847,14 +17847,7 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^3.0.0, make-dir@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.2.tgz#04a1acbf22221e1d6ef43559f43e05a90dbb4392"
-  integrity sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==
-  dependencies:
-    semver "^6.0.0"
-
-make-dir@^3.1.0:
+make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `make-dir` (done automatically with `npx yarn-deduplicate --packages make-dir`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> make-dir@3.0.2
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> make-dir@3.0.2
< wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> make-dir@3.0.2
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> make-dir@3.0.2
< wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> make-dir@3.0.2
> wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> make-dir@3.1.0
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> make-dir@3.1.0
> wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> make-dir@3.1.0
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> make-dir@3.1.0
> wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> make-dir@3.1.0
```