### PR TITLE
Adds plan specific signup flows for monthly plans

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -243,6 +243,14 @@ export function generateFlows( {
 				'Signup flow for creating an online store with an Atomic site, forked from the design-first flow',
 			lastModified: '2019-11-27',
 		};
+
+		flows[ 'ecommerce-monthly' ] = {
+			steps: [ 'user', 'domains', 'plans-ecommerce-monthly' ],
+			destination: getSignupDestination,
+			description: 'Signup flow for creating an online store with an Atomic site',
+			lastModified: '2021-02-02',
+			showRecaptcha: true,
+		};
 	}
 
 	if ( isEnabled( 'signup/wpcc' ) ) {
@@ -399,6 +407,33 @@ export function generateFlows( {
 		lastModified: '2020-11-30',
 		pageTitle: translate( 'Launch your site' ),
 		providesDependenciesInQuery: [ 'siteSlug' ],
+	};
+
+	flows[ 'business-monthly' ] = {
+		steps: [ 'user', 'domains', 'plans-business-monthly' ],
+		destination: getSignupDestination,
+		description:
+			'Create an account and a blog and then add the business monthly plan to the users cart.',
+		lastModified: '2021-02-02',
+		showRecaptcha: true,
+	};
+
+	flows[ 'premium-monthly' ] = {
+		steps: [ 'user', 'domains', 'plans-premium-monthly' ],
+		destination: getSignupDestination,
+		description:
+			'Create an account and a blog and then add the premium monthly plan to the users cart.',
+		lastModified: '2021-02-02',
+		showRecaptcha: true,
+	};
+
+	flows[ 'personal-monthly' ] = {
+		steps: [ 'user', 'domains', 'plans-personal-monthly' ],
+		destination: getSignupDestination,
+		description:
+			'Create an account and a blog and then add the personal monthly plan to the users cart.',
+		lastModified: '2021-02-02',
+		showRecaptcha: true,
 	};
 
 	return flows;

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -67,6 +67,10 @@ const stepNameToModuleName = {
 	'p2-details': 'p2-details',
 	'p2-site': 'p2-site',
 	'domain-upsell': 'domain-upsell',
+	'plans-business-monthly': 'plans',
+	'plans-ecommerce-monthly': 'plans',
+	'plans-personal-monthly': 'plans',
+	'plans-premium-monthly': 'plans',
 };
 
 export function getStepModuleName( stepName ) {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -13,6 +13,10 @@ import {
 	PLAN_PREMIUM,
 	PLAN_BUSINESS,
 	PLAN_ECOMMERCE,
+	PLAN_PERSONAL_MONTHLY,
+	PLAN_PREMIUM_MONTHLY,
+	PLAN_BUSINESS_MONTHLY,
+	PLAN_ECOMMERCE_MONTHLY,
 	TYPE_FREE,
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
@@ -671,6 +675,50 @@ export function generateSteps( {
 			stepName: 'p2-site',
 			apiRequestFunction: createWpForTeamsSite,
 			providesDependencies: [ 'siteSlug' ],
+		},
+
+		'plans-personal-monthly': {
+			stepName: 'plans-personal-monthly',
+			apiRequestFunction: addPlanToCart,
+			fulfilledStepCallback: isPlanFulfilled,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'cartItem' ],
+			defaultDependencies: {
+				cartItem: PLAN_PERSONAL_MONTHLY,
+			},
+		},
+
+		'plans-premium-monthly': {
+			stepName: 'plans-premium-monthly',
+			apiRequestFunction: addPlanToCart,
+			fulfilledStepCallback: isPlanFulfilled,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'cartItem' ],
+			defaultDependencies: {
+				cartItem: PLAN_PREMIUM_MONTHLY,
+			},
+		},
+
+		'plans-business-monthly': {
+			stepName: 'plans-business-monthly',
+			apiRequestFunction: addPlanToCart,
+			fulfilledStepCallback: isPlanFulfilled,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'cartItem' ],
+			defaultDependencies: {
+				cartItem: PLAN_BUSINESS_MONTHLY,
+			},
+		},
+
+		'plans-ecommerce-monthly': {
+			stepName: 'plans-ecommerce-monthly',
+			apiRequestFunction: addPlanToCart,
+			fulfilledStepCallback: isPlanFulfilled,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'cartItem' ],
+			defaultDependencies: {
+				cartItem: PLAN_ECOMMERCE_MONTHLY,
+			},
 		},
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds signup flows for the monthly Personal, Premium, Business and eCommerce plans. These are similar to the annual plan specific flows (https://wordpress.com/start/personal)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Test these flows by following these URLs and verifying that:
1. The plans step is not shown.
2. The monthly plan is automatically added to the cart at the end of the flow.
3. (Optional) You are able to complete the purchase.

* /start/personal-monthly
* /start/premium-monthly
* /start/business-monthly
* /start/ecommerce-monthly

### Known Issue
The copy on the domains step mentions that the domain registration is free. This issue is also present when going through the /start/free flow as well. I will be taking this up separately, and it seems to be related to 408-gh-Automattic/dotcom-manage as well.