### PR TITLE
Gutenboarding: Fix clicking "Create a new account" exits Anchor-ified Gutenboarding

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -169,9 +169,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 
 	const langFragment = lang ? `/${ lang }` : '';
 
-	let loginRedirectUrl = window.location.origin + '/new';
-	if ( isAnchorFmSignup ) {
-		loginRedirectUrl += `${ makePath( Step.IntentGathering ) }?new`;
+	const addAnchorQueryParts = ( url: string ): string => {
 		const queryParts = {
 			anchor_podcast: anchorFmPodcastId,
 			anchor_episode: anchorFmEpisodeId,
@@ -179,15 +177,26 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 		};
 		for ( const [ k, v ] of Object.entries( queryParts ) ) {
 			if ( v ) {
-				loginRedirectUrl += `&${ k }=${ encodeURIComponent( v ) }`;
+				url += `&${ k }=${ encodeURIComponent( v ) }`;
 			}
 		}
+		return url;
+	};
+
+	let loginRedirectUrl = window.location.origin + '/new';
+	if ( isAnchorFmSignup ) {
+		loginRedirectUrl += `${ makePath( Step.IntentGathering ) }?new`;
+		loginRedirectUrl = addAnchorQueryParts( loginRedirectUrl );
 	} else {
 		loginRedirectUrl += `${ makePath( Step.CreateSite ) }?new`;
 	}
 	loginRedirectUrl = encodeURIComponent( loginRedirectUrl );
 
-	const signupUrl = encodeURIComponent( `/new${ makePath( Step[ currentStep ] ) }?signup` );
+	let signupUrl = `/new${ makePath( Step[ currentStep ] ) }?signup`;
+	if ( isAnchorFmSignup ) {
+		signupUrl = addAnchorQueryParts( signupUrl );
+	}
+	signupUrl = encodeURIComponent( signupUrl );
 	const loginUrl = `/log-in/new${ langFragment }?redirect_to=${ loginRedirectUrl }&signup_url=${ signupUrl }`;
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds Anchor query params to the `signupUrl` on the Login page so that users are taken back to the Anchor-ified signup if they click "Create a new account" instead of logging in.
<img width="589" alt="Screen Shot 2021-02-01 at 11 49 07 AM" src="https://user-images.githubusercontent.com/1689238/106532533-5a828880-64be-11eb-8700-651214f0898a.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to 'https://calypso.localhost:3000/new?anchor_podcast=3e51070&anchor_episode=e5f332f1-a347-40d9-a79b-ce30884057e5&spotify_url=https://open.spotify.com/show/6HTZdaDHjqXKDE4acYffoD?si=EVfDYETjQCu7pasVG5D73Q'
* Click "Log in"
* Click "Create a new account"
* You should see the Anchor-ified Gutenboarding signup modal.
* Regression: test that the regular Gutenboarding signup link still works correctly.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 455-gh-Automattic/dotcom-manage