### PR TITLE
E2E: skip gutenboarding test

### DIFF
--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -36,7 +36,7 @@ before( async function () {
 
 describe( 'Gutenboarding: (' + screenSize + ')', function () {
 	this.timeout( mochaTimeOut );
-	describe( 'Create new site as existing user @parallel @canary', function () {
+	describe.skip( 'Create new site as existing user @parallel @canary', function () {
 		const siteTitle = dataHelper.randomPhrase();
 		const domainQuery = dataHelper.randomPhrase();
 		let newSiteDomain = '';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* temporary disable the gutenboarding canary test while we investigate failures

#### Testing instructions

* no more `Failed Test:  Gutenboarding: (mobile) Create new site as existing user`

Related to https://github.com/Automattic/wp-calypso/issues/49466
p1613067244270700-slack-C02DQP0FP