### PR TITLE
Coming Soon: remove WooCommerce demo notice

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -53,7 +53,8 @@ function render_fallback_coming_soon_page() {
 	add_filter( 'wpcom_disable_logged_out_follow', '__return_true', 10, 1 ); // Disable follow actionbar.
 	add_filter( 'wpl_is_enabled_sitewide', '__return_false', 10, 1 ); // Disable likes.
 	add_filter( 'jetpack_implode_frontend_css', '__return_false', 99 ); // Jetpack "implodes" all registered CSS files into one file.
-
+	remove_filter( 'woocommerce_demo_store', '__return_false' ); // Prevent the the wocommerce demo store notice from displaying
+	
 	wp_enqueue_style( 'recoleta-font', '//s1.wp.com/i/fonts/recoleta/css/400.min.css', array(), PLUGIN_VERSION );
 
 	include __DIR__ . '/fallback-coming-soon-page.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -53,8 +53,8 @@ function render_fallback_coming_soon_page() {
 	add_filter( 'wpcom_disable_logged_out_follow', '__return_true', 10, 1 ); // Disable follow actionbar.
 	add_filter( 'wpl_is_enabled_sitewide', '__return_false', 10, 1 ); // Disable likes.
 	add_filter( 'jetpack_implode_frontend_css', '__return_false', 99 ); // Jetpack "implodes" all registered CSS files into one file.
-	remove_filter( 'woocommerce_demo_store', '__return_false' ); // Prevent the the wocommerce demo store notice from displaying
-	
+	remove_filter( 'woocommerce_demo_store', '__return_false' ); // Prevent the the wocommerce demo store notice from displaying.
+
 	wp_enqueue_style( 'recoleta-font', '//s1.wp.com/i/fonts/recoleta/css/400.min.css', array(), PLUGIN_VERSION );
 
 	include __DIR__ . '/fallback-coming-soon-page.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -53,7 +53,7 @@ function render_fallback_coming_soon_page() {
 	add_filter( 'wpcom_disable_logged_out_follow', '__return_true', 10, 1 ); // Disable follow actionbar.
 	add_filter( 'wpl_is_enabled_sitewide', '__return_false', 10, 1 ); // Disable likes.
 	add_filter( 'jetpack_implode_frontend_css', '__return_false', 99 ); // Jetpack "implodes" all registered CSS files into one file.
-	remove_filter( 'woocommerce_demo_store', '__return_false' ); // Prevent the the wocommerce demo store notice from displaying.
+	add_filter( 'woocommerce_demo_store', '__return_false' ); // Prevent the the wocommerce demo store notice from displaying.
 
 	wp_enqueue_style( 'recoleta-font', '//s1.wp.com/i/fonts/recoleta/css/400.min.css', array(), PLUGIN_VERSION );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR attempts to remove the `woocommerce_demo_store` filter for the coming soon page for ecommerce sites.

We need to do this as new Ecommerce sites show a demo notice banner.

See https://github.com/Automattic/wp-calypso/pull/48614#issuecomment-755920627

**Before**
<img width="1388" alt="Screen Shot 2021-02-08 at 1 54 33 pm" src="https://user-images.githubusercontent.com/6458278/107170769-476b3d80-6a15-11eb-8f95-b25edd1a4336.png">

**After**
<img width="1386" alt="Screen Shot 2021-02-08 at 1 53 29 pm" src="https://user-images.githubusercontent.com/6458278/107170791-518d3c00-6a15-11eb-8f29-3a050ccb2300.png">

#### Testing instructions

Apply https://github.com/Automattic/wp-calypso/pull/48614 to ensure that the /new flow will set the ecommerce site as coming soon

From `/apps/editing-toolkit` run `yarn dev --sync`

Create a new ecommerce site, then sandbox it (if Chrome doesn't like the SSL cert then you can build the ETK and upload the plugin manually)

Check that the WooCommerce banner doesn't show on the Coming Soon page


Related to #48614
