### PR TITLE
Contact: Add 2021 holiday closure notices

### DIFF
--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -22,7 +22,7 @@ class PrimaryHeader extends Component {
 				<ClosureNotice
 					displayAt="2021-03-28 00:00Z"
 					closesAt="2021-04-04 00:00Z"
-					reopensAt="2021-04-05 07:00Z"
+					reopensAt="2021-04-05 06:00Z"
 					holidayName="Easter"
 				/>
 				<ClosureNotice

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -20,7 +20,7 @@ class PrimaryHeader extends Component {
 		return (
 			<Fragment>
 				<ClosureNotice
-					displayAt="2021-03-28 0:00Z"
+					displayAt="2021-03-28 00:00Z"
 					closesAt="2021-04-04 00:00Z"
 					reopensAt="2021-04-05 07:00Z"
 					holidayName="Easter"

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -20,15 +20,21 @@ class PrimaryHeader extends Component {
 		return (
 			<Fragment>
 				<ClosureNotice
-					displayAt="2020-12-17 00:00Z"
-					closesAt="2020-12-24 00:00Z"
-					reopensAt="2020-12-26 07:00Z"
+					displayAt="2021-03-28 0:00Z"
+					closesAt="2021-04-04 00:00Z"
+					reopensAt="2021-04-05 07:00Z"
+					holidayName="Easter"
+				/>
+				<ClosureNotice
+					displayAt="2021-12-17 00:00Z"
+					closesAt="2021-12-24 00:00Z"
+					reopensAt="2021-12-26 07:00Z"
 					holidayName="Christmas"
 				/>
 				<ClosureNotice
-					displayAt="2020-12-26 07:00Z"
-					closesAt="2020-12-31 00:00Z"
-					reopensAt="2021-01-02 07:00Z"
+					displayAt="2021-12-26 07:00Z"
+					closesAt="2021-12-31 00:00Z"
+					reopensAt="2022-01-02 07:00Z"
 					holidayName="New Year's Day"
 				/>
 				<Card>

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -609,18 +609,25 @@ class HelpContact extends React.Component {
 				{ isUserAffectedByLiveChatClosure && (
 					<>
 						<ChatHolidayClosureNotice
+							holidayName="Easter"
+							compact={ compact }
+							displayAt="2021-03-28 00:00Z"
+							closesAt="2021-04-04 00:00Z"
+							reopensAt="2021-04-05 07:00Z"
+						/>
+						<ChatHolidayClosureNotice
 							holidayName="Christmas"
 							compact={ compact }
-							displayAt="2020-12-17 00:00Z"
-							closesAt="2020-12-24 00:00Z"
-							reopensAt="2020-12-26 07:00Z"
+							displayAt="2021-12-17 00:00Z"
+							closesAt="2021-12-24 00:00Z"
+							reopensAt="2021-12-26 07:00Z"
 						/>
 						<ChatHolidayClosureNotice
 							holidayName="New Year's Day"
 							compact={ compact }
-							displayAt="2020-12-26 07:00Z"
-							closesAt="2020-12-31 00:00Z"
-							reopensAt="2021-01-02 07:00Z"
+							displayAt="2021-12-26 07:00Z"
+							closesAt="2021-12-31 00:00Z"
+							reopensAt="2022-01-02 07:00Z"
 						/>
 					</>
 				) }

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -613,7 +613,7 @@ class HelpContact extends React.Component {
 							compact={ compact }
 							displayAt="2021-03-28 00:00Z"
 							closesAt="2021-04-04 00:00Z"
-							reopensAt="2021-04-05 07:00Z"
+							reopensAt="2021-04-05 06:00Z"
 						/>
 						<ChatHolidayClosureNotice
 							holidayName="Christmas"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds notices to the Contact form prior to and during holiday chat closures for 2021.

Ref: pbg9X-fu5-p2

#### Testing instructions

Hop in your Delorean and push the pedal to 88mph because we're time-traveling!

(... Or open your system clock settings and get ready to adjust them :P)

Open both http://calypso.localhost:3000/help/contact and http://calypso.localhost:3000/me/concierge, and check the message at the top when you set your clock to the following times:

- **Now** — Nothing
- **March 28 0:00 UTC** — Pre-closure messages for Easter
- **April 4 0:00 UTC** — Closure messages for Easter
- **April 5 7:00 UTC** — Nothing
- **December 17 0:00 UTC** — Pre-closure messages for Christmas
- **December 24 0:00 UTC** — Closure messages for Christmas
- **December 26 7:00 UTC** — Pre-closure messages for New Year's Day
- **December 31 0:00 UTC** — Closure messages for New Year's Day
- **January 2, 2021 7:00 UTC** — Nothing
