### PR TITLE
Jetpack cloud: use appropriate selector to check if the user's primary site is a Jetpack site

### DIFF
--- a/client/jetpack-cloud/index.js
+++ b/client/jetpack-cloud/index.js
@@ -8,13 +8,13 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sites, siteSelection } from 'calypso/my-sites/controller';
 import { startJetpackCloudOAuthOverride } from 'calypso/lib/jetpack/oauth-override';
 import { translate } from 'i18n-calypso';
 import Landing from './sections/landing';
-import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import getPrimarySiteIsJetpack from 'calypso/state/selectors/get-primary-site-is-jetpack';
 
 const debug = new Debug( 'calypso:jetpack-cloud:controller' );
 
@@ -34,8 +34,9 @@ const redirectToPrimarySiteLanding = ( context ) => {
 	debug( 'controller: redirectToPrimarySiteLanding', context );
 	const state = context.store.getState();
 	const currentUser = getCurrentUser( state );
+	const isPrimarySiteJetpackSite = getPrimarySiteIsJetpack( state );
 
-	isJetpackSite( state, currentUser.primary_blog )
+	isPrimarySiteJetpackSite
 		? page( `/landing/${ currentUser.primarySiteSlug }` )
 		: page( `/landing` );
 };


### PR DESCRIPTION
#### Motivation

Related to 1164141197617539-as-1199910287671366.

When a user lands on Jetpack cloud for the first time, chances are that the app won't be able to figure out if the user's primary site is indeed a Jetpack site. If this happens, the app will prompt the user to select a site instead of automatically redirect the user to `/backup/:site` or `/scan/:site`. This is not a great UX and we can definitely do better.

The problem comes from checking whether the user's primary site is a Jetpack site with the `isJetpackSite` selector. This selector works only if the user's list of sites is already cached on the client-side and there are many scenarios in which this is not going to be the case (when a user visits Jetpack cloud for the first time is one of them).

We can easily fix this by using instead the `isPrimarySiteJetpackSite` selector. This one gets the information about whether the user's primary site is a Jetpack site directly from the `user` object (which is always present at this point).

#### Changes proposed in this Pull Request

* Replace `isJetpackSite` with `isPrimarySiteJetpackSite` selector.

#### Testing instructions

**Prerequisite**
* Make sure your user's primary site is a Jetpack site.

**Instructions to see the problem**
* Visit `https://cloud.jetpack.com`.
* Open the Application tab in the Developer Console (Google Chrome).
* Select Storage > IndexedDB > calypso and click on the `Delete database` button.
* Visit `https://cloud.jetpack.com` again.
* Observe that you are prompted to select a site and that your user's primary site is not automatically selected.

**Instructions to test the fix**
* Download this PR and run the app with `yarn start-jetpack-cloud`.
* Visit `http://jetpack.cloud.localhost:3000/`.
* Open the Application tab in the Developer Console (Google Chrome).
* Select Storage > IndexedDB > calypso and click on the `Delete database` button.
* Visit `http://jetpack.cloud.localhost:3000/` again.
* Observe that you are **not** prompted to select a site and that your user's primary site is automatically selected. You should have landed on either `/backup/:site` or `/scan/:site`.

#### Demo – before
![JPCloudUnreliableControllerFix](https://user-images.githubusercontent.com/3418513/107279679-1cddac80-6a36-11eb-9857-370e2678c36e.gif)

#### Demo – after
![JPCloudUnreliableController](https://user-images.githubusercontent.com/3418513/107279691-1fd89d00-6a36-11eb-93e7-e55a4cc452c5.gif)