### PR TITLE
Focused Launch: Make the back button sticky in detailed steps

### DIFF
--- a/packages/launch/src/focused-launch/style.scss
+++ b/packages/launch/src/focused-launch/style.scss
@@ -1,6 +1,8 @@
 @import '~@wordpress/base-styles/mixins';
 @import '~@wordpress/base-styles/variables';
 @import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/z-index';
+@import '~@automattic/onboarding/styles/variables';
 
 body.is-focused-launch-complete .editor-gutenberg-launch__launch-button {
 	display: none;
@@ -17,13 +19,35 @@ body.is-focused-launch-complete .editor-gutenberg-launch__launch-button {
 }
 
 .focused-launch-details__back-button-wrapper {
-	margin-bottom: 24px;
-	background-color: #fff;
-	padding: 0 10px;
-	position: -webkit-sticky;
-	position: sticky;
-	top: 60px;
-	z-index: 1;
+	// The result of padding + marging:
+	// - the wrapper adds 12px of white space above and below the button text
+	// - negative margin top makes up for the padding (12px - 12px = 0px)
+	// - on the bottom, margin and padding sum together (12px + 12px = 24px)
+	padding: 12px 0;
+	margin: -12px 0 12px;
+
+	@supports ( position: sticky ) {
+		// Position sticky with a z-index high enough to stay on top of the header
+		position: sticky;
+		z-index: z-index( '.components-modal__header' ) + 1;
+
+		background: #fff;
+		top: $onboarding-header-height;
+
+		@include break-medium {
+			// top + translateY to vertically center the button in the modal header
+			top: $onboarding-header-height / 2;
+			transform: translateY( -50% );
+			// Necessary to avoid the button to overlap the WP logo in the modal header
+			background: none;
+			padding-left: 24px;
+		}
+
+		@include break-large {
+			// Padding left not needed anymore for large screens
+			padding-left: 0;
+		}
+	}
 }
 
 .focused-launch-details__header {

--- a/packages/launch/src/focused-launch/style.scss
+++ b/packages/launch/src/focused-launch/style.scss
@@ -18,6 +18,12 @@ body.is-focused-launch-complete .editor-gutenberg-launch__launch-button {
 
 .focused-launch-details__back-button-wrapper {
 	margin-bottom: 24px;
+	background-color: #fff;
+	padding: 0 10px;
+	position: -webkit-sticky;
+	position: sticky;
+	top: 60px;
+	z-index: 1;
 }
 
 .focused-launch-details__header {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR sticks the back button in detailed focused steps to the top after scrolling.

#### Testing instructions

1. Create or reuse a site that is created with `/start` flow.
2. Sandbox this site.
3. In `apps/editing-toolkit` run `yarn dev --sync`.
4. Go to https://[yoursite].wordpress.com/wp-admin/post-new.php
5. Click launch.
6. Go to detailed domain picker step, scroll down, "Go back" should stay on top.
7. Same for the plans detailed step.

Fixes #49818
