### PR TITLE
Only show store deprecation popover for business stores

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -751,13 +751,15 @@ export class MySitesSidebar extends Component {
 				forceInternalLink
 				className="sidebar__store"
 			>
-				<InfoPopover
-					className="sidebar__store-tooltip"
-					position="bottom right"
-					showOnHover={ true }
-				>
-					{ infoCopy }
-				</InfoPopover>
+				{ isBusiness( site.plan ) && (
+					<InfoPopover
+						className="sidebar__store-tooltip"
+						position="bottom right"
+						showOnHover={ true }
+					>
+						{ infoCopy }
+					</InfoPopover>
+				) }
 			</SidebarItem>
 		);
 	}


### PR DESCRIPTION
Fixes #49734 

This only shows the store deprecation popover/tooltip (shown in the Store menu item) if the store is a business store; e-commerce stores should not get the notice as they already redirect straight to wp-admin.

#### Testing instructions
1. In an e-commerce plan (select Store when selecting the site options) the tooltip should not be present
2. In a business plan the tooltip should be present