### PR TITLE
Sidebar: avoid /plugins REST request on non-Jetpack sites

### DIFF
--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -31,21 +31,23 @@ const useSiteMenuItems = () => {
 	useEffect( () => {
 		if ( selectedSiteId && siteDomain ) {
 			dispatch( requestAdminMenu( selectedSiteId ) );
-			dispatch( fetchPlugins( [ selectedSiteId ] ) );
+			if ( isJetpack ) {
+				dispatch( fetchPlugins( [ selectedSiteId ] ) );
+			}
 		}
-	}, [ dispatch, selectedSiteId, siteDomain ] );
+	}, [ dispatch, isJetpack, selectedSiteId, siteDomain ] );
 
 	/**
 	 * As a general rule we allow fallback data to remain as static as possible.
 	 * Therefore we should avoid relying on API responses to determine what is/isn't
-	 * shown in the fallback data as then we have a situatoin where we are waiting on
+	 * shown in the fallback data as then we have a situation where we are waiting on
 	 * network requests to display fallback data when it should be possible to display
 	 * without this. There are a couple of exceptions to this below where the menu items
 	 * are sufficiently important to the UX that it is worth attempting the API request
 	 * to determine whether or not the menu item should show in the fallback data.
 	 */
 	const shouldShowWooCommerce = useSelector(
-		( state ) => !! getPluginOnSite( state, selectedSiteId, 'woocommerce' )?.active
+		( state ) => !! ( isJetpack && getPluginOnSite( state, selectedSiteId, 'woocommerce' )?.active )
 	);
 	const shouldShowThemes = useSelector( ( state ) =>
 		canCurrentUser( state, selectedSiteId, 'edit_theme_options' )


### PR DESCRIPTION
The unified sidebar issues a request to `/sites/:site/plugins`, to detect whether we have Woo installed. But this request is supported only for Jetpack/Atomic sites, sending it with a `:site` that is Simple always fails:

<img width="1058" alt="Screenshot 2021-02-10 at 12 51 36" src="https://user-images.githubusercontent.com/664258/107513258-40c0ff80-6ba8-11eb-85cc-abdd2f173b91.png">

This PR sends the request only if the site is Jetpack (which includes Atomic).