### PR TITLE
Add context parameter support to Titan redirect page

### DIFF
--- a/client/lib/titan/constants.js
+++ b/client/lib/titan/constants.js
@@ -1,1 +1,3 @@
+export const TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL = 'create_email_account';
+export const TITAN_CONTROL_PANEL_CONTEXT_IMPORT_EMAIL = 'import_email';
 export const TITAN_MAIL_MONTHLY_SLUG = 'wp_titan_mail_monthly';

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -789,14 +789,14 @@ Undocumented.prototype.getTitanDetailsForIncomingRedirect = function ( mode, jwt
 /**
  * Retrieves the auto login link to Titan's control panel.
  *
- * @param orderId The Titan order ID
+ * @param emailAccountId The email account ID
  * @param context Optional context enum to launch into a specific part of the control panel
  * @param fn The callback function
  */
-Undocumented.prototype.getTitanControlPanelAutoLoginURL = function ( orderId, context, fn ) {
+Undocumented.prototype.getTitanControlPanelAutoLoginURL = function ( emailAccountId, context, fn ) {
 	return this.wpcom.req.get(
 		{
-			path: `/emails/titan/${ encodeURIComponent( orderId ) }/control-panel-auto-login-url`,
+			path: `/emails/titan/${ encodeURIComponent( emailAccountId ) }/control-panel-auto-login-url`,
 			apiNamespace: 'wpcom/v2',
 		},
 		{ context },
@@ -807,13 +807,13 @@ Undocumented.prototype.getTitanControlPanelAutoLoginURL = function ( orderId, co
 /**
  * Retrieves the URL to embed Titan's control panel in an iframe.
  *
- * @param orderId the Titan order ID
+ * @param emailAccountId The email account ID
  * @param fn The callback function
  */
-Undocumented.prototype.getTitanControlPanelIframeURL = function ( orderId, fn ) {
+Undocumented.prototype.getTitanControlPanelIframeURL = function ( emailAccountId, fn ) {
 	return this.wpcom.req.get(
 		{
-			path: `/emails/titan/${ encodeURIComponent( orderId ) }/control-panel-iframe-url`,
+			path: `/emails/titan/${ encodeURIComponent( emailAccountId ) }/control-panel-iframe-url`,
 			apiNamespace: 'wpcom/v2',
 		},
 		fn

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -789,15 +789,17 @@ Undocumented.prototype.getTitanDetailsForIncomingRedirect = function ( mode, jwt
 /**
  * Retrieves the auto login link to Titan's control panel.
  *
- * @param orderId the Titan order ID
+ * @param orderId The Titan order ID
+ * @param context Optional context enum to launch into a specific part of the control panel
  * @param fn The callback function
  */
-Undocumented.prototype.getTitanControlPanelAutoLoginURL = function ( orderId, fn ) {
+Undocumented.prototype.getTitanControlPanelAutoLoginURL = function ( orderId, context, fn ) {
 	return this.wpcom.req.get(
 		{
 			path: `/emails/titan/${ encodeURIComponent( orderId ) }/control-panel-auto-login-url`,
 			apiNamespace: 'wpcom/v2',
 		},
+		{ context },
 		fn
 	);
 };

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -67,6 +67,7 @@ export default {
 			<TitanControlPanelRedirect
 				domainName={ pageContext.params.domain }
 				siteSlug={ pageContext.params.site }
+				context={ pageContext.query.context }
 			/>
 		);
 

--- a/client/my-sites/email/email-management/titan-control-panel-redirect/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-redirect/index.jsx
@@ -29,6 +29,7 @@ import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powe
 class TitanControlPanelRedirect extends React.Component {
 	static propTypes = {
 		// Props
+		context: PropTypes.string,
 		domainName: PropTypes.string.isRequired,
 		siteSlug: PropTypes.string.isRequired,
 
@@ -58,18 +59,20 @@ class TitanControlPanelRedirect extends React.Component {
 		}
 
 		this._fetchTriggered = true;
-		const { domain, translate } = this.props;
+		const { context, domain, translate } = this.props;
 
-		fetchTitanAutoLoginURL( getTitanMailOrderId( domain ) ).then( ( { error, loginURL } ) => {
-			if ( error ) {
-				this._fetchTriggered = false;
-				this.props.errorNotice(
-					error ?? translate( 'An unknown error occurred. Please try again later.' )
-				);
-			} else {
-				window.location = loginURL;
+		fetchTitanAutoLoginURL( getTitanMailOrderId( domain ), context ).then(
+			( { error, loginURL } ) => {
+				if ( error ) {
+					this._fetchTriggered = false;
+					this.props.errorNotice(
+						error ?? translate( 'An unknown error occurred. Please try again later.' )
+					);
+				} else {
+					window.location = loginURL;
+				}
 			}
-		} );
+		);
 	}
 
 	render() {

--- a/client/my-sites/email/email-management/titan-functions.js
+++ b/client/my-sites/email/email-management/titan-functions.js
@@ -7,14 +7,16 @@
  */
 import wpcom from 'calypso/lib/wp';
 
-export const fetchTitanAutoLoginURL = ( orderId ) => {
+export const fetchTitanAutoLoginURL = ( orderId, context ) => {
 	return new Promise( ( resolve ) => {
-		wpcom.undocumented().getTitanControlPanelAutoLoginURL( orderId, ( serverError, result ) => {
-			resolve( {
-				error: serverError?.message,
-				loginURL: serverError ? null : result.auto_login_url,
+		wpcom
+			.undocumented()
+			.getTitanControlPanelAutoLoginURL( orderId, context, ( serverError, result ) => {
+				resolve( {
+					error: serverError?.message,
+					loginURL: serverError ? null : result.auto_login_url,
+				} );
 			} );
-		} );
 	} );
 };
 

--- a/client/my-sites/email/email-management/titan-functions.js
+++ b/client/my-sites/email/email-management/titan-functions.js
@@ -7,11 +7,11 @@
  */
 import wpcom from 'calypso/lib/wp';
 
-export const fetchTitanAutoLoginURL = ( orderId, context ) => {
+export const fetchTitanAutoLoginURL = ( emailAccountId, context ) => {
 	return new Promise( ( resolve ) => {
 		wpcom
 			.undocumented()
-			.getTitanControlPanelAutoLoginURL( orderId, context, ( serverError, result ) => {
+			.getTitanControlPanelAutoLoginURL( emailAccountId, context, ( serverError, result ) => {
 				resolve( {
 					error: serverError?.message,
 					loginURL: serverError ? null : result.auto_login_url,
@@ -20,9 +20,9 @@ export const fetchTitanAutoLoginURL = ( orderId, context ) => {
 	} );
 };
 
-export const fetchTitanIframeURL = ( orderId ) => {
+export const fetchTitanIframeURL = ( emailAccountId ) => {
 	return new Promise( ( resolve ) => {
-		wpcom.undocumented().getTitanControlPanelIframeURL( orderId, ( serverError, result ) => {
+		wpcom.undocumented().getTitanControlPanelIframeURL( emailAccountId, ( serverError, result ) => {
 			resolve( {
 				error: serverError?.message,
 				iframeURL: serverError ? null : result.iframe_url,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change adds client-side support for the `context` URL parameter that's being added to the back end in D57197-code. The end goal is to support launching into specific sections of the control panel when that's relevant.

This PR does **not** handle the client-side work to enable this feature for the embedded control panel that's run in an iframe.

#### Testing instructions

**Note:** If you're testing locally, you'll need to run with the `titan/iframe-control-panel` feature disabled (the easiest way to do that is by adding `?flags=-titan/iframe-control-panel` to the URL).

Ensure that the back end you're testing against has D57197-code applied/deployed.

* For a domain and site where you have a Titan/Email subscription with at least one unused mailbox, verify that the following links work as described:
    1. Navigate to `/email/[yourdomain]/titan/control-panel/[siteSlug]?context=create_email_account` and verify that the control panel opens the create account modal window in the `email-accounts` path.
    2. Navigate to `/email/[yourdomain]/titan/control-panel/[siteSlug]?context=import_email` and verify that the control panel opens the import email tab/section.
    3. Navigate to `/email/[yourdomain]/titan/control-panel/[siteSlug]` and verify that the control panel opens the `email-accounts` path.
    4. Navigate to `/email/[yourdomain]/titan/control-panel/[siteSlug]?context=bad-bad-bad` and verify that the control panel opens the `email-accounts` path.