### PR TITLE
Build: Add process browser

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -302,6 +302,9 @@ const webpackConfig = {
 			__i18n_text_domain__: JSON.stringify( 'default' ),
 			global: 'window',
 		} ),
+		new webpack.ProvidePlugin( {
+			process: 'process/browser',
+		} ),
 		new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
 		new webpack.IgnorePlugin( { resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ } ),
 		...SassConfig.plugins( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a polyfill for providing `process` to the browser. This is required for instances where we're using `@wordpress` packages that reference `process.env.VAR` environment variables.

See https://github.com/webpack/changelog-v5#automatic-nodejs-polyfills-removed for more details.

This is also needed for #50094.

#### Testing instructions

* Verify Calypso builds well, smoke test, and verify all tests still pass. 
* This is hard to test directly 😅  To do it you need to:
  * Checkout Gutenberg locally.
  * In the Gutenberg repo, ~cherry-pick all commits from these PRs: https://github.com/WordPress/gutenberg/pull/29067, https://github.com/WordPress/gutenberg/pull/29068, https://github.com/WordPress/gutenberg/pull/29069, and https://github.com/WordPress/gutenberg/pull/29070~ make sure you're operating with the latest primary branch.
  * In Gutenberg, run `npm run build` to generate a fresh build.
  * In the Calypso repo, cherry-pick all commits from #50094 after checking out this branch.
  * In Calypso's `package.json` and `client/package.json`, point `@wordpress/components` to `file:../gutenberg/packages/components` and the same for the `@wordpress/a11y` package and run `yarn`. Note that I'm assuming you checked out Gutenberg in the same dir you checked out your local Calypso in, and you named the main dir `gutenberg`.
  * Verify Calypso builds well with no errors, and runs with no errors.
* Testing this will be much easier once the above Gutenberg PRs are merged and new versions of the relevant `@wordpress` packages are released. 
