### PR TITLE
Deduplicate v8-compile-cache

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -27637,17 +27637,12 @@ uuid@^8.3.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-v8-compile-cache@2.0.3, v8-compile-cache@^2.0.3:
+v8-compile-cache@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz#00f7494d2ae2b688cfe2899df6ed2c54bef91dbe"
   integrity sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==
 
-v8-compile-cache@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
-  integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
-
-v8-compile-cache@^2.2.0:
+v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1, v8-compile-cache@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
   integrity sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `v8-compile-cache` (done automatically with `npx yarn-deduplicate --packages v8-compile-cache`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/scripts@12.5.0 -> ... -> v8-compile-cache@2.0.3
< @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/scripts@12.5.0 -> ... -> v8-compile-cache@2.1.1
< @automattic/wpcom-editing-toolkit@2.18.0 -> eslint@7.12.0 -> ... -> v8-compile-cache@2.0.3
< wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> v8-compile-cache@2.0.3
< wp-calypso@0.17.0 -> eslint@7.12.0 -> ... -> v8-compile-cache@2.0.3
< wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> v8-compile-cache@2.1.1
> @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/scripts@12.5.0 -> ... -> v8-compile-cache@2.2.0
> @automattic/wpcom-editing-toolkit@2.18.0 -> eslint@7.12.0 -> ... -> v8-compile-cache@2.2.0
> wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> v8-compile-cache@2.2.0
> wp-calypso@0.17.0 -> eslint@7.12.0 -> ... -> v8-compile-cache@2.2.0
> wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> v8-compile-cache@2.2.0
```