### PR TITLE
State: Move monitor notices away from middleware

### DIFF
--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -21,8 +21,6 @@ import {
 	SITE_DELETE,
 	SITE_DELETE_FAILURE,
 	SITE_DELETE_RECEIVE,
-	SITE_MONITOR_SETTINGS_UPDATE_SUCCESS,
-	SITE_MONITOR_SETTINGS_UPDATE_FAILURE,
 } from 'calypso/state/action-types';
 import { purchasesRoot } from 'calypso/me/purchases/paths';
 
@@ -63,12 +61,6 @@ export const onInviteResendRequestFailure = () =>
 
 const onGuidedTransferHostDetailsSaveSuccess = () =>
 	successNotice( translate( 'Thanks for confirming those details!' ) );
-
-const onSiteMonitorSettingsUpdateSuccess = () =>
-	successNotice( translate( 'Settings saved successfully!' ) );
-
-const onSiteMonitorSettingsUpdateFailure = () =>
-	successNotice( translate( 'There was a problem saving your changes. Please, try again.' ) );
 
 const onSiteDelete = ( { siteId } ) => ( dispatch, getState ) => {
 	const siteDomain = getSiteDomain( getState(), siteId );
@@ -122,8 +114,6 @@ export const handlers = {
 	[ SITE_DELETE ]: onSiteDelete,
 	[ SITE_DELETE_FAILURE ]: onSiteDeleteFailure,
 	[ SITE_DELETE_RECEIVE ]: onSiteDeleteReceive,
-	[ SITE_MONITOR_SETTINGS_UPDATE_SUCCESS ]: onSiteMonitorSettingsUpdateSuccess,
-	[ SITE_MONITOR_SETTINGS_UPDATE_FAILURE ]: onSiteMonitorSettingsUpdateFailure,
 };
 
 /**

--- a/client/state/sites/monitor/actions.js
+++ b/client/state/sites/monitor/actions.js
@@ -1,7 +1,12 @@
 /**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
  * Internal dependencies
  */
-
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import {
 	SITE_MONITOR_SETTINGS_RECEIVE,
 	SITE_MONITOR_SETTINGS_REQUEST,
@@ -16,7 +21,7 @@ import wp from 'calypso/lib/wp';
 /**
  * Request the Jetpack monitor settings for a certain site.
  *
- * @param  {Int}       siteId  ID of the site.
+ * @param  {number}       siteId  ID of the site.
  * @returns {Function}          Action thunk to request the Jetpack monitor settings when called.
  */
 export const requestSiteMonitorSettings = ( siteId ) => {
@@ -54,7 +59,7 @@ export const requestSiteMonitorSettings = ( siteId ) => {
 /**
  * Update the Jetpack monitor settings for a certain site.
  *
- * @param  {Int}       siteId    ID of the site.
+ * @param  {number}       siteId    ID of the site.
  * @param  {object}    settings  Monitor settings.
  * @returns {Function}            Action thunk to update the Jetpack monitor settings when called.
  */
@@ -77,6 +82,7 @@ export const updateSiteMonitorSettings = ( siteId, settings ) => {
 					siteId,
 					settings,
 				} );
+				dispatch( successNotice( translate( 'Settings saved successfully!' ) ) );
 			} )
 			.catch( ( error ) => {
 				dispatch( {
@@ -85,6 +91,9 @@ export const updateSiteMonitorSettings = ( siteId, settings ) => {
 					settings,
 					error,
 				} );
+				dispatch(
+					errorNotice( translate( 'There was a problem saving your changes. Please, try again.' ) )
+				);
 			} );
 	};
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the site monitor notices away from the notices middleware and into the corresponding action thunks. This way these notices get modularized together with the corresponding state modules and don't clutter the main entry point.

This PR also uses the opportunity to fix the error notice to actually be an error notice. It felt so weird to display an error message with a success notice. 🙈 

#### Testing instructions

* Go to `/settings/security/:site` where `:site` is a Jetpack or Atomic site.
* Make sure the "Downtime Monitor" module is enabled.
* Toggle one of the "Send Notifications ..." settings. 
* Verify you still get a "Settings saved successfully!" success notice once the request finishes.
* Disable your network connection.
* Toggle one of the "Send Notifications" settings. 
* Verify you still get a "There was a problem saving your changes. Please, try again." error notice. Verify it is an error notice and not a success notice 😅  
* Verify all tests still pass.