### PR TITLE
e2e: Fix renew test for local runs

### DIFF
--- a/test/e2e/lib/pages/purchases-page.js
+++ b/test/e2e/lib/pages/purchases-page.js
@@ -72,7 +72,7 @@ export default class PurchasesPage extends AsyncBaseContainer {
 		await this._waitForPurchases();
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			by.css( `a.purchase-item[data-e2e-connected-site=true]` )
+			by.css( `a.purchase-item[data-e2e-connected-site=true] svg` )
 		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The `Renew a Plan` test was failing on local test runs. It was failing because the test was clicking the center of the element, which happened to be another link. This change makes it so that it clicks the arrow instead

#### Testing instructions

* Make sure the renew a plan test passes in CI and Locally for both desktop and mobile.
