### PR TITLE
Admin Menu: Handle WP Admin URLs on mapped domains

### DIFF
--- a/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
@@ -67,10 +67,17 @@ describe( 'handlers', () => {
 				children: [
 					{
 						parent: 'my-custom-menu-3',
-						slug: 'my-custom-menu-4',
+						slug: 'my-custom-menu-3',
 						title: 'Settings',
 						type: 'submenu-item',
 						url: 'https://example.wordpress.com/wp-admin/settings.php',
+					},
+                    {
+						parent: 'my-custom-menu-4',
+						slug: 'my-custom-menu-4',
+						title: 'Malicious Child',
+						type: 'submenu-item',
+						url: 'javascript:alert("not good")',
 					},
 				],
 			},

--- a/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
@@ -24,12 +24,14 @@ describe( 'requestFetchAdminMenu', () => {
 } );
 
 describe( 'handlers', () => {
+	const getState = () => ( {
+		sites: {
+			items: { 73738: { options: { admin_url: 'https://example.wordpress.com/wp-admin' } } },
+		},
+	} );
+
 	test( 'should create correct success action on fetch success ', () => {
 		const dispatch = jest.fn();
-		const getState = () => ( {
-			currentUser: { capabilities: { 73738: {} } },
-			sites: { items: { 73738: { ID: 73738, domain: 'example.wordpress.com' } } },
-		} );
 		const menuData = {};
 		const action = receiveAdminMenu( 73738, menuData );
 		handleSuccess( { siteId: 73738 }, menuData )( dispatch, getState );
@@ -39,10 +41,6 @@ describe( 'handlers', () => {
 
 	test( 'should sanitize menu URLs', () => {
 		const dispatch = jest.fn();
-		const getState = () => ( {
-			currentUser: { capabilities: { 73738: {} } },
-			sites: { items: { 73738: { ID: 73738, domain: 'example.wordpress.com' } } },
-		} );
 		const unsafeMenu = [
 			{
 				icon: 'dashicons-warning',
@@ -57,6 +55,22 @@ describe( 'handlers', () => {
 						title: 'Or here',
 						type: 'submenu-item',
 						url: 'http://example.com',
+					},
+				],
+			},
+			{
+				icon: 'dashicons-default',
+				slug: 'my-custom-menu-3',
+				title: 'Home',
+				type: 'menu-item',
+				url: '/home',
+				children: [
+					{
+						parent: 'my-custom-menu-3',
+						slug: 'my-custom-menu-4',
+						title: 'Settings',
+						type: 'submenu-item',
+						url: 'https://example.wordpress.com/wp-admin/settings.php',
 					},
 				],
 			},

--- a/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
@@ -72,7 +72,7 @@ describe( 'handlers', () => {
 						type: 'submenu-item',
 						url: 'https://example.wordpress.com/wp-admin/settings.php',
 					},
-                    {
+					{
 						parent: 'my-custom-menu-4',
 						slug: 'my-custom-menu-4',
 						title: 'Malicious Child',
@@ -85,6 +85,7 @@ describe( 'handlers', () => {
 		const sanitizedMenu = [ ...unsafeMenu ];
 		sanitizedMenu[ 0 ].url = '';
 		sanitizedMenu[ 0 ].children[ 0 ].url = '';
+		sanitizedMenu[ 1 ].children[ 1 ].url = '';
 		const action = receiveAdminMenu( 73738, sanitizedMenu );
 
 		handleSuccess( { siteId: 73738 }, unsafeMenu )( dispatch, getState );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #49718 we added a sanitization process for the admin menu URLs to ensure they all link to either Calypso or WP Admin. However, there is a bug on Simple sites with a mapped domain since I incorrectly assumed that all WP Admin URLs for those sites follow a `<CUSTOM_DOMAIN>/wp-admin` format, while they actually don't contain the custom domain at all, and instead they use the standard `<SITE_SLUG>.wordpress.com/wp-admin` format.

This PR fixes that regression by using the `getSiteAdminUrl` selector which returns the appropriate WP Admin URL for the given site.

#### Testing instructions

* Open the Calypso live link below.
* Switch to a Simple site without a mapped domain, and make sure that menu items linking to Calypso (e.g. My Home) and WP Admin (e.g. Posts > Categories) work as expected.
* Repeat with a Simple site with a mapped domain.
* Repeat with an Atomic site with and without mapped domain.
* Repeat with a Jetpack site.
