### PR TITLE
i18n: Add missing translators comments in ETK components

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/template/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/template/edit.js
@@ -177,7 +177,10 @@ const TemplateEdit = compose(
 							{ navigateToTemplate && (
 								<div className="template-block__loading">
 									<Spinner />{ ' ' }
-									{ sprintf( __( 'Loading editor for: %s', 'full-site-editing' ), templateTitle ) }
+									{
+										/* translators: %s is a template title. */
+										sprintf( __( 'Loading editor for: %s', 'full-site-editing' ), templateTitle )
+									}
 								</div>
 							) }
 							<Button
@@ -188,7 +191,10 @@ const TemplateEdit = compose(
 								isLarge
 								ref={ navButton }
 							>
-								{ sprintf( __( 'Edit %s', 'full-site-editing' ), templateTitle ) }
+								{
+									/* translators: %s is a template title. */
+									sprintf( __( 'Edit %s', 'full-site-editing' ), templateTitle )
+								}
 							</Button>
 						</Placeholder>
 					</Fragment>

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-options/use-site-options.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-options/use-site-options.js
@@ -50,10 +50,12 @@ export function useSiteOptions(
 			)
 			.catch( () => {
 				createErrorNotice(
+					/* translators: %s is a site option (e.g. `title`, `description`, etc.). */
 					sprintf( __( 'Unable to load site %s', 'full-site-editing' ), siteOption )
 				);
 				setSiteOptions( {
 					...siteOptions,
+					/* translators: %s is a site option (e.g. `title`, `description`, etc.). */
 					option: sprintf( __( 'Error loading site %s', 'full-site-editing' ), siteOption ),
 					error: true,
 				} );
@@ -94,6 +96,7 @@ export function useSiteOptions(
 			.then( () => updatePreviousOption( option ) )
 			.catch( () => {
 				createErrorNotice(
+					/* translators: %s is a site option (e.g. `title`, `description`, etc.). */
 					sprintf( __( 'Unable to save site %s', 'full-site-editing' ), siteOption )
 				);
 				revertOption();

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/no-support.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/no-support.js
@@ -5,12 +5,10 @@ import { __, sprintf } from '@wordpress/i18n';
 
 export default ( { unsupportedFeature } ) => (
 	<p>
-		{
+		{ sprintf(
 			/* translators: %s: feature name (i.e. font pairings, etc) */
-			sprintf(
-				__( "Your active theme doesn't support %s.", 'full-site-editing' ),
-				unsupportedFeature
-			)
-		}
+			__( "Your active theme doesn't support %s.", 'full-site-editing' ),
+			unsupportedFeature
+		) }
 	</p>
 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add missing translators comments in ETK components

#### Testing instructions

* Check if translators comments make sense.

Related to #49312
