### PR TITLE
i18n: Add missing fields for interface account settings

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -92,6 +92,8 @@ const INTERFACE_FIELDS = [
 	'language',
 	'enable_translator',
 	'calypso_preferences',
+	'i18n_empathy_mode',
+	'use_fallback_for_incomplete_languages',
 ];
 
 /* eslint-disable react/prefer-es6-class */


### PR DESCRIPTION
After splitting the account settings form in #48710 updating the settings for `Display interface in English` and `Empathy Mode` has stopped working.

#### Changes proposed in this Pull Request

* Add `i18n_empathy_mode` and `use_fallback_for_incomplete_languages` to `INTERFACE_FIELDS` array to properly update unsaved settings when submitting the form.

#### Testing instructions

* Go to `/me/account`.
* Select different non-Mag-16 language and toggle on `Display interface in English` and `Empathy Mode`.
* Save settings, wait for page to reload and confirm that `i18n_empathy_mode` and `use_fallback_for_incomplete_languages` settings have been saved.
* Open **Interface language** picker and toggle off `Display interface in English` and `Empathy Mode` without changing the language.
* Confirm the save interface settings button detects the unsaved settings properly and gets enabled.
* Save settings again and confirm the settings have been toggled off.