### PR TITLE
Deduplicate sass-loader

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -24303,18 +24303,7 @@ sass-graph@2.2.5:
     scss-tokenizer "^0.2.3"
     yargs "^13.3.2"
 
-sass-loader@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-8.0.0.tgz#e7b07a3e357f965e6b03dd45b016b0a9746af797"
-  integrity sha512-+qeMu563PN7rPdit2+n5uuYVR0SSVwm0JsOUsaJXzgYcClWSlmX0iHDnmeOobPkf5kUglVot3QS6SyLyaQoJ4w==
-  dependencies:
-    clone-deep "^4.0.1"
-    loader-utils "^1.2.3"
-    neo-async "^2.6.1"
-    schema-utils "^2.1.0"
-    semver "^6.3.0"
-
-sass-loader@^8.0.2:
+sass-loader@^8.0.0, sass-loader@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-8.0.2.tgz#debecd8c3ce243c76454f2e8290482150380090d"
   integrity sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==
@@ -24376,7 +24365,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.0.0, schema-utils@^2.1.0, schema-utils@^2.5.0, schema-utils@^2.6.1, schema-utils@^2.6.5, schema-utils@^2.6.6, schema-utils@^2.7.0:
+schema-utils@^2.0.0, schema-utils@^2.5.0, schema-utils@^2.6.1, schema-utils@^2.6.5, schema-utils@^2.6.6, schema-utils@^2.7.0:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.1.tgz#1ca4f32d1b24c590c203b8e7a50bf0ea4cd394d7"
   integrity sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `sass-loader` (done automatically with `npx yarn-deduplicate --packages sass-loader`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> sass-loader@8.0.0
< @automattic/o2-blocks@1.0.0 -> @automattic/calypso-build@7.0.0 -> ... -> sass-loader@8.0.0
< @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/calypso-build@7.0.0 -> ... -> sass-loader@8.0.0
< wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> sass-loader@8.0.0
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> sass-loader@8.0.0
> @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> sass-loader@8.0.2
> @automattic/o2-blocks@1.0.0 -> @automattic/calypso-build@7.0.0 -> ... -> sass-loader@8.0.2
> @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/calypso-build@7.0.0 -> ... -> sass-loader@8.0.2
> wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> sass-loader@8.0.2
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> sass-loader@8.0.2
```