### PR TITLE
Billing: Hide disallowed payment methods when changing payment method

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -961,6 +961,14 @@ Undocumented.prototype.getPaymentMethods = function ( query, fn ) {
 };
 
 /**
+ * Get a list of the user's allowed payment methods
+ */
+Undocumented.prototype.getAllowedPaymentMethods = function () {
+	debug( '/me/allowed-payment-methods query' );
+	return this.wpcom.req.get( { path: '/me/allowed-payment-methods' } );
+};
+
+/**
  * Assign a stored payment method to a subscription.
  *
  * @param {string} subscriptionId The subscription ID (a.k.a. purchase ID) to be assigned

--- a/client/me/purchases/manage-purchase/change-payment-method/use-fetch-available-payment-methods.ts
+++ b/client/me/purchases/manage-purchase/change-payment-method/use-fetch-available-payment-methods.ts
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { useReducer, useEffect, useRef } from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import wp from 'calypso/lib/wp';
+
+const wpcom = wp.undocumented();
+
+// Aliasing wpcom functions explicitly bound to wpcom is required here;
+// otherwise we get `this is not defined` errors.
+const wpcomGetAllowedPaymentMethods = () => wpcom.getAllowedPaymentMethods();
+
+export default function useFetchAvailablePaymentMethods(): AvailablePaymentMethodsState {
+	const isSubscribed = useRef< boolean >( true );
+	const [ state, dispatch ] = useReducer( availablePaymentMethodsReducer, {
+		error: undefined,
+		isFetching: false,
+		data: [],
+	} );
+	useEffect( () => {
+		dispatch( { type: 'BEGIN' } );
+		wpcomGetAllowedPaymentMethods()
+			.then( ( paymentMethods: string[] ) => {
+				isSubscribed.current && dispatch( { type: 'SUCCESS', payload: paymentMethods } );
+			} )
+			.catch( ( error: Error ) => {
+				isSubscribed.current && dispatch( { type: 'ERROR', payload: error.message } );
+			} );
+		return () => {
+			isSubscribed.current = false;
+		};
+	}, [] );
+	return state;
+}
+
+export interface AvailablePaymentMethodsState {
+	error: string | undefined;
+	isFetching: boolean;
+	data: string[];
+}
+
+interface AvailablePaymentMethodsBeginAction {
+	type: 'BEGIN';
+}
+
+interface AvailablePaymentMethodsErrorAction {
+	type: 'ERROR';
+	payload: string;
+}
+
+interface AvailablePaymentMethodsSuccessAction {
+	type: 'SUCCESS';
+	payload: string[];
+}
+
+type AvailablePaymentMethodsAction =
+	| AvailablePaymentMethodsBeginAction
+	| AvailablePaymentMethodsErrorAction
+	| AvailablePaymentMethodsSuccessAction;
+
+function availablePaymentMethodsReducer(
+	state: AvailablePaymentMethodsState,
+	action: AvailablePaymentMethodsAction
+): AvailablePaymentMethodsState {
+	switch ( action.type ) {
+		case 'BEGIN':
+			return { ...state, error: undefined, data: [], isFetching: true };
+		case 'ERROR':
+			return { ...state, error: action.payload, data: [], isFetching: false };
+		case 'SUCCESS':
+			return { ...state, error: undefined, data: action.payload, isFetching: false };
+		default:
+			return state;
+	}
+}

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import React, { useEffect, useCallback, useState, useContext, createContext } from 'react';
+import React, { useRef, useEffect, useCallback, useState, useContext, createContext } from 'react';
 import { loadScript } from '@automattic/load-script';
 // We are several versions old for react-stripe-elements, and probably should
 // actually upgrade to the new Stripe.js anyway. Trying to use the actual types
@@ -427,16 +427,17 @@ function useStripeConfiguration(
 		() => setReloadCount( ( count ) => count + 1 ),
 		[]
 	);
+	const memoizedRequestArgs = useMemoCompare( requestArgs, areRequestArgsEqual );
 
 	useEffect( () => {
 		debug( 'loading stripe configuration' );
 		let isSubscribed = true;
-		fetchStripeConfiguration( requestArgs || {} )
+		fetchStripeConfiguration( memoizedRequestArgs || {} )
 			.then( ( configuration ) => {
 				if ( ! isSubscribed ) {
 					return;
 				}
-				if ( requestArgs?.needs_intent && ! configuration.setup_intent_id ) {
+				if ( memoizedRequestArgs?.needs_intent && ! configuration.setup_intent_id ) {
 					debug( 'invalid stripe configuration; missing setup_intent_id', configuration );
 					throw new StripeConfigurationError(
 						'Error loading new payment method configuration. Received invalid data from the server.'
@@ -461,8 +462,21 @@ function useStripeConfiguration(
 		return () => {
 			isSubscribed = false;
 		};
-	}, [ requestArgs, stripeReloadCount, fetchStripeConfiguration ] );
+	}, [ memoizedRequestArgs, stripeReloadCount, fetchStripeConfiguration ] );
 	return { stripeConfiguration, stripeConfigurationError, reloadStripeConfiguration };
+}
+
+function areRequestArgsEqual(
+	previous: undefined | null | GetStripeConfigurationArgs,
+	next: undefined | null | GetStripeConfigurationArgs
+): boolean {
+	if ( next?.country !== previous?.country ) {
+		return false;
+	}
+	if ( next?.needs_intent !== previous?.needs_intent ) {
+		return false;
+	}
+	return true;
 }
 
 function StripeHookProviderInnerWrapper( {
@@ -610,4 +624,30 @@ function getStripeLocaleForLocale( locale: string | null | undefined ): string {
 		return 'auto';
 	}
 	return stripeLocale;
+}
+
+// See https://usehooks.com/useMemoCompare/
+function useMemoCompare< A, B >(
+	next: B,
+	compare: ( previous: A | B | undefined, next: B ) => boolean
+): A | B | undefined {
+	// Ref for storing previous value
+	const previousRef = useRef< undefined | A | B >();
+	const previous = previousRef.current;
+
+	// Pass previous and next value to compare function
+	// to determine whether to consider them equal.
+	const isEqual = compare( previous, next );
+
+	// If not equal update previousRef to next value.
+	// We only update if not equal so that this hook continues to return
+	// the same old value if compare keeps returning true.
+	useEffect( () => {
+		if ( ! isEqual ) {
+			previousRef.current = next;
+		}
+	} );
+
+	// Finally, if equal then return the previous value
+	return isEqual ? previous : next;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When changing the payment method for a subscription, we currently display three payment method options: existing credit cards, a new credit card, or PayPal.

However, there are certain locales in which we do not support PayPal, which can cause a problem for the user (you'd be able to create the billing agreement but the charge will always fail).

In this PR we check which payment methods are allowed and remove payment methods that the server says we cannot use. This should in theory only be PayPal but the logic also applies to credit cards in case that was ever an issue.

Requires D56781-code which adds a `/me/allowed-payment-methods` API endpoint, extracting that logic from the `/me/shopping-cart` endpoint.

Fixes 122-gh-Automattic/payments-shilling 

As a side effect, this also fixes a bug which caused the "change payment method" page to load quite slowly in some cases because of a memoization issue.

#### Testing instructions

- Use an account that has at least one product subscription (eg: a plan).
- Visit `/purchases`, choose your site, and then click on a subscription.
- Click the "Change payment method" button.
- Verify that the resulting page loads successfully and that you're presented with a  list of your previously saved credit cards, a new credit card option, and PayPal.
- Change your currency to `INR` or `BRL` and reload the page.
- Verify that previously saved cards are still shown as well as the new card option, but that PayPal does not appear.