### PR TITLE
Billing: Add option to assign payment method to all subscriptions when adding card

### DIFF
--- a/client/me/purchases/add-new-payment-method/index.jsx
+++ b/client/me/purchases/add-new-payment-method/index.jsx
@@ -1,15 +1,16 @@
 /**
  * External dependencies
  */
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import page from 'page';
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
 import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import { errorNotice } from 'calypso/state/notices/actions';
 import { concatTitle } from 'calypso/lib/react-helpers';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -46,6 +47,12 @@ function AddNewPaymentMethod() {
 		activePayButtonText: translate( 'Save card' ),
 	} );
 	const paymentMethodList = useMemo( () => [ stripeMethod ].filter( Boolean ), [ stripeMethod ] );
+	const reduxDispatch = useDispatch();
+	useEffect( () => {
+		if ( stripeLoadingError ) {
+			reduxDispatch( errorNotice( stripeLoadingError.message ) );
+		}
+	}, [ stripeLoadingError, reduxDispatch ] );
 
 	if ( paymentMethodList.length === 0 ) {
 		return <PaymentMethodLoader title={ addPaymentMethodTitle } />;

--- a/client/me/purchases/components/payment-method-sidebar/index.jsx
+++ b/client/me/purchases/components/payment-method-sidebar/index.jsx
@@ -71,22 +71,7 @@ function MainCard( { purchase } ) {
 		);
 	}
 
-	return (
-		<Card className="payment-method-sidebar__details-card">
-			<CardHeading
-				tagName="h1"
-				size={ 16 }
-				isBold={ true }
-				className="payment-method-sidebar__title"
-			>
-				{ translate( 'Usage' ) }
-			</CardHeading>
-
-			<p className="payment-method-sidebar__paragraph">
-				{ translate( 'This card will be used for future renewals of existing purchases.' ) }
-			</p>
-		</Card>
-	);
+	return null;
 }
 
 PaymentMethodSidebar.propTypes = {

--- a/client/me/purchases/components/payment-method-sidebar/index.jsx
+++ b/client/me/purchases/components/payment-method-sidebar/index.jsx
@@ -19,11 +19,10 @@ import './style.scss';
 
 export default function PaymentMethodSidebar( { purchase } ) {
 	const translate = useTranslate();
-	const moment = useLocalizedMoment();
 
 	return (
 		<React.Fragment>
-			{ renderMainCard( purchase, translate, moment ) }
+			<MainCard purchase={ purchase } />
 
 			<Card className="payment-method-sidebar__security-card">
 				<CardHeading
@@ -44,7 +43,10 @@ export default function PaymentMethodSidebar( { purchase } ) {
 	);
 }
 
-function renderMainCard( purchase, translate, moment ) {
+function MainCard( { purchase } ) {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
 	if ( purchase ) {
 		const purchaseMessaging = purchase.renewDate
 			? translate( 'Next payment on %s', { args: moment( purchase.renewDate ).format( 'LL' ) } )

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -31,12 +31,14 @@ const wpcomCreatePayPalAgreement = (
 export async function assignNewCardProcessor(
 	{
 		purchase,
+		useForAllSubscriptions,
 		translate,
 		stripe,
 		stripeConfiguration,
 		reduxDispatch,
 	}: {
 		purchase: Purchase | undefined;
+		useForAllSubscriptions?: boolean;
 		translate: ReturnType< typeof useTranslate >;
 		stripe: Stripe | null;
 		stripeConfiguration: StripeConfiguration | null;
@@ -83,6 +85,7 @@ export async function assignNewCardProcessor(
 	const result = await saveCreditCard( {
 		token,
 		stripeConfiguration,
+		useForAllSubscriptions,
 	} );
 
 	return makeSuccessResponse( result );

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -154,14 +154,11 @@ export default function PaymentMethodSelector( {
 							aria-label={ assignAllSubscriptionsText }
 						/>
 						{ assignAllSubscriptionsText }
+						<AllSubscriptionsEffectWarning useForAllSubscriptions={ useForAllSubscriptions } />
 					</FormLabel>
 				) }
 
 				<CheckoutSubmitButton />
-
-				{ ! purchase && (
-					<AllSubscriptionsEffectWarning useForAllSubscriptions={ useForAllSubscriptions } />
-				) }
 			</Card>
 		</CheckoutProvider>
 	);
@@ -176,17 +173,17 @@ function AllSubscriptionsEffectWarning( {
 
 	if ( useForAllSubscriptions ) {
 		return (
-			<div className="payment-method-selector__all-subscriptions-effect-warning">
+			<span className="payment-method-selector__all-subscriptions-effect-warning">
 				{ translate( 'This card will be used for future renewals of existing purchases.' ) }
-			</div>
+			</span>
 		);
 	}
 	return (
-		<div className="payment-method-selector__all-subscriptions-effect-warning">
+		<span className="payment-method-selector__all-subscriptions-effect-warning">
 			{ translate(
 				'This card will not be assigned to any subscriptions. You can assign it to a subscription from the subscription page.'
 			) }
-		</div>
+		</span>
 	);
 }
 

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useStripe } from '@automattic/calypso-stripe';
 import {
@@ -52,7 +52,7 @@ export default function PaymentMethodSelector( {
 } ): JSX.Element {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
-	const { isStripeLoading, stripe, stripeConfiguration } = useStripe();
+	const { isStripeLoading, stripe, stripeConfiguration, stripeLoadingError } = useStripe();
 	const currentlyAssignedPaymentMethodId = getPaymentMethodIdFromPayment( purchase?.payment );
 
 	const showErrorMessage = useCallback(
@@ -94,6 +94,12 @@ export default function PaymentMethodSelector( {
 	const assignAllSubscriptionsText = String(
 		translate( 'Assign this payment method to all of my subscriptions' )
 	);
+
+	useEffect( () => {
+		if ( stripeLoadingError ) {
+			showErrorMessage( stripeLoadingError );
+		}
+	}, [ stripeLoadingError, showErrorMessage ] );
 
 	return (
 		<CheckoutProvider

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -90,7 +90,7 @@ export default function PaymentMethodSelector( {
 		onPaymentSelectComplete( { successCallback, translate, showSuccessMessage, purchase } );
 	} );
 
-	const [ isChecked, setIsChecked ] = useState< boolean >( true );
+	const [ useForAllSubscriptions, setUseForAllSubscriptions ] = useState< boolean >( true );
 	const assignAllSubscriptionsText = String(
 		translate( 'Assign this payment method to all of my subscriptions' )
 	);
@@ -111,6 +111,7 @@ export default function PaymentMethodSelector( {
 					assignNewCardProcessor(
 						{
 							purchase,
+							useForAllSubscriptions,
 							translate,
 							stripe,
 							stripeConfiguration,
@@ -138,14 +139,16 @@ export default function PaymentMethodSelector( {
 					</p>
 				</div>
 
-				<FormLabel>
-					<FormInputCheckbox
-						checked={ isChecked }
-						onChange={ () => setIsChecked( ( checked ) => ! checked ) }
-						aria-label={ assignAllSubscriptionsText }
-					/>
-					{ assignAllSubscriptionsText }
-				</FormLabel>
+				{ ! purchase && (
+					<FormLabel>
+						<FormInputCheckbox
+							checked={ useForAllSubscriptions }
+							onChange={ () => setUseForAllSubscriptions( ( checked ) => ! checked ) }
+							aria-label={ assignAllSubscriptionsText }
+						/>
+						{ assignAllSubscriptionsText }
+					</FormLabel>
+				) }
 
 				<CheckoutSubmitButton />
 			</Card>

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -140,8 +140,9 @@ export default function PaymentMethodSelector( {
 				</div>
 
 				{ ! purchase && (
-					<FormLabel>
+					<FormLabel className="payment-method-selector__all-subscriptions-checkbox-label">
 						<FormInputCheckbox
+							className="payment-method-selector__all-subscriptions-checkbox"
 							checked={ useForAllSubscriptions }
 							onChange={ () => setUseForAllSubscriptions( ( checked ) => ! checked ) }
 							aria-label={ assignAllSubscriptionsText }

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -90,7 +90,7 @@ export default function PaymentMethodSelector( {
 		onPaymentSelectComplete( { successCallback, translate, showSuccessMessage, purchase } );
 	} );
 
-	const [ useForAllSubscriptions, setUseForAllSubscriptions ] = useState< boolean >( true );
+	const [ useForAllSubscriptions, setUseForAllSubscriptions ] = useState< boolean >( ! purchase );
 	const assignAllSubscriptionsText = String(
 		translate( 'Assign this payment method to all of my subscriptions' )
 	);

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -152,8 +152,35 @@ export default function PaymentMethodSelector( {
 				) }
 
 				<CheckoutSubmitButton />
+
+				{ ! purchase && (
+					<AllSubscriptionsEffectWarning useForAllSubscriptions={ useForAllSubscriptions } />
+				) }
 			</Card>
 		</CheckoutProvider>
+	);
+}
+
+function AllSubscriptionsEffectWarning( {
+	useForAllSubscriptions,
+}: {
+	useForAllSubscriptions: boolean;
+} ) {
+	const translate = useTranslate();
+
+	if ( useForAllSubscriptions ) {
+		return (
+			<div className="payment-method-selector__all-subscriptions-effect-warning">
+				{ translate( 'This card will be used for future renewals of existing purchases.' ) }
+			</div>
+		);
+	}
+	return (
+		<div className="payment-method-selector__all-subscriptions-effect-warning">
+			{ translate(
+				'This card will not be assigned to any subscriptions. You can assign it to a subscription from the subscription page.'
+			) }
+		</div>
 	);
 }
 

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useStripe } from '@automattic/calypso-stripe';
 import {
@@ -36,6 +36,8 @@ import {
 import getPaymentMethodIdFromPayment from './get-payment-method-id-from-payment';
 import TosText from './tos-text';
 import type { Purchase } from 'calypso/lib/purchases/types';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import FormLabel from 'calypso/components/forms/form-label';
 
 import './style.scss';
 
@@ -88,6 +90,11 @@ export default function PaymentMethodSelector( {
 		onPaymentSelectComplete( { successCallback, translate, showSuccessMessage, purchase } );
 	} );
 
+	const [ isChecked, setIsChecked ] = useState< boolean >( true );
+	const assignAllSubscriptionsText = String(
+		translate( 'Assign this payment method to all of my subscriptions' )
+	);
+
 	return (
 		<CheckoutProvider
 			onPaymentComplete={ () =>
@@ -130,6 +137,15 @@ export default function PaymentMethodSelector( {
 						<TosText />
 					</p>
 				</div>
+
+				<FormLabel>
+					<FormInputCheckbox
+						checked={ isChecked }
+						onChange={ () => setIsChecked( ( checked ) => ! checked ) }
+						aria-label={ assignAllSubscriptionsText }
+					/>
+					{ assignAllSubscriptionsText }
+				</FormLabel>
 
 				<CheckoutSubmitButton />
 			</Card>

--- a/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
@@ -21,7 +21,10 @@ export async function saveCreditCard( {
 	token: string;
 	stripeConfiguration: StripeConfiguration;
 } ): Promise< StoredCardEndpointResponse > {
-	const additionalData = getParamsForApi( token, stripeConfiguration );
+	const additionalData = getParamsForApi( {
+		cardToken: token,
+		stripeConfiguration,
+	} );
 	const response = await wpcom.me().storedCardAdd( token, additionalData );
 	if ( response.error ) {
 		recordTracksEvent( 'calypso_purchases_add_new_payment_method_error' );
@@ -40,7 +43,11 @@ export async function updateCreditCard( {
 	token: string;
 	stripeConfiguration: StripeConfiguration;
 } ): Promise< StoredCardEndpointResponse > {
-	const updatedCreditCardApiParams = getParamsForApi( token, stripeConfiguration, purchase );
+	const updatedCreditCardApiParams = getParamsForApi( {
+		cardToken: token,
+		stripeConfiguration,
+		purchase,
+	} );
 	const response = await wpcom.updateCreditCard( updatedCreditCardApiParams );
 	if ( response.error ) {
 		recordTracksEvent( 'calypso_purchases_save_new_payment_method_error' );
@@ -50,11 +57,15 @@ export async function updateCreditCard( {
 	return response;
 }
 
-function getParamsForApi(
-	cardToken: string,
-	stripeConfiguration: StripeConfiguration,
-	purchase?: Purchase | undefined
-) {
+function getParamsForApi( {
+	cardToken,
+	stripeConfiguration,
+	purchase,
+}: {
+	cardToken: string;
+	stripeConfiguration: StripeConfiguration;
+	purchase?: Purchase | undefined;
+} ) {
 	return {
 		payment_partner: stripeConfiguration ? stripeConfiguration.processor_id : '',
 		paygate_token: cardToken,

--- a/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
@@ -17,13 +17,16 @@ type StoredCardEndpointResponse = unknown;
 export async function saveCreditCard( {
 	token,
 	stripeConfiguration,
+	useForAllSubscriptions,
 }: {
 	token: string;
 	stripeConfiguration: StripeConfiguration;
+	useForAllSubscriptions: boolean;
 } ): Promise< StoredCardEndpointResponse > {
 	const additionalData = getParamsForApi( {
 		cardToken: token,
 		stripeConfiguration,
+		useForAllSubscriptions,
 	} );
 	const response = await wpcom.me().storedCardAdd( token, additionalData );
 	if ( response.error ) {
@@ -61,14 +64,18 @@ function getParamsForApi( {
 	cardToken,
 	stripeConfiguration,
 	purchase,
+	useForAllSubscriptions,
 }: {
 	cardToken: string;
 	stripeConfiguration: StripeConfiguration;
 	purchase?: Purchase | undefined;
+	useForAllSubscriptions?: boolean;
 } ) {
 	return {
 		payment_partner: stripeConfiguration ? stripeConfiguration.processor_id : '',
 		paygate_token: cardToken,
+		...( useForAllSubscriptions === true ? { use_for_existing: true } : {} ),
+		...( useForAllSubscriptions === false ? { use_for_existing: false } : {} ), // if undefined, we do not add this property
 		...( purchase ? { purchaseId: purchase.id } : {} ),
 	};
 }

--- a/client/me/purchases/manage-purchase/payment-method-selector/style.scss
+++ b/client/me/purchases/manage-purchase/payment-method-selector/style.scss
@@ -47,7 +47,7 @@
 	}
 }
 
-.payment-method-selector__all-subscriptions-checkbox {
+.form-checkbox.payment-method-selector__all-subscriptions-checkbox {
 	margin: 2px 10px 2px 0;
 }
 

--- a/client/me/purchases/manage-purchase/payment-method-selector/style.scss
+++ b/client/me/purchases/manage-purchase/payment-method-selector/style.scss
@@ -47,15 +47,15 @@
 	}
 }
 
-.form-checkbox.payment-method-selector__all-subscriptions-checkbox {
-	margin: 2px 10px 2px 0;
+.payment-method-selector__all-subscriptions-checkbox-label {
+	margin-bottom: 1.5em;
 }
 
-.payment-method-selector__all-subscriptions-checkbox-label {
-	margin-bottom: 16px;
+.form-checkbox.payment-method-selector__all-subscriptions-checkbox {
+	margin: 2px 8px 2px 0;
 }
 
 .payment-method-selector__all-subscriptions-effect-warning {
-	margin: 10px 0 0;
 	font-size: $font-body-small;
+	font-style: italic;
 }

--- a/client/me/purchases/manage-purchase/payment-method-selector/style.scss
+++ b/client/me/purchases/manage-purchase/payment-method-selector/style.scss
@@ -46,3 +46,11 @@
 		}
 	}
 }
+
+.payment-method-selector__all-subscriptions-checkbox {
+	margin: 2px 10px 2px 0;
+}
+
+.payment-method-selector__all-subscriptions-checkbox-label {
+	margin-bottom: 16px;
+}

--- a/client/me/purchases/manage-purchase/payment-method-selector/style.scss
+++ b/client/me/purchases/manage-purchase/payment-method-selector/style.scss
@@ -54,3 +54,8 @@
 .payment-method-selector__all-subscriptions-checkbox-label {
 	margin-bottom: 16px;
 }
+
+.payment-method-selector__all-subscriptions-effect-warning {
+	margin: 10px 0 0;
+	font-size: $font-body-small;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently the "Add payment method" forms at both the account and site-level display text in the sidebar that reads `This card will be used for future renewals of existing purchases.` and when the form is submitted, it assigns the newly added payment method to all existing subscriptions.

This PR adds a checkbox (defaulting to checked) to the form which allows the user to decide if they want to do that, or if they just want to add a card and assign it later. It moves the sidebar warning inline just underneath the submit button, and changes the warning's text if the checkbox is not checked.

**NOTE** Once https://github.com/Automattic/wp-calypso/pull/49897 is merged, this PR will include the site-level form as well. Since this PR removes the sidebar warning that the card will be used for all subscriptions, we should wait to merge this until that is complete so that we make sure that we replace it with the checkbox on all the active forms at once. (We cannot keep the sidebar warning because it is a React sibling of the `PaymentMethodSelector` where the checkbox lives and has no way to know the state of the checkbox.) That said, no changes will be needed to this PR to support that form, so this can be reviewed now.

Fixes https://github.com/Automattic/wp-calypso/issues/50047

#### Screenshots

Before:

<img width="756" alt="Screen Shot 2021-02-12 at 5 58 19 PM" src="https://user-images.githubusercontent.com/2036909/107831391-f84a4300-6d5b-11eb-8664-18a6befb19a3.png">

After:

<img width="754" alt="Screen Shot 2021-02-12 at 5 54 29 PM" src="https://user-images.githubusercontent.com/2036909/107831401-fda78d80-6d5b-11eb-909c-7d3573343149.png">

Close-up of checkbox checked (note text after button):

<img width="532" alt="Screen Shot 2021-02-12 at 5 54 56 PM" src="https://user-images.githubusercontent.com/2036909/107831434-0f893080-6d5c-11eb-95c3-3fe9a9e78171.png">


Close-up of checkbox unchecked (note text after button):

<img width="524" alt="Screen Shot 2021-02-12 at 5 54 49 PM" src="https://user-images.githubusercontent.com/2036909/107831415-06985f00-6d5c-11eb-90ff-f92b57660ddb.png">

#### Testing instructions

- Use a site that has at least one subscription.
- Visit http://calypso.localhost:3000/me/purchases/add-payment-method and verify that you see the checkbox mentioned.
- Add a new card (if your API is sandboxed you can use a [stripe test card](https://stripe.com/docs/testing) with a unique last 4 digits so you can more easily tell the cards apart) using the form and leave the checkbox checked.
- Verify that the form submits correctly, and that your subscription has the new card assigned to it.
- Repeat the above steps with a new card, but uncheck the box.
- Verify that the form submits correctly, and that your subscription _does not_ have the card assigned to it.
- Verify that the new card shows up in the list of payment methods on http://calypso.localhost:3000/me/purchases/payment-methods