### PR TITLE
Fix broken plans styles related to scrolling

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -10,12 +10,6 @@ $plan-features-sidebar-width: 272px;
 	// If experiment succeeds the following styles
 	// need to be moved to the corresponding selectors
 
-	.plans-features-main__group.is-wpcom {
-		overflow: auto;
-		max-height: calc( 100vh - 115px );
-		margin-top: 14px;
-	}
-
 	// To be moved to line 651 approximately
 	.plan-features--signup {
 		.plan-features__table {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove change introduced in commit https://github.com/Automattic/wp-calypso/pull/48728/commits/1c775d02791d1662184466ce67d916030364ad41 and moved in https://github.com/Automattic/wp-calypso/commit/4c3d656a4a905a0519f2eb3e4393f882cd127663. 
* Introduced by PR #48728 and moved in #49458
* Removed because it is breaking the UI in relation to scroll.

#### Testing instructions
- Assign yourself to ExPlat experiment introduced here pcbrnV-XN-p2
- Refresh browser
- Go into the plans page in any calypso signup flow
- Check mobile, desktop resolutions with smaller viewport heights to see if any broken scroll bar views appear



