### PR TITLE
E2E test: Move check for the Premium Content block from Earn to Grow

### DIFF
--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -289,7 +289,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 					'OpenTable',
 					'Payments',
 					'Pay with PayPal',
-					'Premium Content',
 					'Pricing Table',
 				].forEach( ( block ) =>
 					assert.ok(
@@ -314,6 +313,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 					'Mailchimp',
 					'Revue',
 					'Subscription Form',
+					'Premium Content',
 					'Click to Tweet',
 					'Logos',
 					'Contact Form',


### PR DESCRIPTION
With the recent move to adding the [Premium Content block to Jetpack](https://github.com/Automattic/jetpack/pull/17907), it looks like the block has moved in the inserter from the Earn section to the Grow section, and this caused one of the e2e tests to fail. To get the e2e tests passing again, this PR updates the check to look for the Premium Content block in the Grow section.

#### Changes proposed in this Pull Request

* Move the check for the Premium Content block from the Earn section to the Grow section in the e2e test that covers its presence in the inserter.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See if the e2e tests pass

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
