### PR TITLE
TwoStepAuthorization: use Redux to re-fetch user settings

### DIFF
--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -14,7 +14,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import config from '@automattic/calypso-config';
 import emitter from 'calypso/lib/mixins/emitter';
-import userSettings from 'calypso/lib/user-settings';
+import { fetchUserSettings } from 'calypso/state/user-settings/actions';
 import { reduxDispatch } from 'calypso/lib/redux-bridge';
 import { requestConnectedApplications } from 'calypso/state/connected-applications/actions';
 import { requestUserProfileLinks } from 'calypso/state/profile-links/actions';
@@ -100,7 +100,7 @@ TwoStepAuthorization.prototype.refreshDataOnSuccessfulAuth = function () {
 	// If the validation was successful AND re-auth was required, fetch
 	// data from the following modules.
 	if ( this.isReauthRequired() ) {
-		userSettings.fetchSettings();
+		reduxDispatch( fetchUserSettings() );
 		reduxDispatch( requestConnectedApplications() );
 		reduxDispatch( requestUserProfileLinks() );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* TwoStepAuthorization: Use `fetchUserSettings` action to re-fetch user settings instead of `userSettings.fetchSettings`

#### Testing instructions

* You can trigger the Re-auth dialog by e.g. changing your password, username or any other security related settings
* After you entered the 2FA code you should see an XHR request to `/settings`

Related to #24162
