### PR TITLE
Focused Launch: fix disabled free plan regressions, add missing "translators" comments

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -82,10 +82,11 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, on
 							<br />
 							<span className="nux-launch__summary-item__domain-price">
 								{ __( 'Domain Registration', 'full-site-editing' ) }:{ ' ' }
-								{
-									/* translators: %s is the price with currency. Eg: $15/year. */
-									sprintf( __( '%s/year', 'full-site-editing' ), domain.cost )
-								}
+								{ sprintf(
+									// translators: %s is the price with currency. Eg: $15/year
+									__( '%s/year', 'full-site-editing' ),
+									domain.cost
+								) }
 							</span>
 						</>
 					) }

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -215,10 +215,11 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 				{ ! isFree && ! isUnavailable && (
 					<>
 						<span className="domain-picker__price-cost">
-							{
-								/* translators: %s is the price with currency. Eg: $15/year. */
-								sprintf( __( '%s/year', __i18n_text_domain__ ), cost )
-							}
+							{ sprintf(
+								// translators: %s is the price with currency. Eg: $15/year
+								__( '%s/year', __i18n_text_domain__ ),
+								cost
+							) }
 						</span>
 						<span className="domain-picker__price-inclusive">
 							{ /* Intentional whitespace to get the spacing around the text right */ }{ ' ' }

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -226,7 +226,11 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 							{ paidIncludedDomainLabel }{ ' ' }
 						</span>
 						<span className="domain-picker__price-renewal">
-							{ sprintf( __( 'Renews at: %s /year', __i18n_text_domain__ ), cost ) }
+							{ sprintf(
+								// translators: %s is the domain renewal cost (i.e. "Renews at: 20$ / year" )
+								__( 'Renews at: %s /year', __i18n_text_domain__ ),
+								cost
+							) }
 						</span>
 					</>
 				) }

--- a/packages/plans-grid/src/plans-feature-list/style.scss
+++ b/packages/plans-grid/src/plans-feature-list/style.scss
@@ -94,6 +94,7 @@ ul.plans-feature-list__item-group {
 			}
 		}
 
+		// Disabled/unavailable text color for when item is a button
 		&.is-unavailable,
 		.plans-accordion &.is-unavailable {
 			color: var( --studio-orange-40 );
@@ -103,6 +104,19 @@ ul.plans-feature-list__item-group {
 			&:focus {
 				color: var( --studio-orange-30 );
 			}
+		}
+	}
+
+	// Disabled/unavailable text color for when item is not a button
+	// (but is a disabled feature)
+	.plans-feature-list__item--disabled-message & {
+		font-weight: 700;
+		color: var( --studio-orange-40 );
+		text-decoration: line-through;
+
+		&:hover,
+		&:focus {
+			color: var( --studio-orange-30 );
 		}
 	}
 }

--- a/packages/plans-grid/src/plans-feature-list/style.scss
+++ b/packages/plans-grid/src/plans-feature-list/style.scss
@@ -195,6 +195,7 @@ ul.plans-feature-list__item-group {
 	.plans-feature-list__item--requires-annual-disabled
 		.plans-feature-list__item-content-wrapper--domain-button.is-cta
 		&,
+	.plans-feature-list__item--disabled-message &,
 	.plans-feature-list__item--disabled-message
 		.plans-feature-list__item-content-wrapper--domain-button.is-cta
 		& {

--- a/packages/plans-grid/src/plans-feature-list/style.scss
+++ b/packages/plans-grid/src/plans-feature-list/style.scss
@@ -61,67 +61,12 @@ ul.plans-feature-list__item-group {
 .plans-feature-list__item-content-wrapper,
 .plans-feature-list__item-content-wrapper.components-button.is-link {
 	display: flex;
-	align-items: center;
-
-	font-size: $font-body-small;
-	font-weight: 400;
-	line-height: 1.2;
-	letter-spacing: 0.2px;
-	color: var( --studio-gray-70 );
-
-	.plans-accordion & {
-		align-items: flex-end;
-	}
+	align-items: flex-end;
+	padding: 0;
+	text-decoration: none;
 
 	&.plans-feature-list__item-content-wrapper--domain-button {
-		color: var( --studio-blue-40 );
-		font-weight: 700;
-		padding: 0;
-		text-decoration: none;
 		cursor: pointer;
-
-		&:hover,
-		&:focus {
-			color: var( --studio-blue-30 );
-		}
-
-		.plans-accordion & {
-			color: var( --studio-gray-70 );
-
-			&.is-cta {
-				color: var( --studio-gray-100 );
-			}
-
-			&:hover,
-			&:focus {
-				color: var( --studio-gray-50 );
-			}
-		}
-
-		// Disabled/unavailable text color for when item is a button
-		&.is-unavailable,
-		.plans-accordion &.is-unavailable {
-			color: var( --studio-orange-40 );
-			text-decoration: line-through;
-
-			&:hover,
-			&:focus {
-				color: var( --studio-orange-30 );
-			}
-		}
-	}
-
-	// Disabled/unavailable text color for when item is not a button
-	// (but is a disabled feature)
-	.plans-feature-list__item--disabled-message & {
-		font-weight: 700;
-		color: var( --studio-orange-40 );
-		text-decoration: line-through;
-
-		&:hover,
-		&:focus {
-			color: var( --studio-orange-30 );
-		}
 	}
 }
 
@@ -181,16 +126,76 @@ ul.plans-feature-list__item-group {
 
 // The text describing the feature
 .plans-feature-list__item-description {
+	font-size: $font-body-small;
+	line-height: 1.2;
+	letter-spacing: 0.2px;
+	font-weight: 400;
+	color: var( --studio-gray-70 );
+
+	// Text is bold when it's a button,
+	// or when it's a disabled feature (e.g. custom domain on a free plan)
+	.plans-feature-list__item-content-wrapper--domain-button &,
+	.plans-feature-list__item--disabled-message & {
+		font-weight: 700;
+	}
+
+	// When it's a button (e.g. custom domain), the text color is blue (including
+	// hover/focus), unless the plans grid variation is "accordion"
+	.plans-feature-list__item-content-wrapper--domain-button:not( .is-unavailable ) & {
+		color: var( --studio-blue-40 );
+
+		&:hover,
+		&:focus {
+			color: var( --studio-blue-30 );
+		}
+	}
+
+	// When it's the accordion variation, the feature button has grey text.
+	.plans-accordion
+		.plans-feature-list__item-content-wrapper--domain-button:not( .is-unavailable )
+		& {
+		color: var( --studio-gray-70 );
+
+		&.is-cta {
+			color: var( --studio-gray-100 );
+		}
+
+		&:hover,
+		&:focus {
+			color: var( --studio-gray-50 );
+		}
+	}
+
+	// When the feature is unavailable (in case of button),
+	// or disabled (in case of custom domain on a free plan), text color is orange
+	.plans-feature-list__item-content-wrapper--domain-button.is-unavailable &,
+	.plans-feature-list__item--disabled-message & {
+		color: var( --studio-orange-40 );
+	}
+
+	// In case the feature is unavailable as a button, also add hover/focus orange
+	.plans-feature-list__item-content-wrapper--domain-button.is-unavailable & {
+		&:hover,
+		&:focus {
+			color: var( --studio-orange-30 );
+		}
+	}
+
+	// Text is underlined when the item acts as a CTA
 	.plans-feature-list__item-content-wrapper--domain-button.is-cta & {
 		text-decoration: underline;
 	}
 
-	.plans-feature-list__item--disabled-message &,
-	.plans-feature-list__item--disabled-message
-		.plans-feature-list__item-content-wrapper--domain-button.is-cta
-		&,
+	// Text has a strike-through effect when it's disabled. This happens when:
+	// - the feature is disabled for a free plan when picking a custom domain
+	// - the feature is available for annually-billed plans, and the user
+	//   is looking at the monthly version of a plan
+	.plans-feature-list__item-content-wrapper--domain-button.is-unavailable &,
 	.plans-feature-list__item--requires-annual-disabled &,
 	.plans-feature-list__item--requires-annual-disabled
+		.plans-feature-list__item-content-wrapper--domain-button.is-cta
+		&,
+	.plans-feature-list__item--disabled-message
 		.plans-feature-list__item-content-wrapper--domain-button.is-cta
 		& {
 		text-decoration: line-through;

--- a/packages/plans-grid/src/plans-feature-list/style.scss
+++ b/packages/plans-grid/src/plans-feature-list/style.scss
@@ -61,13 +61,17 @@ ul.plans-feature-list__item-group {
 .plans-feature-list__item-content-wrapper,
 .plans-feature-list__item-content-wrapper.components-button.is-link {
 	display: flex;
-	align-items: flex-end;
+	align-items: center;
 
 	font-size: $font-body-small;
 	font-weight: 400;
 	line-height: 1.2;
 	letter-spacing: 0.2px;
 	color: var( --studio-gray-70 );
+
+	.plans-accordion & {
+		align-items: flex-end;
+	}
 
 	&.plans-feature-list__item-content-wrapper--domain-button {
 		color: var( --studio-blue-40 );

--- a/packages/plans-grid/src/plans-table/plan-item.tsx
+++ b/packages/plans-grid/src/plans-table/plan-item.tsx
@@ -95,7 +95,7 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 
 	const isDesktop = useViewportMatch( 'mobile', '>=' );
 
-	// show a nbps in price while loading to prevent a janky UI
+	// show a nbsp in price while loading to prevent a jump in the UI
 	const nbsp = '\u00A0';
 
 	React.useEffect( () => {
@@ -103,6 +103,11 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 	}, [ allPlansExpanded ] );
 
 	const isOpen = allPlansExpanded || isDesktop || isPopular || isOpenInternalState;
+
+	const fullWidthCtaLabelSelected = __( 'Current Selection', __i18n_text_domain__ );
+
+	// translators: %s is a WordPress.com plan name (eg: Free, Personal)
+	const fullWidthCtaLabelUnselected = __( 'Select %s', __i18n_text_domain__ );
 
 	return (
 		<div
@@ -160,7 +165,7 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 						</div>
 
 						{ /*
-							For the free plan, the following div is still rendered invisibile
+							For the free plan, the following div is still rendered invisible
 							and ignored by screen readers (via aria-hidden) to ensure the same
 							vertical spacing as the rest of the plan cards
 						 */ }
@@ -207,12 +212,8 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 											<>
 												{ isSelected ? TickIcon : '' }
 												{ isSelected
-													? sprintf( __( 'Current Selection', __i18n_text_domain__ ), name )
-													: sprintf(
-															// translators: %s is a WordPress.com plan name (eg: Free, Personal)
-															__( 'Select %s', __i18n_text_domain__ ),
-															name
-													  ) }
+													? sprintf( fullWidthCtaLabelSelected, name )
+													: sprintf( fullWidthCtaLabelUnselected, name ) }
 											</>
 										) }
 									</span>

--- a/packages/plans-grid/src/plans-table/plan-item.tsx
+++ b/packages/plans-grid/src/plans-table/plan-item.tsx
@@ -63,7 +63,7 @@ export interface Props {
 }
 
 // NOTE: there is some duplicate markup between this plan item (used in the
-// 'table' version of the plans grid) and the accortion plan item (used in the
+// 'table' version of the plans grid) and the accordion plan item (used in the
 // 'accordion' version of the plans grid). Ideally the code should be refactored
 // to use the same markup, with just different styles
 
@@ -203,11 +203,18 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 									disabled={ !! disabledLabel }
 								>
 									<span>
-										{ isSelected ? TickIcon : '' }
-										{ isSelected
-											? sprintf( __( 'Current Selection', __i18n_text_domain__ ), name )
-											: /* translators: %s is a WordPress.com plan name (eg: Free, Personal) */
-											  sprintf( __( 'Select %s', __i18n_text_domain__ ), name ) }
+										{ disabledLabel ?? (
+											<>
+												{ isSelected ? TickIcon : '' }
+												{ isSelected
+													? sprintf( __( 'Current Selection', __i18n_text_domain__ ), name )
+													: sprintf(
+															// translators: %s is a WordPress.com plan name (eg: Free, Personal)
+															__( 'Select %s', __i18n_text_domain__ ),
+															name
+													  ) }
+											</>
+										) }
 									</span>
 								</Button>
 							) }
@@ -220,8 +227,11 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 							onPickDomain={ onPickDomainClick }
 							disabledLabel={
 								disabledLabel &&
-								// Translators: %s is the domain name (e.g. "example.com is not included")
-								sprintf( __( '%s is not included', __i18n_text_domain__ ), domain?.domain_name )
+								sprintf(
+									// Translators: %s is the domain name (e.g. "example.com is not included")
+									__( '%s is not included', __i18n_text_domain__ ),
+									domain?.domain_name
+								)
 							}
 							billingPeriod={ billingPeriod }
 						/>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Use the `disabledLabel` when the plan's item is disabled
* Change text color of the "custom domain" feature to orange, when custom domain is not available
* Add missing "translators" comment for a string in the domain picker package
* Format "translators" comments for a few launch-related strings, so that the comment is just above to the translated text (and not the `sprintf` function)

### Testing instructions

#### Focused Launch

- Prepare your sandbox:
  - Make sure you have an active ssh connection to your sandbox
  - Clear your sandbox and pull the latest version from trunk
  - Add an unlaunched site **created via `/start`** to your sandbox
- Pull this PR's branch on your local machine and run the project locally:
  - Run `yarn && yarn start` in the root folder
  - After the command above has finished compiling, in a separate terminal window run `cd apps/editing-toolkit && yarn dev --sync`
- Visit `calyspo.localhost:3000/page/UNLAUNCHED_SITE_CREATED_WITH_START.wordpress.com/home?flags=create/focused-launch-flow`
- Click on the "Launch" button to open Focused Launch flow
- Pick a custom domain in the summary view
- Click on "View all plans" to enter plan details view
   - [x] The free plan's button should be disabled, and the button's label should say "Unavailable with domain"
   - [x] The custom domain feature item's text color should be orange, same as the cross icon to its left
   - [x] The custom domain feature item's text-decoration prop should be `strike-through`.

#### Gutenboarding

- Visit `/new`
- Pick a custom domain in the domain picker, advance to the plans step
- In the plans step, expand the free plan card, and not how the text/style of the feature hasn't changed from what's currently live in production


#### Screenshots

Before:

![image](https://user-images.githubusercontent.com/1083581/106447926-59336a80-6482-11eb-8b6a-ea41859a7aef.png)

After:

<img width="1057" alt="Screenshot 2021-02-01 at 12 05 58" src="https://user-images.githubusercontent.com/1083581/106450729-dc09f480-6485-11eb-8625-2f40e11e5cef.png">


Fixes #49409
Fixes #49525
Related to #49312
