### PR TITLE
ci(docker) Use cache when building docker images for e2e tests

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -236,6 +236,7 @@ object BuildDockerImage : BuildType({
 					--label com.a8c.build-id=%teamcity.build.id%
 					--build-arg workers=16
 					--build-arg node_memory=32768
+					--build-arg use_cache=true
 				""".trimIndent().replace("\n"," ")
 			}
 			param("dockerImage.platform", "linux")

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM node:${node_version} as builder-cache-false
 ###################
 # This image contains a directory /calypso/.cache which includes caches
 # for yarn, terser, css-loader and babel.
-FROM registry.a8c.com/calypso/ci:latest as builder-cache-true
+FROM registry.a8c.com/calypso/base:latest as builder-cache-true
 
 ENV YARN_CACHE_FOLDER=/calypso/.cache/yarn
 ENV NPM_CONFIG_CACHE=/calypso/.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM node:${node_version} as builder-cache-false
 ###################
 # This image contains a directory /calypso/.cache which includes caches
 # for yarn, terser, css-loader and babel.
-FROM registry.a8c.com/calypso/base:latest as builder-cache-true
+FROM registry.a8c.com/calypso/ci:latest as builder-cache-true
 
 ENV YARN_CACHE_FOLDER=/calypso/.cache/yarn
 ENV NPM_CONFIG_CACHE=/calypso/.cache


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use [this image](https://github.com/Automattic/wp-calypso/blob/trunk/Dockerfile.base#L36) (an image with `/calypso/.cache` prepopulated) instead of directly using `node:12.20.1`

#### Testing instructions

Verify the build 'Build docker image' for this branch completes and produces docker images (check the tab 'Docker Info')
