### PR TITLE
Emails: Prevent placeholder from showing on Email page when site domains are fetching

### DIFF
--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -20,8 +20,7 @@ import { MOVE_DOMAIN } from 'calypso/lib/url/support';
 import { getName } from 'calypso/lib/purchases';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedDomain } from 'calypso/lib/domains';
-import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
-import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
+import { getTitanProductName, hasTitanMailWithUs } from 'calypso/lib/titan';
 
 class RemoveDomainDialog extends Component {
 	static propTypes = {

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -43,9 +43,8 @@ import { withoutHttp } from 'calypso/lib/url';
 import RemovePurchase from 'calypso/me/purchases/remove-purchase';
 import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'calypso/lib/gsuite';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { getMaxTitanMailboxCount } from 'calypso/lib/titan';
+import { getMaxTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils';
-import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -41,8 +41,7 @@ import {
 import Spinner from 'calypso/components/spinner';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getMaxTitanMailboxCount } from 'calypso/lib/titan/get-max-titan-mailbox-count';
-import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
+import { getMaxTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
 
 class DomainItem extends PureComponent {
 	static propTypes = {

--- a/client/my-sites/domains/domain-management/list/list-header.jsx
+++ b/client/my-sites/domains/domain-management/list/list-header.jsx
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 import { CompactCard } from '@automattic/components';
 import InfoPopover from 'calypso/components/info-popover';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
-import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
+import { getTitanProductName } from 'calypso/lib/titan';
 
 /**
  * Style dependencies

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -47,7 +47,7 @@ import PendingGSuiteTosNotice from 'calypso/my-sites/domains/components/domain-w
 import TitanControlPanelLoginCard from 'calypso/my-sites/email/email-management/titan-control-panel-login-card';
 import TitanManagementNav from 'calypso/my-sites/email/email-management/titan-management-nav';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
+import { hasTitanMailWithUs } from 'calypso/lib/titan';
 
 /**
  * Style dependencies

--- a/client/my-sites/email/email-management/gsuite-users-card/style.scss
+++ b/client/my-sites/email/email-management/gsuite-users-card/style.scss
@@ -37,54 +37,54 @@
 
 .gsuite-users-card__foldable-card {
 	margin-bottom: 0;
+}
 
-	.gsuite-users-card__foldable-card-header-icon {
-		margin-right: 10px;
-		max-width: 36px;
+.gsuite-users-card__foldable-card-header-icon {
+	margin-right: 10px;
+	max-width: 36px;
+}
+
+.gsuite-users-card__foldable-card-header-text {
+	display: flex;
+	flex-direction: column;
+
+	em {
+		color: var( --color-neutral-50 );
+		font-style: normal;
+	}
+}
+
+.gsuite-users-card__foldable-card-services {
+	column-gap: 10px;
+	display: grid;
+	grid-template-columns: repeat( 7, 1fr );
+	list-style: none;
+	margin: 0;
+	row-gap: 10px;
+
+	@include breakpoint-deprecated( '<960px' ) {
+		grid-template-columns: repeat( 4, 1fr );
+		grid-template-rows: repeat( 2, 1fr );
 	}
 
-	.gsuite-users-card__foldable-card-header-text {
+	a {
+		align-items: center;
 		display: flex;
 		flex-direction: column;
+		padding: 10px;
+		text-align: center;
 
-		em {
-			color: var( --color-neutral-50 );
-			font-style: normal;
-		}
-	}
-
-	.gsuite-users-card__foldable-card-services {
-		column-gap: 10px;
-		display: grid;
-		grid-template-columns: repeat( 7, 1fr );
-		list-style: none;
-		margin: 0;
-		row-gap: 10px;
-
-		@include breakpoint-deprecated( '<960px' ) {
-			grid-template-columns: repeat( 4, 1fr );
-			grid-template-rows: repeat( 2, 1fr );
+		&:hover {
+			background-color: #eee;
+			border-radius: 5px;
 		}
 
-		a {
-			align-items: center;
-			display: flex;
-			flex-direction: column;
-			padding: 10px;
-			text-align: center;
+		img {
+			max-width: 30px;
+		}
 
-			&:hover {
-				background-color: #eee;
-				border-radius: 5px;
-			}
-
-			img {
-				max-width: 30px;
-			}
-
-			strong {
-				padding-top: 5px;
-			}
+		strong {
+			padding-top: 5px;
 		}
 	}
 }

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -23,11 +23,7 @@ import {
 import getGSuiteUsers from 'calypso/state/selectors/get-gsuite-users';
 import hasLoadedGSuiteUsers from 'calypso/state/selectors/has-loaded-gsuite-users';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
-import {
-	getDomainsBySiteId,
-	hasLoadedSiteDomains,
-	isRequestingSiteDomains,
-} from 'calypso/state/sites/domains/selectors';
+import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import GSuiteUsersCard from 'calypso/my-sites/email/email-management/gsuite-users-card';
 import Placeholder from 'calypso/my-sites/email/email-management/gsuite-users-card/placeholder';
@@ -51,7 +47,7 @@ import { localizeUrl } from 'calypso/lib/i18n-utils';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import EmailProvidersComparison from '../email-providers-comparison';
-import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
+import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import { type as domainTypes } from 'calypso/lib/domains/constants';
 
 /**
@@ -130,15 +126,9 @@ class EmailManagement extends React.Component {
 	}
 
 	content() {
-		const {
-			domains,
-			hasGSuiteUsersLoaded,
-			hasSiteDomainsLoaded,
-			isFetchingSiteDomains,
-			selectedDomainName,
-		} = this.props;
+		const { domains, hasGSuiteUsersLoaded, hasSiteDomainsLoaded, selectedDomainName } = this.props;
 
-		if ( ! hasGSuiteUsersLoaded || ! hasSiteDomainsLoaded || isFetchingSiteDomains ) {
+		if ( ! hasGSuiteUsersLoaded || ! hasSiteDomainsLoaded ) {
 			return <Placeholder />;
 		}
 
@@ -276,7 +266,6 @@ export default connect( ( state ) => {
 		gsuiteUsers: getGSuiteUsers( state, selectedSiteId ),
 		hasGSuiteUsersLoaded: hasLoadedGSuiteUsers( state, selectedSiteId ),
 		hasSiteDomainsLoaded: hasLoadedSiteDomains( state, selectedSiteId ),
-		isFetchingSiteDomains: isRequestingSiteDomains( state, selectedSiteId ),
 		previousRoute: getPreviousRoute( state ),
 		selectedSiteId,
 		selectedSiteSlug: getSelectedSiteSlug( state ),

--- a/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
@@ -17,8 +17,7 @@ import {
 	fetchTitanAutoLoginURL,
 	fetchTitanIframeURL,
 } from 'calypso/my-sites/email/email-management/titan-functions';
-import { getTitanMailOrderId } from 'calypso/lib/titan/get-titan-mail-order-id';
-import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
+import { getTitanMailOrderId, getTitanProductName } from 'calypso/lib/titan';
 
 /**
  * Style dependencies

--- a/client/my-sites/email/email-management/titan-management-nav/style.scss
+++ b/client/my-sites/email/email-management/titan-management-nav/style.scss
@@ -27,54 +27,54 @@
 
 .titan-management-nav__foldable-card {
 	margin-bottom: 0;
+}
 
-	.titan-management-nav__foldable-card-header-icon {
-		fill: var( --color-wordpress-com );
-		margin-left: -2px;
-		margin-right: 7px;
+.titan-management-nav__foldable-card-header-icon {
+	fill: var( --color-wordpress-com );
+	margin-left: -2px;
+	margin-right: 7px;
+}
+
+.titan-management-nav__foldable-card-header-text {
+	display: flex;
+	flex-direction: column;
+
+	em {
+		color: var( --color-neutral-50 );
+		font-style: normal;
+	}
+}
+
+.titan-management-nav__foldable-card-services {
+	column-gap: 10px;
+	display: grid;
+	grid-template-columns: repeat( 7, 1fr );
+	list-style: none;
+	margin: 0;
+	row-gap: 10px;
+
+	@include breakpoint-deprecated( '<960px' ) {
+		grid-template-columns: repeat( 4, 1fr );
 	}
 
-	.titan-management-nav__foldable-card-header-text {
+	a {
+		align-items: center;
 		display: flex;
 		flex-direction: column;
+		padding: 10px;
+		text-align: center;
 
-		em {
-			color: var( --color-neutral-50 );
-			font-style: normal;
-		}
-	}
-
-	.titan-management-nav__foldable-card-services {
-		column-gap: 10px;
-		display: grid;
-		grid-template-columns: repeat( 7, 1fr );
-		list-style: none;
-		margin: 0;
-		row-gap: 10px;
-
-		@include breakpoint-deprecated( '<960px' ) {
-			grid-template-columns: repeat( 4, 1fr );
+		&:hover {
+			background-color: #eee;
+			border-radius: 5px; /* stylelint-disable-line scales/radii */
 		}
 
-		a {
-			align-items: center;
-			display: flex;
-			flex-direction: column;
-			padding: 10px;
-			text-align: center;
+		img {
+			max-width: 30px;
+		}
 
-			&:hover {
-				background-color: #eee;
-				border-radius: 5px; /* stylelint-disable-line scales/radii */
-			}
-
-			img {
-				max-width: 30px;
-			}
-
-			strong {
-				padding-top: 5px;
-			}
+		strong {
+			padding-top: 5px;
 		}
 	}
 }

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -46,7 +46,7 @@ import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powe
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
 import gSuiteLogo from 'calypso/assets/images/email-providers/gsuite.svg';
 import forwardingIcon from 'calypso/assets/images/email-providers/forwarding.svg';
-import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
+import { getTitanProductName } from 'calypso/lib/titan';
 
 /**
  * Style dependencies

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -225,7 +225,7 @@ class GSuiteAddUsers extends React.Component {
 
 				<SectionHeader
 					label={ translate( 'Add New Users', {
-						comments: "'Users' refers to Google Workspace user accounts",
+						comment: 'This refers to Google Workspace user accounts',
 					} ) }
 				/>
 

--- a/client/my-sites/email/titan-mail-quantity-selection/index.jsx
+++ b/client/my-sites/email/titan-mail-quantity-selection/index.jsx
@@ -41,15 +41,15 @@ import AddEmailAddressesCardPlaceholder from 'calypso/my-sites/email/gsuite-add-
 import { getSelectedDomain } from 'calypso/lib/domains';
 import {
 	getConfiguredTitanMailboxCount,
+	getMaxTitanMailboxCount,
 	getTitanExpiryDate,
 	getTitanMailboxPurchaseCost,
 	getTitanMailboxRenewalCost,
-	getMaxTitanMailboxCount,
+	getTitanProductName,
 	hasTitanMailWithUs,
 } from 'calypso/lib/titan';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { getProductBySlug, getProductsList } from 'calypso/state/products-list/selectors';
-import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
 import {
 	TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL,
 	TITAN_MAIL_MONTHLY_SLUG,


### PR DESCRIPTION
This pull request updates the `Email` page to only show a placeholder when G Suite users and site domains have not loaded yet. This solves an issue where the placeholder could be displayed twice or more as soon as site domains are fetched more than once:

![screenshot](https://user-images.githubusercontent.com/594356/110462142-979af580-80d0-11eb-8d0d-638e8338cbe7.png)


This pull request also makes the following improvements:

* Remove unnecessary indentation in stylesheets
* Simplify imports of Titan functions
* Fix invalid translation comment in `Add New Users` page

#### Testing instructions

1. Run `git checkout update/email-page` and start your server, or open a [live branch](https://calypso.live/?branch=update/email-page)
2. Log into a WordPress.com account with an email account
3. Open the [`Domains` page](http://calypso.localhost:3000/domains)
4. Click on a domain with mailboxes
5. Click the `Manage your email accounts` option
6. Assert that the placeholder is displayed for a short time
7. Click the `Back` button in the section header
8. Click the `Manage your email accounts` option again
9. Assert that no placeholder is displayed this time