### PR TITLE
Users: Make clear message less status aware

### DIFF
--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -73,7 +73,7 @@ export class PeopleInviteDetails extends React.PureComponent {
 		);
 		const clearMessage = translate(
 			'If you no longer wish to see this record, you can clear it. ' +
-				'The person will still remain a member of this site.'
+				"It will not effect the person's membership status."
 		);
 
 		return (

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -73,7 +73,7 @@ export class PeopleInviteDetails extends React.PureComponent {
 		);
 		const clearMessage = translate(
 			'If you no longer wish to see this record, you can clear it. ' +
-				"It will not effect the person's membership status."
+				"It will not affect the person's membership status."
 		);
 
 		return (


### PR DESCRIPTION
Fixes #50061

#### Changes proposed in this Pull Request

* Updates the message about clearing user invitations to not assume that person is still a member of the site.

#### Testing instructions

1. Go to My Site > Manage > Users > Invite > Invite a user
2. Once a user accepts the invite, check if the user is added to the role as expected
3. Remove the same user
4. Check in Invite > Invited people list here
5. You should see the user/email with Accepted status
6. Click on "Clear Invites" button

