### PR TITLE
Fix usage of outputPath for building apps

### DIFF
--- a/apps/notifications/webpack.config.js
+++ b/apps/notifications/webpack.config.js
@@ -15,7 +15,8 @@ const spawnSync = require( 'child_process' ).spawnSync;
  * Return a webpack config object
  *
  * Arguments to this function replicate webpack's so this config can be used on the command line,
- * with individual options overridden by command line args.
+ * with individual options overridden by command line args. Note that webpack-cli seems to convert
+ * kebab-case (like `--ouput-path`) to camelCase (`outputPath`)
  *
  * @see {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-function}
  * @see {@link https://webpack.js.org/api/cli/}
@@ -23,17 +24,16 @@ const spawnSync = require( 'child_process' ).spawnSync;
  * @param  {object}  env                           environment options
  * @param  {object}  argv                          options map
  * @param  {object}  argv.entry                    Entry point(s)
- * @param  {string}  argv.'output-path'            Output path
- * @param  {string}  argv.'output-filename'        Output filename pattern
- * @param  {string}  argv.'output-library-target'  Output library target
+ * @param  {string}  argv.outputPath                Output path
+ * @param  {string}  argv.outputFilename            Output filename pattern
  * @returns {object}                                webpack config
  */
 function getWebpackConfig(
 	env = {},
 	{
 		entry = path.join( __dirname, 'src', 'standalone' ),
-		'output-path': outputPath = path.join( __dirname, 'dist' ),
-		'output-filename': outputFilename = 'build.min.js',
+		outputPath = path.join( __dirname, 'dist' ),
+		outputFilename = 'build.min.js',
 	}
 ) {
 	const webpackConfig = getBaseWebpackConfig( env, {

--- a/apps/wpcom-block-editor/webpack.config.js
+++ b/apps/wpcom-block-editor/webpack.config.js
@@ -19,7 +19,8 @@ const isDevelopment = process.env.NODE_ENV !== 'production';
  * Return a webpack config object
  *
  * Arguments to this function replicate webpack's so this config can be used on the command line,
- * with individual options overridden by command line args.
+ * with individual options overridden by command line args. Note that webpack-cli seems to convert
+ * kebab-case (like `--ouput-path`) to camelCase (`outputPath`)
  *
  * @see {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-function}
  * @see {@link https://webpack.js.org/api/cli/}
@@ -27,9 +28,8 @@ const isDevelopment = process.env.NODE_ENV !== 'production';
  * @param   {object}  env                           environment options
  * @param   {object}  argv                          options map
  * @param   {object}  argv.entry                    Entry point(s)
- * @param   {string}  argv.'output-path'            Output path
- * @param   {string}  argv.'output-filename'        Output filename pattern
- * @param   {string}  argv.'output-library-target'  Output library target
+ * @param   {string}  argv.outputPath               Output path
+ * @param   {string}  argv.outputFilename           Output filename pattern
  * @returns {object}                                webpack config
  */
 function getWebpackConfig(
@@ -42,8 +42,8 @@ function getWebpackConfig(
 			'calypso.editor': path.join( __dirname, 'src', 'calypso', 'editor' ),
 			'calypso.tinymce': path.join( __dirname, 'src', 'calypso', 'tinymce' ),
 		},
-		'output-path': outputPath = path.join( __dirname, 'dist' ),
-		'output-filename': outputFilename = isDevelopment ? '[name].js' : '[name].min.js',
+		outputPath = path.join( __dirname, 'dist' ),
+		outputFilename = isDevelopment ? '[name].js' : '[name].min.js',
 	}
 ) {
 	const webpackConfig = getBaseWebpackConfig( env, {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Uses camelCase to read argv arguments passed when building webpack

#### Testing instructions

Build notifications and verify the output directory contains all expected files:

```
$ cd apps/notifications/
$ yarn build --output-path="../../artifacts/notifications"
$ ls ../../artifacts/notifications
build.min.css  build.min.js  build.min.rtl.css  cache-buster.txt  index.html  rtl.html
```