### PR TITLE
Patterns: Use custom viewport width where available when registering patterns

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -94,13 +94,18 @@ class Block_Patterns_From_API {
 			if ( $this->can_register_pattern( $pattern ) ) {
 				$is_premium = isset( $pattern['pattern_meta']['is_premium'] ) ? boolval( $pattern['pattern_meta']['is_premium'] ) : false;
 
+				// Set custom viewport width for the pattern preview with a
+				// default width of 1280 and ensure a safe minimum width of 320.
+				$viewport_width = isset( $pattern['pattern_meta']['viewport_width'] ) ? intval( $pattern['pattern_meta']['viewport_width'] ) : 1280;
+				$viewport_width = $viewport_width < 320 ? 320 : $viewport_width;
+
 				register_block_pattern(
 					self::PATTERN_NAMESPACE . $pattern['name'],
 					array(
 						'title'         => $pattern['title'],
 						'description'   => $pattern['description'],
 						'content'       => $pattern['html'],
-						'viewportWidth' => 1280,
+						'viewportWidth' => $viewport_width,
 						'categories'    => array_keys(
 							$pattern['categories']
 						),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If a `viewport_width` value is available from the `pattern_meta` use it when registering patterns to ensure that the preview is rendered at an acceptable width
* Preserve a default of 1280 if no width is provided
* Ensure a minimum width of 320 so that we never accidentally register a pattern with a 0 or otherwise too low width.

#### Screenshots

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/107470934-56daba00-6bc0-11eb-9736-3126a2306a07.png) | ![image](https://user-images.githubusercontent.com/14988353/107470920-4de9e880-6bc0-11eb-8a30-e1e7e87c9039.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In your `0-sandbox.php` file add the following to test with a source site that has a `viewport_width_xxx` pattern meta tag (where `xxx` is the pixel width) attached to a pattern. An easy one to use is `andysfakeblockpatternsourcesite`:

```
add_filter( 'a8c_override_patterns_source_site', function () { return 'andysfakeblockpatternsourcesite.<replace_with_the_real_domain>'; } );
```

* Sandbox your test site and open the inserter. In the Uncategorized category, you should see that the pattern looks larger / more zoomed in than without this change applied.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 77-gh-Automattic/view-design