### PR TITLE
Plans data-store: refactor unit tests and fix TypeScript errors

### DIFF
--- a/packages/data-stores/src/plans/actions.ts
+++ b/packages/data-stores/src/plans/actions.ts
@@ -3,42 +3,58 @@
  */
 import type { Plan, PlanFeature, FeaturesByType, PlanProduct } from './types';
 
-export const setFeatures = ( features: Record< string, PlanFeature >, locale: string ) => {
-	return {
-		type: 'SET_FEATURES' as const,
-		features,
-		locale,
-	};
+type setFeaturesAction = {
+	type: 'SET_FEATURES';
+	features: Record< string, PlanFeature >;
+	locale: string;
 };
+export const setFeatures = (
+	features: Record< string, PlanFeature >,
+	locale: string
+): setFeaturesAction => ( {
+	type: 'SET_FEATURES' as const,
+	features,
+	locale,
+} );
 
-export const setFeaturesByType = ( featuresByType: Array< FeaturesByType >, locale: string ) => {
-	return {
-		type: 'SET_FEATURES_BY_TYPE' as const,
-		featuresByType,
-		locale,
-	};
+type setFeaturesByTypeAction = {
+	type: 'SET_FEATURES_BY_TYPE';
+	featuresByType: Array< FeaturesByType >;
+	locale: string;
 };
+export const setFeaturesByType = (
+	featuresByType: Array< FeaturesByType >,
+	locale: string
+): setFeaturesByTypeAction => ( {
+	type: 'SET_FEATURES_BY_TYPE' as const,
+	featuresByType,
+	locale,
+} );
 
-export const setPlans = ( plans: Plan[], locale: string ) => {
-	return {
-		type: 'SET_PLANS' as const,
-		plans,
-		locale,
-	};
+type setPlansAction = {
+	type: 'SET_PLANS';
+	plans: Plan[];
+	locale: string;
 };
+export const setPlans = ( plans: Plan[], locale: string ): setPlansAction => ( {
+	type: 'SET_PLANS' as const,
+	plans,
+	locale,
+} );
 
-export const setPlanProducts = ( products: PlanProduct[] ) => {
-	return {
-		type: 'SET_PLAN_PRODUCTS' as const,
-		products,
-	};
+type setPlanProductsAction = {
+	type: 'SET_PLAN_PRODUCTS';
+	products: PlanProduct[];
 };
+export const setPlanProducts = ( products: PlanProduct[] ): setPlanProductsAction => ( {
+	type: 'SET_PLAN_PRODUCTS' as const,
+	products,
+} );
 
-export const resetPlan = () => {
-	return {
-		type: 'RESET_PLAN' as const,
-	};
-};
+type resetPlanAction = { type: 'RESET_PLAN' };
+export const resetPlan = (): resetPlanAction => ( {
+	type: 'RESET_PLAN' as const,
+} );
 
 export type PlanAction = ReturnType<
 	| typeof setFeatures
@@ -46,4 +62,5 @@ export type PlanAction = ReturnType<
 	| typeof setPlans
 	| typeof resetPlan
 	| typeof setPlanProducts
+	| ( () => { type: 'NOOP' } )
 >;

--- a/packages/data-stores/src/plans/mock/mock-constants.ts
+++ b/packages/data-stores/src/plans/mock/mock-constants.ts
@@ -1,0 +1,474 @@
+/**
+ * Internal dependencies
+ */
+import type {
+	Plan,
+	PlanProduct,
+	FeaturesByType,
+	PlanSimplifiedFeature,
+	PricedAPIPlan,
+	DetailsAPIResponse,
+} from '../types';
+
+// Features
+
+// Feature details
+
+export const MOCK_FEATURE_CUSTOM_DOMAIN = {
+	id: 'custom-domain',
+	name: 'Free domain for One Year',
+	description:
+		'Get a free domain for one year. Premium domains not included. Your domain will renew at its regular price.',
+};
+
+export const MOCK_FEATURE_LIVE_SUPPORT = {
+	id: 'support-live',
+	name: 'Live chat support',
+	description:
+		'High quality support to help you get your website up and running and working how you want it.',
+};
+export const MOCK_FEATURE_PRIORITY_SUPPORT = {
+	id: 'priority-support',
+	name: '24/7 Priority live chat support',
+	description: 'Receive faster support from our WordPress experts - weekends included.',
+};
+
+export const MOCK_FEATURE_RECURRING_PAYMENTS = {
+	id: 'recurring-payments',
+	name: 'Sell subscriptions (recurring payments)',
+	description: 'Accept one-time, monthly or annual payments on your website.',
+};
+
+export const MOCK_FEATURE_WORDADS = {
+	id: 'wordads',
+	name: 'WordAds',
+	description: 'Put your site to work and earn through ad revenue.',
+};
+
+// Features by type
+
+export const MOCK_FEATURES_BY_TYPE_GENERAL: FeaturesByType = {
+	id: 'general',
+	name: null,
+	features: [
+		MOCK_FEATURE_CUSTOM_DOMAIN.id,
+		MOCK_FEATURE_LIVE_SUPPORT.id,
+		MOCK_FEATURE_PRIORITY_SUPPORT.id,
+	],
+};
+
+export const MOCK_FEATURES_BY_TYPE_COMMERCE: FeaturesByType = {
+	id: 'commerce',
+	name: 'Commerce',
+	features: [ MOCK_FEATURE_RECURRING_PAYMENTS.id ],
+};
+
+export const MOCK_FEATURES_BY_TYPE_MARKETING: FeaturesByType = {
+	id: 'marketing',
+	name: 'Marketing',
+	features: [ MOCK_FEATURE_WORDADS.id ],
+};
+
+export const MOCK_SIMPLIFIED_FEATURE_CUSTOM_DOMAIN: PlanSimplifiedFeature = {
+	name: MOCK_FEATURE_CUSTOM_DOMAIN.name,
+	requiresAnnuallyBilledPlan: true,
+};
+
+export const MOCK_SIMPLIFIED_FEATURE_LIVE_SUPPORT: PlanSimplifiedFeature = {
+	name: MOCK_FEATURE_LIVE_SUPPORT.name,
+	requiresAnnuallyBilledPlan: true,
+};
+
+export const MOCK_SIMPLIFIED_FEATURE_PRIORITY_SUPPORT: PlanSimplifiedFeature = {
+	name: MOCK_FEATURE_PRIORITY_SUPPORT.name,
+	requiresAnnuallyBilledPlan: false,
+};
+
+// Free
+// TODO: path_slug doesn't exist on monthly and free plans
+export const MOCK_PLAN_PRICE_APIS_FREE: PricedAPIPlan = {
+	product_id: 1,
+	product_name: 'WordPress.com Free',
+	meta: null,
+	prices: {
+		USD: 0,
+		AUD: 0,
+		CAD: 0,
+		EUR: 0,
+		GBP: 0,
+		JPY: 0,
+		BRL: 0,
+		PHP: 0,
+		IDR: 0,
+		MXN: 0,
+		NZD: 0,
+		INR: 0,
+		ILS: 0,
+		RUB: 0,
+		SEK: 0,
+		HUF: 0,
+		CHF: 0,
+		CZK: 0,
+		DKK: 0,
+		HKD: 0,
+		NOK: 0,
+		PLN: 0,
+		SGD: 0,
+		TWD: 0,
+		THB: 0,
+		TRY: 0,
+	},
+	cost: 0,
+	blog_id: null,
+	product_slug: 'free_plan',
+	description: '',
+	bill_period: -1,
+	product_type: 'bundle',
+	available: 'yes',
+	multi: 0,
+	bd_slug: 'wp-free-plan',
+	bd_variation_slug: 'wp-bundles',
+	outer_slug: null,
+	extra: null,
+	capability: 'manage_options',
+	product_name_short: 'Free',
+	icon: 'https://s0.wordpress.com/i/store/plan-free.png',
+	icon_active: 'https://s0.wordpress.com/i/store/plan-free-active.png',
+	cost__from_plan: 0,
+	currency__from_plan: 'EUR',
+	initial_cost_matched: true,
+	bill_period_label: 'for life',
+	price: '€0',
+	formatted_price: '€0',
+	raw_price: 0,
+	tagline: 'Perfect for anyone creating a basic blog or site',
+	currency_code: 'EUR',
+	features_highlight: [
+		{
+			items: [ 'free-blog', 'space', 'support' ],
+		},
+	],
+};
+
+export const MOCK_PLAN_FREE: Plan = {
+	description: 'Mock free plan',
+	features: [
+		{
+			name: 'Free plan highlighted feature',
+			requiresAnnuallyBilledPlan: false,
+		},
+	],
+	storage: '3 GB',
+	title: 'Free',
+	featuresSlugs: {
+		subdomain: true,
+	},
+	isFree: true,
+	isPopular: false,
+	periodAgnosticSlug: 'free',
+	productIds: [ 1 ],
+};
+
+export const MOCK_PLAN_PRODUCT_FREE: PlanProduct = {
+	productId: 1,
+	billingPeriod: 'ANNUALLY',
+	periodAgnosticSlug: 'free',
+	storeSlug: 'free_plan',
+	rawPrice: 0,
+	pathSlug: 'free',
+	price: '€0',
+	annualPrice: '€0',
+};
+
+// Premium
+
+export const MOCK_PLAN_PREMIUM: Plan = {
+	description: 'Mock premium plan',
+	features: [
+		{
+			name: MOCK_FEATURE_CUSTOM_DOMAIN.name,
+			requiresAnnuallyBilledPlan: true,
+		},
+		{
+			name: MOCK_FEATURE_LIVE_SUPPORT.name,
+			requiresAnnuallyBilledPlan: true,
+		},
+		{
+			name: 'Premium plan highlighted feature',
+			requiresAnnuallyBilledPlan: false,
+		},
+	],
+	storage: '13 GB',
+	title: 'Premium',
+	featuresSlugs: {
+		'custom-domain': true,
+		'support-live': true,
+		'recurring-payments': true,
+		wordads: true,
+	},
+	isFree: false,
+	isPopular: true,
+	periodAgnosticSlug: 'premium',
+	productIds: [ 1003, 1013 ],
+};
+
+export const MOCK_PLAN_PRICE_APIS_PREMIUM_ANNUALLY: PricedAPIPlan = {
+	product_id: 1003,
+	product_name: 'WordPress.com Premium',
+	meta: null,
+	prices: {
+		USD: 96,
+		AUD: 120,
+		CAD: 120,
+		JPY: 10800,
+		EUR: 96,
+		GBP: 84,
+		BRL: 312,
+		HUF: 27000,
+		MXN: 1620,
+		NZD: 120,
+		RUB: 6600,
+		ILS: 336,
+		SEK: 840,
+		INR: 4200,
+		PHP: 4992,
+		PLN: 399,
+		CHF: 96,
+		CZK: 2280,
+		DKK: 624,
+		TWD: 2880,
+		THB: 3348,
+		HKD: 756,
+		NOK: 840,
+		SGD: 132,
+		IDR: 1072800,
+		TRY: 299,
+	},
+	cost: 96,
+	blog_id: null,
+	path_slug: 'premium',
+	product_slug: 'value_bundle',
+	description: '',
+	bill_period: 365,
+	product_type: 'bundle',
+	available: 'yes',
+	multi: 0,
+	bd_slug: 'wp-bundles',
+	bd_variation_slug: 'wp-value-bundle',
+	outer_slug: null,
+	extra: '',
+	capability: 'manage_options',
+	product_name_short: 'Premium',
+	icon: 'https://s0.wordpress.com/i/store/plan-premium.png',
+	icon_active: 'https://s0.wordpress.com/i/store/plan-premium-active.png',
+	bundle_product_ids: [
+		9,
+		12,
+		45,
+		15,
+		5,
+		49,
+		50,
+		6,
+		46,
+		54,
+		56,
+		57,
+		58,
+		59,
+		60,
+		62,
+		63,
+		64,
+		65,
+		66,
+		67,
+		68,
+		72,
+		73,
+		74,
+		76,
+		75,
+		16,
+	],
+	cost__from_plan: 96,
+	currency__from_plan: 'EUR',
+	initial_cost_matched: true,
+	bill_period_label: 'per year',
+	price: '€96',
+	formatted_price: '€96',
+	raw_price: 96,
+	tagline: 'Perfect for bloggers, creatives, and other professionals',
+	currency_code: 'EUR',
+	features_highlight: [
+		{
+			items: [
+				'custom-design',
+				'videopress',
+				'support',
+				'space',
+				'custom-domain',
+				'no-adverts/no-adverts.php',
+			],
+		},
+		{
+			title: 'Included with all plans',
+			items: [ 'free-blog' ],
+		},
+	],
+};
+
+export const MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY: PlanProduct = {
+	productId: 1003,
+	billingPeriod: 'ANNUALLY',
+	periodAgnosticSlug: 'premium',
+	storeSlug: 'value_bundle',
+	rawPrice: 96,
+	pathSlug: 'premium',
+	price: '€8',
+	annualPrice: '€96',
+	annualDiscount: 43,
+};
+
+// TODO: path_slug doesn't exist on monthly plans
+export const MOCK_PLAN_PRICE_APIS_PREMIUM_MONTHLY: PricedAPIPlan = {
+	product_id: 1013,
+	product_name: 'WordPress.com Premium',
+	meta: null,
+	prices: {
+		USD: 14,
+		IDR: 89400,
+		JPY: 1248,
+		EUR: 14,
+		GBP: 12.6,
+		BRL: 49.7,
+		NZD: 20.3,
+		AUD: 20.3,
+		CAD: 18.9,
+		INR: 980,
+		ILS: 53.2,
+		RUB: 910,
+		MXN: 280,
+		SEK: 154,
+		HUF: 4550,
+		CHF: 14,
+		CZK: 336,
+		DKK: 101.5,
+		HKD: 112,
+		NOK: 140,
+		PHP: 770,
+		PLN: 56,
+		SGD: 21,
+		TWD: 448,
+		THB: 490,
+		TRY: 77,
+	},
+	cost: 14,
+	blog_id: null,
+	product_slug: 'value_bundle_monthly',
+	description: '',
+	bill_period: 31,
+	product_type: 'bundle',
+	available: 'yes',
+	multi: 0,
+	bd_slug: 'wp-bundles',
+	bd_variation_slug: 'wp-value-bundle-monthly',
+	outer_slug: null,
+	extra: null,
+	capability: 'manage_options',
+	product_name_short: 'Premium',
+	bundle_product_ids: [ 9, 12, 45, 15, 6, 16, 49, 50 ],
+	cost__from_plan: 14,
+	currency__from_plan: 'EUR',
+	initial_cost_matched: true,
+	bill_period_label: 'per month',
+	price: '€14',
+	formatted_price: '€14',
+	raw_price: 14,
+	tagline: null,
+	currency_code: 'EUR',
+};
+
+// TODO: path_slug doesn't exist on monthly plans
+export const MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY: PlanProduct = {
+	productId: 1013,
+	billingPeriod: 'MONTHLY',
+	periodAgnosticSlug: 'premium',
+	storeSlug: 'value_bundle_monthly',
+	rawPrice: 14,
+	price: '€14',
+	annualPrice: '€168',
+	annualDiscount: 43,
+};
+
+// Plan details APIs
+
+export const MOCK_PLAN_DETAILS_API: DetailsAPIResponse = {
+	groups: [
+		{
+			slug: 'personal',
+			name: 'Personal',
+		},
+	],
+	plans: [
+		{
+			support_priority: 1,
+			support_name: 'free',
+			groups: [ 'personal' ],
+			products: [
+				{
+					plan_id: 1,
+				},
+			],
+			name: 'WordPress.com Free',
+			short_name: 'Free',
+			nonlocalized_short_name: 'Free',
+			tagline: 'Mock free plan',
+			description:
+				'If you just want to start creating, get a free site and be on your way to publishing in less than five minutes.',
+			features: [ 'subdomain' ],
+			highlighted_features: [ 'Free plan highlighted feature' ],
+			storage: '3 GB',
+			icon: 'https://s0.wordpress.com/i/store/mobile/plans-free.png',
+		},
+		{
+			support_priority: 4,
+			support_name: 'premium',
+			groups: [ 'business' ],
+			products: [
+				{
+					plan_id: 1003,
+				},
+				{
+					plan_id: 1013,
+				},
+			],
+			name: 'WordPress.com Premium',
+			short_name: 'Premium',
+			nonlocalized_short_name: 'Premium',
+			tagline: 'Mock premium plan',
+			description:
+				'Build a unique website with advanced design tools, CSS editing, lots of space for audio and video, and the ability to monetize your site with ads.',
+			features: [ 'custom-domain', 'support-live', 'recurring-payments', 'wordads' ],
+			highlighted_features: [
+				MOCK_FEATURE_CUSTOM_DOMAIN.name,
+				MOCK_FEATURE_LIVE_SUPPORT.name,
+				'Premium plan highlighted feature',
+			],
+			storage: '13 GB',
+			icon: 'https://s0.wordpress.com/i/store/mobile/plans-premium.png',
+		},
+	],
+	features_by_type: [
+		MOCK_FEATURES_BY_TYPE_GENERAL,
+		MOCK_FEATURES_BY_TYPE_COMMERCE,
+		MOCK_FEATURES_BY_TYPE_MARKETING,
+	],
+	features: [
+		MOCK_FEATURE_CUSTOM_DOMAIN,
+		MOCK_FEATURE_LIVE_SUPPORT,
+		MOCK_FEATURE_PRIORITY_SUPPORT,
+		MOCK_FEATURE_RECURRING_PAYMENTS,
+		MOCK_FEATURE_WORDADS,
+	],
+};

--- a/packages/data-stores/src/plans/mock/mock-constants.ts
+++ b/packages/data-stores/src/plans/mock/mock-constants.ts
@@ -10,17 +10,29 @@ import type {
 	DetailsAPIResponse,
 } from '../types';
 
-// Features
+/**
+ * This file contains mock data for the plans data-store unit tests.
+ * There 2 main sections:
+ * - APIs: mocks of the data returned by the REST APIs
+ * - Data-store objects: mocks of the objects that are created by the
+ *   data-store's resolvers when reading/transforming plan APIs data
+ *
+ * For the sake of testing, only a few plans are mocked:
+ * - Free plan
+ * - Premium plan (annually and monthly billed)
+ */
 
-// Feature details
+//==============================================================================
+// APIs
+//==============================================================================
 
+// Individual Features
 export const MOCK_FEATURE_CUSTOM_DOMAIN = {
 	id: 'custom-domain',
 	name: 'Free domain for One Year',
 	description:
 		'Get a free domain for one year. Premium domains not included. Your domain will renew at its regular price.',
 };
-
 export const MOCK_FEATURE_LIVE_SUPPORT = {
 	id: 'support-live',
 	name: 'Live chat support',
@@ -32,21 +44,18 @@ export const MOCK_FEATURE_PRIORITY_SUPPORT = {
 	name: '24/7 Priority live chat support',
 	description: 'Receive faster support from our WordPress experts - weekends included.',
 };
-
 export const MOCK_FEATURE_RECURRING_PAYMENTS = {
 	id: 'recurring-payments',
 	name: 'Sell subscriptions (recurring payments)',
 	description: 'Accept one-time, monthly or annual payments on your website.',
 };
-
 export const MOCK_FEATURE_WORDADS = {
 	id: 'wordads',
 	name: 'WordAds',
 	description: 'Put your site to work and earn through ad revenue.',
 };
 
-// Features by type
-
+// Feature groups (by type)
 export const MOCK_FEATURES_BY_TYPE_GENERAL: FeaturesByType = {
 	id: 'general',
 	name: null,
@@ -56,36 +65,90 @@ export const MOCK_FEATURES_BY_TYPE_GENERAL: FeaturesByType = {
 		MOCK_FEATURE_PRIORITY_SUPPORT.id,
 	],
 };
-
 export const MOCK_FEATURES_BY_TYPE_COMMERCE: FeaturesByType = {
 	id: 'commerce',
 	name: 'Commerce',
 	features: [ MOCK_FEATURE_RECURRING_PAYMENTS.id ],
 };
-
 export const MOCK_FEATURES_BY_TYPE_MARKETING: FeaturesByType = {
 	id: 'marketing',
 	name: 'Marketing',
 	features: [ MOCK_FEATURE_WORDADS.id ],
 };
 
-export const MOCK_SIMPLIFIED_FEATURE_CUSTOM_DOMAIN: PlanSimplifiedFeature = {
-	name: MOCK_FEATURE_CUSTOM_DOMAIN.name,
-	requiresAnnuallyBilledPlan: true,
+// All plans details (from APIs)
+export const MOCK_PLAN_DETAILS_API: DetailsAPIResponse = {
+	groups: [
+		{
+			slug: 'personal',
+			name: 'Personal',
+		},
+	],
+	plans: [
+		{
+			support_priority: 1,
+			support_name: 'free',
+			groups: [ 'personal' ],
+			products: [
+				{
+					plan_id: 1,
+				},
+			],
+			name: 'WordPress.com Free',
+			short_name: 'Free',
+			nonlocalized_short_name: 'Free',
+			tagline: 'Mock free plan',
+			description:
+				'If you just want to start creating, get a free site and be on your way to publishing in less than five minutes.',
+			features: [ 'subdomain' ],
+			highlighted_features: [ 'Free plan highlighted feature' ],
+			storage: '3 GB',
+			icon: 'https://s0.wordpress.com/i/store/mobile/plans-free.png',
+		},
+		{
+			support_priority: 4,
+			support_name: 'premium',
+			groups: [ 'business' ],
+			products: [
+				{
+					plan_id: 1003,
+				},
+				{
+					plan_id: 1013,
+				},
+			],
+			name: 'WordPress.com Premium',
+			short_name: 'Premium',
+			nonlocalized_short_name: 'Premium',
+			tagline: 'Mock premium plan',
+			description:
+				'Build a unique website with advanced design tools, CSS editing, lots of space for audio and video, and the ability to monetize your site with ads.',
+			features: [ 'custom-domain', 'support-live', 'recurring-payments', 'wordads' ],
+			highlighted_features: [
+				MOCK_FEATURE_CUSTOM_DOMAIN.name,
+				MOCK_FEATURE_LIVE_SUPPORT.name,
+				'Premium plan highlighted feature',
+			],
+			storage: '13 GB',
+			icon: 'https://s0.wordpress.com/i/store/mobile/plans-premium.png',
+		},
+	],
+	features_by_type: [
+		MOCK_FEATURES_BY_TYPE_GENERAL,
+		MOCK_FEATURES_BY_TYPE_COMMERCE,
+		MOCK_FEATURES_BY_TYPE_MARKETING,
+	],
+	features: [
+		MOCK_FEATURE_CUSTOM_DOMAIN,
+		MOCK_FEATURE_LIVE_SUPPORT,
+		MOCK_FEATURE_PRIORITY_SUPPORT,
+		MOCK_FEATURE_RECURRING_PAYMENTS,
+		MOCK_FEATURE_WORDADS,
+	],
 };
 
-export const MOCK_SIMPLIFIED_FEATURE_LIVE_SUPPORT: PlanSimplifiedFeature = {
-	name: MOCK_FEATURE_LIVE_SUPPORT.name,
-	requiresAnnuallyBilledPlan: true,
-};
-
-export const MOCK_SIMPLIFIED_FEATURE_PRIORITY_SUPPORT: PlanSimplifiedFeature = {
-	name: MOCK_FEATURE_PRIORITY_SUPPORT.name,
-	requiresAnnuallyBilledPlan: false,
-};
-
-// Free
-// TODO: path_slug doesn't exist on monthly and free plans
+// Individual plan (from APIs)
+// @TODO: path_slug doesn't exist on monthly and free plans
 export const MOCK_PLAN_PRICE_APIS_FREE: PricedAPIPlan = {
 	product_id: 1,
 	product_name: 'WordPress.com Free',
@@ -149,69 +212,6 @@ export const MOCK_PLAN_PRICE_APIS_FREE: PricedAPIPlan = {
 		},
 	],
 };
-
-export const MOCK_PLAN_FREE: Plan = {
-	description: 'Mock free plan',
-	features: [
-		{
-			name: 'Free plan highlighted feature',
-			requiresAnnuallyBilledPlan: false,
-		},
-	],
-	storage: '3 GB',
-	title: 'Free',
-	featuresSlugs: {
-		subdomain: true,
-	},
-	isFree: true,
-	isPopular: false,
-	periodAgnosticSlug: 'free',
-	productIds: [ 1 ],
-};
-
-export const MOCK_PLAN_PRODUCT_FREE: PlanProduct = {
-	productId: 1,
-	billingPeriod: 'ANNUALLY',
-	periodAgnosticSlug: 'free',
-	storeSlug: 'free_plan',
-	rawPrice: 0,
-	pathSlug: 'free',
-	price: '€0',
-	annualPrice: '€0',
-};
-
-// Premium
-
-export const MOCK_PLAN_PREMIUM: Plan = {
-	description: 'Mock premium plan',
-	features: [
-		{
-			name: MOCK_FEATURE_CUSTOM_DOMAIN.name,
-			requiresAnnuallyBilledPlan: true,
-		},
-		{
-			name: MOCK_FEATURE_LIVE_SUPPORT.name,
-			requiresAnnuallyBilledPlan: true,
-		},
-		{
-			name: 'Premium plan highlighted feature',
-			requiresAnnuallyBilledPlan: false,
-		},
-	],
-	storage: '13 GB',
-	title: 'Premium',
-	featuresSlugs: {
-		'custom-domain': true,
-		'support-live': true,
-		'recurring-payments': true,
-		wordads: true,
-	},
-	isFree: false,
-	isPopular: true,
-	periodAgnosticSlug: 'premium',
-	productIds: [ 1003, 1013 ],
-};
-
 export const MOCK_PLAN_PRICE_APIS_PREMIUM_ANNUALLY: PricedAPIPlan = {
 	product_id: 1003,
 	product_name: 'WordPress.com Premium',
@@ -317,20 +317,6 @@ export const MOCK_PLAN_PRICE_APIS_PREMIUM_ANNUALLY: PricedAPIPlan = {
 		},
 	],
 };
-
-export const MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY: PlanProduct = {
-	productId: 1003,
-	billingPeriod: 'ANNUALLY',
-	periodAgnosticSlug: 'premium',
-	storeSlug: 'value_bundle',
-	rawPrice: 96,
-	pathSlug: 'premium',
-	price: '€8',
-	annualPrice: '€96',
-	annualDiscount: 43,
-};
-
-// TODO: path_slug doesn't exist on monthly plans
 export const MOCK_PLAN_PRICE_APIS_PREMIUM_MONTHLY: PricedAPIPlan = {
 	product_id: 1013,
 	product_name: 'WordPress.com Premium',
@@ -389,7 +375,82 @@ export const MOCK_PLAN_PRICE_APIS_PREMIUM_MONTHLY: PricedAPIPlan = {
 	currency_code: 'EUR',
 };
 
-// TODO: path_slug doesn't exist on monthly plans
+//==============================================================================
+// Data-store objects
+//==============================================================================
+
+// Plans
+export const MOCK_PLAN_FREE: Plan = {
+	description: 'Mock free plan',
+	features: [
+		{
+			name: 'Free plan highlighted feature',
+			requiresAnnuallyBilledPlan: false,
+		},
+	],
+	storage: '3 GB',
+	title: 'Free',
+	featuresSlugs: {
+		subdomain: true,
+	},
+	isFree: true,
+	isPopular: false,
+	periodAgnosticSlug: 'free',
+	productIds: [ 1 ],
+};
+export const MOCK_PLAN_PREMIUM: Plan = {
+	description: 'Mock premium plan',
+	features: [
+		{
+			name: MOCK_FEATURE_CUSTOM_DOMAIN.name,
+			requiresAnnuallyBilledPlan: true,
+		},
+		{
+			name: MOCK_FEATURE_LIVE_SUPPORT.name,
+			requiresAnnuallyBilledPlan: true,
+		},
+		{
+			name: 'Premium plan highlighted feature',
+			requiresAnnuallyBilledPlan: false,
+		},
+	],
+	storage: '13 GB',
+	title: 'Premium',
+	featuresSlugs: {
+		'custom-domain': true,
+		'support-live': true,
+		'recurring-payments': true,
+		wordads: true,
+	},
+	isFree: false,
+	isPopular: true,
+	periodAgnosticSlug: 'premium',
+	productIds: [ 1003, 1013 ],
+};
+
+// Plan products
+export const MOCK_PLAN_PRODUCT_FREE: PlanProduct = {
+	productId: 1,
+	billingPeriod: 'ANNUALLY',
+	periodAgnosticSlug: 'free',
+	storeSlug: 'free_plan',
+	rawPrice: 0,
+	pathSlug: 'free',
+	price: '€0',
+	annualPrice: '€0',
+};
+export const MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY: PlanProduct = {
+	productId: 1003,
+	billingPeriod: 'ANNUALLY',
+	periodAgnosticSlug: 'premium',
+	storeSlug: 'value_bundle',
+	rawPrice: 96,
+	pathSlug: 'premium',
+	price: '€8',
+	annualPrice: '€96',
+	annualDiscount: 43,
+};
+// @TODO: path_slug doesn't exist on monthly plan product
 export const MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY: PlanProduct = {
 	productId: 1013,
 	billingPeriod: 'MONTHLY',
@@ -401,74 +462,16 @@ export const MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY: PlanProduct = {
 	annualDiscount: 43,
 };
 
-// Plan details APIs
-
-export const MOCK_PLAN_DETAILS_API: DetailsAPIResponse = {
-	groups: [
-		{
-			slug: 'personal',
-			name: 'Personal',
-		},
-	],
-	plans: [
-		{
-			support_priority: 1,
-			support_name: 'free',
-			groups: [ 'personal' ],
-			products: [
-				{
-					plan_id: 1,
-				},
-			],
-			name: 'WordPress.com Free',
-			short_name: 'Free',
-			nonlocalized_short_name: 'Free',
-			tagline: 'Mock free plan',
-			description:
-				'If you just want to start creating, get a free site and be on your way to publishing in less than five minutes.',
-			features: [ 'subdomain' ],
-			highlighted_features: [ 'Free plan highlighted feature' ],
-			storage: '3 GB',
-			icon: 'https://s0.wordpress.com/i/store/mobile/plans-free.png',
-		},
-		{
-			support_priority: 4,
-			support_name: 'premium',
-			groups: [ 'business' ],
-			products: [
-				{
-					plan_id: 1003,
-				},
-				{
-					plan_id: 1013,
-				},
-			],
-			name: 'WordPress.com Premium',
-			short_name: 'Premium',
-			nonlocalized_short_name: 'Premium',
-			tagline: 'Mock premium plan',
-			description:
-				'Build a unique website with advanced design tools, CSS editing, lots of space for audio and video, and the ability to monetize your site with ads.',
-			features: [ 'custom-domain', 'support-live', 'recurring-payments', 'wordads' ],
-			highlighted_features: [
-				MOCK_FEATURE_CUSTOM_DOMAIN.name,
-				MOCK_FEATURE_LIVE_SUPPORT.name,
-				'Premium plan highlighted feature',
-			],
-			storage: '13 GB',
-			icon: 'https://s0.wordpress.com/i/store/mobile/plans-premium.png',
-		},
-	],
-	features_by_type: [
-		MOCK_FEATURES_BY_TYPE_GENERAL,
-		MOCK_FEATURES_BY_TYPE_COMMERCE,
-		MOCK_FEATURES_BY_TYPE_MARKETING,
-	],
-	features: [
-		MOCK_FEATURE_CUSTOM_DOMAIN,
-		MOCK_FEATURE_LIVE_SUPPORT,
-		MOCK_FEATURE_PRIORITY_SUPPORT,
-		MOCK_FEATURE_RECURRING_PAYMENTS,
-		MOCK_FEATURE_WORDADS,
-	],
+// Plan "simplified" features
+export const MOCK_SIMPLIFIED_FEATURE_CUSTOM_DOMAIN: PlanSimplifiedFeature = {
+	name: MOCK_FEATURE_CUSTOM_DOMAIN.name,
+	requiresAnnuallyBilledPlan: true,
+};
+export const MOCK_SIMPLIFIED_FEATURE_LIVE_SUPPORT: PlanSimplifiedFeature = {
+	name: MOCK_FEATURE_LIVE_SUPPORT.name,
+	requiresAnnuallyBilledPlan: true,
+};
+export const MOCK_SIMPLIFIED_FEATURE_PRIORITY_SUPPORT: PlanSimplifiedFeature = {
+	name: MOCK_FEATURE_PRIORITY_SUPPORT.name,
+	requiresAnnuallyBilledPlan: false,
 };

--- a/packages/data-stores/src/plans/mock/mock-constants.ts
+++ b/packages/data-stores/src/plans/mock/mock-constants.ts
@@ -148,7 +148,6 @@ export const MOCK_PLAN_DETAILS_API: DetailsAPIResponse = {
 };
 
 // Individual plan (from APIs)
-// @TODO: path_slug doesn't exist on monthly and free plans
 export const MOCK_PLAN_PRICE_APIS_FREE: PricedAPIPlan = {
 	product_id: 1,
 	product_name: 'WordPress.com Free',
@@ -450,7 +449,6 @@ export const MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY: PlanProduct = {
 	annualPrice: '€96',
 	annualDiscount: 43,
 };
-// @TODO: path_slug doesn't exist on monthly plan product
 export const MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY: PlanProduct = {
 	productId: 1013,
 	billingPeriod: 'MONTHLY',

--- a/packages/data-stores/src/plans/mock/mock-constants.ts
+++ b/packages/data-stores/src/plans/mock/mock-constants.ts
@@ -10,6 +10,7 @@ import type {
 	PricedAPIPlanPaidAnnually,
 	PricedAPIPlanPaidMonthly,
 	DetailsAPIResponse,
+	APIPlanDetail,
 } from '../types';
 
 /**
@@ -23,6 +24,29 @@ import type {
  * - Free plan
  * - Premium plan (annually and monthly billed)
  */
+
+//==============================================================================
+// Mock TypeScript interfaces
+// (allow us to use real-ish APIs data without TypeScript complaining about
+// extra props that are otherwise ignored in this data-store)
+//==============================================================================
+
+interface MockPricedAPIPlanFree extends PricedAPIPlanFree {
+	[ key: string ]: unknown;
+}
+interface MockAPIPlanDetail extends APIPlanDetail {
+	[ key: string ]: unknown;
+}
+interface MockDetailsAPIResponse extends DetailsAPIResponse {
+	plans: MockAPIPlanDetail[];
+	[ key: string ]: unknown;
+}
+interface MockPricedAPIPlanPaidAnnually extends PricedAPIPlanPaidAnnually {
+	[ key: string ]: unknown;
+}
+interface MockPricedAPIPlanPaidMonthly extends PricedAPIPlanPaidMonthly {
+	[ key: string ]: unknown;
+}
 
 //==============================================================================
 // APIs
@@ -79,7 +103,7 @@ export const MOCK_FEATURES_BY_TYPE_MARKETING: FeaturesByType = {
 };
 
 // All plans details (from APIs)
-export const MOCK_PLAN_DETAILS_API: DetailsAPIResponse = {
+export const MOCK_PLAN_DETAILS_API: MockDetailsAPIResponse = {
 	groups: [
 		{
 			slug: 'personal',
@@ -150,7 +174,8 @@ export const MOCK_PLAN_DETAILS_API: DetailsAPIResponse = {
 };
 
 // Individual plan (from APIs)
-export const MOCK_PLAN_PRICE_APIS_FREE: PricedAPIPlanFree = {
+
+export const MOCK_PLAN_PRICE_APIS_FREE: MockPricedAPIPlanFree = {
 	product_id: 1,
 	product_name: 'WordPress.com Free',
 	meta: null,
@@ -213,7 +238,8 @@ export const MOCK_PLAN_PRICE_APIS_FREE: PricedAPIPlanFree = {
 		},
 	],
 };
-export const MOCK_PLAN_PRICE_APIS_PREMIUM_ANNUALLY: PricedAPIPlanPaidAnnually = {
+
+export const MOCK_PLAN_PRICE_APIS_PREMIUM_ANNUALLY: MockPricedAPIPlanPaidAnnually = {
 	product_id: 1003,
 	product_name: 'WordPress.com Premium',
 	meta: null,
@@ -318,7 +344,8 @@ export const MOCK_PLAN_PRICE_APIS_PREMIUM_ANNUALLY: PricedAPIPlanPaidAnnually = 
 		},
 	],
 };
-export const MOCK_PLAN_PRICE_APIS_PREMIUM_MONTHLY: PricedAPIPlanPaidMonthly = {
+
+export const MOCK_PLAN_PRICE_APIS_PREMIUM_MONTHLY: MockPricedAPIPlanPaidMonthly = {
 	product_id: 1013,
 	product_name: 'WordPress.com Premium',
 	meta: null,

--- a/packages/data-stores/src/plans/mock/mock-constants.ts
+++ b/packages/data-stores/src/plans/mock/mock-constants.ts
@@ -6,7 +6,9 @@ import type {
 	PlanProduct,
 	FeaturesByType,
 	PlanSimplifiedFeature,
-	PricedAPIPlan,
+	PricedAPIPlanFree,
+	PricedAPIPlanPaidAnnually,
+	PricedAPIPlanPaidMonthly,
 	DetailsAPIResponse,
 } from '../types';
 
@@ -148,7 +150,7 @@ export const MOCK_PLAN_DETAILS_API: DetailsAPIResponse = {
 };
 
 // Individual plan (from APIs)
-export const MOCK_PLAN_PRICE_APIS_FREE: PricedAPIPlan = {
+export const MOCK_PLAN_PRICE_APIS_FREE: PricedAPIPlanFree = {
 	product_id: 1,
 	product_name: 'WordPress.com Free',
 	meta: null,
@@ -211,7 +213,7 @@ export const MOCK_PLAN_PRICE_APIS_FREE: PricedAPIPlan = {
 		},
 	],
 };
-export const MOCK_PLAN_PRICE_APIS_PREMIUM_ANNUALLY: PricedAPIPlan = {
+export const MOCK_PLAN_PRICE_APIS_PREMIUM_ANNUALLY: PricedAPIPlanPaidAnnually = {
 	product_id: 1003,
 	product_name: 'WordPress.com Premium',
 	meta: null,
@@ -316,7 +318,7 @@ export const MOCK_PLAN_PRICE_APIS_PREMIUM_ANNUALLY: PricedAPIPlan = {
 		},
 	],
 };
-export const MOCK_PLAN_PRICE_APIS_PREMIUM_MONTHLY: PricedAPIPlan = {
+export const MOCK_PLAN_PRICE_APIS_PREMIUM_MONTHLY: PricedAPIPlanPaidMonthly = {
 	product_id: 1013,
 	product_name: 'WordPress.com Premium',
 	meta: null,

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -16,8 +16,8 @@ import type {
 	DetailsAPIResponse,
 	PlanFeature,
 	PlanProduct,
-	Feature,
 	PlanSlug,
+	DetailsAPIFeature,
 } from './types';
 import {
 	PLAN_FREE,
@@ -79,13 +79,13 @@ function calculateDiscounts( planProducts: PlanProduct[] ) {
 	}
 }
 
-function processFeatures( features: Feature[] ) {
+function processFeatures( features: DetailsAPIFeature[] ) {
 	return features.reduce( ( features, feature ) => {
 		features[ feature.id ] = {
 			id: feature.id,
 			name: feature.name,
 			description: feature.description,
-			type: feature.type ?? 'checkbox',
+			type: 'checkbox',
 			requiresAnnuallyBilledPlan:
 				FEATURE_IDS_THAT_REQUIRE_ANNUALLY_BILLED_PLAN.indexOf( feature.id ) > -1,
 		};

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -151,6 +151,8 @@ function normalizePlanProducts(
 			periodAgnosticSlug: periodAgnosticPlan.periodAgnosticSlug,
 			storeSlug: planProduct.product_slug,
 			rawPrice: planProduct.raw_price,
+			// Not all plans returned from /plans have a `path_slug`
+			// Free plan is an exception, and is given a hardcoded path_slug
 			pathSlug: planProduct.product_slug === PLAN_FREE ? 'free' : planProduct.path_slug,
 			price:
 				planProduct?.bill_period === MONTHLY_PLAN_BILLING_PERIOD || planProduct.raw_price === 0

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -132,9 +132,7 @@ function normalizePlanProducts(
 	periodAgnosticPlans: Plan[]
 ): PlanProduct[] {
 	const plansProducts: PlanProduct[] = plansProductSlugs.reduce( ( plans, slug ) => {
-		const planProduct = pricedPlans.find(
-			( pricedPlan ) => pricedPlan.product_slug === slug
-		) as PricedAPIPlan;
+		const planProduct = pricedPlans.find( ( pricedPlan ) => pricedPlan.product_slug === slug );
 
 		if ( ! planProduct ) {
 			return plans;
@@ -146,6 +144,7 @@ function normalizePlanProducts(
 
 		plans.push( {
 			productId: planProduct.product_id,
+			// This means that free plan is considered "annually billed"
 			billingPeriod:
 				planProduct.bill_period === MONTHLY_PLAN_BILLING_PERIOD ? 'MONTHLY' : 'ANNUALLY',
 			periodAgnosticSlug: periodAgnosticPlan.periodAgnosticSlug,

--- a/packages/data-stores/src/plans/test/reducer.ts
+++ b/packages/data-stores/src/plans/test/reducer.ts
@@ -4,97 +4,52 @@
 import reducer from '../reducer';
 import { setPlans, setFeaturesByType, setFeatures, setPlanProducts } from '../actions';
 import { PLAN_FREE, PLAN_PREMIUM } from '../constants';
+import {
+	MOCK_PLAN_FREE,
+	MOCK_PLAN_PRODUCT_FREE,
+	MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY,
+	MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY,
+	MOCK_FEATURES_BY_TYPE_GENERAL,
+	MOCK_FEATURES_BY_TYPE_COMMERCE,
+	MOCK_FEATURES_BY_TYPE_MARKETING,
+	MOCK_SIMPLIFIED_FEATURE_CUSTOM_DOMAIN,
+	MOCK_SIMPLIFIED_FEATURE_LIVE_SUPPORT,
+	MOCK_SIMPLIFIED_FEATURE_PRIORITY_SUPPORT,
+} from '../mock/mock-constants';
+
+const LOCALE_EN = 'en';
 
 describe( 'Plans reducer', () => {
 	describe( 'Plans', () => {
 		it( 'defaults to no plans info', () => {
-			const { plans } = reducer( undefined, { type: 'DUMMY' } );
+			const { plans } = reducer( undefined, { type: 'NOOP' } );
 			expect( plans ).toEqual( {} );
 		} );
 
 		it( 'replaces old plans with new plans', () => {
-			let state = reducer(
-				undefined,
-				setPlans(
-					[
-						{
-							title: 'free plan',
-							description: 'it is free',
-							features: [],
-							isFree: true,
-							isPopular: false,
-							periodAgnosticSlug: 'free',
-							productIds: [ 1 ],
-						},
-					],
-					'en'
-				)
-			);
+			let state = reducer( undefined, setPlans( [ MOCK_PLAN_FREE ], LOCALE_EN ) );
 
 			state = reducer(
 				state,
 				setPlanProducts( [
-					{
-						productId: 1,
-						price: '0',
-						annualPrice: '0',
-						rawPrice: 0,
-						billingPeriod: 'ANNUALLY',
-						pathSlug: 'free',
-						annualDiscount: 0,
-						storeSlug: 'free_plan',
-						periodAgnosticSlug: 'free',
-					},
-					{
-						productId: 2,
-						price: '0',
-						annualPrice: '0',
-						rawPrice: 0,
-						billingPeriod: 'MONTHLY',
-						pathSlug: 'premium',
-						annualDiscount: 0,
-						storeSlug: 'value_bundle_monthly',
-						periodAgnosticSlug: 'premium',
-					},
-					{
-						productId: 3,
-						price: '0',
-						annualPrice: '0',
-						rawPrice: 0,
-						billingPeriod: 'ANNUALLY',
-						pathSlug: 'premium',
-						annualDiscount: 0,
-						storeSlug: 'value_bundle',
-						periodAgnosticSlug: 'premium',
-					},
+					MOCK_PLAN_PRODUCT_FREE,
+					MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY,
+					MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY,
 				] )
 			);
 
-			const { plans } = reducer(
-				state,
-				setPlans(
-					[
-						{
-							title: 'new free',
-							description: 'it is free',
-							features: [],
-							isPopular: true,
-							periodAgnosticSlug: 'free',
-							productIds: [ 1 ],
-						},
-					],
-					'en'
-				)
-			);
+			const newFreePlan = { ...MOCK_PLAN_FREE, title: 'new free' };
 
-			expect( plans.en[ 0 ].title ).toBe( 'new free' );
-			expect( plans.en[ 1 ] ).toBeUndefined();
+			const { plans } = reducer( state, setPlans( [ newFreePlan ], LOCALE_EN ) );
+
+			expect( plans[ LOCALE_EN ][ 0 ].title ).toBe( newFreePlan.title );
+			expect( plans[ LOCALE_EN ][ 1 ] ).toBeUndefined();
 		} );
 	} );
 
 	describe( 'Features By Type', () => {
 		it( 'defaults to no featuresByType info', () => {
-			const { featuresByType } = reducer( undefined, { type: 'DUMMY' } );
+			const { featuresByType } = reducer( undefined, { type: 'NOOP' } );
 			expect( featuresByType ).toEqual( {} );
 		} );
 
@@ -102,65 +57,47 @@ describe( 'Plans reducer', () => {
 			const state = reducer(
 				undefined,
 				setFeaturesByType(
-					[
-						{
-							id: '1',
-							name: 'one',
-							features: [],
-						},
-						{
-							id: '2',
-							name: 'two',
-							features: [],
-						},
-					],
-					'en'
+					[ MOCK_FEATURES_BY_TYPE_GENERAL, MOCK_FEATURES_BY_TYPE_COMMERCE ],
+					LOCALE_EN
 				)
 			);
 
 			const { featuresByType } = reducer(
 				state,
-				setFeaturesByType(
-					[
-						{
-							id: '3',
-							name: 'three',
-							features: [],
-						},
-					],
-					'en'
-				)
+				setFeaturesByType( [ MOCK_FEATURES_BY_TYPE_MARKETING ], LOCALE_EN )
 			);
 
-			expect( featuresByType.en ).toEqual( [
-				{
-					id: '3',
-					name: 'three',
-					features: [],
-				},
-			] );
+			expect( featuresByType[ LOCALE_EN ] ).toEqual( [ MOCK_FEATURES_BY_TYPE_MARKETING ] );
 		} );
 	} );
 
 	describe( 'Features', () => {
 		it( 'defaults to no feature info', () => {
-			const { features } = reducer( undefined, { type: 'DUMMY' } );
+			const { features } = reducer( undefined, { type: 'NOOP' } );
 			expect( features ).toEqual( {} );
 		} );
 
 		it( 'replaces old features with new features', () => {
 			const state = reducer(
 				undefined,
-				setFeatures( { [ PLAN_FREE ]: { name: 'name' }, [ PLAN_PREMIUM ]: { name: 'name' } }, 'en' )
+				setFeatures(
+					{
+						[ PLAN_FREE ]: MOCK_SIMPLIFIED_FEATURE_CUSTOM_DOMAIN,
+						[ PLAN_PREMIUM ]: MOCK_SIMPLIFIED_FEATURE_LIVE_SUPPORT,
+					},
+					LOCALE_EN
+				)
 			);
 
 			const { features } = reducer(
 				state,
-				setFeatures( { [ PLAN_FREE ]: { name: 'new name' } }, 'en' )
+				setFeatures( { [ PLAN_FREE ]: MOCK_SIMPLIFIED_FEATURE_PRIORITY_SUPPORT }, LOCALE_EN )
 			);
 
-			expect( features.en[ PLAN_FREE ].name ).toBe( 'new name' );
-			expect( features.en[ PLAN_PREMIUM ] ).toBeUndefined();
+			expect( features[ LOCALE_EN ][ PLAN_FREE ].name ).toBe(
+				MOCK_SIMPLIFIED_FEATURE_PRIORITY_SUPPORT.name
+			);
+			expect( features[ LOCALE_EN ][ PLAN_PREMIUM ] ).toBeUndefined();
 		} );
 	} );
 } );

--- a/packages/data-stores/src/plans/test/resolvers.ts
+++ b/packages/data-stores/src/plans/test/resolvers.ts
@@ -2,7 +2,25 @@
  * Internal dependencies
  */
 import { getSupportedPlans } from '../resolvers';
-import { PLAN_FREE, PLAN_PREMIUM, PLAN_PREMIUM_MONTHLY } from '../constants';
+import {
+	MOCK_PLAN_PRICE_APIS_FREE,
+	MOCK_PLAN_PRICE_APIS_PREMIUM_ANNUALLY,
+	MOCK_PLAN_PRICE_APIS_PREMIUM_MONTHLY,
+	MOCK_PLAN_DETAILS_API,
+	MOCK_PLAN_FREE,
+	MOCK_PLAN_PREMIUM,
+	MOCK_PLAN_PRODUCT_FREE,
+	MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY,
+	MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY,
+	MOCK_FEATURE_CUSTOM_DOMAIN,
+	MOCK_FEATURE_LIVE_SUPPORT,
+	MOCK_FEATURE_PRIORITY_SUPPORT,
+	MOCK_FEATURE_RECURRING_PAYMENTS,
+	MOCK_FEATURE_WORDADS,
+	MOCK_FEATURES_BY_TYPE_GENERAL,
+	MOCK_FEATURES_BY_TYPE_COMMERCE,
+	MOCK_FEATURES_BY_TYPE_MARKETING,
+} from '../mock/mock-constants';
 
 // Don't need to mock specific functions for any tests, but mocking
 // module because it accesses the `document` global.
@@ -15,67 +33,13 @@ describe( 'getSupportedPlans', () => {
 		const iter = getSupportedPlans();
 
 		const planPriceData = [
-			{
-				currency_code: 'INR',
-				product_slug: PLAN_FREE,
-				raw_price: 0,
-				product_id: 1,
-			},
-			{
-				// premium plan, billed annually
-				currency_code: 'INR',
-				product_slug: PLAN_PREMIUM,
-				path_slug: 'premium',
-				raw_price: 12,
-				product_id: 2,
-			},
-			{
-				// premium plan, billed monthly
-				currency_code: 'INR',
-				product_slug: PLAN_PREMIUM_MONTHLY,
-				raw_price: 13,
-				product_id: 3,
-				bill_period: 31,
-			},
+			MOCK_PLAN_PRICE_APIS_FREE,
+			MOCK_PLAN_PRICE_APIS_PREMIUM_ANNUALLY,
+			MOCK_PLAN_PRICE_APIS_PREMIUM_MONTHLY,
 		];
 
 		const planDetailedData = {
-			groups: [],
-			plans: [
-				{
-					products: [
-						{
-							plan_id: 1,
-						},
-						{
-							plan_id: 2,
-						},
-						{
-							plan_id: 3,
-						},
-					],
-					features: [ 'custom-domain' ],
-					highlighted_features: [ 'Custom domain', 'Other feature' ],
-					nonlocalized_short_name: 'Premium',
-				},
-			],
-			features_by_type: [
-				{
-					id: 'general',
-					name: null,
-					features: [ 'custom-domain', 'other-feature' ],
-				},
-			],
-			features: [
-				{
-					id: 'custom-domain',
-					name: 'Custom domain',
-				},
-				{
-					id: 'other-feature',
-					name: 'Other feature',
-				},
-			],
+			body: MOCK_PLAN_DETAILS_API,
 		};
 
 		// request to prices endpoint
@@ -99,100 +63,54 @@ describe( 'getSupportedPlans', () => {
 		} );
 
 		// setPlans call
-		expect( iter.next( { body: planDetailedData } ).value ).toEqual( {
+		expect( iter.next( planDetailedData ).value ).toEqual( {
 			locale: 'en',
 			type: 'SET_PLANS',
-			plans: [
-				{
-					description: undefined,
-					features: [
-						{
-							name: 'Custom domain',
-							requiresAnnuallyBilledPlan: true,
-						},
-						{
-							name: 'Other feature',
-							requiresAnnuallyBilledPlan: false,
-						},
-					],
-					featuresSlugs: {
-						'custom-domain': true,
-					},
-					isFree: false,
-					isPopular: true,
-					periodAgnosticSlug: 'premium',
-					productIds: [ 1, 2, 3 ],
-					storage: undefined,
-					title: undefined,
-				},
-			],
+			plans: [ MOCK_PLAN_FREE, MOCK_PLAN_PREMIUM ],
 		} );
 
 		// setPlanProducts call
 		expect( iter.next().value ).toEqual( {
 			type: 'SET_PLAN_PRODUCTS',
 			products: [
-				{
-					annualPrice: '₹0',
-					billingPeriod: 'ANNUALLY',
-					pathSlug: 'free',
-					periodAgnosticSlug: 'premium',
-					price: '₹0',
-					productId: 1,
-					rawPrice: 0,
-					storeSlug: 'free_plan',
-				},
-				{
-					annualDiscount: 92,
-					annualPrice: '₹12',
-					billingPeriod: 'ANNUALLY',
-					pathSlug: 'premium',
-					periodAgnosticSlug: 'premium',
-					price: '₹1',
-					productId: 2,
-					rawPrice: 12,
-					storeSlug: 'value_bundle',
-				},
-				{
-					annualPrice: '₹156',
-					annualDiscount: 92,
-					billingPeriod: 'MONTHLY',
-					pathSlug: undefined,
-					periodAgnosticSlug: 'premium',
-					price: '₹13',
-					productId: 3,
-					rawPrice: 13,
-					storeSlug: 'value_bundle_monthly',
-				},
+				MOCK_PLAN_PRODUCT_FREE,
+				MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY,
+				MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY,
 			],
 		} );
 
 		expect( iter.next().value ).toEqual( {
 			locale: 'en',
 			type: 'SET_FEATURES',
-			features: {
-				'custom-domain': {
-					id: 'custom-domain',
-					name: 'Custom domain',
-					description: undefined,
-					type: 'checkbox',
-					requiresAnnuallyBilledPlan: true,
-				},
-				'other-feature': {
-					id: 'other-feature',
-					name: 'Other feature',
-					description: undefined,
-					type: 'checkbox',
-					requiresAnnuallyBilledPlan: false,
-				},
-			},
+			features: [
+				MOCK_FEATURE_CUSTOM_DOMAIN,
+				MOCK_FEATURE_LIVE_SUPPORT,
+				MOCK_FEATURE_PRIORITY_SUPPORT,
+				MOCK_FEATURE_RECURRING_PAYMENTS,
+				MOCK_FEATURE_WORDADS,
+			].reduce(
+				( dict, feature ) => ( {
+					...dict,
+					[ feature.id ]: {
+						...feature,
+						type: 'checkbox',
+						requiresAnnuallyBilledPlan:
+							feature.id === MOCK_FEATURE_CUSTOM_DOMAIN.id ||
+							feature.id === MOCK_FEATURE_LIVE_SUPPORT.id ||
+							feature.id === MOCK_FEATURE_PRIORITY_SUPPORT.id,
+					},
+				} ),
+				{}
+			),
 		} );
 
 		expect( iter.next().value ).toEqual( {
 			locale: 'en',
 			type: 'SET_FEATURES_BY_TYPE',
 			featuresByType: [
-				{ id: 'general', name: null, features: [ 'custom-domain', 'other-feature' ] },
+				MOCK_FEATURES_BY_TYPE_GENERAL,
+				MOCK_FEATURES_BY_TYPE_COMMERCE,
+				MOCK_FEATURES_BY_TYPE_MARKETING,
 			],
 		} );
 	} );

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -156,8 +156,11 @@ export interface Feature {
 	type: string;
 }
 
+export type DetailsAPIFeature = Omit< Feature, 'type' >;
+
 export interface DetailsAPIResponse {
+	groups: { slug: string; name: string }[];
 	plans: APIPlanDetail[];
 	features_by_type: FeaturesByType[];
-	features: Feature[];
+	features: DetailsAPIFeature[];
 }

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -56,7 +56,7 @@ export interface PlanProduct {
 export interface PricedAPIPlan {
 	product_id: number;
 	product_name: string;
-	meta: Record< string, unknown >;
+	meta: Record< string, unknown > | null;
 	prices: {
 		AUD: number;
 		BRL: number;
@@ -85,35 +85,34 @@ export interface PricedAPIPlan {
 		USD: number;
 		TRY: number;
 	};
-	bundle_product_ids: {
-		0: number;
-		1: number;
-		2: number;
-		3: number;
-		4: number;
-		5: number;
-		6: number;
-	};
+	bundle_product_ids?: number[];
+	blog_id: null;
 	path_slug: PlanPath;
 	product_slug: StorePlanSlug;
 	description: string;
 	cost: number;
-	bill_period: 31 | 365;
+	bill_period: -1 | 31 | 365;
 	product_type: string;
 	available: string;
 	multi: number;
 	bd_slug: string;
 	bd_variation_slug: string;
-	outer_slug: string;
-	extra: string;
+	outer_slug: string | null;
+	extra: string | null;
 	capability: string;
 	product_name_short: string;
+	icon?: string;
+	icon_active?: string;
+	cost__from_plan: number;
+	currency__from_plan: string;
+	initial_cost_matched: boolean;
 	bill_period_label: string;
 	price: string;
 	formatted_price: string;
 	raw_price: number;
-	tagline: Record< string, unknown >;
+	tagline: string | null;
 	currency_code: string;
+	features_highlight: { title?: string; items: string[] }[];
 }
 
 export type PlanFeature = {
@@ -145,7 +144,7 @@ export interface APIPlanDetail {
 
 export interface FeaturesByType {
 	id: string;
-	name: string;
+	name: string | null;
 	features: string[];
 }
 

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -41,7 +41,7 @@ export interface PlanProduct {
 	storeSlug: StorePlanSlug;
 	annualDiscount?: number;
 	periodAgnosticSlug: PlanSlug;
-	pathSlug: PlanPath;
+	pathSlug?: PlanPath;
 	/** Useful for two cases:
 	 * 1) to show how much we bill the users for annual plans ($8/mo billed $96)
 	 * 2) to show how much a monthly plan would cost in a year (billed 12$/mo costs $144/yr)
@@ -87,7 +87,7 @@ export interface PricedAPIPlan {
 	};
 	bundle_product_ids?: number[];
 	blog_id: null;
-	path_slug: PlanPath;
+	path_slug?: PlanPath;
 	product_slug: StorePlanSlug;
 	description: string;
 	cost: number;
@@ -112,7 +112,7 @@ export interface PricedAPIPlan {
 	raw_price: number;
 	tagline: string | null;
 	currency_code: string;
-	features_highlight: { title?: string; items: string[] }[];
+	features_highlight?: { title?: string; items: string[] }[];
 }
 
 export type PlanFeature = {

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -106,14 +106,16 @@ export interface FeaturesByType {
 	features: string[];
 }
 
-export interface Feature {
+export interface DetailsAPIFeature {
 	id: string;
 	name: string;
 	description: string;
-	type: string;
 }
 
-export type DetailsAPIFeature = Omit< Feature, 'type' >;
+export interface Feature extends DetailsAPIFeature {
+	// TODO: https://github.com/Automattic/wp-calypso/issues/49991
+	type: 'checkbox';
+}
 
 export interface DetailsAPIResponse {
 	plans: APIPlanDetail[];

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -50,69 +50,32 @@ export interface PlanProduct {
 }
 
 /**
- * types of an item from https://public-api.wordpress.com/rest/v1.5/plans response
- * can be super useful later
+ * Item returned from https://public-api.wordpress.com/rest/v1.5/plans response
+ * Only the properties that are actually used in the store are typed
  */
 export interface PricedAPIPlan {
 	product_id: number;
 	product_name: string;
-	meta: Record< string, unknown > | null;
-	prices: {
-		AUD: number;
-		BRL: number;
-		CAD: number;
-		CHF: number;
-		CZK: number;
-		DKK: number;
-		EUR: number;
-		GBP: number;
-		HKD: number;
-		HUF: number;
-		IDR: number;
-		ILS: number;
-		INR: number;
-		JPY: number;
-		MXN: number;
-		NOK: number;
-		NZD: number;
-		PHP: number;
-		PLN: number;
-		RUB: number;
-		SEK: number;
-		SGD: number;
-		THB: number;
-		TWD: number;
-		USD: number;
-		TRY: number;
-	};
-	bundle_product_ids?: number[];
-	blog_id: null;
 	path_slug?: PlanPath;
 	product_slug: StorePlanSlug;
-	description: string;
-	cost: number;
 	bill_period: -1 | 31 | 365;
-	product_type: string;
-	available: string;
-	multi: number;
-	bd_slug: string;
-	bd_variation_slug: string;
-	outer_slug: string | null;
-	extra: string | null;
-	capability: string;
-	product_name_short: string;
-	icon?: string;
-	icon_active?: string;
-	cost__from_plan: number;
-	currency__from_plan: string;
-	initial_cost_matched: boolean;
-	bill_period_label: string;
-	price: string;
-	formatted_price: string;
 	raw_price: number;
-	tagline: string | null;
 	currency_code: string;
-	features_highlight?: { title?: string; items: string[] }[];
+	[ key: string ]: unknown;
+}
+export interface PricedAPIPlanFree extends PricedAPIPlan {
+	product_id: 1;
+	cost: 0;
+	product_slug: 'free_plan';
+	bill_period: -1;
+	raw_price: 0;
+}
+export interface PricedAPIPlanPaidAnnually extends PricedAPIPlan {
+	path_slug: PlanPath;
+	bill_period: 365;
+}
+export interface PricedAPIPlanPaidMonthly extends PricedAPIPlan {
+	bill_period: 31;
 }
 
 export type PlanFeature = {
@@ -125,21 +88,16 @@ export type PlanFeature = {
 };
 
 export interface APIPlanDetail {
-	support_priority: number;
-	support_name: string;
-	groups: string[];
+	nonlocalized_short_name: PlanNonlocalizedShortName;
+	tagline: string;
+	storage: string;
+	short_name: string;
 	products: {
 		plan_id: number;
 	}[];
-	name: string;
-	short_name: string;
-	nonlocalized_short_name: PlanNonlocalizedShortName;
-	tagline: string;
-	description: string;
-	features: string[];
 	highlighted_features: string[];
-	storage: string;
-	icon: string;
+	features: string[];
+	[ key: string ]: unknown;
 }
 
 export interface FeaturesByType {
@@ -158,8 +116,8 @@ export interface Feature {
 export type DetailsAPIFeature = Omit< Feature, 'type' >;
 
 export interface DetailsAPIResponse {
-	groups: { slug: string; name: string }[];
 	plans: APIPlanDetail[];
 	features_by_type: FeaturesByType[];
 	features: DetailsAPIFeature[];
+	[ key: string ]: unknown;
 }

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -61,7 +61,6 @@ export interface PricedAPIPlan {
 	bill_period: -1 | 31 | 365;
 	raw_price: number;
 	currency_code: string;
-	[ key: string ]: unknown;
 }
 export interface PricedAPIPlanFree extends PricedAPIPlan {
 	product_id: 1;
@@ -97,7 +96,6 @@ export interface APIPlanDetail {
 	}[];
 	highlighted_features: string[];
 	features: string[];
-	[ key: string ]: unknown;
 }
 
 export interface FeaturesByType {
@@ -121,5 +119,4 @@ export interface DetailsAPIResponse {
 	plans: APIPlanDetail[];
 	features_by_type: FeaturesByType[];
 	features: DetailsAPIFeature[];
-	[ key: string ]: unknown;
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Add mock data for tests that mimics real-world data
* Fix TypeScript errors
* Change a few types based on the data coming from API endpoints (including making `path_slug` optional). Types from APIs data have been simplified (only properties that are actually used are typed, in order to make it more explicit)

## Testing instructions

- `yarn test-packages:watch packages/data-stores/src/plans` — the plans data-store tests should pass
- Smoke test plans grid on Gutenboarding, Step by Step launch and Focused Launch
  - For good measure, open all plans grid ts/tsx files and check that there are not TypeScript errors

Closes #49536 