### PR TITLE
Add monthly pricing to My Plans page

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -488,9 +488,12 @@ export function plansLink( url, siteSlug, intervalType, forceIntervalType = fals
 	return formatUrl( getUrlFromParts( resultUrl ), originalUrlType );
 }
 
-export function applyTestFiltersToPlansList( planName, abtest ) {
+export function applyTestFiltersToPlansList( planName, abtest, extraArgs = {} ) {
 	const filteredPlanConstantObj = { ...getPlan( planName ) };
-	const filteredPlanFeaturesConstantList = getPlan( planName ).getPlanCompareFeatures( abtest );
+	const filteredPlanFeaturesConstantList = getPlan( planName ).getPlanCompareFeatures(
+		abtest,
+		extraArgs
+	);
 
 	// these becomes no-ops when we removed some of the abtest overrides, but
 	// we're leaving the code in place for future tests

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -330,6 +330,10 @@ export function isWpComFreePlan( planSlug ) {
 	return planMatches( planSlug, { type: TYPE_FREE, group: GROUP_WPCOM } );
 }
 
+export function isWpComMonthlyPlan( planSlug ) {
+	return planMatches( planSlug, { term: TERM_MONTHLY, group: GROUP_WPCOM } );
+}
+
 export function isJetpackBusinessPlan( planSlug ) {
 	return planMatches( planSlug, { type: TYPE_BUSINESS, group: GROUP_JETPACK } );
 }

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -186,12 +186,14 @@ const getPlanEcommerceDetails = () => ( {
 		i18n.translate(
 			'Learn more about everything included with eCommerce and take advantage of its powerful marketplace features.'
 		),
-	getPlanCompareFeatures: () =>
+	getPlanCompareFeatures: ( _, { isLoggedInMonthlyPricing } = {} ) =>
 		compact( [
 			// pay attention to ordering, shared features should align on /plan page
 			constants.FEATURE_CUSTOM_DOMAIN,
+			isLoggedInMonthlyPricing && constants.FEATURE_LIVE_CHAT_SUPPORT,
+			isLoggedInMonthlyPricing && constants.FEATURE_EMAIL_SUPPORT,
 			constants.FEATURE_JETPACK_ADVANCED,
-			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS,
+			! isLoggedInMonthlyPricing && constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS,
 			constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 			constants.FEATURE_ADVANCED_DESIGN,
 			constants.FEATURE_200GB_STORAGE,
@@ -288,12 +290,14 @@ const getPlanPremiumDetails = () => ( {
 				' Google Analytics support,' +
 				' and the ability to monetize your site with ads.'
 		),
-	getPlanCompareFeatures: () =>
+	getPlanCompareFeatures: ( _, { isLoggedInMonthlyPricing } = {} ) =>
 		compact( [
 			// pay attention to ordering, shared features should align on /plan page
 			constants.FEATURE_CUSTOM_DOMAIN,
+			isLoggedInMonthlyPricing && constants.FEATURE_LIVE_CHAT_SUPPORT,
+			isLoggedInMonthlyPricing && constants.FEATURE_EMAIL_SUPPORT,
 			constants.FEATURE_JETPACK_ESSENTIAL,
-			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
+			! isLoggedInMonthlyPricing && constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
 			constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 			constants.FEATURE_ADVANCED_DESIGN,
 			constants.FEATURE_13GB_STORAGE,
@@ -369,12 +373,14 @@ const getPlanBusinessDetails = () => ( {
 		i18n.translate(
 			'Learn more about everything included with Business and take advantage of its professional features.'
 		),
-	getPlanCompareFeatures: () =>
+	getPlanCompareFeatures: ( _, { isLoggedInMonthlyPricing } = {} ) =>
 		compact( [
 			// pay attention to ordering, shared features should align on /plan page
 			constants.FEATURE_CUSTOM_DOMAIN,
+			isLoggedInMonthlyPricing && constants.FEATURE_LIVE_CHAT_SUPPORT,
+			isLoggedInMonthlyPricing && constants.FEATURE_EMAIL_SUPPORT,
 			constants.FEATURE_JETPACK_ADVANCED,
-			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS,
+			! isLoggedInMonthlyPricing && constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS,
 			constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 			constants.FEATURE_ADVANCED_DESIGN,
 			constants.FEATURE_200GB_STORAGE,

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -242,7 +242,7 @@ export class PlanFeaturesHeader extends Component {
 		}
 
 		if ( ( isInSignup || isLoggedInMonthlyPricing ) && ! isMonthlyPlan ) {
-			return translate( 'Billed annually' );
+			return translate( 'billed annually' );
 		}
 
 		if ( typeof discountPrice !== 'number' || typeof rawPrice !== 'number' ) {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -280,6 +280,7 @@ export class PlanFeaturesHeader extends Component {
 			isInSignup,
 			plansWithScroll,
 			isLoggedInMonthlyPricing,
+			isMonthlyPlan,
 		} = this.props;
 
 		const isDiscounted = !! discountPrice;
@@ -306,7 +307,7 @@ export class PlanFeaturesHeader extends Component {
 			return (
 				<p className={ timeframeClasses }>
 					{ ! isPlaceholder ? perMonthDescription : '' }
-					{ isDiscounted && ! isPlaceholder && (
+					{ isDiscounted && ! isPlaceholder && ! isMonthlyPlan && (
 						<InfoPopover
 							className="plan-features__header-tip-info"
 							position={ isMobile() ? 'top' : 'bottom left' }
@@ -322,9 +323,9 @@ export class PlanFeaturesHeader extends Component {
 	}
 
 	isPlanCurrent() {
-		const { planType, current, currentSitePlan } = this.props;
+		const { planType, current, currentSitePlan, isLoggedInMonthlyPricing, isJetpack } = this.props;
 
-		if ( ! currentSitePlan ) {
+		if ( ! currentSitePlan || ( isLoggedInMonthlyPricing && ! isJetpack ) ) {
 			return current;
 		}
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -320,8 +320,7 @@ export class PlanFeatures extends Component {
 				isPlaceholder,
 				hideMonthly,
 			} = properties;
-			const { rawPrice, discountPrice } = properties;
-			const { annualPricePerMonth, isMonthlyPlan } = properties;
+			const { rawPrice, discountPrice, isMonthlyPlan } = properties;
 			const planDescription = isInVerticalScrollingPlansExperiment
 				? planConstantObj.getShortDescription( abtest )
 				: planConstantObj.getDescription( abtest );
@@ -347,7 +346,6 @@ export class PlanFeatures extends Component {
 						isInSignup={ isInSignup }
 						selectedPlan={ selectedPlan }
 						showPlanCreditsApplied={ true === showPlanCreditsApplied && ! this.hasDiscountNotice() }
-						annualPricePerMonth={ annualPricePerMonth }
 						isMonthlyPlan={ isMonthlyPlan }
 						audience={ planConstantObj.getAudience() }
 						isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
@@ -414,6 +412,7 @@ export class PlanFeatures extends Component {
 				isPlaceholder,
 				hideMonthly,
 				rawPrice,
+				isMonthlyPlan,
 			} = properties;
 			let { discountPrice } = properties;
 			const classes = classNames( 'plan-features__table-item', 'has-border-top' );
@@ -446,8 +445,6 @@ export class PlanFeatures extends Component {
 				billingTimeFrame = planConstantObj.getSignupBillingTimeFrame();
 			}
 
-			const { annualPricePerMonth, isMonthlyPlan } = properties;
-
 			return (
 				<th scope="col" key={ planName } className={ classes }>
 					<PlanFeaturesHeader
@@ -472,7 +469,6 @@ export class PlanFeatures extends Component {
 						showPlanCreditsApplied={ true === showPlanCreditsApplied && ! this.hasDiscountNotice() }
 						title={ planConstantObj.getTitle() }
 						plansWithScroll={ withScroll }
-						annualPricePerMonth={ annualPricePerMonth }
 						isMonthlyPlan={ isMonthlyPlan }
 						isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 						isLoggedInMonthlyPricing={
@@ -891,6 +887,7 @@ export default connect(
 				const bestValue = isBestValue( plan ) && ! isPaid;
 				const currentPlan = sitePlan && sitePlan.product_slug;
 				const planPath = getPlanPath( plan ) || '';
+				const isMonthlyPlan = isMonthly( plan );
 
 				const checkoutUrlArgs = {};
 				// Auto-apply the coupon code to the cart for WPCOM sites
@@ -955,18 +952,6 @@ export default connect(
 					? getPlanDiscountedRawPrice( state, selectedSiteId, plan, isMonthlyObj )
 					: getDiscountedRawPrice( state, planProductId, showMonthlyPrice );
 
-				let annualPricePerMonth = rawPrice;
-				const isMonthlyPlan = isMonthly( plan );
-				if ( isMonthlyPlan ) {
-					// Get annual price per month for comparison
-					const yearlyPlan = getPlanBySlug( state, getYearlyPlanByMonthly( plan ) );
-					if ( yearlyPlan ) {
-						annualPricePerMonth = siteId
-							? getSitePlanRawPrice( state, selectedSiteId, plan, { isMonthly: true } )
-							: getPlanRawPrice( state, yearlyPlan.product_id, true );
-					}
-				}
-
 				const annualPlansOnlyFeatures = planConstantObj.getAnnualPlansOnlyFeatures?.() || [];
 				if ( annualPlansOnlyFeatures.length > 0 ) {
 					planFeatures = planFeatures.map( ( feature ) => {
@@ -1016,7 +1001,6 @@ export default connect(
 					rawPrice,
 					relatedMonthlyPlan,
 					siteIsPrivateAndGoingAtomic,
-					annualPricePerMonth,
 					isMonthlyPlan,
 				};
 			} )

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -42,7 +42,6 @@ import {
 	planMatches,
 	applyTestFiltersToPlansList,
 	getMonthlyPlanByYearly,
-	getYearlyPlanByMonthly,
 	getPlanPath,
 	isFreePlan,
 	isWpComEcommercePlan,
@@ -343,7 +342,7 @@ export class PlanFeatures extends Component {
 						isPlaceholder={ isPlaceholder }
 						basePlansPath={ basePlansPath }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
-						isInSignup={ isInSignup }
+						displayPerMonthNotation={ isInSignup }
 						selectedPlan={ selectedPlan }
 						showPlanCreditsApplied={ true === showPlanCreditsApplied && ! this.hasDiscountNotice() }
 						isMonthlyPlan={ isMonthlyPlan }

--- a/client/my-sites/plan-features/item.jsx
+++ b/client/my-sites/plan-features/item.jsx
@@ -15,13 +15,17 @@ export default function PlanFeaturesItem( {
 	description,
 	hideInfoPopover,
 	hideGridicon = false,
+	availableForCurrentPlan = true,
 } ) {
 	const isMobile = useMobileBreakpoint();
 
 	return (
 		<div className="plan-features__item">
-			{ ! hideGridicon && (
+			{ ! hideGridicon && availableForCurrentPlan && (
 				<Gridicon className="plan-features__item-checkmark" size={ 18 } icon="checkmark" />
+			) }
+			{ ! hideGridicon && ! availableForCurrentPlan && (
+				<Gridicon className="plan-features__item-unavailable" size={ 18 } icon="cross" />
 			) }
 			{ children }
 			{ hideInfoPopover ? null : (

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -42,27 +42,27 @@ $plan-features-sidebar-width: 272px;
 				border-top: solid 8px;
 				border-radius: 2px 2px 0 0;
 				padding-bottom: 12px;
-		
+
 				&.is-blogger-plan {
 					border-color: var( --color-plan-blogger );
 					border-bottom: solid 2px var( --color-neutral-10 );
 				}
-		
+
 				&.is-personal-plan {
 					border-color: var( --color-plan-personal );
 					border-bottom: solid 2px var( --color-neutral-10 );
 				}
-		
+
 				&.is-premium-plan {
 					border-color: var( --color-plan-premium );
 					border-bottom: solid 2px var( --color-neutral-10 );
 				}
-		
+
 				&.is-business-plan {
 					border-color: var( --color-plan-business );
 					border-bottom: solid 2px var( --color-neutral-10 );
 				}
-		
+
 				&.is-ecommerce-plan {
 					border-color: var( --color-plan-ecommerce );
 					border-bottom: solid 2px var( --color-neutral-10 );
@@ -81,7 +81,7 @@ $plan-features-sidebar-width: 272px;
 					font-size: $font-title-medium;
 					font-weight: 400;
 				}
-				
+
 				.plan-price__integer {
 					font-weight: 600;
 				}
@@ -460,6 +460,19 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
+.plan-features__header-interval-discount {
+	margin-top: -1em;
+	margin-bottom: 1.4em;
+	font-size: $font-body-extra-small;
+	font-weight: 400;
+	color: var( --color-success );
+	line-height: normal;
+
+	&.is-crossed-out {
+		text-decoration: line-through;
+	}
+}
+
 .plan-features__header-title-free {
 	font-size: 1.5rem;
 	line-height: 1.5;
@@ -586,6 +599,13 @@ $plan-features-sidebar-width: 272px;
 	margin-right: 10px;
 }
 
+.plan-features__item-unavailable {
+	flex: 0 1 auto;
+	fill: var( --color-neutral-30 );
+	margin-right: 10px;
+	transform: translate( 0, 2px );
+}
+
 .plan-features__item-tip-info {
 	flex: 0 1 auto;
 }
@@ -627,6 +647,13 @@ $plan-features-sidebar-width: 272px;
 	flex-direction: column;
 	flex: 1 0 0;
 	width: 100%;
+
+	&.is-annual-plan-feature:not( .is-available ) {
+		.plan-features__item-title {
+			text-decoration: line-through;
+			color: var( --color-neutral-30 );
+		}
+	}
 }
 
 .plan-features__item-title-outlined {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -458,18 +458,9 @@ $plan-features-sidebar-width: 272px;
 			margin-bottom: 9px;
 		}
 	}
-}
 
-.plan-features__header-interval-discount {
-	margin-top: -1em;
-	margin-bottom: 1.4em;
-	font-size: $font-body-extra-small;
-	font-weight: 400;
-	color: var( --color-success );
-	line-height: normal;
-
-	&.is-crossed-out {
-		text-decoration: line-through;
+	&.is-logged-in-monthly-pricing {
+		font-style: normal;
 	}
 }
 

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -396,6 +396,15 @@ describe( 'PlanIntervalDiscount', () => {
 		translate: identity,
 		billingTimeFrame: '',
 		title: '',
+		planType: PLAN_JETPACK_FREE,
+	};
+	const monthlyPlanProps = {
+		...baseProps,
+		isYearly: false,
+		rawPrice: 14,
+		relatedMonthlyPlan: null,
+		relatedYearlyPlan: { raw_price: 96 },
+		planType: PLAN_PREMIUM_MONTHLY,
 	};
 	test( 'should show interval discount for Jetpack during signup', () => {
 		const wrapper = shallow( <PlanFeaturesHeader { ...baseProps } isInSignup isJetpack /> );
@@ -417,6 +426,22 @@ describe( 'PlanIntervalDiscount', () => {
 			<PlanFeaturesHeader { ...baseProps } isInSignup isJetpack isSiteAT />
 		);
 		expect( wrapper.find( PlanIntervalDiscount ) ).toHaveLength( 0 );
+	} );
+
+	test( 'should show interval discount for those eligible for monthly pricing', () => {
+		const wrapper = shallow(
+			<PlanFeaturesHeader { ...baseProps } isLoggedInMonthlyPricing planType={ PLAN_PREMIUM } />
+		);
+		expect( wrapper.find( '.plan-features__header-interval-discount' ) ).toHaveLength( 1 );
+	} );
+
+	test( 'should cross out interval discount for monthly plans', () => {
+		const wrapper = shallow(
+			<PlanFeaturesHeader { ...monthlyPlanProps } isLoggedInMonthlyPricing />
+		);
+		expect(
+			wrapper.find( '.plan-features__header-interval-discount' ).hasClass( 'is-crossed-out' )
+		).toBe( true );
 	} );
 } );
 

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -440,7 +440,7 @@ describe( 'PlanFeaturesHeader.renderPriceGroup()', () => {
 		expect( myProps.discounted ).toBe( false );
 		expect( myProps.original ).toBe( false );
 		expect( myProps.currencyCode ).toBe( 'USD' );
-		expect( myProps.isInSignup ).toBe( false );
+		expect( myProps.displayPerMonthNotation ).toBe( false );
 	} );
 	test( 'Should return two prices when two numbers are passed: one original and one discounted', () => {
 		const comp = new PlanFeaturesHeader( baseProps );
@@ -453,7 +453,7 @@ describe( 'PlanFeaturesHeader.renderPriceGroup()', () => {
 		expect( props1.discounted ).toBe( false );
 		expect( props1.original ).toBe( true );
 		expect( props1.currencyCode ).toBe( 'USD' );
-		expect( props1.isInSignup ).toBe( false );
+		expect( props1.displayPerMonthNotation ).toBe( false );
 
 		// We need the dive() here to pick up defaultProps
 		const props2 = wrapper.find( PlanPrice ).at( 1 ).dive().props();
@@ -461,7 +461,7 @@ describe( 'PlanFeaturesHeader.renderPriceGroup()', () => {
 		expect( props2.discounted ).toBe( true );
 		expect( props2.original ).toBe( false );
 		expect( props2.currencyCode ).toBe( 'USD' );
-		expect( props2.isInSignup ).toBe( false );
+		expect( props2.displayPerMonthNotation ).toBe( false );
 	} );
 } );
 

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -398,14 +398,6 @@ describe( 'PlanIntervalDiscount', () => {
 		title: '',
 		planType: PLAN_JETPACK_FREE,
 	};
-	const monthlyPlanProps = {
-		...baseProps,
-		isYearly: false,
-		rawPrice: 14,
-		relatedMonthlyPlan: null,
-		relatedYearlyPlan: { raw_price: 96 },
-		planType: PLAN_PREMIUM_MONTHLY,
-	};
 	test( 'should show interval discount for Jetpack during signup', () => {
 		const wrapper = shallow( <PlanFeaturesHeader { ...baseProps } isInSignup isJetpack /> );
 		expect( wrapper.find( PlanIntervalDiscount ) ).toHaveLength( 1 );
@@ -426,22 +418,6 @@ describe( 'PlanIntervalDiscount', () => {
 			<PlanFeaturesHeader { ...baseProps } isInSignup isJetpack isSiteAT />
 		);
 		expect( wrapper.find( PlanIntervalDiscount ) ).toHaveLength( 0 );
-	} );
-
-	test( 'should show interval discount for those eligible for monthly pricing', () => {
-		const wrapper = shallow(
-			<PlanFeaturesHeader { ...baseProps } isLoggedInMonthlyPricing planType={ PLAN_PREMIUM } />
-		);
-		expect( wrapper.find( '.plan-features__header-interval-discount' ) ).toHaveLength( 1 );
-	} );
-
-	test( 'should cross out interval discount for monthly plans', () => {
-		const wrapper = shallow(
-			<PlanFeaturesHeader { ...monthlyPlanProps } isLoggedInMonthlyPricing />
-		);
-		expect(
-			wrapper.find( '.plan-features__header-interval-discount' ).hasClass( 'is-crossed-out' )
-		).toBe( true );
 	} );
 } );
 

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -27,7 +27,7 @@ export class PlanPrice extends Component {
 			discounted,
 			className,
 			displayFlatPrice,
-			isInSignup,
+			displayPerMonthNotation,
 			isOnSale,
 			taxText,
 			translate,
@@ -112,7 +112,7 @@ export class PlanPrice extends Component {
 						{ translate( '(+%(taxText)s tax)', { args: { taxText } } ) }
 					</sup>
 				) }
-				{ isInSignup && (
+				{ displayPerMonthNotation && (
 					<span className="plan-price__term">
 						{ translate( 'per{{newline/}}month', {
 							components: { newline: <br /> },
@@ -138,6 +138,7 @@ PlanPrice.propTypes = {
 	isOnSale: PropTypes.bool,
 	taxText: PropTypes.string,
 	translate: PropTypes.func.isRequired,
+	displayPerMonthNotation: PropTypes.bool,
 };
 
 PlanPrice.defaultProps = {
@@ -146,4 +147,5 @@ PlanPrice.defaultProps = {
 	discounted: false,
 	className: '',
 	isOnSale: false,
+	displayPerMonthNotation: false,
 };

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -265,6 +265,7 @@ export class PlansFeaturesMain extends Component {
 					siteId={ siteId }
 					isReskinned={ isReskinned }
 					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
+					kindOfPlanTypeSelector={ this.getKindOfPlanTypeSelector( this.props ) }
 				/>
 			</div>
 		);

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -56,7 +56,7 @@ export const generatePath: GeneratePathFunction = ( props, additionalArgs = {} )
 				...defaultArgs,
 				...additionalArgs,
 			},
-			''
+			document.location?.search
 		);
 	}
 

--- a/client/my-sites/plans-features-main/test/plan-type-selector.jsx
+++ b/client/my-sites/plans-features-main/test/plan-type-selector.jsx
@@ -33,7 +33,7 @@ describe( '<PlanTypeSelector />', () => {
 
 	test( 'Should show IntervalTypeToggle when kind is set to `interval`', () => {
 		const comp = shallow(
-			<PlanTypeSelector { ...myProps } displayJetpackPlans={ true } intervalType="monthly" />
+			<PlanTypeSelector { ...myProps } kind="interval" intervalType="monthly" />
 		);
 
 		expect( comp.find( 'IntervalTypeToggle' ).length ).toBe( 1 );

--- a/client/my-sites/plans-features-main/test/plan-type-selector.jsx
+++ b/client/my-sites/plans-features-main/test/plan-type-selector.jsx
@@ -20,8 +20,10 @@ describe( '<PlanTypeSelector />', () => {
 		withWPPlanTabs: true,
 	};
 
-	test( 'Should show CustomerTypeToggle when withWPPlanTabs is set to true', () => {
-		const comp = shallow( <PlanTypeSelector { ...myProps } customerType="personal" /> );
+	test( 'Should show CustomerTypeToggle when kind is set to `customer`', () => {
+		const comp = shallow(
+			<PlanTypeSelector { ...myProps } kind="customer" customerType="personal" />
+		);
 
 		expect( comp.find( 'CustomerTypeToggle' ).length ).toBe( 1 );
 
@@ -29,7 +31,7 @@ describe( '<PlanTypeSelector />', () => {
 		expect( comp.find( 'CustomerTypeToggle[customerType="personal"]' ).length ).toBe( 1 );
 	} );
 
-	test( 'Should show IntervalTypeToggle when displayJetpackPlans is set to true', () => {
+	test( 'Should show IntervalTypeToggle when kind is set to `interval`', () => {
 		const comp = shallow(
 			<PlanTypeSelector { ...myProps } displayJetpackPlans={ true } intervalType="monthly" />
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As a part of the Monthly pricing phase 4, this PR enables the monthly plans to the My Plans page. For more details, see pcbrnV-1gA-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

First of all, the monthly pricing is available only for free users and monthly plan users. You should make sure the following changes don't affect on any pages as long as you are a non-monthly plan user.

* If your site is either on the free plan or a monthly plan, My Plans page should display the Interval type selector (red box) and all four paid plans should show up in a row.
  <img width="1024" alt="Plans_‹_PremiumSite_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/108209282-76985200-716d-11eb-8e85-e523ea3cf6e3.png">
* With a non-monthly paid plan, the Customer type selector should appear instead of the Interval type selector.
  <img width="800" alt="Plans_‹_Taggon_on_wordpress_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/107378112-00716b00-6b2f-11eb-9dc1-eedf47679090.png">
* Make sure the both site selectors work as expected.
* Check the `plans` step of the new site creation flow. It should not change.
  <img width="800" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/107378619-7ece0d00-6b2f-11eb-8d9e-fdbb6bb58c81.png">
