### PR TITLE
Nav Unification: ensure Classic Bright shows when intentionally selected

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -1,4 +1,5 @@
-:root {
+:root,
+.color-scheme.is-classic-bright .is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-blue-50 );
 	--color-primary-rgb: var( --studio-blue-50-rgb );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For Nav Unification we're overwriting the default colors of Calypso. This means that when a user intentionally selects the Classic Bright colors scheme in their account settings, Calypso still shows the Classic Dark colors. This is because Classic Bright in Calypso wasn't so much a color scheme but just the default colors. This PR changes that by adding a selector for Classic Bright specifically.  

Fixes https://github.com/Automattic/wp-calypso/issues/49604

|Before|After|
|-|-|
|<img width="289" alt="Screenshot 2021-02-04 at 11 27 18" src="https://user-images.githubusercontent.com/1562646/106881135-70ba5f80-66dd-11eb-8386-541f8cab92cd.png">|<img width="293" alt="Screenshot 2021-02-04 at 11 18 08" src="https://user-images.githubusercontent.com/1562646/106881151-744de680-66dd-11eb-8f5d-87e4ed8b4832.png">|

#### Testing instructions

* Checkout this branch locally or use the calypso.live link
* Go to /me/account and activate the Classic Bright color scheme 
* Go to My Sites and confirm it looks like the After state screenshot above
* Open wp-admin in a second tab (e.g. /wp-admin/link-manager.php)
* Confirm it shows Classic Bright and the interface colors match Calypso

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
