### PR TITLE
Prevent redirection for missing quantity errors

### DIFF
--- a/client/my-sites/email/titan-mail-quantity-selection/index.jsx
+++ b/client/my-sites/email/titan-mail-quantity-selection/index.jsx
@@ -112,12 +112,13 @@ class TitanMailQuantitySelection extends React.Component {
 			] )
 			.then( () => {
 				const { errors } = this.props?.cart?.messages;
+				const errorCodesToDisplayLocally = [ 'invalid-quantity', 'missing_quantity_data' ];
 				if (
 					errors &&
 					errors.length &&
-					errors.filter( ( error ) => error.code === 'invalid-quantity' ).length
+					errors.filter( ( error ) => errorCodesToDisplayLocally.includes( error.code ) ).length
 				) {
-					// Stay on the page as there's an invalid quantity error
+					// Stay on the page to show the relevant error
 					return;
 				}
 				return this.isMounted && page( '/checkout/' + selectedSite.slug );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is a follow-up to the back end changes in D56052-code which adds some additional checks when adding extra licenses/mailboxes to quantity-based products, and ensures that when we hit one of these new errors, we correctly show the error message to the user.
* Note that the implementation involves a minor tweak to the logic introduced in PR #49185.

#### Testing instructions

* Follow the testing instructions in D56052-code to produce this situation. (If you've already set that up for testing, you can simply re-use the same domain name.)
* Verify that when you try to add mailboxes for that domain, we show an error message on the quantity selection page.