### PR TITLE
Checkout: Use useShoppingCart in order review

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker.tsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { Component, FunctionComponent } from 'react';
+import React, { FunctionComponent } from 'react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { RadioButton } from '@automattic/composite-checkout';
@@ -12,7 +12,7 @@ export type WPCOMProductSlug = string;
 
 export type WPCOMProductVariant = {
 	variantLabel: string;
-	variantDetails: Component;
+	variantDetails: React.ReactNode;
 	productSlug: WPCOMProductSlug;
 	productId: number;
 };

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -24,6 +24,49 @@ import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
 import type { GetProductVariants } from '../hooks/product-variants';
 import type { OnChangeItemVariant } from './item-variation-picker';
 
+const DomainURL = styled.div`
+	color: ${ ( props ) => props.theme.colors.textColorLight };
+	font-size: 14px;
+	margin-top: -10px;
+	word-break: break-word;
+
+	.is-summary & {
+		margin-bottom: 10px;
+	}
+`;
+
+const CouponLinkWrapper = styled.div`
+	font-size: 14px;
+	margin: 10px 0 20px;
+
+	.is-summary & {
+		margin-bottom: 0;
+	}
+`;
+
+const CouponField = styled( Coupon )`
+	margin: 20px 30px 20px 0;
+
+	.rtl & {
+		margin: 20px 0 20px 30px;
+	}
+
+	.is-summary & {
+		margin: 10px 0 0;
+	}
+`;
+
+const CouponEnableButton = styled.button`
+	cursor: pointer;
+	text-decoration: underline;
+	color: ${ ( props ) => props.theme.colors.highlight };
+	font-size: 14px;
+
+	:hover {
+		text-decoration: none;
+	}
+`;
+
 export default function WPCheckoutOrderReview( {
 	className,
 	removeProductFromCart,
@@ -155,46 +198,3 @@ function CouponFieldArea( {
 		</CouponLinkWrapper>
 	);
 }
-
-const DomainURL = styled.div`
-	color: ${ ( props ) => props.theme.colors.textColorLight };
-	font-size: 14px;
-	margin-top: -10px;
-	word-break: break-word;
-
-	.is-summary & {
-		margin-bottom: 10px;
-	}
-`;
-
-const CouponLinkWrapper = styled.div`
-	font-size: 14px;
-	margin: 10px 0 20px;
-
-	.is-summary & {
-		margin-bottom: 0;
-	}
-`;
-
-const CouponField = styled( Coupon )`
-	margin: 20px 30px 20px 0;
-
-	.rtl & {
-		margin: 20px 0 20px 30px;
-	}
-
-	.is-summary & {
-		margin: 10px 0 0;
-	}
-`;
-
-const CouponEnableButton = styled.button`
-	cursor: pointer;
-	text-decoration: underline;
-	color: ${ ( props ) => props.theme.colors.highlight };
-	font-size: 14px;
-
-	:hover {
-		text-decoration: none;
-	}
-`;

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -416,9 +416,10 @@ export default function CompositeCheckout( {
 		  } );
 	debug( 'filtered payment method objects', paymentMethods );
 
+	const planSlugs = getPlanProductSlugs( responseCart.products );
 	const getItemVariants = useProductVariants( {
 		siteId,
-		productSlug: getPlanProductSlugs( responseCart.products )[ 0 ],
+		productSlug: planSlugs.length > 0 ? planSlugs[ 0 ] : undefined,
 	} );
 
 	const { analyticsPath, analyticsProps } = getAnalyticsPath(

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -27,16 +27,13 @@ import type { WPCOMProductSlug, WPCOMProductVariant } from '../components/item-v
 
 const debug = debugFactory( 'calypso:composite-checkout:product-variants' );
 
-export interface Product {
-	// TODO: Whatever is stored in state and returned by the getProductsList selector
-	product_id: number;
-	currency_code: string;
-}
-
-export interface PossibleProductVariant {
+export interface AvailableProductVariant {
 	planSlug: string;
 	plan: Plan;
-	product: Product;
+	product: {
+		product_id: number;
+		currency_code: string;
+	};
 	priceFullBeforeDiscount: number;
 	priceFull: number;
 	priceFinal: number;
@@ -100,7 +97,7 @@ export function useProductVariants( {
 		}
 	}, [ shouldFetchProducts, haveFetchedProducts, reduxDispatch ] );
 
-	const getProductVariant = ( variant: PossibleProductVariant ): WPCOMProductVariant => {
+	const getProductVariant = ( variant: AvailableProductVariant ): WPCOMProductVariant => {
 		return {
 			variantLabel: getTermText( variant.plan.term, translate ),
 			variantDetails: <VariantPrice variant={ variant } />,
@@ -123,8 +120,8 @@ export function useProductVariants( {
 }
 
 function replaceFullPriceWithMonthlyCost(
-	products: PossibleProductVariant[]
-): PossibleProductVariant[] {
+	products: AvailableProductVariant[]
+): AvailableProductVariant[] {
 	const monthlyPlan = products.filter( ( product ) => product.plan?.term === TERM_MONTHLY )?.[ 0 ];
 
 	if ( ! monthlyPlan ) {
@@ -149,7 +146,7 @@ function replaceFullPriceWithMonthlyCost(
 	} );
 }
 
-function VariantPrice( { variant }: { variant: PossibleProductVariant } ) {
+function VariantPrice( { variant }: { variant: AvailableProductVariant } ) {
 	const currentPrice = variant.priceFinal || variant.priceFull;
 	const isDiscounted = currentPrice !== variant.priceFullBeforeDiscount;
 	return (
@@ -165,7 +162,7 @@ function VariantPrice( { variant }: { variant: PossibleProductVariant } ) {
 	);
 }
 
-function VariantPriceDiscount( { variant }: { variant: PossibleProductVariant } ) {
+function VariantPriceDiscount( { variant }: { variant: AvailableProductVariant } ) {
 	const translate = useTranslate();
 	const discountPercentage = Math.round(
 		100 - ( variant.priceFinal / variant.priceFullBeforeDiscount ) * 100

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -22,10 +22,56 @@ import {
 	TERM_MONTHLY,
 } from 'calypso/lib/plans/constants';
 import { requestProductsList } from 'calypso/state/products-list/actions';
+import type { Plan } from 'calypso/lib/plans/types';
+import type { WPCOMProductSlug, WPCOMProductVariant } from '../components/item-variation-picker';
 
 const debug = debugFactory( 'calypso:composite-checkout:product-variants' );
 
-export function useProductVariants( { siteId, productSlug } ) {
+export interface Product {
+	// TODO: Whatever is stored in state and returned by the getProductsList selector
+	product_id: number;
+	currency_code: string;
+}
+
+export interface PossibleProductVariant {
+	planSlug: string;
+	plan: Plan;
+	product: Product;
+	priceFullBeforeDiscount: number;
+	priceFull: number;
+	priceFinal: number;
+	priceMonthly: number;
+}
+
+export type GetProductVariants = ( productSlug: WPCOMProductSlug ) => WPCOMProductVariant[];
+
+const Discount = styled.span`
+	color: ${ ( props ) => props.theme.colors.discount };
+	margin-right: 8px;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
+`;
+
+const DoNotPayThis = styled.span`
+	text-decoration: line-through;
+	margin-right: 8px;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
+`;
+
+export function useProductVariants( {
+	siteId,
+	productSlug,
+}: {
+	siteId: number | undefined;
+	productSlug: string | undefined;
+} ): GetProductVariants {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 
@@ -54,7 +100,7 @@ export function useProductVariants( { siteId, productSlug } ) {
 		}
 	}, [ shouldFetchProducts, haveFetchedProducts, reduxDispatch ] );
 
-	const getproductVariant = ( variant ) => {
+	const getProductVariant = ( variant: PossibleProductVariant ): WPCOMProductVariant => {
 		return {
 			variantLabel: getTermText( variant.plan.term, translate ),
 			variantDetails: <VariantPrice variant={ variant } />,
@@ -63,20 +109,22 @@ export function useProductVariants( { siteId, productSlug } ) {
 		};
 	};
 
-	return ( anyProductSlug ) => {
+	return ( anyProductSlug: string ) => {
 		if ( anyProductSlug !== productSlug ) {
 			return [];
 		}
 
 		if ( ! isWpComPlan( productSlug ) ) {
-			return productsWithPrices.map( getproductVariant );
+			return productsWithPrices.map( getProductVariant );
 		}
 
-		return replaceFullPriceWithMonthlyCost( productsWithPrices ).map( getproductVariant );
+		return replaceFullPriceWithMonthlyCost( productsWithPrices ).map( getProductVariant );
 	};
 }
 
-function replaceFullPriceWithMonthlyCost( products ) {
+function replaceFullPriceWithMonthlyCost(
+	products: PossibleProductVariant[]
+): PossibleProductVariant[] {
 	const monthlyPlan = products.filter( ( product ) => product.plan?.term === TERM_MONTHLY )?.[ 0 ];
 
 	if ( ! monthlyPlan ) {
@@ -101,7 +149,7 @@ function replaceFullPriceWithMonthlyCost( products ) {
 	} );
 }
 
-function VariantPrice( { variant } ) {
+function VariantPrice( { variant }: { variant: PossibleProductVariant } ) {
 	const currentPrice = variant.priceFinal || variant.priceFull;
 	const isDiscounted = currentPrice !== variant.priceFullBeforeDiscount;
 	return (
@@ -117,7 +165,7 @@ function VariantPrice( { variant } ) {
 	);
 }
 
-function VariantPriceDiscount( { variant } ) {
+function VariantPriceDiscount( { variant }: { variant: PossibleProductVariant } ) {
 	const translate = useTranslate();
 	const discountPercentage = Math.round(
 		100 - ( variant.priceFinal / variant.priceFullBeforeDiscount ) * 100
@@ -133,7 +181,7 @@ function VariantPriceDiscount( { variant } ) {
 	);
 }
 
-function useVariantPlanProductSlugs( productSlug ) {
+function useVariantPlanProductSlugs( productSlug: string | undefined ): string[] {
 	const reduxDispatch = useDispatch();
 
 	const chosenPlan = getPlan( productSlug );
@@ -168,40 +216,22 @@ function useVariantPlanProductSlugs( productSlug ) {
 	} );
 }
 
-function getTermText( term, translate ) {
+function getTermText( term: string, translate: ReturnType< typeof useTranslate > ): string {
 	switch ( term ) {
 		case TERM_BIENNIALLY:
-			return translate( 'Two years' );
+			return String( translate( 'Two years' ) );
 
 		case TERM_ANNUALLY:
-			return translate( 'One year' );
+			return String( translate( 'One year' ) );
 
 		case TERM_MONTHLY:
-			return translate( 'One month' );
+			return String( translate( 'One month' ) );
+		default:
+			return '';
 	}
 }
 
-const Discount = styled.span`
-	color: ${ ( props ) => props.theme.colors.discount };
-	margin-right: 8px;
-
-	.rtl & {
-		margin-right: 0;
-		margin-left: 8px;
-	}
-`;
-
-const DoNotPayThis = styled.span`
-	text-decoration: line-through;
-	margin-right: 8px;
-
-	.rtl & {
-		margin-right: 0;
-		margin-left: 8px;
-	}
-`;
-
-function myFormatCurrency( price, code, options = {} ) {
+function myFormatCurrency( price: number, code: string, options = {} ) {
 	const precision = CURRENCIES[ code ].precision;
 	const EPSILON = Math.pow( 10, -precision ) - 0.000000001;
 

--- a/client/state/products-list/selectors/compute-products-with-prices.js
+++ b/client/state/products-list/selectors/compute-products-with-prices.js
@@ -16,7 +16,7 @@ import { computeFullAndMonthlyPricesForPlan } from './compute-full-and-monthly-p
  * products, and their full and monthly prices
  *
  * @param {object} state Current redux state
- * @param {number} siteId Site ID to consider
+ * @param {number|undefined} siteId Site ID to consider
  * @param {string[]} planSlugs Plans constants
  * @param {number} credits The number of free credits in cart
  * @param {object} couponDiscounts Absolute values of any discounts coming from a discount coupon


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `WPCOMCartItem` type was created as a sort of hack to allow passing `ResponseCartItem` object data through checkout via the `useLineItems` hook that's part of the `composite-checkout` package, since the generic product data available in that hook's types is not sufficient. However, now that `useShoppingCart` is available, we can get the `ResponseCartItem` products directly where they are needed. This will make it easier to manipulate and query cart items in the code since there will only be one data type we need to understand, and since `ResponseCartItem` predates `WPCOMCartItem`, there's already considerable support for it in calypso.

This PR replaces `useLineItems` in `WPCheckoutOrderReview` with `useShoppingCart`.

In order to be sure that these types are being used correctly, this also converts that component to TypeScript.

Collapsed:

![review-collapsed](https://user-images.githubusercontent.com/2036909/108003703-87a46000-6fc1-11eb-984d-58c580f90971.png)

Expanded:

![review-expanded](https://user-images.githubusercontent.com/2036909/108003715-8bd07d80-6fc1-11eb-8e07-2931c7092dca.png)


#### Testing instructions

- Add a plan to your cart.
- Verify that first step (the order review) shows the plan correctly.
- Click "edit" to expand the first step.
- Verify you see the yearly, monthly, and two-year plan variations.
- Click to change the plan variation and verify that it changes correctly.