### PR TITLE
Focused Launch - Summary View: Fix launch button's size (to contain the copy in verbose languages)

### DIFF
--- a/packages/launch/src/focused-launch/summary/style.scss
+++ b/packages/launch/src/focused-launch/summary/style.scss
@@ -192,7 +192,7 @@ $commentary-column-gap-wide: 100px;
 	}
 
 	.focused-launch-summary__launch-button {
-		flex: 1;
+		flex-grow: 1;
 	}
 
 	@include break-small {

--- a/packages/launch/src/focused-launch/summary/style.scss
+++ b/packages/launch/src/focused-launch/summary/style.scss
@@ -152,19 +152,22 @@ $commentary-column-gap-wide: 100px;
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
+		gap: 20px;
+		flex-wrap: wrap-reverse;
 	}
 
 	@include break-medium {
 		flex-direction: column-reverse;
 		align-items: flex-start;
-		gap: 20px;
 		width: calc( 100% - #{$commentary-column-width-medium + $commentary-column-gap-small} );
+		flex-wrap: nowrap;
 	}
 
 	@include break-large {
 		flex-direction: row;
 		align-items: center;
 		width: calc( 100% - #{$commentary-column-width-large + $commentary-column-gap-large} );
+		flex-wrap: wrap-reverse;
 	}
 
 	@include break-wide {
@@ -178,6 +181,7 @@ $commentary-column-gap-wide: 100px;
 
 	@include break-small {
 		margin-bottom: 0;
+		flex-shrink: 0;
 	}
 
 	> * {

--- a/packages/launch/src/focused-launch/summary/style.scss
+++ b/packages/launch/src/focused-launch/summary/style.scss
@@ -193,10 +193,6 @@ $commentary-column-gap-wide: 100px;
 
 	.focused-launch-summary__launch-button {
 		flex: 1;
-
-		@include break-small {
-			flex: 0;
-		}
 	}
 
 	@include break-small {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The launch button is too narrow for its copy. This happens with more verbose languages like German in particular. Since there is plenty of screen estate left, we're able to let the button grow to a size where the copy fits. 

#### Technical Changes

* Remove `flex: 0;` from `.focused-launch-summary__launch-button` on breakpoints `> small`.

#### Testing instructions

#### Focused Launch

1. Make sure that you switch to a more verbose language (e.g. German or Dutch).
2. Go to `/page/[UNLAUNCHED_SITE_ID].wordpress.com/home?flags=create/focused-launch-flow`.
3. Click "Launch" to open the Focused Launch flow.
4. Ensure that:
    * [ ] The copy fits inside the launch button.
5. Open DevTools and scale the page.
6. Ensure that the launch button:
    * [ ] is 100% on small viewports.
    * [ ] scales properly on viewports `>mobile`.
    * [ ] the copy fits.

#### Step-by-Step Launch

1. Make sure that you switch to a more verbose language (e.g. German or Dutch).
2. Go to `/page/[UNLAUNCHED_SITE_ID].wordpress.com/home?flags=create/focused-launch-flow`.
3. Click "Launch" to open the Focused Launch flow.
4. Ensure that:
    * [ ] Everything looks the same as on production.
5. Open DevTools and scale the page.
6. Ensure that:
    * [ ] Everything looks the same as on production.

Part of #49635
