### PR TITLE
Plans redesign: Mobile and tablet views

### DIFF
--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -51,7 +51,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 
 		return (
 			<span>
-				<div>
+				<div className="plan-features-comparison__popular-tag-container">
 					{ popular && ! selectedPlan && (
 						<PlanPill isInSignup={ isInSignup }>{ translate( 'Popular' ) }</PlanPill>
 					) }
@@ -272,14 +272,8 @@ export class PlanFeaturesComparisonHeader extends Component {
 	}
 
 	renderPriceGroup( fullPrice, discountedPrice = null ) {
-		const {
-			currencyCode,
-			isInSignup,
-			plansWithScroll,
-			isInVerticalScrollingPlansExperiment,
-		} = this.props;
-		const displayFlatPrice =
-			isInSignup && ! plansWithScroll && ! isInVerticalScrollingPlansExperiment;
+		const { currencyCode, isInSignup, plansWithScroll, isMobileView } = this.props;
+		const displayFlatPrice = isInSignup && ! plansWithScroll && ! isMobileView;
 
 		if ( fullPrice && discountedPrice ) {
 			return (

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -100,12 +100,17 @@ export class PlanFeaturesComparison extends Component {
 			'plans-wrapper': isInSignup,
 		} );
 
+		const mobileView = (
+			<div className="plan-features-comparison__mobile">{ this.renderMobileView() }</div>
+		);
+
 		return (
 			<div className={ planWrapperClasses }>
 				<QueryActivePromotions />
 				<div className={ planClasses }>
 					{ this.renderNotice() }
 					<div ref={ this.contentRef } className="plan-features-comparison__content">
+						{ mobileView }
 						<div>
 							<table className={ tableClasses }>
 								<caption className="plan-features-comparison__screen-reader-text screen-reader-text">
@@ -174,6 +179,111 @@ export class PlanFeaturesComparison extends Component {
 
 	getBannerContainer() {
 		return document.querySelector( '.plans-features-main__notice' );
+	}
+
+	renderMobileView() {
+		const {
+			basePlansPath,
+			canPurchase,
+			isInSignup,
+			isLandingPage,
+			isJetpack,
+			planProperties,
+			selectedPlan,
+			showPlanCreditsApplied,
+			isLaunchPage,
+		} = this.props;
+
+		// move any free plan to last place in mobile view
+		let freePlanProperties;
+		const reorderedPlans = planProperties.filter( ( properties ) => {
+			if ( isFreePlan( properties.planName ) ) {
+				freePlanProperties = properties;
+				return false;
+			}
+			return true;
+		} );
+
+		if ( freePlanProperties ) {
+			reorderedPlans.push( freePlanProperties );
+		}
+
+		return map( reorderedPlans, ( properties ) => {
+			const {
+				availableForPurchase,
+				currencyCode,
+				current,
+				planConstantObj,
+				planName,
+				popular,
+				newPlan,
+				bestValue,
+				relatedMonthlyPlan,
+				rawPriceForMonthlyPlan,
+				primaryUpgrade,
+				isPlaceholder,
+				hideMonthly,
+			} = properties;
+			const { rawPrice, rawPriceAnnual, discountPrice } = properties;
+			const { annualPricePerMonth, isMonthlyPlan } = properties;
+			return (
+				<div className="plan-features-comparison__mobile-plan" key={ planName }>
+					<PlanFeaturesComparisonHeader
+						availableForPurchase={ availableForPurchase }
+						current={ current }
+						currencyCode={ currencyCode }
+						isJetpack={ isJetpack }
+						popular={ popular }
+						newPlan={ newPlan }
+						bestValue={ bestValue }
+						title={ planConstantObj.getTitle() }
+						planType={ planName }
+						rawPrice={ rawPrice }
+						rawPriceAnnual={ rawPriceAnnual }
+						rawPriceForMonthlyPlan={ rawPriceForMonthlyPlan }
+						discountPrice={ discountPrice }
+						billingTimeFrame={ planConstantObj.getBillingTimeFrame() }
+						hideMonthly={ hideMonthly }
+						isPlaceholder={ isPlaceholder }
+						basePlansPath={ basePlansPath }
+						relatedMonthlyPlan={ relatedMonthlyPlan }
+						isInSignup={ isInSignup }
+						selectedPlan={ selectedPlan }
+						showPlanCreditsApplied={ true === showPlanCreditsApplied && ! this.hasDiscountNotice() }
+						annualPricePerMonth={ annualPricePerMonth }
+						isMonthlyPlan={ isMonthlyPlan }
+						audience={ planConstantObj.getAudience() }
+						isMobileView={ true }
+					/>
+					<PlanFeaturesComparisonActions
+						availableForPurchase={ availableForPurchase }
+						canPurchase={ canPurchase }
+						className={ getPlanClass( planName ) }
+						current={ current }
+						freePlan={ isFreePlan( planName ) }
+						isInSignup={ isInSignup }
+						isLandingPage={ isLandingPage }
+						isLaunchPage={ isLaunchPage }
+						isPlaceholder={ isPlaceholder }
+						isPopular={ popular }
+						onUpgradeClick={ () => this.handleUpgradeClick( properties ) }
+						planName={ planConstantObj.getTitle() }
+						planType={ planName }
+						primaryUpgrade={ primaryUpgrade }
+						selectedPlan={ selectedPlan }
+					/>
+					{ /* <FoldableCard header={ translate( 'Show features' ) } clickableHeader compact>
+						{ this.renderMobileFeatures( features ) }
+					</FoldableCard> */ }
+				</div>
+			);
+		} );
+	}
+
+	renderMobileFeatures( features ) {
+		return map( features, ( currentFeature, index ) => {
+			return currentFeature ? this.renderFeatureItem( currentFeature, index ) : null;
+		} );
 	}
 
 	renderPlanHeaders() {

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -223,9 +223,10 @@ export class PlanFeaturesComparison extends Component {
 				primaryUpgrade,
 				isPlaceholder,
 				hideMonthly,
+				features,
 			} = properties;
 			const { rawPrice, rawPriceAnnual, discountPrice } = properties;
-			const { annualPricePerMonth, isMonthlyPlan } = properties;
+			const { annualPricePerMonth, isMonthlyPlan, missingFeaturesForAnnualPlans } = properties;
 			return (
 				<div className="plan-features-comparison__mobile-plan" key={ planName }>
 					<PlanFeaturesComparisonHeader
@@ -272,17 +273,19 @@ export class PlanFeaturesComparison extends Component {
 						primaryUpgrade={ primaryUpgrade }
 						selectedPlan={ selectedPlan }
 					/>
-					{ /* <FoldableCard header={ translate( 'Show features' ) } clickableHeader compact>
-						{ this.renderMobileFeatures( features ) }
-					</FoldableCard> */ }
+					{ this.renderMobileFeatures( features, missingFeaturesForAnnualPlans ) }
 				</div>
 			);
 		} );
 	}
 
-	renderMobileFeatures( features ) {
+	renderMobileFeatures( features, missingFeaturesForAnnualPlans ) {
 		return map( features, ( currentFeature, index ) => {
-			return currentFeature ? this.renderFeatureItem( currentFeature, index ) : null;
+			const isFeatureMissingForPlan =
+				missingFeaturesForAnnualPlans.includes( currentFeature.getSlug() ) ||
+				! currentFeature.availableForCurrentPlan;
+			const type = isFeatureMissingForPlan ? 'missingFeature' : 'availableFeature';
+			return currentFeature ? this.renderFeatureItem( currentFeature, index, type ) : null;
 		} );
 	}
 

--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -16,6 +16,22 @@ $plan-features-sidebar-width: 272px;
 		}
 	}
 
+	.formatted-header {
+		@media ( max-width: 1040px ) {
+			text-align: left;
+		}
+	}
+
+	.plan-features-comparison__popular-tag-container {
+		@media ( max-width: 1040px ) {
+		display: flex;
+		position: absolute;
+		top: 15px;
+		right: 0;
+		margin-right: 15px;
+		}
+	}
+
 	.plans-features-main__group.is-wpcom .plan-features-comparison__header {
 		&.is-blogger-plan {
 			border-bottom: none;
@@ -42,11 +58,16 @@ $plan-features-sidebar-width: 272px;
 		justify-content: center;
 		font-weight: 400;
 		margin-top: 30px;
+
+		@media ( max-width: 1040px ) {
+			margin-top: 10px;
+		}
 	}
 
 	.plan-features-comparison__pricing {
 		padding: 8px 16px;
 		margin: 0;
+		text-align: center;
 		
 
 		.plan-price {
@@ -95,6 +116,10 @@ $plan-features-sidebar-width: 272px;
 		.plan-features-comparison__header-title {
 			color: var( --studio-gray-80 );
 			font-weight: 400;
+
+			@media ( max-width: 1040px ) {
+				font-size: $font-title-medium;
+			}
 		}
 
 		.is-premium-plan .plan-features-comparison__header-title {
@@ -110,6 +135,10 @@ $plan-features-sidebar-width: 272px;
 		background-color: var( --studio-green-5 );
 		color: var( --studio-gray-80 );
 		font-size: $font-body-small;
+
+		@media ( max-width: 1040px ) {
+			transform: none;
+		}
 	}
 
 	.plan-features__actions-button {
@@ -234,6 +263,8 @@ $plan-features-sidebar-width: 272px;
 	border: solid 1px var( --color-neutral-5 );
 	background-color: var( --color-surface );
 	margin-bottom: 24px;
+	position: relative;
+	border-radius: 6px; /* stylelint-disable-line */
 }
 
 .is-section-plans .plan-features-comparison__table {
@@ -398,7 +429,6 @@ $plan-features-sidebar-width: 272px;
 	width: 56px;
 	height: 56px;
 	margin-right: 15px;
-	border-radius: 50%;
 }
 
 .is-section-plans .plan-features-comparison__header-figure {

--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -228,12 +228,7 @@ $plan-features-sidebar-width: 272px;
 	}
 
 	.plan-features-comparison__item {
-		border-bottom: solid 1px var( --color-neutral-5 );
 		font-size: $font-body-small;
-	}
-
-	.plan-features-comparison__item:last-child {
-		border-bottom: none;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implements the experiment that redesigns the signup flow plans step. Users in the treatment group will see the new plans step UI in mobile and tablet views.

NOTE:

* This PR uses the changes in https://github.com/Automattic/wp-calypso/pull/50040 as the base branch and is built on top of it.
*
**Mobile view**

![calypso localhost_3000_start_plans(Pixel 2 XL) (1)](https://user-images.githubusercontent.com/1269602/108042496-de637580-7065-11eb-9ac2-2209eadd74ff.png)




#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
