### PR TITLE
E2E: Enable /new onboarding canary test

### DIFF
--- a/test/e2e/lib/pages/gutenboarding/design-selector-page.js
+++ b/test/e2e/lib/pages/gutenboarding/design-selector-page.js
@@ -18,11 +18,11 @@ export default class DesignSelectorPage extends AsyncBaseContainer {
 
 	async selectFreeDesign() {
 		const freeOptions = await this.driver.findElements( this.freeOptionSelector );
-		freeOptions[ dataHelper.getRandomInt( 0, freeOptions.length - 1 ) ].click();
+		await freeOptions[ dataHelper.getRandomInt( 0, freeOptions.length - 1 ) ].click();
 	}
 
 	async selectPaidDesign() {
 		const paidOptions = await this.driver.findElements( this.paidOptionSelector );
-		paidOptions[ dataHelper.getRandomInt( 0, paidOptions.length - 1 ) ].click();
+		await paidOptions[ dataHelper.getRandomInt( 0, paidOptions.length - 1 ) ].click();
 	}
 }

--- a/test/e2e/lib/pages/gutenboarding/style-preview-page.js
+++ b/test/e2e/lib/pages/gutenboarding/style-preview-page.js
@@ -21,14 +21,25 @@ export default class StylePreviewPage extends AsyncBaseContainer {
 	}
 
 	async selectFontPairing( fontIndex ) {
-		const fontOptions = await this.driver.findElements(
-			By.css( 'button.style-preview__font-option' )
-		);
+		let fontOptions;
+		if ( this.screenSize === 'MOBILE' ) {
+			const mobileExpandFontOptionsButton = By.css(
+				'.style-preview__font-options-mobile .style-preview__font-option-select'
+			);
+			await driverHelper.clickWhenClickable( this.driver, mobileExpandFontOptionsButton );
+			fontOptions = await this.driver.findElements(
+				By.css( '.style-preview__font-options-mobile button.style-preview__font-option' )
+			);
+		} else {
+			fontOptions = await this.driver.findElements(
+				By.css( '.style-preview__font-options-desktop button.style-preview__font-option' )
+			);
+		}
 
 		if ( fontIndex === undefined ) {
 			fontIndex = dataHelper.getRandomInt( 0, fontOptions.length - 1 );
 		}
 
-		fontOptions[ fontIndex ].click();
+		await fontOptions[ fontIndex ].click();
 	}
 }

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -36,7 +36,7 @@ before( async function () {
 
 describe( 'Gutenboarding: (' + screenSize + ')', function () {
 	this.timeout( mochaTimeOut );
-	describe.skip( 'Create new site as existing user @parallel @canary', function () {
+	describe( 'Create new site as existing user @parallel @canary', function () {
 		const siteTitle = dataHelper.randomPhrase();
 		const domainQuery = dataHelper.randomPhrase();
 		let newSiteDomain = '';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Enable the test that was previously disabled in #49366 after fixing mobile issues:
* In application: Intent capture step was fixed in #49772. See demos:
  * Before: https://cloudup.com/cM37We3g8pp
  * After: https://cloudup.com/cM37We3g8pp
* In tests: style picker selection needs specific selectors on mobile (see: https://cloudup.com/cddVizoew-o)

#### Testing instructions
* `wp-gutenboarding-spec` should pass

Related to #49466
