### PR TITLE
Anchor: Add Anchor to the Horizon and wpcalypso environments.

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -13,13 +13,9 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"livechat_support_locales": [
-		"en",
-		"es",
-		"pt-br"
-	],
+	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
-		"anchor-fm-dev": false,
+		"anchor-fm-dev": true,
 		"automated-transfer": true,
 		"async-payments": false,
 		"ad-tracking": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -15,14 +15,10 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"livechat_support_locales": [
-		"en",
-		"es",
-		"pt-br"
-	],
+	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
-		"anchor-fm-dev": false,
+		"anchor-fm-dev": true,
 		"async-payments": false,
 		"automated-transfer": true,
 		"blogger-plan": false,


### PR DESCRIPTION
This PR adds Anchor integration functionality to the Horizon and `wpcalypso` test environments, in preparation for upcoming user testing.

Fixes 459-gh-Automattic/dotcom-manage

**Testing Instructions**
* N/A