### PR TITLE
Update Titan control panel iframe height to 1200px

### DIFF
--- a/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
@@ -132,7 +132,7 @@ class TitanControlPanelLoginCard extends React.Component {
 							title={ translate( 'Email Control Panel' ) }
 							src={ this.state.iframeURL }
 							width="100%"
-							height="650px"
+							height="1000px"
 						/>
 					) : (
 						<div>{ translate( 'Loading the control panel…' ) }</div>

--- a/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
@@ -132,7 +132,7 @@ class TitanControlPanelLoginCard extends React.Component {
 							title={ translate( 'Email Control Panel' ) }
 							src={ this.state.iframeURL }
 							width="100%"
-							height="1000px"
+							height="1200px"
 						/>
 					) : (
 						<div>{ translate( 'Loading the control panel…' ) }</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR changes the `height` attribute of the embedded Titan control panel from `650px` to `1200px` per a request from the Titan developers

#### Testing instructions

* Verify that the Titan control panel is taller by default when the `titan/iframe-control-panel` feature flag is enabled.
You can access the iframed control panel by navigating to `/email/:domain/titan/manage/:siteSlug?flags=titan/iframe-control-panel`