### PR TITLE
Add env var to skip TSC

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -62,6 +62,7 @@ project {
 		text("calypso.run_full_eslint", "false", label = "Run full eslint", description = "True will lint all files, empty/false will lint only changed files", allowEmpty = true)
 		text("env.DOCKER_BUILDKIT", "1", label = "Enable Docker BuildKit", description = "Enables BuildKit (faster image generation). Values 0 or 1", allowEmpty = true)
 		password("CONFIG_E2E_ENCRYPTION_KEY", "credentialsJSON:16d15e36-f0f2-4182-8477-8d8072d0b5ec", display = ParameterDisplay.HIDDEN)
+		text("env.SKIP_TSC", "true", label = "Skip TS type generation", description = "Skips running `tsc` on yarn install", allowEmpty = true)
 	}
 
 	features {
@@ -1325,7 +1326,7 @@ object WPComPlugins_EditorToolKit : BuildType({
 
 				yarn build
 				cd editing-toolkit-plugin/
-				
+
 				# Metadata file with info for the download script.
 				echo -e "commit_hash=%build.vcs.number%\nbuild_number=%build.number%\n" > build_meta.txt
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -342,7 +342,8 @@ object RunAllUnitTests : BuildType({
 				export NODE_ENV="test"
 
 				# Run type checks
-				yarn run tsc --project client/landing/gutenboarding
+				yarn tsc --build packages/tsconfig.json
+				yarn tsc --project client/landing/gutenboarding
 			""".trimIndent()
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 			dockerPull = true

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 		"build-client-if-prod": "node -e \"process.env.CALYPSO_ENV === 'production' && process.exit(1)\" || yarn run build-client-both && yarn run build-languages-if-enabled",
 		"build-client-if-desktop": "node -e \"(process.env.CALYPSO_ENV === 'desktop' || process.env.CALYPSO_ENV === 'desktop-development') && process.exit(1)\" || yarn run build-client-fallback",
 		"build-client-stats": "NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=true PROGRESS=true yarn run build-client-evergreen",
-		"build-packages": "tsc --build packages/tsconfig.json && lerna run prepare --stream",
+		"build-packages": "{ [[ \"$SKIP_TSC\" == \"true\" ]] || tsc --build packages/tsconfig.json; } && lerna run prepare --stream",
 		"build-languages": "yarn run translate && node bin/build-languages.js",
 		"build-languages-if-enabled": "node -e \"(process.env.BUILD_TRANSLATION_CHUNKS === 'true' || process.env.ENABLE_FEATURES === 'use-translation-chunks') && process.exit(1)\" || yarn run build-languages",
 		"calypso-doctor": "./node_modules/.bin/calypso-doctor",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds env var to skip `tsc` compilation. Since #47502 we don't need to run `tsc` to compile the project, we only run it to provide better TypeScript typings for IDEs.

This should shave off ~40s every time we run `yarn install` in CI (pretty much in every build).

Update: running `tsc` on `yarn postinstall` was doing implicit typechecking, failing the build if the are TS type errors. In order to not lose this capability, I added an explicit typecheck when running unit tests.

#### Testing instructions

* Smoke test live branch to ensure Calypso still compiles
* Verify tests are green
* Check if TeamCity builds are faster compared with `trunk` (note that `Run unit tests` will be about the same)