### PR TITLE
Domains: Show a less confusing message in domain-only flow

### DIFF
--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -56,7 +56,7 @@ export class SignupProcessingScreen extends Component {
 
 	getTitle() {
 		if ( this.props.flowName === 'domain' ) {
-			return this.props.translate( 'We are preparing your domain for purchase…' );
+			return this.props.translate( 'We are preparing the domain for purchase…' );
 		}
 
 		return this.props.translate( '{{strong}}Hooray!{{/strong}} Your site will be ready shortly.', {

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -55,6 +55,10 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	getTitle() {
+		if ( this.props.flowName === 'domain' ) {
+			return this.props.translate( 'We are preparing your domain for purchase…' );
+		}
+
 		return this.props.translate( '{{strong}}Hooray!{{/strong}} Your site will be ready shortly.', {
 			components: { strong: <strong />, br: <br /> },
 			comment:


### PR DESCRIPTION
Fixes #50048

_Technically_, there is a site being created, but that's behind the scenes and from user perspective it's very confusing to mention that.

#### Testing instructions

Go to calypso.localhost:3000/domains/

Choose a domain, select "Just buy a domain". You should see a message like this:

<img width="568" alt="Screenshot 2021-02-15 at 13 57 52" src="https://user-images.githubusercontent.com/3392497/107955569-d76d3200-6f95-11eb-8b98-02c70adf64d4.png">

Go to calypso.localhost:3000/start/

Choose a domain (can be free subdomain), finish the onboarding. You should see the usual "Hooray! We are setting up your site" message.

<img width="453" alt="Screenshot 2021-02-15 at 13 55 22" src="https://user-images.githubusercontent.com/3392497/107955286-82312080-6f95-11eb-8404-6973a2611625.png">
