### PR TITLE
ABTest, Checkout: Remove FRESHPACK prefill test, use test variant

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -68,14 +68,4 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: false,
 	},
-	prefillFRESHPACKCouponCode: {
-		datestamp: '20210203',
-		variations: {
-			test: 50,
-			control: 50,
-		},
-		localeTargets: 'any',
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 };

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -104,7 +104,7 @@ const wpcom = wp.undocumented();
 const wpcomGetStoredCards = (): StoredCard[] => wpcom.getStoredCards();
 
 // Can be safely removed after 2021-02-14 when the FRESHPACK coupon expires
-import { abtest } from 'calypso/lib/abtest';
+import moment from 'moment';
 import { isJetpackProductSlug, isJetpackPlanSlug } from 'calypso/lib/products-values';
 const useMaybeGetFRESHPACKCode = ( products: RequestCartProduct[] ) =>
 	useMemo( () => {
@@ -118,8 +118,9 @@ const useMaybeGetFRESHPACKCode = ( products: RequestCartProduct[] ) =>
 			return undefined;
 		}
 
-		const shouldPrefillCode = abtest( 'prefillFRESHPACKCouponCode' ) === 'test';
-		return shouldPrefillCode ? 'FRESHPACK' : undefined;
+		const endDate = moment.utc( '2021-02-15' );
+
+		return moment().isBefore( endDate ) ? 'FRESHPACK' : undefined;
 	}, [ products ] );
 
 export default function CompositeCheckout( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `prefillFRESHPACKCouponCode` test from `active-tests.js`.
* Always prefill the FRESHPACK coupon if a Jetpack item is in the cart and no other coupon has been applied.
* Date-limit so that the FRESHPACK coupon is only pre-filled until 11:59 PM UTC on 2021-02-14, since the coupon expires after that date.

Relates to #49606, `1196108640073826-as-1199876664867775`.

#### Known issues

* If someone adds a Jetpack item to their cart and attempts to check out after having *already purchased* with the FRESHPACK coupon, they will see an error message at the checkout page saying, "Sorry, but we were not able to find that coupon. Please check that you typed the coupon code correctly and that this coupon is for the product you have selected."

#### Testing instructions

##### Case 1: Coupon code is correctly prefilled

* Open Calypso Blue in your testing environment.
* Verify that in the development helper panel in the lower right of your screen, in the `ABTESTS` section, `prefillFRESHPACKCouponCode` is no longer part of the list of active tests (see reference screenshots).
* Select a self-hosted Jetpack site that has not yet used the FRESHPACK coupon code.
* Select a Jetpack product or bundle and attempt to check out.
* Verify that the FRESHPACK coupon code is automatically applied to your cart.

##### Case 2: Date limiting works as expected

* Clear out any items in your cart from Case 1.
* Set your system time to 2021-02-15 (UTC) or later.
* Select a product and attempt to check out as in Case 1.
* Verify that the FRESHPACK coupon code is **not** automatically applied to your cart.

#### Reference screenshots

<img width="250" alt="image" src="https://user-images.githubusercontent.com/670067/107521849-a5646600-6b78-11eb-8fcb-93c567dcb910.png">

<img width="572" alt="image" src="https://user-images.githubusercontent.com/670067/107522227-186ddc80-6b79-11eb-9c99-3c556a8e37ba.png">