### PR TITLE
People: remove never-finished bulkEditing code from lists

### DIFF
--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -15,7 +15,6 @@ import { connect } from 'react-redux';
 import Gridicon from 'calypso/components/gridicon';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
 import { Card, Button } from '@automattic/components';
-import classNames from 'classnames';
 import PeopleListSectionHeader from 'calypso/my-sites/people/people-list-section-header';
 import InfiniteList from 'calypso/components/infinite-list';
 import NoResults from 'calypso/my-sites/no-results';
@@ -35,15 +34,7 @@ import { addQueryArgs } from 'calypso/lib/url';
 const MAX_FOLLOWERS = 1000;
 
 class Followers extends Component {
-	constructor() {
-		super();
-
-		this.infiniteList = React.createRef();
-	}
-
-	state = {
-		bulkEditing: false,
-	};
+	infiniteList = React.createRef();
 
 	renderPlaceholders() {
 		return <PeopleListItem key="people-list-item-placeholder" />;
@@ -95,7 +86,6 @@ class Followers extends Component {
 				user={ follower }
 				type="follower"
 				site={ this.props.site }
-				isSelectable={ this.state.bulkEditing }
 				onRemove={ () => this.removeFollower( follower ) }
 			/>
 		);
@@ -138,10 +128,6 @@ class Followers extends Component {
 
 	render() {
 		const key = deterministicStringify( omit( this.props.query, [ 'max', 'page' ] ) );
-		const listClass = classNames( {
-			'bulk-editing': this.state.bulkEditing,
-			'people-invites__invites-list': true,
-		} );
 
 		if ( this.noFollowerSearchResults() ) {
 			return (
@@ -254,7 +240,7 @@ class Followers extends Component {
 						</Button>
 					) }
 				</PeopleListSectionHeader>
-				<Card className={ listClass }>{ followers }</Card>
+				<Card className="people-invites__invites-list">{ followers }</Card>
 				{ this.isLastPage() && <ListEnd /> }
 			</>
 		);

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -13,10 +13,6 @@
 		border-bottom: none;
 	}
 
-	.bulk-editing & {
-		padding-left: 40px;
-	}
-
 	&:focus {
 		outline: 2px solid var( --color-primary-light );
 		z-index: z-index( 'root', '.people-list-item.card.is-compact:focus' );

--- a/client/my-sites/people/team-list/team.jsx
+++ b/client/my-sites/people/team-list/team.jsx
@@ -14,7 +14,6 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import classNames from 'classnames';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
 import { fetchUsers } from 'calypso/lib/users/actions';
 import InfiniteList from 'calypso/components/infinite-list';
@@ -26,27 +25,13 @@ import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 const debug = debugFactory( 'calypso:my-sites:people:team-list' );
 
 class Team extends React.Component {
-	static displayName = 'Team';
-
-	constructor() {
-		super();
-
-		this.infiniteList = React.createRef();
-	}
-
-	state = {
-		bulkEditing: false,
-	};
+	infiniteList = React.createRef();
 
 	isLastPage = () =>
 		this.props.totalUsers <= this.props.users.length + this.props.excludedUsers.length;
 
 	render() {
 		const key = deterministicStringify( omit( this.props.fetchOptions, [ 'number', 'offset' ] ) );
-		const listClass = classNames( {
-			'bulk-editing': this.state.bulkEditing,
-			'people-invites__invites-list': true,
-		} );
 		let people;
 		let headerText;
 		if ( this.props.totalUsers ) {
@@ -124,23 +109,15 @@ class Team extends React.Component {
 					site={ this.props.site }
 					isPlaceholder={ this.props.fetchingUsers || this.props.fetchOptions.search }
 				/>
-				<Card className={ listClass }>{ people }</Card>
+				<Card className="people-invites__invites-list">{ people }</Card>
 				{ this.isLastPage() && <ListEnd /> }
 			</div>
 		);
 	}
 
-	renderPerson = ( user ) => {
-		return (
-			<PeopleListItem
-				key={ user.ID }
-				user={ user }
-				type="user"
-				site={ this.props.site }
-				isSelectable={ this.state.bulkEditing }
-			/>
-		);
-	};
+	renderPerson = ( user ) => (
+		<PeopleListItem key={ user.ID } user={ user } type="user" site={ this.props.site } />
+	);
 
 	fetchNextPage = () => {
 		const offset = this.props.users.length;

--- a/client/my-sites/people/viewers-list/viewers.jsx
+++ b/client/my-sites/people/viewers-list/viewers.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
 /**
  * External dependencies
  */
@@ -19,18 +21,8 @@ import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { removeViewer } from 'calypso/state/viewers/actions';
 import { getViewers, getTotalViewers, isFetchingViewers } from 'calypso/state/viewers/selectors';
 
-class Viewers extends React.PureComponent {
-	static displayName = 'Viewers';
-
-	constructor() {
-		super();
-
-		this.infiniteList = React.createRef();
-	}
-
-	state = {
-		bulkEditing: false,
-	};
+class Viewers extends React.Component {
+	infiniteList = React.createRef();
 
 	renderPlaceholders = () => <PeopleListItem key="people-list-item-placeholder" />;
 
@@ -84,7 +76,6 @@ class Viewers extends React.PureComponent {
 				user={ viewer }
 				type="viewer"
 				site={ this.props.site }
-				isSelectable={ this.state.bulkEditing }
 				onRemove={ removeThisViewer }
 			/>
 		);
@@ -95,7 +86,6 @@ class Viewers extends React.PureComponent {
 	isLastPage = () => this.props.totalViewers <= this.props.viewers.length;
 
 	render() {
-		const listClass = this.state.bulkEditing ? 'bulk-editing' : null;
 		let viewers;
 		let emptyContentArgs = {
 			title:
@@ -147,7 +137,7 @@ class Viewers extends React.PureComponent {
 					isPlaceholder={ this.props.fetching }
 					count={ this.props.fetching ? null : this.props.totalViewers }
 				/>
-				<Card className={ listClass }>{ viewers }</Card>
+				<Card className="people-invites__invites-list">{ viewers }</Card>
 				{ this.isLastPage() && <ListEnd /> }
 			</div>
 		);


### PR DESCRIPTION
The `bulkEditing` state is always `false` in all people lists. Let's remove the code for a feature that was never finished.

Also adds some class properties syntax instead of constructors.

And adds the `"people-invites__invites-list"` class name to the `Viewers` list, which otherwise would have a large padding, unlike all other people lists.

Found when reviewing #49664.