### PR TITLE
Checkout: Use useShoppingCart to get plans in CheckoutHelpLink

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -7,9 +7,10 @@ import { useTranslate } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import styled from '@emotion/styled';
 import { keyframes } from '@emotion/core';
-import { get } from 'lodash';
-import { useEvents, useLineItemsOfType } from '@automattic/composite-checkout';
-import type { LineItem, Theme } from '@automattic/composite-checkout';
+import { useEvents } from '@automattic/composite-checkout';
+import { useShoppingCart } from '@automattic/shopping-cart';
+import type { Theme } from '@automattic/composite-checkout';
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -33,6 +34,7 @@ import {
 	isWpComPersonalPlan,
 	isWpComPremiumPlan,
 } from 'calypso/lib/plans';
+import { isPlan } from 'calypso/lib/products-values';
 
 type StyledProps = {
 	theme?: Theme;
@@ -133,7 +135,8 @@ const LoadingButton = styled.p< StyledProps >`
 export default function CheckoutHelpLink(): JSX.Element {
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
-	const plans = useLineItemsOfType( 'plan' );
+	const { responseCart } = useShoppingCart();
+	const plans = responseCart.products.filter( ( product ) => isPlan( product ) );
 
 	const supportVariationDetermined = useSelector( isSupportVariationDetermined );
 	const supportVariation = useSelector( getSupportVariation );
@@ -187,7 +190,7 @@ export default function CheckoutHelpLink(): JSX.Element {
 	);
 }
 
-function getHighestWpComPlanLabel( plans: LineItem[] ) {
+function getHighestWpComPlanLabel( plans: ResponseCartProduct[] ) {
 	const planMatchersInOrder = [
 		{ label: 'WordPress.com eCommerce', matcher: isWpComEcommercePlan },
 		{ label: 'WordPress.com Business', matcher: isWpComBusinessPlan },
@@ -196,7 +199,7 @@ function getHighestWpComPlanLabel( plans: LineItem[] ) {
 	];
 	for ( const { label, matcher } of planMatchersInOrder ) {
 		for ( const plan of plans ) {
-			if ( matcher( get( plan, 'wpcom_meta.product_slug' ) ) ) {
+			if ( matcher( plan.product_slug ) ) {
 				return label;
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `WPCOMCartItem` type was created as a sort of hack to allow passing `ResponseCartItem` object data through checkout via the `useLineItems` hook that's part of the `composite-checkout` package, since the generic product data available in that hook's types is not sufficient. However, now that `useShoppingCart` is available, we can get the `ResponseCartItem` products directly where they are needed. This will make it easier to manipulate and query cart items in the code since there will only be one data type we need to understand, and since `ResponseCartItem` predates `WPCOMCartItem`, there's already considerable support for it in calypso.

This PR modifies `CheckoutHelpLink` to replace `useLineItems` with `useShoppingCart` to fetch the plan product slugs.

#### Screenshots

![Screen Shot 2021-01-27 at 11 51 31 AM](https://user-images.githubusercontent.com/942359/106027609-0e3be080-6099-11eb-8d84-7a49f21d14c6.png)

#### Testing instructions

This is difficult to test because the happychat button has several conditions that need to be true. It's easier to mock it by altering the code. Apply the following patch on top of this PR, then load checkout with a plan in the cart and verify that you see "It worked!"

```diff
diff --git a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
index 52abbb3424..f287e6261d 100644
--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -18,8 +18,6 @@ import type { ResponseCartProduct } from '@automattic/shopping-cart';
 import { HappychatButton as HappychatButtonUnstyled } from 'calypso/components/happychat/button';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSupportLevel from 'calypso/state/selectors/get-support-level';
-import isPresalesChatAvailable from 'calypso/state/happychat/selectors/is-presales-chat-available';
-import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 import isSupportVariationDetermined from 'calypso/state/selectors/is-support-variation-determined';
 import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-support-types';
 import { showInlineHelpPopover } from 'calypso/state/inline-help/actions';
@@ -68,13 +66,7 @@ export function PaymentChatButton( { plan }: { plan: string | undefined } ): JSX
 			} )
 		);
 	};
-
-	return (
-		<HappychatButton onClick={ chatButtonClicked }>
-			<Gridicon icon="chat" />
-			{ translate( 'Need help? Chat with us.' ) }
-		</HappychatButton>
-	);
+	return <h2>It worked</h2>;
 }
 
 const CheckoutHelpLinkWrapper = styled.div< StyledProps >`
@@ -141,8 +133,8 @@ export default function CheckoutHelpLink(): JSX.Element {
 	const supportVariationDetermined = useSelector( isSupportVariationDetermined );
 	const supportVariation = useSelector( getSupportVariation );
 
-	const happyChatAvailable = useSelector( isHappychatAvailable );
-	const presalesChatAvailable = useSelector( isPresalesChatAvailable );
+	const happyChatAvailable = true;
+	const presalesChatAvailable = true;
 	const presalesEligiblePlanLabel = getHighestWpComPlanLabel( plans );
 	const isPresalesChatEligible = presalesChatAvailable && presalesEligiblePlanLabel;
```

<img width="344" alt="Screen Shot 2021-02-10 at 7 53 46 PM" src="https://user-images.githubusercontent.com/2036909/107592009-e0e34c80-6bd9-11eb-8631-7107cfe54df6.png">
