### PR TITLE
PlansGrid: update Signup label for annual plans on details table

### DIFF
--- a/packages/plans-grid/src/plans-details/index.tsx
+++ b/packages/plans-grid/src/plans-details/index.tsx
@@ -51,13 +51,14 @@ const PlansDetails: React.FunctionComponent< Props > = ( { onSelect, locale, bil
 	const isLoading = ! supportedPlans?.length;
 	const placeholderPlans = [ 1, 2, 3, 4, 5 ];
 
+	// @TODO: clean this up when translations are done and we don't need fallbackAnnualBillingLabel
 	const newAnnualBillingLabel = __( 'Monthly price (billed yearly)', __i18n_text_domain__ );
 	const fallbackAnnualBillingLabel = __(
 		'Monthly subscription (billed yearly)',
 		__i18n_text_domain__
 	);
 	const annualBillingLabel =
-		locale === 'en' || hasTranslation?.( 'Monthly Price (billed yearly)', __i18n_text_domain__ )
+		locale === 'en' || hasTranslation?.( 'Monthly price (billed yearly)', __i18n_text_domain__ )
 			? newAnnualBillingLabel
 			: fallbackAnnualBillingLabel;
 

--- a/packages/plans-grid/src/plans-details/index.tsx
+++ b/packages/plans-grid/src/plans-details/index.tsx
@@ -29,7 +29,7 @@ type Props = {
 };
 
 const PlansDetails: React.FunctionComponent< Props > = ( { onSelect, locale, billingPeriod } ) => {
-	const { __ } = useI18n();
+	const { __, hasTranslation } = useI18n();
 
 	const { supportedPlans, planProducts, features, featuresByType } = useSelect( ( select ) => {
 		const { getPlanProduct, getFeatures, getFeaturesByType, getSupportedPlans } = select(
@@ -50,6 +50,18 @@ const PlansDetails: React.FunctionComponent< Props > = ( { onSelect, locale, bil
 
 	const isLoading = ! supportedPlans?.length;
 	const placeholderPlans = [ 1, 2, 3, 4, 5 ];
+
+	const newAnnualBillingLabel = __( 'Monthly price (billed yearly)', __i18n_text_domain__ );
+	const fallbackAnnualBillingLabel = __(
+		'Monthly subscription (billed yearly)',
+		__i18n_text_domain__
+	);
+	const annualBillingLabel =
+		locale === 'en' || hasTranslation?.( 'Monthly Price (billed yearly)', __i18n_text_domain__ )
+			? newAnnualBillingLabel
+			: fallbackAnnualBillingLabel;
+
+	const monthlyBillingLabel = __( 'Monthly subscription', __i18n_text_domain__ );
 
 	return (
 		<div className="plans-details">
@@ -167,11 +179,7 @@ const PlansDetails: React.FunctionComponent< Props > = ( { onSelect, locale, bil
 						<th colSpan={ 6 }>{ __( 'Sign up', __i18n_text_domain__ ) }</th>
 					</tr>
 					<tr className="plans-details__feature-row" key="price">
-						<th>
-							{ billingPeriod === 'ANNUALLY'
-								? __( 'Monthly Price (billed yearly)', __i18n_text_domain__ )
-								: __( 'Monthly subscription', __i18n_text_domain__ ) }
-						</th>
+						<th>{ billingPeriod === 'ANNUALLY' ? annualBillingLabel : monthlyBillingLabel }</th>
 						{ isLoading
 							? placeholderPlans.map( ( placeholder ) => (
 									<td key={ placeholder }>

--- a/packages/plans-grid/src/plans-details/index.tsx
+++ b/packages/plans-grid/src/plans-details/index.tsx
@@ -169,7 +169,7 @@ const PlansDetails: React.FunctionComponent< Props > = ( { onSelect, locale, bil
 					<tr className="plans-details__feature-row" key="price">
 						<th>
 							{ billingPeriod === 'ANNUALLY'
-								? __( 'Monthly subscription (billed yearly)', __i18n_text_domain__ )
+								? __( 'Monthly Price (billed yearly)', __i18n_text_domain__ )
 								: __( 'Monthly subscription', __i18n_text_domain__ ) }
 						</th>
 						{ isLoading


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update copy to avoid confusion as mentioned in https://github.com/Automattic/wp-calypso/pull/48963#issuecomment-773439592
* Keep already translated string as a fallback so we don't need to use "String Freeze"
* Extract the `__()` calls out of ternaries as discussed in p1612463769120800/1612255293.049500-slack-C013QHLF28Y

#### Testing instructions

* Go to `/new/plans` and at the very bottom of the page you should see the changed label

#### Screenshot
<img width="1640" alt="Screenshot 2021-02-04 at 21 36 39" src="https://user-images.githubusercontent.com/14192054/106945947-22cf4700-6731-11eb-8896-b14c6943a9ec.png">