### PR TITLE
WelcomeTour: capture mousedown event and call preventDefault on the event

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
@@ -82,8 +82,17 @@ function WelcomeTourFrame() {
 	// Preload card images
 	cardContent.forEach( ( card ) => ( new window.Image().src = card.imgSrc ) );
 
+	// Some editor menus close when they lose focus (onblur), but when the tour is open or minimized the user should
+	// be able to interact with menus (ex: the Block Inserter). To make that happen we capture the onMouseDown event
+	const captureWelcomeTourFrameClick = ( e ) => {
+		e.preventDefault();
+	};
+
 	return (
-		<div className="wpcom-editor-welcome-tour-frame">
+		<div
+			className="wpcom-editor-welcome-tour-frame"
+			onMouseDownCapture={ captureWelcomeTourFrameClick }
+		>
 			{ ! isMinimized ? (
 				<WelcomeTourCard
 					cardContent={ cardContent[ currentCardIndex ] }


### PR DESCRIPTION
The Welcome Tour component ( a tutorial guide aka Welcome Guide) is meant to stay on top of the editor and allow the user to interact with the editor.  One hickup discovered is that when the Block Inserter panel was open, clicking on the Tour closed the Inserter Panel, which is probably not the best experience for the user (having the Tour open implies the user is trying to learn something from the Tour slides).  The change in the PR prevents click from the Tour from bubbling up to the Block Inserter panel.

Prior work & discussion: https://github.com/Automattic/wp-calypso/pull/49507



#### Changes proposed in this Pull Request

* WelcomeTour: capture mousedown event and call preventDefault on the event in the WelcomeTourFrame div to prevent the onblur event from firing in other areas of the UI (e.g. the Block Inserter panel)

https://stackoverflow.com/questions/17769005/onclick-and-onblur-ordering-issue was helpful.

Interestingly https://developer.wordpress.org/block-editor/components/isolated-event-container/ claims it captures and prevents propagation of mousedown events, but using that as a wrapper div in `WelcomeTourFrame` didn't solve the issue (the Block Inserter panel still closed).

#### Testing instructions

Set the currently running experiment to variant OR add `define( 'SHOW_WELCOME_TOUR', true );` to sandbox-0.php

Before each test, reset your NUX status, clear your Application data (local storage and IndexDB) and enable the NUX tour in your user meta/attributes in wpsh;

How to reset your NUX status:
echo update_user_meta( [YOUR_USER_ID], 'wpcom_block_editor_nux_status', 'enabled' );
echo update_user_attribute( [YOU_USER_ID], 'wpcom-block-editor-preferences', [ 'nux-status' => 'enabled' ] );

This ensures the NUX modal will popup.

* Open editor
* If Welcome Tour doesn't pop up, open it from Editor Options Menu
* Click [+] to open Block Inserter
* Click anywhere on Tour
* Block Inserter should **stay open**
* Click anywhere in editor, Block Inserter should close, Welcome Tour should remain as-is
