### PR TITLE
build(webpack): Enable persistent cache (opt-in)

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -182,7 +182,7 @@ object BuildBaseImages : BuildType({
 	}
 
 	failureConditions {
-		executionTimeoutMin = 20
+		executionTimeoutMin = 30
 	}
 
 	features {

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM registry.a8c.com/calypso/base:latest as builder-cache-true
 
 ENV YARN_CACHE_FOLDER=/calypso/.cache/yarn
 ENV NPM_CONFIG_CACHE=/calypso/.cache
-
+ENV PERSISTENT_CACHE=true
 
 ###################
 FROM builder-cache-${use_cache} as builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM node:${node_version} as builder-cache-false
 ###################
 # This image contains a directory /calypso/.cache which includes caches
 # for yarn, terser, css-loader and babel.
-FROM registry.a8c.com/calypso/base:webpack as builder-cache-true
+FROM registry.a8c.com/calypso/base:latest as builder-cache-true
 
 ENV YARN_CACHE_FOLDER=/calypso/.cache/yarn
 ENV NPM_CONFIG_CACHE=/calypso/.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM node:${node_version} as builder-cache-false
 ###################
 # This image contains a directory /calypso/.cache which includes caches
 # for yarn, terser, css-loader and babel.
-FROM registry.a8c.com/calypso/base:latest as builder-cache-true
+FROM registry.a8c.com/calypso/base:webpack as builder-cache-true
 
 ENV YARN_CACHE_FOLDER=/calypso/.cache/yarn
 ENV NPM_CONFIG_CACHE=/calypso/.cache

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,6 +12,7 @@ ENV NODE_ENV=production
 ENV CALYPSO_ENV=production
 ENV NODE_OPTIONS=--max-old-space-size=$node_memory
 ENV HOME=/calypso
+ENV PERSISTENT_CACHE=true
 
 RUN git clone --branch v0.37.0 --depth 1 https://github.com/nvm-sh/nvm.git "$NVM_DIR" \
 	&& echo ". ${NVM_DIR}/nvm.sh" >> "${HOME}/.bashrc"

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -396,8 +396,7 @@ const webpackConfig = {
 	...( shouldUsePersistentCache
 		? {
 				cache: {
-					// eslint-disable-next-line inclusive-language/use-inclusive-words
-					// More info in https://github.com/webpack/changelog-v5/blob/master/guides/persistent-caching.md
+					// More info in https://github.com/webpack/changelog-v5/blob/f518964326583c74e9b78296faebdb9c32b01ea8/guides/persistent-caching.md
 					type: 'filesystem',
 					version: [
 						shouldBuildChunksMap,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable webpack filesystem cache when `PERSISTENT_CACHE` is enabled.
* Set `PERSISTENT_CACHE=true` when generating the base docker images (so the `cache` image has a webpack cache). This require increasing the the timeout so TeamCity doesn't kill the build after 20m.
* Set `PERSISTENT_CACHE=true` when building Calypso app images starting off `cache` image (currently only e2e images use the cache, production images are built without any cache usage).
