### PR TITLE
ExPlat: Self-Contained Client Internals (except for request)

### DIFF
--- a/packages/explat-client/.eslintrc.js
+++ b/packages/explat-client/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/explat-client/package.json
+++ b/packages/explat-client/package.json
@@ -21,5 +21,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch",
 		"prepack": "yarn run clean && yarn run build",
 		"test": "yarn jest"
+	},
+	"dependencies": {
+		"@automattic/calypso-polyfills": "^1.0.0"
 	}
 }

--- a/packages/explat-client/package.json
+++ b/packages/explat-client/package.json
@@ -22,7 +22,7 @@
 		"prepack": "yarn run clean && yarn run build",
 		"test": "yarn jest"
 	},
-	"dependencies": {
+	"devDependencies": {
 		"@automattic/calypso-polyfills": "^1.0.0"
 	}
 }

--- a/packages/explat-client/src/internal/experiment-assignments.ts
+++ b/packages/explat-client/src/internal/experiment-assignments.ts
@@ -1,0 +1,56 @@
+/**
+ * Internal dependencies
+ */
+import { ExperimentAssignment } from '../types';
+import * as Timing from './timing';
+
+/**
+ * Check if an ExperimentAssignment is still alive (as in the TTL).
+ *
+ * @param experimentAssignment The experiment assignment to check
+ */
+export function isAlive( experimentAssignment: ExperimentAssignment ): boolean {
+	return (
+		Timing.monotonicNow() <
+		experimentAssignment.ttl * Timing.MILLISECONDS_PER_SECOND +
+			experimentAssignment.retrievedTimestamp
+	);
+}
+
+/**
+ * Milliseconds between now and when the experiment was received for us to consider it recent.
+ */
+const maximumRecencyDelta = 1000 * 60 * 60 * 24 * 14; // 2 Weeks
+
+/**
+ * Check if an ExperimentAssignment is recent.
+ * This is used to prevent experiments from running forever in offline contexts.
+ *
+ * @param experimentAssignment The experiment assignment to check
+ */
+export function isRecent( experimentAssignment: ExperimentAssignment ): boolean {
+	const delta = Timing.monotonicNow() - experimentAssignment.retrievedTimestamp;
+	return delta < maximumRecencyDelta;
+}
+
+/**
+ * The ttl (in seconds) for a fallback assignment.
+ * This limits the number of requests being sent to our server in the case of our server failing to return a working assignment
+ * and will be the minimum amount of time in-between requests per experiment.
+ */
+const fallbackExperimentAssignmentTtl = 60;
+
+/**
+ * A fallback ExperimentAssignment we return when we can't retrieve one.
+ *
+ * @param experimentName The name of the experiment
+ */
+export const createFallbackExperimentAssignment = (
+	experimentName: string
+): ExperimentAssignment => ( {
+	experimentName,
+	variationName: null,
+	retrievedTimestamp: Timing.monotonicNow(),
+	ttl: fallbackExperimentAssignmentTtl,
+	isFallbackExperimentAssignment: true,
+} );

--- a/packages/explat-client/src/internal/experiment-assignments.ts
+++ b/packages/explat-client/src/internal/experiment-assignments.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { ExperimentAssignment } from '../types';
+import type { ExperimentAssignment } from '../types';
 import * as Timing from './timing';
 
 /**

--- a/packages/explat-client/src/internal/state.ts
+++ b/packages/explat-client/src/internal/state.ts
@@ -7,6 +7,11 @@ import * as ExperimentAssignments from './experiment-assignments';
 
 const experimentNameToExperimentAssignment: Record< string, ExperimentAssignment | undefined > = {};
 
+/**
+ * Store an ExperimentAssignment.
+ *
+ * @param experimentAssignment The ExperimentAssignment
+ */
 export function storeExperimentAssignment( experimentAssignment: ExperimentAssignment ): void {
 	Validations.validateExperimentAssignment( experimentAssignment );
 
@@ -35,6 +40,11 @@ export function storeExperimentAssignment( experimentAssignment: ExperimentAssig
 	] = experimentAssignment;
 }
 
+/**
+ * Retrieve an ExperimentAssignment.
+ *
+ * @param experimentName The experiment name.
+ */
 export function retrieveExperimentAssignment(
 	experimentName: string
 ): ExperimentAssignment | undefined {

--- a/packages/explat-client/src/internal/state.ts
+++ b/packages/explat-client/src/internal/state.ts
@@ -1,0 +1,42 @@
+/**
+ * Internal dependencies
+ */
+import { ExperimentAssignment } from '../types';
+import * as Validations from './validations';
+import * as ExperimentAssignments from './experiment-assignments';
+
+const experimentNameToExperimentAssignment: Record< string, ExperimentAssignment | undefined > = {};
+
+export function storeExperimentAssignment( experimentAssignment: ExperimentAssignment ): void {
+	Validations.validateExperimentAssignment( experimentAssignment );
+
+	const previousExperimentAssignment =
+		experimentNameToExperimentAssignment[ experimentAssignment.experimentName ];
+	if (
+		previousExperimentAssignment &&
+		experimentAssignment.retrievedTimestamp < previousExperimentAssignment.retrievedTimestamp
+	) {
+		throw new Error(
+			'Trying to store an older experiment assignment than is present in the store, likely a race condition.'
+		);
+	}
+
+	if (
+		previousExperimentAssignment &&
+		! previousExperimentAssignment.isFallbackExperimentAssignment &&
+		ExperimentAssignments.isRecent( previousExperimentAssignment ) &&
+		experimentAssignment.isFallbackExperimentAssignment
+	) {
+		throw new Error( 'Replacing recent ExperimentAssignment with fallback ExperimentAssignment.' );
+	}
+
+	experimentNameToExperimentAssignment[
+		experimentAssignment.experimentName
+	] = experimentAssignment;
+}
+
+export function retrieveExperimentAssignment(
+	experimentName: string
+): ExperimentAssignment | undefined {
+	return experimentNameToExperimentAssignment[ experimentName ];
+}

--- a/packages/explat-client/src/internal/state.ts
+++ b/packages/explat-client/src/internal/state.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { ExperimentAssignment } from '../types';
+import type { ExperimentAssignment } from '../types';
 import * as Validations from './validations';
 import * as ExperimentAssignments from './experiment-assignments';
 

--- a/packages/explat-client/src/internal/test-common.ts
+++ b/packages/explat-client/src/internal/test-common.ts
@@ -1,11 +1,11 @@
-export const validExperimentAssignmentA = {
+export const validExperimentAssignment = {
 	experimentName: 'experiment_name_a',
 	variationName: 'treatment',
 	retrievedTimestamp: Date.now(),
 	ttl: 60,
 };
 
-export const validExperimentAssignmentB = {
+export const validFallbackExperimentAssignment = {
 	experimentName: 'experiment_name_b',
 	variationName: null,
 	retrievedTimestamp: Date.now(),

--- a/packages/explat-client/src/internal/test-common.ts
+++ b/packages/explat-client/src/internal/test-common.ts
@@ -1,0 +1,14 @@
+export const validExperimentAssignmentA = {
+	experimentName: 'experiment_name_a',
+	variationName: 'treatment',
+	retrievedTimestamp: Date.now(),
+	ttl: 60,
+};
+
+export const validExperimentAssignmentB = {
+	experimentName: 'experiment_name_b',
+	variationName: null,
+	retrievedTimestamp: Date.now(),
+	ttl: 60,
+	isFallbackExperimentAssignment: true,
+};

--- a/packages/explat-client/src/internal/test/experiment-assignments.ts
+++ b/packages/explat-client/src/internal/test/experiment-assignments.ts
@@ -2,19 +2,19 @@
  * Internal dependencies
  */
 import * as ExperimentAssignments from '../experiment-assignments';
-import { validExperimentAssignmentA } from '../test-common';
+import { validExperimentAssignment } from '../test-common';
 
 describe( 'isAlive', () => {
 	it( 'returns true for ExperimentAssignments within ttl', () => {
 		expect(
 			ExperimentAssignments.isAlive( {
-				...validExperimentAssignmentA,
+				...validExperimentAssignment,
 				retrievedTimestamp: Date.now(),
 			} )
 		).toBe( true );
 		expect(
 			ExperimentAssignments.isAlive( {
-				...validExperimentAssignmentA,
+				...validExperimentAssignment,
 				retrievedTimestamp: Date.now() - 1000 * 59,
 			} )
 		).toBe( true );
@@ -22,7 +22,7 @@ describe( 'isAlive', () => {
 	it( 'returns false for ExperimentAssignments outside of ttl', () => {
 		expect(
 			ExperimentAssignments.isAlive( {
-				...validExperimentAssignmentA,
+				...validExperimentAssignment,
 				retrievedTimestamp: Date.now() - 1000 * 60,
 			} )
 		).toBe( false );
@@ -33,13 +33,13 @@ describe( 'isRecent', () => {
 	it( 'returns true for ExperimentAssignments within maximumRecencyDelta', () => {
 		expect(
 			ExperimentAssignments.isRecent( {
-				...validExperimentAssignmentA,
+				...validExperimentAssignment,
 				retrievedTimestamp: Date.now(),
 			} )
 		).toBe( true );
 		expect(
 			ExperimentAssignments.isRecent( {
-				...validExperimentAssignmentA,
+				...validExperimentAssignment,
 				retrievedTimestamp: Date.now() - 1000 * 60 * 60 * 24 * 14 + 100,
 			} )
 		).toBe( true );
@@ -47,7 +47,7 @@ describe( 'isRecent', () => {
 	it( 'returns false for ExperimentAssignments outside of maximumRecencyDelta', () => {
 		expect(
 			ExperimentAssignments.isRecent( {
-				...validExperimentAssignmentA,
+				...validExperimentAssignment,
 				retrievedTimestamp: Date.now() - 1000 * 60 * 60 * 24 * 14,
 			} )
 		).toBe( false );

--- a/packages/explat-client/src/internal/test/experiment-assignments.ts
+++ b/packages/explat-client/src/internal/test/experiment-assignments.ts
@@ -1,0 +1,79 @@
+/**
+ * Internal dependencies
+ */
+import * as ExperimentAssignments from '../experiment-assignments';
+import { validExperimentAssignmentA } from '../test-common';
+
+describe( 'isAlive', () => {
+	it( 'returns true for ExperimentAssignments within ttl', () => {
+		expect(
+			ExperimentAssignments.isAlive( {
+				...validExperimentAssignmentA,
+				retrievedTimestamp: Date.now(),
+			} )
+		).toBe( true );
+		expect(
+			ExperimentAssignments.isAlive( {
+				...validExperimentAssignmentA,
+				retrievedTimestamp: Date.now() - 1000 * 59,
+			} )
+		).toBe( true );
+	} );
+	it( 'returns false for ExperimentAssignments outside of ttl', () => {
+		expect(
+			ExperimentAssignments.isAlive( {
+				...validExperimentAssignmentA,
+				retrievedTimestamp: Date.now() - 1000 * 60,
+			} )
+		).toBe( false );
+	} );
+} );
+
+describe( 'isRecent', () => {
+	it( 'returns true for ExperimentAssignments within maximumRecencyDelta', () => {
+		expect(
+			ExperimentAssignments.isRecent( {
+				...validExperimentAssignmentA,
+				retrievedTimestamp: Date.now(),
+			} )
+		).toBe( true );
+		expect(
+			ExperimentAssignments.isRecent( {
+				...validExperimentAssignmentA,
+				retrievedTimestamp: Date.now() - 1000 * 60 * 60 * 24 * 14 + 100,
+			} )
+		).toBe( true );
+	} );
+	it( 'returns false for ExperimentAssignments outside of maximumRecencyDelta', () => {
+		expect(
+			ExperimentAssignments.isRecent( {
+				...validExperimentAssignmentA,
+				retrievedTimestamp: Date.now() - 1000 * 60 * 60 * 24 * 14,
+			} )
+		).toBe( false );
+	} );
+} );
+
+describe( 'createFallbackExperimentAssignment', () => {
+	it( 'creates a fallback ExperimentAssignment', () => {
+		const now = Date.now();
+		const fallbackExperimentAssignment = ExperimentAssignments.createFallbackExperimentAssignment(
+			'experiment_name'
+		);
+
+		expect( fallbackExperimentAssignment.retrievedTimestamp ).toBeGreaterThan( now );
+		expect( ExperimentAssignments.isAlive( fallbackExperimentAssignment ) ).toBe( true );
+		expect( ExperimentAssignments.isRecent( fallbackExperimentAssignment ) ).toBe( true );
+
+		expect( {
+			...fallbackExperimentAssignment,
+			retrievedTimestamp: now,
+		} ).toEqual( {
+			experimentName: 'experiment_name',
+			variationName: null,
+			retrievedTimestamp: now,
+			ttl: 60,
+			isFallbackExperimentAssignment: true,
+		} );
+	} );
+} );

--- a/packages/explat-client/src/internal/test/state.ts
+++ b/packages/explat-client/src/internal/test/state.ts
@@ -1,0 +1,53 @@
+/**
+ * Internal dependencies
+ */
+import * as State from '../state';
+import { validExperimentAssignmentA, validExperimentAssignmentB } from '../test-common';
+
+describe( 'state', () => {
+	it( 'should save and retrieve valid EAs', () => {
+		expect( State.retrieveExperimentAssignment( validExperimentAssignmentA.experimentName ) ).toBe(
+			undefined
+		);
+		State.storeExperimentAssignment( validExperimentAssignmentA );
+		expect(
+			State.retrieveExperimentAssignment( validExperimentAssignmentA.experimentName )
+		).toEqual( validExperimentAssignmentA );
+
+		expect( State.retrieveExperimentAssignment( validExperimentAssignmentB.experimentName ) ).toBe(
+			undefined
+		);
+		State.storeExperimentAssignment( validExperimentAssignmentB );
+		expect(
+			State.retrieveExperimentAssignment( validExperimentAssignmentB.experimentName )
+		).toEqual( validExperimentAssignmentB );
+	} );
+
+	it( 'should throw for storing an EA for a currently stored Experiment with an older date', () => {
+		expect( State.retrieveExperimentAssignment( validExperimentAssignmentB.experimentName ) ).toBe(
+			validExperimentAssignmentB
+		);
+		expect( () =>
+			State.storeExperimentAssignment( {
+				...validExperimentAssignmentB,
+				retrievedTimestamp: validExperimentAssignmentB.retrievedTimestamp - 1,
+			} )
+		).toThrowErrorMatchingInlineSnapshot(
+			`"Trying to store an older experiment assignment than is present in the store, likely a race condition."`
+		);
+	} );
+
+	it( 'should throw for overwriting a recent EA with a fallback', () => {
+		expect( State.retrieveExperimentAssignment( validExperimentAssignmentA.experimentName ) ).toBe(
+			validExperimentAssignmentA
+		);
+		expect( () =>
+			State.storeExperimentAssignment( {
+				...validExperimentAssignmentA,
+				isFallbackExperimentAssignment: true,
+			} )
+		).toThrowErrorMatchingInlineSnapshot(
+			`"Replacing recent ExperimentAssignment with fallback ExperimentAssignment."`
+		);
+	} );
+} );

--- a/packages/explat-client/src/internal/test/state.ts
+++ b/packages/explat-client/src/internal/test/state.ts
@@ -5,7 +5,7 @@ import * as State from '../state';
 import { validExperimentAssignment, validFallbackExperimentAssignment } from '../test-common';
 
 describe( 'state', () => {
-	it( 'should save and retrieve valid EAs', () => {
+	it( 'should save and retrieve valid ExperimentAssignments', () => {
 		expect( State.retrieveExperimentAssignment( validExperimentAssignment.experimentName ) ).toBe(
 			undefined
 		);
@@ -23,7 +23,7 @@ describe( 'state', () => {
 		).toEqual( validFallbackExperimentAssignment );
 	} );
 
-	it( 'should throw for storing an EA for a currently stored Experiment with an older date', () => {
+	it( 'should throw for storing an ExperimentAssignment for a currently stored Experiment with an older date', () => {
 		expect(
 			State.retrieveExperimentAssignment( validFallbackExperimentAssignment.experimentName )
 		).toBe( validFallbackExperimentAssignment );
@@ -37,7 +37,7 @@ describe( 'state', () => {
 		);
 	} );
 
-	it( 'should throw for overwriting a recent EA with a fallback', () => {
+	it( 'should throw for overwriting a recent ExperimentAssignment with a fallback', () => {
 		expect( State.retrieveExperimentAssignment( validExperimentAssignment.experimentName ) ).toBe(
 			validExperimentAssignment
 		);

--- a/packages/explat-client/src/internal/test/state.ts
+++ b/packages/explat-client/src/internal/test/state.ts
@@ -2,35 +2,35 @@
  * Internal dependencies
  */
 import * as State from '../state';
-import { validExperimentAssignmentA, validExperimentAssignmentB } from '../test-common';
+import { validExperimentAssignment, validFallbackExperimentAssignment } from '../test-common';
 
 describe( 'state', () => {
 	it( 'should save and retrieve valid EAs', () => {
-		expect( State.retrieveExperimentAssignment( validExperimentAssignmentA.experimentName ) ).toBe(
+		expect( State.retrieveExperimentAssignment( validExperimentAssignment.experimentName ) ).toBe(
 			undefined
 		);
-		State.storeExperimentAssignment( validExperimentAssignmentA );
+		State.storeExperimentAssignment( validExperimentAssignment );
 		expect(
-			State.retrieveExperimentAssignment( validExperimentAssignmentA.experimentName )
-		).toEqual( validExperimentAssignmentA );
+			State.retrieveExperimentAssignment( validExperimentAssignment.experimentName )
+		).toEqual( validExperimentAssignment );
 
-		expect( State.retrieveExperimentAssignment( validExperimentAssignmentB.experimentName ) ).toBe(
-			undefined
-		);
-		State.storeExperimentAssignment( validExperimentAssignmentB );
 		expect(
-			State.retrieveExperimentAssignment( validExperimentAssignmentB.experimentName )
-		).toEqual( validExperimentAssignmentB );
+			State.retrieveExperimentAssignment( validFallbackExperimentAssignment.experimentName )
+		).toBe( undefined );
+		State.storeExperimentAssignment( validFallbackExperimentAssignment );
+		expect(
+			State.retrieveExperimentAssignment( validFallbackExperimentAssignment.experimentName )
+		).toEqual( validFallbackExperimentAssignment );
 	} );
 
 	it( 'should throw for storing an EA for a currently stored Experiment with an older date', () => {
-		expect( State.retrieveExperimentAssignment( validExperimentAssignmentB.experimentName ) ).toBe(
-			validExperimentAssignmentB
-		);
+		expect(
+			State.retrieveExperimentAssignment( validFallbackExperimentAssignment.experimentName )
+		).toBe( validFallbackExperimentAssignment );
 		expect( () =>
 			State.storeExperimentAssignment( {
-				...validExperimentAssignmentB,
-				retrievedTimestamp: validExperimentAssignmentB.retrievedTimestamp - 1,
+				...validFallbackExperimentAssignment,
+				retrievedTimestamp: validFallbackExperimentAssignment.retrievedTimestamp - 1,
 			} )
 		).toThrowErrorMatchingInlineSnapshot(
 			`"Trying to store an older experiment assignment than is present in the store, likely a race condition."`
@@ -38,12 +38,12 @@ describe( 'state', () => {
 	} );
 
 	it( 'should throw for overwriting a recent EA with a fallback', () => {
-		expect( State.retrieveExperimentAssignment( validExperimentAssignmentA.experimentName ) ).toBe(
-			validExperimentAssignmentA
+		expect( State.retrieveExperimentAssignment( validExperimentAssignment.experimentName ) ).toBe(
+			validExperimentAssignment
 		);
 		expect( () =>
 			State.storeExperimentAssignment( {
-				...validExperimentAssignmentA,
+				...validExperimentAssignment,
 				isFallbackExperimentAssignment: true,
 			} )
 		).toThrowErrorMatchingInlineSnapshot(

--- a/packages/explat-client/src/internal/test/timing.ts
+++ b/packages/explat-client/src/internal/test/timing.ts
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+// This is required to fix the "regeneratorRuntime is not defined" error
+import '@automattic/calypso-polyfills';
+
+/**
+ * Internal dependencies
+ */
+import * as Timing from '../timing';
+
+describe( 'monotonicNow', () => {
+	it( 'should be strictly monotonic', () => {
+		const spiedGetTime = jest.spyOn( global.Date, 'now' );
+		const lastNow = Timing.monotonicNow();
+		spiedGetTime.mockImplementationOnce( () => lastNow );
+		expect( Timing.monotonicNow() ).toBe( lastNow + 1 );
+		spiedGetTime.mockImplementationOnce( () => lastNow );
+		expect( Timing.monotonicNow() ).toBe( lastNow + 2 );
+	} );
+} );
+
+const delayedValue = < T >( value, delayMilliseconds ): Promise< T > =>
+	new Promise( ( res ) => setTimeout( () => res( value ), delayMilliseconds ) );
+
+describe( 'timeoutPromise', () => {
+	it( 'should resolve promises below the timeout', async () => {
+		expect( Timing.timeoutPromise( new Promise( ( res ) => res( 123 ) ), 1 ) ).resolves.toBe( 123 );
+		expect( Timing.timeoutPromise( delayedValue( 123, 1 ), 2 ) ).resolves.toBe( 123 );
+	} );
+	it( 'should throw if promise gets timed-out', async () => {
+		expect( Timing.timeoutPromise( delayedValue( null, 2 ), 1 ) ).rejects.toThrowError();
+		expect( Timing.timeoutPromise( delayedValue( null, 3 ), 2 ) ).rejects.toThrowError();
+	} );
+} );
+
+describe( 'asyncOneAtATime', () => {
+	it( 'it should wrap an async function and behave the same', () => {
+		const f = Timing.asyncOneAtATime( async () => delayedValue( 123, 0 ) );
+		expect( f() ).resolves.toBe( 123 );
+	} );
+
+	it( 'it should return the same promise when called multiple times', () => {
+		const f = Timing.asyncOneAtATime( async () => delayedValue( 123, 1 ) );
+		const a = f();
+		const b = f();
+		const c = f();
+		expect( a ).toBe( b );
+		expect( b ).toBe( c );
+		expect( a ).resolves.toBe( 123 );
+	} );
+
+	it( 'it should return a different promise after the last has resolved', async () => {
+		const f = Timing.asyncOneAtATime( async () => delayedValue( 123, 5 ) );
+		const a = f();
+		const b = f();
+		expect( a ).toBe( b );
+		expect( a ).resolves.toBe( 123 );
+
+		await delayedValue( null, 5 );
+		const c = f();
+		const d = f();
+		expect( a ).not.toBe( c );
+		expect( c ).toBe( d );
+		expect( c ).resolves.toBe( 123 );
+	} );
+} );

--- a/packages/explat-client/src/internal/test/validations.ts
+++ b/packages/explat-client/src/internal/test/validations.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import * as Validations from '../validations';
-import { validExperimentAssignmentA, validExperimentAssignmentB } from '../test-common';
+import { validExperimentAssignment, validFallbackExperimentAssignment } from '../test-common';
 
 describe( 'isObject', () => {
 	it( 'returns true for an object', () => {
@@ -37,67 +37,67 @@ describe( 'isName', () => {
 
 describe( 'isExperimentAssignment', () => {
 	it( 'returns true for a valid ExperimentAssignment', () => {
-		expect( Validations.isExperimentAssignment( validExperimentAssignmentA ) ).toBe( true );
-		expect( Validations.isExperimentAssignment( validExperimentAssignmentB ) ).toBe( true );
+		expect( Validations.isExperimentAssignment( validExperimentAssignment ) ).toBe( true );
+		expect( Validations.isExperimentAssignment( validFallbackExperimentAssignment ) ).toBe( true );
 	} );
 	it( 'returns false for an invalid ExperimentAssignment', () => {
 		expect(
 			Validations.isExperimentAssignment( {
-				...validExperimentAssignmentA,
+				...validExperimentAssignment,
 				experimentName: undefined,
 			} )
 		).toBe( false );
 		expect(
 			Validations.isExperimentAssignment( {
-				...validExperimentAssignmentB,
+				...validFallbackExperimentAssignment,
 				experimentName: null,
 			} )
 		).toBe( false );
 		expect(
 			Validations.isExperimentAssignment( {
-				...validExperimentAssignmentB,
+				...validFallbackExperimentAssignment,
 				experimentName: 1,
 			} )
 		).toBe( false );
 		expect(
 			Validations.isExperimentAssignment( {
-				...validExperimentAssignmentA,
+				...validExperimentAssignment,
 				variationName: undefined,
 			} )
 		).toBe( false );
 		expect(
 			Validations.isExperimentAssignment( {
-				...validExperimentAssignmentB,
+				...validFallbackExperimentAssignment,
 				variationName: 0,
 			} )
 		).toBe( false );
 		expect(
 			Validations.isExperimentAssignment( {
-				...validExperimentAssignmentA,
+				...validExperimentAssignment,
 				retrievedTimestamp: undefined,
 			} )
 		).toBe( false );
 		expect(
 			Validations.isExperimentAssignment( {
-				...validExperimentAssignmentB,
+				...validFallbackExperimentAssignment,
 				retrievedTimestamp: 'string',
 			} )
 		).toBe( false );
 		expect(
 			Validations.isExperimentAssignment( {
-				...validExperimentAssignmentA,
+				...validExperimentAssignment,
 				ttl: undefined,
 			} )
 		).toBe( false );
 		expect(
 			Validations.isExperimentAssignment( {
-				...validExperimentAssignmentB,
+				...validFallbackExperimentAssignment,
 				ttl: 'string',
 			} )
 		).toBe( false );
 		expect(
 			Validations.isExperimentAssignment( {
-				...validExperimentAssignmentB,
+				...validFallbackExperimentAssignment,
 				ttl: 0,
 			} )
 		).toBe( false );
@@ -106,17 +106,17 @@ describe( 'isExperimentAssignment', () => {
 
 describe( 'validateExperimentAssignment', () => {
 	it( 'returns a valid ExperimentAssignment', () => {
-		expect( Validations.validateExperimentAssignment( validExperimentAssignmentA ) ).toEqual(
-			validExperimentAssignmentA
+		expect( Validations.validateExperimentAssignment( validExperimentAssignment ) ).toEqual(
+			validExperimentAssignment
 		);
-		expect( Validations.validateExperimentAssignment( validExperimentAssignmentB ) ).toEqual(
-			validExperimentAssignmentB
+		expect( Validations.validateExperimentAssignment( validFallbackExperimentAssignment ) ).toEqual(
+			validFallbackExperimentAssignment
 		);
 	} );
 	it( 'throws if there is an invalid ExperimentAssignment', () => {
 		expect( () => {
 			Validations.validateExperimentAssignment( {
-				...validExperimentAssignmentB,
+				...validFallbackExperimentAssignment,
 				experimentName: null,
 			} );
 		} ).toThrowErrorMatchingInlineSnapshot( `"Invalid ExperimentAssignment"` );

--- a/packages/explat-client/src/internal/test/validations.ts
+++ b/packages/explat-client/src/internal/test/validations.ts
@@ -1,0 +1,124 @@
+/**
+ * Internal dependencies
+ */
+import * as Validations from '../validations';
+import { validExperimentAssignmentA, validExperimentAssignmentB } from '../test-common';
+
+describe( 'isObject', () => {
+	it( 'returns true for an object', () => {
+		expect( Validations.isObject( {} ) ).toBe( true );
+		expect( Validations.isObject( { key: 'value' } ) ).toBe( true );
+		expect( Validations.isObject( new Error( 'foo' ) ) ).toBe( true );
+	} );
+	it( 'returns false for a non object', () => {
+		expect( Validations.isObject( undefined ) ).toBe( false );
+		expect( Validations.isObject( null ) ).toBe( false );
+		expect( Validations.isObject( 1 ) ).toBe( false );
+		expect( Validations.isObject( 'object' ) ).toBe( false );
+	} );
+} );
+
+describe( 'isName', () => {
+	it( 'returns true for a valid name', () => {
+		expect( Validations.isName( 'experiment_name' ) ).toBe( true );
+		expect( Validations.isName( 'experiment_123_name' ) ).toBe( true );
+		expect( Validations.isName( 'experiment_123_123' ) ).toBe( true );
+	} );
+	it( 'returns false for an invalid name', () => {
+		expect( Validations.isName( 'experiment_123_123_' ) ).toBe( false );
+		expect( Validations.isName( '_experiment_123_123' ) ).toBe( false );
+		expect( Validations.isName( 'a' ) ).toBe( false );
+		expect( Validations.isName( 123 ) ).toBe( false );
+		expect( Validations.isName( {} ) ).toBe( false );
+		expect( Validations.isName( undefined ) ).toBe( false );
+		expect( Validations.isName( null ) ).toBe( false );
+	} );
+} );
+
+describe( 'isExperimentAssignment', () => {
+	it( 'returns true for a valid ExperimentAssignment', () => {
+		expect( Validations.isExperimentAssignment( validExperimentAssignmentA ) ).toBe( true );
+		expect( Validations.isExperimentAssignment( validExperimentAssignmentB ) ).toBe( true );
+	} );
+	it( 'returns false for an invalid ExperimentAssignment', () => {
+		expect(
+			Validations.isExperimentAssignment( {
+				...validExperimentAssignmentA,
+				experimentName: undefined,
+			} )
+		).toBe( false );
+		expect(
+			Validations.isExperimentAssignment( {
+				...validExperimentAssignmentB,
+				experimentName: null,
+			} )
+		).toBe( false );
+		expect(
+			Validations.isExperimentAssignment( {
+				...validExperimentAssignmentB,
+				experimentName: 1,
+			} )
+		).toBe( false );
+		expect(
+			Validations.isExperimentAssignment( {
+				...validExperimentAssignmentA,
+				variationName: undefined,
+			} )
+		).toBe( false );
+		expect(
+			Validations.isExperimentAssignment( {
+				...validExperimentAssignmentB,
+				variationName: 0,
+			} )
+		).toBe( false );
+		expect(
+			Validations.isExperimentAssignment( {
+				...validExperimentAssignmentA,
+				retrievedTimestamp: undefined,
+			} )
+		).toBe( false );
+		expect(
+			Validations.isExperimentAssignment( {
+				...validExperimentAssignmentB,
+				retrievedTimestamp: 'string',
+			} )
+		).toBe( false );
+		expect(
+			Validations.isExperimentAssignment( {
+				...validExperimentAssignmentA,
+				ttl: undefined,
+			} )
+		).toBe( false );
+		expect(
+			Validations.isExperimentAssignment( {
+				...validExperimentAssignmentB,
+				ttl: 'string',
+			} )
+		).toBe( false );
+		expect(
+			Validations.isExperimentAssignment( {
+				...validExperimentAssignmentB,
+				ttl: 0,
+			} )
+		).toBe( false );
+	} );
+} );
+
+describe( 'validateExperimentAssignment', () => {
+	it( 'returns a valid ExperimentAssignment', () => {
+		expect( Validations.validateExperimentAssignment( validExperimentAssignmentA ) ).toEqual(
+			validExperimentAssignmentA
+		);
+		expect( Validations.validateExperimentAssignment( validExperimentAssignmentB ) ).toEqual(
+			validExperimentAssignmentB
+		);
+	} );
+	it( 'throws if there is an invalid ExperimentAssignment', () => {
+		expect( () => {
+			Validations.validateExperimentAssignment( {
+				...validExperimentAssignmentB,
+				experimentName: null,
+			} );
+		} ).toThrowErrorMatchingInlineSnapshot( `"Invalid ExperimentAssignment"` );
+	} );
+} );

--- a/packages/explat-client/src/internal/timing.ts
+++ b/packages/explat-client/src/internal/timing.ts
@@ -1,0 +1,61 @@
+export const MILLISECONDS_PER_SECOND = 1000;
+
+let lastNow = Date.now();
+/**
+ * Returns the time in miliseconds.
+ * A strictly increasing version of Date.now()
+ *
+ * Gives us some minimimal guarentees about user clocks.
+ */
+export function monotonicNow(): number {
+	const maybeNow = Date.now();
+
+	lastNow = lastNow < maybeNow ? maybeNow : lastNow + 1;
+
+	return lastNow;
+}
+
+/**
+ * Timeouts a promise. Returns timeoutValue in event of timeout.
+ *
+ * @param promise The promise to timeout
+ * @param timeoutMilliseconds The timeout time in milliseconds
+ */
+export function timeoutPromise< T >(
+	promise: Promise< T >,
+	timeoutMilliseconds: number
+): Promise< T | null > {
+	return Promise.race( [
+		promise,
+		new Promise< null >( ( _res, rej ) =>
+			setTimeout( () => rej( new Error( 'Promise has timed-out.' ) ), timeoutMilliseconds )
+		),
+	] );
+}
+
+/**
+ * Wraps an async function so that if it is called multiple times it will just return the same promise - until the promise is fulfilled.
+ *
+ * Once the promise has been fulfilled it will reset.
+ *
+ * @param f The function to wrap
+ */
+export function asyncOneAtATime< T >( f: () => Promise< T > ): () => Promise< T > {
+	let isRunning = false;
+	let lastPromise: Promise< T > | null = null;
+	return () => {
+		if ( ! isRunning ) {
+			isRunning = true;
+			lastPromise = f();
+			const afterwards = () => {
+				isRunning = false;
+			};
+			lastPromise.then( afterwards );
+			lastPromise.catch( afterwards );
+		}
+		if ( lastPromise === null ) {
+			throw new Error( 'Invalid state: lastPromise should not be null.' );
+		}
+		return lastPromise;
+	};
+}

--- a/packages/explat-client/src/internal/validations.ts
+++ b/packages/explat-client/src/internal/validations.ts
@@ -1,0 +1,54 @@
+/**
+ * Internal dependencies
+ */
+import { ExperimentAssignment } from '../types';
+
+export function isObject( x: unknown ): x is Record< string, unknown > {
+	return typeof x === 'object' && x !== null;
+}
+
+const nameRegex = new RegExp( '^[a-z][a-z0-9_]*[a-z0-9]$' );
+
+/**
+ * Test if a piece of data is a valid name
+ *
+ * @param name The data to test
+ */
+export function isName( name: unknown ): name is string {
+	return typeof name === 'string' && nameRegex.test( name );
+}
+
+/**
+ * Test if a piece of data is a valid experimentAssignment
+ *
+ * @param experimentAssignment The data to test
+ */
+export function isExperimentAssignment(
+	experimentAssignment: unknown
+): experimentAssignment is ExperimentAssignment {
+	return (
+		isObject( experimentAssignment ) &&
+		isName( experimentAssignment[ 'experimentName' ] ) &&
+		( isName( experimentAssignment[ 'variationName' ] ) ||
+			experimentAssignment[ 'variationName' ] === null ) &&
+		typeof experimentAssignment[ 'retrievedTimestamp' ] === 'number' &&
+		typeof experimentAssignment[ 'ttl' ] === 'number' &&
+		experimentAssignment[ 'ttl' ] !== 0
+	);
+}
+
+/**
+ * Basic validation of ExperimentAssignment
+ * Throws if invalid, returns the experimentAssignment if valid.
+ *
+ * @param experimentAssignment The data to validate
+ */
+export function validateExperimentAssignment(
+	experimentAssignment: unknown
+): ExperimentAssignment {
+	if ( ! isExperimentAssignment( experimentAssignment ) ) {
+		throw new Error( 'Invalid ExperimentAssignment' );
+	}
+
+	return experimentAssignment;
+}

--- a/packages/explat-client/src/internal/validations.ts
+++ b/packages/explat-client/src/internal/validations.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { ExperimentAssignment } from '../types';
+import type { ExperimentAssignment } from '../types';
 
 export function isObject( x: unknown ): x is Record< string, unknown > {
 	return typeof x === 'object' && x !== null;

--- a/packages/explat-client/src/types.ts
+++ b/packages/explat-client/src/types.ts
@@ -17,6 +17,10 @@ export interface ExperimentAssignment {
 	 * Time to live from when it was retrieved, seconds
 	 */
 	ttl: number;
+	/**
+	 * A marker for fallback assignments - when we can't retrieve from the server.
+	 */
+	isFallbackExperimentAssignment?: boolean;
 }
 
 // ## Abstracting the outside world
@@ -27,7 +31,7 @@ export interface Config {
 		anonId,
 	}: {
 		experimentName: string;
-		anonId?: string;
+		anonId: string | null;
 	} ) => Promise< unknown >;
 	getAnonId: () => Promise< string | null >;
 	logError: ( error: Record< string, string > & { message: string } ) => void;

--- a/packages/explat-client/src/types.ts
+++ b/packages/explat-client/src/types.ts
@@ -1,0 +1,35 @@
+// ## The data structures
+
+export interface ExperimentAssignment {
+	/**
+	 * The name of the experiment assignment
+	 */
+	experimentName: string;
+	/**
+	 * The name of the assigned variation,
+	 */
+	variationName: string | null;
+	/**
+	 * The timestamp of when this assignment was retrieved.
+	 */
+	retrievedTimestamp: number;
+	/**
+	 * Time to live from when it was retrieved, seconds
+	 */
+	ttl: number;
+}
+
+// ## Abstracting the outside world
+
+export interface Config {
+	fetchExperimentAssignment: ( {
+		experimentName,
+		anonId,
+	}: {
+		experimentName: string;
+		anonId?: string;
+	} ) => Promise< unknown >;
+	getAnonId: () => Promise< string | null >;
+	logError: ( error: Record< string, string > & { message: string } ) => void;
+	isDevelopmentMode: boolean;
+}


### PR DESCRIPTION
**This PR adds internal functions for the Explat Self-contained client.**
- Just missing `request.ts`

Part of a series rebuilding the reference WIP PR #48475

#### Testing instructions

* See added Automated Tests 
* `yarn test-packages explat-client`
