### PR TITLE
Update DIFM CTA on /themes to use ExternalLink.

### DIFF
--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -17,6 +17,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import isUpworkBannerDismissed from 'calypso/state/selectors/is-upwork-banner-dismissed';
 import QueryPreferences from 'calypso/components/data/query-preferences';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import ExternalLink from 'calypso/components/external-link';
 
 /**
  * Style dependencies
@@ -78,7 +79,7 @@ class UpworkBanner extends PureComponent {
 			return null;
 		}
 		return (
-			<a
+			<ExternalLink
 				className="upwork-banner"
 				role="button"
 				style={ { backgroundColor: '#DAF5FC' } }
@@ -104,7 +105,7 @@ class UpworkBanner extends PureComponent {
 					className="upwork-banner__image"
 					src={ builderIllustration }
 				/>
-			</a>
+			</ExternalLink>
 		);
 	}
 }

--- a/client/blocks/upwork-banner/test/__snapshots__/index.js.snap
+++ b/client/blocks/upwork-banner/test/__snapshots__/index.js.snap
@@ -2,9 +2,10 @@
 
 exports[`UpworkBanner renders correctly 1`] = `
 <a
-  className="upwork-banner"
+  className="external-link upwork-banner"
   href="https://wordpress.com/built-by-wordpress-com/"
   onClick={[Function]}
+  rel="external"
   role="button"
   style={
     Object {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Replace regular `a` element with the `ExternalLink` component so the router will properly direct users to the non-Calypso [DIFM page](https://wordpress.com/built-by-wordpress-com/) on WordPress.com.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Head to **My Site > Design > Themes** (https://wordpress.com/themes).
- Click on "Show all themes".
- Click on the "Find your expert" button under the "Let our WordPress experts build your site" banner.
- Check the Network tab to confirm Tracks events are still firing, as expected.
- Confirm the browser navigates to https://wordpress.com/built-by-wordpress-com/.

Fixes #48947