### PR TITLE
Disable HotModuleReplacement

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -349,7 +349,6 @@ const webpackConfig = {
 				output: path.resolve( '.', `chunks-map.${ extraPath }.json` ),
 			} ),
 		new RequireChunkCallbackPlugin(),
-		isDevelopment && new webpack.HotModuleReplacementPlugin(),
 		...( ! config.isEnabled( 'desktop' )
 			? [
 					new webpack.NormalModuleReplacementPlugin(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Disable `HotModuleReplacement`

Having this enabled without a proper HMR setup is causing lots of troubles, mainly developers getting an error when they change a file or switch branches while `yarn start` is running:

![image](https://user-images.githubusercontent.com/975703/108229127-cfe98c80-713f-11eb-9e17-bc3cceed0e77.png)


Now, in order to see a change in the browser, the developer must do a page refresh.

Note that this will also the disable the notification about the state of the compilation:

![image](https://user-images.githubusercontent.com/975703/108229095-c6602480-713f-11eb-8dd9-f3f04cb95098.png)


I think we should at least try to get HMR working, and I plan to work on it soon. At least we should bring back the notification because it is working today and providing value. But for now, it looks like the friction caused by the error overweights the value of the notification.

#### Testing instructions

Run `yarn start`, change a file in Calypso (or switch branches) and verify it doesn't break anymore.