### PR TITLE
Domains: Improve transfer out messaging

### DIFF
--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -13,7 +13,11 @@ import { fetchUsers } from 'calypso/lib/users/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getPlansBySite } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { getDomainsBySiteId, isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
+import {
+	getDomainsBySiteId,
+	hasLoadedSiteDomains,
+	isRequestingSiteDomains,
+} from 'calypso/state/sites/domains/selectors';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QueryContactDetailsCache from 'calypso/components/data/query-contact-details-cache';
@@ -28,6 +32,7 @@ function getStateFromStores( props ) {
 	return {
 		context: props.context,
 		domains: props.selectedSite ? props.domains : null,
+		hasSiteDomainsLoaded: props.hasSiteDomainsLoaded,
 		isRequestingSiteDomains: props.isRequestingSiteDomains,
 		products: props.products,
 		selectedDomainName: props.selectedDomainName,
@@ -106,6 +111,7 @@ class DomainManagementData extends React.Component {
 						currentUser={ this.props.currentUser }
 						domains={ this.props.domains }
 						getStateFromStores={ getStateFromStores }
+						hasSiteDomainsLoaded={ this.props.hasSiteDomainsLoaded }
 						isRequestingSiteDomains={ this.props.isRequestingSiteDomains }
 						products={ this.props.productsList }
 						selectedDomainName={ this.props.selectedDomainName }
@@ -126,6 +132,7 @@ export default connect( ( state ) => {
 	return {
 		currentUser: getCurrentUser( state ),
 		domains: getDomainsBySiteId( state, siteId ),
+		hasSiteDomainsLoaded: hasLoadedSiteDomains( state, siteId ),
 		isRequestingSiteDomains: isRequestingSiteDomains( state, siteId ),
 		productsList: getProductsList( state ),
 		sitePlans: getPlansBySite( state, selectedSite ),

--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -96,7 +96,6 @@ export const STATS_TOP_POSTS_PAGES = `${ root }/stats/#top-posts-pages`;
 export const STATS_VIEWS_BY_COUNTRY = `${ root }/stats/#views-by-country`;
 export const SUPPORT_ROOT = `${ root }/`;
 export const TRANSFER_DOMAIN_REGISTRATION = `${ root }/transfer-domain-registration`;
-export const TRANSFER_DOMAIN_REGISTRATION_WITH_NEW_REGISTRAR = `${ root }/transfer-domain-registration#starting-the-transfer-with-your-new-registrar`;
 export const TWITTER_TIMELINE_WIDGET = `${ root }/widgets/twitter-timeline-widget`;
 export const UPDATE_CONTACT_INFORMATION = `${ root }/update-contact-information/`;
 export const UPDATE_CONTACT_INFORMATION_EMAIL_OR_NAME_CHANGES = `${ root }/update-contact-information/#email-or-name-changes`;

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/index.jsx
@@ -102,7 +102,11 @@ class Transfer extends React.Component {
 	};
 
 	isDataLoading() {
-		return ! this.props.wapiDomainInfo.hasLoadedFromServer || this.props.isRequestingSiteDomains;
+		return (
+			! this.props.wapiDomainInfo.hasLoadedFromServer ||
+			this.props.isRequestingSiteDomains ||
+			! this.props.hasSiteDomainsLoaded
+		);
 	}
 }
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
@@ -11,6 +11,10 @@ import { localize } from 'i18n-calypso';
 import { Card, Button } from '@automattic/components';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import {
+	domainManagementEditContactInfo,
+	domainManagementNameServers,
+} from 'calypso/my-sites/domains/paths';
+import {
 	fetchWapiDomainInfo,
 	requestDomainTransferCode,
 } from 'calypso/state/domains/transfer/actions';
@@ -47,8 +51,8 @@ class Locked extends React.Component {
 	}
 
 	render() {
-		const { translate } = this.props;
-		const { privateDomain } = getSelectedDomain( this.props );
+		const { translate, selectedSite } = this.props;
+		const { privateDomain, domain: domainName } = getSelectedDomain( this.props );
 
 		return (
 			<div>
@@ -63,6 +67,36 @@ class Locked extends React.Component {
 						<a href={ TRANSFER_DOMAIN_REGISTRATION } target="_blank" rel="noopener noreferrer">
 							{ translate( 'Learn More.' ) }
 						</a>
+					</p>
+					<p>
+						{ translate(
+							"{{strong}}Transferring your domain can take up to two weeks.{{/strong}} During this time, your domain will be unlocked and your contact information will become available in the domain's public records.",
+							{
+								components: { strong: <strong /> },
+							}
+						) }
+					</p>
+					<p>
+						{ translate(
+							'Your domain will continue to work, but {{strong}}domain settings such as {{nameserversLink}}name servers{{/nameserversLink}} and {{contactInformationEditLink}}contact information{{/contactInformationEditLink}} cannot be changed during the transfer.{{/strong}} If you need to make changes, please do so before starting.',
+							{
+								components: {
+									strong: <strong />,
+									nameserversLink: (
+										<a
+											rel="noopener noreferrer"
+											href={ domainManagementNameServers( selectedSite.slug, domainName ) }
+										/>
+									),
+									contactInformationEditLink: (
+										<a
+											rel="noopener noreferrer"
+											href={ domainManagementEditContactInfo( selectedSite.slug, domainName ) }
+										/>
+									),
+								},
+							}
+						) }
 					</p>
 					{ this.isManualTransferRequired() && this.renderManualTransferInfo() }
 					<Button

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
 import { Card, Button } from '@automattic/components';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { requestDomainTransferCode } from 'calypso/state/domains/transfer/actions';
-import { TRANSFER_DOMAIN_REGISTRATION } from 'calypso/lib/url/support';
 import { getDomainWapiInfoByDomainName } from 'calypso/state/domains/transfer/selectors';
 import TransferOutWarning from './warning.jsx';
 import { registrar as registrarNames } from 'calypso/lib/domains/constants';
@@ -60,9 +59,6 @@ class Locked extends React.Component {
 							: translate(
 									'To transfer your domain, we must unlock it. It will remain unlocked until the transfer is canceled or completed.'
 							  ) }{ ' ' }
-						<a href={ TRANSFER_DOMAIN_REGISTRATION } target="_blank" rel="noopener noreferrer">
-							{ translate( 'Learn More.' ) }
-						</a>
 					</p>
 					<TransferOutWarning domainName={ domainName } selectedSiteSlug={ selectedSite.slug } />
 					{ this.isManualTransferRequired() && this.renderManualTransferInfo() }

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
@@ -10,16 +10,11 @@ import { localize } from 'i18n-calypso';
  */
 import { Card, Button } from '@automattic/components';
 import { getSelectedDomain } from 'calypso/lib/domains';
-import {
-	domainManagementEditContactInfo,
-	domainManagementNameServers,
-} from 'calypso/my-sites/domains/paths';
-import {
-	fetchWapiDomainInfo,
-	requestDomainTransferCode,
-} from 'calypso/state/domains/transfer/actions';
+import { requestDomainTransferCode } from 'calypso/state/domains/transfer/actions';
 import { TRANSFER_DOMAIN_REGISTRATION } from 'calypso/lib/url/support';
 import { getDomainWapiInfoByDomainName } from 'calypso/state/domains/transfer/selectors';
+import TransferOutWarning from './warning.jsx';
+import { registrar as registrarNames } from 'calypso/lib/domains/constants';
 
 class Locked extends React.Component {
 	unlockAndRequestTransferCode = () => {
@@ -52,52 +47,24 @@ class Locked extends React.Component {
 
 	render() {
 		const { translate, selectedSite } = this.props;
-		const { privateDomain, domain: domainName } = getSelectedDomain( this.props );
+		const { domain: domainName, privateDomain, registrar } = getSelectedDomain( this.props );
 
 		return (
 			<div>
 				<Card className="transfer-out__card">
 					<p>
-						{ privateDomain
+						{ privateDomain && registrar === registrarNames.WWD
 							? translate(
-									'To transfer your domain, we must unlock it and remove Privacy Protection. ' +
-										'Your contact information will be publicly available during the transfer period.'
+									'To transfer your domain, we must unlock it and remove Privacy Protection. Your contact information will be publicly available during the transfer period. The domain will remain unlocked and your contact information will be publicly available until the transfer is canceled or completed.'
 							  )
-							: translate( 'To transfer your domain, we must unlock it.' ) }{ ' ' }
+							: translate(
+									'To transfer your domain, we must unlock it. It will remain unlocked until the transfer is canceled or completed.'
+							  ) }{ ' ' }
 						<a href={ TRANSFER_DOMAIN_REGISTRATION } target="_blank" rel="noopener noreferrer">
 							{ translate( 'Learn More.' ) }
 						</a>
 					</p>
-					<p>
-						{ translate(
-							"{{strong}}Transferring your domain can take up to two weeks.{{/strong}} During this time, your domain will be unlocked and your contact information will become available in the domain's public records.",
-							{
-								components: { strong: <strong /> },
-							}
-						) }
-					</p>
-					<p>
-						{ translate(
-							'Your domain will continue to work, but {{strong}}domain settings such as {{nameserversLink}}name servers{{/nameserversLink}} and {{contactInformationEditLink}}contact information{{/contactInformationEditLink}} cannot be changed during the transfer.{{/strong}} If you need to make changes, please do so before starting.',
-							{
-								components: {
-									strong: <strong />,
-									nameserversLink: (
-										<a
-											rel="noopener noreferrer"
-											href={ domainManagementNameServers( selectedSite.slug, domainName ) }
-										/>
-									),
-									contactInformationEditLink: (
-										<a
-											rel="noopener noreferrer"
-											href={ domainManagementEditContactInfo( selectedSite.slug, domainName ) }
-										/>
-									),
-								},
-							}
-						) }
-					</p>
+					<TransferOutWarning domainName={ domainName } selectedSiteSlug={ selectedSite.slug } />
 					{ this.isManualTransferRequired() && this.renderManualTransferInfo() }
 					<Button
 						className="transfer-out__action-button"
@@ -122,7 +89,6 @@ export default connect(
 		};
 	},
 	{
-		fetchWapiDomainInfo,
 		requestDomainTransferCode,
 	}
 )( localize( Locked ) );

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
@@ -12,11 +12,12 @@ import { Card, Button } from '@automattic/components';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import {
 	cancelDomainTransferRequest,
-	fetchWapiDomainInfo,
 	requestDomainTransferCode,
 } from 'calypso/state/domains/transfer/actions';
 import { TRANSFER_DOMAIN_REGISTRATION_WITH_NEW_REGISTRAR } from 'calypso/lib/url/support';
 import { getDomainWapiInfoByDomainName } from 'calypso/state/domains/transfer/selectors';
+import TransferOutWarning from './warning.jsx';
+import { registrar as registrarNames } from 'calypso/lib/domains/constants';
 
 class Unlocked extends React.Component {
 	state = {
@@ -167,32 +168,49 @@ class Unlocked extends React.Component {
 		);
 	}
 
-	render() {
-		const { isSubmitting, translate } = this.props;
-		const domain = getSelectedDomain( this.props );
-		const { privateDomain, domainLockingAvailable } = domain;
+	renderDomainStateMessage( domain ) {
+		const { selectedSite, translate } = this.props;
+		const { domain: domainName, domainLockingAvailable, privateDomain, registrar } = domain;
 		const privacyDisabled = ! privateDomain;
 
 		let domainStateMessage;
-		if ( domainLockingAvailable && privacyDisabled ) {
+		if ( domainLockingAvailable && privacyDisabled && registrar === registrarNames.WWD ) {
 			domainStateMessage = translate(
 				'Your domain is unlocked and ' +
-					'Privacy Protection has been disabled to prepare for transfer.'
+					'Privacy Protection has been disabled to prepare for transfer. It will remain in this state until the transfer is canceled or completed.'
+			);
+		} else if ( domainLockingAvailable ) {
+			domainStateMessage = translate(
+				'Your domain is unlocked to prepare for transfer. It will remain unlocked until the transfer is canceled or completed.'
 			);
 		} else if ( privacyDisabled ) {
 			domainStateMessage = translate(
-				'Privacy Protection for your ' + 'domain has been disabled to prepare for transfer.'
+				'Privacy Protection for your domain has been disabled to prepare for transfer. It will remain disabled until the transfer is canceled or completed.'
 			);
-		} else if ( domainLockingAvailable ) {
-			domainStateMessage = translate( 'Your domain is unlocked to prepare for transfer.' );
 		}
+
+		if ( ! domainStateMessage ) {
+			return null;
+		}
+
+		return (
+			<div>
+				<p>{ domainStateMessage }</p>
+				<TransferOutWarning domainName={ domainName } selectedSiteSlug={ selectedSite.slug } />
+			</div>
+		);
+	}
+
+	render() {
+		const { isSubmitting, translate } = this.props;
+		const domain = getSelectedDomain( this.props );
 
 		return (
 			<div>
 				<Card className="transfer-out__card">
 					<div className="transfer-out__content">
 						{ isSubmitting && <p>{ translate( 'Sending request…' ) }</p> }
-						{ domainStateMessage && <p>{ domainStateMessage }</p> }
+						{ this.renderDomainStateMessage( domain ) }
 						{ this.renderBody( domain ) }
 						<a
 							href={ TRANSFER_DOMAIN_REGISTRATION_WITH_NEW_REGISTRAR }
@@ -239,7 +257,6 @@ export default connect(
 	},
 	{
 		cancelDomainTransferRequest,
-		fetchWapiDomainInfo,
 		requestDomainTransferCode,
 	}
 )( localize( Unlocked ) );

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
@@ -14,7 +14,6 @@ import {
 	cancelDomainTransferRequest,
 	requestDomainTransferCode,
 } from 'calypso/state/domains/transfer/actions';
-import { TRANSFER_DOMAIN_REGISTRATION_WITH_NEW_REGISTRAR } from 'calypso/lib/url/support';
 import { getDomainWapiInfoByDomainName } from 'calypso/state/domains/transfer/selectors';
 import TransferOutWarning from './warning.jsx';
 import { registrar as registrarNames } from 'calypso/lib/domains/constants';
@@ -177,7 +176,7 @@ class Unlocked extends React.Component {
 		if ( domainLockingAvailable && privacyDisabled && registrar === registrarNames.WWD ) {
 			domainStateMessage = translate(
 				'Your domain is unlocked and ' +
-					'Privacy Protection has been disabled to prepare for transfer. It will remain in this state until the transfer is canceled or completed.'
+					'Privacy Protection has been disabled to prepare for transfer. Your contact information will be publicly available during the transfer period. The domain will remain unlocked and your contact information will be publicly available until the transfer is canceled or completed.'
 			);
 		} else if ( domainLockingAvailable ) {
 			domainStateMessage = translate(
@@ -212,13 +211,6 @@ class Unlocked extends React.Component {
 						{ isSubmitting && <p>{ translate( 'Sending request…' ) }</p> }
 						{ this.renderDomainStateMessage( domain ) }
 						{ this.renderBody( domain ) }
-						<a
-							href={ TRANSFER_DOMAIN_REGISTRATION_WITH_NEW_REGISTRAR }
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							{ translate( 'Learn More.' ) }
-						</a>
 					</div>
 					{ this.renderSendButton( domain ) }
 					{ this.renderCancelButton( domain ) }

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/warning.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/warning.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -11,12 +12,13 @@ import {
 	domainManagementEditContactInfo,
 	domainManagementNameServers,
 } from 'calypso/my-sites/domains/paths';
+import { TRANSFER_DOMAIN_REGISTRATION } from 'calypso/lib/url/support';
 
 export default function TransferOutWarning( { domainName, selectedSiteSlug } ) {
 	return (
 		<p>
 			{ translate(
-				'Most transfers can be completed in a week or less; however depending on your domain it may take longer. Your domain will continue to work, but {{strong}}domain settings such as {{nameserversLink}}name servers{{/nameserversLink}} and {{contactInformationEditLink}}contact information{{/contactInformationEditLink}} cannot be changed during the transfer.{{/strong}} If you need to make changes, please do so before starting the transfer process.',
+				'Most transfers can be completed in a week or less; however depending on your domain it may take longer. Your domain will continue to work, but {{strong}}domain settings such as {{nameserversLink}}name servers{{/nameserversLink}} and {{contactInformationEditLink}}contact information{{/contactInformationEditLink}} cannot be changed during the transfer{{/strong}}. If you need to make changes, please do so before starting the transfer process.',
 				{
 					components: {
 						strong: <strong />,
@@ -34,7 +36,15 @@ export default function TransferOutWarning( { domainName, selectedSiteSlug } ) {
 						),
 					},
 				}
-			) }
+			) }{ ' ' }
+			<a href={ TRANSFER_DOMAIN_REGISTRATION } target="_blank" rel="noopener noreferrer">
+				{ translate( 'Learn more about domain transfers.' ) }
+			</a>
 		</p>
 	);
 }
+
+TransferOutWarning.propTypes = {
+	domainName: PropTypes.string.isRequired,
+	selectedSiteSlug: PropTypes.string.isRequired,
+};

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/warning.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/warning.jsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { translate } from 'i18n-calypso';
+import {
+	domainManagementEditContactInfo,
+	domainManagementNameServers,
+} from 'calypso/my-sites/domains/paths';
+
+export default function TransferOutWarning( { domainName, selectedSiteSlug } ) {
+	return (
+		<p>
+			{ translate(
+				'Most transfers can be completed in a week or less; however depending on your domain it may take longer. Your domain will continue to work, but {{strong}}domain settings such as {{nameserversLink}}name servers{{/nameserversLink}} and {{contactInformationEditLink}}contact information{{/contactInformationEditLink}} cannot be changed during the transfer.{{/strong}} If you need to make changes, please do so before starting the transfer process.',
+				{
+					components: {
+						strong: <strong />,
+						nameserversLink: (
+							<a
+								rel="noopener noreferrer"
+								href={ domainManagementNameServers( selectedSiteSlug, domainName ) }
+							/>
+						),
+						contactInformationEditLink: (
+							<a
+								rel="noopener noreferrer"
+								href={ domainManagementEditContactInfo( selectedSiteSlug, domainName ) }
+							/>
+						),
+					},
+				}
+			) }
+		</p>
+	);
+}


### PR DESCRIPTION
Fixes #7090

#### Changes proposed in this Pull Request

The current transfer out view does not explain properly what are the implications of a transfer out and what limitations are put in place when it's in that state:

<img width="758" alt="Screenshot 2021-02-11 at 17 06 40" src="https://user-images.githubusercontent.com/3392497/107677769-8659f700-6c92-11eb-8a44-e037f11c3a6c.png">

This PR tries to address it using the copy proposed in https://github.com/Automattic/wp-calypso/issues/7090#issuecomment-242102230 and then improved by @wensco in https://github.com/Automattic/wp-calypso/pull/50007#issuecomment-779375246 ❤️ 

#### Testing instructions

Go to Upgrades -> Domains -> example.com -> Transfer domain -> Transfer to another registrar.

Depending on the domain type and its state, the screen should look:

Non-WWD domain that is locked:

<img width="751" alt="Screenshot 2021-02-22 at 11 48 16" src="https://user-images.githubusercontent.com/3392497/108704417-e6a72f00-7503-11eb-8ac5-e7bbb5b30fc6.png">

Non-WWD domain that is unlocked:

<img width="746" alt="Screenshot 2021-02-22 at 11 48 59" src="https://user-images.githubusercontent.com/3392497/108704478-fc1c5900-7503-11eb-892b-d3cee276d72a.png">

WWD domain that is locked and has privacy enabled:

<img width="748" alt="Screenshot 2021-02-22 at 11 49 42" src="https://user-images.githubusercontent.com/3392497/108704601-240bbc80-7504-11eb-8814-7948768d6804.png">

WWD domain that is unlocked and has privacy disabled (note that there's sometimes a delay caused by the WWD API with regards to disabling privacy protection, so it might just say it's unlocked for a minute or two):

<img width="757" alt="Screenshot 2021-02-22 at 12 21 09" src="https://user-images.githubusercontent.com/3392497/108707813-7b139080-7508-11eb-9033-872301a9c59a.png">

Make sure the links go to the correct views (name server change and contact info edit).