### PR TITLE
Add subHeaderText to main pages

### DIFF
--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -78,6 +78,9 @@ export class CommentsManagement extends Component {
 						brandFont
 						className="comments__page-heading"
 						headerText={ translate( 'Comments' ) }
+						subHeaderText={ translate(
+							'View, reply to, and manage all the comments across your site.'
+						) }
 						align="left"
 					/>
 				) }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -79,7 +79,7 @@ const Home = ( {
 			<FormattedHeader
 				brandFont
 				headerText={ translate( 'My Home' ) }
-				subHeaderText={ translate( 'Your home base for posting, editing, and growing your site.' ) }
+				subHeaderText={ translate( 'Your hub for posting, editing, and growing your site.' ) }
 				align="left"
 			/>
 			<div className="customer-home__view-site-button">

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -105,6 +105,9 @@ export const Sharing = ( {
 				brandFont
 				className="marketing__page-heading"
 				headerText={ translate( 'Marketing and Integrations' ) }
+				subHeaderText={ translate(
+					'Explore tools to build your audience, market your site, and engage your visitors.'
+				) }
 				align="left"
 			/>
 			{ filters.length > 0 && (

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -364,6 +364,9 @@ class Media extends Component {
 					brandFont
 					className="media__page-heading"
 					headerText={ translate( 'Media' ) }
+					subHeaderText={ translate(
+						'Manage all the media on your site, including images, video, and more.'
+					) }
 					align="left"
 				/>
 				{ this.showDialog() && (

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -98,6 +98,7 @@ class PagesMain extends React.Component {
 					brandFont
 					className="pages__page-heading"
 					headerText={ translate( 'Pages' ) }
+					subHeaderText={ translate( 'Create, edit, and manage the pages on your site.' ) }
 					align="left"
 				/>
 				<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ status } />

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -100,6 +100,9 @@ class People extends React.Component {
 					brandFont
 					className="people__page-heading"
 					headerText={ translate( 'People' ) }
+					subHeaderText={ translate(
+						'Invite contributors to your site and manage their access settings.'
+					) }
 					align="left"
 				/>
 				<div>

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -132,7 +132,14 @@ class Plans extends React.Component {
 					) }
 					{ canAccessPlans && (
 						<>
-							<FormattedHeader brandFont headerText={ translate( 'Plans' ) } align="left" />
+							<FormattedHeader
+								brandFont
+								headerText={ translate( 'Plans' ) }
+								subHeaderText={
+									'See and compare the features available on each WordPress.com plan.'
+								}
+								align="left"
+							/>
 							<div id="plans" className="plans plans__has-sidebar">
 								<PlansNavigation path={ this.props.context.path } />
 								{ isEnabled( 'p2/p2-plus' ) && isWPForTeamsSite ? (

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -421,7 +421,7 @@ export class PluginsMain extends Component {
 							headerText={ this.props.translate( 'Plugins' ) }
 							align="left"
 							subHeaderText={ this.props.translate(
-								'Plugins are extensions that add useful features to your site.'
+								'Add new functionality and integrations to your site with plugins.'
 							) }
 						/>
 						<div className="plugins__main-buttons">

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -496,7 +496,7 @@ export class PluginsBrowser extends Component {
 							headerText={ this.props.translate( 'Plugins' ) }
 							align="left"
 							subHeaderText={ this.props.translate(
-								'Plugins are extensions that add useful features to your site.'
+								'Add new functionality and integrations to your site with plugins.'
 							) }
 						/>
 						<div className="plugins-browser__main-buttons">

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -82,6 +82,7 @@ class PostsMain extends React.Component {
 					brandFont
 					className="posts__page-heading"
 					headerText={ translate( 'Posts' ) }
+					subHeaderText={ translate( 'Create, edit, and manage the posts on your site.' ) }
 					align="left"
 				/>
 				<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ statusSlug } />

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -39,6 +39,9 @@ const SiteSettingsComponent = ( { siteId, translate } ) => {
 				brandFont
 				className="site-settings__page-heading"
 				headerText={ translate( 'Settings' ) }
+				subHeaderText={ translate(
+					'Manage your site settings, including language, time zone, site visibility, and more.'
+				) }
 				align="left"
 			/>
 			<SiteSettingsNavigation section={ 'general' } />

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -167,6 +167,9 @@ class StatsSite extends Component {
 					className="stats__section-header"
 					headerText={ translate( 'Stats and Insights' ) }
 					align="left"
+					subHeaderText={ translate(
+						"Learn more about the activity and behavior of your site's visitors."
+					) }
 				/>
 				<StatsNavigation
 					selectedItem={ 'traffic' }

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -93,6 +93,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 				brandFont
 				className="themes__page-heading"
 				headerText={ translate( 'Themes' ) }
+				subHeaderText={ translate( 'Select or update the visual design for your site.' ) }
 				align="left"
 			/>
 			<CurrentTheme siteId={ siteId } />

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -76,6 +76,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 				brandFont
 				className="themes__page-heading"
 				headerText={ translate( 'Themes' ) }
+				subHeaderText={ translate( 'Select or update the visual design for your site.' ) }
 				align="left"
 			/>
 			<CurrentTheme siteId={ siteId } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As part of making it easier to navigate Calypso, this adds `subHeaderText` props to the main, top-level pages. We'll continue adding more as we go!

Pages affected in this PR:

- My Home
- Stats
- Plans
- Pages
- Posts
- Comments
- Media
- Themes
- Plugins
- Marketing
- Users
- Settings

**Visuals** (not comprehensive)

<img width="1107" alt="Screen Shot 2021-02-12 at 10 14 33 AM" src="https://user-images.githubusercontent.com/2124984/107792139-cbc60500-6d22-11eb-84b1-9cd4f0ba1f45.png">
<img width="1118" alt="Screen Shot 2021-02-12 at 10 14 41 AM" src="https://user-images.githubusercontent.com/2124984/107792141-cc5e9b80-6d22-11eb-99b3-000abb383292.png">
<img width="1377" alt="Screen Shot 2021-02-12 at 10 14 49 AM" src="https://user-images.githubusercontent.com/2124984/107792143-cc5e9b80-6d22-11eb-97de-8d5e4ff5255e.png">

#### Testing instructions

* Switch to this PR or use calypso.live
* Navigate through the pages listed above; make sure there are no spelling errors, visual errors, or other weirdness.
