### PR TITLE
Anchor Gutenboarding: anchorFmIsNewSite allowed to contain all alphanumeric characters

### DIFF
--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -135,11 +135,11 @@ export interface AnchorFmParams {
 	anchorFmIsNewSite: string | null;
 }
 export function useAnchorFmParams(): AnchorFmParams {
-	const sanitizeAlphaNumeric = ( id: string ) => id.replace( /[^a-zA-Z0-9]/g, '' );
+	const sanitizePodcast = ( id: string ) => id.replace( /[^a-zA-Z0-9]/g, '' );
 	const anchorFmPodcastId = useAnchorParameter( {
 		queryParamName: 'anchor_podcast',
 		locationStateParamName: 'anchorFmPodcastId',
-		sanitize: sanitizeAlphaNumeric,
+		sanitize: sanitizePodcast,
 	} );
 
 	// Allow all characters allowed in urls
@@ -189,7 +189,7 @@ export function useAnchorFmParams(): AnchorFmParams {
 	const anchorFmIsNewSite = useAnchorParameter( {
 		queryParamName: 'anchor_is_new_site',
 		locationStateParamName: 'anchorFmIsNewSite',
-		sanitize: sanitizeAlphaNumeric,
+		sanitize: ( flag: string ) => ( flag === 'true' ? 'true' : 'false' ),
 	} );
 
 	return {

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -135,11 +135,11 @@ export interface AnchorFmParams {
 	anchorFmIsNewSite: string | null;
 }
 export function useAnchorFmParams(): AnchorFmParams {
-	const sanitizePodcast = ( id: string ) => id.replace( /[^a-zA-Z0-9]/g, '' );
+	const sanitizeAlphaNumeric = ( id: string ) => id.replace( /[^a-zA-Z0-9]/g, '' );
 	const anchorFmPodcastId = useAnchorParameter( {
 		queryParamName: 'anchor_podcast',
 		locationStateParamName: 'anchorFmPodcastId',
-		sanitize: sanitizePodcast,
+		sanitize: sanitizeAlphaNumeric,
 	} );
 
 	// Allow all characters allowed in urls
@@ -189,7 +189,7 @@ export function useAnchorFmParams(): AnchorFmParams {
 	const anchorFmIsNewSite = useAnchorParameter( {
 		queryParamName: 'anchor_is_new_site',
 		locationStateParamName: 'anchorFmIsNewSite',
-		sanitize: sanitizeNumberParam,
+		sanitize: sanitizeAlphaNumeric,
 	} );
 
 	return {


### PR DESCRIPTION
### Fix an anchor gutenboarding bug that resulted in an infinite redirect loop sometimes.

#### Changes proposed in this Pull Request

* The value of the anchor parameter `anchorFmIsNewSite` is allowed to contain letters as well as numbers.
  * Previously, `"true"` was being sanitized to `""`, which is a falsy value.

#### Testing instructions

* Visit http://calypso.localhost:3000/new?anchor_podcast=141c05c&anchor_episode=0489ee41-e8e4-46c0-994c-4564a0a88798&anchor_is_new_site=true
  * Before this change: Infinite redirect loop
  * After this change: Stay on intent screen
