### PR TITLE
Update copy for pending backups

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/no-backups-yet.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/no-backups-yet.jsx
@@ -10,7 +10,7 @@ import { useSelector, useDispatch } from 'react-redux';
  */
 import ExternalLink from 'calypso/components/external-link';
 import { JETPACK_CONTACT_SUPPORT, CALYPSO_CONTACT } from 'calypso/lib/url/support';
-import { selectedSiteId } from 'calypso/state/help/actions';
+import { selectSiteId } from 'calypso/state/help/actions';
 import { addQueryArgs } from 'calypso/lib/url';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import getRawSite from 'calypso/state/selectors/get-raw-site';
@@ -31,7 +31,7 @@ const NoBackupsYet = () => {
 	const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 	const siteName = useSelector( ( state ) => getRawSite( state, siteId ) )?.name;
 	const dispatch = useDispatch();
-	const onSupportClick = useCallback( () => dispatch( selectedSiteId( siteId ) ), [
+	const onSupportClick = useCallback( () => dispatch( selectSiteId( siteId ) ), [
 		dispatch,
 		siteId,
 	] );

--- a/client/components/jetpack/daily-backup-status/status-card/no-backups-yet.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/no-backups-yet.jsx
@@ -2,13 +2,16 @@
  * External dependencies
  */
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
-import { useSelector } from 'react-redux';
+import React, { useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import ExternalLink from 'calypso/components/external-link';
+import { JETPACK_CONTACT_SUPPORT, CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import { selectedSiteId } from 'calypso/state/help/actions';
+import { addQueryArgs } from 'calypso/lib/url';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import getRawSite from 'calypso/state/selectors/get-raw-site';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
@@ -27,6 +30,11 @@ const NoBackupsYet = () => {
 	const siteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) );
 	const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 	const siteName = useSelector( ( state ) => getRawSite( state, siteId ) )?.name;
+	const dispatch = useDispatch();
+	const onSupportClick = useCallback( () => dispatch( selectedSiteId( siteId ) ), [
+		dispatch,
+		siteId,
+	] );
 
 	return (
 		<>
@@ -43,23 +51,28 @@ const NoBackupsYet = () => {
 				{ translate( 'Your first backup will be ready soon' ) }
 			</h2>
 			<div className="status-card__label">
-				{ isJetpackCloud()
-					? translate(
-							'Your first backup will appear here {{strong}}within 24 hours{{/strong}} and you will receive an email once the backup has been completed.',
-							{
-								components: {
-									strong: <strong />,
-								},
-							}
-					  )
-					: translate(
-							'Your first backup will appear here {{strong}}within 24 hours{{/strong}} and you will receive a notification once the backup has been completed.',
-							{
-								components: {
-									strong: <strong />,
-								},
-							}
-					  ) }
+				{ translate(
+					"No backups yet, but don't worry, one should become available soon. {{support}}Contact support{{/support}} if you still see this message after {{strong}}24 hours{{/strong}}, or if you still need help.",
+					{
+						components: {
+							strong: <strong />,
+							support: (
+								<a
+									{ ...( isJetpackCloud()
+										? {
+												href: addQueryArgs( { url: siteUrl }, JETPACK_CONTACT_SUPPORT ),
+												target: '_blank',
+												rel: 'noopener noreferrer',
+										  }
+										: {
+												href: CALYPSO_CONTACT,
+												onClick: onSupportClick,
+										  } ) }
+								/>
+							),
+						},
+					}
+				) }
 			</div>
 			<ul className="status-card__link-list">
 				<li>


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the copy mentioning pending backups in the Backup section, so that users have better expectations.

Fixes 1164141197617539-as-1196090710229513

### Testing instructions

- Download the PR and run both Calypso and cloud concurrently
- Select a site that doesn't have Backup
- Purchase a product that has Backup and visit `/backup/:site` in both platforms
- Check that the copy matches the capture below
- In Calypso, clicking "Contact support" should redirect you to `/help/contact`, with the site selected
- In cloud, it should open the [Jetpack Contact Support page](P1moTy-pc-p2)  in a new tab

### Screenshots

_Before_
<img width="777" alt="Screen Shot 2021-02-12 at 11 05 43 AM" src="https://user-images.githubusercontent.com/1620183/107797843-645f8380-6d29-11eb-90f9-c8747263aaf3.png">

_After_
<img width="754" alt="Screen Shot 2021-02-12 at 11 51 54 AM" src="https://user-images.githubusercontent.com/1620183/107797881-6fb2af00-6d29-11eb-8c07-cfb56bd575c4.png">

_Calypso contact form_
<img width="748" alt="Screen Shot 2021-02-12 at 11 51 46 AM" src="https://user-images.githubusercontent.com/1620183/107797929-7b05da80-6d29-11eb-8d42-083532414f11.png">