### PR TITLE
Adding WhatsNew data store for more flexible WhatsNew component

### DIFF
--- a/client/components/whats-new/index.js
+++ b/client/components/whats-new/index.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import { useSelect } from '@wordpress/data';
 import { WhatsNewState } from '@automattic/data-stores';
-import Card from '@automattic/components';
 
 /**
  * Internal dependencies
@@ -15,9 +14,9 @@ const WHATS_NEW_STORE = WhatsNewState.register();
 function WhatsNew() {
 	const whatsNewList = useSelect( ( select ) => select( WHATS_NEW_STORE ).getWhatsNewList() );
 	return (
-		<Card>
+		<div>
 			<div>{ JSON.stringify( whatsNewList ) }</div>
-		</Card>
+		</div>
 	);
 }
 

--- a/client/components/whats-new/index.js
+++ b/client/components/whats-new/index.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelect } from '@wordpress/data';
+import { WhatsNewState } from '@automattic/data-stores';
+import Card from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+
+const WHATS_NEW_STORE = WhatsNewState.register();
+
+function WhatsNew() {
+	const whatsNewList = useSelect( ( select ) => select( WHATS_NEW_STORE ).getWhatsNewList() );
+	return (
+		<Card>
+			<div>{ JSON.stringify( whatsNewList ) }</div>
+		</Card>
+	);
+}
+
+export default WhatsNew;

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -25,6 +25,7 @@ import {
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import WhatsNew from 'calypso/components/whats-new';
 
 /**
  * Images
@@ -114,6 +115,8 @@ export const MarketingTools: FunctionComponent = () => {
 			<PageViewTracker path="/marketing/tools/:site" title="Marketing > Tools" />
 
 			<MarketingToolsHeader handleButtonClick={ handleBusinessToolsClick } />
+
+			<WhatsNew />
 
 			<div className="tools__feature-list">
 				<MarketingToolsFeature

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -12,6 +12,7 @@ import * as Launch from './launch';
 import * as WPCOMFeatures from './wpcom-features';
 import * as VerticalsTemplates from './verticals-templates';
 import * as I18n from './i18n';
+import * as WhatsNewState from './whats-new';
 
 export {
 	Auth,
@@ -24,6 +25,7 @@ export {
 	Plans,
 	Launch,
 	WPCOMFeatures,
+	WhatsNewState,
 	persistenceConfigFactory,
 };
 

--- a/packages/data-stores/src/whats-new/actions.ts
+++ b/packages/data-stores/src/whats-new/actions.ts
@@ -1,0 +1,12 @@
+export const toggleModal = () =>
+	( {
+		type: 'TOGGLE_WHATS_NEW',
+	} as const );
+
+export const receiveWhatsNewList = ( list: string ) =>
+	( {
+		type: 'WHATS_NEW_LIST_RECEIVE',
+		list,
+	} as const );
+
+export type Action = ReturnType< typeof toggleModal | typeof receiveWhatsNewList >;

--- a/packages/data-stores/src/whats-new/constants.ts
+++ b/packages/data-stores/src/whats-new/constants.ts
@@ -1,0 +1,1 @@
+export const STORE_KEY = 'automattic/whatsNew';

--- a/packages/data-stores/src/whats-new/index.ts
+++ b/packages/data-stores/src/whats-new/index.ts
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { controls } from '@wordpress/data-controls';
+import { registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY } from './constants';
+import reducer, { State } from './reducer';
+import * as actions from './actions';
+import * as resolvers from './resolvers';
+import * as selectors from './selectors';
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
+
+export type { WhatsNewState } from './types';
+export type { State };
+
+let isRegistered = false;
+export function register(): typeof STORE_KEY {
+	if ( ! isRegistered ) {
+		isRegistered = true;
+		registerStore< State >( STORE_KEY, {
+			actions,
+			controls,
+			reducer: reducer as any,
+			resolvers,
+			selectors,
+		} );
+	}
+	return STORE_KEY;
+}
+
+declare module '@wordpress/data' {
+	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof actions >;
+	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
+}

--- a/packages/data-stores/src/whats-new/reducer.ts
+++ b/packages/data-stores/src/whats-new/reducer.ts
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import type { Reducer } from 'redux';
+import { combineReducers } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import type { WhatsNewState } from './types';
+import type { Action } from './actions';
+
+const whatsNewList: Reducer< WhatsNewState, Action > = ( state = {}, action ) => {
+	if ( action.type === 'WHATS_NEW_LIST_RECEIVE' ) {
+		return {
+			...state,
+			list: action.list,
+		};
+	}
+	return state;
+};
+
+const reducer = combineReducers( { whatsNewList } );
+
+export type State = ReturnType< typeof reducer >;
+
+export default reducer;

--- a/packages/data-stores/src/whats-new/reducer.ts
+++ b/packages/data-stores/src/whats-new/reducer.ts
@@ -10,7 +10,7 @@ import { combineReducers } from '@wordpress/data';
 import type { WhatsNewState } from './types';
 import type { Action } from './actions';
 
-const whatsNewList: Reducer< WhatsNewState, Action > = ( state = {}, action ) => {
+const whatsNewList: Reducer< WhatsNewState | undefined, Action > = ( state = {}, action ) => {
 	if ( action.type === 'WHATS_NEW_LIST_RECEIVE' ) {
 		return {
 			...state,

--- a/packages/data-stores/src/whats-new/reducer.ts
+++ b/packages/data-stores/src/whats-new/reducer.ts
@@ -10,7 +10,7 @@ import { combineReducers } from '@wordpress/data';
 import type { WhatsNewState } from './types';
 import type { Action } from './actions';
 
-const whatsNewList: Reducer< WhatsNewState | undefined, Action > = ( state = {}, action ) => {
+const list: Reducer< WhatsNewState[], Action > = ( state = [], action ) => {
 	if ( action.type === 'WHATS_NEW_LIST_RECEIVE' ) {
 		return {
 			...state,
@@ -20,7 +20,7 @@ const whatsNewList: Reducer< WhatsNewState | undefined, Action > = ( state = {},
 	return state;
 };
 
-const reducer = combineReducers( { whatsNewList } );
+const reducer = combineReducers( { list } );
 
 export type State = ReturnType< typeof reducer >;
 

--- a/packages/data-stores/src/whats-new/resolvers.ts
+++ b/packages/data-stores/src/whats-new/resolvers.ts
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { apiFetch } from '@wordpress/data-controls';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { receiveWhatsNewList } from './actions';
+import { wpcomRequest } from '../wpcom-request-controls';
+import { STORE_KEY } from './constants';
 
 /**
  * Fetch list of active What's New announcements.
@@ -15,8 +16,11 @@ import { receiveWhatsNewList } from './actions';
  * API response.
  */
 export function* getWhatsNewList() {
-	const url = 'https://public-api.wordpress.com/wpcom/v2/whats-new/list';
-	const list = yield apiFetch( { url } );
-
-	return receiveWhatsNewList( list );
+	try {
+		const list = yield wpcomRequest( {
+			path: 'whats-new/list',
+			apiVersion: '2',
+		} );
+		yield dispatch( STORE_KEY ).receiveWhatsNewList( list );
+	} catch ( e ) {}
 }

--- a/packages/data-stores/src/whats-new/resolvers.ts
+++ b/packages/data-stores/src/whats-new/resolvers.ts
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { apiFetch } from '@wordpress/data-controls';
+
+/**
+ * Internal dependencies
+ */
+import { receiveWhatsNewList } from './actions';
+
+/**
+ * Fetch list of active What's New announcements.
+ *
+ * At this time no validation or normalization is happening on the
+ * API response.
+ */
+export function* getWhatsNewList() {
+	const url = 'https://public-api.wordpress.com/wpcom/v2/whats-new/list';
+	const list = yield apiFetch( { url } );
+
+	return receiveWhatsNewList( list );
+}

--- a/packages/data-stores/src/whats-new/selectors.ts
+++ b/packages/data-stores/src/whats-new/selectors.ts
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import type { State } from './reducer';
+
+export const getState = ( state: State ) => state;
+export const getWhatsNewList = ( state: State ) => state.whatsNewList;

--- a/packages/data-stores/src/whats-new/types.ts
+++ b/packages/data-stores/src/whats-new/types.ts
@@ -1,0 +1,6 @@
+/**
+ * Representation of What's New lists
+ */
+export interface WhatsNewState {
+	list?: string;
+}


### PR DESCRIPTION
This is a modified version of the WIP WhatsNew component in [49957](https://github.com/Automattic/wp-calypso/pull/49957) that uses @wordpress/data and @automattic/data-stores. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
