### PR TITLE
Onboarding: make Brice design available again

### DIFF
--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -145,7 +145,6 @@
 			"categories": [ "featured", "charity", "non-profit" ],
 			"is_premium": false,
 			"features": [],
-			"hide": true
 		},
 		{
 			"title": "Barnsbury",

--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -144,7 +144,7 @@
 			},
 			"categories": [ "featured", "charity", "non-profit" ],
 			"is_premium": false,
-			"features": [],
+			"features": []
 		},
 		{
 			"title": "Barnsbury",

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -82,6 +82,9 @@ export function getAvailableDesigns(
 ): AvailableDesigns {
 	let designs = availableDesigns;
 
+	// We can tell different environments (via the config JSON) to show pre-prod "alpha" designs.
+	// Otherwise they'll be hidden by default.
+	// Here we filter out designs that have been marked as alpha in available-designs-config.json
 	if ( ! includeAlphaDesigns ) {
 		designs = {
 			...designs,
@@ -96,12 +99,6 @@ export function getAvailableDesigns(
 		featured: designs.featured.filter( ( design ) =>
 			useFseDesigns ? design.is_fse : ! design.is_fse
 		),
-	};
-
-	// Filter out designs that have been marked as hidden in the json config
-	designs = {
-		...designs,
-		featured: designs.featured.filter( ( { hide } ) => ! hide ),
 	};
 
 	return designs;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable brice design

Bug affecting this design has been sorted out https://github.com/Automattic/themes/issues/3186

Aside: there is `hide` flag as well `is_alpha` flag — no idea what's the difference but both can be used to hide designs in the grid. 🤔 

#### Testing instructions

- Open /new/designs and observe Brice design, test link: https://calypso.live/new/design?branch=update/onboarding-brice-on