### PR TITLE
plans-grid: Fix translators comment format

### DIFF
--- a/packages/plans-grid/src/plans-interval-toggle/index.tsx
+++ b/packages/plans-grid/src/plans-interval-toggle/index.tsx
@@ -90,7 +90,7 @@ const PlansIntervalToggle: React.FunctionComponent< PlansIntervalToggleProps > =
 					{ intervalType === 'MONTHLY' && maxMonthlyDiscountPercentage && (
 						<PopupMessages>
 							{ sprintf(
-								// translators: will be like "Save up to 30% by paying annually... Please keep "%%" for the percent sign"
+								// translators: will be like "Save up to 30% by paying annually...". Please keep "%%" for the percent sign
 								__(
 									'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',
 									__i18n_text_domain__

--- a/packages/plans-grid/src/plans-interval-toggle/index.tsx
+++ b/packages/plans-grid/src/plans-interval-toggle/index.tsx
@@ -90,8 +90,7 @@ const PlansIntervalToggle: React.FunctionComponent< PlansIntervalToggleProps > =
 					{ intervalType === 'MONTHLY' && maxMonthlyDiscountPercentage && (
 						<PopupMessages>
 							{ sprintf(
-								// Translators: will be like "Save up to 30% by paying annually..."
-								// Please keep "%%" for the percent sign
+								// translators: will be like "Save up to 30% by paying annually... Please keep "%%" for the percent sign"
 								__(
 									'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',
 									__i18n_text_domain__


### PR DESCRIPTION
Fix translators comment in PlansIntervalToggle component to be on a single line so it fulfils @wordpress/i18n-translator-comments lint rules

#### Changes proposed in this Pull Request

* Format translators comment in PlansIntervalToggle component to be on a single line

#### Testing instructions

* Confirm lint problem has been resolved in `Check code style for branches (Calypso)`.

Related to #49312
