### PR TITLE
Add commit URL to ETK build

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1208,7 +1208,6 @@ object WPComPlugins_EditorToolKit : BuildType({
 	artifactRules = "editing-toolkit.zip"
 
 	buildNumberPattern = "%build.prefix%.%build.counter%"
-
 	params {
 		param("build.prefix", "3")
 	}
@@ -1329,7 +1328,11 @@ object WPComPlugins_EditorToolKit : BuildType({
 				cd editing-toolkit-plugin/
 
 				# Metadata file with info for the download script.
-				echo -e "commit_hash=%build.vcs.number%\nbuild_number=%build.number%\n" > build_meta.txt
+				tee build_meta.txt <<-EOM
+					commit_hash=%build.vcs.number%
+					commit_url=https://github.com/Automattic/wp-calypso/commit/%build.vcs.number%
+					build_number=%build.number%
+					EOM
 
 				zip -r ../../../editing-toolkit.zip .
 			""".trimIndent()

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -39,6 +39,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+View the commit history here: https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit
 
 = 2.18 =
 * Introduces a "What's New" dialogue for the editor. (https://github.com/Automattic/wp-calypso/pull/48722)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds the commit URL to the ETK build. This is so that the download script can add it to phabricator, and we link back to the original commit from svn.

#### Testing instructions
1. Download the editing toolkit artifact from the TC build
2. Open the build_meta.txt file
3. Verify the field `commit_url` is populated correctly.
