### PR TITLE
Revert "Gutenboarding: Enable language picker on production."

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -15,6 +15,7 @@ import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import DomainPickerButton from '../domain-picker-button';
 import PlansButton from '../plans-button';
 import { useCurrentStep, useIsAnchorFm, usePath, Step } from '../../path';
+import { isEnabled } from '@automattic/calypso-config';
 import Link from '../link';
 
 /**
@@ -51,16 +52,19 @@ const Header: React.FunctionComponent = () => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 	const changeLocaleButton = () => {
-		return (
-			<div className="gutenboarding__header-section-item gutenboarding__header-language-section">
-				<Link to={ makePath( Step.LanguageModal ) }>
-					<span className="gutenboarding__header-site-language-label">
-						{ __( 'Site Language' ) }
-					</span>
-					<span className="gutenboarding__header-site-language-badge">{ locale }</span>
-				</Link>
-			</div>
-		);
+		if ( isEnabled( 'gutenboarding/language-picker' ) ) {
+			return (
+				<div className="gutenboarding__header-section-item gutenboarding__header-language-section">
+					<Link to={ makePath( Step.LanguageModal ) }>
+						<span className="gutenboarding__header-site-language-label">
+							{ __( 'Site Language' ) }
+						</span>
+						<span className="gutenboarding__header-site-language-badge">{ locale }</span>
+					</Link>
+				</div>
+			);
+		}
+		return null;
 	};
 
 	return (

--- a/config/development.json
+++ b/config/development.json
@@ -75,6 +75,7 @@
 		"google-drive": true,
 		"google-workspace-migration": true,
 		"gutenboarding/alpha-templates": true,
+		"gutenboarding/language-picker": true,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,
 		"gutenboarding/show-vertical-input": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -48,6 +48,7 @@
 		"gdpr-banner": true,
 		"google-my-business": false,
 		"gutenboarding/alpha-templates": true,
+		"gutenboarding/language-picker": true,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,
 		"gutenboarding/mshot-preview": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -51,6 +51,7 @@
 		"google-my-business": true,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
+		"gutenboarding/language-picker": false,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,
 		"happychat": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -59,6 +59,7 @@
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
 		"gutenboarding/alpha-templates": true,
+		"gutenboarding/language-picker": false,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,
 		"happychat": true,

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -46,7 +46,12 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 		} );
 
 		step( 'Can visit Gutenboarding page and see Onboarding block', async function () {
-			const page = await NewPage.Visit( driver, NewPage.getGutenboardingURL() );
+			const page = await NewPage.Visit(
+				driver,
+				NewPage.getGutenboardingURL( {
+					query: 'flags=gutenboarding/language-picker',
+				} )
+			);
 			const blockExists = await page.waitForBlock();
 			assert( blockExists, 'Onboarding block is not rendered' );
 		} );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#49674

Quick revert due to #49677 and #49679

Disables the language picker in production