### PR TITLE
Protect against empty match reasons

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -300,7 +300,9 @@ class DomainRegistrationSuggestion extends React.Component {
 		}
 
 		const isExactFullMatch =
-			matchReasons.includes( SLD_EXACT_MATCH ) && matchReasons.includes( TLD_EXACT_MATCH );
+			matchReasons &&
+			matchReasons.includes( SLD_EXACT_MATCH ) &&
+			matchReasons.includes( TLD_EXACT_MATCH );
 		let title;
 		let progressBarProps;
 		if ( isRecommended ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #50095, which is a bug introduced in #50001 when no match reasons are returned for one of the first two suggestions. This is likely to occur for generic searches like `test` or `preview`.

#### Testing instructions

* On a local branch or on [calypso.live](https://calypso.live/?branch=fix/error-in-domain-search), navigate to `/start/domains` and search for `test` or `preview`.
* The search should complete and results should appear. 

Prior to this change, the screen would just turn white.

Fixes #50095