### PR TITLE
Focused Launch - Summary View: Fix checkmark size in sidebar

### DIFF
--- a/packages/launch/src/focused-launch/summary/style.scss
+++ b/packages/launch/src/focused-launch/summary/style.scss
@@ -134,6 +134,10 @@ $commentary-column-gap-wide: 100px;
 	@include break-large {
 		width: $commentary-column-width-large;
 	}
+
+	& svg {
+		flex-shrink: 0;
+	}
 }
 
 .focused-launch-summary__data-input {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The sidebar items in the summary view are scaled with flexbox causing the checkmarks to shrink when the copy is claiming more space. Since the length of the item's copy differs in size, the scaling for each checkmark is different too. By preventing the checkmarks to shrink they maintain their initial size, whatever the length of the copy might be.

#### Technical Changes

* Add `flex-shrink: 0;` to `.focused-launch-summary__side-commentary svg`.

#### Testing instructions

#### Focused Launch

1. Make sure that you switch to a more verbose language (e.g. German or Dutch).
2. Go to `/page/[UNLAUNCHED_SITE_ID].wordpress.com/home?flags=create/focused-launch-flow`.
3. Click "Launch" to open the Focused Launch flow.
4. Ensure that:
    * [ ] All the checkmarks in the sidebar have the same size.
5. Open DevTools and scale the page but stay on a viewport that `> mobile`.
6. Ensure that:
    * [ ] All the checkmarks in the sidebar have the same size.

#### Step-by-Step Launch

1. Make sure that you switch to a more verbose language (e.g. German or Dutch).
2. Go to `/page/[UNLAUNCHED_SITE_ID].wordpress.com/home?flags=create/focused-launch-flow`.
3. Click "Launch" to open the Focused Launch flow.
4. Ensure that:
    * [ ] Everything looks the same as on production.
5. Open DevTools and scale the page but stay on a viewport that `> mobile`.
6. Ensure that:
    * [ ] Everything looks the same as on production.

Part of #49635
