### PR TITLE
Store|Woo: Add the Store deprecation message back

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
@@ -13,6 +13,7 @@ import { localize, translate } from 'i18n-calypso';
 
 import { Card, Button } from '@automattic/components';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import config from '@automattic/calypso-config';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 /**
  * Image dependencies
@@ -30,26 +31,44 @@ class StoreMoveNoticeView extends Component {
 	};
 
 	render = () => {
-		const { site } = this.props;
+		const { site, isStoreRemoved } = this.props;
 
 		return (
-			<Card className={ classNames( 'dashboard__store-move-notice', 'store-removed' ) }>
+			<Card
+				className={ classNames( 'dashboard__store-move-notice', {
+					'store-removed': isStoreRemoved,
+				} ) }
+			>
 				<img src={ megaphoneImage } alt="" />
 				<h1>{ translate( 'Find all of your business features in WooCommerce' ) }</h1>
 				<p>
-					{ translate(
-						'We’ve rolled your favorite Store features into WooCommerce. In addition to Products and Orders, you have top-level access for managing your Analytics, Marketing, and Customers. {{link}}Learn more{{/link}} about what has changed.',
-						{
-							components: {
-								link: (
-									<a
-										onClick={ this.trackLearnMoreAboutWooCommerceClick }
-										href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/"
-									/>
-								),
-							},
-						}
-					) }
+					{ isStoreRemoved
+						? translate(
+								'We’ve rolled your favorite Store features into WooCommerce. In addition to Products and Orders, you have top-level access for managing your Analytics, Marketing, and Customers. {{link}}Learn more{{/link}} about what has changed.',
+								{
+									components: {
+										link: (
+											<a
+												onClick={ this.trackLearnMoreAboutWooCommerceClick }
+												href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/"
+											/>
+										),
+									},
+								}
+						  )
+						: translate(
+								'We’re retiring Store on February 22. With WooCommerce, discover a more flexible store management experience — including top-level access to your Analytics, Marketing, and Customers. {{link}}Learn more{{/link}} about what to expect.',
+								{
+									components: {
+										link: (
+											<a
+												onClick={ this.trackLearnMoreAboutWooCommerceClick }
+												href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/"
+											/>
+										),
+									},
+								}
+						  ) }
 				</p>
 				<Button
 					primary
@@ -66,6 +85,7 @@ class StoreMoveNoticeView extends Component {
 function mapStateToProps( state ) {
 	return {
 		site: getSelectedSiteWithFallback( state ),
+		isStoreRemoved: config.isEnabled( 'woocommerce/store-removed' ),
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In #50070, the Store deprecation message was inadvertently removed, showing the Store removed message in all environments regardless of feature flag
* This PR adds back in the Store deprecation message, when the `woocommerce/store-removed` feature flag is *not* enabled (`stage`, `production` environments)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

With a Business plan site with WooCommerce installed...

1. Run this branch with

```
DISABLE_FEATURES=woocommerce/store-removed yarn start
```

(This will disable the feature flag, as it is on `stage` and `production`)

2. Go to `http://calypso.localhost:3000/store/YOUR_SITE_GOES_HERE` and make sure the Store deprecation message is displayed:

<img width="962" alt="Screen Shot 2021-02-16 at 17 04 32" src="https://user-images.githubusercontent.com/2098816/108129550-5ccb1200-707c-11eb-860f-ca06bf444a09.png">

3. Run this branch with

```
yarn start
```

(This has the feature flag enabled)

4. Go to `http://calypso.localhost:3000/store/YOUR_SITE_GOES_HERE` and make sure the Store removed message is displayed:

<img width="962" alt="Screen Shot 2021-02-16 at 16 41 46" src="https://user-images.githubusercontent.com/2098816/108129525-5177e680-707c-11eb-896e-93591a4b98d0.png">
