### PR TITLE
Media library: Don't photonize VideoPress poster images

### DIFF
--- a/client/my-sites/media-library/list-item-video.jsx
+++ b/client/my-sites/media-library/list-item-video.jsx
@@ -11,7 +11,7 @@ import React from 'react';
 import resize from 'calypso/lib/resize-image-url';
 import ListItemFileDetails from './list-item-file-details';
 import Gridicon from 'calypso/components/gridicon';
-import { MEDIA_IMAGE_THUMBNAIL } from 'calypso/lib/media/constants';
+import { MEDIA_IMAGE_THUMBNAIL, SCALE_CHOICES } from 'calypso/lib/media/constants';
 
 /**
  * Style dependencies
@@ -24,13 +24,23 @@ export default class extends React.Component {
 
 	static propTypes = {
 		media: PropTypes.object,
+		scale: PropTypes.number,
+		maxScale: PropTypes.number,
 		maxImageWidth: PropTypes.number,
 		thumbnailType: PropTypes.string,
 	};
 
 	static defaultProps = {
 		maxImageWidth: 450,
+		maxScale: SCALE_CHOICES[ SCALE_CHOICES.length - 1 ],
 	};
+
+	static getDerivedStateFromProps( props, state ) {
+		const maxSeenScale = state.maxSeenScale || 0;
+		return props.scale > maxSeenScale ? { maxSeenScale: props.scale } : null;
+	}
+
+	state = {};
 
 	getHighestQualityThumbnail = () => {
 		if ( this.props.media.thumbnails ) {
@@ -47,10 +57,14 @@ export default class extends React.Component {
 
 		if ( thumbnail ) {
 			// Non MEDIA_IMAGE_THUMBNAIL video media is accessible via Photon
+			const width = Math.round(
+				( 1 / this.props.maxScale ) * this.state.maxSeenScale * this.props.maxImageWidth
+			);
+
 			const url =
 				this.props.thumbnailType === MEDIA_IMAGE_THUMBNAIL
 					? thumbnail
-					: resize( thumbnail, { w: this.props.maxImageWidth } );
+					: resize( thumbnail, { resize: `${ width },${ width }` } );
 
 			return <MediaFile src={ url } component={ ListItemVideo } placeholder={ ListItemVideo } />;
 		}

--- a/client/my-sites/media-library/list-item-video.jsx
+++ b/client/my-sites/media-library/list-item-video.jsx
@@ -4,11 +4,11 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import photon from 'photon';
 
 /**
  * Internal dependencies
  */
+import resize from 'calypso/lib/resize-image-url';
 import ListItemFileDetails from './list-item-file-details';
 import Gridicon from 'calypso/components/gridicon';
 import { MEDIA_IMAGE_THUMBNAIL } from 'calypso/lib/media/constants';
@@ -50,7 +50,7 @@ export default class extends React.Component {
 			const url =
 				this.props.thumbnailType === MEDIA_IMAGE_THUMBNAIL
 					? thumbnail
-					: photon( thumbnail, { width: this.props.maxImageWidth } );
+					: resize( thumbnail, { w: this.props.maxImageWidth } );
 
 			return <MediaFile src={ url } component={ ListItemVideo } placeholder={ ListItemVideo } />;
 		}

--- a/client/my-sites/media-library/test/list-item-video.jsx
+++ b/client/my-sites/media-library/test/list-item-video.jsx
@@ -6,13 +6,13 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
-import photon from 'photon';
 import React from 'react';
 
 /**
  * Internal dependencies
  */
 import fixtures from './fixtures';
+import resize from 'calypso/lib/resize-image-url';
 import ListItemVideo from 'calypso/my-sites/media-library/list-item-video';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
@@ -53,11 +53,14 @@ describe( 'MediaLibraryListItem video', () => {
 	} );
 
 	const expectedBackground = () =>
-		styleUrl( photon( fixtures.media[ 1 ].thumbnails.fmt_hd, { width: WIDTH } ) );
+		styleUrl(
+			resize( fixtures.media[ 1 ].thumbnails.fmt_hd, { resize: `${ WIDTH },${ WIDTH }` } )
+		);
 	const getItem = ( type ) => (
 		<ListItemVideo
 			media={ fixtures.media[ 1 ] }
 			scale={ 1 }
+			maxScale={ 1 }
 			maxImageWidth={ WIDTH }
 			thumbnailType={ type }
 		/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates video thumbnails in the media library so that VideoPress poster image URLs are not passed through Photon, but instead have regular wpcom-images resize params applied.

This didn't use to be possible, as `videos . files . wordpress . com` did not support direct image resize parameters like other `* . files . wordpress . com` domains. However, this was addressed in D49897-code (more background in pxWta-Rs-p2).

The result of the change in this PR is that we're not unnecessarily Photon-wrapping those images and, more importantly, this fixes an issue where video thumbnails wouldn't load for any private VideoPress-enabled WP.com site (because Photon couldn't access those private URLs).

Note: I replicated some of the work added for image thumbnails in https://github.com/Automattic/wp-calypso/pull/30542 so that the same scaling rules are applied to video thumbnails.

#### Testing instructions

* Without this patch, open the media library for any private, VideoPress-enabled WordPress.com site: https://wordpress.com/media/videos/some-wpcom-site-url
* Notice that video thumbnails don't load, and observing the network log shows the media requests fails with 403 errors
* Apply this patch and revisit the media library
* Observe thumbnails load
* Inspect network requests and verify that the images are being correctly resized