### PR TITLE
Move out store setup from extension/woocommerce to my-sites section

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -56,6 +56,7 @@ import {
 	getSiteOption,
 	canCurrentUserUseCalypsoStore,
 	canCurrentUserUseWooCommerceCoreStore,
+	getSiteWoocommerceUrl,
 } from 'calypso/state/sites/selectors';
 import getSiteChecklist from 'calypso/state/selectors/get-site-checklist';
 import getSiteTaskList from 'calypso/state/selectors/get-site-task-list';
@@ -765,7 +766,13 @@ export class MySitesSidebar extends Component {
 	}
 
 	woocommerce() {
-		const { site, canUserUseWooCommerceCoreStore, siteSuffix, isSiteWpcomStore } = this.props;
+		const {
+			site,
+			canUserUseWooCommerceCoreStore,
+			siteSuffix,
+			isSiteWpcomStore,
+			woocommerceUrl,
+		} = this.props;
 
 		if ( ! site ) {
 			return null;
@@ -785,7 +792,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		let storeLink = site.options.admin_url + 'admin.php?page=wc-admin&from-calypso';
+		let storeLink = woocommerceUrl;
 		if ( ! isSiteWpcomStore ) {
 			// Navigate to Store UI for installation.
 			storeLink = '/store' + siteSuffix + '?redirect_after_install';
@@ -1216,6 +1223,7 @@ function mapStateToProps( state ) {
 		sitePlanSlug: getSitePlanSlug( state, siteId ),
 		onboardingUrl: getOnboardingUrl( state ),
 		isSiteWpcomStore: getSiteOption( state, siteId, 'is_wpcom_store' ), // 'is_automated_transfer' && 'woocommerce_is_active'
+		woocommerceUrl: getSiteWoocommerceUrl( state, siteId ),
 	};
 }
 

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -259,6 +259,7 @@ describe( 'MySitesSidebar', () => {
 					},
 				},
 				isSiteWpcomStore: true,
+				woocommerceUrl: 'http://test.com/wp-admin/admin.php?page=wc-admin&from-calypso',
 			} );
 			const WooCommerce = () => Sidebar.woocommerce();
 

--- a/client/my-sites/woocommerce/controller.js
+++ b/client/my-sites/woocommerce/controller.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import page from 'page';
+
+/**
+ * Internal Dependencies
+ */
+import main from './main';
+import { getSiteFragment } from 'calypso/lib/route';
+import {
+	getSelectedSiteWithFallback,
+	getSiteOption,
+	getSiteWoocommerceUrl,
+} from 'calypso/state/sites/selectors';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+
+export function checkPrerequisites( context, next ) {
+	const state = context.store.getState();
+	const site = getSelectedSiteWithFallback( state );
+	const siteId = site ? site.ID : null;
+
+	// Only allow AT sites to access.
+	if ( ! isAtomicSite( state, siteId ) ) {
+		return page.redirect( `/home/${ site.slug }` );
+	}
+
+	// WooCommerce plugin is already installed, redirect to Woo.
+	if ( getSiteOption( state, siteId, 'is_wpcom_store' ) ) {
+		const redirectUrl = getSiteWoocommerceUrl( state, siteId );
+		window.location.href = redirectUrl;
+		return;
+	}
+
+	next();
+}
+
+export function setup( context, next ) {
+	// Invalid site, redirect to select site.
+	if ( ! getSiteFragment( context.path ) ) {
+		return page.redirect( '/woocommerce' );
+	}
+
+	context.primary = React.createElement( main );
+	next();
+}

--- a/client/my-sites/woocommerce/controller.js
+++ b/client/my-sites/woocommerce/controller.js
@@ -39,7 +39,7 @@ export function checkPrerequisites( context, next ) {
 export function setup( context, next ) {
 	// Invalid site, redirect to select site.
 	if ( ! getSiteFragment( context.path ) ) {
-		return page.redirect( '/woocommerce' );
+		return page.redirect( '/woocommerce-installation' );
 	}
 
 	context.primary = React.createElement( main );

--- a/client/my-sites/woocommerce/dashboard/required-plugins-install-view.jsx
+++ b/client/my-sites/woocommerce/dashboard/required-plugins-install-view.jsx
@@ -1,0 +1,544 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { find } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import {
+	activatePlugin,
+	installPlugin,
+	fetchPlugins,
+} from 'calypso/state/plugins/installed/actions';
+import { Button, ProgressBar } from '@automattic/components';
+import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import { fetchPluginData } from 'calypso/state/plugins/wporg/actions';
+import { getAllPlugins as getAllWporgPlugins } from 'calypso/state/plugins/wporg/selectors';
+import {
+	getPlugins as getInstalledPlugins,
+	getStatusForSite,
+} from 'calypso/state/plugins/installed/selectors';
+import SetupHeader from './setup/header';
+import SetupNotices from './setup/notices';
+import hasSitePendingAutomatedTransfer from 'calypso/state/selectors/has-site-pending-automated-transfer';
+import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
+import { getSelectedSiteWithFallback, getSiteWoocommerceUrl } from 'calypso/state/sites/selectors';
+import { recordTrack } from '../lib/analytics';
+
+// Time in seconds to complete various steps.
+const TIME_TO_TRANSFER_ACTIVE = 5;
+const TIME_TO_TRANSFER_UPLOADING = 5;
+const TIME_TO_TRANSFER_BACKFILLING = 25;
+const TIME_TO_TRANSFER_COMPLETE = 6;
+const TIME_TO_PLUGIN_INSTALLATION = 15;
+
+const transferStatusesToTimes = {};
+
+transferStatusesToTimes[ transferStates.PENDING ] = TIME_TO_TRANSFER_ACTIVE;
+
+// ACTIVE and PENDING have the same time because it's a way to show some progress even
+// if nothing happened yet (good for UX).
+transferStatusesToTimes[ transferStates.ACTIVE ] =
+	transferStatusesToTimes[ transferStates.PENDING ];
+
+transferStatusesToTimes[ transferStates.UPLOADING ] =
+	TIME_TO_TRANSFER_UPLOADING + transferStatusesToTimes[ transferStates.ACTIVE ];
+
+transferStatusesToTimes[ transferStates.BACKFILLING ] =
+	TIME_TO_TRANSFER_BACKFILLING + transferStatusesToTimes[ transferStates.UPLOADING ];
+
+transferStatusesToTimes[ transferStates.COMPLETE ] =
+	TIME_TO_TRANSFER_COMPLETE + transferStatusesToTimes[ transferStates.BACKFILLING ];
+
+/**
+ * Get the list of plugins required to use Store on WP.com
+ *
+ * @returns {Array} List of plugin slugs
+ */
+function getRequiredPluginsForCalypso() {
+	return [ 'woocommerce', 'woocommerce-services' ];
+}
+
+/**
+ * Get the list of plugins we want to install for site setup
+ *
+ * @returns {Array} List of plugin slugs
+ */
+function getPluginsForStoreSetup() {
+	return [ 'woocommerce', 'woocommerce-gateway-stripe', 'woocommerce-services' ];
+}
+
+class RequiredPluginsInstallView extends Component {
+	static propTypes = {
+		fixMode: PropTypes.bool,
+		site: PropTypes.shape( {
+			ID: PropTypes.number.isRequired,
+		} ),
+		skipConfirmation: PropTypes.bool,
+	};
+
+	constructor( props ) {
+		super( props );
+		const { automatedTransferStatus } = this.props;
+		this.state = {
+			engineState: props.skipConfirmation ? 'INITIALIZING' : 'CONFIRMING',
+			toActivate: [],
+			toInstall: [],
+			workingOn: '',
+			progress: automatedTransferStatus ? transferStatusesToTimes[ automatedTransferStatus ] : 0,
+			totalSeconds: this.getTotalSeconds(),
+		};
+		this.updateTimer = false;
+	}
+
+	componentDidMount() {
+		const { hasPendingAT } = this.props;
+
+		this.createUpdateTimer();
+
+		if ( hasPendingAT ) {
+			this.startSetup();
+		}
+	}
+
+	componentWillUnmount() {
+		this.destroyUpdateTimer();
+	}
+
+	UNSAFE_componentWillReceiveProps( nextProps ) {
+		const { automatedTransferStatus: currentATStatus, siteId, hasPendingAT } = this.props;
+		const { automatedTransferStatus: nextATStatus } = nextProps;
+
+		if ( hasPendingAT && nextATStatus ) {
+			this.setState( {
+				progress: transferStatusesToTimes[ nextATStatus ],
+			} );
+		}
+
+		const { BACKFILLING, COMPLETE } = transferStates;
+
+		if ( BACKFILLING === currentATStatus && COMPLETE === nextATStatus ) {
+			this.setState( {
+				engineState: 'INITIALIZING',
+				workingOn: '',
+			} );
+
+			this.props.fetchPlugins( [ siteId ] );
+		}
+	}
+
+	createUpdateTimer = () => {
+		if ( this.updateTimer ) {
+			return;
+		}
+
+		// Proceed at rate of approximately 60 fps
+		this.updateTimer = window.setInterval( () => {
+			this.updateEngine();
+		}, 17 );
+	};
+
+	destroyUpdateTimer = () => {
+		if ( this.updateTimer ) {
+			window.clearInterval( this.updateTimer );
+			this.updateTimer = false;
+		}
+	};
+
+	doInitialization = () => {
+		const { fixMode, site, sitePlugins, wporgPlugins } = this.props;
+		const { workingOn } = this.state;
+
+		if ( ! site ) {
+			return;
+		}
+
+		let waitingForPluginListFromSite = false;
+		if ( ! sitePlugins ) {
+			waitingForPluginListFromSite = true;
+		} else if ( ! Array.isArray( sitePlugins ) ) {
+			waitingForPluginListFromSite = true;
+		} else if ( 0 === sitePlugins.length ) {
+			waitingForPluginListFromSite = true;
+		}
+
+		if ( waitingForPluginListFromSite ) {
+			if ( workingOn === 'WAITING_FOR_PLUGIN_LIST_FROM_SITE' ) {
+				return;
+			}
+
+			this.setState( {
+				workingOn: 'WAITING_FOR_PLUGIN_LIST_FROM_SITE',
+			} );
+			return;
+		}
+
+		// Iterate over the required plugins, fetching plugin
+		// data from wordpress.org for each into state
+		const requiredPlugins = fixMode ? getRequiredPluginsForCalypso() : getPluginsForStoreSetup();
+		let pluginDataLoaded = true;
+		for ( const requiredPluginSlug of requiredPlugins ) {
+			const pluginData = wporgPlugins?.[ requiredPluginSlug ] ?? {};
+			// pluginData will be null until the action has had
+			// a chance to try and fetch data for the plugin slug
+			// given. Note that non-wp-org plugins
+			// will be accepted too, but with
+			// { fetched: false, wporg: false }
+			// as their response
+			if ( ! pluginData ) {
+				this.props.fetchPluginData( requiredPluginSlug );
+				pluginDataLoaded = false;
+			}
+		}
+		if ( ! pluginDataLoaded ) {
+			if ( workingOn === 'LOAD_PLUGIN_DATA' ) {
+				return;
+			}
+
+			this.setState( {
+				workingOn: 'LOAD_PLUGIN_DATA',
+			} );
+			return;
+		}
+
+		const toInstall = [];
+		const toActivate = [];
+		let pluginInstallationTotalSteps = 0;
+		for ( const requiredPluginSlug of requiredPlugins ) {
+			const pluginFound = find( sitePlugins, { slug: requiredPluginSlug } );
+			if ( ! pluginFound ) {
+				toInstall.push( requiredPluginSlug );
+				toActivate.push( requiredPluginSlug );
+				pluginInstallationTotalSteps++;
+			} else if ( ! pluginFound.active ) {
+				toActivate.push( requiredPluginSlug );
+				pluginInstallationTotalSteps++;
+			}
+		}
+
+		if ( toInstall.length ) {
+			this.setState( {
+				engineState: 'INSTALLING',
+				toActivate,
+				toInstall,
+				workingOn: '',
+				pluginInstallationTotalSteps,
+			} );
+			return;
+		}
+
+		if ( toActivate.length ) {
+			this.setState( {
+				engineState: 'ACTIVATING',
+				toActivate,
+				workingOn: '',
+				pluginInstallationTotalSteps,
+			} );
+			return;
+		}
+
+		this.setState( {
+			engineState: 'DONESUCCESS',
+		} );
+	};
+
+	doInstallation = () => {
+		const { pluginsStatus, site, sitePlugins } = this.props;
+
+		// If we are working on nothing presently, get the next thing to install and install it
+		if ( 0 === this.state.workingOn.length ) {
+			const toInstall = this.state.toInstall;
+
+			// Nothing left to install? Advance to activation step
+			if ( 0 === toInstall.length ) {
+				this.setState( {
+					engineState: 'ACTIVATING',
+				} );
+				return;
+			}
+
+			const workingOn = toInstall.shift();
+			// In lieu of waiting on details of plugins from wporg, let's assemble the object ourselves.
+			const plugin = {
+				id: workingOn,
+				slug: workingOn,
+			};
+
+			this.props.installPlugin( site.ID, plugin );
+
+			this.setState( {
+				toInstall,
+				workingOn,
+			} );
+			return;
+		}
+
+		// Otherwise, if we are working on something presently, see if it has appeared in state yet
+		const pluginFound = find( sitePlugins, { slug: this.state.workingOn } );
+		if ( pluginFound ) {
+			this.setState( {
+				workingOn: '',
+				progress: this.state.progress + this.getPluginInstallationTime(),
+			} );
+		}
+
+		// Or, it's in the error state
+		const pluginStatus = pluginsStatus[ this.state.workingOn ];
+		if ( pluginStatus && 'error' === pluginStatus.status ) {
+			this.setState( {
+				engineState: 'DONEFAILURE',
+			} );
+		}
+	};
+
+	doActivation = () => {
+		const { site, sitePlugins } = this.props;
+
+		// If we are working on nothing presently, get the next thing to activate and activate it
+		if ( 0 === this.state.workingOn.length ) {
+			const toActivate = this.state.toActivate;
+
+			// Nothing left to activate? Advance to done success
+			if ( 0 === toActivate.length ) {
+				this.setState( {
+					engineState: 'DONESUCCESS',
+				} );
+				return;
+			}
+
+			const workingOn = toActivate.shift();
+
+			// It is best to use sitePlugins to get the right id since the
+			// plugin id isn't always slug/slug unless the main plugin PHP
+			// file is the same name as the plugin folder
+			const pluginToActivate = find( sitePlugins, { slug: workingOn } );
+			// Already active? Skip it
+			if ( pluginToActivate.active ) {
+				this.setState( {
+					toActivate,
+					workingOn: '',
+				} );
+				return;
+			}
+
+			// Otherwise, activate!
+			this.props.activatePlugin( site.ID, pluginToActivate );
+
+			this.setState( {
+				toActivate,
+				workingOn,
+			} );
+			return;
+		}
+
+		// See if activation has appeared in state yet
+		const pluginFound = find( sitePlugins, { slug: this.state.workingOn } );
+		if ( pluginFound && pluginFound.active ) {
+			this.setState( {
+				workingOn: '',
+				progress: this.state.progress + this.getPluginInstallationTime(),
+			} );
+		}
+	};
+
+	doneSuccess = () => {
+		this.setState( {
+			engineState: 'IDLE',
+		} );
+
+		// Delay to ensure user wont bump into permission error
+		// that happens if navigated to wc-admin too soon.
+		setTimeout( () => {
+			window.location.replace( this.props.woocommerceUrl );
+		}, 2000 );
+		return false;
+	};
+
+	updateEngine = () => {
+		switch ( this.state.engineState ) {
+			case 'INITIALIZING':
+				this.doInitialization();
+				break;
+			case 'INSTALLING':
+				this.doInstallation();
+				break;
+			case 'ACTIVATING':
+				this.doActivation();
+				break;
+			case 'DONESUCCESS':
+				this.doneSuccess();
+				break;
+		}
+	};
+
+	getPluginInstallationTime = () => {
+		const { pluginInstallationTotalSteps } = this.state;
+
+		if ( pluginInstallationTotalSteps ) {
+			return TIME_TO_PLUGIN_INSTALLATION / pluginInstallationTotalSteps;
+		}
+
+		// If there's some error, return 3 seconds for a single plugin installation time.
+		return 3;
+	};
+
+	startSetup = () => {
+		const { hasPendingAT } = this.props;
+
+		recordTrack( 'calypso_woocommerce_dashboard_action_click', {
+			action: 'initial-setup',
+		} );
+
+		if ( ! hasPendingAT ) {
+			this.setState( {
+				engineState: 'INITIALIZING',
+			} );
+		}
+	};
+
+	renderConfirmScreen = () => {
+		const { translate } = this.props;
+		return (
+			<div className="dashboard__setup-wrapper setup__wrapper">
+				<SetupNotices />
+				<div className="card dashboard__setup-confirm">
+					<SetupHeader
+						imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-setup.svg' }
+						imageWidth={ 160 }
+						title={ translate( 'Have something to sell?' ) }
+						subtitle={ translate(
+							'You can sell your products right on your site and ship them to customers in a snap!'
+						) }
+					>
+						<Button onClick={ this.startSetup } primary>
+							{ translate( 'Set up my store!' ) }
+						</Button>
+					</SetupHeader>
+				</div>
+			</div>
+		);
+	};
+
+	getTotalSeconds = () => {
+		const { hasPendingAT } = this.props;
+
+		if ( hasPendingAT ) {
+			return transferStatusesToTimes[ transferStates.COMPLETE ] + TIME_TO_PLUGIN_INSTALLATION;
+		}
+
+		return TIME_TO_PLUGIN_INSTALLATION;
+	};
+
+	renderContactSupport() {
+		const { translate, wporgPlugins } = this.props;
+		const { workingOn } = this.state;
+		const plugin = wporgPlugins?.[ workingOn ] ?? {};
+
+		const subtitle = [
+			<p key="line-1">
+				{ translate(
+					"Your store is missing some required plugins. We can't fix this automatically " +
+						'due to a problem with the {{b}}%(pluginName)s{{/b}} plugin.',
+					{
+						args: { pluginName: plugin.name || workingOn },
+						components: { b: <strong /> },
+					}
+				) }
+			</p>,
+			<p key="line-2">
+				{ translate( "Please contact support and we'll get your store back up and running!" ) }
+			</p>,
+		];
+
+		return (
+			<div className="dashboard__setup-wrapper setup__wrapper">
+				<div className="card dashboard__plugins-install-view">
+					<SetupHeader
+						imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-store-creation.svg' }
+						imageWidth={ 160 }
+						title={ translate( "We can't update your store" ) }
+						subtitle={ subtitle }
+					>
+						<Button primary href={ CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer">
+							{ this.props.translate( 'Get in touch' ) }
+						</Button>
+					</SetupHeader>
+				</div>
+			</div>
+		);
+	}
+
+	render() {
+		const { hasPendingAT, fixMode, translate } = this.props;
+		const { engineState, progress, totalSeconds } = this.state;
+
+		if ( ! hasPendingAT && 'CONFIRMING' === engineState ) {
+			return this.renderConfirmScreen();
+		}
+
+		if ( 'DONEFAILURE' === engineState ) {
+			return this.renderContactSupport();
+		}
+
+		const title = fixMode ? translate( 'Updating your store' ) : translate( 'Building your store' );
+
+		return (
+			<div className="dashboard__setup-wrapper setup__wrapper">
+				<SetupNotices />
+				<div className="card dashboard__plugins-install-view">
+					<SetupHeader
+						imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-store-creation.svg' }
+						imageWidth={ 160 }
+						title={ title }
+						subtitle={ translate( "Give us a minute and we'll move right along." ) }
+					>
+						<ProgressBar value={ progress } total={ totalSeconds } isPulsing />
+					</SetupHeader>
+				</div>
+			</div>
+		);
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	const siteId = site.ID;
+	const sitePlugins = site ? getInstalledPlugins( state, [ siteId ] ) : [];
+	const pluginsStatus = getStatusForSite( state, siteId );
+	const woocommerceUrl = getSiteWoocommerceUrl( state, siteId );
+
+	return {
+		site,
+		siteId,
+		sitePlugins,
+		pluginsStatus,
+		wporgPlugins: getAllWporgPlugins( state ),
+		automatedTransferStatus: getAutomatedTransferStatus( state, siteId ),
+		hasPendingAT: hasSitePendingAutomatedTransfer( state, siteId ),
+		woocommerceUrl,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			activatePlugin,
+			fetchPluginData,
+			installPlugin,
+			fetchPlugins,
+		},
+		dispatch
+	);
+}
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( RequiredPluginsInstallView ) );

--- a/client/my-sites/woocommerce/dashboard/setup/header.jsx
+++ b/client/my-sites/woocommerce/dashboard/setup/header.jsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SetupHeader = ( { imageSource, imageWidth, subtitle, title, children } ) => {
+	const Tag = 'string' === typeof subtitle ? 'p' : 'div';
+
+	return (
+		<div className="setup__header">
+			{ imageSource && (
+				<img src={ imageSource } width={ imageWidth } className="setup__header-image" alt="" />
+			) }
+			{ <h2 className="setup__header-title form-section-heading">{ title }</h2> }
+			{ subtitle && <Tag className="setup__header-subtitle">{ subtitle }</Tag> }
+			{ children }
+		</div>
+	);
+};
+
+SetupHeader.propTypes = {
+	imageSource: PropTypes.string,
+	imageWidth: PropTypes.number,
+	title: PropTypes.string.isRequired,
+	subtitle: PropTypes.oneOfType( [ PropTypes.array, PropTypes.string ] ),
+};
+
+export default SetupHeader;

--- a/client/my-sites/woocommerce/dashboard/setup/notices.jsx
+++ b/client/my-sites/woocommerce/dashboard/setup/notices.jsx
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUser, isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
+import Notice from 'calypso/components/notice';
+
+class SetupNotices extends Component {
+	static propTypes = {
+		currentUserEmail: PropTypes.string,
+		currentUserEmailVerified: PropTypes.bool,
+		translate: PropTypes.func,
+	};
+
+	possiblyRenderEmailWarning = () => {
+		const { currentUserEmail, currentUserEmailVerified, translate } = this.props;
+
+		if ( ! currentUserEmail || currentUserEmailVerified ) {
+			return null;
+		}
+
+		return (
+			<Notice
+				status="is-warning"
+				showDismiss={ false }
+				text={ translate(
+					"You need to confirm your email address to activate your account. We've sent " +
+						'an email to {{strong}}%(email)s{{/strong}} with instructions for you to follow.',
+					{
+						components: {
+							strong: <strong />,
+						},
+						args: {
+							email: currentUserEmail,
+						},
+					}
+				) }
+			/>
+		);
+	};
+
+	render = () => {
+		return <div>{ this.possiblyRenderEmailWarning() }</div>;
+	};
+}
+
+function mapStateToProps( state ) {
+	const currentUser = getCurrentUser( state );
+	const currentUserEmail = get( currentUser, 'email', '' );
+	const currentUserEmailVerified = isCurrentUserEmailVerified( state );
+
+	return {
+		currentUserEmail,
+		currentUserEmailVerified,
+	};
+}
+
+export default connect( mapStateToProps )( localize( SetupNotices ) );

--- a/client/my-sites/woocommerce/dashboard/setup/style.scss
+++ b/client/my-sites/woocommerce/dashboard/setup/style.scss
@@ -1,0 +1,57 @@
+.setup__header {
+	text-align: center;
+	padding-top: 16px;
+
+	img {
+		max-width: 160px;
+		margin-bottom: 12px;
+	}
+
+	.setup__header-title {
+		margin: 0 auto 6px;
+		max-width: 450px;
+	}
+
+	.setup__header-subtitle {
+		color: var( --color-text-subtle );
+		margin: 0 auto 32px;
+		max-width: 520px;
+	}
+
+	.button {
+		margin-bottom: 8px;
+	}
+}
+
+.setup__confirm .setup__header-subtitle {
+	color: var( --color-neutral-70 );
+	max-width: 490px;
+}
+
+.setup__location {
+	padding: 16px;
+
+	@include breakpoint-deprecated( '>960px' ) {
+		padding: 32px 32px 16px;
+	}
+}
+
+.setup__location .setup__footer {
+	padding: 16px 32px 0;
+}
+
+.setup__footer {
+	align-items: center;
+	border-top: none;
+	display: flex;
+	justify-content: center;
+	padding: 24px 24px 0;
+	margin-left: -24px;
+	margin-right: -24px;
+
+	@include breakpoint-deprecated( '>960px' ) {
+		margin-left: -32px;
+		margin-right: -32px;
+		padding: 32px 32px 0;
+	}
+}

--- a/client/my-sites/woocommerce/index.js
+++ b/client/my-sites/woocommerce/index.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { siteSelection, navigation, sites } from 'calypso/my-sites/controller';
+import { makeLayout } from 'calypso/controller';
+import { checkPrerequisites, setup } from './controller';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export default function ( router ) {
+	router( '/woocommerce', siteSelection, sites, makeLayout );
+	router( '/woocommerce/:site', siteSelection, navigation, checkPrerequisites, setup, makeLayout );
+}

--- a/client/my-sites/woocommerce/index.js
+++ b/client/my-sites/woocommerce/index.js
@@ -11,6 +11,13 @@ import { checkPrerequisites, setup } from './controller';
 import './style.scss';
 
 export default function ( router ) {
-	router( '/woocommerce', siteSelection, sites, makeLayout );
-	router( '/woocommerce/:site', siteSelection, navigation, checkPrerequisites, setup, makeLayout );
+	router( '/woocommerce-installation', siteSelection, sites, makeLayout );
+	router(
+		'/woocommerce-installation/:site',
+		siteSelection,
+		navigation,
+		checkPrerequisites,
+		setup,
+		makeLayout
+	);
 }

--- a/client/my-sites/woocommerce/lib/analytics/index.js
+++ b/client/my-sites/woocommerce/lib/analytics/index.js
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import * as tracks from 'calypso/lib/analytics/tracks';
+import * as tracksUtils from './tracks-utils';
+const debug = debugFactory( 'woocommerce:analytics' );
+
+export const recordTrack = tracksUtils.recordTrack( tracks, debug );

--- a/client/my-sites/woocommerce/lib/analytics/test/tracks-utils.js
+++ b/client/my-sites/woocommerce/lib/analytics/test/tracks-utils.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { recordTrack } from '../tracks-utils';
+
+describe( 'recordTrack', () => {
+	it( 'should be a function', () => {
+		expect( recordTrack ).to.be.a( 'function' );
+	} );
+
+	it( 'should curry the tracks object', () => {
+		const tracksSpy = {
+			recordTracksEvent: spy(),
+		};
+
+		expect( recordTrack( tracksSpy, noop ) ).to.be.a( 'function' );
+	} );
+
+	it( 'should call tracks to record an event with properties', () => {
+		const tracksSpy = {
+			recordTracksEvent: spy(),
+		};
+
+		const eventProps = {
+			a: 1,
+			b: 2.2,
+			c: '3',
+		};
+
+		recordTrack( tracksSpy, noop )( 'calypso_woocommerce_tracks_utils_test', eventProps );
+
+		expect( tracksSpy.recordTracksEvent ).to.have.been.calledWith(
+			'calypso_woocommerce_tracks_utils_test',
+			eventProps
+		);
+	} );
+
+	it( 'should log tracks via debug', () => {
+		const debugSpy = spy();
+
+		const eventProps = { a: 1 };
+
+		recordTrack( { recordTracksEvent: noop }, debugSpy )(
+			'calypso_woocommerce_tracks_utils_test',
+			eventProps
+		);
+
+		expect( debugSpy ).to.have.been.calledWith(
+			"track 'calypso_woocommerce_tracks_utils_test': ",
+			eventProps
+		);
+	} );
+
+	it( 'should ignore and debug log tracks with an improper event name', () => {
+		const tracksSpy = {
+			recordTracksEvent: spy(),
+		};
+		const debugSpy = spy();
+
+		recordTrack( tracksSpy, debugSpy )( 'calypso_somethingelse_invalid_name', { a: 1 } );
+
+		expect( tracksSpy.recordTracksEvent ).to.not.have.been.called;
+		expect( debugSpy ).to.have.been.calledWith(
+			"invalid store track name: 'calypso_somethingelse_invalid_name', must start with 'calypso_woocommerce_'"
+		);
+	} );
+} );

--- a/client/my-sites/woocommerce/lib/analytics/tracks-utils.js
+++ b/client/my-sites/woocommerce/lib/analytics/tracks-utils.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { startsWith } from 'lodash';
+
+export const recordTrack = ( tracks, debug ) => ( eventName, eventProperties ) => {
+	if ( ! startsWith( eventName, 'calypso_woocommerce_' ) ) {
+		debug( `invalid store track name: '${ eventName }', must start with 'calypso_woocommerce_'` );
+		return;
+	}
+
+	debug( `track '${ eventName }': `, eventProperties || {} );
+
+	tracks.recordTracksEvent( eventName, eventProperties );
+};

--- a/client/my-sites/woocommerce/main.jsx
+++ b/client/my-sites/woocommerce/main.jsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import RequiredPluginsInstallView from './dashboard/required-plugins-install-view';
+import Main from 'calypso/components/main';
+
+export function Woocommerce() {
+	return (
+		<div className="woocommerce">
+			<Main class="main" wideLayout>
+				<RequiredPluginsInstallView></RequiredPluginsInstallView>
+			</Main>
+		</div>
+	);
+}
+
+export default localize( Woocommerce );

--- a/client/my-sites/woocommerce/style.scss
+++ b/client/my-sites/woocommerce/style.scss
@@ -1,0 +1,11 @@
+.woocommerce {
+	@import 'dashboard/setup/style';
+
+	.main {
+		padding-top: 72px;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			padding-top: 35px;
+		}
+	}
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -491,6 +491,12 @@ const sections = [
 		module: 'calypso/jetpack-cloud/sections/partner-portal',
 		group: 'jetpack-cloud',
 	},
+	{
+		name: 'woocommerce',
+		paths: [ '/woocommerce' ],
+		module: 'calypso/my-sites/woocommerce',
+		group: 'woocommerce',
+	},
 ];
 
 for ( const extension of require( './extensions' ) ) {

--- a/client/sections.js
+++ b/client/sections.js
@@ -492,10 +492,10 @@ const sections = [
 		group: 'jetpack-cloud',
 	},
 	{
-		name: 'woocommerce',
-		paths: [ '/woocommerce' ],
+		name: 'woocommerce-installation',
+		paths: [ '/woocommerce-installation' ],
 		module: 'calypso/my-sites/woocommerce',
-		group: 'woocommerce',
+		group: 'woocommerce-installation',
 	},
 ];
 

--- a/client/state/sites/selectors/get-site-with-fallback.js
+++ b/client/state/sites/selectors/get-site-with-fallback.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
+
+/**
+ * Gets currently selected site or, if that isn't available and the user has
+ * just one site, returns the user's primary site as a fallback
+ *
+ * @param {object} state Global state tree
+ * @returns {?object} Site
+ */
+export default function getSelectedSiteWithFallback( state ) {
+	let siteId = getSelectedSiteId( state );
+	if ( ! siteId && 1 === getCurrentUserSiteCount( state ) ) {
+		siteId = getPrimarySiteId( state );
+	}
+	return getSite( state, siteId );
+}

--- a/client/state/sites/selectors/get-site-woocommerce-url.js
+++ b/client/state/sites/selectors/get-site-woocommerce-url.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import getSiteAdminUrl from './get-site-admin-url';
+
+/**
+ * Returns a site's wp-admin WooCommerce plugin URL, or null if the admin URL
+ * for the site cannot be determined.
+ *
+ * @param  {object}  state  Global state tree
+ * @param  {number}  siteId Site ID
+ * @returns {?string}        Full URL to WooCommerce plugin in wp-admin
+ */
+export default function getSiteWoocommerceUrl( state, siteId ) {
+	return getSiteAdminUrl( state, siteId, 'admin.php?page=wc-admin&from-calypso' );
+}

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -57,3 +57,5 @@ export { default as isSiteConflicting } from './is-site-conflicting';
 export { default as isSitePreviewable } from './is-site-previewable';
 export { default as isSSOEnabled } from './is-sso-enabled';
 export { default as verifyJetpackModulesActive } from './verify-jetpack-modules-active';
+export { default as getSelectedSiteWithFallback } from './get-site-with-fallback';
+export { default as getSiteWoocommerceUrl } from './get-site-woocommerce-url';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the setup of WooCommerce for Atomic sites that do not yet have the WooCommerce plugin out `extensions/woocommerce` to a standalone page in located under my-sites.

The new section can be accessed via `https://wordpress.com/woocommerce/{site}`. In order to support Nav Unification, the actual link to the new woocommerce section from sidebar should be addressed in `wpcomsh` repository.

Fixes #49424.

#### Testing instructions

* Start calypso in local.
* Create a new business plan site (Alternatively, you can also disable WooCommerce plugin in an existing business site).
* If site is not yet Atomic, go to plugins, and install any plugin other than WooCommerce to convert site to Atomic.
* In the site's URL, replace `home` with `woocommerce`.
* Click on "Setup my store".
* Observe the progress and page should redirect to first step of WooCommerce onboarding wizard.
* For tracks, `calypso_woocommerce_dashboard_action_click` should be called with `{ action: 'initial-setup' }` when setup is run.

#### Demo

![](https://cdn-std.droplr.net/files/acc_1119691/5ckAOc)

