### PR TITLE
Gutenboarding: reinstate Doyle design

### DIFF
--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -77,7 +77,7 @@
 				"base": "Fira Sans"
 			},
 			"categories": [ "featured", "business" ],
-			"is_premium": true,
+			"is_premium": false,
 			"features": []
 		},
 		{

--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -68,6 +68,19 @@
 			"features": []
 		},
 		{
+			"title": "Doyle",
+			"slug": "doyle",
+			"template": "doyle",
+			"theme": "alves",
+			"fonts": {
+				"headings": "Playfair Display",
+				"base": "Fira Sans"
+			},
+			"categories": [ "featured", "business" ],
+			"is_premium": true,
+			"features": []
+		},
+		{
 			"title": "Bowen",
 			"slug": "bowen",
 			"template": "bowen",


### PR DESCRIPTION
#### Screenshot

![image](https://user-images.githubusercontent.com/14988353/107310713-10faf480-6ae1-11eb-99b6-0ac97979d665.png)

#### Changes proposed in this Pull Request

* Revert #48723 to add the Doyle design back into the design selection screen of Gutenboarding now that https://github.com/Automattic/themes/issues/2976 is resolved.

#### Outstanding issues

* [x] ~Note there is still an issue with button alignment: (could be the same as the issue @ianstewart raised in: p1612550526184000/1612384721.081900-slack-C013QHLF28Y)~ Update: fixed in D56946-code and the underlying issue is logged in: https://github.com/WordPress/gutenberg/issues/28957

<!--
Screenshot of the preview from the font selection step:
![image](https://user-images.githubusercontent.com/14988353/107171646-6965bf80-6a17-11eb-99f7-e62245ae0d66.png)

This is set to be centred within the editor:
![image](https://user-images.githubusercontent.com/14988353/107171730-974b0400-6a17-11eb-9699-6dc4ca434d03.png)

And on the front end it renders as right-aligned:
![image](https://user-images.githubusercontent.com/14988353/107171773-af228800-6a17-11eb-9345-eb19bb18fa60.png)

* There is also an issue with button color for the Learn more button:
![image](https://user-images.githubusercontent.com/14988353/107171804-c8c3cf80-6a17-11eb-9054-890c85a0bcc4.png)
-->

~CC: @ianstewart should this one still be flagged as Premium?~ Update: confirmed that it is not to be flagged as premium, so I've updated this to be `is_premium: false`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new` and go to create a new site selecting the `Doyle` design
* Make sure that the design is rendering correctly in the preview in the font selection step
* Create a new site, and make sure the design is looking correct in the editor and on the front end of the site

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #