### PR TITLE
Account settings: Add dashboard appearance toggle for using WP Admin links

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -964,7 +964,7 @@ const Account = createReactClass( {
 							this.communityTranslator() }
 
 						{ config.isEnabled( 'nav-unification' ) && (
-							<FormFieldset>
+							<FormFieldset className="account__link-destination">
 								<FormLabel id="account__link_destination" htmlFor="link_destination">
 									{ translate( 'Dashboard appearance' ) }
 								</FormLabel>
@@ -973,7 +973,7 @@ const Account = createReactClass( {
 									onChange={ this.toggleLinkDestination }
 								>
 									{ translate(
-										'Replace all dashboard pages with WP Admin equivalents when possible'
+										'Replace all dashboard pages with WP Admin equivalents when possible.'
 									) }
 								</FormToggle>
 							</FormFieldset>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -68,7 +68,9 @@ import user from 'calypso/lib/user';
  * Style dependencies
  */
 import './style.scss';
+import FormToggle from 'calypso/components/forms/form-toggle';
 
+const linkDestinationKey = 'calypso_preferences.linkDestination';
 const colorSchemeKey = 'calypso_preferences.colorScheme';
 
 /**
@@ -166,6 +168,16 @@ const Account = createReactClass( {
 		// store any selected locale variant so we can test it against those with no GP translation sets
 		const localeVariantSelected = isLocaleVariant( value ) ? value : '';
 		this.setState( { redirect, localeVariantSelected } );
+	},
+
+	toggleLinkDestination( linkDestination ) {
+		// Set a fallback link destination if no default value is provided by the API.
+		// This is a workaround that allows us to use userSettings.updateSetting() without an
+		// existing value. Without this workaround the save button wouldn't become active.
+		// TODO: the API should provide a default value, which would make this line obsolete
+		update( this.props.userSettings.settings, linkDestinationKey, ( value ) => value || false );
+
+		this.updateUserSetting( linkDestinationKey, linkDestination );
 	},
 
 	updateColorScheme( colorScheme ) {
@@ -950,6 +962,20 @@ const Account = createReactClass( {
 
 						{ canDisplayCommunityTranslator( this.getUserSetting( 'language' ) ) &&
 							this.communityTranslator() }
+
+						{ config.isEnabled( 'nav-unification' ) && (
+							<FormFieldset>
+								<FormLabel id="account__link_destination" htmlFor="link_destination">
+									{ translate( 'Dashboard appearance' ) }
+								</FormLabel>
+								<FormToggle
+									checked={ !! this.getUserSetting( 'linkDestination' ) }
+									onChange={ this.toggleLinkDestination }
+								>
+									{ translate( 'Replace all dashboard pages with WP Admin equivalents' ) }
+								</FormToggle>
+							</FormFieldset>
+						) }
 
 						{ config.isEnabled( 'me/account/color-scheme-picker' ) &&
 							supportsCssCustomProperties() && (

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -63,12 +63,12 @@ import {
 import FormattedHeader from 'calypso/components/formatted-header';
 import wpcom from 'calypso/lib/wp';
 import user from 'calypso/lib/user';
+import FormToggle from 'calypso/components/forms/form-toggle';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-import FormToggle from 'calypso/components/forms/form-toggle';
 
 const linkDestinationKey = 'calypso_preferences.linkDestination';
 const colorSchemeKey = 'calypso_preferences.colorScheme';
@@ -972,7 +972,9 @@ const Account = createReactClass( {
 									checked={ !! this.getUserSetting( linkDestinationKey ) }
 									onChange={ this.toggleLinkDestination }
 								>
-									{ translate( 'Replace all dashboard pages with WP Admin equivalents' ) }
+									{ translate(
+										'Replace all dashboard pages with WP Admin equivalents when possible'
+									) }
 								</FormToggle>
 							</FormFieldset>
 						) }

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -969,7 +969,7 @@ const Account = createReactClass( {
 									{ translate( 'Dashboard appearance' ) }
 								</FormLabel>
 								<FormToggle
-									checked={ !! this.getUserSetting( 'linkDestination' ) }
+									checked={ !! this.getUserSetting( linkDestinationKey ) }
 									onChange={ this.toggleLinkDestination }
 								>
 									{ translate( 'Replace all dashboard pages with WP Admin equivalents' ) }

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -23,3 +23,7 @@
 .account__settings-form select {
 	width: 100%;
 }
+
+.account__link-destination .components-toggle-control__label {
+	color: var( --color-text-subtle );
+}


### PR DESCRIPTION
Fixes #47043

#### Changes proposed in this Pull Request

Add a new toggle to the Account settings page for opting out from Calypso links in the new unified menu.

<img width="933" alt="Screen Shot 2021-02-02 at 11 17 15" src="https://user-images.githubusercontent.com/1233880/106586301-919d7c00-6548-11eb-83cd-52e6e1d03292.png">


#### Testing instructions

- Use Firefox because Chrome has a bug whereby if you have 2-factor auth enabled it will constantly ask for your auth details 🤦 .
- Go to `/me/account`.
- Confirm there is a new checkbox for toggling the link destination setting in the interface settings form.
- Enable the new setting and save the interface settings.
- Go to My Sites.
- Check the sidebar menu and make sure that all pages with WP Admin equivalents link to WP Admin.
- Go again to `/me/account`.
- Disable the new setting  and save the interface settings.
- Go to My Sites.
- Check the sidebar menu and make sure that all pages with WP Admin equivalents link to Calypso.
