### PR TITLE
Deduplicate object-is

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19561,12 +19561,7 @@ object-inspect@^1.8.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
 
-object-is@^1.0.1, object-is@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.2.tgz#6b80eb84fe451498f65007982f035a5b445edec4"
-  integrity sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==
-
-object-is@^1.1.2:
+object-is@^1.0.1, object-is@^1.0.2, object-is@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.4.tgz#63d6c83c00a43f4cbc9434eb9757c8a5b8565068"
   integrity sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `object-is` (done automatically with `npx yarn-deduplicate --packages object-is`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> object-is@1.0.2
< @automattic/wpcom-editing-toolkit@2.17.0 -> @wordpress/scripts@12.5.0 -> ... -> object-is@1.0.2
< @automattic/wpcom-editing-toolkit@2.17.0 -> enzyme@3.11.0 -> ... -> object-is@1.0.2
< wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> object-is@1.0.2
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> object-is@1.0.2
< wp-calypso@0.17.0 -> enzyme@3.11.0 -> ... -> object-is@1.0.2
< wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> object-is@1.0.2
> @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> object-is@1.1.4
> @automattic/wpcom-editing-toolkit@2.17.0 -> @wordpress/scripts@12.5.0 -> ... -> object-is@1.1.4
> @automattic/wpcom-editing-toolkit@2.17.0 -> enzyme@3.11.0 -> ... -> object-is@1.1.4
> wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> object-is@1.1.4
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> object-is@1.1.4
> wp-calypso@0.17.0 -> enzyme@3.11.0 -> ... -> object-is@1.1.4
> wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> object-is@1.1.4
```

[Changelog](https://github.com/es-shims/object-is/blob/main/CHANGELOG.md)