### PR TITLE
Deduplicate strip-json-comments

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -25609,12 +25609,7 @@ strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-strip-json-comments@^3.0.1, strip-json-comments@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
-  integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
-
-strip-json-comments@^3.1.1:
+strip-json-comments@^3.0.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `strip-json-comments` (done automatically with `npx yarn-deduplicate --packages strip-json-comments`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/scripts@12.5.0 -> ... -> strip-json-comments@3.1.0
< @automattic/wpcom-editing-toolkit@2.18.0 -> eslint@7.12.0 -> ... -> strip-json-comments@3.1.0
< wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> strip-json-comments@3.1.0
< wp-calypso@0.17.0 -> eslint@7.12.0 -> ... -> strip-json-comments@3.1.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/scripts@12.5.0 -> ... -> strip-json-comments@3.1.1
> @automattic/wpcom-editing-toolkit@2.18.0 -> eslint@7.12.0 -> ... -> strip-json-comments@3.1.1
> wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> strip-json-comments@3.1.1
> wp-calypso@0.17.0 -> eslint@7.12.0 -> ... -> strip-json-comments@3.1.1
```