### PR TITLE
FSE: Hide font selection step from onboarding flow

### DIFF
--- a/client/landing/gutenboarding/hooks/use-steps.ts
+++ b/client/landing/gutenboarding/hooks/use-steps.ts
@@ -3,6 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useLocale } from '@automattic/i18n-utils';
+import { isEnabled } from '@automattic/calypso-config';
 
 /**
  * Internal dependencies
@@ -41,6 +42,11 @@ export default function useSteps(): Array< StepType > {
 			Step.Features,
 			Step.Plans,
 		];
+	}
+
+	// Remove the Style (fonts) step from the Site Editor flow.
+	if ( isEnabled( 'gutenboarding/site-editor' ) ) {
+		steps = steps.filter( ( step ) => step !== Step.Style );
 	}
 
 	// Logic necessary to skip Domains or Plans steps


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* remove the style (font selection) step from FSE onboarding

#### Testing instructions

* check out and build branch
* visit http://calypso.localhost:3000/new?flags=gutenboarding/site-editor
* verify that, after picking a theme, you are taken directly to the features step
* visit http://calypso.localhost:3000/new
* verify that, after picking a theme, you are presented with the style (font selection) step

Fixes #50085 
Supersedes #50194