### PR TITLE
Nav Unification: ensure Sidebar can be scrolled on smaller viewports

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -90,12 +90,6 @@ class Layout extends Component {
 					.classList.add( `is-${ this.props.colorSchemePreference }` );
 			}
 		}
-
-		// This code should be removed when the nav-unification project has been rolled out to 100% of the customers.
-		if ( config.isEnabled( 'nav-unification' ) ) {
-			window.addEventListener( 'scroll', scrollCallback );
-			window.addEventListener( 'resize', scrollCallback );
-		}
 	}
 
 	componentWillUnmount() {
@@ -116,6 +110,13 @@ class Layout extends Component {
 		if ( prevProps.colorSchemePreference === this.props.colorSchemePreference ) {
 			return;
 		}
+
+		// This code should be removed when the nav-unification project has been rolled out to 100% of the customers.
+		if ( config.isEnabled( 'nav-unification' ) ) {
+			window.addEventListener( 'scroll', scrollCallback );
+			window.addEventListener( 'resize', scrollCallback );
+		}
+
 		if ( typeof document !== 'undefined' ) {
 			const classList = document.querySelector( 'body' ).classList;
 			classList.remove( `is-${ prevProps.colorSchemePreference }` );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -100,6 +100,11 @@ class Layout extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
+		// This code should be removed when the nav-unification project has been rolled out to 100% of the customers.
+		if ( config.isEnabled( 'nav-unification' ) ) {
+			window.addEventListener( 'scroll', scrollCallback );
+			window.addEventListener( 'resize', scrollCallback );
+		}
 		if ( prevProps.teams !== this.props.teams ) {
 			// This is temporary helper function until we have rolled out to 100% of customers.
 			this.isNavUnificationEnabled();
@@ -110,13 +115,6 @@ class Layout extends Component {
 		if ( prevProps.colorSchemePreference === this.props.colorSchemePreference ) {
 			return;
 		}
-
-		// This code should be removed when the nav-unification project has been rolled out to 100% of the customers.
-		if ( config.isEnabled( 'nav-unification' ) ) {
-			window.addEventListener( 'scroll', scrollCallback );
-			window.addEventListener( 'resize', scrollCallback );
-		}
-
 		if ( typeof document !== 'undefined' ) {
 			const classList = document.querySelector( 'body' ).classList;
 			classList.remove( `is-${ prevProps.colorSchemePreference }` );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR aims to solve the BLOCKER issue https://github.com/Automattic/wp-calypso/issues/49116 reported in Beta 1 i.e. the sidebar not being scrollable in smaller viewports.

After some sleuthing it turned out that the root of the issue is the check `config.isEnabled( 'nav-unification' )` not returning the correct value at the time it's being checked. This check returning the wrong value resulted in the necessary scroll event listener not being added and thus the `handleScroll` function that handles scrolling the sidebar not being triggered.

To fix this issue we thus just need to move the check to later in the render cycle when the check is guaranteed to return the correct value (eventually). 

Fixes https://github.com/Automattic/wp-calypso/issues/49116


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* First ensure you can replicate the issue on `trunk` locally.
* To do so reliably, in `client/state/initial-state.js` change `if ( shouldAddSympathy() )` to `if ( true )`. This will ensure you're always loading the application in a non-hydrated state.
* Confirm you can reproduce the issue of the sidebar not scrolling on viewports with a height smaller than the sidebar.

* Now check out this branch locally
* Again to reproduce reliably, in `client/state/initial-state.js` change `if ( shouldAddSympathy() )` to `if ( true )`.
* Confirm you can't reproduce the issue i.e. the sidebar can be scrolled on viewports with a height smaller than the sidebar.
