### PR TITLE
State: Remove withoutNotice() high-order action creator

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -37,7 +37,6 @@ import {
 import { pauseGuidedTour, resumeGuidedTour } from 'calypso/state/guided-tours/actions';
 import { deleteKeyringConnection } from 'calypso/state/sharing/keyring/actions';
 import { getGuidedTourState } from 'calypso/state/guided-tours/selectors';
-import { withoutNotice } from 'calypso/state/notices/actions';
 import { clearMediaErrors, changeMediaSource } from 'calypso/state/media/actions';
 
 /**
@@ -469,12 +468,7 @@ export default connect(
 		toggleGuidedTour: ( shouldPause ) => ( dispatch ) => {
 			dispatch( shouldPause ? pauseGuidedTour() : resumeGuidedTour() );
 		},
-		deleteKeyringConnection: ( connection ) => ( dispatch ) => {
-			// We don't want this to trigger a global notice - a notice is shown inline
-			const deleteKeyring = withoutNotice( () => deleteKeyringConnection( connection ) );
-
-			dispatch( deleteKeyring() );
-		},
+		deleteKeyringConnection,
 		clearMediaErrors,
 		changeMediaSource,
 	},

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -40,7 +40,7 @@ import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { setPreviewUrl } from 'calypso/state/ui/preview/actions';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { savePost, deletePost, trashPost, restorePost } from 'calypso/state/posts/actions';
-import { infoNotice, withoutNotice } from 'calypso/state/notices/actions';
+import { infoNotice } from 'calypso/state/notices/actions';
 import { isEligibleForGutenframe } from 'calypso/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import { getEditorDuplicatePostPath } from 'calypso/state/editor/selectors';
@@ -614,7 +614,7 @@ class Page extends Component {
 		switch ( status ) {
 			case 'delete':
 				this.performUpdate( {
-					action: () => this.props.deletePost( page.site_ID, page.ID ),
+					action: () => this.props.deletePost( page.site_ID, page.ID, true ),
 					progressNotice: {
 						status: 'is-error',
 						icon: 'trash',
@@ -633,7 +633,7 @@ class Page extends Component {
 
 			case 'trash':
 				this.performUpdate( {
-					action: () => this.props.trashPost( page.site_ID, page.ID, page ),
+					action: () => this.props.trashPost( page.site_ID, page.ID, true ),
 					undo: page.status !== 'trash' ? 'restore' : 'undo',
 					progressNotice: {
 						status: 'is-error',
@@ -653,7 +653,7 @@ class Page extends Component {
 
 			case 'restore':
 				this.performUpdate( {
-					action: () => this.props.restorePost( page.site_ID, page.ID ),
+					action: () => this.props.restorePost( page.site_ID, page.ID, true ),
 					undo: page.status === 'trash' ? 'trash' : 'undo',
 					progressNotice: {
 						status: 'is-warning',
@@ -673,7 +673,7 @@ class Page extends Component {
 
 			case 'publish':
 				this.performUpdate( {
-					action: () => this.props.savePost( page.site_ID, page.ID, { status } ),
+					action: () => this.props.savePost( page.site_ID, page.ID, { status }, true ),
 					progressNotice: {
 						status: 'is-info',
 						icon: 'reader',
@@ -781,10 +781,10 @@ const mapState = ( state, props ) => {
 
 const mapDispatch = {
 	infoNotice,
-	savePost: withoutNotice( savePost ),
-	deletePost: withoutNotice( deletePost ),
-	trashPost: withoutNotice( trashPost ),
-	restorePost: withoutNotice( restorePost ),
+	savePost,
+	deletePost,
+	trashPost,
+	restorePost,
 	setPreviewUrl,
 	setLayoutFocus,
 	recordEvent,

--- a/client/state/jetpack-connect/actions/is-user-connected.js
+++ b/client/state/jetpack-connect/actions/is-user-connected.js
@@ -9,7 +9,6 @@ import { omit } from 'lodash';
  */
 import wpcom from 'calypso/lib/wp';
 import { receiveDeletedSite, receiveSite } from 'calypso/state/sites/actions';
-import { withoutNotice } from 'calypso/state/notices/actions';
 import { JETPACK_CONNECT_USER_ALREADY_CONNECTED } from 'calypso/state/jetpack-connect/action-types';
 import {
 	SITE_REQUEST,
@@ -65,7 +64,7 @@ export function isUserConnected( siteId, siteIsOnSitesList ) {
 				debug( 'user is not connected from', error );
 				if ( siteIsOnSitesList ) {
 					debug( 'removing site from sites list', siteId );
-					dispatch( withoutNotice( receiveDeletedSite )( siteId ) );
+					dispatch( receiveDeletedSite( siteId ) );
 				}
 			} );
 	};

--- a/client/state/notices/actions.ts
+++ b/client/state/notices/actions.ts
@@ -7,7 +7,6 @@ import impureLodash from 'calypso/lib/impure-lodash';
  * Internal dependencies
  */
 import { NOTICE_CREATE, NOTICE_REMOVE } from 'calypso/state/action-types';
-import { extendAction } from 'calypso/state/utils';
 import type {
 	NoticeActionCreator,
 	NoticeActionCreatorWithStatus,
@@ -50,8 +49,3 @@ export const warningNotice: NoticeActionCreator = ( text, noticeOptions ) =>
 	createNotice( 'is-warning', text, noticeOptions );
 export const plainNotice: NoticeActionCreator = ( text, noticeOptions ) =>
 	createNotice( 'is-plain', text, noticeOptions );
-
-// Higher-order action creator: modify the wrapped creator to return actions with the
-// `notices.skip` meta, so that it's ignored by the notices middleware.
-export const withoutNotice = ( actionCreator ) => ( ...args ) =>
-	extendAction( actionCreator( ...args ), { meta: { notices: { skip: true } } } );

--- a/client/state/posts/actions/delete-post.js
+++ b/client/state/posts/actions/delete-post.js
@@ -21,9 +21,10 @@ import 'calypso/state/posts/init';
  *
  * @param  {number}   siteId Site ID
  * @param  {number}   postId Post ID
+ * @param  {boolean}  silent Whether to stop related notices from appearing
  * @returns {Function}        Action thunk
  */
-export function deletePost( siteId, postId ) {
+export function deletePost( siteId, postId, silent = false ) {
 	return ( dispatch, getState ) => {
 		dispatch( {
 			type: POST_DELETE,
@@ -41,6 +42,10 @@ export function deletePost( siteId, postId ) {
 					postId,
 				} );
 
+				if ( silent ) {
+					return;
+				}
+
 				dispatch( successNotice( translate( 'Post successfully deleted' ) ) );
 			},
 			( error ) => {
@@ -50,6 +55,10 @@ export function deletePost( siteId, postId ) {
 					postId,
 					error,
 				} );
+
+				if ( silent ) {
+					return;
+				}
 
 				const post = getSitePost( getState(), siteId, postId );
 

--- a/client/state/posts/actions/restore-post.js
+++ b/client/state/posts/actions/restore-post.js
@@ -25,9 +25,10 @@ import 'calypso/state/posts/init';
  *
  * @param  {number}   siteId Site ID
  * @param  {number}   postId Post ID
+ * @param  {boolean}  silent Whether to stop related notices from appearing
  * @returns {Function}        Action thunk
  */
-export function restorePost( siteId, postId ) {
+export function restorePost( siteId, postId, silent = false ) {
 	return ( dispatch, getState ) => {
 		dispatch( {
 			type: POST_RESTORE,
@@ -45,7 +46,9 @@ export function restorePost( siteId, postId ) {
 					postId,
 				} );
 				dispatch( receivePost( restoredPost ) );
-				dispatch( successNotice( translate( 'Post successfully restored' ) ) );
+				if ( ! silent ) {
+					dispatch( successNotice( translate( 'Post successfully restored' ) ) );
+				}
 			},
 			( error ) => {
 				dispatch( {
@@ -54,6 +57,10 @@ export function restorePost( siteId, postId ) {
 					postId,
 					error,
 				} );
+
+				if ( silent ) {
+					return;
+				}
 
 				const post = getSitePost( getState(), siteId, postId );
 

--- a/client/state/posts/actions/save-post-success.js
+++ b/client/state/posts/actions/save-post-success.js
@@ -19,9 +19,10 @@ import 'calypso/state/posts/init';
  * @param  {number}   postId     Post ID
  * @param  {object}   savedPost  Updated post
  * @param  {object}   post       Post attributes
+ * @param  {boolean}  silent     Whether to stop related notices from appearing
  * @returns {object}              Action thunk
  */
-export function savePostSuccess( siteId, postId = null, savedPost, post ) {
+export function savePostSuccess( siteId, postId = null, savedPost, post, silent = false ) {
 	return ( dispatch ) => {
 		dispatch( {
 			type: POST_SAVE_SUCCESS,
@@ -30,6 +31,10 @@ export function savePostSuccess( siteId, postId = null, savedPost, post ) {
 			savedPost,
 			post,
 		} );
+
+		if ( silent ) {
+			return;
+		}
 
 		switch ( post.status ) {
 			case 'trash': {

--- a/client/state/posts/actions/save-post.js
+++ b/client/state/posts/actions/save-post.js
@@ -16,9 +16,10 @@ import 'calypso/state/posts/init';
  * @param  {number}   siteId Site ID
  * @param  {number}   postId Post ID
  * @param  {object}   post   Post attributes
+ * @param  {boolean}  silent Whether to stop related notices from appearing
  * @returns {Function}        Action thunk
  */
-export function savePost( siteId, postId = null, post ) {
+export function savePost( siteId, postId = null, post, silent = false ) {
 	return ( dispatch ) => {
 		dispatch( {
 			type: POST_SAVE,
@@ -34,7 +35,7 @@ export function savePost( siteId, postId = null, post ) {
 
 		saveResult.then(
 			( savedPost ) => {
-				dispatch( savePostSuccess( siteId, postId, savedPost, post ) );
+				dispatch( savePostSuccess( siteId, postId, savedPost, post, silent ) );
 				dispatch( receivePost( savedPost ) );
 			},
 			( error ) => {

--- a/client/state/posts/actions/trash-post.js
+++ b/client/state/posts/actions/trash-post.js
@@ -14,9 +14,10 @@ import 'calypso/state/posts/init';
  *
  * @param  {number}   siteId Site ID
  * @param  {number}   postId Post ID
+ * @param  {boolean}  silent Whether to stop related notices from appearing
  * @returns {Function}        Action thunk
  */
-export function trashPost( siteId, postId ) {
+export function trashPost( siteId, postId, silent = false ) {
 	return ( dispatch ) => {
 		// Trashing post is almost equivalent to saving the post with status field set to `trash`
 		// and the action behaves like it was doing exactly that -- it dispatches the `POST_SAVE_*`
@@ -40,7 +41,7 @@ export function trashPost( siteId, postId ) {
 
 		trashResult.then(
 			( savedPost ) => {
-				dispatch( savePostSuccess( siteId, postId, savedPost, post ) );
+				dispatch( savePostSuccess( siteId, postId, savedPost, post, silent ) );
 				dispatch( receivePost( savedPost ) );
 			},
 			( error ) => {

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -356,7 +356,8 @@ describe( 'actions', () => {
 					2916284,
 					null,
 					{ ID: 13640, title: 'Hello World' },
-					{ title: 'Hello World' }
+					{ title: 'Hello World' },
+					false
 				);
 			} );
 		} );
@@ -394,7 +395,8 @@ describe( 'actions', () => {
 					2916284,
 					13640,
 					{ ID: 13640, title: 'Updated' },
-					{ title: 'Updated' }
+					{ title: 'Updated' },
+					false
 				);
 			} );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #50035 we removed the notices middleware. Since then, the `withoutNotice` high-order action creator is essentially useless. Its purpose was to trigger the relevant lower-level action creators with the side effect of bypassing the notices middleware, resulting in no notices being displayed from it. However, since that notice middleware is gone, the bypassing is no longer needed. Thus, no need for the `withoutNotice` high-order action creator.

However, in the process of removing the notices middleware, we introduced a couple of regressions, where suppressed notices are now no longer suppressed. This PR intends to fix all those instances, in addition to removing any `withoutNotice` usage and its definition altogether. 

#### Testing instructions

* Make sure you are connected to your Google Photos account.
* Expire the connection by removing permissions from https://myaccount.google.com/u/1/permissions (or whatever that link looks like for you)
* Make sure that you don't receive a notification that the connection has been removed when you try to access photos from Google Photos in the media library
* Open Pages in Calypso.
* Publish a new page, update and save an existing page, trash a page and restore a page from a previous version, and verify you don't see Calypso notices when you do those.
