### PR TITLE
Domains: Make Domain Connect toggle more visible

### DIFF
--- a/client/my-sites/domains/domain-management/dns-records/item.scss
+++ b/client/my-sites/domains/domain-management/dns-records/item.scss
@@ -38,7 +38,10 @@
 	}
 
 	&.is-disabled {
-		opacity: 0.2;
-		cursor: not-allowed;
+		.dns-records__list-type,
+		.dns-records__list-info {
+			opacity: 0.4;
+			cursor: not-allowed;
+		}
 	}
 }

--- a/client/my-sites/domains/domain-management/dns-records/item.scss
+++ b/client/my-sites/domains/domain-management/dns-records/item.scss
@@ -39,7 +39,8 @@
 
 	&.is-disabled {
 		.dns-records__list-type,
-		.dns-records__list-info {
+		.dns-records__list-info,
+		.dns__list-remove {
 			opacity: 0.4;
 			cursor: not-allowed;
 		}


### PR DESCRIPTION
Fixes #47016

#### Changes proposed in this Pull Request

The toggle for the domain connect TXT record inherits the disabled style, so it becomes less visible and as a result appears disabled as well:

<img width="697" alt="Screenshot 2021-02-10 at 15 46 57" src="https://user-images.githubusercontent.com/3392497/107536824-1ed07880-6bba-11eb-8c1a-682055475b98.png">

I've adjusted the CSS rules and also lessened the opacity as it was really hard to see the record with `0.2` opacity.

#### Testing instructions
Go to Domains -> example.com -> DNS records and verify that when you toggle (disable) the Domain Connect record, the toggle remains "active":

<img width="696" alt="Screenshot 2021-02-10 at 16 05 23" src="https://user-images.githubusercontent.com/3392497/107536950-47587280-6bba-11eb-987d-161ee499308b.png">
