### PR TITLE
i18n: Add translatable strings from Guide component in nav unification modal

### DIFF
--- a/client/blocks/nav-unification-modal/index.jsx
+++ b/client/blocks/nav-unification-modal/index.jsx
@@ -54,8 +54,10 @@ const Modal = () => {
 	const translate = useTranslate();
 
 	/**
-	 * Translate calls will ensure that the following strings from the Guide component would be extracted
-	 * and their respective translation would be loaded and displayed properly in the nav unifcation modal
+	 * Since we don't extract strings from external packages in node_modules,
+	 * translatable strings from the Guide component are not being extracted.
+	 * In order to get these strings extracted and their translations loaded,
+	 * we need to have the following translate calls included in this component.
 	 */
 	translate( 'Previous' );
 	translate( 'Next' );

--- a/client/blocks/nav-unification-modal/index.jsx
+++ b/client/blocks/nav-unification-modal/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { Guide } from '@wordpress/components';
 import { Title } from '@automattic/onboarding';
 import { useSelector, useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -12,7 +13,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { useTranslate } from 'i18n-calypso';
 
 /**
  * Image dependencies
@@ -52,6 +52,14 @@ const Modal = () => {
 	const dismissPreference = `nav-unification-modal-${ userId }`;
 	const isDismissed = useSelector( ( state ) => getPreference( state, dismissPreference ) );
 	const translate = useTranslate();
+
+	/**
+	 * Translate calls will ensure that the following strings from the Guide component would be extracted
+	 * and their respective translation would be loaded and displayed properly in the nav unifcation modal
+	 */
+	translate( 'Previous' );
+	translate( 'Next' );
+	translate( 'Finish' );
 
 	if ( ! hasPreferences || isDismissed ) {
 		return null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add translatable strings from `@wordpress/components`'s Guide component in nav unification modal component to ensure that these strings are getting extracted and their respective translations are being loaded properly.

#### Testing instructions

* Check `calypso-strings.pot` artifact in `ci/circleci: translate` and confirm it contains `Previous`, `Next` and `Finish` strings.

Fixes #49981
