### PR TITLE
remove `lib/user-settings` from notifications settings controller

### DIFF
--- a/client/me/notification-settings/controller.js
+++ b/client/me/notification-settings/controller.js
@@ -7,7 +7,6 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import userSettings from 'calypso/lib/user-settings';
 import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 import NotificationsComponent from 'calypso/me/notification-settings/main';
 import CommentSettingsComponent from 'calypso/me/notification-settings/comment-settings';
@@ -53,7 +52,6 @@ export function subscriptions( context, next ) {
 	context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) );
 
 	context.primary = React.createElement( NotificationSubscriptions, {
-		userSettings: userSettings,
 		path: context.path,
 	} );
 	next();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As of #48878 we don't use the user settings flux store in the reader subscription settings, so passing it on from the controller is unnecessary. This PR cleans it up.

* Remove `lib/user-settings` from `me/notifications-settings/controller`

#### Testing instructions

* Go to `me/notifications/subscriptions` and make sure the page loads fine
* Change some of the settings and verify they're saved

Related to https://github.com/Automattic/wp-calypso/issues/24162
