### PR TITLE
Fix Facebook analytics, split on WPCOM/Jetpack.

### DIFF
--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isJetpackPlan } from 'calypso/lib/products-values';
+import { isJetpackPlan, isJetpackProduct } from 'calypso/lib/products-values';
 import {
 	costToUSD,
 	isAdTrackingAllowed,
@@ -172,11 +172,17 @@ export async function recordOrder( cart, orderId ) {
 
 function splitWpcomJetpackCartInfo( cart ) {
 	const jetpackCost = cart.products
-		.map( ( product ) => ( isJetpackPlan( product ) ? product.cost : 0 ) )
+		.map( ( product ) =>
+			isJetpackPlan( product ) || isJetpackProduct( product ) ? product.cost : 0
+		)
 		.reduce( ( accumulator, cost ) => accumulator + cost, 0 );
 	const wpcomCost = cart.total_cost - jetpackCost;
-	const wpcomProducts = cart.products.filter( ( product ) => ! isJetpackPlan( product ) );
-	const jetpackProducts = cart.products.filter( ( product ) => isJetpackPlan( product ) );
+	const wpcomProducts = cart.products.filter(
+		( product ) => ! isJetpackPlan( product ) && ! isJetpackProduct( product )
+	);
+	const jetpackProducts = cart.products.filter(
+		( product ) => isJetpackPlan( product ) || isJetpackProduct( product )
+	);
 
 	return {
 		wpcomProducts: wpcomProducts,

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -331,7 +331,7 @@ function recordOrderInFacebook( cart, orderId, wpcomJetpackCartInfo ) {
 
 	// WPCom
 	if ( wpcomJetpackCartInfo.containsWpcomProducts ) {
-		if ( null !== wpcomJetpackCartInfo.wpcomCostUSD ) {
+		if ( null !== wpcomJetpackCartInfo.wpcomCostUSD && wpcomJetpackCartInfo.wpcomCostUSD > 0 ) {
 			const params = [
 				'trackSingle',
 				TRACKING_IDS.facebookInit,
@@ -353,7 +353,7 @@ function recordOrderInFacebook( cart, orderId, wpcomJetpackCartInfo ) {
 
 	// Jetpack
 	if ( wpcomJetpackCartInfo.containsJetpackProducts ) {
-		if ( null !== wpcomJetpackCartInfo.jetpackCostUSD ) {
+		if ( null !== wpcomJetpackCartInfo.jetpackCostUSD && wpcomJetpackCartInfo.jetpackCostUSD > 0 ) {
 			const params = [
 				'trackSingle',
 				TRACKING_IDS.facebookJetpackInit,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Separates WP.com from Jetpack purchase events in analytics library, such that just one `Purchase` event fires for each.

#### Testing instructions

- Open a new incognito window.
- In the same window, visit each of these URLs. In each case, open DevTools console, run the following.
  - First replace `[VALUE]` in the snippet below. Check field guide for `store_sandbox=[VALUE]`. 
    - https://wordpress.com/
    - https://calypso.live/start?branch=fix/analytics-facebook

```
var doc = document, cD = doc.location.hostname.split( '.' ).slice( -2 ).join( '.' );
doc.cookie = 'store_sandbox=[VALUE]; path=/; domain=.' + cD + '; samesite=none; secure';
doc.cookie = 'flags=a8c-analytics.on,gdpr-banner,google-analytics,ad-tracking; path=/; domain=.' + cD;
doc.cookie = 'sensitive_pixel_option=yes; path=/; domain=.' + cD;
localStorage.setItem( 'debug', 'calypso:*' );
```

---

- Visit: https://calypso.live/start?branch=fix/analytics-facebook
- Set Network tab in DevTools to "Preserve log" on.

---

- Complete a WP.com purchase using `store_sandbox` cookie with test CC number.
  - Filter Network tab by `facebook` and confirm `ev=Purchase` pixel fires ONE time only and review request params.

![Screen Shot on 2021-02-04 at 21:31:28](https://user-images.githubusercontent.com/1563559/106983025-3b406100-6733-11eb-86bf-71ef01bf9771.png)


---

- Set up jurassic.ninja Jetpack site and connect to WP.com test user.
- Complete a Jetpack purchase (whatever you like) using `store_sandbox` cookie with test CC number.
  - NOTE: When you arrive at Jetpack checkout, be sure to change `cloud.jetpack.com` in address bar to `hash-37310d66d9dce40e1d6da614cb9603e9e690b95f.calypso.live` and reload the checkout page. This will make sure you're on the test branch whenever you complete checkout, otherwise the test will not work as expected.
  - Filter Network tab by `facebook` and confirm `ev=Purchase` pixel fires ONE time only and review request params.

![Screen Shot on 2021-02-04 at 22:47:27](https://user-images.githubusercontent.com/1563559/106987229-ff10fe80-673a-11eb-8b19-417f650f3ed8.png)
