### PR TITLE
Enable `BUILD_TRANSLATION_CHUNKS` on cache image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -10,6 +10,7 @@ ENV NPM_CONFIG_CACHE=/calypso/.cache
 ENV NVM_DIR=/calypso/.nvm
 ENV NODE_ENV=production
 ENV CALYPSO_ENV=production
+ENV BUILD_TRANSLATION_CHUNKS=true
 ENV NODE_OPTIONS=--max-old-space-size=$node_memory
 ENV HOME=/calypso
 ENV PERSISTENT_CACHE=true


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Set `BUILD_TRANSLATION_CHUNKS=true` on the cache image.

This doesn't change the output of said image (translation chunks are not cached anyway). However, the goal is to have the same set of env vars than the final app image, so the webpack cache version (https://github.com/Automattic/wp-calypso/blob/trunk/client/webpack.config.js#L401) matches.

#### Testing instructions

N/A