### PR TITLE
Remove links to manifest.js in dev mode

### DIFF
--- a/client/document/domains-landing.jsx
+++ b/client/document/domains-landing.jsx
@@ -98,12 +98,7 @@ function DomainsLanding( {
 				 * this lets us have the performance benefit in prod, without breaking HMR in dev
 				 * since the manifest needs to be updated on each save
 				 */ }
-				{ env === 'development' && (
-					<>
-						<script src="/calypso/evergreen/manifest.js" />
-						<script src="/calypso/evergreen/runtime.js" />
-					</>
-				) }
+				{ env === 'development' && <script src="/calypso/evergreen/runtime.js" /> }
 				{ env !== 'development' &&
 					manifests.map( ( manifest ) => (
 						<script

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -203,12 +203,7 @@ class Document extends React.Component {
 					 * this lets us have the performance benefit in prod, without breaking HMR in dev
 					 * since the manifest needs to be updated on each save
 					 */ }
-					{ env === 'development' && (
-						<>
-							<script src={ `/calypso/${ target }/manifest.js` } />
-							<script src={ `/calypso/${ target }/runtime.js` } />
-						</>
-					) }
+					{ env === 'development' && <script src={ `/calypso/${ target }/runtime.js` } /> }
 					{ env !== 'development' &&
 						manifests.map( ( manifest ) => (
 							<script


### PR DESCRIPTION
After we disabled the `ExtractManifestPlugin` in #49333, we also need to remove the `<script>` tag that requests the `manifest.js` file in dev mode. That script doesn't exist any more. There's just one `runtime.js`.

Fixes console errors like this one:

<img width="677" alt="Screenshot 2021-02-02 at 10 28 02" src="https://user-images.githubusercontent.com/664258/106580174-e25da680-6541-11eb-8269-65639fefb668.png">

The PR reverts a small part of #44988 that added the `manifest.js` links to dev mode when the extraction plugin was originally added.

**How to test:**
Just run `yarn start` and verify the above error gets fixed with this patch.
