### PR TITLE
Deduplicate p-limit

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19894,14 +19894,7 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.0.2.tgz#1664e010af3cadc681baafd3e2a437be7b0fb5fe"
-  integrity sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==
-  dependencies:
-    p-try "^2.0.0"
-
-p-limit@^3.1.0:
+p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `p-limit` (done automatically with `npx yarn-deduplicate --packages p-limit`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> p-limit@3.0.2
< @automattic/wpcom-editing-toolkit@2.17.0 -> @wordpress/scripts@12.5.0 -> ... -> p-limit@3.0.2
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> p-limit@3.0.2
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> p-limit@3.0.2
< wp-calypso@0.17.0 -> webpack@5.13.0 -> ... -> p-limit@3.0.2
< wp-e2e-tests@0.0.1 -> mocha@8.1.3 -> ... -> p-limit@3.0.2
> @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> p-limit@3.1.0
> @automattic/wpcom-editing-toolkit@2.17.0 -> @wordpress/scripts@12.5.0 -> ... -> p-limit@3.1.0
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> p-limit@3.1.0
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> p-limit@3.1.0
> wp-calypso@0.17.0 -> webpack@5.13.0 -> ... -> p-limit@3.1.0
> wp-e2e-tests@0.0.1 -> mocha@8.1.3 -> ... -> p-limit@3.1.0
```