### PR TITLE
Plans: Make 'Real-time' product name casing consistent

### DIFF
--- a/client/blocks/product-selector/docs/example.jsx
+++ b/client/blocks/product-selector/docs/example.jsx
@@ -23,8 +23,8 @@ const products = [
 		optionShortNames: {
 			jetpack_backup_daily: 'Daily Backups',
 			jetpack_backup_daily_monthly: 'Daily Backups',
-			jetpack_backup_realtime: 'Real-Time Backups',
-			jetpack_backup_realtime_monthly: 'Real-Time Backups',
+			jetpack_backup_realtime: 'Real-time Backups',
+			jetpack_backup_realtime_monthly: 'Real-time Backups',
 		},
 		optionsLabel: 'Backup options',
 	},

--- a/client/components/product-card/docs/example.jsx
+++ b/client/components/product-card/docs/example.jsx
@@ -85,7 +85,7 @@ function ProductCardExample() {
 							billingTimeFrame: isPlaceholder ? null : 'per year',
 							fullPrice: isPlaceholder ? null : 25,
 							slug: 'jetpack_backup_realtime_monthly',
-							title: 'Real-Time Backups',
+							title: 'Real-time Backups',
 						},
 					] }
 					selectedSlug={ selectedProductOption }
@@ -112,8 +112,8 @@ function ProductCardExample() {
 				purchase={ purchase }
 			>
 				<ProductCardAction
-					intro="Get Real-Time Backups $16 /year"
-					label="Upgrade to Real-Time Backups"
+					intro="Get Real-time Backups $16 /year"
+					label="Upgrade to Real-time Backups"
 				/>
 			</ProductCard>
 
@@ -121,7 +121,7 @@ function ProductCardExample() {
 			<ProductCard
 				title={
 					<Fragment>
-						Jetpack Backup <em>Real-Time</em>
+						Jetpack Backup <em>Real-time</em>
 					</Fragment>
 				}
 				subtitle={
@@ -134,7 +134,7 @@ function ProductCardExample() {
 				purchase={ purchase }
 			>
 				<ProductCardAction
-					intro="Get Real-Time backups"
+					intro="Get Real-time backups"
 					label="Upgrade to Professional $299/year"
 				/>
 			</ProductCard>

--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -76,7 +76,7 @@ export const getJetpackProductsDisplayNames = () => {
 
 	const backupRealtime = (
 		<>
-			{ translate( 'Backup {{em}}Real-Time{{/em}}', {
+			{ translate( 'Backup {{em}}Real-time{{/em}}', {
 				components: {
 					em: <em />,
 				},
@@ -88,7 +88,7 @@ export const getJetpackProductsDisplayNames = () => {
 
 	const scanRealtime = (
 		<>
-			{ translate( 'Scan {{em}}Real-Time{{/em}}', {
+			{ translate( 'Scan {{em}}Real-time{{/em}}', {
 				components: {
 					em: <em />,
 				},
@@ -133,7 +133,7 @@ export const getJetpackProductsCallToAction = () => {
 
 	const backupRealtime = (
 		<>
-			{ translate( 'Get Backup {{em}}Real-Time{{/em}}', {
+			{ translate( 'Get Backup {{em}}Real-time{{/em}}', {
 				components: {
 					em: <em />,
 				},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Related to `1196108640073826-as-1199527862646257`.

* Change casing from Real-Time (capital T) to Real-time (lowercase t) for product and plan names that include this phrase.

#### Testing instructions

* In any environment, open the Plans/Pricing page.
* Verify that all real-time products and plans have Real-time spelled with a lowercase t.

#### Reference screenshot

<img width="718" alt="image" src="https://user-images.githubusercontent.com/670067/107792849-38d59c80-6d1b-11eb-809c-687e55822f8e.png">