### PR TITLE
Add a new YAML configuration file to enable GitHub Actions stale bot.

### DIFF
--- a/.github/workflows/mark-issue-stale.yml
+++ b/.github/workflows/mark-issue-stale.yml
@@ -1,0 +1,22 @@
+
+name: 'Close stale issues and PR'
+on:
+  schedule:
+    - cron: '30 * * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is stale because it has been 180 days with no activity. You can keep the issue open by adding a comment. If you do, please provide additional context and explain why you’d like it to remain open. You can also close the issue yourself — if you do, please add a brief explanation and apply one of relevant issue close labels.'
+          days-before-stale: 180
+          exempt-issue-labels: '[Pri] High,[Pri] BLOCKER,[Status] Keep Open'
+          # Disable auto-close of both issues and PRs.
+          days-before-close: -1
+          # Dry run
+          debug-only: true
+          # Get issues in ascending order.
+          ascending: true


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Try out GitHub Actions-based stale bot.

* addition of `mark-issue-stale.yml` that calls the bot with the following parameters:
  * days before stale: 180
  * automatically close issues: disabled
 
Dry run parameter is enabled for the bot currently, to avoid making any changes to the issues.
Corresponding secret `ACTIONS_STEP_DEBUG` is set in the repository.

#### Testing instructions

Wait until the crontab fires.
