### PR TITLE
What's New: fix store issues related to missing function

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/store.js
@@ -1,36 +1,34 @@
 /**
  * External dependencies
  */
-import { createReduxStore, register } from '@wordpress/data';
+import { registerStore } from '@wordpress/data';
 
 const DEFAULT_STATE = {
 	whatsNew: false,
 };
 
 const actions = {
-	toggleWhatsNew() {
-		return {
-			type: 'TOGGLE_FEATURE',
-		};
-	},
+	toggleWhatsNew: () => ( {
+		type: 'TOGGLE_FEATURE',
+	} ),
 };
 
-const store = createReduxStore( 'whats-new', {
-	reducer( state = DEFAULT_STATE, action ) {
-		switch ( action.type ) {
-			case 'TOGGLE_FEATURE':
-				return {
-					whatsNew: ! state.whatsNew,
-				};
-		}
-		return state;
-	},
-	actions,
-	selectors: {
-		isWhatsNewActive( state ) {
-			return state.whatsNew;
-		},
-	},
-} );
+const selectors = {
+	isWhatsNewActive: ( state ) => state.whatsNew,
+};
 
-register( store );
+function reducer( state = DEFAULT_STATE, action ) {
+	switch ( action.type ) {
+		case 'TOGGLE_FEATURE':
+			return {
+				whatsNew: ! state.whatsNew,
+			};
+	}
+	return state;
+}
+
+registerStore( 'automattic/whats-new', {
+	reducer,
+	actions,
+	selectors,
+} );

--- a/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
@@ -20,23 +20,21 @@ const dragDropImage = 'https://s0.wp.com/i/whats-new/drag-drop.png';
 const singlePageSiteImage = 'https://s0.wp.com/i/whats-new/single-page-website.png';
 
 function WhatsNewMenuItem() {
-	const { toggleWhatsNew } = useDispatch( 'whats-new' );
-	const isActive = useSelect( ( select ) => select( 'whats-new' ).isWhatsNewActive() );
+	const { toggleWhatsNew } = useDispatch( 'automattic/whats-new' );
+	const isActive = useSelect( ( select ) => select( 'automattic/whats-new' ).isWhatsNewActive() );
 	const whatsNewPages = getWhatsNewPages();
 
 	// Record Tracks event if user opens What's New
 	useEffect( () => {
 		if ( isActive ) {
-			recordTracksEvent( 'block_editor_whats_new_open' );
+			recordTracksEvent( 'calypso_block_editor_whats_new_open' );
 		}
 	}, [ isActive ] );
 
 	return (
 		<>
 			<Fill name="ToolsMoreMenuGroup">
-				<MenuItem onClick={ () => toggleWhatsNew() }>
-					{ __( "What's new", 'full-site-editing' ) }
-				</MenuItem>
+				<MenuItem onClick={ toggleWhatsNew }>{ __( "What's new", 'full-site-editing' ) }</MenuItem>
 			</Fill>
 			{ isActive && (
 				<Guide
@@ -136,7 +134,7 @@ function WhatsNewPage( {
 	imgSrc,
 } ) {
 	useEffect( () => {
-		recordTracksEvent( 'block_editor_whats_new_slide_view', {
+		recordTracksEvent( 'calypso_block_editor_whats_new_slide_view', {
 			slide_number: pageNumber,
 			is_last_slide: isLastPage,
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
`createReduxStore` is apparently not available in WordPress 5.6, just in the latest Gutenberg plugin. Therefore, it will be incompatible with Atomic sites not running the latest Gutenberg plugin version. This updates to use the more frequently used `registerStore` function. I also tweaked a few other things:

1. Added a store namespace
2. separated the store components into separate variables
3. Fixed the broken tracks events (they had to be prefixed with `calypso_` for some reason.)

#### Testing instructions
1. Whats new should work exactly the same on simple sites.
2. Whats new should now start to work on Atomic sites without the Gutenberg plugin.

We uncovered this issue testing #49778. Thanks @dkoo!

Also, my apologies @donlair, I should have tested on Atomic before approving your PR, and payed better attention to the JS error log! I didn't know that this would be an issue.
