### PR TITLE
Disable jsx-a11y/no-onchange lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -263,6 +263,10 @@ module.exports = {
 		// i18n-calypso translate triggers false failures
 		'jsx-a11y/anchor-has-content': 'off',
 
+		// Deprecated rule, the problems using <select> with keyboards this addressed don't appear to be an issue anymore
+		// https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/398
+		'jsx-a11y/no-onchange': 'off',
+
 		'no-restricted-imports': [
 			2,
 			{

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-onchange */
-
 /**
  * External dependencies
  */

--- a/client/components/forms/form-country-select/index.jsx
+++ b/client/components/forms/form-country-select/index.jsx
@@ -17,7 +17,6 @@ import FormSelect from 'calypso/components/forms/form-select';
  */
 import './style.scss';
 
-/* eslint-disable jsx-a11y/no-onchange */
 export class FormCountrySelect extends Component {
 	static propTypes = {
 		countriesList: PropTypes.array.isRequired,
@@ -74,6 +73,5 @@ export class FormCountrySelect extends Component {
 		);
 	}
 }
-/* eslint-enable jsx-a11y/no-onchange */
 
 export default localize( FormCountrySelect );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
@@ -204,7 +204,6 @@ function EbanxTefFields() {
 function BankSelector( { id, value, onChange, label, isError, errorMessage, disabled } ) {
 	const { __ } = useI18n();
 	const bankOptions = getBankOptions( __ );
-	/* eslint-disable jsx-a11y/no-onchange */
 	return (
 		<SelectWrapper>
 			<label htmlFor={ id } disabled={ disabled }>
@@ -223,7 +222,6 @@ function BankSelector( { id, value, onChange, label, isError, errorMessage, disa
 			<ErrorMessage isError={ isError } errorMessage={ errorMessage } />
 		</SelectWrapper>
 	);
-	/* eslint-enable jsx-a11y/no-onchange */
 }
 
 function BankOption( { value, label } ) {

--- a/client/my-sites/google-my-business/stats/chart.js
+++ b/client/my-sites/google-my-business/stats/chart.js
@@ -97,7 +97,6 @@ function getAggregation( props ) {
 }
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/* eslint-disable jsx-a11y/no-onchange */
 
 class GoogleMyBusinessStatsChart extends Component {
 	static propTypes = {
@@ -311,7 +310,6 @@ class GoogleMyBusinessStatsChart extends Component {
 	}
 }
 /* eslint-enable wpcalypso/jsx-classname-namespace */
-/* eslint-enable jsx-a11y/no-onchange */
 
 export default connect(
 	( state, ownProps ) => {

--- a/client/my-sites/marketing/connections/mailchimp-settings.jsx
+++ b/client/my-sites/marketing/connections/mailchimp-settings.jsx
@@ -92,7 +92,6 @@ const MailchimpSettings = ( {
 		);
 	}
 
-	/* eslint-disable jsx-a11y/no-onchange */
 	return (
 		<div>
 			<QueryMailchimpLists siteId={ siteId } />
@@ -132,7 +131,6 @@ const MailchimpSettings = ( {
 			{ common }
 		</div>
 	);
-	/* eslint-enable jsx-a11y/no-onchange */
 };
 
 export const renderMailchimpLogo = () => (

--- a/packages/composite-checkout/src/lib/payment-methods/ideal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/ideal.js
@@ -118,7 +118,6 @@ function IdealFields() {
 function BankSelector( { id, value, onChange, label, isError, errorMessage, disabled } ) {
 	const { __ } = useI18n();
 	const bankOptions = getBankOptions( __ );
-	/* eslint-disable jsx-a11y/no-onchange */
 	return (
 		<SelectWrapper>
 			<label htmlFor={ id } disabled={ disabled }>
@@ -137,7 +136,6 @@ function BankSelector( { id, value, onChange, label, isError, errorMessage, disa
 			<ErrorMessage isError={ isError } errorMessage={ errorMessage } />
 		</SelectWrapper>
 	);
-	/* eslint-enable jsx-a11y/no-onchange */
 }
 
 function BankOption( { value, label } ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable the `jsx-a11y/no-onchange` lint rule
* Remove instances where this had been explicitly disabled

As outlined in jsx-eslint/eslint-plugin-jsx-a11y#398, the rule is no longer relevant. It goes against the official React docs and keyboard navigation in `<select>` controls works fine using the `onChange` prop. The issue was in browsers older than IE 11.

I believe the issue was that pressing the down key while moving through the options would immediately call `onChange`, which a React dev would probably use to set some state that could cause all sort of DOM changes, perhaps even making it impossible to make the selection you want.

The rule was removed from the `jsx-a11y/recommended` list in jsx-eslint/eslint-plugin-jsx-a11y#757 which will be shipped in a future release. I just wanted to get ahead of that release because I'm working on a PR that uses `<select>` now and discovered the warning wasn't doing anything useful.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* CI should pass, no lint warnings.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

