### PR TITLE
Anchor Gutenboarding uses client side redirect and understands is_new_site param

### DIFF
--- a/client/landing/gutenboarding/hooks/use-detect-matching-anchor-site.ts
+++ b/client/landing/gutenboarding/hooks/use-detect-matching-anchor-site.ts
@@ -3,6 +3,7 @@
  */
 import * as React from 'react';
 import { useSelect } from '@wordpress/data';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -26,6 +27,7 @@ export default function useDetectMatchingAnchorSite(): boolean {
 		anchorFmSpotifyUrl,
 		anchorFmSite,
 		anchorFmPost,
+		anchorFmIsNewSite,
 	} = useAnchorFmParams();
 	const isAnchorFm = useIsAnchorFm();
 	const currentUserExists = useSelect( ( select ) => !! select( USER_STORE ).getCurrentUser() );
@@ -33,7 +35,7 @@ export default function useDetectMatchingAnchorSite(): boolean {
 
 	React.useEffect( () => {
 		// Must be a logged-in user on anchor FM to check
-		if ( ! isAnchorFm || ! currentUserExists ) {
+		if ( ! isAnchorFm || ! currentUserExists || anchorFmIsNewSite ) {
 			setIsLoading( false );
 			return;
 		}
@@ -50,7 +52,11 @@ export default function useDetectMatchingAnchorSite(): boolean {
 			)
 			.then( ( result: AnchorEndpointResult ) => {
 				if ( result?.location ) {
-					window.location.href = result.location;
+					try {
+						page( result.location );
+					} catch ( err ) {
+						window.location.href = result.location;
+					}
 				} else {
 					setIsLoading( false );
 				}
@@ -66,6 +72,7 @@ export default function useDetectMatchingAnchorSite(): boolean {
 		anchorFmSpotifyUrl,
 		anchorFmSite,
 		anchorFmPost,
+		anchorFmIsNewSite,
 	] );
 	return isLoading;
 }

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -178,8 +178,14 @@ export function useAnchorFmParams(): AnchorFmParams {
 		locationStateParamName: 'anchorFmPost',
 		sanitize: sanitizeNumberParam,
 	} );
+
+	// anchorFmIsNewSite:
 	// Indicates the backend has told us we need to make a new site and
 	// we don't need to query it anymore.
+	// If we start with "/new?anchor_podcast=abcdef0", the backend might say there's
+	// no matching site and redirect us to "/new?anchor_podcast=abcdef0&anchor_episode=1234-123456&anchor_is_new_site=true",
+	// because it found the last episode and wanted to pass that information to us.
+	// In this case, we don't need to ask the backend again after restarting gutenboarding.
 	const anchorFmIsNewSite = useAnchorParameter( {
 		queryParamName: 'anchor_is_new_site',
 		locationStateParamName: 'anchorFmIsNewSite',

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -56,6 +56,7 @@ export interface GutenLocationStateType {
 	anchorFmSpotifyUrl?: string;
 	anchorFmSite?: string;
 	anchorFmPost?: string;
+	anchorFmIsNewSite?: string;
 }
 export type GutenLocationStateKeyType = keyof GutenLocationStateType;
 
@@ -131,6 +132,7 @@ export interface AnchorFmParams {
 	anchorFmSpotifyUrl: string | null;
 	anchorFmSite: string | null;
 	anchorFmPost: string | null;
+	anchorFmIsNewSite: string | null;
 }
 export function useAnchorFmParams(): AnchorFmParams {
 	const sanitizePodcast = ( id: string ) => id.replace( /[^a-zA-Z0-9]/g, '' );
@@ -176,6 +178,13 @@ export function useAnchorFmParams(): AnchorFmParams {
 		locationStateParamName: 'anchorFmPost',
 		sanitize: sanitizeNumberParam,
 	} );
+	// Indicates the backend has told us we need to make a new site and
+	// we don't need to query it anymore.
+	const anchorFmIsNewSite = useAnchorParameter( {
+		queryParamName: 'anchor_is_new_site',
+		locationStateParamName: 'anchorFmIsNewSite',
+		sanitize: sanitizeNumberParam,
+	} );
 
 	return {
 		anchorFmPodcastId,
@@ -183,6 +192,7 @@ export function useAnchorFmParams(): AnchorFmParams {
 		anchorFmSpotifyUrl,
 		anchorFmSite,
 		anchorFmPost,
+		anchorFmIsNewSite,
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When `use-detect-matching-anchor-site.ts` finds a URL from the anchor backend, it uses a client side redirect using `page()` instead of a `window.location` based redirect.
* Add `anchorFmIsNewSite` variable controlled by `anchor_is_new_site` in query string.  If present, do not ask the backend for matching sites when starting anchor gutenboarding.

#### Testing instructions

* Apply D56604-code
* Magic URLs without episode_ids: First time visiting them on a new account, you should make a site, second time, you should be redirected to that site.  The site should be able to pull the episode information.
  * http://calypso.localhost:3000/new?&anchor_podcast=22b6608&spotify_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q&flags=anchor-fm-dev
