### PR TITLE
G Suite: Update cancelation survey for Google Workspace

### DIFF
--- a/client/components/gsuite/gsuite-learn-more/index.jsx
+++ b/client/components/gsuite/gsuite-learn-more/index.jsx
@@ -9,14 +9,15 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { ADDING_GOOGLE_APPS_TO_YOUR_SITE } from 'calypso/lib/url/support';
+import { ADDING_GSUITE_TO_YOUR_SITE } from 'calypso/lib/url/support';
+import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const GSuiteLearnMore = ( { onLearnMoreClick } ) => {
+const GSuiteLearnMore = ( { onLearnMoreClick, productSlug } ) => {
 	const translate = useTranslate();
 
 	return (
@@ -24,14 +25,18 @@ const GSuiteLearnMore = ( { onLearnMoreClick } ) => {
 			<p>
 				{ translate(
 					'{{strong}}No setup or software required.{{/strong}} ' +
-						'{{a}}Learn more about integrating G Suite with your site.{{/a}}',
+						'{{a}}Learn more about integrating %(googleMailService)s with your site.{{/a}}',
 					{
+						args: {
+							googleMailService: getGoogleMailServiceFamily( productSlug ),
+						},
+						comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
 						components: {
 							strong: <strong />,
 							a: (
 								<a
 									className="gsuite-learn-more__link"
-									href={ ADDING_GOOGLE_APPS_TO_YOUR_SITE }
+									href={ ADDING_GSUITE_TO_YOUR_SITE }
 									target="_blank"
 									rel="noopener noreferrer"
 									onClick={ onLearnMoreClick }

--- a/client/components/gsuite/gsuite-learn-more/test/__snapshots__/index.js.snap
+++ b/client/components/gsuite/gsuite-learn-more/test/__snapshots__/index.js.snap
@@ -11,7 +11,7 @@ exports[`GSuiteLearnMore it renders GSuiteLearnMore with no props 1`] = `
      
     <a
       className="gsuite-learn-more__link"
-      href="https://wordpress.com/support/adding-g-suite-to-your-site"
+      href="https://wordpress.com/support/add-email/adding-g-suite-to-your-site/"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
@@ -10,6 +10,7 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import CardHeading from 'calypso/components/card-heading';
+import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import GSuiteFeatures from 'calypso/components/gsuite/gsuite-features';
 import GSuiteLearnMore from 'calypso/components/gsuite/gsuite-learn-more';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -25,20 +26,30 @@ class GSuiteCancellationFeatures extends Component {
 
 	render() {
 		const { purchase, translate } = this.props;
-		const { meta: gsuiteDomain, productSlug } = purchase;
+		const { meta: domainName, productSlug } = purchase;
+
 		return (
 			<div className="gsuite-cancel-purchase-dialog__features">
 				<CardHeading tagName="h3" size={ 24 }>
 					{ translate( "Are you sure? Here's what you'll be missing:" ) }
 				</CardHeading>
+
 				<p>
 					{ translate(
-						'If you cancel and remove G Suite from {{siteName/}} you will lose access to the following: ',
-						{ components: { siteName: <em>{ gsuiteDomain }</em> } }
+						'If you cancel and remove %(googleMailService)s from {{siteName/}} you will lose access to the following: ',
+						{
+							args: {
+								googleMailService: getGoogleMailServiceFamily( productSlug ),
+							},
+							comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+							components: { siteName: <em>{ domainName }</em> },
+						}
 					) }
 				</p>
-				<GSuiteFeatures productSlug={ productSlug } domainName={ gsuiteDomain } type={ 'list' } />
-				<GSuiteLearnMore onClick={ this.handleLearnMoreClick } />
+
+				<GSuiteFeatures productSlug={ productSlug } domainName={ domainName } type={ 'list' } />
+
+				<GSuiteLearnMore onClick={ this.handleLearnMoreClick } productSlug={ productSlug } />
 			</div>
 		);
 	}

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-survey.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-survey.jsx
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
+import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import MultipleChoiceQuestion from 'calypso/components/multiple-choice-question';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -21,18 +22,18 @@ class GSuiteCancellationSurvey extends Component {
 		const {
 			disabled,
 			onSurveyAnswerChange,
+			purchase: { productSlug },
 			surveyAnswerId,
 			surveyAnswerText,
 			translate,
 		} = this.props;
+
 		return (
 			<MultipleChoiceQuestion
 				answers={ [
 					{
 						id: 'too-expensive',
 						answerText: translate( "It's too expensive." ),
-						textInput: true,
-						textInputPrompt: translate( 'How can we improve G Suite?' ),
 					},
 					{
 						id: 'do-not-need-it',
@@ -57,7 +58,12 @@ class GSuiteCancellationSurvey extends Component {
 						doNotShuffle: true,
 					},
 				] }
-				question={ translate( 'Please tell us why you are cancelling G Suite:' ) }
+				question={ translate( 'Please tell us why you are cancelling %(googleMailService)s:', {
+					args: {
+						googleMailService: getGoogleMailServiceFamily( productSlug ),
+					},
+					comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+				} ) }
 				onAnswerChange={ onSurveyAnswerChange }
 				disabled={ disabled }
 				selectedAnswerId={ surveyAnswerId }
@@ -70,6 +76,7 @@ class GSuiteCancellationSurvey extends Component {
 GSuiteCancellationSurvey.propTypes = {
 	disabled: PropTypes.bool.isRequired,
 	onSurveyAnswerChange: PropTypes.func.isRequired,
+	purchase: PropTypes.object.isRequired,
 	translate: PropTypes.func.isRequired,
 	surveyAnswerId: PropTypes.string,
 	surveyAnswerText: PropTypes.string,

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -206,6 +206,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 	render() {
 		const { isVisible, onClose, purchase } = this.props;
 		const { surveyAnswerId, surveyAnswerText, isRemoving } = this.state;
+
 		return (
 			// By checking isVisible here we prevent rendering a "reset" dialog state before it closes
 			isVisible && (
@@ -221,6 +222,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 						<GSuiteCancellationSurvey
 							disabled={ isRemoving }
 							onSurveyAnswerChange={ this.onSurveyAnswerChange }
+							purchase={ purchase }
 							surveyAnswerId={ surveyAnswerId }
 							surveyAnswerText={ surveyAnswerText }
 						/>

--- a/client/lib/gsuite/get-google-mail-service-family.js
+++ b/client/lib/gsuite/get-google-mail-service-family.js
@@ -16,6 +16,7 @@ export function getGoogleMailServiceFamily( productSlug = null ) {
 			case GSUITE_BASIC_SLUG:
 			case GSUITE_BUSINESS_SLUG:
 				return GSUITE_PRODUCT_FAMILY;
+
 			case GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY:
 				return GOOGLE_WORKSPACE_PRODUCT_FAMILY;
 		}
@@ -24,5 +25,6 @@ export function getGoogleMailServiceFamily( productSlug = null ) {
 	if ( config.isEnabled( 'google-workspace-migration' ) ) {
 		return GOOGLE_WORKSPACE_PRODUCT_FAMILY;
 	}
+
 	return GSUITE_PRODUCT_FAMILY;
 }

--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -6,7 +6,7 @@ import { localizeUrl } from 'calypso/lib/i18n-utils';
 const root = localizeUrl( 'https://wordpress.com/support/' ).replace( /\/$/, '' );
 
 export const ACCOUNT_RECOVERY = `${ root }/account-recovery`;
-export const ADDING_GOOGLE_APPS_TO_YOUR_SITE = `${ root }/adding-g-suite-to-your-site`;
+export const ADDING_GSUITE_TO_YOUR_SITE = `${ root }/add-email/adding-g-suite-to-your-site/`;
 export const ADDING_USERS = `${ root }/adding-users`;
 export const AUTO_RENEWAL = `${ root }/auto-renewal`;
 export const BANDPAGE_WIDGET = `${ root }/widgets/bandpage-widget`;
@@ -15,7 +15,6 @@ export const CHANGE_NAME_SERVERS = `${ root }/domains/custom-dns/#changing-name-
 export const CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS = `${ root }/domains/change-name-servers/#finding-out-your-new-name-server`;
 export const COMMENTS = `${ root }/category/comments`;
 export const COMMUNITY_TRANSLATOR = `${ root }/community-translator`;
-export const COMPLETING_GOOGLE_APPS_SIGNUP = `${ root }/adding-g-suite-to-your-site/#completing-sign-up`;
 export const CONCIERGE_SUPPORT = `${ root }/concierge-support`;
 export const CONNECT = `${ root }/connect`;
 export const CONTACT = `${ root }/contact`;
@@ -56,7 +55,7 @@ export const FOLLOWERS = `${ root }/followers`;
 export const FORMS = `${ root }/forms`;
 export const GETTING_MORE_VIEWS_AND_TRAFFIC = `${ root }/getting-more-views-and-traffic`;
 export const GOOGLE_ANALYTICS = `${ root }/google-analytics`;
-export const GOOGLE_APPS_LEARNING_CENTER = 'https://gsuite.google.com/learning-center/';
+export const GSUITE_LEARNING_CENTER = 'https://gsuite.google.com/learning-center/';
 export const GOOGLE_PLUS_EMBEDS = `${ root }/google-plus-embeds`;
 export const GRAVATAR_HOVERCARDS = `${ root }/gravatar-hovercards`;
 export const GUIDED_TRANSFER = `${ root }/guided-transfer`;

--- a/client/me/purchases/cancel-purchase/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/cancellation-effect.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
+import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { getName, getSubscriptionEndDate, isRefundable } from 'calypso/lib/purchases';
 import {
 	isDomainMapping,
@@ -66,12 +67,14 @@ function refundableCancellationEffectDetail( purchase, translate, overrides ) {
 
 	if ( isGSuiteOrGoogleWorkspace( purchase ) ) {
 		return translate(
-			'You will be refunded %(cost)s, but your G Suite account will continue working without interruption. ' +
-				'You will be able to manage your G Suite billing directly through Google.',
+			'You will be refunded %(cost)s, and your %(googleMailService)s account will continue working without interruption. ' +
+				'You will be able to set up billing for your account directly with Google.',
 			{
 				args: {
+					googleMailService: getGoogleMailServiceFamily( purchase.productSlug ),
 					cost: refundText,
 				},
+				comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
 			}
 		);
 	}
@@ -111,11 +114,13 @@ function nonrefundableCancellationEffectDetail( purchase, translate ) {
 
 	if ( isGSuiteOrGoogleWorkspace( purchase ) ) {
 		return translate(
-			'Your G Suite account remains active until it expires on %(subscriptionEndDate)s.',
+			'Your %(googleMailService)s account remains active until it expires on %(subscriptionEndDate)s.',
 			{
 				args: {
+					googleMailService: getGoogleMailServiceFamily( purchase.productSlug ),
 					subscriptionEndDate,
 				},
+				comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
 			}
 		);
 	}

--- a/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
@@ -69,8 +69,7 @@ describe( 'cancellation-effect', () => {
 				productsValues.isGSuiteOrGoogleWorkspace = () => true;
 				const headline = cancellationEffectDetail( purchase, translate );
 				expect( headline.text ).to.equal(
-					'You will be refunded %(cost)s, but your G Suite account will continue working without interruption. ' +
-						'You will be able to manage your G Suite billing directly through Google.'
+					'You will be refunded %(cost)s, and your %(googleMailService)s account will continue working without interruption. You will be able to set up billing for your account directly with Google.'
 				);
 			} );
 
@@ -116,7 +115,7 @@ describe( 'cancellation-effect', () => {
 				productsValues.isGSuiteOrGoogleWorkspace = () => true;
 				const headline = cancellationEffectDetail( purchase, translate );
 				expect( headline.text ).to.equal(
-					'Your G Suite account remains active until it expires on %(subscriptionEndDate)s.'
+					'Your %(googleMailService)s account remains active until it expires on %(subscriptionEndDate)s.'
 				);
 			} );
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -271,15 +271,10 @@ class RemovePurchase extends Component {
 							//{ components: { domain: <em>{ getIncludedDomain( purchase ) }</em> } }
 						} )
 					}{ ' ' }
-					{ isGSuiteOrGoogleWorkspace( purchase )
-						? translate(
-								'Your G Suite account will continue working without interruption. ' +
-									'You will be able to manage your G Suite billing directly through Google.'
-						  )
-						: translate(
-								'You will not be able to reuse it again without purchasing a new subscription.',
-								{ comment: "'it' refers to a product purchased by a user" }
-						  ) }
+					{ translate(
+						'You will not be able to reuse it again without purchasing a new subscription.',
+						{ comment: "'it' refers to a product purchased by a user" }
+					) }
 				</p>
 
 				{ isPlan( purchase ) && hasIncludedDomain( purchase ) && includedDomainText }

--- a/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
@@ -7,7 +7,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { CONTACT, GOOGLE_APPS_LEARNING_CENTER } from 'calypso/lib/url/support';
+import { CONTACT, GSUITE_LEARNING_CENTER } from 'calypso/lib/url/support';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import { useSelector } from 'react-redux';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
@@ -112,7 +112,7 @@ const GoogleAppsDetails = ( { purchases } ) => {
 				},
 				comment: '%(productFamily)s can be either "G Suite" or "Google Workspace"',
 			} ) }
-			href={ GOOGLE_APPS_LEARNING_CENTER }
+			href={ GSUITE_LEARNING_CENTER }
 			target="_blank"
 			rel="noopener noreferrer"
 			requiredText={ i18n.translate( 'Almost done! One step remaining…' ) }


### PR DESCRIPTION
This pull request updates the cancelation survey displayed on the `Purchase Settings` page (when a user opts to remove a Google Workspace subscription) in order to show the right product name:

![screenshot](https://user-images.githubusercontent.com/594356/107384487-4fe57600-6af2-11eb-9e83-eb574b972702.png)

![screenshot](https://user-images.githubusercontent.com/594356/107384585-64297300-6af2-11eb-88d9-7e4bbae3f95a.png)

It also updates some copy from the `Cancel Purchase` page and dialog:

![screenshot](https://user-images.githubusercontent.com/594356/107403132-08b4b080-6b05-11eb-94d5-b27c5f8b28ac.png)

![screenshot](https://user-images.githubusercontent.com/594356/107403216-2255f800-6b05-11eb-8009-312c17d174cc.png)

#### Testing instructions

1. Run `git checkout update/cancelation-survey-for-google-workspace` and start your server, or open a [live branch](https://calypso.live/?branch=update/cancelation-survey-for-google-workspace)
2. Log into a WordPress.com account with a Google Workspace account
3. Open the [`Purchases` page](http://calypso.localhost:3000/me/purchases)
4. Click the Google Workspace subscription
5. Click the `Remove Google Workspace Business Starter` option
6. Assert that all the steps from the survey show `Google Workspace` instead of `G Suite`

> Note the `Cancel Purchase` page seems to be accessible only if the subscription was purchased without free credits.