### PR TITLE
Checkout: Prevent checkout masterbar close from reloading checkout

### DIFF
--- a/client/layout/masterbar/checkout.jsx
+++ b/client/layout/masterbar/checkout.jsx
@@ -27,7 +27,7 @@ class CheckoutMasterbar extends React.Component {
 			previousPath &&
 			'' !== previousPath &&
 			previousPath !== window.location.href &&
-			! previousPath.includes( '/checkout/no-site' )
+			! previousPath.includes( '/checkout/' )
 		) {
 			closeUrl = previousPath;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This alters the "X" close button in the checkout masterbar, which usually goes to the previous page (as stored in Redux) so that it won't reload checkout, even if checkout was the previous page.

One thing we should verify is that there's no other page whose route contains `/checkout/` that might be a legitimate "previous page" for this masterbar button. I think that the only routes with `/checkout/` are checkout itself, the thank-you pages, and the upsell pages, and none of those seem to me like a place I'd want the "X" button to return us to.

#### Testing instructions

- Visit checkout with a product in the URL like `/checkout/example.com/personal`.
- Complete step 2, click the back button, and then click the X. 
- Verify that you are redirected to the plans page.
