### PR TITLE
Deduplicate neo-async

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -18894,12 +18894,7 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
-  integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
-
-neo-async@^2.6.2:
+neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `neo-async` (done automatically with `npx yarn-deduplicate --packages neo-async`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> neo-async@2.6.1
< @automattic/o2-blocks@1.0.0 -> @automattic/calypso-build@7.0.0 -> ... -> neo-async@2.6.1
< @automattic/wpcom-editing-toolkit@2.16.0 -> @automattic/calypso-build@7.0.0 -> ... -> neo-async@2.6.1
< @automattic/wpcom-editing-toolkit@2.16.0 -> @wordpress/scripts@12.5.0 -> ... -> neo-async@2.6.1
< wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> neo-async@2.6.1
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> neo-async@2.6.1
< wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> neo-async@2.6.1
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> neo-async@2.6.1
< wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> neo-async@2.6.1
> @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> neo-async@2.6.2
> @automattic/o2-blocks@1.0.0 -> @automattic/calypso-build@7.0.0 -> ... -> neo-async@2.6.2
> @automattic/wpcom-editing-toolkit@2.16.0 -> @automattic/calypso-build@7.0.0 -> ... -> neo-async@2.6.2
> @automattic/wpcom-editing-toolkit@2.16.0 -> @wordpress/scripts@12.5.0 -> ... -> neo-async@2.6.2
> wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> neo-async@2.6.2
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> neo-async@2.6.2
> wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> neo-async@2.6.2
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> neo-async@2.6.2
> wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> neo-async@2.6.2
```