### PR TITLE
fix: Show pointer cursor for radio and toggles

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -3,6 +3,13 @@
 	background-color: var( --color-primary );
 }
 
+.components-form-toggle {
+	input[type='checkbox'] {
+		cursor: pointer;
+
+	}
+}
+
 /* @wordpress/components Button overrides */
 .components-button {
 	&,
@@ -88,6 +95,7 @@
 .components-radio-control {
 	&__input[type='radio'] {
 		padding: 6px;
+		cursor: pointer;
 
 		&:checked {
 			border-color: var( --color-accent );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes #49995

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a page with a toggle on it (like `/marketing/traffic/:site`) and verify that when hovering over the toggle you see the pointer cursor
* Open the `/devdocs/wordpress-components-gallery` and scroll to the Radio input and verify that when hovering over the radio choices you see the pointer cursor.
