### PR TITLE
ETK: Update to 2.19

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.18
+ * Version: 2.19
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'A8C_ETK_PLUGIN_VERSION', '2.18' );
+define( 'A8C_ETK_PLUGIN_VERSION', '2.19' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.5
 Tested up to: 5.6
-Stable tag: 2.18
+Stable tag: 2.19
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -40,6 +40,10 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 == Changelog ==
 View the commit history here: https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit
+
+= 2.19 =
+* Unhide draft button when site hasn't launched yet. (https://github.com/Automattic/wp-calypso/pull/49766)
+* Fix issues in Focused Launch
 
 = 2.18 =
 * Introduces a "What's New" dialogue for the editor. (https://github.com/Automattic/wp-calypso/pull/48722)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.18.0",
+	"version": "2.19.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Bumps version of Editing Toolkit to 2.19

### [Editing Toolkit changes included in this release](https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit)

- [x] ETK: Add commit URL to ETK build (#50020) @noahtallen 
- [x] ETK: Remove dev-plugin (#49846) @noahtallen 
- [x] Unhide draft button when site hasn't launched yet. (#49766) @yansern 

### Other [changes](https://github.com/Automattic/wp-calypso/commits/trunk/packages) included from the [imported @automattic packages](https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/tsconfig.json#L37-L46) and their imports

- [x] Plans store: remove hardcoded path_slug for the Free plan (#49993) @ciampo 
- [x] Plans data-store: refactor unit tests and fix TypeScript errors (#49595) @ciampo 
- [x] Focused Launch - Summary View: Fix launch button's size (to contain the copy in verbose languages) (#49765) @StefanNieuwenhuis 
- [x] Domain Picker: don't inherit work-break prop from domain name (#49823) @alshakero
- [x] Focused Launch: Make the back button sticky in detailed steps (#49822) @alshakero
- [x] Honor locale information in the plans reducer (#49759) @alshakero
- [x] Domain Picker: Use i18n API correctly in UseYourDomainItem component (#49834) @alshakero 
- [x] Focused Launch: prevent domain related 404 error when opening the flow ( #49872) @razvanpapadopol 


### Testing instructions

1. Load the diff on your sandbox (D56851-code) and confirm that the above changes work correctly
2. When a change has been tested to work correctly, please mark it as checked in the list above
3. Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.
    - [x] Tested on atomic 