### PR TITLE
My Home: Activate dev mode on Horizon and wpcalypso for testing.

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -51,6 +51,7 @@
 		"gutenboarding/landscape-preview": true,
 		"happychat": false,
 		"help": true,
+		"home/layout-dev": true,
 		"inline-help": true,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -60,6 +60,7 @@
 		"gutenboarding/new-launch-mobile": true,
 		"happychat": true,
 		"help": true,
+		"home/layout-dev": true,
 		"inline-help": true,
 		"i18n/translation-scanner": true,
 		"ive/use-external-assignment": true,


### PR DESCRIPTION
This PR activates the My Home dev mode for Horizon and `wpcalypso` (it's currently only available to local development). This conveniently allows us to expose our Anchor call-to-action card (the only My Home card in developer mode right now) for upcoming testing.

<img width="1231" alt="Screen Shot 2021-02-04 at 2 41 45 PM" src="https://user-images.githubusercontent.com/349751/106966202-bedd5c00-66f9-11eb-9457-0af8ba614b45.png">

Part of 454-gh-Automattic/dotcom-manage

**Testing Instructions**
N/A