### PR TITLE
Disable premium block patterns feature due to performance concerns

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -265,11 +265,11 @@ add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );
  */
 function load_wpcom_block_patterns_modifications() {
 	// Disable the premium patterns feature temporarily due to performance issues (#50069).
-	/*
-	if ( apply_filters( 'a8c_enable_block_patterns_modifications', true ) ) {
-		require_once __DIR__ . '/block-patterns/class-block-patterns-modifications.php';
-	}
-	*/
+	// phpcs:disable
+	// if ( apply_filters( 'a8c_enable_block_patterns_modifications', false ) ) {
+	// 	require_once __DIR__ . '/block-patterns/class-block-patterns-modifications.php';
+	// }
+	// phpcs:enable
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_patterns_modifications' );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -265,9 +265,11 @@ add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );
  */
 function load_wpcom_block_patterns_modifications() {
 	// Disable the premium patterns feature temporarily due to performance issues (#50069).
-	// if ( apply_filters( 'a8c_enable_block_patterns_modifications', true ) ) {
-	// 	require_once __DIR__ . '/block-patterns/class-block-patterns-modifications.php';
-	// }
+	/*
+	if ( apply_filters( 'a8c_enable_block_patterns_modifications', true ) ) {
+		require_once __DIR__ . '/block-patterns/class-block-patterns-modifications.php';
+	}
+	*/
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_patterns_modifications' );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -264,9 +264,10 @@ add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );
  * are loaded via load_block_patterns_from_api.
  */
 function load_wpcom_block_patterns_modifications() {
-	if ( apply_filters( 'a8c_enable_block_patterns_modifications', true ) ) {
-		require_once __DIR__ . '/block-patterns/class-block-patterns-modifications.php';
-	}
+	// Disable the premium patterns feature temporarily due to performance issues (#50069).
+	// if ( apply_filters( 'a8c_enable_block_patterns_modifications', true ) ) {
+	// 	require_once __DIR__ . '/block-patterns/class-block-patterns-modifications.php';
+	// }
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_patterns_modifications' );
 


### PR DESCRIPTION
While investigating #50069 I haven't (yet) managed to come up with a quick fix for the premium patterns feature as it's currently implemented. Now might be a good time to switch it off and propose a more stable long-term approach in Gutenberg. While the performance of the feature isn't (yet) causing a slow down in the editor, I believe it might in the next version of Gutenberg. We can pre-emptively disable the feature while we pursue alternate approaches.

#### Changes proposed in this Pull Request

* Temporarily disable the premium block patterns feature (the pink dot next to a premium pattern in the inserter) due to performance issues. (Note: the feature doesn't appear to be working correctly at the moment, anyway, as the color isn't rendering for the dot)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the diff associated with this PR, and smoke test that you can still see the patterns in the inserter.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #50069
