### PR TITLE
Add flash sale coupons to allowed auto-apply list

### DIFF
--- a/client/lib/cart/actions.js
+++ b/client/lib/cart/actions.js
@@ -126,6 +126,8 @@ export function getRememberedCoupon() {
 		'ALT',
 		'FBSAVE15',
 		'FIVERR',
+		'FLASHFB200FF',
+		'FLASHFB500FF',
 		'GENEA',
 		'KITVISA',
 		'LINKEDIN',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add flash sale coupons to allowed auto-apply list

More info: https://wp.me/pau2Xa-2HI

#### Testing instructions

* From the coupon page of network admin, search for the `FLASHFB200FF` coupon.
* Edit it to change the start date to be today or before.
* With a free site, visit http://calypso.localhost:3000/plans?coupon=FLASHFB200FF.
* Choose any paid plan.
* On the checkout page you should see a message that the coupon was successfully applied.
* Edit the coupon again to change the start date back to the original date (2/23/2021).

<img width="1672" alt="Screen Shot 2021-02-11 at 11 58 20 AM" src="https://user-images.githubusercontent.com/690843/107691733-af619400-6c60-11eb-9b64-e147aba12398.png">
