### PR TITLE
State: Add IDs to Gravatar notices

### DIFF
--- a/client/state/current-user/gravatar-status/actions.js
+++ b/client/state/current-user/gravatar-status/actions.js
@@ -37,5 +37,5 @@ export const receiveGravatarImageFailed = ( { errorMessage, statName } ) => ( di
 			}
 		)
 	);
-	dispatch( errorNotice( errorMessage ) );
+	dispatch( errorNotice( errorMessage, { id: 'gravatar-upload' } ) );
 };

--- a/client/state/data-layer/wpcom/gravatar-upload/index.js
+++ b/client/state/data-layer/wpcom/gravatar-upload/index.js
@@ -55,7 +55,10 @@ export function announceSuccess( { file } ) {
 			);
 			dispatch(
 				successNotice(
-					translate( 'You successfully uploaded a new profile photo — looking sharp!' )
+					translate( 'You successfully uploaded a new profile photo — looking sharp!' ),
+					{
+						id: 'gravatar-upload',
+					}
 				)
 			);
 		} );
@@ -73,7 +76,10 @@ export function announceFailure() {
 			{ type: GRAVATAR_UPLOAD_REQUEST_FAILURE }
 		),
 		errorNotice(
-			translate( 'Hmm, your new profile photo was not saved. Please try uploading again.' )
+			translate( 'Hmm, your new profile photo was not saved. Please try uploading again.' ),
+			{
+				id: 'gravatar-upload',
+			}
 		),
 	];
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As @noahtallen found while testing https://github.com/Automattic/wp-calypso/pull/49914#pullrequestreview-588179235 we don't currently have unique IDs for the gravatar upload notices. This PR adds them.

#### Testing instructions

* Go through the instructions of #49914 and specifically try uploading several large images one after another.
* Verify that every new notice removes previous ones and notices still work well.