### PR TITLE
Stats Sparkline: rewrite as divs powered by REST instead of img request to site

### DIFF
--- a/client/blocks/stats-sparkline/README.md
+++ b/client/blocks/stats-sparkline/README.md
@@ -1,6 +1,6 @@
 # StatsSparkline
 
-The `StatsSparkline` block renders an image of a chart representing hourly views for a given site.
+The `StatsSparkline` block renders a chart representing hourly views for a given site.
 
 ## Usage
 
@@ -16,7 +16,7 @@ import StatsSparkline from 'calypso/blocks/stats-sparkline';
 
 <table>
 	<tr><th>Type</th><td>Number</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
 </table>
 
 The site ID to display the sparkline for.
@@ -28,4 +28,4 @@ The site ID to display the sparkline for.
 	<tr><th>Required</th><td>No</td></tr>
 </table>
 
-Optional className that is applied to the sparkline image.
+Optional className that is applied to the sparkline chart.

--- a/client/blocks/stats-sparkline/index.jsx
+++ b/client/blocks/stats-sparkline/index.jsx
@@ -19,12 +19,14 @@ import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors'
  */
 import './style.scss';
 
-const StatsSparklineChart = ( { className, hourlyViews } ) => {
+const DEFAULT_HEIGHT = 20;
+
+const StatsSparklineChart = ( { className, hourlyViews, height = DEFAULT_HEIGHT } ) => {
 	const translate = useTranslate();
 	const highestViews = Math.max( ...hourlyViews );
 	const title = translate( 'Highest hourly views %(highestViews)s', { args: { highestViews } } );
 
-	const chartHeight = 24 - 7; // 24px is the desired height, 7px is the total top+bottom padding
+	const chartHeight = height - 7; // remove the 5px + 2px = 7px total top+bottom padding
 	const chartWidth = 2 * hourlyViews.length - 1; // 1px bars with 1px space in between
 
 	return (

--- a/client/blocks/stats-sparkline/index.jsx
+++ b/client/blocks/stats-sparkline/index.jsx
@@ -12,7 +12,6 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 
 /**
@@ -55,15 +54,10 @@ const StatsSparklineChart = ( { className, hourlyViews } ) => {
 	);
 };
 const StatsSparkline = ( { className, siteId } ) => {
-	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const hourlyViews = useSelector( ( state ) => {
 		const statsInsights = getSiteStatsNormalizedData( state, siteId, 'statsInsights' );
 		return statsInsights.hourlyViews ? Object.values( statsInsights.hourlyViews ) : null;
 	} );
-
-	if ( ! siteId || isJetpack ) {
-		return null;
-	}
 
 	return (
 		<>

--- a/client/blocks/stats-sparkline/style.scss
+++ b/client/blocks/stats-sparkline/style.scss
@@ -1,10 +1,11 @@
 .stats-sparkline {
+	--color-stats-sparkline: var( --color-sidebar-gridicon-fill );
 	padding: 5px 0 2px;
 }
 
 .stats-sparkline__bar {
 	display: inline-block;
-	background-color: var( --color-sidebar-gridicon-fill );
+	background-color: var( --color-stats-sparkline );
 	width: 1px;
 	height: 100%;
 	transform-origin: 0% 100%;

--- a/client/blocks/stats-sparkline/style.scss
+++ b/client/blocks/stats-sparkline/style.scss
@@ -1,0 +1,16 @@
+.stats-sparkline {
+	padding: 5px 0 2px;
+}
+
+.stats-sparkline__bar {
+	display: inline-block;
+	background-color: var( --color-sidebar-gridicon-fill );
+	width: 1px;
+	height: 100%;
+	transform-origin: 0% 100%;
+	margin-left: 1px;
+
+	&:first-child {
+		margin-left: 0;
+	}
+}

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -157,6 +157,10 @@
 		color: var( --color-sidebar-menu-selected-text );
 		background-color: var( --color-sidebar-menu-selected-background );
 
+		.stats-sparkline {
+			--color-stats-sparkline: var( --color-sidebar-menu-selected-text );
+		}
+
 		.sidebar__menu-icon {
 			fill: var( --color-sidebar-menu-selected-text );
 		}

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -172,6 +172,10 @@ $font-size: rem( 14px );
 		}
 
 		.sidebar__menu-item-parent.selected .sidebar__menu-link {
+			.stats-sparkline {
+				--color-stats-sparkline: var( --color-sidebar-menu-selected-text );
+			}
+
 			.sidebar__menu-icon {
 				color: var( --color-sidebar-menu-selected-text );
 			}
@@ -238,6 +242,10 @@ $font-size: rem( 14px );
 			&.sidebar__menu--selected .sidebar__heading {
 				background: var( --color-sidebar-menu-selected-background );
 				color: var( --color-sidebar-menu-selected-text );
+
+				.stats-sparkline {
+					--color-stats-sparkline: var( --color-sidebar-menu-selected-text );
+				}
 
 				.sidebar__menu-icon {
 					color: var( --color-sidebar-menu-selected-text );
@@ -458,8 +466,6 @@ $font-size: rem( 14px );
 	}
 
 	.sidebar-unified__sparkline {
-		width: 80px;
-		height: 21px;
 		margin-right: 8px;
 	}
 
@@ -496,19 +502,6 @@ $font-size: rem( 14px );
 				}
 			}
 		}
-	}
-
-	/*
-	 * Because the sparkline is an image, there's an exception here
-	 * where specific color schemes are targeted instead of using
-	 * CSS variables. This ensures that the sparkline can still be
-	 * seen (as white) on some of the darker color schemes.
-	 */
-	.is-classic-blue .sidebar__menu li.stats.selected .sidebar-unified__sparkline,
-	.is-powder-snow .sidebar__menu li.stats.selected .sidebar-unified__sparkline,
-	.is-nightfall .sidebar__menu li.stats.selected .sidebar-unified__sparkline {
-		filter: brightness( 100 );
-		-webkit-filter: brightness( 100 );
 	}
 }
 


### PR DESCRIPTION
The current sidebar stats sparkline loads an image with a chart from the actual site:
```
<img src="https://example.wordpress.com/wp-includes/charts/admin-bar-hours-scales.php" />
```
This only works when the browser has authentication cookies for that site and when they are not blocked as 3rd party cookies by the browser. If we use OAuth as Calypso authentication, the sparkline won't work.

For example, @nsakaimbo had to do a very complicated workaround in #46621 to make the sparkline work in the Desktop app. That can be now reverted.

This PR rewrites the sparkline to a React component (drawing scaled divs) powered by the "stats insights" data from REST.

I tried to match the original chart as closely as possible. Here is a screenshot from my testing that shows the PHP image on top, and the new React components on bottom:
<img width="201" alt="Screenshot 2021-02-11 at 9 22 47" src="https://user-images.githubusercontent.com/664258/107620060-67d50b00-6c54-11eb-978f-b4a00656a3f4.png">

@mreishus @cpapazoglou Can you check that the new sparkline works correctly with the unified nav? The new sparkline component ignores/overrides the following styles:
```
.sidebar-unified__sparkline {
  width: 80px;
  height: 21px;
}
```
The width of the sparkline is now always 48 + 47 = 95px, because there are data for last 48 hours, which means 48 bars 1px wide and 47 1px spaces between them. If we want to scale the chart down, it's harder to do than an image.

The default height is 20px now and is adjustable by passing a prop: `<StatsSparkline height={ 24 } />`. The chart can accomodate to any height.

