### PR TITLE
Deduplicate object.entries

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19636,17 +19636,7 @@ object.defaults@^1.1.0:
     for-own "^1.0.0"
     isobject "^3.0.0"
 
-object.entries@^1.1.0, object.entries@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.1.tgz#ee1cf04153de02bb093fec33683900f57ce5399b"
-  integrity sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
-    has "^1.0.3"
-
-object.entries@^1.1.2:
+object.entries@^1.1.0, object.entries@^1.1.1, object.entries@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.2.tgz#bc73f00acb6b6bb16c203434b10f9a7e797d3add"
   integrity sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `object.entries` (done automatically with `npx yarn-deduplicate --packages object.entries`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> object.entries@1.1.1
< @automattic/wpcom-editing-toolkit@2.17.0 -> @wordpress/scripts@12.5.0 -> ... -> object.entries@1.1.1
< @automattic/wpcom-editing-toolkit@2.17.0 -> enzyme@3.11.0 -> ... -> object.entries@1.1.1
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> object.entries@1.1.1
< wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> object.entries@1.1.1
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> object.entries@1.1.1
< wp-calypso@0.17.0 -> enzyme@3.11.0 -> ... -> object.entries@1.1.1
> @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> object.entries@1.1.2
> @automattic/wpcom-editing-toolkit@2.17.0 -> @wordpress/scripts@12.5.0 -> ... -> object.entries@1.1.2
> @automattic/wpcom-editing-toolkit@2.17.0 -> enzyme@3.11.0 -> ... -> object.entries@1.1.2
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> object.entries@1.1.2
> wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> object.entries@1.1.2
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> object.entries@1.1.2
> wp-calypso@0.17.0 -> enzyme@3.11.0 -> ... -> object.entries@1.1.2
```

[Changelog](https://github.com/es-shims/Object.entries/blob/main/CHANGELOG.md)