### PR TITLE
State: Move gravatar notices away from middleware

### DIFF
--- a/client/state/current-user/gravatar-status/actions.js
+++ b/client/state/current-user/gravatar-status/actions.js
@@ -12,6 +12,7 @@ import {
 	recordTracksEvent,
 	withAnalytics,
 } from 'calypso/state/analytics/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
 
 import 'calypso/state/data-layer/wpcom/gravatar-upload';
 
@@ -23,14 +24,18 @@ export function uploadGravatar( file, email ) {
 	} );
 }
 
-export const receiveGravatarImageFailed = ( { errorMessage, statName } ) =>
-	withAnalytics(
-		composeAnalytics(
-			recordTracksEvent( 'calypso_edit_gravatar_file_receive_failure' ),
-			bumpStat( 'calypso_gravatar_update_error', statName )
-		),
-		{
-			type: GRAVATAR_RECEIVE_IMAGE_FAILURE,
-			errorMessage,
-		}
+export const receiveGravatarImageFailed = ( { errorMessage, statName } ) => ( dispatch ) => {
+	dispatch(
+		withAnalytics(
+			composeAnalytics(
+				recordTracksEvent( 'calypso_edit_gravatar_file_receive_failure' ),
+				bumpStat( 'calypso_gravatar_update_error', statName )
+			),
+			{
+				type: GRAVATAR_RECEIVE_IMAGE_FAILURE,
+				errorMessage,
+			}
+		)
 	);
+	dispatch( errorNotice( errorMessage ) );
+};

--- a/client/state/current-user/gravatar-status/test/actions.js
+++ b/client/state/current-user/gravatar-status/test/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import { receiveGravatarImageFailed, uploadGravatar } from '../actions';
@@ -12,13 +7,15 @@ import {
 	GRAVATAR_UPLOAD_REQUEST,
 } from 'calypso/state/action-types';
 
+const dispatch = jest.fn();
+
 describe( 'actions', () => {
 	describe( '#uploadGravatar', () => {
 		test( 'dispatches request action with the file and email', () => {
 			const action = uploadGravatar( 'file', 'email' );
-			expect( action.type ).to.equal( GRAVATAR_UPLOAD_REQUEST );
-			expect( action.file ).to.equal( 'file' );
-			expect( action.email ).to.equal( 'email' );
+			expect( action.type ).toEqual( GRAVATAR_UPLOAD_REQUEST );
+			expect( action.file ).toEqual( 'file' );
+			expect( action.email ).toEqual( 'email' );
 		} );
 	} );
 
@@ -26,13 +23,15 @@ describe( 'actions', () => {
 		test( 'dispatches image receive failure action with error message', () => {
 			const errorMessage = 'error';
 			const statName = 'statName';
-			const result = receiveGravatarImageFailed( {
+			receiveGravatarImageFailed( {
 				errorMessage,
 				statName,
+			} )( dispatch );
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: GRAVATAR_RECEIVE_IMAGE_FAILURE,
+				errorMessage,
+				meta: expect.any( Object ),
 			} );
-			expect( result ).to.have.property( 'type', GRAVATAR_RECEIVE_IMAGE_FAILURE );
-			expect( result ).to.have.property( 'errorMessage', errorMessage );
-			expect( result ).to.have.property( 'meta' );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/gravatar-upload/index.js
+++ b/client/state/data-layer/wpcom/gravatar-upload/index.js
@@ -1,7 +1,11 @@
 /**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
  * Internal dependencies
  */
-
 import {
 	GRAVATAR_UPLOAD_RECEIVE,
 	GRAVATAR_UPLOAD_REQUEST,
@@ -16,7 +20,7 @@ import {
 	recordTracksEvent,
 	withAnalytics,
 } from 'calypso/state/analytics/actions';
-
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 
 export function uploadGravatar( action ) {
@@ -49,19 +53,29 @@ export function announceSuccess( { file } ) {
 					type: GRAVATAR_UPLOAD_REQUEST_SUCCESS,
 				} )
 			);
+			dispatch(
+				successNotice(
+					translate( 'You successfully uploaded a new profile photo — looking sharp!' )
+				)
+			);
 		} );
 		fileReader.readAsDataURL( file );
 	};
 }
 
 export function announceFailure() {
-	return withAnalytics(
-		composeAnalytics(
-			recordTracksEvent( 'calypso_edit_gravatar_upload_failure' ),
-			bumpStat( 'calypso_gravatar_update_error', 'unsuccessful_http_response' )
+	return [
+		withAnalytics(
+			composeAnalytics(
+				recordTracksEvent( 'calypso_edit_gravatar_upload_failure' ),
+				bumpStat( 'calypso_gravatar_update_error', 'unsuccessful_http_response' )
+			),
+			{ type: GRAVATAR_UPLOAD_REQUEST_FAILURE }
 		),
-		{ type: GRAVATAR_UPLOAD_REQUEST_FAILURE }
-	);
+		errorNotice(
+			translate( 'Hmm, your new profile photo was not saved. Please try uploading again.' )
+		),
+	];
 }
 
 registerHandlers( 'state/data-layer/wpcom/gravatar-upload/index.js', {

--- a/client/state/data-layer/wpcom/gravatar-upload/test/index.js
+++ b/client/state/data-layer/wpcom/gravatar-upload/test/index.js
@@ -100,6 +100,6 @@ describe( '#announceFailure()', () => {
 	test( 'should dispatch an error notice', () => {
 		const result = announceFailure();
 
-		expect( result.type ).toEqual( GRAVATAR_UPLOAD_REQUEST_FAILURE );
+		expect( result[ 0 ].type ).toEqual( GRAVATAR_UPLOAD_REQUEST_FAILURE );
 	} );
 } );

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -11,9 +11,6 @@ import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getInviteForSite } from 'calypso/state/invites/selectors';
 import {
-	GRAVATAR_RECEIVE_IMAGE_FAILURE,
-	GRAVATAR_UPLOAD_REQUEST_FAILURE,
-	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
 	GUIDED_TRANSFER_HOST_DETAILS_SAVE_SUCCESS,
 	INVITE_RESEND_REQUEST_FAILURE,
 	INVITES_DELETE_REQUEST_SUCCESS,
@@ -29,16 +26,6 @@ import { purchasesRoot } from 'calypso/me/purchases/paths';
 /**
  * Handlers
  */
-
-export const onGravatarReceiveImageFailure = ( action ) => errorNotice( action.errorMessage );
-
-export const onGravatarUploadRequestFailure = () =>
-	errorNotice(
-		translate( 'Hmm, your new profile photo was not saved. Please try uploading again.' )
-	);
-
-export const onGravatarUploadRequestSuccess = () =>
-	successNotice( translate( 'You successfully uploaded a new profile photo — looking sharp!' ) );
 
 export const onDeleteInvitesFailure = ( action ) => ( dispatch, getState ) => {
 	for ( const inviteId of action.inviteIds ) {
@@ -112,9 +99,6 @@ const onSiteDeleteFailure = ( { error } ) => {
  */
 
 export const handlers = {
-	[ GRAVATAR_RECEIVE_IMAGE_FAILURE ]: onGravatarReceiveImageFailure,
-	[ GRAVATAR_UPLOAD_REQUEST_FAILURE ]: onGravatarUploadRequestFailure,
-	[ GRAVATAR_UPLOAD_REQUEST_SUCCESS ]: onGravatarUploadRequestSuccess,
 	[ INVITES_DELETE_REQUEST_SUCCESS ]: onDeleteInvitesSuccess,
 	[ INVITES_DELETE_REQUEST_FAILURE ]: onDeleteInvitesFailure,
 	[ INVITE_RESEND_REQUEST_FAILURE ]: onInviteResendRequestFailure,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the gravatar notices away from the notices middleware and into the corresponding action thunks. This way these notices get modularized together with the corresponding state modules and don't clutter the main entry point.

We also refactor some tests to use `jest` because that makes it easier to test nested thunks.

#### Testing instructions

* Go to `/me`
* Change your gravatar and verify you still get a success notice.
* Try uploading a HUGE image and verify you still get an error notice.
* Verify all tests still pass.
