### PR TITLE
fix(account): cancel pending email change

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -63,6 +63,7 @@ import user from 'calypso/lib/user';
 import FormToggle from 'calypso/components/forms/form-toggle';
 import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
 import {
+	cancelPendingEmailChange,
 	clearUnsavedUserSettings,
 	removeUnsavedUserSetting,
 	setUserSetting,
@@ -387,21 +388,6 @@ const Account = createReactClass( {
 		);
 	},
 
-	cancelEmailChange() {
-		const { translate, userSettings } = this.props;
-		userSettings.cancelPendingEmailChange( ( error, response ) => {
-			if ( error ) {
-				debug( 'Error canceling email change: ' + JSON.stringify( error ) );
-				this.props.errorNotice(
-					translate( 'There was a problem canceling the email change. Please, try again.' )
-				);
-			} else {
-				debug( JSON.stringify( 'Email change canceled successfully' + response ) );
-				this.props.successNotice( translate( 'The email change has been successfully canceled.' ) );
-			}
-		} );
-	},
-
 	handleRadioChange( event ) {
 		const { name, value } = event.currentTarget;
 		this.setState( { [ name ]: value } );
@@ -581,7 +567,9 @@ const Account = createReactClass( {
 					}
 				) }
 			>
-				<NoticeAction onClick={ this.cancelEmailChange }>{ translate( 'Cancel' ) }</NoticeAction>
+				<NoticeAction onClick={ () => this.props.cancelPendingEmailChange() }>
+					{ translate( 'Cancel' ) }
+				</NoticeAction>
 			</Notice>
 		);
 	},
@@ -1131,6 +1119,7 @@ export default compose(
 		} ),
 		{
 			bumpStat,
+			cancelPendingEmailChange,
 			clearUnsavedUserSettings,
 			errorNotice,
 			removeNotice,

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -89,6 +89,15 @@ export function userSettingsSaveFailure( { settingsOverride }, error ) {
 		];
 	}
 
+	if ( settingsOverride?.user_email_change_pending !== undefined ) {
+		return [
+			errorNotice(
+				translate( 'There was a problem canceling the email change. Please, try again.' )
+			),
+			saveUserSettingsFailure( settingsOverride, error ),
+		];
+	}
+
 	return [
 		errorNotice( error.message || translate( 'There was a problem saving your changes.' ), {
 			id: 'save-user-settings',
@@ -116,6 +125,11 @@ export const userSettingsSaveSuccess = ( { settingsOverride }, data ) => ( dispa
 	const userLibModule = require( 'calypso/lib/user' );
 	const userLib = userLibModule.default ? userLibModule.default : userLibModule; // TODO: delete line after removing add-module-exports.
 	userLib().fetch();
+
+	if ( settingsOverride?.user_email_change_pending !== undefined ) {
+		dispatch( successNotice( translate( 'The email change has been successfully canceled.' ) ) );
+		return;
+	}
 
 	dispatch(
 		successNotice( translate( 'Settings saved successfully!' ), {


### PR DESCRIPTION
In #49760 I reduxified `lib/user-settings` for `/me/account` and it seems like I forgot this piece of functionality. Thanks to @arunsathiya for reporting!

#### Changes proposed in this Pull Request

* Account: fix pending email change cancelation

#### Testing instructions

* Go to `/me/account` and attempt to change your email address
* Click _Cancel_ on the notice below the email address field
* Make sure the pending email change is canceled successfully

fixes #49969
