### PR TITLE
Deduplicate nopt

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19279,15 +19279,7 @@ noop-logger@^0.1.1:
   dependencies:
     abbrev "1"
 
-nopt@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
-  integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
-
-nopt@~4.0.1:
+nopt@^4.0.1, nopt@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
   integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `nopt` (done automatically with `npx yarn-deduplicate --packages nopt`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/wpcom-editing-toolkit@2.17.0 -> @wordpress/env@2.1.0 -> ... -> nopt@4.0.1
< wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> nopt@4.0.1
> @automattic/wpcom-editing-toolkit@2.17.0 -> @wordpress/env@2.1.0 -> ... -> nopt@4.0.3
> wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> nopt@4.0.3
```