### PR TITLE
Change import to import type in client/lib/url helpers

### DIFF
--- a/client/lib/url/add-query-args.ts
+++ b/client/lib/url/add-query-args.ts
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { pickBy } from 'lodash';
-import { Primitive } from 'utility-types';
+import type { Primitive } from 'utility-types';
 
 /**
  * Internal dependencies
  */
-import { URL as URLString } from 'calypso/types';
+import type { URL as URLString } from 'calypso/types';
 import { determineUrlType, URL_TYPE } from './url-type';
 import format from './format';
 

--- a/client/lib/url/format.ts
+++ b/client/lib/url/format.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { URL as URLString } from 'calypso/types';
+import type { URL as URLString } from 'calypso/types';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change `import` to `import type` in client/lib/url helpers

#### Testing instructions


* `NODE_OPTIONS='--max-old-space-size=4096' tsc --project client/landing/gutenboarding`
* You may need to pull in the changes from the `add/anchor-gutenboarding-same-site-redirect` branch from #49571 to see the errors

Before:
```
client/lib/url/add-query-args.ts:5:1 - error TS1371: This import is never used as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'.

5 import { Primitive } from 'utility-types';
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

client/lib/url/add-query-args.ts:10:1 - error TS1371: This import is never used as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'.

10 import { URL as URLString } from 'calypso/types';
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

client/lib/url/format.ts:4:1 - error TS1371: This import is never used as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'.

4 import { URL as URLString } from 'calypso/types';
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 3 errors.

```

After: No errors.

Related to #49571.
