### PR TITLE
Force light color scheme in the Jetpack Connection header

### DIFF
--- a/client/components/jetpack-header/eurodns.jsx
+++ b/client/components/jetpack-header/eurodns.jsx
@@ -7,7 +7,7 @@ import React from 'react';
  * Module variables
  */
 
-const lightColorSchemeLogo = (
+const darkColorSchemeLogo = (
 	<g transform="translate(360.000000, 0.000000) scale(6.5)" fillRule="nonzero">
 		<g fill="#FFF">
 			<path
@@ -72,7 +72,7 @@ const lightColorSchemeLogo = (
 	</g>
 );
 
-const darkColorSchemeLogo = (
+const lightColorSchemeLogo = (
 	<g transform="translate(360.000000, 0.000000) scale(6.5)" fillRule="nonzero">
 		<g fill="#3EC1E6">
 			<path

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -54,7 +54,7 @@ export class JetpackConnectMainWrapper extends PureComponent {
 		} );
 
 		const width = isWoo || isWooDna ? 200 : undefined;
-		const darkColorScheme = isWoo || isWooDna ? false : true;
+		const darkColorScheme = false;
 
 		return (
 			<Main className={ classNames( className, wrapperClassName ) }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We have two versions of partner logos; one for the darc color scheme and one for the light color scheme. Previously Woo and WooDna were using the light color scheme and the rest of Jetpack was using the dark one.

Now that we're using a light background for the connection flow our partner logos don't look right so we need to force the light color scheme so that they render the correct versions of the logos.

This patch does two things:
1. Forces the light color scheme for the JetpackHeader components.
2. Flips the light and dark schemes for the EuroDns logo which was set incorrectly before.

### Other considerations

This change makes it so that the dark scheme is not used at all but I think it's a safe bet to keep the code there anyways. In the likely event that either the Woo or WordPress.com palette changes in the future it will be very easy to have each of these with it's own dark/light scheme as it has been until now.

#### Before and after screenshots for each logo

Before | After
--- | ---
![bluehost_dark](https://user-images.githubusercontent.com/348248/106638108-1dafa380-6549-11eb-86b4-51de8e6a06dd.png) | ![bluehost_light](https://user-images.githubusercontent.com/348248/106638117-22745780-6549-11eb-8dbb-9cf9029ca6fa.png)
![dreamhost_dark](https://user-images.githubusercontent.com/348248/106638220-4041bc80-6549-11eb-9a1b-a42433d191bb.png) | ![dreamhost_light](https://user-images.githubusercontent.com/348248/106638228-42a41680-6549-11eb-81c8-b51af4e5c74b.png)
![eurodns_dark](https://user-images.githubusercontent.com/348248/106638300-58194080-6549-11eb-8494-f76c4c255a4a.png) | ![eurodns_light](https://user-images.githubusercontent.com/348248/106638315-5c455e00-6549-11eb-9d12-21ad8da3dafd.png)
![inmotion_dark](https://user-images.githubusercontent.com/348248/106638327-5fd8e500-6549-11eb-85ad-9b0a93a84a4d.png) | ![inmotion_light](https://user-images.githubusercontent.com/348248/106638339-636c6c00-6549-11eb-884f-22bd6a8ff3ef.png)
![liquidweb_dark](https://user-images.githubusercontent.com/348248/106638989-189f2400-654a-11eb-8724-03bcc2b22f3d.png) | ![liquidweb_light](https://user-images.githubusercontent.com/348248/106638997-1b017e00-654a-11eb-90c6-0f15814d5401.png)
![milesweb_dark](https://user-images.githubusercontent.com/348248/106639010-1e950500-654a-11eb-96a9-8713b591176e.png) |  ![milesweb_light](https://user-images.githubusercontent.com/348248/106639030-2359b900-654a-11eb-8f36-5c6eb8f1a0c4.png)
![pressable_dark](https://user-images.githubusercontent.com/348248/106639038-26ed4000-654a-11eb-973d-8e1fba1ab2ab.png) | ![pressable_light](https://user-images.githubusercontent.com/348248/106639063-2eace480-654a-11eb-82d2-12e6617c4b2d.png)

#### Testing instructions

1. Create a temporary WordPress site and install Jetpack. But don't connect it. You will not need to connect Jetpack at all to test this PR.
2. In wp-admin go to the Jetpack Dashboard and look for the "Set up Jetpack" button but don't click on it.
3. Open your browser's console and paste `jpConnect.forceVariation = 'original';` in it. Hit "Enter" to run the command. This will force the Calypso connection flow. If you need to go back to this step you will need to re-execute this command as it is not persistent.
4. Click on the "Set up Jetpack" button and you should be redirected to a URL that starts with `https://wordpress.com/jetpack/connect/authorize` followed by a lot of query params. If you haven't then the previous step failed and you need to go back to step 2.
5. Copy the the above url into your clipboard except for the domain. So, just copy the path and query string.
6. Launch your Calypso dev environment and paste what you copied in the previous step so that the same path and query string is opened up in your local Calypso dev.
7. You should now be looking at a regular connection prompt.
8. At the end of the query string, add the following: `&partner_id=` and for the id use any of the ones below:

Partner | partner_id
--- | ---
Pressable | 49640
Dreamhost | 51946
Inmotion | 57836
Bluehost | 58712
Miles | 57733
Liquidweb | 60179
Eurodns | 65774

9. Hit enter to reload the page with the new `partner_id`.
10. You should now see the darker version of each partner logo and not the white one.
11. Repeat with all the partner IDs and make sure they all render the dark version of their logos.
