### PR TITLE
Minor format changes.

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/difm-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/difm-upsell/index.jsx
@@ -85,12 +85,18 @@ export class DifmUpsell extends PureComponent {
 						</p>
 						<p>
 							{ translate(
-								'Whether you’re launching a store, a business, or even online courses, we’ll help you stand out online with a beautiful, functional, secure website that’s built just for you.'
+								'Whether you’re launching a store, a business, or even online courses, we’ll help you stand out online with a beautiful, functional, secure website that’s built {{em}}just for you{{/em}}.',
+								{
+									components: { em: <em /> },
+								}
 							) }
 						</p>
 						<p>
 							{ translate(
-								'You’ll work with a dedicated engagement manager throughout the entire project, ensuring that your vision is carried through from start to finish. All for a one-time fee.'
+								'You’ll work with a dedicated engagement manager throughout the entire project, ensuring that your vision is carried through from start to finish. {{b}}All for a one-time fee.{{/b}}',
+								{
+									components: { b: <b /> },
+								}
 							) }
 						</p>
 						<p>{ translate( 'Our premium website building service is perfect for:' ) }</p>
@@ -140,8 +146,8 @@ export class DifmUpsell extends PureComponent {
 						</p>
 
 						<p>
-							{ translate( '{{b}}Custom websites starting at $4,900{{/b}}', {
-								components: { b: <b /> },
+							{ translate( '{{em}}Custom websites starting at $4,900.{{/em}}', {
+								components: { em: <em /> },
 							} ) }
 						</p>
 					</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR is a follow-up to https://github.com/Automattic/wp-calypso/pull/49301. It just changes some minor formatting styles in the offer. 

Before:
![image](https://user-images.githubusercontent.com/538790/107507690-3995f380-6ba0-11eb-80e0-be65faaf3b0d.png)

After:
![image](https://user-images.githubusercontent.com/538790/107508194-f0926f00-6ba0-11eb-9736-582578e98483.png)
 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set yourself to the treatment group in the experiment post_purchase_difm_upsell
* Navigate to /start. 
* Go through the signup flow and purchase a Business plan.
* In the DIFM offer page, make sure the offer is looking like the After screenshot.


Related to https://github.com/Automattic/wp-calypso/pull/49301
