### PR TITLE
Account Settings: Remove duplicated interface fields

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -102,8 +102,6 @@ const INTERFACE_FIELDS = [
 	'use_fallback_for_incomplete_languages',
 	'enable_translator',
 	'calypso_preferences',
-	'i18n_empathy_mode',
-	'use_fallback_for_incomplete_languages',
 ];
 
 /* eslint-disable react/prefer-es6-class */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove duplicated interface fields for empathy mode and incomplete translations fallback in Account settings component. The duplicated fields were added in #49875 as they were previously missing, but since #49760 also had them added and was merged a few minutes earlier, it resulted in having the same entries twice in the `INTERFACE_FIELDS` array.

#### Testing instructions

* Review code changes.
* Confirm `Display interface in English` and `Empathy Mode` settings are still working as expected.

Related to #49760 #49875
