### PR TITLE
ci(docker) Rename docker images

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -104,21 +104,7 @@ object BuildBaseImages : BuildType({
 					registry.a8c.com/calypso/base:latest
 					registry.a8c.com/calypso/base:%build.number%
 				""".trimIndent()
-				commandArgs = "--no-cache --target builder"
-			}
-			param("dockerImage.platform", "linux")
-		}
-		dockerCommand {
-			name = "Build CI image"
-			commandType = build {
-				source = file {
-					path = "Dockerfile.base"
-				}
-				namesAndTags = """
-					registry.a8c.com/calypso/ci:latest
-					registry.a8c.com/calypso/ci:%build.number%
-				""".trimIndent()
-				commandArgs = "--target ci"
+				commandArgs = "--no-cache --target base"
 			}
 			param("dockerImage.platform", "linux")
 		}
@@ -170,8 +156,6 @@ object BuildBaseImages : BuildType({
 				namesAndTags = """
 					registry.a8c.com/calypso/base:latest
 					registry.a8c.com/calypso/base:%build.number%
-					registry.a8c.com/calypso/ci:latest
-					registry.a8c.com/calypso/ci:%build.number%
 					registry.a8c.com/calypso/ci-desktop:latest
 					registry.a8c.com/calypso/ci-desktop:%build.number%
 					registry.a8c.com/calypso/ci-e2e:latest

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,5 +1,7 @@
-#### builder image
-FROM node:12.20.1 as builder
+#### cache image
+#### This image is not pushed to any repository and it shouldn't be used as base image for any other docker build.
+#### Its main goal is to create a `/calypso/.cache` that can be copied over other images that can benefit from a warm cache.
+FROM node:12.20.1 as cache
 
 ARG node_memory=8192
 WORKDIR /calypso
@@ -19,7 +21,7 @@ RUN git clone --branch v0.37.0 --depth 1 https://github.com/nvm-sh/nvm.git "$NVM
 COPY . .
 
 # Run nvm.sh in a different dir so it doesn't try to use the version specified in /calypso/.nvmrc.
-# If not, it will fail the image generation
+# If not, it will fail the image generation.
 RUN cd / \
 	&& . "$NVM_DIR/nvm.sh" \
 	&& cd $HOME \
@@ -31,8 +33,9 @@ RUN cd / \
 
 ENTRYPOINT [ "/bin/bash" ]
 
-#### ci image
-FROM node:12.20.1 as ci
+#### base image
+#### This image can be used as a base image for other builds, or to uni test and build calypso.
+FROM node:12.20.1 as base
 
 ARG node_memory=8192
 ARG UID=1003
@@ -48,19 +51,20 @@ RUN chown $UID /calypso
 # Set bash as the default shell
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 # Copy nvm cache so we don't need to download it again
-COPY --from=builder --chown=$UID /calypso/.nvm /calypso/.nvm
+COPY --from=cache --chown=$UID /calypso/.nvm /calypso/.nvm
 # Copy all other caches (webpack, babel, yarn...)
-COPY --from=builder --chown=$UID /calypso/.cache /calypso/.cache
-COPY --from=builder --chown=$UID /calypso/.bashrc /calypso/.bashrc
+COPY --from=cache --chown=$UID /calypso/.cache /calypso/.cache
+COPY --from=cache --chown=$UID /calypso/.bashrc /calypso/.bashrc
 
 ENTRYPOINT [ "/bin/bash" ]
 
 #### ci-desktop image
-FROM ci as ci-desktop
+#### This image is used to run desktop tests.
+FROM base as ci-desktop
 
 ENV ELECTRON_BUILDER_ARGS='-c.linux.target=dir'
 ENV USE_HARD_LINKS=false
-# This chrome image is the latest version supported by wp-desktop's chromedriver, declared in desktop/package.json
+# This chrome image is the latest version supported by wp-desktop's chromedriver, declared in desktop/package.json.
 ENV CHROME_VERSION="80.0.3987.163-1"
 ENV DISPLAY=:99
 
@@ -97,10 +101,11 @@ RUN wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-
 ENTRYPOINT [ "/bin/bash" ]
 
 #### ci-e2e image
+#### This image is used to run e2e tests. The only difference with ci-desktop is the Chrome version.
 FROM ci-desktop as ci-e2e
 
-# This chrome image is the latest version that accepts SameSite=None
-# test/e2e/test/mocha.env.js will install a compatible chromedriver
+# This chrome image is the latest version that accepts SameSite=None.
+# test/e2e/test/mocha.env.js will install a compatible chromedriver.
 ENV CHROME_VERSION="84.0.4147.135-1"
 ENV DETECT_CHROMEDRIVER_VERSION=true
 
@@ -112,7 +117,8 @@ ENTRYPOINT [ "/bin/bash" ]
 
 
 #### ci-wpcom image
-FROM ci as ci-wpcom
+#### This image is used to test and build WPCOM plugins in Calypso repo.
+FROM base as ci-wpcom
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 COPY --from=builder --chown=$UID /calypso/composer.* /calypso/


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Renames docker image `ci` to `base` to be more clear about its intention
* Stop building `ci` images in TeamCity
* Adds comments explaining where each image should and shouldn't be used

Note: TeamCity tests still run using `/ci:latest`, which now we don't build anymore. The tests will continue to work (the image still exists in the repo), but they may not run with a fresh cache. Once this PR lands and we build a set of images with the new names, I'll do the change in TeamCity (#49545). 
