### PR TITLE
Specify the label to be used by `actions/stale` bot.

### DIFF
--- a/.github/workflows/mark-issue-stale.yml
+++ b/.github/workflows/mark-issue-stale.yml
@@ -21,4 +21,4 @@ jobs:
           # Get issues in ascending (oldest first) order.
           ascending: true
           # Label to apply when issue is marked stale.
-          stale-issue-label: '[Status] - Stale'
+          stale-issue-label: '[Status] Stale'

--- a/.github/workflows/mark-issue-stale.yml
+++ b/.github/workflows/mark-issue-stale.yml
@@ -20,3 +20,5 @@ jobs:
           days-before-close: -1
           # Get issues in ascending (oldest first) order.
           ascending: true
+          # Label to apply when issue is marked stale.
+          stale-issue-label: '[Status] - Stale'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* specify to the actions/stale bot to use `[Status] - Stale` label instead of the default `Stale`.

#### Testing instructions

N/A