### PR TITLE
Update product title font to SemiCondensed Bold

### DIFF
--- a/client/components/jetpack/card/i5/jetpack-free-card-i5/style.scss
+++ b/client/components/jetpack/card/i5/jetpack-free-card-i5/style.scss
@@ -18,6 +18,7 @@
 .jetpack-free-card-i5__title {
 	color: var( --studio-gray-100 );
 
+	font-family: 'Noto Sans SemiCondensed Bold', 'Noto Sans', $sans;
 	font-size: 1.875rem;
 	font-weight: 700;
 }

--- a/client/components/jetpack/card/i5/jetpack-product-card-i5/style.scss
+++ b/client/components/jetpack/card/i5/jetpack-product-card-i5/style.scss
@@ -71,6 +71,7 @@
 
 	color: var( --studio-gray-100 );
 
+	font-family: 'Noto Sans SemiCondensed Bold', 'Noto Sans', $sans;
 	font-size: 2rem;
 	font-weight: 700;
 	line-height: 1.2;

--- a/client/my-sites/plans/jetpack-plans/style.scss
+++ b/client/my-sites/plans/jetpack-plans/style.scss
@@ -1,3 +1,13 @@
+@font-face {
+	font-display: swap;
+	font-family: 'Noto Sans SemiCondensed Bold';
+	font-weight: 700;
+	src:
+		url( 'https://s1.wp.com/i/fonts/notosans/NotoSans-SemiCondensedBold.woff2' ) format( 'woff2' ),
+		url( 'https://s1.wp.com/i/fonts/notosans/NotoSans-SemiCondensedBold.woff' ) format( 'woff' ),
+		url( 'https://s1.wp.com/i/fonts/notosans/NotoSans-SemiCondensedBold.ttf' ) format( 'truetype' );
+}
+
 .selector__main {
 	position: relative;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Relates to `1196108640073826-as-1199527862646257`.

* Update the font for product name headers to use Noto Sans SemiCondensed Bold instead of Noto Sans.

#### Testing instructions

* Apply `D57103-code` to your development sandbox.
* Alias `s1.wp.com` so that it points to your development sandbox.
* Apply this PR, either in Calypso Live or in a local testing environment.
* **NOTE:** If Calypso was already running before you applied this PR, you'll need to stop the server and do a complete rebuild.
* Verify that on Calypso Blue, Calypso Green, and in Jetpack Connect, all Jetpack product/plan names are rendered in Noto Sans SemiCondensed Bold (see reference screenshots for help telling the difference).

#### Reference screenshots

##### Before (Noto Sans Regular) / After (Noto Sans SemiCondensed Bold)

<img width="325" alt="image" src="https://user-images.githubusercontent.com/670067/107994298-01c4ec80-6fa2-11eb-8e15-d06165dc0802.png"> <img width="335" alt="image" src="https://user-images.githubusercontent.com/670067/107994228-d4783e80-6fa1-11eb-93cb-5b2b73eda9d9.png">