### PR TITLE
Signup: Add flag to prefill email when asked to create new account

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -52,6 +52,8 @@ import { preventWidows } from 'calypso/lib/formatting';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { sendEmailLogin } from 'calypso/state/auth/actions';
 
+import { addQueryArgs } from 'calypso/lib/route';
+
 export class LoginForm extends Component {
 	static propTypes = {
 		accountType: PropTypes.string,
@@ -425,8 +427,12 @@ export class LoginForm extends Component {
 
 		const langFragment = locale && locale !== 'en' ? `/${ locale }` : '';
 
-		let signupUrl = config( 'signup_url' );
 		const signupFlow = get( currentQuery, 'signup_flow' );
+
+		let signupUrl = config( 'signup_url' );
+		if ( config.isEnabled( 'jetpack/prefill-signup-email' ) ) {
+			signupUrl = addQueryArgs( { email: this.state.usernameOrEmail }, signupUrl );
+		}
 
 		// copied from login-links.jsx
 		if (

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -444,10 +444,15 @@ export class UserStep extends Component {
 		const isReskinned =
 			'onboarding' === flowName && 'reskinned' === getABTestVariation( 'reskinSignupFlow' );
 
+		const email = config.isEnabled( 'jetpack/prefill-signup-email' )
+			? this.props.initialContext?.query?.email
+			: undefined;
+
 		return (
 			<>
 				<SignupForm
 					{ ...omit( this.props, [ 'translate' ] ) }
+					email={ email }
 					redirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl() }
 					disabled={ this.userCreationStarted() }
 					submitting={ this.userCreationStarted() }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -45,6 +45,7 @@
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,
+		"jetpack/prefill-signup-email": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,
@@ -71,9 +72,7 @@
 		"scan": true,
 		"jetpack-connect": true
 	},
-	"site_filter": [
-		"jetpack"
-	],
+	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -43,6 +43,7 @@
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,
+		"jetpack/prefill-signup-email": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,
@@ -68,9 +69,7 @@
 		"scan": true,
 		"jetpack-connect": true
 	},
-	"site_filter": [
-		"jetpack"
-	],
+	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Create a new feature flag, `jetpack/prefill-signup-email` to control whether the email address people enter on the log-in screen is carried forward when they attempt to create a new account.
* Add a query parameter `email` to the "create a new account" link on the log-in screen that stores the initial email address input.
* On the new account page, read the `email` parameter from the browser's query string and pre-fill that value into the "Your email address" field.

#### Testing instructions

**NOTE:** These changes are eventually meant to affect just Calypso Green ("Jetpack Cloud"). Since Calypso Green doesn't have its own login/signup flow (yet), you'll need to test in Calypso Blue for now.

* Apply this branch to your testing environment and enable the `jetpack/prefill-signup-email` flag in `config/development.json`.
* Start Calypso Blue in a private browsing window and visit `calypso.localhost:3000/log-in`.
* Enter an email address that is not currently associated with an existing WordPress.com account.
* Verify that you see a notice under the email address input field that says, "User does not exist. Would you like to create a new account?"
* Verify that the "create a new account" link in the notice points to a URL with a query parameter `email`, whose value matches the email address you entered.
* Click the "create a new account" link and verify that the email you entered is immediately visible on the subsequent signup form (see Reference screenshots).

#### Reference screenshots

<img width="421" alt="image" src="https://user-images.githubusercontent.com/670067/107420323-641f7800-6ade-11eb-8fd7-6cd06cb720f0.png">

<img width="414" alt="image" src="https://user-images.githubusercontent.com/670067/107420410-7d282900-6ade-11eb-9c7a-cdfc25d951bd.png">