### PR TITLE
State: Move account recovery notices away from middleware

### DIFF
--- a/client/state/account-recovery/settings/actions.js
+++ b/client/state/account-recovery/settings/actions.js
@@ -24,6 +24,17 @@ import {
 	ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS,
 	ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED,
 } from 'calypso/state/action-types';
+import {
+	onAccountRecoveryPhoneValidationFailed,
+	onAccountRecoveryPhoneValidationSuccess,
+	onAccountRecoverySettingsDeleteFailed,
+	onAccountRecoverySettingsDeleteSuccess,
+	onAccountRecoverySettingsFetchFailed,
+	onAccountRecoverySettingsUpdateFailed,
+	onAccountRecoverySettingsUpdateSuccess,
+	onResentAccountRecoveryEmailValidationFailed,
+	onResentAccountRecoveryEmailValidationSuccess,
+} from 'calypso/state/account-recovery/settings/notices';
 
 import 'calypso/state/account-recovery/init';
 
@@ -54,7 +65,10 @@ export const accountRecoverySettingsFetch = () => ( dispatch ) => {
 		.then( ( accountRecoverySettings ) =>
 			dispatch( accountRecoverySettingsFetchSuccess( accountRecoverySettings ) )
 		)
-		.catch( ( error ) => dispatch( accountRecoverySettingsFetchFailed( error ) ) );
+		.catch( ( error ) => {
+			dispatch( accountRecoverySettingsFetchFailed( error ) );
+			dispatch( onAccountRecoverySettingsFetchFailed() );
+		} );
 };
 
 const updateSuccessAction = ( target, value ) => ( {
@@ -96,8 +110,14 @@ export const updateAccountRecoveryPhone = ( newPhone ) => ( dispatch ) => {
 		.undocumented()
 		.me()
 		.updateAccountRecoveryPhone( newPhone.countryCode, newPhone.number )
-		.then( () => dispatch( updateAccountRecoveryPhoneSuccess( newPhone ) ) )
-		.catch( ( error ) => dispatch( updateAccountRecoveryPhoneFailed( error ) ) );
+		.then( () => {
+			dispatch( updateAccountRecoveryPhoneSuccess( newPhone ) );
+			dispatch( onAccountRecoverySettingsUpdateSuccess( { target: TARGET_PHONE } ) );
+		} )
+		.catch( ( error ) => {
+			dispatch( updateAccountRecoveryPhoneFailed( error ) );
+			dispatch( onAccountRecoverySettingsUpdateFailed( { target: TARGET_PHONE } ) );
+		} );
 };
 
 export const deleteAccountRecoveryPhoneSuccess = () => deleteSuccessAction( TARGET_PHONE );
@@ -115,8 +135,14 @@ export const deleteAccountRecoveryPhone = () => ( dispatch ) => {
 		.undocumented()
 		.me()
 		.deleteAccountRecoveryPhone()
-		.then( () => dispatch( deleteAccountRecoveryPhoneSuccess() ) )
-		.catch( ( error ) => dispatch( deleteAccountRecoveryPhoneFailed( error ) ) );
+		.then( () => {
+			dispatch( deleteAccountRecoveryPhoneSuccess() );
+			dispatch( onAccountRecoverySettingsDeleteSuccess( { target: TARGET_PHONE } ) );
+		} )
+		.catch( ( error ) => {
+			dispatch( deleteAccountRecoveryPhoneFailed( error ) );
+			dispatch( onAccountRecoverySettingsDeleteFailed( { target: TARGET_PHONE } ) );
+		} );
 };
 
 export const updateAccountRecoveryEmailSuccess = ( email ) =>
@@ -135,8 +161,14 @@ export const updateAccountRecoveryEmail = ( newEmail ) => ( dispatch ) => {
 		.undocumented()
 		.me()
 		.updateAccountRecoveryEmail( newEmail )
-		.then( () => dispatch( updateAccountRecoveryEmailSuccess( newEmail ) ) )
-		.catch( ( error ) => dispatch( updateAccountRecoveryEmailFailed( error ) ) );
+		.then( () => {
+			dispatch( updateAccountRecoveryEmailSuccess( newEmail ) );
+			dispatch( onAccountRecoverySettingsUpdateSuccess( { target: TARGET_EMAIL } ) );
+		} )
+		.catch( ( error ) => {
+			dispatch( updateAccountRecoveryEmailFailed( error ) );
+			dispatch( onAccountRecoverySettingsUpdateFailed( { target: TARGET_EMAIL } ) );
+		} );
 };
 
 export const deleteAccountRecoveryEmailSuccess = () => deleteSuccessAction( TARGET_EMAIL );
@@ -154,8 +186,14 @@ export const deleteAccountRecoveryEmail = () => ( dispatch ) => {
 		.undocumented()
 		.me()
 		.deleteAccountRecoveryEmail()
-		.then( () => dispatch( deleteAccountRecoveryEmailSuccess() ) )
-		.catch( ( error ) => dispatch( deleteAccountRecoveryEmailFailed( error ) ) );
+		.then( () => {
+			dispatch( deleteAccountRecoveryEmailSuccess() );
+			dispatch( onAccountRecoverySettingsDeleteSuccess( { target: TARGET_EMAIL } ) );
+		} )
+		.catch( ( error ) => {
+			dispatch( deleteAccountRecoveryEmailFailed( error ) );
+			dispatch( onAccountRecoverySettingsDeleteFailed( { target: TARGET_EMAIL } ) );
+		} );
 };
 
 export const resendAccountRecoveryEmailValidationSuccess = () => {
@@ -183,8 +221,14 @@ export const resendAccountRecoveryEmailValidation = () => ( dispatch ) => {
 		.undocumented()
 		.me()
 		.newValidationAccountRecoveryEmail()
-		.then( () => dispatch( resendAccountRecoveryEmailValidationSuccess() ) )
-		.catch( ( error ) => dispatch( resendAccountRecoveryEmailValidationFailed( error ) ) );
+		.then( () => {
+			dispatch( resendAccountRecoveryEmailValidationSuccess() );
+			dispatch( onResentAccountRecoveryEmailValidationSuccess( { target: TARGET_EMAIL } ) );
+		} )
+		.catch( ( error ) => {
+			dispatch( resendAccountRecoveryEmailValidationFailed( error ) );
+			dispatch( onResentAccountRecoveryEmailValidationFailed( { target: TARGET_EMAIL } ) );
+		} );
 };
 
 export const resendAccountRecoveryPhoneValidationSuccess = () => {
@@ -212,8 +256,14 @@ export const resendAccountRecoveryPhoneValidation = () => ( dispatch ) => {
 		.undocumented()
 		.me()
 		.newValidationAccountRecoveryPhone()
-		.then( () => dispatch( resendAccountRecoveryPhoneValidationSuccess() ) )
-		.catch( ( error ) => dispatch( resendAccountRecoveryPhoneValidationFailed( error ) ) );
+		.then( () => {
+			dispatch( resendAccountRecoveryPhoneValidationSuccess() );
+			dispatch( onResentAccountRecoveryEmailValidationSuccess( { target: TARGET_PHONE } ) );
+		} )
+		.catch( ( error ) => {
+			dispatch( resendAccountRecoveryPhoneValidationFailed( error ) );
+			dispatch( onResentAccountRecoveryEmailValidationFailed( { target: TARGET_PHONE } ) );
+		} );
 };
 
 export const validateAccountRecoveryPhoneSuccess = () => {
@@ -238,6 +288,12 @@ export const validateAccountRecoveryPhone = ( code ) => ( dispatch ) => {
 		.undocumented()
 		.me()
 		.validateAccountRecoveryPhone( replace( code, /\s/g, '' ) )
-		.then( () => dispatch( validateAccountRecoveryPhoneSuccess() ) )
-		.catch( ( error ) => dispatch( validateAccountRecoveryPhoneFailed( error ) ) );
+		.then( () => {
+			dispatch( validateAccountRecoveryPhoneSuccess() );
+			dispatch( onAccountRecoveryPhoneValidationSuccess() );
+		} )
+		.catch( ( error ) => {
+			dispatch( validateAccountRecoveryPhoneFailed( error ) );
+			dispatch( onAccountRecoveryPhoneValidationFailed() );
+		} );
 };

--- a/client/state/account-recovery/settings/notices.js
+++ b/client/state/account-recovery/settings/notices.js
@@ -16,7 +16,7 @@ import {
 
 const getUpdateSuccessMessage = ( target, getState ) => {
 	switch ( target ) {
-		case 'phone':
+		case 'phone': {
 			const oldPhone = getAccountRecoveryPhone( getState() );
 
 			if ( null == oldPhone ) {
@@ -24,8 +24,9 @@ const getUpdateSuccessMessage = ( target, getState ) => {
 			}
 
 			return translate( 'Successfully updated. Please check your phone for the validation code.' );
+		}
 
-		case 'email':
+		case 'email': {
 			const oldEmail = getAccountRecoveryEmail( getState() );
 
 			if ( ! oldEmail ) {
@@ -37,6 +38,7 @@ const getUpdateSuccessMessage = ( target, getState ) => {
 			return translate(
 				'Successfully updated. Please check your mailbox for the validation email.'
 			);
+		}
 
 		default:
 			return translate( 'Successfully updated the recovery option.', {

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -13,15 +13,6 @@ import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getInviteForSite } from 'calypso/state/invites/selectors';
 import { restorePost } from 'calypso/state/posts/actions';
 import {
-	ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
-	ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
-	ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
-	ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
-	ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
-	ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_SUCCESS,
-	ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED,
-	ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS,
-	ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED,
 	BILLING_RECEIPT_EMAIL_SEND_FAILURE,
 	BILLING_RECEIPT_EMAIL_SEND_SUCCESS,
 	BILLING_TRANSACTION_REQUEST_FAILURE,
@@ -44,18 +35,6 @@ import {
 	SITE_MONITOR_SETTINGS_UPDATE_FAILURE,
 } from 'calypso/state/action-types';
 import { purchasesRoot, billingHistoryReceipt } from 'calypso/me/purchases/paths';
-
-import {
-	onAccountRecoverySettingsFetchFailed,
-	onAccountRecoverySettingsUpdateFailed,
-	onAccountRecoverySettingsDeleteFailed,
-	onAccountRecoverySettingsUpdateSuccess,
-	onAccountRecoverySettingsDeleteSuccess,
-	onResentAccountRecoveryEmailValidationSuccess,
-	onResentAccountRecoveryEmailValidationFailed,
-	onAccountRecoveryPhoneValidationSuccess,
-	onAccountRecoveryPhoneValidationFailed,
-} from './account-recovery';
 
 /**
  * Handlers
@@ -233,15 +212,6 @@ export const onBillingTransactionRequestFailure = ( { transactionId, error } ) =
  */
 
 export const handlers = {
-	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]: onAccountRecoverySettingsFetchFailed,
-	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: onAccountRecoverySettingsUpdateSuccess,
-	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]: onAccountRecoverySettingsUpdateFailed,
-	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS ]: onAccountRecoverySettingsDeleteSuccess,
-	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]: onAccountRecoverySettingsDeleteFailed,
-	[ ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_SUCCESS ]: onResentAccountRecoveryEmailValidationSuccess,
-	[ ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED ]: onResentAccountRecoveryEmailValidationFailed,
-	[ ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS ]: onAccountRecoveryPhoneValidationSuccess,
-	[ ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED ]: onAccountRecoveryPhoneValidationFailed,
 	[ BILLING_RECEIPT_EMAIL_SEND_FAILURE ]: onBillingReceiptEmailSendFailure,
 	[ BILLING_RECEIPT_EMAIL_SEND_SUCCESS ]: onBillingReceiptEmailSendSuccess,
 	[ BILLING_TRANSACTION_REQUEST_FAILURE ]: onBillingTransactionRequestFailure,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the account recovery notices away from the notices middleware and into the corresponding action thunks. This way these notices get modularized together with the account recovery state module and don't clutter the main entry point.

#### Testing instructions

* Go through the account recovery flows and verify everything (specifically, the notices) still works the same way, including:
  * Adding a new account recovery phone number
  * Updating an account recovery phone number
  * Deleting an existing account recovery phone number
  * Adding a new account recovery email
  * Updating an account recovery email
  * Deleting an existing account recovery email
  * Requesting a new validation code.
* Verify all tests pass.
