### PR TITLE
Remove order count if store is removed

### DIFF
--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -325,7 +325,6 @@ function mapStateToProps( state ) {
 	const finishedAddressSetup = getSetStoreAddressDuringInitialSetup( state );
 	const hasProducts = getCountProducts( state ) > 0;
 	const isLoaded = areCountsLoaded( state );
-	const totalNewOrders = getCountNewOrders( state );
 	const settingsGeneralLoaded = areSettingsGeneralLoaded( state, siteId );
 	const storeLocation = getStoreLocation( state, siteId );
 	const pluginsLoaded = arePluginsLoaded( state, siteId );
@@ -334,6 +333,11 @@ function mapStateToProps( state ) {
 	const totalPendingReviews = isStoreRemoved ? 0 : getCountPendingReviews( state );
 	const shouldRedirectAfterInstall =
 		'' === get( getCurrentQueryArguments( state ), 'redirect_after_install' );
+
+	let totalNewOrders = 0;
+	if ( ! isStoreRemoved ) {
+		totalNewOrders = getCountNewOrders( state );
+	}
 
 	return {
 		allRequiredPluginsActive,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #48958 

* This PR removes the order count displayed in the sidebar after the store removal by setting the order count to 0.

#### Testing instructions

1. Start calypso with `woocommerce/store-removed` feature enabled or append URL with `?flags=woocommerce/store-removed`
2. Have Business site with at least 1 order with `processing`, `pending payment`, or `on-hold` status.
2. Manually navigate to store UI by replacing the URL with `/store/SITENAMEHERE`, example: `http://calypso.localhost:3000/store/ilyastestwoo5.wpcomstaging.com?flags=woocommerce/store-removed`
3. Confirm that there is no UI glitch described in the original issue #48958 
