### PR TITLE
Domains: Put thresholds on match scores

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -23,6 +23,8 @@ import {
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	parseMatchReasons,
+	SLD_EXACT_MATCH,
+	TLD_EXACT_MATCH,
 	VALID_MATCH_REASONS,
 } from 'calypso/components/domains/domain-registration-suggestion/utility';
 import { ProgressBar } from '@automattic/components';
@@ -287,7 +289,7 @@ class DomainRegistrationSuggestion extends React.Component {
 
 	renderProgressBar() {
 		const {
-			suggestion: { isRecommended, isBestAlternative, relevance: matchScore },
+			suggestion: { isRecommended, isBestAlternative, match_reasons: matchReasons },
 			translate,
 			isFeatured,
 			showStrikedOutPrice,
@@ -297,6 +299,8 @@ class DomainRegistrationSuggestion extends React.Component {
 			return null;
 		}
 
+		const isExactFullMatch =
+			matchReasons.includes( SLD_EXACT_MATCH ) && matchReasons.includes( TLD_EXACT_MATCH );
 		let title;
 		let progressBarProps;
 		if ( isRecommended ) {
@@ -304,7 +308,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			progressBarProps = {
 				color: NOTICE_GREEN,
 				title,
-				value: Math.min( matchScore * 100, 90 ),
+				value: isExactFullMatch ? 100 : 90,
 			};
 		}
 
@@ -312,7 +316,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			title = translate( 'Best Alternative' );
 			progressBarProps = {
 				title,
-				value: Math.min( matchScore * 100, 80 ),
+				value: isExactFullMatch ? 100 : 82,
 			};
 		}
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -304,7 +304,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			progressBarProps = {
 				color: NOTICE_GREEN,
 				title,
-				value: matchScore * 100 || 90,
+				value: Math.min( matchScore * 100, 90 ),
 			};
 		}
 
@@ -312,7 +312,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			title = translate( 'Best Alternative' );
 			progressBarProps = {
 				title,
-				value: matchScore * 100 || 80,
+				value: Math.min( matchScore * 100, 80 ),
 			};
 		}
 

--- a/client/components/domains/domain-registration-suggestion/utility.js
+++ b/client/components/domains/domain-registration-suggestion/utility.js
@@ -8,11 +8,14 @@ import { translate } from 'i18n-calypso';
  */
 import { getTld } from 'calypso/lib/domains';
 
+export const TLD_EXACT_MATCH = 'tld-exact';
+export const SLD_EXACT_MATCH = 'exact-match';
+
 // NOTE: This is actually a sorted list.
 export const VALID_MATCH_REASONS = [
-	'exact-match',
+	SLD_EXACT_MATCH,
 	'similar-match',
-	'tld-exact',
+	TLD_EXACT_MATCH,
 	'tld-similar',
 	'tld-common',
 ];


### PR DESCRIPTION
Initially introduced in https://github.com/Automattic/wp-calypso/pull/24933

Looks like there was a change at our backend provider that made these match scores to be often `1` and `0.99` for the first two suggestions. Which results in an issue described in https://github.com/Automattic/wp-calypso/issues/36738

~Alternative approach (mentioned by @hambai here https://github.com/Automattic/wp-calypso/pull/24933#pullrequestreview-121392271) would be to normalize these scores on the backend. But honestly, these numbers are pretty arbitrary as is and I'd rather normalize them for presentation only.~

Final version:

 - If it's an exact SLD _and_ TLD match (searched for `example.com`, got a `example.com` result), show 100% score.
 - Otherwise, if it's the recommended one, show 90%. If alternative, 82%.

#### Testing instructions

Go to Domains -> Add domain. Search for something. Make sure the scores for the featured suggestions are clearly different from each other and not the same:

<img width="1071" alt="Screenshot 2021-02-11 at 16 33 56" src="https://user-images.githubusercontent.com/3392497/107667369-6c66e700-6c87-11eb-9418-82c11dcb6ab2.png">

Check mobile view as well:

![Screen Shot 2021-02-11 at 16 33 46](https://user-images.githubusercontent.com/3392497/107667413-75f04f00-6c87-11eb-90d4-400d41fa5732.png)

Check for exact SLD and TLD match the score is 100%:

<img width="1076" alt="Screenshot 2021-02-15 at 15 37 21" src="https://user-images.githubusercontent.com/3392497/107967202-bb24c180-6fa4-11eb-912c-f2c9c99967db.png">


Fixes #36738
