### PR TITLE
SEO Tools: Update the availibility logic for Jetpack sites.

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -33,6 +33,7 @@ import {
 } from 'calypso/state/site-settings/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
+import getJetpackModules from 'calypso/state/selectors/get-jetpack-modules';
 import isHiddenSite from 'calypso/state/selectors/is-hidden-site';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
@@ -47,7 +48,6 @@ import {
 	FEATURE_ADVANCED_SEO,
 	FEATURE_SEO_PREVIEW_TOOLS,
 	TYPE_BUSINESS,
-	JETPACK_RESET_PLANS,
 } from 'calypso/lib/plans/constants';
 import { findFirstSimilarPlanKey } from 'calypso/lib/plans';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
@@ -368,19 +368,17 @@ export class SeoForm extends React.Component {
 						</NoticeAction>
 					</Notice>
 				) }
-
-				{ ! this.props.hasSeoPreviewFeature &&
-					! this.props.hasAdvancedSEOFeature &&
-					selectedSite.plan && (
-						<UpsellNudge
-							{ ...upsellProps }
-							description={ translate(
-								'Get tools to optimize your site for improved search engine results.'
-							) }
-							event={ 'calypso_seo_settings_upgrade_nudge' }
-							showIcon={ true }
-						/>
-					) }
+				{ ! showAdvancedSeo && (
+					<UpsellNudge
+						forceDisplay={ siteIsJetpack }
+						{ ...upsellProps }
+						description={ translate(
+							'Get tools to optimize your site for improved search engine results.'
+						) }
+						event={ 'calypso_seo_settings_upgrade_nudge' }
+						showIcon={ true }
+					/>
+				) }
 				<form onChange={ this.props.markChanged } className="seo-settings__seo-form">
 					{ showAdvancedSeo && ! conflictedSeoPlugin && (
 						<div>
@@ -482,13 +480,15 @@ export class SeoForm extends React.Component {
 
 const mapStateToProps = ( state ) => {
 	const selectedSite = getSelectedSite( state );
-	// SEO Tools are available with Business plan on WordPress.com, and with Premium plan on Jetpack sites
-	const isAdvancedSeoEligible =
-		selectedSite.plan &&
-		( hasSiteSeoFeature( selectedSite ) ||
-			JETPACK_RESET_PLANS.includes( selectedSite.plan.product_slug ) );
 	const siteId = getSelectedSiteId( state );
 	const siteIsJetpack = isJetpackSite( state, siteId );
+	// SEO Tools are available with Business plan on WordPress.com, and
+	// will soon be available on all Jetpack sites, so we're checking
+	// the availability of the module.
+	const isAdvancedSeoEligible =
+		selectedSite.plan &&
+		hasSiteSeoFeature( selectedSite ) &&
+		( ! siteIsJetpack || get( getJetpackModules( state, siteId ), 'seo-tools.available', false ) );
 
 	const activePlugins = getPlugins( state, [ siteId ], 'active' );
 	const conflictedSeoPlugin = siteIsJetpack

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -368,7 +368,7 @@ export class SeoForm extends React.Component {
 						</NoticeAction>
 					</Notice>
 				) }
-				{ ! showAdvancedSeo && (
+				{ ! showAdvancedSeo && selectedSite.plan && (
 					<UpsellNudge
 						forceDisplay={ siteIsJetpack }
 						{ ...upsellProps }

--- a/client/my-sites/site-settings/seo-settings/help.jsx
+++ b/client/my-sites/site-settings/seo-settings/help.jsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import { Card } from '@automattic/components';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import SupportInfo from 'calypso/components/support-info';
+import getJetpackModules from 'calypso/state/selectors/get-jetpack-modules';
 import { hasFeature } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -76,7 +78,9 @@ const SeoSettingsHelpCard = ( {
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteIsJetpack = isJetpackSite( state, siteId );
-	const hasAdvancedSEOFeature = hasFeature( state, siteId, FEATURE_ADVANCED_SEO );
+	const hasAdvancedSEOFeature =
+		hasFeature( state, siteId, FEATURE_ADVANCED_SEO ) &&
+		( ! siteIsJetpack || get( getJetpackModules( state, siteId ), 'seo-tools.available', false ) );
 
 	return {
 		siteId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #49504 we were fixing an issue where the SEO Tools plan gating wasn't taking the new Jetpack plans into account. We intended on changing this feature so that it's available to all Jetpack sites, so took this opportunity to update the logic.

But the corresponding logic needs updating in Jetpack, and so people with a free plan on Jetpack are currently getting an error when they try and enable the feature.

The change in Jetpack is being handled in automattic/jetpack#17309 but until that's merged and released the problem will persist in Calypso.

This change updates the logic to check if the `seo-tools` module is available. We call this API endpoint anyway, so it shouldn't have any performance impact, and when the module becomes available in a later version of Jetpack, then the UI will update. This also covers the situation where a site continues to run an older version of Jetpack.

#### Testing instructions

* Create a Jetpack with a free plan
* Go to /marketing/traffic
* Without this PR you should see a toggle to turn on the SEO features, which won't work. 
* With this PR then you should continue to see the nudge to upgrade.
* Check this with Jetpack sites with a paid plan - the feature should be available
* Check with simple sites - free and premium plans should be prompted to upgrade, business plan sites should have the feature available.


