### PR TITLE
Connect to Pinghub w/ cookie auth

### DIFF
--- a/desktop/app/lib/notifications/api/index.js
+++ b/desktop/app/lib/notifications/api/index.js
@@ -25,7 +25,7 @@ class WPNotificationsAPI extends EventEmitter {
 		clearTimeout( this.pingTimeout );
 
 		this.pingTimeout = setTimeout( () => {
-			log.info( 'Websock heartbeat timed out, attempting to reconnect...' );
+			log.info( 'Websocket heartbeat timed out, attempting to reconnect...' );
 			this.ws.terminate();
 			this.connect();
 			// heartbeat timeout: server ping interval + conservative assumption of latency.

--- a/desktop/app/window-handlers/login-status/index.js
+++ b/desktop/app/window-handlers/login-status/index.js
@@ -10,6 +10,7 @@ const menu = require( '../../lib/menu' );
 const Config = require( '../../lib/config' );
 const platform = require( '../../lib/platform' );
 const SessionManager = require( '../../lib/session' );
+const WPNotificationsAPI = require( '../../lib/notifications/api' );
 
 module.exports = function ( mainWindow ) {
 	menu.set( app, mainWindow );
@@ -19,6 +20,13 @@ module.exports = function ( mainWindow ) {
 	} );
 	SessionManager.on( 'logged-out', () => {
 		handleLogout( mainWindow );
+	} );
+
+	SessionManager.on( 'api:connect', () => {
+		WPNotificationsAPI.connect();
+	} );
+	SessionManager.on( 'api:disconnect', () => {
+		WPNotificationsAPI.disconnect();
 	} );
 };
 


### PR DESCRIPTION
### Description

This PR amends Pinghub implementation to use cookie auth (instead of OAuth token as previous).

Depends on #49632.