### PR TITLE
state-utils: Extract getInitialState

### DIFF
--- a/client/state/utils/get-initial-state.js
+++ b/client/state/utils/get-initial-state.js
@@ -1,3 +1,0 @@
-export function getInitialState( reducer ) {
-	return reducer( undefined, { type: '@@calypso/INIT' } );
-}

--- a/client/state/utils/schema-utils.js
+++ b/client/state/utils/schema-utils.js
@@ -3,6 +3,7 @@
  */
 import validator from 'is-my-json-valid';
 import { forEach, get, isEmpty, isEqual } from 'lodash';
+import { getInitialState } from '@automattic/state-utils';
 
 /**
  * WordPress dependencies
@@ -13,7 +14,6 @@ import warn from '@wordpress/warning';
  * Internal dependencies
  */
 import { DESERIALIZE, SERIALIZE } from 'calypso/state/action-types';
-import { getInitialState } from './get-initial-state';
 
 export function isValidStateWithSchema( state, schema, debugInfo ) {
 	const validate = validator( schema, {

--- a/client/state/utils/without-persistence.js
+++ b/client/state/utils/without-persistence.js
@@ -1,8 +1,12 @@
 /**
+ * External dependencies
+ */
+import { getInitialState } from '@automattic/state-utils';
+
+/**
  * Internal dependencies
  */
 import { DESERIALIZE, SERIALIZE } from 'calypso/state/action-types';
-import { getInitialState } from './get-initial-state';
 
 /**
  * Wraps a reducer such that it won't persist any state to the browser's local storage

--- a/packages/state-utils/CHANGELOG.md
+++ b/packages/state-utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-alpha.2
+
+Extracted `getInitialState` into `state-utils`.
+
 ## 1.0.0-alpha.1
 
 Extracted `withStorageKey` into `state-utils`.

--- a/packages/state-utils/src/get-initial-state/index.ts
+++ b/packages/state-utils/src/get-initial-state/index.ts
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import type { Reducer } from 'redux';
+
+export default function getInitialState< TState >( reducer: Reducer< TState > ): TState {
+	return reducer( undefined, { type: '@@calypso/INIT' } );
+}

--- a/packages/state-utils/src/index.ts
+++ b/packages/state-utils/src/index.ts
@@ -1,2 +1,3 @@
 export { default as createSelector } from './create-selector';
+export { default as getInitialState } from './get-initial-state';
 export { default as withStorageKey } from './with-storage-key';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Extracts `getInitialState` into `state-utils`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test the app
* Build passes
* Unit tests pass