### PR TITLE
ExPlat: Fix flaky unit tests

### DIFF
--- a/packages/explat-client/src/internal/test/timing.ts
+++ b/packages/explat-client/src/internal/test/timing.ts
@@ -29,16 +29,20 @@ describe( 'timeoutPromise', () => {
 	it( 'should resolve promises below the timeout', async () => {
 		const promise1 = Timing.timeoutPromise( new Promise( ( res ) => res( 123 ) ), 1 );
 		jest.advanceTimersToNextTimer();
+		jest.advanceTimersToNextTimer();
 		await expect( promise1 ).resolves.toBe( 123 );
 		const promise2 = Timing.timeoutPromise( delayedValue( 123, 1 ), 4 );
+		jest.advanceTimersToNextTimer();
 		jest.advanceTimersToNextTimer();
 		await expect( promise2 ).resolves.toBe( 123 );
 	} );
 	it( 'should throw if promise gets timed-out', async () => {
 		const promise1 = Timing.timeoutPromise( delayedValue( null, 4 ), 1 );
 		jest.advanceTimersToNextTimer();
+		jest.advanceTimersToNextTimer();
 		await expect( promise1 ).rejects.toThrowError();
 		const promise2 = Timing.timeoutPromise( delayedValue( null, 5 ), 2 );
+		jest.advanceTimersToNextTimer();
 		jest.advanceTimersToNextTimer();
 		await expect( promise2 ).rejects.toThrowError();
 	} );

--- a/packages/explat-client/src/internal/test/timing.ts
+++ b/packages/explat-client/src/internal/test/timing.ts
@@ -28,22 +28,18 @@ const delayedValue = < T >( value, delayMilliseconds ): Promise< T > =>
 describe( 'timeoutPromise', () => {
 	it( 'should resolve promises below the timeout', async () => {
 		const promise1 = Timing.timeoutPromise( new Promise( ( res ) => res( 123 ) ), 1 );
-		jest.advanceTimersToNextTimer();
-		jest.advanceTimersToNextTimer();
+		jest.advanceTimersByTime( 2 );
 		await expect( promise1 ).resolves.toBe( 123 );
 		const promise2 = Timing.timeoutPromise( delayedValue( 123, 1 ), 4 );
-		jest.advanceTimersToNextTimer();
-		jest.advanceTimersToNextTimer();
+		jest.advanceTimersByTime( 5 );
 		await expect( promise2 ).resolves.toBe( 123 );
 	} );
 	it( 'should throw if promise gets timed-out', async () => {
 		const promise1 = Timing.timeoutPromise( delayedValue( null, 4 ), 1 );
-		jest.advanceTimersToNextTimer();
-		jest.advanceTimersToNextTimer();
+		jest.advanceTimersByTime( 5 );
 		await expect( promise1 ).rejects.toThrowError();
 		const promise2 = Timing.timeoutPromise( delayedValue( null, 5 ), 2 );
-		jest.advanceTimersToNextTimer();
-		jest.advanceTimersToNextTimer();
+		jest.advanceTimersByTime( 6 );
 		await expect( promise2 ).rejects.toThrowError();
 	} );
 } );
@@ -52,7 +48,7 @@ describe( 'asyncOneAtATime', () => {
 	it( 'it should wrap an async function and behave the same', async () => {
 		const f = Timing.asyncOneAtATime( async () => delayedValue( 123, 0 ) );
 		const promise = f();
-		jest.advanceTimersToNextTimer();
+		jest.advanceTimersByTime( 1 );
 		await expect( promise ).resolves.toBe( 123 );
 	} );
 
@@ -63,7 +59,7 @@ describe( 'asyncOneAtATime', () => {
 		const c = f();
 		expect( a ).toBe( b );
 		expect( b ).toBe( c );
-		jest.advanceTimersToNextTimer();
+		jest.advanceTimersByTime( 2 );
 		await expect( a ).resolves.toBe( 123 );
 	} );
 
@@ -72,19 +68,17 @@ describe( 'asyncOneAtATime', () => {
 		const a = f();
 		const b = f();
 		expect( a ).toBe( b );
-		jest.advanceTimersToNextTimer();
-		jest.advanceTimersToNextTimer();
+		jest.advanceTimersByTime( 4 );
 		await expect( a ).resolves.toBe( 123 );
 
 		const delay = delayedValue( null, 3 );
-		jest.advanceTimersToNextTimer();
+		jest.advanceTimersByTime( 4 );
 		await delay;
 		const c = f();
 		const d = f();
 		expect( a ).not.toBe( c );
 		expect( c ).toBe( d );
-		jest.advanceTimersToNextTimer();
-		jest.advanceTimersToNextTimer();
+		jest.advanceTimersByTime( 4 );
 		await expect( c ).resolves.toBe( 123 );
 	} );
 } );

--- a/packages/explat-client/src/internal/test/timing.ts
+++ b/packages/explat-client/src/internal/test/timing.ts
@@ -28,11 +28,11 @@ describe( 'timeoutPromise', () => {
 		await expect( Timing.timeoutPromise( new Promise( ( res ) => res( 123 ) ), 1 ) ).resolves.toBe(
 			123
 		);
-		await expect( Timing.timeoutPromise( delayedValue( 123, 1 ), 2 ) ).resolves.toBe( 123 );
+		await expect( Timing.timeoutPromise( delayedValue( 123, 1 ), 4 ) ).resolves.toBe( 123 );
 	} );
 	it( 'should throw if promise gets timed-out', async () => {
-		await expect( Timing.timeoutPromise( delayedValue( null, 2 ), 1 ) ).rejects.toThrowError();
-		await expect( Timing.timeoutPromise( delayedValue( null, 3 ), 2 ) ).rejects.toThrowError();
+		await expect( Timing.timeoutPromise( delayedValue( null, 4 ), 1 ) ).rejects.toThrowError();
+		await expect( Timing.timeoutPromise( delayedValue( null, 5 ), 2 ) ).rejects.toThrowError();
 	} );
 } );
 
@@ -53,13 +53,13 @@ describe( 'asyncOneAtATime', () => {
 	} );
 
 	it( 'it should return a different promise after the last has resolved', async () => {
-		const f = Timing.asyncOneAtATime( async () => delayedValue( 123, 5 ) );
+		const f = Timing.asyncOneAtATime( async () => delayedValue( 123, 3 ) );
 		const a = f();
 		const b = f();
 		expect( a ).toBe( b );
 		await expect( a ).resolves.toBe( 123 );
 
-		await delayedValue( null, 5 );
+		await delayedValue( null, 3 );
 		const c = f();
 		const d = f();
 		expect( a ).not.toBe( c );

--- a/packages/explat-client/src/internal/test/timing.ts
+++ b/packages/explat-client/src/internal/test/timing.ts
@@ -71,9 +71,7 @@ describe( 'asyncOneAtATime', () => {
 		jest.advanceTimersByTime( 4 );
 		await expect( a ).resolves.toBe( 123 );
 
-		const delay = delayedValue( null, 3 );
 		jest.advanceTimersByTime( 4 );
-		await delay;
 		const c = f();
 		const d = f();
 		expect( a ).not.toBe( c );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR tunes some of the delays in the unit tests to prevent failing tests.

See p1613165357012400-slack-CDRRDATPS



#### Testing instructions
 
* AT
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
