### PR TITLE
Tidy up after recent Focused Launch checkout changes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
@@ -15,6 +15,7 @@ import LaunchModal from './launch-modal';
 import { LAUNCH_STORE } from './stores';
 import { FLOW_ID } from './constants';
 import { openCheckout, redirectToWpcomPath, getCurrentLaunchFlowUrl } from './utils';
+import { inIframe } from '../../block-inserter-modifications/contextual-tips/utils';
 
 const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > ) =>
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -54,6 +55,7 @@ registerPlugin( 'a8c-editor-site-launch', {
 						redirectTo: redirectToWpcomPath,
 						openCheckout,
 						getCurrentLaunchFlowUrl,
+						isInIframe: inIframe(),
 					} }
 				>
 					<LaunchModal onClose={ closeSidebar } isLaunchImmediately={ isAnchorFm } />

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
@@ -33,7 +33,7 @@ export const redirectToWpcomPath = ( url: string ): void => {
  * @param onSuccessCallback Called when the checkout opens as a modal and is completed successfully
  */
 export const openCheckout = (
-	siteSlug: string = window?.currentSiteId?.toString() || '',
+	siteSlug = window._currentSiteId.toString(),
 	isEcommerce = false,
 	onSuccessCallback?: () => void
 ): void => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
@@ -21,6 +21,17 @@ export const redirectToWpcomPath = ( url: string ): void => {
 	redirectParentWindow( `${ origin }${ path }` );
 };
 
+/**
+ * Opens the checkout.
+ *
+ * If possible, the checkout is opened as a modal without a page redirect (for Focused Launch).
+ * Otherwise, as a fallback, the user is redirected to the /checkout page or the /home page
+ * (in this case, `siteSlug` and `isEcommerce` params are used to construct the redirect url)
+ *
+ * @param siteSlug The slug (id) of the current site.
+ * @param isEcommerce True if the eCommerce plan is going to be in the checkout.
+ * @param onSuccessCallback Called when the checkout opens as a modal and is completed successfully
+ */
 export const openCheckout = (
 	siteSlug: string = window?.currentSiteId?.toString() || '',
 	isEcommerce = false,

--- a/apps/editing-toolkit/typings/fse/index.d.ts
+++ b/apps/editing-toolkit/typings/fse/index.d.ts
@@ -12,8 +12,6 @@ interface Window {
 		anchorFmPodcastId?: string;
 		locale?: string;
 	};
-	// TODO: One of this is correct. Guess which one?
-	currentSiteId?: number;
 	_currentSiteId: number;
 	calypsoifyGutenberg?: {
 		isGutenboarding?: boolean;

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -53,7 +53,7 @@ const FocusedLaunch: React.FunctionComponent = () => {
 	}, [ selectedPlanProductId, planProductIdFromCart, setPlanProductId, hasPaidPlan ] );
 
 	// The user may have previously used the launch flow to pick a paid plan,
-	// but they may have then purchased that paid plan before launching.
+	// but they may have then purchased that paid plan or other plan before deciding to continue Launch flow.
 	// In this scenario, the site has a paid plan but it is not launched yet.
 	// So when launch modal reopens, we need to unset the selected plan product
 	// id (that was previously selected, but is not needed anymore).

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -52,7 +52,13 @@ const FocusedLaunch: React.FunctionComponent = () => {
 		}
 	}, [ selectedPlanProductId, planProductIdFromCart, setPlanProductId, hasPaidPlan ] );
 
-	// If there is a purchased plan, remove any selected plan from Launch store
+	// The user may have previously used the launch flow to pick a paid plan,
+	// but they may have then purchased that paid plan before launching.
+	// In this scenario, the site has a paid plan but it is not launched yet.
+	// So when launch modal reopens, we need to unset the selected plan product
+	// id (that was previously selected, but is not needed anymore).
+	// This is one of the cases mentioned in
+	// https://github.com/Automattic/wp-calypso/issues/49958
 	const { unsetPlanProductId } = useDispatch( LAUNCH_STORE );
 	React.useEffect( () => {
 		if ( hasPaidPlan ) {

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -574,9 +574,11 @@ const Summary: React.FunctionComponent = () => {
 		}
 	}, [ title, showSiteTitleStep, isSiteTitleStepVisible ] );
 
+	// Launch the site directly if Free plan and subdomain are selected.
+	// Otherwise, show checkout as the next step.
 	const handleLaunch = () => {
-		// Launch the site directly if Free plan and subdomain are selected.
-		// Otherwise, show checkout as the next step.
+		// !isSelectedPlanPaid is used instead of !isSelectedPlanFree because
+		// user may be entering the launch flow after they have paid for a plan.
 		if ( ! selectedDomain && ! isSelectedPlanPaid ) {
 			launchSite( siteId );
 		} else {

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -577,7 +577,7 @@ const Summary: React.FunctionComponent = () => {
 	// Launch the site directly if Free plan and subdomain are selected.
 	// Otherwise, show checkout as the next step.
 	const handleLaunch = () => {
-		// !isSelectedPlanPaid is used instead of !isSelectedPlanFree because
+		// checking for not having a selected paid plan instead of checking for a selected Free plan because
 		// user may be entering the launch flow after they have paid for a plan.
 		if ( ! selectedDomain && ! isSelectedPlanPaid ) {
 			launchSite( siteId );

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -43,8 +43,12 @@ const FocusedLaunchModal: React.FunctionComponent< FocusedLaunchModalProps > = (
 
 	React.useEffect( () => {
 		if ( isLaunchImmediately ) {
-			// if there was a plan in cart before redirect to payment processing,
+			// This happens when the user enters the block editor again after
+			// checkout redirection (i.e. when in Calypso, paying with paypal).
+			// If there was a plan in cart before redirect to payment processing,
 			// remove it now since we don't need to reload the page when dismissing Success view
+			// For more details, see
+			// https://github.com/Automattic/wp-calypso/issues/50122
 			unsetPlanProductId();
 			launchSite( siteId );
 		}

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -47,8 +47,8 @@ const FocusedLaunchModal: React.FunctionComponent< FocusedLaunchModalProps > = (
 			// checkout redirection (i.e. when in Calypso, paying with paypal).
 			// If there was a plan in cart before redirect to payment processing,
 			// remove it now since we don't need to reload the page when dismissing Success view
-			// For more details, see
-			// https://github.com/Automattic/wp-calypso/issues/50122
+			// Calling `unsetPlanProductId()` won't be needed after 
+			// https://github.com/Automattic/wp-calypso/issues/50185 is fixed.
 			unsetPlanProductId();
 			launchSite( siteId );
 		}

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -47,7 +47,7 @@ const FocusedLaunchModal: React.FunctionComponent< FocusedLaunchModalProps > = (
 			// checkout redirection (i.e. when in Calypso, paying with paypal).
 			// If there was a plan in cart before redirect to payment processing,
 			// remove it now since we don't need to reload the page when dismissing Success view
-			// Calling `unsetPlanProductId()` won't be needed after 
+			// Calling `unsetPlanProductId()` won't be needed after
 			// https://github.com/Automattic/wp-calypso/issues/50185 is fixed.
 			unsetPlanProductId();
 			launchSite( siteId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Following work from #48452:

* Add more details to some of the Focused Launch logic in the form of inline comments
* Add missing `isInIframe` prop for the Step by Step launch context
* Rename mistyped `window.currentSiteId` to `window._currentSiteId` (and fixed related TypeScript type)

#### Testing instructions

Most changes are just comments.

* Open `apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx` and verify that the TypeScript error is gone


Related to #48452
