### PR TITLE
Focused Launch - Summary View: Fix incorrect HE support link

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -211,6 +211,7 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, on
 											isLink
 											href={ localizeUrl( 'https://wordpress.com/help/contact', locale ) }
 											target="_blank"
+											rel="noopener noreferrer"
 										>
 											{ __( 'Ask a Happiness Engineer', 'full-site-editing' ) }
 										</Button>

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -689,6 +689,7 @@ const Summary: React.FunctionComponent = () => {
 						isLink
 						href={ localizeUrl( 'https://wordpress.com/help/contact', locale ) }
 						target="_blank"
+						rel="noopener noreferrer"
 					>
 						{ __( 'Ask a Happiness Engineer', __i18n_text_domain__ ) }
 					</Button>

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -687,7 +687,7 @@ const Summary: React.FunctionComponent = () => {
 					<p>{ __( 'Questions? Our experts can assist.', __i18n_text_domain__ ) }</p>
 					<Button
 						isLink
-						href={ localizeUrl( 'https://wordpress.com/help', locale ) }
+						href={ localizeUrl( 'https://wordpress.com/help/contact', locale ) }
 						target="_blank"
 					>
 						{ __( 'Ask a Happiness Engineer', __i18n_text_domain__ ) }

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -8,12 +8,12 @@ import { Link } from 'react-router-dom';
 import { ActionButtons, NextButton, SubTitle, Title } from '@automattic/onboarding';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
-import { TextControl, SVG, Path, Tooltip, Circle, Rect } from '@wordpress/components';
+import { TextControl, SVG, Path, Tooltip, Circle, Rect, Button } from '@wordpress/components';
 import DomainPicker, { mockDomainSuggestion } from '@automattic/domain-picker';
 import classNames from 'classnames';
 import { Icon, check } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useLocale } from '@automattic/i18n-utils';
+import { useLocalizeUrl, useLocale } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -543,9 +543,12 @@ const Summary: React.FunctionComponent = () => {
 	const { domainSearch, isLoading } = useDomainSearch();
 	const { isPaidPlan: hasPaidPlan } = useSite();
 
-	const { siteId, redirectTo } = React.useContext( LaunchContext );
+	const { siteId } = React.useContext( LaunchContext );
 
 	const { goToCheckout } = useCart();
+
+	const locale = useLocale();
+	const localizeUrl = useLocalizeUrl();
 
 	// When the summary view is active, the modal should be dismissible, and
 	// the modal title should be visible
@@ -568,17 +571,6 @@ const Summary: React.FunctionComponent = () => {
 		if ( selectedDomain || ! isSelectedPlanFree ) {
 			goToCheckout();
 		}
-	};
-
-	const onAskForHelpClick = ( event: React.MouseEvent< HTMLAnchorElement, MouseEvent > ) => {
-		const helpHref = ( event.target as HTMLAnchorElement ).getAttribute( 'href' );
-
-		if ( ! helpHref ) {
-			return;
-		}
-
-		redirectTo( helpHref );
-		event.preventDefault();
 	};
 
 	// Prepare Steps
@@ -693,9 +685,13 @@ const Summary: React.FunctionComponent = () => {
 
 				<div className="focused-launch-summary__ask-for-help">
 					<p>{ __( 'Questions? Our experts can assist.', __i18n_text_domain__ ) }</p>
-					<a href="/help" onClick={ onAskForHelpClick }>
+					<Button
+						isLink
+						href={ localizeUrl( 'https://wordpress.com/help', locale ) }
+						target="_blank"
+					>
 						{ __( 'Ask a Happiness Engineer', __i18n_text_domain__ ) }
-					</a>
+					</Button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Opening the _Ask a Happiness Engineer_ link in a new tab/window, redirects the user to `https://[SITE_SLUG]/help`, which resolves in an error page displaying _Oops! That page can’t be found_. 

With the changes implemented in this PR, the user is redirected to `https://wordpress.com/help/contact`.

**NOTE**.  The _Ask a Happiness Engineer_ link is aligned with its counterpart in the step-by-step-launch (background: #47947).

#### Technical changes

* remove `onAskForHelpClick` method since it's redundant.
* remove `redirectTo` method since it's redundant.
* use `useLocale` hook to provide the correct locale for the help url.
* use `useLocalizeUrl` hook to localize the url.
* transform `<a/>` to a `<Button/>` to utilize all the features provided by `@wordpress/components`.
* add `target="_blank"` to the button to ensure `/help` is always opened in a new tab/window.

### Testing instructions

#### Focused Launch

1. Make sure you're on the right experiment's variant.
2. Create a site through `/start` or reuse an existing, unlaunched site.
3. Go to `/page/[UNLAUNCHED_SITE_ID].wordpress.com/home`.
4. Click "Launch" to open the Focused Launch flow.
5. Click on the _Ask a Happiness Engineer_ link and ensure that:
    * [ ] The page opens in a new tab/window.
    * [ ] The page redirects to `https://wordpress.com/help/contact`.
6. Switch to a different language (e.g. Spanish).
7. Repeat steps 3-5.

#### Step-by-step-launch (regression)

1. Create a site through `/new` or reuse an existing, unlaunched site.
2. Go to `/page/[UNLAUNCHED_SITE_ID].wordpress.com/home`.
3. Click "Launch" to open the Focused Launch flow.
4. Click on the _Ask a Happiness Engineer_ link and ensure that:
    * [ ] The same happens as on production.
5. Switch to a different language (e.g. Spanish).
6. Repeat steps 2-4.

fixes #49698
