### PR TITLE
Explat: Update documentation with correct pathname

### DIFF
--- a/client/components/experiment/readme.md
+++ b/client/components/experiment/readme.md
@@ -14,7 +14,7 @@ import Experiment, {
 	DefaultVariation,
 	Variation,
 	LoadingVariations,
-} from 'client/components/experiment';
+} from 'calypso/components/experiment';
 
 function SomeExperiment( props ) {
 	return (


### PR DESCRIPTION
I ran into an error when I included the experiment components from `/client/components/experiment`; looks like we need to use `/calypso/components/experiment` so this updates the documentation for future experimenters. :) 
