### PR TITLE
Anchor Gutenboarding: Add error page for invalid podcast ids

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/anchor-error/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/anchor-error/index.tsx
@@ -1,13 +1,42 @@
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 /**
  * External dependencies
  */
 import * as React from 'react';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { Title } from '@automattic/onboarding';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const AnchorError: React.FunctionComponent = () => {
 	return (
-		<div className="gutenboarding-page">
-			Sorry, we were not able to locate that Anchor Podcast ID.{ ' ' }
-			<a href="https://anchor.fm">Return to anchor.</a>
+		<div className="anchor-error__container">
+			<div className="anchor-error__center">
+				<Title>{ __( 'We’re sorry!' ) }</Title>
+				<div className="anchor-error__text-container">
+					We’re unable to locate your podcast.
+					<br />
+					Return to Anchor or continue with site creation.
+				</div>
+
+				<div className="anchor-error__button-container">
+					<Button isPrimary href="/new" className="anchor-error__button">
+						{ __( 'Continue' ) }
+					</Button>
+				</div>
+				<div className="anchor-error__link-container">
+					<Button isLink href="https://anchor.fm">
+						{ __( 'Back to Anchor.fm' ) }
+					</Button>
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/anchor-error/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/anchor-error/index.tsx
@@ -17,7 +17,7 @@ import './style.scss';
 
 const AnchorError: React.FunctionComponent = () => {
 	return (
-		<div className="anchor-error__container">
+		<div className="anchor-error__flex-container">
 			<div className="anchor-error__center">
 				<Title>{ __( 'We’re sorry!' ) }</Title>
 				<div className="anchor-error__text-container">

--- a/client/landing/gutenboarding/onboarding-block/anchor-error/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/anchor-error/index.tsx
@@ -1,0 +1,14 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+const AnchorError: React.FunctionComponent = () => {
+	return (
+		<div className="gutenboarding-page">
+			Sorry, we were not able to locate that Anchor Podcast ID.{ ' ' }
+			<a href="https://anchor.fm">Return to anchor.</a>
+		</div>
+	);
+};
+export default AnchorError;

--- a/client/landing/gutenboarding/onboarding-block/anchor-error/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/anchor-error/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import * as React from 'react';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 
@@ -9,6 +10,7 @@ import { Button } from '@wordpress/components';
  * Internal dependencies
  */
 import { Title } from '@automattic/onboarding';
+import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 
 /**
  * Style dependencies
@@ -16,6 +18,14 @@ import { Title } from '@automattic/onboarding';
 import './style.scss';
 
 const AnchorError: React.FunctionComponent = () => {
+	const { setSiteTitle } = useDispatch( ONBOARD_STORE );
+
+	// If displaying this error, we don't want a title to display in the header.
+	// Clear title on load.
+	React.useEffect( () => {
+		setSiteTitle( '' );
+	}, [ setSiteTitle ] );
+
 	return (
 		<div className="anchor-error__flex-container">
 			<div className="anchor-error__center">

--- a/client/landing/gutenboarding/onboarding-block/anchor-error/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/anchor-error/index.tsx
@@ -27,13 +27,13 @@ const AnchorError: React.FunctionComponent = () => {
 				</div>
 
 				<div className="anchor-error__button-container">
-					<Button isPrimary href="/new" className="anchor-error__button">
-						{ __( 'Continue' ) }
+					<Button className="anchor-error__button" isPrimary href="/new">
+						<span>{ __( 'Continue' ) }</span>
 					</Button>
 				</div>
 				<div className="anchor-error__link-container">
-					<Button isLink href="https://anchor.fm">
-						{ __( 'Back to Anchor.fm' ) }
+					<Button className="anchor-error__link" isLink href="https://anchor.fm">
+						<span>{ __( 'Back to Anchor.fm' ) }</span>
 					</Button>
 				</div>
 			</div>

--- a/client/landing/gutenboarding/onboarding-block/anchor-error/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/anchor-error/index.tsx
@@ -31,9 +31,9 @@ const AnchorError: React.FunctionComponent = () => {
 			<div className="anchor-error__center">
 				<Title>{ __( 'We’re sorry!' ) }</Title>
 				<div className="anchor-error__text-container">
-					We’re unable to locate your podcast.
+					{ __( 'We’re unable to locate your podcast.' ) }
 					<br />
-					Return to Anchor or continue with site creation.
+					{ __( 'Return to Anchor or continue with site creation.' ) }
 				</div>
 
 				<div className="anchor-error__button-container">

--- a/client/landing/gutenboarding/onboarding-block/anchor-error/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/anchor-error/style.scss
@@ -15,6 +15,10 @@
 	text-align: center;
 }
 
+.anchor-error__text-container {
+	color: var( --studio-gray-60 );
+}
+
 .anchor-error__button-container {
 	margin-top: 2rem;
 	text-align: center;

--- a/client/landing/gutenboarding/onboarding-block/anchor-error/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/anchor-error/style.scss
@@ -1,0 +1,40 @@
+@import 'assets/stylesheets/gutenberg-base-styles';
+@import '~@automattic/calypso-color-schemes/src/calypso-color-schemes';
+@import '../../mixins';
+
+.anchor-error__flex-container {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-direction: column;
+	height: 80vh;
+}
+.anchor-error__center {
+	margin-top: 4em;
+	max-width: 640px;
+	text-align: center;
+}
+
+.anchor-error__button-container {
+	margin-top: 2rem;
+	text-align: center;
+}
+.anchor-error__button {
+	min-width: 150px;
+	& span {
+		margin: 0 auto;
+	}
+}
+
+.anchor-error__link-container {
+	margin-top: 1rem;
+}
+
+.anchor-error__link {
+	&.components-button.is-link:not( :disabled ), &.components-button.is-link:not( :disabled ) {
+		color: var( --studio-gray-40 );
+	}
+	&.components-button.is-link:hover:not( :disabled ), &.components-button.is-link:active:not( :disabled ) {
+		color: var( --studio-gray-60 );
+	}
+}

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -19,12 +19,14 @@ import {
 	useCurrentStep,
 	usePath,
 	useNewQueryParam,
+	useAnchorFmParams,
 } from '../path';
 import { usePrevious } from '../hooks/use-previous';
 import DesignSelector from './design-selector';
 import CreateSite from './create-site';
 import CreateSiteError from './create-site-error';
 import AcquireIntent from './acquire-intent';
+import AnchorError from './anchor-error';
 import StylePreview from './style-preview';
 import Features from './features';
 import Plans from './plans';
@@ -43,6 +45,7 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 	const newSiteError = useSelect( ( select ) => select( SITE_STORE ).getNewSiteError() );
 	const shouldTriggerCreate = useNewQueryParam();
 	const isAnchorFmSignup = useIsAnchorFm();
+	const { isAnchorFmPodcastIdError } = useAnchorFmParams();
 
 	const makePath = usePath();
 	const currentStep = useCurrentStep();
@@ -123,7 +126,7 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 			) }
 			<Switch>
 				<Route exact path={ makePath( Step.IntentGathering ) }>
-					<AcquireIntent />
+					{ isAnchorFmPodcastIdError ? <AnchorError /> : <AcquireIntent /> }
 				</Route>
 
 				<Route path={ makePath( Step.DesignSelection ) }>

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -116,6 +116,10 @@ export function useNewQueryParam() {
 
 export function useIsAnchorFm(): boolean {
 	const { anchorFmPodcastId } = useAnchorFmParams();
+	return isAnchorPodcastIdValid( anchorFmPodcastId );
+}
+
+function isAnchorPodcastIdValid( anchorFmPodcastId: string | null ): boolean {
 	return Boolean( anchorFmPodcastId && anchorFmPodcastId.match( /^[0-9a-f]{7,8}$/i ) );
 }
 
@@ -133,6 +137,7 @@ export interface AnchorFmParams {
 	anchorFmSite: string | null;
 	anchorFmPost: string | null;
 	anchorFmIsNewSite: string | null;
+	isAnchorFmPodcastIdError: boolean;
 }
 export function useAnchorFmParams(): AnchorFmParams {
 	const sanitizePodcast = ( id: string ) => id.replace( /[^a-zA-Z0-9]/g, '' );
@@ -141,6 +146,8 @@ export function useAnchorFmParams(): AnchorFmParams {
 		locationStateParamName: 'anchorFmPodcastId',
 		sanitize: sanitizePodcast,
 	} );
+	const isAnchorFmPodcastIdError =
+		anchorFmPodcastId !== null && ! isAnchorPodcastIdValid( anchorFmPodcastId );
 
 	// Allow all characters allowed in urls
 	// Reserved characters: !*'();:@&=+$,/?#[]
@@ -194,6 +201,7 @@ export function useAnchorFmParams(): AnchorFmParams {
 
 	return {
 		anchorFmPodcastId,
+		isAnchorFmPodcastIdError,
 		anchorFmEpisodeId,
 		anchorFmSpotifyUrl,
 		anchorFmSite,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The Acquire Intent page ("My Podcast is called ____") looks for invalid anchor IDs and shows a new error screen (needs design work).

![2021-02-17_13-45](https://user-images.githubusercontent.com/937354/108259204-6f9a2100-7126-11eb-896f-fc529d2808ed.png)


#### Testing instructions

* http://calypso.localhost:3000/new?anchor_podcast=:podcast-id
  *   Should show error
* http://calypso.localhost:3000/new?anchor_podcast=141c05c
  *  Should continue to work (anchor flavored gutenboarding)
* http://calypso.localhost:3000/new
  * Should continue to work (regular gutenboarding)

Related to 476-gh-Automattic/dotcom-manage