### PR TITLE
Deduplicate object.fromentries

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19655,17 +19655,7 @@ object.entries@^1.1.2:
     es-abstract "^1.17.5"
     has "^1.0.3"
 
-"object.fromentries@^2.0.0 || ^1.0.0", object.fromentries@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.2.tgz#4a09c9b9bb3843dd0f89acdb517a794d4f355ac9"
-  integrity sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
-    has "^1.0.3"
-
-object.fromentries@^2.0.3:
+"object.fromentries@^2.0.0 || ^1.0.0", object.fromentries@^2.0.2, object.fromentries@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.3.tgz#13cefcffa702dc67750314a3305e8cb3fad1d072"
   integrity sha512-IDUSMXs6LOSJBWE++L0lzIbSqHl9KDCfff2x/JSEIDtEUavUnyMYC2ZGay/04Zq4UT8lvd4xNhU4/YHKibAOlw==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `object.fromentries` (done automatically with `npx yarn-deduplicate --packages object.fromentries`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/wpcom-editing-toolkit@2.17.0 -> @wordpress/scripts@12.5.0 -> ... -> object.fromentries@2.0.2
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> object.fromentries@2.0.2
< wp-calypso@0.17.0 -> eslint-plugin-react@7.21.5 -> ... -> object.fromentries@2.0.2
> @automattic/wpcom-editing-toolkit@2.17.0 -> @wordpress/scripts@12.5.0 -> ... -> object.fromentries@2.0.3
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> object.fromentries@2.0.3
> wp-calypso@0.17.0 -> eslint-plugin-react@7.21.5 -> ... -> object.fromentries@2.0.3
```

[Changelog](https://github.com/es-shims/Object.fromentries/blob/main/CHANGELOG.md)