### PR TITLE
Fixes layout padding for <660px breakpoints

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -641,6 +641,10 @@ $font-size: rem( 14px );
 			min-height: initial;
 		}
 
+		&.focus-content .layout__content {
+			padding: 47px 0 0;
+		}
+
 		// client/layout/sidebar/style.scss
 		.sidebar {
 			position: absolute;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Nav-unification introduced some new paddings for `<782px` breakpoints. We need to account for `<660px` breakpoints too.

* Fixes layout padding for <660px breakpoints

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- load calypso as a11n
- Resize window to `<660px` breakpoint
- Check that the paddings are similar to the after SS

Before | After
-------|------
![](https://cln.sh/wkJjuE+)| ![](https://cln.sh/MeEh5K+)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1612444029194400-slack-C02DQP0FP