### PR TITLE
ci(docker): Copy composer utils from cache image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -121,7 +121,7 @@ ENTRYPOINT [ "/bin/bash" ]
 FROM base as ci-wpcom
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
-COPY --from=builder --chown=$UID /calypso/composer.* /calypso/
+COPY --from=cache --chown=$UID /calypso/composer.* /calypso/
 
 RUN apt update &&\
 	apt-get install -y apt-transport-https zip &&\


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Copy composer files from `cache` image.

The image was renamed from `builder` to `cache` in #49532, but I forgot to update this `COPY` instruction

