### PR TITLE
search: Convert to function component

### DIFF
--- a/packages/search/jest.config.js
+++ b/packages/search/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+	testEnvironment: 'jsdom',
+};

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -32,6 +32,7 @@
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
 		"@babel/runtime": "^7.12.5",
 		"@wordpress/components": "^12.0.1",
+		"@wordpress/compose": "^3.23.1",
 		"@wordpress/icons": "^2.9.0",
 		"classnames": "^2.2.6",
 		"lodash": "^4.17.20",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -43,7 +43,9 @@
 		"react-dom": "^16.8"
 	},
 	"devDependencies": {
-		"@storybook/addon-actions": "^6.1.10"
+		"@storybook/addon-actions": "^6.1.10",
+		"@testing-library/react": "^11.2.5",
+		"@testing-library/user-event": "^12.8.1"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",

--- a/packages/search/src/search.stories.jsx
+++ b/packages/search/src/search.stories.jsx
@@ -10,10 +10,9 @@ export default { title: 'Search', component: Search };
 const BoxedSearch = ( props ) => (
 	<div style={ { position: 'relative', width: '270px', height: '50px' } }>
 		<Search
-			__={ ( str ) => str }
 			placeholder="Search..."
 			fitsContainer
-			onSearch={ ( search ) => console.log( 'Searched: ', search ) } // eslint-disable-line no-console
+			onSearch={ ( search ) => console.log( 'Searched:', search ) } // eslint-disable-line no-console
 			{ ...props }
 		/>
 	</div>
@@ -32,7 +31,8 @@ export const Delayed = () => {
 };
 
 export const Searching = () => {
-	return <BoxedSearch searching initialValue="Kiwi" />;
+	// eslint-disable-next-line jsx-a11y/no-autofocus
+	return <BoxedSearch searching defaultValue="Kiwi" autoFocus />;
 };
 
 export const Disabled = () => <BoxedSearch disabled isOpen />;
@@ -58,3 +58,5 @@ export const WithOverlayStyling = () => {
 
 	return <BoxedSearch overlayStyling={ overlayStyling } />;
 };
+
+export const WithDefaultValue = () => <BoxedSearch defaultValue="a default search value" />;

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -13,6 +13,12 @@ import { debounce } from 'lodash';
  */
 import { Button, Spinner } from '@wordpress/components';
 import { close, search, Icon } from '@wordpress/icons';
+import { useInstanceId } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { useUpdateEffect } from './utils';
 
 /**
  * Style dependencies
@@ -90,9 +96,6 @@ type State = {
 	hasFocus: boolean;
 };
 
-let currentId = 0;
-const getUniqueId = () => currentId++;
-
 //This is fix for IE11. Does not work on Edge.
 //On IE11 scrollLeft value for input is always 0.
 //We are calculating it manually using TextRange object.
@@ -166,7 +169,7 @@ const InnerSearch: React.ForwardRefRenderFunction< ImperativeHandle, Props > = (
 		hasFocus: autoFocus ?? false,
 	} );
 
-	const instanceId = React.useMemo( () => getUniqueId(), [] );
+	const instanceId = useInstanceId( InnerSearch, 'search' );
 	const searchInput: React.MutableRefObject< HTMLInputElement | null > = React.useRef( null );
 	const openIcon: React.RefObject< HTMLButtonElement | null > = React.useRef( null );
 	const overlay: React.RefObject< HTMLDivElement | null > = React.useRef( null );
@@ -199,11 +202,11 @@ const InnerSearch: React.ForwardRefRenderFunction< ImperativeHandle, Props > = (
 		[ onSearchProp, delayTimeout ]
 	);
 
-	React.useEffect( () => {
+	useUpdateEffect( () => {
 		if ( keyword ) {
 			doSearch( keyword );
 		} else {
-			// explicitly bypass debouncing when there is no keyword is empty
+			// explicitly bypass debouncing when keyword is empty
 			if ( delaySearch.current ) {
 				// Cancel any pending debounce
 				doSearch.cancel?.();

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -259,12 +259,11 @@ const InnerSearch = (
 	const openListener = keyListener( openSearch );
 
 	const scrollOverlay = (): void => {
-		overlay &&
-			window.requestAnimationFrame( () => {
-				if ( overlay.current && searchInput.current ) {
-					overlay.current.scrollLeft = getScrollLeft( searchInput.current );
-				}
-			} );
+		window.requestAnimationFrame( () => {
+			if ( overlay.current && searchInput.current ) {
+				overlay.current.scrollLeft = getScrollLeft( searchInput.current );
+			}
+		} );
 	};
 
 	React.useEffect( () => {

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 
-import { useI18n, I18nReact } from '@automattic/react-i18n';
+import { useI18n } from '@automattic/react-i18n';
 import classNames from 'classnames';
 import React from 'react';
 import type {
@@ -57,7 +57,6 @@ const keyListener = (
 };
 
 type Props = {
-	__: I18nReact[ '__' ];
 	autoFocus?: boolean;
 	className?: string;
 	compact?: boolean;

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -216,121 +216,106 @@ const InnerSearch = (
 		onSearchChange?.( keyword );
 	}, [ doSearch, keyword, onSearchChange ] );
 
-	const openSearch = React.useCallback(
-		( event: KeyboardOrMouseEvent ): void => {
-			event.preventDefault();
+	const openSearch = ( event: KeyboardOrMouseEvent ): void => {
+		event.preventDefault();
 
-			setKeyword( '' );
-			setIsOpen( true );
+		setKeyword( '' );
+		setIsOpen( true );
 
-			focus();
-			// no need to call `onSearchOpen` as it will be called by `onFocus` once the searcbox is focused
-			// prevent outlines around the open icon after being clicked
-			openIcon.current?.blur();
-			recordEvent?.( 'Clicked Open Search' );
-		},
-		[ recordEvent, focus ]
-	);
+		focus();
+		// no need to call `onSearchOpen` as it will be called by `onFocus` once the searcbox is focused
+		// prevent outlines around the open icon after being clicked
+		openIcon.current?.blur();
+		recordEvent?.( 'Clicked Open Search' );
+	};
 
-	const closeSearch = React.useCallback(
-		( event: KeyboardOrMouseEvent ): void => {
-			event.preventDefault();
+	const closeSearch = ( event: KeyboardOrMouseEvent ): void => {
+		event.preventDefault();
 
-			if ( disabled ) {
-				return;
-			}
+		if ( disabled ) {
+			return;
+		}
 
-			setKeyword( '' );
-			setIsOpen( false );
+		setKeyword( '' );
+		setIsOpen( false );
 
-			if ( searchInput.current ) {
-				searchInput.current.value = ''; // will not trigger onChange
-			}
+		if ( searchInput.current ) {
+			searchInput.current.value = ''; // will not trigger onChange
+		}
 
-			if ( pinned ) {
-				searchInput.current?.blur();
-				openIcon.current?.focus();
-			} else {
-				searchInput.current?.focus();
-			}
+		if ( pinned ) {
+			searchInput.current?.blur();
+			openIcon.current?.focus();
+		} else {
+			searchInput.current?.focus();
+		}
 
-			onSearchClose?.( event );
+		onSearchClose?.( event );
 
-			recordEvent?.( 'Clicked Close Search' );
-		},
-		[ disabled, pinned, onSearchClose, recordEvent ]
-	);
+		recordEvent?.( 'Clicked Close Search' );
+	};
 
-	const closeListener = React.useMemo( () => keyListener( closeSearch ), [ closeSearch ] );
-	const openListener = React.useMemo( () => keyListener( openSearch ), [ openSearch ] );
+	const closeListener = keyListener( closeSearch );
+	const openListener = keyListener( openSearch );
 
-	const scrollOverlay = React.useCallback( (): void => {
+	const scrollOverlay = (): void => {
 		overlay &&
 			window.requestAnimationFrame( () => {
 				if ( overlay.current && searchInput.current ) {
 					overlay.current.scrollLeft = getScrollLeft( searchInput.current );
 				}
 			} );
-	}, [] );
+	};
 
 	React.useEffect( () => {
 		scrollOverlay();
-	}, [ keyword, isOpen, hasFocus, scrollOverlay ] );
+	}, [ keyword, isOpen, hasFocus ] );
 
-	const onBlur = React.useCallback(
-		( event: FocusEvent< HTMLInputElement > ): void => {
-			if ( onBlurProp ) {
-				onBlurProp( event );
-			}
+	const onBlur = ( event: FocusEvent< HTMLInputElement > ): void => {
+		if ( onBlurProp ) {
+			onBlurProp( event );
+		}
 
-			setHasFocus( false );
-		},
-		[ onBlurProp ]
-	);
+		setHasFocus( false );
+	};
 
-	const onChange = React.useCallback( ( event: ChangeEvent< HTMLInputElement > ): void => {
+	const onChange = ( event: ChangeEvent< HTMLInputElement > ): void => {
 		setKeyword( event.target.value );
-	}, [] );
+	};
 
-	const onKeyUp = React.useCallback(
-		( event: KeyboardEvent< HTMLInputElement > ): void => {
-			if ( event.key === 'Enter' && window.innerWidth < 480 ) {
-				//dismiss soft keyboards
-				blur();
-			}
+	const onKeyUp = ( event: KeyboardEvent< HTMLInputElement > ): void => {
+		if ( event.key === 'Enter' && window.innerWidth < 480 ) {
+			//dismiss soft keyboards
+			blur();
+		}
 
-			if ( ! pinned ) {
-				return;
-			}
+		if ( ! pinned ) {
+			return;
+		}
 
-			if ( event.key === 'Escape' ) {
-				closeListener( event );
-			}
-			scrollOverlay();
-		},
-		[ pinned, blur, closeListener, scrollOverlay ]
-	);
+		if ( event.key === 'Escape' ) {
+			closeListener( event );
+		}
+		scrollOverlay();
+	};
 
-	const onKeyDown = React.useCallback(
-		( event: KeyboardEvent< HTMLInputElement > ): void => {
-			scrollOverlay();
+	const onKeyDown = ( event: KeyboardEvent< HTMLInputElement > ): void => {
+		scrollOverlay();
 
-			if (
-				event.key === 'Escape' &&
-				// currentTarget will be the input element, rather than target which can be anything
-				event.currentTarget?.value === ''
-			) {
-				closeListener( event );
-			}
+		if (
+			event.key === 'Escape' &&
+			// currentTarget will be the input element, rather than target which can be anything
+			event.currentTarget?.value === ''
+		) {
+			closeListener( event );
+		}
 
-			onKeyDownProp?.( event );
-		},
-		[ scrollOverlay, closeListener, onKeyDownProp ]
-	);
+		onKeyDownProp?.( event );
+	};
 
 	// Puts the cursor at end of the text when starting
 	// with `defaultValue` set.
-	const onFocus = React.useCallback( (): void => {
+	const onFocus = (): void => {
 		setHasFocus( true );
 		onSearchOpen?.();
 
@@ -344,12 +329,12 @@ const InnerSearch = (
 			searchInput.current.value = '';
 			searchInput.current.value = setValue;
 		}
-	}, [ onSearchOpen ] );
+	};
 
-	const handleSubmit = React.useCallback( ( event: FormEvent ): void => {
+	const handleSubmit = ( event: FormEvent ): void => {
 		event.preventDefault();
 		event.stopPropagation();
-	}, [] );
+	};
 
 	const searchValue = keyword;
 	const placeholder = placeholderProp || __( 'Search…', __i18n_text_domain__ );

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -202,7 +202,7 @@ const InnerSearch = (
 
 	useEffect( () => {
 		if ( keyword ) {
-			doSearch( keyword );
+			onSearchProp( keyword );
 		}
 		// Disable reason: This effect covers the case where a keyword was passed in as the default value and we only want to run it on first search; the useUpdateEffect below will handle the rest of the time that keyword updates
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -5,7 +5,7 @@
 
 import { useI18n } from '@automattic/react-i18n';
 import classNames from 'classnames';
-import React from 'react';
+import React, { Ref } from 'react';
 import type {
 	RefObject,
 	MutableRefObject,
@@ -127,7 +127,7 @@ type ImperativeHandle = {
 	clear: () => void;
 };
 
-const InnerSearch: React.ForwardRefRenderFunction< ImperativeHandle, Props > = (
+const InnerSearch = (
 	{
 		delaySearch,
 		disabled,
@@ -159,9 +159,9 @@ const InnerSearch: React.ForwardRefRenderFunction< ImperativeHandle, Props > = (
 		minLength,
 		maxLength,
 		hideClose,
-	},
-	forwardedRef
-) => {
+	}: Props,
+	forwardedRef: Ref< ImperativeHandle >
+): JSX.Element => {
 	const { __ } = useI18n();
 	const [ keyword, setKeyword ] = React.useState( defaultValue );
 	const [ isOpen, setIsOpen ] = React.useState( defaultIsOpen );

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -5,8 +5,9 @@
 
 import { useI18n } from '@automattic/react-i18n';
 import classNames from 'classnames';
-import React, { Ref } from 'react';
+import React, { useEffect } from 'react';
 import type {
+	Ref,
 	RefObject,
 	MutableRefObject,
 	ChangeEvent,
@@ -197,6 +198,14 @@ const InnerSearch = (
 		[ onSearchProp, delayTimeout, delaySearch ]
 	);
 
+	useEffect( () => {
+		if ( keyword ) {
+			doSearch( keyword );
+		}
+		// Disable reason: This effect covers the case where a keyword was passed in as the default value and we only want to run it on first search; the useUpdateEffect below will handle the rest of the time that keyword updates
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
 	useUpdateEffect( () => {
 		if ( keyword ) {
 			doSearch( keyword );
@@ -334,7 +343,7 @@ const InnerSearch = (
 	);
 
 	// Puts the cursor at end of the text when starting
-	// with `initialValue` set.
+	// with `defaultValue` set.
 	const onFocus = React.useCallback( (): void => {
 		setHasFocus( true );
 		onSearchOpen?.();
@@ -343,7 +352,7 @@ const InnerSearch = (
 			return;
 		}
 
-		const setValue = searchInput.current.value ?? '';
+		const setValue = searchInput.current.value;
 		if ( setValue ) {
 			// Firefox needs clear or won't move cursor to end
 			searchInput.current.value = '';

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -135,7 +135,9 @@ const InnerSearch = (
 		pinned,
 		onSearchClose,
 		onSearchChange,
-		onSearch: onSearchProp,
+		onSearch: onSearchProp = () => {
+			/* noop default */
+		},
 		onBlur: onBlurProp,
 		onKeyDown: onKeyDownProp,
 		onClick,
@@ -234,7 +236,7 @@ const InnerSearch = (
 			setIsOpen( true );
 
 			focus();
-			onSearchOpen?.( event );
+			// no need to call `onSearchOpen` as it will be called by `onFocus` once the searcbox is focused
 			// prevent outlines around the open icon after being clicked
 			openIcon.current?.blur();
 			recordEvent?.( 'Clicked Open Search' );

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -42,13 +42,13 @@ const SEARCH_DEBOUNCE_MS = 300;
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = (): void => {};
 
-const keyListener = (
-	methodToCall: (
-		e:
-			| MouseEvent< HTMLButtonElement | HTMLInputElement >
-			| KeyboardEvent< HTMLButtonElement | HTMLInputElement >
-	) => void
-) => ( event: KeyboardEvent< HTMLButtonElement | HTMLInputElement > ) => {
+type KeyboardOrMouseEvent =
+	| MouseEvent< HTMLButtonElement | HTMLInputElement >
+	| KeyboardEvent< HTMLButtonElement | HTMLInputElement >;
+
+const keyListener = ( methodToCall: ( e: KeyboardOrMouseEvent ) => void ) => (
+	event: KeyboardEvent< HTMLButtonElement | HTMLInputElement >
+) => {
 	switch ( event.key ) {
 		case ' ':
 		case 'Enter':
@@ -81,16 +81,8 @@ type Props = {
 	onKeyDown?: ( event: KeyboardEvent< HTMLInputElement > ) => void;
 	onSearch: ( search: string ) => void;
 	onSearchChange?: ( search: string ) => void;
-	onSearchOpen?: (
-		event?:
-			| MouseEvent< HTMLButtonElement | HTMLInputElement >
-			| KeyboardEvent< HTMLButtonElement | HTMLInputElement >
-	) => void;
-	onSearchClose?: (
-		event:
-			| MouseEvent< HTMLButtonElement | HTMLInputElement >
-			| KeyboardEvent< HTMLButtonElement | HTMLInputElement >
-	) => void;
+	onSearchOpen?: () => void;
+	onSearchClose?: ( event: KeyboardOrMouseEvent ) => void;
 	overlayStyling?: ( search: string ) => React.ReactNode;
 	placeholder?: string;
 	pinned?: boolean;
@@ -225,11 +217,7 @@ const InnerSearch = (
 	}, [ doSearch, keyword, onSearchChange ] );
 
 	const openSearch = React.useCallback(
-		(
-			event:
-				| MouseEvent< HTMLButtonElement | HTMLInputElement >
-				| KeyboardEvent< HTMLButtonElement | HTMLInputElement >
-		): void => {
+		( event: KeyboardOrMouseEvent ): void => {
 			event.preventDefault();
 
 			setKeyword( '' );
@@ -241,15 +229,11 @@ const InnerSearch = (
 			openIcon.current?.blur();
 			recordEvent?.( 'Clicked Open Search' );
 		},
-		[ onSearchOpen, recordEvent, focus ]
+		[ recordEvent, focus ]
 	);
 
 	const closeSearch = React.useCallback(
-		(
-			event:
-				| MouseEvent< HTMLButtonElement | HTMLInputElement >
-				| KeyboardEvent< HTMLButtonElement | HTMLInputElement >
-		): void => {
+		( event: KeyboardOrMouseEvent ): void => {
 			event.preventDefault();
 
 			if ( disabled ) {

--- a/packages/search/src/test/index.js
+++ b/packages/search/src/test/index.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
+import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
 
 /**
@@ -12,16 +12,147 @@ import { act } from 'react-dom/test-utils';
 import Search from '..';
 
 describe( 'search', () => {
-	it( 'should return a ref with focus', () => {
-		const ref = React.createRef();
-		render( <Search ref={ ref } /> );
-		const searchBox = screen.getByRole( 'searchbox' );
-		expect( document.activeElement ).not.toBe( searchBox );
+	const focusResolve = () => new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+	describe( 'ref', () => {
+		let ref;
 
-		act( () => {
-			ref.focus();
+		beforeEach( () => {
+			ref = React.createRef();
+			render( <Search ref={ ref } /> );
 		} );
 
-		expect( document.activeElement ).toBe( searchBox );
+		const doCallFocus = ( innerRef ) => {
+			act( () => {
+				innerRef.current.focus();
+			} );
+
+			// Unfortunately we need to wait for `focus` to run as it puts itself at the end of the stack by calling to setTimeout
+			// is there a better way to test this that doesn't leak the implementation detail?
+			return focusResolve();
+		};
+
+		it( 'should have focus', async () => {
+			const searchbox = screen.getByRole( 'searchbox' );
+			expect( document.activeElement ).not.toBe( searchbox );
+			await doCallFocus( ref );
+			expect( document.activeElement ).toBe( searchbox );
+		} );
+
+		it( 'should return a ref with blur', async () => {
+			const searchbox = screen.getByRole( 'searchbox' );
+			await doCallFocus( ref );
+			expect( document.activeElement ).toBe( searchbox );
+			ref.current.blur();
+			expect( document.activeElement ).not.toBe( searchbox );
+		} );
+
+		it( 'should return a ref with clear', () => {
+			const searchbox = screen.getByRole( 'searchbox' );
+			userEvent.type( searchbox, 'This is a test search' );
+			expect( searchbox.value ).toBe( 'This is a test search' );
+			act( () => {
+				ref.current.clear();
+			} );
+
+			expect( searchbox.value ).toBe( '' );
+		} );
+	} );
+
+	it( 'should call onSearch and onSearchChange when search changes', () => {
+		const searchString = '12345';
+		const onSearch = jest.fn();
+		const onSearchChange = jest.fn();
+		render( <Search onSearch={ onSearch } onSearchChange={ onSearchChange } /> );
+		const searchbox = screen.getByRole( 'searchbox' );
+		userEvent.type( searchbox, searchString );
+		expect( onSearch ).toHaveBeenCalledTimes( 5 ); // once per character
+		expect( onSearch ).toHaveBeenCalledWith( '1' );
+		expect( onSearch ).toHaveBeenCalledWith( '12' );
+		expect( onSearch ).toHaveBeenCalledWith( '123' );
+		expect( onSearch ).toHaveBeenCalledWith( '1234' );
+		expect( onSearch ).toHaveBeenCalledWith( '12345' );
+		expect( onSearchChange ).toHaveBeenCalledTimes( 5 );
+		expect( onSearchChange ).toHaveBeenCalledWith( '1' );
+		expect( onSearchChange ).toHaveBeenCalledWith( '12' );
+		expect( onSearchChange ).toHaveBeenCalledWith( '123' );
+		expect( onSearchChange ).toHaveBeenCalledWith( '1234' );
+		expect( onSearchChange ).toHaveBeenCalledWith( '12345' );
+	} );
+
+	it( 'should call onKeyDown when typing into search', () => {
+		const searchString = '12345';
+		const onKeyDown = jest.fn();
+		render( <Search onKeyDown={ onKeyDown } /> );
+		const searchbox = screen.getByRole( 'searchbox' );
+		userEvent.type( searchbox, searchString );
+		expect( onKeyDown ).toHaveBeenCalledTimes( 5 ); // once per character
+		// it gets called with the raw event, so it's not really possible to assert what it was called with
+	} );
+
+	it( 'should generate a unique id for each searchbox', () => {
+		render( <Search /> );
+		render( <Search /> );
+		render( <Search /> );
+
+		const searchboxes = screen.getAllByRole( 'searchbox' );
+		expect( searchboxes ).toHaveLength( 3 );
+		// put the ids into object keys to get the unique IDs
+		const uniqueIds = Object.keys(
+			searchboxes.reduce( ( acc, s ) => ( { ...acc, [ s.id ]: true } ), {} )
+		);
+		expect( uniqueIds ).toHaveLength( 3 );
+	} );
+
+	it( 'should call onSearchOpen when search is focused', () => {
+		const onSearchOpen = jest.fn();
+		render( <Search onSearchOpen={ onSearchOpen } /> );
+		const searchbox = screen.getByRole( 'searchbox' );
+		userEvent.click( searchbox );
+		expect( onSearchOpen ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should open and focus the search element when clicking the open search button', async () => {
+		const onSearchOpen = jest.fn();
+		render( <Search pinned defaultIsOpen={ false } onSearchOpen={ onSearchOpen } /> );
+		const openButton = screen.getByLabelText( 'Open Search' );
+		userEvent.click( openButton );
+		await focusResolve();
+		const searchbox = screen.getByRole( 'searchbox' );
+		expect( onSearchOpen ).toHaveBeenCalledTimes( 1 );
+		expect( document.activeElement ).toBe( searchbox );
+	} );
+
+	it( 'should close search and call onSearchClose when clicking the close button', () => {
+		const onSearchClose = jest.fn();
+		render(
+			<Search
+				pinned
+				defaultIsOpen
+				defaultValue="test default search value"
+				onSearchClose={ onSearchClose }
+			/>
+		);
+
+		const closeButton = screen.getByLabelText( 'Close Search' );
+
+		userEvent.click( closeButton );
+		const searchbox = screen.queryByRole( 'searchbox' );
+		expect( searchbox ).toBeNull();
+		expect( onSearchClose ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should call onSearch when a default value is provided but not call onSearchChange', () => {
+		const onSearch = jest.fn();
+		const onSearchChange = jest.fn();
+		const defaultValue = 'a default search value';
+		render(
+			<Search
+				onSearch={ onSearch }
+				onSearchChange={ onSearchChange }
+				defaultValue={ defaultValue }
+			/>
+		);
+		expect( onSearch ).toHaveBeenCalledWith( defaultValue );
+		expect( onSearchChange ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/search/src/test/index.js
+++ b/packages/search/src/test/index.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { act } from 'react-dom/test-utils';
+
+/**
+ * Internal dependencies
+ */
+import Search from '..';
+
+describe( 'search', () => {
+	it( 'should return a ref with focus', () => {
+		const ref = React.createRef();
+		render( <Search ref={ ref } /> );
+		const searchBox = screen.getByRole( 'searchbox' );
+		expect( document.activeElement ).not.toBe( searchBox );
+
+		act( () => {
+			ref.focus();
+		} );
+
+		expect( document.activeElement ).toBe( searchBox );
+	} );
+} );

--- a/packages/search/src/test/index.js
+++ b/packages/search/src/test/index.js
@@ -141,7 +141,7 @@ describe( 'search', () => {
 		expect( onSearchClose ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'should call onSearch when a default value is provided but not call onSearchChange', () => {
+	it( 'should call onSearch without debouncing when a default value is provided but not call onSearchChange', () => {
 		const onSearch = jest.fn();
 		const onSearchChange = jest.fn();
 		const defaultValue = 'a default search value';
@@ -150,8 +150,11 @@ describe( 'search', () => {
 				onSearch={ onSearch }
 				onSearchChange={ onSearchChange }
 				defaultValue={ defaultValue }
+				delaySearch
+				delayTimeout={ 1000 }
 			/>
 		);
+		// Just assert that onSearch was called immediately, if it is debounced then this assertion will fail.
 		expect( onSearch ).toHaveBeenCalledWith( defaultValue );
 		expect( onSearchChange ).not.toHaveBeenCalled();
 	} );

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -1,1 +1,7 @@
 declare const __i18n_text_domain__: string;
+
+declare module '@wordpress/compose' {
+	function useInstanceId( object: any, prefix: string ): string;
+
+	export { useInstanceId };
+}

--- a/packages/search/src/utils.ts
+++ b/packages/search/src/utils.ts
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * A `React.useEffect` that will not run on the first render.
+ *
+ * Source:
+ * https://github.com/reakit/reakit/blob/HEAD/packages/reakit-utils/src/useUpdateEffect.ts
+ *
+ * @param effect The effect.
+ * @param deps Dependencies of the effect.
+ */
+export function useUpdateEffect( effect: React.EffectCallback, deps: React.DependencyList ): void {
+	const mounted = React.useRef( false );
+	React.useEffect( () => {
+		if ( mounted.current ) {
+			return effect();
+		}
+		mounted.current = true;
+		return undefined;
+		// eslint-disable-next-line
+	}, deps );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3620,6 +3620,20 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
+"@testing-library/dom@^7.28.1":
+  version "7.29.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.29.6.tgz#eb37844fb431186db7960a7ff6749ea65a19617c"
+  integrity sha512-vzTsAXa439ptdvav/4lsKRcGpAQX7b6wBIqia7+iNzqGJ5zjswApxA6jDAsexrc6ue9krWcbh8o+LYkBXW+GCQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.4"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
+
 "@testing-library/jest-dom@^5.11.6", "@testing-library/jest-dom@^5.9.0":
   version "5.11.6"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.6.tgz#782940e82e5cd17bc0a36f15156ba16f3570ac81"
@@ -3658,6 +3672,21 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.27.1"
+
+"@testing-library/react@^11.2.5":
+  version "11.2.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.5.tgz#ae1c36a66c7790ddb6662c416c27863d87818eb9"
+  integrity sha512-yEx7oIa/UWLe2F2dqK0FtMF9sJWNXD+2PPtp39BvE0Kh9MJ9Kl0HrZAgEuhUJR+Lx8Di6Xz+rKwSdEPY2UV8ZQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^7.28.1"
+
+"@testing-library/user-event@^12.8.1":
+  version "12.8.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.8.1.tgz#aa897d6e7f0cf2208385abc2da2ac3f5844bbd00"
+  integrity sha512-u521YhkCKip0DQNDpfj9V97PU7UlCTkW5jURUD4JipuVe/xDJ32dJSIHlT2pqAs/I91OFB8p6LtqaLZpOu8BWQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 "@types/anymatch@*":
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3606,21 +3606,7 @@
   resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.0.7.tgz#0cd915785ec4190f08a3a6acc9b61fc38fb5f1a9"
   integrity sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==
 
-"@testing-library/dom@^7.27.1", "@testing-library/dom@^7.8.0":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.27.1.tgz#b760182513357e4448a8461f9565d733a88d71d0"
-  integrity sha512-AF56RoeUU8bO4DOvLyMI44H3O1LVKZQi2D/m5fNDr+iR4drfOFikTr26hT6IY7YG+l8g69FXsHERa+uThaYYQg==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/runtime" "^7.12.5"
-    "@types/aria-query" "^4.2.0"
-    aria-query "^4.2.2"
-    chalk "^4.1.0"
-    dom-accessibility-api "^0.5.4"
-    lz-string "^1.4.4"
-    pretty-format "^26.6.2"
-
-"@testing-library/dom@^7.28.1":
+"@testing-library/dom@^7.28.1", "@testing-library/dom@^7.8.0":
   version "7.29.6"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.29.6.tgz#eb37844fb431186db7960a7ff6749ea65a19617c"
   integrity sha512-vzTsAXa439ptdvav/4lsKRcGpAQX7b6wBIqia7+iNzqGJ5zjswApxA6jDAsexrc6ue9krWcbh8o+LYkBXW+GCQ==
@@ -3665,15 +3651,7 @@
     "@testing-library/dom" "^7.8.0"
     "@types/testing-library__react" "^10.0.1"
 
-"@testing-library/react@^11.2.0":
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.0.tgz#ce977a76b6342ea95c71ccd6de3012b1635fb559"
-  integrity sha512-90xKYJzskZ7q/AoSuWraQL4EGZlr75uZvDt3nrO4M+rugN02zjO45tmOBq/JBOgDiMIL1tkhHioKXjJsVaSINA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@testing-library/dom" "^7.27.1"
-
-"@testing-library/react@^11.2.5":
+"@testing-library/react@^11.2.0", "@testing-library/react@^11.2.5":
   version "11.2.5"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.5.tgz#ae1c36a66c7790ddb6662c416c27863d87818eb9"
   integrity sha512-yEx7oIa/UWLe2F2dqK0FtMF9sJWNXD+2PPtp39BvE0Kh9MJ9Kl0HrZAgEuhUJR+Lx8Di6Xz+rKwSdEPY2UV8ZQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Converts the `Search` component to be a function component.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `search:storybook:start` and test the search component.
* Open `/plugins` and ensure that search still works
* Open `/people/edit/:site/:user` where `site` is a site with more than 10 users. Scroll to the bottom and select the option to attribute works to another user and ensure search still functions.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
