### PR TITLE
Fix anchor backend errors when visiting gutenboarding

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2654,6 +2654,11 @@ Undocumented.prototype.getMatchingAnchorSite = function (
 		site: anchorFmSite,
 		post: anchorFmPost,
 	};
+	Object.keys( queryParts ).forEach( ( k ) => {
+		if ( queryParts[ k ] === null ) {
+			delete queryParts[ k ];
+		}
+	} );
 	return this.wpcom.req.get(
 		{
 			path: '/anchor',


### PR DESCRIPTION
https://public-api.wordpress.com/wpcom/v2/anchor?_envelope=1&podcast=22b6608&episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q&site=&post=

Creates errors like

"site is not of type number" and "post is not of type number"

#### Changes proposed in this Pull Request

* getMatchingAnchorSite doesn't include query params that have null as their values

#### Testing instructions


* Use the magic URL to create a site for this podcast if you haven't already: https://calypso.localhost:3000/new?&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q&flags=anchor-fm-dev
* When you visit it a second time while logged in, it should redirect you to that site instead of asking you for a site title again.

Introduced by https://github.com/Automattic/wp-calypso/pull/49777