### PR TITLE
Fix content width for Store deprecation notice on smaller screens

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -165,9 +165,11 @@
 		margin: 17px;
 	}
 
-	p {
-		max-width: 50%;
-		margin: auto;
+	@media screen and ( min-width: 720px ) {
+		p {
+			max-width: 50%;
+			margin: auto;
+		}
 	}
 
 	&.store-removed {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes margin rules on the Store deprecation notice for smaller screens.

#### Before

![105116156-25ad2380-5b05-11eb-8667-1a2ad5ad56da](https://user-images.githubusercontent.com/9312929/108007094-15229700-7038-11eb-8f35-13bcc6bfd756.png)

#### After

##### Small Screen Sizes

<img width="399" alt="Screen Shot 2021-02-15 at 6 06 33 pm" src="https://user-images.githubusercontent.com/9312929/107934895-94be5080-6fbb-11eb-9cbe-6bd79218f7e5.png">

<img width="767" alt="Screen Shot 2021-02-15 at 6 00 06 pm" src="https://user-images.githubusercontent.com/9312929/107934994-ba4b5a00-6fbb-11eb-8d2c-e7325320d188.png">

##### Large Screen Sizes

<img width="1037" alt="Screen Shot 2021-02-15 at 6 05 57 pm" src="https://user-images.githubusercontent.com/9312929/107934957-ac95d480-6fbb-11eb-990d-db4755f3fd12.png">

<img width="1383" alt="Screen Shot 2021-02-15 at 6 06 14 pm" src="https://user-images.githubusercontent.com/9312929/107934935-a1db3f80-6fbb-11eb-8942-32433c5816ee.png">

#### Testing instructions

* With a business site with an existing store set up.
* Go to the old store URL - http://calypso.localhost:3000/store/EXAMPLE.wpcomstaging.com to display the notice.
* View the notice io a small screen and ensure the content flows to each side of the screen.
* View the notice on a large screen and ensure the content has a margin to center it.

Related to #49060
