### PR TITLE
ABTest: Stop the jetpackSimplifyPricingPage test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -68,14 +68,4 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: false,
 	},
-	jetpackSimplifyPricingPage: {
-		datestamp: '20210125',
-		variations: {
-			test: 50,
-			control: 50,
-		},
-		localeTargets: 'any',
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 };

--- a/client/my-sites/plans/jetpack-plans/abtest.ts
+++ b/client/my-sites/plans/jetpack-plans/abtest.ts
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { abtest } from 'calypso/lib/abtest';
 import { getUrlParts } from 'calypso/lib/url/url-parts';
 
 const VERSIONS = [ 'i5', 'spp' ];
@@ -25,13 +24,8 @@ export const getJetpackCROActiveVersion = (): string => {
 		}
 	}
 
-	// Otherwise, check for the assigned A/B test value
-	const variant = abtest( 'jetpackSimplifyPricingPage' );
-
-	switch ( variant ) {
-		case 'test':
-			return 'spp';
-		default:
-			return DEFAULT_VERSION;
-	}
+	// The `spp` iteration still exists for now,
+	// but the test is over, so we don't need (or want) to call `abtest`.
+	// Instead, always return the default iteration.
+	return DEFAULT_VERSION;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `jetpackSimplifyPricingPage` from the list of active tests.
* Remove calls to `abtest` to determine the active CRO iteration. When `getJetpackCROActiveVersion` is called, default to `DEFAULT_VERSION` if an iteration isn't explicitly set in the browser URL.

#### Testing instructions

* On Calypso Blue, Green, and in Jetpack Connect, verify that all pricing pages show the default ("i5") iteration.
* Verify that the `jetpackSimplifyPricingPage` test is no longer part of the list of active A/B tests in the test helper panel.
* Verify that all pages perform as intended with no unexpected errors.
* Verify that the "spp" iteration is still reachable by including `cloud-pricing-page=spp` as a query parameter in the browser URL.