### PR TITLE
Update/49420 always deprecate store

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -175,7 +175,6 @@ class Dashboard extends Component {
 			setupChoicesLoading,
 			storeLocation,
 			shouldRedirectAfterInstall,
-			isCalypsoStoreDeprecatedOrRemoved,
 			isSiteWpcomStore,
 		} = this.props;
 
@@ -194,11 +193,7 @@ class Dashboard extends Component {
 			return <RequiredPluginsInstallView site={ selectedSite } />;
 		}
 
-		if (
-			finishedInstallOfRequiredPlugins &&
-			isCalypsoStoreDeprecatedOrRemoved &&
-			shouldRedirectAfterInstall
-		) {
+		if ( finishedInstallOfRequiredPlugins && shouldRedirectAfterInstall ) {
 			// Redirect to Core UI setup after finish installation if store is
 			// installed on this site. This check is needed because of an edge
 			// case where, if WooCommerce was installed then removed, then
@@ -277,10 +272,9 @@ class Dashboard extends Component {
 			siteId,
 			finishedInstallOfRequiredPlugins,
 			shouldRedirectAfterInstall,
-			isCalypsoStoreDeprecatedOrRemoved,
 		} = this.props;
 		const useWideLayout = isSetupComplete ? true : false;
-		const shouldShowStoreNotice = isCalypsoStoreDeprecatedOrRemoved && ! shouldRedirectAfterInstall;
+		const shouldShowStoreNotice = ! shouldRedirectAfterInstall;
 		const shouldRenderDashboardContents =
 			! config.isEnabled( 'woocommerce/store-removed' ) ||
 			! finishedInstallOfRequiredPlugins ||
@@ -325,9 +319,6 @@ function mapStateToProps( state ) {
 	const loading = setupChoicesLoading || ! hasCounts || settingsGeneralLoading;
 	const shouldRedirectAfterInstall =
 		'' === get( getCurrentQueryArguments( state ), 'redirect_after_install' );
-	const isCalypsoStoreDeprecatedOrRemoved =
-		config.isEnabled( 'woocommerce/store-deprecated' ) ||
-		config.isEnabled( 'woocommerce/store-removed' );
 
 	const isSiteWpcomStore = getSiteOption( state, siteId, 'is_wpcom_store' );
 
@@ -347,7 +338,6 @@ function mapStateToProps( state ) {
 		siteId,
 		storeLocation,
 		shouldRedirectAfterInstall,
-		isCalypsoStoreDeprecatedOrRemoved,
 		isSiteWpcomStore,
 	};
 }

--- a/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
@@ -43,28 +43,24 @@ class StoreMoveNoticeView extends Component {
 	};
 
 	render = () => {
-		const { site, isStoreDeprecated, isStoreRemoved } = this.props;
-		const status = getStoreStatus( isStoreDeprecated, isStoreRemoved );
+		const { site, isStoreRemoved } = this.props;
+		const status = getStoreStatus( true, isStoreRemoved );
 
 		return (
 			<Card className={ classNames( 'dashboard__store-move-notice', status ) }>
 				<img src={ megaphoneImage } alt="" />
 				<h1>{ translate( 'Find all of your business features in WooCommerce' ) }</h1>
 				<p>
-					{ isStoreDeprecated &&
-						translate(
-							'We’re retiring Store on February 22. With WooCommerce, discover a more flexible store management experience — including top-level access to your Analytics, Marketing, and Customers. {{link}}Learn more{{/link}} about what to expect.',
-							{
-								components: {
-									link: (
-										<a
-											onClick={ this.trackLearnMoreAboutWooCommerceClick }
-											href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/"
-										/>
-									),
-								},
-							}
-						) }
+					{ translate(
+						'We’re retiring Store on February 22. With WooCommerce, discover a more flexible store management experience — including top-level access to your Analytics, Marketing, and Customers. {{link}}Learn more{{/link}} about what to expect.',
+						{
+							components: {
+								link: (
+									<a href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/" />
+								),
+							},
+						}
+					) }
 					{ isStoreRemoved &&
 						translate(
 							'We’ve rolled your favorite Store features into WooCommerce. In addition to Products and Orders, you have top-level access for managing your Analytics, Marketing, and Customers. {{link}}Learn more{{/link}} about what has changed.',
@@ -95,7 +91,6 @@ class StoreMoveNoticeView extends Component {
 function mapStateToProps( state ) {
 	return {
 		site: getSelectedSiteWithFallback( state ),
-		isStoreDeprecated: config.isEnabled( 'woocommerce/store-deprecated' ),
 		isStoreRemoved: config.isEnabled( 'woocommerce/store-removed' ),
 	};
 }

--- a/client/extensions/woocommerce/app/orders/index.js
+++ b/client/extensions/woocommerce/app/orders/index.js
@@ -33,7 +33,7 @@ function Orders( { className, params, site, translate } ) {
 			<ActionHeader breadcrumbs={ <span>{ translate( 'Orders' ) }</span> }>
 				{ addButton }
 			</ActionHeader>
-			{ config.isEnabled( 'woocommerce/store-deprecated' ) && <StoreDeprecatedNotice /> }
+			{ <StoreDeprecatedNotice /> }
 			<OrdersList currentStatus={ params && params.filter } />
 		</Main>
 	);

--- a/client/extensions/woocommerce/app/products/index.js
+++ b/client/extensions/woocommerce/app/products/index.js
@@ -9,7 +9,6 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { trim } from 'lodash';
-import config from '@automattic/calypso-config';
 
 /**
  * Internal dependencies
@@ -128,7 +127,7 @@ class Products extends Component {
 						{ translate( 'Add a product' ) }
 					</Button>
 				</ActionHeader>
-				{ config.isEnabled( 'woocommerce/store-deprecated' ) && <StoreDeprecatedNotice /> }
+				{ <StoreDeprecatedNotice /> }
 				{ this.renderSectionNav() }
 				{ productsDisplay }
 			</Main>

--- a/client/extensions/woocommerce/app/promotions/index.js
+++ b/client/extensions/woocommerce/app/promotions/index.js
@@ -9,7 +9,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import config from '@automattic/calypso-config';
 
 /**
  * Internal dependencies
@@ -111,7 +110,7 @@ class Promotions extends Component {
 						{ translate( 'Add promotion' ) }
 					</Button>
 				</ActionHeader>
-				{ config.isEnabled( 'woocommerce/store-deprecated' ) && <StoreDeprecatedNotice /> }
+				{ <StoreDeprecatedNotice /> }
 				{ content }
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/reviews/index.js
+++ b/client/extensions/woocommerce/app/reviews/index.js
@@ -7,7 +7,6 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import config from '@automattic/calypso-config';
 
 /**
  * Internal dependencies
@@ -33,7 +32,7 @@ class Reviews extends Component {
 		return (
 			<Main className={ classes } wideLayout>
 				<ActionHeader breadcrumbs={ <span>{ translate( 'Reviews' ) }</span> } />
-				{ config.isEnabled( 'woocommerce/store-deprecated' ) && <StoreDeprecatedNotice /> }
+				{ <StoreDeprecatedNotice /> }
 				<ReviewsList
 					productId={ params && params.product_id && Number( params.product_id ) }
 					currentStatus={ params && params.filter }

--- a/client/extensions/woocommerce/app/settings/navigation.js
+++ b/client/extensions/woocommerce/app/settings/navigation.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { find } from 'lodash';
 import { localize } from 'i18n-calypso';
-import config from '@automattic/calypso-config';
 
 /**
  * Internal dependencies
@@ -45,7 +44,7 @@ export const SettingsNavigation = ( { site, activeSection, translate } ) => {
 	const section = find( items, { id: activeSection } );
 	return (
 		<div>
-			{ config.isEnabled( 'woocommerce/store-deprecated' ) && <StoreDeprecatedNotice /> }
+			{ <StoreDeprecatedNotice /> }
 			<SectionNav selectedText={ section && section.title }>
 				<NavTabs>
 					{ items.map( ( { id, path, title } ) => {

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -716,9 +716,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		const isCalypsoStoreDeprecated = isEnabled( 'woocommerce/store-deprecated' );
-
-		if ( ! isSiteWpcomStore && isCalypsoStoreDeprecated && isBusiness( site.plan ) ) {
+		if ( ! isSiteWpcomStore && isBusiness( site.plan ) ) {
 			return null;
 		}
 
@@ -771,14 +769,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		const isCalypsoStoreDeprecatedOrRemoved =
-			isEnabled( 'woocommerce/store-deprecated' ) || isEnabled( 'woocommerce/store-removed' );
-
-		if (
-			! isCalypsoStoreDeprecatedOrRemoved ||
-			! isBusiness( site.plan ) ||
-			! canUserUseWooCommerceCoreStore
-		) {
+		if ( ! isBusiness( site.plan ) || ! canUserUseWooCommerceCoreStore ) {
 			// Right now, we only use the "WooCommerce" label for Business plan sites.
 			// eCommerce sites continue to use the "Store" label for now
 			// (see handling in `store()` above.

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -176,28 +176,6 @@ describe( 'MySitesSidebar', () => {
 			config.isEnabled.mockImplementation( () => true );
 		} );
 
-		test( 'Should return null item if woocommerce/store-deprecated and woocommerce/store-removed is disabled', () => {
-			// Enable all features except for store deprecation and removal
-			config.isEnabled.mockImplementation( ( feature ) => {
-				return (
-					feature !== 'woocommerce/store-deprecated' && feature !== 'woocommerce/store-removed'
-				);
-			} );
-			const Sidebar = new MySitesSidebar( {
-				canUserUseWooCommerceCoreStore: true,
-				...defaultProps,
-				site: {
-					plan: {
-						product_slug: 'business-bundle',
-					},
-				},
-			} );
-			const WooCommerce = () => Sidebar.woocommerce();
-
-			const wrapper = shallow( <WooCommerce /> );
-			expect( wrapper.html() ).toEqual( null );
-		} );
-
 		test( 'Should return null item if site has Personal plan', () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseWooCommerceCoreStore: false,

--- a/client/state/sites/selectors/can-current-user-use-calypso-store.js
+++ b/client/state/sites/selectors/can-current-user-use-calypso-store.js
@@ -35,8 +35,5 @@ export default function canCurrentUserUseCalypsoStore( state, siteId = null ) {
 	const subscribedDate = new Date( currentPlan.subscribedDate );
 	const subscribedBeforeDeprecation = subscribedDate < STORE_DEPRECATION_START_DATE;
 
-	return (
-		canCurrentUserUseAnyWooCommerceBasedStore( state, siteId ) &&
-		( config.isEnabled( 'woocommerce/store-deprecated' ) ? subscribedBeforeDeprecation : true )
-	);
+	return canCurrentUserUseAnyWooCommerceBasedStore( state, siteId ) && subscribedBeforeDeprecation;
 }

--- a/client/state/sites/selectors/can-current-user-use-woocommerce-core-store.js
+++ b/client/state/sites/selectors/can-current-user-use-woocommerce-core-store.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import config from '@automattic/calypso-config';
 import canCurrentUserUseAnyWooCommerceBasedStore from 'calypso/state/sites/selectors/can-current-user-use-any-woocommerce-based-store';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
@@ -25,13 +24,8 @@ export default function canCurrentUserUseWooCommerceCoreStore( state, siteId = n
 		return false;
 	}
 
-	const isCalypsoStoreDeprecatedOrRemoved =
-		config.isEnabled( 'woocommerce/store-deprecated' ) ||
-		config.isEnabled( 'woocommerce/store-removed' );
-
 	return (
 		canCurrentUserUseAnyWooCommerceBasedStore( state, siteId ) &&
-		( isEcommercePlan( currentPlan.productSlug ) ||
-			( isBusinessPlan( currentPlan.productSlug ) && isCalypsoStoreDeprecatedOrRemoved ) )
+		( isEcommercePlan( currentPlan.productSlug ) || isBusinessPlan( currentPlan.productSlug ) )
 	);
 }

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -3626,9 +3626,7 @@ describe( 'selectors', () => {
 		beforeEach( () => {
 			// Enable all features except for store deprecation and removal
 			config.isEnabled.mockImplementation( ( feature ) => {
-				return (
-					feature !== 'woocommerce/store-deprecated' && feature !== 'woocommerce/store-removed'
-				);
+				return feature !== 'woocommerce/store-removed';
 			} );
 		} );
 
@@ -3777,19 +3775,6 @@ describe( 'selectors', () => {
 			).toBe( false );
 		} );
 
-		test( 'should return false if site is Business and Store is not deprecated or removed', () => {
-			// Enable all features except for store deprecation
-			config.isEnabled.mockImplementation( ( feature ) => {
-				return (
-					feature !== 'woocommerce/store-deprecated' && feature !== 'woocommerce/store-removed'
-				);
-			} );
-
-			expect(
-				canCurrentUserUseWooCommerceCoreStore( createState( true, true, false, PLAN_BUSINESS ) )
-			).toBe( false );
-		} );
-
 		test( 'should return true if site is Business and Store is deprecated but not removed', () => {
 			// Enable all features except for store removal
 			config.isEnabled.mockImplementation( ( feature ) => feature !== 'woocommerce/store-removed' );
@@ -3800,11 +3785,6 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'should return true if site is Business and Store is not deprecated but is removed', () => {
-			// Enable all features except for store deprecation
-			config.isEnabled.mockImplementation(
-				( feature ) => feature !== 'woocommerce/store-deprecated'
-			);
-
 			expect(
 				canCurrentUserUseWooCommerceCoreStore( createState( true, true, false, PLAN_BUSINESS ) )
 			).toBe( true );

--- a/config/development.json
+++ b/config/development.json
@@ -27,11 +27,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
-	"livechat_support_locales": [
-		"en",
-		"es",
-		"pt-br"
-	],
+	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
 		"anchor-fm-dev": true,
@@ -221,7 +217,6 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
-		"woocommerce/store-deprecated": true,
 		"woocommerce/store-removed": false,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false

--- a/config/production.json
+++ b/config/production.json
@@ -171,7 +171,6 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
-		"woocommerce/store-deprecated": true,
 		"woocommerce/store-removed": false,
 		"wpcom-user-bootstrap": true
 	},

--- a/config/stage.json
+++ b/config/stage.json
@@ -14,11 +14,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"livechat_support_locales": [
-		"en",
-		"es",
-		"pt-br"
-	],
+	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
 		"anchor-fm-dev": false,
@@ -181,7 +177,6 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
-		"woocommerce/store-deprecated": true,
 		"woocommerce/store-removed": false,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -187,7 +187,6 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
-		"woocommerce/store-deprecated": true,
 		"woocommerce/store-removed": false,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #49420 

- Removes use of `woocommerce/store-deprecated` flag and assumes that the store is always deprecated. 

#### Testing instructions

1. Start Calypso locally
2. Navigate the menu and each submenu as usual and confirm that each page behaves the same as when you had `woocommerce/store-deprecated` (Deprecated notice & menu)