### PR TITLE
perf(rum): Instrument calls to i18n.addTranslations

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -294,7 +294,7 @@ function addRequireChunkTranslationsHandler(
 			localeSlug,
 			targetBuild
 		).then( ( translations ) => {
-			i18n.addTranslations( { ...translations, ...userTranslations } );
+			addTranslations( { ...translations, ...userTranslations } );
 			loadedTranslationChunks[ chunkId ] = true;
 		} );
 
@@ -366,7 +366,7 @@ export default async function switchLocale( localeSlug ) {
 			// Load individual translation chunks
 			translatedInstalledChunks.forEach( ( chunkId ) =>
 				getTranslationChunkFile( chunkId, localeSlug, window?.BUILD_TARGET )
-					.then( ( translations ) => i18n.addTranslations( translations ) )
+					.then( ( translations ) => addTranslations( translations ) )
 					.catch( ( error ) => {
 						debug( `Encountered an error loading translation chunk ${ chunkId }.` );
 						debug( error );
@@ -473,7 +473,7 @@ export function loadUserUndeployedTranslations( currentLocaleSlug ) {
 		} )
 		.then( ( res ) => res.json() )
 		.then( ( translations ) => {
-			i18n.addTranslations( translations );
+			addTranslations( translations );
 
 			return translations;
 		} );
@@ -544,4 +544,18 @@ function loadCSS( cssUrl, currentLink ) {
 
 		document.head.insertBefore( link, currentLink ? currentLink.nextSibling : null );
 	} );
+}
+
+/**
+ * Add translations.
+ *
+ * This function also saves the duration of the call as a performance measure
+ *
+ * @param translations translations to add
+ */
+function addTranslations( translations ) {
+	window.performance?.mark( 'add_translations_start' );
+	i18n.addTranslations( translations );
+	window.performance?.measure( 'add_translations', 'add_translations_start' );
+	window.performance?.clearMarks( 'add_translations_start' );
 }

--- a/client/lib/performance-tracking/collectors/translations.js
+++ b/client/lib/performance-tracking/collectors/translations.js
@@ -1,0 +1,10 @@
+export const collectTranslationTimings = () => {
+	const measures = window.performance?.getEntriesByName( 'add_translations' ) || [];
+	const count = measures.length;
+	const total = Math.round( measures.reduce( ( acc, measure ) => acc + measure.duration, 0 ) );
+	return { count, total };
+};
+
+export const clearTranslationTimings = () => {
+	window.performance?.clearMeasures( 'add_translations' );
+};

--- a/client/lib/performance-tracking/lib.js
+++ b/client/lib/performance-tracking/lib.js
@@ -15,8 +15,9 @@ import {
 	getCurrentUserVisibleSiteCount,
 	getCurrentUserCountryCode,
 	isCurrentUserBootstrapped,
+	getCurrentUserLocale,
 } from 'calypso/state/current-user/selectors';
-
+import { collectTranslationTimings, clearTranslationTimings } from './collectors/translations';
 /**
  * This reporter is added to _all_ performance tracking metrics.
  * Be sure to add only metrics that make sense for tracked pages and are always present.
@@ -32,6 +33,12 @@ const buildDefaultCollector = ( state ) => {
 	const sitesVisibleCount = getCurrentUserVisibleSiteCount( state );
 	const userCountryCode = getCurrentUserCountryCode( state );
 	const userBootstrapped = isCurrentUserBootstrapped( state );
+	const userLocale = getCurrentUserLocale( state );
+	const {
+		count: translationsChunksCount,
+		total: translationsChunksDuration,
+	} = collectTranslationTimings();
+	clearTranslationTimings();
 
 	return ( report ) => {
 		report.data.set( 'siteId', siteId );
@@ -42,6 +49,9 @@ const buildDefaultCollector = ( state ) => {
 		report.data.set( 'sitesVisibleCount', sitesVisibleCount );
 		report.data.set( 'userCountryCode', userCountryCode );
 		report.data.set( 'userBootstrapped', userBootstrapped );
+		report.data.set( 'userLocale', userLocale );
+		report.data.set( 'translationsChunksDuration', translationsChunksDuration );
+		report.data.set( 'translationsChunksCount', translationsChunksCount );
 	};
 };
 

--- a/client/lib/performance-tracking/test/lib.js
+++ b/client/lib/performance-tracking/test/lib.js
@@ -16,7 +16,9 @@ import {
 	getCurrentUserSiteCount,
 	getCurrentUserVisibleSiteCount,
 	isCurrentUserBootstrapped,
+	getCurrentUserLocale,
 } from 'calypso/state/current-user/selectors';
+import { collectTranslationTimings, clearTranslationTimings } from '../collectors/translations';
 
 jest.mock( '@automattic/calypso-config', () => ( {
 	isEnabled: jest.fn(),
@@ -37,8 +39,13 @@ jest.mock( 'calypso/state/current-user/selectors', () => ( {
 	getCurrentUserSiteCount: jest.fn(),
 	getCurrentUserVisibleSiteCount: jest.fn(),
 	isCurrentUserBootstrapped: jest.fn(),
+	getCurrentUserLocale: jest.fn(),
 } ) );
 jest.mock( 'calypso/state/selectors/is-site-wpcom-atomic', () => jest.fn() );
+jest.mock( '../collectors/translations', () => ( {
+	collectTranslationTimings: jest.fn(),
+	clearTranslationTimings: jest.fn(),
+} ) );
 
 const withFeatureEnabled = () =>
 	config.isEnabled.mockImplementation( ( key ) => key === 'rum-tracking/logstash' );
@@ -105,6 +112,7 @@ describe( 'startPerformanceTracking', () => {
 describe( 'stopPerformanceTracking', () => {
 	beforeEach( () => {
 		withFeatureEnabled();
+		collectTranslationTimings.mockImplementation( () => ( {} ) );
 	} );
 
 	afterEach( () => {
@@ -144,6 +152,7 @@ describe( 'stopPerformanceTracking', () => {
 		getCurrentUserVisibleSiteCount.mockImplementation( () => 1 );
 		getCurrentUserCountryCode.mockImplementation( () => 'es' );
 		isCurrentUserBootstrapped.mockImplementation( () => true );
+		getCurrentUserLocale.mockImplementation( () => 'es' );
 
 		// Run the default collector
 		stopPerformanceTracking( 'pageName', { state } );
@@ -160,6 +169,7 @@ describe( 'stopPerformanceTracking', () => {
 		expect( report.data.get( 'sitesVisibleCount' ) ).toBe( 1 );
 		expect( report.data.get( 'userCountryCode' ) ).toBe( 'es' );
 		expect( report.data.get( 'userBootstrapped' ) ).toBe( true );
+		expect( report.data.get( 'userLocale' ) ).toBe( 'es' );
 	} );
 
 	it( 'uses metdata to generate a collector', () => {
@@ -178,5 +188,23 @@ describe( 'stopPerformanceTracking', () => {
 		metadataCollector( report );
 
 		expect( report.data.get( 'foo' ) ).toBe( 42 );
+	} );
+
+	it( 'detects performance of translation chunks', () => {
+		collectTranslationTimings.mockImplementation( () => ( {
+			count: 1,
+			total: 10,
+		} ) );
+		const report = {
+			data: new Map(),
+		};
+
+		stopPerformanceTracking( 'pageName' );
+		const defaultCollector = stop.mock.calls[ 0 ][ 1 ].collectors[ 0 ];
+		defaultCollector( report );
+
+		expect( report.data.get( 'translationsChunksDuration' ) ).toBe( 10 );
+		expect( report.data.get( 'translationsChunksCount' ) ).toBe( 1 );
+		expect( clearTranslationTimings ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use performance marks to instrument calls to `i18n.addTranslations`
* Collect such marks and add `translationsChunksCount` and `translationsChunksDuration` to the RUM report
* Add user local to the RUM report

#### Testing instructions

* Go to the live page, to one of the instrumented pages (eg: stats). Add `?useTranslationChunks=true` to the URL.
* Change the language to non-English and refresh the page
* Verify you have a network call to `/logstash`. The payload should contain `translationsChunksDuration` and `translationsChunksCount`

