### PR TITLE
Design Picker: re-enable Reynolds design

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -130,7 +130,7 @@
 			},
 			"categories": [ "featured", "portfolio" ],
 			"is_premium": false,
-			"is_alpha": true,
+			"is_alpha": false,
 			"features": []
 		},
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Re-Enable Reynolds in [`/new`](https://wordpress.com/new) onboarding flow. It was disabled in https://github.com/Automattic/wp-calypso/pull/48887

#### Testing instructions


* Open /new
* Proceed to design
* Observe design

Here's a direct test link that's easier, no need to open live-branch for testing:

https://public-api.wordpress.com/rest/v1/template/demo/rockfield/reynolds/?language=en&site_title=&font_headings=Playfair%20Display&font_base=Fira%20Sans

Depends on:
- [x] https://github.com/Automattic/block-experiments/pull/161 merged and deployed to .com
- [x] https://github.com/Automattic/themes/issues/2971  / https://github.com/Automattic/themes/pull/3197 merged & deployed to .com
- [x] Issues with button colors: https://github.com/Automattic/wp-calypso/pull/49608#issuecomment-776850229

FYI @ianstewart — this PR allows easy testing of Reynolds design while it's disabled:

https://calypso.live/new/design?branch=update/re-enable-reynolds-design