### PR TITLE
Gutenboarding: Check for existing site title before replacing with podcast title

### DIFF
--- a/client/landing/gutenboarding/hooks/use-site-title.ts
+++ b/client/landing/gutenboarding/hooks/use-site-title.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 
 /**
@@ -13,11 +13,14 @@ import usePodcastTitle from './use-podcast-title';
 export default function useSiteTitle(): void {
 	const { setSiteTitle } = useDispatch( ONBOARD_STORE );
 	const podcastTitle = usePodcastTitle();
+	const { siteTitle } = useSelect( ( select ) => ( {
+		siteTitle: select( ONBOARD_STORE ).getSelectedSiteTitle(),
+	} ) );
 
 	useEffect( () => {
-		if ( podcastTitle ) {
+		if ( podcastTitle && ! siteTitle ) {
 			// Set initial site title to podcast title
 			setSiteTitle( podcastTitle );
 		}
-	}, [ podcastTitle, setSiteTitle ] );
+	}, [ podcastTitle, setSiteTitle, siteTitle ] );
 }

--- a/client/landing/gutenboarding/hooks/use-site-title.ts
+++ b/client/landing/gutenboarding/hooks/use-site-title.ts
@@ -13,14 +13,14 @@ import usePodcastTitle from './use-podcast-title';
 export default function useSiteTitle(): void {
 	const { setSiteTitle } = useDispatch( ONBOARD_STORE );
 	const podcastTitle = usePodcastTitle();
-	const { siteTitle } = useSelect( ( select ) => ( {
-		siteTitle: select( ONBOARD_STORE ).getSelectedSiteTitle(),
+	const { hasSiteTitle } = useSelect( ( select ) => ( {
+		hasSiteTitle: select( ONBOARD_STORE ).getSelectedSiteTitle().length > 0,
 	} ) );
 
 	useEffect( () => {
-		if ( podcastTitle && ! siteTitle ) {
+		if ( podcastTitle && ! hasSiteTitle ) {
 			// Set initial site title to podcast title
 			setSiteTitle( podcastTitle );
 		}
-	}, [ podcastTitle, setSiteTitle, siteTitle ] );
+	}, [ podcastTitle, setSiteTitle, hasSiteTitle ] );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a check for an existing site title before replacing it with the podcast title

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit `/new/?anchor_podcast=22b6608`
2. Check that the podcast title is populated in the site title field.
2. Replace the podcast title with a custom title.
3. Continue to the font pairing step
4. Refresh the browser page
5. Check that the custom title displays both in the font preview and at the top of the page:
<img width="897" alt="Screen Shot 2021-02-16 at 2 41 52 PM" src="https://user-images.githubusercontent.com/1689238/108113534-a52b0580-7065-11eb-90d4-d11f8ec629cd.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 472-gh-Automattic/dotcom-manage