### PR TITLE
Checkout: stop casting purchaseId to a string for analytics

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -421,7 +421,7 @@ export default function CompositeCheckout( {
 	} );
 
 	const { analyticsPath, analyticsProps } = getAnalyticsPath(
-		String( purchaseId ),
+		purchaseId,
 		productAliasFromUrl,
 		siteSlug,
 		feature,
@@ -699,7 +699,7 @@ function getPlanProductSlugs( items: ResponseCartProduct[] ): string[] {
 }
 
 function getAnalyticsPath(
-	purchaseId: string | undefined,
+	purchaseId: number | undefined,
 	product: string | undefined,
 	selectedSiteSlug: string | undefined,
 	selectedFeature: string | undefined,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes a regression added in https://github.com/Automattic/wp-calypso/pull/46758 which caused all checkout page loads to be reported in analytics as renewals.

Props to @ebinnion for finding this bug!

Before:

<img width="681" alt="wrong-analytics-path" src="https://user-images.githubusercontent.com/2036909/106821995-3d7bc000-664c-11eb-8452-805a407c22b4.png">

After:

![right-analytics-path](https://user-images.githubusercontent.com/2036909/106821999-4076b080-664c-11eb-8da8-005668572107.png)


#### Testing instructions

- Add a non-renewal product to your cart and visit checkout.
- Enable debugging for analytics (`localStorage.setItem('debug', 'calypso:analytics')`) in your browser's javascript console and then reload the page.
- Examine the analytics logs in your browser's javascript console to verify that the `calypso_page_view` event is sent including a `path` that matches the URL pattern you see in your browser.