### PR TITLE
New Onboarding: Add Fredrickson design

### DIFF
--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -355,6 +355,20 @@
 			"categories": [ "featured" ],
 			"is_premium": false,
 			"features": []
+		},
+		{
+			"title": "Fredrickson",
+			"slug": "fredrickson",
+			"template": "fredrickson",
+			"theme": "blank-canvas",
+			"preview": "static",
+			"fonts": {
+				"headings": "Cabin",
+				"base": "Cabin"
+			},
+			"categories": [ "featured" ],
+			"is_premium": false,
+			"features": []
 		}
 	]
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

Hi! This PR adds [Fredrickson](https://fredricksonstarter.wordpress.com/) to the list of onboarding starter designs.

<img width="1123" alt="Screen Shot 2021-02-11 at 3 37 58 pm" src="https://user-images.githubusercontent.com/6458278/107602903-2c036b00-6c7f-11eb-8262-f0ad2f4ca752.png">

You like that?!

#### Testing instructions

Apply D56871-code and fire up this branch

- [ ] Check that the design preview image appears on /new/design
- [ ] The demo should display on /new/style
- [ ] Create a site. Your site should match the [Fredrickson starter site](https://fredricksonstarter.wordpress.com/) 

Related to https://github.com/Automattic/wp-calypso/issues/49617
