### PR TITLE
ExPlat: some Promise type fixups

### DIFF
--- a/packages/explat-client/src/internal/test/timing.ts
+++ b/packages/explat-client/src/internal/test/timing.ts
@@ -20,14 +20,12 @@ describe( 'monotonicNow', () => {
 	} );
 } );
 
-const delayedValue = < T >( value, delayMilliseconds ): Promise< T > =>
+const delayedValue = < T >( value: T, delayMilliseconds: number ): Promise< T > =>
 	new Promise( ( res ) => setTimeout( () => res( value ), delayMilliseconds ) );
 
 describe( 'timeoutPromise', () => {
 	it( 'should resolve promises below the timeout', async () => {
-		await expect( Timing.timeoutPromise( new Promise( ( res ) => res( 123 ) ), 1 ) ).resolves.toBe(
-			123
-		);
+		await expect( Timing.timeoutPromise( Promise.resolve( 123 ), 1 ) ).resolves.toBe( 123 );
 		await expect( Timing.timeoutPromise( delayedValue( 123, 1 ), 2 ) ).resolves.toBe( 123 );
 	} );
 	it( 'should throw if promise gets timed-out', async () => {

--- a/packages/explat-client/src/internal/timing.ts
+++ b/packages/explat-client/src/internal/timing.ts
@@ -24,10 +24,10 @@ export function monotonicNow(): number {
 export function timeoutPromise< T >(
 	promise: Promise< T >,
 	timeoutMilliseconds: number
-): Promise< T | null > {
+): Promise< T > {
 	return Promise.race( [
 		promise,
-		new Promise< null >( ( _res, rej ) =>
+		new Promise< T >( ( _res, rej ) =>
 			setTimeout( () => rej( new Error( 'Promise has timed-out.' ) ), timeoutMilliseconds )
 		),
 	] );


### PR DESCRIPTION
Few ExPlat fixups I found while looking at #50068 🙂 

- `timeoutPromise< T >` return type is `Promise< T >`, not `Promise< T, null >`. The function never returns a promise that would resolve to `null`. The returned promise either resolves to `T` or rejects with a timeout error
- `delayedValue` needs its params annotated to stop TypeScript from warning about them implicitly having `any` type
- `new Promise( r => r( x ) )` is equivalent to `Promise.resolve( x )`, let's use the latter

I also have some feedback about the `asyncOneAtATime` tests. They should be testing something else. Returning a same or different promise is not the point of the function. The function would work well even if it returned a different promise every time. The point is that the wrapped function `f` is not called again while it's still resolving. Testing the important behavior would look like:
```js
const counter = 1;
const wrapped = asyncOneAtATime( () => delayedValue( counter++, 100 ) );

// call the wrapped function twice
const a = wrapped();
const b = wrapped();

// check that the counter was advanced only once and both promises resolve to the same value.
await expect( a ).resolves.toBe( 1 );
await expect( b ).resolves.toBe( 1 );

// check that the counter advances now after the original task finished
const c = wrapped();
await expect( c ).resolves.toBe( 2 );
```