### PR TITLE
Happy Chat: Track some site info in Custom Fields

### DIFF
--- a/client/state/happychat/middleware-calypso.js
+++ b/client/state/happychat/middleware-calypso.js
@@ -44,7 +44,9 @@ import isHappychatClientConnected from 'calypso/state/happychat/selectors/is-hap
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
+import { getHelpSelectedSiteId } from 'calypso/state/help/selectors';
 import getSectionName from 'calypso/state/ui/selectors/get-section-name';
+import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
 
 const getRouteSetMessage = ( state, path ) => {
 	return `Looking at https://wordpress.com${ path }`;
@@ -165,8 +167,13 @@ export default ( store ) => ( next ) => ( action ) => {
 						sendEvent( getRouteSetMessage( state, getCurrentRoute( state ) ) )
 					)
 				);
+				const siteId = getHelpSelectedSiteId( state );
 				dispatch(
-					setChatCustomFields( { calypsoSectionName: getSectionName( state ) || '__unknown__' } )
+					setChatCustomFields( {
+						calypsoSectionName: getSectionName( state ) || '__unknown__',
+						wpcomSiteId: '' + siteId, // Convert to string for Custom Fields
+						wpcomSitePlan: getSitePlanSlug( state, siteId ),
+					} )
 				);
 			}
 			break;

--- a/client/state/happychat/test/middleware-calypso.js
+++ b/client/state/happychat/test/middleware-calypso.js
@@ -103,12 +103,30 @@ describe( 'middleware', () => {
 			let state;
 			beforeEach( () => {
 				state = {
+					currentUser: {
+						locale: 'en',
+						capabilities: {},
+					},
 					happychat: {
 						chat: { status: HAPPYCHAT_CHAT_STATUS_DEFAULT },
 					},
 					route: { path: { current: '/happychat' } },
 					ui: {
 						section: { name: 'happychat' },
+					},
+					sites: {
+						items: {
+							1: {
+								ID: 1,
+								plan: {
+									product_id: 2002,
+									product_slug: 'jetpack_free',
+									product_name_short: 'Free',
+									free_trial: false,
+									expired: false,
+								},
+							},
+						},
 					},
 				};
 
@@ -134,6 +152,8 @@ describe( 'middleware', () => {
 						type: HAPPYCHAT_IO_SET_CUSTOM_FIELDS,
 						payload: {
 							calypsoSectionName: 'happychat',
+							wpcomSiteId: '1',
+							wpcomSitePlan: 'jetpack_free',
 						},
 					} )
 				);


### PR DESCRIPTION
### Changes proposed in this Pull Request

When a chat starts, send along info about the selected site as Custom Fields.

#### Testing instructions

Start a chat, and in the HUD you should see `wpcomSiteId` and `wpcomSitePlan` fields appear with the corresponding ID and plan slug.
