### PR TITLE
Reinstate skip to navigation, query for post types

### DIFF
--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -26,6 +26,7 @@ import useDomainsViewStatus from './use-domains-view-status';
 import { getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
 import Sidebar from 'calypso/layout/sidebar';
 import SidebarSeparator from 'calypso/layout/sidebar/separator';
+import SidebarRegion from 'calypso/layout/sidebar/region';
 import 'calypso/state/admin-menu/init';
 import Spinner from 'calypso/components/spinner';
 import { itemLinkMatches } from '../sidebar/utils';
@@ -52,9 +53,9 @@ export const MySitesSidebarUnified = ( { path } ) => {
 	return (
 		<Fragment>
 			<Sidebar>
-				<li>
+				<SidebarRegion>
 					<CurrentSite forceAllSitesView={ isAllDomainsView } />
-				</li>
+				</SidebarRegion>
 				{ menuItems.map( ( item, i ) => {
 					const isSelected = item?.url && itemLinkMatches( item.url, path );
 

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -22,6 +22,7 @@ import PostTypeForbidden from './post-type-forbidden';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getPostType, isPostTypeSupported } from 'calypso/state/post-types/selectors';
+import QueryPostTypes from 'calypso/components/data/query-post-types';
 
 function Types( {
 	siteId,
@@ -59,6 +60,7 @@ function Types( {
 				] }
 			{ ! postTypeSupported && <PostTypeUnsupported type={ query.type } /> }
 			{ ! userCanEdit && <PostTypeForbidden /> }
+			{ siteId && <QueryPostTypes siteId={ siteId } /> }
 		</Main>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Uses `SidebarRegion` component instead of simple `li`. The `SidebarRegion` component includes a `SkipNavigation` component useful for a11y
* Makes sure that post-types are in state when visiting `/types/wp_block/[DOMAIN]`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Skip to navigation**
* Using the dark color-scheme "Tab" until focus reaches the sidebar
* The first focused element (before "Switch Sites") should be "Skip Navigation"
![](https://cln.sh/hPRW5E+)

**Post Types**
* Visit `/types/wp_block/[DOMAIN]` 
* Make sure you are not seeing "Content type unsupported" (before screenshot)

Before | After
-------|------
![image](https://user-images.githubusercontent.com/12430020/107367891-86b68e80-6ae8-11eb-844f-fc984ae86b98.png)| ![](https://cln.sh/Xtll2l+)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #49396
