### PR TITLE
Fix missing draft button when site is unlaunched.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/styles.scss
@@ -1,9 +1,5 @@
 // Added to body to allow general overrides
 .editor-gutenberg-launch__fse-overrides {
-	.editor-post-switch-to-draft {
-		display: none;
-	}
-
 	// Override 'Save' button to have tertiary styles.
 	.edit-post-header__settings {
 		.editor-post-publish-button__button {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The draft button should be displayed even when site is unlaunched.
See https://github.com/Automattic/wp-calypso/issues/49358 for more information.

#### Testing instructions

**Setup**
1. Run `yarn dev --sync` on `apps\editing-tookit`
2. Create a new site. DON'T launch the site.
3. Sandbox the site.

**Test**
1. Edit a post. The headers button should be: **Switch to Draft  | Preview | Update | Launch**.
2. Launch the site.
3. Edit a post. The header buttons should be: **Switch to Draft | Preview | Update**.
4. Navigate to **Settings > General > Privacy**, and put back the site into **Coming Soon**.
5. Edit a post. The header buttons should be: **Switch to Draft | Preview | Update | Update Site Visibility**. 

Fixes https://github.com/Automattic/wp-calypso/issues/49358