### PR TITLE
New onboarding: remove `/gutenboarding` dev flow rerouter 

### DIFF
--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -42,26 +42,13 @@ function generateGetSuperProps() {
 }
 
 type Site = SiteStore.SiteDetails;
-
 interface AppWindow extends Window {
 	BUILD_TARGET?: string;
 }
+
 declare const window: AppWindow;
 
-/**
- * Handle redirects from development phase
- * TODO: Remove after a few months. See section definition as well.
- */
-const DEVELOPMENT_BASENAME = '/gutenboarding';
-
 window.AppBoot = async () => {
-	if ( window.location.pathname.startsWith( DEVELOPMENT_BASENAME ) ) {
-		const url = new URL( window.location.href );
-		url.pathname = 'new' + url.pathname.substring( DEVELOPMENT_BASENAME.length );
-		window.location.replace( url.toString() );
-		return;
-	}
-
 	setupWpDataDebug();
 	// User is left undefined here because the user account will not be created
 	// until after the user has completed the gutenboarding flow.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Over in https://github.com/Automattic/wp-calypso/pull/44485 we removed the section definition for `/gutenboarding`. Since then `/gutenboarding` alias route has no longer worked.

The `/gutenboarding` alias route that was used during early stages of development.

This PR removes a piece of code that handled redirects from `/gutenboarding`.

There are also some low-effort formatting changes.

#### Testing instructions

Fire up this branch and head to `/new` 

The onboarding flow should work as expected, and the apocalypse delayed for another cycle.

Fixes #50086
