### PR TITLE
Partner Portal: Add license list sorting UI and layout changes

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -26,11 +26,19 @@ export function partnerKeyContext( context: PageJS.Context, next: () => void ): 
 }
 
 export function partnerPortalContext( context: PageJS.Context, next: () => void ): void {
+	const { s: search, sort_field: sortField, sort_direction: sortDirection } = context.query;
 	const licenseFilter = stringToLicenseFilter( context.params.state );
 
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;
-	context.primary = <Licenses licenseFilter={ licenseFilter } search={ context.query.s || '' } />;
+	context.primary = (
+		<Licenses
+			licenseFilter={ licenseFilter }
+			search={ search || '' }
+			sortDirection={ sortDirection }
+			sortField={ sortField }
+		/>
+	);
 	context.footer = <JetpackComFooter />;
 	next();
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
@@ -77,6 +77,8 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 
 		> *:nth-child(#{$column-domain}) {
 			grid-column-end: auto;
+			justify-self: start;
+			padding: 16px 0;
 		}
 
 		> *:nth-child(#{$column-actions}),
@@ -100,6 +102,7 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 		}
 
 		h2 {
+			justify-self: end;
 			font-weight: 400;
 		}
 
@@ -110,6 +113,8 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 		button {
 			display: flex;
 			align-items: center;
+			justify-self: end;
+			padding: 16px 0;
 			font-weight: inherit;
 			cursor: pointer;
 		}

--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
@@ -92,12 +92,16 @@ $grid-wide: 1fr 118px 118px 118px 128px 36px;
 			grid-template-columns: $grid-wide;
 		}
 
-		h2 {
+		h2, h2 button {
 			font-size: 0.875rem;
 			line-height: 1.25rem;
 			font-weight: 600;
 			color: var( --studio-gray-70 );
 			white-space: nowrap;
+		}
+
+		button {
+			cursor: pointer;
 		}
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
@@ -2,11 +2,11 @@
 @import '~@wordpress/base-styles/_mixins.scss';
 
 $column-domain: 1;
-$column-actions: 5;
-$column-toggle: 6;
+$column-actions: 4;
+$column-toggle: 5;
 
-$grid-xlarge: 1fr 104px 104px 104px 128px 30px;
-$grid-wide: 1fr 118px 118px 118px 128px 36px;
+$grid-xlarge: 1fr 114px 114px 128px 30px;
+$grid-wide: 1fr 128px 128px 128px 36px;
 
 .license-list-item {
 	display: grid;
@@ -95,13 +95,36 @@ $grid-wide: 1fr 118px 118px 118px 128px 36px;
 		h2, h2 button {
 			font-size: 0.875rem;
 			line-height: 1.25rem;
-			font-weight: 600;
-			color: var( --studio-gray-70 );
 			white-space: nowrap;
+			color: var( --studio-gray-70 );
+		}
+
+		h2 {
+			font-weight: 400;
+		}
+
+		h2.is-selected {
+			font-weight: 600;
 		}
 
 		button {
+			display: flex;
+			align-items: center;
+			font-weight: inherit;
 			cursor: pointer;
+		}
+	}
+
+	.is-selected &__sort-indicator {
+		opacity: 1;
+	}
+
+	&__sort-indicator {
+		transition: transform 0.2s ease;
+		opacity: 0;
+
+		&.is-sort-asc {
+			transform: rotateZ( 180deg );
 		}
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -32,6 +32,11 @@ import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/typ
  */
 import './style.scss';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 interface Props {
 	licenseFilter: LicenseFilter;
 	sortDirection: string;
@@ -71,7 +76,7 @@ export default function LicenseList( {
 		<div className="license-list">
 			<QueryJetpackPartnerPortalLicenses />
 
-			<LicenseListItem header>
+			<LicenseListItem header className="license-list__header">
 				<h2>{ translate( 'License state' ) }</h2>
 				<h2 className={ classnames( { 'is-selected': 'issued_at' === sortField } ) }>
 					<button onClick={ () => setSortingConfig( 'issued_at' ) }>

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
@@ -20,6 +20,7 @@ import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/licen
 import LicensePreview, {
 	LicensePreviewPlaceholder,
 } from 'calypso/jetpack-cloud/sections/partner-portal/license-preview';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Style dependencies
@@ -31,6 +32,17 @@ export default function LicenseList(): ReactElement {
 	const hasFetched = useSelector( hasFetchedLicenses );
 	const isFetching = useSelector( isFetchingLicenses );
 	const licenses = useSelector( getPaginatedLicenses ) as PaginatedItems< License >;
+	const [ sortConfig, setSortConfig ] = useState( { direction: 'asc', field: 'attached_at' } );
+
+	const onSort = ( newSortField: string ): void => {
+		let newSortDirection = 'asc';
+
+		if ( sortConfig.field === newSortField ) {
+			newSortDirection = sortConfig.direction === 'asc' ? 'desc' : 'asc';
+		}
+
+		setSortConfig( { field: newSortField, direction: newSortDirection } );
+	};
 
 	return (
 		<div className="license-list">
@@ -38,9 +50,24 @@ export default function LicenseList(): ReactElement {
 
 			<LicenseListItem header>
 				<h2>{ translate( 'License state' ) }</h2>
-				<h2>{ translate( 'Issued on' ) }</h2>
-				<h2>{ translate( 'Attached on' ) }</h2>
-				<h2>{ translate( 'Revoked on' ) }</h2>
+				<h2>
+					<button onClick={ () => onSort( 'issued_at' ) }>
+						{ translate( 'Issued on' ) }
+						<Gridicon icon="dropdown" />
+					</button>
+				</h2>
+				<h2>
+					<button onClick={ () => onSort( 'attached_at' ) }>
+						{ translate( 'Attached on' ) }
+						<Gridicon icon="dropdown" />
+					</button>
+				</h2>
+				<h2>
+					<button onClick={ () => onSort( 'revoked_at' ) }>
+						{ translate( 'Revoked on' ) }
+						<Gridicon icon="dropdown" />
+					</button>
+				</h2>
 				<div>{ /* Intentionally empty header. */ }</div>
 				<div>{ /* Intentionally empty header. */ }</div>
 			</LicenseListItem>

--- a/client/jetpack-cloud/sections/partner-portal/license-list/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/style.scss
@@ -1,4 +1,11 @@
 .license-list {
+	&__header {
+		&.card.is-compact {
+			padding-top: 0;
+			padding-bottom: 0;
+		}
+	}
+
 	&__message {
 		color: var( --color-neutral-light );
 		font-style: italic;

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -9,8 +9,9 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+
 import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
-import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { LicenseState, LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { Button } from '@automattic/components';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import Gridicon from 'calypso/components/gridicon';
@@ -32,6 +33,7 @@ interface Props {
 	issuedAt: string;
 	attachedAt: string | null;
 	revokedAt: string | null;
+	licenseFilter: LicenseFilter;
 }
 
 export default function LicensePreview( {
@@ -43,6 +45,7 @@ export default function LicensePreview( {
 	issuedAt,
 	attachedAt,
 	revokedAt,
+	licenseFilter,
 }: Props ): ReactElement {
 	const translate = useTranslate();
 	const [ isOpen, setOpen ] = useState( false );
@@ -100,29 +103,31 @@ export default function LicensePreview( {
 					<FormattedDate date={ issuedAt } format="YYYY-MM-DD" />
 				</div>
 
-				<div>
-					<div className="license-preview__label">{ translate( 'Attached on:' ) }</div>
+				{ licenseFilter !== LicenseFilter.Revoked ? (
+					<div>
+						<div className="license-preview__label">{ translate( 'Attached on:' ) }</div>
 
-					{ licenseState === LicenseState.Attached && (
-						<FormattedDate date={ attachedAt } format="YYYY-MM-DD" />
-					) }
+						{ licenseState === LicenseState.Attached && (
+							<FormattedDate date={ attachedAt } format="YYYY-MM-DD" />
+						) }
 
-					{ licenseState !== LicenseState.Attached && (
-						<Gridicon icon="minus" className="license-preview__no-value" />
-					) }
-				</div>
+						{ licenseState !== LicenseState.Attached && (
+							<Gridicon icon="minus" className="license-preview__no-value" />
+						) }
+					</div>
+				) : (
+					<div>
+						<div className="license-preview__label">{ translate( 'Revoked on:' ) }</div>
 
-				<div>
-					<div className="license-preview__label">{ translate( 'Revoked on:' ) }</div>
+						{ licenseState === LicenseState.Revoked && (
+							<FormattedDate date={ revokedAt } format="YYYY-MM-DD" />
+						) }
 
-					{ licenseState === LicenseState.Revoked && (
-						<FormattedDate date={ revokedAt } format="YYYY-MM-DD" />
-					) }
-
-					{ licenseState !== LicenseState.Revoked && (
-						<Gridicon icon="minus" className="license-preview__no-value" />
-					) }
-				</div>
+						{ licenseState !== LicenseState.Revoked && (
+							<Gridicon icon="minus" className="license-preview__no-value" />
+						) }
+					</div>
+				) }
 
 				<div>
 					{ licenseState === LicenseState.Detached && (

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -17,9 +17,16 @@ import LicenseStateFilter from 'calypso/jetpack-cloud/sections/partner-portal/li
 interface Props {
 	licenseFilter: LicenseFilter;
 	search: string;
+	sortDirection?: string;
+	sortField?: string;
 }
 
-export default function Licenses( { licenseFilter, search }: Props ): ReactElement {
+export default function Licenses( {
+	licenseFilter,
+	search,
+	sortDirection = 'asc',
+	sortField = 'issued_at',
+}: Props ): ReactElement {
 	const translate = useTranslate();
 
 	return (
@@ -30,7 +37,11 @@ export default function Licenses( { licenseFilter, search }: Props ): ReactEleme
 
 			<LicenseStateFilter licenseFilter={ licenseFilter } search={ search } />
 
-			<LicenseList />
+			<LicenseList
+				licenseFilter={ licenseFilter }
+				sortDirection={ sortDirection }
+				sortField={ sortField }
+			/>
 		</Main>
 	);
 }


### PR DESCRIPTION
Context:
* Project thread: pbtFPC-Um-p2
* i4 designs: pbtFPC-103-p2

#### Changes proposed in this Pull Request

* Only shows the "Revoked on" column when the "Revoked" filter is active
* The list header now has `font-weight: 400` and only the active sort column has `700`
* Add the dropdown arrow to the sortable column headers and only shows it if the current column is selected
* Replaces the URL with the current sorting config

_Note: this PR only adds the UI. We will still work on its functionality, so it won't sort the list at this point_

![image](https://user-images.githubusercontent.com/5714212/108211308-4cae4380-710b-11eb-80b0-485097ca7cc7.png)


#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key, if prompted.
* Check the license list header and confirm it matches the design in the screenshot above
* Make sure you can click through each sortable column and it changes the URL
* Make sure the "Revoked On" column only shows up when the Revoked filter is active, otherwise it should show "Attached On"
