### PR TITLE
Set an order for page layout categories

### DIFF
--- a/packages/page-template-modal/src/components/page-template-modal.js
+++ b/packages/page-template-modal/src/components/page-template-modal.js
@@ -18,6 +18,7 @@ import replacePlaceholders from '../utils/replace-placeholders';
 import ensureAssets from '../utils/ensure-assets';
 import mapBlocksRecursively from '../utils/map-blocks-recursively';
 import containsMissingBlock from '../utils/contains-missing-block';
+import { sortGroupNames } from '../utils/group-utils';
 
 export default class PageTemplateModal extends Component {
 	state = {
@@ -280,16 +281,8 @@ export default class PageTemplateModal extends Component {
 			}
 		}
 
-		return this.sortGroupsNames( templateGroups );
-	};
-
-	sortGroupsNames = ( groups ) => {
-		return Object.keys( groups )
-			.sort()
-			.reduce( ( result, key ) => {
-				result[ key ] = groups[ key ];
-				return result;
-			}, {} );
+		const preferredGroupOrder = [ 'about', 'blog', 'home-page', 'gallery', 'services', 'contact' ];
+		return sortGroupNames( preferredGroupOrder, templateGroups );
 	};
 
 	getTemplatesForGroup = ( groupName ) => {
@@ -339,7 +332,7 @@ export default class PageTemplateModal extends Component {
 		const blankGroup = this.renderTemplateGroup( 'blank', __( 'Blank', __i18n_text_domain__ ) );
 
 		const homePageGroup = this.props.isFrontPage
-			? this.renderTemplateGroup( 'home-page', __( 'Home Page', __i18n_text_domain__ ) )
+			? this.renderTemplateGroup( 'home-page', __( 'Home', __i18n_text_domain__ ) )
 			: null;
 
 		const renderedGroups = [];
@@ -364,10 +357,10 @@ export default class PageTemplateModal extends Component {
 			return null;
 		}
 
-		return this.renderTemplatesList( templates, groupName, groupTitle );
+		return this.renderTemplatesList( templates, groupTitle );
 	};
 
-	renderTemplatesList = ( templatesList, groupName, groupTitle ) => {
+	renderTemplatesList = ( templatesList, groupTitle ) => {
 		if ( ! templatesList.length ) {
 			return null;
 		}

--- a/packages/page-template-modal/src/utils/group-utils.js
+++ b/packages/page-template-modal/src/utils/group-utils.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { intersection, difference } from 'lodash';
+
+/**
+ * Sorts the keys on the group object to have a preferred order.
+ * If some groups exist without a preferred order, they will be included last
+ *
+ * @param {Array<string>} preferredGroupOrder the order of group slugs that we want
+ * @param {object} groupsObject an object with all group information, with group names as keys
+ */
+export function sortGroupNames( preferredGroupOrder, groupsObject ) {
+	const groups = Object.keys( groupsObject );
+
+	const orderedGroups = intersection( preferredGroupOrder, groups );
+	const remainingGroups = difference( groups, preferredGroupOrder );
+	const allGroups = orderedGroups.concat( remainingGroups );
+
+	return allGroups.reduce( ( result, groupName ) => {
+		result[ groupName ] = groupsObject[ groupName ];
+		return result;
+	}, {} );
+}

--- a/packages/page-template-modal/src/utils/group-utils.js
+++ b/packages/page-template-modal/src/utils/group-utils.js
@@ -15,7 +15,7 @@ export function sortGroupNames( preferredGroupOrder, groupsObject ) {
 
 	const orderedGroups = intersection( preferredGroupOrder, groups );
 	const remainingGroups = difference( groups, preferredGroupOrder );
-	const allGroups = orderedGroups.concat( remainingGroups );
+	const allGroups = orderedGroups.concat( remainingGroups.sort() );
 
 	return allGroups.reduce( ( result, groupName ) => {
 		result[ groupName ] = groupsObject[ groupName ];


### PR DESCRIPTION
Currently the order of page layout categories is determined by an alphabetical sort on the group name.

But as part of the page layout picker redesign we want to set an explicit order

This change allows an explicit order to be set.

Categories without a specified order will be returned at the end of the list.

The other changes required to complete  #49863 are merging the "Restaurants" category into "services" and renaming the title for "Home Page" to be "Home". These are data changes and need to be made on the patterns source site.

Additionally, there is code to put the `home-page` category at the start of the list when creating a new home page (I haven't tested this code path, and am not sure how to). In this case, it uses a fixed label which I updated from "Home Page" to "Home". When adding a regular page however, this label comes from what's set up on the patterns source site.

### Testing instructions

checkout this PR and sync to your sandbox
`yarn dev --sync`
The categories on the page layout picker should be as follows
 
* About
* Blog
* Home Page ( to be renamed "Home" on patterns source site)
* Gallery
* Services (to include layouts from restaurant category on patterns source site #49862)
* Contact
* Restaurant ( to be deleted on patterns source site )


fixes #49863
