### PR TITLE
Update stylelint-scales package

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,10 +1,23 @@
 {
 	"plugins": ["@signal-noise/stylelint-scales"],
 	"rules": {
-		"scales/font-weight": [[ 400, 600, 700, "normal", "bold", "inherit" ]],
-		"scales/font-size": [[ 0.75, 0.875, 1, 1.25, 1.5, 2, 2.25, 3, 3.375 ], { unit: "rem" }],
-		"scales/radii": [[ 2 ], { unit: "px" }],
-
+		"declaration-property-unit-allowed-list": {
+			"/^font-size$|^font$/": ["rem"],
+			"/radius$/": ["px"]
+		},
+		"scales/font-weights": [400, 600, 700],
+		"scales/font-sizes": [
+			{
+				"scale": [0.75, 0.875, 1, 1.25, 1.5, 2, 2.25, 3, 3.375],
+				"units": ["rem"]
+			}
+		],
+		"scales/radii": [
+			{
+				"scale": [2],
+				"units": ["px"]
+			}
+		],
 		"color-hex-case": "lower",
 		"color-no-invalid-hex": true,
 

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
 		"@babel/core": "^7.12.3",
 		"@babel/register": "^7.12.1",
 		"@babel/runtime": "^7.12.5",
-		"@signal-noise/stylelint-scales": "^1.4.0",
+		"@signal-noise/stylelint-scales": "^2.0.0",
 		"@storybook/addon-actions": "^6.1.10",
 		"@storybook/preset-scss": "^1.0.3",
 		"@storybook/react": "^6.1.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3058,18 +3058,15 @@
     lodash.merge "^4.4.0"
     postcss "^5.0.21"
 
-"@signal-noise/stylelint-scales@^1.4.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@signal-noise/stylelint-scales/-/stylelint-scales-1.5.0.tgz#c7264639a779c8402e9630d6aabac6f99175d83b"
-  integrity sha512-V7penWCQ8DYaI0m14JD3z8G+E3LLJX6QL08A66wotlxt5MU0NRi+tkEWepzXsIT9BvSV7yKiEtsApa5gc+VVmQ==
+"@signal-noise/stylelint-scales@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@signal-noise/stylelint-scales/-/stylelint-scales-2.0.0.tgz#f81d31a75fd78f1883b9239f6ba8264bf56aa47a"
+  integrity sha512-+FCPJK5F1Lve5SWT619E2ZU20w92DM5Bph49qy4Ifdsw5UMs84MDynEu/AgygkezvKb2EwwIenRwnLRiiH+Anw==
   dependencies:
-    camelcase "^6.0.0"
-    css-border-property "^1.1.0"
     css-global-keywords "^1.0.1"
     font-family "^0.2.0"
-    lodash "^4.17.20"
     parse-css-font "^4.0.0"
-    postcss-values-parser "^3.2.1"
+    postcss-values-parser "^4.0.0"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -9565,24 +9562,10 @@ css-blank-pseudo@^0.1.4:
   dependencies:
     postcss "^7.0.5"
 
-css-border-property@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/css-border-property/-/css-border-property-1.1.0.tgz#3b54eb8d07917d0b5069ecbc9783ffa419e2d532"
-  integrity sha1-O1TrjQeRfQtQaey8l4P/pBni1TI=
-  dependencies:
-    is-border-style "^0.1.0"
-    is-color "^0.2.0"
-    is-css-length "^0.1.0"
-
 css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
   integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
-
-css-color-names@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.1.tgz#5d0548fa256456ede4a9a0c2ac7ab19d3eb1ad81"
-  integrity sha1-XQVI+iVkVu3kqaDCrHqxnT6xrYE=
 
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
@@ -14003,7 +13986,7 @@ header-case@^1.0.0:
     no-case "^2.2.0"
     upper-case "^1.1.3"
 
-hex-color-regex@^1.0.3, hex-color-regex@^1.1.0:
+hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
@@ -14929,11 +14912,6 @@ is-boolean-object@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.1.tgz#10edc0900dd127697a92f6f9807c7617d68ac48e"
   integrity sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ==
 
-is-border-style@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/is-border-style/-/is-border-style-0.1.0.tgz#360b0059cae2905a3cc1d53a174c2cb1771ae4e0"
-  integrity sha1-NgsAWcrikFo8wdU6F0wssXca5OA=
-
 is-buffer@^1.0.2, is-buffer@^1.1.0, is-buffer@^1.1.4, is-buffer@^1.1.5, is-buffer@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -14968,29 +14946,12 @@ is-color-stop@^1.0.0:
     rgb-regex "^1.0.1"
     rgba-regex "^1.0.0"
 
-is-color@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/is-color/-/is-color-0.2.0.tgz#9d40c6997107f88dfc5ca02762cc51b3ae8039d3"
-  integrity sha1-nUDGmXEH+I38XKAnYsxRs66AOdM=
-  dependencies:
-    css-color-names "0.0.1"
-    hex-color-regex "^1.0.3"
-    hsl-regex "^1.0.0"
-    hsla-regex "^1.0.0"
-    rgb-regex "^1.0.1"
-    rgba-regex "^1.0.0"
-
 is-core-module@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
   integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
   dependencies:
     has "^1.0.3"
-
-is-css-length@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/is-css-length/-/is-css-length-0.1.0.tgz#34156f82e88b09865f40e7009748142dce674c80"
-  integrity sha1-NBVvguiLCYZfQOcAl0gULc5nTIA=
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -21350,7 +21311,7 @@ postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-values-parser@^3.0.5, postcss-values-parser@^3.2.1:
+postcss-values-parser@^3.0.5:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-3.2.1.tgz#55114607de6631338ba8728d3e9c15785adcc027"
   integrity sha512-SQ7/88VE9LhJh9gc27/hqnSU/aZaREVJcRVccXBmajgP2RkjdJzNyH/a9GCVMI5nsRhT0jC5HpUMwfkz81DVVg==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Upgrade from 1.4 to 2.0

<img width="759" alt="Screen Shot 2021-02-09 at 10 24 51 AM" src="https://user-images.githubusercontent.com/2124984/107385886-527ba780-6ac1-11eb-8cdb-6355ca77ea16.png">
<img width="672" alt="Screen Shot 2021-02-09 at 10 25 05 AM" src="https://user-images.githubusercontent.com/2124984/107385892-53acd480-6ac1-11eb-9274-15a75be8d1fc.png">
<img width="724" alt="Screen Shot 2021-02-09 at 10 25 17 AM" src="https://user-images.githubusercontent.com/2124984/107385897-54de0180-6ac1-11eb-96e8-e55daab94cc4.png">


#### Testing instructions

* Switch to this PR and run `yarn`
* Add a new `border-radius`, `font-size`, or `font-weight` rule to any stylesheet and make sure your linter flags incorrect values (see above screenshots for examples).