### PR TITLE
Anchor Gutenboarding: Listen for "site" and "post" params

### DIFF
--- a/client/landing/gutenboarding/hooks/use-detect-matching-anchor-site.ts
+++ b/client/landing/gutenboarding/hooks/use-detect-matching-anchor-site.ts
@@ -20,7 +20,13 @@ interface AnchorEndpointResult {
 // see if there's already a site that belongs to me that matches these parameters.
 // If it's found, redirect the browser to it
 export default function useDetectMatchingAnchorSite(): boolean {
-	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyUrl } = useAnchorFmParams();
+	const {
+		anchorFmPodcastId,
+		anchorFmEpisodeId,
+		anchorFmSpotifyUrl,
+		anchorFmSite,
+		anchorFmPost,
+	} = useAnchorFmParams();
 	const isAnchorFm = useIsAnchorFm();
 	const currentUserExists = useSelect( ( select ) => !! select( USER_STORE ).getCurrentUser() );
 	const [ isLoading, setIsLoading ] = React.useState( !! ( isAnchorFm && currentUserExists ) );
@@ -35,7 +41,13 @@ export default function useDetectMatchingAnchorSite(): boolean {
 		setIsLoading( true );
 		wpcom
 			.undocumented()
-			.getMatchingAnchorSite( anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyUrl )
+			.getMatchingAnchorSite(
+				anchorFmPodcastId,
+				anchorFmEpisodeId,
+				anchorFmSpotifyUrl,
+				anchorFmSite,
+				anchorFmPost
+			)
 			.then( ( result: AnchorEndpointResult ) => {
 				if ( result?.location ) {
 					window.location.href = result.location;
@@ -46,6 +58,14 @@ export default function useDetectMatchingAnchorSite(): boolean {
 			.catch( () => {
 				setIsLoading( false );
 			} );
-	}, [ isAnchorFm, currentUserExists, anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyUrl ] );
+	}, [
+		isAnchorFm,
+		currentUserExists,
+		anchorFmPodcastId,
+		anchorFmEpisodeId,
+		anchorFmSpotifyUrl,
+		anchorFmSite,
+		anchorFmPost,
+	] );
 	return isLoading;
 }

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -54,6 +54,8 @@ export interface GutenLocationStateType {
 	anchorFmPodcastId?: string;
 	anchorFmEpisodeId?: string;
 	anchorFmSpotifyUrl?: string;
+	anchorFmSite?: string;
+	anchorFmPost?: string;
 }
 export type GutenLocationStateKeyType = keyof GutenLocationStateType;
 
@@ -127,6 +129,8 @@ export interface AnchorFmParams {
 	anchorFmPodcastId: string | null;
 	anchorFmEpisodeId: string | null;
 	anchorFmSpotifyUrl: string | null;
+	anchorFmSite: string | null;
+	anchorFmPost: string | null;
 }
 export function useAnchorFmParams(): AnchorFmParams {
 	const sanitizePodcast = ( id: string ) => id.replace( /[^a-zA-Z0-9]/g, '' );
@@ -157,10 +161,28 @@ export function useAnchorFmParams(): AnchorFmParams {
 		sanitize: sanitizeShowUrl,
 	} );
 
+	// "site" and "post" are strings consisting of digits only. Example URL:
+	// http://wordpress.com/new?site=181129564&post=5&anchor_podcast=22b6608
+	// We store them as strings for consistency with the other param types
+	// and simplicity in code and type signatures.
+	const sanitizeNumberParam = ( id: string ) => id.replace( /^\D+$/g, '' );
+	const anchorFmSite = useAnchorParameter( {
+		queryParamName: 'site',
+		locationStateParamName: 'anchorFmSite',
+		sanitize: sanitizeNumberParam,
+	} );
+	const anchorFmPost = useAnchorParameter( {
+		queryParamName: 'post',
+		locationStateParamName: 'anchorFmPost',
+		sanitize: sanitizeNumberParam,
+	} );
+
 	return {
 		anchorFmPodcastId,
 		anchorFmEpisodeId,
 		anchorFmSpotifyUrl,
+		anchorFmSite,
+		anchorFmPost,
 	};
 }
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2633,6 +2633,8 @@ Undocumented.prototype.getJetpackPartnerPortalPartner = function () {
  * @param anchorFmPodcastId {string | null}  Example: 22b6608
  * @param anchorFmEpisodeId {string | null}  Example: e324a06c-3148-43a4-85d8-34c0d8222138
  * @param anchorFmSpotifyUrl {string | null} Example: https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q
+ * @param anchorFmSite {string | null} Example: 181129564
+ * @param anchorFmPost {string | null} Example: 5
  * @returns {Promise} A promise
  *    The promise should resolve to a json object containing ".location" key as {string|false} type.
  *    False - There were no matching sites detected, the user should create a new one.
@@ -2641,12 +2643,16 @@ Undocumented.prototype.getJetpackPartnerPortalPartner = function () {
 Undocumented.prototype.getMatchingAnchorSite = function (
 	anchorFmPodcastId,
 	anchorFmEpisodeId,
-	anchorFmSpotifyUrl
+	anchorFmSpotifyUrl,
+	anchorFmSite,
+	anchorFmPost
 ) {
 	const queryParts = {
 		podcast: anchorFmPodcastId,
 		episode: anchorFmEpisodeId,
 		spotify_url: anchorFmSpotifyUrl,
+		site: anchorFmSite,
+		post: anchorFmPost,
 	};
 	return this.wpcom.req.get(
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Anchor Gutenboarding, which is the `/new?anchor_podcast=12345a6` type of URL, will now listen for `site` and `post` params.
  * Example url: http://calypso.localhost:3000/new?site=181129564&post=5&anchor_podcast=22b6608

#### Testing instructions (New Functionality)

* Gather a `site_id` that belongs to you, and a `post_id` that belongs to that blog.
* Edit this url and insert your `site` and `post` ids: `http://calypso.localhost:3000/new?site=181129564&post=5&anchor_podcast=22b6608`
* Visting this URL should redirect you to editing that post (And insert a Spotify badge if `&spotify_url=XYZ` is added to the original url, provided XYZ is replaced with a a valid spotify url like `https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q`)

#### Testing Instructions (Old Functionality)

The testing instructions from https://github.com/Automattic/wp-calypso/pull/49571 should continue to work (Different style /new urls without `site` and `post` bring you to gutenboarding to make a new anchor site, or to edit an existing site)