### PR TITLE
DIFM upsell A/B test: Record tracks event when difm intake is submitted

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -55,16 +55,14 @@ const Home = ( {
 		}
 
 		if ( noticeType === 'difm-success' ) {
+			reduxDispatch( recordTracksEvent( 'calypso_difm_intake_submitted' ) );
+
 			const successMessage = translate( 'Your application has been sent!' );
-			reduxDispatch(
-				successNotice( successMessage, {
-					isPersistent: true,
-				} )
-			);
+			reduxDispatch( successNotice( successMessage ) );
 		}
 
 		return;
-	}, [ noticeType, layout, reduxDispatch, translate ] );
+	}, [ noticeType, layout, canUserUseCustomerHome, reduxDispatch, translate ] );
 
 	if ( ! canUserUseCustomerHome ) {
 		const title = translate( 'This page is not available on this site.' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow up to https://github.com/Automattic/wp-calypso/pull/49301. In this PR:

* We fire a new Tracks event when Customer Home is loaded with the `?notice=difm-success` query prop in the URL. This query prop is appended when the Crowdsignal DIFM intake form redirects after a successful submission, so loading Customer Home with this query prop is a reasonable proxy for the intake form submitted event.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set yourself to the treatment group in the experiment `post_purchase_difm_upsell`
* Navigate to /start. In your browser console, type `localStorage.setItem( 'debug', 'calypso:analytics*' );` and reload page. You should now see Tracks event firing in your console.
* Go through the signup flow and purchase a Business plan. 
* In the DIFM offer page, click Accept and submit the intake form. 
* You should now get redirected to `wordpress.com/home?notice=difm_success`. Replace wordpress.com with your calypso.localhost or hash calypso URL and load the page again.
* Confirm that you can see the `calypso_difm_intake_submitted` event getting fired (filter the console results with the tracks event name as the search term for better clarity).

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

