### PR TITLE
ETK: update to v2.18

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.17
+ * Version: 2.18
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'A8C_ETK_PLUGIN_VERSION', '2.17' );
+define( 'A8C_ETK_PLUGIN_VERSION', '2.18' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.5
 Tested up to: 5.6
-Stable tag: 2.17
+Stable tag: 2.18
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,12 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.18 =
+* Introduces a "What's New" dialogue for the editor. (https://github.com/Automattic/wp-calypso/pull/48722)
+* Updates newspack blocks to v1.20, fixing issues with AMP and "specific posts" mode. (https://github.com/Automattic/wp-calypso/pull/49778)
+* Fix issues in the plan selector. (https://github.com/Automattic/wp-calypso/pull/49523)
+* Improve translations in site launch and onboarding. (https://github.com/Automattic/wp-calypso/pull/47947)
 
 = 2.17 =
 * WelcomeTour: capture mousedown event and call preventDefault on the event (https://github.com/Automattic/wp-calypso/pull/49583)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.17.0",
+	"version": "2.18.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
_Note: planning to deploy this on Monday (feb 8)_

#### Changes proposed in this Pull Request
Includes the following PRs:
- https://github.com/Automattic/wp-calypso/pull/49812
- https://github.com/Automattic/wp-calypso/pull/49489
- https://github.com/Automattic/wp-calypso/pull/49745
- https://github.com/Automattic/wp-calypso/pull/49695
- https://github.com/Automattic/wp-calypso/pull/49692
- https://github.com/Automattic/wp-calypso/pull/49778
- https://github.com/Automattic/wp-calypso/pull/49780
- https://github.com/Automattic/wp-calypso/pull/49740
- https://github.com/Automattic/wp-calypso/pull/48722
- https://github.com/Automattic/wp-calypso/pull/49523
- https://github.com/Automattic/wp-calypso/pull/47947

#### Testing instructions
- [x] Test that "what's new" works on simple and atomic
- [x] Test that the newspack block update works on simple and atomic
- [x] Test version constant change and PHPCS fixes
- [x] Test the focused launch fixes (cc @ciampo, @StefanNieuwenhuis)
- [x] Test the new localized URL (cc @StefanNieuwenhuis, @razvanpapadopol)
- [x] Test the ETK-related string extraction (cc @ciampo, @StefanNieuwenhuis)
- [x] Test Hide Featured category from being registered for patterns and layouts (cc @andrewserong )
- [x] Test the removal of the WooCommerce demo notice from coming soon sites (cc @ramonjd )
- [x] Test the update to the most recent version of color palette to ETK (cc @porada )