### PR TITLE
e2e: Fix selector so it doesn't try 2021 theme

### DIFF
--- a/test/e2e/lib/pages/themes-page.js
+++ b/test/e2e/lib/pages/themes-page.js
@@ -57,7 +57,7 @@ export default class ThemesPage extends AsyncBaseContainer {
 
 	async clickNewThemeMoreButton() {
 		const selector = by.css(
-			".theme-showcase__all-themes .is-actionable:not(.is-active):not([data-e2e-theme*='twenty-twenty-one']) button"
+			".theme-showcase__all-themes .is-actionable[data-e2e-theme*='twenty-fifteen']:not(.is-active) button"
 		);
 
 		await driverHelper.scrollIntoView( this.driver, selector );
@@ -67,7 +67,7 @@ export default class ThemesPage extends AsyncBaseContainer {
 	async getFirstThemeName() {
 		// Get the first theme that isn't the Twenty-Twenty-One theme
 		const selector = by.css(
-			".theme-showcase__all-themes .is-actionable:not(.is-active):not([data-e2e-theme*='twenty-twenty-one']) h2"
+			".theme-showcase__all-themes .is-actionable[data-e2e-theme*='twenty-fifteen']:not(.is-active) h2"
 		);
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
 		await driverHelper.scrollIntoView( this.driver, selector );

--- a/test/e2e/lib/pages/themes-page.js
+++ b/test/e2e/lib/pages/themes-page.js
@@ -106,9 +106,11 @@ export default class ThemesPage extends AsyncBaseContainer {
 	}
 
 	async clearSearch() {
+		const closeSelector = by.css( '.themes-magic-search-card__icon-close' );
+		await driverHelper.scrollIntoView( this.driver, closeSelector );
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			by.css( '.themes-magic-search-card__icon-close' )
+			closeSelector
 		);
 	}
 

--- a/test/e2e/lib/pages/themes-page.js
+++ b/test/e2e/lib/pages/themes-page.js
@@ -56,7 +56,7 @@ export default class ThemesPage extends AsyncBaseContainer {
 	}
 
 	async clickNewThemeMoreButton() {
-		const selector = by.css( '.theme-showcase__all-themes .is-actionable:not(.is-active) button' );
+		const selector = by.css( '.theme-showcase__all-themes .is-actionable:not(.is-active):not([data-e2e-theme*=\'twenty-twenty-one\']) button' );
 
 		await driverHelper.scrollIntoView( this.driver, selector );
 		return await driverHelper.clickWhenClickable( this.driver, selector );

--- a/test/e2e/lib/pages/themes-page.js
+++ b/test/e2e/lib/pages/themes-page.js
@@ -66,7 +66,9 @@ export default class ThemesPage extends AsyncBaseContainer {
 
 	async getFirstThemeName() {
 		// Get the first theme that isn't the Twenty-Twenty-One theme
-		const selector = by.css( ".theme-showcase__all-themes .is-actionable:not(.is-active):not([data-e2e-theme*='twenty-twenty-one']) h2" );
+		const selector = by.css(
+			".theme-showcase__all-themes .is-actionable:not(.is-active):not([data-e2e-theme*='twenty-twenty-one']) h2"
+		);
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
 		return await this.driver.findElement( selector ).getText();
 	}

--- a/test/e2e/lib/pages/themes-page.js
+++ b/test/e2e/lib/pages/themes-page.js
@@ -56,7 +56,9 @@ export default class ThemesPage extends AsyncBaseContainer {
 	}
 
 	async clickNewThemeMoreButton() {
-		const selector = by.css( '.theme-showcase__all-themes .is-actionable:not(.is-active):not([data-e2e-theme*=\'twenty-twenty-one\']) button' );
+		const selector = by.css(
+			".theme-showcase__all-themes .is-actionable:not(.is-active):not([data-e2e-theme*='twenty-twenty-one']) button"
+		);
 
 		await driverHelper.scrollIntoView( this.driver, selector );
 		return await driverHelper.clickWhenClickable( this.driver, selector );

--- a/test/e2e/lib/pages/themes-page.js
+++ b/test/e2e/lib/pages/themes-page.js
@@ -70,6 +70,7 @@ export default class ThemesPage extends AsyncBaseContainer {
 			".theme-showcase__all-themes .is-actionable:not(.is-active):not([data-e2e-theme*='twenty-twenty-one']) h2"
 		);
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
+		await driverHelper.scrollIntoView( this.driver, selector );
 		return await this.driver.findElement( selector ).getText();
 	}
 

--- a/test/e2e/lib/pages/themes-page.js
+++ b/test/e2e/lib/pages/themes-page.js
@@ -65,7 +65,8 @@ export default class ThemesPage extends AsyncBaseContainer {
 	}
 
 	async getFirstThemeName() {
-		const selector = by.css( '.theme-showcase__all-themes .is-actionable:not(.is-active) h2' );
+		// Get the first theme that isn't the Twenty-Twenty-One theme
+		const selector = by.css( ".theme-showcase__all-themes .is-actionable:not(.is-active):not([data-e2e-theme*='twenty-twenty-one']) h2" );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
 		return await this.driver.findElement( selector ).getText();
 	}

--- a/test/e2e/specs/wp-theme-multisite-spec.js
+++ b/test/e2e/specs/wp-theme-multisite-spec.js
@@ -148,7 +148,7 @@ describe( `[${ host }] Themes: All sites (${ screenSize })`, function () {
 					await this.siteSelector.selectFirstSite();
 					return await this.siteSelector.ok();
 				} );
-				
+
 				describe( 'Successful activation dialog', function () {
 					step( 'should show the successful activation dialog', async function () {
 						const themeDialogComponent = await ThemeDialogComponent.Expect( driver );

--- a/test/e2e/specs/wp-theme-multisite-spec.js
+++ b/test/e2e/specs/wp-theme-multisite-spec.js
@@ -67,7 +67,7 @@ describe( `[${ host }] Themes: All sites (${ screenSize })`, function () {
 				assert( displayed, 'Popover menu not displayed' );
 			} );
 
-			describe.skip( 'when "Try & Customize" is clicked', function () {
+			describe( 'when "Try & Customize" is clicked', function () {
 				step( 'click try and customize popover', async function () {
 					await this.themesPage.clickPopoverItem( 'Try & Customize' );
 					this.siteSelector = await SiteSelectorComponent.Expect( driver );
@@ -148,9 +148,8 @@ describe( `[${ host }] Themes: All sites (${ screenSize })`, function () {
 					await this.siteSelector.selectFirstSite();
 					return await this.siteSelector.ok();
 				} );
-
-				// Skip reason: https://github.com/Automattic/wp-calypso/issues/50130
-				describe.skip( 'Successful activation dialog', function () {
+				
+				describe( 'Successful activation dialog', function () {
 					step( 'should show the successful activation dialog', async function () {
 						const themeDialogComponent = await ThemeDialogComponent.Expect( driver );
 						return await themeDialogComponent.goToThemeDetail();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  This PR Fixes the e2e test for themes. The test was trying to click a link in an overlay that didn't show up for the 2021 theme. I excluded that them so that it will try other themes

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure all tests for themes pass in CI

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #50131 
