### PR TITLE
Anchor: Have user edit the homepage after site creation.

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -15,7 +15,7 @@ import { PLANS_STORE } from '../stores/plans';
 import { recordOnboardingComplete } from '../lib/analytics';
 import { useSelectedPlan, useShouldRedirectToEditorAfterCheckout } from './use-selected-plan';
 import { clearLastNonEditorRoute } from '../lib/clear-last-non-editor-route';
-import { useIsAnchorFm, useAnchorFmParams, useOnboardingFlow } from '../path';
+import { useOnboardingFlow } from '../path';
 
 const wpcom = wp.undocumented();
 
@@ -72,9 +72,7 @@ export default function useOnSiteCreation(): void {
 		select( PLANS_STORE ).getPlanProductById( selectedPlanProductId )
 	);
 
-	const isAnchorFmSignup = useIsAnchorFm();
 	const flow = useOnboardingFlow();
-	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyUrl } = useAnchorFmParams();
 
 	const { resetOnboardStore, setIsRedirecting, setSelectedSite } = useDispatch( ONBOARD_STORE );
 	const flowCompleteTrackingParams = {
@@ -144,17 +142,6 @@ export default function useOnSiteCreation(): void {
 			let destination;
 			if ( design?.is_fse ) {
 				destination = `/site-editor/${ newSite.site_slug }/`;
-			} else if ( isAnchorFmSignup ) {
-				const params = {
-					anchor_podcast: anchorFmPodcastId,
-					anchor_episode: anchorFmEpisodeId,
-					spotify_url: anchorFmSpotifyUrl,
-				};
-				const queryString = Object.keys( params )
-					.filter( ( key ) => params[ key as keyof typeof params ] != null )
-					.map( ( key ) => key + '=' + params[ key as keyof typeof params ] )
-					.join( '&' );
-				destination = `/post/${ newSite.site_slug }?${ queryString }`;
 			} else {
 				destination = `/page/${ newSite.site_slug }/home`;
 			}
@@ -172,9 +159,5 @@ export default function useOnSiteCreation(): void {
 		flowCompleteTrackingParams,
 		shouldRedirectToEditorAfterCheckout,
 		design,
-		isAnchorFmSignup,
-		anchorFmPodcastId,
-		anchorFmEpisodeId,
-		anchorFmSpotifyUrl,
 	] );
 }


### PR DESCRIPTION
Instead of a new Anchor user being dropped into the editor with their first episode post, we'll have them edit their homepage instead (as we do in standard Gutenboarding). This will give the new user a better sense of what their site looks like, and makes the connection to the design that they chose during signup. They'll also be ready to replace placeholder content, like the hosts and sponsors.

<img width="1686" alt="Screen Shot 2021-02-10 at 8 10 09 AM" src="https://user-images.githubusercontent.com/349751/107537161-6e418500-6b77-11eb-8d20-e196770883c1.png">

**Testing Instructions**
* Switch to this branch and load http://calypso.localhost:3000/new?anchor_podcast=141c05c.
* Go through signup.
* Verify you are finally redirected to the editor with the site's homepage loaded.

Fixes 470-gh-Automattic/dotcom-manage