### PR TITLE
Plans: Update page styling for upcoming tests

### DIFF
--- a/client/components/jetpack/card/i5/jetpack-product-card-i5/index.tsx
+++ b/client/components/jetpack/card/i5/jetpack-product-card-i5/index.tsx
@@ -11,7 +11,6 @@ import { Button, ProductIcon } from '@automattic/components';
  * Internal dependencies
  */
 import JetpackProductCardTimeFrame from './time-frame';
-import { preventWidows } from 'calypso/lib/formatting';
 import PlanPrice from 'calypso/my-sites/plan-price';
 import JetpackProductCardFeatures, { Props as FeaturesProps } from './features';
 import InfoPopover from 'calypso/components/info-popover';
@@ -111,7 +110,7 @@ const JetpackProductCardAlt2: React.FC< Props > = ( {
 				{ createElement(
 					`h${ parsedHeadingLevel }`,
 					{ className: 'jetpack-product-card-i5__product-name' },
-					<>{ preventWidows( productName ) }</>
+					<>{ productName }</>
 				) }
 				<p className="jetpack-product-card-i5__description">{ description }</p>
 				{ isOwned && (

--- a/client/components/jetpack/card/i5/jetpack-product-card-i5/style.scss
+++ b/client/components/jetpack/card/i5/jetpack-product-card-i5/style.scss
@@ -244,8 +244,6 @@
 	margin: 0;
 
 	color: var( --studio-gray-100 );
-
-	font-weight: 700;
 }
 
 /* Prices Loading state */

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -98,14 +98,14 @@
 	}
 
 	// On cloud.jetpack.com, we want to override the primary color, used on
-	// the featured product card, with --studio-purple-50.
+	// the featured product card, with --studio-pink-50.
 	.jetpack-product-card-i5.is-featured {
 		.jetpack-product-card-i5__header {
-			background-color: var( --studio-purple-50 );
+			background-color: var( --studio-pink-50 );
 		}
 
 		.jetpack-product-card-i5__body {
-			border: solid 2px var( --studio-purple-50 );
+			border: solid 2px var( --studio-pink-50 );
 		}
 	}
 }

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -437,7 +437,10 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 const getPlanJetpackSecurityRealtimeDetails = () => ( {
 	group: constants.GROUP_JETPACK,
 	type: constants.TYPE_SECURITY_REALTIME,
-	getTitle: () => translate( 'Security {{em}}Real-time{{/em}}', { components: { em: <em /> } } ),
+	getTitle: () =>
+		translate( 'Security {{em}}Real-time{{/em}}', {
+			components: { em: <em style={ { whiteSpace: 'nowrap' } } /> },
+		} ),
 	getAudience: () => translate(),
 	availableFor: ( plan ) =>
 		[

--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -29,25 +29,25 @@ export const getJetpackProductsShortNames = () => {
 		} ),
 		[ CONSTANTS.PRODUCT_JETPACK_BACKUP_REALTIME ]: translate( 'Backup {{em}}Real-time{{/em}}', {
 			components: {
-				em: createElement( 'em' ),
+				em: createElement( 'em', { style: { whiteSpace: 'nowrap' } } ),
 			},
 		} ),
 		[ CONSTANTS.PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: translate(
 			'Backup {{em}}Real-time{{/em}}',
 			{
 				components: {
-					em: createElement( 'em' ),
+					em: createElement( 'em', { style: { whiteSpace: 'nowrap' } } ),
 				},
 			}
 		),
 		[ CONSTANTS.PRODUCT_JETPACK_SCAN_REALTIME ]: translate( 'Scan {{em}}Real-time{{/em}}', {
 			components: {
-				em: createElement( 'em' ),
+				em: createElement( 'em', { style: { whiteSpace: 'nowrap' } } ),
 			},
 		} ),
 		[ CONSTANTS.PRODUCT_JETPACK_SCAN_REALTIME_MONTHLY ]: translate( 'Scan {{em}}Real-time{{/em}}', {
 			components: {
-				em: createElement( 'em' ),
+				em: createElement( 'em', { style: { whiteSpace: 'nowrap' } } ),
 			},
 		} ),
 		[ CONSTANTS.PRODUCT_JETPACK_SCAN ]: translate( 'Scan' ),
@@ -78,7 +78,7 @@ export const getJetpackProductsDisplayNames = () => {
 		<>
 			{ translate( 'Backup {{em}}Real-Time{{/em}}', {
 				components: {
-					em: <em />,
+					em: <em style={ { whiteSpace: 'nowrap' } } />,
 				},
 			} ) }
 		</>
@@ -90,7 +90,7 @@ export const getJetpackProductsDisplayNames = () => {
 		<>
 			{ translate( 'Scan {{em}}Real-Time{{/em}}', {
 				components: {
-					em: <em />,
+					em: <em style={ { whiteSpace: 'nowrap' } } />,
 				},
 			} ) }
 		</>
@@ -135,7 +135,7 @@ export const getJetpackProductsCallToAction = () => {
 		<>
 			{ translate( 'Get Backup {{em}}Real-Time{{/em}}', {
 				components: {
-					em: <em />,
+					em: <em style={ { whiteSpace: 'nowrap' } } />,
 				},
 			} ) }
 		</>

--- a/client/my-sites/plans/jetpack-plans/more-info-box/style.scss
+++ b/client/my-sites/plans/jetpack-plans/more-info-box/style.scss
@@ -24,10 +24,9 @@
 }
 
 .more-info-box__more-button.button {
-	display: flex;
+	display: inline-flex;
 	align-items: center;
 
-	max-width: 310px;
 	margin: 0 auto;
 	padding: 10px 16px 10px 40px;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Related to `1196108640073826-as-1199527862646257`.

* Allow product names to flow normally onto multiple lines, but prevent line wrapping on the hyphenated word "Real-time."
* Make the font weight for product feature bullet points normal instead of bold.
* Make the "Recommended" product header and border pink instead of purple on Calypso Green.
* Make the "Compare all product bundles" button one line when the viewport allows it.

#### Testing instructions

##### All environments

* Open the Plans/Pricing page.
* Verify that no matter the viewport size, the word "Real-time" in a product name is never wrapped so that "Real-" is on one line and "time" is on another.
* Verify that product feature bullet points are no longer bolded.
* Verify that the text of the "Compare all product bundles" button is now all on one line, as long as the browser viewport is wide enough to accommodate it.

<img height="300" alt="image" src="https://user-images.githubusercontent.com/670067/107795252-0c6f4f80-6d1e-11eb-9edd-accdbc79c4b5.png"> <img height="300" alt="image" src="https://user-images.githubusercontent.com/670067/107795292-1729e480-6d1e-11eb-8714-0c3a34468fbf.png">

<img width="434" alt="image" src="https://user-images.githubusercontent.com/670067/107795210-ffeaf700-6d1d-11eb-9891-19c043b63c4c.png">

##### Calypso Green only

* Open the Pricing page.
* Verify that the "Recommended" product card header and border are `studio-pink-50` instead of `studio-purple-50`.

<img width="1050" alt="image" src="https://user-images.githubusercontent.com/670067/107794937-ae426c80-6d1d-11eb-9053-7dec7307eb24.png">