### PR TITLE
fix: hasSiteProduct cache key

### DIFF
--- a/client/state/sites/selectors/has-site-product.ts
+++ b/client/state/sites/selectors/has-site-product.ts
@@ -36,6 +36,6 @@ export default createSelector(
 		if ( ! Array.isArray( productSlug ) ) {
 			productSlug = [ productSlug ];
 		}
-		return `{ siteId || 0 }-${ productSlug.join( '-' ) }`;
+		return `${ siteId }-${ productSlug.join( '-' ) }`;
 	}
 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the `getCacheKey` implementation for the `hasSiteProduct` selector.

Just caught this while I was doing an audit of our usages of the cache key parameter for https://github.com/Automattic/wp-calypso/pull/49367#issuecomment-770918821 and was fairly certain it was a typo, correct me if I'm wrong @ChaosExAnima!

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* I'm actually unsure how to test this. Maybe @ChaosExAnima can adivse?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
