### PR TITLE
Admin menu: Sanitize URLs

### DIFF
--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -65,7 +65,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 							key={ item.slug }
 							path={ path }
 							link={ item.url }
-							selected={ isSelected }
+							selected={ !! isSelected }
 							sidebarCollapsed={ sidebarIsCollapsed }
 							{ ...item }
 						/>

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -66,8 +66,8 @@ export const MySitesSidebarUnifiedMenu = ( {
 		<li>
 			<ExpandableSidebarMenu
 				onClick={ () => {
-					if ( link ) {
-						if ( isWithinBreakpoint( '>782px' ) ) {
+					if ( isWithinBreakpoint( '>782px' ) ) {
+						if ( link ) {
 							if ( isExternal( link ) ) {
 								// If the URL is external, page() will fail to replace state between different domains.
 								externalRedirect( link );
@@ -76,11 +76,11 @@ export const MySitesSidebarUnifiedMenu = ( {
 
 							// Only open the page if menu is NOT full-width, otherwise just open / close the section instead of directly redirecting to the section.
 							page( link );
+						}
 
-							if ( ! sidebarCollapsed ) {
-								// Keep only current submenu open.
-								reduxDispatch( collapseAllMySitesSidebarSections() );
-							}
+						if ( ! sidebarCollapsed ) {
+							// Keep only current submenu open.
+							reduxDispatch( collapseAllMySitesSidebarSections() );
 						}
 					}
 

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -47,8 +47,8 @@ export const MySitesSidebarUnifiedMenu = ( {
 	const isExpanded = useSelector( ( state ) => isSidebarSectionOpen( state, sectionId ) );
 
 	const selectedMenuItem =
-		children &&
-		children.find( ( menuItem ) => menuItem.url && itemLinkMatches( menuItem.url, path ) );
+		Array.isArray( children ) &&
+		children.find( ( menuItem ) => menuItem?.url && itemLinkMatches( menuItem.url, path ) );
 	const childIsSelected = !! selectedMenuItem;
 
 	/**

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -47,7 +47,8 @@ export const MySitesSidebarUnifiedMenu = ( {
 	const isExpanded = useSelector( ( state ) => isSidebarSectionOpen( state, sectionId ) );
 
 	const selectedMenuItem =
-		children && children.find( ( menuItem ) => itemLinkMatches( menuItem.url, path ) );
+		children &&
+		children.find( ( menuItem ) => menuItem.url && itemLinkMatches( menuItem.url, path ) );
 	const childIsSelected = !! selectedMenuItem;
 
 	/**
@@ -65,19 +66,21 @@ export const MySitesSidebarUnifiedMenu = ( {
 		<li>
 			<ExpandableSidebarMenu
 				onClick={ () => {
-					if ( isWithinBreakpoint( '>782px' ) ) {
-						if ( isExternal( link ) ) {
-							// If the URL is external, page() will fail to replace state between different domains.
-							externalRedirect( link );
-							return;
-						}
+					if ( link ) {
+						if ( isWithinBreakpoint( '>782px' ) ) {
+							if ( isExternal( link ) ) {
+								// If the URL is external, page() will fail to replace state between different domains.
+								externalRedirect( link );
+								return;
+							}
 
-						// Only open the page if menu is NOT full-width, otherwise just open / close the section instead of directly redirecting to the section.
-						page( link );
+							// Only open the page if menu is NOT full-width, otherwise just open / close the section instead of directly redirecting to the section.
+							page( link );
 
-						if ( ! sidebarCollapsed ) {
-							// Keep only current submenu open.
-							reduxDispatch( collapseAllMySitesSidebarSections() );
+							if ( ! sidebarCollapsed ) {
+								// Keep only current submenu open.
+								reduxDispatch( collapseAllMySitesSidebarSections() );
+							}
 						}
 					}
 

--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -49,7 +49,7 @@ const sanitizeMenuItem = ( menuItem, site ) => {
 
 export const handleSuccess = ( { siteId }, menuData ) => ( dispatch, getState ) => {
 	if ( ! Array.isArray( menuData ) ) {
-		return receiveAdminMenu( siteId, menuData );
+		return dispatch( receiveAdminMenu( siteId, menuData ) );
 	}
 
 	// Sanitize menu data.

--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -29,12 +29,17 @@ const sanitizeUrl = ( url, site ) => {
 };
 
 const sanitizeMenuItem = ( menuItem, site ) => {
+	if ( ! menuItem ) {
+		return menuItem;
+	}
+
 	let sanitizedChildren;
 	if ( Array.isArray( menuItem.children ) ) {
 		sanitizedChildren = menuItem.children.map( ( subMenuItem ) =>
 			sanitizeMenuItem( subMenuItem, site )
 		);
 	}
+
 	return {
 		...menuItem,
 		url: sanitizeUrl( menuItem.url, site ),

--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -19,9 +19,9 @@ export const requestFetchAdminMenu = ( action ) =>
 	);
 
 const sanitizeUrl = ( url, site ) => {
-	if ( new RegExp( `^https?://${ site?.domain }` ).test( url ) ) {
-		return url;
-	} else if ( /^\//.test( url ) ) {
+	const isSafeInternalUrl = new RegExp( '^/' ).test( url );
+	const isSafeSiteDomainUrl = new RegExp( `^https?://${ site?.domain }` ).test( url );
+	if ( isSafeInternalUrl || isSafeSiteDomainUrl ) {
 		return url;
 	}
 

--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -30,7 +30,7 @@ const sanitizeUrl = ( url, site ) => {
 
 const sanitizeMenuItem = ( menuItem, site ) => {
 	let sanitizedChildren;
-	if ( menuItem.children ) {
+	if ( Array.isArray( menuItem.children ) ) {
 		sanitizedChildren = menuItem.children.map( ( subMenuItem ) =>
 			sanitizeMenuItem( subMenuItem, site )
 		);
@@ -43,6 +43,11 @@ const sanitizeMenuItem = ( menuItem, site ) => {
 };
 
 export const handleSuccess = ( { siteId }, menuData ) => ( dispatch, getState ) => {
+	if ( ! Array.isArray( menuData ) ) {
+		return receiveAdminMenu( siteId, menuData );
+	}
+
+	// Sanitize menu data.
 	const site = getSite( getState(), siteId );
 	return dispatch(
 		receiveAdminMenu(

--- a/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
@@ -25,9 +25,50 @@ describe( 'requestFetchAdminMenu', () => {
 
 describe( 'handlers', () => {
 	test( 'should create correct success action on fetch success ', () => {
+		const dispatch = jest.fn();
+		const getState = () => ( {
+			currentUser: { capabilities: { 73738: {} } },
+			sites: { items: { 73738: { ID: 73738, domain: 'example.wordpress.com' } } },
+		} );
 		const menuData = {};
 		const action = receiveAdminMenu( 73738, menuData );
-		const output = handleSuccess( { siteId: 73738 }, menuData );
-		expect( output ).toEqual( action );
+		handleSuccess( { siteId: 73738 }, menuData )( dispatch, getState );
+		expect( dispatch ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch ).toHaveBeenCalledWith( expect.objectContaining( action ) );
+	} );
+
+	test( 'should sanitize menu URLs', () => {
+		const dispatch = jest.fn();
+		const getState = () => ( {
+			currentUser: { capabilities: { 73738: {} } },
+			sites: { items: { 73738: { ID: 73738, domain: 'example.wordpress.com' } } },
+		} );
+		const unsafeMenu = [
+			{
+				icon: 'dashicons-warning',
+				slug: 'my-custom-menu',
+				title: 'Click here',
+				type: 'menu-item',
+				url: 'javascript:alert("hello")',
+				children: [
+					{
+						parent: 'my-custom-menu',
+						slug: 'my-custom-menu-2',
+						title: 'Or here',
+						type: 'submenu-item',
+						url: 'http://example.com',
+					},
+				],
+			},
+		];
+		const sanitizedMenu = [ ...unsafeMenu ];
+		sanitizedMenu[ 0 ].url = '';
+		sanitizedMenu[ 0 ].children[ 0 ].url = '';
+		const action = receiveAdminMenu( 73738, sanitizedMenu );
+
+		handleSuccess( { siteId: 73738 }, unsafeMenu )( dispatch, getState );
+
+		expect( dispatch ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch ).toHaveBeenCalledWith( expect.objectContaining( action ) );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sanitize the URLs of the admin menu items before rendering to ensure that only internal links are used.

Further reading: p9o2xV-1fe-p2

#### Testing instructions

- Add the code below to the `0-sandbox.php` file in your WP.com sandbox:
```
add_filter( 'rest_post_dispatch', function ( $response ) {
	if ( '/wpcom/v2/sites/(?P<wpcom_site>[\w.:-]+)/admin-menu' === $response->get_matched_route() ) {
		$data = $response->get_data();
		array_unshift( $data, [
			'icon'     => 'dashicons-warning',
			'slug'     => 'my-custom-menu',
			'title'    => 'Click here',
			'type'     => 'menu-item',
			'url'      => 'javascript:alert("hello")',
			'children' => [ [
				'parent' => 'my-custom-menu',
				'slug'   => 'my-custom-menu-2',
				'title'  => 'Or here',
				'type'   => 'submenu-item',
				'url'    => 'http://example.com',
			] ]
		] );
		$response->set_data( $data );
	}
	return $response;
} );
```
- Sandbox the API.
- Go to wordpress.com and note how:
  - Clicking on "Click here" (first menu item) triggers a javascript alert.
  - Clicking on "Or here" (submenu of first menu item) redirects to an external domain.
- Open the Calypso live link from below.
- Make sure that clicking on "Click here" doesn't trigger any javascript alert.
- Make sure that clicking on "Or here" doesn't redirect to an external domain.
- Make sure the rest of the menu items still work as usual. Test with sites with `*.wordpress.com` domains and custom domains.