### PR TITLE
G Suite: Show description and billing cycle in checkout

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -681,7 +681,7 @@ function purchaseType( purchase ) {
 	}
 
 	if ( isGoogleWorkspace( purchase ) ) {
-		return i18n.translate( 'Productivity And Collaboration Tools at %(domain)s', {
+		return i18n.translate( 'Productivity and Collaboration Tools at %(domain)s', {
 			args: {
 				domain: purchase.meta,
 			},

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -24,6 +24,7 @@ import {
 	isDomainTransferProduct,
 	isDomainProduct,
 	isDotComPlan,
+	isGSuiteOrGoogleWorkspace,
 	isTitanMail,
 } from 'calypso/lib/products-values';
 import { isRenewal } from 'calypso/lib/cart-values/cart-items';
@@ -449,6 +450,14 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): i18nCalypso.
 
 	if ( isPlan( serverCartItem ) ) {
 		return isRenewalItem ? translate( 'Plan Renewal' ) : translate( 'Plan Subscription' );
+	}
+
+	if ( isGSuiteOrGoogleWorkspace( serverCartItem ) ) {
+		if ( isRenewalItem ) {
+			return translate( 'Productivity and Collaboration Tools Renewal' );
+		}
+
+		return translate( 'Productivity and Collaboration Tools' );
 	}
 
 	if (


### PR DESCRIPTION
This pull request updates the checkout to show a description for G Suite and Google Workspace products. It also highlights the annual billing cycle in a similar way than for domains:

Before | After
------ | -----
![B](https://user-images.githubusercontent.com/594356/107347108-c28c2c80-6ac5-11eb-976c-f27604367bed.png) | ![A](https://user-images.githubusercontent.com/594356/107347319-fc5d3300-6ac5-11eb-9a7d-1089fe7d93c5.png)

#### Testing instructions

1. Run `git checkout update/checkout-for-gsuite` and start your server, or open a [live branch](https://calypso.live/?branch=update/checkout-for-gsuite)
2. Add a domain and a Google Workspace product to the shopping cart
3. Check that `Productivity And Collaboration Tools: billed annually` is shown for Google Workspace Business Starter