### PR TITLE
Remove no-serialization unit tests and withoutPersistence

### DIFF
--- a/client/extensions/wp-super-cache/state/cache/reducer.js
+++ b/client/extensions/wp-super-cache/state/cache/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 
-import { combineReducers, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers } from 'calypso/state/utils';
 import {
 	WP_SUPER_CACHE_DELETE_CACHE,
 	WP_SUPER_CACHE_DELETE_CACHE_FAILURE,
@@ -23,7 +23,7 @@ import {
  * @param  {object} action Action object
  * @returns {object} Updated deleting state
  */
-const deleteStatus = withoutPersistence( ( state = {}, action ) => {
+const deleteStatus = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case WP_SUPER_CACHE_DELETE_CACHE: {
 			const { siteId } = action;
@@ -61,7 +61,7 @@ const deleteStatus = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Returns the updated preloading state after an action has been dispatched.
@@ -71,7 +71,7 @@ const deleteStatus = withoutPersistence( ( state = {}, action ) => {
  * @param  {object} action Action object
  * @returns {object} Updated preloading state
  */
-const preloading = withoutPersistence( ( state = {}, action ) => {
+const preloading = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case WP_SUPER_CACHE_PRELOAD_CACHE: {
 			const { siteId } = action;
@@ -96,7 +96,7 @@ const preloading = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Returns the updated cache testing state after an action has been dispatched.
@@ -106,7 +106,7 @@ const preloading = withoutPersistence( ( state = {}, action ) => {
  * @param  {object} action Action object
  * @returns {object} Updated cache testing state
  */
-const testing = withoutPersistence( ( state = {}, action ) => {
+const testing = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case WP_SUPER_CACHE_TEST_CACHE: {
 			const { siteId } = action;
@@ -131,7 +131,7 @@ const testing = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Tracks the cache test results for a particular site.
@@ -140,7 +140,7 @@ const testing = withoutPersistence( ( state = {}, action ) => {
  * @param  {object} action Action object
  * @returns {object} Updated cache test results
  */
-const items = withoutPersistence( ( state = {}, action ) => {
+const items = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case WP_SUPER_CACHE_TEST_CACHE_SUCCESS: {
 			const { siteId, data } = action;
@@ -153,7 +153,7 @@ const items = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 export default combineReducers( {
 	deleteStatus,

--- a/client/extensions/wp-super-cache/state/cache/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/cache/test/reducer.js
@@ -19,7 +19,6 @@ import {
 	WP_SUPER_CACHE_TEST_CACHE_SUCCESS,
 } from '../../action-types';
 import reducer from '../reducer';
-import { SERIALIZE, DESERIALIZE } from 'calypso/state/action-types';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -105,22 +104,6 @@ describe( 'reducer', () => {
 				},
 			} );
 		} );
-
-		test( 'should not persist state', () => {
-			const state = reducer( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = reducer( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state.deleteStatus ).to.eql( {} );
-		} );
 	} );
 
 	describe( 'testing()', () => {
@@ -180,22 +163,6 @@ describe( 'reducer', () => {
 				[ primarySiteId ]: false,
 			} );
 		} );
-
-		test( 'should not persist state', () => {
-			const state = reducer( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = reducer( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state.testing ).to.eql( {} );
-		} );
 	} );
 
 	describe( 'preloading()', () => {
@@ -254,22 +221,6 @@ describe( 'reducer', () => {
 			expect( state.preloading ).to.eql( {
 				[ primarySiteId ]: false,
 			} );
-		} );
-
-		test( 'should not persist state', () => {
-			const state = reducer( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = reducer( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state.preloading ).to.eql( {} );
 		} );
 	} );
 
@@ -357,22 +308,6 @@ describe( 'reducer', () => {
 			expect( state.items ).to.eql( {
 				[ primarySiteId ]: newResults,
 			} );
-		} );
-
-		test( 'should not persist state', () => {
-			const state = reducer( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = reducer( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state.items ).to.eql( {} );
 		} );
 	} );
 } );

--- a/client/extensions/wp-super-cache/state/plugins/reducer.js
+++ b/client/extensions/wp-super-cache/state/plugins/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import { itemsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_RECEIVE_PLUGINS,
@@ -22,7 +22,7 @@ import {
  * @param  {object} action Action object
  * @returns {object} Updated requesting state
  */
-export const requesting = withoutPersistence( ( state = {}, action ) => {
+export const requesting = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case WP_SUPER_CACHE_REQUEST_PLUGINS: {
 			const { siteId } = action;
@@ -47,7 +47,7 @@ export const requesting = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Returns the updated plugin toggling state after an action has been dispatched.
@@ -57,7 +57,7 @@ export const requesting = withoutPersistence( ( state = {}, action ) => {
  * @param  {object} action Action object
  * @returns {object} Updated saving state
  */
-export const toggling = withoutPersistence( ( state = {}, action ) => {
+export const toggling = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case WP_SUPER_CACHE_TOGGLE_PLUGIN: {
 			const { siteId, plugin } = action;
@@ -92,7 +92,7 @@ export const toggling = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Tracks the plugins for a particular site.

--- a/client/extensions/wp-super-cache/state/plugins/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/plugins/test/reducer.js
@@ -83,22 +83,6 @@ describe( 'reducer', () => {
 				[ primarySiteId ]: false,
 			} );
 		} );
-
-		test( 'should not persist state', () => {
-			const state = requesting( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = requesting( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.eql( {} );
-		} );
 	} );
 
 	describe( 'toggling()', () => {
@@ -160,22 +144,6 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {
 				[ primarySiteId ]: { no_adverts_for_friends: false },
 			} );
-		} );
-
-		test( 'should not persist state', () => {
-			const state = toggling( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = toggling( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.eql( {} );
 		} );
 	} );
 

--- a/client/extensions/wp-super-cache/state/settings/reducer.js
+++ b/client/extensions/wp-super-cache/state/settings/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import { itemsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS,
@@ -25,7 +25,7 @@ import {
  * @param  {object} action Action object
  * @returns {object} Updated requesting state
  */
-const requesting = withoutPersistence( ( state = {}, action ) => {
+const requesting = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case WP_SUPER_CACHE_REQUEST_SETTINGS: {
 			const { siteId } = action;
@@ -54,7 +54,7 @@ const requesting = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Returns the updated saving state after an action has been dispatched.
@@ -64,7 +64,7 @@ const requesting = withoutPersistence( ( state = {}, action ) => {
  * @param  {object} action Action object
  * @returns {object} Updated saving state
  */
-const saveStatus = withoutPersistence( ( state = {}, action ) => {
+const saveStatus = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case WP_SUPER_CACHE_SAVE_SETTINGS: {
 			const { siteId } = action;
@@ -105,7 +105,7 @@ const saveStatus = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Returns the updated restoring state after an action has been dispatched.
@@ -115,7 +115,7 @@ const saveStatus = withoutPersistence( ( state = {}, action ) => {
  * @param  {object} action Action object
  * @returns {object} Updated restoring state
  */
-export const restoring = withoutPersistence( ( state = {}, action ) => {
+export const restoring = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case WP_SUPER_CACHE_RESTORE_SETTINGS: {
 			const { siteId } = action;
@@ -144,7 +144,7 @@ export const restoring = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Tracks the settings for a particular site.

--- a/client/extensions/wp-super-cache/state/settings/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/settings/test/reducer.js
@@ -89,22 +89,6 @@ describe( 'reducer', () => {
 				[ primarySiteId ]: false,
 			} );
 		} );
-
-		test( 'should not persist state', () => {
-			const state = reducer( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state.requesting ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = reducer( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state.requesting ).to.eql( {} );
-		} );
 	} );
 
 	describe( 'saveStatus()', () => {
@@ -189,22 +173,6 @@ describe( 'reducer', () => {
 				},
 			} );
 		} );
-
-		test( 'should not persist state', () => {
-			const state = reducer( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state.saveStatus ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = reducer( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state.saveStatus ).to.eql( {} );
-		} );
 	} );
 
 	describe( 'restoring()', () => {
@@ -261,22 +229,6 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {
 				[ primarySiteId ]: false,
 			} );
-		} );
-
-		test( 'should not persist state', () => {
-			const state = restoring( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = restoring( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.eql( {} );
 		} );
 	} );
 

--- a/client/extensions/wp-super-cache/state/stats/reducer.js
+++ b/client/extensions/wp-super-cache/state/stats/reducer.js
@@ -6,7 +6,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import { statsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_DELETE_CACHE_SUCCESS,
@@ -26,7 +26,7 @@ import {
  * @param  {object} action Action object
  * @returns {object} Updated generating state
  */
-export const generating = withoutPersistence( ( state = {}, action ) => {
+export const generating = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case WP_SUPER_CACHE_GENERATE_STATS: {
 			const { siteId } = action;
@@ -51,7 +51,7 @@ export const generating = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Returns the updated deleting state after an action has been dispatched.
@@ -61,7 +61,7 @@ export const generating = withoutPersistence( ( state = {}, action ) => {
  * @param  {object} action Action object
  * @returns {object} Updated deleting state
  */
-const deleting = withoutPersistence( ( state = {}, action ) => {
+const deleting = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case WP_SUPER_CACHE_DELETE_FILE: {
 			const { siteId } = action;
@@ -86,7 +86,7 @@ const deleting = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Tracks the stats for a particular site.

--- a/client/extensions/wp-super-cache/state/stats/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/stats/test/reducer.js
@@ -83,22 +83,6 @@ describe( 'reducer', () => {
 				[ primarySiteId ]: false,
 			} );
 		} );
-
-		test( 'should not persist state', () => {
-			const state = generating( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = generating( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.eql( {} );
-		} );
 	} );
 
 	describe( 'deleting()', () => {
@@ -179,22 +163,6 @@ describe( 'reducer', () => {
 			expect( state.deleting ).to.eql( {
 				[ primarySiteId ]: false,
 			} );
-		} );
-
-		test( 'should not persist state', () => {
-			const state = reducer( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state.deleting ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = reducer( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state.deleting ).to.eql( {} );
 		} );
 	} );
 

--- a/client/extensions/wp-super-cache/state/status/reducer.js
+++ b/client/extensions/wp-super-cache/state/status/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import { itemsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_RECEIVE_STATUS,
@@ -17,7 +17,7 @@ import {
  * @param  {object} action Action object
  * @returns {object} Updated requesting state
  */
-const requesting = withoutPersistence( ( state = {}, action ) => {
+const requesting = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case WP_SUPER_CACHE_RECEIVE_STATUS: {
 			const { siteId } = action;
@@ -38,7 +38,7 @@ const requesting = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Tracks the status for a particular site.

--- a/client/extensions/wp-super-cache/state/status/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/status/test/reducer.js
@@ -81,22 +81,6 @@ describe( 'reducer', () => {
 				[ primarySiteId ]: false,
 			} );
 		} );
-
-		test( 'should not persist state', () => {
-			const state = reducer( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state.requesting ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = reducer( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state.requesting ).to.eql( {} );
-		} );
 	} );
 
 	describe( 'items()', () => {

--- a/client/extensions/zoninator/state/zones/reducer.js
+++ b/client/extensions/zoninator/state/zones/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import { itemsSchema } from './schema';
 import {
 	ZONINATOR_ADD_ZONE,
@@ -13,7 +13,7 @@ import {
 	ZONINATOR_UPDATE_ZONES,
 } from '../action-types';
 
-export const requesting = withoutPersistence( ( state = {}, action ) => {
+export const requesting = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case ZONINATOR_REQUEST_ZONES: {
 			const { siteId } = action;
@@ -30,9 +30,9 @@ export const requesting = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
-export const saving = withoutPersistence( ( state = {}, action ) => {
+export const saving = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case ZONINATOR_ADD_ZONE:
 		case ZONINATOR_SAVE_ZONE: {
@@ -47,7 +47,7 @@ export const saving = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
 	switch ( action.type ) {

--- a/client/extensions/zoninator/state/zones/test/reducer.js
+++ b/client/extensions/zoninator/state/zones/test/reducer.js
@@ -82,22 +82,6 @@ describe( 'reducer', () => {
 				[ primarySiteId ]: false,
 			} );
 		} );
-
-		test( 'should not persist state', () => {
-			const state = requesting( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = requesting( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.deep.equal( {} );
-		} );
 	} );
 
 	describe( 'items()', () => {

--- a/client/state/billing-transactions/reducer.js
+++ b/client/state/billing-transactions/reducer.js
@@ -11,7 +11,7 @@ import {
 	BILLING_TRANSACTIONS_REQUEST_FAILURE,
 	BILLING_TRANSACTIONS_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
-import { combineReducers, withoutPersistence, withSchemaValidation } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import { billingTransactionsSchema } from './schema';
 import individualTransactions from './individual-transactions/reducer';
 import ui from './ui/reducer';
@@ -43,7 +43,7 @@ export const items = withSchemaValidation( billingTransactionsSchema, ( state = 
  * @param  {object} action Action payload
  * @returns {object}        Updated state
  */
-export const requesting = withoutPersistence( ( state = false, action ) => {
+export const requesting = ( state = false, action ) => {
 	switch ( action.type ) {
 		case BILLING_TRANSACTIONS_REQUEST:
 			return true;
@@ -54,7 +54,7 @@ export const requesting = withoutPersistence( ( state = false, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Returns the updated sending email requests state after an action has been dispatched.
@@ -64,7 +64,7 @@ export const requesting = withoutPersistence( ( state = false, action ) => {
  * @param  {object} action Action payload
  * @returns {object}        Updated state
  */
-export const sendingReceiptEmail = withoutPersistence( ( state = {}, action ) => {
+export const sendingReceiptEmail = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case BILLING_RECEIPT_EMAIL_SEND: {
 			const { receiptId } = action;
@@ -93,7 +93,7 @@ export const sendingReceiptEmail = withoutPersistence( ( state = {}, action ) =>
 	}
 
 	return state;
-} );
+};
 
 const combinedReducer = combineReducers( {
 	items,

--- a/client/state/billing-transactions/test/reducer.js
+++ b/client/state/billing-transactions/test/reducer.js
@@ -66,22 +66,6 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( false );
 		} );
-
-		test( 'should not persist state', () => {
-			const state = requesting( true, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = requesting( true, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.eql( false );
-		} );
 	} );
 
 	describe( '#items()', () => {
@@ -217,22 +201,6 @@ describe( 'reducer', () => {
 				12345678: false,
 				...state,
 			} );
-		} );
-
-		test( 'should not persist state', () => {
-			const state = sendingReceiptEmail( currentState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = sendingReceiptEmail( currentState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.eql( {} );
 		} );
 	} );
 } );

--- a/client/state/jetpack/modules/reducer.js
+++ b/client/state/jetpack/modules/reducer.js
@@ -21,7 +21,7 @@ import {
 	JETPACK_SETTINGS_UPDATE,
 	JETPACK_SETTINGS_SAVE_SUCCESS,
 } from 'calypso/state/action-types';
-import { combineReducers, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers } from 'calypso/state/utils';
 
 const createItemsReducer = ( active ) => {
 	return ( state, { siteId, moduleSlug } ) => {
@@ -94,7 +94,7 @@ const createSettingsItemsReducer = () => {
  * @param  {object} action action
  * @returns {Array}         Updated state
  */
-export const items = withoutPersistence( ( state = {}, action ) => {
+export const items = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case JETPACK_MODULE_ACTIVATE_SUCCESS:
 			return createItemsReducer( true )( state, action );
@@ -109,7 +109,7 @@ export const items = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * `Reducer` function which handles request/response actions
@@ -119,7 +119,7 @@ export const items = withoutPersistence( ( state = {}, action ) => {
  * @param {object} action - action
  * @returns {object} updated state
  */
-export const requests = withoutPersistence( ( state = {}, action ) => {
+export const requests = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case JETPACK_MODULE_ACTIVATE:
 			return createRequestsReducer( { activating: true } )( state, action );
@@ -142,7 +142,7 @@ export const requests = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 export const reducer = combineReducers( {
 	items,

--- a/client/state/jetpack/modules/test/reducer.js
+++ b/client/state/jetpack/modules/test/reducer.js
@@ -22,8 +22,6 @@ import {
 	JETPACK_MODULES_REQUEST_SUCCESS,
 	JETPACK_SETTINGS_UPDATE,
 	JETPACK_SETTINGS_SAVE_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
 
 describe( 'reducer', () => {
@@ -55,24 +53,6 @@ describe( 'reducer', () => {
 			};
 			const stateOut = itemsReducer( deepFreeze( stateIn ), action );
 			expect( stateOut[ siteId ][ 'module-b' ].active ).to.be.false;
-		} );
-
-		test( 'should not persist state', () => {
-			const stateIn = MODULES_FIXTURE;
-			const action = {
-				type: SERIALIZE,
-			};
-			const stateOut = itemsReducer( deepFreeze( stateIn ), action );
-			expect( stateOut ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const stateIn = MODULES_FIXTURE;
-			const action = {
-				type: DESERIALIZE,
-			};
-			const stateOut = itemsReducer( deepFreeze( stateIn ), action );
-			expect( stateOut ).to.eql( {} );
 		} );
 
 		test( 'should replace the items object for the site with a new list of modules', () => {
@@ -274,26 +254,6 @@ describe( 'reducer', () => {
 				};
 				const stateOut = requestsReducer( deepFreeze( stateIn ), action );
 				expect( stateOut[ siteId ].fetchingModules ).to.be.false;
-			} );
-		} );
-
-		describe( 'persistence', () => {
-			test( 'should not persist state', () => {
-				const stateIn = REQUESTS_FIXTURE;
-				const action = {
-					type: SERIALIZE,
-				};
-				const stateOut = requestsReducer( deepFreeze( stateIn ), action );
-				expect( stateOut ).to.be.undefined;
-			} );
-
-			test( 'should not load persisted state', () => {
-				const stateIn = REQUESTS_FIXTURE;
-				const action = {
-					type: DESERIALIZE,
-				};
-				const stateOut = requestsReducer( deepFreeze( stateIn ), action );
-				expect( stateOut ).to.eql( {} );
 			} );
 		} );
 	} );

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -7,7 +7,7 @@ import { get, isEmpty, pick, startsWith } from 'lodash';
  * Internal dependencies
  */
 import { withStorageKey } from '@automattic/state-utils';
-import { combineReducers, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers } from 'calypso/state/utils';
 import magicLogin from './magic-login/reducer';
 import {
 	LOGIN_AUTH_ACCOUNT_TYPE_REQUEST,
@@ -46,7 +46,7 @@ import {
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/route';
 
-export const isRequesting = withoutPersistence( ( state = false, action ) => {
+export const isRequesting = ( state = false, action ) => {
 	switch ( action.type ) {
 		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST:
 			return true;
@@ -75,10 +75,10 @@ export const isRequesting = withoutPersistence( ( state = false, action ) => {
 	}
 
 	return state;
-} );
+};
 
 export const redirectTo = combineReducers( {
-	original: withoutPersistence( ( state = null, action ) => {
+	original: ( state = null, action ) => {
 		switch ( action.type ) {
 			case ROUTE_SET: {
 				const { path, query } = action;
@@ -93,8 +93,8 @@ export const redirectTo = combineReducers( {
 		}
 
 		return state;
-	} ),
-	sanitized: withoutPersistence( ( state = null, action ) => {
+	},
+	sanitized: ( state = null, action ) => {
 		switch ( action.type ) {
 			case LOGIN_REQUEST:
 				return null;
@@ -121,10 +121,10 @@ export const redirectTo = combineReducers( {
 		}
 
 		return state;
-	} ),
+	},
 } );
 
-export const isFormDisabled = withoutPersistence( ( state = false, action ) => {
+export const isFormDisabled = ( state = false, action ) => {
 	switch ( action.type ) {
 		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST:
 			return true;
@@ -149,9 +149,9 @@ export const isFormDisabled = withoutPersistence( ( state = false, action ) => {
 	}
 
 	return state;
-} );
+};
 
-export const requestError = withoutPersistence( ( state = null, action ) => {
+export const requestError = ( state = null, action ) => {
 	switch ( action.type ) {
 		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST:
 			return null;
@@ -208,9 +208,9 @@ export const requestError = withoutPersistence( ( state = null, action ) => {
 	}
 
 	return state;
-} );
+};
 
-export const requestSuccess = withoutPersistence( ( state = null, action ) => {
+export const requestSuccess = ( state = null, action ) => {
 	switch ( action.type ) {
 		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST:
 			return null;
@@ -239,9 +239,9 @@ export const requestSuccess = withoutPersistence( ( state = null, action ) => {
 	}
 
 	return state;
-} );
+};
 
-export const requestNotice = withoutPersistence( ( state = null, action ) => {
+export const requestNotice = ( state = null, action ) => {
 	switch ( action.type ) {
 		case TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST: {
 			const { notice } = action;
@@ -269,7 +269,7 @@ export const requestNotice = withoutPersistence( ( state = null, action ) => {
 	}
 
 	return state;
-} );
+};
 
 const updateTwoStepNonce = ( state, { twoStepNonce, nonceType } ) =>
 	Object.assign( {}, state, {
@@ -291,7 +291,7 @@ const twoFactorProperties = [
 	'user_id',
 ];
 
-export const twoFactorAuth = withoutPersistence( ( state = null, action ) => {
+export const twoFactorAuth = ( state = null, action ) => {
 	switch ( action.type ) {
 		case LOGIN_REQUEST:
 			return null;
@@ -340,9 +340,9 @@ export const twoFactorAuth = withoutPersistence( ( state = null, action ) => {
 	}
 
 	return state;
-} );
+};
 
-export const isRequestingTwoFactorAuth = withoutPersistence( ( state = false, action ) => {
+export const isRequestingTwoFactorAuth = ( state = false, action ) => {
 	switch ( action.type ) {
 		case TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST:
 			return true;
@@ -353,9 +353,9 @@ export const isRequestingTwoFactorAuth = withoutPersistence( ( state = false, ac
 	}
 
 	return state;
-} );
+};
 
-export const twoFactorAuthRequestError = withoutPersistence( ( state = null, action ) => {
+export const twoFactorAuthRequestError = ( state = null, action ) => {
 	switch ( action.type ) {
 		case TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST:
 			return null;
@@ -372,78 +372,74 @@ export const twoFactorAuthRequestError = withoutPersistence( ( state = null, act
 	}
 
 	return state;
-} );
+};
 
-export const twoFactorAuthPushPoll = withoutPersistence(
-	( state = { inProgress: false, success: false }, action ) => {
-		switch ( action.type ) {
-			case TWO_FACTOR_AUTHENTICATION_PUSH_POLL_START:
-				return {
-					...state,
-					inProgress: true,
-					success: false,
-				};
-			case TWO_FACTOR_AUTHENTICATION_PUSH_POLL_STOP:
-				return { ...state, inProgress: false };
-			case TWO_FACTOR_AUTHENTICATION_PUSH_POLL_COMPLETED:
-				return {
-					...state,
-					inProgress: false,
-					success: true,
-				};
-		}
-
-		return state;
+export const twoFactorAuthPushPoll = ( state = { inProgress: false, success: false }, action ) => {
+	switch ( action.type ) {
+		case TWO_FACTOR_AUTHENTICATION_PUSH_POLL_START:
+			return {
+				...state,
+				inProgress: true,
+				success: false,
+			};
+		case TWO_FACTOR_AUTHENTICATION_PUSH_POLL_STOP:
+			return { ...state, inProgress: false };
+		case TWO_FACTOR_AUTHENTICATION_PUSH_POLL_COMPLETED:
+			return {
+				...state,
+				inProgress: false,
+				success: true,
+			};
 	}
-);
 
-export const socialAccount = withoutPersistence(
-	( state = { isCreating: false, createError: null }, action ) => {
-		switch ( action.type ) {
-			case SOCIAL_CREATE_ACCOUNT_REQUEST:
-				return { isCreating: true };
-			case SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE: {
-				const { error } = action;
+	return state;
+};
 
-				return {
-					isCreating: false,
-					createError: error,
-				};
-			}
-			case SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS: {
-				const {
-					data: { username, bearerToken },
-				} = action;
+export const socialAccount = ( state = { isCreating: false, createError: null }, action ) => {
+	switch ( action.type ) {
+		case SOCIAL_CREATE_ACCOUNT_REQUEST:
+			return { isCreating: true };
+		case SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE: {
+			const { error } = action;
 
-				return {
-					isCreating: false,
-					username,
-					bearerToken,
-					createError: null,
-				};
-			}
-			case SOCIAL_LOGIN_REQUEST_FAILURE: {
-				const { error } = action;
-
-				return {
-					...state,
-					requestError: error,
-				};
-			}
-			case CURRENT_USER_RECEIVE:
-				return {
-					...state,
-					bearerToken: null,
-					username: null,
-					createError: null,
-				};
-			case LOGIN_REQUEST:
-				return { ...state, createError: null };
+			return {
+				isCreating: false,
+				createError: error,
+			};
 		}
+		case SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS: {
+			const {
+				data: { username, bearerToken },
+			} = action;
 
-		return state;
+			return {
+				isCreating: false,
+				username,
+				bearerToken,
+				createError: null,
+			};
+		}
+		case SOCIAL_LOGIN_REQUEST_FAILURE: {
+			const { error } = action;
+
+			return {
+				...state,
+				requestError: error,
+			};
+		}
+		case CURRENT_USER_RECEIVE:
+			return {
+				...state,
+				bearerToken: null,
+				username: null,
+				createError: null,
+			};
+		case LOGIN_REQUEST:
+			return { ...state, createError: null };
 	}
-);
+
+	return state;
+};
 
 const userExistsErrorHandler = ( state, { error, authInfo } ) => {
 	if ( error.code === 'user_exists' ) {
@@ -457,7 +453,7 @@ const userExistsErrorHandler = ( state, { error, authInfo } ) => {
 	return state;
 };
 
-export const socialAccountLink = withoutPersistence( ( state = { isLinking: false }, action ) => {
+export const socialAccountLink = ( state = { isLinking: false }, action ) => {
 	switch ( action.type ) {
 		case SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE:
 			return userExistsErrorHandler( state, action );
@@ -472,9 +468,9 @@ export const socialAccountLink = withoutPersistence( ( state = { isLinking: fals
 	}
 
 	return state;
-} );
+};
 
-export const authAccountType = withoutPersistence( ( state = null, action ) => {
+export const authAccountType = ( state = null, action ) => {
 	switch ( action.type ) {
 		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST:
 			return null;
@@ -493,16 +489,16 @@ export const authAccountType = withoutPersistence( ( state = null, action ) => {
 	}
 
 	return state;
-} );
+};
 
-export const lastCheckedUsernameOrEmail = withoutPersistence( ( state = null, action ) => {
+export const lastCheckedUsernameOrEmail = ( state = null, action ) => {
 	switch ( action.type ) {
 		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST:
 			return action.usernameOrEmail;
 	}
 
 	return state;
-} );
+};
 
 const combinedReducer = combineReducers( {
 	authAccountType,

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -22,8 +22,6 @@ import {
 	LOGIN_REQUEST,
 	LOGIN_REQUEST_FAILURE,
 	LOGIN_REQUEST_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE,
 	TWO_FACTOR_AUTHENTICATION_UPDATE_NONCE,
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST,
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE,
@@ -113,22 +111,6 @@ describe( 'reducer', () => {
 			expect( state ).to.be.false;
 		} );
 
-		test( 'should not persist state', () => {
-			const state = isRequesting( true, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = isRequesting( true, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.be.false;
-		} );
-
 		test( 'should set isFormDisabled to true value if a request is initiated', () => {
 			let state = isFormDisabled( undefined, {
 				type: LOGIN_REQUEST,
@@ -202,22 +184,6 @@ describe( 'reducer', () => {
 
 			expect( state ).to.be.false;
 		} );
-
-		test( 'should not persist state', () => {
-			const state = isRequestingTwoFactorAuth( true, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = isRequestingTwoFactorAuth( true, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.be.false;
-		} );
 	} );
 
 	describe( 'requestError', () => {
@@ -278,22 +244,6 @@ describe( 'reducer', () => {
 
 			expect( state ).to.be.null;
 		} );
-
-		test( 'should not persist state', () => {
-			const state = requestError( 'some error', {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = requestError( 'some error', {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.be.null;
-		} );
 	} );
 
 	describe( 'twoFactorAuthRequestError', () => {
@@ -331,22 +281,6 @@ describe( 'reducer', () => {
 		test( 'should reset the error to null when switching routes', () => {
 			const state = twoFactorAuthRequestError( 'some error', {
 				type: ROUTE_SET,
-			} );
-
-			expect( state ).to.be.null;
-		} );
-
-		test( 'should not persist state', () => {
-			const state = twoFactorAuthRequestError( 'some error', {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = twoFactorAuthRequestError( 'some error', {
-				type: DESERIALIZE,
 			} );
 
 			expect( state ).to.be.null;
@@ -393,22 +327,6 @@ describe( 'reducer', () => {
 
 			expect( state ).to.be.null;
 		} );
-
-		test( 'should not persist state', () => {
-			const state = requestNotice( true, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = requestNotice( true, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.be.null;
-		} );
 	} );
 
 	describe( 'requestSuccess', () => {
@@ -440,22 +358,6 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.be.false;
-		} );
-
-		test( 'should not persist state', () => {
-			const state = requestSuccess( true, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = requestSuccess( true, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.be.null;
 		} );
 	} );
 
@@ -548,22 +450,6 @@ describe( 'reducer', () => {
 				two_step_id: 12345678,
 				two_step_nonce_authenticator: 'foo',
 			} );
-		} );
-
-		test( 'should not persist state', () => {
-			const state = twoFactorAuth( true, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = twoFactorAuth( true, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.be.null;
 		} );
 
 		test( 'should reset the "notice" value when an SMS code request is made', () => {

--- a/client/state/oauth2-clients/ui/reducer.js
+++ b/client/state/oauth2-clients/ui/reducer.js
@@ -6,10 +6,10 @@ import { startsWith } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers } from 'calypso/state/utils';
 import { ROUTE_SET } from 'calypso/state/action-types';
 
-export const currentClientId = withoutPersistence( ( state = null, action ) => {
+export const currentClientId = ( state = null, action ) => {
 	switch ( action.type ) {
 		case ROUTE_SET: {
 			const { path, query } = action;
@@ -26,7 +26,7 @@ export const currentClientId = withoutPersistence( ( state = null, action ) => {
 	}
 
 	return state;
-} );
+};
 
 export default combineReducers( {
 	currentClientId,

--- a/client/state/oauth2-clients/ui/test/reducer.js
+++ b/client/state/oauth2-clients/ui/test/reducer.js
@@ -7,7 +7,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import reducer, { currentClientId } from '../reducer';
-import { ROUTE_SET, SERIALIZE, DESERIALIZE } from 'calypso/state/action-types';
+import { ROUTE_SET } from 'calypso/state/action-types';
 
 describe( 'reducer', () => {
 	test( 'should include expected keys in return value', () => {
@@ -32,20 +32,6 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.equal( 42 );
-		} );
-
-		test( 'should not persist state', () => {
-			const state = currentClientId( true, {
-				type: SERIALIZE,
-			} );
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = currentClientId( true, {
-				type: DESERIALIZE,
-			} );
-			expect( state ).to.be.null;
 		} );
 	} );
 } );

--- a/client/state/post-formats/reducer.js
+++ b/client/state/post-formats/reducer.js
@@ -3,7 +3,7 @@
  */
 import { withStorageKey } from '@automattic/state-utils';
 import { postFormatsItemsSchema } from './schema';
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import {
 	POST_FORMATS_RECEIVE,
 	POST_FORMATS_REQUEST,
@@ -19,7 +19,7 @@ import {
  * @param  {object} action Action payload
  * @returns {object}        Updated state
  */
-export const requesting = withoutPersistence( ( state = {}, action ) => {
+export const requesting = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case POST_FORMATS_REQUEST: {
 			const { siteId } = action;
@@ -36,7 +36,7 @@ export const requesting = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Returns the updated items state after an action has been dispatched. The

--- a/client/state/post-formats/test/reducer.js
+++ b/client/state/post-formats/test/reducer.js
@@ -93,32 +93,6 @@ describe( 'reducer', () => {
 				12345678: false,
 			} );
 		} );
-
-		test( 'should not persist state', () => {
-			const state = requesting(
-				deepFreeze( {
-					12345678: true,
-				} ),
-				{
-					type: SERIALIZE,
-				}
-			);
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = requesting(
-				deepFreeze( {
-					12345678: true,
-				} ),
-				{
-					type: DESERIALIZE,
-				}
-			);
-
-			expect( state ).to.eql( {} );
-		} );
 	} );
 
 	describe( '#items()', () => {

--- a/client/state/site-roles/reducer.js
+++ b/client/state/site-roles/reducer.js
@@ -3,7 +3,7 @@
  */
 import { withStorageKey } from '@automattic/state-utils';
 import { siteRolesSchema } from './schema';
-import { combineReducers, withoutPersistence, withSchemaValidation } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import {
 	SITE_ROLES_RECEIVE,
 	SITE_ROLES_REQUEST,
@@ -20,7 +20,7 @@ import {
  * @param  {object} action Action payload
  * @returns {object}        Updated state
  */
-export const requesting = withoutPersistence( ( state = {}, action ) => {
+export const requesting = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SITE_ROLES_REQUEST: {
 			const { siteId } = action;
@@ -37,7 +37,7 @@ export const requesting = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Returns the updated items state after an action has been dispatched. The

--- a/client/state/site-roles/test/reducer.js
+++ b/client/state/site-roles/test/reducer.js
@@ -75,32 +75,6 @@ describe( 'reducer', () => {
 				12345678: false,
 			} );
 		} );
-
-		test( 'should not persist state', () => {
-			const state = requesting(
-				deepFreeze( {
-					12345678: true,
-				} ),
-				{
-					type: SERIALIZE,
-				}
-			);
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = requesting(
-				deepFreeze( {
-					12345678: true,
-				} ),
-				{
-					type: DESERIALIZE,
-				}
-			);
-
-			expect( state ).to.eql( {} );
-		} );
 	} );
 
 	describe( '#items()', () => {

--- a/client/state/site-settings/reducer.js
+++ b/client/state/site-settings/reducer.js
@@ -7,7 +7,7 @@ import { includes } from 'lodash';
  * Internal dependencies
  */
 import { withStorageKey } from '@automattic/state-utils';
-import { combineReducers, withoutPersistence, withSchemaValidation } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import { items as itemSchemas } from './schema';
 import {
 	MEDIA_DELETE,
@@ -29,7 +29,7 @@ import {
  * @param  {object} action Action payload
  * @returns {object}        Updated state
  */
-export const requesting = withoutPersistence( ( state = {}, action ) => {
+export const requesting = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SITE_SETTINGS_REQUEST: {
 			const { siteId } = action;
@@ -46,7 +46,7 @@ export const requesting = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Returns the save Request status after an action has been dispatched. The
@@ -56,7 +56,7 @@ export const requesting = withoutPersistence( ( state = {}, action ) => {
  * @param  {object} action Action payload
  * @returns {object}        Updated state
  */
-export const saveRequests = withoutPersistence( ( state = {}, action ) => {
+export const saveRequests = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SITE_SETTINGS_SAVE: {
 			const { siteId } = action;
@@ -85,7 +85,7 @@ export const saveRequests = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Returns the updated items state after an action has been dispatched. The

--- a/client/state/site-settings/test/reducer.js
+++ b/client/state/site-settings/test/reducer.js
@@ -88,28 +88,6 @@ describe( 'reducer', () => {
 				2916284: false,
 			} );
 		} );
-
-		test( 'should not persist state', () => {
-			const previousState = deepFreeze( {
-				2916284: true,
-			} );
-			const state = requesting( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const previousState = deepFreeze( {
-				2916284: true,
-			} );
-			const state = requesting( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.eql( {} );
-		} );
 	} );
 
 	describe( 'saveRequests()', () => {
@@ -172,28 +150,6 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {
 				2916284: { saving: false, status: 'error', error: 'my error' },
 			} );
-		} );
-
-		test( 'should not persist state', () => {
-			const previousState = deepFreeze( {
-				2916284: { saving: true, status: 'pending', error: false },
-			} );
-			const state = saveRequests( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const previousState = deepFreeze( {
-				2916284: { saving: true, status: 'pending', error: false },
-			} );
-			const state = saveRequests( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.eql( {} );
 		} );
 	} );
 

--- a/client/state/sites/connection/reducer.js
+++ b/client/state/sites/connection/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 
-import { combineReducers, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers } from 'calypso/state/utils';
 import {
 	SITE_CONNECTION_STATUS_RECEIVE,
 	SITE_CONNECTION_STATUS_REQUEST,
@@ -15,7 +15,7 @@ const createRequestingReducer = ( requesting ) => ( state, { siteId } ) => ( {
 	[ siteId ]: requesting,
 } );
 
-export const items = withoutPersistence( ( state = {}, action ) => {
+export const items = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SITE_CONNECTION_STATUS_RECEIVE: {
 			const { siteId, status } = action;
@@ -28,9 +28,9 @@ export const items = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
-export const requesting = withoutPersistence( ( state = {}, action ) => {
+export const requesting = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SITE_CONNECTION_STATUS_REQUEST:
 			return createRequestingReducer( true )( state, action );
@@ -41,7 +41,7 @@ export const requesting = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 export default combineReducers( {
 	items,

--- a/client/state/sites/connection/test/reducer.js
+++ b/client/state/sites/connection/test/reducer.js
@@ -13,8 +13,6 @@ import {
 	SITE_CONNECTION_STATUS_REQUEST,
 	SITE_CONNECTION_STATUS_REQUEST_FAILURE,
 	SITE_CONNECTION_STATUS_REQUEST_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
@@ -77,24 +75,6 @@ describe( 'reducer', () => {
 				2916284: false,
 				77203074: false,
 			} );
-		} );
-
-		test( 'should not persist state', () => {
-			const original = deepFreeze( {
-				2916284: true,
-			} );
-			const state = items( original, { type: SERIALIZE } );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const original = deepFreeze( {
-				2916284: true,
-			} );
-			const state = items( original, { type: DESERIALIZE } );
-
-			expect( state ).to.eql( {} );
 		} );
 	} );
 
@@ -161,24 +141,6 @@ describe( 'reducer', () => {
 				2916284: false,
 				77203074: false,
 			} );
-		} );
-
-		test( 'should not persist state', () => {
-			const original = deepFreeze( {
-				2916284: true,
-			} );
-			const state = requesting( original, { type: SERIALIZE } );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const original = deepFreeze( {
-				2916284: true,
-			} );
-			const state = requesting( original, { type: DESERIALIZE } );
-
-			expect( state ).to.eql( {} );
 		} );
 	} );
 } );

--- a/client/state/sites/monitor/reducer.js
+++ b/client/state/sites/monitor/reducer.js
@@ -7,7 +7,7 @@ import { stubFalse, stubTrue } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, keyedReducer, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers, keyedReducer } from 'calypso/state/utils';
 import {
 	SITE_MONITOR_SETTINGS_RECEIVE,
 	SITE_MONITOR_SETTINGS_REQUEST,
@@ -18,7 +18,7 @@ import {
 	SITE_MONITOR_SETTINGS_UPDATE_SUCCESS,
 } from 'calypso/state/action-types';
 
-export const items = withoutPersistence( ( state = {}, action ) => {
+export const items = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SITE_MONITOR_SETTINGS_RECEIVE: {
 			const { siteId, settings } = action;
@@ -31,39 +31,33 @@ export const items = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
+};
+
+export const requesting = keyedReducer( 'siteId', ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_MONITOR_SETTINGS_REQUEST:
+			return stubTrue( state, action );
+		case SITE_MONITOR_SETTINGS_REQUEST_SUCCESS:
+			return stubFalse( state, action );
+		case SITE_MONITOR_SETTINGS_REQUEST_FAILURE:
+			return stubFalse( state, action );
+	}
+
+	return state;
 } );
 
-export const requesting = keyedReducer(
-	'siteId',
-	withoutPersistence( ( state = {}, action ) => {
-		switch ( action.type ) {
-			case SITE_MONITOR_SETTINGS_REQUEST:
-				return stubTrue( state, action );
-			case SITE_MONITOR_SETTINGS_REQUEST_SUCCESS:
-				return stubFalse( state, action );
-			case SITE_MONITOR_SETTINGS_REQUEST_FAILURE:
-				return stubFalse( state, action );
-		}
+export const updating = keyedReducer( 'siteId', ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_MONITOR_SETTINGS_UPDATE:
+			return stubTrue( state, action );
+		case SITE_MONITOR_SETTINGS_UPDATE_SUCCESS:
+			return stubFalse( state, action );
+		case SITE_MONITOR_SETTINGS_UPDATE_FAILURE:
+			return stubFalse( state, action );
+	}
 
-		return state;
-	} )
-);
-
-export const updating = keyedReducer(
-	'siteId',
-	withoutPersistence( ( state = {}, action ) => {
-		switch ( action.type ) {
-			case SITE_MONITOR_SETTINGS_UPDATE:
-				return stubTrue( state, action );
-			case SITE_MONITOR_SETTINGS_UPDATE_SUCCESS:
-				return stubFalse( state, action );
-			case SITE_MONITOR_SETTINGS_UPDATE_FAILURE:
-				return stubFalse( state, action );
-		}
-
-		return state;
-	} )
-);
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/sites/monitor/test/reducer.js
+++ b/client/state/sites/monitor/test/reducer.js
@@ -16,8 +16,6 @@ import {
 	SITE_MONITOR_SETTINGS_UPDATE,
 	SITE_MONITOR_SETTINGS_UPDATE_FAILURE,
 	SITE_MONITOR_SETTINGS_UPDATE_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
@@ -90,24 +88,6 @@ describe( 'reducer', () => {
 				2916284: otherSettings,
 				77203074: settings,
 			} );
-		} );
-
-		test( 'should not persist state', () => {
-			const original = deepFreeze( {
-				2916284: true,
-			} );
-			const state = items( original, { type: SERIALIZE } );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const original = deepFreeze( {
-				2916284: true,
-			} );
-			const state = items( original, { type: DESERIALIZE } );
-
-			expect( state ).to.eql( {} );
 		} );
 	} );
 

--- a/client/state/sites/sharing-buttons/reducer.js
+++ b/client/state/sites/sharing-buttons/reducer.js
@@ -6,7 +6,7 @@ import { uniqBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import { items as itemSchemas } from './schema';
 import {
 	SHARING_BUTTONS_RECEIVE,
@@ -27,7 +27,7 @@ import {
  * @param  {object} action Action payload
  * @returns {object}        Updated state
  */
-export const requesting = withoutPersistence( ( state = {}, action ) => {
+export const requesting = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SHARING_BUTTONS_REQUEST: {
 			const { siteId } = action;
@@ -52,7 +52,7 @@ export const requesting = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Returns the save Request status after an action has been dispatched. The
@@ -62,7 +62,7 @@ export const requesting = withoutPersistence( ( state = {}, action ) => {
  * @param  {object} action Action payload
  * @returns {object}        Updated state
  */
-export const saveRequests = withoutPersistence( ( state = {}, action ) => {
+export const saveRequests = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SHARING_BUTTONS_SAVE: {
 			const { siteId } = action;
@@ -91,7 +91,7 @@ export const saveRequests = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Returns the updated items state after an action has been dispatched. The

--- a/client/state/sites/sharing-buttons/test/reducer.js
+++ b/client/state/sites/sharing-buttons/test/reducer.js
@@ -87,28 +87,6 @@ describe( 'reducer', () => {
 				2916284: false,
 			} );
 		} );
-
-		test( 'should not persist state', () => {
-			const previousState = deepFreeze( {
-				2916284: true,
-			} );
-			const state = requesting( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const previousState = deepFreeze( {
-				2916284: true,
-			} );
-			const state = requesting( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.eql( {} );
-		} );
 	} );
 
 	describe( 'saveRequests()', () => {
@@ -170,28 +148,6 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {
 				2916284: { saving: false, status: 'error' },
 			} );
-		} );
-
-		test( 'should not persist state', () => {
-			const previousState = deepFreeze( {
-				2916284: { saving: true, status: 'pending' },
-			} );
-			const state = saveRequests( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const previousState = deepFreeze( {
-				2916284: { saving: true, status: 'pending' },
-			} );
-			const state = saveRequests( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.eql( {} );
 		} );
 	} );
 

--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -7,7 +7,7 @@ import { merge, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import { getSerializedStatsQuery } from './utils';
 import { itemSchema } from './schema';
 import {
@@ -24,7 +24,7 @@ import {
  * @param  {object} action Action payload
  * @returns {object}        Updated state
  */
-export const requests = withoutPersistence( ( state = {}, action ) => {
+export const requests = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SITE_STATS_REQUEST: {
 			const { siteId, statType, query } = action;
@@ -62,7 +62,7 @@ export const requests = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 /**
  * Returns the updated items state after an action has been dispatched. The

--- a/client/state/stats/lists/test/reducer.js
+++ b/client/state/stats/lists/test/reducer.js
@@ -152,40 +152,6 @@ describe( 'reducer', () => {
 				},
 			} );
 		} );
-
-		test( 'should not persist state', () => {
-			const original = deepFreeze( {
-				2916284: {
-					statsStreak: {
-						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': {
-							requesting: true,
-							status: 'pending',
-						},
-					},
-				},
-			} );
-
-			const state = requests( original, { type: SERIALIZE } );
-
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const original = deepFreeze( {
-				2916284: {
-					statsStreak: {
-						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': {
-							requesting: true,
-							status: 'pending',
-						},
-					},
-				},
-			} );
-
-			const state = requests( original, { type: DESERIALIZE } );
-
-			expect( state ).to.eql( {} );
-		} );
 	} );
 
 	describe( 'items()', () => {

--- a/client/state/wordads/settings/reducer.js
+++ b/client/state/wordads/settings/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, withoutPersistence, withSchemaValidation } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import { items as itemsSchema } from './schema';
 import {
 	WORDADS_SETTINGS_RECEIVE,
@@ -53,7 +53,7 @@ export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) =
  * @param  {object}  action Action payload
  * @returns {object}        Updated state
  */
-export const requests = withoutPersistence( ( state = {}, action ) => {
+export const requests = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case WORDADS_SETTINGS_SAVE: {
 			const { siteId } = action;
@@ -75,7 +75,7 @@ export const requests = withoutPersistence( ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
 
 export default combineReducers( {
 	items,

--- a/client/state/wordads/settings/test/reducer.js
+++ b/client/state/wordads/settings/test/reducer.js
@@ -189,27 +189,5 @@ describe( 'reducer', () => {
 				2916284: false,
 			} );
 		} );
-
-		test( 'should not persist state', () => {
-			const previousState = deepFreeze( {
-				2916284: false,
-			} );
-			const state = requests( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).toBeUndefined();
-		} );
-
-		test( 'should not load persisted state', () => {
-			const previousState = deepFreeze( {
-				2916284: false,
-			} );
-			const state = requests( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).toEqual( {} );
-		} );
 	} );
 } );


### PR DESCRIPTION
We have plenty of reducers that are wrapped with the `withoutPersistence` wrapper. This wrapper is not needed for plain reducers, because it will be [added automatically](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/utils/reducer-utils.js#L239-L251) by `combineReducers`.

Then we have 30+ unit tests that repeatedly test the same thing for these wrapped reducers: that dispatching `SERIALIZE` on them returns `undefined` and that dispatching `DESERIALIZE` ignores the "serialized state" param and returns the reducer's initial state.

This PR removes all the "should not persist state" unit tests and removes `withoutPersistence` from the tested reducers.

It's part of an effort to remove all `SERIALIZE` and `DESERIALIZE` usages and migrate to a more TypeScript friendly approach outlined in https://github.com/Automattic/wp-calypso/pull/49618#discussion_r570980750

**How to test:**
Unit tests pass, no observable user-visible behavior changes.