### PR TITLE
State: Move invites notices away from middleware

### DIFF
--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -2,12 +2,16 @@
  * External dependencies
  */
 import debugFactory from 'debug';
+import { translate } from 'i18n-calypso';
+import { truncate } from 'lodash';
 const debug = debugFactory( 'calypso:invites-actions' );
 
 /**
  * Internal dependencies
  */
 import wpcom from 'calypso/lib/wp';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { getInviteForSite } from 'calypso/state/invites/selectors';
 import {
 	INVITES_DELETE_REQUEST,
 	INVITES_DELETE_REQUEST_FAILURE,
@@ -84,6 +88,7 @@ export function resendInvite( siteId, inviteId ) {
 					inviteId,
 					error,
 				} );
+				dispatch( errorNotice( translate( 'Invitation failed to resend.' ) ) );
 			} );
 	};
 }
@@ -91,6 +96,19 @@ export function resendInvite( siteId, inviteId ) {
 export function deleteInvite( siteId, inviteId ) {
 	return deleteInvites( siteId, [ inviteId ] );
 }
+
+const deleteInvitesFailureNotice = ( siteId, inviteIds ) => ( dispatch, getState ) => {
+	for ( const inviteId of inviteIds ) {
+		const invite = getInviteForSite( getState(), siteId, inviteId );
+		dispatch(
+			errorNotice(
+				translate( 'An error occurred while deleting the invite for %s.', {
+					args: truncate( invite.user.email, { length: 20 } ),
+				} )
+			)
+		);
+	}
+};
 
 export function deleteInvites( siteId, inviteIds ) {
 	return ( dispatch ) => {
@@ -113,6 +131,14 @@ export function deleteInvites( siteId, inviteIds ) {
 						inviteIds: data.deleted,
 						data,
 					} );
+					dispatch(
+						successNotice(
+							translate( 'Invite deleted.', 'Invites deleted.', { count: inviteIds.length } ),
+							{
+								displayOnNextPage: true,
+							}
+						)
+					);
 				}
 
 				// It's possible for the request to succeed, but the deletion to fail.
@@ -123,6 +149,7 @@ export function deleteInvites( siteId, inviteIds ) {
 						inviteIds: data.invalid,
 						data,
 					} );
+					dispatch( deleteInvitesFailureNotice( siteId, inviteIds ) );
 				}
 			} )
 			.catch( ( error ) => {
@@ -132,6 +159,7 @@ export function deleteInvites( siteId, inviteIds ) {
 					inviteIds,
 					error,
 				} );
+				dispatch( deleteInvitesFailureNotice( siteId, inviteIds ) );
 			} );
 	};
 }

--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -103,7 +103,7 @@ const deleteInvitesFailureNotice = ( siteId, inviteIds ) => ( dispatch, getState
 		dispatch(
 			errorNotice(
 				translate( 'An error occurred while deleting the invite for %s.', {
-					args: truncate( invite.user.email, { length: 20 } ),
+					args: truncate( invite.user.email || invite.user.login, { length: 20 } ),
 				} )
 			)
 		);

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -2,19 +2,15 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { get, truncate } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
-import { getInviteForSite } from 'calypso/state/invites/selectors';
 import {
 	GUIDED_TRANSFER_HOST_DETAILS_SAVE_SUCCESS,
-	INVITE_RESEND_REQUEST_FAILURE,
-	INVITES_DELETE_REQUEST_SUCCESS,
-	INVITES_DELETE_REQUEST_FAILURE,
 	SITE_DELETE,
 	SITE_DELETE_FAILURE,
 	SITE_DELETE_RECEIVE,
@@ -26,27 +22,6 @@ import { purchasesRoot } from 'calypso/me/purchases/paths';
 /**
  * Handlers
  */
-
-export const onDeleteInvitesFailure = ( action ) => ( dispatch, getState ) => {
-	for ( const inviteId of action.inviteIds ) {
-		const invite = getInviteForSite( getState(), action.siteId, inviteId );
-		dispatch(
-			errorNotice(
-				translate( 'An error occurred while deleting the invite for %s.', {
-					args: truncate( invite.user.email, { length: 20 } ),
-				} )
-			)
-		);
-	}
-};
-
-export const onDeleteInvitesSuccess = ( { inviteIds } ) =>
-	successNotice( translate( 'Invite deleted.', 'Invites deleted.', { count: inviteIds.length } ), {
-		displayOnNextPage: true,
-	} );
-
-export const onInviteResendRequestFailure = () =>
-	errorNotice( translate( 'Invitation failed to resend.' ) );
 
 const onGuidedTransferHostDetailsSaveSuccess = () =>
 	successNotice( translate( 'Thanks for confirming those details!' ) );
@@ -99,9 +74,6 @@ const onSiteDeleteFailure = ( { error } ) => {
  */
 
 export const handlers = {
-	[ INVITES_DELETE_REQUEST_SUCCESS ]: onDeleteInvitesSuccess,
-	[ INVITES_DELETE_REQUEST_FAILURE ]: onDeleteInvitesFailure,
-	[ INVITE_RESEND_REQUEST_FAILURE ]: onInviteResendRequestFailure,
 	[ GUIDED_TRANSFER_HOST_DETAILS_SAVE_SUCCESS ]: onGuidedTransferHostDetailsSaveSuccess,
 	[ SITE_DELETE ]: onSiteDelete,
 	[ SITE_DELETE_FAILURE ]: onSiteDeleteFailure,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the invites notices away from the notices middleware and into the corresponding action thunks. This way these notices get modularized together with the corresponding state modules and don't clutter the main entry point.

This PR also uses the opportunity to fix an issue with the invite removal error notice - currently, if the invite was by username, it won't contain an email. Because the notice uses the email, the user will see this:

![](https://cldup.com/bkTOvbMyEa.png)

This PR updates the notice so it falls back to the username in that case.

#### Testing instructions

* Go to `/people/invites/:site` where `:site` is a WP.com simple site.
* If you have no invites, create some by inviting folks to your site.
* With internet connection disabled, click on "Resend invite" and verify you still get an error notice.
* Open the invite.
* With internet connection disabled, click on "Revoke Invite" and verify you still get an error notice.
* Make sure to try again the last step with an invite by WP.com username, and verify you see the username in the error notice.
