### PR TITLE
Plans Grid: Remove maxMonthlyDiscountPercentage fallback value

### DIFF
--- a/packages/plans-grid/src/plans-interval-toggle/index.tsx
+++ b/packages/plans-grid/src/plans-interval-toggle/index.tsx
@@ -96,7 +96,7 @@ const PlansIntervalToggle: React.FunctionComponent< PlansIntervalToggleProps > =
 									'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',
 									__i18n_text_domain__
 								),
-								{ maxDiscount: maxMonthlyDiscountPercentage ?? 0 }
+								{ maxDiscount: maxMonthlyDiscountPercentage }
 							) }
 						</PopupMessages>
 					) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As commented in https://github.com/Automattic/wp-calypso/pull/48963#discussion_r570397661, this PR removes the fallback value for `maxMonthlyDiscountPercentage`, since that variable is guaranteed to be defined

#### Testing instructions

- Check that there are not TypeScript errors in `packages/plans-grid/src/plans-interval-toggle/index.tsx`
- In gutenboarding ([`/new`](https://hash-3ccbb6335df876efe323f59423694afa9934269f.calypso.live/new)), navigate to the plans step and smoke test the "monthly"/"annually" plans toggle. When selecting monthly, a tooltip should appear, showing some text (which includes the `maxMonthlyDiscountPercentage` variable)

Related to #48963 
