### PR TITLE
Jetpack Cloud: Remove Olark pre-sales chat from pricing page

### DIFF
--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -10,8 +10,6 @@ import React, { useMemo } from 'react';
  */
 import JetpackComMasterbar from '../jpcom-masterbar';
 import FormattedHeader from 'calypso/components/formatted-header';
-import OlarkChat from 'calypso/components/olark-chat';
-import config from '@automattic/calypso-config';
 import { preventWidows } from 'calypso/lib/formatting';
 import { getForCurrentCROIteration } from 'calypso/my-sites/plans/jetpack-plans/iterations';
 import { Iterations } from 'calypso/my-sites/plans/jetpack-plans/iterations';
@@ -26,7 +24,6 @@ import FreshStart2021SaleBanner from 'calypso/components/jetpack/fresh-start-202
 import './style.scss';
 
 const Header: React.FC< Props > = ( { urlQueryArgs } ) => {
-	const identity = config( 'olark_chat_identity' );
 	const translate = useTranslate();
 
 	const iterationClassName = useMemo(
@@ -43,7 +40,6 @@ const Header: React.FC< Props > = ( { urlQueryArgs } ) => {
 
 	return (
 		<>
-			{ identity && <OlarkChat { ...{ identity } } /> }
 			<JetpackComMasterbar />
 
 			<FreshStart2021SaleBanner urlQueryArgs={ urlQueryArgs } />

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -28,7 +28,6 @@
 	"jetpack_connect_url": false,
 	"mc_analytics_enabled": false,
 	"oauth_client_id": false,
-	"olark_chat_identity": false,
 	"protocol": "http",
 	"port": 3000,
 	"happychat_url": "https://happychat.io/customer",

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -71,11 +71,8 @@
 		"scan": true,
 		"jetpack-connect": true
 	},
-	"site_filter": [
-		"jetpack"
-	],
+	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
-	"theme_color": "#2fb41f",
-	"olark_chat_identity": "5581-687-10-4070"
+	"theme_color": "#2fb41f"
 }

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -66,9 +66,6 @@
 		"scan": true,
 		"jetpack-connect": true
 	},
-	"site_filter": [
-		"jetpack"
-	],
-	"theme": "jetpack-cloud",
-	"olark_chat_identity": "5581-687-10-4070"
+	"site_filter": [ "jetpack" ],
+	"theme": "jetpack-cloud"
 }

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -65,6 +65,5 @@
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
-	"theme_color": "#2fb41f",
-	"olark_chat_identity": "5581-687-10-4070"
+	"theme_color": "#2fb41f"
 }

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -68,11 +68,8 @@
 		"scan": true,
 		"jetpack-connect": true
 	},
-	"site_filter": [
-		"jetpack"
-	],
+	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
-	"theme_color": "#2fb41f",
-	"olark_chat_identity": "5581-687-10-4070"
+	"theme_color": "#2fb41f"
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes the Pre-sales chat from the Calypso Green Jetpack pricing page. It leaves the component available for future use but removes the config vars and loading logic for that page.

#### Testing instructions

* Load up Calypso Green with `yarn start-jetpack-cloud` and check the pricing page at `jetpack.cloud.localhost:3000/pricing` for errors.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
