### PR TITLE
Remove the use of woocommerce/store-removed. Store is removed permanently.

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
@@ -13,7 +13,6 @@ import { localize, translate } from 'i18n-calypso';
 
 import { Card, Button } from '@automattic/components';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
-import config from '@automattic/calypso-config';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 /**
  * Image dependencies
@@ -22,53 +21,24 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import megaphoneImage from 'calypso/assets/images/woocommerce/megaphone.svg';
 
 class StoreMoveNoticeView extends Component {
-	trackTryWooCommerceClick = () => {
-		this.props.recordTracksEvent( 'calypso_store_try_woocommerce_click' );
-	};
-
-	trackLearnMoreAboutWooCommerceClick = () => {
-		this.props.recordTracksEvent( 'calypso_store_learn_more_about_woocommerce_click' );
-	};
-
 	render = () => {
-		const { site, isStoreRemoved } = this.props;
+		const { site } = this.props;
 
 		return (
-			<Card
-				className={ classNames( 'dashboard__store-move-notice', {
-					'store-removed': isStoreRemoved,
-				} ) }
-			>
+			<Card className={ classNames( 'dashboard__store-move-notice', 'store-removed' ) }>
 				<img src={ megaphoneImage } alt="" />
 				<h1>{ translate( 'Find all of your business features in WooCommerce' ) }</h1>
 				<p>
-					{ isStoreRemoved
-						? translate(
-								'We’ve rolled your favorite Store features into WooCommerce. In addition to Products and Orders, you have top-level access for managing your Analytics, Marketing, and Customers. {{link}}Learn more{{/link}} about what has changed.',
-								{
-									components: {
-										link: (
-											<a
-												onClick={ this.trackLearnMoreAboutWooCommerceClick }
-												href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/"
-											/>
-										),
-									},
-								}
-						  )
-						: translate(
-								'We’re retiring Store on February 22. With WooCommerce, discover a more flexible store management experience — including top-level access to your Analytics, Marketing, and Customers. {{link}}Learn more{{/link}} about what to expect.',
-								{
-									components: {
-										link: (
-											<a
-												onClick={ this.trackLearnMoreAboutWooCommerceClick }
-												href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/"
-											/>
-										),
-									},
-								}
-						  ) }
+					{ translate(
+						'We’ve rolled your favorite Store features into WooCommerce. In addition to Products and Orders, you have top-level access for managing your Analytics, Marketing, and Customers. {{link}}Learn more{{/link}} about what has changed.',
+						{
+							components: {
+								link: (
+									<a href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/" />
+								),
+							},
+						}
+					) }
 				</p>
 				<Button
 					primary
@@ -85,7 +55,6 @@ class StoreMoveNoticeView extends Component {
 function mapStateToProps( state ) {
 	return {
 		site: getSelectedSiteWithFallback( state ),
-		isStoreRemoved: config.isEnabled( 'woocommerce/store-removed' ),
 	};
 }
 

--- a/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
@@ -21,6 +21,14 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import megaphoneImage from 'calypso/assets/images/woocommerce/megaphone.svg';
 
 class StoreMoveNoticeView extends Component {
+	trackTryWooCommerceClick = () => {
+		this.props.recordTracksEvent( 'calypso_store_try_woocommerce_click' );
+	};
+
+	trackLearnMoreAboutWooCommerceClick = () => {
+		this.props.recordTracksEvent( 'calypso_store_learn_more_about_woocommerce_click' );
+	};
+
 	render = () => {
 		const { site } = this.props;
 
@@ -34,7 +42,10 @@ class StoreMoveNoticeView extends Component {
 						{
 							components: {
 								link: (
-									<a href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/" />
+									<a
+										onClick={ this.trackLearnMoreAboutWooCommerceClick }
+										href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/"
+									/>
 								),
 							},
 						}

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -279,7 +279,6 @@ function addTracksContext( context, next ) {
 }
 
 export default async function ( _, addReducer ) {
-	const isStoreRemoved = config.isEnabled( 'woocommerce/store-removed' );
 	await addReducer( [ 'extensions', 'woocommerce' ], reducer );
 	installActionHandlers();
 
@@ -289,7 +288,7 @@ export default async function ( _, addReducer ) {
 	getStorePages().forEach( function ( storePage ) {
 		if ( config.isEnabled( storePage.configKey ) ) {
 			// Store deprecation would redirect most store pages to dashboard
-			if ( isStoreRemoved && ! ( '/store/:site' === storePage.path ) ) {
+			if ( ! ( '/store/:site' === storePage.path ) ) {
 				page( storePage.path, addTracksContext, ( context ) => {
 					context.store.dispatch( bumpStat( 'calypso_store_post_sunset', storePage.statName ) );
 					page.redirect( `/store/${ context.params.site }?${ context.querystring }` );

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -15,12 +15,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { areAllRequiredPluginsActive } from 'woocommerce/state/selectors/plugins';
-import {
-	areCountsLoaded,
-	getCountProducts,
-	getCountNewOrders,
-	getCountPendingReviews,
-} from 'woocommerce/state/sites/data/counts/selectors';
+import { areCountsLoaded, getCountProducts } from 'woocommerce/state/sites/data/counts/selectors';
 import {
 	areSettingsGeneralLoaded,
 	getStoreLocation,
@@ -95,7 +90,6 @@ class StoreSidebar extends Component {
 			settingsGeneralLoaded,
 			siteSuffix,
 			storeLocation,
-			isStoreRemoved,
 			shouldRedirectAfterInstall,
 		} = this.props;
 
@@ -114,7 +108,7 @@ class StoreSidebar extends Component {
 
 			// Don't show sidebar items if store's removed & user is going to redirect
 			// to WooCommerce after installation
-			if ( isStoreRemoved && shouldRedirectAfterInstall ) {
+			if ( shouldRedirectAfterInstall ) {
 				showAllSidebarItems = false;
 			}
 		}
@@ -143,17 +137,10 @@ class StoreSidebar extends Component {
 	};
 
 	products = () => {
-		const { site, siteSuffix, translate, isStoreRemoved } = this.props;
-		let link;
-		let selected;
+		const { site, translate } = this.props;
 
-		if ( isStoreRemoved ) {
-			link = site.URL + '/wp-admin/edit.php?post_type=product';
-			selected = false;
-		} else {
-			link = '/store/products' + siteSuffix;
-			selected = this.isItemLinkSelected( [ link, '/store/products/categories' + siteSuffix ] );
-		}
+		const link = site.URL + '/wp-admin/edit.php?post_type=product';
+		const selected = false;
 
 		const classes = classNames( {
 			products: true,
@@ -172,17 +159,9 @@ class StoreSidebar extends Component {
 	};
 
 	reviews = () => {
-		const { site, siteSuffix, translate, totalPendingReviews, isStoreRemoved } = this.props;
-		let link;
-		let selected;
-
-		if ( isStoreRemoved ) {
-			link = site.URL + '/wp-admin/edit-comments.php';
-			selected = false;
-		} else {
-			link = '/store/reviews' + siteSuffix;
-			selected = this.isItemLinkSelected( [ '/store/reviews' ] );
-		}
+		const { site, translate, totalPendingReviews } = this.props;
+		const link = site.URL + '/wp-admin/edit-comments.php';
+		const selected = false;
 
 		const classes = classNames( {
 			reviews: true,
@@ -203,17 +182,10 @@ class StoreSidebar extends Component {
 	};
 
 	orders = () => {
-		const { totalNewOrders, site, siteSuffix, translate, isStoreRemoved } = this.props;
-		let link;
-		let selected;
+		const { totalNewOrders, site, translate } = this.props;
 
-		if ( isStoreRemoved ) {
-			link = site.URL + '/wp-admin/edit.php?post_type=shop_order';
-			selected = false;
-		} else {
-			link = '/store/orders' + siteSuffix;
-			selected = this.isItemLinkSelected( [ '/store/order', '/store/orders' ] );
-		}
+		const link = site.URL + '/wp-admin/edit.php?post_type=shop_order';
+		const selected = false;
 
 		const classes = classNames( {
 			orders: true,
@@ -234,17 +206,10 @@ class StoreSidebar extends Component {
 			return null;
 		}
 
-		const { site, siteSuffix, translate, isStoreRemoved } = this.props;
-		let link;
-		let selected;
+		const { site, translate } = this.props;
 
-		if ( isStoreRemoved ) {
-			link = site.URL + '/wp-admin/edit.php?post_type=shop_coupon';
-			selected = false;
-		} else {
-			link = '/store/promotions' + siteSuffix;
-			selected = this.isItemLinkSelected( [ link ] );
-		}
+		const link = site.URL + '/wp-admin/edit.php?post_type=shop_coupon';
+		const selected = false;
 
 		const classes = classNames( {
 			promotions: true,
@@ -263,22 +228,10 @@ class StoreSidebar extends Component {
 	};
 
 	settings = () => {
-		const { site, siteSuffix, translate, isStoreRemoved } = this.props;
-		const childLinks = [
-			'/store/settings/payments',
-			'/store/settings/shipping',
-			'/store/settings/taxes',
-			'/store/settings/email',
-		];
-		let link;
-		let selected;
-		if ( isStoreRemoved ) {
-			link = site.URL + '/wp-admin/admin.php?page=wc-settings';
-			selected = false;
-		} else {
-			link = '/store/settings' + siteSuffix;
-			selected = this.isItemLinkSelected( [ link, ...childLinks ] );
-		}
+		const { site, translate } = this.props;
+
+		const link = site.URL + '/wp-admin/admin.php?page=wc-settings';
+		const selected = false;
 
 		const classes = classNames( {
 			settings: true,
@@ -329,15 +282,10 @@ function mapStateToProps( state ) {
 	const storeLocation = getStoreLocation( state, siteId );
 	const pluginsLoaded = arePluginsLoaded( state, siteId );
 	const allRequiredPluginsActive = areAllRequiredPluginsActive( state, siteId );
-	const isStoreRemoved = config.isEnabled( 'woocommerce/store-removed' );
-	const totalPendingReviews = isStoreRemoved ? 0 : getCountPendingReviews( state );
 	const shouldRedirectAfterInstall =
 		'' === get( getCurrentQueryArguments( state ), 'redirect_after_install' );
-
-	let totalNewOrders = 0;
-	if ( ! isStoreRemoved ) {
-		totalNewOrders = getCountNewOrders( state );
-	}
+	const totalNewOrders = 0;
+	const totalPendingReviews = 0;
 
 	return {
 		allRequiredPluginsActive,
@@ -352,7 +300,6 @@ function mapStateToProps( state ) {
 		siteId,
 		siteSuffix: site ? '/' + site.slug : '',
 		storeLocation,
-		isStoreRemoved,
 		shouldRedirectAfterInstall,
 	};
 }

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -54,7 +54,6 @@ import {
 	isJetpackSite,
 	canCurrentUserUseEarn,
 	getSiteOption,
-	canCurrentUserUseCalypsoStore,
 	canCurrentUserUseWooCommerceCoreStore,
 	getSiteWoocommerceUrl,
 } from 'calypso/state/sites/selectors';
@@ -695,7 +694,6 @@ export class MySitesSidebar extends Component {
 			translate,
 			site,
 			siteSuffix,
-			canUserUseCalypsoStore,
 			canUserUseWooCommerceCoreStore,
 			isSiteWpcomStore,
 		} = this.props;
@@ -713,7 +711,7 @@ export class MySitesSidebar extends Component {
 			// So, we'll just continue to change the link here as we have been doing.
 			experience = 'wpadmin-woocommerce-core';
 			storeLink = site.options.admin_url + 'admin.php?page=wc-admin';
-		} else if ( ! canUserUseCalypsoStore ) {
+		} else {
 			return null;
 		}
 
@@ -1168,7 +1166,6 @@ function mapStateToProps( state ) {
 		canUserPublishPosts: canCurrentUser( state, siteId, 'publish_posts' ),
 		canUserViewStats: canCurrentUser( state, siteId, 'view_stats' ),
 		canUserManagePlugins: canCurrentUserManagePlugins( state ),
-		canUserUseCalypsoStore: canCurrentUserUseCalypsoStore( state, siteId ),
 		canUserUseWooCommerceCoreStore: canCurrentUserUseWooCommerceCoreStore( state, siteId ),
 		canUserUseEarn: canCurrentUserUseEarn( state, siteId ),
 		canUserUseCustomerHome: canCurrentUserUseCustomerHome( state, siteId ),

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -69,7 +69,7 @@ describe( 'MySitesSidebar', () => {
 			expect( wrapper.html() ).toEqual( null );
 		} );
 
-		test( 'Should return Calypsoified store menu item if user can use store on this site and the site is an ecommerce plan', () => {
+		test( 'Should return wp-admin menu item if user can use store on this site and the site is an ecommerce plan', () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseCalypsoStore: true,
 				canUserUseWooCommerceCoreStore: true,

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -69,24 +69,7 @@ describe( 'MySitesSidebar', () => {
 			expect( wrapper.html() ).toEqual( null );
 		} );
 
-		test( 'Should return store menu item if user can use store on this site', () => {
-			const Sidebar = new MySitesSidebar( {
-				canUserUseCalypsoStore: true,
-				isSiteWpcomStore: true,
-				...defaultProps,
-				site: {
-					plan: {
-						product_slug: 'business-bundle',
-					},
-				},
-			} );
-			const Store = () => Sidebar.store();
-
-			const wrapper = shallow( <Store /> );
-			expect( wrapper.props().link ).toEqual( '/store/mysite.com' );
-		} );
-
-		test( 'Should return wp-admin menu item if user can use store on this site and the site is an ecommerce plan', () => {
+		test( 'Should return Calypsoified store menu item if user can use store on this site and the site is an ecommerce plan', () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseCalypsoStore: true,
 				canUserUseWooCommerceCoreStore: true,

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -5,7 +5,6 @@ export { default as canCurrentUserUseAds } from './can-current-user-use-ads';
 export { default as canCurrentUserUseCustomerHome } from './can-current-user-use-customer-home';
 export { default as canCurrentUserUseEarn } from './can-current-user-use-earn';
 export { default as canCurrentUserUseAnyWooCommerceBasedStore } from './can-current-user-use-any-woocommerce-based-store';
-export { default as canCurrentUserUseCalypsoStore } from './can-current-user-use-calypso-store';
 export { default as canCurrentUserUseWooCommerceCoreStore } from './can-current-user-use-woocommerce-core-store';
 export { default as canJetpackSiteAutoUpdateCore } from './can-jetpack-site-auto-update-core';
 export { default as canJetpackSiteAutoUpdateFiles } from './can-jetpack-site-auto-update-files';

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -38,7 +38,6 @@ import {
 	canCurrentUserUseAds,
 	canCurrentUserUseCustomerHome,
 	canCurrentUserUseAnyWooCommerceBasedStore,
-	canCurrentUserUseCalypsoStore,
 	canCurrentUserUseWooCommerceCoreStore,
 	canJetpackSiteUpdateFiles,
 	canJetpackSiteAutoUpdateFiles,
@@ -57,12 +56,7 @@ import {
 } from '../selectors';
 import config from '@automattic/calypso-config';
 import { userState } from 'calypso/state/selectors/test/fixtures/user-state';
-import {
-	PLAN_BUSINESS,
-	PLAN_ECOMMERCE,
-	PLAN_FREE,
-	STORE_DEPRECATION_START_DATE,
-} from 'calypso/lib/plans/constants';
+import { PLAN_BUSINESS, PLAN_ECOMMERCE, PLAN_FREE } from 'calypso/lib/plans/constants';
 
 jest.mock( '@automattic/calypso-config', () => {
 	const configMock = () => '';
@@ -3577,115 +3571,6 @@ describe( 'selectors', () => {
 			expect( canCurrentUserUseAnyWooCommerceBasedStore( createState( false, false, true ) ) ).toBe(
 				false
 			);
-		} );
-	} );
-
-	describe( 'canCurrentUserUseCalypsoStore()', () => {
-		const createState = (
-			manage_options,
-			is_automated_transfer,
-			has_pending_automated_transfer,
-			subscribedDate = '2020-12-01T00:00:00+00:00'
-		) => ( {
-			ui: {
-				selectedSiteId: 1,
-			},
-			currentUser: {
-				capabilities: {
-					1: {
-						manage_options,
-					},
-				},
-			},
-			sites: {
-				items: {
-					1: {
-						options: {
-							is_automated_transfer,
-							has_pending_automated_transfer,
-						},
-						plan: {
-							PLAN_BUSINESS,
-						},
-					},
-				},
-				plans: {
-					1: {
-						data: {
-							0: {
-								currentPlan: true,
-								productSlug: PLAN_BUSINESS,
-								subscribedDate,
-							},
-						},
-					},
-				},
-			},
-		} );
-
-		beforeEach( () => {
-			// Enable all features except for store deprecation and removal
-			config.isEnabled.mockImplementation( ( feature ) => {
-				return feature !== 'woocommerce/store-removed';
-			} );
-		} );
-
-		test( 'should return true if site is AT and user can manage it', () => {
-			expect( canCurrentUserUseCalypsoStore( createState( true, true, false ) ) ).toBe( true );
-		} );
-
-		test( 'should return false if site is not AT and user can manage it', () => {
-			expect( canCurrentUserUseCalypsoStore( createState( true, false, false ) ) ).toBe( false );
-		} );
-
-		test( "should return false if site is AT and user can't manage it", () => {
-			expect( canCurrentUserUseCalypsoStore( createState( false, true, false ) ) ).toBe( false );
-		} );
-
-		test( "should return true if user can't manage a site, but it has background transfer and atomic store flow is enabled", () => {
-			expect( canCurrentUserUseCalypsoStore( createState( false, false, true ) ) ).toBe( true );
-		} );
-
-		test( "should return false if user can't manage a site, but it has background transfer and atomic store flow is disabled", () => {
-			// Enable all features except for the atomic store flow
-			config.isEnabled.mockImplementation( ( feature ) => feature !== 'signup/atomic-store-flow' );
-
-			expect( canCurrentUserUseCalypsoStore( createState( false, false, true ) ) ).toBe( false );
-		} );
-
-		test( 'should return true if plan subscription date is before Store deprecation', () => {
-			// Enable all features except for store removal, including store deprecation
-			config.isEnabled.mockImplementation( ( feature ) => feature !== 'woocommerce/store-removed' );
-
-			expect( canCurrentUserUseCalypsoStore( createState( true, true, false ) ) ).toBe( true );
-		} );
-
-		test( 'should return false if plan subscription date is on or after Store deprecation', () => {
-			// Enable all features except for store removal, including store deprecation
-			config.isEnabled.mockImplementation( ( feature ) => feature !== 'woocommerce/store-removed' );
-
-			const subscriptionDate = new Date();
-			subscriptionDate.setDate( STORE_DEPRECATION_START_DATE.getDate() + 1 );
-
-			expect(
-				canCurrentUserUseCalypsoStore( createState( true, true, false, subscriptionDate ) )
-			).toBe( false );
-		} );
-
-		test( 'should return false if extension dashboard is not enabled', () => {
-			// Enable all features except for the extension dashboard
-			config.isEnabled.mockImplementation(
-				( feature ) => feature !== 'woocommerce/extension-dashboard'
-			);
-
-			expect( canCurrentUserUseCalypsoStore( createState( true, true, false ) ) ).toBe( false );
-		} );
-
-		test( 'should return false if store is removed', () => {
-			// Enable all features, including store removal
-			config.isEnabled.mockImplementation( () => true );
-
-			expect( canCurrentUserUseCalypsoStore( createState( true, true, false ) ) ).toBe( false );
 		} );
 	} );
 

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -157,7 +157,6 @@
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
-		"woocommerce/store-removed": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -211,7 +211,6 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
-		"woocommerce/store-removed": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false
 	}

--- a/config/production.json
+++ b/config/production.json
@@ -168,7 +168,6 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
-		"woocommerce/store-removed": true,
 		"wpcom-user-bootstrap": true
 	},
 	"rtl": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -172,7 +172,6 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
-		"woocommerce/store-removed": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true
 	},

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -182,7 +182,6 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
-		"woocommerce/store-removed": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #49430 

This PR removes the use of `woocommerce/store-removed`. The store is now removed permanently. 

#### Testing instructions

1. Start Calypso locally
2. Manually navigate to store UI by replacing the URL with /store/SITENAMEHERE, example: http://calypso.localhost:3000/store/ilyastestwoo5.wpcomstaging.com?flags=woocommerce/store-removed
3. Confirm that the store UI behaves when the `woocommerce/store-removed` feature flag was enabled.