### PR TITLE
State: Move billing transactions notices away from middleware

### DIFF
--- a/client/state/billing-transactions/actions.js
+++ b/client/state/billing-transactions/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
  * Internal dependencies
  */
 import {
@@ -11,6 +16,7 @@ import {
 	BILLING_TRANSACTIONS_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
 import wp from 'calypso/lib/wp';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 import 'calypso/state/billing-transactions/init';
 
@@ -58,6 +64,7 @@ export const sendBillingReceiptEmail = ( receiptId ) => {
 					type: BILLING_RECEIPT_EMAIL_SEND_SUCCESS,
 					receiptId,
 				} );
+				dispatch( successNotice( translate( 'Your receipt was sent by email successfully.' ) ) );
 			} )
 			.catch( ( error ) => {
 				dispatch( {
@@ -65,6 +72,13 @@ export const sendBillingReceiptEmail = ( receiptId ) => {
 					receiptId,
 					error,
 				} );
+				dispatch(
+					errorNotice(
+						translate(
+							'There was a problem sending your receipt. Please try again later or contact support.'
+						)
+					)
+				);
 			} );
 	};
 };

--- a/client/state/billing-transactions/individual-transactions/actions.js
+++ b/client/state/billing-transactions/individual-transactions/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
  * Internal dependencies
  */
 import {
@@ -9,6 +14,8 @@ import {
 	BILLING_TRANSACTION_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
 import wp from 'calypso/lib/wp';
+import { billingHistoryReceipt } from 'calypso/me/purchases/paths';
+import { errorNotice } from 'calypso/state/notices/actions';
 
 import 'calypso/state/billing-transactions/init';
 
@@ -39,6 +46,31 @@ export const requestBillingTransaction = ( transactionId ) => ( dispatch ) => {
 				transactionId,
 				error,
 			} );
+
+			const displayOnNextPage = true;
+			const id = `transaction-fetch-${ transactionId }`;
+			if ( 'invalid_receipt' === error.error ) {
+				dispatch(
+					errorNotice(
+						translate( "Sorry, we couldn't find receipt #%s.", { args: transactionId } ),
+						{
+							id,
+							displayOnNextPage,
+							duration: 5000,
+						}
+					)
+				);
+				return;
+			}
+
+			dispatch(
+				errorNotice( translate( "Sorry, we weren't able to load the requested receipt." ), {
+					id,
+					displayOnNextPage,
+					button: translate( 'Try again' ),
+					href: billingHistoryReceipt( transactionId ),
+				} )
+			);
 		} );
 };
 

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -13,9 +13,6 @@ import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getInviteForSite } from 'calypso/state/invites/selectors';
 import { restorePost } from 'calypso/state/posts/actions';
 import {
-	BILLING_RECEIPT_EMAIL_SEND_FAILURE,
-	BILLING_RECEIPT_EMAIL_SEND_SUCCESS,
-	BILLING_TRANSACTION_REQUEST_FAILURE,
 	GRAVATAR_RECEIVE_IMAGE_FAILURE,
 	GRAVATAR_UPLOAD_REQUEST_FAILURE,
 	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
@@ -34,21 +31,11 @@ import {
 	SITE_MONITOR_SETTINGS_UPDATE_SUCCESS,
 	SITE_MONITOR_SETTINGS_UPDATE_FAILURE,
 } from 'calypso/state/action-types';
-import { purchasesRoot, billingHistoryReceipt } from 'calypso/me/purchases/paths';
+import { purchasesRoot } from 'calypso/me/purchases/paths';
 
 /**
  * Handlers
  */
-
-export const onBillingReceiptEmailSendFailure = () =>
-	errorNotice(
-		translate(
-			'There was a problem sending your receipt. Please try again later or contact support.'
-		)
-	);
-
-export const onBillingReceiptEmailSendSuccess = () =>
-	successNotice( translate( 'Your receipt was sent by email successfully.' ) );
 
 export const onGravatarReceiveImageFailure = ( action ) => errorNotice( action.errorMessage );
 
@@ -185,36 +172,11 @@ const onSiteDeleteFailure = ( { error } ) => {
 	return errorNotice( error.message );
 };
 
-export const onBillingTransactionRequestFailure = ( { transactionId, error } ) => {
-	const displayOnNextPage = true;
-	const id = `transaction-fetch-${ transactionId }`;
-	if ( 'invalid_receipt' === error.error ) {
-		return errorNotice(
-			translate( "Sorry, we couldn't find receipt #%s.", { args: transactionId } ),
-			{
-				id,
-				displayOnNextPage,
-				duration: 5000,
-			}
-		);
-	}
-
-	return errorNotice( translate( "Sorry, we weren't able to load the requested receipt." ), {
-		id,
-		displayOnNextPage,
-		button: translate( 'Try again' ),
-		href: billingHistoryReceipt( transactionId ),
-	} );
-};
-
 /**
  * Handler action type mapping
  */
 
 export const handlers = {
-	[ BILLING_RECEIPT_EMAIL_SEND_FAILURE ]: onBillingReceiptEmailSendFailure,
-	[ BILLING_RECEIPT_EMAIL_SEND_SUCCESS ]: onBillingReceiptEmailSendSuccess,
-	[ BILLING_TRANSACTION_REQUEST_FAILURE ]: onBillingTransactionRequestFailure,
 	[ GRAVATAR_RECEIVE_IMAGE_FAILURE ]: onGravatarReceiveImageFailure,
 	[ GRAVATAR_UPLOAD_REQUEST_FAILURE ]: onGravatarUploadRequestFailure,
 	[ GRAVATAR_UPLOAD_REQUEST_SUCCESS ]: onGravatarUploadRequestSuccess,

--- a/client/state/notices/test/middleware.js
+++ b/client/state/notices/test/middleware.js
@@ -11,14 +11,12 @@ import thunk from 'redux-thunk';
  */
 import noticesMiddleware, {
 	handlers,
-	onBillingTransactionRequestFailure,
 	onPostDeleteFailure,
 	onPostRestoreFailure,
 	onPostSaveSuccess,
 } from '../middleware';
 import PostQueryManager from 'calypso/lib/query-manager/post';
 import {
-	BILLING_TRANSACTION_REQUEST_FAILURE,
 	NOTICE_CREATE,
 	POST_DELETE_FAILURE,
 	POST_RESTORE_FAILURE,
@@ -229,51 +227,6 @@ describe( 'middleware', () => {
 					notice: {
 						status: 'is-success',
 						text: 'Post successfully published',
-					},
-				} );
-			} );
-		} );
-
-		describe( 'onBillingTransactionRequestFailure()', () => {
-			const transactionId = 1234;
-
-			test( 'should dispatch a "not found" notice for invalid_receipt error', () => {
-				const noticeAction = onBillingTransactionRequestFailure( {
-					type: BILLING_TRANSACTION_REQUEST_FAILURE,
-					transactionId,
-					error: {
-						error: 'invalid_receipt',
-					},
-				} );
-
-				expect( noticeAction ).toMatchObject( {
-					type: NOTICE_CREATE,
-					notice: {
-						status: 'is-error',
-						text: `Sorry, we couldn't find receipt #${ transactionId }.`,
-						noticeId: `transaction-fetch-${ transactionId }`,
-						displayOnNextPage: true,
-						duration: 5000,
-					},
-				} );
-			} );
-
-			test( 'should dispatch a "problem" notice for errors other than invalid_receipt', () => {
-				const noticeAction = onBillingTransactionRequestFailure( {
-					type: BILLING_TRANSACTION_REQUEST_FAILURE,
-					transactionId,
-					error: {
-						error: 'http_request_failed',
-					},
-				} );
-
-				expect( noticeAction ).toMatchObject( {
-					type: NOTICE_CREATE,
-					notice: {
-						status: 'is-error',
-						text: "Sorry, we weren't able to load the requested receipt.",
-						noticeId: `transaction-fetch-${ transactionId }`,
-						displayOnNextPage: true,
 					},
 				} );
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the billing transactions notices away from the notices middleware and into the corresponding action thunks. This way these notices get modularized together with the billing transactions state module and don't clutter the main entry point.

#### Testing instructions

* Go to `/me/purchases/billing`
* Click "Email receipt" on a receipt.
* Verify you get a success notice on a successful request.
* Disable your network connection.
* Verify you get an error notice.
* Re-enable your connection.
* Click on "View Receipt".
* Change the ID of the receipt in the URL.
* Verify you get an error notice.
* Verify all tests pass.
