### PR TITLE
Me: Use Redux for notices in formBase mixin

### DIFF
--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -8,8 +8,14 @@ const debug = debugFactory( 'calypso:me:form-base' );
 /**
  * Internal dependencies
  */
-import notices from 'calypso/notices';
 import user from 'calypso/lib/user';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
+import { reduxDispatch } from 'calypso/lib/redux-bridge';
+
+const noticeId = 'me-settings-notice';
+const noticeOptions = {
+	id: noticeId,
+};
 
 export default {
 	componentDidMount: function () {
@@ -48,9 +54,11 @@ export default {
 
 	showNotice: function () {
 		if ( this.props.userSettings.initialized && this.state.showNotice ) {
-			notices.clearNotices( 'notices' );
+			reduxDispatch( removeNotice( noticeId ) );
 
-			notices.success( this.props.translate( 'Settings saved successfully!' ) );
+			reduxDispatch(
+				successNotice( this.props.translate( 'Settings saved successfully!' ), noticeOptions )
+			);
 			this.state.showNotice = false;
 		}
 	},
@@ -74,9 +82,14 @@ export default {
 
 		// handle error case here
 		if ( error.message ) {
-			notices.error( error.message );
+			reduxDispatch( errorNotice( error.message, noticeOptions ) );
 		} else {
-			notices.error( this.props.translate( 'There was a problem saving your changes.' ) );
+			reduxDispatch(
+				errorNotice(
+					this.props.translate( 'There was a problem saving your changes.' ),
+					noticeOptions
+				)
+			);
 		}
 
 		this.setState( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the `formBase` mixin to use Redux. Even though this mixin is going away soon with @flootr's recent work, this PR aims to quickly get its notices out of the way because they're some of the few left that still use the legacy event emitter store. 

#### Testing instructions

* Go to `/me/account`
* Verify saving the form still yields a success notice.
* Disable your internet connection, and try saving; then verify it still yields an error notice.

Part of #48408.