### PR TITLE
New Onboarding: re-add top bar to checkout

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -308,8 +308,7 @@ export default compose(
 		const isJetpack = isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId );
 		const isCheckoutFromGutenboarding =
 			'checkout' === sectionName && '1' === currentQuery?.preLaunch;
-		const noMasterbarForRoute =
-			isJetpackLogin || isCheckoutFromGutenboarding || currentRoute === '/me/account/closed';
+		const noMasterbarForRoute = isJetpackLogin || currentRoute === '/me/account/closed';
 		const noMasterbarForSection = [ 'signup', 'jetpack-connect' ].includes( sectionName );
 		const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();
 		const isJetpackWooCommerceFlow =


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Re-introduce top bar with back button in /checkout step after New Onboarding

<img width="976" alt="Screenshot 2021-02-01 at 22 55 17" src="https://user-images.githubusercontent.com/14192054/106517179-d2fa4100-64e0-11eb-98f1-988bad28799b.png">

#### Testing instructions

* Go to /new
* Create a site with a paid plan selected
* On /checkout page, there should be a top bar with a back button on the left
* Clicking that button should redirect to plans page in Calypso

Related to #44219
