### PR TITLE
Jetpack Cloud, Plans: Change site slug replace to replaceAll on Free card

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card-button/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card-button/index.tsx
@@ -50,7 +50,9 @@ const JetpackFreeCardButton: FC< JetpackFreeCardButtonProps > = ( {
 		// Ensure that URL is valid
 		try {
 			// Slugs of secondary sites of a multisites network follow this syntax: example.net::second-site
-			wpAdminUrlFromQuery = new URL( `https://${ site.replace( '::', '/' ) }/wp-admin/admin.php` );
+			wpAdminUrlFromQuery = new URL(
+				`https://${ site.replaceAll( '::', '/' ) }/wp-admin/admin.php`
+			);
 		} catch ( e ) {}
 
 		if ( wpAdminUrlFromQuery ) {


### PR DESCRIPTION
Fixes `1164141197617539-as-1199717536351667`.

#### Changes proposed in this Pull Request

* When building the **Start for free** link on the Jetpack Free product card, change the string replacement call from `replace` to `replaceAll` so that all instances of `::` are replaced with `/`, instead of only the first instance.

#### Testing prerequisites

1. You must have access to a self-hosted WordPress multisite, where the root of the multisite network is in a subdirectory (i.e., the network admin URL would be `https://mysite.example/multi/wp-admin`).
2. You must have administrator access to a member site residing in a nested subdirectory (e.g., `/multi/my-member-site`) that has not yet been connected to Jetpack.

#### Testing instructions

* Log in as an administrator to the member site's wp-admin interface and connect Jetpack.
* You should be redirected to the pricing page on `cloud.jetpack.com`. Inspect the **Start for free* button on the Jetpack Free product card and note that clicking the button sends you to an invalid URL (HTTP 404 Not Found).
* Modify your browser's URL to point to your Calypso Green testing environment instead (e.g., `http://jetpack.cloud.localhost:3000/pricing/<site_slug>/...`)
* Inspect the button again and verify that it now points to an appropriate, well-formed URL on the member site's wp-admin interface.
* Click the link and verify you're brought to the **My Plan** page inside the member site's wp-admin interface.

#### Reference screenshot

<img width="735" alt="image" src="https://user-images.githubusercontent.com/670067/106911745-19f65b00-66c8-11eb-9d4b-02ca17755016.png">