### PR TITLE
Adminbar: hide in WP Mobile Apps - with fixes

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -122,6 +122,7 @@ class Document extends React.Component {
 						[ 'is-group-' + sectionGroup ]: sectionGroup,
 						[ 'is-section-' + sectionName ]: sectionName,
 						'is-white-signup': sectionName === 'signup',
+						'is-mobile-app-view': app?.isWpMobileApp,
 					} ) }
 				>
 					{ /* eslint-disable wpcalypso/jsx-classname-namespace, react/no-danger */ }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -13,6 +13,7 @@ import classnames from 'classnames';
 import AsyncLoad from 'calypso/components/async-load';
 import MasterbarLoggedIn from 'calypso/layout/masterbar/logged-in';
 import JetpackCloudMasterbar from 'calypso/components/jetpack/masterbar';
+import EmptyMasterbar from 'calypso/layout/masterbar/empty';
 import HtmlIsIframeClassname from 'calypso/layout/html-is-iframe-classname';
 import notices from 'calypso/notices';
 import config from '@automattic/calypso-config';
@@ -47,6 +48,7 @@ import Experiment from 'calypso/components/experiment';
 import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
+import { isWpMobileApp } from 'calypso/lib/mobile-app';
 
 /**
  * Style dependencies
@@ -129,6 +131,10 @@ class Layout extends Component {
 			return false;
 		}
 
+		if ( isWpMobileApp() ) {
+			return false;
+		}
+
 		const exemptedSections = [ 'jetpack-connect', 'happychat', 'devdocs', 'help' ];
 		const exemptedRoutes = [ '/log-in/jetpack', '/me/account/closed' ];
 		const exemptedRoutesStartingWith = [ '/start/p2' ];
@@ -143,6 +149,9 @@ class Layout extends Component {
 	}
 
 	renderMasterbar() {
+		if ( this.props.masterbarIsHidden ) {
+			return <EmptyMasterbar />;
+		}
 		const MasterbarComponent = config.isEnabled( 'jetpack-cloud' )
 			? JetpackCloudMasterbar
 			: MasterbarLoggedIn;
@@ -332,7 +341,10 @@ export default compose(
 
 		return {
 			masterbarIsHidden:
-				! masterbarIsVisible( state ) || noMasterbarForSection || noMasterbarForRoute,
+				! masterbarIsVisible( state ) ||
+				noMasterbarForSection ||
+				noMasterbarForRoute ||
+				isWpMobileApp(),
 			isJetpack,
 			isJetpackLogin,
 			isJetpackWooCommerceFlow,

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -27,6 +27,7 @@ import BodySectionCssClass from './body-section-css-class';
 import GdprBanner from 'calypso/blocks/gdpr-banner';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { withCurrentRoute } from 'calypso/components/route';
+import { isWpMobileApp } from 'calypso/lib/mobile-app';
 
 /**
  * Style dependencies
@@ -91,7 +92,7 @@ const LayoutLoggedOut = ( {
 
 			masterbar = <OauthClientMasterbar oauth2Client={ oauth2Client } />;
 		}
-	} else if ( config.isEnabled( 'jetpack-cloud' ) ) {
+	} else if ( config.isEnabled( 'jetpack-cloud' ) || isWpMobileApp() ) {
 		masterbar = null;
 	} else {
 		masterbar = (

--- a/client/layout/masterbar/empty.jsx
+++ b/client/layout/masterbar/empty.jsx
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const EmptyMasterbar = () => <header id="header" className="masterbar" />;
+
+export default EmptyMasterbar;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1,5 +1,12 @@
 $autobar-height: 20px;
 
+// Hide the masterbar on WP Mobile App views.
+.is-mobile-app-view {
+	.masterbar {
+		display: none;
+	}
+}
+
 // The WordPress.com Masterbar
 .masterbar {
 	background: var( --color-masterbar-background );

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -316,3 +316,15 @@
 		}
 	}
 }
+
+.layout.has-no-masterbar {
+	--masterbar-height: 0;
+
+	.layout__content {
+		padding-top: 32px;
+	}
+	&.has-no-sidebar .layout__content {
+		padding-top: 0;
+	}
+}
+

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -316,8 +316,11 @@
 		}
 	}
 }
-
-.layout.has-no-masterbar {
+// Only apply the no-masterbar rule to logged in sections
+// This is done since most has-no-masterbar section have their own padding set already that we don't want to overwrite 
+.layout.has-no-masterbar.is-group-me,
+.layout.has-no-masterbar.is-group-sites,
+.layout.has-no-masterbar.is-section-reader {
 	--masterbar-height: 0;
 
 	.layout__content {
@@ -327,4 +330,3 @@
 		padding-top: 0;
 	}
 }
-

--- a/client/lib/mobile-app/index.js
+++ b/client/lib/mobile-app/index.js
@@ -4,5 +4,8 @@
  * @returns {boolean} Whether the user agent matches the ones used on the WordPress mobile apps.
  */
 export function isWpMobileApp() {
-	return navigator && /wp-(android|iphone)/.test( navigator.userAgent );
+	if ( typeof navigator === 'undefined' ) {
+		return false;
+	}
+	return navigator.userAgent && /wp-(android|iphone)/.test( navigator.userAgent );
 }

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -61,6 +61,9 @@
 	}
 }
 
+.is-mobile-app-view .theme__sheet-action-bar.card {
+	display: none;
+}
 .theme__sheet-primary-button {
 	position: absolute;
 	top: 5px;

--- a/client/server/lib/is-wp-mobile-app/index.js
+++ b/client/server/lib/is-wp-mobile-app/index.js
@@ -1,0 +1,10 @@
+/**
+ * Returns whether source matches a WordPress mobile app.
+ *
+ * @param source string
+ *
+ * @returns {boolean} Whether source matches the ones used on the WordPress mobile apps.
+ */
+export default function isWpMobileApp( source ) {
+	return /wp-(android|iphone)/.test( source );
+}

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -34,6 +34,7 @@ import {
 } from 'calypso/server/render';
 import stateCache from 'calypso/server/state-cache';
 import getBootstrappedUser from 'calypso/server/user-bootstrap';
+import isWpMobileApp from 'calypso/server/lib/is-wp-mobile-app';
 import { createReduxStore } from 'calypso/state';
 import { setDocumentHeadLink } from 'calypso/state/document-head/actions';
 import { setStore } from 'calypso/state/redux-store';
@@ -174,6 +175,7 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 	context.app = {
 		// use ipv4 address when is ipv4 mapped address
 		clientIp: request.ip ? request.ip.replace( '::ffff:', '' ) : request.ip,
+		isWpMobileApp: isWpMobileApp( request.useragent.source ),
 		isDebug,
 		staticUrls: staticFilesUrls,
 	};


### PR DESCRIPTION
This PR fixes intent is to fix what was broken on the https://github.com/Automattic/wp-calypso/pull/49281 and needed to be reverted. 

The reason why https://github.com/Automattic/wp-calypso/pull/49281 broke sign up and probably other sections is because the css selector specificity was too high and overwrote the custom top padding of the signup section. 

The fix that I am proposing is applying no-master-bar rule to only specific sections. (me, reader, sites)
These sections are defined in https://github.com/Automattic/wp-calypso/blob/56b728155d028a4e8cbf916ce4f70689e5dca573/client/sections.js

### Screenshots

Reader Section
<img width="947" alt="Screen Shot 2021-02-03 at 3 42 15 PM" src="https://user-images.githubusercontent.com/115071/106828862-d526e180-663f-11eb-8d9a-06e1a60003e8.png">

Me Section
<img width="917" alt="Screen_Shot_2021-02-03_at_3_42_05_PM" src="https://user-images.githubusercontent.com/115071/106829092-4c5c7580-6640-11eb-93fc-c83e43a713fa.png">


Home Section 
<img width="887" alt="Screen Shot 2021-02-03 at 4 50 39 PM" src="https://user-images.githubusercontent.com/115071/106828920-f556a080-663f-11eb-9cbc-ee00240a8e30.png">

Individual Theme view (logged in)  (back button as well as Activate theme) 
<img width="976" alt="Screen Shot 2021-02-03 at 3 55 46 PM" src="https://user-images.githubusercontent.com/115071/106828947-0b646100-6640-11eb-8a05-46ce43e9efeb.png">

Individual Theme view
<img width="929" alt="Screen Shot 2021-02-03 at 3 56 00 PM" src="https://user-images.githubusercontent.com/115071/106828972-14edc900-6640-11eb-8958-73d9b3fb9d50.png">

Notice the missing


#### Testing instructions

1. Add a new device in the Responsive design testing tool. 

<img width="383" alt="Screen Shot 2021-01-25 at 5 19 55 PM" src="https://user-images.githubusercontent.com/115071/105786337-b9ca2100-5f31-11eb-84bd-af1452a6f70f.png">

<img width="807" alt="Screen Shot 2021-01-25 at 5 22 33 PM" src="https://user-images.githubusercontent.com/115071/105786430-ee3ddd00-5f31-11eb-83a6-67be2bcf5e01.png">

the device should have the following agent. 
```
Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36 wp-android/4.7
```
or 
```
Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16B91 wp-iphone/12.1
```

* Select the device. Notice that the masterbar as well as the inline help is gone in calypso.
<img width="928" alt="Screen Shot 2021-01-25 at 5 23 10 PM" src="https://user-images.githubusercontent.com/115071/105786486-044b9d80-5f32-11eb-81d5-49f8eca094c1.png">

Page in question that we want to clean up is 
http://calypso.localhost:3000/theme/spearhead/example.com

Check Sign up sections
http://calypso.localhost:3000/start
http://calypso.localhost:3000/start/p2/p2-site
http://calypso.localhost:3000/jetpack/connect 



