### PR TITLE
Server build: bundle safe Automattic and WordPress dependencies

### DIFF
--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -55,6 +55,11 @@ function getExternals() {
 				// (there are symlinks into `packages/` from the `node_modules` folder)
 				...packagesInMonorepo().map( ( pkg ) => new RegExp( `^${ pkg.name }(/|$)` ) ),
 
+				// Bundle all `@automattic/*` and `@wordpress/*` packages, too.
+				// We can guarantee that they are safe.
+				/^@automattic\//,
+				/^@wordpress\//,
+
 				// bundle the core-js polyfills. We pick only a very small subset of the library
 				// to polyfill a few things that are not supported by the latest LTS Node.js,
 				// and this avoids shipping the entire library which is fairly big.


### PR DESCRIPTION
When creating the server bundle, inline the `@automattic/*` and `@wordpress/*` packages instead of keeping them external and copying them to production `node_modules`.

Prevents the kinds of issues reported by @mreishus in https://github.com/Automattic/wp-calypso/pull/49571#issuecomment-772875631 where `@wordpress/url` transitively depends on a `react-native` peer that is not installed and the copy script then fails to find it.

The fix is not reliable at all of course, and any other package can break the build the same way at any time. But still, externalizing packages like `@automattic/color-studio`, `@wordpress/is-shallow-equal` or `@wordpress/url` is not needed. We have control over them and know that they are bundler-safe. The externalize-and-copy approach is intended for third-party Node.js-only packages.