### PR TITLE
i18n: Fix translatable title strings rendering on purchases sections

### DIFF
--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -37,7 +38,7 @@ export function BillingHistoryContent( {
 	);
 }
 
-export default function BillingHistory(): JSX.Element {
+function BillingHistory(): JSX.Element {
 	return (
 		<Main className="billing-history is-wide-layout">
 			<DocumentHead title={ titles.billingHistory } />
@@ -50,3 +51,4 @@ export default function BillingHistory(): JSX.Element {
 		</Main>
 	);
 }
+export default localize( BillingHistory );

--- a/client/me/purchases/cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/cancel-purchase/loading-placeholder.jsx
@@ -4,6 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -43,4 +44,4 @@ CancelPurchaseLoadingPlaceholder.propTypes = {
 	getManagePurchaseUrlFor: PropTypes.func.isRequired,
 };
 
-export default CancelPurchaseLoadingPlaceholder;
+export default localize( CancelPurchaseLoadingPlaceholder );

--- a/client/me/purchases/confirm-cancel-domain/loading-placeholder.jsx
+++ b/client/me/purchases/confirm-cancel-domain/loading-placeholder.jsx
@@ -4,6 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -40,4 +41,4 @@ ConfirmCancelDomainLoadingPlaceholder.propTypes = {
 	selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 };
 
-export default ConfirmCancelDomainLoadingPlaceholder;
+export default localize( ConfirmCancelDomainLoadingPlaceholder );

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -3,6 +3,7 @@
  */
 import { noop } from 'lodash';
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -17,8 +18,7 @@ import ManagePurchase from './manage-purchase';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
 import PurchasesList from './purchases-list';
-import { concatTitle } from 'calypso/lib/react-helpers';
-import { setDocumentHeadTitle } from 'calypso/state/document-head/actions';
+import DocumentHead from 'calypso/components/data/document-head';
 import titles from './titles';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -26,22 +26,31 @@ import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { managePurchase as managePurchaseUrl, purchasesRoot } from 'calypso/me/purchases/paths';
 import FormattedHeader from 'calypso/components/formatted-header';
 
-// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-function setTitle( context, ...title ) {
-	context.store.dispatch( setDocumentHeadTitle( concatTitle( titles.purchases, ...title ) ) );
-}
+const PurchasesWrapper = ( { title = null, children } ) => {
+	return (
+		<React.Fragment>
+			<DocumentHead title={ title } />
+			{ children }
+		</React.Fragment>
+	);
+};
 
 const userHasNoSites = ( state ) => getCurrentUserSiteCount( state ) <= 0;
 
 function noSites( context, analyticsPath ) {
-	setTitle( context );
-	context.primary = (
-		<Main className="purchases__no-site is-wide-layout">
-			<PageViewTracker path={ analyticsPath } title="Purchases > No Sites" />
-			<PurchasesNavigation section="activeUpgrades" />
-			<NoSitesMessage />
-		</Main>
-	);
+	const NoSitesWrapper = localize( () => {
+		return (
+			<PurchasesWrapper>
+				<Main className="purchases__no-site is-wide-layout">
+					<PageViewTracker path={ analyticsPath } title="Purchases > No Sites" />
+					<PurchasesNavigation section="activeUpgrades" />
+					<NoSitesMessage />
+				</Main>
+			</PurchasesWrapper>
+		);
+	} );
+
+	context.primary = <NoSitesWrapper />;
 	makeLayout( context, noop );
 	clientRender( context );
 }
@@ -53,20 +62,24 @@ export function addCardDetails( context, next ) {
 		return noSites( context, '/me/purchases/:site/:purchaseId/payment/add' );
 	}
 
-	setTitle( context, titles.addCardDetails );
+	const AddCardDetailsWrapper = localize( () => {
+		return (
+			<PurchasesWrapper title={ titles.addCardDetails }>
+				<Main className="purchases__add-cart-details is-wide-layout">
+					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+					<AddPaymentMethod
+						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+						siteSlug={ context.params.site }
+						getManagePurchaseUrlFor={ managePurchaseUrl }
+						purchaseListUrl={ purchasesRoot }
+						isFullWidth={ true }
+					/>
+				</Main>
+			</PurchasesWrapper>
+		);
+	} );
 
-	context.primary = (
-		<Main className="purchases__add-cart-details is-wide-layout">
-			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
-			<AddPaymentMethod
-				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-				siteSlug={ context.params.site }
-				getManagePurchaseUrlFor={ managePurchaseUrl }
-				purchaseListUrl={ purchasesRoot }
-				isFullWidth={ true }
-			/>
-		</Main>
-	);
+	context.primary = <AddCardDetailsWrapper />;
 	next();
 }
 
@@ -76,17 +89,21 @@ export function addCreditCard( context, next ) {
 }
 
 export function cancelPurchase( context, next ) {
-	setTitle( context, titles.cancelPurchase );
+	const CancelPurchaseWrapper = localize( () => {
+		return (
+			<PurchasesWrapper title={ titles.cancelPurchase }>
+				<Main className="purchases__cancel is-wide-layout">
+					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+					<CancelPurchase
+						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+						siteSlug={ context.params.site }
+					/>
+				</Main>
+			</PurchasesWrapper>
+		);
+	} );
 
-	context.primary = (
-		<Main className="purchases__cancel is-wide-layout">
-			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
-			<CancelPurchase
-				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-				siteSlug={ context.params.site }
-			/>
-		</Main>
-	);
+	context.primary = <CancelPurchaseWrapper />;
 	next();
 }
 
@@ -97,17 +114,21 @@ export function confirmCancelDomain( context, next ) {
 		return noSites( context, '/me/purchases/:site/:purchaseId/confirm-cancel-domain' );
 	}
 
-	setTitle( context, titles.confirmCancelDomain );
+	const ConfirmCancelDomainWrapper = localize( () => {
+		return (
+			<PurchasesWrapper title={ titles.confirmCancelDomain }>
+				<Main className="purchases__cancel-domain confirm-cancel-domain is-wide-layout">
+					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+					<ConfirmCancelDomain
+						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+						siteSlug={ context.params.site }
+					/>
+				</Main>
+			</PurchasesWrapper>
+		);
+	} );
 
-	context.primary = (
-		<Main className="purchases__cancel-domain confirm-cancel-domain is-wide-layout">
-			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
-			<ConfirmCancelDomain
-				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-				siteSlug={ context.params.site }
-			/>
-		</Main>
-	);
+	context.primary = <ConfirmCancelDomainWrapper />;
 	next();
 }
 
@@ -118,45 +139,63 @@ export function editCardDetails( context, next ) {
 		return noSites( context, '/me/purchases/:site/:purchaseId/payment/edit/:cardId' );
 	}
 
-	setTitle( context, titles.editCardDetails );
+	const EditCardDetailsWrapper = localize( () => {
+		return (
+			<PurchasesWrapper title={ titles.editCardDetails }>
+				<Main className="purchases__change is-wide-layout">
+					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+					<ChangePaymentMethod
+						cardId={ context.params.cardId }
+						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+						siteSlug={ context.params.site }
+						getManagePurchaseUrlFor={ managePurchaseUrl }
+						purchaseListUrl={ purchasesRoot }
+						isFullWidth={ true }
+					/>
+				</Main>
+			</PurchasesWrapper>
+		);
+	} );
 
-	context.primary = (
-		<Main className="purchases__change is-wide-layout">
-			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
-			<ChangePaymentMethod
-				cardId={ context.params.cardId }
-				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-				siteSlug={ context.params.site }
-				getManagePurchaseUrlFor={ managePurchaseUrl }
-				purchaseListUrl={ purchasesRoot }
-				isFullWidth={ true }
-			/>
-		</Main>
-	);
+	context.primary = <EditCardDetailsWrapper />;
 	next();
 }
 
 export function list( context, next ) {
-	setTitle( context );
+	const ListWrapper = localize( () => {
+		return (
+			<PurchasesWrapper>
+				<PurchasesList noticeType={ context.params.noticeType } />
+			</PurchasesWrapper>
+		);
+	} );
 
-	context.primary = <PurchasesList noticeType={ context.params.noticeType } />;
+	context.primary = <ListWrapper />;
 	next();
 }
 
 export function managePurchase( context, next ) {
-	setTitle( context, titles.managePurchase );
-	const classes = 'manage-purchase is-wide-layout';
+	const ManagePurchasesWrapper = localize( () => {
+		const classes = 'manage-purchase is-wide-layout';
 
-	context.primary = (
-		<Main className={ classes }>
-			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
-			<PageViewTracker path="/me/purchases/:site/:purchaseId" title="Purchases > Manage Purchase" />
-			<ManagePurchase
-				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-				siteSlug={ context.params.site }
-			/>
-		</Main>
-	);
+		return (
+			<PurchasesWrapper title={ titles.managePurchase }>
+				<Main className={ classes }>
+					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+					<PageViewTracker
+						path="/me/purchases/:site/:purchaseId"
+						title="Purchases > Manage Purchase"
+					/>
+					<ManagePurchase
+						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+						siteSlug={ context.params.site }
+					/>
+				</Main>
+			</PurchasesWrapper>
+		);
+	} );
+
+	context.primary = <ManagePurchasesWrapper />;
 	next();
 }
 
@@ -172,19 +211,23 @@ export function changePaymentMethod( context, next ) {
 		return noSites( context, '/me/purchases/:site/:purchaseId/payment-method/change/:cardId' );
 	}
 
-	setTitle( context, titles.changePaymentMethod );
+	const ChangePaymentMethodWrapper = localize( () => {
+		return (
+			<PurchasesWrapper title={ titles.changePaymentMethod }>
+				<Main className="purchases__edit-payment-method is-wide-layout">
+					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+					<ChangePaymentMethod
+						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+						siteSlug={ context.params.site }
+						getManagePurchaseUrlFor={ managePurchaseUrl }
+						purchaseListUrl={ purchasesRoot }
+						isFullWidth={ true }
+					/>
+				</Main>
+			</PurchasesWrapper>
+		);
+	} );
 
-	context.primary = (
-		<Main className="purchases__edit-payment-method is-wide-layout">
-			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
-			<ChangePaymentMethod
-				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-				siteSlug={ context.params.site }
-				getManagePurchaseUrlFor={ managePurchaseUrl }
-				purchaseListUrl={ purchasesRoot }
-				isFullWidth={ true }
-			/>
-		</Main>
-	);
+	context.primary = <ChangePaymentMethodWrapper />;
 	next();
 }

--- a/client/me/purchases/manage-purchase/add-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/add-payment-method/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -134,5 +135,5 @@ const mapStateToProps = ( state, { purchaseId } ) => ( {
 } );
 
 export default connect( mapStateToProps, { clearPurchases, recordTracksEvent } )(
-	AddPaymentMethod
+	localize( AddPaymentMethod )
 );

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -181,5 +182,5 @@ function ChangePaymentMethodWrapper( props ) {
 }
 
 export default connect( mapStateToProps, { clearPurchases, recordTracksEvent } )(
-	ChangePaymentMethodWrapper
+	localize( ChangePaymentMethodWrapper )
 );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -142,7 +142,6 @@ class ManagePurchase extends Component {
 		purchaseListUrl: purchasesRoot,
 		getAddNewPaymentMethodUrlFor: getAddNewPaymentMethodPath,
 		getChangePaymentMethodUrlFor: getChangePaymentMethodPath,
-		cardTitle: titles.managePurchase,
 		getCancelPurchaseUrlFor: cancelPurchase,
 		getManagePurchaseUrlFor: managePurchase,
 	};
@@ -733,7 +732,9 @@ class ManagePurchase extends Component {
 				{ siteId && <QuerySiteDomains siteId={ siteId } /> }
 				{ isPurchaseTheme && <QueryCanonicalTheme siteId={ siteId } themeId={ purchase.meta } /> }
 
-				<HeaderCake backHref={ this.props.purchaseListUrl }>{ this.props.cardTitle }</HeaderCake>
+				<HeaderCake backHref={ this.props.purchaseListUrl }>
+					{ this.props.cardTitle || titles.managePurchase }
+				</HeaderCake>
 				{ showExpiryNotice ? (
 					<Notice status="is-info" text={ <PlanRenewalMessage /> } showDismiss={ false }>
 						<NoticeAction href={ `/plans/${ siteSlug || '' }` }>

--- a/client/me/purchases/payment-methods/main.tsx
+++ b/client/me/purchases/payment-methods/main.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -21,7 +22,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
  */
 import './style.scss';
 
-export default function PaymentMethods(): JSX.Element {
+function PaymentMethods(): JSX.Element {
 	return (
 		<Main className="payment-methods__main is-wide-layout">
 			<DocumentHead title={ titles.paymentMethods } />
@@ -33,3 +34,5 @@ export default function PaymentMethods(): JSX.Element {
 		</Main>
 	);
 }
+
+export default localize( PaymentMethods );

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -4,7 +4,7 @@
 
 import i18n from 'i18n-calypso';
 
-export default {
+const titles = {
 	addCreditCard: i18n.translate( 'Add Credit Card' ),
 	addPaymentMethod: i18n.translate( 'Add Payment Method' ),
 	cancelPurchase: i18n.translate( 'Cancel Purchase' ),
@@ -19,3 +19,50 @@ export default {
 	paymentMethods: i18n.translate( 'Payment Methods' ),
 	pendingPayments: i18n.translate( 'Pending Payments' ),
 };
+
+/**
+ * Define properties with translatable strings getters.
+ */
+Object.defineProperties( titles, {
+	addCreditCard: {
+		get: () => i18n.translate( 'Add Credit Card' ),
+	},
+	addPaymentMethod: {
+		get: () => i18n.translate( 'Add Payment Method' ),
+	},
+	cancelPurchase: {
+		get: () => i18n.translate( 'Cancel Purchase' ),
+	},
+	confirmCancelDomain: {
+		get: () => i18n.translate( 'Cancel Domain' ),
+	},
+	editCardDetails: {
+		get: () => i18n.translate( 'Change Credit Card' ),
+	},
+	changePaymentMethod: {
+		get: () => i18n.translate( 'Change Payment Method' ),
+	},
+	addCardDetails: {
+		get: () => i18n.translate( 'Add Credit Card' ),
+	},
+	managePurchase: {
+		get: () => i18n.translate( 'Purchase Settings' ),
+	},
+	sectionTitle: {
+		get: () => i18n.translate( 'Purchases' ),
+	},
+	activeUpgrades: {
+		get: () => i18n.translate( 'Active Upgrades' ),
+	},
+	billingHistory: {
+		get: () => i18n.translate( 'Billing History' ),
+	},
+	paymentMethods: {
+		get: () => i18n.translate( 'Payment Methods' ),
+	},
+	pendingPayments: {
+		get: () => i18n.translate( 'Pending Payments' ),
+	},
+} );
+
+export default titles;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Define `/me/purchases` titles with getters that would fire translate function every time they're being accessed, so that titles would update properly for async loaded translations.
* Remove `setTitle` action dispatcher and use `<DocumentHead />` instead for setting the title
* Wrap components that use the shared `titles` in `localize` hoc, to ensure component will be re-rendered and call the translate functions after adding translation asynchronously.  

#### Testing instructions

* Change UI language no any non-English Mag-16
* Go to `/me/purchases?flags=use-translation-chunks`
* Confirm navigation items are translated in the selected language

#### Merge instructions
* Requires #49730 to be merged first
* Drop https://github.com/Automattic/wp-calypso/pull/49730/commits/144fecd9f460272c77c6c3c9b84325fb5a3edec0 before merging

Related to p1612455006017200-slack-C74C3THK7
