### PR TITLE
Deduplicate nan

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -18810,12 +18810,7 @@ mz@^2.5.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.12.1, nan@^2.13.2:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
-  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
-
-nan@^2.14.0:
+nan@^2.12.1, nan@^2.13.2, nan@^2.14.0:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `nan` (done automatically with `npx yarn-deduplicate --packages nan`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> nan@2.14.0
< @automattic/o2-blocks@1.0.0 -> @automattic/calypso-build@7.0.0 -> ... -> nan@2.14.0
< @automattic/wpcom-editing-toolkit@2.16.0 -> @automattic/calypso-build@7.0.0 -> ... -> nan@2.14.0
< @automattic/wpcom-editing-toolkit@2.16.0 -> @wordpress/scripts@12.5.0 -> ... -> nan@2.14.0
< wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> nan@2.14.0
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> nan@2.14.0
< wp-calypso@0.17.0 -> node-sass@4.13.0 -> ... -> nan@2.14.0
> @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> nan@2.14.1
> @automattic/o2-blocks@1.0.0 -> @automattic/calypso-build@7.0.0 -> ... -> nan@2.14.1
> @automattic/wpcom-editing-toolkit@2.16.0 -> @automattic/calypso-build@7.0.0 -> ... -> nan@2.14.1
> @automattic/wpcom-editing-toolkit@2.16.0 -> @wordpress/scripts@12.5.0 -> ... -> nan@2.14.1
> wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> nan@2.14.1
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> nan@2.14.1
> wp-calypso@0.17.0 -> node-sass@4.13.0 -> ... -> nan@2.14.1
```