### PR TITLE
ci(teamcity) Allow image_tag to be configurable

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -86,6 +86,7 @@ object BuildBaseImages : BuildType({
 
 	params {
 		param("build.prefix", "1.0")
+		param("image_tag", "latest")
 	}
 
 	vcs {
@@ -101,7 +102,7 @@ object BuildBaseImages : BuildType({
 					path = "Dockerfile.base"
 				}
 				namesAndTags = """
-					registry.a8c.com/calypso/base:latest
+					registry.a8c.com/calypso/base:%image_tag%
 					registry.a8c.com/calypso/base:%build.number%
 				""".trimIndent()
 				commandArgs = "--no-cache --target base"
@@ -115,7 +116,7 @@ object BuildBaseImages : BuildType({
 					path = "Dockerfile.base"
 				}
 				namesAndTags = """
-					registry.a8c.com/calypso/ci-desktop:latest
+					registry.a8c.com/calypso/ci-desktop:%image_tag%
 					registry.a8c.com/calypso/ci-desktop:%build.number%
 				""".trimIndent()
 				commandArgs = "--target ci-desktop"
@@ -129,7 +130,7 @@ object BuildBaseImages : BuildType({
 					path = "Dockerfile.base"
 				}
 				namesAndTags = """
-					registry.a8c.com/calypso/ci-e2e:latest
+					registry.a8c.com/calypso/ci-e2e:%image_tag%
 					registry.a8c.com/calypso/ci-e2e:%build.number%
 				""".trimIndent()
 				commandArgs = "--target ci-e2e"
@@ -143,7 +144,7 @@ object BuildBaseImages : BuildType({
 					path = "Dockerfile.base"
 				}
 				namesAndTags = """
-					registry.a8c.com/calypso/ci-wpcom:latest
+					registry.a8c.com/calypso/ci-wpcom:%image_tag%
 					registry.a8c.com/calypso/ci-wpcom:%build.number%
 				""".trimIndent()
 				commandArgs = "--target ci-wpcom"
@@ -154,13 +155,13 @@ object BuildBaseImages : BuildType({
 			name = "Push images"
 			commandType = push {
 				namesAndTags = """
-					registry.a8c.com/calypso/base:latest
+					registry.a8c.com/calypso/base:%image_tag%
 					registry.a8c.com/calypso/base:%build.number%
-					registry.a8c.com/calypso/ci-desktop:latest
+					registry.a8c.com/calypso/ci-desktop:%image_tag%
 					registry.a8c.com/calypso/ci-desktop:%build.number%
-					registry.a8c.com/calypso/ci-e2e:latest
+					registry.a8c.com/calypso/ci-e2e:%image_tag%
 					registry.a8c.com/calypso/ci-e2e:%build.number%
-					registry.a8c.com/calypso/ci-wpcom:latest
+					registry.a8c.com/calypso/ci-wpcom:%image_tag%
 					registry.a8c.com/calypso/ci-wpcom:%build.number%
 				""".trimIndent()
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Extract the tag `:latest` to a configurable property that defaults to `:latest`. This should allow us to run 'Build docker images' in branches and change the tag, ir order to avoid overwriting the image `:latest` generated by `trunk`
 
#### Testing instructions

* Go to TC and try to run the build `Build docker image` for this branch, verify it doesn't fail
