### PR TITLE
Launch from editor: update tracks event props

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
@@ -52,7 +52,7 @@ domReady( () => {
 			e.preventDefault();
 
 			recordTracksEvent( 'calypso_newsite_editor_launch_click', {
-				is_new_site: isGutenboarding,
+				is_new_site: !! isGutenboarding,
 				launch_flow: launchFlow,
 				is_in_iframe: inIframe(),
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `is_new_site` prop on `calypso_newsite_editor_launch_click` event should be a Boolean as defined in event registration:  431-gh-Automattic/tracks-events-registration

#### Testing instructions

* For a site created on /start, when pressing Launch button `is_new_site` should be `false`
* For a site created on /new it should be `true`

Related to #46839