### PR TITLE
Focused Launch: Fix domain picker item flex spacing

### DIFF
--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -378,7 +378,7 @@ $accent-blue: #117ac9;
 	// free domains don't include the wide phrase "Included in paid plans"
 	// they only include "Free" or "Default" word, this shrinks their width 
 	.domain-picker__price {
-		flex-grow: 0;
+		flex-grow: 0.1 // this is practically the same as 0. But 0 breaks IE.
 	}
 }
 

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -374,6 +374,14 @@ $accent-blue: #117ac9;
 	}
 }
 
+.domain-picker__suggestion-item.is-free {
+	// free domains don't include the wide phrase "Included in paid plans"
+	// they only include "Free" or "Default" word, this shrinks their width 
+	.domain-picker__price {
+		flex-grow: 0;
+	}
+}
+
 .domain-picker__suggestion-item.type-individual-item {
 	.domain-picker__price {
 		display: flex;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR tries to avoid the too-early breaking of domain picker items.
* This issue seems deceptively easy to fix. I tried several ideas but none of them met all the condititons (IE support and works in both domain picker modes). I ended up with a very simple (probably simplistic) solution of limited the width of the price column when the domain is free.


#### Why is it hard?

In each domain item, there two competing columns. The domain name column, and the price column. We prefer the domain picker to stay in one line, but not too rigid to make the phrase "Included in paid plans" narrow enough to render one word per line. We need the domain picker to stay in one line as long as it doesn't squeeze the price too much.

The current solution is to split the columns by 50:50 and remove the competition between the two columns entirely. This tells the domain name to stay in one line as long as it's shorter than 50% of the item. Easy and clean enough. 

In free domains though, 50% is way too much for the price column, because they don't have the phrase "Included in paid plans". This PR adds a special case for free domains to have a narrower price column. As for the paid domains, I think the 50:50 makes the most sense.


#### Testing instructions

1. Create or reuse a site that is created with `/start` flow.
2. Sandbox this site.
3. In `apps/editing-toolkit` run `yarn dev --sync`.
4. Go to https://[yoursite].wordpress.com/wp-admin/post-new.php
5. Click launch.
6. In the domain picker step, verify that #49817 is fixed.

#### Regression testing

1. Go to calypso.live/new?branch=fix/domain-picker-flex
2. Reach the domain step.
3. Verify that #49817 is fixed.
4. Using BrowserStack, you can test this in IE11 too.

Fixes https://github.com/Automattic/wp-calypso/issues/49817
