### PR TITLE
Checkout: Redirecting non-connected Jetpack users to the connection flow

### DIFF
--- a/client/my-sites/checkout/checkout/test/maybe-jetpack-authorize.js
+++ b/client/my-sites/checkout/checkout/test/maybe-jetpack-authorize.js
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import {
+	shouldRedirectToJetpackAuthorize,
+	getJetpackAuthorizeURL,
+} from 'calypso/my-sites/controller';
+
+describe( 'redirectToJetpack', () => {
+	test( 'redirect needed', () => {
+		const context = { query: { unlinked: '1' } };
+		const response = { site: { URL: 'https://example.org' } };
+		const expectedRedirectURLMatch = /^https:\/\/example.org\/wp-admin\/\?(.*)&action=authorize_redirect&dest_url=/i;
+
+		const needsRedirect = shouldRedirectToJetpackAuthorize( context, response );
+		expect( needsRedirect ).toBe( true );
+
+		const initiateRedirect = getJetpackAuthorizeURL( context, response );
+		expect( initiateRedirect ).toMatch( expectedRedirectURLMatch );
+	} );
+
+	test( 'redirect not needed', () => {
+		const context = { query: { 'something-else': '1' } };
+		const response = { site: { URL: 'https://example.org' } };
+
+		const needsRedirect = shouldRedirectToJetpackAuthorize( context, response );
+		expect( needsRedirect ).toBe( false );
+	} );
+} );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -444,16 +444,8 @@ export function siteSelection( context, next ) {
 				if ( onSelectedSiteAvailable( context, basePath ) ) {
 					next();
 				}
-			} else if ( '1' === context.query?.unlinked && response?.site?.URL ) {
-				const authorizePath = addQueryArgs(
-					{
-						page: 'jetpack',
-						action: 'authorize_redirect',
-						dest_url: removeQueryArgs( window.origin + context.path, 'unlinked' ),
-					},
-					trailingslashit( response?.site?.URL ) + 'wp-admin/'
-				);
-				externalRedirect( authorizePath );
+			} else if ( shouldRedirectToJetpackAuthorize( context, response ) ) {
+				redirectToJetpackAuthorize( context, response );
 			} else {
 				// If the site has loaded but siteId is still invalid then redirect to allSitesPath.
 				const allSitesPath = addQueryArgs(
@@ -594,4 +586,33 @@ export function wpForTeamsGeneralNotSupportedRedirect( context, next ) {
 	}
 
 	next();
+}
+
+/**
+ * Whether we need to redirect user to the Jetpack site for authorization.
+ *
+ * @param {object} context -- The context object.
+ * @param {object} response -- The site information HTTP response.
+ * @returns {boolean} -- Whether we need to redirect user to the Jetpack site for authorization.
+ */
+export function shouldRedirectToJetpackAuthorize( context, response ) {
+	return '1' === context.query?.unlinked && !! response?.site?.URL;
+}
+
+/**
+ * Redirect the user to the Jetpack site for authorization.
+ *
+ * @param {object} context -- The context object.
+ * @param {object} response -- The site information HTTP response.
+ */
+export function redirectToJetpackAuthorize( context, response ) {
+	const authorizePath = addQueryArgs(
+		{
+			page: 'jetpack',
+			action: 'authorize_redirect',
+			dest_url: removeQueryArgs( window.origin + context.path, 'unlinked' ),
+		},
+		trailingslashit( response?.site?.URL ) + 'wp-admin/'
+	);
+	externalRedirect( authorizePath );
 }

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -445,7 +445,7 @@ export function siteSelection( context, next ) {
 					next();
 				}
 			} else if ( shouldRedirectToJetpackAuthorize( context, response ) ) {
-				redirectToJetpackAuthorize( context, response );
+				externalRedirect( getJetpackAuthorizeURL( context, response ) );
 			} else {
 				// If the site has loaded but siteId is still invalid then redirect to allSitesPath.
 				const allSitesPath = addQueryArgs(
@@ -593,20 +593,21 @@ export function wpForTeamsGeneralNotSupportedRedirect( context, next ) {
  *
  * @param {object} context -- The context object.
  * @param {object} response -- The site information HTTP response.
- * @returns {boolean} -- Whether we need to redirect user to the Jetpack site for authorization.
+ * @returns {boolean} shouldRedirect -- Whether we need to redirect user to the Jetpack site for authorization.
  */
 export function shouldRedirectToJetpackAuthorize( context, response ) {
 	return '1' === context.query?.unlinked && !! response?.site?.URL;
 }
 
 /**
- * Redirect the user to the Jetpack site for authorization.
+ * Get redirect URL to the Jetpack site for authorization.
  *
  * @param {object} context -- The context object.
  * @param {object} response -- The site information HTTP response.
+ * @returns {string} redirectURL -- The redirect URL.
  */
-export function redirectToJetpackAuthorize( context, response ) {
-	const authorizePath = addQueryArgs(
+export function getJetpackAuthorizeURL( context, response ) {
+	return addQueryArgs(
 		{
 			page: 'jetpack',
 			action: 'authorize_redirect',
@@ -614,5 +615,4 @@ export function redirectToJetpackAuthorize( context, response ) {
 		},
 		trailingslashit( response?.site?.URL ) + 'wp-admin/'
 	);
-	externalRedirect( authorizePath );
 }

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -139,6 +139,7 @@ export function requestSite( siteFragment, forceWpcom = false ) {
 					return dispatch( {
 						type: SITE_REQUEST_FAILURE,
 						siteId: siteFragment,
+						site,
 						error: i18n.translate( 'No access to manage the site' ),
 					} );
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When non-connected users initiate the upgrade flow in Jetpack, they need to be connected before proceeding to checkout.
This PR initiates the connection flow for such users, and redirects them back to checkout afterwards.

The flow:
1. A non-connected user clicks "Upgrade" in Jetpack.
2. They get redirected to checkout with a GET parameter `unlinked=1`.
3. Calypso's Checkout component detects the parameter, makes sure that the user is still not connected to the site, and redirects user back to Jetpack to initiate the connection flow.
4. After user is connected, Jetpack redirects them back to the same checkout URL to complete the purchase.

The Jetpack PR: https://github.com/Automattic/jetpack/pull/17822

#### Testing instructions

The new functionality cannot be tested by itself, so the goal is to make sure that the existing Jetpack checkout flows work as expected.

1. Connect a Jetpack site and purchase a low tier plan (e.g. Backup Daily). Make sure everything goes smoothly.
2. Go to Jetpack Dashboard and purchase an upgrade. Everything should work as expected.
