### PR TITLE
Domain Upsell: Handles errors from the secure your brand API

### DIFF
--- a/client/signup/steps/domain-upsell/index.jsx
+++ b/client/signup/steps/domain-upsell/index.jsx
@@ -10,6 +10,7 @@ import StepWrapper from 'calypso/signup/step-wrapper';
 import {
 	getSecureYourBrand,
 	isRequestingSecureYourBrand,
+	hasSecureYourBrandError,
 } from 'calypso/state/secure-your-brand/selectors';
 import { Button, Card } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
@@ -61,10 +62,6 @@ export default function DomainUpsellStep( props ) {
 	);
 }
 
-function getDomainName( siteSlug ) {
-	return siteSlug.replace( '.wordpress.com', '.blog' );
-}
-
 function FormattedSuggestion( translate, suggestion, isRecommended ) {
 	const currency = suggestion.currency;
 	return (
@@ -106,7 +103,7 @@ function RecommendedDomains( props ) {
 	const selectDomain = ( event ) => setSelectedDomain( event.target.value );
 	const secureYourBrand = useSelector( ( state ) => getSecureYourBrand( state ) );
 	const isLoading = useSelector( ( state ) => isRequestingSecureYourBrand( state ) );
-	const domain = getDomainName( siteSlug );
+	const hasError = useSelector( ( state ) => hasSecureYourBrandError( state ) );
 	const productData = secureYourBrand.product_data;
 	const selectedProduct = productData?.filter(
 		( product ) => product.domain === selectedDomain
@@ -150,9 +147,13 @@ function RecommendedDomains( props ) {
 		goToNextStep();
 	};
 
+	if ( hasError ) {
+		handleSkipButtonClick();
+	}
+
 	return (
 		<div className="domain-upsell">
-			{ ! productData && <QuerySecureYourBrand domain={ domain } /> }
+			{ ! productData && ! isLoading && ! hasError && <QuerySecureYourBrand domain={ siteSlug } /> }
 			<Card style={ { maxWidth: '615px' } } className="domain-upsell__card">
 				{ isLoading ? (
 					[ ...Array( 3 ) ].map( ( e, i ) => (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If the API returns an error, this step is skipped.
* Adds a `noRetry` policy to the HTTP call since the default policy is to retry thrice. Ideally, this should be fixed in the underlying HTTP library, 4xx errors should not be retried.
* Removes the `getDomainName` function since it is not required once D56540-code is deployed.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sign up for a free account, in the domains step use a .blog subdomain (eg: foo.home.blog)
* Once signup is complete, start the launch flow by clicking on the checklist item.
* On the domain selection step, select "Skip Purchase" and on the Plans step, select "Start with a free site".
* The next step should load but should immediately get skipped since the API will return an error.

Please note, the API error has been fixed in D56540-code.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #49570