### PR TITLE
Docs: Deprecate the legacy notices library

### DIFF
--- a/client/notices/README.md
+++ b/client/notices/README.md
@@ -1,5 +1,7 @@
 # Notices
 
+**NOTE: This library is deprecated. Consider using the [Redux notices](./client/state/notices/README.md) instead.**
+
 Provides some helper functions to render a notice on the UI. Types of notices are `error`, `success`, `info`, and `warning`.
 
 ## How to use?


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We've been reduxifying the legacy notices in #48408. As we're drawing close to removing all of the legacy instances, this PR adds a notice to the README that the old way of triggering notices is deprecated.

#### Testing instructions

Testing not needed, this is a README change.

Part of #48408.
