### PR TITLE
Signup: Fix Google sign-up unexpected error.

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -205,6 +205,12 @@ export class UserStep extends Component {
 	};
 
 	isOauth2RedirectValid( oauth2Redirect ) {
+		// Allow Google sign-up to work.
+		// See: https://github.com/Automattic/wp-calypso/issues/49572
+		if ( oauth2Redirect === undefined ) {
+			return true;
+		}
+
 		try {
 			const url = new URL( oauth2Redirect );
 			return url.host === 'public-api.wordpress.com';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This fixes the error message "An unexpected error has occurred" when user attempts to sign-up with Google. 

See convo: p1612274114056300-slack-C013QHLF28Y

#### Testing instructions

* Go to `calypso.localhost:3000/start/user`.
* Click "Continue with Google" to create a user using Google account.
* It should not show the error "An unexpected error has occured".
* It should redirect to `/start/domains`.

Fixes: #49572