### PR TITLE
Replace deprecated file-loader with asset-resource

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -144,20 +144,9 @@ const outputDir = path.resolve( isDesktop ? './desktop' : '.' );
 const fileLoader = FileConfig.loader(
 	// The server bundler express middleware serves assets from a hard-coded publicPath.
 	// This is required so that running calypso via `yarn start` doesn't break.
-	isDevelopment
-		? {
-				outputPath: 'images',
-				publicPath: `/calypso/${ extraPath }/images/`,
-				esModules: true,
-		  }
-		: {
-				// File-loader does not understand absolute paths so __dirname won't work.
-				// Build off `output.path` for a result like `/…/public/evergreen/../images/`.
-				outputPath: path.join( '..', 'images' ),
-				publicPath: '/calypso/images/',
-				emitFile: browserslistEnv === defaultBrowserslistEnv, // Only output files once.
-				esModules: true,
-		  }
+	{
+		outputPath: isDevelopment ? 'images' : '../images',
+	}
 );
 
 const webpackConfig = {

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Breaking: drop support for wepback 4
 - Breaking: renamed option `output-jsonp-function` to `output-chunk-loading-global`
+- Breaking `./webpack/file-loader` loader doesn't support options anymore. It uses the new `asset/resource` instead of `file-loader`
 - Added: support for webpack 5
 - Updated dependencies
   - @wordpress/dependency-extraction-webpack-plugin to ^2.9.0

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -58,7 +58,6 @@
 		"duplicate-package-checker-webpack-plugin": "^3.0.0",
 		"enzyme-adapter-react-16": "^1.15.1",
 		"enzyme-to-json": "^3.4.3",
-		"file-loader": "^4.3.0",
 		"jest-config": "^26.4.0",
 		"jest-emotion": "^10.0.27",
 		"jest-enzyme": "^7.1.2",

--- a/packages/calypso-build/webpack/file-loader.js
+++ b/packages/calypso-build/webpack/file-loader.js
@@ -1,19 +1,10 @@
 /**
- * Return a Webpack loader configuration object for files / images.
- *
- * @param  {object} options File loader options
- * @returns {object}         Webpack loader object
+ * Return a Webpack loader configuration object for images.
  */
-module.exports.loader = ( options ) => ( {
+module.exports.loader = () => ( {
 	test: /\.(?:gif|jpg|jpeg|png|svg)$/i,
-	use: [
-		{
-			loader: require.resolve( 'file-loader' ),
-			options: {
-				name: '[name]-[hash].[ext]',
-				outputPath: 'images/',
-				...options,
-			},
-		},
-	],
+	type: 'asset/resource',
+	generator: {
+		filename: 'images/[name]-[contenthash][ext]',
+	},
 } );

--- a/packages/calypso-build/webpack/file-loader.js
+++ b/packages/calypso-build/webpack/file-loader.js
@@ -1,10 +1,15 @@
+const path = require( 'path' );
+
 /**
  * Return a Webpack loader configuration object for images.
+ *
+ * @param {object} options Options object
+ * @param {string} options.outputPath Path inside `options.path` to save the images, defaults to 'images'
  */
-module.exports.loader = () => ( {
+module.exports.loader = ( { outputPath = 'images' } = {} ) => ( {
 	test: /\.(?:gif|jpg|jpeg|png|svg)$/i,
 	type: 'asset/resource',
 	generator: {
-		filename: 'images/[name]-[contenthash][ext]',
+		filename: path.join( outputPath, '[name]-[contenthash][ext]' ),
 	},
 } );

--- a/yarn.lock
+++ b/yarn.lock
@@ -12389,14 +12389,6 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
-file-loader@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-4.3.0.tgz#780f040f729b3d18019f20605f723e844b8a58af"
-  integrity sha512-aKrYPYjF1yG3oX0kWRrqrSMfgftm7oJW5M+m4owoldH5C51C0RkIwB++JbRvEW3IU6/ZG5n8UvEcdgwOt2UOWA==
-  dependencies:
-    loader-utils "^1.2.3"
-    schema-utils "^2.5.0"
-
 file-loader@^6.0.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Drop usage of `file-loader` ([deprecated](https://webpack.js.org/loaders/file-loader/) in favour of `asset/resource`)

#### Testing instructions

* Run `rm -fr public/evergreen && yarn build-client-evergreen` in this branch and in `trunk`. Compare the directories `public/evergreen/images`. They should contain the same files with the same size, the only change should be the `hash` in the name.

* Check that UI images load in calypso.live (eg: illustrations in Home)
