### PR TITLE
useDetectMatchingAnchorSite: Move away from wpcom.undocumented - Doesn't work

### DIFF
--- a/client/landing/gutenboarding/hooks/use-detect-matching-anchor-site.ts
+++ b/client/landing/gutenboarding/hooks/use-detect-matching-anchor-site.ts
@@ -9,6 +9,8 @@ import page from 'page';
  * Internal dependencies
  */
 import wpcom from 'calypso/lib/wp';
+import { requestAnchorMatchingSite } from 'calypso/state/data-getters';
+import { waitForHttpData } from 'calypso/state/data-layer/http-data';
 import { USER_STORE } from '../stores/user';
 import { useIsAnchorFm, useAnchorFmParams } from '../path';
 
@@ -40,6 +42,39 @@ export default function useDetectMatchingAnchorSite(): boolean {
 			return;
 		}
 
+		// Fails with error
+		// Error: Cannot use HTTP data without injecting Redux store enhancer!
+		// Changing <AcquireIntent> (where this hook is used) to "export default connect( null, null )( AcquireIntent );" (connect from react-redux)
+		// Causes a new error about <Provider>/store missing (Not used in gutenboarding?)
+		console.log( 'new method of making fetch:' );
+		waitForHttpData( () => ( {
+			match: requestAnchorMatchingSite(
+				anchorFmPodcastId,
+				anchorFmEpisodeId,
+				anchorFmSpotifyUrl,
+				anchorFmSite,
+				anchorFmPost
+			),
+		} ) ).then( ( result ) => {
+			console.log( 'fetch done: ' );
+			console.log( { result } );
+		} );
+
+		// Does this return a promise? - Doesn't work
+		// Error: Cannot use HTTP data without injecting Redux store enhancer!
+		/*
+		const a = requestAnchorMatchingSite(
+			anchorFmPodcastId,
+			anchorFmEpisodeId,
+			anchorFmSpotifyUrl,
+			anchorFmSite,
+			anchorFmPost
+		);
+		console.log( { a } );
+		*/
+
+		// Use wpcom.undocumented() (Works)
+		/*
 		setIsLoading( true );
 		wpcom
 			.undocumented()
@@ -64,6 +99,7 @@ export default function useDetectMatchingAnchorSite(): boolean {
 			.catch( () => {
 				setIsLoading( false );
 			} );
+			*/
 	}, [
 		isAnchorFm,
 		currentUserExists,

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -12,3 +12,4 @@ export { default as requestGeoLocation } from './request-geo-location';
 export { default as requestFeedDiscovery } from './request-feed-discovery';
 export { default as requestSiteAlerts } from './request-site-alerts';
 export { default as requestDpa } from './request-dpa';
+export { default as requestAnchorMatchingSite } from './request-anchor-matching-site';

--- a/client/state/data-getters/request-anchor-matching-site.js
+++ b/client/state/data-getters/request-anchor-matching-site.js
@@ -1,0 +1,48 @@
+/**
+ * Internal dependencies
+ */
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { requestHttpData } from 'calypso/state/data-layer/http-data';
+
+const requestAnchorMatchingSite = (
+	anchorFmPodcastId,
+	anchorFmEpisodeId,
+	anchorFmSpotifyUrl,
+	anchorFmSite,
+	anchorFmPost
+) => {
+	const queryParts = {
+		podcast: anchorFmPodcastId,
+		episode: anchorFmEpisodeId,
+		spotify_url: anchorFmSpotifyUrl,
+		site: anchorFmSite,
+		post: anchorFmPost,
+	};
+	const id =
+		'request-matching-anchor-site-' +
+		Object.values( queryParts )
+			.map( ( x ) => x ?? '' )
+			.join( '-' );
+
+	Object.keys( queryParts ).forEach( ( k ) => {
+		if ( queryParts[ k ] === null ) {
+			delete queryParts[ k ];
+		}
+	} );
+
+	return requestHttpData(
+		id,
+		http(
+			{
+				method: 'GET',
+				path: '/anchor',
+				apiNamespace: 'wpcom/v2',
+			},
+			queryParts
+		),
+		{
+			freshness: -Infinity, // disable Caching
+		}
+	);
+};
+export default requestAnchorMatchingSite;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Unsuccessful attempt to move away from wpcom.undocumented for a one-off XHR.
* The goal is to make an XHR without using global state (redux or @wordpress/data) Since the fetched value is only used in one place, it doesn't make sense to go through the effort of setting up a reducer, action creators, selectors etc for it: [Dan Abramov: You Might Not Need Redux](https://medium.com/@dan_abramov/you-might-not-need-redux-be46360cf367).
* wpcom.undocumented() works fine but I'm told it should be avoided.
* This approach tries to use `requestHttpData()` using patterns found in `client/state/data-getters/`, but it doesn't work. Errors are thrown about `dispatch()` not being available, and if I apply react-redux's `connect()` to the component that's using this hook, errors about `<Provider>` and `store` are thrown.
* Is there a supported way to do a lightweight XHR request without global state (redux or @wordpress/data)?

#### Testing instructions

* While logged in, visit http://calypso.localhost:3000/new?anchor_podcast=9fa55c4 . This will trigger `useDetectMatchingAnchorSite()` to run. It should try to run an XHR to //public-api.wordpress.com/wpcom/v2/anchor and print the result in the console.  However, it errors.