### PR TITLE
Add error state to failed activities in cloud activity log

### DIFF
--- a/client/components/activity-card/index.jsx
+++ b/client/components/activity-card/index.jsx
@@ -295,11 +295,15 @@ class ActivityCard extends Component {
 		const backupTimeDisplay = applySiteOffset
 			? applySiteOffset( activity.activityTs ).format( 'LT' )
 			: '';
-
 		const showActivityContent = this.state.showContent;
+		const hasActivityFailed = activity.activityStatus === 'error';
 
 		return (
-			<div className={ classnames( className, 'activity-card' ) }>
+			<div
+				className={ classnames( className, 'activity-card', {
+					'with-error': hasActivityFailed,
+				} ) }
+			>
 				<QueryRewindState siteId={ siteId } />
 				{ ! summarize && (
 					<div className="activity-card__time">

--- a/client/components/activity-card/style.scss
+++ b/client/components/activity-card/style.scss
@@ -35,6 +35,20 @@
 		margin: 8px 0;
 		font-style: italic;
 	}
+
+	&.with-error {
+		.activity-card__time-icon {
+			fill: var( --color-error );
+		}
+
+		.activity-card__time-text {
+			color: var( --color-error );
+		}
+
+		.card {
+			border: solid 1px var( --color-error );
+		}
+	}
 }
 
 .activity-card__time {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds an error state to failed activities in the Activity log section of Jetpack cloud.

Fixes 1164141197617539-as-1199528785870461

### Implementation notes

- Added a red border
- Updated the colour of the icon and timestamp
- The icon is outlined, whereas it's filled in the mockups. This requires a patch in the BE.
- I haven't updated the typographic values

### Testing instructions

- Run this PR locally in cloud
- Visit the activity log section
- Make sure that at least one activity has failed (the easiest way might be to trigger a restore with no credentials set). Alternatively, set the value of `activityStatus` to `error` in `client/state/data-layer/wpcom/sites/activity/from-api.js`, in which case you won't see the warning icon.
- Check the changes are applied to the card

### Screenshots

#### Mockups
<img width="601" alt="Screen Shot 2021-02-08 at 11 51 10 AM" src="https://user-images.githubusercontent.com/1620183/107432647-4827d080-6af6-11eb-996c-1655ab6e3518.png">


#### Implementation
<img width="562" alt="Screen Shot 2021-02-09 at 4 41 07 PM" src="https://user-images.githubusercontent.com/1620183/107432626-3f36ff00-6af6-11eb-8502-8d5226d2b5f8.png">