### PR TITLE
reduxify(account): remove `userSettings` from community translator related code

### DIFF
--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -12,8 +12,8 @@ import { connect } from 'react-redux';
  */
 import Translatable from './translatable';
 import languages from '@automattic/languages';
-import userSettings from 'calypso/lib/user-settings';
 import isCommunityTranslatorEnabled from 'calypso/state/selectors/is-community-translator-enabled';
+import { fetchUserSettings } from 'calypso/state/user-settings/actions';
 
 /**
  * Style dependencies
@@ -31,6 +31,7 @@ class CommunityTranslator extends Component {
 	initialized = false;
 
 	componentDidMount() {
+		this.props.fetchUserSettings();
 		this.setLanguage();
 
 		// wrap translations from i18n
@@ -42,12 +43,10 @@ class CommunityTranslator extends Component {
 		// the callback is overwritten by the translator on load/unload, so we're returning it within an anonymous function.
 		i18n.registerComponentUpdateHook( () => {} );
 		i18n.on( 'change', this.refresh );
-		userSettings.on( 'change', this.refresh );
 	}
 
 	componentWillUnmount() {
 		i18n.off( 'change', this.refresh );
-		userSettings.removeListener( 'change', this.refresh );
 	}
 
 	setLanguage() {
@@ -63,11 +62,6 @@ class CommunityTranslator extends Component {
 
 	refresh = () => {
 		if ( this.initialized ) {
-			return;
-		}
-
-		if ( ! userSettings.getSettings() ) {
-			debug( 'initialization failed because userSettings are not ready' );
 			return;
 		}
 
@@ -163,6 +157,9 @@ class CommunityTranslator extends Component {
 	}
 }
 
-export default connect( ( state ) => ( {
-	isCommunityTranslatorEnabled: isCommunityTranslatorEnabled( state ),
-} ) )( localize( CommunityTranslator ) );
+export default connect(
+	( state ) => ( {
+		isCommunityTranslatorEnabled: isCommunityTranslatorEnabled( state ),
+	} ),
+	{ fetchUserSettings }
+)( localize( CommunityTranslator ) );

--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import i18n, { localize } from 'i18n-calypso';
 import debugModule from 'debug';
 import { find, isEmpty } from 'lodash';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ import { find, isEmpty } from 'lodash';
 import Translatable from './translatable';
 import languages from '@automattic/languages';
 import userSettings from 'calypso/lib/user-settings';
-import { isCommunityTranslatorEnabled } from 'calypso/components/community-translator/utils';
+import isCommunityTranslatorEnabled from 'calypso/state/selectors/is-community-translator-enabled';
 
 /**
  * Style dependencies
@@ -70,7 +71,7 @@ class CommunityTranslator extends Component {
 			return;
 		}
 
-		if ( ! isCommunityTranslatorEnabled() ) {
+		if ( ! this.props.isCommunityTranslatorEnabled ) {
 			debug( 'not initializing, not enabled' );
 			return;
 		}
@@ -95,7 +96,7 @@ class CommunityTranslator extends Component {
 	 * @returns {object} DOM object
 	 */
 	wrapTranslation( originalFromPage, displayedTranslationFromPage, optionsFromPage ) {
-		if ( ! isCommunityTranslatorEnabled() ) {
+		if ( ! this.props.isCommunityTranslatorEnabled ) {
 			return displayedTranslationFromPage;
 		}
 
@@ -162,4 +163,6 @@ class CommunityTranslator extends Component {
 	}
 }
 
-export default localize( CommunityTranslator );
+export default connect( ( state ) => ( {
+	isCommunityTranslatorEnabled: isCommunityTranslatorEnabled( state ),
+} ) )( localize( CommunityTranslator ) );

--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -13,7 +13,7 @@ import { connect } from 'react-redux';
 import Translatable from './translatable';
 import languages from '@automattic/languages';
 import isCommunityTranslatorEnabled from 'calypso/state/selectors/is-community-translator-enabled';
-import { fetchUserSettings } from 'calypso/state/user-settings/actions';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
 
 /**
  * Style dependencies
@@ -31,7 +31,6 @@ class CommunityTranslator extends Component {
 	initialized = false;
 
 	componentDidMount() {
-		this.props.fetchUserSettings();
 		this.setLanguage();
 
 		// wrap translations from i18n
@@ -153,13 +152,10 @@ class CommunityTranslator extends Component {
 	}
 
 	render() {
-		return null;
+		return <QueryUserSettings />;
 	}
 }
 
-export default connect(
-	( state ) => ( {
-		isCommunityTranslatorEnabled: isCommunityTranslatorEnabled( state ),
-	} ),
-	{ fetchUserSettings }
-)( localize( CommunityTranslator ) );
+export default connect( ( state ) => ( {
+	isCommunityTranslatorEnabled: isCommunityTranslatorEnabled( state ),
+} ) )( localize( CommunityTranslator ) );

--- a/client/components/community-translator/test/utils.js
+++ b/client/components/community-translator/test/utils.js
@@ -20,11 +20,6 @@ jest.mock( '@automattic/viewport', () => ( {
 	isMobile: jest.fn(),
 } ) );
 
-jest.mock( 'calypso/lib/user-settings', () => ( {
-	getSetting: jest.fn(),
-	getOriginalSetting: jest.fn(),
-} ) );
-
 // see: `languages` array in config/_shared.json
 const languagesMock = [
 	{

--- a/client/components/community-translator/test/utils.js
+++ b/client/components/community-translator/test/utils.js
@@ -9,11 +9,7 @@ import { isMobile } from '@automattic/viewport';
 /**
  * Internal dependencies
  */
-import {
-	canDisplayCommunityTranslator,
-	getTranslationPermaLink,
-	normalizeDetailsFromTranslationData,
-} from '../utils';
+import { getTranslationPermaLink, normalizeDetailsFromTranslationData } from '../utils';
 import {
 	GP_PROJECT,
 	GP_BASE_URL,
@@ -69,27 +65,6 @@ const mockGpApiResponseItem = {
 describe( 'Community Translator', () => {
 	afterEach( () => {
 		isMobile.mockReset();
-	} );
-	describe( 'canDisplayCommunityTranslator()', () => {
-		test( 'should display community translator in non-mobile and non-en locale', () => {
-			isMobile.mockReturnValue( false );
-			expect( canDisplayCommunityTranslator( 'it', '' ) ).toBe( true );
-		} );
-
-		test( 'should not display community translator in non-mobile and en locale', () => {
-			isMobile.mockReturnValue( false );
-			expect( canDisplayCommunityTranslator( 'en', '' ) ).toBe( false );
-		} );
-
-		test( 'should not display community translator in mobile', () => {
-			isMobile.mockReturnValue( true );
-			expect( canDisplayCommunityTranslator( 'de', '' ) ).toBe( false );
-		} );
-
-		test( 'should not display community translator when locale is not defined', () => {
-			isMobile.mockReturnValue( false );
-			expect( canDisplayCommunityTranslator( undefined ) ).toBe( false );
-		} );
 	} );
 
 	describe( 'getTranslationPermaLink()', () => {

--- a/client/components/community-translator/utils.js
+++ b/client/components/community-translator/utils.js
@@ -1,72 +1,17 @@
 /**
  * External dependencies
  */
-import { isMobile } from '@automattic/viewport';
 import { head, find, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import userSettings from 'calypso/lib/user-settings';
 import { postRequest } from 'calypso/lib/i18n-utils/glotpress';
 import {
 	GP_PROJECT,
 	GP_BASE_URL,
 	GP_PROJECT_TRANSLATION_SET_SLUGS,
-	ENABLE_TRANSLATOR_KEY,
 } from 'calypso/lib/i18n-utils/constants';
-import { canBeTranslated } from 'calypso/lib/i18n-utils';
-
-/**
- * Checks whether the CT can be displayed, that is, if the chosen locale and device allow it
- *
- * @param {string} locale user's localeSlug
- * @param {object} localeVariant user's localeVariant slug (if any)
- * @returns {boolean} whether the CT can be displayed
- */
-export function canDisplayCommunityTranslator(
-	locale = userSettings.getSetting( 'language' ),
-	localeVariant = userSettings.getSetting( 'locale_variant' )
-) {
-	// restrict mobile devices from translator for now while we refine touch interactions
-	if ( isMobile() ) {
-		return false;
-	}
-
-	// disable for locales with no official GP translation sets.
-	if ( ! locale || ! canBeTranslated( locale ) ) {
-		return false;
-	}
-
-	// likewise, disable for locale variants with no official GP translation sets
-	if ( localeVariant && ! canBeTranslated( localeVariant ) ) {
-		return false;
-	}
-
-	return true;
-}
-
-/**
- * Checks whether the CT is enabled, that is, if
- * 1) the user has chosen to enable it,
- * 2) it can be displayed based on the user's language and device settings
- *
- * @returns {Bool} whether the CT should be enabled
- */
-export function isCommunityTranslatorEnabled() {
-	if (
-		! userSettings.getSettings() ||
-		! userSettings.getOriginalSetting( ENABLE_TRANSLATOR_KEY )
-	) {
-		return false;
-	}
-
-	if ( ! canDisplayCommunityTranslator() ) {
-		return false;
-	}
-
-	return true;
-}
 
 /**
  * Prepares and triggers a request to get GP string

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -32,7 +32,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import KeyboardShortcutsMenu from 'calypso/lib/keyboard-shortcuts/menu';
 import SupportUser from 'calypso/support/support-user';
-import { isCommunityTranslatorEnabled } from 'calypso/components/community-translator/utils';
+import isCommunityTranslatorEnabled from 'calypso/state/selectors/is-community-translator-enabled';
 import { isE2ETest } from 'calypso/lib/e2e';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import BodySectionCssClass from './body-section-css-class';
@@ -265,7 +265,7 @@ class Layout extends Component {
 					</div>
 				</div>
 				{ config.isEnabled( 'i18n/community-translator' )
-					? isCommunityTranslatorEnabled() && (
+					? this.props.isCommunityTranslatorEnabled && (
 							<AsyncLoad require="calypso/components/community-translator" />
 					  )
 					: config( 'restricted_me_access' ) && (
@@ -347,6 +347,7 @@ export default compose(
 			isJetpackWooDnaFlow,
 			isJetpackMobileFlow,
 			isEligibleForJITM,
+			isCommunityTranslatorEnabled: isCommunityTranslatorEnabled( state ),
 			oauth2Client,
 			wccomFrom,
 			isSupportSession: isSupportSession( state ),

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -46,7 +46,7 @@ import { getLanguage, isLocaleVariant, canBeTranslated } from 'calypso/lib/i18n-
 import isRequestingMissingSites from 'calypso/state/selectors/is-requesting-missing-sites';
 import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { canDisplayCommunityTranslator } from 'calypso/components/community-translator/utils';
+import canDisplayCommunityTranslator from 'calypso/state/selectors/can-display-community-translator';
 import { ENABLE_TRANSLATOR_KEY } from 'calypso/lib/i18n-utils/constants';
 import AccountSettingsCloseLink from './close-link';
 import { requestGeoLocation } from 'calypso/state/data-getters';
@@ -1056,8 +1056,7 @@ const Account = createReactClass( {
 							{ this.thankTranslationContributors() }
 						</FormFieldset>
 
-						{ canDisplayCommunityTranslator( this.getUserSetting( 'language' ) ) &&
-							this.communityTranslator() }
+						{ this.props.canDisplayCommunityTranslator && this.communityTranslator() }
 
 						{ config.isEnabled( 'nav-unification' ) && (
 							<FormFieldset className="account__link-destination">
@@ -1106,12 +1105,13 @@ const Account = createReactClass( {
 export default compose(
 	connect(
 		( state ) => ( {
-			requestingMissingSites: isRequestingMissingSites( state ),
+			canDisplayCommunityTranslator: canDisplayCommunityTranslator( state ),
 			countryCode: requestGeoLocation().data,
 			currentUserDate: getCurrentUserDate( state ),
 			currentUserDisplayName: getCurrentUserDisplayName( state ),
 			currentUserName: getCurrentUserName( state ),
 			isPendingEmailChange: isPendingEmailChange( state ),
+			requestingMissingSites: isRequestingMissingSites( state ),
 			userSettings: getUserSettings( state ),
 			unsavedUserSettings: getUnsavedUserSettings( state ),
 			visibleSiteCount: getCurrentUserVisibleSiteCount( state ),

--- a/client/state/selectors/can-display-community-translator.js
+++ b/client/state/selectors/can-display-community-translator.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { isMobile } from '@automattic/viewport';
+
+/**
+ * Internal dependencies
+ */
+import { canBeTranslated } from 'calypso/lib/i18n-utils';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
+
+/**
+ * Checks whether the CT can be displayed, that is, if the chosen locale and device allow it
+ *
+ * @param {object} state Global state tree
+ * @returns {boolean} whether the CT can be displayed
+ */
+export default function canDisplayCommunityTranslator( state ) {
+	const language = getUserSetting( state, 'language' );
+	const localeVariant = getUserSetting( state, 'locale_variant' );
+
+	// restrict mobile devices from translator for now while we refine touch interactions
+	if ( isMobile() ) {
+		return false;
+	}
+
+	// disable for locales with no official GP translation sets.
+	if ( ! language || ! canBeTranslated( language ) ) {
+		return false;
+	}
+
+	// likewise, disable for locale variants with no official GP translation sets
+	if ( localeVariant && ! canBeTranslated( localeVariant ) ) {
+		return false;
+	}
+
+	return true;
+}

--- a/client/state/selectors/is-community-translator-enabled.js
+++ b/client/state/selectors/is-community-translator-enabled.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import { ENABLE_TRANSLATOR_KEY } from 'calypso/lib/i18n-utils/constants';
+import canDisplayCommunityTranslator from 'calypso/state/selectors/can-display-community-translator';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
+
+/**
+ * Checks whether the CT is enabled, that is, if
+ * 1) the user has chosen to enable it,
+ * 2) it can be displayed based on the user's language and device settings
+ *
+ * @param {object} state Global state tree
+ * @returns {boolean} whether the CT should be enabled
+ */
+export default function isCommunityTranslatorEnabled( state ) {
+	const enableTranslator = getUserSetting( state, ENABLE_TRANSLATOR_KEY );
+
+	if ( ! enableTranslator ) {
+		return false;
+	}
+
+	if ( ! canDisplayCommunityTranslator( state ) ) {
+		return false;
+	}
+
+	return true;
+}

--- a/client/state/selectors/test/can-display-community-translator.js
+++ b/client/state/selectors/test/can-display-community-translator.js
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * External dependencies
+ */
+import { isMobile } from '@automattic/viewport';
+
+/**
+ * Internal dependencies
+ */
+import canDisplayCommunityTranslator from '../can-display-community-translator';
+
+jest.mock( '@automattic/viewport', () => ( {
+	isMobile: jest.fn(),
+} ) );
+
+describe( 'canDisplayCommunityTranslator()', () => {
+	test( 'should display community translator in non-mobile and non-en locale', () => {
+		isMobile.mockReturnValue( false );
+		const state = { userSettings: { settings: { language: 'it' } } };
+		expect( canDisplayCommunityTranslator( state ) ).toBe( true );
+	} );
+
+	test( 'should not display community translator in non-mobile and en locale', () => {
+		isMobile.mockReturnValue( false );
+		const state = { userSettings: { settings: { language: 'en' } } };
+		expect( canDisplayCommunityTranslator( state ) ).toBe( false );
+	} );
+
+	test( 'should not display community translator in mobile', () => {
+		isMobile.mockReturnValue( true );
+		const state = { userSettings: { settings: { language: 'de' } } };
+		expect( canDisplayCommunityTranslator( state ) ).toBe( false );
+	} );
+
+	test( 'should not display community translator when locale is not defined', () => {
+		isMobile.mockReturnValue( false );
+		const state = { userSettings: {} };
+		expect( canDisplayCommunityTranslator( state ) ).toBe( false );
+	} );
+
+	test( `should not display community translator if locale variant can't be translated`, () => {
+		isMobile.mockReturnValue( false );
+		const state = { userSettings: { settings: { language: 'sr', locale_variant: 'sr_latin' } } };
+		expect( canDisplayCommunityTranslator( state ) ).toBe( false );
+	} );
+
+	test( 'should display community translator when locale is defined but still unsaved', () => {
+		isMobile.mockReturnValue( false );
+		const state = {
+			userSettings: {
+				settings: { language: 'en' },
+				unsavedSettings: { language: 'de' },
+			},
+		};
+		expect( canDisplayCommunityTranslator( state ) ).toBe( true );
+	} );
+} );

--- a/client/state/selectors/test/is-community-translator-enabled.js
+++ b/client/state/selectors/test/is-community-translator-enabled.js
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import isCommunityTranslatorEnabled from '../is-community-translator-enabled';
+import canDisplayCommunityTranslator from 'calypso/state/selectors/can-display-community-translator';
+
+jest.mock( 'calypso/state/selectors/can-display-community-translator', () => jest.fn() );
+
+describe( 'isCommunityTranslatorEnabled()', () => {
+	test( 'should return `false` if translator is not enabled', () => {
+		canDisplayCommunityTranslator.mockReturnValue( true );
+		const state = {
+			userSettings: {
+				settings: {
+					enable_translator: false,
+				},
+			},
+		};
+		expect( isCommunityTranslatorEnabled( state ) ).toBe( false );
+	} );
+
+	test( 'should return `true` if translator is enabled and language is translatable', () => {
+		canDisplayCommunityTranslator.mockReturnValue( true );
+		const state = {
+			userSettings: {
+				settings: {
+					enable_translator: true,
+				},
+			},
+		};
+		expect( isCommunityTranslatorEnabled( state ) ).toBe( true );
+	} );
+
+	test( 'should return `false` if translator is enabled but language is not translatable', () => {
+		canDisplayCommunityTranslator.mockReturnValue( false );
+		const state = {
+			userSettings: {
+				settings: {
+					enable_translator: true,
+				},
+			},
+		};
+		expect( isCommunityTranslatorEnabled( state ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
This PR takes care of the removal of `lib/user-settings` in code which was introduced by https://github.com/Automattic/wp-calypso/pull/21591. That component is not activated throughout Calypso though so when testing we mostly make sure we don't break existing functionality.

To prevent confusion, there's a Community Translator component and there's a Community Translator Launcher. The latter is actively used in Calypso.

Please note https://github.com/Automattic/wp-calypso/pull/50029 which merges into this PR!

#### Changes proposed in this Pull Request

* Extract `isCommunityTranslatorEnabled` from `components/community-translator/utils` into selector space
* Extract `canDisplayCommunityTranslator` from `components/community-translator/utils` into selector space
* Use newly created selectors in `/me/account` and `layout` and remove old code

#### Testing instructions

* Go to `/me/account` and make sure the following applies:
  * Language set to EN: you don't see an option to activate the community translator
  * Language set to SR: you don't see an option to activate the community translator
  * Language set to DE (or any other except for EN/SR): you see an option to activate the community translator

<img width="510" alt="Screenshot 2021-02-12 at 10 42 37" src="https://user-images.githubusercontent.com/9202899/107752443-07f76680-6d1f-11eb-9676-444aca4c35e4.png">

I'm not really sure how to test `isCommunityTranslatorEnabled` because the `<CommunityTranslator />` component is not activated in any environment. You can verify, however, that the Community Translator Launcher still appears as expected (see screenshot below)

<img width="236" alt="Screenshot 2021-02-12 at 10 45 13" src="https://user-images.githubusercontent.com/9202899/107752722-6fadb180-6d1f-11eb-9eac-35fc2e1aec3e.png">



Related to #24162
