### PR TITLE
desktop rewrite: implement SessionManager

### DIFF
--- a/desktop/app/lib/cookie-auth/README.md
+++ b/desktop/app/lib/cookie-auth/README.md
@@ -1,3 +1,0 @@
-# Cookie Auth
-
-Sets a WordPress.com login cookie using the OAuth token. This is required for the notifications client and post previews to work.

--- a/desktop/app/lib/keychain/index.js
+++ b/desktop/app/lib/keychain/index.js
@@ -7,26 +7,17 @@ const keytar = require( 'keytar' );
  * Module constants
  */
 const keychainService = 'WordPress.com';
-const credentialsKey = 'User Credentials';
 
-function set( key, value ) {
-	return keytar.setPassword( keychainService, key, value );
+async function write( key, value ) {
+	return keytar.setPassword( keychainService, key, JSON.stringify( value ) );
 }
 
-function get( key ) {
-	return keytar.getPassword( keychainService, key );
-}
-
-async function setUserInfo( info ) {
-	return await set( credentialsKey, JSON.stringify( info ) );
-}
-
-async function getUserInfo() {
-	const info = await get( credentialsKey );
-	if ( info ) {
-		return JSON.parse( info );
+async function fetch( key ) {
+	let value = await keytar.getPassword( keychainService, key );
+	if ( value ) {
+		value = JSON.parse( value );
 	}
-	return null;
+	return value;
 }
 
 async function clear() {
@@ -40,6 +31,6 @@ async function clear() {
 
 module.exports = {
 	clear,
-	setUserInfo,
-	getUserInfo,
+	write,
+	fetch,
 };

--- a/desktop/app/lib/keychain/index.js
+++ b/desktop/app/lib/keychain/index.js
@@ -12,7 +12,7 @@ async function write( key, value ) {
 	return keytar.setPassword( keychainService, key, JSON.stringify( value ) );
 }
 
-async function fetch( key ) {
+async function read( key ) {
 	let value = await keytar.getPassword( keychainService, key );
 	if ( value ) {
 		value = JSON.parse( value );
@@ -32,5 +32,5 @@ async function clear() {
 module.exports = {
 	clear,
 	write,
-	fetch,
+	read,
 };

--- a/desktop/app/lib/notifications/api/index.js
+++ b/desktop/app/lib/notifications/api/index.js
@@ -7,7 +7,7 @@ const EventEmitter = require( 'events' ).EventEmitter;
 /*
  * Internal dependencies
  */
-const state = require( '../../../lib/state' );
+const keychain = require( '../../../lib/keychain' );
 const { fetchNote, markReadStatus } = require( './notes' );
 const log = require( '../../../lib/logger' )( 'desktop:notifications:api' );
 
@@ -34,7 +34,7 @@ class WPNotificationsAPI extends EventEmitter {
 	}
 
 	async connect() {
-		const token = state.getUser().token;
+		const token = await keychain.fetch( 'wp_oauth_token' );
 
 		if ( ! token ) {
 			log.info( 'Failed to initialize websocket: token is NULL' );

--- a/desktop/app/lib/notifications/api/index.js
+++ b/desktop/app/lib/notifications/api/index.js
@@ -34,7 +34,7 @@ class WPNotificationsAPI extends EventEmitter {
 	}
 
 	async connect() {
-		const token = await keychain.fetch( 'wp_oauth_token' );
+		const token = await keychain.read( 'wp_oauth_token' );
 
 		if ( ! token ) {
 			log.info( 'Failed to initialize websocket: token is NULL' );

--- a/desktop/app/lib/notifications/api/index.js
+++ b/desktop/app/lib/notifications/api/index.js
@@ -25,19 +25,21 @@ class WPNotificationsAPI extends EventEmitter {
 		clearTimeout( this.pingTimeout );
 
 		this.pingTimeout = setTimeout( () => {
-			// TODO: Add Retry attempts
-			log.info( 'Websock heartbeat timed out, attempting to reconnect...' );
+			log.info( 'Websocket heartbeat timed out, attempting to reconnect...' );
 			this.ws.terminate();
 			this.connect();
 			// heartbeat timeout: server ping interval + conservative assumption of latency.
 		}, pingMs + 1000 );
 	}
 
-	async connect() {
-		const token = await keychain.read( 'wp_oauth_token' );
+	async connect( cookie ) {
+		// If a cookie value was not explicitly passed in, let's try to fetch it from the keychain
+		if ( ! cookie ) {
+			cookie = await keychain.read( 'wp_api_sec' );
+		}
 
-		if ( ! token ) {
-			log.info( 'Failed to initialize websocket: token is NULL' );
+		if ( ! cookie ) {
+			log.info( 'Failed to initialize websocket: missing wp_api_sec cookie' );
 			this.ws = null;
 			return;
 		}
@@ -47,7 +49,8 @@ class WPNotificationsAPI extends EventEmitter {
 			[],
 			{
 				headers: {
-					Authorization: `Bearer ${ token }`,
+					Origin: `https://public-api.wordpress.com`,
+					Cookie: `wp_api_sec=${ decodeURIComponent( cookie ) }`,
 				},
 			}
 		);

--- a/desktop/app/lib/session/index.js
+++ b/desktop/app/lib/session/index.js
@@ -8,7 +8,7 @@ const url = require( 'url' );
 /**
  * Internal Dependencies
  */
-const log = require( '../../lib/logger' )( 'cookie-auth' );
+const log = require( '../logger' )( 'cookie-auth' );
 
 /**
  * Module variables

--- a/desktop/app/lib/state/index.js
+++ b/desktop/app/lib/state/index.js
@@ -8,18 +8,6 @@ function State() {
 	this.loggedIn = false;
 }
 
-State.prototype.isLoggedIn = function () {
-	return this.loggedIn;
-};
-
-State.prototype.login = async function () {
-	this.loggedIn = true;
-};
-
-State.prototype.logout = function () {
-	this.loggedIn = false;
-};
-
 State.prototype.setLogPath = function ( path ) {
 	this.logPath = path;
 };

--- a/desktop/app/lib/state/index.js
+++ b/desktop/app/lib/state/index.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-const keychain = require( '../../lib/keychain' );
-
-/**
  * Module variables
  */
 
@@ -11,36 +6,18 @@ let state = false;
 
 function State() {
 	this.loggedIn = false;
-	this.user = false;
 }
 
 State.prototype.isLoggedIn = function () {
 	return this.loggedIn;
 };
 
-State.prototype.login = async function ( { user, token } ) {
+State.prototype.login = async function () {
 	this.loggedIn = true;
-
-	if ( user && token ) {
-		this.user = {
-			id: user.id,
-			token: `${ token }`,
-		};
-		keychain.setUserInfo( this.user );
-	}
-};
-
-State.prototype.getUser = function () {
-	if ( ! this.user && this.loggedIn ) {
-		this.user = keychain.getUserInfo();
-	}
-	return this.user;
 };
 
 State.prototype.logout = function () {
 	this.loggedIn = false;
-	this.user = false;
-	keychain.clear();
 };
 
 State.prototype.setLogPath = function ( path ) {

--- a/desktop/app/mainWindow/index.js
+++ b/desktop/app/mainWindow/index.js
@@ -8,7 +8,7 @@ const { app, BrowserWindow, ipcMain: ipc } = require( 'electron' );
  */
 const Config = require( '../lib/config' );
 const Settings = require( '../lib/settings' );
-const cookieAuth = require( '../lib/cookie-auth' );
+const session = require( '../lib/session' );
 const appInstance = require( '../lib/app-instance' );
 const platform = require( '../lib/platform' );
 const System = require( '../lib/system' );
@@ -41,7 +41,7 @@ function showAppWindow() {
 
 	mainWindow = new BrowserWindow( config );
 
-	cookieAuth( mainWindow, function () {
+	session( mainWindow, function () {
 		mainWindow.webContents.send( 'cookie-auth-complete' );
 	} );
 

--- a/desktop/app/mainWindow/index.js
+++ b/desktop/app/mainWindow/index.js
@@ -8,7 +8,7 @@ const { app, BrowserWindow, ipcMain: ipc } = require( 'electron' );
  */
 const Config = require( '../lib/config' );
 const Settings = require( '../lib/settings' );
-const session = require( '../lib/session' );
+const SessionManager = require( '../lib/session' );
 const appInstance = require( '../lib/app-instance' );
 const platform = require( '../lib/platform' );
 const System = require( '../lib/system' );
@@ -41,9 +41,7 @@ function showAppWindow() {
 
 	mainWindow = new BrowserWindow( config );
 
-	session( mainWindow, function () {
-		mainWindow.webContents.send( 'cookie-auth-complete' );
-	} );
+	SessionManager.init( mainWindow );
 
 	mainWindow.webContents.on( 'did-finish-load', function () {
 		mainWindow.webContents.send( 'app-config', System.getDetails() );

--- a/desktop/app/window-handlers/login-status/index.js
+++ b/desktop/app/window-handlers/login-status/index.js
@@ -10,6 +10,7 @@ const menu = require( '../../lib/menu' );
 const Config = require( '../../lib/config' );
 const platform = require( '../../lib/platform' );
 const SessionManager = require( '../../lib/session' );
+const WPNotificationsAPI = require( '../../lib/notifications/api' );
 
 module.exports = function ( mainWindow ) {
 	menu.set( app, mainWindow );
@@ -19,6 +20,13 @@ module.exports = function ( mainWindow ) {
 	} );
 	SessionManager.on( 'logged-out', () => {
 		handleLogout( mainWindow );
+	} );
+
+	SessionManager.on( 'api:connect', () => {
+		WPNotificationsAPI.connect();
+	} );
+	SessionManager.on( 'api:disconnect', () => {
+		WPNotificationsAPI.disconnect();
 	} );
 };
 

--- a/desktop/app/window-handlers/login-status/index.js
+++ b/desktop/app/window-handlers/login-status/index.js
@@ -9,6 +9,7 @@ const { app, ipcMain: ipc } = require( 'electron' );
  */
 const menu = require( '../../lib/menu' );
 const state = require( '../../lib/state' );
+const keychain = require( '../../lib/keychain' );
 const platform = require( '../../lib/platform' );
 const log = require( '../../lib/logger' )( 'desktop:login' );
 const WPNotificationsAPI = require( '../../lib/notifications/api' );
@@ -19,13 +20,14 @@ module.exports = function ( mainWindow ) {
 	ipc.on(
 		'user-login-status',
 		debounce(
-			async ( _, loggedIn, user, token ) => {
+			async ( _, loggedIn, _user, token ) => {
 				log.info( 'Received user login status: ', loggedIn );
 
 				if ( loggedIn ) {
 					menu.enableLoggedInItems( app, mainWindow );
 					platform.setDockMenu( true );
-					state.login( { user, token } );
+					state.login();
+					keychain.write( 'wp_oauth_token', token );
 
 					try {
 						await WPNotificationsAPI.connect();

--- a/desktop/app/window-handlers/login-status/index.js
+++ b/desktop/app/window-handlers/login-status/index.js
@@ -1,52 +1,34 @@
 /**
  * External Dependencies
  */
-const { debounce } = require( 'lodash' );
-const { app, ipcMain: ipc } = require( 'electron' );
+const { app } = require( 'electron' );
 
 /**
  * Internal dependencies
  */
 const menu = require( '../../lib/menu' );
-const state = require( '../../lib/state' );
-const keychain = require( '../../lib/keychain' );
+const Config = require( '../../lib/config' );
 const platform = require( '../../lib/platform' );
-const log = require( '../../lib/logger' )( 'desktop:login' );
-const WPNotificationsAPI = require( '../../lib/notifications/api' );
+const SessionManager = require( '../../lib/session' );
 
 module.exports = function ( mainWindow ) {
 	menu.set( app, mainWindow );
 
-	ipc.on(
-		'user-login-status',
-		debounce(
-			async ( _, loggedIn, _user, token ) => {
-				log.info( 'Received user login status: ', loggedIn );
-
-				if ( loggedIn ) {
-					menu.enableLoggedInItems( app, mainWindow );
-					platform.setDockMenu( true );
-					state.login();
-					keychain.write( 'wp_oauth_token', token );
-
-					try {
-						await WPNotificationsAPI.connect();
-					} catch ( e ) {
-						log.info( 'API failed to connect: ', e );
-					}
-				} else {
-					menu.disableLoggedInItems( app, mainWindow );
-					platform.setDockMenu( false );
-					state.logout();
-
-					WPNotificationsAPI.disconnect();
-				}
-			},
-			300,
-			{ leading: true, trailing: false }
-		)
-	);
-
-	// on boot, request user login-status
-	mainWindow.webContents.send( 'request-user-login-status' );
+	SessionManager.on( 'logged-in', () => {
+		handleLogin( mainWindow );
+	} );
+	SessionManager.on( 'logged-out', () => {
+		handleLogout( mainWindow );
+	} );
 };
+
+function handleLogin( mainWindow ) {
+	menu.enableLoggedInItems( app, mainWindow );
+	platform.setDockMenu( true );
+}
+
+function handleLogout( mainWindow ) {
+	platform.setDockMenu( false );
+	menu.disableLoggedInItems( app, mainWindow );
+	mainWindow.webContents.loadURL( Config.loginURL );
+}


### PR DESCRIPTION
### Description

This PR implements a `SessionManager` class to observe and broadcast authentication events off of the application's `MainWindow`, as well as decouples the keychain from the `state` module. (_Note_: eventually would like to deprecate the `state` module entirely, but this is a first step.)

Depends on #49626 