### PR TITLE
Editing Toolkit: Update to v2.20

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.19
+ * Version: 2.20
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'A8C_ETK_PLUGIN_VERSION', '2.19' );
+define( 'A8C_ETK_PLUGIN_VERSION', '2.20' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.5
 Tested up to: 5.6
-Stable tag: 2.19
+Stable tag: 2.20
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -40,6 +40,17 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 == Changelog ==
 View the commit history here: https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit
+
+= 2.20 =
+* Move page template modal into its own package (https://github.com/Automattic/wp-calypso/pull/49661)
+* Patterns: Reveal the Featured pattern category and make it the first in the list (https://github.com/Automattic/wp-calypso/pull/49907)
+* Focused Launch - Summary View: Fix incorrect HE support link (https://github.com/Automattic/wp-calypso/pull/50115)
+* Update Newspack Blocks to v1.21.0 (https://github.com/Automattic/wp-calypso/pull/50154)
+* Focused Launch: Only launch site if checkout is complete (https://github.com/Automattic/wp-calypso/pull/48452)
+* Launch: Cleanup calypsoifyGutenberg (https://github.com/Automattic/wp-calypso/pull/49067)
+* Remove Anchor-specific welcome guide (https://github.com/Automattic/wp-calypso/pull/50161)
+* Patterns: Allow custom viewport width when registering patterns (https://github.com/Automattic/wp-calypso/pull/49906)
+* Disable premium block patterns feature due to performance issues (https://github.com/Automattic/wp-calypso/pull/50111)
 
 = 2.19 =
 * Unhide draft button when site hasn't launched yet. (https://github.com/Automattic/wp-calypso/pull/49766)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -51,6 +51,8 @@ View the commit history here: https://github.com/Automattic/wp-calypso/commits/t
 * Remove Anchor-specific welcome guide (https://github.com/Automattic/wp-calypso/pull/50161)
 * Patterns: Allow custom viewport width when registering patterns (https://github.com/Automattic/wp-calypso/pull/49906)
 * Disable premium block patterns feature due to performance issues (https://github.com/Automattic/wp-calypso/pull/50111)
+* Focused Launch: Fix billing period tracking in summary (https://github.com/Automattic/wp-calypso/pull/49930)
+* Focused Launch: Fix domain picker item flex spacing (https://github.com/Automattic/wp-calypso/pull/49883)
 
 = 2.19 =
 * Unhide draft button when site hasn't launched yet. (https://github.com/Automattic/wp-calypso/pull/49766)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -42,6 +42,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 View the commit history here: https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit
 
 = 2.20 =
+* Page layout picker: Fix broken web fonts in page layout picker large preview (https://github.com/Automattic/wp-calypso/pull/50253)
 * Move page template modal into its own package (https://github.com/Automattic/wp-calypso/pull/49661)
 * Patterns: Reveal the Featured pattern category and make it the first in the list (https://github.com/Automattic/wp-calypso/pull/49907)
 * Focused Launch - Summary View: Fix incorrect HE support link (https://github.com/Automattic/wp-calypso/pull/50115)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.19.0",
+	"version": "2.20.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bump version of Editing Toolkit plugin to 2.20

## [Editing toolkit changes included in this release](https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit)

* [ ] remove negative left margin (https://github.com/Automattic/wp-calypso/pull/50250) @Addison-Stavlo 
* [x] Launch: Fix logic to compute redirectToWpcomPath origin (https://github.com/Automattic/wp-calypso/pull/50241) @ciampo
* [x] Tidy up after recent Focused Launch checkout changes (https://github.com/Automattic/wp-calypso/pull/50182) @ciampo
* [x] i18n: Add missing translators comments in ETK components (https://github.com/Automattic/wp-calypso/pull/50190) @yuliyan 
* [x] Disable premium block patterns feature due to performance issues (https://github.com/Automattic/wp-calypso/pull/50111) @andrewserong 
* [x] Patterns: Allow custom viewport width when registering patterns (https://github.com/Automattic/wp-calypso/pull/49906) @andrewserong 
* [x] Remove Anchor-specific welcome guide (https://github.com/Automattic/wp-calypso/pull/50161) @allilevine 
* [x] Launch: Cleanup calypsoifyGutenberg (https://github.com/Automattic/wp-calypso/pull/49067) @yansern @ciampo 
* [x] Focused Launch: Only launch site if checkout is complete (https://github.com/Automattic/wp-calypso/pull/48452) @StefanNieuwenhuis  @razvanpapadopol 
* [x] chore(@automattic/page-template-modal): Use the same dependencies than ETK (https://github.com/Automattic/wp-calypso/pull/50114) @scinos @roo2 
* [x] Update Newspack Blocks to v1.21.0 (https://github.com/Automattic/wp-calypso/pull/50154) @dkoo 
* [x] Focused Launch - Summary View: Fix incorrect HE support link (https://github.com/Automattic/wp-calypso/pull/50115) @StefanNieuwenhuis 
* [x] Patterns: Reveal the Featured pattern category and make it the first in the list (https://github.com/Automattic/wp-calypso/pull/49907) @andrewserong 
* [x] Move page template modal into its own package (https://github.com/Automattic/wp-calypso/pull/49661)  @roo2

### Other [changes](https://github.com/Automattic/wp-calypso/commits/trunk/packages) included from the [imported @automattic packages](https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/tsconfig.json#L37-L46) and their imports

* [x] Page layout picker: Fix broken web fonts in page layout picker large preview (https://github.com/Automattic/wp-calypso/pull/50253)
* [x] Billing: Hide disallowed payment methods when changing payment method (https://github.com/Automattic/wp-calypso/pull/49959) @sirbrillig (Does this change affect the ETK release? I don't _think_ so, but we might want to double check)
* [x] Focused Launch: Fix billing period tracking in summary (https://github.com/Automattic/wp-calypso/pull/49930) @ciampo
* [x] Focused Launch: Fix domain picker item flex spacing (https://github.com/Automattic/wp-calypso/pull/49883) @ciampo
* [x] plans-grid: Fix translators comment format (https://github.com/Automattic/wp-calypso/pull/50191) @yuliyan 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Load the diff on your sandbox (D57237-code) and confirm that the above changes work correctly
2. When a change has been tested to work correctly, please mark it as checked in the list above
3. Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.
   * [x] Tested on atomic with and without Gutenberg plugin active
