### PR TITLE
State: Move site deletion notices away from middleware

### DIFF
--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -7,15 +7,8 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { successNotice, errorNotice } from 'calypso/state/notices/actions';
-import { getSiteDomain } from 'calypso/state/sites/selectors';
-import {
-	GUIDED_TRANSFER_HOST_DETAILS_SAVE_SUCCESS,
-	SITE_DELETE,
-	SITE_DELETE_FAILURE,
-	SITE_DELETE_RECEIVE,
-} from 'calypso/state/action-types';
-import { purchasesRoot } from 'calypso/me/purchases/paths';
+import { successNotice } from 'calypso/state/notices/actions';
+import { GUIDED_TRANSFER_HOST_DETAILS_SAVE_SUCCESS } from 'calypso/state/action-types';
 
 /**
  * Handlers
@@ -24,52 +17,12 @@ import { purchasesRoot } from 'calypso/me/purchases/paths';
 const onGuidedTransferHostDetailsSaveSuccess = () =>
 	successNotice( translate( 'Thanks for confirming those details!' ) );
 
-const onSiteDelete = ( { siteId } ) => ( dispatch, getState ) => {
-	const siteDomain = getSiteDomain( getState(), siteId );
-
-	dispatch(
-		successNotice( translate( '%(siteDomain)s is being deleted.', { args: { siteDomain } } ), {
-			duration: 5000,
-			id: 'site-delete',
-		} )
-	);
-};
-
-const onSiteDeleteReceive = ( { siteId } ) => ( dispatch, getState ) => {
-	const siteDomain = getSiteDomain( getState(), siteId );
-
-	dispatch(
-		successNotice( translate( '%(siteDomain)s has been deleted.', { args: { siteDomain } } ), {
-			duration: 5000,
-			id: 'site-delete',
-		} )
-	);
-};
-
-const onSiteDeleteFailure = ( { error } ) => {
-	if ( error.error === 'active-subscriptions' ) {
-		return errorNotice(
-			translate( 'You must cancel any active subscriptions prior to deleting your site.' ),
-			{
-				id: 'site-delete',
-				showDismiss: false,
-				button: translate( 'Manage Purchases' ),
-				href: purchasesRoot,
-			}
-		);
-	}
-	return errorNotice( error.message );
-};
-
 /**
  * Handler action type mapping
  */
 
 export const handlers = {
 	[ GUIDED_TRANSFER_HOST_DETAILS_SAVE_SUCCESS ]: onGuidedTransferHostDetailsSaveSuccess,
-	[ SITE_DELETE ]: onSiteDelete,
-	[ SITE_DELETE_FAILURE ]: onSiteDeleteFailure,
-	[ SITE_DELETE_RECEIVE ]: onSiteDeleteReceive,
 };
 
 /**

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -1,15 +1,17 @@
 /**
  * External dependencies
  */
-
 import { omit } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import wpcom from 'calypso/lib/wp';
 import config from '@automattic/calypso-config';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
+import { purchasesRoot } from 'calypso/me/purchases/paths';
 import {
 	SITE_DELETE,
 	SITE_DELETE_FAILURE,
@@ -140,7 +142,7 @@ export function requestSite( siteFragment, forceWpcom = false ) {
 						type: SITE_REQUEST_FAILURE,
 						siteId: siteFragment,
 						site,
-						error: i18n.translate( 'No access to manage the site' ),
+						error: translate( 'No access to manage the site' ),
 					} );
 				}
 
@@ -168,6 +170,12 @@ export function requestSite( siteFragment, forceWpcom = false ) {
 	};
 }
 
+const siteDeletionNoticeId = 'site-delete';
+const siteDeletionNoticeOptions = {
+	duration: 5000,
+	id: siteDeletionNoticeId,
+};
+
 /**
  * Returns a function which, when invoked, triggers a network request to delete
  * a site.
@@ -176,11 +184,21 @@ export function requestSite( siteFragment, forceWpcom = false ) {
  * @returns {Function}        Action thunk
  */
 export function deleteSite( siteId ) {
-	return ( dispatch ) => {
+	return ( dispatch, getState ) => {
+		const siteDomain = getSiteDomain( getState(), siteId );
+
 		dispatch( {
 			type: SITE_DELETE,
 			siteId,
 		} );
+
+		dispatch(
+			successNotice(
+				translate( '%(siteDomain)s is being deleted.', { args: { siteDomain } } ),
+				siteDeletionNoticeOptions
+			)
+		);
+
 		return wpcom
 			.undocumented()
 			.deleteSite( siteId )
@@ -190,6 +208,12 @@ export function deleteSite( siteId ) {
 					type: SITE_DELETE_SUCCESS,
 					siteId,
 				} );
+				dispatch(
+					successNotice(
+						translate( '%(siteDomain)s has been deleted.', { args: { siteDomain } } ),
+						siteDeletionNoticeOptions
+					)
+				);
 			} )
 			.catch( ( error ) => {
 				dispatch( {
@@ -197,6 +221,22 @@ export function deleteSite( siteId ) {
 					siteId,
 					error,
 				} );
+				if ( error.error === 'active-subscriptions' ) {
+					dispatch(
+						errorNotice(
+							translate( 'You must cancel any active subscriptions prior to deleting your site.' ),
+							{
+								id: siteDeletionNoticeId,
+								showDismiss: false,
+								button: translate( 'Manage Purchases' ),
+								href: purchasesRoot,
+							}
+						)
+					);
+					return;
+				}
+
+				dispatch( errorNotice( error.message, siteDeletionNoticeOptions ) );
 			} );
 	};
 }

--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -216,6 +216,12 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'deleteSite()', () => {
+		const getState = () => ( {
+			sites: {
+				items: {},
+			},
+		} );
+
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
@@ -231,7 +237,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch delete action when thunk triggered', () => {
-			deleteSite( 2916284 )( spy );
+			deleteSite( 2916284 )( spy, getState );
 
 			expect( spy ).to.have.been.calledWith( {
 				type: SITE_DELETE,
@@ -240,13 +246,13 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch receive deleted site when request completes', () => {
-			return deleteSite( 2916284 )( spy ).then( () => {
+			return deleteSite( 2916284 )( spy, getState ).then( () => {
 				expect( spy ).to.have.been.calledWith( receiveDeletedSite( 2916284 ) );
 			} );
 		} );
 
 		test( 'should dispatch delete success action when request completes', () => {
-			return deleteSite( 2916284 )( spy ).then( () => {
+			return deleteSite( 2916284 )( spy, getState ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: SITE_DELETE_SUCCESS,
 					siteId: 2916284,
@@ -255,7 +261,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch fail action when request for delete fails', () => {
-			return deleteSite( 77203074 )( spy ).then( () => {
+			return deleteSite( 77203074 )( spy, getState ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: SITE_DELETE_FAILURE,
 					siteId: 77203074,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the site deletion notices away from the notices middleware and into the corresponding action thunks. This way these notices get modularized together with the corresponding state modules and don't clutter the main entry point.

#### Testing instructions

* Go to `/settings/delete-site/:site` where `:site` is a WP.com simple site.
* Open the above in 2 separate tabs.
* Click the Delete button.
* Input the domain name in the prompt and confirm.
* Verify you're seeing a `DOMAIN NAME is being deleted.` success notice.
* Verify after deletion that notice is replaced with a "DOMAIN NAME has been deleted." success notice.
* Try deleting the site in the second tab.
* Verify you're still getting an error notice with the error upon deletion.
* Try the above steps with a site with an active plan.
* Verify you're getting a "You must cancel any active subscriptions prior to deleting your site." error notice.
* Verify tests still pass.