### PR TITLE
notes(follow-link): migrate to function component

### DIFF
--- a/apps/notifications/src/panel/helpers/use-safe.js
+++ b/apps/notifications/src/panel/helpers/use-safe.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useRef, useLayoutEffect } from 'react';
+
+/**
+ * Hook to be used to make sure a function `fn` is called only
+ * if the component which uses it is still mounted.
+ *
+ * @param {Function} fn A function you want to be safe to call
+ */
+export default function useSafe( fn ) {
+	const mounted = useRef( false );
+
+	useLayoutEffect( () => {
+		mounted.current = true;
+		return () => ( mounted.current = false );
+	}, [] );
+
+	return useCallback( ( ...args ) => ( mounted.current ? fn( ...args ) : void 0 ), [ fn ] );
+}

--- a/apps/notifications/src/panel/templates/follow-link.jsx
+++ b/apps/notifications/src/panel/templates/follow-link.jsx
@@ -3,8 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -12,43 +11,44 @@ import { localize } from 'i18n-calypso';
 import { wpcom } from '../rest-client/wpcom';
 import { bumpStat } from '../rest-client/bump-stat';
 import Gridicon from './gridicons';
+import useSafe from '../helpers/use-safe';
 
-export const FollowLink = createReactClass( {
-	displayName: 'FollowLink',
+const followStatTypes = {
+	comment: 'note_commented_post',
+	comment_like: 'note_liked_comment',
+	like: 'note_liked_post',
+	follow: 'note_followed',
+	reblog: 'note_reblog_post',
+};
 
-	propTypes: {
-		site: PropTypes.number,
-		isFollowing: PropTypes.bool,
-	},
+export const FollowLink = ( { site, noteType, isFollowing: initialIsFollowing } ) => {
+	const translate = useTranslate();
 
-	followStatTypes: {
-		comment: 'note_commented_post',
-		comment_like: 'note_liked_comment',
-		like: 'note_liked_post',
-		follow: 'note_followed',
-		reblog: 'note_reblog_post',
-	},
+	const [ isRequestRunning, setIsRequestRunning ] = React.useState( false );
+	const [ isFollowing, setIsFollowing ] = React.useState( initialIsFollowing );
 
-	getInitialState: function () {
-		return {
-			isFollowing: this.props.isFollowing,
-		};
-	},
+	const safeSetIsFollowing = useSafe( setIsFollowing );
+	const safeSetIsRequestRunning = useSafe( setIsRequestRunning );
 
-	toggleFollowStatus: function ( event ) {
-		const isFollowing = this.state.isFollowing;
+	function toggleFollowStatus() {
+		if ( isRequestRunning ) {
+			return;
+		}
 
-		const follower = wpcom().site( this.props.site ).follow();
-		const component = this;
+		const follower = wpcom().site( site ).follow();
+		setIsRequestRunning( true );
 
-		const updateState = function ( error, data ) {
-			if ( error ) throw error;
+		// optimistically update local state
+		const previousState = isFollowing;
+		setIsFollowing( ! isFollowing );
 
-			if ( component.isMounted() ) {
-				component.setState( {
-					isFollowing: data.is_following,
-				} );
+		const updateState = ( error, data ) => {
+			safeSetIsRequestRunning( false );
+			if ( error ) {
+				safeSetIsFollowing( previousState );
+				throw error;
 			}
+			safeSetIsFollowing( data.is_following );
 		};
 
 		if ( isFollowing ) {
@@ -58,39 +58,27 @@ export const FollowLink = createReactClass( {
 			follower.add( updateState );
 
 			const stats = { 'notes-click-action': 'follow' };
-			stats.follow_source = this.followStatTypes[ this.props.noteType ];
+			stats.follow_source = followStatTypes[ noteType ];
 			bumpStat( stats );
 		}
+	}
 
-		// but optimistically update the client
-		this.setState( {
-			isFollowing: ! isFollowing,
-		} );
-	},
+	const icon = isFollowing ? 'reader-following' : 'reader-follow';
+	const linkText = isFollowing
+		? translate( 'Following', { context: 'you are following' } )
+		: translate( 'Follow', { context: 'verb: imperative' } );
 
-	render: function () {
-		let gridicon_icon;
-		let link_text;
+	return (
+		<button className="follow-link" onClick={ toggleFollowStatus }>
+			<Gridicon icon={ icon } size={ 18 } />
+			{ linkText }
+		</button>
+	);
+};
 
-		if ( this.state.isFollowing ) {
-			gridicon_icon = 'reader-following';
-			link_text = this.props.translate( 'Following', {
-				context: 'you are following',
-			} );
-		} else {
-			gridicon_icon = 'reader-follow';
-			link_text = this.props.translate( 'Follow', {
-				context: 'verb: imperative',
-			} );
-		}
+FollowLink.propTypes = {
+	site: PropTypes.number,
+	isFollowing: PropTypes.bool,
+};
 
-		return (
-			<button className="follow-link" onClick={ this.toggleFollowStatus }>
-				<Gridicon icon={ gridicon_icon } size={ 18 } />
-				{ link_text }
-			</button>
-		);
-	},
-} );
-
-export default localize( FollowLink );
+export default FollowLink;


### PR DESCRIPTION
In the notifications panel when you hit _Follow_ or _Following_ on a user block you'll see a warning in the console that `isMounted` is deprecated (this warning is suppressed in prod, so test with dev).

<img width="667" alt="Screenshot 2021-02-17 at 10 00 32" src="https://user-images.githubusercontent.com/9202899/108180789-75ccd500-7107-11eb-85ca-c18725f4feb3.png">

#### Changes proposed in this Pull Request

* FollowLink: migrate to function component
* Fix the warning as described above

#### Testing instructions

In Calypso:

* Open the notifications panel and open a notification related to another user
* Hit the _Follow_ or _Unfollow_ button
* You should see a request in the _Network_ tab
* The `isFollowing` state should be updated optimistically and be locked until the request has finished
* Make sure you don't see a warning like described above

In non-Calypso environment:

Follow the Build process as described here: PCYsg-elI-p2 (without the last step) then follow the steps provided above