### PR TITLE
Reader: improve accessibility of CommentsButton block

### DIFF
--- a/client/blocks/comment-button/README.md
+++ b/client/blocks/comment-button/README.md
@@ -17,6 +17,5 @@ function render() {
 - `commentCount`: Number indicating the number of comments to be displayed next to the button.
 - `href`: String URL destination to be used with a `tagName` of `a`. Defaults to `null`.
 - `onClick`: Function to be executed when the user clicks the button.
-- `showLabel`: Boolean indicating whether or not the label with the comments count is visible. Defaults to `true`.
 - `size`: Number with the size of the comments icon to be displayed. Defaults to 24.
 - `target`: String `target` attribute to be used with a `tagName` of `a`. Defaults to `null`.

--- a/client/blocks/comment-button/README.md
+++ b/client/blocks/comment-button/README.md
@@ -19,5 +19,4 @@ function render() {
 - `onClick`: Function to be executed when the user clicks the button.
 - `showLabel`: Boolean indicating whether or not the label with the comments count is visible. Defaults to `true`.
 - `size`: Number with the size of the comments icon to be displayed. Defaults to 24.
-- `tagName`: String with the HTML tag we are going to use to render the component. Defaults to 'li'.
 - `target`: String `target` attribute to be used with a `tagName` of `a`. Defaults to `null`.

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import { noop } from 'lodash';
@@ -24,20 +23,29 @@ function CommentButton( props ) {
 	const translate = useTranslate();
 
 	return (
-		<a className="comment-button" href={ href } onClick={ onClick } target={ target }>
+		<a className="comment-button" href={ href } onClick={ onClick } tabIndex="0" target={ target }>
 			<Gridicon aria-hidden="true" icon="comment" size={ size } className="comment-button__icon" />
 			<span className="comment-button__label">
 				{ commentCount > 0 && (
 					<span className="comment-button__label-count">{ commentCount }</span>
 				) }
-				{ commentCount > 0 && (
-					<span className="comment-button__label-status">
-						{ translate( 'Comment', 'Comments', {
-							context: 'noun',
-							count: commentCount,
-						} ) }
-					</span>
-				) }
+				<span className="comment-button__label-status">
+					{ commentCount > 0 && (
+						<Fragment>
+							{ translate( 'Comment', 'Comments', {
+								context: 'noun',
+								count: commentCount,
+							} ) }
+						</Fragment>
+					) }
+					{ commentCount === 0 && (
+						<Fragment>
+							{ translate( 'Comment', {
+								context: 'verb',
+							} ) }
+						</Fragment>
+					) }
+				</span>
 			</span>
 		</a>
 	);

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -20,22 +20,17 @@ import { getPostTotalCommentsCount } from 'calypso/state/comments/selectors';
 import './style.scss';
 
 function CommentButton( props ) {
-	const { commentCount, href, onClick, showLabel, target } = props;
+	const { commentCount, href, onClick, size, target } = props;
 	const translate = useTranslate();
 
 	return (
 		<a className="comment-button" href={ href } onClick={ onClick } target={ target }>
-			<Gridicon
-				aria-hidden="true"
-				icon="comment"
-				size={ props.size }
-				className="comment-button__icon"
-			/>
+			<Gridicon aria-hidden="true" icon="comment" size={ size } className="comment-button__icon" />
 			<span className="comment-button__label">
 				{ commentCount > 0 && (
 					<span className="comment-button__label-count">{ commentCount }</span>
 				) }
-				{ showLabel && commentCount > 0 && (
+				{ commentCount > 0 && (
 					<span className="comment-button__label-status">
 						{ translate( 'Comment', 'Comments', {
 							context: 'noun',
@@ -52,7 +47,6 @@ CommentButton.propTypes = {
 	commentCount: PropTypes.number,
 	href: PropTypes.string,
 	onClick: PropTypes.func,
-	showLabel: PropTypes.bool,
 	target: PropTypes.string,
 };
 
@@ -60,7 +54,6 @@ CommentButton.defaultProps = {
 	commentCount: 0,
 	href: null,
 	onClick: noop,
-	showLabel: true,
 	size: 24,
 	target: null,
 };

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
-import { noop, omitBy } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,32 +20,31 @@ import { getPostTotalCommentsCount } from 'calypso/state/comments/selectors';
 import './style.scss';
 
 function CommentButton( props ) {
-	const { commentCount, href, onClick, showLabel, tagName, target } = props;
+	const { commentCount, href, onClick, showLabel, target } = props;
 	const translate = useTranslate();
 
-	return React.createElement(
-		tagName,
-		omitBy(
-			{
-				className: 'comment-button',
-				href: 'a' === tagName ? href : null,
-				onClick,
-				target: 'a' === tagName ? target : null,
-			},
-			( prop ) => prop === null
-		),
-		<Gridicon icon="comment" size={ props.size } className="comment-button__icon" />,
-		<span className="comment-button__label">
-			{ commentCount > 0 && <span className="comment-button__label-count">{ commentCount }</span> }
-			{ showLabel && commentCount > 0 && (
-				<span className="comment-button__label-status">
-					{ translate( 'Comment', 'Comments', {
-						context: 'noun',
-						count: commentCount,
-					} ) }
-				</span>
-			) }
-		</span>
+	return (
+		<a className="comment-button" href={ href } onClick={ onClick } target={ target }>
+			<Gridicon
+				aria-hidden="true"
+				icon="comment"
+				size={ props.size }
+				className="comment-button__icon"
+			/>
+			<span className="comment-button__label">
+				{ commentCount > 0 && (
+					<span className="comment-button__label-count">{ commentCount }</span>
+				) }
+				{ showLabel && commentCount > 0 && (
+					<span className="comment-button__label-status">
+						{ translate( 'Comment', 'Comments', {
+							context: 'noun',
+							count: commentCount,
+						} ) }
+					</span>
+				) }
+			</span>
+		</a>
 	);
 }
 
@@ -54,7 +53,6 @@ CommentButton.propTypes = {
 	href: PropTypes.string,
 	onClick: PropTypes.func,
 	showLabel: PropTypes.bool,
-	tagName: PropTypes.string,
 	target: PropTypes.string,
 };
 
@@ -64,7 +62,6 @@ CommentButton.defaultProps = {
 	onClick: noop,
 	showLabel: true,
 	size: 24,
-	tagName: 'li',
 	target: null,
 };
 

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -47,7 +47,6 @@ function CommentButton( props ) {
 				) }
 				{ commentCount === 0 && (
 					<span className="comment-button__label-status">
-						>
 						{ translate( 'Comment', {
 							context: 'verb',
 						} ) }

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -27,25 +27,32 @@ function CommentButton( props ) {
 			<Gridicon aria-hidden="true" icon="comment" size={ size } className="comment-button__icon" />
 			<span className="comment-button__label">
 				{ commentCount > 0 && (
-					<span className="comment-button__label-count">{ commentCount }</span>
-				) }
-				<span className="comment-button__label-status">
-					{ commentCount > 0 && (
-						<Fragment>
-							{ translate( 'Comment', 'Comments', {
+					<Fragment>
+						{ translate(
+							'{{count}}%(number)d{{/count}} {{label}}Comment{{/label}}',
+							'{{count}}%(number)d{{/count}} {{label}}Comments{{/label}}',
+							{
+								args: {
+									number: commentCount,
+								},
+								components: {
+									count: <span className="comment-button__label-count" />,
+									label: <span className="comment-button__label-status" />,
+								},
 								context: 'noun',
 								count: commentCount,
-							} ) }
-						</Fragment>
-					) }
-					{ commentCount === 0 && (
-						<Fragment>
-							{ translate( 'Comment', {
-								context: 'verb',
-							} ) }
-						</Fragment>
-					) }
-				</span>
+							}
+						) }
+					</Fragment>
+				) }
+				{ commentCount === 0 && (
+					<span className="comment-button__label-status">
+						>
+						{ translate( 'Comment', {
+							context: 'verb',
+						} ) }
+					</span>
+				) }
 			</span>
 		</a>
 	);

--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -1,17 +1,11 @@
 .comment-button {
 	align-items: center;
 	box-sizing: border-box;
-	color: var( --color-text-subtle );
 	cursor: pointer;
 	display: inline-flex;
 	list-style-type: none;
 	padding: 4px;
 	position: relative;
-
-	&:hover,
-	&:active {
-		color: var( --color-primary );
-	}
 
 	.comment-button__label-count {
 		margin-right: 4px;
@@ -21,6 +15,19 @@
 		@include breakpoint-deprecated( '<480px' ) {
 			@include hide-content-accessibly();
 		}
+	}
+}
+
+a.comment-button {
+	color: var( --color-text-subtle );
+
+	&:visited {
+		color: var( --color-text-subtle );
+	}
+
+	&:hover,
+	&:active {
+		color: var( --color-primary );
 	}
 }
 

--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -19,7 +19,7 @@
 
 	.comment-button__label-status {
 		@include breakpoint-deprecated( '<480px' ) {
-			display: none;
+			@include hide-content-accessibly();
 		}
 	}
 }

--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -7,10 +7,6 @@
 	padding: 4px;
 	position: relative;
 
-	.comment-button__label-count {
-		margin-right: 4px;
-	}
-
 	.comment-button__label-status {
 		@include breakpoint-deprecated( '<480px' ) {
 			@include hide-content-accessibly();

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -43,7 +43,7 @@ import {
 	RelatedPostsFromSameSite,
 	RelatedPostsFromOtherSites,
 } from 'calypso/components/related-posts';
-import { getStreamUrlFromPost } from 'calypso/reader/route';
+import { getPostUrl, getStreamUrlFromPost } from 'calypso/reader/route';
 import { like as likePost, unlike as unlikePost } from 'calypso/state/posts/likes/actions';
 import FeaturedImage from 'calypso/blocks/reader-full-post/featured-image';
 import { getFeed } from 'calypso/state/reader/feeds/selectors';
@@ -467,6 +467,7 @@ export class FullPostView extends React.Component {
 						<div className="reader-full-post__sidebar-comment-like">
 							{ shouldShowComments( post ) && (
 								<CommentButton
+									href={ getPostUrl( post ) + '#comments' }
 									key="comment-button"
 									commentCount={ commentCount }
 									onClick={ this.handleCommentClick }
@@ -550,7 +551,11 @@ export class FullPostView extends React.Component {
 								/>
 							) }
 
-							<div className="reader-full-post__comments-wrapper" ref={ this.commentsWrapper }>
+							<div
+								id="comments"
+								className="reader-full-post__comments-wrapper"
+								ref={ this.commentsWrapper }
+							>
 								{ shouldShowComments( post ) && (
 									<Comments
 										showNestingReplyArrow={ true }

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -470,7 +470,6 @@ export class FullPostView extends React.Component {
 									key="comment-button"
 									commentCount={ commentCount }
 									onClick={ this.handleCommentClick }
-									tagName="div"
 								/>
 							) }
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -387,7 +387,7 @@
 	}
 
 	.comment-button__label-status {
-		display: none;
+		@include hide-content-accessibly();
 	}
 }
 

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -89,7 +89,6 @@ const ReaderPostActions = ( props ) => {
 						key="comment-button"
 						commentCount={ post.discussion.comment_count }
 						onClick={ onCommentClick }
-						tagName="button"
 						size={ iconSize }
 					/>
 				</li>

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -20,6 +20,7 @@ import { userCan } from 'calypso/state/posts/utils';
 import * as stats from 'calypso/reader/stats';
 import { localize } from 'i18n-calypso';
 import ReaderVisitLink from 'calypso/blocks/reader-visit-link';
+import { getPostUrl } from 'calypso/reader/route';
 
 /**
  * Style dependencies
@@ -86,6 +87,7 @@ const ReaderPostActions = ( props ) => {
 			{ shouldShowComments( post ) && (
 				<li className="reader-post-actions__item">
 					<CommentButton
+						href={ getPostUrl( post ) + '#comments' }
 						key="comment-button"
 						commentCount={ post.discussion.comment_count }
 						onClick={ onCommentClick }

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -30,7 +30,9 @@
 
 	& > button {
 		line-height: inherit;
+	}
 
+	& > button,  & > a {
 		&:focus {
 			outline: thin dotted;
 		}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -605,7 +605,7 @@
 	.reader-share__button-label,
 	.comment-button__label-status,
 	.like-button__label-status {
-		display: none;
+		@include hide-content-accessibly();
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the comment button label readable by screenreaders.
* Use a `a` element for the component (currently uses a mixture of `div` and `button`).

<img width="839" alt="Screen Shot 2021-02-04 at 15 27 31" src="https://user-images.githubusercontent.com/17325/106836216-a0795f80-66fd-11eb-9054-ae3ef211664c.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Go to Reader at http://calypso.localhost:3000 and find a post with a Reader comments button. Ensure that:

* Comments button is keyboard-accessible.
* Comments button has a blue focus outline when selected.

<img width="847" alt="Screen Shot 2021-02-12 at 15 18 30" src="https://user-images.githubusercontent.com/17325/107723246-9a126580-6d45-11eb-9c76-efdee5fcdcbb.png">

* When viewing a full post, the comments label is still hidden at mobile screen widths (should show count only).

Desktop width:

<img width="771" alt="Screen Shot 2021-02-12 at 15 19 18" src="https://user-images.githubusercontent.com/17325/107723329-bc0be800-6d45-11eb-93fd-a71b784b1ae6.png">

Mobile width:

<img width="445" alt="Screen Shot 2021-02-12 at 15 19 23" src="https://user-images.githubusercontent.com/17325/107723340-c1693280-6d45-11eb-9d0a-b715e973a469.png">


Related to https://github.com/Automattic/wp-calypso/issues/46737.
