### PR TITLE
Store|Woo: Update Store deprecation message

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
@@ -14,7 +14,7 @@ import { localize, translate } from 'i18n-calypso';
 import { Card, Button } from '@automattic/components';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import config from '@automattic/calypso-config';
-
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 /**
  * Image dependencies
  */
@@ -34,6 +34,14 @@ function getStoreStatus( isStoreDeprecated, isStoreRemoved ) {
 }
 
 class StoreMoveNoticeView extends Component {
+	trackTryWooCommerceClick = () => {
+		this.props.recordTracksEvent( 'calypso_store_try_woocommerce_click' );
+	};
+
+	trackLearnMoreAboutWooCommerceClick = () => {
+		this.props.recordTracksEvent( 'calypso_store_learn_more_about_woocommerce_click' );
+	};
+
 	render = () => {
 		const { site, isStoreDeprecated, isStoreRemoved } = this.props;
 		const status = getStoreStatus( isStoreDeprecated, isStoreRemoved );
@@ -45,11 +53,14 @@ class StoreMoveNoticeView extends Component {
 				<p>
 					{ isStoreDeprecated &&
 						translate(
-							'We’re retiring Store on February 22. With WooCommerce, discover a more flexible store management experience – including top-level access to your Analytics, Marketing, and Customers. {{link}}Learn more{{/link}} about what to expect.',
+							'We’re retiring Store on February 22. With WooCommerce, discover a more flexible store management experience — including top-level access to your Analytics, Marketing, and Customers. {{link}}Learn more{{/link}} about what to expect.',
 							{
 								components: {
 									link: (
-										<a href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/" />
+										<a
+											onClick={ this.trackLearnMoreAboutWooCommerceClick }
+											href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/"
+										/>
 									),
 								},
 							}
@@ -60,13 +71,20 @@ class StoreMoveNoticeView extends Component {
 							{
 								components: {
 									link: (
-										<a href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/" />
+										<a
+											onClick={ this.trackLearnMoreAboutWooCommerceClick }
+											href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/"
+										/>
 									),
 								},
 							}
 						) }
 				</p>
-				<Button primary href={ site.URL + '/wp-admin/admin.php?page=wc-admin&from-calypso' }>
+				<Button
+					primary
+					onClick={ this.trackTryWooCommerceClick }
+					href={ site.URL + '/wp-admin/admin.php?page=wc-admin&from-calypso' }
+				>
 					{ translate( 'Try WooCommerce now' ) }
 				</Button>
 			</Card>
@@ -82,4 +100,6 @@ function mapStateToProps( state ) {
 	};
 }
 
-export default connect( mapStateToProps )( localize( StoreMoveNoticeView ) );
+export default connect( mapStateToProps, {
+	recordTracksEvent,
+} )( localize( StoreMoveNoticeView ) );

--- a/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
@@ -45,7 +45,7 @@ class StoreMoveNoticeView extends Component {
 				<p>
 					{ isStoreDeprecated &&
 						translate(
-							'We’re rolling your favorite Store features into WooCommerce. In addition to Products and Orders, you’ll have top-level access for managing your Analytics, Marketing, and Customers. {{link}}Learn more{{/link}} about what to expect in February.',
+							'We’re retiring Store on February 22. With WooCommerce, discover a more flexible store management experience – including top-level access to your Analytics, Marketing, and Customers. {{link}}Learn more{{/link}} about what to expect.',
 							{
 								components: {
 									link: (
@@ -67,7 +67,7 @@ class StoreMoveNoticeView extends Component {
 						) }
 				</p>
 				<Button primary href={ site.URL + '/wp-admin/admin.php?page=wc-admin&from-calypso' }>
-					{ translate( 'Go to WooCommerce Home' ) }
+					{ translate( 'Try WooCommerce now' ) }
 				</Button>
 			</Card>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Updates the Store deprecation message (see discussion: pbIJXs-sE-p2#comment-1799)
- Adds Tracks events to the "learn more" and "Try WooCommerce now" actions

##### Before

<img width="749" alt="Screen Shot 2021-02-03 at 09 58 15" src="https://user-images.githubusercontent.com/2098816/106778250-c3c7e000-6613-11eb-9671-2dc4d0010d3e.png">

##### After

<img width="963" alt="Screen Shot 2021-02-03 at 10 54 10" src="https://user-images.githubusercontent.com/2098816/106778286-cde9de80-6613-11eb-9aa9-a1439fa19ff3.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run branch
* Enable debugging of Tracks events in browser dev console: `localStorage.setItem( 'debug', 'calypso:analytics*' )`
* Go to `/store/:site_suffix` for a Business site with Store
* Verify updated message
* Verify that clicking on "learn more" link records `calypso_store_learn_more_about_woocommerce_click` Tracks event
* Verify that clicking on "Try WooCommerce now" button records `calypso_store_try_woocommerce_click` Tracks event