### PR TITLE
Themes: Disable flaky e2e tests

### DIFF
--- a/test/e2e/specs/wp-theme-multisite-spec.js
+++ b/test/e2e/specs/wp-theme-multisite-spec.js
@@ -67,7 +67,7 @@ describe( `[${ host }] Themes: All sites (${ screenSize })`, function () {
 				assert( displayed, 'Popover menu not displayed' );
 			} );
 
-			describe( 'when "Try & Customize" is clicked', function () {
+			describe.skip( 'when "Try & Customize" is clicked', function () {
 				step( 'click try and customize popover', async function () {
 					await this.themesPage.clickPopoverItem( 'Try & Customize' );
 					this.siteSelector = await SiteSelectorComponent.Expect( driver );
@@ -149,7 +149,8 @@ describe( `[${ host }] Themes: All sites (${ screenSize })`, function () {
 					return await this.siteSelector.ok();
 				} );
 
-				describe( 'Successful activation dialog', function () {
+				// Skip reason:
+				describe.skip( 'Successful activation dialog', function () {
 					step( 'should show the successful activation dialog', async function () {
 						const themeDialogComponent = await ThemeDialogComponent.Expect( driver );
 						return await themeDialogComponent.goToThemeDetail();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable flaky e2e tests in themes. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Failing tests are not run

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #50130
