### PR TITLE
Deduplicate onetime

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19759,14 +19759,7 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-onetime@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
-  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
-  dependencies:
-    mimic-fn "^2.1.0"
-
-onetime@^5.1.2:
+onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `onetime` (done automatically with `npx yarn-deduplicate --packages onetime`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/wpcom-editing-toolkit@2.17.0 -> @wordpress/env@2.1.0 -> ... -> onetime@5.1.0
< @automattic/wpcom-editing-toolkit@2.17.0 -> @wordpress/scripts@12.5.0 -> ... -> onetime@5.1.0
< @automattic/wpcom-editing-toolkit@2.17.0 -> jest@26.4.0 -> ... -> onetime@5.1.0
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> onetime@5.1.0
< wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> onetime@5.1.0
< wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> onetime@5.1.0
< wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> onetime@5.1.0
> @automattic/wpcom-editing-toolkit@2.17.0 -> @wordpress/env@2.1.0 -> ... -> onetime@5.1.2
> @automattic/wpcom-editing-toolkit@2.17.0 -> @wordpress/scripts@12.5.0 -> ... -> onetime@5.1.2
> @automattic/wpcom-editing-toolkit@2.17.0 -> jest@26.4.0 -> ... -> onetime@5.1.2
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> onetime@5.1.2
> wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> onetime@5.1.2
> wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> onetime@5.1.2
> wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> onetime@5.1.2
```

[Changelog](https://github.com/sindresorhus/onetime/releases)