### PR TITLE
Inline Help: Use WP Components Popover

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -10,6 +10,7 @@ import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import { withMobileBreakpoint } from '@automattic/viewport-react';
 import { __ } from '@wordpress/i18n';
+import { Popover } from '@wordpress/components';
 
 /**
  * Internal Dependencies
@@ -17,7 +18,6 @@ import { __ } from '@wordpress/i18n';
 import { VIEW_CONTACT, VIEW_RICH_RESULT } from './constants';
 import { selectResult, resetInlineHelpContactForm } from 'calypso/state/inline-help/actions';
 import { Button } from '@automattic/components';
-import Popover from 'calypso/components/popover';
 import InlineHelpSearchResults from './inline-help-search-results';
 import InlineHelpSearchCard from './inline-help-search-card';
 import InlineHelpRichResult from './inline-help-rich-result';
@@ -31,6 +31,7 @@ class InlineHelpPopover extends Component {
 	static propTypes = {
 		onClose: PropTypes.func.isRequired,
 		setDialogState: PropTypes.func.isRequired,
+		context: PropTypes.element.isRequired,
 	};
 
 	static defaultProps = {
@@ -188,11 +189,12 @@ class InlineHelpPopover extends Component {
 
 		return (
 			<Popover
-				isVisible
 				onClose={ this.props.onClose }
 				position="top left"
-				context={ this.props.context }
+				expandOnMobile={ false }
+				noArrow={ false }
 				className={ classNames( 'inline-help__popover', popoverClasses ) }
+				getAnchorRect={ () => this.props.context.getBoundingClientRect() }
 			>
 				{ this.renderPopoverContent() }
 				{ this.renderPopoverFooter() }

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -129,12 +129,7 @@
 	z-index: z-index( 'root', '.inline-help__mobile-overlay' );
 }
 
-.inline-help__popover.popover {
-	@include breakpoint-deprecated( '<660px' ) {
-		margin-top: -5px;
-		width: calc( 100% - 28px );
-	}
-
+.components-popover .components-popover__content {
 	p {
 		font-size: $font-body-extra-small;
 
@@ -152,18 +147,12 @@
 		}
 	}
 
-	@include breakpoint-deprecated( '>660px' ) {
-		width: 320px;
-
-		position: fixed;
-		top: auto !important;
-		bottom: 76px !important;
+	@include breakpoint-deprecated( '<660px' ) {
+		width: calc( 100vw - 28px );
 	}
 
-	&.is-top .popover__arrow::before,
-	&.is-top-left .popover__arrow::before,
-	&.is-top-right .popover__arrow::before {
-		border-top: 10px solid var( --color-neutral-0 );
+	@include breakpoint-deprecated( '>660px' ) {
+		width: 320px;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `@wordpress/components` Popover for Inline Help.

This is one of the steps we'll need to take in order to make Inline Help run in wp-admin. (extracting/de-coupling from Calypso) The alternative is to extract Calypso's popover component, but why do that if core has one already for us? Additionally, in the nearish future we'll be able to take advantage of the next generation of Popover once the CSS-in-JS version is merged.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Force inline-help to show by modifying [this line](https://github.com/automattic/wp-calypso/blob/b1780bdc090d3c78f41b296cb2901148dd59a78f/client/state/selectors/is-inline-help-visible.js#L15) to always return true. Test the inline help and ensure that it works like it does in production including on mobile.