### PR TITLE
Add quantity summary to billing purchase history when available

### DIFF
--- a/client/me/purchases/billing-history/billing-history-list.jsx
+++ b/client/me/purchases/billing-history/billing-history-list.jsx
@@ -86,6 +86,9 @@ class BillingHistoryList extends React.Component {
 					<strong>{ transaction.plan }</strong>
 					<small>{ transaction.domain }</small>
 					{ termLabel ? <small>{ termLabel }</small> : null }
+					{ transaction.product_quantity_summary && (
+						<small>{ transaction.product_quantity_summary }</small>
+					) }
 				</div>
 			);
 		} else {

--- a/client/me/purchases/billing-history/billing-history-list.jsx
+++ b/client/me/purchases/billing-history/billing-history-list.jsx
@@ -15,7 +15,12 @@ import { capitalPDangit } from 'calypso/lib/formatting';
 import { CompactCard } from '@automattic/components';
 import Pagination from 'calypso/components/pagination';
 import BillingHistoryFilters from 'calypso/me/purchases/billing-history/billing-history-filters';
-import { getTransactionTermLabel, groupDomainProducts, renderTransactionAmount } from './utils';
+import {
+	getTransactionTermLabel,
+	groupDomainProducts,
+	renderTransactionAmount,
+	renderTransactionQuantitySummary,
+} from './utils';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { setPage } from 'calypso/state/billing-transactions/ui/actions';
 import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-transaction-filters';
@@ -86,8 +91,8 @@ class BillingHistoryList extends React.Component {
 					<strong>{ transaction.plan }</strong>
 					<small>{ transaction.domain }</small>
 					{ termLabel ? <small>{ termLabel }</small> : null }
-					{ transaction.product_quantity_summary && (
-						<small>{ transaction.product_quantity_summary }</small>
+					{ transaction.licensed_quantity && (
+						<small>{ renderTransactionQuantitySummary( transaction, this.props.translate ) }</small>
 					) }
 				</div>
 			);

--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -19,7 +19,12 @@ import { withLocalizedMoment, useLocalizedMoment } from 'calypso/components/loca
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { billingHistory } from 'calypso/me/purchases/paths';
 import QueryBillingTransaction from 'calypso/components/data/query-billing-transaction';
-import { getTransactionTermLabel, groupDomainProducts, renderTransactionAmount } from './utils';
+import {
+	getTransactionTermLabel,
+	groupDomainProducts,
+	renderTransactionAmount,
+	renderTransactionQuantitySummary,
+} from './utils';
 import getPastBillingTransaction from 'calypso/state/selectors/get-past-billing-transaction';
 import isPastBillingTransactionError from 'calypso/state/selectors/is-past-billing-transaction-error';
 import {
@@ -199,7 +204,9 @@ function ReceiptLineItems( { transaction } ) {
 					{ termLabel ? <em>{ termLabel }</em> : null }
 					<br />
 					<em>{ item.domain }</em>
-					{ item.product_quantity_summary && <em>{ item.product_quantity_summary }</em> }
+					{ item.licensed_quantity && (
+						<em>{ renderTransactionQuantitySummary( item, translate ) }</em>
+					) }
 				</td>
 				<td className={ 'billing-history__receipt-amount ' + transaction.credit }>
 					{ item.amount }

--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -199,6 +199,7 @@ function ReceiptLineItems( { transaction } ) {
 					{ termLabel ? <em>{ termLabel }</em> : null }
 					<br />
 					<em>{ item.domain }</em>
+					{ item.product_quantity_summary && <em>{ item.product_quantity_summary }</em> }
 				</td>
 				<td className={ 'billing-history__receipt-amount ' + transaction.credit }>
 					{ item.amount }

--- a/client/me/purchases/billing-history/utils.jsx
+++ b/client/me/purchases/billing-history/utils.jsx
@@ -9,6 +9,7 @@ import formatCurrency from '@automattic/format-currency';
  * Internal dependencies
  */
 import { getPlanTermLabel } from 'calypso/lib/plans';
+import { isGoogleWorkspace, isTitanMail } from 'calypso/lib/products-values';
 
 export const groupDomainProducts = ( originalItems, translate ) => {
 	const transactionItems = Object.keys( originalItems ).map( ( key ) => {
@@ -80,6 +81,133 @@ export function renderTransactionAmount( transaction, { translate, addingTax = f
 			<div className="billing-history__transaction-tax-amount">{ taxAmount }</div>
 		</Fragment>
 	);
+}
+
+function renderTransactionQuantitySummaryForTitanMail(
+	licensed_quantity,
+	new_quantity,
+	isRenewal,
+	isUpgrade,
+	translate
+) {
+	if ( isRenewal ) {
+		return translate( 'Renewal for %(quantity)s mailbox', 'Renewal for %(quantity)s mailboxes', {
+			args: { quantity: licensed_quantity },
+			count: licensed_quantity,
+			context: 'Renewal description with number of mailboxes renewed',
+			comment: '%(quantity)s is number of mailboxes renewed',
+		} );
+	}
+
+	if ( isUpgrade ) {
+		return translate(
+			'Purchase of %(quantity)s new mailbox',
+			'Purchase of %(quantity)s new mailboxes',
+			{
+				args: { quantity: new_quantity },
+				count: new_quantity,
+				context: 'Purchase description with additional number of mailboxes purchased',
+				comment: '%(quantity)s is additional number of mailboxes purchased',
+			}
+		);
+	}
+
+	return translate( 'Purchase of %(quantity)s mailbox', 'Purchase of %(quantity)s mailboxes', {
+		args: { quantity: licensed_quantity },
+		count: licensed_quantity,
+		context: 'Purchase description with number of mailboxes purchased',
+		comment: '%(quantity)s is number of mailboxes purchased',
+	} );
+}
+
+function renderTransactionQuantitySummaryForGoogleWorkspace(
+	licensed_quantity,
+	new_quantity,
+	isRenewal,
+	isUpgrade,
+	translate
+) {
+	if ( isRenewal ) {
+		return translate( 'Renewal for %(quantity)s user', 'Renewal for %(quantity)s users', {
+			args: { quantity: licensed_quantity },
+			count: licensed_quantity,
+			context: 'Renewal description with number of users renewed',
+			comment: '%(quantity)s is number of users renewed',
+		} );
+	}
+
+	if ( isUpgrade ) {
+		return translate( 'Purchase of %(quantity)s new user', 'Purchase of %(quantity)s new users', {
+			args: { quantity: new_quantity },
+			count: new_quantity,
+			context: 'Purchase description with additional number of users purchased',
+			comment: '%(quantity)s is additional number of users purchased',
+		} );
+	}
+
+	return translate( 'Purchase of %(quantity)s user', 'Purchase of %(quantity)s users', {
+		args: { quantity: licensed_quantity },
+		count: licensed_quantity,
+		context: 'Purchase description with number of users purchased',
+		comment: '%(quantity)s is number of users purchased',
+	} );
+}
+
+export function renderTransactionQuantitySummary(
+	{ licensed_quantity, new_quantity, type, wpcom_product_slug },
+	translate
+) {
+	if ( ! licensed_quantity ) {
+		return null;
+	}
+
+	licensed_quantity = parseInt( licensed_quantity );
+	new_quantity = parseInt( new_quantity );
+	const product = { product_slug: wpcom_product_slug };
+	const isRenewal = 'recurring' === type;
+	const isUpgrade = 'new purchase' === type && new_quantity > 0;
+
+	if ( isTitanMail( product ) ) {
+		return renderTransactionQuantitySummaryForTitanMail(
+			licensed_quantity,
+			new_quantity,
+			isRenewal,
+			isUpgrade,
+			translate
+		);
+	} else if ( isGoogleWorkspace( product ) ) {
+		return renderTransactionQuantitySummaryForGoogleWorkspace(
+			licensed_quantity,
+			new_quantity,
+			isRenewal,
+			isUpgrade,
+			translate
+		);
+	}
+	if ( isRenewal ) {
+		return translate( 'Renewal for %(quantity)s item', 'Renewal for %(quantity)s items', {
+			args: { quantity: licensed_quantity },
+			count: licensed_quantity,
+			context: 'Renewal description with number of items renewed',
+			comment: '%(quantity)s is number of items renewed',
+		} );
+	}
+
+	if ( isUpgrade ) {
+		return translate( 'Purchase of %(quantity)s new item', 'Purchase of %(quantity)s new items', {
+			args: { quantity: new_quantity },
+			count: new_quantity,
+			context: 'Purchase description with additional number of items purchased',
+			comment: '%(quantity)s is additional number of items purchased',
+		} );
+	}
+
+	return translate( 'Purchase of %(quantity)s item', 'Purchase of %(quantity)s items', {
+		args: { quantity: licensed_quantity },
+		count: licensed_quantity,
+		context: 'Purchase description with number of items purchased',
+		comment: '%(quantity)s is number of items purchased',
+	} );
 }
 
 export function getTransactionTermLabel( transaction, translate ) {

--- a/client/me/purchases/billing-history/utils.jsx
+++ b/client/me/purchases/billing-history/utils.jsx
@@ -94,7 +94,6 @@ function renderTransactionQuantitySummaryForTitanMail(
 		return translate( 'Renewal for %(quantity)s mailbox', 'Renewal for %(quantity)s mailboxes', {
 			args: { quantity: licensed_quantity },
 			count: licensed_quantity,
-			context: 'Renewal description with number of mailboxes renewed',
 			comment: '%(quantity)s is number of mailboxes renewed',
 		} );
 	}
@@ -106,7 +105,6 @@ function renderTransactionQuantitySummaryForTitanMail(
 			{
 				args: { quantity: new_quantity },
 				count: new_quantity,
-				context: 'Purchase description with additional number of mailboxes purchased',
 				comment: '%(quantity)s is additional number of mailboxes purchased',
 			}
 		);
@@ -115,7 +113,6 @@ function renderTransactionQuantitySummaryForTitanMail(
 	return translate( 'Purchase of %(quantity)s mailbox', 'Purchase of %(quantity)s mailboxes', {
 		args: { quantity: licensed_quantity },
 		count: licensed_quantity,
-		context: 'Purchase description with number of mailboxes purchased',
 		comment: '%(quantity)s is number of mailboxes purchased',
 	} );
 }
@@ -131,7 +128,6 @@ function renderTransactionQuantitySummaryForGoogleWorkspace(
 		return translate( 'Renewal for %(quantity)s user', 'Renewal for %(quantity)s users', {
 			args: { quantity: licensed_quantity },
 			count: licensed_quantity,
-			context: 'Renewal description with number of users renewed',
 			comment: '%(quantity)s is number of users renewed',
 		} );
 	}
@@ -140,7 +136,6 @@ function renderTransactionQuantitySummaryForGoogleWorkspace(
 		return translate( 'Purchase of %(quantity)s new user', 'Purchase of %(quantity)s new users', {
 			args: { quantity: new_quantity },
 			count: new_quantity,
-			context: 'Purchase description with additional number of users purchased',
 			comment: '%(quantity)s is additional number of users purchased',
 		} );
 	}
@@ -148,7 +143,6 @@ function renderTransactionQuantitySummaryForGoogleWorkspace(
 	return translate( 'Purchase of %(quantity)s user', 'Purchase of %(quantity)s users', {
 		args: { quantity: licensed_quantity },
 		count: licensed_quantity,
-		context: 'Purchase description with number of users purchased',
 		comment: '%(quantity)s is number of users purchased',
 	} );
 }
@@ -188,7 +182,6 @@ export function renderTransactionQuantitySummary(
 		return translate( 'Renewal for %(quantity)s item', 'Renewal for %(quantity)s items', {
 			args: { quantity: licensed_quantity },
 			count: licensed_quantity,
-			context: 'Renewal description with number of items renewed',
 			comment: '%(quantity)s is number of items renewed',
 		} );
 	}
@@ -197,7 +190,6 @@ export function renderTransactionQuantitySummary(
 		return translate( 'Purchase of %(quantity)s new item', 'Purchase of %(quantity)s new items', {
 			args: { quantity: new_quantity },
 			count: new_quantity,
-			context: 'Purchase description with additional number of items purchased',
 			comment: '%(quantity)s is additional number of items purchased',
 		} );
 	}
@@ -205,7 +197,6 @@ export function renderTransactionQuantitySummary(
 	return translate( 'Purchase of %(quantity)s item', 'Purchase of %(quantity)s items', {
 		args: { quantity: licensed_quantity },
 		count: licensed_quantity,
-		context: 'Purchase description with number of items purchased',
 		comment: '%(quantity)s is number of items purchased',
 	} );
 }

--- a/client/me/purchases/billing-history/utils.jsx
+++ b/client/me/purchases/billing-history/utils.jsx
@@ -91,29 +91,29 @@ function renderTransactionQuantitySummaryForTitanMail(
 	translate
 ) {
 	if ( isRenewal ) {
-		return translate( 'Renewal for %(quantity)s mailbox', 'Renewal for %(quantity)s mailboxes', {
+		return translate( 'Renewal for %(quantity)d mailbox', 'Renewal for %(quantity)d mailboxes', {
 			args: { quantity: licensed_quantity },
 			count: licensed_quantity,
-			comment: '%(quantity)s is number of mailboxes renewed',
+			comment: '%(quantity)d is number of mailboxes renewed',
 		} );
 	}
 
 	if ( isUpgrade ) {
 		return translate(
-			'Purchase of %(quantity)s new mailbox',
-			'Purchase of %(quantity)s new mailboxes',
+			'Purchase of %(quantity)d additional mailbox',
+			'Purchase of %(quantity)d additional mailboxes',
 			{
 				args: { quantity: new_quantity },
 				count: new_quantity,
-				comment: '%(quantity)s is additional number of mailboxes purchased',
+				comment: '%(quantity)d is additional number of mailboxes purchased',
 			}
 		);
 	}
 
-	return translate( 'Purchase of %(quantity)s mailbox', 'Purchase of %(quantity)s mailboxes', {
+	return translate( 'Purchase of %(quantity)d mailbox', 'Purchase of %(quantity)d mailboxes', {
 		args: { quantity: licensed_quantity },
 		count: licensed_quantity,
-		comment: '%(quantity)s is number of mailboxes purchased',
+		comment: '%(quantity)d is number of mailboxes purchased',
 	} );
 }
 
@@ -125,25 +125,29 @@ function renderTransactionQuantitySummaryForGoogleWorkspace(
 	translate
 ) {
 	if ( isRenewal ) {
-		return translate( 'Renewal for %(quantity)s user', 'Renewal for %(quantity)s users', {
+		return translate( 'Renewal for %(quantity)d user', 'Renewal for %(quantity)d users', {
 			args: { quantity: licensed_quantity },
 			count: licensed_quantity,
-			comment: '%(quantity)s is number of users renewed',
+			comment: '%(quantity)d is number of users renewed',
 		} );
 	}
 
 	if ( isUpgrade ) {
-		return translate( 'Purchase of %(quantity)s new user', 'Purchase of %(quantity)s new users', {
-			args: { quantity: new_quantity },
-			count: new_quantity,
-			comment: '%(quantity)s is additional number of users purchased',
-		} );
+		return translate(
+			'Purchase of %(quantity)d additional user',
+			'Purchase of %(quantity)d additional users',
+			{
+				args: { quantity: new_quantity },
+				count: new_quantity,
+				comment: '%(quantity)d is additional number of users purchased',
+			}
+		);
 	}
 
-	return translate( 'Purchase of %(quantity)s user', 'Purchase of %(quantity)s users', {
+	return translate( 'Purchase of %(quantity)d user', 'Purchase of %(quantity)d users', {
 		args: { quantity: licensed_quantity },
 		count: licensed_quantity,
-		comment: '%(quantity)s is number of users purchased',
+		comment: '%(quantity)d is number of users purchased',
 	} );
 }
 
@@ -179,25 +183,29 @@ export function renderTransactionQuantitySummary(
 		);
 	}
 	if ( isRenewal ) {
-		return translate( 'Renewal for %(quantity)s item', 'Renewal for %(quantity)s items', {
+		return translate( 'Renewal for %(quantity)d item', 'Renewal for %(quantity)d items', {
 			args: { quantity: licensed_quantity },
 			count: licensed_quantity,
-			comment: '%(quantity)s is number of items renewed',
+			comment: '%(quantity)d is number of items renewed',
 		} );
 	}
 
 	if ( isUpgrade ) {
-		return translate( 'Purchase of %(quantity)s new item', 'Purchase of %(quantity)s new items', {
-			args: { quantity: new_quantity },
-			count: new_quantity,
-			comment: '%(quantity)s is additional number of items purchased',
-		} );
+		return translate(
+			'Purchase of %(quantity)d additional item',
+			'Purchase of %(quantity)d additional items',
+			{
+				args: { quantity: new_quantity },
+				count: new_quantity,
+				comment: '%(quantity)d is additional number of items purchased',
+			}
+		);
 	}
 
-	return translate( 'Purchase of %(quantity)s item', 'Purchase of %(quantity)s items', {
+	return translate( 'Purchase of %(quantity)d item', 'Purchase of %(quantity)d items', {
 		args: { quantity: licensed_quantity },
 		count: licensed_quantity,
-		comment: '%(quantity)s is number of items purchased',
+		comment: '%(quantity)d is number of items purchased',
 	} );
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Retrieves new parameters `licensed_quantity_summary` and `new_quantity` for purchase history line items and details and uses it to display contextual information for products with upgradeable quantities.

This PR depends on changes from code-D56964.

The purchase billing history UI should look similar to this after changes.

<img width="1023" alt="Screenshot 2021-02-16 at 4 35 04 AM" src="https://user-images.githubusercontent.com/277661/108015393-733b8400-7010-11eb-8184-df12cc24dd4a.png">



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure code-D56964
- Checkout this branch
- Visit your billing history page i.e. /purchases/subscriptions/. You may still need to click on Billing history
- Confirm that the products with upgradeable quantities i.e. Email display meaningful description i.e. quantity upgrades.

