### PR TITLE
Domain Picker: Use i18n API correctly in UseYourDomainItem component

### DIFF
--- a/packages/domain-picker/src/domain-picker/use-your-domain-item.tsx
+++ b/packages/domain-picker/src/domain-picker/use-your-domain-item.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import * as React from 'react';
-import { __, _x } from '@wordpress/i18n';
 import { ArrowButton } from '@automattic/onboarding';
+import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
@@ -15,6 +15,8 @@ interface Props {
 }
 
 const UseYourDomainItem: React.FunctionComponent< Props > = ( { onClick } ) => {
+	const { __, _x } = useI18n();
+
 	return (
 		<WrappingComponent
 			type="button"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The `UseYourDomainItem` used the i18n tooling incorrectly. It's a React component, but it used the static translation function from the module. A mistake that I've made a couple of times and probably needs an eslint rule. This PR fixes it.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit /new
* Go to the domain step
* Change language multiple times, it work as expectd.



Partially fixes #49677 (along with https://github.com/Automattic/wp-calypso/pull/49759).
