### PR TITLE
Anchor Gutenboarding: Query the WPCOM backend for matching anchor sites and redir

### DIFF
--- a/client/landing/gutenboarding/hooks/use-detect-matching-anchor-site.ts
+++ b/client/landing/gutenboarding/hooks/use-detect-matching-anchor-site.ts
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { useSelect } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'calypso/lib/wp';
+import { USER_STORE } from '../stores/user';
+import { useIsAnchorFm, useAnchorFmParams } from '../path';
+
+interface AnchorEndpointResult {
+	location: string | false;
+}
+
+// useDetectMatchingAnchorSite:
+// If I'm making a new site and anchor parameters are available, check wpcom backend to
+// see if there's already a site that belongs to me that matches these parameters.
+// If it's found, redirect the browser to it
+export default function useDetectMatchingAnchorSite(): void {
+	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyUrl } = useAnchorFmParams();
+	const isAnchorFm = useIsAnchorFm();
+	const currentUserExists = useSelect( ( select ) => !! select( USER_STORE ).getCurrentUser() );
+	React.useEffect( () => {
+		// Must be a logged-in user on anchor FM to check
+		if ( ! isAnchorFm || ! currentUserExists ) {
+			return;
+		}
+
+		// Build URL to Endpoint
+		const anchorEndpointBase = '/anchor';
+		const queryParts = {
+			podcast: anchorFmPodcastId,
+			episode: anchorFmEpisodeId,
+			spotify_url: anchorFmSpotifyUrl,
+		};
+		const anchorEndpointUrl = addQueryArgs( anchorEndpointBase, queryParts );
+
+		// Hit Endpoint
+		wpcom.req
+			.get( {
+				path: anchorEndpointUrl,
+				method: 'GET',
+				apiNamespace: 'wpcom/v2',
+			} )
+			.then( ( result: AnchorEndpointResult ) => {
+				if ( result?.location ) {
+					window.location.href = result.location;
+				}
+			} );
+	}, [ isAnchorFm, currentUserExists, anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyUrl ] );
+}

--- a/client/landing/gutenboarding/hooks/use-detect-matching-anchor-site.ts
+++ b/client/landing/gutenboarding/hooks/use-detect-matching-anchor-site.ts
@@ -19,23 +19,33 @@ interface AnchorEndpointResult {
 // If I'm making a new site and anchor parameters are available, check wpcom backend to
 // see if there's already a site that belongs to me that matches these parameters.
 // If it's found, redirect the browser to it
-export default function useDetectMatchingAnchorSite(): void {
+export default function useDetectMatchingAnchorSite(): boolean {
 	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyUrl } = useAnchorFmParams();
 	const isAnchorFm = useIsAnchorFm();
 	const currentUserExists = useSelect( ( select ) => !! select( USER_STORE ).getCurrentUser() );
+	const [ isLoading, setIsLoading ] = React.useState( !! ( isAnchorFm && currentUserExists ) );
+
 	React.useEffect( () => {
 		// Must be a logged-in user on anchor FM to check
 		if ( ! isAnchorFm || ! currentUserExists ) {
+			setIsLoading( false );
 			return;
 		}
 
+		setIsLoading( true );
 		wpcom
 			.undocumented()
 			.getMatchingAnchorSite( anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyUrl )
 			.then( ( result: AnchorEndpointResult ) => {
 				if ( result?.location ) {
 					window.location.href = result.location;
+				} else {
+					setIsLoading( false );
 				}
+			} )
+			.catch( () => {
+				setIsLoading( false );
 			} );
 	}, [ isAnchorFm, currentUserExists, anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyUrl ] );
+	return isLoading;
 }

--- a/client/landing/gutenboarding/hooks/use-detect-matching-anchor-site.ts
+++ b/client/landing/gutenboarding/hooks/use-detect-matching-anchor-site.ts
@@ -3,7 +3,6 @@
  */
 import * as React from 'react';
 import { useSelect } from '@wordpress/data';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -30,22 +29,9 @@ export default function useDetectMatchingAnchorSite(): void {
 			return;
 		}
 
-		// Build URL to Endpoint
-		const anchorEndpointBase = '/anchor';
-		const queryParts = {
-			podcast: anchorFmPodcastId,
-			episode: anchorFmEpisodeId,
-			spotify_url: anchorFmSpotifyUrl,
-		};
-		const anchorEndpointUrl = addQueryArgs( anchorEndpointBase, queryParts );
-
-		// Hit Endpoint
-		wpcom.req
-			.get( {
-				path: anchorEndpointUrl,
-				method: 'GET',
-				apiNamespace: 'wpcom/v2',
-			} )
+		wpcom
+			.undocumented()
+			.getMatchingAnchorSite( anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyUrl )
 			.then( ( result: AnchorEndpointResult ) => {
 				if ( result?.location ) {
 					window.location.href = result.location;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -16,6 +16,7 @@ import VerticalSelect from './vertical-select';
 import SiteTitle from './site-title';
 import { useTrackStep } from '../../hooks/use-track-step';
 import useStepNavigation from '../../hooks/use-step-navigation';
+import useDetectMatchingAnchorSite from '../../hooks/use-detect-matching-anchor-site';
 import { recordVerticalSkip, recordSiteTitleSkip } from '../../lib/analytics';
 import Arrow from './arrow';
 import { isGoodDefaultDomainQuery } from '@automattic/domain-picker';
@@ -55,6 +56,8 @@ const AcquireIntent: React.FunctionComponent = () => {
 		selected_vertical_label: getSelectedVertical()?.label,
 		has_selected_site_title: hasSiteTitle(),
 	} ) );
+
+	useDetectMatchingAnchorSite();
 
 	const handleSkip = () => {
 		skipSiteVertical();

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -20,6 +20,7 @@ import useDetectMatchingAnchorSite from '../../hooks/use-detect-matching-anchor-
 import { recordVerticalSkip, recordSiteTitleSkip } from '../../lib/analytics';
 import Arrow from './arrow';
 import { isGoodDefaultDomainQuery } from '@automattic/domain-picker';
+import { useIsAnchorFm } from '../../path';
 
 /**
  * Style dependencies
@@ -57,7 +58,9 @@ const AcquireIntent: React.FunctionComponent = () => {
 		has_selected_site_title: hasSiteTitle(),
 	} ) );
 
-	useDetectMatchingAnchorSite();
+	// Allow Anchor Gutenboarding to check the backend for matching sites and redirect if found.
+	const isAnchorFm = useIsAnchorFm();
+	const isLookingUpMatchingAnchorSites = useDetectMatchingAnchorSite();
 
 	const handleSkip = () => {
 		skipSiteVertical();
@@ -106,6 +109,12 @@ const AcquireIntent: React.FunctionComponent = () => {
 	const siteVertical = getSelectedVertical();
 
 	const showVerticalInput = config.isEnabled( 'gutenboarding/show-vertical-input' );
+
+	// In the case of an Anchor signup, we ask the backend to see if they already
+	// have an anchor site. If we're still waiting for this response, don't show anything yet.
+	if ( isAnchorFm && isLookingUpMatchingAnchorSites ) {
+		return <div className="gutenboarding-page acquire-intent" />;
+	}
 
 	return (
 		<div className="gutenboarding-page acquire-intent">

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -14,7 +14,7 @@ import MailingList from './mailing-list';
 import config from '@automattic/calypso-config';
 import { getLanguage, getLocaleSlug } from 'calypso/lib/i18n-utils';
 import readerContentWidth from 'calypso/reader/lib/content-width';
-import { addQueryArgs } from '@wordpress/url';
+import addQueryArgs from 'calypso/lib/url/add-query-args';
 
 const debug = debugFactory( 'calypso:wpcom-undocumented:undocumented' );
 const { Blob } = globalThis; // The linter complains if I don't do this...?
@@ -2649,7 +2649,7 @@ Undocumented.prototype.getMatchingAnchorSite = function (
 		episode: anchorFmEpisodeId,
 		spotify_url: anchorFmSpotifyUrl,
 	};
-	const anchorEndpointUrl = addQueryArgs( '/anchor', queryParts );
+	const anchorEndpointUrl = addQueryArgs( queryParts, '/anchor' );
 	return this.wpcom.req.get( {
 		path: anchorEndpointUrl,
 		method: 'GET',

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -14,7 +14,6 @@ import MailingList from './mailing-list';
 import config from '@automattic/calypso-config';
 import { getLanguage, getLocaleSlug } from 'calypso/lib/i18n-utils';
 import readerContentWidth from 'calypso/reader/lib/content-width';
-import addQueryArgs from 'calypso/lib/url/add-query-args';
 
 const debug = debugFactory( 'calypso:wpcom-undocumented:undocumented' );
 const { Blob } = globalThis; // The linter complains if I don't do this...?
@@ -2649,12 +2648,14 @@ Undocumented.prototype.getMatchingAnchorSite = function (
 		episode: anchorFmEpisodeId,
 		spotify_url: anchorFmSpotifyUrl,
 	};
-	const anchorEndpointUrl = addQueryArgs( queryParts, '/anchor' );
-	return this.wpcom.req.get( {
-		path: anchorEndpointUrl,
-		method: 'GET',
-		apiNamespace: 'wpcom/v2',
-	} );
+	return this.wpcom.req.get(
+		{
+			path: '/anchor',
+			method: 'GET',
+			apiNamespace: 'wpcom/v2',
+		},
+		queryParts
+	);
 };
 
 export default Undocumented;

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -14,6 +14,7 @@ import MailingList from './mailing-list';
 import config from '@automattic/calypso-config';
 import { getLanguage, getLocaleSlug } from 'calypso/lib/i18n-utils';
 import readerContentWidth from 'calypso/reader/lib/content-width';
+import { addQueryArgs } from '@wordpress/url';
 
 const debug = debugFactory( 'calypso:wpcom-undocumented:undocumented' );
 const { Blob } = globalThis; // The linter complains if I don't do this...?
@@ -2623,6 +2624,36 @@ Undocumented.prototype.getJetpackPartnerPortalPartner = function () {
 	return this.wpcom.req.get( {
 		apiNamespace: 'wpcom/v2',
 		path: '/jetpack-licensing/partner',
+	} );
+};
+
+/**
+ * Look for a site belonging to the currently logged in user that matches the
+ * anchor parameters specified.
+ *
+ * @param anchorFmPodcastId {string | null}  Example: 22b6608
+ * @param anchorFmEpisodeId {string | null}  Example: e324a06c-3148-43a4-85d8-34c0d8222138
+ * @param anchorFmSpotifyUrl {string | null} Example: https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q
+ * @returns {Promise} A promise
+ *    The promise should resolve to a json object containing ".location" key as {string|false} type.
+ *    False - There were no matching sites detected, the user should create a new one.
+ *    String - The URL to redirect the user to, to edit a new or existing post on that site.
+ */
+Undocumented.prototype.getMatchingAnchorSite = function (
+	anchorFmPodcastId,
+	anchorFmEpisodeId,
+	anchorFmSpotifyUrl
+) {
+	const queryParts = {
+		podcast: anchorFmPodcastId,
+		episode: anchorFmEpisodeId,
+		spotify_url: anchorFmSpotifyUrl,
+	};
+	const anchorEndpointUrl = addQueryArgs( '/anchor', queryParts );
+	return this.wpcom.req.get( {
+		path: anchorEndpointUrl,
+		method: 'GET',
+		apiNamespace: 'wpcom/v2',
 	} );
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The "Gather Intent" step of anchor flavored gutenboarding now checks to see if you already have an existing anchor site matching the params, and if so, skips gutenboarding and redirects your browser there.

![2021-02-01_17-20](https://user-images.githubusercontent.com/937354/106530431-e9d56f00-64b1-11eb-826d-f360e71fa42d.png)


#### Testing instructions

* Apply D56339-code
* Start Calypso
* Part 1: New user
  * Open an incognito window and visit a "magic gutenboarding podcast url"
  * Register a new account and go through the gutenboarding process. Note the account email and password.
  * You should end up on a newly created site with anchor content in it and be the exact same as before.
* Part 2: Returning User (Already Logged In)
  * If you still have the incognito window used before that's logged in, make a new tab.  If you don't, visit http://calypso.localhost:3000 and log in to this account.
  * In your already logged in state, visit Magic Gutenboarding Podcast Urls. 
    * If you visit one for the same podcast, you should start to go through the gutenboarding process, but instead of making a new site, you're redirected to your already existing site.
    * If you visit one for a podcast you haven't made yet, you should go through the gutenboarding process again and make a second site.
* Part 3: Returning User (Not logged in, log in during Gutenboarding)
  * Close all incognito windows and open a new one, to guarantee you'll be logged out.
  * In this window, visit a magic gutenboarding podcast url.  
  * You should see the register screen.  Here, log in instead.
![2021-02-01_17-15](https://user-images.githubusercontent.com/937354/106530050-33718a00-64b1-11eb-9e2c-821a80452f16.png)
  * You should skip the gutenboarding process and be taken to your site. (If you are using gutenboarding url corresponding to an anchor podcast that you've already made a site for.)

* Magic Gutenboarding Podcast Urls
    * "Brave Not Perfect": http://calypso.localhost:3000/new?anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q&flags=anchor-fm-dev

Related to 439-gh-Automattic/dotcom-manage