### PR TITLE
Domain Picker: dont inherit work-break prop from domain name

### DIFF
--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -498,6 +498,7 @@ $accent-blue: #117ac9;
 .domain-picker__item-tip {
 	font-size: $font-body-extra-small;
 	color: var( --studio-gray-40 );
+	word-break: initial; // don't inherit word-breaking behaviour from domain name
 }
 
 .domain-picker__error {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR resets the word-breaking behavior to its default. It used to inherit the value from the domain name wrapper.

#### Testing instructions

1. Create or reuse a site that is created with `/start` flow.
2. Sandbox this site.
3. In `apps/editing-toolkit` run `yarn dev --sync`.
4. Go to https://[yoursite].wordpress.com/wp-admin/post-new.php
5. Click launch.
6. Go to detailed domain picker step, and see that #49815 is fixed.

Fixes #49815
