### PR TITLE
Checkout: Use useShoppingCart in PrePurchaseNotices to get product slugs

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { useLineItems } from '@automattic/composite-checkout';
+import { useShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -39,13 +39,8 @@ const PrePurchaseNotices = () => {
 	const selectedSite = useSelector( getSelectedSite );
 	const siteId = selectedSite?.ID;
 
-	// We used to directly reference the cart itself here (passed in as a prop),
-	// but for some reason, cart items take ~20 seconds to populate in some cases,
-	// whereas line items are immediately available on page load.
-	const [ lineItems ] = useLineItems();
-	const cartItemSlugs = lineItems
-		.map( ( item ) => item.wpcom_meta?.product_slug )
-		.filter( ( item ) => item );
+	const { responseCart } = useShoppingCart();
+	const cartItemSlugs = responseCart.products.map( ( item ) => item.product_slug );
 
 	const currentSitePlan = useSelector( ( state ) => {
 		if ( ! siteId ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `WPCOMCartItem` type was created as a sort of hack to allow passing `ResponseCartItem` object data through checkout via the `useLineItems` hook that's part of the `composite-checkout` package, since the generic product data available in that hook's types is not sufficient. However, now that `useShoppingCart` is available, we can get the `ResponseCartItem` products directly where they are needed. This will make it easier to manipulate and query cart items in the code since there will only be one data type we need to understand, and since `ResponseCartItem` predates `WPCOMCartItem`, there's already considerable support for it in calypso.

This PR modifies `PrePurchaseNotices` to use `useShoppingCart` instead of `useLineItems`.

<img width="1189" alt="Screen Shot 2021-02-10 at 7 04 08 PM" src="https://user-images.githubusercontent.com/2036909/107588903-c5c10e80-6bd2-11eb-8f5b-14a090f55f59.png">


#### Testing instructions

- Connect a Jetpack site to WordPress.com (you can use https://jurassic.ninja).
- Visit http://calypso.localhost:3000/checkout/example.com/jetpack_security_daily (for your site) and purchase the "Jetpack Security" plan.
- Visit http://calypso.localhost:3000/checkout/spontaneous-catfish.jurassic.ninja/jetpack_backup_daily (for your site).
- Verify that you see the notice `You currently own Jetpack Security Daily. The product you are about to purchase, Backup Daily, is already included in this plan.` at the top of the checkout page.