### PR TITLE
Show close icon when Help FAB is open

### DIFF
--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -154,7 +154,7 @@ class InlineHelp extends Component {
 					title={ translate( 'Help' ) }
 					ref={ this.inlineHelpToggleRef }
 				>
-					<Gridicon icon="help" size={ 48 } />
+					<Gridicon icon={isPopoverVisible ? 'cross' : 'help'} size={ 48 } />
 				</Button>
 				{ isPopoverVisible && (
 					<InlineHelpPopover


### PR DESCRIPTION
Show "close" icon when help FAB is open, making it more clear that re-clicking it closes it:

Closed:

<img width="83" alt="image" src="https://user-images.githubusercontent.com/87168/107033983-bbf86f00-67be-11eb-89e6-eb3b004a8dd4.png">


Open, before:

<img width="395" alt="Screenshot 2021-02-05 at 14 22 50" src="https://user-images.githubusercontent.com/87168/107033944-b1d67080-67be-11eb-8e73-6f2e4a0ed8b9.png">
#### Changes proposed in this Pull Request

Open, after:

<img width="341" alt="Screenshot 2021-02-05 at 14 51 55" src="https://user-images.githubusercontent.com/87168/107036219-eef03200-67c1-11eb-9b7f-6bb332f06bd0.png">


#### Testing instructions


* Open Calypso and try help FAB in different screensizes
