### PR TITLE
Layout: AsyncLoad MasterbarItemNew

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -13,7 +13,6 @@ import React from 'react';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import Masterbar from './masterbar';
 import Item from './item';
-import Publish from './publish';
 import Notifications from './notifications';
 import Gravatar from 'calypso/components/gravatar';
 import config from '@automattic/calypso-config';
@@ -231,13 +230,15 @@ class MasterbarLoggedIn extends React.Component {
 				) }
 				<AsyncLoad require="calypso/my-sites/resume-editing" placeholder={ null } />
 				{ ! domainOnlySite && ! isMigrationInProgress && (
-					<Publish
+					<AsyncLoad
+						require="./publish"
+						placeholder={ null }
 						isActive={ this.isActive( 'post' ) }
 						className="masterbar__item-new"
 						tooltip={ translate( 'Create a New Post' ) }
 					>
 						{ translate( 'Write' ) }
-					</Publish>
+					</AsyncLoad>
 				) }
 				<Item
 					tipTarget="me"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

By removing the posts notices from the notices middleware in #49874, I've noticed that we've essentially removed one of the big consumers of posts state from the main entry point. With that change, the last consumer of posts state remained the `MasterbarItemNew` component. This PR attempts to async-load it to unburden the main entry point from all that posts state. 

Now, because posts are used in many other sections, this results in an increase of many sections and async loaded component chunks. This is expected to me and actually demonstrates that webpack does its job well. As much as I like that, I'd like some feedback on whether this change and the results in the bundle sizes are actually worth it. 

cc @sgomes and the rest of @Automattic/team-calypso 😉 

#### Testing instructions

* Load any page in Calypso as a logged in user
* Verify the drafts / new post area in the masterbar still works the same way.

#### Notes

This PR depends on #49874 and has to be rebased after it lands.