### PR TITLE
Intent capture: dont set value needlessly in intent capture field

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/acquire-intent-text-input/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/acquire-intent-text-input/index.tsx
@@ -37,7 +37,7 @@ const canvasContext = textSizingCanvas.getContext( '2d' ) as CanvasRenderingCont
  * @param element The input element
  */
 function getTextWidth( text: string, element: HTMLInputElement | undefined ) {
-	if ( ! element ) {
+	if ( ! element || ! text ) {
 		return 0;
 	}
 	const computedCSS = window.getComputedStyle( element );
@@ -81,7 +81,7 @@ const AcquireIntentTextInput: React.FunctionComponent< Props > = ( {
 				autoCorrect="off"
 				onChange={ handleChange }
 				spellCheck={ false }
-				value={ value }
+				defaultValue={ value }
 				onFocus={ onFocus }
 				onBlur={ onBlur }
 				onKeyDown={ onKeyDown }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/acquire-intent-text-input/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/acquire-intent-text-input/index.tsx
@@ -27,7 +27,8 @@ interface Props {
  * This is needed for the underline width.
  */
 const textSizingCanvas = document.createElement( 'canvas' );
-textSizingCanvas.width = textSizingCanvas.height = 2000;
+textSizingCanvas.width = 2000;
+textSizingCanvas.height = 100;
 const canvasContext = textSizingCanvas.getContext( '2d' ) as CanvasRenderingContext2D;
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* It seems setting the value field is really slowing things down in the intent capture field. And there is no reason to set it. This removes React out of the picture and hands things over to the browser. 
* If someone is curious, I'd appreciate an investigation why setting `.value` is slow. I found out it's slow by using the Audit tab in Safari dev tools. But I couldn't find why it is slow (didn't dig deep). But I suspect it's a React issue.
* The canvas issue is just a small optimization that didn't make much (any?) difference. 

#### Testing instructions

1. On iOS (or BrowerStack - iOS), go to https://hash-ec0c98c8230c9cabc293c75d726f13a326b4d0b8.calypso.live/new. 
2. Typing your site title should be snappy.


Related to p1612484493135700-slack-CRNF6A9DX