### PR TITLE
Domains: Fix bad translation string components

### DIFF
--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -110,6 +110,7 @@ class RegisteredDomainType extends React.Component {
 				{
 					components: {
 						domainsLink: domainsLink( DOMAIN_EXPIRATION ),
+						strong: <strong />,
 					},
 				}
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a bug with a string missing a component in domain management for when a domain has expired.

Before:
![](https://cldup.com/A_pxlvuDUv.png)

After:
![](https://cldup.com/yxlWJNhqO2.png)

#### Testing instructions

* Go to `/domains/manage/:domain/edit/:site` where `:domain` is an expired domain in the `:site` site.
* Verify the string now looks good.
