### PR TITLE
Framework: Remove usages of lodash split()

### DIFF
--- a/client/gutenberg/editor/media-utils.js
+++ b/client/gutenberg/editor/media-utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, head, includes, isArray, reduce, split } from 'lodash';
+import { get, head, includes, isArray, reduce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -21,9 +21,7 @@ export const mediaCalypsoToGutenberg = ( media ) => {
 		url: get( media, 'URL' ),
 		alt: get( media, 'alt' ),
 		// TODO: replace with `{ source: 'rich-text' }` after updating Gutenberg
-		caption: !! media.caption
-			? parseWithAttributeSchema( media.caption, { source: 'children' } )
-			: '',
+		caption: media.caption ? parseWithAttributeSchema( media.caption, { source: 'children' } ) : '',
 		description: get( media, 'description' ),
 		filename: get( media, 'file' ),
 		height: get( media, 'height' ),
@@ -43,7 +41,7 @@ export const mediaCalypsoToGutenberg = ( media ) => {
 			),
 		},
 		title: get( media, 'title' ),
-		type: head( split( get( media, 'mime_type', '' ), '/' ) ),
+		type: head( get( media, 'mime_type', '' ).split( '/' ) ),
 		width: get( media, 'width' ),
 	};
 };

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { head, includes, isEmpty, split } from 'lodash';
+import { head, includes, isEmpty } from 'lodash';
 import page from 'page';
 
 /**
@@ -106,7 +106,7 @@ export function getRoleFromScope( scope ) {
 	if ( ! includes( scope, ':' ) ) {
 		return null;
 	}
-	const role = head( split( scope, ':', 1 ) );
+	const role = head( scope.split( ':', 1 ) );
 	if ( ! isEmpty( role ) ) {
 		return role;
 	}

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import config from '@automattic/calypso-config';
 import titlecase from 'to-title-case';
 import Gridicon from 'calypso/components/gridicon';
-import { head, split } from 'lodash';
+import { head } from 'lodash';
 import photon from 'photon';
 import page from 'page';
 
@@ -209,7 +209,7 @@ class ThemeSheet extends React.Component {
 		if ( this.isLoaded() ) {
 			// Results are being returned with photon params like `?w=…`. This makes the photon
 			// module abort and return null. Strip query string.
-			return head( split( head( this.props.screenshots ), '?', 1 ) );
+			return head( head( this.props.screenshots ).split( '?', 1 ) );
 		}
 		return null;
 	}

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -9,7 +9,7 @@ import crypto from 'crypto';
 import { execSync } from 'child_process';
 import cookieParser from 'cookie-parser';
 import debugFactory from 'debug';
-import { get, includes, pick, snakeCase, split } from 'lodash';
+import { get, includes, pick, snakeCase } from 'lodash';
 import bodyParser from 'body-parser';
 // eslint-disable-next-line no-restricted-imports
 import superagent from 'superagent'; // Don't have Node.js fetch lib yet.
@@ -537,7 +537,7 @@ const renderServerError = ( entrypoint = 'entry-main' ) => ( err, req, res, next
  */
 function handleLocaleSubdomains( req, res, next ) {
 	const langSlug = req.hostname?.endsWith( config( 'hostname' ) )
-		? split( req.hostname, '.' )[ 0 ]
+		? req.hostname.split( '.' )[ 0 ]
 		: null;
 
 	if ( langSlug && includes( config( 'magnificent_non_en_locales' ), langSlug ) ) {

--- a/client/state/sites/selectors/get-site-theme-showcase-path.js
+++ b/client/state/sites/selectors/get-site-theme-showcase-path.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes, split } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,7 +23,7 @@ export default function getSiteThemeShowcasePath( state, siteId ) {
 		return null;
 	}
 
-	const [ type, slug ] = split( getSiteOption( state, siteId, 'theme_slug' ), '/', 2 );
+	const [ type, slug ] = getSiteOption( state, siteId, 'theme_slug' )?.split( '/', 2 ) ?? [];
 
 	// to accomodate a8c and other theme types
 	if ( ! includes( [ 'pub', 'premium' ], type ) ) {

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { every, get, includes, map, mapKeys, omit, omitBy, some, split, startsWith } from 'lodash';
+import { every, get, includes, map, mapKeys, omit, omitBy, some, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -118,7 +118,7 @@ export function normalizeWporgTheme( theme ) {
  * @returns {?string}            Theme ID
  */
 export function getThemeIdFromStylesheet( stylesheet ) {
-	const [ , slug ] = split( stylesheet, '/', 2 );
+	const [ , slug ] = stylesheet?.split( '/', 2 ) ?? [];
 	if ( ! slug ) {
 		return stylesheet;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We have only several usages of lodash's `split()` method. `split()` is pretty general and can be replaced with its alternative `String.split()`. This PR addresses that, in order to make us a bit less dependent on lodash.

This PR should not offer any visual or functional changes.

#### Testing instructions

* Verify the changes make sense.
* Verify tests still pass.

