### PR TITLE
Focused Launch: prevent 404 error when opening the flow

### DIFF
--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -42,8 +42,14 @@ export function useDomainSuggestionFromCart(): DomainSuggestions.DomainSuggestio
 
 	const domainName = domainProductFromCart?.meta;
 
-	const domainDetails = useSelect( ( select ) =>
-		select( DOMAIN_SUGGESTIONS_STORE ).isAvailable( domainName || '' )
+	const domainDetails = useSelect(
+		( select ) => {
+			if ( ! domainName ) {
+				return;
+			}
+			return select( DOMAIN_SUGGESTIONS_STORE ).isAvailable( domainName );
+		},
+		[ domainName ]
 	);
 
 	// if the domain is still available, forge a domain suggestion from it and return it


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Don't call `/domains/{DOMAIN_NAME}/is-available` API endpoint without a domain.

#### Testing instructions

* Open Focused Launch modal without having a domain in cart
* There should be no 404 error caused by a call to `https://public-api.wordpress.com/rest/v1.3/domains//is-available?is_cart_pre_check=true`
* Add a domain to cart
* Open Focused Launch modal
* Domain should be pre-selected

Related to #49870, #49871
