### PR TITLE
Add meta file to ETK TC build

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1324,8 +1324,11 @@ object WPComPlugins_EditorToolKit : BuildType({
 				sed -i -e "/^Stable tag:\s/c\Stable tag: %build.number%" ./editing-toolkit-plugin/readme.txt
 
 				yarn build
-
 				cd editing-toolkit-plugin/
+				
+				# Metadata file with info for the download script.
+				echo -e "commit_hash=%build.vcs.number%\nbuild_number=%build.number%\n" > build_meta.txt
+
 				zip -r ../../../editing-toolkit.zip .
 			""".trimIndent()
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a meta file to the TeamCity build for Editing Toolkit. This will be useful for the download script to have some information to display to the developer (D55966-code). 

#### Testing instructions

* TBD
