### PR TITLE
Deduplicate ws

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -28547,12 +28547,7 @@ ws@^6.0.0, ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.0.0, ws@^7.1.2, ws@^7.2.3:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.0.tgz#4b2f7f219b3d3737bc1a2fbf145d825b94d38ffd"
-  integrity sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==
-
-ws@^7.3.1:
+ws@^7.0.0, ws@^7.1.2, ws@^7.2.3, ws@^7.3.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
   integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `ws` (done automatically with `npx yarn-deduplicate --packages ws`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> ws@7.3.0
< @automattic/o2-blocks@1.0.0 -> @automattic/calypso-build@7.0.0 -> ... -> ws@7.3.0
< @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/calypso-build@7.0.0 -> ... -> ws@7.3.0
< @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/scripts@12.5.0 -> ... -> ws@7.3.0
< @automattic/wpcom-editing-toolkit@2.18.0 -> jest@26.4.0 -> ... -> ws@7.3.0
< @automattic/wpcom-editing-toolkit@2.18.0 -> puppeteer@3.1.0 -> ... -> ws@7.3.0
< wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> ws@7.3.0
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> ws@7.3.0
< wp-calypso@0.17.0 -> capture-website@1.0.0 -> ... -> ws@7.3.0
< wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> ws@7.3.0
< wp-e2e-tests@0.0.1 -> xunit-viewer@5.2.0 -> ... -> ws@7.3.0
> @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> ws@7.3.1
> @automattic/o2-blocks@1.0.0 -> @automattic/calypso-build@7.0.0 -> ... -> ws@7.3.1
> @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/calypso-build@7.0.0 -> ... -> ws@7.3.1
> @automattic/wpcom-editing-toolkit@2.18.0 -> @wordpress/scripts@12.5.0 -> ... -> ws@7.3.1
> @automattic/wpcom-editing-toolkit@2.18.0 -> jest@26.4.0 -> ... -> ws@7.3.1
> @automattic/wpcom-editing-toolkit@2.18.0 -> puppeteer@3.1.0 -> ... -> ws@7.3.1
> wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> ws@7.3.1
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> ws@7.3.1
> wp-calypso@0.17.0 -> capture-website@1.0.0 -> ... -> ws@7.3.1
> wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> ws@7.3.1
> wp-e2e-tests@0.0.1 -> xunit-viewer@5.2.0 -> ... -> ws@7.3.1
```