### PR TITLE
Don't show reviews count after store removal

### DIFF
--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -326,12 +326,12 @@ function mapStateToProps( state ) {
 	const hasProducts = getCountProducts( state ) > 0;
 	const isLoaded = areCountsLoaded( state );
 	const totalNewOrders = getCountNewOrders( state );
-	const totalPendingReviews = getCountPendingReviews( state );
 	const settingsGeneralLoaded = areSettingsGeneralLoaded( state, siteId );
 	const storeLocation = getStoreLocation( state, siteId );
 	const pluginsLoaded = arePluginsLoaded( state, siteId );
 	const allRequiredPluginsActive = areAllRequiredPluginsActive( state, siteId );
 	const isStoreRemoved = config.isEnabled( 'woocommerce/store-removed' );
+	const totalPendingReviews = isStoreRemoved ? 0 : getCountPendingReviews( state );
 	const shouldRedirectAfterInstall =
 		'' === get( getCurrentQueryArguments( state ), 'redirect_after_install' );
 


### PR DESCRIPTION
Fixes #49802 

This removed the reviews count if the store has been removed. Without this the link out icon incorrectly overlays the reviews count.

### Testing instructions

1. Add a pending review pending admin review to the store
2. Go to a store page with the store removed, eg `http://calypso.localhost:3000/store/becdetat202101281405.wpcomstaging.com?flags=woocommerce/store-removed`
3. The pending review counter should not be displayed next to the review menu item

![image](https://user-images.githubusercontent.com/224531/107171423-7af69980-6a0e-11eb-8ba1-82eecb131aa1.png)
