### PR TITLE
Adds a permanent feature flag via cookie in login if env var FLAGS exists.

### DIFF
--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -53,6 +53,8 @@ export default class LoginFlow {
 
 	async login( { emailSSO = false, jetpackSSO = false } = {} ) {
 		await driverManager.ensureNotLoggedIn( this.driver );
+		process.env.FLAGS &&
+			( await this.driver.manage().addCookie( { name: 'flags', value: process.env.FLAGS } ) );
 
 		// Disabling re-use of cookies as latest versions of Chrome don't currently support it.
 		// We can check later to see if we can find a different way to support it.


### PR DESCRIPTION
There are some features like **nav-unification**[pbAPfg-Ou-p2] where some major UI changes are introduced. In that cases we want to be able to run existing tests with the feature enabled so that we can fix them or create new ones before rolling out in production. Creating a new user - site as suggested in pciE2j-bk-p2#comment-264 would probably require creating a new "nav-unification" user for each different user used in tests. 

Since [login](https://github.com/Automattic/wp-calypso/blob/HEAD/test/e2e/lib/flows/login-flow.js#L54) is the entrypoint of most ( if not all ) e2e tests and most features require a logged in user it made sense adding a cookie right after `ensureNotLoggedIn` is triggered (which deletes all cookies).

#### Changes proposed in this Pull Request

* Adds a permanent feature flag via cookie in login if env var FLAGS exists

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In `trunk`, run a spec file and make sure it runs with success and tests pass (don't forget decrypting your conf once again)
* set `"calypsoBaseURL": "http://calypso.localhost:3000",` in your local config
* `cd test/e2e`
* `./node_modules/.bin/mocha specs/wp-calypso-seo-preview.js`

In this branch, run the same spec with an env flag `FLAGS='nav-unification'`
* set `"calypsoBaseURL": "http://calypso.localhost:3000",` in your local config
* `cd test/e2e`
* `env FLAGS='nav-unification' ./node_modules/.bin/mocha specs/wp-calypso-seo-preview.js`
* while this should run with success, tests should not pass
* in `test/e2e/screenshots/` there should be a screenshot with nav-unification enabled


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #49250