### PR TITLE
Partner Portal: Reorganize the licenses page views slightly in preparation for the data layer

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -15,7 +15,7 @@ import Header from './header';
 import JetpackComFooter from 'calypso/jetpack-cloud/sections/pricing/jpcom-footer';
 import PartnerPortalSidebar from 'calypso/jetpack-cloud/sections/partner-portal/sidebar';
 import SelectPartnerKey from 'calypso/jetpack-cloud/sections/partner-portal/select-partner-key';
-import LicenseList from 'calypso/jetpack-cloud/sections/partner-portal/license-list';
+import Licenses from 'calypso/jetpack-cloud/sections/partner-portal/primary/licenses';
 
 export function partnerKeyContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
@@ -30,9 +30,7 @@ export function partnerPortalContext( context: PageJS.Context, next: () => void 
 
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;
-	context.primary = (
-		<LicenseList licenseFilter={ licenseFilter } search={ context.query.s || '' } />
-	);
+	context.primary = <Licenses licenseFilter={ licenseFilter } search={ context.query.s || '' } />;
 	context.footer = <JetpackComFooter />;
 	next();
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -87,12 +87,12 @@ export default function LicenseDetails( {
 
 				<li className="license-details__list-item">
 					<h4 className="license-details__label">{ translate( "Owner's User ID" ) }</h4>
-					<span>{ username }</span>
+					{ username ? <span>{ username }</span> : <Gridicon icon="minus" /> }
 				</li>
 
 				<li className="license-details__list-item">
 					<h4 className="license-details__label">{ translate( 'Blog ID' ) }</h4>
-					<span>{ blogId }</span>
+					{ blogId ? <span>{ blogId }</span> : <Gridicon icon="minus" /> }
 				</li>
 			</ul>
 			<div className="license-details__actions">

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -7,20 +7,12 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
-import Main from 'calypso/components/main';
-import CardHeading from 'calypso/components/card-heading';
-import DocumentHead from 'calypso/components/data/document-head';
 import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
-import LicensePreview from 'calypso/jetpack-cloud/sections/partner-portal/license-preview';
-import LicenseStateFilter from 'calypso/jetpack-cloud/sections/partner-portal/license-state-filter';
+import LicensePreview, {
+	LicensePreviewPlaceholder,
+} from 'calypso/jetpack-cloud/sections/partner-portal/license-preview';
 
-interface Props {
-	licenseFilter: LicenseFilter;
-	search: string;
-}
-
-export default function LicenseList( { licenseFilter, search }: Props ): ReactElement {
+export default function LicenseList(): ReactElement {
 	const translate = useTranslate();
 
 	const data = [
@@ -67,13 +59,7 @@ export default function LicenseList( { licenseFilter, search }: Props ): ReactEl
 	];
 
 	return (
-		<Main wideLayout={ true } className="license-list">
-			<DocumentHead title={ translate( 'Licenses' ) } />
-
-			<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>
-
-			<LicenseStateFilter licenseFilter={ licenseFilter } search={ search } />
-
+		<div className="license-list">
 			<LicenseListItem header>
 				<h2>{ translate( 'License state' ) }</h2>
 				<h2>{ translate( 'Issued on' ) }</h2>
@@ -96,6 +82,10 @@ export default function LicenseList( { licenseFilter, search }: Props ): ReactEl
 					revokedAt={ license.revokedAt }
 				/>
 			) ) }
-		</Main>
+
+			<LicensePreviewPlaceholder />
+			<LicensePreviewPlaceholder />
+			<LicensePreviewPlaceholder />
+		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -156,3 +156,41 @@ export default function LicensePreview( {
 		</div>
 	);
 }
+
+export function LicensePreviewPlaceholder(): ReactElement {
+	const translate = useTranslate();
+
+	return (
+		<div className="license-preview license-preview--placeholder">
+			<LicenseListItem className="license-preview__card">
+				<div>
+					<h3 className="license-preview__domain">{ translate( 'Loading' ) }</h3>
+
+					<div className="license-preview__product" />
+				</div>
+
+				<div>
+					<div className="license-preview__label">{ translate( 'Issued on:' ) }</div>
+
+					<div />
+				</div>
+
+				<div>
+					<div className="license-preview__label">{ translate( 'Attached on:' ) }</div>
+
+					<div />
+				</div>
+
+				<div>
+					<div className="license-preview__label">{ translate( 'Revoked on:' ) }</div>
+
+					<div />
+				</div>
+
+				<div />
+
+				<div />
+			</LicenseListItem>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -121,4 +121,10 @@
 	&__toggle {
 		padding: 0;
 	}
+
+	&--placeholder &__domain,
+	&--placeholder &__product,
+	&--placeholder &__label + div {
+		@include placeholder( --color-neutral-10 );
+	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement } from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'calypso/components/main';
+import CardHeading from 'calypso/components/card-heading';
+import DocumentHead from 'calypso/components/data/document-head';
+import LicenseList from 'calypso/jetpack-cloud/sections/partner-portal/license-list';
+import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import LicenseStateFilter from 'calypso/jetpack-cloud/sections/partner-portal/license-state-filter';
+
+interface Props {
+	licenseFilter: LicenseFilter;
+	search: string;
+}
+
+export default function Licenses( { licenseFilter, search }: Props ): ReactElement {
+	const translate = useTranslate();
+
+	return (
+		<Main wideLayout={ true } className="licenses">
+			<DocumentHead title={ translate( 'Licenses' ) } />
+
+			<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>
+
+			<LicenseStateFilter licenseFilter={ licenseFilter } search={ search } />
+
+			<LicenseList />
+		</Main>
+	);
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reorganize the licenses page of the Partner Portal to improve code organization, add placeholder components and fix a minor issue where a dash did not appear when a username or blog_id are not available in the license details component.

#### Testing instructions

* Make sure the Licenses page of the Partner Portal looks like the following:
![Screenshot 2021-02-11 at 19 54 06](https://user-images.githubusercontent.com/22746396/107677414-e8baf380-6ca2-11eb-9a73-df7b2099e80d.png)

Part of #49344
