### PR TITLE
Patterns: Reveal the Featured pattern category, and make it the first in the list

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -81,9 +81,9 @@ class Block_Patterns_From_API {
 			}
 		}
 
-		// Unregister existing categories so that we can insert them in the desired order (alphabetically)
-		$existing_categories = [];
-		foreach( \WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered() as $existing_category ) {
+		// Unregister existing categories so that we can insert them in the desired order (alphabetically).
+		$existing_categories = array();
+		foreach ( \WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered() as $existing_category ) {
 			$existing_categories[ $existing_category['name'] ] = $existing_category;
 			unregister_block_pattern_category( $existing_category['name'] );
 		}
@@ -91,9 +91,12 @@ class Block_Patterns_From_API {
 		$pattern_categories = array_merge( $pattern_categories, $existing_categories );
 
 		// Order categories alphabetically by their label.
-		uasort( $pattern_categories, function( $a, $b ) {
-			return strnatcasecmp( $a['label'], $b['label'] );
-		} );
+		uasort(
+			$pattern_categories,
+			function( $a, $b ) {
+				return strnatcasecmp( $a['label'], $b['label'] );
+			}
+		);
 
 		// Move the Featured category to be the first category.
 		if ( isset( $pattern_categories['featured'] ) ) {
@@ -101,7 +104,7 @@ class Block_Patterns_From_API {
 			unset( $pattern_categories['featured'] );
 			$pattern_categories = array_merge(
 				array(
-					'featured' => $featured_category
+					'featured' => $featured_category,
 				),
 				$pattern_categories
 			);

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -90,8 +90,10 @@ class Block_Patterns_From_API {
 
 		$pattern_categories = array_merge( $pattern_categories, $existing_categories );
 
-		// Order categories alphabetically by their slug.
-		ksort( $pattern_categories );
+		// Order categories alphabetically by their label.
+		uasort( $pattern_categories, function( $a, $b ) {
+			return strnatcasecmp( $a['label'], $b['label'] );
+		} );
 
 		// Move the Featured category to be the first category.
 		if ( isset( $pattern_categories['featured'] ) ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -100,7 +100,7 @@ class Block_Patterns_From_API {
 
 		// Move the Featured category to be the first category.
 		if ( isset( $pattern_categories['featured'] ) ) {
-			$featured_category = $pattern_categories['featured'];
+			$featured_category  = $pattern_categories['featured'];
 			$pattern_categories = array( 'featured' => $featured_category ) + $pattern_categories;
 		}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -101,13 +101,7 @@ class Block_Patterns_From_API {
 		// Move the Featured category to be the first category.
 		if ( isset( $pattern_categories['featured'] ) ) {
 			$featured_category = $pattern_categories['featured'];
-			unset( $pattern_categories['featured'] );
-			$pattern_categories = array_merge(
-				array(
-					'featured' => $featured_category,
-				),
-				$pattern_categories
-			);
+			$pattern_categories = array( 'featured' => $featured_category ) + $pattern_categories;
 		}
 
 		// Register categories (and re-register existing categories).

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -93,7 +93,7 @@ class Block_Patterns_From_API {
 		// Order categories alphabetically by their label.
 		uasort(
 			$pattern_categories,
-			function( $a, $b ) {
+			function ( $a, $b ) {
 				return strnatcasecmp( $a['label'], $b['label'] );
 			}
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reveal the Featured pattern category in the pattern inserter
* Unregister existing pattern categories, and re-register them along with the pattern categories we're registering in the ETK plugin, so that they're all sorted alphabetically
* Once sorted alphabetically by slug, move the Featured category to be the first in the list

#### Screenshot

![featured-category-pattern-inserter](https://user-images.githubusercontent.com/14988353/107475534-6958f180-6bc8-11eb-9534-da4469e6daa4.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this change in your sandbox, and test the pattern inserter. Are the pattern categories working correctly and sorted correctly?
* What about if we have the Twenty Twenty One theme applied (or any theme with its own patterns), does the sorting hold up (I haven't tested this yet)
* What about in another language, is the sorting correct? (We might need to adjust to sort by the `label` instead of the slug 🤔

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 120-gh-Automattic/view-design
CC: @joanrho 