### PR TITLE
Deduplicate resolve

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -14980,7 +14980,7 @@ is-color@^0.2.0:
     rgb-regex "^1.0.1"
     rgba-regex "^1.0.0"
 
-is-core-module@^2.0.0, is-core-module@^2.1.0:
+is-core-module@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
   integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
@@ -23971,15 +23971,7 @@ resolve@1.1.7, resolve@~1.1.0:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1:
-  version "1.18.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.18.1.tgz#018fcb2c5b207d2a6424aee361c5a266da8f4130"
-  integrity sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==
-  dependencies:
-    is-core-module "^2.0.0"
-    path-parse "^1.0.6"
-
-resolve@^1.9.0:
+resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1, resolve@^1.9.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
   integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `resolve` (done automatically with `npx yarn-deduplicate --packages resolve`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> resolve@1.18.1
< @automattic/o2-blocks@1.0.0 -> @automattic/calypso-build@7.0.0 -> ... -> resolve@1.18.1
< @automattic/o2-blocks@1.0.0 -> @wordpress/block-editor@5.2.1 -> ... -> resolve@1.18.1
< @automattic/o2-blocks@1.0.0 -> @wordpress/components@12.0.1 -> ... -> resolve@1.18.1
< @automattic/o2-blocks@1.0.0 -> @wordpress/editor@9.25.1 -> ... -> resolve@1.18.1
< @automattic/wpcom-block-editor@1.0.0-alpha.0 -> @wordpress/block-editor@5.2.1 -> ... -> resolve@1.18.1
< @automattic/wpcom-block-editor@1.0.0-alpha.0 -> @wordpress/components@12.0.1 -> ... -> resolve@1.18.1
< @automattic/wpcom-block-editor@1.0.0-alpha.0 -> @wordpress/edit-post@3.26.1 -> ... -> resolve@1.18.1
< @automattic/wpcom-block-editor@1.0.0-alpha.0 -> @wordpress/edit-site@1.16.1 -> ... -> resolve@1.18.1
< @automattic/wpcom-block-editor@1.0.0-alpha.0 -> @wordpress/editor@9.25.1 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/calypso-build@7.0.0 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/composite-checkout@1.0.0 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/domain-picker@1.0.0-alpha.0 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/launch@1.0.0 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/onboarding@1.0.0 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/plans-grid@1.0.0-alpha.0 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> @babel/core@7.12.9 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/block-editor@5.2.1 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/components@12.0.1 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/edit-post@3.26.1 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/editor@9.25.1 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/nux@3.24.1 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/scripts@12.5.0 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/server-side-render@1.20.1 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> jest@26.4.0 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> newspack-blocks@1.20.0 -> ... -> resolve@1.18.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> npm-run-all@4.1.5 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> @automattic/wp-babel-makepot@1.0.2 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> @babel/core@7.12.9 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> @storybook/addon-actions@6.1.10 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> @wordpress/components@12.0.1 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> babel-eslint@10.1.0 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> concurrently@5.1.0 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> eslint-plugin-import@2.22.1 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> eslint-plugin-react@7.21.5 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> node-sass-package-importer@5.3.2 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> node-sass@4.14.1 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> npm-run-all@4.1.5 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> resolve@1.18.1
< wp-calypso@0.17.0 -> whybundled@1.4.2 -> ... -> resolve@1.18.1
< wp-e2e-tests@0.0.1 -> @babel/core@7.12.9 -> ... -> resolve@1.18.1
< wp-e2e-tests@0.0.1 -> concurrently@3.6.1 -> ... -> resolve@1.18.1
< wp-e2e-tests@0.0.1 -> grunt-cli@1.3.2 -> ... -> resolve@1.18.1
< wp-e2e-tests@0.0.1 -> grunt-concurrent@2.3.1 -> ... -> resolve@1.18.1
< wp-e2e-tests@0.0.1 -> grunt@1.1.0 -> ... -> resolve@1.18.1
< wp-e2e-tests@0.0.1 -> testarmada-magellan-local-executor@2.0.3 -> ... -> resolve@1.18.1
< wp-e2e-tests@0.0.1 -> testarmada-magellan-mocha-plugin@9.0.1 -> ... -> resolve@1.18.1
< wp-e2e-tests@0.0.1 -> testarmada-magellan@11.0.10 -> ... -> resolve@1.18.1
< wp-e2e-tests@0.0.1 -> xunit-viewer@5.2.0 -> ... -> resolve@1.18.1
> @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> resolve@1.19.0
> @automattic/o2-blocks@1.0.0 -> @automattic/calypso-build@7.0.0 -> ... -> resolve@1.19.0
> @automattic/o2-blocks@1.0.0 -> @wordpress/block-editor@5.2.1 -> ... -> resolve@1.19.0
> @automattic/o2-blocks@1.0.0 -> @wordpress/components@12.0.1 -> ... -> resolve@1.19.0
> @automattic/o2-blocks@1.0.0 -> @wordpress/editor@9.25.1 -> ... -> resolve@1.19.0
> @automattic/wpcom-block-editor@1.0.0-alpha.0 -> @wordpress/block-editor@5.2.1 -> ... -> resolve@1.19.0
> @automattic/wpcom-block-editor@1.0.0-alpha.0 -> @wordpress/components@12.0.1 -> ... -> resolve@1.19.0
> @automattic/wpcom-block-editor@1.0.0-alpha.0 -> @wordpress/edit-post@3.26.1 -> ... -> resolve@1.19.0
> @automattic/wpcom-block-editor@1.0.0-alpha.0 -> @wordpress/edit-site@1.16.1 -> ... -> resolve@1.19.0
> @automattic/wpcom-block-editor@1.0.0-alpha.0 -> @wordpress/editor@9.25.1 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/calypso-build@7.0.0 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/composite-checkout@1.0.0 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/domain-picker@1.0.0-alpha.0 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/launch@1.0.0 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/onboarding@1.0.0 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/plans-grid@1.0.0-alpha.0 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> @babel/core@7.12.9 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/block-editor@5.2.1 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/components@12.0.1 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/edit-post@3.26.1 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/editor@9.25.1 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/nux@3.24.1 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/scripts@12.5.0 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/server-side-render@1.20.1 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> jest@26.4.0 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> newspack-blocks@1.20.0 -> ... -> resolve@1.19.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> npm-run-all@4.1.5 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> @automattic/wp-babel-makepot@1.0.2 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> @babel/core@7.12.9 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> @storybook/addon-actions@6.1.10 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> @wordpress/components@12.0.1 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> babel-eslint@10.1.0 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> concurrently@5.1.0 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> eslint-plugin-import@2.22.1 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> eslint-plugin-react@7.21.5 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> node-sass-package-importer@5.3.2 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> node-sass@4.14.1 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> npm-run-all@4.1.5 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> resolve@1.19.0
> wp-calypso@0.17.0 -> whybundled@1.4.2 -> ... -> resolve@1.19.0
> wp-e2e-tests@0.0.1 -> @babel/core@7.12.9 -> ... -> resolve@1.19.0
> wp-e2e-tests@0.0.1 -> concurrently@3.6.1 -> ... -> resolve@1.19.0
> wp-e2e-tests@0.0.1 -> grunt-cli@1.3.2 -> ... -> resolve@1.19.0
> wp-e2e-tests@0.0.1 -> grunt-concurrent@2.3.1 -> ... -> resolve@1.19.0
> wp-e2e-tests@0.0.1 -> grunt@1.1.0 -> ... -> resolve@1.19.0
> wp-e2e-tests@0.0.1 -> testarmada-magellan-local-executor@2.0.3 -> ... -> resolve@1.19.0
> wp-e2e-tests@0.0.1 -> testarmada-magellan-mocha-plugin@9.0.1 -> ... -> resolve@1.19.0
> wp-e2e-tests@0.0.1 -> testarmada-magellan@11.0.10 -> ... -> resolve@1.19.0
> wp-e2e-tests@0.0.1 -> xunit-viewer@5.2.0 -> ... -> resolve@1.19.0
```