### PR TITLE
Config: Override protocol, hostname and port variables when loading the config

### DIFF
--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -41,9 +41,9 @@ export default {
 		let authUrl;
 
 		if ( config( 'oauth_client_id' ) ) {
-			const protocol = process.env.PROTOCOL || config( 'protocol' );
-			const host = process.env.HOST || config( 'hostname' );
-			const port = process.env.PORT || config( 'port' );
+			const protocol = config( 'protocol' );
+			const host = config( 'hostname' );
+			const port = config( 'port' );
 			const redirectUri = `${ protocol }://${ host }:${ port }/api/oauth/token`;
 
 			const params = new URLSearchParams( {

--- a/client/server/bundler/index.js
+++ b/client/server/bundler/index.js
@@ -12,9 +12,9 @@ const { execSync } = require( 'child_process' );
 
 const config = require( '@automattic/calypso-config' );
 
-const protocol = process.env.PROTOCOL || config( 'protocol' );
-const host = process.env.HOST || config( 'hostname' );
-const port = process.env.PORT || config( 'port' );
+const protocol = config( 'protocol' );
+const host = config( 'hostname' );
+const port = config( 'port' );
 const shouldProfile = process.env.PROFILE === 'true';
 const shouldBuildChunksMap =
 	process.env.BUILD_TRANSLATION_CHUNKS === 'true' ||

--- a/client/server/config/parser.js
+++ b/client/server/config/parser.js
@@ -58,13 +58,18 @@ module.exports = function ( configPath, defaultOpts ) {
 	}
 
 	if (
-		! ( secretsPath === realSecretsPath ) &&
+		secretsPath !== realSecretsPath &&
 		data.features &&
 		data.features[ 'wpcom-user-bootstrap' ]
 	) {
 		console.error( 'Disabling server-side user-bootstrapping because of a missing secrets.json' );
 		data.features[ 'wpcom-user-bootstrap' ] = false;
 	}
+
+	// `protocol`, `hostname` and `port` config values can be overridden by env variables
+	data.protocol = process.env.PROTOCOL || data.protocol;
+	data.hostname = process.env.HOST || data.hostname;
+	data.port = process.env.PORT || data.port;
 
 	const serverData = assign( {}, data, getDataFromFile( secretsPath ) );
 	const clientData = assign( {}, data );

--- a/client/server/index.js
+++ b/client/server/index.js
@@ -13,14 +13,14 @@ import fs from 'fs';
  * Internal dependencies
  */
 import boot from './boot';
-import config from './config';
+import config from '@automattic/calypso-config';
 import { getLogger } from './lib/logger';
 
 const logger = getLogger();
 const start = Date.now();
-const protocol = process.env.PROTOCOL || config( 'protocol' );
-const port = process.env.PORT || config( 'port' );
-const host = process.env.HOST || config( 'hostname' );
+const protocol = config( 'protocol' );
+const port = config( 'port' );
+const host = config( 'hostname' );
 const app = boot();
 
 function sendBootStatus( status ) {


### PR DESCRIPTION
Calypso has three config variables `config( 'protocol' )`, `config( 'hostname' )` and `config( 'port' )` that are specified in the JSON configs for various environment, but are also overridable with the `PROTOCOL`, `HOST` and `PORT` environment variables.

Until now, these overrides were implemented in consumer code that reads these variables. This PR moves the overrides to one place, to the config parser.

**How to test:**
Run Calypso in dev mode on a custom port:
```
PORT=9999 yarn start
```

Verify that the server code uses the overridden version of the `config( 'port' )` variable, e.g., when writing this to console:
```
Ready! You can load http://calypso.localhost:9999/ now. Have fun!
```

Then test that when you load Calypso to your browser, the `window.configData` has the expected value for the `port` property.