### PR TITLE
Domains: Improve default screen on domain-only sites

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -13,6 +13,7 @@ import React from 'react';
 import { Button } from '@automattic/components';
 import EmptyContent from 'calypso/components/empty-content';
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
+import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import { emailManagement } from 'calypso/my-sites/email/paths';
@@ -39,13 +40,13 @@ const DomainOnly = ( { primaryDomain, hasNotice, recordTracks, siteId, slug, tra
 		);
 	}
 
+	const hasEmailWithUs = hasGSuiteWithUs( primaryDomain ) || hasTitanMailWithUs( primaryDomain );
 	const domainName = primaryDomain.name;
-	const domainHasGSuiteWithUs = hasGSuiteWithUs( primaryDomain );
 
 	const recordEmailClick = () => {
-		const tracksName = domainHasGSuiteWithUs
-			? 'calypso_domain_only_gsuite_manage'
-			: 'calypso_domain_only_gsuite_cta';
+		const tracksName = hasEmailWithUs
+			? 'calypso_domain_only_email_manage'
+			: 'calypso_domain_only_email_cta';
 		recordTracks( tracksName, {
 			domain: domainName,
 		} );
@@ -67,10 +68,9 @@ const DomainOnly = ( { primaryDomain, hasNotice, recordTracks, siteId, slug, tra
 				<Button
 					className="empty-content__action button"
 					href={ emailManagement( slug, domainName ) }
-					primary={ ! domainHasGSuiteWithUs }
 					onClick={ recordEmailClick }
 				>
-					{ domainHasGSuiteWithUs ? translate( 'Manage email' ) : translate( 'Add email' ) }
+					{ hasEmailWithUs ? translate( 'Manage email' ) : translate( 'Add email' ) }
 				</Button>
 			</EmptyContent>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The default screen for domain only-purchases has two primary buttons if you don't have email set up:

<img width="710" alt="Screenshot 2021-02-10 at 12 02 00" src="https://user-images.githubusercontent.com/3392497/107507668-cee0ba00-6b97-11eb-8012-fed40c5db58b.png">

The `Add Email` button is primary when there's no G Suite account on the domain. However, that should not be the primary action here. And we're missing a check for Titan as well.

#### Testing instructions

Create a new domain-only site from wordpress.com/domains and verify that only the Create new site button is primary, no matter if you have any email service on the domain (Google Workspace or Titan).

<img width="686" alt="Screenshot 2021-02-10 at 12 14 10" src="https://user-images.githubusercontent.com/3392497/107508914-9641e000-6b99-11eb-937d-c6540ba8181e.png">

Fixes #38512