### PR TITLE
Patterns: Hide Featured category from being registered for patterns and layouts

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -77,7 +77,10 @@ class Block_Patterns_From_API {
 
 		foreach ( (array) $block_patterns as $pattern ) {
 			foreach ( (array) $pattern['categories'] as $slug => $category ) {
-				$pattern_categories[ $slug ] = $category['title'];
+				// Temporarily skip the 'featured' category so that we can expose it at another time.
+				if ( 'featured' !== $slug ) {
+					$pattern_categories[ $slug ] = $category['title'];
+				}
 			}
 		}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
@@ -281,7 +281,8 @@ class PageTemplateModal extends Component {
 		const templateGroups = {};
 		for ( const template of this.props.templates ) {
 			for ( const key in template.categories ) {
-				if ( ! ( key in templateGroups ) ) {
+				// Temporarily skip the 'featured' category so that we can expose it at another time.
+				if ( key !== 'featured' && ! ( key in templateGroups ) ) {
 					templateGroups[ key ] = template.categories[ key ];
 				}
 			}


### PR DESCRIPTION
This PR skips registering the pattern category if it matches the `featured` slug so that we can hide the Featured category for both patterns and page layouts while they're being worked on. The patterns will still appear in other categories if they also have other categories attached, it's just that the Featured category will not appear.

#### Changes proposed in this Pull Request

* Skip registering the `featured` category for patterns
* Skip adding a template group if the key matches `featured` for starter page templates

#### Screenshots

Note that the tiny screenshots in the left hand previews below do not work, because test sites aren't wired up to be rendered for those buttons. That issue is unrelated to this PR.

| Page layout picker before | Page layout picker after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/106847750-a83c0280-6703-11eb-8e0d-90655b1ec3b8.png) | ![image](https://user-images.githubusercontent.com/14988353/106847718-978b8c80-6703-11eb-9fb7-84bfbb2ed3d7.png) |

|  Pattern inserter before | Pattern inserter after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/106847838-d6214700-6703-11eb-8f33-64842620c5fd.png) | ![image](https://user-images.githubusercontent.com/14988353/106847842-dae5fb00-6703-11eb-9d87-59e1b9700a34.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To test with a source site that already uses the Featured category, in your `0-sandbox.php` file add the following `add_filter( 'a8c_override_patterns_source_site', function () { return 'andysfakeblockpatternsourcesite.<your_domain>'; } );` replacing `<your_domain>` with the real wordpress.com domain.
* Go to add a new page, and you should see a Featured category. The left-most featured layout also appears as the left-most Home Page layout.
* Insert the layout or dismiss the page layout picker.
* Open up the pattern inserter and check that you can see patterns in the Featured category, and in the Premium category.
* Apply the diff associated with this PR to your sandbox, and sandbox a test site.
* Go to add a page. There should be no Featured category, but you should still see the left-most Home Page layout. Insert it into your page.
* Then, open up the pattern inserter. You should see the patterns that were in Featured should still show in the Premium category.

If you'd like to test with your own or another block patterns source site, make sure that the patterns you're testing have the `is_web` `pattern_meta` tag, and you've assigned the `layout` or `pattern` tag to the post.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 120-gh-Automattic/view-design