### PR TITLE
[e2e] Dismiss guide modal

### DIFF
--- a/desktop/e2e/tests/lib/components/gutenberg-editor-component.js
+++ b/desktop/e2e/tests/lib/components/gutenberg-editor-component.js
@@ -8,7 +8,6 @@ const webdriver = require( 'selenium-webdriver' );
  */
 const driverHelper = require( '../driver-helper' );
 const AsyncBaseContainer = require( '../async-base-container' );
-const GuideComponent = require( './guide-component.js' );
 
 const By = webdriver.By;
 const until = webdriver.until;
@@ -52,8 +51,7 @@ class GutenbergEditorComponent extends AsyncBaseContainer {
 		if ( dismissPageTemplateSelector ) {
 			await this.dismissPageTemplateSelector();
 		}
-		const editorWelcomeModal = await GuideComponent.Expect( this.driver );
-		await editorWelcomeModal.dismissModal( '.components-guide' );
+		await this.dismissEditorWelcomeModal();
 		return await this.closeSidebar();
 	}
 
@@ -82,6 +80,20 @@ class GutenbergEditorComponent extends AsyncBaseContainer {
 				By.css( '.page-template-modal__buttons .components-button.is-primary' )
 			);
 			await this.driver.executeScript( 'arguments[0].click()', useBlankButton );
+		}
+	}
+
+	async dismissEditorWelcomeModal() {
+		const welcomeModal = By.css( '.components-guide__container' );
+		if (
+			await driverHelper.isEventuallyPresentAndDisplayed(
+				this.driver,
+				welcomeModal,
+				this.explicitWaitMS / 5
+			)
+		) {
+			// eslint-disable-next-line no-undef
+			await this.driver.findElement( By.css( '.components-guide' ) ).sendKeys( Key.ESCAPE );
 		}
 	}
 

--- a/desktop/e2e/tests/lib/components/gutenberg-editor-component.js
+++ b/desktop/e2e/tests/lib/components/gutenberg-editor-component.js
@@ -8,6 +8,7 @@ const webdriver = require( 'selenium-webdriver' );
  */
 const driverHelper = require( '../driver-helper' );
 const AsyncBaseContainer = require( '../async-base-container' );
+const GuideComponent = require( './guide-component.js' );
 
 const By = webdriver.By;
 const until = webdriver.until;
@@ -51,7 +52,8 @@ class GutenbergEditorComponent extends AsyncBaseContainer {
 		if ( dismissPageTemplateSelector ) {
 			await this.dismissPageTemplateSelector();
 		}
-		await this.dismissEditorWelcomeModal();
+		const editorWelcomeModal = await GuideComponent.Expect( this.driver );
+		await editorWelcomeModal.dismissModal( '.components-guide' );
 		return await this.closeSidebar();
 	}
 
@@ -80,20 +82,6 @@ class GutenbergEditorComponent extends AsyncBaseContainer {
 				By.css( '.page-template-modal__buttons .components-button.is-primary' )
 			);
 			await this.driver.executeScript( 'arguments[0].click()', useBlankButton );
-		}
-	}
-
-	async dismissEditorWelcomeModal() {
-		const welcomeModal = By.css( '.components-guide__container' );
-		if (
-			await driverHelper.isEventuallyPresentAndDisplayed(
-				this.driver,
-				welcomeModal,
-				this.explicitWaitMS / 5
-			)
-		) {
-			// eslint-disable-next-line no-undef
-			await this.driver.findElement( By.css( '.components-guide' ) ).sendKeys( Key.ESCAPE );
 		}
 	}
 

--- a/test/e2e/lib/components/guide-component.js
+++ b/test/e2e/lib/components/guide-component.js
@@ -15,7 +15,7 @@ export default class GuideComponent extends AsyncBaseContainer {
 		super( driver, By.css( '.components-guide' ) );
 	}
 
-	async dismissModal( selector, waitOverride ) {
+	async dismiss( selector, waitOverride ) {
 		if (
 			await driverHelper.isEventuallyPresentAndDisplayed(
 				this.driver,

--- a/test/e2e/lib/components/guide-component.js
+++ b/test/e2e/lib/components/guide-component.js
@@ -15,7 +15,7 @@ export default class GuideComponent extends AsyncBaseContainer {
 		super( driver, By.css( '.components-guide' ) );
 	}
 
-	async dismiss( selector, waitOverride ) {
+	async dismiss( waitOverride, selector = '.components-guide' ) {
 		if (
 			await driverHelper.isEventuallyPresentAndDisplayed(
 				this.driver,

--- a/test/e2e/lib/components/guide-component.js
+++ b/test/e2e/lib/components/guide-component.js
@@ -15,12 +15,12 @@ export default class GuideComponent extends AsyncBaseContainer {
 		super( driver, By.css( '.components-guide' ) );
 	}
 
-	async dismissModal( selector ) {
+	async dismissModal( selector, waitOverride ) {
 		if (
 			await driverHelper.isEventuallyPresentAndDisplayed(
 				this.driver,
 				By.css( '.components-guide__container' ),
-				this.explicitWaitMS / 5
+				waitOverride
 			)
 		) {
 			try {

--- a/test/e2e/lib/components/guide-component.js
+++ b/test/e2e/lib/components/guide-component.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { By, Key } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import * as driverHelper from '../driver-helper.js';
+
+import AsyncBaseContainer from '../async-base-container.js';
+
+export default class GuideComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.components-guide' ) );
+	}
+
+	async dismissModal( selector ) {
+		if (
+			await driverHelper.isEventuallyPresentAndDisplayed(
+				this.driver,
+				By.css( '.components-guide__container' ),
+				this.explicitWaitMS / 5
+			)
+		) {
+			try {
+				// Easiest way to dismiss it, but it might not work in IE.
+				await this.driver.findElement( By.css( selector ) ).sendKeys( Key.ESCAPE );
+			} catch {
+				// Click to the last page of the welcome guide.
+				await driverHelper.clickWhenClickable(
+					this.driver,
+					By.css( 'ul.components-guide__page-control li:last-child button' )
+				);
+				// Click the finish button.
+				await driverHelper.clickWhenClickable(
+					this.driver,
+					By.css( '.components-guide__finish-button' )
+				);
+			}
+		}
+	}
+}

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -13,6 +13,7 @@ import CustomerHome from '../pages/customer-home-page';
 
 import SidebarComponent from '../components/sidebar-component.js';
 import NavBarComponent from '../components/nav-bar-component.js';
+import GuideComponent from '../components/guide-component.js';
 
 import * as dataHelper from '../data-helper';
 import * as driverManager from '../driver-manager';
@@ -95,6 +96,13 @@ export default class LoginFlow {
 		}
 
 		await loginPage.login( this.account.email || this.account.username, this.account.password );
+
+		if ( process.env.FLAGS === 'nav-unification' ) {
+			// Makes sure that the nav-unification welcome modal will be dismissed.
+			const guideComponent = await GuideComponent.Expect( this.driver );
+			await guideComponent.dismissModal( '.nav-unification-modal ' );
+		}
+
 		return await loginCookieHelper.saveLogin( this.driver, this.account.username );
 	}
 

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -100,7 +100,7 @@ export default class LoginFlow {
 		if ( process.env.FLAGS === 'nav-unification' ) {
 			// Makes sure that the nav-unification welcome modal will be dismissed.
 			const guideComponent = new GuideComponent( this.driver );
-			await guideComponent.dismissModal( '.nav-unification-modal', 1000 );
+			await guideComponent.dismiss( '.nav-unification-modal', 1000 );
 		}
 
 		return await loginCookieHelper.saveLogin( this.driver, this.account.username );

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -100,7 +100,7 @@ export default class LoginFlow {
 		if ( process.env.FLAGS === 'nav-unification' ) {
 			// Makes sure that the nav-unification welcome modal will be dismissed.
 			const guideComponent = new GuideComponent( this.driver );
-			await guideComponent.dismiss( '.nav-unification-modal', 1000 );
+			await guideComponent.dismiss( 1000, '.nav-unification-modal' );
 		}
 
 		return await loginCookieHelper.saveLogin( this.driver, this.account.username );

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -99,8 +99,8 @@ export default class LoginFlow {
 
 		if ( process.env.FLAGS === 'nav-unification' ) {
 			// Makes sure that the nav-unification welcome modal will be dismissed.
-			const guideComponent = new GuideComponent( this.driver, 1000 );
-			await guideComponent.dismissModal( '.nav-unification-modal' );
+			const guideComponent = new GuideComponent( this.driver );
+			await guideComponent.dismissModal( '.nav-unification-modal', 1000 );
 		}
 
 		return await loginCookieHelper.saveLogin( this.driver, this.account.username );

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -99,7 +99,7 @@ export default class LoginFlow {
 
 		if ( process.env.FLAGS === 'nav-unification' ) {
 			// Makes sure that the nav-unification welcome modal will be dismissed.
-			const guideComponent = await GuideComponent.Expect( this.driver );
+			const guideComponent = new GuideComponent( this.driver, 1000 );
 			await guideComponent.dismissModal( '.nav-unification-modal' );
 		}
 

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -100,7 +100,7 @@ export default class LoginFlow {
 		if ( process.env.FLAGS === 'nav-unification' ) {
 			// Makes sure that the nav-unification welcome modal will be dismissed.
 			const guideComponent = await GuideComponent.Expect( this.driver );
-			await guideComponent.dismissModal( '.nav-unification-modal ' );
+			await guideComponent.dismissModal( '.nav-unification-modal' );
 		}
 
 		return await loginCookieHelper.saveLogin( this.driver, this.account.username );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -62,7 +62,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			await this.dismissPageTemplateSelector();
 		}
 		const editorWelcomeModal = new GuideComponent( this.driver );
-		await editorWelcomeModal.dismiss( '.components-guide', 4000 );
+		await editorWelcomeModal.dismiss( 4000 );
 		return await this.closeSidebar();
 	}
 

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -61,7 +61,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		if ( dismissPageTemplateSelector ) {
 			await this.dismissPageTemplateSelector();
 		}
-		const editorWelcomeModal = await GuideComponent.Expect( this.driver );
+		const editorWelcomeModal = new GuideComponent( this.driver, 4000 );
 		await editorWelcomeModal.dismissModal( '.components-guide' );
 		return await this.closeSidebar();
 	}

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import webdriver, { By, Key, until } from 'selenium-webdriver';
+import webdriver, { By, until } from 'selenium-webdriver';
 import { kebabCase } from 'lodash';
 
 /**
@@ -15,6 +15,7 @@ import { ContactFormBlockComponent } from './blocks';
 import { ShortcodeBlockComponent } from './blocks/shortcode-block-component';
 import { ImageBlockComponent } from './blocks/image-block-component';
 import { FileBlockComponent } from './blocks/file-block-component';
+import GuideComponent from '../components/guide-component.js';
 
 export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	constructor( driver, url, editorType = 'iframe' ) {
@@ -60,7 +61,8 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		if ( dismissPageTemplateSelector ) {
 			await this.dismissPageTemplateSelector();
 		}
-		await this.dismissEditorWelcomeModal();
+		const editorWelcomeModal = await GuideComponent.Expect( this.driver );
+		await editorWelcomeModal.dismissModal( '.components-guide' );
 		return await this.closeSidebar();
 	}
 
@@ -665,33 +667,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 					By.css( '.page-template-modal__buttons .components-button.is-primary' )
 				);
 				await this.driver.executeScript( 'arguments[0].click()', useBlankButton );
-			}
-		}
-	}
-
-	async dismissEditorWelcomeModal() {
-		const welcomeModal = By.css( '.components-guide__container' );
-		if (
-			await driverHelper.isEventuallyPresentAndDisplayed(
-				this.driver,
-				welcomeModal,
-				this.explicitWaitMS / 5
-			)
-		) {
-			try {
-				// Easiest way to dismiss it, but it might not work in IE.
-				await this.driver.findElement( By.css( '.components-guide' ) ).sendKeys( Key.ESCAPE );
-			} catch {
-				// Click to the last page of the welcome guide.
-				await driverHelper.clickWhenClickable(
-					this.driver,
-					By.css( 'ul.components-guide__page-control li:last-child button' )
-				);
-				// Click the finish button.
-				await driverHelper.clickWhenClickable(
-					this.driver,
-					By.css( '.components-guide__finish-button' )
-				);
 			}
 		}
 	}

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -62,7 +62,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			await this.dismissPageTemplateSelector();
 		}
 		const editorWelcomeModal = new GuideComponent( this.driver );
-		await editorWelcomeModal.dismissModal( '.components-guide', 4000 );
+		await editorWelcomeModal.dismiss( '.components-guide', 4000 );
 		return await this.closeSidebar();
 	}
 

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -61,8 +61,8 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		if ( dismissPageTemplateSelector ) {
 			await this.dismissPageTemplateSelector();
 		}
-		const editorWelcomeModal = new GuideComponent( this.driver, 4000 );
-		await editorWelcomeModal.dismissModal( '.components-guide' );
+		const editorWelcomeModal = new GuideComponent( this.driver );
+		await editorWelcomeModal.dismissModal( '.components-guide', 4000 );
 		return await this.closeSidebar();
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a guide component for e2e tests and a dismissModal function.
* Dismisses nav-unification welcome modal on login of e2e tests.
* Refactors gutenberg component to use the guide component.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* e2e tests in Circle Ci should still pass
* running `env FLAGS='nav-unification' ./node_modules/.bin/mocha specs/wp-calypso-seo-preview.js` for `"calypsoBaseURL": "http://calypso.localhost:3000",` no longer reports `TimeoutError: Timed out waiting for element with css selector of 'header.masterbar a.masterbar__item'` to be clickable. It will report an other problem though which is sidebar related (https://github.com/Automattic/wp-calypso/issues/50174)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #50173
