### PR TITLE
Display non-plan products billing interval next to line items in purchase billing history and detail view

### DIFF
--- a/client/me/purchases/billing-history/billing-history-list.jsx
+++ b/client/me/purchases/billing-history/billing-history-list.jsx
@@ -15,12 +15,11 @@ import { capitalPDangit } from 'calypso/lib/formatting';
 import { CompactCard } from '@automattic/components';
 import Pagination from 'calypso/components/pagination';
 import BillingHistoryFilters from 'calypso/me/purchases/billing-history/billing-history-filters';
-import { groupDomainProducts, renderTransactionAmount } from './utils';
+import { getTransactionTermLabel, groupDomainProducts, renderTransactionAmount } from './utils';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { setPage } from 'calypso/state/billing-transactions/ui/actions';
 import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-transaction-filters';
 import getFilteredBillingTransactions from 'calypso/state/selectors/get-filtered-billing-transactions';
-import { getPlanTermLabel } from 'calypso/lib/plans';
 import isSendingBillingReceiptEmail from 'calypso/state/selectors/is-sending-billing-receipt-email';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { sendBillingReceiptEmail as sendBillingReceiptEmailAction } from 'calypso/state/billing-transactions/actions';
@@ -81,7 +80,7 @@ class BillingHistoryList extends React.Component {
 	serviceNameDescription = ( transaction ) => {
 		let description;
 		if ( transaction.domain ) {
-			const termLabel = getPlanTermLabel( transaction.wpcom_product_slug, this.props.translate );
+			const termLabel = getTransactionTermLabel( transaction, this.props.translate );
 			description = (
 				<div>
 					<strong>{ transaction.plan }</strong>

--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -19,7 +19,7 @@ import { withLocalizedMoment, useLocalizedMoment } from 'calypso/components/loca
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { billingHistory } from 'calypso/me/purchases/paths';
 import QueryBillingTransaction from 'calypso/components/data/query-billing-transaction';
-import { groupDomainProducts, renderTransactionAmount } from './utils';
+import { getTransactionTermLabel, groupDomainProducts, renderTransactionAmount } from './utils';
 import getPastBillingTransaction from 'calypso/state/selectors/get-past-billing-transaction';
 import isPastBillingTransactionError from 'calypso/state/selectors/is-past-billing-transaction-error';
 import {
@@ -27,7 +27,6 @@ import {
 	requestBillingTransaction,
 } from 'calypso/state/billing-transactions/individual-transactions/actions';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
-import { getPlanTermLabel } from 'calypso/lib/plans';
 import { PARTNER_PAYPAL_EXPRESS } from 'calypso/lib/checkout/payment-methods';
 import titles from 'calypso/me/purchases/titles';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -191,7 +190,7 @@ function ReceiptLineItems( { transaction } ) {
 	const groupedTransactionItems = groupDomainProducts( transaction.items, translate );
 
 	const items = groupedTransactionItems.map( ( item ) => {
-		const termLabel = getPlanTermLabel( item.wpcom_product_slug, translate );
+		const termLabel = getTransactionTermLabel( item, translate );
 		return (
 			<tr key={ item.id }>
 				<td className="billing-history__receipt-item-name">

--- a/client/me/purchases/billing-history/utils.jsx
+++ b/client/me/purchases/billing-history/utils.jsx
@@ -5,6 +5,11 @@ import { find, map, partition, reduce, some } from 'lodash';
 import React, { Fragment } from 'react';
 import formatCurrency from '@automattic/format-currency';
 
+/**
+ * Internal dependencies
+ */
+import { getPlanTermLabel } from 'calypso/lib/plans';
+
 export const groupDomainProducts = ( originalItems, translate ) => {
 	const transactionItems = Object.keys( originalItems ).map( ( key ) => {
 		return Object.assign( {}, originalItems[ key ] );
@@ -75,4 +80,17 @@ export function renderTransactionAmount( transaction, { translate, addingTax = f
 			<div className="billing-history__transaction-tax-amount">{ taxAmount }</div>
 		</Fragment>
 	);
+}
+
+export function getTransactionTermLabel( transaction, translate ) {
+	switch ( transaction.months_per_renewal_interval ) {
+		case 1:
+			return translate( 'Monthly subscription' );
+		case 12:
+			return translate( 'Annual subscription' );
+		case 24:
+			return translate( 'Two year subscription' );
+		default:
+			return getPlanTermLabel( transaction.wpcom_product_slug, translate );
+	}
 }


### PR DESCRIPTION
We use a new parameter from the backend, `months_per_renewal_interval ` to display billing interval for products that are not plans.

This PR depends on D56872-code

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure D56872-code
* Checkout this branch
* Visit your billing history page i.e. `/purchases/subscriptions/`. You may still need to click on `Billing history`
* Confirm that the products display the billing interval next to them

- Before ( only plans had intervals )
<img width="530" alt="Screenshot 2021-02-11 at 10 42 49 AM" src="https://user-images.githubusercontent.com/277661/107621222-33fae500-6c56-11eb-8eb1-5312879def3d.png">

- After ( all products have intervals  )
<img width="704" alt="Screenshot 2021-02-11 at 10 43 25 AM" src="https://user-images.githubusercontent.com/277661/107621253-3eb57a00-6c56-11eb-82a7-df7fb2401e05.png">



