### PR TITLE
Checkout: Don't show "switch to annual plan" link for monthly renewals

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -39,6 +39,10 @@ export default function WPCheckoutOrderSummary( {
 	const taxLineItem = getTaxLineItem( responseCart );
 	const totalLineItem = getTotalLineItem( responseCart );
 
+	const hasRenewalInCart = responseCart.products.some(
+		( product ) => product.extra.purchaseType === 'renewal'
+	);
+
 	const isCartUpdating = FormStatus.VALIDATING === formStatus;
 
 	const plan = responseCart.products.find( ( product ) => isPlan( product ) );
@@ -62,7 +66,7 @@ export default function WPCheckoutOrderSummary( {
 						nextDomainIsFree={ nextDomainIsFree }
 					/>
 				) }
-				{ ! isCartUpdating && hasMonthlyPlan && (
+				{ ! isCartUpdating && hasMonthlyPlan && ! hasRenewalInCart && (
 					<SwitchToAnnualPlan plan={ plan } onChangePlanLength={ onChangePlanLength } />
 				) }
 			</CheckoutSummaryFeatures>


### PR DESCRIPTION
Clicking the "switch to annual plan" link in the Checkout sidebar for monthly renewal causes Checkout to fail. Originally, [this link was hidden for renewals](https://github.com/Automattic/wp-calypso/commit/29d0b4c5544e35cb1f7d73a7c3a275e88153333e), but at some point that check was removed. This PR puts the check back in place.

See #48894. This PR specifically fixes the regression from [this comment](https://github.com/Automattic/wp-calypso/issues/48894#issuecomment-766932486) and not the greater feature of switching intervals from monthly to yearly, which I believe Marketing is tackling.

/cc @paulbonahora @taggon 

**Before:**
![Screen Shot 2021-02-14 at 12 48 22 PM](https://user-images.githubusercontent.com/942359/107884717-8c371e80-6ec4-11eb-93a8-718c0fc65ef4.png)

**After:**
<img width="946" alt="Screen Shot 2021-02-14 at 12 47 56 PM" src="https://user-images.githubusercontent.com/942359/107884721-948f5980-6ec4-11eb-952d-2fe2be9ec0a3.png">

**To test:**
- on a site with a monthly plan
- visit the site's subscription settings
- click "renew now"
- verify that the link isn't shown in Checkout's sidebar
- on a site without a plan
- add a monthly plan to your cart
- verify that the link is shown in Checkout's sidebar