### PR TITLE
Nav Unification: fix detached sidebar blocker issue

### DIFF
--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -49,10 +49,14 @@ export const handleScroll = ( event: React.UIEvent< HTMLElement > ): void => {
 
 		if (
 			windowHeight >= secondaryElHeight + masterbarHeight &&
-			content.style.minHeight !== 'initial'
+			secondaryEl !== undefined &&
+			secondaryEl !== null &&
+			( content.style.minHeight !== 'initial' || secondaryEl.style.position )
 		) {
 			// In case that window is taller than the sidebar we reinstate the content min-height. CSS code: client/layout/style.scss:30.
 			content.style.minHeight = 'initial';
+			// In case that window is taller than the sidebar after resize we need to clean up any previously set inline styles
+			secondaryEl.removeAttribute( 'style' );
 		}
 	}
 

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -49,7 +49,7 @@ export const handleScroll = ( event: React.UIEvent< HTMLElement > ): void => {
 
 		if (
 			windowHeight >= secondaryElHeight + masterbarHeight &&
-			secondaryEl !== undefined &&
+			content !== null &&
 			secondaryEl !== null &&
 			( content.style.minHeight !== 'initial' || secondaryEl.style.position )
 		) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR aims to fix a blocker issue where the sidebar could get into a detached state after resizing the viewport.

The identified cause for the issue is that when the viewport is shorter than the sidebar, we add some inline styles to position the sidebar accordingly. When we resize the viewport to then be taller than the sidebar, we didn't remove the inline styles previously set. This PR aims to rectify that.

Fixes https://github.com/Automattic/wp-calypso/issues/49175

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before|After|
|-|-|
|<img width="535" alt="Screenshot 2021-02-11 at 17 31 59" src="https://user-images.githubusercontent.com/1562646/107666888-50674380-6c8f-11eb-9f31-4e0af79be960.png">|<img width="546" alt="Screenshot 2021-02-11 at 17 32 48" src="https://user-images.githubusercontent.com/1562646/107666901-54936100-6c8f-11eb-92e9-da87f58deda6.png">|

**First it's important to reproduce the issue in production so you can be sure the changes proposed here fix the issue. The most reliable way to reproduce the issue I've found is the following:**

* Load /home page with enough space for the entire sidebar to fit the screen
* Resize the window to make the height smaller than the sidebar
* Scroll down the page to the end and all the way up again
* Resize the window to make the height taller than the sidebar
* Scrolling the page now leaves the sidebar in a detached state

**After reproducing the issue in production, test with the calypso.live link for this PR. The issue shouldn't be present anymore. In addition the sidebar should still behave as expected across viewport heights.**
