### PR TITLE
Deduplicate mime

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -18347,12 +18347,7 @@ mime@1.6.0, mime@^1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.0.3, mime@^2.4.4:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
-  integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
-
-mime@^2.3.1:
+mime@^2.0.3, mime@^2.3.1, mime@^2.4.4:
   version "2.4.7"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.7.tgz#962aed9be0ed19c91fd7dc2ece5d7f4e89a90d74"
   integrity sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `mime` (done automatically with `npx yarn-deduplicate --packages mime`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> mime@2.4.4
< wp-calypso@0.17.0 -> capture-website@1.0.0 -> ... -> mime@2.4.4
< wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> mime@2.4.4
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> mime@2.4.7
> wp-calypso@0.17.0 -> capture-website@1.0.0 -> ... -> mime@2.4.7
> wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> mime@2.4.7
```