### PR TITLE
Happy Chat: Set section name as a Custom Field

### DIFF
--- a/client/state/happychat/middleware-calypso.js
+++ b/client/state/happychat/middleware-calypso.js
@@ -30,7 +30,12 @@ import {
 	HAPPYCHAT_CHAT_STATUS_ASSIGNED,
 	HAPPYCHAT_CHAT_STATUS_PENDING,
 } from 'calypso/state/happychat/constants';
-import { sendEvent, sendLog, sendPreferences } from 'calypso/state/happychat/connection/actions';
+import {
+	sendEvent,
+	sendLog,
+	sendPreferences,
+	setChatCustomFields,
+} from 'calypso/state/happychat/connection/actions';
 import getHappychatChatStatus from 'calypso/state/happychat/selectors/get-happychat-chat-status';
 import getGroups from 'calypso/state/happychat/selectors/get-groups';
 import getSkills from 'calypso/state/happychat/selectors/get-skills';
@@ -39,6 +44,7 @@ import isHappychatClientConnected from 'calypso/state/happychat/selectors/is-hap
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
+import getSectionName from 'calypso/state/ui/selectors/get-section-name';
 
 const getRouteSetMessage = ( state, path ) => {
 	return `Looking at https://wordpress.com${ path }`;
@@ -158,6 +164,9 @@ export default ( store ) => ( next ) => ( action ) => {
 						recordTracksEvent( 'calypso_happychat_start' ),
 						sendEvent( getRouteSetMessage( state, getCurrentRoute( state ) ) )
 					)
+				);
+				dispatch(
+					setChatCustomFields( { calypsoSectionName: getSectionName( state ) || '__unknown__' } )
 				);
 			}
 			break;

--- a/client/state/happychat/test/middleware-calypso.js
+++ b/client/state/happychat/test/middleware-calypso.js
@@ -30,6 +30,7 @@ import {
 	ANALYTICS_EVENT_RECORD,
 	HAPPYCHAT_IO_SEND_MESSAGE_EVENT,
 	HAPPYCHAT_IO_SEND_MESSAGE_LOG,
+	HAPPYCHAT_IO_SET_CUSTOM_FIELDS,
 	SITE_SETTINGS_SAVE_SUCCESS,
 } from 'calypso/state/action-types';
 
@@ -106,6 +107,9 @@ describe( 'middleware', () => {
 						chat: { status: HAPPYCHAT_CHAT_STATUS_DEFAULT },
 					},
 					route: { path: { current: '/happychat' } },
+					ui: {
+						section: { name: 'happychat' },
+					},
 				};
 
 				store.getState.mockReturnValue( state );
@@ -123,6 +127,14 @@ describe( 'middleware', () => {
 						payload: expect.objectContaining( {
 							text: 'Looking at https://wordpress.com/happychat',
 						} ),
+					} )
+				);
+				expect( store.dispatch ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						type: HAPPYCHAT_IO_SET_CUSTOM_FIELDS,
+						payload: {
+							calypsoSectionName: 'happychat',
+						},
 					} )
 				);
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

To help us understand better where our chats are coming from, when the chat is started let's set a Custom Field that says what section the customer is on.

#### Testing instructions

Open a Happy Chat session from a few different pages, and in the HUD you should see a Custom Field for `calypsoSectionName` that matches the section you chatted from.