### PR TITLE
Framework: Remove usages of lodash pull()

### DIFF
--- a/client/extensions/woocommerce/app/products/product-variation-types-form.js
+++ b/client/extensions/woocommerce/app/products/product-variation-types-form.js
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { find, debounce, isNumber, indexOf, pull } from 'lodash';
+import { find, debounce, isNumber, indexOf } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -68,8 +68,7 @@ class ProductVariationTypesForm extends Component {
 	};
 
 	removeAttributeNameError = ( id ) => {
-		const attributeNameErrors = this.state.attributeNameErrors;
-		pull( attributeNameErrors, id );
+		const attributeNameErrors = this.state.attributeNameErrors.filter( ( e ) => e !== id );
 		this.setState( { attributeNameErrors } );
 	};
 

--- a/client/extensions/woocommerce/state/ui/shipping/zones/locations/reducer.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/locations/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, pull } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -97,20 +97,20 @@ function handleLocationsSelectState( state, { stateCode, selected } ) {
 		remove: [],
 		removeAll: false,
 	};
-	const add = [ ...states.add ];
-	const remove = [ ...states.remove ];
+	let add = [ ...states.add ];
+	let remove = [ ...states.remove ];
 	const removeAll = states.removeAll;
 
 	if ( selected ) {
 		if ( ! find( add, stateCode ) ) {
 			add.push( stateCode );
 		}
-		pull( remove, stateCode );
+		remove = remove.filter( ( s ) => s !== stateCode );
 	} else {
 		if ( ! find( remove, stateCode ) ) {
 			remove.push( stateCode );
 		}
-		pull( add, stateCode );
+		add = add.filter( ( s ) => s !== stateCode );
 	}
 	return {
 		...state,

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { filter, find, flow, forEach, map, pull, take } from 'lodash';
+import { filter, find, flow, forEach, map, take } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -143,7 +143,7 @@ export default function waitForImagesToLoad( post ) {
 				.then( () => {
 					// check to see if all of the promises have settled
 					// if so, accept what loaded and resolve the main promise
-					promises = pull( promises, promise );
+					promises = promises.filter( ( p ) => p !== promise );
 					if ( promises.length === 0 ) {
 						const imagesInOrder = filter(
 							map( imagesToCheck, ( src ) => {

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -4,7 +4,7 @@
 
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { identity, includes, noop, pull, union } from 'lodash';
+import { identity, includes, noop, union } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -119,10 +119,10 @@ export class MediaLibraryFilterBar extends Component {
 	}
 
 	renderTabItems() {
-		const tabs = this.getFiltersForSource( this.props.source );
+		let tabs = this.getFiltersForSource( this.props.source );
 
 		if ( ! this.props.post ) {
-			pull( tabs, 'this-post' );
+			tabs = tabs.filter( ( tab ) => tab !== 'this-post' );
 		}
 
 		if ( tabs.length === 0 ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We have only a couple usages of lodash's `pull()` method. They can be refactored to use native methods. This PR removes them, in order to make us a bit less dependent on lodash.

`pull()` is pretty general and can be replaced with a simple `.filter()`, especially when used with a single value, which seems to be happening in all existing usages.

This PR should not offer any visual or functional changes.

#### Testing instructions

* Go to `/media/:site` and verify you don't see a "This Post" tab.
* Go to `/post/:site/:post` and open the media modal by attempting to insert an image; verify you see a "This Post" tab.
* Verify the rest of the changes make sense.
* Verify tests still pass.

