### PR TITLE
Config parser: merge features objects from config files

### DIFF
--- a/client/server/config/parser.js
+++ b/client/server/config/parser.js
@@ -7,7 +7,7 @@
  */
 const fs = require( 'fs' );
 const path = require( 'path' );
-const assign = require( 'lodash/assign' );
+const { assign, assignWith } = require( 'lodash' );
 const debug = require( 'debug' )( 'config' );
 
 function getDataFromFile( file ) {
@@ -43,7 +43,10 @@ module.exports = function ( configPath, defaultOpts ) {
 	const disabledFeatures = opts.disabledFeatures ? opts.disabledFeatures.split( ',' ) : [];
 
 	configFiles.forEach( function ( file ) {
-		assign( data, getDataFromFile( file ) );
+		// merge the objects in `features` field, and do a simple assignment for other fields
+		assignWith( data, getDataFromFile( file ), ( objValue, srcValue, key ) =>
+			key === 'features' ? { ...objValue, ...srcValue } : undefined
+		);
 	} );
 
 	if ( data.hasOwnProperty( 'features' ) ) {


### PR DESCRIPTION
When the config parser merges data from various config files, e.g.,
- `config/_shared.json`
- `config/development.json`
- `config/development.local.json`

Then we should merge the `features` object into the existing one, instead of overwriting it.

**How to test:**
Create a local `config/development.local.json` file:
```
{
  "oauth_client_id": "my-app-id",
  "features": {
    "oauth": true
  }
}
```
That enables OAuth for your local Calypso instead of using WordPress.com cookies.

After you boot up Calypso with this config, then inspecting `window.configData.features` should show you all the features defined in `config/development.json`, not just the local `features: { oauth: true }` bit.

After correctly booting up with OAuth enabled, you should see an authorization screen instead of the classic login screen:

<img width="855" alt="Screenshot 2021-02-10 at 13 12 43" src="https://user-images.githubusercontent.com/664258/107509127-4fa4b380-6ba2-11eb-8b1f-e799bc4d6595.png">
