### PR TITLE
Fix a typo on the Jetpack Scan threat ignore alert message

### DIFF
--- a/client/components/jetpack/threat-dialog/index.tsx
+++ b/client/components/jetpack/threat-dialog/index.tsx
@@ -90,7 +90,7 @@ const ThreatDialog: React.FC< Props > = ( {
 						{ action === 'fix'
 							? getThreatFix( threat.fixable )
 							: translate(
-									'You shouldn’t ignore a security unless you are absolute sure it’s harmless. If you choose to ignore this threat, it will remain on your site "{{strong}}%s{{/strong}}".',
+									'You shouldn’t ignore a security issue unless you are absolute sure it’s harmless. If you choose to ignore this threat, it will remain on your site "{{strong}}%s{{/strong}}".',
 									{
 										args: [ siteName ],
 										components: {

--- a/client/components/jetpack/threat-dialog/index.tsx
+++ b/client/components/jetpack/threat-dialog/index.tsx
@@ -90,7 +90,7 @@ const ThreatDialog: React.FC< Props > = ( {
 						{ action === 'fix'
 							? getThreatFix( threat.fixable )
 							: translate(
-									'You shouldn’t ignore a security issue unless you are absolute sure it’s harmless. If you choose to ignore this threat, it will remain on your site "{{strong}}%s{{/strong}}".',
+									'You shouldn’t ignore a security issue unless you are absolutely sure it’s harmless. If you choose to ignore this threat, it will remain on your site "{{strong}}%s{{/strong}}".',
 									{
 										args: [ siteName ],
 										components: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the Ignore Threat alert message to fix a typo


<img width="702" alt="Screen Shot 2021-02-09 at 1 55 29 PM" src="https://user-images.githubusercontent.com/793774/107413658-faec3480-6ade-11eb-9267-d05b07c7b054.png">


#### Testing instructions

1. Start calypso in local
2. Go to a site with Jetpack Scan enabled
3. Tap on a current threat
4. Tap Ignore
5. Verify the alert message does not have any typos

Related to https://github.com/wordpress-mobile/WordPress-iOS/pull/15842
