### PR TITLE
Load the Portal navigation asynchonously to avoid an unnecessary bump in initial entrypoint bundle size

### DIFF
--- a/client/components/jetpack/masterbar/index.jsx
+++ b/client/components/jetpack/masterbar/index.jsx
@@ -17,7 +17,7 @@ import Masterbar from 'calypso/layout/masterbar/masterbar';
 import ProfileDropdown from 'calypso/components/jetpack/profile-dropdown';
 import { useBreakpoint } from '@automattic/viewport-react';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
-import PortalNav from 'calypso/components/jetpack/portal-nav';
+import AsyncLoad from 'calypso/components/async-load';
 
 /**
  * Style dependencies
@@ -58,7 +58,7 @@ const JetpackCloudMasterBar = () => {
 			>
 				<JetpackLogo size={ 28 } full={ ! isNarrow || isExteriorPage } />
 			</Item>
-			<PortalNav />
+			<AsyncLoad require="calypso/components/jetpack/portal-nav" placeholder={ null } />
 			<Item className="masterbar__item-title">{ headerTitle }</Item>
 			<Item
 				tipTarget="me"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Load the Portal navigation in an async manner as it is unnecessary to load it synchronously.

#### Testing instructions

* Please contact Infinity to be granted a partner key in order to test the visibility of the navigation or edit the component manually.

 ![Screenshot 2021-01-12 at 21 44 21](https://user-images.githubusercontent.com/22746396/104366096-8777f700-5521-11eb-9aaf-4ca8fc377a07.png)

Related to https://github.com/Automattic/wp-calypso/pull/48827/files#r569416661
