### PR TITLE
Do only one compression pass

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -208,9 +208,7 @@ const webpackConfig = {
 							safari10: false,
 					  }
 					: {
-							compress: {
-								passes: 2,
-							},
+							compress: true,
 							mangle: true,
 					  } ),
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Disable `passes:2` (it defaults to `passes:1`).

Although doing two passes reduces the total bundle size a bit (~44kb for evergreen builds), it adds a significant amount of time to the build process (~45s in my local laptop, ~20s in CI). I think the default `passes:1` gives us a better balance build time vs bundle size.

#### Testing instructions

Smoke test live branch.