### PR TITLE
Checkout: Ensure long domain names don't overflow

### DIFF
--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -142,6 +142,7 @@
 
 .purchase-detail__text {
 	flex-grow: 1;
+	word-break: break-word;
 }
 
 .purchase-detail__body {

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -38,7 +38,7 @@
 
 	&:last-child {
 		border-bottom: 1px solid var( --color-neutral-0 );
-		border-radius: 0 0 3px 3px;
+		border-radius: 0 0 2px 2px;
 	}
 }
 
@@ -179,6 +179,7 @@
 	font-size: $font-title-small;
 	font-weight: 400;
 	margin-top: 15px;
+	word-break: break-word;
 }
 
 .checkout-thank-you__header.is-placeholder {


### PR DESCRIPTION
Fixes #49842

#### Changes proposed in this Pull Request
If you have a long domain name (registering or mapping), it causes an overflow on the Thank You screen. See https://github.com/Automattic/wp-calypso/issues/49842.

#### Testing instructions
Easiest way to reproduce is to buy a mapping for a subdomain you already own on WPCOM. Make it a super long subdomain. On the checkout Thank You screen, it should not overflow:

<img width="738" alt="Screenshot 2021-02-10 at 12 22 58" src="https://user-images.githubusercontent.com/3392497/107510224-8cb97780-6b9b-11eb-91d8-cb1d3e247625.png">

Make sure to check the mobile view as well:

![Screen Shot 2021-02-10 at 12 24 21](https://user-images.githubusercontent.com/3392497/107510260-9642df80-6b9b-11eb-8083-cf13cb04b7df.png)

