### PR TITLE
Fix for `new-launch` signup flow to not clear the `selectedSiteId` by default

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -288,7 +288,7 @@ export default {
 		context.store.dispatch( setLayoutFocus( 'content' ) );
 		context.store.dispatch( setCurrentFlowName( flowName ) );
 
-		if ( flowName !== 'launch-site' ) {
+		if ( ! [ 'launch-site', 'new-launch' ].includes( flowName ) ) {
 			context.store.dispatch( setSelectedSiteId( null ) );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Since https://github.com/Automattic/wp-calypso/pull/49680 the signup launch flow is actually correctly setting the `selectedSiteId` state. However the `new-launch` flow is unsetting that state and that breaks the initial suggestions in the domain step

#### Testing instructions

* Open up the new-launch flow for unlaunched site - http://calypso.localhost:3000/start/new-launch/domains-launch?siteSlug=examplesiteslug.wordpress.com&source=home
* Verify that you see initial domain suggestions and you're not stuck on the placeholder screen:
* You might want to delete your local browser indexDB Calypso database and refresh to reproduce this

stuck on the placeholder screen:
<img width="1041" alt="Screenshot 2021-02-16 at 21 27 02" src="https://user-images.githubusercontent.com/1355045/108111802-dfb09480-709d-11eb-9b69-6caed7f4f4ed.png">

what you should see - two domain suggestions:
<img width="1010" alt="Screenshot 2021-02-16 at 21 30 16" src="https://user-images.githubusercontent.com/1355045/108112077-45048580-709e-11eb-8363-6876e11f6421.png">


Related to #
