### PR TITLE
Nav Unification: Decode Entities & Strip HTML of Label

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -16,6 +16,7 @@ import MaterialIcon from 'calypso/components/material-icon';
 import Count from 'calypso/components/count';
 import { preload } from 'calypso/sections-helper';
 import TranslatableString from 'calypso/components/translatable/proptype';
+import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 
 export default function SidebarItem( props ) {
 	const isExternalLink = isExternal( props.link );
@@ -69,7 +70,7 @@ export default function SidebarItem( props ) {
 
 				{ /* eslint-disable wpcalypso/jsx-classname-namespace */ }
 				<span className="sidebar__menu-link-text menu-link-text" data-e2e-sidebar={ props.label }>
-					{ props.label }
+					{ stripHTML( decodeEntities( props.label ) ) }
 					{ !! count && <Count count={ count } /> }
 				</span>
 				{ showAsExternal && <Gridicon icon="external" size={ 24 } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensures the labels in the Nav Unification menu appears properly 

#### Testing instructions

You should just be able to verify the changes in the sidebar menu! 

It's worth noting that it doesn't apply to just "Backup & Scan" label mentioned in the original issue either; although it seems to be the only one with Jetpack, this PR should also fix the issue with custom plugins.

**Before:**
<img width="445" alt="Screenshot 2021-02-15 at 11 14 59" src="https://user-images.githubusercontent.com/43215253/107939785-2065bc00-6f7f-11eb-8b0a-b2fa6f885b9a.png">

**After:**
<img width="457" alt="Screenshot 2021-02-15 at 11 14 29" src="https://user-images.githubusercontent.com/43215253/107939818-2fe50500-6f7f-11eb-969c-2d0dad2050e1.png">

cc @mmtr, @papazoglou, @tjcafferkey  

Fixes #50076 