### PR TITLE
Plans store: always pass locale to the plans store

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -21,6 +21,7 @@ import {
 	SubmitButtonWrapper,
 	FormStatus,
 } from '@automattic/composite-checkout';
+import { useLocale } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -33,12 +34,11 @@ import './styles.scss';
 const TickIcon = <Icon icon={ check } size={ 17 } />;
 
 const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, onPrevStep } ) => {
-	const { domain, plan, LaunchStep, isStepCompleted, isFlowCompleted, planProductId } = useSelect(
+	const { domain, LaunchStep, isStepCompleted, isFlowCompleted, planProductId } = useSelect(
 		( select ) => {
 			const launchStore = select( LAUNCH_STORE );
 			return {
 				domain: launchStore.getSelectedDomain(),
-				plan: launchStore.getSelectedPlan(),
 				LaunchStep: launchStore.getLaunchStep(),
 				isStepCompleted: launchStore.isStepCompleted,
 				isFlowCompleted: launchStore.isFlowCompleted(),
@@ -47,9 +47,12 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, on
 		}
 	);
 
-	const planProduct = useSelect( ( select ) =>
-		select( PLANS_STORE ).getPlanProductById( planProductId )
-	);
+	const locale = useLocale();
+
+	const [ plan, planProduct ] = useSelect( ( select ) => [
+		select( PLANS_STORE ).getPlanByProductId( planProductId, locale ),
+		select( PLANS_STORE ).getPlanProductById( planProductId ),
+	] );
 
 	const { title } = useTitle();
 	const { siteSubdomain } = useSiteDomains();

--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -24,10 +24,11 @@ import type { Plan } from '../stores/plans';
  */
 export function usePlanFromPath(): Plan | undefined {
 	const planPath = usePlanRouteParam();
+	const locale = useLocale();
 
 	const [ isPlanFree, planFromPath, selectedFeatures ] = useSelect( ( select ) => [
 		select( PLANS_STORE ).isPlanFree,
-		select( PLANS_STORE ).getPlanByPath( planPath ),
+		select( PLANS_STORE ).getPlanByPath( planPath, locale ),
 		select( ONBOARD_STORE ).getSelectedFeatures(),
 	] );
 
@@ -54,11 +55,11 @@ export function useSelectedPlan(): Plan | undefined {
 	);
 
 	const recommendedPlan = useSelect( ( select ) =>
-		select( PLANS_STORE ).getPlanByPeriodAgnosticSlug( recommendedPlanSlug )
+		select( PLANS_STORE ).getPlanByPeriodAgnosticSlug( recommendedPlanSlug, locale )
 	);
 
 	const selectedPlan = useSelect( ( select ) =>
-		select( PLANS_STORE ).getPlanByProductId( selectedPlanProductId )
+		select( PLANS_STORE ).getPlanByProductId( selectedPlanProductId, locale )
 	);
 
 	const planFromPath = usePlanFromPath();

--- a/client/landing/gutenboarding/hooks/use-steps.ts
+++ b/client/landing/gutenboarding/hooks/use-steps.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { useLocale } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -12,6 +13,7 @@ import { PLANS_STORE } from '../stores/plans';
 import { usePlanFromPath } from './use-selected-plan';
 
 export default function useSteps(): Array< StepType > {
+	const locale = useLocale();
 	const { hasSiteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 	const isAnchorFmSignup = useIsAnchorFm();
 
@@ -47,7 +49,9 @@ export default function useSteps(): Array< StepType > {
 		select( ONBOARD_STORE ).getState()
 	);
 	const planProductId = useSelect( ( select ) => select( ONBOARD_STORE ).getPlanProductId() );
-	const plan = useSelect( ( select ) => select( PLANS_STORE ).getPlanByProductId( planProductId ) );
+	const plan = useSelect( ( select ) =>
+		select( PLANS_STORE ).getPlanByProductId( planProductId, locale )
+	);
 	const hasPlanFromPath = !! usePlanFromPath();
 
 	if ( domain && ! hasUsedDomainsStep ) {

--- a/client/landing/gutenboarding/onboarding-block/language/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/language/index.tsx
@@ -11,14 +11,13 @@ import LanguagePicker, { createLanguageGroups } from '@automattic/language-picke
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { ChangeLocaleContextConsumer } from '../../components/locale-context';
 import { I18N_STORE } from '../../stores/i18n';
-import { PLANS_STORE } from '../../stores/plans';
 import { USER_STORE } from '../../stores/user';
 import { Step, usePath } from '../../path';
 import type { StepNameType } from '../../path';
@@ -51,8 +50,6 @@ const LanguageStep: React.FunctionComponent< Props > = ( { previousStep } ) => {
 	const history = useHistory();
 	const makePath = usePath();
 
-	const { invalidateResolution } = useDispatch( 'core/data' );
-
 	const goBack = ( lang = '' ) => {
 		staticPreviousStep.current
 			? history.push( makePath( Step[ staticPreviousStep.current ], lang ) )
@@ -73,10 +70,6 @@ const LanguageStep: React.FunctionComponent< Props > = ( { previousStep } ) => {
 						languageGroups={ createLanguageGroups( __ ) }
 						languages={ languages }
 						onSelectLanguage={ ( language ) => {
-							// Invalidate the resolution cache for getSupportedPlans
-							// when the locale changes, to force the data for the plans grid
-							// to be fetched again, fresh from the plans/details and plans endpoints.
-							invalidateResolution( PLANS_STORE, 'getSupportedPlans', [ language.langSlug ] );
 							changeLocale( language.langSlug );
 							goBack( language.langSlug );
 						} }

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -28,8 +28,8 @@ export const getSelectedDomain = ( state: State ): DomainSuggestions.DomainSugge
 	state.domain;
 export const getSelectedPlanProductId = ( state: State ): number | undefined => state.planProductId;
 
-export const getSelectedPlan = ( state: State ): Plan | undefined =>
-	select( PLANS_STORE ).getPlanByProductId( state.planProductId );
+export const getSelectedPlan = ( state: State, locale: string ): Plan | undefined =>
+	select( PLANS_STORE ).getPlanByProductId( state.planProductId, locale );
 
 /**
  * Returns the product id of the the last paid plan the user had picked.

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -12,7 +12,6 @@ import { PLANS_STORE, STORE_KEY as LAUNCH_STORE } from './constants';
 import type { State } from './reducer';
 import type { LaunchStepType } from './types';
 import type * as DomainSuggestions from '../domain-suggestions';
-import type { Plan } from '../plans';
 
 export const getLaunchSequence = (): typeof LaunchSequence => LaunchSequence;
 export const getLaunchStep = (): typeof LaunchStep => LaunchStep;
@@ -27,9 +26,6 @@ export const hasPaidDomain = ( state: State ): boolean => {
 export const getSelectedDomain = ( state: State ): DomainSuggestions.DomainSuggestion | undefined =>
 	state.domain;
 export const getSelectedPlanProductId = ( state: State ): number | undefined => state.planProductId;
-
-export const getSelectedPlan = ( state: State, locale: string ): Plan | undefined =>
-	select( PLANS_STORE ).getPlanByProductId( state.planProductId, locale );
 
 /**
  * Returns the product id of the the last paid plan the user had picked.

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -34,14 +34,15 @@ export const getFeaturesByType = ( state: State ): Array< FeaturesByType > => st
 
 export const getPlanByProductId = (
 	_state: State,
-	productId: number | undefined
+	productId: number | undefined,
+	locale: string
 ): Plan | undefined => {
 	if ( ! productId ) {
 		return undefined;
 	}
 
 	return select( STORE_KEY )
-		.getSupportedPlans()
+		.getSupportedPlans( locale )
 		.find( ( plan ) => plan.productIds.indexOf( productId ) > -1 );
 };
 
@@ -60,13 +61,14 @@ export const getPlanProductById = (
 
 export const getPlanByPeriodAgnosticSlug = (
 	_state: State,
-	slug: PlanSlug | undefined
+	slug: PlanSlug | undefined,
+	locale: string
 ): Plan | undefined => {
 	if ( ! slug ) {
 		return undefined;
 	}
 	return select( STORE_KEY )
-		.getSupportedPlans()
+		.getSupportedPlans( locale )
 		.find( ( plan ) => plan.periodAgnosticSlug === slug );
 };
 
@@ -82,11 +84,11 @@ export const getDefaultFreePlan = ( _: State, locale: string ): Plan | undefined
 		.find( ( plan ) => plan.periodAgnosticSlug === TIMELESS_PLAN_FREE );
 };
 
-export const getSupportedPlans = ( state: State, _locale?: string ): Plan[] => {
+export const getSupportedPlans = ( state: State, _locale: string ): Plan[] => {
 	return state.plans;
 };
 
-export const getPlansProducts = ( state: State, _locale?: string ): PlanProduct[] => {
+export const getPlansProducts = ( state: State ): PlanProduct[] => {
 	return state.planProducts;
 };
 
@@ -108,7 +110,11 @@ export const getPrices = ( _state: State, _locale: string ): Record< StorePlanSl
 		}, {} as Record< StorePlanSlug, string > );
 };
 
-export const getPlanByPath = ( _state: State, path?: PlanPath ): Plan | undefined => {
+export const getPlanByPath = (
+	_state: State,
+	path: PlanPath | undefined,
+	locale: string
+): Plan | undefined => {
 	if ( ! path ) {
 		return undefined;
 	}
@@ -121,7 +127,7 @@ export const getPlanByPath = ( _state: State, path?: PlanPath ): Plan | undefine
 	}
 
 	return select( STORE_KEY )
-		.getSupportedPlans()
+		.getSupportedPlans( locale )
 		.find( ( plan ) => plan.periodAgnosticSlug === planProduct?.periodAgnosticSlug );
 };
 

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -280,6 +280,8 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 	hasPaidDomain = false,
 	selectedPaidDomain = false,
 } ) => {
+	const locale = useLocale();
+
 	const { setPlanProductId } = useDispatch( LAUNCH_STORE );
 
 	const billingPeriod = 'ANNUALLY';
@@ -293,11 +295,11 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 	);
 
 	const selectedPlan = useSelect( ( select ) =>
-		select( PLANS_STORE ).getPlanByProductId( selectedPlanProductId )
+		select( PLANS_STORE ).getPlanByProductId( selectedPlanProductId, locale )
 	);
 
 	const selectedPaidPlan = useSelect( ( select ) =>
-		select( PLANS_STORE ).getPlanByProductId( selectedPaidPlanProductId )
+		select( PLANS_STORE ).getPlanByProductId( selectedPaidPlanProductId, locale )
 	);
 
 	const { defaultPaidPlan, defaultFreePlan } = usePlans();

--- a/packages/launch/src/hooks/use-cart.ts
+++ b/packages/launch/src/hooks/use-cart.ts
@@ -3,6 +3,7 @@
  */
 import * as React from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useLocale } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -14,6 +15,7 @@ import { useSiteDomains } from '../hooks';
 
 export function useCart(): { goToCheckout: () => Promise< void > } {
 	const { siteId, flow, openCheckout } = React.useContext( LaunchContext );
+	const locale = useLocale();
 
 	const { planProductId, domain } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 
@@ -21,7 +23,9 @@ export function useCart(): { goToCheckout: () => Promise< void > } {
 		select( PLANS_STORE ).getPlanProductById( planProductId as number )
 	);
 
-	const plan = useSelect( ( select ) => select( PLANS_STORE ).getPlanByProductId( planProductId ) );
+	const plan = useSelect( ( select ) =>
+		select( PLANS_STORE ).getPlanByProductId( planProductId, locale )
+	);
 
 	const isEcommercePlan = useSelect( ( select ) =>
 		select( PLANS_STORE ).isPlanEcommerce( plan?.periodAgnosticSlug )

--- a/packages/plans-grid/src/plans-accordion/index.tsx
+++ b/packages/plans-grid/src/plans-accordion/index.tsx
@@ -73,7 +73,7 @@ const PlansAccordion: React.FunctionComponent< Props > = ( {
 	);
 
 	const recommendedPlan = useSelect( ( select ) =>
-		select( PLANS_STORE ).getPlanByPeriodAgnosticSlug( recommendedPlanSlug )
+		select( PLANS_STORE ).getPlanByPeriodAgnosticSlug( recommendedPlanSlug, locale )
 	);
 
 	const primaryPlan = recommendedPlan || popularPlan;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Defaulting to `en` locale can cause two redundant requests to `/plans` and `plans/details` endpoints. Making sure to always pass the `locale` ensures only the needed network requests are issued.

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Gutenboarding

* Open Chrome DevTools network tab.
* Go to plans grid in `https://calypso.live/new?branch=update/always-pass-locale`.
* Make sure one request to `plans/details` is issued.
* Change the language to anything else. One more request should be issued.
* Change it back. No requests should be issued.

#### Step by step launch
* Continue the gutenboarding flow and create a site with a free plan
* Sandbox that newly created site
* In `apps/editing-toolkit` run `yarn dev --sync`.
* Refresh the editor page to get the sandboxed version.
* Press "Launch" in the editor.
* In the plan step, only one request to `plans/details` should be made.

#### Focused launch
* Sandbox water656094407.wordpress.com
* In `apps/editing-toolkit` run `yarn dev --sync`.
* Go to https://water656094407.wordpress.com/wp-admin/post-new.php
* Click launch.
* One network request should be issued to `plans/details`.

Fixes: https://github.com/Automattic/wp-calypso/issues/49143