### PR TITLE
Remove store in development and wpcalypso environments

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -159,7 +159,7 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/store-deprecated": true,
-		"woocommerce/store-removed": false,
+		"woocommerce/store-removed": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -27,11 +27,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
-	"livechat_support_locales": [
-		"en",
-		"es",
-		"pt-br"
-	],
+	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
 		"anchor-fm-dev": true,
@@ -222,7 +218,7 @@
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
 		"woocommerce/store-deprecated": true,
-		"woocommerce/store-removed": false,
+		"woocommerce/store-removed": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false
 	}

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -15,11 +15,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"livechat_support_locales": [
-		"en",
-		"es",
-		"pt-br"
-	],
+	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
 		"anchor-fm-dev": false,
@@ -191,7 +187,7 @@
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
 		"woocommerce/store-deprecated": true,
-		"woocommerce/store-removed": false,
+		"woocommerce/store-removed": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #49428 

This PR enables `woocommerce/store-removed` flag to prepare for the launch of the removal of Store.

#### Testing instructions

1. Start Calypso locally
2. Navigate to the menu and each submenu and confirm that they have `store-removed` behavior. 

Please refer to #49428 for the acceptance criteria.
