### PR TITLE
state(user-settings): allow for nested attributes in `unsavedUserSettings`

### DIFF
--- a/client/state/user-settings/helpers.js
+++ b/client/state/user-settings/helpers.js
@@ -1,0 +1,45 @@
+/**
+ * Set a (nested) value in an object. Will create keys if they're not existent.
+ *
+ * @param {object} obj Object to operate on
+ * @param {string | Array} path Key to set. Can be an array to represent nested values
+ * @param {string} value Value which key should be set to
+ */
+export function setValue( obj, path, value ) {
+	if ( ! Array.isArray( path ) ) {
+		path = [ path ];
+	}
+	function doSet( o = {}, i ) {
+		return {
+			...o,
+			[ path[ i ] ]: i === path.length - 1 ? value : doSet( o[ path[ i ] ], i + 1 ),
+		};
+	}
+	return doSet( obj, 0 );
+}
+
+/**
+ * Remove a (nested) value from an object. It will clean up empty objects in the tree.
+ *
+ * @param {object} obj Object to operate on
+ * @param {string | Array} path Key to remove. Can be an array to represent nested values
+ */
+export function removeValue( obj, path ) {
+	if ( ! Array.isArray( path ) ) {
+		path = [ path ];
+	}
+	function doRemove( o, i ) {
+		if ( ! o ) {
+			return {};
+		}
+		if ( i < path.length - 1 ) {
+			const r = doRemove( o[ path[ i ] ], i + 1 );
+			if ( Object.keys( r ).length > 0 ) {
+				return { ...o, [ path[ i ] ]: r };
+			}
+		}
+		const { [ path[ i ] ]: r, ...or } = o;
+		return or;
+	}
+	return doRemove( obj, 0 );
+}

--- a/client/state/user-settings/reducer.js
+++ b/client/state/user-settings/reducer.js
@@ -34,7 +34,7 @@ export const settings = ( state = {}, { type, settingValues } ) => {
 export const unsavedSettings = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case USER_SETTINGS_UNSAVED_CLEAR: {
-			const settingNames = action.settingNames;
+			const { settingNames } = action;
 
 			if ( ! settingNames ) {
 				return {};

--- a/client/state/user-settings/reducer.js
+++ b/client/state/user-settings/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { omit } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,6 +19,7 @@ import {
 	USER_SETTINGS_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
 import { combineReducers } from 'calypso/state/utils';
+import { setValue, removeValue } from './helpers';
 
 export const settings = ( state = {}, { type, settingValues } ) => {
 	switch ( type ) {
@@ -32,26 +33,30 @@ export const settings = ( state = {}, { type, settingValues } ) => {
 
 export const unsavedSettings = ( state = {}, action ) => {
 	switch ( action.type ) {
-		case USER_SETTINGS_UNSAVED_CLEAR:
-			// After a successful save, remove the saved settings (either all of them,
-			// or a subset) from the `unsavedSettings`.
-			if ( ! action.settingNames ) {
+		case USER_SETTINGS_UNSAVED_CLEAR: {
+			const settingNames = action.settingNames;
+
+			if ( ! settingNames ) {
 				return {};
 			}
-			return omit( state, action.settingNames );
 
-		case USER_SETTINGS_UNSAVED_SET:
-			if ( state[ action.settingName ] === action.value ) {
+			if ( Array.isArray( settingNames ) ) {
+				return settingNames.reduce( removeValue, state );
+			}
+
+			return removeValue( state, settingNames );
+		}
+		case USER_SETTINGS_UNSAVED_SET: {
+			if ( get( state, action.settingName ) === action.value ) {
 				return state;
 			}
-			return { ...state, [ action.settingName ]: action.value };
-
-		case USER_SETTINGS_UNSAVED_REMOVE:
-			return omit( state, action.settingName );
-
-		default:
-			return state;
+			return setValue( state, action.settingName, action.value );
+		}
+		case USER_SETTINGS_UNSAVED_REMOVE: {
+			return removeValue( state, action.settingName );
+		}
 	}
+	return state;
 };
 
 export const fetching = ( state = false, action ) => {

--- a/client/state/user-settings/test/helpers.js
+++ b/client/state/user-settings/test/helpers.js
@@ -1,0 +1,174 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { setValue, removeValue } from '../helpers';
+
+describe( 'setValue()', () => {
+	test( 'should set simple key to value in obj and return a new object', () => {
+		const state = deepFreeze( {} );
+
+		const result = setValue( state, 'foo', 'bar' );
+		expect( result ).toEqual( { foo: 'bar' } );
+	} );
+
+	test( 'should set simple key to value in obj and keep existing values', () => {
+		const state = deepFreeze( { baz: 'qux' } );
+
+		const result = setValue( state, 'foo', 'bar' );
+		expect( result ).toEqual( { foo: 'bar', baz: 'qux' } );
+	} );
+
+	test( 'should set simple key to value in obj and keep existing nested values', () => {
+		const state = deepFreeze( { foo: { bar: 'baz' } } );
+
+		const result = setValue( state, 'qux', 'quz' );
+		expect( result ).toEqual( { foo: { bar: 'baz' }, qux: 'quz' } );
+	} );
+
+	test( 'should set nested key to value in obj and return a new object', () => {
+		const state = deepFreeze( {} );
+
+		const result = setValue( state, [ 'foo', 'bar' ], 'baz' );
+		expect( result ).toEqual( { foo: { bar: 'baz' } } );
+	} );
+
+	test( 'should set nested key to value in obj and keep existing value', () => {
+		const state = deepFreeze( { foo: 'bar' } );
+
+		const result = setValue( state, [ 'baz', 'qux' ], 'quz' );
+		expect( result ).toEqual( { foo: 'bar', baz: { qux: 'quz' } } );
+	} );
+
+	test( 'should set nested key to value in obj and keep existing (other) nested values', () => {
+		const state = deepFreeze( { foo: { bar: 'baz' } } );
+
+		const result = setValue( state, [ 'foo', 'qux' ], 'quz' );
+		expect( result ).toEqual( { foo: { bar: 'baz', qux: 'quz' } } );
+	} );
+
+	test( 'should set nested key to value in obj and overwrite if key is already set', () => {
+		const state = deepFreeze( { foo: { bar: 'baz' } } );
+
+		const result = setValue( state, [ 'foo', 'bar' ], 'qux' );
+		expect( result ).toEqual( { foo: { bar: 'qux' } } );
+	} );
+
+	test( 'should set deeply nested key to value in obj', () => {
+		const state = deepFreeze( {} );
+
+		const result = setValue( state, [ 'foo', 'bar', 'baz' ], 'qux' );
+		expect( result ).toEqual( { foo: { bar: { baz: 'qux' } } } );
+	} );
+
+	test( 'should set deeply nested key to value in obj and keep others', () => {
+		const state = deepFreeze( { abc: 'def' } );
+
+		const result = setValue( state, [ 'foo', 'bar', 'baz' ], 'qux' );
+		expect( result ).toEqual( { foo: { bar: { baz: 'qux' } }, abc: 'def' } );
+	} );
+
+	test( 'should set deeply nested key to value in obj and keep other nested ones', () => {
+		const state = deepFreeze( { foo: { bar: 'baz' } } );
+
+		const result = setValue( state, [ 'foo', 'abc', 'def' ], 'qux' );
+		expect( result ).toEqual( { foo: { bar: 'baz', abc: { def: 'qux' } } } );
+	} );
+
+	test( 'should overwrite existing keys if value is already set (not null)', () => {
+		const state = deepFreeze( { foo: 1 } );
+
+		const result = setValue( state, [ 'foo', 'bar' ], 'baz' );
+		expect( result ).toEqual( { foo: { bar: 'baz' } } );
+	} );
+
+	test( 'should overwrite existing keys if value is set to `null`', () => {
+		const state = deepFreeze( { foo: null } );
+
+		const result = setValue( state, [ 'foo', 'bar' ], 'baz' );
+		expect( result ).toEqual( { foo: { bar: 'baz' } } );
+	} );
+
+	test( 'should overwrite existing keys if value is set to `undefined`', () => {
+		const state = deepFreeze( { foo: undefined } );
+
+		const result = setValue( state, [ 'foo', 'bar' ], 'baz' );
+		expect( result ).toEqual( { foo: { bar: 'baz' } } );
+	} );
+} );
+
+describe( 'removeValue()', () => {
+	test( 'should remove simple value from obj', () => {
+		const state = deepFreeze( { foo: 'bar' } );
+
+		const result = removeValue( state, 'foo' );
+		expect( result ).toEqual( {} );
+	} );
+
+	test( 'should remove simple value from obj but keep others', () => {
+		const state = deepFreeze( { foo: 'bar', baz: 'qux' } );
+
+		const result = removeValue( state, 'foo' );
+		expect( result ).toEqual( { baz: 'qux' } );
+	} );
+
+	test( 'should remove simple value from obj but keep nested others', () => {
+		const state = deepFreeze( { foo: 'bar', baz: { qux: 'quz' } } );
+
+		const result = removeValue( state, 'foo' );
+		expect( result ).toEqual( { baz: { qux: 'quz' } } );
+	} );
+
+	test( 'should remove nested value from obj', () => {
+		const state = deepFreeze( { foo: { bar: 'baz' } } );
+
+		const result = removeValue( state, [ 'foo', 'bar' ] );
+		expect( result ).toEqual( {} );
+	} );
+
+	test( 'should remove nested value from obj but keep other simple attributes', () => {
+		const state = deepFreeze( { foo: { bar: 'baz' }, qux: 'quz' } );
+
+		const result = removeValue( state, [ 'foo', 'bar' ] );
+		expect( result ).toEqual( { qux: 'quz' } );
+	} );
+
+	test( 'should remove nested value from obj but keep key if it contains more attributes', () => {
+		const state = deepFreeze( { foo: { bar: 'baz', qux: 'quz' } } );
+
+		const result = removeValue( state, [ 'foo', 'bar' ] );
+		expect( result ).toEqual( { foo: { qux: 'quz' } } );
+	} );
+
+	test( 'should remove deeply nested value from obj', () => {
+		const state = deepFreeze( { foo: { bar: { baz: 'qux' } } } );
+
+		const result = removeValue( state, [ 'foo', 'bar', 'baz' ] );
+		expect( result ).toEqual( {} );
+	} );
+
+	test( 'should remove deeply nested value from obj and keep others', () => {
+		const state = deepFreeze( { foo: { bar: { baz: 'qux' } }, abc: 'def' } );
+
+		const result = removeValue( state, [ 'foo', 'bar', 'baz' ] );
+		expect( result ).toEqual( { abc: 'def' } );
+	} );
+
+	test( 'should remove deeply nested value from obj and keep other nested ones', () => {
+		const state = deepFreeze( { foo: { bar: { baz: 'qux' }, abc: 'def' } } );
+
+		const result = removeValue( state, [ 'foo', 'bar', 'baz' ] );
+		expect( result ).toEqual( { foo: { abc: 'def' } } );
+	} );
+
+	test( 'should ignore values which are not set', () => {
+		const state = deepFreeze( { foo: { bar: 'baz' } } );
+
+		const result = removeValue( state, [ 'foo', 'qux' ] );
+		expect( result ).toEqual( { foo: { bar: 'baz' } } );
+	} );
+} );

--- a/client/state/user-settings/test/reducer.js
+++ b/client/state/user-settings/test/reducer.js
@@ -89,6 +89,20 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		test( 'should store a nexted user setting', () => {
+			const state = unsavedSettings( undefined, {
+				type: USER_SETTINGS_UNSAVED_SET,
+				settingName: [ 'foo', 'bar' ],
+				value: 'baz',
+			} );
+
+			expect( state ).toEqual( {
+				foo: {
+					bar: 'baz',
+				},
+			} );
+		} );
+
 		test( 'should store additional user setting after it is set', () => {
 			const original = deepFreeze( {
 				foo: 'bar',
@@ -106,6 +120,25 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		test( 'should store additional nested user setting after it is set', () => {
+			const original = deepFreeze( {
+				foo: 'bar',
+			} );
+
+			const state = unsavedSettings( original, {
+				type: USER_SETTINGS_UNSAVED_SET,
+				settingName: [ 'baz', 'bar' ],
+				value: 'qux',
+			} );
+
+			expect( state ).toEqual( {
+				foo: 'bar',
+				baz: {
+					bar: 'qux',
+				},
+			} );
+		} );
+
 		test( 'should remove a user setting', () => {
 			const original = deepFreeze( {
 				foo: 'bar',
@@ -119,6 +152,46 @@ describe( 'reducer', () => {
 
 			expect( state ).toEqual( {
 				foo: 'bar',
+			} );
+		} );
+
+		test( 'should remove a nested user setting', () => {
+			const original = deepFreeze( {
+				foo: 'bar',
+				baz: {
+					bar: 'qux',
+				},
+			} );
+
+			const state = unsavedSettings( original, {
+				type: USER_SETTINGS_UNSAVED_REMOVE,
+				settingName: [ 'baz', 'bar' ],
+			} );
+
+			expect( state ).toEqual( {
+				foo: 'bar',
+			} );
+		} );
+
+		test( 'should keep non-empty top level setting keys', () => {
+			const original = deepFreeze( {
+				foo: 'bar',
+				baz: {
+					qux: 'bar',
+					bar: 'qux',
+				},
+			} );
+
+			const state = unsavedSettings( original, {
+				type: USER_SETTINGS_UNSAVED_REMOVE,
+				settingName: [ 'baz', 'bar' ],
+			} );
+
+			expect( state ).toEqual( {
+				foo: 'bar',
+				baz: {
+					qux: 'bar',
+				},
 			} );
 		} );
 


### PR DESCRIPTION
This PR is a spin-off from #49105 to make individual parts easier to review.

#### Changes proposed in this Pull Request

* Introduce `setValue` and `removeValue` helpers to deal with nested user settings in state (huge props to @jsnajdr for helping me with these 🎉 )
* Adjust `userSettings` reducer to use those helpers

#### Testing instructions

* Smoke-test parts of Calypso which use `userSettings` state (e.g. `/me`)
* Ensure all existing tests for the userSettings reducer still pass

#### Why introduce `setValue` and `removeValue`?

For the `unsavedUserSettings` reducer we need a way to immutably set and remove nested attributes and delete empty attributes from the state object. This doesn't seem to be possible with lodash functions (`set` and `unset` mutate objects and therefore a `deepClone` would be necessary). There's a similar function in [`lib/user-settings`](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/user-settings/index.js#L33-L48) but it's not pure either (flux doesn't have that requirement). It's probably good to also look at the tests to get a better understanding.

related to #24162
