### PR TITLE
ETK: Change PLUGIN_VERSION to A8C_ETK_PLUGIN_VERSION

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1192,7 +1192,7 @@ object WPComPlugins_EditorToolKit : BuildType({
 				cd apps/editing-toolkit
 
 				# Update plugin version in the plugin file.
-				sed -i -e "/^\s\* Version:/c\ * Version: %build.number%" -e "/^define( 'PLUGIN_VERSION'/c\define( 'PLUGIN_VERSION', '%build.number%' );" ./editing-toolkit-plugin/full-site-editing-plugin.php
+				sed -i -e "/^\s\* Version:/c\ * Version: %build.number%" -e "/^define( 'A8C_ETK_PLUGIN_VERSION'/c\define( 'A8C_ETK_PLUGIN_VERSION', '%build.number%' );" ./editing-toolkit-plugin/full-site-editing-plugin.php
 
 				# Update plugin stable tag in readme.txt.
 				sed -i -e "/^Stable tag:\s/c\Stable tag: %build.number%" ./editing-toolkit-plugin/readme.txt

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -37,7 +37,7 @@ class Block_Patterns_From_API {
 				'_',
 				array(
 					'block_patterns',
-					PLUGIN_VERSION,
+					A8C_ETK_PLUGIN_VERSION,
 					$this->get_block_patterns_locale(),
 				)
 			)
@@ -92,7 +92,7 @@ class Block_Patterns_From_API {
 				$is_premium = isset( $pattern['pattern_meta']['is_premium'] ) ? boolval( $pattern['pattern_meta']['is_premium'] ) : false;
 
 				register_block_pattern(
-					Block_Patterns_From_API::PATTERN_NAMESPACE . $pattern['name'],
+					self::PATTERN_NAMESPACE . $pattern['name'],
 					array(
 						'title'         => $pattern['title'],
 						'description'   => $pattern['description'],

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -54,7 +54,7 @@ function render_fallback_coming_soon_page() {
 	add_filter( 'wpl_is_enabled_sitewide', '__return_false', 10, 1 ); // Disable likes.
 	add_filter( 'jetpack_implode_frontend_css', '__return_false', 99 ); // Jetpack "implodes" all registered CSS files into one file.
 
-	wp_enqueue_style( 'recoleta-font', '//s1.wp.com/i/fonts/recoleta/css/400.min.css', array(), PLUGIN_VERSION );
+	wp_enqueue_style( 'recoleta-font', '//s1.wp.com/i/fonts/recoleta/css/400.min.css', array(), A8C_ETK_PLUGIN_VERSION );
 
 	include __DIR__ . '/fallback-coming-soon-page.php';
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.17' );
+define( 'A8C_ETK_PLUGIN_VERSION', '2.17' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -34,7 +34,7 @@ class Starter_Page_Templates {
 			'_',
 			array(
 				'starter_page_templates',
-				PLUGIN_VERSION,
+				A8C_ETK_PLUGIN_VERSION,
 				get_option( 'site_vertical', 'default' ),
 				get_locale(),
 			)
@@ -84,7 +84,7 @@ class Starter_Page_Templates {
 			'single'         => true,
 			'show_in_rest'   => true,
 			'object_subtype' => 'page',
-			'auth_callback'  => function() {
+			'auth_callback'  => function () {
 				return current_user_can( 'edit_posts' );
 			},
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This has been bothering me for a while, but I think this was set to `PLUGIN_VERSION` when we added plugin namespaces. Unfortunately, namespaces aren't automatic with `define`. As a result, currently, `PLUGIN_VERSION` is defined globally in PHP. Definitely seems ripe for conflicts :)

Here we change it to `A8C_ETK_PLUGIN_VERSION`.

I'm also hoping to use this in wpcom in the info section.

#### Testing instructions
- plugin should continue working
- this diff also needs updated to make sure that the wp.org deploy works: D56532-code. This is thankfully the only thing which needs to happen, as I could not find the version used elsewhere.

