### PR TITLE
Plugins: Cleanup mocks in plugin upload

### DIFF
--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -32,9 +32,6 @@ const ERROR_RESPONSE = {
 	message: 'folder_exists',
 };
 
-jest.mock( 'calypso/dispatcher' );
-jest.mock( 'calypso/state/sites/selectors' );
-
 describe( 'uploadPlugin', () => {
 	test( 'should return an http request action', () => {
 		const action = uploadPlugin( { siteId, file: 'xyz' } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR cleans up mocks in plugin upload data layer tests. They are no longer necessary since we reduxified the WP.org plugins.

#### Testing instructions

* Verify all tests still pass.
