### PR TITLE
Fix wrong domain/mapping/transfer prices in launch-site flow

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -55,6 +55,7 @@ import {
 	isNextDomainFree,
 	hasToUpgradeToPayForADomain,
 } from 'calypso/lib/cart-values/cart-items';
+import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Style dependencies
@@ -727,4 +728,4 @@ export default connect(
 		recordGoButtonClickInTransferDomain,
 		recordMapDomainButtonClick,
 	}
-)( localize( TransferDomainStep ) );
+)( withShoppingCart( localize( TransferDomainStep ) ) );

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -55,7 +55,6 @@ import {
 	isNextDomainFree,
 	hasToUpgradeToPayForADomain,
 } from 'calypso/lib/cart-values/cart-items';
-import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Style dependencies
@@ -728,4 +727,4 @@ export default connect(
 		recordGoButtonClickInTransferDomain,
 		recordMapDomainButtonClick,
 	}
-)( withShoppingCart( localize( TransferDomainStep ) ) );
+)( localize( TransferDomainStep ) );

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -46,6 +46,7 @@ import {
 	DOMAINS_WITH_PLANS_ONLY,
 	NON_PRIMARY_DOMAINS_TO_FREE_USERS,
 } from 'calypso/state/current-user/constants';
+import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Style dependencies
@@ -462,4 +463,4 @@ export default connect(
 		recordTransferButtonClickInUseYourDomain,
 		recordMappingButtonClickInUseYourDomain,
 	}
-)( localize( UseYourDomainStep ) );
+)( withShoppingCart( localize( UseYourDomainStep ) ) );

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -46,7 +46,6 @@ import {
 	DOMAINS_WITH_PLANS_ONLY,
 	NON_PRIMARY_DOMAINS_TO_FREE_USERS,
 } from 'calypso/state/current-user/constants';
-import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Style dependencies
@@ -463,4 +462,4 @@ export default connect(
 		recordTransferButtonClickInUseYourDomain,
 		recordMappingButtonClickInUseYourDomain,
 	}
-)( withShoppingCart( localize( UseYourDomainStep ) ) );
+)( localize( UseYourDomainStep ) );

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -129,13 +129,13 @@ const transferDomain = ( context, next ) => {
 				title="Domain Search > Domain Transfer"
 			/>
 			<DocumentHead title={ translate( 'Transfer a Domain' ) } />
-			<CartData>
+			<CalypsoShoppingCartProvider>
 				<TransferDomain
 					basePath={ sectionify( context.path ) }
 					initialQuery={ context.query.initialQuery }
 					useStandardBack={ useStandardBack }
 				/>
-			</CartData>
+			</CalypsoShoppingCartProvider>
 		</Main>
 	);
 	next();
@@ -157,13 +157,13 @@ const useYourDomain = ( context, next ) => {
 				title="Domain Search > Use Your Own Domain"
 			/>
 			<DocumentHead title={ translate( 'Use Your Own Domain' ) } />
-			<CartData>
+			<CalypsoShoppingCartProvider>
 				<UseYourDomainStep
 					basePath={ sectionify( context.path ) }
 					initialQuery={ context.query.initialQuery }
 					goBack={ handleGoBack }
 				/>
-			</CartData>
+			</CalypsoShoppingCartProvider>
 		</Main>
 	);
 	next();
@@ -183,7 +183,7 @@ const transferDomainPrecheck = ( context, next ) => {
 				path={ domainManagementTransferInPrecheck( ':site', ':domain' ) }
 				title="My Sites > Domains > Selected Domain"
 			/>
-			<CartData>
+			<CalypsoShoppingCartProvider>
 				<div>
 					<TransferDomainStep
 						forcePrecheck={ true }
@@ -191,7 +191,7 @@ const transferDomainPrecheck = ( context, next ) => {
 						goBack={ handleGoBack }
 					/>
 				</div>
-			</CartData>
+			</CalypsoShoppingCartProvider>
 		</Main>
 	);
 	next();

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -129,13 +129,13 @@ const transferDomain = ( context, next ) => {
 				title="Domain Search > Domain Transfer"
 			/>
 			<DocumentHead title={ translate( 'Transfer a Domain' ) } />
-			<CalypsoShoppingCartProvider>
+			<CartData>
 				<TransferDomain
 					basePath={ sectionify( context.path ) }
 					initialQuery={ context.query.initialQuery }
 					useStandardBack={ useStandardBack }
 				/>
-			</CalypsoShoppingCartProvider>
+			</CartData>
 		</Main>
 	);
 	next();
@@ -157,13 +157,13 @@ const useYourDomain = ( context, next ) => {
 				title="Domain Search > Use Your Own Domain"
 			/>
 			<DocumentHead title={ translate( 'Use Your Own Domain' ) } />
-			<CalypsoShoppingCartProvider>
+			<CartData>
 				<UseYourDomainStep
 					basePath={ sectionify( context.path ) }
 					initialQuery={ context.query.initialQuery }
 					goBack={ handleGoBack }
 				/>
-			</CalypsoShoppingCartProvider>
+			</CartData>
 		</Main>
 	);
 	next();
@@ -183,7 +183,7 @@ const transferDomainPrecheck = ( context, next ) => {
 				path={ domainManagementTransferInPrecheck( ':site', ':domain' ) }
 				title="My Sites > Domains > Selected Domain"
 			/>
-			<CalypsoShoppingCartProvider>
+			<CartData>
 				<div>
 					<TransferDomainStep
 						forcePrecheck={ true }
@@ -191,7 +191,7 @@ const transferDomainPrecheck = ( context, next ) => {
 						goBack={ handleGoBack }
 					/>
 				</div>
-			</CalypsoShoppingCartProvider>
+			</CartData>
 		</Main>
 	);
 	next();

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -17,7 +17,6 @@ import {
 	domainTransfer,
 	updatePrivacyForDomain,
 } from 'calypso/lib/cart-values/cart-items';
-import { addItem, addItems } from 'calypso/lib/cart/actions';
 import Notice from 'calypso/components/notice';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import isSiteUpgradeable from 'calypso/state/selectors/is-site-upgradeable';
@@ -29,6 +28,8 @@ import {
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import TrademarkClaimsNotice from 'calypso/components/domains/trademark-claims-notice';
+import { withShoppingCart } from '@automattic/shopping-cart';
+import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 
 export class TransferDomain extends Component {
 	static propTypes = {
@@ -69,14 +70,19 @@ export class TransferDomain extends Component {
 	addDomainToCart = ( suggestion ) => {
 		const { selectedSiteSlug } = this.props;
 
-		addItem(
-			domainRegistration( {
-				productSlug: suggestion.product_slug,
-				domain: suggestion.domain_name,
-			} )
-		);
-
-		page( '/checkout/' + selectedSiteSlug );
+		this.props.shoppingCartManager
+			.addProductsToCart( [
+				fillInSingleCartItemAttributes(
+					domainRegistration( {
+						productSlug: suggestion.product_slug,
+						domain: suggestion.domain_name,
+					} ),
+					this.props.productsList
+				),
+			] )
+			.then( () => {
+				page( '/checkout/' + selectedSiteSlug );
+			} );
 	};
 
 	handleRegisterDomain = ( suggestion ) => {
@@ -109,9 +115,11 @@ export class TransferDomain extends Component {
 			transfer = updatePrivacyForDomain( transfer, true );
 		}
 
-		addItems( [ transfer ] );
-
-		page( '/checkout/' + selectedSiteSlug );
+		this.props.shoppingCartManager
+			.addProductsToCart( [ fillInSingleCartItemAttributes( transfer, this.props.productsList ) ] )
+			.then( () => {
+				page( '/checkout/' + selectedSiteSlug );
+			} );
 	};
 
 	UNSAFE_componentWillMount() {
@@ -191,4 +199,4 @@ export default connect( ( state ) => ( {
 	domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 	isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
 	productsList: getProductsList( state ),
-} ) )( TransferDomain );
+} ) )( withShoppingCart( TransferDomain ) );

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -17,6 +17,7 @@ import {
 	domainTransfer,
 	updatePrivacyForDomain,
 } from 'calypso/lib/cart-values/cart-items';
+import { addItem, addItems } from 'calypso/lib/cart/actions';
 import Notice from 'calypso/components/notice';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import isSiteUpgradeable from 'calypso/state/selectors/is-site-upgradeable';
@@ -28,8 +29,6 @@ import {
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import TrademarkClaimsNotice from 'calypso/components/domains/trademark-claims-notice';
-import { withShoppingCart } from '@automattic/shopping-cart';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 
 export class TransferDomain extends Component {
 	static propTypes = {
@@ -70,19 +69,14 @@ export class TransferDomain extends Component {
 	addDomainToCart = ( suggestion ) => {
 		const { selectedSiteSlug } = this.props;
 
-		this.props.shoppingCartManager
-			.addProductsToCart( [
-				fillInSingleCartItemAttributes(
-					domainRegistration( {
-						productSlug: suggestion.product_slug,
-						domain: suggestion.domain_name,
-					} ),
-					this.props.productsList
-				),
-			] )
-			.then( () => {
-				page( '/checkout/' + selectedSiteSlug );
-			} );
+		addItem(
+			domainRegistration( {
+				productSlug: suggestion.product_slug,
+				domain: suggestion.domain_name,
+			} )
+		);
+
+		page( '/checkout/' + selectedSiteSlug );
 	};
 
 	handleRegisterDomain = ( suggestion ) => {
@@ -115,11 +109,9 @@ export class TransferDomain extends Component {
 			transfer = updatePrivacyForDomain( transfer, true );
 		}
 
-		this.props.shoppingCartManager
-			.addProductsToCart( [ fillInSingleCartItemAttributes( transfer, this.props.productsList ) ] )
-			.then( () => {
-				page( '/checkout/' + selectedSiteSlug );
-			} );
+		addItems( [ transfer ] );
+
+		page( '/checkout/' + selectedSiteSlug );
 	};
 
 	UNSAFE_componentWillMount() {
@@ -199,4 +191,4 @@ export default connect( ( state ) => ( {
 	domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 	isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
 	productsList: getProductsList( state ),
-} ) )( withShoppingCart( TransferDomain ) );
+} ) )( TransferDomain );

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -68,16 +68,16 @@ export class TransferDomain extends Component {
 	};
 
 	addDomainToCart = ( suggestion ) => {
-		const { selectedSiteSlug } = this.props;
+		const { selectedSiteSlug, shoppingCartManager, productsList } = this.props;
 
-		this.props.shoppingCartManager
+		shoppingCartManager
 			.addProductsToCart( [
 				fillInSingleCartItemAttributes(
 					domainRegistration( {
 						productSlug: suggestion.product_slug,
 						domain: suggestion.domain_name,
 					} ),
-					this.props.productsList
+					productsList
 				),
 			] )
 			.then( () => {
@@ -99,7 +99,7 @@ export class TransferDomain extends Component {
 	};
 
 	handleTransferDomain = ( domain, authCode, supportsPrivacy ) => {
-		const { selectedSiteSlug } = this.props;
+		const { selectedSiteSlug, shoppingCartManager } = this.props;
 
 		this.setState( { errorMessage: null } );
 
@@ -115,7 +115,7 @@ export class TransferDomain extends Component {
 			transfer = updatePrivacyForDomain( transfer, true );
 		}
 
-		this.props.shoppingCartManager
+		shoppingCartManager
 			.addProductsToCart( [ fillInSingleCartItemAttributes( transfer, this.props.productsList ) ] )
 			.then( () => {
 				page( '/checkout/' + selectedSiteSlug );

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -312,27 +312,22 @@ export default {
 		const { getState, dispatch } = signupStore;
 		const signupDependencies = getSignupDependencyStore( getState() );
 
-		const siteFragment = signupDependencies?.siteSlug || query?.siteSlug;
-		const siteId = getSiteId( getState(), siteFragment );
+		const siteSlug = signupDependencies?.siteSlug || query?.siteSlug;
+		const siteId = getSiteId( getState(), siteSlug );
 		if ( siteId ) {
 			dispatch( setSelectedSiteId( siteId ) );
 			next();
 		} else {
-			// Fetch the site by siteFragment and then try to select again
-			dispatch( requestSite( siteFragment ) ).then( () => {
-				let freshSiteId = getSiteId( getState(), siteFragment );
+			// Fetch the site by siteSlug and then try to select again
+			dispatch( requestSite( siteSlug ) ).then( () => {
+				let freshSiteId = getSiteId( getState(), siteSlug );
 
 				if ( ! freshSiteId ) {
-					const wpcomStagingFragment = siteFragment.replace(
-						/\b.wordpress.com/,
-						'.wpcomstaging.com'
-					);
+					const wpcomStagingFragment = siteSlug.replace( /\b.wordpress.com/, '.wpcomstaging.com' );
 					freshSiteId = getSiteId( getState(), wpcomStagingFragment );
 				}
 
 				if ( freshSiteId ) {
-					// onSelectedSiteAvailable might render an error page about domain-only sites or redirect
-					// to wp-admin. In that case, don't continue handling the route.
 					dispatch( setSelectedSiteId( freshSiteId ) );
 					next();
 				}

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -43,6 +43,9 @@ import { requestGeoLocation } from 'calypso/state/data-getters';
 import { getDotBlogVerticalId } from './config/dotblog-verticals';
 import { abtest } from 'calypso/lib/abtest';
 import user from 'calypso/lib/user';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import getSiteId from 'calypso/state/selectors/get-site-id';
+import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 
 /**
  * Constants
@@ -302,6 +305,18 @@ export default {
 			stepComponent,
 			pageTitle: getFlowPageTitle( flowName ),
 		} );
+
+		next();
+	},
+	setSelectedSiteForSignup( { store: signupStore, query }, next ) {
+		const state = signupStore.getState();
+		const selectedSiteId = getSelectedSiteId( state );
+		const signupDependencies = getSignupDependencyStore( state );
+
+		if ( ! selectedSiteId && ( signupDependencies?.siteSlug || query?.siteSlug ) ) {
+			const siteId = getSiteId( state, signupDependencies?.siteSlug || query?.siteSlug );
+			signupStore.dispatch( setSelectedSiteId( siteId ) );
+		}
 
 		next();
 	},

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -24,6 +24,7 @@ export default function () {
 		controller.saveInitialContext,
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.redirectToFlow,
+		controller.setSelectedSiteForSignup,
 		controller.start,
 		controller.importSiteInfoFromQuery,
 		makeLayout,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -43,7 +43,7 @@ import { getDomainProductSlug, TRUENAME_COUPONS, TRUENAME_TLDS } from 'calypso/l
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { getAvailableProductsList } from 'calypso/state/products-list/selectors';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { getSite } from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { getVerticalForDomainSuggestions } from 'calypso/state/signup/steps/site-vertical/selectors';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
@@ -563,18 +563,20 @@ class DomainsStep extends React.Component {
 
 		return (
 			<div className="domains__step-section-wrapper" key="transferForm">
-				<TransferDomainStep
-					analyticsSection={ this.getAnalyticsSection() }
-					basePath={ this.props.path }
-					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-					initialQuery={ initialQuery }
-					isSignupStep
-					mapDomainUrl={ this.getMapDomainUrl() }
-					onRegisterDomain={ this.handleAddDomain }
-					onTransferDomain={ this.handleAddTransfer }
-					onSave={ this.onTransferSave }
-					products={ this.props.productsList }
-				/>
+				<CalypsoShoppingCartProvider>
+					<TransferDomainStep
+						analyticsSection={ this.getAnalyticsSection() }
+						basePath={ this.props.path }
+						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+						initialQuery={ initialQuery }
+						isSignupStep
+						mapDomainUrl={ this.getMapDomainUrl() }
+						onRegisterDomain={ this.handleAddDomain }
+						onTransferDomain={ this.handleAddTransfer }
+						onSave={ this.onTransferSave }
+						products={ this.props.productsList }
+					/>
+				</CalypsoShoppingCartProvider>
 			</div>
 		);
 	};
@@ -584,16 +586,18 @@ class DomainsStep extends React.Component {
 
 		return (
 			<div className="domains__step-section-wrapper" key="useYourDomainForm">
-				<UseYourDomainStep
-					analyticsSection={ this.getAnalyticsSection() }
-					basePath={ this.props.path }
-					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-					initialQuery={ initialQuery }
-					isSignupStep
-					mapDomainUrl={ this.getMapDomainUrl() }
-					transferDomainUrl={ this.getTransferDomainUrl() }
-					products={ this.props.productsList }
-				/>
+				<CalypsoShoppingCartProvider>
+					<UseYourDomainStep
+						analyticsSection={ this.getAnalyticsSection() }
+						basePath={ this.props.path }
+						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+						initialQuery={ initialQuery }
+						isSignupStep
+						mapDomainUrl={ this.getMapDomainUrl() }
+						transferDomainUrl={ this.getTransferDomainUrl() }
+						products={ this.props.productsList }
+					/>
+				</CalypsoShoppingCartProvider>
 			</div>
 		);
 	};
@@ -796,7 +800,7 @@ export default connect(
 			siteGoals: getSiteGoals( state ),
 			siteType: getSiteType( state ),
 			vertical: getVerticalForDomainSuggestions( state ),
-			selectedSite: getSite( state, ownProps.signupDependencies.siteSlug ),
+			selectedSite: getSelectedSite( state ),
 			isSitePreviewVisible: isSitePreviewVisible( state ),
 			sites: getSitesItems( state ),
 			isReskinned,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -563,20 +563,18 @@ class DomainsStep extends React.Component {
 
 		return (
 			<div className="domains__step-section-wrapper" key="transferForm">
-				<CalypsoShoppingCartProvider>
-					<TransferDomainStep
-						analyticsSection={ this.getAnalyticsSection() }
-						basePath={ this.props.path }
-						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						initialQuery={ initialQuery }
-						isSignupStep
-						mapDomainUrl={ this.getMapDomainUrl() }
-						onRegisterDomain={ this.handleAddDomain }
-						onTransferDomain={ this.handleAddTransfer }
-						onSave={ this.onTransferSave }
-						products={ this.props.productsList }
-					/>
-				</CalypsoShoppingCartProvider>
+				<TransferDomainStep
+					analyticsSection={ this.getAnalyticsSection() }
+					basePath={ this.props.path }
+					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+					initialQuery={ initialQuery }
+					isSignupStep
+					mapDomainUrl={ this.getMapDomainUrl() }
+					onRegisterDomain={ this.handleAddDomain }
+					onTransferDomain={ this.handleAddTransfer }
+					onSave={ this.onTransferSave }
+					products={ this.props.productsList }
+				/>
 			</div>
 		);
 	};
@@ -586,18 +584,16 @@ class DomainsStep extends React.Component {
 
 		return (
 			<div className="domains__step-section-wrapper" key="useYourDomainForm">
-				<CalypsoShoppingCartProvider>
-					<UseYourDomainStep
-						analyticsSection={ this.getAnalyticsSection() }
-						basePath={ this.props.path }
-						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						initialQuery={ initialQuery }
-						isSignupStep
-						mapDomainUrl={ this.getMapDomainUrl() }
-						transferDomainUrl={ this.getTransferDomainUrl() }
-						products={ this.props.productsList }
-					/>
-				</CalypsoShoppingCartProvider>
+				<UseYourDomainStep
+					analyticsSection={ this.getAnalyticsSection() }
+					basePath={ this.props.path }
+					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+					initialQuery={ initialQuery }
+					isSignupStep
+					mapDomainUrl={ this.getMapDomainUrl() }
+					transferDomainUrl={ this.getTransferDomainUrl() }
+					products={ this.props.productsList }
+				/>
 			</div>
 		);
 	};

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -563,18 +563,20 @@ class DomainsStep extends React.Component {
 
 		return (
 			<div className="domains__step-section-wrapper" key="transferForm">
-				<TransferDomainStep
-					analyticsSection={ this.getAnalyticsSection() }
-					basePath={ this.props.path }
-					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-					initialQuery={ initialQuery }
-					isSignupStep
-					mapDomainUrl={ this.getMapDomainUrl() }
-					onRegisterDomain={ this.handleAddDomain }
-					onTransferDomain={ this.handleAddTransfer }
-					onSave={ this.onTransferSave }
-					products={ this.props.productsList }
-				/>
+				<CalypsoShoppingCartProvider>
+					<TransferDomainStep
+						analyticsSection={ this.getAnalyticsSection() }
+						basePath={ this.props.path }
+						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+						initialQuery={ initialQuery }
+						isSignupStep
+						mapDomainUrl={ this.getMapDomainUrl() }
+						onRegisterDomain={ this.handleAddDomain }
+						onTransferDomain={ this.handleAddTransfer }
+						onSave={ this.onTransferSave }
+						products={ this.props.productsList }
+					/>
+				</CalypsoShoppingCartProvider>
 			</div>
 		);
 	};
@@ -584,16 +586,18 @@ class DomainsStep extends React.Component {
 
 		return (
 			<div className="domains__step-section-wrapper" key="useYourDomainForm">
-				<UseYourDomainStep
-					analyticsSection={ this.getAnalyticsSection() }
-					basePath={ this.props.path }
-					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-					initialQuery={ initialQuery }
-					isSignupStep
-					mapDomainUrl={ this.getMapDomainUrl() }
-					transferDomainUrl={ this.getTransferDomainUrl() }
-					products={ this.props.productsList }
-				/>
+				<CalypsoShoppingCartProvider>
+					<UseYourDomainStep
+						analyticsSection={ this.getAnalyticsSection() }
+						basePath={ this.props.path }
+						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+						initialQuery={ initialQuery }
+						isSignupStep
+						mapDomainUrl={ this.getMapDomainUrl() }
+						transferDomainUrl={ this.getTransferDomainUrl() }
+						products={ this.props.productsList }
+					/>
+				</CalypsoShoppingCartProvider>
 			</div>
 		);
 	};


### PR DESCRIPTION
The domain/mapping/transfer prices for the `launch-site` signup flow are wrong. Turns out that since we don't have a `selectedSite` redux state set for the signup when you pass down the `siteSlug` query param we also don't get the correct `cart` and `selectedSite` object in multiple components so we can't actually render the correct price

#### Changes proposed in this Pull Request

* Set the global selectedSiteId if there is a `siteSlug` provided to the signup flow
* Update some of the components we use to use `CalypsoShoppingCartProvider` so we can always get the cart

#### Testing instructions

* Create a new unlaunched site (not created via gutenboarding) and purchase a plan only subscription (don't bundle domain). Now try to launch the site by clicking the "Launch site" on My Home.
* You should be forwarded to `/start/launch-site`. Since you have a plan without bundled domain you should see "First year free with your plan" for all domain suggestions
* If you click on "I already own a domain" you should also see "free with your plan" for both mapping and 

