### PR TITLE
Gutenboarding: Enable language picker on production.

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -53,7 +53,7 @@ const Header: React.FunctionComponent = () => {
 
 	const changeLocaleButton = () => {
 		return (
-			<div className="gutenboarding__header-section-item gutenboarding__header-section-item--right gutenboarding__header-language-section">
+			<div className="gutenboarding__header-section-item gutenboarding__header-language-section">
 				<Link to={ makePath( Step.LanguageModal ) }>
 					<span className="gutenboarding__header-site-language-label">
 						{ __( 'Site Language' ) }
@@ -88,11 +88,9 @@ const Header: React.FunctionComponent = () => {
 					{ showDomainsButton && <DomainPickerButton /> }
 				</div>
 				{ showLocaleButton && changeLocaleButton() }
-				{ showPlansButton && (
-					<div className="gutenboarding__header-section-item gutenboarding__header-plan-section gutenboarding__header-section-item--right">
-						<PlansButton />
-					</div>
-				) }
+				<div className="gutenboarding__header-section-item gutenboarding__header-plan-section gutenboarding__header-section-item--right">
+					{ showPlansButton && <PlansButton /> }
+				</div>
 			</section>
 		</div>
 	);

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -15,7 +15,6 @@ import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import DomainPickerButton from '../domain-picker-button';
 import PlansButton from '../plans-button';
 import { useCurrentStep, useIsAnchorFm, usePath, Step } from '../../path';
-import { isEnabled } from '@automattic/calypso-config';
 import Link from '../link';
 
 /**

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -52,19 +52,16 @@ const Header: React.FunctionComponent = () => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 	const changeLocaleButton = () => {
-		if ( isEnabled( 'gutenboarding/language-picker' ) ) {
-			return (
-				<div className="gutenboarding__header-section-item gutenboarding__header-language-section">
-					<Link to={ makePath( Step.LanguageModal ) }>
-						<span className="gutenboarding__header-site-language-label">
-							{ __( 'Site Language' ) }
-						</span>
-						<span className="gutenboarding__header-site-language-badge">{ locale }</span>
-					</Link>
-				</div>
-			);
-		}
-		return null;
+		return (
+			<div className="gutenboarding__header-section-item gutenboarding__header-section-item--right gutenboarding__header-language-section">
+				<Link to={ makePath( Step.LanguageModal ) }>
+					<span className="gutenboarding__header-site-language-label">
+						{ __( 'Site Language' ) }
+					</span>
+					<span className="gutenboarding__header-site-language-badge">{ locale }</span>
+				</Link>
+			</div>
+		);
 	};
 
 	return (
@@ -91,9 +88,11 @@ const Header: React.FunctionComponent = () => {
 					{ showDomainsButton && <DomainPickerButton /> }
 				</div>
 				{ showLocaleButton && changeLocaleButton() }
-				<div className="gutenboarding__header-section-item gutenboarding__header-plan-section gutenboarding__header-section-item--right">
-					{ showPlansButton && <PlansButton /> }
-				</div>
+				{ showPlansButton && (
+					<div className="gutenboarding__header-section-item gutenboarding__header-plan-section gutenboarding__header-section-item--right">
+						<PlansButton />
+					</div>
+				) }
 			</section>
 		</div>
 	);

--- a/config/development.json
+++ b/config/development.json
@@ -75,7 +75,6 @@
 		"google-drive": true,
 		"google-workspace-migration": true,
 		"gutenboarding/alpha-templates": true,
-		"gutenboarding/language-picker": true,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,
 		"gutenboarding/show-vertical-input": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -48,7 +48,6 @@
 		"gdpr-banner": true,
 		"google-my-business": false,
 		"gutenboarding/alpha-templates": true,
-		"gutenboarding/language-picker": true,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,
 		"gutenboarding/mshot-preview": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -51,7 +51,6 @@
 		"google-my-business": true,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
-		"gutenboarding/language-picker": false,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,
 		"happychat": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -59,7 +59,6 @@
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
 		"gutenboarding/alpha-templates": true,
-		"gutenboarding/language-picker": false,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,
 		"happychat": true,

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -46,12 +46,7 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 		} );
 
 		step( 'Can visit Gutenboarding page and see Onboarding block', async function () {
-			const page = await NewPage.Visit(
-				driver,
-				NewPage.getGutenboardingURL( {
-					query: 'flags=gutenboarding/language-picker',
-				} )
-			);
+			const page = await NewPage.Visit( driver, NewPage.getGutenboardingURL() );
 			const blockExists = await page.waitForBlock();
 			assert( blockExists, 'Onboarding block is not rendered' );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable language picker on production by removing `gutenboarding/language-picker` feature flag.

Please ensure https://github.com/Automattic/wp-calypso/pull/49671 is merged before merging this one. Context: pbAok1-dn-p2#comment-3916

#### Testing instructions

* Go to `/new` and you should see the language picker.

Related to #43532