### PR TITLE
ci: Better output for e2e tests in TeamCity

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -859,8 +859,6 @@ object RunCanaryE2eTests : BuildType({
 
 				export LIVEBRANCHES=true
 				export NODE_CONFIG_ENV=test
-
-				## Uncomment to debug Magellan
 				export MAGELLANDEBUG=true
 
 				IMAGE_URL="https://calypso.live?image=registry.a8c.com/calypso/app:build-${BuildDockerImage.depParamRefs.buildNumber}";

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -861,7 +861,7 @@ object RunCanaryE2eTests : BuildType({
 				export NODE_CONFIG_ENV=test
 
 				## Uncomment to debug Magellan
-				#export MAGELLANDEBUG=true
+				export MAGELLANDEBUG=true
 
 				IMAGE_URL="https://calypso.live?image=registry.a8c.com/calypso/app:build-${BuildDockerImage.depParamRefs.buildNumber}";
 				MAX_LOOP=10

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -860,6 +860,7 @@ object RunCanaryE2eTests : BuildType({
 				export LIVEBRANCHES=true
 				export NODE_CONFIG_ENV=test
 				export MAGELLANDEBUG=true
+				export TEST_VIDEO=true
 
 				IMAGE_URL="https://calypso.live?image=registry.a8c.com/calypso/app:build-${BuildDockerImage.depParamRefs.buildNumber}";
 				MAX_LOOP=10
@@ -888,9 +889,6 @@ object RunCanaryE2eTests : BuildType({
 
 				# Decrypt config
 				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
-
-				# Start framebuffer
-				Xvfb ${'$'}{DISPLAY} -screen 0 1440x1000x24 &
 
 				# Run the test
 				./run.sh -R -a %E2E_WORKERS% -C -s "mobile,desktop" -u "${'$'}{URL%/}"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -954,7 +954,6 @@ object RunCanaryE2eTests : BuildType({
 
 	failureConditions {
 		executionTimeoutMin = 20
-		supportTestRetry = true
 	}
 
 	dependencies {

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -166,10 +166,14 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 
 				// eslint-disable-next-line no-case-declarations
 				const service = new chrome.ServiceBuilder( chromedriver.path )
-					.loggingTo( './chromedriver.' + Math.random() + '.log' )
+					.loggingTo( './chromedriver.' + process.pid + '.log' )
 					.enableVerboseLogging()
 					.build();
 				chrome.setDefaultService( service );
+				options.setChromeLogFile( './chrome.' + process.pid + '.log' );
+				options.addArguments( '--enable-logging' );
+				options.addArguments( '--log-level 0' );
+				options.addArguments( '--log-net-log ./chrome.net.' + process.pid + '.log' );
 
 				builder = new webdriver.Builder();
 				builder.setChromeOptions( options );

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -265,10 +265,10 @@ else # Not using multiple CircleCI containers, just queue up the tests in sequen
       for locale in ${LOCALE_ARRAY[@]}; do
         for config in "${MAGELLAN_CONFIGS[@]}"; do
           if [ "$config" != "" ]; then
-            CMD="env BROWSERSIZE=$size BROWSERLOCALE=$locale NODE_CONFIG='{$NODE_CONFIG_ARG}' $MAGELLAN --mocha_args='$MOCHA_ARGS' --config='$config' --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER --debug"
-
-            eval $CMD
+		  	echo "Starting"
+            BROWSERSIZE=$size BROWSERLOCALE=$locale NODE_CONFIG='{$NODE_CONFIG_ARG}' yarn magellan --mocha_args='$MOCHA_ARGS' --config='$config' --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER --debug
             RETURN+=$?
+			echo "Done"
           fi
         done
       done

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -231,7 +231,7 @@ if [ $PARALLEL == 1 ]; then
   fi
   if [ $CIRCLE_NODE_INDEX == $DESKTOP ]; then
       echo "Executing tests at desktop screen width"
-      CMD="env BROWSERSIZE=desktop NODE_CONFIG='{$NODE_CONFIG_ARG}' $MAGELLAN --config=$MAGELLAN_CONFIGS --mocha_args='$MOCHA_ARGS' --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER"
+      CMD="env BROWSERSIZE=desktop NODE_CONFIG='{$NODE_CONFIG_ARG}' $MAGELLAN --config=$MAGELLAN_CONFIGS --mocha_args="${MOCHA_ARGS}" --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER"
 
       eval $CMD
       RETURN+=$?
@@ -266,7 +266,7 @@ else # Not using multiple CircleCI containers, just queue up the tests in sequen
         for config in "${MAGELLAN_CONFIGS[@]}"; do
           if [ "$config" != "" ]; then
 		  	echo "Starting"
-            BROWSERSIZE=$size BROWSERLOCALE=$locale NODE_CONFIG='{$NODE_CONFIG_ARG}' yarn magellan --mocha_args='$MOCHA_ARGS' --config='$config' --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER --debug
+			BROWSERSIZE="${size}" BROWSERLOCALE="${locale}" NODE_CONFIG="'{${NODE_CONFIG_ARG}}'" yarn magellan --mocha_args="${MOCHA_ARGS}" --config="${config}" --max_workers="${WORKERS}" --local_browser="${LOCAL_BROWSER}" --debug
             RETURN+=$?
 			echo "Done"
           fi

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -231,7 +231,7 @@ if [ $PARALLEL == 1 ]; then
   fi
   if [ $CIRCLE_NODE_INDEX == $DESKTOP ]; then
       echo "Executing tests at desktop screen width"
-      CMD="env BROWSERSIZE=desktop NODE_CONFIG='{$NODE_CONFIG_ARG}' $MAGELLAN --config=$MAGELLAN_CONFIGS --mocha_args="${MOCHA_ARGS}" --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER"
+      CMD="env BROWSERSIZE=desktop NODE_CONFIG='{$NODE_CONFIG_ARG}' $MAGELLAN --config=$MAGELLAN_CONFIGS --mocha_args='$MOCHA_ARGS' --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER"
 
       eval $CMD
       RETURN+=$?

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -266,7 +266,7 @@ else # Not using multiple CircleCI containers, just queue up the tests in sequen
         for config in "${MAGELLAN_CONFIGS[@]}"; do
           if [ "$config" != "" ]; then
 		  	echo "Starting"
-			BROWSERSIZE="${size}" BROWSERLOCALE="${locale}" NODE_CONFIG="'{${NODE_CONFIG_ARG}}'" yarn magellan --mocha_args="${MOCHA_ARGS}" --config="${config}" --max_workers="${WORKERS}" --local_browser="${LOCAL_BROWSER}" --debug
+			BROWSERSIZE="${size}" BROWSERLOCALE="${locale}" NODE_CONFIG="{${NODE_CONFIG_ARG}}" yarn magellan --mocha_args="${MOCHA_ARGS}" --config="${config}" --max_workers="${WORKERS}" --local_browser="${LOCAL_BROWSER}" --debug
             RETURN+=$?
 			echo "Done"
           fi


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Prefix each message from `mocha` with the test executor ID. This should help us identify which test is producing which messages.
* Record chrome and crhomedriver logs
* Use `TEST_VIDEO=true` instead of starting our own `xfvb`. See this file for more info: https://github.com/Automattic/wp-calypso/blob/4537033c6794449ce0a10b69d72daf5fa658d553/test/e2e/lib/video-recorder.js#L43
* Do not tell TeamCity we are retrying test. If not, it will mark tests as `muted` when they fail once (see https://www.jetbrains.com/help/teamcity/build-failure-conditions.html#Common+build+failure+conditions)

Before:
![image](https://user-images.githubusercontent.com/975703/107939415-f617fc80-6f86-11eb-9609-876ac226f379.png)

After:
![image](https://user-images.githubusercontent.com/975703/107939494-18117f00-6f87-11eb-9e1e-e50b702b6853.png)



#### Testing instructions

* Run `Canary e2e tests` in TeamCity for this branch and observe the results.
