### PR TITLE
CommunityTranslator: remove `lib/userSettings`

### DIFF
--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -12,8 +12,8 @@ import { connect } from 'react-redux';
  */
 import Translatable from './translatable';
 import languages from '@automattic/languages';
-import userSettings from 'calypso/lib/user-settings';
 import isCommunityTranslatorEnabled from 'calypso/state/selectors/is-community-translator-enabled';
+import { fetchUserSettings } from 'calypso/state/user-settings/actions';
 
 /**
  * Style dependencies
@@ -31,6 +31,7 @@ class CommunityTranslator extends Component {
 	initialized = false;
 
 	componentDidMount() {
+		this.props.fetchUserSettings();
 		this.setLanguage();
 
 		// wrap translations from i18n
@@ -42,12 +43,10 @@ class CommunityTranslator extends Component {
 		// the callback is overwritten by the translator on load/unload, so we're returning it within an anonymous function.
 		i18n.registerComponentUpdateHook( () => {} );
 		i18n.on( 'change', this.refresh );
-		userSettings.on( 'change', this.refresh );
 	}
 
 	componentWillUnmount() {
 		i18n.off( 'change', this.refresh );
-		userSettings.removeListener( 'change', this.refresh );
 	}
 
 	setLanguage() {
@@ -63,11 +62,6 @@ class CommunityTranslator extends Component {
 
 	refresh = () => {
 		if ( this.initialized ) {
-			return;
-		}
-
-		if ( ! userSettings.getSettings() ) {
-			debug( 'initialization failed because userSettings are not ready' );
 			return;
 		}
 
@@ -163,6 +157,9 @@ class CommunityTranslator extends Component {
 	}
 }
 
-export default connect( ( state ) => ( {
-	isCommunityTranslatorEnabled: isCommunityTranslatorEnabled( state ),
-} ) )( localize( CommunityTranslator ) );
+export default connect(
+	( state ) => ( {
+		isCommunityTranslatorEnabled: isCommunityTranslatorEnabled( state ),
+	} ),
+	{ fetchUserSettings }
+)( localize( CommunityTranslator ) );

--- a/client/components/community-translator/test/utils.js
+++ b/client/components/community-translator/test/utils.js
@@ -20,11 +20,6 @@ jest.mock( '@automattic/viewport', () => ( {
 	isMobile: jest.fn(),
 } ) );
 
-jest.mock( 'calypso/lib/user-settings', () => ( {
-	getSetting: jest.fn(),
-	getOriginalSetting: jest.fn(),
-} ) );
-
 // see: `languages` array in config/_shared.json
 const languagesMock = [
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `userSettings` from `components/community-translator`

#### Testing instructions

This component isn't actively used anywhere in Calypso (the corresponding flag `i18n/community-translator` isn't activated for any environment). It was introduced in https://github.com/Automattic/wp-calypso/pull/21591 but has not been touched since. It may be enough to check if the code changes make sense.

Merges into #50027 and related to #24162
