### PR TITLE
Partner Portal: Add license list data layer tests

### DIFF
--- a/client/state/partner-portal/licenses/test/actions.js
+++ b/client/state/partner-portal/licenses/test/actions.js
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Internal dependencies
+ */
+import * as actions from 'calypso/state/partner-portal/licenses/actions';
+import {
+	JETPACK_PARTNER_PORTAL_LICENSES_REQUEST,
+	JETPACK_PARTNER_PORTAL_LICENSES_RECEIVE,
+} from 'calypso/state/action-types';
+
+jest.mock( 'calypso/state/partner-portal/partner/selectors', () => ( {
+	getActivePartnerKey: () => ( { oauth2_token: 'fake_oauth2_token' } ),
+} ) );
+
+describe( 'actions', () => {
+	describe( '#fetchLicenses()', () => {
+		test( 'should dispatch a request action when called', () => {
+			const { fetchLicenses } = actions;
+			const dispatch = jest.fn();
+
+			fetchLicenses( dispatch, () => null );
+
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: JETPACK_PARTNER_PORTAL_LICENSES_REQUEST,
+				fetcher: 'wpcomJetpackLicensing',
+			} );
+		} );
+	} );
+
+	describe( '#receiveLicenses()', () => {
+		test( 'should return an action when called', () => {
+			const { receiveLicenses } = actions;
+			const licenses = [];
+
+			expect( receiveLicenses( licenses ) ).toEqual( {
+				type: JETPACK_PARTNER_PORTAL_LICENSES_RECEIVE,
+				licenses,
+			} );
+		} );
+	} );
+} );

--- a/client/state/partner-portal/licenses/test/handlers.js
+++ b/client/state/partner-portal/licenses/test/handlers.js
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import * as handlers from 'calypso/state/partner-portal/licenses/handlers';
+import {
+	WPCOM_HTTP_REQUEST,
+	JETPACK_PARTNER_PORTAL_LICENSES_RECEIVE,
+} from 'calypso/state/action-types';
+
+describe( 'handlers', () => {
+	describe( '#fetchLicenses()', () => {
+		test( 'should return an http request action', () => {
+			const { fetchLicenses } = handlers;
+			const action = {
+				type: 'TEST_ACTION',
+				fetcher: 'wpcomJetpackLicensing',
+			};
+			const expected = {
+				type: WPCOM_HTTP_REQUEST,
+				body: undefined,
+				method: 'GET',
+				path: '/jetpack-licensing/licenses',
+				query: { apiNamespace: 'wpcom/v2' },
+				formData: undefined,
+				onSuccess: action,
+				onFailure: action,
+				onProgress: action,
+				onStreamRecord: action,
+				options: { options: { fetcher: action.fetcher } },
+			};
+
+			expect( fetchLicenses( action ) ).toEqual( expected );
+		} );
+	} );
+
+	describe( '#receiveLicenses()', () => {
+		test( 'should return a LICENSES_RECEIVE action', () => {
+			const { receiveLicenses } = handlers;
+			const paginatedLicenses = [ 'foo' ];
+			const expected = {
+				type: JETPACK_PARTNER_PORTAL_LICENSES_RECEIVE,
+				paginatedLicenses,
+			};
+
+			expect( receiveLicenses( null, paginatedLicenses ) ).toEqual( expected );
+		} );
+	} );
+
+	describe( '#receiveLicensesError()', () => {
+		test( 'should return an error notice action', () => {
+			const { receiveLicensesError } = handlers;
+			const expected = {
+				type: 'NOTICE_CREATE',
+				notice: {
+					showDismiss: true,
+					noticeId: '1',
+					status: 'is-error',
+					text: translate( 'Failed to retrieve your licenses. Please try again later.' ),
+				},
+			};
+
+			expect( receiveLicensesError() ).toEqual( expected );
+		} );
+	} );
+} );

--- a/client/state/partner-portal/licenses/test/reducer.js
+++ b/client/state/partner-portal/licenses/test/reducer.js
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Internal dependencies
+ */
+import * as reducers from 'calypso/state/partner-portal/licenses/reducer';
+import {
+	JETPACK_PARTNER_PORTAL_LICENSES_REQUEST,
+	JETPACK_PARTNER_PORTAL_LICENSES_RECEIVE,
+} from 'calypso/state/action-types';
+
+describe( 'reducer', () => {
+	describe( '#hasFetched', () => {
+		test( 'should return true on request success', () => {
+			const { hasFetched } = reducers;
+
+			const state = undefined;
+			const action = { type: JETPACK_PARTNER_PORTAL_LICENSES_RECEIVE };
+			expect( hasFetched( state, action ) ).toEqual( true );
+		} );
+	} );
+
+	describe( '#isFetching', () => {
+		test( 'should return true on request start', () => {
+			const { isFetching } = reducers;
+
+			const state = undefined;
+			const action = { type: JETPACK_PARTNER_PORTAL_LICENSES_REQUEST };
+			expect( isFetching( state, action ) ).toEqual( true );
+		} );
+
+		test( 'should return false on request success', () => {
+			const { isFetching } = reducers;
+
+			const state = undefined;
+			const action = { type: JETPACK_PARTNER_PORTAL_LICENSES_RECEIVE };
+			expect( isFetching( state, action ) ).toEqual( false );
+		} );
+	} );
+
+	describe( '#paginated', () => {
+		test( 'should return the value of paginatedLicenses on request success', () => {
+			const { paginated } = reducers;
+
+			const state = undefined;
+			const action = {
+				type: JETPACK_PARTNER_PORTAL_LICENSES_RECEIVE,
+				paginatedLicenses: [ 'foo' ],
+			};
+			expect( paginated( state, action ) ).toEqual( action.paginatedLicenses );
+		} );
+	} );
+} );

--- a/client/state/partner-portal/licenses/test/selectors.js
+++ b/client/state/partner-portal/licenses/test/selectors.js
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Internal dependencies
+ */
+import * as selectors from 'calypso/state/partner-portal/licenses/selectors';
+
+describe( 'selectors', () => {
+	describe( '#hasFetchedLicenses()', () => {
+		test( 'should return the value of hasFetched', () => {
+			const { hasFetchedLicenses } = selectors;
+			const state = {
+				partnerPortal: {
+					licenses: {
+						hasFetched: false,
+					},
+				},
+			};
+
+			expect( hasFetchedLicenses( state ) ).toEqual( false );
+
+			state.partnerPortal.licenses.hasFetched = true;
+			expect( hasFetchedLicenses( state ) ).toEqual( true );
+		} );
+	} );
+
+	describe( '#isFetchingLicenses()', () => {
+		test( 'should return the value of isFetching', () => {
+			const { isFetchingLicenses } = selectors;
+			const state = {
+				partnerPortal: {
+					licenses: {
+						isFetching: false,
+					},
+				},
+			};
+
+			expect( isFetchingLicenses( state ) ).toEqual( false );
+
+			state.partnerPortal.licenses.isFetching = true;
+			expect( isFetchingLicenses( state ) ).toEqual( true );
+		} );
+	} );
+
+	describe( '#getPaginatedLicenses()', () => {
+		test( 'should return the value of paginated', () => {
+			const { getPaginatedLicenses } = selectors;
+			const state = {
+				partnerPortal: {
+					licenses: {
+						paginated: null,
+					},
+				},
+			};
+
+			expect( getPaginatedLicenses( state ) ).toEqual( null );
+
+			const value = { totalPages: 0 };
+			state.partnerPortal.licenses.paginated = value;
+			expect( getPaginatedLicenses( state ) ).toEqual( value );
+		} );
+	} );
+} );

--- a/client/state/partner-portal/partner/test/selectors.js
+++ b/client/state/partner-portal/partner/test/selectors.js
@@ -1,0 +1,200 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Internal dependencies
+ */
+import * as selectors from 'calypso/state/partner-portal/partner/selectors';
+
+describe( 'selectors', () => {
+	describe( '#getActivePartnerKeyId()', () => {
+		test( 'should return the value of activePartnerKey', () => {
+			const { getActivePartnerKeyId } = selectors;
+			const state = {
+				partnerPortal: {
+					partner: {
+						activePartnerKey: 0,
+					},
+				},
+			};
+
+			expect( getActivePartnerKeyId( state ) ).toEqual(
+				state.partnerPortal.partner.activePartnerKey
+			);
+
+			state.partnerPortal.partner.activePartnerKey = 1;
+			expect( getActivePartnerKeyId( state ) ).toEqual(
+				state.partnerPortal.partner.activePartnerKey
+			);
+		} );
+	} );
+
+	describe( '#getActivePartnerKey()', () => {
+		test( 'should return null if there is no current partner', () => {
+			const { getActivePartnerKey } = selectors;
+			const state = {
+				partnerPortal: {
+					partner: {
+						current: null,
+						activePartnerKey: 0,
+					},
+				},
+			};
+
+			expect( getActivePartnerKey( state ) ).toEqual( null );
+
+			// Make sure an invalid state does not return an incorrect value.
+			state.partnerPortal.partner.activePartnerKey = 1;
+			expect( getActivePartnerKey( state ) ).toEqual( null );
+		} );
+
+		test( 'should return null if there is a partner but the active key is invalid', () => {
+			const { getActivePartnerKey } = selectors;
+			const state = {
+				partnerPortal: {
+					partner: {
+						current: { keys: [] },
+						activePartnerKey: 1,
+					},
+				},
+			};
+
+			expect( getActivePartnerKey( state ) ).toEqual( null );
+		} );
+
+		test( 'should return the currently active key', () => {
+			const { getActivePartnerKey } = selectors;
+			const key = { id: 1 };
+			const state = {
+				partnerPortal: {
+					partner: {
+						current: { keys: [ key ] },
+						activePartnerKey: 1,
+					},
+				},
+			};
+
+			expect( getActivePartnerKey( state ) ).toEqual( key );
+		} );
+	} );
+
+	describe( '#hasActivePartnerKey()', () => {
+		test( 'should return false if there is no current partner', () => {
+			const { hasActivePartnerKey } = selectors;
+			const state = {
+				partnerPortal: {
+					partner: {
+						current: null,
+						activePartnerKey: 0,
+					},
+				},
+			};
+
+			expect( hasActivePartnerKey( state ) ).toEqual( false );
+
+			// Make sure an invalid state does not return an incorrect value.
+			state.partnerPortal.partner.activePartnerKey = 1;
+			expect( hasActivePartnerKey( state ) ).toEqual( false );
+		} );
+
+		test( 'should return false if there is a partner but the active key is invalid', () => {
+			const { hasActivePartnerKey } = selectors;
+			const state = {
+				partnerPortal: {
+					partner: {
+						current: { keys: [] },
+						activePartnerKey: 1,
+					},
+				},
+			};
+
+			expect( hasActivePartnerKey( state ) ).toEqual( false );
+		} );
+
+		test( 'should return true if there is a valid active key', () => {
+			const { hasActivePartnerKey } = selectors;
+			const state = {
+				partnerPortal: {
+					partner: {
+						current: { keys: [ { id: 1 } ] },
+						activePartnerKey: 1,
+					},
+				},
+			};
+
+			expect( hasActivePartnerKey( state ) ).toEqual( true );
+		} );
+	} );
+
+	describe( '#hasFetchedPartner()', () => {
+		test( 'should return the value of hasFetched', () => {
+			const { hasFetchedPartner } = selectors;
+			const state = {
+				partnerPortal: {
+					partner: {
+						hasFetched: false,
+					},
+				},
+			};
+
+			expect( hasFetchedPartner( state ) ).toEqual( state.partnerPortal.partner.hasFetched );
+
+			state.partnerPortal.partner.hasFetched = true;
+			expect( hasFetchedPartner( state ) ).toEqual( state.partnerPortal.partner.hasFetched );
+		} );
+	} );
+
+	describe( '#isFetchingPartner()', () => {
+		test( 'should return the value of isFetching', () => {
+			const { isFetchingPartner } = selectors;
+			const state = {
+				partnerPortal: {
+					partner: {
+						isFetching: false,
+					},
+				},
+			};
+
+			expect( isFetchingPartner( state ) ).toEqual( state.partnerPortal.partner.isFetching );
+
+			state.partnerPortal.partner.isFetching = true;
+			expect( isFetchingPartner( state ) ).toEqual( state.partnerPortal.partner.isFetching );
+		} );
+	} );
+
+	describe( '#getCurrentPartner()', () => {
+		test( 'should return the value of getCurrentPartner', () => {
+			const { getCurrentPartner } = selectors;
+			const state = {
+				partnerPortal: {
+					partner: {
+						current: null,
+					},
+				},
+			};
+
+			expect( getCurrentPartner( state ) ).toEqual( state.partnerPortal.partner.current );
+
+			state.partnerPortal.partner.current = { keys: [] };
+			expect( getCurrentPartner( state ) ).toEqual( state.partnerPortal.partner.current );
+		} );
+	} );
+
+	describe( '#getPartnerRequestError()', () => {
+		test( 'should return the value of error', () => {
+			const { getPartnerRequestError } = selectors;
+			const state = {
+				partnerPortal: {
+					partner: {
+						error: '',
+					},
+				},
+			};
+
+			expect( getPartnerRequestError( state ) ).toEqual( state.partnerPortal.partner.error );
+
+			state.partnerPortal.partner.error = 'Foo';
+			expect( getPartnerRequestError( state ) ).toEqual( state.partnerPortal.partner.error );
+		} );
+	} );
+} );

--- a/client/state/partner-portal/test/selectors.js
+++ b/client/state/partner-portal/test/selectors.js
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Internal dependencies
+ */
+import * as selectors from 'calypso/state/partner-portal/selectors';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+
+jest.mock( 'calypso/state/selectors/get-current-route', () => jest.fn() );
+
+describe( 'selectors', () => {
+	describe( '#isPartnerPortal()', () => {
+		test( 'should return true for URLs starting with /partner-portal', () => {
+			const { isPartnerPortal } = selectors;
+
+			getCurrentRoute.mockReturnValueOnce( '' );
+			expect( isPartnerPortal( {} ) ).toEqual( false );
+
+			getCurrentRoute.mockReturnValueOnce( '/partner' );
+			expect( isPartnerPortal( {} ) ).toEqual( false );
+
+			getCurrentRoute.mockReturnValueOnce( '/partner-portal' );
+			expect( isPartnerPortal( {} ) ).toEqual( true );
+
+			getCurrentRoute.mockReturnValueOnce( '/partner-portals' );
+			expect( isPartnerPortal( {} ) ).toEqual( true );
+
+			getCurrentRoute.mockReturnValueOnce( '/partner-portal/foo' );
+			expect( isPartnerPortal( {} ) ).toEqual( true );
+		} );
+	} );
+} );


### PR DESCRIPTION
Context:
* Project thread: pbtFPC-Um-p2
* i4 designs: pbtFPC-103-p2

#### Changes proposed in this Pull Request

* Add tests for the data layer of the license listing view in the Partner Portal.

#### Testing instructions
* Only automated tests apply.

Part of #49344
