### PR TITLE
Deduplicate signal-exit

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -24718,12 +24718,7 @@ side-channel@^1.0.2:
     es-abstract "^1.17.0-next.1"
     object-inspect "^1.7.0"
 
-signal-exit@^3.0.0, signal-exit@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
-  integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
-
-signal-exit@^3.0.3:
+signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `signal-exit` (done automatically with `npx yarn-deduplicate --packages signal-exit`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> signal-exit@3.0.2
< @automattic/o2-blocks@1.0.0 -> @automattic/calypso-build@7.0.0 -> ... -> signal-exit@3.0.2
< @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/calypso-build@7.0.0 -> ... -> signal-exit@3.0.2
< @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/env@2.1.0 -> ... -> signal-exit@3.0.2
< @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/scripts@12.5.0 -> ... -> signal-exit@3.0.2
< @automattic/wpcom-editing-toolkit@2.18.0 -> jest@26.4.0 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> node-sass@4.14.1 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> postcss-cli@6.1.3 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> replace@1.1.5 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> sharp@0.25.3 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> signal-exit@3.0.2
< wp-calypso@0.17.0 -> whybundled@1.4.2 -> ... -> signal-exit@3.0.2
< wp-e2e-tests@0.0.1 -> grunt-concurrent@2.3.1 -> ... -> signal-exit@3.0.2
< wp-e2e-tests@0.0.1 -> grunt@1.1.0 -> ... -> signal-exit@3.0.2
> @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> signal-exit@3.0.3
> @automattic/o2-blocks@1.0.0 -> @automattic/calypso-build@7.0.0 -> ... -> signal-exit@3.0.3
> @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/calypso-build@7.0.0 -> ... -> signal-exit@3.0.3
> @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/env@2.1.0 -> ... -> signal-exit@3.0.3
> @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/scripts@12.5.0 -> ... -> signal-exit@3.0.3
> @automattic/wpcom-editing-toolkit@2.18.0 -> jest@26.4.0 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> node-sass@4.14.1 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> postcss-cli@6.1.3 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> replace@1.1.5 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> sharp@0.25.3 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> signal-exit@3.0.3
> wp-calypso@0.17.0 -> whybundled@1.4.2 -> ... -> signal-exit@3.0.3
> wp-e2e-tests@0.0.1 -> grunt-concurrent@2.3.1 -> ... -> signal-exit@3.0.3
> wp-e2e-tests@0.0.1 -> grunt@1.1.0 -> ... -> signal-exit@3.0.3
```