### PR TITLE
Checkout: Use ResponseCart directly for products in CompositeCheckout component

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -342,7 +342,12 @@ export default function CompositeCheckout( {
 	const {
 		canMakePayment: isApplePayAvailable,
 		isLoading: isApplePayLoading,
-	} = useIsApplePayAvailable( stripe, stripeConfiguration, !! stripeLoadingError, items );
+	} = useIsApplePayAvailable(
+		stripe,
+		stripeConfiguration,
+		!! stripeLoadingError,
+		responseCart.currency
+	);
 
 	const paymentMethodObjects = useCreatePaymentMethods( {
 		isStripeLoading,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -365,7 +365,7 @@ export default function CompositeCheckout( {
 	// changing them because it can cause awkward UX. Here we try to wait for
 	// them to be all finished loading before we pass them along.
 	const arePaymentMethodsLoading =
-		items.length < 1 ||
+		responseCart.products.length < 1 ||
 		isInitialCartLoading ||
 		// Only wait for stored cards to load if we are using cards
 		( allowedPaymentMethods.includes( 'card' ) && isLoadingStoredCards ) ||

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -16,7 +16,8 @@ import {
 	Button,
 } from '@automattic/composite-checkout';
 import { ThemeProvider } from 'emotion-theming';
-import { useShoppingCart, ResponseCart } from '@automattic/shopping-cart';
+import { useShoppingCart } from '@automattic/shopping-cart';
+import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 import colorStudio from '@automattic/color-studio';
 import { useStripe } from '@automattic/calypso-stripe';
 
@@ -79,7 +80,6 @@ import {
 } from './types/wpcom-store-state';
 import { StoredCard } from './types/stored-cards';
 import { CountryListItem } from './types/country-list-item';
-import { WPCOMCartItem } from './types/checkout-cart';
 import doesValueExist from './lib/does-value-exist';
 import EmptyCart from './components/empty-cart';
 import getContactDetailsType from './lib/get-contact-details-type';
@@ -391,7 +391,7 @@ export default function CompositeCheckout( {
 
 	const getItemVariants = useProductVariants( {
 		siteId,
-		productSlug: getPlanProductSlugs( items )[ 0 ],
+		productSlug: getPlanProductSlugs( responseCart.products )[ 0 ],
 	} );
 
 	const { analyticsPath, analyticsProps } = getAnalyticsPath(
@@ -665,12 +665,12 @@ export default function CompositeCheckout( {
 	);
 }
 
-function getPlanProductSlugs( items: WPCOMCartItem[] ): string[] {
+function getPlanProductSlugs( items: ResponseCartProduct[] ): string[] {
 	return items
 		.filter( ( item ) => {
-			return item.type !== 'tax' && getPlan( item.wpcom_meta.product_slug );
+			return getPlan( item.product_slug );
 		} )
-		.map( ( item ) => item.wpcom_meta.product_slug );
+		.map( ( item ) => item.product_slug );
 }
 
 function getAnalyticsPath(

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -70,7 +70,6 @@ import useAddProductsFromUrl from './hooks/use-add-products-from-url';
 import useDetectedCountryCode from './hooks/use-detected-country-code';
 import WPCheckout from './components/wp-checkout';
 import { useWpcomStore } from './hooks/wpcom-store';
-import { areDomainsInLineItems } from './hooks/has-domains';
 import {
 	emptyManagedContactDetails,
 	applyContactDetailsRequiredMask,
@@ -263,11 +262,13 @@ export default function CompositeCheckout( {
 		return url;
 	}, [ getThankYouUrlBase, recordEvent ] );
 
+	const contactDetailsType = getContactDetailsType( responseCart );
+
 	useWpcomStore(
 		registerStore,
 		applyContactDetailsRequiredMask(
 			emptyManagedContactDetails,
-			areDomainsInLineItems( items ) ? domainRequiredContactDetails : taxRequiredContactDetails
+			contactDetailsType === 'domain' ? domainRequiredContactDetails : taxRequiredContactDetails
 		),
 		updateContactDetailsCache
 	);
@@ -432,7 +433,6 @@ export default function CompositeCheckout( {
 		[ addProductsToCart, products, recordEvent ]
 	);
 
-	const contactDetailsType = getContactDetailsType( responseCart );
 	const includeDomainDetails = contactDetailsType === 'domain';
 	const includeGSuiteDetails = contactDetailsType === 'gsuite';
 	const transactionOptions = { createUserAndSiteBeforeTransaction };

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -323,7 +323,7 @@ export default function CompositeCheckout( {
 	const doNotRedirect = isInitialCartLoading || isCartPendingUpdate || areThereErrors;
 	const areWeRedirecting = useRedirectIfCartEmpty(
 		doNotRedirect,
-		items,
+		responseCart.products,
 		cartEmptyRedirectUrl,
 		createUserAndSiteBeforeTransaction
 	);

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -546,13 +546,13 @@ export default function CompositeCheckout( {
 		isInitialCartLoading ||
 		arePaymentMethodsLoading ||
 		paymentMethods.length < 1 ||
-		items.length < 1;
+		responseCart.products.length < 1;
 	if ( isLoading ) {
 		debug( 'still loading because one of these is true', {
 			isInitialCartLoading,
 			paymentMethods: paymentMethods.length < 1,
 			arePaymentMethodsLoading: arePaymentMethodsLoading,
-			items: items.length < 1,
+			items: responseCart.products.length < 1,
 		} );
 	}
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useEffect, useState } from 'react';
-import type { LineItem } from '@automattic/composite-checkout';
 import type { Stripe, StripeConfiguration } from '@automattic/calypso-stripe';
 import debugFactory from 'debug';
 
@@ -27,7 +26,7 @@ export default function useIsApplePayAvailable(
 	stripe: Stripe | null,
 	stripeConfiguration: StripeConfiguration | null,
 	isStripeError: boolean,
-	items: LineItem[]
+	currency: string | null
 ): CanMakePaymentState {
 	const [ canMakePayment, setCanMakePayment ] = useState< CanMakePaymentState >( {
 		isLoading: true,
@@ -101,10 +100,6 @@ export default function useIsApplePayAvailable(
 			}
 		}
 
-		const currency = items.reduce(
-			( firstCurrency, item ) => firstCurrency || item.amount.currency,
-			null
-		);
 		const paymentRequestOptions = {
 			requestPayerName: true,
 			requestPayerPhone: false,
@@ -131,7 +126,7 @@ export default function useIsApplePayAvailable(
 		} );
 
 		return unsubscribe;
-	}, [ canMakePayment, stripe, items, stripeConfiguration, isStripeError ] );
+	}, [ canMakePayment, stripe, currency, stripeConfiguration, isStripeError ] );
 
 	debug( 'useIsApplePayAvailable', canMakePayment );
 	return canMakePayment;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-stored-cards.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-stored-cards.ts
@@ -3,7 +3,7 @@
  */
 import { useReducer, useEffect } from 'react';
 import debugFactory from 'debug';
-import { useTranslate, TranslateResult } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -15,12 +15,12 @@ const debug = debugFactory( 'calypso:composite-checkout:use-stored-cards' );
 export interface StoredCardState {
 	storedCards: StoredCard[];
 	isLoading: boolean;
-	error: string | TranslateResult | null;
+	error: string | null;
 }
 
 type StoredCardAction =
 	| { type: 'FETCH_END'; payload: StoredCard[] }
-	| { type: 'FETCH_ERROR'; payload: string | TranslateResult };
+	| { type: 'FETCH_ERROR'; payload: string };
 
 export default function useStoredCards(
 	getStoredCards: () => StoredCard[],
@@ -46,7 +46,7 @@ export default function useStoredCards(
 		fetchStoredCards()
 			.then( ( cards ) => {
 				if ( ! Array.isArray( cards ) ) {
-					const payload = translate( 'There was a problem loading your stored cards.' );
+					const payload = String( translate( 'There was a problem loading your stored cards.' ) );
 					debug( 'stored cards response is not an array', cards );
 					isSubscribed && dispatch( { type: 'FETCH_ERROR', payload } );
 					return;
@@ -62,7 +62,7 @@ export default function useStoredCards(
 		return () => {
 			isSubscribed = false;
 		};
-	}, [ getStoredCards, isLoggedOutCart ] );
+	}, [ getStoredCards, isLoggedOutCart, translate ] );
 
 	if ( isLoggedOutCart ) {
 		return { ...state, isLoading: false };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `CompositeCheckout` component has a number of decisions to make based on the products in the cart. The cart returns those products as objects of the type `ResponseCartProduct`. 

The `CheckoutProvider` wrapper used by `CompositeCheckout` has the option to pass in line items for use by its children, but they must be of the type `LineItem`, so `CompositeCheckout` uses a translation function to transform each product into a `LineItem` and then uses those line items to make its various decisions before passing them along. Over time, `LineItem` has been proven insufficient for the number of variables needed by checkout in calypso, so we extended it to create `WPCOMCartItem` which allows holding more of the properties of `ResponseCartProduct`.

However, it turns out that we don't need `WPCOMCartItem` at all since we already have access to the `ResponseCartProduct` objects (and in fact, since these predate the current version of calypso there's already plenty of utilities to deal with them). 

In this PR we replace all uses of `WPCOMCartItem` in the `CompositeCheckout` component with the raw `ResponseCartProduct` except for the data passed into `CheckoutProvider`. That data should also be removed, but first we'll need to replace all its other uses so for now we leave it intact.

#### Testing instructions

1. Add just a plan to your cart and visit checkout.
1. Verify that checkout loads.
1. Edit the contact form. Verify that all the fields are required and that leaving them blank will not let you continue.
1. Edit the order step and verify that you can change plan variants successfully.
1. Repeat steps 1-3 with a domain in your cart.