### PR TITLE
Nav Unification: Move modal entry point from Layout file to Sidebar Navigation file

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -299,9 +299,6 @@ class Layout extends Component {
 				{ config.isEnabled( 'legal-updates-banner' ) && (
 					<AsyncLoad require="calypso/blocks/legal-updates-banner" placeholder={ null } />
 				) }
-				{ config.isEnabled( 'nav-unification' ) && ! config.isEnabled( 'jetpack-cloud' ) && (
-					<AsyncLoad require="calypso/blocks/nav-unification-modal" placeholder={ null } />
-				) }
 				<QueryReaderTeams />
 			</div>
 		);

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -16,6 +16,7 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
+import AsyncLoad from 'calypso/components/async-load';
 import CurrentSite from 'calypso/my-sites/current-site';
 import MySitesSidebarUnifiedItem from './item';
 import MySitesSidebarUnifiedMenu from './menu';
@@ -29,6 +30,7 @@ import 'calypso/state/admin-menu/init';
 import Spinner from 'calypso/components/spinner';
 import { itemLinkMatches } from '../sidebar/utils';
 import { getSidebarIsCollapsed } from 'calypso/state/ui/selectors';
+
 import './style.scss';
 
 export const MySitesSidebarUnified = ( { path } ) => {
@@ -48,34 +50,39 @@ export const MySitesSidebarUnified = ( { path } ) => {
 	}
 
 	return (
-		<Sidebar>
-			<li>
-				<CurrentSite forceAllSitesView={ isAllDomainsView } />
-			</li>
-			{ menuItems.map( ( item, i ) => {
-				const isSelected = item?.url && itemLinkMatches( item.url, path );
+		<>
+			<Sidebar>
+				<li>
+					<CurrentSite forceAllSitesView={ isAllDomainsView } />
+				</li>
+				{ menuItems.map( ( item, i ) => {
+					const isSelected = item?.url && itemLinkMatches( item.url, path );
 
-				if ( 'separator' === item?.type ) {
-					return <SidebarSeparator key={ i } />;
-				}
+					if ( 'separator' === item?.type ) {
+						return <SidebarSeparator key={ i } />;
+					}
 
-				if ( item?.children?.length ) {
+					if ( item?.children?.length ) {
+						return (
+							<MySitesSidebarUnifiedMenu
+								key={ item.slug }
+								path={ path }
+								link={ item.url }
+								selected={ isSelected }
+								sidebarCollapsed={ sidebarIsCollapsed }
+								{ ...item }
+							/>
+						);
+					}
+
 					return (
-						<MySitesSidebarUnifiedMenu
-							key={ item.slug }
-							path={ path }
-							link={ item.url }
-							selected={ !! isSelected }
-							sidebarCollapsed={ sidebarIsCollapsed }
-							{ ...item }
-						/>
+						<MySitesSidebarUnifiedItem key={ item.slug } selected={ isSelected } { ...item } />
 					);
-				}
-
-				return <MySitesSidebarUnifiedItem key={ item.slug } selected={ isSelected } { ...item } />;
-			} ) }
-			<CollapseSidebar key="collapse" title="Collapse menu" icon="dashicons-admin-collapse" />
-		</Sidebar>
+				} ) }
+				<CollapseSidebar key="collapse" title="Collapse menu" icon="dashicons-admin-collapse" />
+			</Sidebar>
+			<AsyncLoad require="calypso/blocks/nav-unification-modal" placeholder={ null } />
+		</>
 	);
 };
 

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -10,7 +10,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { useSelector } from 'react-redux';
 
 /**
@@ -50,7 +50,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 	}
 
 	return (
-		<>
+		<Fragment>
 			<Sidebar>
 				<li>
 					<CurrentSite forceAllSitesView={ isAllDomainsView } />
@@ -82,7 +82,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 				<CollapseSidebar key="collapse" title="Collapse menu" icon="dashicons-admin-collapse" />
 			</Sidebar>
 			<AsyncLoad require="calypso/blocks/nav-unification-modal" placeholder={ null } />
-		</>
+		</Fragment>
 	);
 };
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/49824

#### Changes proposed in this Pull Request

The modal was getting rendered in the main Calypso `Layout.tsx` based on two conditions (Nav unification is enabled, and Jetpack cloud isn't). This Layout component gets rendered on every Calypso screen which resulted in us seeing the modal in places we were not seeing the new navigation (e.g. Block Editor).

This change moves the modal out of the `Layout.tsx` component and into the new `MySitesSidebarUnified` component meaning this modal should only get rendered when the navigation does for the end user.

#### Testing instructions

* Visit the Calypso.live link below.
* Ensure you're proxied > hover over the Calypso badge in the bottom right > Preferences > Click "x" next to `nav-unification-modal` if you have already seen it. This will reset your user preference and enable you to view it again.
* Load various parts of Calypso where we expect the modal to render, and not to render and ensure outcome is as expected (Some reported areas to test are on the issue https://github.com/Automattic/wp-calypso/issues/49824)
