### PR TITLE
Anchor: Remove Publish button and post on Launch

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
@@ -83,7 +83,11 @@ domReady( () => {
 			} else {
 				// Save post in the background while step-by-step or focused launch flow opens
 				setTimeout( () => {
-					dispatch( 'core/editor' ).savePost();
+					if ( isAnchorFm ) {
+						dispatch( 'core/editor' ).editPost( { status: 'publish' } );
+					} else {
+						dispatch( 'core/editor' ).savePost();
+					}
 				}, 1000 );
 			}
 		} );

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
@@ -41,6 +41,7 @@ domReady( () => {
 		}
 
 		const { launchUrl, launchFlow, isGutenboarding, anchorFmPodcastId } = siteLaunchOptions;
+		const isAnchorFm = !! anchorFmPodcastId;
 
 		// Wrap 'Launch' button link to control launch flow.
 		const launchButton = document.createElement( 'a' );
@@ -58,7 +59,6 @@ domReady( () => {
 			} );
 
 			// Enable anchor-flavoured gutenboarding features (the launch button works immediately).
-			const isAnchorFm = !! anchorFmPodcastId;
 			if ( isAnchorFm ) {
 				dispatch( 'automattic/launch' ).enableAnchorFm();
 			}
@@ -106,6 +106,10 @@ domReady( () => {
 
 		// Put 'Launch' and 'Save' back on bar in desired order.
 		settingsBar.prepend( launchButton );
-		saveButton && settingsBar.prepend( saveButton );
+		if ( isAnchorFm ) {
+			saveButton && settingsBar.removeChild( saveButton );
+		} else {
+			saveButton && settingsBar.prepend( saveButton );
+		}
 	} );
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
@@ -106,8 +106,8 @@ domReady( () => {
 
 		// Put 'Launch' and 'Save' back on bar in desired order.
 		settingsBar.prepend( launchButton );
-		if ( isAnchorFm ) {
-			saveButton && settingsBar.removeChild( saveButton );
+		if ( isAnchorFm && saveButton ) {
+			saveButton.style.display = 'none';
 		} else {
 			saveButton && settingsBar.prepend( saveButton );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove Publish button when site has a podcast id

Before | After
------- | ----
<img width="456" alt="Screen Shot 2021-02-04 at 3 29 57 PM" src="https://user-images.githubusercontent.com/1689238/106951549-e59d9180-66fd-11eb-8665-437ca13e6f4f.png"> | <img width="375" alt="Screen Shot 2021-02-04 at 3 03 55 PM" src="https://user-images.githubusercontent.com/1689238/106951427-c272e200-66fd-11eb-8f87-3490ca3c299d.png">

* Publish episode post when Launch button is clicked

#### Testing instructions
(based on https://github.com/Automattic/wp-calypso/pull/48938)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Need to build and sync `apps/editing-toolkit` from this branch to sandbox
  * In a terminal tab:
  * `cd ./apps/editing-toolkit`
  * `yarn dev --sync` (if you get errors related to newspack syncing, try `composer install`)
* Need to create new site using anchor gutenboarding
  * Run calypso locally
  * Sandbox public-api
  * Visit http://calypso.localhost:3000/new?anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q and create a new site. You can either use incognito and make a new account or log into an existing account.
  * Go through all anchor gutenboarding steps.
  * You should end on an editor page with the podcast player embedded.  Keep that tab/URL.
* Need to sandbox that exact site you just created
  * Check the URL to see the site you created, and add that to your /etc/hosts to point to your sandbox.  For example, it might look like `bravenotperfectwithreshmasaujani340284555.wp.com`
  * F5 / hard refresh your editor page, or [clear DNS cache in browser](https://techwiser.com/clear-dns-cache-on-browser/) if necessary. Very important: If you press the three vertical dots in the top right, the bottom of the sidebar should read `Editing Toolkit: dev`. If it doesn't, you won't see the changes here.
  * Check that there is no publish button in the upper right menu.
  * Click "Launch" and check that the episode post is published and your latest edits are saved.
  * Edit or add a new post and check that the Publish / Update buttons are back.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 438-gh-Automattic/dotcom-manage