### PR TITLE
i18n: Fix language picker incomplete notice translatable string

### DIFF
--- a/client/components/language-picker/modal.tsx
+++ b/client/components/language-picker/modal.tsx
@@ -90,7 +90,7 @@ function IncompleteLocaleNoticeMessage( {
 		>
 			<div className="language-picker__modal-incomplete-locale-notice-info">
 				{
-					/* translators: %(languageName)s is a localized language name, %(percentTranslated)d is a percentage number (0-100). %% is the escaped percent sign. */
+					/* translators: %(languageName)s is a localized language name, %(percentTranslated)d%% is a percentage number (0-100), followed by an escaped percent sign %%. */
 					sprintf( __( '(%(languageName)s is only %(percentTranslated)d%% translated)' ), {
 						languageName,
 						percentTranslated,

--- a/client/components/language-picker/modal.tsx
+++ b/client/components/language-picker/modal.tsx
@@ -3,6 +3,7 @@
  */
 import { Dialog } from '@automattic/components';
 import { useI18n } from '@automattic/react-i18n';
+import { sprintf } from '@wordpress/i18n';
 import type { I18nReact } from '@automattic/react-i18n';
 import LanguagePicker, { createLanguageGroups } from '@automattic/language-picker';
 import type { Language, LocalizedLanguageNames } from '@automattic/language-picker';
@@ -88,7 +89,13 @@ function IncompleteLocaleNoticeMessage( {
 			}
 		>
 			<div className="language-picker__modal-incomplete-locale-notice-info">
-				{ __( `(${ languageName } is only ${ percentTranslated }% translated)` ) }
+				{
+					/* translators: %(languageName)s is a localized language name, %(percentTranslated)d is a percentage number (0-100). */
+					sprintf( __( '(%(languageName)s is only %(percentTranslated)d%% translated)' ), {
+						languageName,
+						percentTranslated,
+					} )
+				}
 				<Icon icon={ info } size={ 20 } />
 			</div>
 		</Tooltip>

--- a/client/components/language-picker/modal.tsx
+++ b/client/components/language-picker/modal.tsx
@@ -90,7 +90,7 @@ function IncompleteLocaleNoticeMessage( {
 		>
 			<div className="language-picker__modal-incomplete-locale-notice-info">
 				{
-					/* translators: %(languageName)s is a localized language name, %(percentTranslated)d is a percentage number (0-100). */
+					/* translators: %(languageName)s is a localized language name, %(percentTranslated)d is a percentage number (0-100). %% is the escaped percent sign. */
 					sprintf( __( '(%(languageName)s is only %(percentTranslated)d%% translated)' ), {
 						languageName,
 						percentTranslated,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace variables in incomplete translations notice with placeholders and return formatted string with `sprintf`

**Screenshot**
![image](https://user-images.githubusercontent.com/2722412/106486141-007fc400-64ba-11eb-90c0-9be5068ce86e.png)


#### Testing instructions

* Navigate to `/me/account` and open language picker
* Select a language with low translations percent, e.g. any non-mag-16 language (except for Romanian, as its translations percent is above the threshold).
* Confirm the notice message shows the formatted strings, incl. the localized language name and translations percent, e.g. `(Қазақ тілі is only 5% translated)`

Related to #49312
