### PR TITLE
Gutenboarding: hide Brice from design picker

### DIFF
--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -144,7 +144,8 @@
 			},
 			"categories": [ "featured", "charity", "non-profit" ],
 			"is_premium": false,
-			"features": []
+			"features": [],
+			"hide": true
 		},
 		{
 			"title": "Barnsbury",

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -98,6 +98,12 @@ export function getAvailableDesigns(
 		),
 	};
 
+	// Filter out designs that have been marked as hidden in the json config
+	designs = {
+		...designs,
+		featured: designs.featured.filter( ( { hide } ) => ! hide ),
+	};
+
 	return designs;
 }
 

--- a/client/landing/gutenboarding/stores/onboard/types.ts
+++ b/client/landing/gutenboarding/stores/onboard/types.ts
@@ -43,4 +43,10 @@ export interface Design {
 	theme: string;
 	title: string;
 	features: Array< DesignFeatures >;
+
+	/**
+	 * Quickly hide a design from the picker without having to remove
+	 * it from the available-designs-config.json file.
+	 */
+	hide?: boolean;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add ability to temporary hide a design with a `hide` flag so we don't have to remove it from the config file (json files don't support simply commenting it out)
* Hide the Brice theme

Temporary hiding the theme because of an issue with the Brice design Automattic/themes#3186

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/new`
* Advance to the design picker
* The `Brice` theme is not available

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/themes#3186
