### PR TITLE
Enable woocommerce/store-removed in stage and prod

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -168,7 +168,7 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
-		"woocommerce/store-removed": false,
+		"woocommerce/store-removed": true,
 		"wpcom-user-bootstrap": true
 	},
 	"rtl": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -172,7 +172,7 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
-		"woocommerce/store-removed": false,
+		"woocommerce/store-removed": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #49429  

This PR enables `woocommerce/store-removed` flag in stage and production environments.

#### Testing instructions

1. Start Calypso locally
2. Navigate to the menu and each submenu and confirm that they have `store-removed` behavior. 

Please refer to #49429  for the acceptance criteria.
