### PR TITLE
Jetpack: Fix missing preventWidows import

### DIFF
--- a/client/components/jetpack/card/i5/jetpack-product-card-i5/index.tsx
+++ b/client/components/jetpack/card/i5/jetpack-product-card-i5/index.tsx
@@ -14,6 +14,7 @@ import JetpackProductCardTimeFrame from './time-frame';
 import PlanPrice from 'calypso/my-sites/plan-price';
 import JetpackProductCardFeatures, { Props as FeaturesProps } from './features';
 import InfoPopover from 'calypso/components/info-popover';
+import { preventWidows } from 'calypso/lib/formatting';
 
 /**
  * Type dependencies


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There's a use of `preventWidows()` with missing import in the plans page for Jetpack sites. 

Reproducing is easy: just open `/plans/:site` where `:site` is a multisite network.

This PR adds the import.

#### Testing instructions

* Go to `/plans/:site` where `:site` is a multisite.
* Verify it loads well now and there are no console errors.
