### PR TITLE
Deduplicate mime-types

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -18318,24 +18318,17 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.43.0, "mime-db@>= 1.43.0 < 2":
-  version "1.43.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
-  integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
-
 mime-db@1.44.0:
   version "1.44.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
-mime-types@^2.1.12, mime-types@^2.1.25, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
-  version "2.1.26"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
-  integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
-  dependencies:
-    mime-db "1.43.0"
+"mime-db@>= 1.43.0 < 2":
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
+  integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
 
-mime-types@^2.1.27:
+mime-types@^2.1.12, mime-types@^2.1.25, mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.27"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
   integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `mime-types` (done automatically with `npx yarn-deduplicate --packages mime-types`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> mime-types@2.1.26
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> mime-types@2.1.26
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> mime-types@2.1.26
< wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> mime-types@2.1.26
< wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> mime-types@2.1.26
< wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> mime-types@2.1.26
< wp-calypso@0.17.0 -> node-sass@4.13.0 -> ... -> mime-types@2.1.26
< wp-calypso@0.17.0 -> request@2.88.2 -> ... -> mime-types@2.1.26
< wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> mime-types@2.1.26
> wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> mime-types@2.1.27
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> mime-types@2.1.27
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> mime-types@2.1.27
> wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> mime-types@2.1.27
> wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> mime-types@2.1.27
> wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> mime-types@2.1.27
> wp-calypso@0.17.0 -> node-sass@4.13.0 -> ... -> mime-types@2.1.27
> wp-calypso@0.17.0 -> request@2.88.2 -> ... -> mime-types@2.1.27
> wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> mime-types@2.1.27
```