### PR TITLE
Purchases: Reduxify notices in GSuiteCancelPurchaseDialog

### DIFF
--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -18,7 +18,7 @@ import { getName, purchaseType } from 'calypso/lib/purchases';
 import { getPurchasesError } from 'calypso/state/purchases/selectors';
 import GSuiteCancellationFeatures from './gsuite-cancellation-features';
 import GSuiteCancellationSurvey from './gsuite-cancellation-survey';
-import notices from 'calypso/notices';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { purchasesRoot } from 'calypso/me/purchases/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { removePurchase } from 'calypso/state/purchases/actions';
@@ -108,7 +108,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 
 		const response = await survey.submit();
 		if ( ! response.success ) {
-			notices.error( response.err );
+			this.props.errorNotice( response.err );
 		}
 	};
 
@@ -120,11 +120,11 @@ class GSuiteCancelPurchaseDialog extends Component {
 		const { purchasesError } = this.props;
 
 		if ( purchasesError ) {
-			notices.error( purchasesError );
+			this.props.errorNotice( purchasesError );
 			return false;
 		}
 
-		notices.success(
+		this.props.successNotice(
 			translate( '%(productName)s was removed from {{domain/}}.', {
 				args: {
 					productName,
@@ -134,7 +134,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 				},
 			} ),
 			{
-				persistent: true,
+				displayOnNextPage: true,
 			}
 		);
 
@@ -252,7 +252,9 @@ export default connect(
 		};
 	},
 	{
+		errorNotice,
 		recordTracksEvent,
 		removePurchase,
+		successNotice,
 	}
 )( localize( GSuiteCancelPurchaseDialog ) );

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -134,7 +134,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 				},
 			} ),
 			{
-				displayOnNextPage: true,
+				isPersistent: true,
 			}
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Purchases: Reduxify notices in RemovePurchase

#### Testing instructions

* Go to `/me/purchases`
* Try removing a G suite purchase and verify you still get a success notice.
* Attempt removing a G suite purchase after forcing the code to trigger a failure and verify you're still getting an error notice.

cc @Automattic/shilling I've personally been unable to repro this because I currently have no G Suite purchases. Could I ask you for your 👀  in testing this? Thanks!

Part of #48408.