### PR TITLE
Focused Launch: Fix billing period tracking in summary

### DIFF
--- a/packages/data-stores/src/launch/actions.ts
+++ b/packages/data-stores/src/launch/actions.ts
@@ -153,25 +153,27 @@ export const disablePersistentSuccessView = () =>
 		type: 'DISABLE_SUCCESS_VIEW',
 	} as const );
 
-// TODO: I feel that there is a better way to type this
-type SetPlanActionParams = () =>
-	| {
-			readonly type: 'SET_PLAN_BILLING_PERIOD';
-			readonly billingPeriod: Plans.PlanBillingPeriod;
-	  }
-	| {
-			readonly type: 'SET_PLAN_PRODUCT_ID';
-			readonly planProductId: number | undefined;
-	  };
+/**
+ * Usually we use ReturnType of all the action creators to deduce all the actions.
+ * This works until one of the action creators is a generator and doesn't actually "Return" an action.
+ * This type helper allows for actions to be both functions and generators
+ */
+type ReturnOrGeneratorYieldUnion< T extends ( ...args: any ) => any > = T extends (
+	...args: any
+) => infer Return
+	? Return extends Generator< infer T, infer U, any >
+		? T | U
+		: Return
+	: never;
 
-export type LaunchAction = ReturnType<
+export type LaunchAction = ReturnOrGeneratorYieldUnion<
 	| typeof setSiteTitle
 	| typeof unsetDomain
 	| typeof setStep
 	| typeof setDomain
 	| typeof confirmDomainSelection
 	| typeof setDomainSearch
-	| SetPlanActionParams
+	| typeof setPlanProductId
 	| typeof openFocusedLaunch
 	| typeof closeFocusedLaunch
 	| typeof unsetPlanProductId

--- a/packages/data-stores/src/launch/actions.ts
+++ b/packages/data-stores/src/launch/actions.ts
@@ -55,20 +55,27 @@ export const setDomainSearch = ( domainSearch: string ) =>
 		domainSearch,
 	} as const );
 
-const __setBillingPeriod = ( billingPeriod: Plans.PlanBillingPeriod ) =>
+/**
+ * It's not recommended to export this function. We need the billing period
+ * to be a side-effect of the plan. Please don't export this action creator as you might
+ * create a discrepancy between the selected plan and the selected billing period
+ *
+ * @param billingPeriod the period
+ */
+const __internalSetBillingPeriod = ( billingPeriod: Plans.PlanBillingPeriod ) =>
 	( {
 		type: 'SET_PLAN_BILLING_PERIOD',
 		billingPeriod,
 	} as const );
 
-export const setPlanProductId = function* setPlanProductId( planProductId: number | undefined ) {
+export const setPlanProductId = function* ( planProductId: number | undefined ) {
 	const isFree = select( PLANS_STORE ).isPlanProductFree( planProductId );
 
 	if ( ! isFree ) {
 		const planProduct = select( PLANS_STORE ).getPlanProductById( planProductId );
 		const billingPeriod = planProduct?.billingPeriod ?? 'ANNUALLY';
 
-		yield __setBillingPeriod( billingPeriod );
+		yield __internalSetBillingPeriod( billingPeriod );
 	}
 
 	return {

--- a/packages/data-stores/src/launch/constants.ts
+++ b/packages/data-stores/src/launch/constants.ts
@@ -1,3 +1,4 @@
+export { FREE_PLAN_PRODUCT_ID } from '../plans';
 export const STORE_KEY = 'automattic/launch';
 export const SITE_STORE = 'automattic/site';
 export const PLANS_STORE = 'automattic/onboard/plans';

--- a/packages/data-stores/src/launch/constants.ts
+++ b/packages/data-stores/src/launch/constants.ts
@@ -1,4 +1,3 @@
-export { FREE_PLAN_PRODUCT_ID } from '../plans';
 export const STORE_KEY = 'automattic/launch';
 export const SITE_STORE = 'automattic/site';
 export const PLANS_STORE = 'automattic/onboard/plans';

--- a/packages/data-stores/src/launch/index.ts
+++ b/packages/data-stores/src/launch/index.ts
@@ -34,6 +34,7 @@ export function register(): typeof STORE_KEY {
 				'domain',
 				'domainSearch',
 				'planProductId',
+				'planBillingPeriod',
 				'confirmedDomainSelection',
 				'isExperimental',
 				'isAnchorFm',

--- a/packages/data-stores/src/launch/reducer.ts
+++ b/packages/data-stores/src/launch/reducer.ts
@@ -11,8 +11,7 @@ import type * as DomainSuggestions from '../domain-suggestions';
 import { LaunchStep } from './data';
 import type { LaunchStepType } from './types';
 import type { LaunchAction } from './actions';
-
-const FREE_PLAN_PRODUCT_ID = 1;
+import { FREE_PLAN_PRODUCT_ID } from './constants';
 
 const step: Reducer< LaunchStepType, LaunchAction > = ( state = LaunchStep.Name, action ) => {
 	if ( action.type === 'SET_STEP' ) {

--- a/packages/data-stores/src/launch/reducer.ts
+++ b/packages/data-stores/src/launch/reducer.ts
@@ -11,7 +11,6 @@ import type * as DomainSuggestions from '../domain-suggestions';
 import { LaunchStep } from './data';
 import type { LaunchStepType } from './types';
 import type { LaunchAction } from './actions';
-import { FREE_PLAN_PRODUCT_ID } from './constants';
 
 const step: Reducer< LaunchStepType, LaunchAction > = ( state = LaunchStep.Name, action ) => {
 	if ( action.type === 'SET_STEP' ) {
@@ -60,13 +59,6 @@ const planProductId: Reducer< number | undefined, LaunchAction > = ( state, acti
 	}
 	if ( action.type === 'UNSET_PLAN_PRODUCT_ID' ) {
 		return undefined;
-	}
-	return state;
-};
-
-const paidPlanProductId: Reducer< number | undefined, LaunchAction > = ( state, action ) => {
-	if ( action.type === 'SET_PLAN_PRODUCT_ID' && action.planProductId !== FREE_PLAN_PRODUCT_ID ) {
-		return action.planProductId;
 	}
 	return state;
 };
@@ -163,7 +155,6 @@ const reducer = combineReducers( {
 	domain,
 	confirmedDomainSelection,
 	domainSearch,
-	paidPlanProductId,
 	planProductId,
 	isSidebarOpen,
 	isSidebarFullscreen,

--- a/packages/data-stores/src/launch/reducer.ts
+++ b/packages/data-stores/src/launch/reducer.ts
@@ -11,6 +11,7 @@ import type * as DomainSuggestions from '../domain-suggestions';
 import { LaunchStep } from './data';
 import type { LaunchStepType } from './types';
 import type { LaunchAction } from './actions';
+import type { Plans } from '..';
 
 const step: Reducer< LaunchStepType, LaunchAction > = ( state = LaunchStep.Name, action ) => {
 	if ( action.type === 'SET_STEP' ) {
@@ -59,6 +60,16 @@ const planProductId: Reducer< number | undefined, LaunchAction > = ( state, acti
 	}
 	if ( action.type === 'UNSET_PLAN_PRODUCT_ID' ) {
 		return undefined;
+	}
+	return state;
+};
+
+const planBillingPeriod: Reducer< Plans.PlanBillingPeriod, LaunchAction > = (
+	state = 'ANNUALLY',
+	action
+) => {
+	if ( action.type === 'SET_PLAN_BILLING_PERIOD' ) {
+		return action.billingPeriod;
 	}
 	return state;
 };
@@ -155,6 +166,7 @@ const reducer = combineReducers( {
 	domain,
 	confirmedDomainSelection,
 	domainSearch,
+	planBillingPeriod,
 	planProductId,
 	isSidebarOpen,
 	isSidebarFullscreen,

--- a/packages/data-stores/src/launch/reducer.ts
+++ b/packages/data-stores/src/launch/reducer.ts
@@ -12,6 +12,8 @@ import { LaunchStep } from './data';
 import type { LaunchStepType } from './types';
 import type { LaunchAction } from './actions';
 
+const FREE_PLAN_PRODUCT_ID = 1;
+
 const step: Reducer< LaunchStepType, LaunchAction > = ( state = LaunchStep.Name, action ) => {
 	if ( action.type === 'SET_STEP' ) {
 		return action.step;
@@ -59,6 +61,13 @@ const planProductId: Reducer< number | undefined, LaunchAction > = ( state, acti
 	}
 	if ( action.type === 'UNSET_PLAN_PRODUCT_ID' ) {
 		return undefined;
+	}
+	return state;
+};
+
+const paidPlanProductId: Reducer< number | undefined, LaunchAction > = ( state, action ) => {
+	if ( action.type === 'SET_PLAN_PRODUCT_ID' && action.planProductId !== FREE_PLAN_PRODUCT_ID ) {
+		return action.planProductId;
 	}
 	return state;
 };
@@ -155,6 +164,7 @@ const reducer = combineReducers( {
 	domain,
 	confirmedDomainSelection,
 	domainSearch,
+	paidPlanProductId,
 	planProductId,
 	isSidebarOpen,
 	isSidebarFullscreen,

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -12,6 +12,7 @@ import { STORE_KEY as LAUNCH_STORE, PLANS_STORE } from './constants';
 import type { State } from './reducer';
 import type { LaunchStepType } from './types';
 import type * as DomainSuggestions from '../domain-suggestions';
+import type { Plans } from '..';
 
 export const getLaunchSequence = (): typeof LaunchSequence => LaunchSequence;
 export const getLaunchStep = (): typeof LaunchStep => LaunchStep;
@@ -26,6 +27,17 @@ export const hasPaidDomain = ( state: State ): boolean => {
 export const getSelectedDomain = ( state: State ): DomainSuggestions.DomainSuggestion | undefined =>
 	state.domain;
 export const getSelectedPlanProductId = ( state: State ): number | undefined => state.planProductId;
+
+/**
+ * This returns the readonly value of the billing period.
+ * This value is automatically inferred from the selected paid plan.
+ * If the user picks a free plan, this value will remain unchanged and
+ * will return the billing period of the previously selected paid plan.
+ *
+ * @param state the state
+ */
+export const getLastPlanBillingPeriod = ( state: State ): Plans.PlanBillingPeriod =>
+	state.planBillingPeriod;
 
 export const isSelectedPlanPaid = ( state: State ): boolean =>
 	Boolean( state.planProductId ) &&

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -7,7 +7,7 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import { LaunchSequence, LaunchStep } from './data';
-import { STORE_KEY as LAUNCH_STORE } from './constants';
+import { STORE_KEY as LAUNCH_STORE, PLANS_STORE } from './constants';
 
 import type { State } from './reducer';
 import type { LaunchStepType } from './types';
@@ -26,6 +26,10 @@ export const hasPaidDomain = ( state: State ): boolean => {
 export const getSelectedDomain = ( state: State ): DomainSuggestions.DomainSuggestion | undefined =>
 	state.domain;
 export const getSelectedPlanProductId = ( state: State ): number | undefined => state.planProductId;
+
+export const isSelectedPlanPaid = ( state: State ): boolean =>
+	Boolean( state.planProductId ) &&
+	! select( PLANS_STORE ).isPlanProductFree( state.planProductId );
 
 // Check if a domain has been explicitly selected (including free subdomain)
 /**

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -40,7 +40,8 @@ export const getLastPlanBillingPeriod = ( state: State ): Plans.PlanBillingPerio
 	state.planBillingPeriod;
 
 export const isSelectedPlanPaid = ( state: State ): boolean =>
-	select( PLANS_STORE ).isPlanProductFree( state.planProductId );
+	typeof state.planProductId !== 'undefined' &&
+	! select( PLANS_STORE ).isPlanProductFree( state.planProductId );
 
 // Check if a domain has been explicitly selected (including free subdomain)
 /**

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -40,8 +40,7 @@ export const getLastPlanBillingPeriod = ( state: State ): Plans.PlanBillingPerio
 	state.planBillingPeriod;
 
 export const isSelectedPlanPaid = ( state: State ): boolean =>
-	Boolean( state.planProductId ) &&
-	! select( PLANS_STORE ).isPlanProductFree( state.planProductId );
+	select( PLANS_STORE ).isPlanProductFree( state.planProductId );
 
 // Check if a domain has been explicitly selected (including free subdomain)
 /**

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -7,7 +7,7 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import { LaunchSequence, LaunchStep } from './data';
-import { PLANS_STORE, STORE_KEY as LAUNCH_STORE } from './constants';
+import { STORE_KEY as LAUNCH_STORE } from './constants';
 
 import type { State } from './reducer';
 import type { LaunchStepType } from './types';
@@ -27,22 +27,7 @@ export const getSelectedDomain = ( state: State ): DomainSuggestions.DomainSugge
 	state.domain;
 export const getSelectedPlanProductId = ( state: State ): number | undefined => state.planProductId;
 
-/**
- * Returns the product id of the the last paid plan the user had picked.
- * If they revert to a free plan,
- * this is useful if you want to recommend their once-picked paid plan
- *
- * @param state State
- */
-export const getPaidPlanProductId = ( state: State ): number | undefined => {
-	const productId = state.planProductId;
-	const isFree = select( PLANS_STORE ).isPlanProductFree( productId );
-
-	return productId && ! isFree ? productId : undefined;
-};
-
 // Check if a domain has been explicitly selected (including free subdomain)
-
 /**
  * Check if the user has selected a domain, including explicitly selecting the subdomain
  * This is useful for step/flow completion in the context of highlighting steps or enabling Launch button

--- a/packages/data-stores/src/plans/constants.ts
+++ b/packages/data-stores/src/plans/constants.ts
@@ -4,6 +4,8 @@
 
 export const STORE_KEY = 'automattic/onboard/plans';
 
+export const FREE_PLAN_PRODUCT_ID = 1;
+
 // plans constants
 export const TIMELESS_PLAN_FREE = 'free';
 export const TIMELESS_PLAN_PERSONAL = 'personal';

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -38,6 +38,7 @@ export {
 	TIMELESS_PLAN_PREMIUM,
 	TIMELESS_PLAN_BUSINESS,
 	TIMELESS_PLAN_ECOMMERCE,
+	FREE_PLAN_PRODUCT_ID,
 } from './constants';
 
 let isRegistered = false;

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -12,6 +12,7 @@ import {
 	TIMELESS_PLAN_ECOMMERCE,
 	TIMELESS_PLAN_FREE,
 	STORE_KEY,
+	FREE_PLAN_PRODUCT_ID,
 } from './constants';
 import deprecate from '@wordpress/deprecated';
 import type {
@@ -161,5 +162,5 @@ export const isPlanFree = ( _: State, planSlug?: PlanSlug ): boolean => {
 };
 
 export const isPlanProductFree = ( _: State, planProductId?: number | undefined ): boolean => {
-	return planProductId === 1;
+	return planProductId === FREE_PLAN_PRODUCT_ID;
 };

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -161,6 +161,5 @@ export const isPlanFree = ( _: State, planSlug?: PlanSlug ): boolean => {
 	return planSlug === TIMELESS_PLAN_FREE;
 };
 
-export const isPlanProductFree = ( _: State, planProductId?: number | undefined ): boolean => {
-	return planProductId === FREE_PLAN_PRODUCT_ID;
-};
+export const isPlanProductFree = ( _: State, planProductId: number | undefined ): boolean =>
+	planProductId === FREE_PLAN_PRODUCT_ID;

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -28,7 +28,7 @@ const Success: React.FunctionComponent = () => {
 	const isSiteLaunching = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunching( siteId ) );
 
 	const isSelectedPlanPaid = useSelect(
-		( select ) => !! select( LAUNCH_STORE ).getPaidPlanProductId(),
+		( select ) => select( LAUNCH_STORE ).isSelectedPlanPaid(),
 		[]
 	);
 

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -32,13 +32,12 @@ import FocusedLaunchSummaryItem, {
 	LeadingContentSide,
 	TrailingContentSide,
 } from './focused-launch-summary-item';
-import { LAUNCH_STORE, SITE_STORE, Plan } from '../../stores';
+import { LAUNCH_STORE, SITE_STORE, Plan, PLANS_STORE } from '../../stores';
 import LaunchContext from '../../context';
 import { isValidSiteTitle } from '../../utils';
 import { FOCUSED_LAUNCH_FLOW_ID } from '../../constants';
 
 import './style.scss';
-import { PLANS_STORE } from '@automattic/data-stores/src/launch/constants';
 
 const bulb = (
 	<SVG viewBox="0 0 24 24">
@@ -299,7 +298,7 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 			selectedPlan: plansStore.getPlanByProductId( selectedPlanProductId, locale ),
 			selectedPaidPlan: plansStore.getPlanByProductId( selectedPaidPlanProductId, locale ),
 			billingPeriod:
-				plansStore.getPlanProductById( selectedPlanProductId )?.billingPeriod || 'ANNUALLY',
+				plansStore.getPlanProductById( selectedPaidPlanProductId )?.billingPeriod || 'ANNUALLY',
 		};
 	} );
 

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -32,13 +32,12 @@ import FocusedLaunchSummaryItem, {
 	LeadingContentSide,
 	TrailingContentSide,
 } from './focused-launch-summary-item';
-import { LAUNCH_STORE, SITE_STORE, Plan, PLANS_STORE } from '../../stores';
+import { LAUNCH_STORE, SITE_STORE, Plan, PlanProduct, PLANS_STORE } from '../../stores';
 import LaunchContext from '../../context';
 import { isValidSiteTitle } from '../../utils';
 import { FOCUSED_LAUNCH_FLOW_ID } from '../../constants';
 
 import './style.scss';
-import type { PlanProduct } from '@automattic/data-stores/src/plans';
 
 const bulb = (
 	<SVG viewBox="0 0 24 24">
@@ -303,16 +302,16 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 		PlanProduct | undefined
 	>();
 
+	const [ billingPeriod, setBillingPeriod ] = React.useState< PlanProduct[ 'billingPeriod' ] >(
+		selectedPlanProduct?.billingPeriod ?? 'ANNUALLY'
+	);
+
 	const {
 		defaultPaidPlan,
 		defaultFreePlan,
 		defaultPaidPlanProduct,
 		defaultFreePlanProduct,
-	} = usePlans(
-		selectedPlan?.isFree
-			? nonDefaultPaidPlanProduct?.billingPeriod
-			: selectedPlanProduct?.billingPeriod
-	);
+	} = usePlans( billingPeriod );
 
 	React.useEffect( () => {
 		if (
@@ -323,6 +322,9 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 		) {
 			setNonDefaultPaidPlan( selectedPlan );
 			setNonDefaultPaidPlanProduct( selectedPlanProduct );
+		}
+		if ( selectedPlanProduct && ! selectedPlan?.isFree ) {
+			setBillingPeriod( selectedPlanProduct?.billingPeriod );
 		}
 	}, [ selectedPlan, defaultPaidPlan, nonDefaultPaidPlan, selectedPlanProduct ] );
 

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -32,10 +32,11 @@ import FocusedLaunchSummaryItem, {
 	LeadingContentSide,
 	TrailingContentSide,
 } from './focused-launch-summary-item';
-import { LAUNCH_STORE, SITE_STORE, Plan, PlanProduct, PLANS_STORE } from '../../stores';
+import { LAUNCH_STORE, SITE_STORE, PLANS_STORE } from '../../stores';
 import LaunchContext from '../../context';
 import { isValidSiteTitle } from '../../utils';
 import { FOCUSED_LAUNCH_FLOW_ID } from '../../constants';
+import type { Plan, PlanProduct } from '../../stores';
 
 import './style.scss';
 

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -412,11 +412,16 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 							</span>
 						</p>
 						<div>
-							{ allAvailablePlans.map( ( plan, index ) =>
-								typeof plan === 'undefined' ||
-								typeof allAvailablePlansProducts?.[ index ] === 'undefined' ? (
-									<FocusedLaunchSummaryItem key={ index } isLoading />
-								) : (
+							{ allAvailablePlans.map( ( plan, index ) => {
+								const planProduct = allAvailablePlansProducts[ index ];
+								if (
+									! plan ||
+									! planProduct ||
+									plan.periodAgnosticSlug !== planProduct?.periodAgnosticSlug
+								) {
+									return <FocusedLaunchSummaryItem key={ index } isLoading />;
+								}
+								return (
 									<FocusedLaunchSummaryItem
 										key={ plan.periodAgnosticSlug }
 										isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
@@ -454,8 +459,8 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 											</TrailingContentSide>
 										) }
 									</FocusedLaunchSummaryItem>
-								)
-							) }
+								);
+							} ) }
 						</div>
 						<Link to={ Route.PlanDetails } className="focused-launch-summary__details-link">
 							{ __( 'View all plans', __i18n_text_domain__ ) }

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -531,7 +531,7 @@ const Summary: React.FunctionComponent = () => {
 	}, [] );
 
 	const isSelectedPlanPaid = useSelect(
-		( select ) => !! select( LAUNCH_STORE ).getPaidPlanProductId(),
+		( select ) => select( LAUNCH_STORE ).isSelectedPlanPaid(),
 		[]
 	);
 

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -284,9 +284,10 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 
 	const { setPlanProductId } = useDispatch( LAUNCH_STORE );
 
-	const selectedPlanProductId = useSelect( ( select ) =>
-		select( LAUNCH_STORE ).getSelectedPlanProductId()
-	);
+	const [ selectedPlanProductId, billingPeriod ] = useSelect( ( select ) => [
+		select( LAUNCH_STORE ).getSelectedPlanProductId(),
+		select( LAUNCH_STORE ).getLastPlanBillingPeriod(),
+	] );
 
 	const { selectedPlan, selectedPlanProduct } = useSelect( ( select ) => {
 		const plansStore = select( PLANS_STORE );
@@ -302,10 +303,6 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 	const [ nonDefaultPaidPlanProduct, setNonDefaultPaidPlanProduct ] = React.useState<
 		PlanProduct | undefined
 	>();
-
-	const [ billingPeriod, setBillingPeriod ] = React.useState< PlanProduct[ 'billingPeriod' ] >(
-		selectedPlanProduct?.billingPeriod ?? 'ANNUALLY'
-	);
 
 	const {
 		defaultPaidPlan,
@@ -323,9 +320,6 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 		) {
 			setNonDefaultPaidPlan( selectedPlan );
 			setNonDefaultPaidPlanProduct( selectedPlanProduct );
-		}
-		if ( selectedPlanProduct && ! selectedPlan?.isFree ) {
-			setBillingPeriod( selectedPlanProduct?.billingPeriod );
 		}
 	}, [ selectedPlan, defaultPaidPlan, nonDefaultPaidPlan, selectedPlanProduct ] );
 

--- a/packages/launch/src/hooks/use-plans.tsx
+++ b/packages/launch/src/hooks/use-plans.tsx
@@ -27,13 +27,15 @@ export function usePlans(
 
 	return useSelect(
 		( select ) => {
-			const defaultFreePlan = select( PLANS_STORE ).getDefaultFreePlan( locale );
-			const defaultPaidPlan = select( PLANS_STORE ).getDefaultPaidPlan( locale );
-			const defaultPaidPlanProduct = select( PLANS_STORE ).getPlanProduct(
+			const plansStore = select( PLANS_STORE );
+
+			const defaultFreePlan = plansStore.getDefaultFreePlan( locale );
+			const defaultPaidPlan = plansStore.getDefaultPaidPlan( locale );
+			const defaultPaidPlanProduct = plansStore.getPlanProduct(
 				defaultPaidPlan?.periodAgnosticSlug,
 				billingPeriod
 			);
-			const defaultFreePlanProduct = select( PLANS_STORE ).getPlanProduct(
+			const defaultFreePlanProduct = plansStore.getPlanProduct(
 				defaultFreePlan?.periodAgnosticSlug,
 				billingPeriod
 			);

--- a/packages/launch/src/hooks/use-plans.tsx
+++ b/packages/launch/src/hooks/use-plans.tsx
@@ -15,16 +15,38 @@ import LaunchContext from '../context';
 import { isPlanProduct } from '../utils';
 import type { PlanProductForFlow } from '../utils';
 
-export function usePlans(): {
+export function usePlans(
+	billingPeriod: Plans.PlanBillingPeriod = 'ANNUALLY'
+): {
 	defaultPaidPlan: Plans.Plan | undefined;
 	defaultFreePlan: Plans.Plan | undefined;
+	defaultFreePlanProduct: Plans.PlanProduct | undefined;
+	defaultPaidPlanProduct: Plans.PlanProduct | undefined;
 } {
 	const locale = useLocale();
 
-	return useSelect( ( select ) => ( {
-		defaultPaidPlan: select( PLANS_STORE ).getDefaultPaidPlan( locale ),
-		defaultFreePlan: select( PLANS_STORE ).getDefaultFreePlan( locale ),
-	} ) );
+	return useSelect(
+		( select ) => {
+			const defaultFreePlan = select( PLANS_STORE ).getDefaultFreePlan( locale );
+			const defaultPaidPlan = select( PLANS_STORE ).getDefaultPaidPlan( locale );
+			const defaultPaidPlanProduct = select( PLANS_STORE ).getPlanProduct(
+				defaultPaidPlan?.periodAgnosticSlug,
+				billingPeriod
+			);
+			const defaultFreePlanProduct = select( PLANS_STORE ).getPlanProduct(
+				defaultFreePlan?.periodAgnosticSlug,
+				billingPeriod
+			);
+
+			return {
+				defaultFreePlan,
+				defaultPaidPlan,
+				defaultFreePlanProduct,
+				defaultPaidPlanProduct,
+			};
+		},
+		[ billingPeriod, locale ]
+	);
 }
 
 export function usePlanProductFromCart(): PlanProductForFlow | undefined {

--- a/packages/launch/src/stores.ts
+++ b/packages/launch/src/stores.ts
@@ -20,4 +20,5 @@ const LAUNCH_STORE = Launch.register();
 export { SITE_STORE, PLANS_STORE, DOMAIN_SUGGESTIONS_STORE, LAUNCH_STORE };
 
 export type Plan = Plans.Plan;
+export type PlanProduct = Plans.PlanProduct;
 export type SiteDetailsPlan = Site.SiteDetailsPlan;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I added `getLastPlanBillingPeriod` selector to the plan store to get the billing period of the current or last selected paid plan's period.
* I added a private (i.e unexported) action creator `__setBillingPeriod` to the launch store. And I changed the `setPlanProductId` action creator into a generator that queries the plans store for the plans billing period using its productId, then it dispatches the billing period using the newly-added `__setBillingPeriod` and the reducer records it. The makes the plan readonly and can only be changed by changing the plan. 
* I updated the `usePlans` hook to return the plan products, too.
* I refactored summary view logic around plans and plan products.

#### Testing instructions

1. Create or reuse a site that is created with `/start` flow.
2. Sandbox this site.
3. In `apps/editing-toolkit` run `yarn dev --sync`.
4. Go to https://[yoursite].wordpress.com/wp-admin/post-new.php
5. Click launch.
6. Go to detailed plan page, pick a monthly plan.
7. In summary, now pick a free plan, the prices should remain monthly.
8. Pick a non-default paid plan, it should be rendered in summary, re-pick the default paid plan (Premium), the non-default plan should remain listed.

Fixes #49713