### PR TITLE
Plans store: remove hardcoded path_slug for the Free plan

### DIFF
--- a/packages/data-stores/src/plans/mock/mock-constants.ts
+++ b/packages/data-stores/src/plans/mock/mock-constants.ts
@@ -209,6 +209,7 @@ export const MOCK_PLAN_PRICE_APIS_FREE: MockPricedAPIPlanFree = {
 	},
 	cost: 0,
 	blog_id: null,
+	path_slug: 'free',
 	product_slug: 'free_plan',
 	description: '',
 	bill_period: -1,

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -20,7 +20,6 @@ import type {
 	DetailsAPIFeature,
 } from './types';
 import {
-	PLAN_FREE,
 	TIMELESS_PLAN_FREE,
 	TIMELESS_PLAN_PREMIUM,
 	plansProductSlugs,
@@ -150,9 +149,8 @@ function normalizePlanProducts(
 			periodAgnosticSlug: periodAgnosticPlan.periodAgnosticSlug,
 			storeSlug: planProduct.product_slug,
 			rawPrice: planProduct.raw_price,
-			// Not all plans returned from /plans have a `path_slug`
-			// Free plan is an exception, and is given a hardcoded path_slug
-			pathSlug: planProduct.product_slug === PLAN_FREE ? 'free' : planProduct.path_slug,
+			// Not all plans returned from /plans have a `path_slug` (e.g. monthly plans don't have)
+			pathSlug: planProduct.path_slug,
 			price:
 				planProduct?.bill_period === MONTHLY_PLAN_BILLING_PERIOD || planProduct.raw_price === 0
 					? getFormattedPrice( planProduct )

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -65,6 +65,7 @@ export interface PricedAPIPlan {
 export interface PricedAPIPlanFree extends PricedAPIPlan {
 	product_id: 1;
 	cost: 0;
+	path_slug: 'free';
 	product_slug: 'free_plan';
 	bill_period: -1;
 	raw_price: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the hardcoded `path_slug` from the Plans data-store resolver, since the APIs now include that value directly (this was patched in D56809-code)

#### Testing instructions

* Visit [`/new/free` on the calypso.live link](https://hash-d47f37dbc4796b511ce422b70b11964f085913a5.calypso.live/new/free), go through the steps and make sure that the free plan is pre-selected
* `yarn test-packages:watch packages/data-stores/src/plans` — the plans data-store tests should pass

Closes #49918
