### PR TITLE
Inline Help: Display Close Icon when Open

### DIFF
--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -154,7 +154,7 @@ class InlineHelp extends Component {
 					title={ translate( 'Help' ) }
 					ref={ this.inlineHelpToggleRef }
 				>
-					<Gridicon icon="help" size={ 48 } />
+					<Gridicon icon={ ! isPopoverVisible ? 'help' : 'cross-circle' } size={ 48 } />
 				</Button>
 				{ isPopoverVisible && (
 					<InlineHelpPopover


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switches the Gridicon to one that symbolises "Close" when Inline Help is open 

#### Testing instructions

1. Open Inline Help 
2. Verify the usual **?** turns into an **X**, and turns back when closed

This should also work fine in all colour schemes!

<img width="404" alt="Screenshot 2021-02-05 at 14 45 45" src="https://user-images.githubusercontent.com/43215253/107048854-4d68e080-67c1-11eb-9097-9305a0f255ef.png">


Fixes #49764
cc @simison 
