### PR TITLE
i18n: Use `useLocalizedUrl` for ToS link on signup step

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -7,6 +7,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@automattic/react-i18n';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -29,7 +30,6 @@ import {
 	recordGoogleRecaptchaAction,
 	recordOnboardingError,
 } from '../../lib/analytics';
-import { localizeUrl } from '../../../../lib/i18n-utils';
 import { useTrackModal } from '../../hooks/use-track-modal';
 import config from '@automattic/calypso-config';
 
@@ -61,6 +61,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 	useTrackModal( 'Signup' );
 
 	const lang = useLangRouteParam();
+	const localizeUrl = useLocalizeUrl();
 
 	useEffect( () => {
 		initGoogleRecaptcha(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `useLocalizedUrl` hook to localize the ToS link on the sign up step of the onboarding flow.

#### Testing instructions

* Open `/new/es` (or in any other Mag-16 locale) and navigate through the onboarding flow until reach singup step
* Confirm ToS link points to the localized URL

Fixes https://github.com/Automattic/wp-calypso/issues/49670
