### PR TITLE
Editing Toolkit: Update to 2.17.0

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.16
+ * Version: 2.17
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.16' );
+define( 'PLUGIN_VERSION', '2.17' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.5
 Tested up to: 5.6
-Stable tag: 2.16
+Stable tag: 2.17
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,10 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.17 =
+* Premium Content: Remove from the Editing Toolkit plugin (https://github.com/Automattic/wp-calypso/pull/49561)
+* Anchor: Gutenboarding Launch works immediately without domain or plan selection (https://github.com/Automattic/wp-calypso/pull/48938)
 
 = 2.16 =
 * Fix Global Styles Panel Font Change Update (https://github.com/Automattic/wp-calypso/pull/49216)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -41,6 +41,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 == Changelog ==
 
 = 2.17 =
+* WelcomeTour: capture mousedown event and call preventDefault on the event (https://github.com/Automattic/wp-calypso/pull/49583)
 * Premium Content: Remove from the Editing Toolkit plugin (https://github.com/Automattic/wp-calypso/pull/49561)
 * Anchor: Gutenboarding Launch works immediately without domain or plan selection (https://github.com/Automattic/wp-calypso/pull/48938)
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -44,6 +44,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * WelcomeTour: capture mousedown event and call preventDefault on the event (https://github.com/Automattic/wp-calypso/pull/49583)
 * Premium Content: Remove from the Editing Toolkit plugin (https://github.com/Automattic/wp-calypso/pull/49561)
 * Anchor: Gutenboarding Launch works immediately without domain or plan selection (https://github.com/Automattic/wp-calypso/pull/48938)
+* Editing Toolkit: Update Newspack blocks to v1.19.0 (https://github.com/Automattic/wp-calypso/pull/49493)
+* Plans store: Always pass locale to plans store (https://github.com/Automattic/wp-calypso/pull/49559)
+* Welcome Tour: Prevent clicks on Tour from bubbling up to the Block Inserter (https://github.com/Automattic/wp-calypso/pull/49583)
 
 = 2.16 =
 * Fix Global Styles Panel Font Change Update (https://github.com/Automattic/wp-calypso/pull/49216)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.16.0",
+	"version": "2.17.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bumps version of Editing Toolkit to 2.17.0

#### [Changes included in this release](https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit)

- [x] WelcomeTour: capture mousedown event and call preventDefault on the event (https://github.com/Automattic/wp-calypso/pull/49583)
- [x] Premium Content: Remove from the Editing Toolkit plugin (https://github.com/Automattic/wp-calypso/pull/49561)
- [x] Anchor: Gutenboarding Launch works immediately without domain or plan selection (https://github.com/Automattic/wp-calypso/pull/48938)
- [x] Editing Toolkit: Update Newspack blocks to v1.19.0 (#49493)
- [x] Plans Store: Always pass locale to plans (#49559)
- [x] Welcome Tour: Prevents clicks on Tour from bubbling up to the Block Inserter (#49583)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Load the diff on your sandbox and confirm that the above changes work correctly
2. Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.