### PR TITLE
ETK: Add method to change the order of the block inserter tabs

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/index.ts
@@ -2,3 +2,4 @@
  * Internal dependencies
  */
 import './src/premium-block-patterns';
+import './src/block-inserter-tab-order';

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/src/block-inserter-tab-order.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/src/block-inserter-tab-order.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+domReady( () => {
+	document.addEventListener(
+		'click',
+		function ( event ) {
+			if (
+				event?.target?.classList.contains( 'edit-post-header-toolbar__inserter-toggle' ) ||
+				event?.target?.parentNode.classList.contains( 'edit-post-header-toolbar__inserter-toggle' )
+			) {
+				let attempts = 0;
+				const panelInception = setInterval( () => {
+					const tabsContainer = document.getElementsByClassName( 'components-tab-panel__tabs' );
+					if (
+						! tabsContainer ||
+						! tabsContainer[ 0 ] ||
+						! tabsContainer[ 0 ].childNodes?.length === 0
+					) {
+						attempts++;
+						if ( attempts > 10 ) {
+							clearInterval( panelInception );
+						}
+						return;
+					}
+
+					clearInterval( panelInception );
+					const patterns = tabsContainer[ 0 ].querySelectorAll( '[id$=patterns]' );
+					const blocks = tabsContainer[ 0 ].querySelectorAll( '[id$=blocks]' );
+					const reusable = tabsContainer[ 0 ].querySelectorAll( '[id$=reusable]' );
+					if ( patterns && blocks && reusable ) {
+						patterns[ 0 ].click();
+						tabsContainer[ 0 ].replaceChildren( ...patterns, ...blocks, ...reusable );
+					}
+				}, 100 );
+			}
+		},
+		false
+	);
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a method to reorder the editor block inserter tabs to make the Patterns tab first

A more reliable way to implement this would require the addition of a filter in core gutenberg - https://github.com/WordPress/gutenberg/pull/28705

#### Testing instructions

* Check out PR and build Editor toolkit and sync to sandbox
* On block inserter make sure Patterns tab shows first

<img width="314" alt="Screen Shot 2021-02-03 at 4 40 09 PM" src="https://user-images.githubusercontent.com/3629020/106694977-82005f00-663e-11eb-8efb-27d30c63b416.png">
