### PR TITLE
Enable GitHub Actions stale bot for wp-calypso repository

### DIFF
--- a/.github/workflows/mark-issue-stale.yml
+++ b/.github/workflows/mark-issue-stale.yml
@@ -1,8 +1,8 @@
 
-name: 'Close stale issues and PR'
+name: 'Mark stale issues'
 on:
   schedule:
-    - cron: '30 * * * *'
+    - cron: '30 0 * * *'
 
 jobs:
   stale:
@@ -12,11 +12,11 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue is stale because it has been 180 days with no activity. You can keep the issue open by adding a comment. If you do, please provide additional context and explain why you’d like it to remain open. You can also close the issue yourself — if you do, please add a brief explanation and apply one of relevant issue close labels.'
+          # Days before issue is considered stale.
           days-before-stale: 180
+          # Exempt issue labels.
           exempt-issue-labels: '[Pri] High,[Pri] BLOCKER,[Status] Keep Open'
           # Disable auto-close of both issues and PRs.
           days-before-close: -1
-          # Dry run
-          debug-only: true
-          # Get issues in ascending order.
+          # Get issues in ascending (oldest first) order.
           ascending: true


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- enable run for repository by removing `debug-only: true` marker
- change to run once per day at 00:30Z instead of every hour

#### Note

GitHub Actions based stale bot does not currently have provision to exempt issues with `project` or `milestone` attached to it, unlike [probot/stale](https://github.com/probot/stale).

If this is merged, I would expect a lot of abandoned issues with projects/milestones attached to be marked as stale.
I anticipate a reasonably sized proportion of the issue owners will object to this assessment.

If we do not want to impact issues with `project/milestones` attached, it may be worthwhile to wait until [this PR](https://github.com/actions/stale/issues/283) is landed.

#### Testing instructions

Monitor [this link](https://github.com/Automattic/wp-calypso/actions?query=workflow%3A%22Close+stale+issues+and+PR%22).