### PR TITLE
Deduplicate remark-frontmatter

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -23096,15 +23096,7 @@ relateurl@0.2.x, relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
-remark-frontmatter@^1.1.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/remark-frontmatter/-/remark-frontmatter-1.3.2.tgz#91d9684319cd1b96cc3d9d901f10a978f39c752d"
-  integrity sha512-2eayxITZ8rezsXdgcXnYB3iLivohm2V/ZT4Ne8uhua6A4pk6GdLE2ZzJnbnINtD1HRLaTdB7RwF9sgUbMptJZA==
-  dependencies:
-    fault "^1.0.1"
-    xtend "^4.0.1"
-
-remark-frontmatter@^1.3.2:
+remark-frontmatter@^1.1.0, remark-frontmatter@^1.3.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/remark-frontmatter/-/remark-frontmatter-1.3.3.tgz#67ec63c89da5a84bb793ecec166e11b4eb47af10"
   integrity sha512-fM5eZPBvu2pVNoq3ZPW22q+5Ativ1oLozq2qYt9I2oNyxiUd/tDl0iLLntEVAegpZIslPWg1brhcP1VsaSVUag==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `remark-frontmatter` (done automatically with `npx yarn-deduplicate --packages remark-frontmatter`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> remark-frontmatter@1.3.2
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> remark-frontmatter@1.3.2
> @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> remark-frontmatter@1.3.3
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> remark-frontmatter@1.3.3
```