### PR TITLE
Deduplicate spdx-expression-parse

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -25094,15 +25094,7 @@ spdx-exceptions@^2.1.0:
   resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977"
   integrity sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==
 
-spdx-expression-parse@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
-  integrity sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==
-  dependencies:
-    spdx-exceptions "^2.1.0"
-    spdx-license-ids "^3.0.0"
-
-spdx-expression-parse@^3.0.1:
+spdx-expression-parse@^3.0.0, spdx-expression-parse@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
   integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `spdx-expression-parse` (done automatically with `npx yarn-deduplicate --packages spdx-expression-parse`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> spdx-expression-parse@3.0.0
< @automattic/o2-blocks@1.0.0 -> @automattic/calypso-build@7.0.0 -> ... -> spdx-expression-parse@3.0.0
< @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/calypso-build@7.0.0 -> ... -> spdx-expression-parse@3.0.0
< @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/scripts@12.5.0 -> ... -> spdx-expression-parse@3.0.0
< @automattic/wpcom-editing-toolkit@2.18.0 -> jest@26.4.0 -> ... -> spdx-expression-parse@3.0.0
< @automattic/wpcom-editing-toolkit@2.18.0 -> npm-run-all@4.1.5 -> ... -> spdx-expression-parse@3.0.0
< wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> spdx-expression-parse@3.0.0
< wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> spdx-expression-parse@3.0.0
< wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> spdx-expression-parse@3.0.0
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> spdx-expression-parse@3.0.0
< wp-calypso@0.17.0 -> concurrently@5.1.0 -> ... -> spdx-expression-parse@3.0.0
< wp-calypso@0.17.0 -> eslint-plugin-import@2.22.1 -> ... -> spdx-expression-parse@3.0.0
< wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> spdx-expression-parse@3.0.0
< wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> spdx-expression-parse@3.0.0
< wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> spdx-expression-parse@3.0.0
< wp-calypso@0.17.0 -> node-sass@4.14.1 -> ... -> spdx-expression-parse@3.0.0
< wp-calypso@0.17.0 -> npm-run-all@4.1.5 -> ... -> spdx-expression-parse@3.0.0
< wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> spdx-expression-parse@3.0.0
< wp-calypso@0.17.0 -> whybundled@1.4.2 -> ... -> spdx-expression-parse@3.0.0
< wp-e2e-tests@0.0.1 -> concurrently@3.6.1 -> ... -> spdx-expression-parse@3.0.0
< wp-e2e-tests@0.0.1 -> grunt-concurrent@2.3.1 -> ... -> spdx-expression-parse@3.0.0
< wp-e2e-tests@0.0.1 -> grunt@1.1.0 -> ... -> spdx-expression-parse@3.0.0
< wp-e2e-tests@0.0.1 -> testarmada-magellan-local-executor@2.0.3 -> ... -> spdx-expression-parse@3.0.0
< wp-e2e-tests@0.0.1 -> testarmada-magellan-mocha-plugin@9.0.1 -> ... -> spdx-expression-parse@3.0.0
< wp-e2e-tests@0.0.1 -> testarmada-magellan@11.0.10 -> ... -> spdx-expression-parse@3.0.0
> @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> spdx-expression-parse@3.0.1
> @automattic/o2-blocks@1.0.0 -> @automattic/calypso-build@7.0.0 -> ... -> spdx-expression-parse@3.0.1
> @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/calypso-build@7.0.0 -> ... -> spdx-expression-parse@3.0.1
> @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/scripts@12.5.0 -> ... -> spdx-expression-parse@3.0.1
> @automattic/wpcom-editing-toolkit@2.18.0 -> jest@26.4.0 -> ... -> spdx-expression-parse@3.0.1
> @automattic/wpcom-editing-toolkit@2.18.0 -> npm-run-all@4.1.5 -> ... -> spdx-expression-parse@3.0.1
> wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> spdx-expression-parse@3.0.1
> wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.5.0 -> ... -> spdx-expression-parse@3.0.1
> wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> spdx-expression-parse@3.0.1
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> spdx-expression-parse@3.0.1
> wp-calypso@0.17.0 -> concurrently@5.1.0 -> ... -> spdx-expression-parse@3.0.1
> wp-calypso@0.17.0 -> eslint-plugin-import@2.22.1 -> ... -> spdx-expression-parse@3.0.1
> wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> spdx-expression-parse@3.0.1
> wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> spdx-expression-parse@3.0.1
> wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> spdx-expression-parse@3.0.1
> wp-calypso@0.17.0 -> node-sass@4.14.1 -> ... -> spdx-expression-parse@3.0.1
> wp-calypso@0.17.0 -> npm-run-all@4.1.5 -> ... -> spdx-expression-parse@3.0.1
> wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> spdx-expression-parse@3.0.1
> wp-calypso@0.17.0 -> whybundled@1.4.2 -> ... -> spdx-expression-parse@3.0.1
> wp-e2e-tests@0.0.1 -> concurrently@3.6.1 -> ... -> spdx-expression-parse@3.0.1
> wp-e2e-tests@0.0.1 -> grunt-concurrent@2.3.1 -> ... -> spdx-expression-parse@3.0.1
> wp-e2e-tests@0.0.1 -> grunt@1.1.0 -> ... -> spdx-expression-parse@3.0.1
> wp-e2e-tests@0.0.1 -> testarmada-magellan-local-executor@2.0.3 -> ... -> spdx-expression-parse@3.0.1
> wp-e2e-tests@0.0.1 -> testarmada-magellan-mocha-plugin@9.0.1 -> ... -> spdx-expression-parse@3.0.1
> wp-e2e-tests@0.0.1 -> testarmada-magellan@11.0.10 -> ... -> spdx-expression-parse@3.0.1
```