### PR TITLE
Delete PERSISTENT_CACHE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ FROM registry.a8c.com/calypso/base:latest as builder-cache-true
 
 ENV YARN_CACHE_FOLDER=/calypso/.cache/yarn
 ENV NPM_CONFIG_CACHE=/calypso/.cache
-ENV PERSISTENT_CACHE=true
 
 ###################
 FROM builder-cache-${use_cache} as builder

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,6 @@ ENV CALYPSO_ENV=production
 ENV BUILD_TRANSLATION_CHUNKS=true
 ENV NODE_OPTIONS=--max-old-space-size=$node_memory
 ENV HOME=/calypso
-ENV PERSISTENT_CACHE=true
 
 RUN git clone --branch v0.37.0 --depth 1 https://github.com/nvm-sh/nvm.git "$NVM_DIR" \
 	&& echo ". ${NVM_DIR}/nvm.sh" >> "${HOME}/.bashrc"

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -60,7 +60,6 @@ const shouldBuildChunksMap =
 	process.env.BUILD_TRANSLATION_CHUNKS === 'true' ||
 	process.env.ENABLE_FEATURES === 'use-translation-chunks';
 const isDesktop = calypsoEnv === 'desktop' || calypsoEnv === 'desktop-development';
-const shouldUsePersistentCache = process.env.PERSISTENT_CACHE === 'true';
 
 const defaultBrowserslistEnv = 'evergreen';
 const browserslistEnv = process.env.BROWSERSLIST_ENV || defaultBrowserslistEnv;
@@ -393,36 +392,6 @@ const webpackConfig = {
 		new ExtensiveLodashReplacementPlugin(),
 	].filter( Boolean ),
 	externals: [ 'keytar' ],
-	...( shouldUsePersistentCache
-		? {
-				cache: {
-					// More info in https://github.com/webpack/changelog-v5/blob/f518964326583c74e9b78296faebdb9c32b01ea8/guides/persistent-caching.md
-					type: 'filesystem',
-					version: [
-						shouldBuildChunksMap,
-						shouldMinify,
-						process.env.ENTRY_LIMIT,
-						process.env.SECTION_LIMIT,
-						process.env.SOURCEMAP,
-						process.env.NODE_ENV,
-						process.env.CALYPSO_ENV,
-					].join( '-' ),
-					cacheDirectory: path.resolve( cachePath, 'webpack' ),
-					buildDependencies: {
-						config: [ __filename ],
-					},
-				},
-				snapshot: {
-					managedPaths: [
-						path.resolve( __dirname, '../node_modules' ),
-						path.resolve( __dirname, 'node_modules' ),
-					],
-				},
-				infrastructureLogging: {
-					debug: /webpack\.cache/,
-				},
-		  }
-		: {} ),
 };
 
 module.exports = webpackConfig;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Disables Webpack persistent cache.

After a few experiments in local development and CI, we don't seem to get any real benefit from this cache (maybe because we already have caches for babel, css-loader and terser?):

* On CI, building a docker image based off an image with a warm cache barely reduces the build time in 10 seconds.
* On local, we were not able to find any significant difference for the usual build flows (see p1611849960065300-slack-C7YPUHBB2)

Given the tiny benefit we get from it, I don't think it is worth the cost of adding cache info to the docker image (>1Gb), or devs running into problems because they use a stale cache. 

