### PR TITLE
Update browser history when redirecting to checkout from pricing page

### DIFF
--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -668,7 +668,7 @@ export function checkout(
 	if ( isJetpackCloud() && ! config.isEnabled( 'jetpack-cloud/connect' ) ) {
 		window.location.href = addQueryArgs( urlQueryArgs, `https://wordpress.com${ path }` );
 	} else {
-		page.redirect( addQueryArgs( urlQueryArgs, path ) );
+		page( addQueryArgs( urlQueryArgs, path ) );
 	}
 }
 
@@ -685,7 +685,7 @@ export function manageSitePurchase( siteSlug: string, purchaseId: number ): void
 	if ( isJetpackCloud() ) {
 		window.location.href = `https://wordpress.com${ relativePath }`;
 	} else {
-		page.redirect( relativePath );
+		page( relativePath );
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

In Jetpack cloud, clicking on a product card button in the pricing page redirects you to the checkout page, but without updating the browser history properly. This PR fixes this and ensures that the browser back button is working as expected.

Fixes 1164141197617539-as-1199925948999562

### Testing instructions

- Download the PR and run both calypso and cloud locally

For cloud:
- Visit any site, so that your browser history is not empty
- Go to `http://jetpack.cloud.localhost:3001/pricing/?site=:site`
- Click on any product
- Notice that you're redirected to the checkout page
- Hit the back button of your browser
- Check that you're redirected to the pricing page, and not the initial site you visited

For Calypso:
- Make sure you have a self-hosted Jetpack site with a product
- Visit any site
- Go to `http://calypso.localhost:3000/plans/:site`
- Click on the `Manage Subscription` button, in the card of the product you own
- Notice you're redirected to the purchase page
- Hit the back button of your browser
- Check that you're redirected to the plans page, and not the initial site you visited

### Screenshots

_Expected behaviour_

https://user-images.githubusercontent.com/1620183/107669054-59d8b780-6c5f-11eb-9af9-98f1510cac4c.mov

