### PR TITLE
New Onboarding: hide LanguagePicker button from Plans and Domains modals

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -40,8 +40,9 @@ const Header: React.FunctionComponent = () => {
 	const showPlansButton =
 		[ 'DesignSelection', 'Style', 'Features' ].includes( currentStep ) && ! isAnchorFmSignup;
 
-	// locale button is hidden on AnchorFM flavored gutenboarding
-	const showLocaleButton = ! isAnchorFmSignup;
+	// locale button is hidden on DomainsModal, PlansModal, and AnchorFM flavored gutenboarding
+	const showLocaleButton =
+		! [ 'DomainsModal', 'PlansModal' ].includes( currentStep ) && ! isAnchorFmSignup;
 
 	// CreateSite step clears state before redirecting, don't show the default text in this case
 	const siteTitleDefault = 'CreateSite' === currentStep ? '' : __( 'Start your website' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Temporary fix for https://github.com/Automattic/wp-calypso/issues/49679 by preventing the scenarios where navigation is broken

#### Testing instructions

* Go to wordpress.com/new/design
* Click domain nudge from header to open Domains Modal => _Site language [EN]_ button is removed from header
* Go back and click Plans Button from header => same

Related to #49679
