### PR TITLE
New Onboarding: Add Padding under Feature List

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/features/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/features/style.scss
@@ -16,6 +16,10 @@
 		// Just to make the 2nd sentence fall on second line.
 		max-width: 620px;
 	}
+
+	.features__body {
+		padding-bottom: 20px;
+	}
 }
 
 .features__header {

--- a/client/landing/gutenboarding/onboarding-block/features/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/features/style.scss
@@ -4,7 +4,7 @@
 @import '../../variables.scss';
 
 .gutenboarding-page.features {
-	padding-bottom: $onboarding-footer-height;
+	padding-bottom: $onboarding-footer-height + 28px;
 
 	// TODO: This shouldn't be here. Find out why
 	// this is blue in features page but black in others.
@@ -15,10 +15,6 @@
 	.onboarding-subtitle {
 		// Just to make the 2nd sentence fall on second line.
 		max-width: 620px;
-	}
-
-	.features__body {
-		padding-bottom: 20px;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds some padding beneath the Feature List in the onboarding section

#### Testing instructions

1. Visit `/new/features` with mobile dimensions
2. Scroll to the bottom 
3. Verify there's some space between the last box and the footer

I did experiment with wrapping the padding in a breakpoint, but leaving it without one doesn't seem to make a substantial difference. Let me know if that should be changed though!

**Before:**
<img width="360" alt="Screenshot 2021-02-04 at 10 30 19" src="https://user-images.githubusercontent.com/43215253/106880753-a6a71600-66d4-11eb-95fe-ef87a7fc7f26.png">

**After:**
<img width="370" alt="Screenshot 2021-02-04 at 10 31 41" src="https://user-images.githubusercontent.com/43215253/106880758-a870d980-66d4-11eb-816b-4e54b0d7a3bb.png">

Fixes #49669 
cc @simison 
