### PR TITLE
Update domain email upsell to promote Email and G Suite

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -759,22 +759,6 @@ Undocumented.prototype.validateGoogleAppsContactInformation = function (
 	return result.then?.( camelCaseKeys );
 };
 
-/**
- * Retrieves the Titan order provisioning URL for a domain.
- *
- * @param domain the domain name
- * @param fn The callback function
- */
-Undocumented.prototype.getTitanOrderProvisioningURL = function ( domain, fn ) {
-	return this.wpcom.req.get(
-		{
-			path: `/emails/titan/${ encodeURIComponent( domain ) }/order-provisioning-url`,
-			apiNamespace: 'wpcom/v2',
-		},
-		fn
-	);
-};
-
 Undocumented.prototype.getTitanDetailsForIncomingRedirect = function ( mode, jwt, fn ) {
 	return this.wpcom.req.get(
 		{

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -26,6 +26,7 @@ import MapDomain from 'calypso/my-sites/domains/map-domain';
 import TransferDomain from 'calypso/my-sites/domains/transfer-domain';
 import TransferDomainStep from 'calypso/components/domains/transfer-domain-step';
 import UseYourDomainStep from 'calypso/components/domains/use-your-domain-step';
+import EmailProvidersUpsell from 'calypso/my-sites/email/email-providers-upsell';
 import GSuiteUpgrade from 'calypso/components/upgrades/gsuite';
 import {
 	domainManagementTransferIn,
@@ -220,6 +221,25 @@ const googleAppsWithRegistration = ( context, next ) => {
 	next();
 };
 
+const emailWithRegistration = ( context, next ) => {
+	context.primary = (
+		<Main wideLayout>
+			<PageViewTracker
+				path="/domains/add/:domain/email/:site"
+				title="Domain Search > Domain Registration > Email"
+			/>
+			<DocumentHead
+				title={ translate( 'Register %(domain)s', {
+					args: { domain: context.params.registerDomain },
+				} ) }
+			/>
+			<EmailProvidersUpsell domain={ context.params.registerDomain } />
+		</Main>
+	);
+
+	next();
+};
+
 const redirectIfNoSite = ( redirectTo ) => {
 	return ( context, next ) => {
 		const state = context.store.getState();
@@ -282,6 +302,7 @@ export default {
 	jetpackNoDomainsWarning,
 	siteRedirect,
 	mapDomain,
+	emailWithRegistration,
 	googleAppsWithRegistration,
 	redirectToDomainSearchSuggestion,
 	redirectIfNoSite,

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -19,7 +19,6 @@ import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import Main from 'calypso/components/main';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { canDomainAddGSuite } from 'calypso/lib/gsuite';
 import {
 	hasPlan,
 	hasDomainInCart,
@@ -159,11 +158,7 @@ class DomainSearch extends Component {
 				fillInSingleCartItemAttributes( registration, this.props.productsList ),
 			] )
 			.then( () => {
-				if ( canDomainAddGSuite( domain ) ) {
-					page( '/domains/add/' + domain + '/google-apps/' + this.props.selectedSiteSlug );
-				} else {
-					page( '/checkout/' + this.props.selectedSiteSlug );
-				}
+				page( '/domains/add/' + domain + '/email/' + this.props.selectedSiteSlug );
 			} );
 	}
 

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -241,6 +241,17 @@ export default function () {
 		);
 
 		page(
+			'/domains/add/:registerDomain/email/:domain',
+			siteSelection,
+			navigation,
+			domainsController.redirectIfNoSite( '/domains/add' ),
+			domainsController.jetpackNoDomainsWarning,
+			domainsController.emailWithRegistration,
+			makeLayout,
+			clientRender
+		);
+
+		page(
 			'/domains/add/:registerDomain/google-apps/:domain',
 			siteSelection,
 			navigation,

--- a/client/my-sites/email/email-providers-comparison/custom-email-promo.jsx
+++ b/client/my-sites/email/email-providers-comparison/custom-email-promo.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
+import PromoCard from 'calypso/components/promo-section/promo-card';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export default function CustomEmailPromo( { domainName } ) {
+	const translate = useTranslate();
+	const image = {
+		path: emailIllustration,
+		align: 'right',
+	};
+
+	const translateArgs = {
+		args: {
+			domainName,
+		},
+		comment: '%(domainName)s is the domain name, e.g example.com',
+	};
+
+	return (
+		<PromoCard
+			isPrimary
+			title={ translate( 'Get your own @%(domainName)s email address', translateArgs ) }
+			image={ image }
+			className="email-providers-comparison__action-panel"
+			icon=""
+		>
+			<p>
+				{ translate(
+					'Pick one of our flexible options to connect your domain with email ' +
+						'and start getting emails @%(domainName)s today.',
+					translateArgs
+				) }
+			</p>
+		</PromoCard>
+	);
+}

--- a/client/my-sites/email/email-providers-comparison/custom-email-promo.jsx
+++ b/client/my-sites/email/email-providers-comparison/custom-email-promo.jsx
@@ -15,7 +15,7 @@ import PromoCard from 'calypso/components/promo-section/promo-card';
  */
 import './style.scss';
 
-export default function CustomEmailPromo( { domainName } ) {
+export default function CustomEmailPromo( { domainName, children } ) {
 	const translate = useTranslate();
 	const image = {
 		path: emailIllustration,
@@ -44,6 +44,7 @@ export default function CustomEmailPromo( { domainName } ) {
 					translateArgs
 				) }
 			</p>
+			{ children }
 		</PromoCard>
 	);
 }

--- a/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash';
@@ -58,8 +59,10 @@ class EmailProviderDetails extends React.Component {
 			isButtonBusy,
 		} = this.props;
 
+		const allClassNames = classnames( 'email-provider-details', className );
+
 		return (
-			<PromoCard { ...{ className, title, image, badge } }>
+			<PromoCard { ...{ className: allClassNames, title, image, badge } }>
 				<p className="email-provider-details__description">{ description }</p>
 				<PromoCardPrice { ...{ formattedPrice, discount } } />
 				<Button

--- a/client/my-sites/email/email-providers-comparison/email-provider-details/titan-provider-details.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-details/titan-provider-details.jsx
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import formatCurrency from '@automattic/format-currency';
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
+import Gridicon from 'calypso/components/gridicon';
+import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan.svg';
+import EmailProviderDetails from './index';
+
+export default function TitanProviderDetails( {
+	className,
+	currencyCode,
+	onAddTitanClick,
+	titanMailProduct,
+} ) {
+	const translate = useTranslate();
+	const billingFrequency = translate( 'Monthly billing' );
+	const formattedPrice = translate( '{{price/}} /user /month', {
+		components: {
+			price: <span>{ formatCurrency( titanMailProduct?.cost ?? 0, currencyCode ) }</span>,
+		},
+		comment: '{{price/}} is the formatted price, e.g. $20',
+	} );
+	const providerName = getTitanProductName();
+	const providerCtaText = translate( 'Add %(emailProductName)s', {
+		args: {
+			emailProductName: providerName,
+		},
+		comment: '%(emailProductName)s is the product name, either "Email" or "Titan Mail"',
+	} );
+	const providerEmailLogo = (
+		<Gridicon className="email-provider-details__providers-wordpress-com-email" icon="my-sites" />
+	);
+	const badge = <img src={ poweredByTitanLogo } alt={ translate( 'Powered by Titan' ) } />;
+
+	return (
+		<EmailProviderDetails
+			title={ providerName }
+			description={ translate(
+				'Easy-to-use email with incredibly powerful features. Manage your email and more on any device.'
+			) }
+			image={ providerEmailLogo }
+			features={ [
+				billingFrequency,
+				translate( 'Send and receive from your custom domain' ),
+				translate( '30GB storage' ),
+				translate( 'Email, calendars, and contacts' ),
+				translate( 'One-click import of existing emails and contacts' ),
+				translate( 'Read receipts to track email opens' ),
+			] }
+			formattedPrice={ formattedPrice }
+			buttonLabel={ providerCtaText }
+			hasPrimaryButton={ true }
+			onButtonClick={ onAddTitanClick }
+			badge={ badge }
+			className={ classNames( className, 'titan' ) }
+		/>
+	);
+}

--- a/client/my-sites/email/email-providers-comparison/gsuite-provider-details.jsx
+++ b/client/my-sites/email/email-providers-comparison/gsuite-provider-details.jsx
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import config from '@automattic/calypso-config';
+import EmailProviderDetails from 'calypso/my-sites/email/email-providers-comparison/email-provider-details';
+import { getAnnualPrice, getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
+import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
+import gSuiteLogo from 'calypso/assets/images/email-providers/gsuite.svg';
+import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
+
+export default function GSuiteProviderDetails( {
+	className,
+	currencyCode,
+	gSuiteProduct,
+	onAddGSuiteClick,
+} ) {
+	const translate = useTranslate();
+	let title = translate( 'G Suite by Google' );
+	let description = translate(
+		"We've partnered with Google to offer you email, storage, docs, calendars, and more."
+	);
+	let logo = gSuiteLogo;
+	let buttonLabel = translate( 'Add G Suite' );
+
+	if ( config.isEnabled( 'google-workspace-migration' ) ) {
+		title = getGoogleMailServiceFamily();
+		description = translate(
+			'The best way to create, communicate, and collaborate. An integrated workspace that is simple and easy to use.'
+		);
+		logo = googleWorkspaceIcon;
+		buttonLabel = translate( 'Add %(googleMailService)s', {
+			args: {
+				googleMailService: getGoogleMailServiceFamily(),
+			},
+			comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+		} );
+	}
+
+	return (
+		<EmailProviderDetails
+			title={ title }
+			description={ description }
+			image={ { path: logo } }
+			features={ [
+				translate( 'Annual billing' ),
+				translate( 'Send and receive from your custom domain' ),
+				translate( '30GB storage' ),
+				translate( 'Email, calendars, and contacts' ),
+				translate( 'Video calls, docs, spreadsheets, and more' ),
+				translate( 'Work from anywhere on any device – even offline' ),
+			] }
+			formattedPrice={ translate( '{{price/}} /user /year', {
+				components: {
+					price: <span>{ getAnnualPrice( gSuiteProduct?.cost ?? null, currencyCode ) }</span>,
+				},
+				comment: '{{price/}} is the formatted price, e.g. $20',
+			} ) }
+			discount={
+				hasDiscount( gSuiteProduct )
+					? translate( 'First year %(discountedPrice)s', {
+							args: {
+								discountedPrice: getAnnualPrice( gSuiteProduct.sale_cost, currencyCode ),
+							},
+							comment: '%(discountedPrice)s is a formatted price, e.g. $75',
+					  } )
+					: null
+			}
+			buttonLabel={ buttonLabel }
+			onButtonClick={ onAddGSuiteClick }
+			className={ classNames( className, 'gsuite' ) }
+		/>
+	);
+}

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -4,10 +4,9 @@
 import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import page from 'page';
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,15 +37,11 @@ import wpcom from 'calypso/lib/wp';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import Gridicon from 'calypso/components/gridicon';
-import formatCurrency from '@automattic/format-currency';
 import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
-import titanLogo from 'calypso/assets/images/email-providers/titan.svg';
-import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan.svg';
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
 import gSuiteLogo from 'calypso/assets/images/email-providers/gsuite.svg';
 import forwardingIcon from 'calypso/assets/images/email-providers/forwarding.svg';
-import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
+import TitanProviderDetails from 'calypso/my-sites/email/email-providers-comparison/email-provider-details/titan-provider-details';
 
 /**
  * Style dependencies
@@ -177,68 +172,14 @@ class EmailProvidersComparison extends React.Component {
 	}
 
 	renderTitanDetails( className ) {
-		const { currencyCode, currentUserLocale, titanMailProduct, translate } = this.props;
-		const isEnglish = includes( config( 'english_locales' ), currentUserLocale );
-		const billingFrequency =
-			! config.isEnabled( 'titan/phase-2' ) &&
-			( isEnglish || i18n.hasTranslation( 'Annual or monthly billing' ) )
-				? translate( 'Annual or monthly billing' )
-				: translate( 'Monthly billing' );
-
-		const formattedPrice = config.isEnabled( 'titan/phase-2' )
-			? translate( '{{price/}} /user /month', {
-					components: {
-						price: <span>{ formatCurrency( titanMailProduct?.cost ?? 0, currencyCode ) }</span>,
-					},
-					comment: '{{price/}} is the formatted price, e.g. $20',
-			  } )
-			: translate( '{{price/}} /user /month', {
-					components: {
-						price: <span>{ formatCurrency( 3.5, 'USD' ) }</span>,
-					},
-					comment: '{{price/}} is the formatted price, e.g. $20',
-			  } );
-		const providerName = getTitanProductName();
-		const providerCtaText = translate( 'Add %(emailProductName)s', {
-			args: {
-				emailProductName: providerName,
-			},
-			comment: '%(emailProductName)s is the product name, either "Email" or "Titan Mail"',
-		} );
-		const providerEmailLogo = config.isEnabled( 'titan/phase-2' ) ? (
-			<Gridicon
-				className="email-providers-comparison__providers-wordpress-com-email"
-				icon="my-sites"
-			/>
-		) : (
-			{ path: titanLogo }
-		);
-		const badge = config.isEnabled( 'titan/phase-2' ) ? (
-			<img src={ poweredByTitanLogo } alt={ translate( 'Powered by Titan' ) } />
-		) : null;
+		const { currencyCode, titanMailProduct } = this.props;
 
 		return (
-			<EmailProviderDetails
-				title={ providerName }
-				description={ translate(
-					'Easy-to-use email with incredibly powerful features. Manage your email and more on any device.'
-				) }
-				image={ providerEmailLogo }
-				features={ [
-					billingFrequency,
-					translate( 'Send and receive from your custom domain' ),
-					translate( '30GB storage' ),
-					translate( 'Email, calendars, and contacts' ),
-					translate( 'One-click import of existing emails and contacts' ),
-					translate( 'Read receipts to track email opens' ),
-				] }
-				formattedPrice={ formattedPrice }
-				buttonLabel={ providerCtaText }
-				hasPrimaryButton={ true }
-				isButtonBusy={ this.state.isFetchingProvisioningURL }
-				onButtonClick={ this.onAddTitanClick }
-				badge={ badge }
-				className={ classNames( className, 'titan' ) }
+			<TitanProviderDetails
+				className={ className }
+				currencyCode={ currencyCode }
+				onAddTitanClick={ this.onAddTitanClick }
+				titanMailProduct={ titanMailProduct }
 			/>
 		);
 	}

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -24,8 +24,6 @@ import {
 	GSUITE_BASIC_SLUG,
 } from 'calypso/lib/gsuite/constants';
 import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
-import { getAnnualPrice, getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
-import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import {
@@ -38,9 +36,8 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
-import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
-import gSuiteLogo from 'calypso/assets/images/email-providers/gsuite.svg';
 import forwardingIcon from 'calypso/assets/images/email-providers/forwarding.svg';
+import GSuiteProviderDetails from 'calypso/my-sites/email/email-providers-comparison/gsuite-provider-details';
 import TitanProviderDetails from 'calypso/my-sites/email/email-providers-comparison/titan-provider-details';
 
 /**
@@ -185,61 +182,14 @@ class EmailProvidersComparison extends React.Component {
 	}
 
 	renderGSuiteDetails( className ) {
-		const { currencyCode, gSuiteProduct, translate } = this.props;
-
-		let title = translate( 'G Suite by Google' );
-		let description = translate(
-			"We've partnered with Google to offer you email, storage, docs, calendars, and more."
-		);
-		let logo = gSuiteLogo;
-		let buttonLabel = translate( 'Add G Suite' );
-
-		if ( config.isEnabled( 'google-workspace-migration' ) ) {
-			title = getGoogleMailServiceFamily();
-			description = translate(
-				'The best way to create, communicate, and collaborate. An integrated workspace that is simple and easy to use.'
-			);
-			logo = googleWorkspaceIcon;
-			buttonLabel = translate( 'Add %(googleMailService)s', {
-				args: {
-					googleMailService: getGoogleMailServiceFamily(),
-				},
-				comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
-			} );
-		}
+		const { currencyCode, gSuiteProduct } = this.props;
 
 		return (
-			<EmailProviderDetails
-				title={ title }
-				description={ description }
-				image={ { path: logo } }
-				features={ [
-					translate( 'Annual billing' ),
-					translate( 'Send and receive from your custom domain' ),
-					translate( '30GB storage' ),
-					translate( 'Email, calendars, and contacts' ),
-					translate( 'Video calls, docs, spreadsheets, and more' ),
-					translate( 'Work from anywhere on any device – even offline' ),
-				] }
-				formattedPrice={ translate( '{{price/}} /user /year', {
-					components: {
-						price: <span>{ getAnnualPrice( gSuiteProduct?.cost ?? null, currencyCode ) }</span>,
-					},
-					comment: '{{price/}} is the formatted price, e.g. $20',
-				} ) }
-				discount={
-					hasDiscount( gSuiteProduct )
-						? translate( 'First year %(discountedPrice)s', {
-								args: {
-									discountedPrice: getAnnualPrice( gSuiteProduct.sale_cost, currencyCode ),
-								},
-								comment: '%(discountedPrice)s is a formatted price, e.g. $75',
-						  } )
-						: null
-				}
-				buttonLabel={ buttonLabel }
-				onButtonClick={ this.goToAddGSuite }
-				className={ classNames( className, 'gsuite' ) }
+			<GSuiteProviderDetails
+				className={ className }
+				currencyCode={ currencyCode }
+				gSuiteProduct={ gSuiteProduct }
+				onAddGSuiteClick={ this.goToAddGSuite }
 			/>
 		);
 	}

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -11,7 +11,6 @@ import page from 'page';
  * Internal dependencies
  */
 import config from '@automattic/calypso-config';
-import PromoCard from 'calypso/components/promo-section/promo-card';
 import EmailProviderDetails from './email-provider-details';
 import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
@@ -30,8 +29,8 @@ import {
 import { errorNotice } from 'calypso/state/notices/actions';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
 import forwardingIcon from 'calypso/assets/images/email-providers/forwarding.svg';
+import CustomEmailPromo from 'calypso/my-sites/email/email-providers-comparison/custom-email-promo';
 import GSuiteProviderDetails from 'calypso/my-sites/email/email-providers-comparison/gsuite-provider-details';
 import TitanProviderDetails from 'calypso/my-sites/email/email-providers-comparison/titan-provider-details';
 
@@ -73,35 +72,9 @@ class EmailProvidersComparison extends React.Component {
 	};
 
 	renderHeaderSection() {
-		const { domain, translate } = this.props;
-		const image = {
-			path: emailIllustration,
-			align: 'right',
-		};
+		const { domain } = this.props;
 
-		const translateArgs = {
-			args: {
-				domainName: domain.name,
-			},
-			comment: '%(domainName)s is the domain name, e.g example.com',
-		};
-
-		return (
-			<PromoCard
-				isPrimary
-				title={ translate( 'Get your own @%(domainName)s email address', translateArgs ) }
-				image={ image }
-				className="email-providers-comparison__action-panel"
-			>
-				<p>
-					{ translate(
-						'Pick one of our flexible options to connect your domain with email ' +
-							'and start getting emails @%(domainName)s today.',
-						translateArgs
-					) }
-				</p>
-			</PromoCard>
-		);
+		return <CustomEmailPromo domainName={ domain.name } />;
 	}
 
 	renderForwardingDetails( className ) {

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -41,7 +41,7 @@ import emailIllustration from 'calypso/assets/images/email-providers/email-illus
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
 import gSuiteLogo from 'calypso/assets/images/email-providers/gsuite.svg';
 import forwardingIcon from 'calypso/assets/images/email-providers/forwarding.svg';
-import TitanProviderDetails from 'calypso/my-sites/email/email-providers-comparison/email-provider-details/titan-provider-details';
+import TitanProviderDetails from 'calypso/my-sites/email/email-providers-comparison/titan-provider-details';
 
 /**
  * Style dependencies

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -159,17 +158,13 @@ class EmailProvidersComparison extends React.Component {
 
 	render() {
 		const { isGSuiteSupported } = this.props;
-		const isTitanSupported = config.isEnabled( 'titan/phase-2' );
-		const cardClassName = classNames( [
-			isGSuiteSupported ? null : 'no-gsuite',
-			isTitanSupported ? null : 'no-titan',
-		] );
+		const cardClassName = isGSuiteSupported ? null : 'no-gsuite';
 		return (
 			<>
 				{ this.renderHeaderSection() }
 				<div className="email-providers-comparison__providers">
 					{ this.renderForwardingDetails( cardClassName ) }
-					{ isTitanSupported && this.renderTitanDetails( cardClassName ) }
+					{ this.renderTitanDetails( cardClassName ) }
 					{ isGSuiteSupported && this.renderGSuiteDetails( cardClassName ) }
 					<TrackComponentView
 						eventName="calypso_email_providers_comparison_page_view"

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -14,10 +14,7 @@ import page from 'page';
 import config from '@automattic/calypso-config';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import EmailProviderDetails from './email-provider-details';
-import {
-	getCurrentUserCurrencyCode,
-	getCurrentUserLocale,
-} from 'calypso/state/current-user/selectors';
+import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import {
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
@@ -226,7 +223,6 @@ export default connect(
 
 		return {
 			currencyCode: getCurrentUserCurrencyCode( state ),
-			currentUserLocale: getCurrentUserLocale( state ),
 			gSuiteProduct: getProductBySlug( state, productSlug ),
 			titanMailProduct: getProductBySlug( state, TITAN_MAIL_MONTHLY_SLUG ),
 			currentRoute: getCurrentRoute( state ),

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -28,7 +28,6 @@ import {
 	emailManagementNewGSuiteAccount,
 	emailManagementNewTitanAccount,
 } from 'calypso/my-sites/email/paths';
-import wpcom from 'calypso/lib/wp';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
@@ -46,10 +45,6 @@ class EmailProvidersComparison extends React.Component {
 	static propTypes = {
 		domain: PropTypes.object.isRequired,
 		isGSuiteSupported: PropTypes.bool.isRequired,
-	};
-
-	state = {
-		isFetchingProvisioningURL: false,
 	};
 
 	goToEmailForwarding = () => {
@@ -73,38 +68,9 @@ class EmailProvidersComparison extends React.Component {
 	onAddTitanClick = () => {
 		recordTracksEvent( 'calypso_email_providers_add_click', { provider: 'titan' } );
 
-		if ( config.isEnabled( 'titan/phase-2' ) ) {
-			const { domain, currentRoute, selectedSiteSlug } = this.props;
-			page( emailManagementNewTitanAccount( selectedSiteSlug, domain.name, currentRoute ) );
-		} else {
-			if ( this.state.isFetchingProvisioningURL ) {
-				return;
-			}
+		const { domain, currentRoute, selectedSiteSlug } = this.props;
 
-			const { domain, translate } = this.props;
-			this.setState( { isFetchingProvisioningURL: true } );
-			this.fetchTitanOrderProvisioningURL( domain.name ).then( ( { error, provisioningURL } ) => {
-				this.setState( { isFetchingProvisioningURL: false } );
-				if ( error ) {
-					this.props.errorNotice(
-						translate( 'An unknown error occurred. Please try again later.' )
-					);
-				} else {
-					window.location.href = provisioningURL;
-				}
-			} );
-		}
-	};
-
-	fetchTitanOrderProvisioningURL = ( domain ) => {
-		return new Promise( ( resolve ) => {
-			wpcom.undocumented().getTitanOrderProvisioningURL( domain, ( serverError, result ) => {
-				resolve( {
-					error: serverError,
-					provisioningURL: serverError ? null : result.provisioning_url,
-				} );
-			} );
-		} );
+		page( emailManagementNewTitanAccount( selectedSiteSlug, domain.name, currentRoute ) );
 	};
 
 	renderHeaderSection() {

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -16,10 +16,6 @@
 			width: calc( 50% - 0.5em );
 		}
 
-		&.no-titan {
-			width: calc( 50% - 0.5em );
-		}
-
 		&.gsuite .action-panel__figure img {
 			max-width: 24px;
 		}

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -8,27 +8,8 @@
 		width: calc( 33% - 0.5em );
 		margin: 8px 0;
 
-		.email-providers-comparison__providers-wordpress-com-email {
-			color: var( --color-wordpress-com );
-		}
-
 		&.no-gsuite {
 			width: calc( 50% - 0.5em );
-		}
-
-		&.gsuite .action-panel__figure img {
-			max-width: 24px;
-		}
-
-			&.titan {
-			.promo-card__title-badge {
-				background: none;
-				padding: 0;
-
-				img {
-					max-height: 14px;
-				}
-			}
 		}
 
 		@include breakpoint-deprecated( '<1040px' ) {
@@ -36,6 +17,34 @@
 			&.no-gsuite {
 				width: 100%;
 			}
+		}
+	}
+}
+
+.promo-card.email-provider-details {
+	.email-providers-comparison__providers-wordpress-com-email {
+		color: var( --color-wordpress-com );
+	}
+
+	&.gsuite .action-panel__figure img {
+		max-width: 24px;
+	}
+
+	&.titan {
+		.promo-card__title-badge {
+			background: none;
+			padding: 0;
+
+			img {
+				max-height: 14px;
+			}
+		}
+	}
+
+	@include breakpoint-deprecated( '<1040px' ) {
+		& {
+			margin-bottom: 8px;
+			width: 100%;
 		}
 	}
 }

--- a/client/my-sites/email/email-providers-comparison/titan-provider-details.jsx
+++ b/client/my-sites/email/email-providers-comparison/titan-provider-details.jsx
@@ -12,7 +12,12 @@ import { useTranslate } from 'i18n-calypso';
 import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
 import Gridicon from 'calypso/components/gridicon';
 import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan.svg';
-import EmailProviderDetails from './index';
+import EmailProviderDetails from 'calypso/my-sites/email/email-providers-comparison/email-provider-details';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 export default function TitanProviderDetails( {
 	className,
@@ -36,7 +41,7 @@ export default function TitanProviderDetails( {
 		comment: '%(emailProductName)s is the product name, either "Email" or "Titan Mail"',
 	} );
 	const providerEmailLogo = (
-		<Gridicon className="email-provider-details__providers-wordpress-com-email" icon="my-sites" />
+		<Gridicon className="email-providers-comparison__providers-wordpress-com-email" icon="my-sites" />
 	);
 	const badge = <img src={ poweredByTitanLogo } alt={ translate( 'Powered by Titan' ) } />;
 

--- a/client/my-sites/email/email-providers-upsell/index.jsx
+++ b/client/my-sites/email/email-providers-upsell/index.jsx
@@ -88,7 +88,13 @@ export default function EmailProvidersUpsell( { domain } ) {
 				{ translate( 'Register %(domain)s', { args: { domain } } ) }
 			</HeaderCake>
 
-			<CustomEmailPromo domainName={ domain } />
+			<CustomEmailPromo domainName={ domain }>
+				<div className="email-providers-upsell__intro-actions">
+					<Button onClick={ () => handleSkipClick( 'intro_text' ) }>
+						{ translate( 'No thanks! I just want a domain!' ) }
+					</Button>
+				</div>
+			</CustomEmailPromo>
 			<div className="email-providers-upsell__providers">
 				<TitanProviderDetails
 					className={ titanCardClassName }

--- a/client/my-sites/email/email-providers-upsell/index.jsx
+++ b/client/my-sites/email/email-providers-upsell/index.jsx
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Button, CompactCard } from '@automattic/components';
+import { canUserPurchaseGSuite } from 'calypso/lib/gsuite';
+import config from '@automattic/calypso-config';
+import CustomEmailPromo from 'calypso/my-sites/email/email-providers-comparison/custom-email-promo';
+import {
+	emailManagementNewGSuiteAccount,
+	emailManagementNewTitanAccount,
+} from 'calypso/my-sites/email/paths';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+	GSUITE_BASIC_SLUG,
+} from 'calypso/lib/gsuite/constants';
+import GSuiteProviderDetails from 'calypso/my-sites/email/email-providers-comparison/gsuite-provider-details';
+import HeaderCake from 'calypso/components/header-cake';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
+import TitanProviderDetails from 'calypso/my-sites/email/email-providers-comparison/titan-provider-details';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export default function EmailProvidersUpsell( { domain } ) {
+	const currentRoute = useSelector( getCurrentRoute );
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const translate = useTranslate();
+
+	const handleGoBack = () => {
+		page( `/domains/add/${ selectedSiteSlug }` );
+	};
+
+	const trackAddClick = ( provider ) => {
+		recordTracksEvent( 'calypso_email_upsell_add_click', { provider } );
+	};
+
+	const handleSkipClick = ( skipPosition ) => {
+		recordTracksEvent( 'calypso_email_upsell_skip_click', { skip_position: skipPosition } );
+
+		page( `/checkout/${ selectedSiteSlug }` );
+	};
+
+	const onAddGSuiteClick = () => {
+		trackAddClick( 'google' );
+
+		const planType = config.isEnabled( 'google-workspace-migration' ) ? 'starter' : 'basic';
+
+		page( emailManagementNewGSuiteAccount( selectedSiteSlug, domain, planType, currentRoute ) );
+	};
+
+	const onAddTitanClick = () => {
+		trackAddClick( 'titan' );
+
+		page( emailManagementNewTitanAccount( selectedSiteSlug, domain, currentRoute ) );
+	};
+
+	const showGSuite = canUserPurchaseGSuite();
+	const titanCardClassName = showGSuite ? null : 'no-gsuite';
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+
+	const gSuiteProductSlug = config.isEnabled( 'google-workspace-migration' )
+		? GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
+		: GSUITE_BASIC_SLUG;
+
+	const gSuiteProduct = useSelector( ( state ) => getProductBySlug( state, gSuiteProductSlug ) );
+	const titanMailProduct = useSelector( ( state ) =>
+		getProductBySlug( state, TITAN_MAIL_MONTHLY_SLUG )
+	);
+
+	return (
+		<React.Fragment>
+			<HeaderCake onClick={ handleGoBack }>
+				{ translate( 'Register %(domain)s', { args: { domain } } ) }
+			</HeaderCake>
+
+			<CustomEmailPromo domainName={ domain } />
+			<div className="email-providers-upsell__providers">
+				<TitanProviderDetails
+					className={ titanCardClassName }
+					currencyCode={ currencyCode }
+					onAddTitanClick={ onAddTitanClick }
+					titanMailProduct={ titanMailProduct }
+				/>
+				{ showGSuite && (
+					<GSuiteProviderDetails
+						currencyCode={ currencyCode }
+						gSuiteProduct={ gSuiteProduct }
+						onAddGSuiteClick={ onAddGSuiteClick }
+					/>
+				) }
+			</div>
+			<CompactCard className="email-providers-upsell__actions">
+				<Button onClick={ () => handleSkipClick( 'after_providers' ) }>
+					{ translate( 'Skip for now' ) }
+				</Button>
+			</CompactCard>
+		</React.Fragment>
+	);
+}

--- a/client/my-sites/email/email-providers-upsell/style.scss
+++ b/client/my-sites/email/email-providers-upsell/style.scss
@@ -1,4 +1,4 @@
-.email-providers-upsell__intro_actions {
+.email-providers-upsell__intro-actions {
 	margin-top: 8px;
 }
 

--- a/client/my-sites/email/email-providers-upsell/style.scss
+++ b/client/my-sites/email/email-providers-upsell/style.scss
@@ -1,0 +1,21 @@
+.email-providers-upsell__providers {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	margin-bottom: 16px;
+
+	.promo-card {
+		width: calc( 50% - 0.5em );
+		margin: 0;
+	}
+}
+
+.email-providers-upsell__actions {
+	display: flex;
+	flex-direction: row;
+
+	@include breakpoint-deprecated( '<660px' ) {
+		flex-direction: column;
+	}
+}

--- a/client/my-sites/email/email-providers-upsell/style.scss
+++ b/client/my-sites/email/email-providers-upsell/style.scss
@@ -1,3 +1,7 @@
+.email-providers-upsell__intro_actions {
+	margin-top: 8px;
+}
+
 .email-providers-upsell__providers {
 	display: flex;
 	flex-direction: row;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR creates a new upsell page to promote Email and G Suite to users who purchase a domain. The pieces of this effort are:
* Refactor the existing components from the Email Comparison page to support reusing them in this new component
* Restructure the components from above into a new page, and include clear skip options
* Ensure that we track the various click events correctly
* Update the existing domain registration flow to show the new upsell

#### Testing instructions

Given the areas this touches we need to do the following:
* Verify that the styling and event handling in the existing Email Comparison page works
* Verify that when you add a new domain to your cart in Calypso, you see the new page, and that it works.

We also need to cover the following edge cases:
 * The user is not allowed to buy G Suite
 * Mobile views and styling for both the email comparison and email upsell pages
 * We should confirm things work as expected when the `google-workspace-migration` feature flag is enabled (in both pages as well)
 * I'll think of more tomorrow...

#### Screenshots

<img width="1086" alt="new_upsell_page" src="https://user-images.githubusercontent.com/3376401/108174699-744fdc80-7108-11eb-9b07-022132691cfc.png">

## Concerns

* The current content is _really tall_ -- this means it is going to require scrolling to see all the features on many normal/standard browser windows. I've added the "No thanks!" button to the intro content, so users can skip quickly as partial mitigation. It also help that the CTAs for each option are generally going to be above the fold.
* This ended up being a big PR with a non-trivial testing surface. It may make sense to split the PR up so we handle the refactor into independent components first and then layer on the new screen in a follow-up PR.