### PR TITLE
build-tools: Fix RequireChunkCallbackPlugin installed chunks getter

### DIFF
--- a/build-tools/webpack/require-chunk-callback-plugin.js
+++ b/build-tools/webpack/require-chunk-callback-plugin.js
@@ -24,6 +24,9 @@ class RequireChunkCallbackPlugin {
 					source,
 					'',
 					`
+						// Array to store all loading or loaded chunks
+						var _installedChunks = [];
+
 						function RequireChunkCallback() {
 							this.callbacks = [];
 						}
@@ -51,7 +54,7 @@ class RequireChunkCallbackPlugin {
 						};
 
 						RequireChunkCallback.prototype.getInstalledChunks = function() {
-							return Object.keys( installedChunks ).map( function( chunkId ) {
+							return _installedChunks.map( function( chunkId ) {
 								return ${ chunkIdToURL }( chunkId )
 									.replace( __webpack_require__.p, '' )
 									.replace( /\\.js$/, '' );
@@ -77,7 +80,9 @@ class RequireChunkCallbackPlugin {
 						chunkId: chunkId,
 						publicPath: __webpack_require__.p,
 						scriptSrc: ${ chunkIdToURL }( chunkId )
-					}, promises )`,
+					}, promises );
+
+					_installedChunks.push( chunkId );`,
 				] );
 			} );
 		} );


### PR DESCRIPTION
After migrating to Webpack 5 in #47733, the local variable [`installedChunks`](https://github.com/webpack/webpack/blob/80c5041fe1f909d34975abd33e03bdb069876ea9/lib/web/JsonpChunkLoadingRuntimeModule.js#L111) was no longer available in the `localVars` hook context in the generated runtime script.

#### Changes proposed in this Pull Request

* Implement own collection of installed chunks use it in `getInstalledChunks` getter.

#### Testing instructions

* Open calypso.live and execute `__requireChunkCallback__.getInstalledChunks()` in the console.
* Confirm the printed array contains actual chunk names, instead of `'{index}.undefined,min'`

Related to p1612455006017200-slack-C74C3THK7
