### PR TITLE
Jetpack Cloud Checkout: Redirect to site's /wp-admin after checkout

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -16,7 +16,14 @@ import {
 	PRODUCT_JETPACK_CRM_MONTHLY,
 } from 'calypso/lib/products-values/constants';
 
-export const JETPACK_REDIRECT_URL = 'https://jetpack.com/redirect/';
+// If JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN is true, checkout will redirect to the site's wp-admin,
+// otherwise it will redirect to the JETPACK_REDIRECT_URL. Checkout references these constants in:
+// client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+export const JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN = true;
+export const JETPACK_REDIRECT_URL =
+	'https://jetpack.com/redirect/?source=jetpack-checkout-thankyou';
+export const redirectCloudCheckoutToWpAdmin = () =>
+	JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN ? true : false;
 
 // plans constants
 export const PLAN_BUSINESS_MONTHLY = 'business-bundle-monthly';

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -22,8 +22,7 @@ import {
 export const JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN = true;
 export const JETPACK_REDIRECT_URL =
 	'https://jetpack.com/redirect/?source=jetpack-checkout-thankyou';
-export const redirectCloudCheckoutToWpAdmin = () =>
-	JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN ? true : false;
+export const redirectCloudCheckoutToWpAdmin = () => !! JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN;
 
 // plans constants
 export const PLAN_BUSINESS_MONTHLY = 'business-bundle-monthly';


### PR DESCRIPTION
This PR allows Jetpack Cloud checkout to redirect to the site's wp-admin after checkout complete.

If checkout is taking place on Jetpack Cloud and the product is a non-atomic Jetpack product, post-checkout will redirect to the site's `/wp-admin/admin.php?page=jetpack#/my-plan` page.

### Changes proposed in this Pull Request

- Added `JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN` flag to allow Jetpack Cloud post-checkout to redirect to the site's wp-admin. If we ever want Jetpack Cloud checkout to redirect to another location, we can set this flag to `false` which will then default the redirect to the Jetpack Redirect API location.
- Added unit test

### Testing instructions

- Checkout and run this PR in Jetpack Cloud  (`yarn start-jetpack-cloud`)  
- Select a Jetpack site and go to the pricing page: `jetpack.cloud.localhost:3000/pricing/:site`
- Purchase any Jetpack product.
- Verify you are redirected to the site's /wp-admin jetpack #my-plan page (`https://[:site]/wp-admin/admin.php?page=jetpack#/my-plan` after checkout complete.
- Bonus for testing various products.
- Run unit tests and verify they pass.
    -  `yarn test-client client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js`


Related to 1199409969959876-as-1199888532760590