### PR TITLE
Deduplicate @jest/types

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2013,18 +2013,7 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@jest/types@^26.3.0":
-  version "26.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.3.0.tgz#97627bf4bdb72c55346eef98e3b3f7ddc4941f71"
-  integrity sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^15.0.0"
-    chalk "^4.0.0"
-
-"@jest/types@^26.6.2":
+"@jest/types@^26.3.0", "@jest/types@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
   integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `@jest/types` (done automatically with `npx yarn-deduplicate --packages @jest/types`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> @jest/types@26.3.0
< @automattic/o2-blocks@1.0.0 -> @automattic/calypso-build@7.0.0 -> ... -> @jest/types@26.3.0
< @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/calypso-build@7.0.0 -> ... -> @jest/types@26.3.0
< @automattic/wpcom-editing-toolkit@2.18.0 -> jest@26.4.0 -> ... -> @jest/types@26.3.0
< wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> @jest/types@26.3.0
< wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> @jest/types@26.3.0
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> @jest/types@26.3.0
< wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> @jest/types@26.3.0
> @automattic/notifications@1.0.0 -> calypso@0.17.0 -> ... -> @jest/types@26.6.2
> @automattic/o2-blocks@1.0.0 -> @automattic/calypso-build@7.0.0 -> ... -> @jest/types@26.6.2
> @automattic/wpcom-editing-toolkit@2.18.0 -> @automattic/calypso-build@7.0.0 -> ... -> @jest/types@26.6.2
> @automattic/wpcom-editing-toolkit@2.18.0 -> jest@26.4.0 -> ... -> @jest/types@26.6.2
> wp-calypso@0.17.0 -> @automattic/calypso-build@7.0.0 -> ... -> @jest/types@26.6.2
> wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> @jest/types@26.6.2
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> @jest/types@26.6.2
> wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> @jest/types@26.6.2
```