### PR TITLE
update(account): migrate to class component

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import createReactClass from 'create-react-class';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
 import CSSTransition from 'react-transition-group/CSSTransition';
 import { localize } from 'i18n-calypso';
@@ -105,90 +104,85 @@ const INTERFACE_FIELDS = [
 	'calypso_preferences',
 ];
 
-/* eslint-disable react/prefer-es6-class */
-const Account = createReactClass( {
-	displayName: 'Account',
+class Account extends React.Component {
+	state = {
+		redirect: false,
+		submittingForm: false,
+		formsSubmitting: {},
+		changingUsername: false,
+		usernameAction: 'new',
+	};
 
 	UNSAFE_componentWillMount() {
 		// Clear any username changes that were previously made
 		this.clearUsernameValidation();
 		this.props.removeUnsavedUserSetting( 'user_login' );
-	},
+	}
 
 	componentDidMount() {
 		debug( this.constructor.displayName + ' component is mounted.' );
 		this.debouncedUsernameValidate = debounce( this.validateUsername, 600 );
-	},
+	}
 
 	componentDidUpdate() {
 		if ( ! this.hasUnsavedUserSettings( ACCOUNT_FIELDS.concat( INTERFACE_FIELDS ) ) ) {
 			this.props.markSaved();
 		}
-	},
+	}
 
 	componentWillUnmount() {
 		debug( this.constructor.displayName + ' component is unmounting.' );
 
 		// Silently clean up unsavedSettings before unmounting
 		this.props.clearUnsavedUserSettings();
-	},
+	}
 
-	getInitialState: function () {
-		return {
-			redirect: false,
-			submittingForm: false,
-			formsSubmitting: {},
-			changingUsername: false,
-			usernameAction: 'new',
-		};
-	},
-
-	getDisabledState: function ( formName ) {
+	getDisabledState( formName ) {
 		return formName ? this.state.formsSubmitting[ formName ] : this.state.submittingForm;
-	},
+	}
 
 	getUserSetting( settingName ) {
 		return (
 			get( this.props.unsavedUserSettings, settingName ) ??
 			this.getUserOriginalSetting( settingName )
 		);
-	},
+	}
 
 	getUserOriginalSetting( settingName ) {
 		return get( this.props.userSettings, settingName );
-	},
+	}
 
 	hasUnsavedUserSetting( settingName ) {
 		return has( this.props.unsavedUserSettings, settingName );
-	},
+	}
 
 	hasUnsavedUserSettings( settingNames ) {
 		return settingNames.reduce(
 			( acc, settingName ) => this.hasUnsavedUserSetting( settingName ) || acc,
 			false
 		);
-	},
+	}
 
 	updateUserSetting( settingName, value ) {
 		this.props.setUserSetting( settingName, value );
-	},
+	}
 
-	updateUserSettingInput( event ) {
+	updateUserSettingInput = ( event ) => {
 		this.updateUserSetting( event.target.name, event.target.value );
-	},
+	};
 
-	updateUserSettingCheckbox( event ) {
+	updateUserSettingCheckbox = ( event ) => {
 		this.updateUserSetting( event.target.name, event.target.checked );
-	},
+	};
 
-	updateCommunityTranslatorSetting( event ) {
+	updateCommunityTranslatorSetting = ( event ) => {
 		const { name, checked } = event.target;
 		this.updateUserSetting( name, checked );
 		const redirect = '/me/account';
 		this.setState( { redirect } );
-	},
+	};
 
-	updateLanguage( event ) {
+	updateLanguage = ( event ) => {
 		const { value, empathyMode, useFallbackForIncompleteLanguages } = event.target;
 		this.updateUserSetting( 'language', value );
 
@@ -217,35 +211,35 @@ const Account = createReactClass( {
 		// store any selected locale variant so we can test it against those with no GP translation sets
 		const localeVariantSelected = isLocaleVariant( value ) ? value : '';
 		this.setState( { redirect, localeVariantSelected } );
-	},
+	};
 
-	toggleLinkDestination( linkDestination ) {
+	toggleLinkDestination = ( linkDestination ) => {
 		this.updateUserSetting( linkDestinationKey, linkDestination );
-	},
+	};
 
-	updateColorScheme( colorScheme ) {
+	updateColorScheme = ( colorScheme ) => {
 		this.props.recordTracksEvent( 'calypso_color_schemes_select', { color_scheme: colorScheme } );
 		this.props.recordGoogleEvent( 'Me', 'Selected Color Scheme', 'scheme', colorScheme );
 		this.updateUserSetting( colorSchemeKey, colorScheme );
-	},
+	};
 
 	getEmailAddress() {
 		return this.hasPendingEmailChange()
 			? this.getUserSetting( 'new_user_email' )
 			: this.getUserSetting( 'user_email' );
-	},
+	}
 
-	updateEmailAddress( event ) {
+	updateEmailAddress = ( event ) => {
 		const { value } = event.target;
 		const emailValidationError =
 			( '' === value && 'empty' ) || ( ! emailValidator.validate( value ) && 'invalid' ) || false;
 		this.setState( { emailValidationError } );
 		this.updateUserSetting( 'user_email', value );
-	},
+	};
 
-	updateUserLoginConfirm( event ) {
+	updateUserLoginConfirm = ( event ) => {
 		this.setState( { userLoginConfirm: event.target.value } );
-	},
+	};
 
 	async validateUsername() {
 		const { translate } = this.props;
@@ -290,11 +284,11 @@ const Account = createReactClass( {
 		} catch ( error ) {
 			this.setState( { validationResult: error } );
 		}
-	},
+	}
 
 	hasEmailValidationError() {
 		return !! this.state.emailValidationError;
-	},
+	}
 
 	shouldDisplayCommunityTranslator() {
 		const locale = this.getUserSetting( 'language' );
@@ -321,7 +315,7 @@ const Account = createReactClass( {
 		}
 
 		return true;
-	},
+	}
 
 	communityTranslator() {
 		if ( ! this.shouldDisplayCommunityTranslator() ) {
@@ -357,7 +351,7 @@ const Account = createReactClass( {
 				</FormLabel>
 			</FormFieldset>
 		);
-	},
+	}
 
 	thankTranslationContributors() {
 		if ( ! this.shouldDisplayCommunityTranslator() ) {
@@ -386,14 +380,14 @@ const Account = createReactClass( {
 				) }
 			</FormSettingExplanation>
 		);
-	},
+	}
 
-	handleRadioChange( event ) {
+	handleRadioChange = ( event ) => {
 		const { name, value } = event.currentTarget;
 		this.setState( { [ name ]: value } );
-	},
+	};
 
-	handleSubmitButtonClick() {
+	handleSubmitButtonClick = () => {
 		const { unsavedUserSettings } = this.props;
 		this.recordClickEvent( 'Save Account Settings Button' );
 		if ( this.hasUnsavedUserSetting( colorSchemeKey ) ) {
@@ -414,7 +408,7 @@ const Account = createReactClass( {
 				country_code: this.props.countryCode,
 			} );
 		}
-	},
+	};
 
 	/**
 	 * We handle the username (user_login) change manually through an onChange handler
@@ -422,15 +416,15 @@ const Account = createReactClass( {
 	 *
 	 * @param {object} event Event from onChange of user_login input
 	 */
-	handleUsernameChange( event ) {
+	handleUsernameChange = ( event ) => {
 		this.debouncedUsernameValidate();
 		this.updateUserSetting( 'user_login', event.currentTarget.value );
 		this.setState( { usernameAction: null } );
-	},
+	};
 
-	recordClickEvent( action ) {
+	recordClickEvent = ( action ) => {
 		this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
-	},
+	};
 
 	getClickHandler( action, callback ) {
 		return () => {
@@ -440,11 +434,11 @@ const Account = createReactClass( {
 				callback();
 			}
 		};
-	},
+	}
 
 	getFocusHandler( action ) {
 		return () => this.props.recordGoogleEvent( 'Me', 'Focused on ' + action );
-	},
+	}
 
 	getCheckboxHandler( checkboxName ) {
 		return ( event ) => {
@@ -453,18 +447,18 @@ const Account = createReactClass( {
 
 			this.props.recordGoogleEvent( 'Me', action, 'checked', value );
 		};
-	},
+	}
 
-	handleUsernameChangeBlogRadio( event ) {
+	handleUsernameChangeBlogRadio = ( event ) => {
 		this.props.recordGoogleEvent(
 			'Me',
 			'Clicked Username Change Blog Action radio',
 			'checked',
 			event.target.value
 		);
-	},
+	};
 
-	cancelUsernameChange() {
+	cancelUsernameChange = () => {
 		this.setState( {
 			userLoginConfirm: null,
 			usernameAction: null,
@@ -478,9 +472,9 @@ const Account = createReactClass( {
 		if ( ! Object.keys( otherUnsavedSettings ).length ) {
 			this.props.markSaved();
 		}
-	},
+	};
 
-	async submitUsernameForm() {
+	submitUsernameForm = async () => {
 		const username = this.getUserSetting( 'user_login' );
 		const action = this.state.usernameAction ? this.state.usernameAction : 'none';
 
@@ -499,33 +493,33 @@ const Account = createReactClass( {
 			this.setState( { submittingForm: false, validationResult: error } );
 			this.props.errorNotice( error.message );
 		}
-	},
+	};
 
 	isUsernameValid() {
 		return this.state.validationResult?.success === true;
-	},
+	}
 
 	getUsernameValidationFailureMessage() {
 		return this.state.validationResult?.message ?? null;
-	},
+	}
 
 	getAllowedActions() {
 		return this.state.validationResult?.allowed_actions ?? {};
-	},
+	}
 
 	getValidatedUsername() {
 		return this.state.validationResult?.validatedUsername ?? null;
-	},
+	}
 
 	clearUsernameValidation() {
 		this.setState( { validationResult: false } );
-	},
+	}
 
-	onSiteSelect( siteId ) {
+	onSiteSelect = ( siteId ) => {
 		if ( siteId ) {
 			this.updateUserSetting( 'primary_site_ID', siteId );
 		}
-	},
+	};
 
 	renderJoinDate() {
 		const { currentUserDate, translate, moment } = this.props;
@@ -541,11 +535,11 @@ const Account = createReactClass( {
 				} ) }
 			</span>
 		);
-	},
+	}
 
 	hasPendingEmailChange() {
 		return this.props.isPendingEmailChange;
-	},
+	}
 
 	renderPendingEmailChange() {
 		const { translate } = this.props;
@@ -572,7 +566,7 @@ const Account = createReactClass( {
 				</NoticeAction>
 			</Notice>
 		);
-	},
+	}
 
 	renderUsernameValidation() {
 		const { translate } = this.props;
@@ -602,7 +596,7 @@ const Account = createReactClass( {
 				/>
 			);
 		}
-	},
+	}
 
 	renderUsernameConfirmNotice() {
 		const { translate } = this.props;
@@ -617,7 +611,7 @@ const Account = createReactClass( {
 		}
 
 		return <Notice showDismiss={ false } status={ status } text={ text } />;
-	},
+	}
 
 	renderPrimarySite() {
 		const { onboardingUrl, requestingMissingSites, translate, visibleSiteCount } = this.props;
@@ -643,7 +637,7 @@ const Account = createReactClass( {
 				onSiteSelect={ this.onSiteSelect }
 			/>
 		);
-	},
+	}
 
 	renderEmailValidation() {
 		const { translate } = this.props;
@@ -668,7 +662,7 @@ const Account = createReactClass( {
 		}
 
 		return <FormTextValidation isError={ true } text={ notice } />;
-	},
+	}
 
 	shouldDisableAccountSubmitButton() {
 		return (
@@ -676,14 +670,14 @@ const Account = createReactClass( {
 			this.getDisabledState( ACCOUNT_FORM_NAME ) ||
 			this.hasEmailValidationError()
 		);
-	},
+	}
 
 	shouldDisableInterfaceSubmitButton() {
 		return (
 			! this.hasUnsavedUserSettings( INTERFACE_FIELDS ) ||
 			this.getDisabledState( INTERFACE_FORM_NAME )
 		);
-	},
+	}
 
 	handleSubmitError( error, formName = '' ) {
 		debug( 'Error saving settings: ' + JSON.stringify( error ) );
@@ -704,11 +698,11 @@ const Account = createReactClass( {
 				...( formName && { [ formName ]: false } ),
 			},
 		} );
-	},
+	}
 
 	isSubmittingForm( formName ) {
 		return formName ? this.state.formsSubmitting[ formName ] : this.state.submittingForm;
-	},
+	}
 
 	handleSubmitSuccess( response, formName = '' ) {
 		if ( ! this.hasUnsavedUserSettings( ACCOUNT_FIELDS.concat( INTERFACE_FIELDS ) ) ) {
@@ -742,9 +736,9 @@ const Account = createReactClass( {
 			}
 		);
 		debug( 'Settings saved successfully ' + JSON.stringify( response ) );
-	},
+	}
 
-	submitForm: async function ( event, fields, formName = '' ) {
+	async submitForm( event, fields, formName = '' ) {
 		event.preventDefault();
 		debug( 'Submitting form' );
 
@@ -762,7 +756,7 @@ const Account = createReactClass( {
 		} catch ( error ) {
 			this.handleSubmitError( error, formName );
 		}
-	},
+	}
 
 	/*
 	 * These form fields are displayed when there is not a username change in progress.
@@ -822,7 +816,7 @@ const Account = createReactClass( {
 				</FormButton>
 			</div>
 		);
-	},
+	}
 
 	renderBlogActionFields() {
 		const { translate } = this.props;
@@ -856,7 +850,7 @@ const Account = createReactClass( {
 				}
 			</FormFieldset>
 		);
-	},
+	}
 
 	/*
 	 * These form fields are displayed when a username change is in progress.
@@ -884,7 +878,7 @@ const Account = createReactClass( {
 						id="username_confirm"
 						name="username_confirm"
 						onFocus={ this.getFocusHandler( 'Username Confirm Field' ) }
-						value={ this.state.userLoginConfirm }
+						value={ this.state.userLoginConfirm ?? '' }
 						onChange={ this.updateUserLoginConfirm }
 					/>
 					{ this.renderUsernameConfirmNotice() }
@@ -968,14 +962,15 @@ const Account = createReactClass( {
 				</FormButtonsBar>
 			</div>
 		);
-	},
-	saveAccountSettings( event ) {
-		this.submitForm( event, ACCOUNT_FIELDS, ACCOUNT_FORM_NAME );
-	},
+	}
 
-	saveInterfaceSettings( event ) {
+	saveAccountSettings = ( event ) => {
+		this.submitForm( event, ACCOUNT_FIELDS, ACCOUNT_FORM_NAME );
+	};
+
+	saveInterfaceSettings = ( event ) => {
 		this.submitForm( event, INTERFACE_FIELDS, INTERFACE_FORM_NAME );
-	},
+	};
 
 	render() {
 		const { markChanged, translate } = this.props;
@@ -1099,8 +1094,8 @@ const Account = createReactClass( {
 				{ config.isEnabled( 'me/account-close' ) && <AccountSettingsCloseLink /> }
 			</Main>
 		);
-	},
-} );
+	}
+}
 
 export default compose(
 	connect(

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -105,19 +105,20 @@ const INTERFACE_FIELDS = [
 ];
 
 class Account extends React.Component {
+	constructor( props ) {
+		super( props );
+
+		this.props.removeUnsavedUserSetting( 'user_login' );
+	}
+
 	state = {
 		redirect: false,
 		submittingForm: false,
 		formsSubmitting: {},
 		changingUsername: false,
 		usernameAction: 'new',
+		validationResult: false,
 	};
-
-	UNSAFE_componentWillMount() {
-		// Clear any username changes that were previously made
-		this.clearUsernameValidation();
-		this.props.removeUnsavedUserSetting( 'user_login' );
-	}
 
 	componentDidMount() {
 		debug( this.constructor.displayName + ' component is mounted.' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make `<Account />` a class component and drop `createReactClass`
* remove `UNSAFE_componentWillMount` from `<Account />`

#### Testing instructions

* Make sure changing and saving settings at `/me/account` still works exactly as on prod
* You may want to follow the testing instructions from https://github.com/Automattic/wp-calypso/pull/49760

Follow up to #49760 
