### PR TITLE
OAuth Login: redirect to / after success

### DIFF
--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -10,12 +10,8 @@ import page from 'page';
 import OAuthLogin from './login';
 import ConnectComponent from './connect';
 import { getToken } from 'calypso/lib/oauth-token';
-import wpcom from 'calypso/lib/wp';
 import config from '@automattic/calypso-config';
 import store from 'store';
-import userFactory from 'calypso/lib/user';
-import Main from 'calypso/components/main';
-import PulsingDot from 'calypso/components/pulsing-dot';
 
 /**
  * Style dependencies
@@ -61,36 +57,16 @@ export default {
 		next();
 	},
 
-	// Retrieve token from local storage
-	getToken: function ( context, next ) {
+	// Store token into local storage
+	getToken: function ( context ) {
 		if ( context.hash && context.hash.access_token ) {
 			store.set( 'wpcom_token', context.hash.access_token );
-			wpcom.loadToken( context.hash.access_token );
 		}
 
 		if ( context.hash && context.hash.expires_in ) {
 			store.set( 'wpcom_token_expires_in', context.hash.expires_in );
 		}
 
-		// Extract this into a component...
-		context.primary = (
-			<Main className="auth">
-				<p className="auth__welcome">Loading user...</p>
-				<PulsingDot active />
-			</Main>
-		);
-
-		// Fetch user and redirect to / on success.
-		const user = userFactory();
-		user.fetching = false;
-		user.fetch();
-		user.on( 'change', function () {
-			if ( config.isEnabled( 'devdocs' ) ) {
-				window.location = '/devdocs/welcome';
-			} else {
-				window.location = '/';
-			}
-		} );
-		next();
+		document.location.replace( '/' );
 	},
 };


### PR DESCRIPTION
Simplifies handler for the `/api/oauth/token` route that is redirected to when wordpress.com approves an OAuth login for the Calypso app.

It needs to just store the OAuth token locally and redirect to `/` (with a full reload). The `user.fetch()` call will be done when rebooting the app. No need to do it here.

We also always redirect to `/`, not to `/devdocs/welcome`. We want to load the app for the end user, not for the developer.

**How to test:**
Load Calypso with OAuth enabled:
```
ENABLE_FEATURES=oauth yarn start
```
And verify that you can log in.
