### PR TITLE
Fix React error due to duplicated key in sidebar

### DIFF
--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -61,7 +61,6 @@ export const MySitesSidebarUnifiedMenu = ( {
 			hasAutoExpanded.current = true;
 		}
 	}, [ selected, childIsSelected, reduxDispatch, sectionId, sidebarCollapsed ] );
-
 	return (
 		<li>
 			<ExpandableSidebarMenu
@@ -96,7 +95,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 					const isSelected = selectedMenuItem?.url === item.url;
 					return (
 						<MySitesSidebarUnifiedItem
-							key={ item.slug }
+							key={ item.title }
 							{ ...item }
 							selected={ isSelected }
 							sectionId={ sectionId }


### PR DESCRIPTION
### Changes proposed in this Pull Request

The recently added unified sidebar introduced a React issue for self-hosted Jetpack sites. This PR fixes it by making sure the concerned items have unique keys.

### Testing instructions

- Download the PR and run Calypso **locally**
- Open the console
- Select a self-hosted Jetpack site
- Make sure you don't' see the error below

### Screenshots

_React error_
<img width="857" alt="Screen Shot 2021-02-16 at 4 37 23 PM" src="https://user-images.githubusercontent.com/1620183/108124401-24740580-7075-11eb-9c9a-79517ae3b94e.png">
