### PR TITLE
Honor locale information in the plans reducer

### DIFF
--- a/packages/data-stores/src/plans/actions.ts
+++ b/packages/data-stores/src/plans/actions.ts
@@ -3,24 +3,27 @@
  */
 import type { Plan, PlanFeature, FeaturesByType, PlanProduct } from './types';
 
-export const setFeatures = ( features: Record< string, PlanFeature > ) => {
+export const setFeatures = ( features: Record< string, PlanFeature >, locale: string ) => {
 	return {
 		type: 'SET_FEATURES' as const,
 		features,
+		locale,
 	};
 };
 
-export const setFeaturesByType = ( featuresByType: Array< FeaturesByType > ) => {
+export const setFeaturesByType = ( featuresByType: Array< FeaturesByType >, locale: string ) => {
 	return {
 		type: 'SET_FEATURES_BY_TYPE' as const,
 		featuresByType,
+		locale,
 	};
 };
 
-export const setPlans = ( plans: Plan[] ) => {
+export const setPlans = ( plans: Plan[], locale: string ) => {
 	return {
 		type: 'SET_PLANS' as const,
 		plans,
+		locale,
 	};
 };
 

--- a/packages/data-stores/src/plans/reducer.ts
+++ b/packages/data-stores/src/plans/reducer.ts
@@ -10,34 +10,37 @@ import { combineReducers } from '@wordpress/data';
 import type { PlanAction } from './actions';
 import type { Plan, PlanFeature, FeaturesByType, PlanProduct } from './types';
 
-export const features: Reducer< Record< string, PlanFeature >, PlanAction > = (
+// create a Locale type just for code readability
+type Locale = string;
+
+export const features: Reducer< Record< Locale, Record< string, PlanFeature > >, PlanAction > = (
 	state = {},
 	action
 ) => {
 	switch ( action.type ) {
 		case 'SET_FEATURES':
-			return action.features;
+			return { ...state, [ action.locale ]: action.features };
 		default:
 			return state;
 	}
 };
 
-export const featuresByType: Reducer< Array< FeaturesByType >, PlanAction > = (
-	state = [],
+export const featuresByType: Reducer< Record< Locale, Array< FeaturesByType > >, PlanAction > = (
+	state = {},
 	action
 ) => {
 	switch ( action.type ) {
 		case 'SET_FEATURES_BY_TYPE':
-			return action.featuresByType;
+			return { ...state, [ action.locale ]: action.featuresByType };
 		default:
 			return state;
 	}
 };
 
-export const plans: Reducer< Plan[], PlanAction > = ( state = [], action ) => {
+export const plans: Reducer< Record< Locale, Plan[] >, PlanAction > = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case 'SET_PLANS':
-			return action.plans;
+			return { ...state, [ action.locale ]: action.plans };
 		default:
 			return state;
 	}

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -167,7 +167,7 @@ function normalizePlanProducts(
 	return plansProducts;
 }
 
-export function* getSupportedPlans( locale: string ) {
+export function* getSupportedPlans( locale = 'en' ) {
 	const pricedPlans: PricedAPIPlan[] = yield wpcomRequest( {
 		path: '/plans',
 		query: stringify( { locale } ),

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -167,7 +167,7 @@ function normalizePlanProducts(
 	return plansProducts;
 }
 
-export function* getSupportedPlans( locale = 'en' ) {
+export function* getSupportedPlans( locale: string ) {
 	const pricedPlans: PricedAPIPlan[] = yield wpcomRequest( {
 		path: '/plans',
 		query: stringify( { locale } ),
@@ -207,8 +207,8 @@ export function* getSupportedPlans( locale = 'en' ) {
 
 	const planProducts = normalizePlanProducts( pricedPlans, periodAgnosticPlans );
 
-	yield setPlans( periodAgnosticPlans );
+	yield setPlans( periodAgnosticPlans, locale );
 	yield setPlanProducts( planProducts );
-	yield setFeatures( features );
-	yield setFeaturesByType( plansFeatures.features_by_type );
+	yield setFeatures( features, locale );
+	yield setFeaturesByType( plansFeatures.features_by_type, locale );
 }

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -28,9 +28,11 @@ import type {
 // params are used by the associated resolver.
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-export const getFeatures = ( state: State ): Record< string, PlanFeature > => state.features;
+export const getFeatures = ( state: State, locale: string ): Record< string, PlanFeature > =>
+	state.features[ locale ] ?? {};
 
-export const getFeaturesByType = ( state: State ): Array< FeaturesByType > => state.featuresByType;
+export const getFeaturesByType = ( state: State, locale: string ): Array< FeaturesByType > =>
+	state.featuresByType[ locale ] ?? [];
 
 export const getPlanByProductId = (
 	_state: State,
@@ -85,7 +87,7 @@ export const getDefaultFreePlan = ( _: State, locale: string ): Plan | undefined
 };
 
 export const getSupportedPlans = ( state: State, _locale: string ): Plan[] => {
-	return state.plans;
+	return state.plans[ _locale ] ?? [];
 };
 
 export const getPlansProducts = ( state: State ): PlanProduct[] => {

--- a/packages/data-stores/src/plans/test/reducer.ts
+++ b/packages/data-stores/src/plans/test/reducer.ts
@@ -9,23 +9,26 @@ describe( 'Plans reducer', () => {
 	describe( 'Plans', () => {
 		it( 'defaults to no plans info', () => {
 			const { plans } = reducer( undefined, { type: 'DUMMY' } );
-			expect( plans ).toEqual( [] );
+			expect( plans ).toEqual( {} );
 		} );
 
 		it( 'replaces old plans with new plans', () => {
 			let state = reducer(
 				undefined,
-				setPlans( [
-					{
-						title: 'free plan',
-						description: 'it is free',
-						features: [],
-						isFree: true,
-						isPopular: false,
-						periodAgnosticSlug: 'free',
-						productIds: [ 1 ],
-					},
-				] )
+				setPlans(
+					[
+						{
+							title: 'free plan',
+							description: 'it is free',
+							features: [],
+							isFree: true,
+							isPopular: false,
+							periodAgnosticSlug: 'free',
+							productIds: [ 1 ],
+						},
+					],
+					'en'
+				)
 			);
 
 			state = reducer(
@@ -69,58 +72,67 @@ describe( 'Plans reducer', () => {
 
 			const { plans } = reducer(
 				state,
-				setPlans( [
-					{
-						title: 'new free',
-						description: 'it is free',
-						features: [],
-						isPopular: true,
-						periodAgnosticSlug: 'free',
-						productIds: [ 1 ],
-					},
-				] )
+				setPlans(
+					[
+						{
+							title: 'new free',
+							description: 'it is free',
+							features: [],
+							isPopular: true,
+							periodAgnosticSlug: 'free',
+							productIds: [ 1 ],
+						},
+					],
+					'en'
+				)
 			);
 
-			expect( plans[ 0 ].title ).toBe( 'new free' );
-			expect( plans[ 1 ] ).toBeUndefined();
+			expect( plans.en[ 0 ].title ).toBe( 'new free' );
+			expect( plans.en[ 1 ] ).toBeUndefined();
 		} );
 	} );
 
 	describe( 'Features By Type', () => {
 		it( 'defaults to no featuresByType info', () => {
 			const { featuresByType } = reducer( undefined, { type: 'DUMMY' } );
-			expect( featuresByType ).toEqual( [] );
+			expect( featuresByType ).toEqual( {} );
 		} );
 
 		it( 'replaces old featuresByType info with new featuresByType info', () => {
 			const state = reducer(
 				undefined,
-				setFeaturesByType( [
-					{
-						id: '1',
-						name: 'one',
-						features: [],
-					},
-					{
-						id: '2',
-						name: 'two',
-						features: [],
-					},
-				] )
+				setFeaturesByType(
+					[
+						{
+							id: '1',
+							name: 'one',
+							features: [],
+						},
+						{
+							id: '2',
+							name: 'two',
+							features: [],
+						},
+					],
+					'en'
+				)
 			);
 
 			const { featuresByType } = reducer(
 				state,
-				setFeaturesByType( [
-					{
-						id: '3',
-						name: 'three',
-						features: [],
-					},
-				] )
+				setFeaturesByType(
+					[
+						{
+							id: '3',
+							name: 'three',
+							features: [],
+						},
+					],
+					'en'
+				)
 			);
 
-			expect( featuresByType ).toEqual( [
+			expect( featuresByType.en ).toEqual( [
 				{
 					id: '3',
 					name: 'three',
@@ -139,13 +151,16 @@ describe( 'Plans reducer', () => {
 		it( 'replaces old features with new features', () => {
 			const state = reducer(
 				undefined,
-				setFeatures( { [ PLAN_FREE ]: { name: 'name' }, [ PLAN_PREMIUM ]: { name: 'name' } } )
+				setFeatures( { [ PLAN_FREE ]: { name: 'name' }, [ PLAN_PREMIUM ]: { name: 'name' } }, 'en' )
 			);
 
-			const { features } = reducer( state, setFeatures( { [ PLAN_FREE ]: { name: 'new name' } } ) );
+			const { features } = reducer(
+				state,
+				setFeatures( { [ PLAN_FREE ]: { name: 'new name' } }, 'en' )
+			);
 
-			expect( features[ PLAN_FREE ].name ).toBe( 'new name' );
-			expect( features[ PLAN_PREMIUM ] ).toBeUndefined();
+			expect( features.en[ PLAN_FREE ].name ).toBe( 'new name' );
+			expect( features.en[ PLAN_PREMIUM ] ).toBeUndefined();
 		} );
 	} );
 } );

--- a/packages/data-stores/src/plans/test/resolvers.ts
+++ b/packages/data-stores/src/plans/test/resolvers.ts
@@ -100,6 +100,7 @@ describe( 'getSupportedPlans', () => {
 
 		// setPlans call
 		expect( iter.next( { body: planDetailedData } ).value ).toEqual( {
+			locale: 'en',
 			type: 'SET_PLANS',
 			plans: [
 				{
@@ -167,6 +168,7 @@ describe( 'getSupportedPlans', () => {
 		} );
 
 		expect( iter.next().value ).toEqual( {
+			locale: 'en',
 			type: 'SET_FEATURES',
 			features: {
 				'custom-domain': {
@@ -187,6 +189,7 @@ describe( 'getSupportedPlans', () => {
 		} );
 
 		expect( iter.next().value ).toEqual( {
+			locale: 'en',
 			type: 'SET_FEATURES_BY_TYPE',
 			featuresByType: [
 				{ id: 'general', name: null, features: [ 'custom-domain', 'other-feature' ] },

--- a/packages/plans-grid/src/plans-details/index.tsx
+++ b/packages/plans-grid/src/plans-details/index.tsx
@@ -43,8 +43,8 @@ const PlansDetails: React.FunctionComponent< Props > = ( { onSelect, locale, bil
 		return {
 			supportedPlans,
 			planProducts,
-			features: getFeatures(),
-			featuresByType: getFeaturesByType(),
+			features: getFeatures( locale ),
+			featuresByType: getFeaturesByType( locale ),
 		};
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Recently we started passing the `locale` to the plans endpoints (#47227). This is a fine change. But it makes the assumption that you'll call the resolver with the same locale across the entire session. Because the reducer isn't aware of the locale.

Consider:
1. First call to `getSupportedPlans(en)`, this triggers the resolver, fetches the English plans, caches them, and sets the state.
2. Second call to `getSupportedPlans(de)`, this triggers the resolver, fetches the German plans, caches them, and sets the state.
3. Third call to `getSupportedPlans(en)`, this doesn't trigger the resolver. Because the store assumes the result of`getSupportedPlans(en)` is cached. So it returns the same state as is (the one overwritten by the previous call). Giving you German plans even when you passed an English locale.

The solution is keep track of the locale in the reducer, too.

This doesn't change the API of `getSupportedPlans`. But it does change the API of `getFeatures` and `getFeaturesByType`. I updated all the references to the new design.

#### Testing instructions
1. Visit /new.
2. Switch the language to English -> Any other language -> English.
3. All transitions should be work as expected.

Partially fixes #49677
