### PR TITLE
Jetpack Plans: Make multisite incompatible products disabled.

### DIFF
--- a/client/components/jetpack/card/i5/jetpack-product-card-i5/index.tsx
+++ b/client/components/jetpack/card/i5/jetpack-product-card-i5/index.tsx
@@ -157,16 +157,20 @@ const JetpackProductCardAlt2: React.FC< Props > = ( {
 					<p className="jetpack-product-card-i5__above-button">{ aboveButtonText }</p>
 				) }
 				{ isDisabled && disabledMessage && (
-					<p className="jetpack-product-card-i5__disabled-message">{ disabledMessage }</p>
+					<p className="jetpack-product-card-i5__disabled-message">
+						{ preventWidows( disabledMessage ) }
+					</p>
 				) }
-				<Button
-					primary={ buttonPrimary }
-					className="jetpack-product-card-i5__button"
-					onClick={ onButtonClick }
-					disabled={ isDisabled }
-				>
-					{ buttonLabel }
-				</Button>
+				{ ! isDisabled && (
+					<Button
+						primary={ buttonPrimary }
+						className="jetpack-product-card-i5__button"
+						onClick={ onButtonClick }
+						disabled={ isDisabled }
+					>
+						{ buttonLabel }
+					</Button>
+				) }
 				{ features && features.items.length > 0 && (
 					<JetpackProductCardFeatures features={ features } />
 				) }

--- a/client/components/jetpack/card/i5/jetpack-product-card-i5/style.scss
+++ b/client/components/jetpack/card/i5/jetpack-product-card-i5/style.scss
@@ -107,7 +107,7 @@
 	padding-top: 6px;
 	padding-bottom: 6px;
 
-	border-radius: 4px;
+	border-radius: ( 2px * 2 );
 
 	text-align: center;
 	background-color: rgba( var( --color-success-10-rgb ), 0.1 );
@@ -192,8 +192,6 @@
 
 .jetpack-product-card-i5__disabled-message {
 	color: var( --color-accent );
-
-	text-align: center;
 	font-weight: 600;
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR makes multisite incompatible products and plans disabled (and translucent) with a message "Not available for multisite WordPress installs"

Multisite incompatible products are all Jetpack Backup and Jetpack Scan products and all _plans_ which include Backup and/or Scan products.

Fixes: 1164141197617539-as-1199895424508971

### Testing instructions

* Checkout and run this PR in both Calypso blue and green concurrently.
* Select a multisite connected site (or create a multisite JN site if you don't already have one in your account)
* Go to the Calypso blue Plans page: `calypso.localhost:3000/plans/:site`
* Verify that all Jetpack products/plans (other than Anti-Spam, Site Search, and CRM Entrepreneur) are disabled (and translucent) and display the message, "Not available for multisite WordPress installs".  (See screenshot below)
* Go to Calypso green Plans page `jetpack.localhost:3001/pricing/:site` and verify the same as above.
* Select a non-multisite site and verify the plans/products are not disabled.


**Calypso blue, showing disabled multisite products**
![screenshot-calypso-localhost-3000-plans-exact-shrike-jurassic-ninja-1612965042900](https://user-images.githubusercontent.com/11078128/107518817-76042800-6b7d-11eb-8f18-9c14f877fd45.png)



**Calypso green showing disabled multisite products**
![screenshot-jetpack-cloud-localhost-3001-pricing-exact-shrike-jurassic-ninja-1612899781699](https://user-images.githubusercontent.com/11078128/107419175-7c46c580-6ae5-11eb-8772-a8e643c27eb0.png)
