### PR TITLE
Activity Log: Remove upgrade prompt for sites with Scan

### DIFF
--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -25,7 +25,10 @@ import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { isFreePlan } from 'calypso/lib/plans';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { siteHasBackupProductPurchase } from 'calypso/state/purchases/selectors';
+import {
+	siteHasBackupProductPurchase,
+	siteHasScanProductPurchase,
+} from 'calypso/state/purchases/selectors';
 
 /**
  * Style dependencies
@@ -46,7 +49,7 @@ class IntroBanner extends Component {
 	recordDismiss = () => this.props.recordTracksEvent( 'calypso_activitylog_intro_banner_dismiss' );
 
 	renderCardContent() {
-		const { siteIsJetpack, siteHasBackup, siteSlug, translate } = this.props;
+		const { siteIsJetpack, siteHasBackup, siteHasScan, siteSlug, translate } = this.props;
 		const buttonHref = siteIsJetpack
 			? `/checkout/${ siteSlug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_ACTIVITY_LOG ] }`
 			: `/plans/${ siteSlug }?feature=${ FEATURE_JETPACK_ESSENTIAL }&plan=${ PLAN_PERSONAL }`;
@@ -57,7 +60,7 @@ class IntroBanner extends Component {
 					{ translate(
 						'We’ll keep track of all the events that take place on your site to help manage things easier. '
 					) }
-					{ ! siteHasBackup
+					{ ! siteHasBackup && ! siteHasScan
 						? translate(
 								'With your free plan, you can monitor the 20 most recent events on your site.'
 						  )
@@ -65,7 +68,7 @@ class IntroBanner extends Component {
 								'Looking for something specific? You can filter the events by type and date.'
 						  ) }
 				</p>
-				{ ! siteHasBackup && (
+				{ ! siteHasBackup && ! siteHasScan && (
 					<Fragment>
 						<p>{ translate( 'Upgrade to a paid plan to unlock powerful features:' ) }</p>
 						<ul className="activity-log-banner__intro-list">
@@ -80,16 +83,14 @@ class IntroBanner extends Component {
 						</ul>
 
 						<div className="activity-log-banner__intro-actions">
-							{ ! siteHasBackup && (
-								<Button
-									primary
-									className="activity-log-banner__intro-button"
-									href={ buttonHref }
-									onClick={ this.recordUpgrade }
-								>
-									{ translate( 'Upgrade now' ) }
-								</Button>
-							) }
+							<Button
+								primary
+								className="activity-log-banner__intro-button"
+								href={ buttonHref }
+								onClick={ this.recordUpgrade }
+							>
+								{ translate( 'Upgrade now' ) }
+							</Button>
 							<ExternalLink
 								href="https://en.blog.wordpress.com/2018/10/30/introducing-activity/"
 								icon
@@ -138,11 +139,13 @@ export default connect(
 	( state, { siteId } ) => {
 		const siteIsOnFreePlan = isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) );
 		const hasBackupPurchase = siteHasBackupProductPurchase( state, siteId );
+		const hasScanPurchase = siteHasScanProductPurchase( state, siteId );
 
 		return {
 			siteId,
 			siteIsJetpack: isJetpackSite( state, siteId ),
 			siteHasBackup: ! siteIsOnFreePlan || hasBackupPurchase,
+			siteHasScan: ! siteIsOnFreePlan || hasScanPurchase,
 			siteSlug: getSiteSlug( state, siteId ),
 		};
 	},

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -49,27 +49,27 @@ class IntroBanner extends Component {
 	recordDismiss = () => this.props.recordTracksEvent( 'calypso_activitylog_intro_banner_dismiss' );
 
 	renderCardContent() {
-		const { siteIsJetpack, siteHasBackup, siteHasScan, siteSlug, translate } = this.props;
+		const { siteIsJetpack, siteSlug, translate, siteHasActivityLog } = this.props;
 		const buttonHref = siteIsJetpack
 			? `/checkout/${ siteSlug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_ACTIVITY_LOG ] }`
 			: `/plans/${ siteSlug }?feature=${ FEATURE_JETPACK_ESSENTIAL }&plan=${ PLAN_PERSONAL }`;
 
 		return (
-			<Fragment>
+			<>
 				<p>
 					{ translate(
 						'We’ll keep track of all the events that take place on your site to help manage things easier. '
 					) }
-					{ ! siteHasBackup && ! siteHasScan
+					{ siteHasActivityLog
 						? translate(
-								'With your free plan, you can monitor the 20 most recent events on your site.'
+								'Looking for something specific? You can filter the events by type and date.'
 						  )
 						: translate(
-								'Looking for something specific? You can filter the events by type and date.'
+								'With your free plan, you can monitor the 20 most recent events on your site.'
 						  ) }
 				</p>
-				{ ! siteHasBackup && ! siteHasScan && (
-					<Fragment>
+				{ ! siteHasActivityLog && (
+					<>
 						<p>{ translate( 'Upgrade to a paid plan to unlock powerful features:' ) }</p>
 						<ul className="activity-log-banner__intro-list">
 							<li>
@@ -100,9 +100,9 @@ class IntroBanner extends Component {
 								{ translate( 'Learn more' ) }
 							</ExternalLink>
 						</div>
-					</Fragment>
+					</>
 				) }
-			</Fragment>
+			</>
 		);
 	}
 
@@ -143,10 +143,12 @@ export default connect(
 
 		return {
 			siteId,
-			siteIsJetpack: isJetpackSite( state, siteId ),
-			siteHasBackup: ! siteIsOnFreePlan || hasBackupPurchase,
-			siteHasScan: ! siteIsOnFreePlan || hasScanPurchase,
 			siteSlug: getSiteSlug( state, siteId ),
+			siteIsJetpack: isJetpackSite( state, siteId ),
+
+			// TODO: Eventually use getRewindCapabilities to determine this?
+			// Activity Log doesn't appear to show up there yet though.
+			siteHasActivityLog: ! siteIsOnFreePlan || hasBackupPurchase || hasScanPurchase,
 		};
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes `1164141197617539-as-1199692173271091`.

* Suppress the upgrade prompt and copy on the `IntroMessage` card for sites that have Scan, since Scan sites now have access to Activity Log.
* Combine "free plan," "has Backup," and "has Scan" into one boolean variable to determine the value of a new replacement property, `siteHasActivityLog`.

#### Testing instructions

##### Prerequisites

* Open Calypso Blue in your testing environment.
* Using the lower-right development helper panel, open **Preferences** and use the ❌ to clear `dismissible-card-activity-intro-banner` if it exists.

##### Case 1: Self-hosted, Free plan

* Select a self-hosted Jetpack site with no purchases (i.e., only the Free plan).
* Visit the site's Activity Log (`/activity-log/:site_slug`).
* Verify that the intro banner is displayed with a prompt to **Upgrade** or **Learn more**, with relevant copy (see reference screenshots). **NOTE:** Don't dismiss the banner if you plan on testing other scenarios.

##### Case 2: Self-hosted, Jetpack product purchase exc. Scan, Backup, or a plan

* Follow the same instructions as *Case 1*, but instead use a site that has purchased an individual Jetpack product *other than* Backup or Scan. The results should be the same.

##### Case 3: Self-hosted, Scan purchase

* Open Calypso Blue in your testing environment.
* Select a self-hosted Jetpack site that has Jetpack Scan (purchased individually).
* Visit the site's Activity Log (`/activity-log/:site_slug`).
* Verify that the intro banner is shown, but doesn't mention anything about upgrading (see reference screenshots). **NOTE:** Don't dismiss the banner if you plan on testing other scenarios.

##### Case 4: Self-hosted, Backup purchase

* Follow the same instructions as *Case 3*, but instead select a site that has purchased only Jetpack Backup, rather than Scan or a paid plan/bundle. The results should be the same.

##### Case 5: Self-hosted, paid Jetpack plan

* Follow the same instructions as *Case 3*, but instead select a site that has a paid plan/bundle instead of an individual Scan purchase. The results should be the same.

##### Case 6: WordPress.com-hosted Simple site

**NOTE**: After selecting a different site, ensure that you follow the prerequisite instructions again.

* Follow the same instructions as in *Case 3*, but instead select a Simple site hosted by WordPress.com; no purchases are necessary. The results should be the same.

#### Reference screenshots

##### Upgrade prompt (Cases 1, 2)

<img width="1062" alt="image" src="https://user-images.githubusercontent.com/670067/107038479-32c34700-6782-11eb-8095-7c090a4f64d0.png">

##### No upgrade prompt (Cases 3-6)

<img width="1061" alt="image" src="https://user-images.githubusercontent.com/670067/107038550-4e2e5200-6782-11eb-9e51-c1b79096733c.png">