### PR TITLE
ci(teamcity): Enable docker BuildKit for all builds

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -61,6 +61,7 @@ project {
 		text("docker_image", "registry.a8c.com/calypso/base:latest", label = "Docker image", description = "Default Docker image used to run builds", allowEmpty = true)
 		text("docker_image_e2e", "registry.a8c.com/calypso/ci-e2e:latest", label = "Docker e2e image", description = "Docker image used to run e2e tests", allowEmpty = true)
 		text("calypso.run_full_eslint", "false", label = "Run full eslint", description = "True will lint all files, empty/false will lint only changed files", allowEmpty = true)
+		text("env.DOCKER_BUILDKIT", "1", label = "Enable Docker BuildKit", description = "Enables BuildKit (faster image generation). Values 0 or 1", allowEmpty = true)
 	}
 
 	features {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable [Docker Buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/) across all Calypso projects.

#### Testing instructions

N/A
