### PR TITLE
Simplify Jetpack's signup flow with magic links

### DIFF
--- a/client/assets/images/illustrations/check-email-jetpack.svg
+++ b/client/assets/images/illustrations/check-email-jetpack.svg
@@ -1,0 +1,54 @@
+<svg width="208" height="245" viewBox="0 0 208 245" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g filter="url(#filter0_d)">
+        <path d="M32 116H176V185C176 191.627 170.627 197 164 197H44C37.3726 197 32 191.627 32 185V116Z" fill="white" />
+    </g>
+    <path
+        d="M99.3064 72.3624C102.247 70.5459 105.753 70.5459 108.694 72.3624L174.185 112.818C176.629 114.328 176.598 118.478 174.132 119.937L108.535 158.734C105.68 160.422 102.32 160.422 99.4654 158.734L33.8683 119.937C31.4017 118.478 31.3708 114.328 33.8153 112.818L99.3064 72.3624Z"
+        fill="url(#paint0_linear)" />
+    <mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="32" y="0" width="144" height="160">
+        <path
+            d="M99.3064 1.36381C102.247 -0.454601 105.753 -0.454605 108.694 1.36381L174.185 6.32397C176.629 7.83559 176.598 118.435 174.132 119.896L108.535 158.732C105.68 160.423 102.32 160.423 99.4654 158.732L33.8683 119.896C31.4017 118.435 31.3708 7.83559 33.8153 6.32397L99.3064 1.36381Z"
+            fill="#C4C4C4" />
+    </mask>
+    <g mask="url(#mask0)">
+        <g opacity="0.9" filter="url(#filter1_d)">
+            <rect x="52" y="50" width="104" height="140" rx="6" fill="white" />
+        </g>
+        <circle cx="104" cy="74" r="9" fill="#FAFAFA" />
+        <path fill-rule="evenodd" clip-rule="evenodd"
+            d="M114 74C114 79.5228 109.523 84 104 84C98.4772 84 94 79.5228 94 74C94 68.4772 98.4772 64 104 64C109.523 64 114 68.4772 114 74ZM103.485 75.6607V65.9851L98.5039 75.6607H103.485ZM104.496 72.3212V82.0159L109.496 72.3212H104.496Z"
+            fill="#069E08" />
+    </g>
+    <line x1="79.5" y1="97.5" x2="127.5" y2="97.5" stroke="#AAC6A1" stroke-width="7" stroke-linecap="round" />
+    <line x1="67" y1="113" x2="96" y2="113" stroke="#AAC6A1" stroke-width="4" stroke-linecap="round" />
+    <line x1="67" y1="121" x2="129" y2="121" stroke="#AAC6A1" stroke-width="4" stroke-linecap="round" />
+    <line x1="106" y1="113" x2="117" y2="113" stroke="#AAC6A1" stroke-width="4" stroke-linecap="round" />
+    <line x1="67" y1="130" x2="82" y2="130" stroke="#AAC6A1" stroke-width="4" stroke-linecap="round" />
+    <line x1="91" y1="130" x2="99" y2="130" stroke="#AAC6A1" stroke-width="4" stroke-linecap="round" />
+    <defs>
+        <filter id="filter0_d" x="0" y="100" width="208" height="145" filterUnits="userSpaceOnUse"
+            color-interpolation-filters="sRGB">
+            <feFlood flood-opacity="0" result="BackgroundImageFix" />
+            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" />
+            <feOffset dy="16" />
+            <feGaussianBlur stdDeviation="16" />
+            <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.16 0" />
+            <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow" />
+            <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape" />
+        </filter>
+        <filter id="filter1_d" x="30" y="32" width="148" height="184" filterUnits="userSpaceOnUse"
+            color-interpolation-filters="sRGB">
+            <feFlood flood-opacity="0" result="BackgroundImageFix" />
+            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" />
+            <feOffset dy="4" />
+            <feGaussianBlur stdDeviation="11" />
+            <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.16 0" />
+            <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow" />
+            <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape" />
+        </filter>
+        <linearGradient id="paint0_linear" x1="104" y1="71" x2="104" y2="160" gradientUnits="userSpaceOnUse">
+            <stop offset="0.34375" stop-color="#64CA43" />
+            <stop offset="0.786458" stop-color="#3E7E93" />
+        </linearGradient>
+    </defs>
+</svg>

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -558,6 +558,7 @@ export default connect(
 				redirectTo: stateProps.redirectTo,
 				loginFormFlow: true,
 				showGlobalNotices: true,
+				flow: ownProps.isJetpack ? 'jetpack' : null,
 			} ),
 	} )
 )( localize( Login ) );

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -364,7 +364,10 @@ class Login extends Component {
 				</p>
 			);
 		} else if ( isJetpack ) {
-			headerText = translate( 'Log in or create a WordPress.com account to set up Jetpack' );
+			const isJetpackMagicLinkSignUpFlow = config.isEnabled( 'jetpack/magic-link-signup' );
+			headerText = isJetpackMagicLinkSignUpFlow
+				? translate( 'Log in or create a WordPress.com account to get started with Jetpack' )
+				: translate( 'Log in or create a WordPress.com account to set up Jetpack' );
 			preHeader = (
 				<div className="login__jetpack-logo">
 					<AsyncLoad

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -52,6 +52,7 @@ import { getSignupUrl } from 'calypso/lib/login';
 import { isRegularAccount } from 'calypso/state/login/utils';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { preventWidows } from 'calypso/lib/formatting';
+import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { sendEmailLogin } from 'calypso/state/auth/actions';
 
@@ -269,9 +270,12 @@ export class LoginForm extends Component {
 
 		// Redirect user to the Magic Link form page
 		page(
-			`/log-in/jetpack/link?${ new globalThis.URLSearchParams( {
-				email_address: this.state.usernameOrEmail,
-			} ).toString() }`
+			addQueryArgs(
+				{
+					email_address: this.state.usernameOrEmail,
+				},
+				'/log-in/jetpack/link'
+			)
 		);
 	}
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -20,7 +20,6 @@ import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormsButton from 'calypso/components/forms/form-button';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import { addQueryArgs } from 'calypso/lib/url';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -8,6 +8,7 @@ import ReactDom from 'react-dom';
 import { capitalize, defer, includes, get } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -98,7 +99,7 @@ export class LoginForm extends Component {
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
-		const { disableAutoFocus, requestError, handleUsernameChange } = this.props;
+		const { currentRoute, disableAutoFocus, requestError, handleUsernameChange } = this.props;
 
 		if ( handleUsernameChange && prevState.usernameOrEmail !== this.state.usernameOrEmail ) {
 			handleUsernameChange( this.state.usernameOrEmail );
@@ -114,6 +115,16 @@ export class LoginForm extends Component {
 
 		if ( requestError.field === 'usernameOrEmail' ) {
 			! disableAutoFocus && defer( () => this.usernameOrEmail && this.usernameOrEmail.focus() );
+		}
+
+		// User entered an email address or username that doesn't have a corresponding WPCOM account
+		// and sign-up with magic links is enabled.
+		if (
+			currentRoute.includes( '/log-in/jetpack' ) &&
+			config.isEnabled( 'jetpack/magic-link-signup' ) &&
+			requestError.code === 'unknown_user'
+		) {
+			this.jetpackCreateAccountWithMagicLink();
 		}
 	}
 
@@ -237,6 +248,32 @@ export class LoginForm extends Component {
 	saveUsernameOrEmailRef = ( input ) => {
 		this.usernameOrEmail = input;
 	};
+
+	jetpackCreateAccountWithMagicLink() {
+		// When a user enters a username or an email address that doesn't have a corresponding
+		// WPCOM account, we need to figure out whether the user entered a username or an email
+		// address. If the user entered an email address, we can safely attempt to create a WPCOM
+		// account for this user with the help of magic links. On the other hand, if the user entered
+		// a username, we need to prompt the user specifically for an email address to proceed with
+		// the WPCOM account creation with magic links.
+
+		const isEmailAddress = includes( this.state.usernameOrEmail, '@' );
+		if ( isEmailAddress ) {
+			// With Magic Links, create the user a WPCOM account linked to the entered email address
+			this.props.sendEmailLogin( this.state.usernameOrEmail, {
+				redirectTo: this.props.redirectTo,
+				requestLoginEmailFormFlow: true,
+				createAccount: true,
+			} );
+		}
+
+		// Redirect user to the Magic Link form page
+		page(
+			`/log-in/jetpack/link?${ new globalThis.URLSearchParams( {
+				email_address: this.state.usernameOrEmail,
+			} ).toString() }`
+		);
+	}
 
 	renderPrivateSiteNotice() {
 		if ( this.props.privateSite && ! this.props.isLoggedIn ) {

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -121,6 +121,7 @@ export class LoginForm extends Component {
 		// User entered an email address or username that doesn't have a corresponding WPCOM account
 		// and sign-up with magic links is enabled.
 		if (
+			currentRoute &&
 			currentRoute.includes( '/log-in/jetpack' ) &&
 			config.isEnabled( 'jetpack/magic-link-signup' ) &&
 			requestError.code === 'unknown_user'

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -265,6 +265,7 @@ export class LoginForm extends Component {
 				redirectTo: this.props.redirectTo,
 				requestLoginEmailFormFlow: true,
 				createAccount: true,
+				flow: 'jetpack',
 			} );
 		}
 

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -168,6 +168,58 @@ class SocialLoginForm extends Component {
 		return `https://${ host + login( { isNative: true, socialService: service } ) }`;
 	};
 
+	renderSocialTos = () => {
+		const { redirectTo = '', translate } = this.props;
+
+		const isJetpackMagicLinkSignUpFlow =
+			redirectTo.includes( 'jetpack/connect' ) && config.isEnabled( 'jetpack/magic-link-signup' );
+		if ( isJetpackMagicLinkSignUpFlow ) {
+			return (
+				<>
+					<p className="login__social-tos">
+						{ translate( 'By continuing, you agree to our {{a}}Terms of Service{{/a}}.', {
+							components: {
+								a: (
+									<a
+										href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						} ) }
+					</p>
+					<p className="login__social-tos">
+						{ translate(
+							'If you continue with Google, Apple, or an email that isn’t registered yet,' +
+								' you are creating a new WordPress.com account.'
+						) }
+					</p>
+				</>
+			);
+		}
+		return (
+			<p className="login__social-tos">
+				{ translate(
+					"If you continue with Google or Apple and don't already have a WordPress.com account, you" +
+						' are creating an account and you agree to our' +
+						' {{a}}Terms of Service{{/a}}.',
+					{
+						components: {
+							a: (
+								<a
+									href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
+				) }
+			</p>
+		);
+	};
+
 	render() {
 		const { redirectTo, uxMode } = this.props;
 		const uxModeApple = config.isEnabled( 'sign-in-with-apple/redirect' ) ? 'redirect' : uxMode;
@@ -197,24 +249,7 @@ class SocialLoginForm extends Component {
 						}
 					/>
 
-					<p className="login__social-tos">
-						{ this.props.translate(
-							"If you continue with Google or Apple and don't already have a WordPress.com account, you" +
-								' are creating an account and you agree to our' +
-								' {{a}}Terms of Service{{/a}}.',
-							{
-								components: {
-									a: (
-										<a
-											href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-								},
-							}
-						) }
-					</p>
+					{ this.renderSocialTos() }
 				</div>
 
 				{ this.props.isSocialAccountCreating && (

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -169,10 +169,12 @@ class SocialLoginForm extends Component {
 	};
 
 	renderSocialTos = () => {
-		const { redirectTo = '', translate } = this.props;
+		const { redirectTo, translate } = this.props;
 
 		const isJetpackMagicLinkSignUpFlow =
-			redirectTo.includes( 'jetpack/connect' ) && config.isEnabled( 'jetpack/magic-link-signup' );
+			redirectTo &&
+			redirectTo.includes( 'jetpack/connect' ) &&
+			config.isEnabled( 'jetpack/magic-link-signup' );
 		if ( isJetpackMagicLinkSignUpFlow ) {
 			return (
 				<>

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -798,6 +798,9 @@ export class JetpackAuthorize extends Component {
 	render() {
 		const { translate } = this.props;
 		const wooDna = this.getWooDnaConfig();
+
+		const isJetpackMagicLinkSignUpFlow = config.isEnabled( 'jetpack/magic-link-signup' );
+
 		return (
 			<MainWrapper
 				isWoo={ this.isWooOnboarding() }
@@ -823,7 +826,7 @@ export class JetpackAuthorize extends Component {
 							{ this.renderNotices() }
 							{ this.renderStateAction() }
 						</Card>
-						{ this.renderFooterLinks() }
+						{ ! isJetpackMagicLinkSignUpFlow && this.renderFooterLinks() }
 					</div>
 				</div>
 			</MainWrapper>

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -301,7 +301,9 @@ export class JetpackAuthorize extends Component {
 	 */
 	isJetpackUpgradeFlow( props = this.props ) {
 		const { redirectAfterAuth } = props.authQuery;
-		return redirectAfterAuth.includes( 'page=jetpack&action=authorize_redirect' );
+		return (
+			redirectAfterAuth && redirectAfterAuth.includes( 'page=jetpack&action=authorize_redirect' )
+		);
 	}
 
 	isFromJetpackConnectionManager( props = this.props ) {

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -66,7 +66,12 @@ const DEFAULT_PROPS = deepFreeze( {
 
 jest.mock( '@automattic/calypso-config', () => {
 	const mock = () => 'development';
-	mock.isEnabled = jest.fn( () => true );
+	mock.isEnabled = jest.fn( ( featureFlag ) => {
+		if ( featureFlag === 'jetpack/magic-link-signup' ) {
+			return false;
+		}
+		return true;
+	} );
 	return mock;
 } );
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -97,15 +97,10 @@ export function magicLogin( context, next ) {
 }
 
 function getHandleEmailedLinkFormComponent( flow ) {
-	let component;
-	switch ( flow ) {
-		case 'jetpack-connect':
-			component = HandleEmailedLinkFormJetpackConnect;
-			break;
-		default:
-			component = HandleEmailedLinkForm;
+	if ( flow === 'jetpack-connect' && config.isEnabled( 'jetpack/magic-link-signup' ) ) {
+		return HandleEmailedLinkFormJetpackConnect;
 	}
-	return component;
+	return HandleEmailedLinkForm;
 }
 
 export function magicLoginUse( context, next ) {

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -97,7 +97,7 @@ export function magicLogin( context, next ) {
 }
 
 function getHandleEmailedLinkFormComponent( flow ) {
-	if ( flow === 'jetpack-connect' && config.isEnabled( 'jetpack/magic-link-signup' ) ) {
+	if ( flow === 'jetpack' && config.isEnabled( 'jetpack/magic-link-signup' ) ) {
 		return HandleEmailedLinkFormJetpackConnect;
 	}
 	return HandleEmailedLinkForm;
@@ -118,7 +118,7 @@ export function magicLoginUse( context, next ) {
 
 	const { client_id, email, redirect_to, token } = previousQuery;
 
-	const flow = includes( redirect_to, 'jetpack/connect' ) ? 'jetpack-connect' : null;
+	const flow = includes( redirect_to, 'jetpack/connect' ) ? 'jetpack' : null;
 
 	const PrimaryComponent = getHandleEmailedLinkFormComponent( flow );
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -10,6 +10,7 @@ import { includes } from 'lodash';
  */
 import config from '@automattic/calypso-config';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
+import HandleEmailedLinkFormJetpackConnect from './magic-login/handle-emailed-link-form-jetpack-connect';
 import MagicLogin from './magic-login';
 import WPLogin from './wp-login';
 import { getUrlParts } from 'calypso/lib/url';
@@ -95,6 +96,18 @@ export function magicLogin( context, next ) {
 	next();
 }
 
+function getHandleEmailedLinkFormComponent( flow ) {
+	let component;
+	switch ( flow ) {
+		case 'jetpack-connect':
+			component = HandleEmailedLinkFormJetpackConnect;
+			break;
+		default:
+			component = HandleEmailedLinkForm;
+	}
+	return component;
+}
+
 export function magicLoginUse( context, next ) {
 	/**
 	 * Pull the query arguments out of the URL & into the state.
@@ -108,10 +121,14 @@ export function magicLoginUse( context, next ) {
 
 	const previousQuery = context.state || {};
 
-	const { client_id, email, token } = previousQuery;
+	const { client_id, email, redirect_to, token } = previousQuery;
+
+	const flow = includes( redirect_to, 'jetpack/connect' ) ? 'jetpack-connect' : null;
+
+	const PrimaryComponent = getHandleEmailedLinkFormComponent( flow );
 
 	context.primary = (
-		<HandleEmailedLinkForm clientId={ client_id } emailAddress={ email } token={ token } />
+		<PrimaryComponent clientId={ client_id } emailAddress={ email } token={ token } />
 	);
 
 	next();

--- a/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
+++ b/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+
+import React, { FC, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import RedirectWhenLoggedIn from 'calypso/components/redirect-when-logged-in';
+import {
+	recordPageViewWithClientId as recordPageView,
+	enhanceWithSiteType,
+} from 'calypso/state/analytics/actions';
+import { withEnhancers } from 'calypso/state/utils';
+
+/**
+ * Image dependencies
+ */
+import checkEmailJetpackImage from 'calypso/assets/images/illustrations/check-email-jetpack.svg';
+
+interface Props {
+	emailAddress: string;
+}
+
+const EmailedLoginLinkSuccessfullyJetpackConnect: FC< Props > = ( { emailAddress } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	useEffect( () => {
+		const enhancedRecordPageView = withEnhancers( recordPageView, [ enhanceWithSiteType ] );
+		dispatch( enhancedRecordPageView( '/log-in/jetpack/link', 'Login > Link > Emailed' ) );
+	}, [] );
+
+	return (
+		<div className="magic-login__successfully-jetpack">
+			<RedirectWhenLoggedIn
+				redirectTo="/help"
+				replaceCurrentLocation={ true }
+				waitForEmailAddress={ emailAddress }
+			/>
+
+			<h1 className="magic-login__form-header">{ translate( 'Check your email!' ) }</h1>
+
+			<img
+				alt=""
+				src={ checkEmailJetpackImage }
+				className="magic-login__check-email-image jetpack"
+			/>
+
+			<p>
+				{ emailAddress
+					? translate( 'We just emailed a link to {{strong}}%(emailAddress)s{{/strong}}.', {
+							args: {
+								emailAddress,
+							},
+							components: {
+								strong: <strong />,
+							},
+					  } )
+					: translate( 'We just emailed you a link.' ) }
+			</p>
+			<p>{ translate( 'Please check your inbox and click the link to log in.' ) }</p>
+		</div>
+	);
+};
+
+export default EmailedLoginLinkSuccessfullyJetpackConnect;

--- a/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
+++ b/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
@@ -1,0 +1,125 @@
+/**
+ * External dependencies
+ */
+import React, { FC, useCallback, useEffect, useState } from 'react';
+import classNames from 'classnames';
+import { useDispatch, useSelector } from 'react-redux';
+import { isEmpty } from 'lodash';
+import page from 'page';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import EmptyContent from 'calypso/components/empty-content';
+import EmailedLoginLinkExpired from './emailed-login-link-expired';
+import { login } from 'calypso/lib/paths';
+import { LINK_EXPIRED_PAGE } from 'calypso/state/login/magic-login/constants';
+import {
+	fetchMagicLoginAuthenticate,
+	showMagicLoginLinkExpiredPage,
+} from 'calypso/state/login/magic-login/actions';
+import { rebootAfterLogin } from 'calypso/state/login/actions';
+import getMagicLoginCurrentView from 'calypso/state/selectors/get-magic-login-current-view';
+import getMagicLoginRequestAuthError from 'calypso/state/selectors/get-magic-login-request-auth-error';
+import getMagicLoginRequestedAuthSuccessfully from 'calypso/state/selectors/get-magic-login-requested-auth-successfully';
+import isFetchingMagicLoginAuth from 'calypso/state/selectors/is-fetching-magic-login-auth';
+import {
+	getRedirectToOriginal,
+	getRedirectToSanitized,
+	getTwoFactorNotificationSent,
+	isTwoFactorEnabled,
+} from 'calypso/state/login/selectors';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
+
+interface Props {
+	emailAddress: string;
+	token: string;
+}
+
+const HandleEmailedLinkFormJetpackConnect: FC< Props > = ( { emailAddress, token } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const [ hasSubmitted, setHasSubmitted ] = useState( false );
+
+	const redirectToOriginal = useSelector( ( state ) => getRedirectToOriginal( state ) || '' );
+	const redirectToSanitized = useSelector( ( state ) => getRedirectToSanitized( state ) );
+	const authError = useSelector( ( state ) => getMagicLoginRequestAuthError( state ) );
+	const isAuthenticated = useSelector( ( state ) =>
+		getMagicLoginRequestedAuthSuccessfully( state )
+	);
+	const isExpired = useSelector(
+		( state ) => getMagicLoginCurrentView( state ) === LINK_EXPIRED_PAGE
+	);
+	const isFetching = useSelector( ( state ) => isFetchingMagicLoginAuth( state ) );
+	const twoFactorEnabled = useSelector( ( state ) => isTwoFactorEnabled( state ) );
+	const twoFactorNotificationSent = useSelector( ( state ) =>
+		getTwoFactorNotificationSent( state )
+	);
+
+	useEffect( () => {
+		if ( isEmpty( emailAddress ) || isEmpty( token ) ) {
+			dispatch( showMagicLoginLinkExpiredPage() );
+		} else {
+			setHasSubmitted( true );
+			dispatch( fetchMagicLoginAuthenticate( token, redirectToOriginal ) );
+		}
+	}, [] );
+
+	// Lifted from `blocks/login`
+	// @TODO move to `state/login/actions` & use both places
+	const handleValidToken = useCallback( () => {
+		if ( ! twoFactorEnabled ) {
+			dispatch( rebootAfterLogin( { magic_login: 1 } ) );
+		} else {
+			page(
+				login( {
+					isNative: true,
+					// If no notification is sent, the user is using the authenticator for 2FA by default
+					twoFactorAuthType: twoFactorNotificationSent.replace( 'none', 'authenticator' ),
+					redirectTo: redirectToSanitized,
+				} )
+			);
+		}
+	}, [ dispatch ] );
+
+	useEffect( () => {
+		if ( ! hasSubmitted || isFetching ) {
+			// Don't do anything here unless the browser has received the `POST` response
+			return;
+		}
+
+		if ( authError || ! isAuthenticated ) {
+			// @TODO if this is a 5XX, or timeout, show an error...?
+			dispatch( showMagicLoginLinkExpiredPage() );
+			return;
+		}
+
+		handleValidToken();
+	}, [ authError, dispatch, handleValidToken, hasSubmitted, isAuthenticated, isFetching ] );
+
+	if ( isExpired ) {
+		return <EmailedLoginLinkExpired />;
+	}
+
+	const illustration = '/calypso/images/illustrations/' + 'illustration-nosites.svg';
+
+	dispatch( recordTracksEvent( 'calypso_login_email_link_handle_click_view' ) );
+
+	return (
+		<EmptyContent
+			className={ classNames( 'magic-login__handle-link', {
+				'magic-login__is-fetching-auth': isFetching,
+			} ) }
+			illustration={ illustration }
+			illustrationWidth={ 500 }
+			title={ translate( 'Logging in as %(emailAddress)s …', {
+				args: {
+					emailAddress,
+				},
+			} ) }
+		/>
+	);
+};
+
+export default HandleEmailedLinkFormJetpackConnect;

--- a/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
+++ b/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
@@ -4,7 +4,6 @@
 import React, { FC, useCallback, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
-import { isEmpty } from 'lodash';
 import page from 'page';
 import { useTranslate } from 'i18n-calypso';
 
@@ -31,6 +30,7 @@ import {
 	isTwoFactorEnabled,
 } from 'calypso/state/login/selectors';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
+import JetpackConnected from 'calypso/assets/images/jetpack/connected.svg';
 
 interface Props {
 	emailAddress: string;
@@ -58,7 +58,7 @@ const HandleEmailedLinkFormJetpackConnect: FC< Props > = ( { emailAddress, token
 	);
 
 	useEffect( () => {
-		if ( isEmpty( emailAddress ) || isEmpty( token ) ) {
+		if ( ! emailAddress || ! token ) {
 			dispatch( showMagicLoginLinkExpiredPage() );
 		} else {
 			setHasSubmitted( true );
@@ -102,18 +102,15 @@ const HandleEmailedLinkFormJetpackConnect: FC< Props > = ( { emailAddress, token
 		return <EmailedLoginLinkExpired />;
 	}
 
-	const illustration = '/calypso/images/illustrations/' + 'illustration-nosites.svg';
-
 	dispatch( recordTracksEvent( 'calypso_login_email_link_handle_click_view' ) );
 
 	return (
 		<EmptyContent
-			className={ classNames( 'magic-login__handle-link', {
-				'magic-login__is-fetching-auth': isFetching,
-			} ) }
-			illustration={ illustration }
-			illustrationWidth={ 500 }
-			title={ [
+			className="magic-login__handle-link jetpack"
+			illustration={ JetpackConnected }
+			illustrationWidth={ 150 }
+			title={ translate( 'Welcome back!' ) }
+			line={ [
 				translate( 'Logging in as %(emailAddress)s', {
 					args: {
 						emailAddress,

--- a/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
+++ b/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
@@ -113,11 +113,14 @@ const HandleEmailedLinkFormJetpackConnect: FC< Props > = ( { emailAddress, token
 			} ) }
 			illustration={ illustration }
 			illustrationWidth={ 500 }
-			title={ translate( 'Logging in as %(emailAddress)s …', {
-				args: {
-					emailAddress,
-				},
-			} ) }
+			title={ [
+				translate( 'Logging in as %(emailAddress)s', {
+					args: {
+						emailAddress,
+					},
+				} ),
+				'...',
+			] }
 		/>
 	);
 };

--- a/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
+++ b/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { FC, useCallback, useEffect, useState } from 'react';
-import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
 import page from 'page';
 import { useTranslate } from 'i18n-calypso';

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -142,18 +142,13 @@ class MagicLogin extends React.Component {
 	}
 
 	render() {
-		// If this is part of the Jetpack login flow and the feature flag is enabled,
-		// instruct the magic link API to create a user account when the email address
-		// doesn't have a corresponding WP.com account.
-		// doesn't have a corresponding a WP.com account.
-		const jetpackMagicLinkSignupFlowProps =
-			this.props.isJetpackLogin && config.isEnabled( 'jetpack/magic-link-signup' )
-				? { allowUserAccountCreation: true, isJetpackSignUp: true }
-				: {};
-
+		// If this is part of the Jetpack login flow and the `jetpack/magic-link-signup` feature
+		// flag is enabled, some steps will display a different UI
 		const requestLoginEmailFormProps = {
 			...( this.props.isJetpackLogin ? { flow: 'jetpack' } : {} ),
-			...jetpackMagicLinkSignupFlowProps,
+			...( this.props.isJetpackLogin && config.isEnabled( 'jetpack/magic-link-signup' )
+				? { isJetpackMagicLinkSignUpEnabled: true }
+				: {} ),
 		};
 
 		return (

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -145,12 +145,15 @@ class MagicLogin extends React.Component {
 		// If this is part of the Jetpack login flow and the feature flag is enabled,
 		// instruct the magic link API to create a user account when the email address
 		// doesn't have a corresponding WP.com account.
-		const allowUserAccountCreation =
-			this.props.isJetpackLogin && config.isEnabled( 'jetpack/magic-link-signup' );
+		// doesn't have a corresponding a WP.com account.
+		const jetpackMagicLinkSignupFlowProps =
+			this.props.isJetpackLogin && config.isEnabled( 'jetpack/magic-link-signup' )
+				? { allowUserAccountCreation: true, isJetpackSignUp: true }
+				: {};
 
 		const requestLoginEmailFormProps = {
 			...( this.props.isJetpackLogin ? { flow: 'jetpack' } : {} ),
-			allowUserAccountCreation,
+			...jetpackMagicLinkSignupFlowProps,
 		};
 
 		return (

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import config from '@automattic/calypso-config';
 import { login } from 'calypso/lib/paths';
 import { CHECK_YOUR_EMAIL_PAGE } from 'calypso/state/login/magic-login/constants';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
@@ -141,8 +142,15 @@ class MagicLogin extends React.Component {
 	}
 
 	render() {
-		const formProps = {
+		// If this is part of the Jetpack login flow and the feature flag is enabled,
+		// instruct the magic link API to create a user account when the email address
+		// doesn't have a corresponding WP.com account.
+		const allowUserAccountCreation =
+			this.props.isJetpackLogin && config.isEnabled( 'jetpack/magic-link-signup' );
+
+		const requestLoginEmailFormProps = {
 			...( this.props.isJetpackLogin ? { flow: 'jetpack' } : {} ),
+			allowUserAccountCreation,
 		};
 
 		return (
@@ -158,7 +166,7 @@ class MagicLogin extends React.Component {
 
 				<GlobalNotices id="notices" />
 
-				<RequestLoginEmailForm { ...formProps } />
+				<RequestLoginEmailForm { ...requestLoginEmailFormProps } />
 
 				{ this.renderLinks() }
 			</Main>

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -35,11 +35,10 @@ import { sendEmailLogin } from 'calypso/state/auth/actions';
 class RequestLoginEmailForm extends React.Component {
 	static propTypes = {
 		// mapped to state
-		allowUserAccountCreation: PropTypes.bool,
 		currentUser: PropTypes.object,
 		emailRequested: PropTypes.bool,
 		isFetching: PropTypes.bool,
-		isJetpackSignUp: PropTypes.bool,
+		isJetpackMagicLinkSignUpEnabled: PropTypes.bool,
 		redirectTo: PropTypes.string,
 		requestError: PropTypes.string,
 		showCheckYourEmail: PropTypes.bool,
@@ -92,7 +91,6 @@ class RequestLoginEmailForm extends React.Component {
 			redirectTo: this.props.redirectTo,
 			requestLoginEmailFormFlow: true,
 			...( this.props.flow ? { flow: this.props.flow } : {} ),
-			createAccount: this.props.allowUserAccountCreation,
 		} );
 	};
 
@@ -105,7 +103,7 @@ class RequestLoginEmailForm extends React.Component {
 			currentUser,
 			requestError,
 			isFetching,
-			isJetpackSignUp,
+			isJetpackMagicLinkSignUpEnabled,
 			emailRequested,
 			showCheckYourEmail,
 			translate,
@@ -116,7 +114,7 @@ class RequestLoginEmailForm extends React.Component {
 		if ( showCheckYourEmail ) {
 			const emailAddress = usernameOrEmail.indexOf( '@' ) > 0 ? usernameOrEmail : null;
 
-			return isJetpackSignUp ? (
+			return isJetpackMagicLinkSignUpEnabled ? (
 				<EmailedLoginLinkSuccessfullyJetpackConnect emailAddress={ emailAddress } />
 			) : (
 				<EmailedLoginLinkSuccessfully emailAddress={ emailAddress } />

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import EmailedLoginLinkSuccessfully from './emailed-login-link-successfully';
+import EmailedLoginLinkSuccessfullyJetpackConnect from './emailed-login-link-successfully-jetpack-connect';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -38,6 +39,7 @@ class RequestLoginEmailForm extends React.Component {
 		currentUser: PropTypes.object,
 		emailRequested: PropTypes.bool,
 		isFetching: PropTypes.bool,
+		isJetpackSignUp: PropTypes.bool,
 		redirectTo: PropTypes.string,
 		requestError: PropTypes.string,
 		showCheckYourEmail: PropTypes.bool,
@@ -103,6 +105,7 @@ class RequestLoginEmailForm extends React.Component {
 			currentUser,
 			requestError,
 			isFetching,
+			isJetpackSignUp,
 			emailRequested,
 			showCheckYourEmail,
 			translate,
@@ -112,7 +115,12 @@ class RequestLoginEmailForm extends React.Component {
 
 		if ( showCheckYourEmail ) {
 			const emailAddress = usernameOrEmail.indexOf( '@' ) > 0 ? usernameOrEmail : null;
-			return <EmailedLoginLinkSuccessfully emailAddress={ emailAddress } />;
+
+			return isJetpackSignUp ? (
+				<EmailedLoginLinkSuccessfullyJetpackConnect emailAddress={ emailAddress } />
+			) : (
+				<EmailedLoginLinkSuccessfully emailAddress={ emailAddress } />
+			);
 		}
 
 		const submitEnabled =

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -34,6 +34,7 @@ import { sendEmailLogin } from 'calypso/state/auth/actions';
 class RequestLoginEmailForm extends React.Component {
 	static propTypes = {
 		// mapped to state
+		allowUserAccountCreation: PropTypes.bool,
 		currentUser: PropTypes.object,
 		emailRequested: PropTypes.bool,
 		isFetching: PropTypes.bool,
@@ -89,6 +90,7 @@ class RequestLoginEmailForm extends React.Component {
 			redirectTo: this.props.redirectTo,
 			requestLoginEmailFormFlow: true,
 			...( this.props.flow ? { flow: this.props.flow } : {} ),
+			createAccount: this.props.allowUserAccountCreation,
 		} );
 	};
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -110,6 +110,10 @@
 	margin: 0 auto 1.5em;
 }
 
+.magic-login__check-email-image.jetpack {
+	height: 240px;
+}
+
 .magic-login.is-gutenboarding-login {
 	.magic-login__form-header {
 		@include onboarding-heading-text-mobile;
@@ -144,5 +148,11 @@
 
 	@include break-mobile {
 		padding: 8px 24px;
+	}
+}
+
+.magic-login__successfully-jetpack {
+	p {
+		text-align: center;
 	}
 }

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -20,6 +20,12 @@
 	}
 }
 
+.magic-login__handle-link.jetpack {
+	img {
+		margin: 80px 0;
+	}
+}
+
 .magic-login__request-link {
 	max-width: 400px;
 }

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from '@automattic/calypso-config';
 import AutomatticLogo from 'calypso/components/automattic-logo';
 import DocumentHead from 'calypso/components/data/document-head';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
@@ -222,9 +223,14 @@ export class Login extends React.Component {
 			return <PrivateSite />;
 		}
 
+		const isJetpackMagicLinkSignUpFlow =
+			isJetpack && config.isEnabled( 'jetpack/magic-link-signup' );
+
+		const shouldRenderFooter = ! socialConnect && ! isJetpackMagicLinkSignUpFlow;
+
 		const footer = (
 			<>
-				{ ! socialConnect && (
+				{ shouldRenderFooter && (
 					<LoginLinks
 						locale={ locale }
 						privateSite={ privateSite }

--- a/client/state/auth/actions.js
+++ b/client/state/auth/actions.js
@@ -9,13 +9,14 @@ import 'calypso/state/data-layer/wpcom/auth/send-login-email';
  * Sends an email with a link that allows a user to login WordPress.com or the native apps
  *
  * @param {string} email - email to send to
- * @param {object} options -
+ * @param {object} options object:
  * @param {string} options.redirectTo - url to redirect to after login
  * @param {boolean} options.loginFormFlow - if true, dispatches actions associated with passwordless login
  * @param {boolean} options.requestLoginEmailFormFlow - if true, dispatches actions associated with email me login
  * @param {boolean} options.isMobileAppLogin - if true, will send an email that allows login to the native apps
  * @param {boolean} options.showGlobalNotices - if true, displays global notices to user about the email
  * @param {string} options.flow - name of the login flow
+ * @param {boolean} options.createAccount - if true, instructs the API to create a WPCOM account associated with email
  * @returns {object} action object
  */
 export const sendEmailLogin = (
@@ -27,6 +28,7 @@ export const sendEmailLogin = (
 		requestLoginEmailFormFlow = false,
 		isMobileAppLogin = false,
 		flow = null,
+		createAccount = false,
 	}
 ) => {
 	//Kind of weird usage, but this is a straight port from undocumented.js for now.
@@ -45,5 +47,6 @@ export const sendEmailLogin = (
 		loginFormFlow,
 		requestLoginEmailFormFlow,
 		flow,
+		createAccount,
 	};
 };

--- a/client/state/data-layer/wpcom/auth/send-login-email/index.js
+++ b/client/state/data-layer/wpcom/auth/send-login-email/index.js
@@ -36,6 +36,7 @@ export const sendLoginEmail = ( action ) => {
 		requestLoginEmailFormFlow,
 		isMobileAppLogin,
 		flow,
+		createAccount,
 	} = action;
 	const noticeAction = showGlobalNotices
 		? infoNotice( translate( 'Sending email' ), { duration: 4000 } )
@@ -50,6 +51,13 @@ export const sendLoginEmail = ( action ) => {
 			: [] ),
 		...( loginFormFlow
 			? [ recordTracksEventWithClientId( 'calypso_login_block_login_form_send_magic_link' ) ]
+			: [] ),
+		...( createAccount
+			? [
+					recordTracksEventWithClientId(
+						'calypso_login_block_login_form_send_account_create_magic_link'
+					),
+			  ]
 			: [] ),
 		http(
 			{
@@ -66,6 +74,7 @@ export const sendLoginEmail = ( action ) => {
 					email: email,
 					...( redirect_to && { redirect_to } ),
 					...( flow && { flow } ),
+					create_account: createAccount,
 				},
 			},
 			{ ...action, infoNoticeId: noticeAction ? noticeAction.notice.noticeId : null }

--- a/config/development.json
+++ b/config/development.json
@@ -94,6 +94,7 @@
 		"jetpack/backups-restore": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/personal-plan": false,
+		"jetpack/magic-link-signup": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,
 		"lasagna": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -62,6 +62,7 @@
 		"jetpack/anti-spam-product": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/personal-plan": false,
+		"jetpack/magic-link-signup": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,
 		"lasagna": true,

--- a/config/production.json
+++ b/config/production.json
@@ -64,6 +64,7 @@
 		"jetpack/on-demand-scan": true,
 		"jetpack/backups-restore": true,
 		"jetpack/personal-plan": false,
+		"jetpack/magic-link-signup": false,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -66,6 +66,7 @@
 		"jetpack/on-demand-scan": true,
 		"jetpack/backups-restore": true,
 		"jetpack/personal-plan": false,
+		"jetpack/magic-link-signup": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace the Jetpack's sign-up form with an automatic account creation based on magic links. The idea is to decrease the friction users have to go through in order to setup Jetpack. Instead of asking users to pick an email address, create a username and a password, we will only prompt them for an email address and create the account behind the scene.

#### Notes

* Do not focus on the copy. This is proof of concept focused only on providing a quick version of new the signup flow.

#### Testing instructions

* Download this PR.
* Run `yarn start` to fire up Calypso Blue.
* Open an incognito window (Google Chrome or Firefox are good browser choices).
* Create a Jurassic Ninja site or get a self-hosted site.
* Initiate Jetpack's setup flow.
* Make sure that you're redirected to `/log-in/jetpack` (we don't want to go through the in-place connection flow).
* Copy your browser URL and paste it in a new tab (we are going to test different flows so keep a copy of this first URL).

**Login flow (or nothing has changed)**
* Enter a valid username or email address that has a corresponding WPCOM account.
* Complete the login flow.
* Make sure that you're logged in and everything worked exactly as in production.

**Signup flow (email provided)**
* Enter a valid email address that **doesn't** have a corresponding WPCOM account.
* Verify that you're redirected to the magic link confirmation page (it tells you that an email was sent to you).
* Go to your email inbox and click the CTA of the email you received.
* Verify that a WPCOM account was created and linked to the email you provided and that you're logged in to the application.

**Signup flow (username provided)**
* Enter a username that **doesn't** have a corresponding WPCOM account.
* Verify that you're redirected to the magic link form page (you're prompt for an email address).
* Enter a valid email address that doesn't have a corresponding WPCOM account.
* Verify that you're redirected to the magic link confirmation page (it tells you that an email was sent to you).
* Go to your email inbox and click the CTA of the email you received.
* Verify that a WPCOM account was created and linked to the email you provided and that you're logged in to the application.

Related to 1199916399796129-as-1199945743087583

#### Demo
https://user-images.githubusercontent.com/3418513/109978193-625f6380-7cdc-11eb-8cff-c1b6260c8c0a.mp4

#### Screenshots for translators
**Log in or create a WordPress.com account to get started with Jetpack**
<img width="462" alt="T1" src="https://user-images.githubusercontent.com/3418513/110352929-41b54780-8015-11eb-846e-cede2da55eac.png">

**If you continue with Google, Apple, or an email that isn’t registered yet, you are creating a new WordPress.com account.**
<img width="462" alt="T2" src="https://user-images.githubusercontent.com/3418513/110352922-3feb8400-8015-11eb-992e-8a05fbff2c2e.png">

**We just emailed a link to {{strong}}%(emailAddress)s{{/strong}}.**
<img src="https://user-images.githubusercontent.com/3418513/110352906-3bbf6680-8015-11eb-8d88-ee4a8a516dc0.png" width="462" />
