### PR TITLE
Deduplicate object-inspect

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19551,12 +19551,7 @@ object-hash@^1.3.1:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
   integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
 
-object-inspect@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
-  integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
-
-object-inspect@^1.8.0:
+object-inspect@^1.7.0, object-inspect@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `object-inspect` (done automatically with `npx yarn-deduplicate --packages object-inspect`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> object-inspect@1.7.0
< @automattic/wpcom-editing-toolkit@2.17.0 -> @wordpress/scripts@12.5.0 -> ... -> object-inspect@1.7.0
< @automattic/wpcom-editing-toolkit@2.17.0 -> enzyme@3.11.0 -> ... -> object-inspect@1.7.0
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> object-inspect@1.7.0
< wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> object-inspect@1.7.0
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> object-inspect@1.7.0
< wp-calypso@0.17.0 -> enzyme@3.11.0 -> ... -> object-inspect@1.7.0
< wp-calypso@0.17.0 -> eslint-plugin-react@7.21.5 -> ... -> object-inspect@1.7.0
> @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> object-inspect@1.8.0
> @automattic/wpcom-editing-toolkit@2.17.0 -> @wordpress/scripts@12.5.0 -> ... -> object-inspect@1.8.0
> @automattic/wpcom-editing-toolkit@2.17.0 -> enzyme@3.11.0 -> ... -> object-inspect@1.8.0
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> object-inspect@1.8.0
> wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> object-inspect@1.8.0
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> object-inspect@1.8.0
> wp-calypso@0.17.0 -> enzyme@3.11.0 -> ... -> object-inspect@1.8.0
> wp-calypso@0.17.0 -> eslint-plugin-react@7.21.5 -> ... -> object-inspect@1.8.0
```