### PR TITLE
Checkout: Move line item subtotal calculation to display logic

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -85,7 +85,9 @@ function WPLineItem( {
 
 	const isTitanMail = productSlug === TITAN_MAIL_MONTHLY_SLUG;
 
-	const sublabel = String( getSublabel( item.wpcom_response_cart_product ) );
+	const sublabel = item.wpcom_response_cart_product
+		? String( getSublabel( item.wpcom_response_cart_product ) )
+		: '';
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -528,7 +530,9 @@ function LineItemSublabelAndPrice( { item } ) {
 	const isDomainRegistration = item.wpcom_meta?.is_domain_registration;
 	const isDomainMap = item.type === 'domain_map';
 	const productSlug = item.wpcom_meta?.product_slug;
-	const sublabel = String( getSublabel( item.wpcom_response_cart_product ) );
+	const sublabel = item.wpcom_response_cart_product
+		? String( getSublabel( item.wpcom_response_cart_product ) )
+		: '';
 
 	const isGSuite =
 		isGSuiteOrExtraLicenseProductSlug( productSlug ) || isGoogleWorkspaceProductSlug( productSlug );

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -34,6 +34,7 @@ import {
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
+import { getSublabel } from '../lib/translate-cart';
 
 export function WPOrderReviewSection( { children, className } ) {
 	return <div className={ joinClasses( [ className, 'order-review-section' ] ) }>{ children }</div>;
@@ -84,6 +85,8 @@ function WPLineItem( {
 
 	const isTitanMail = productSlug === TITAN_MAIL_MONTHLY_SLUG;
 
+	const sublabel = String( getSublabel( item.wpcom_response_cart_product ) );
+
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div
@@ -97,7 +100,7 @@ function WPLineItem( {
 			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
 				<LineItemPrice item={ item } isSummary={ isSummary } />
 			</span>
-			{ item.sublabel && (
+			{ sublabel && (
 				<LineItemMeta>
 					<LineItemSublabelAndPrice item={ item } />
 					<DomainDiscountCallout item={ item } />
@@ -525,6 +528,7 @@ function LineItemSublabelAndPrice( { item } ) {
 	const isDomainRegistration = item.wpcom_meta?.is_domain_registration;
 	const isDomainMap = item.type === 'domain_map';
 	const productSlug = item.wpcom_meta?.product_slug;
+	const sublabel = String( getSublabel( item.wpcom_response_cart_product ) );
 
 	const isGSuite =
 		isGSuiteOrExtraLicenseProductSlug( productSlug ) || isGoogleWorkspaceProductSlug( productSlug );
@@ -532,7 +536,7 @@ function LineItemSublabelAndPrice( { item } ) {
 	if ( item.type === 'plan' && item.wpcom_meta?.months_per_bill_period > 1 ) {
 		return translate( '%(sublabel)s: %(monthlyPrice)s /month × %(monthsPerBillPeriod)s', {
 			args: {
-				sublabel: item.sublabel,
+				sublabel: sublabel,
 				monthlyPrice: item.wpcom_meta.item_subtotal_monthly_cost_display,
 				monthsPerBillPeriod: item.wpcom_meta.months_per_bill_period,
 			},
@@ -547,7 +551,7 @@ function LineItemSublabelAndPrice( { item } ) {
 
 		return translate( '%(sublabel)s: %(monthlyPrice)s per month', {
 			args: {
-				sublabel: item.sublabel,
+				sublabel: sublabel,
 				monthlyPrice: item.wpcom_meta.item_subtotal_monthly_cost_display,
 			},
 			comment: 'product type and monthly breakdown of total cost, separated by a colon',
@@ -562,14 +566,14 @@ function LineItemSublabelAndPrice( { item } ) {
 		return translate( '%(premiumLabel)s %(sublabel)s: %(interval)s', {
 			args: {
 				premiumLabel,
-				sublabel: item.sublabel,
+				sublabel: sublabel,
 				interval: translate( 'billed annually' ),
 			},
 			comment:
 				'premium label, product type and billing interval, separated by a colon. ex: ".blog domain registration: billed annually" or "Premium .blog domain registration: billed annually"',
 		} );
 	}
-	return item.sublabel || null;
+	return sublabel || null;
 }
 
 function AnnualDiscountCallout( { item } ) {

--- a/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
@@ -8,7 +8,6 @@ import type { ResponseCart } from '@automattic/shopping-cart';
 /**
  * Internal dependencies
  */
-import type { CheckoutCartItem } from '../types/checkout-cart';
 import type { CheckoutPaymentMethodSlug } from '../types/checkout-payment-method-slug';
 import doesPurchaseHaveFullCredits from './does-purchase-have-full-credits';
 import { readCheckoutPaymentMethodSlug } from './translate-payment-method-names';
@@ -28,8 +27,8 @@ export default function filterAppropriatePaymentMethods( {
 	paymentMethodObjects: PaymentMethod[];
 	countryCode: string;
 	total: LineItem;
-	credits: CheckoutCartItem | null;
-	subtotal: CheckoutCartItem;
+	credits: LineItem | null;
+	subtotal: LineItem;
 	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
 	responseCart: ResponseCart;
 } ): PaymentMethod[] {

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -416,7 +416,7 @@ function getCouponIdFromProducts( items: WPCOMCartItem[] ): string | undefined {
 	return couponItem?.wpcom_meta?.couponCode;
 }
 
-function getSublabel( serverCartItem: ResponseCartProduct ): i18nCalypso.TranslateResult {
+export function getSublabel( serverCartItem: ResponseCartProduct ): i18nCalypso.TranslateResult {
 	const isRenewalItem = isRenewal( serverCartItem );
 	const { meta, product_name: productName } = serverCartItem;
 

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
+import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
+import type { LineItem } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
 
 /**
@@ -13,7 +14,6 @@ import {
 	WPCOMCartItem,
 	WPCOMCartCouponItem,
 	WPCOMCartCreditsItem,
-	CheckoutCartItem,
 } from '../types/checkout-cart';
 import {
 	readWPCOMPaymentMethodClass,
@@ -69,7 +69,7 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 		tax,
 	} = serverCart;
 
-	const taxLineItem: CheckoutCartItem = {
+	const taxLineItem: LineItem = {
 		id: 'tax-line-item',
 		label: String( translate( 'Tax' ) ),
 		type: 'tax', // TODO: does this need to be localized, e.g. tax-us?
@@ -122,7 +122,7 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 		},
 	};
 
-	const savingsLineItem: CheckoutCartItem = {
+	const savingsLineItem: LineItem = {
 		id: 'savings-line-item',
 		label: String( translate( 'Total savings' ) ),
 		type: 'savings',
@@ -133,7 +133,7 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 		},
 	};
 
-	const totalItem: CheckoutCartItem = {
+	const totalItem: LineItem = {
 		id: 'total',
 		type: 'total',
 		label: String( translate( 'Total' ) ),
@@ -144,7 +144,7 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 		},
 	};
 
-	const subtotalItem: CheckoutCartItem = {
+	const subtotalItem: LineItem = {
 		id: 'subtotal',
 		type: 'subtotal',
 		label: String( translate( 'Subtotal' ) ),

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -234,6 +234,7 @@ function translateReponseCartProductToWPCOMCartItem(
 			value: item_subtotal_integer || 0,
 			displayValue: item_subtotal_display || '',
 		},
+		wpcom_response_cart_product: serverCartItem,
 		wpcom_meta: {
 			uuid: uuid,
 			meta,

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -208,7 +208,6 @@ function translateReponseCartProductToWPCOMCartItem(
 	} = serverCartItem;
 
 	let label = product_name || '';
-	const sublabel = String( getSublabel( serverCartItem ) );
 
 	if (
 		serverCartItem.meta &&
@@ -227,7 +226,6 @@ function translateReponseCartProductToWPCOMCartItem(
 	return {
 		id: uuid,
 		label,
-		sublabel,
 		type,
 		amount: {
 			currency: currency || '',

--- a/client/my-sites/checkout/composite-checkout/test/translate-cart.js
+++ b/client/my-sites/checkout/composite-checkout/test/translate-cart.js
@@ -320,9 +320,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 			it( 'has the expected label (the domain name)', function () {
 				expect( clientCart.items[ 1 ].label ).toBe( 'foo.cash' );
 			} );
-			it( 'has the expected sublabel', function () {
-				expect( clientCart.items[ 1 ].sublabel ).toBe( '.cash Domain Registration' );
-			} );
 			it( 'has the expected meta (the domain name)', function () {
 				expect( clientCart.items[ 1 ].wpcom_meta?.meta ).toBe( 'foo.cash' );
 			} );

--- a/client/my-sites/checkout/composite-checkout/types/checkout-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/types/checkout-cart.ts
@@ -1,39 +1,18 @@
 /**
  * External dependencies
  */
-import { ResponseCartProductExtra } from '@automattic/shopping-cart';
+import type { ResponseCartProductExtra } from '@automattic/shopping-cart';
+import type { LineItem, LineItemAmount } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
  */
-import { CheckoutPaymentMethodSlug } from './checkout-payment-method-slug';
-
-/**
- * Amount object as used by composite-checkout. If that
- * package used TS this would belong there.
- */
-export interface CheckoutCartItemAmount {
-	currency: string;
-	value: number;
-	displayValue: string;
-}
-
-/**
- * Cart item object as used by composite-checkout. If that
- * package used TS this would belong there.
- */
-export interface CheckoutCartItem {
-	id: string;
-	label: string;
-	sublabel?: string;
-	type: string;
-	amount: CheckoutCartItemAmount;
-}
+import type { CheckoutPaymentMethodSlug } from './checkout-payment-method-slug';
 
 /**
  * Cart item with WPCOM specific info added.
  */
-export type WPCOMCartItem = CheckoutCartItem & {
+export type WPCOMCartItem = LineItem & {
 	wpcom_meta: {
 		uuid: string;
 		meta?: string;
@@ -63,13 +42,13 @@ export type WPCOMCartItem = CheckoutCartItem & {
 	};
 };
 
-export type WPCOMCartCouponItem = CheckoutCartItem & {
+export type WPCOMCartCouponItem = LineItem & {
 	wpcom_meta: {
 		couponCode: string;
 	};
 };
 
-export type WPCOMCartCreditsItem = CheckoutCartItem & {
+export type WPCOMCartCreditsItem = LineItem & {
 	wpcom_meta: {
 		credits_integer: number;
 		credits_display: string;
@@ -78,13 +57,13 @@ export type WPCOMCartCreditsItem = CheckoutCartItem & {
 
 export interface WPCOMCart {
 	items: WPCOMCartItem[];
-	tax: CheckoutCartItem | null;
-	total: CheckoutCartItem;
-	savings: CheckoutCartItem | null;
-	subtotal: CheckoutCartItem;
+	tax: LineItem | null;
+	total: LineItem;
+	savings: LineItem | null;
+	subtotal: LineItem;
 	coupon: WPCOMCartCouponItem | null;
 	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
-	credits: CheckoutCartItem | null;
+	credits: LineItem | null;
 	couponCode: string | null;
 }
 
@@ -98,8 +77,8 @@ export const emptyWPCOMCart = {
 			value: 0,
 			currency: '',
 			displayValue: '',
-		} as CheckoutCartItemAmount,
-	} as CheckoutCartItem,
+		} as LineItemAmount,
+	} as LineItem,
 	coupon: {
 		id: 'coupon',
 		label: 'Coupon',
@@ -108,7 +87,7 @@ export const emptyWPCOMCart = {
 			value: 0,
 			currency: '',
 			displayValue: '',
-		} as CheckoutCartItemAmount,
+		} as LineItemAmount,
 		wpcom_meta: {
 			couponCode: '',
 		},
@@ -120,8 +99,8 @@ export const emptyWPCOMCart = {
 			value: 0,
 			currency: '',
 			displayValue: '',
-		} as CheckoutCartItemAmount,
-	} as CheckoutCartItem,
+		} as LineItemAmount,
+	} as LineItem,
 	savings: {
 		id: 'savings',
 		label: 'Savings',
@@ -130,8 +109,8 @@ export const emptyWPCOMCart = {
 			value: 0,
 			currency: '',
 			displayValue: '',
-		} as CheckoutCartItemAmount,
-	} as CheckoutCartItem,
+		} as LineItemAmount,
+	} as LineItem,
 	subtotal: {
 		id: 'subtotal',
 		label: 'Subtotal',
@@ -139,14 +118,14 @@ export const emptyWPCOMCart = {
 			value: 0,
 			currency: '',
 			displayValue: '',
-		} as CheckoutCartItemAmount,
-	} as CheckoutCartItem,
+		} as LineItemAmount,
+	} as LineItem,
 	allowedPaymentMethods: [],
 	credits: {
 		id: 'Credits',
 		label: 'Credits',
 		type: 'credits',
-		amount: { value: 0, currency: 'USD', displayValue: '0' } as CheckoutCartItemAmount,
-	} as CheckoutCartItem,
+		amount: { value: 0, currency: 'USD', displayValue: '0' } as LineItemAmount,
+	} as LineItem,
 	couponCode: null,
 } as WPCOMCart;

--- a/client/my-sites/checkout/composite-checkout/types/checkout-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/types/checkout-cart.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { ResponseCartProductExtra } from '@automattic/shopping-cart';
+import type { ResponseCartProductExtra, ResponseCartProduct } from '@automattic/shopping-cart';
 import type { LineItem, LineItemAmount } from '@automattic/composite-checkout';
 
 /**
@@ -13,6 +13,7 @@ import type { CheckoutPaymentMethodSlug } from './checkout-payment-method-slug';
  * Cart item with WPCOM specific info added.
  */
 export type WPCOMCartItem = LineItem & {
+	wpcom_response_cart_product: ResponseCartProduct;
 	wpcom_meta: {
 		uuid: string;
 		meta?: string;

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -118,7 +118,7 @@ Each item is an object with the following properties:
 - `id: string`. A unique identifier for this line item within the array of line items. Do not use the product id; never assume that only one instance of a particular product is present.
 - `type: string`. Not used internally but can be used to organize line items (eg: `tax` for a VAT line item).
 - `label: string`. The displayed title of the line item.
-- `subLabel?: string`. An optional subtitle for the line item.
+- `sublabel?: string`. An optional subtitle for the line item.
 - `amount: { currency: string, value: number, displayValue: string }`. The price of the line item. For line items without a price, set value to 0 and displayValue to an empty string.
 
 ## Data Stores
@@ -542,7 +542,7 @@ No, line items can be anything. The most common use is for products, taxes, subt
 
 ### Do line items amount properties have to have an integer value?
 
-The primary properties used in a line item by default are `id` (which must be unique), `label` (with an optional `subLabel`), and `amount.displayValue`. The other properties (`type`, `amount.currency`, `amount.value`) are not used outside custom implementations, but it's highly recommended that you provide them. As requirements and customizations change, it can be helpful to have a way to perform calculations, conversions, and sorting on line items, which will require those fields. If any required field is undefined, an error will be thrown to help notice these errors as soon as possible.
+The primary properties used in a line item by default are `id` (which must be unique), `label` (with an optional `sublabel`), and `amount.displayValue`. The other properties (`type`, `amount.currency`, `amount.value`) are not used outside custom implementations, but it's highly recommended that you provide them. As requirements and customizations change, it can be helpful to have a way to perform calculations, conversions, and sorting on line items, which will require those fields. If any required field is undefined, an error will be thrown to help notice these errors as soon as possible.
 
 ### Can I add custom properties to line items?
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -46,7 +46,7 @@ const initialItems = [
 	},
 	{
 		label: 'Domain registration',
-		subLabel: 'example.com',
+		sublabel: 'example.com',
 		id: 'wpcom-domain',
 		type: 'domain',
 		amount: { currency: 'USD', value: 0, displayValue: '$0' },

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -46,7 +46,7 @@ export interface LineItem {
 	id: string;
 	type: string;
 	label: string;
-	subLabel?: string;
+	sublabel?: string;
 	amount: LineItemAmount;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`WPLineItem` makes many decisions about how to display a line item in the cart. The sublabel, however, has always been calculated much earlier in the render process, making it hard to find when trying to determine how to modify it for display. Here we move that calculation of the sublabel into `WPLineItem` directly.

(This is also a part of eventually removing `WPCOMCartItem` and `useLineItems` entirely, since they provide a second version of a line item schema which is unnecessary and adds cognitive load.)

Reviewing these commits one-by-one may be the easiest way to see why this involves tangential changes to the code.

#### Testing instructions

- Add a plan renewal to the shopping cart.
- Verify that when you visit checkout you see the text "Plan Renewal" underneath the line item.

<img width="495" alt="Screen Shot 2021-02-01 at 1 39 51 PM" src="https://user-images.githubusercontent.com/2036909/106502908-fbf3e500-6492-11eb-9442-d0a9536fb9f0.png">
