### PR TITLE
Signup: Show the full price of domains for plan flows without a free domain

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -33,6 +33,7 @@ import Badge from 'calypso/components/badge';
 import PremiumBadge from '../premium-badge';
 import InfoPopover from 'calypso/components/info-popover';
 import { HTTPS_SSL } from 'calypso/lib/url/support';
+import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
 
 const NOTICE_GREEN = '#4ab866';
 
@@ -177,8 +178,22 @@ class DomainRegistrationSuggestion extends React.Component {
 	}
 
 	getPriceRule() {
-		const { cart, isDomainOnly, domainsWithPlansOnly, selectedSite, suggestion } = this.props;
-		return getDomainPriceRule( domainsWithPlansOnly, selectedSite, cart, suggestion, isDomainOnly );
+		const {
+			cart,
+			isDomainOnly,
+			domainsWithPlansOnly,
+			selectedSite,
+			suggestion,
+			flowName,
+		} = this.props;
+		return getDomainPriceRule(
+			domainsWithPlansOnly,
+			selectedSite,
+			cart,
+			suggestion,
+			isDomainOnly,
+			flowName
+		);
 	}
 
 	/**
@@ -413,6 +428,7 @@ const mapStateToProps = ( state, props ) => {
 	const currentUserCurrencyCode = getCurrentUserCurrencyCode( state );
 	const stripZeros = props.showStrikedOutPrice ? true : false;
 	const isPremium = props.premiumDomain?.is_premium || props.suggestion?.is_premium;
+	const flowName = getCurrentFlowName( state );
 
 	let productCost;
 	let productSaleCost;
@@ -433,6 +449,7 @@ const mapStateToProps = ( state, props ) => {
 		showHstsNotice: isHstsRequired( productSlug, productsList ),
 		productCost,
 		productSaleCost,
+		flowName,
 	};
 };
 

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1308,12 +1308,36 @@ export function isPaidDomain( domainPriceRule ) {
 	return 'PRICE' === domainPriceRule;
 }
 
-export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestion, isDomainOnly ) {
+const isMonthlyOrFreeFlow = ( flowName ) => {
+	return (
+		flowName &&
+		[
+			'free',
+			'personal-monthly',
+			'premium-monthly',
+			'business-monthly',
+			'ecommerce-monthly',
+		].includes( flowName )
+	);
+};
+
+export function getDomainPriceRule(
+	withPlansOnly,
+	selectedSite,
+	cart,
+	suggestion,
+	isDomainOnly,
+	flowName
+) {
 	if ( ! suggestion.product_slug || suggestion.cost === 'Free' ) {
 		return 'FREE_DOMAIN';
 	}
 
 	if ( suggestion?.is_premium ) {
+		return 'PRICE';
+	}
+
+	if ( isMonthlyOrFreeFlow( flowName ) ) {
 		return 'PRICE';
 	}
 

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -577,6 +577,73 @@ describe( 'getDomainPriceRule()', () => {
 			).toBe( 'UPGRADE_TO_HIGHER_PLAN_TO_BUY' );
 		} );
 	} );
+
+	describe( 'plan flows which do not include a free domain', () => {
+		test( 'should return PRICE if flowName is free', () => {
+			expect(
+				getDomainPriceRule(
+					true,
+					null,
+					{},
+					{ domain_name: 'domain.com', product_slug: 'domain' },
+					false,
+					'free'
+				)
+			).toBe( 'PRICE' );
+		} );
+
+		test( 'should return PRICE if flowName is personal-monthly', () => {
+			expect(
+				getDomainPriceRule(
+					true,
+					null,
+					{},
+					{ domain_name: 'domain.com', product_slug: 'domain' },
+					false,
+					'personal-monthly'
+				)
+			).toBe( 'PRICE' );
+		} );
+
+		test( 'should return PRICE if flowName is premium-monthly', () => {
+			expect(
+				getDomainPriceRule(
+					true,
+					null,
+					{},
+					{ domain_name: 'domain.com', product_slug: 'domain' },
+					false,
+					'premium-monthly'
+				)
+			).toBe( 'PRICE' );
+		} );
+
+		test( 'should return PRICE if flowName is business-monthly', () => {
+			expect(
+				getDomainPriceRule(
+					true,
+					null,
+					{},
+					{ domain_name: 'domain.com', product_slug: 'domain' },
+					false,
+					'business-monthly'
+				)
+			).toBe( 'PRICE' );
+		} );
+
+		test( 'should return PRICE if flowName is ecommerce-monthly', () => {
+			expect(
+				getDomainPriceRule(
+					true,
+					null,
+					{},
+					{ domain_name: 'domain.com', product_slug: 'domain' },
+					false,
+					'ecommerce-monthly'
+				)
+			).toBe( 'PRICE' );
+		} );
+	} );
 } );
 
 describe( 'hasToUpgradeToPayForADomain()', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Plan-specific flows for the free and monthly plans show the price of the domain suggestion as "Free" even though free domains are not included in these plans. This change fixes this behaviour to show the full price. Please see #49992 for more context.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create an account using the `free` or any of the monthly plan-specific flows:
/start/free
/start/personal-monthly
/start/premium-monthly
/start/business-monthly
/start/ecommerce-monthly
* On the domains step, ensure that the full price of the domains is shown.
![image](https://user-images.githubusercontent.com/5436027/108056362-28a12280-7077-11eb-9cfb-a130404662a7.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #49992