### PR TITLE
ci(e2e): Run full e2e suite in TeamCity

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1010,6 +1010,9 @@ object RunCalypsoE2eDesktopTests : BuildType({
 
 	failureConditions {
 		executionTimeoutMin = 20
+		// This will mute tests that failed but eventually passed. Muted tests
+		// will be run in future builds, but they won't be reported as "failing"
+		supportTestRetry = true
 	}
 
 	dependencies {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -837,7 +837,7 @@ object CheckCodeStyleBranch : BuildType({
 object RunCalypsoE2eDesktopTests : BuildType({
 	uuid = "52f38738-92b2-43cb-b7fb-19fce03cb67c"
 	name = "Run Calypso e2e tests (desktop)"
-	description = "Run Calypso e2e tests"
+	description = "Run Calypso e2e tests (desktop)"
 
 	artifactRules = """
 		reports => reports
@@ -1011,6 +1011,7 @@ object RunCalypsoE2eDesktopTests : BuildType({
 	failureConditions {
 		executionTimeoutMin = 20
 		// With testFailure=true, TeamCity detects test that fail but succeed after a retry as build failures
+		// With this option disabled, TeamCity fails the build if `yarn magellan` returns an exit code other than 0.
 		testFailure = false
 	}
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -836,8 +836,8 @@ object CheckCodeStyleBranch : BuildType({
 
 object RunCalypsoE2eDesktopTests : BuildType({
 	uuid = "52f38738-92b2-43cb-b7fb-19fce03cb67c"
-	name = "Run Calypso e2e tests (desktop)"
-	description = "Run Calypso e2e tests (desktop)"
+	name = "Run browser e2e tests (desktop)"
+	description = "Run browser e2e tests (desktop)"
 
 	artifactRules = """
 		reports => reports
@@ -1035,7 +1035,7 @@ object WpCalypso : GitVcsRoot({
 })
 
 object WpDesktop : Project({
-	name = "Desktop"
+	name = "Desktop app"
 	buildType(WpDesktop_DesktopE2ETests)
 
 	params {
@@ -1047,7 +1047,7 @@ object WpDesktop : Project({
 })
 
 object WpDesktop_DesktopE2ETests : BuildType({
-	name = "Desktop e2e tests"
+	name = "Run e2e tests"
 	description = "Run wp-desktop e2e tests in Linux"
 
 	artifactRules = """

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -835,7 +835,7 @@ object CheckCodeStyleBranch : BuildType({
 })
 
 object RunCalypsoE2eDesktopTests : BuildType({
-	id(RunCanaryE2eTests)
+	id("calypso_RunCanaryE2eTests")
 	name = "Run Calypso e2e tests (desktop)"
 	description = "Run Calypso e2e tests"
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1010,9 +1010,6 @@ object RunCalypsoE2eDesktopTests : BuildType({
 
 	failureConditions {
 		executionTimeoutMin = 20
-		// This will mute tests that failed but eventually passed. Muted tests
-		// will be run in future builds, but they won't be reported as "failing"
-		supportTestRetry = true
 	}
 
 	dependencies {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -835,7 +835,7 @@ object CheckCodeStyleBranch : BuildType({
 })
 
 object RunCalypsoE2eDesktopTests : BuildType({
-	id("calypso_RunCanaryE2eTests")
+	uuid = "52f38738-92b2-43cb-b7fb-19fce03cb67c"
 	name = "Run Calypso e2e tests (desktop)"
 	description = "Run Calypso e2e tests"
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -975,7 +975,6 @@ object RunCalypsoE2eDesktopTests : BuildType({
 			type = "xml-report-plugin"
 			param("xmlReportParsing.reportType", "junit")
 			param("xmlReportParsing.reportDirs", "test/e2e/temp/**/reports/*.xml")
-			param("xmlReportParsing.logInternalSystemError", "true");
 		}
 		perfmon {
 		}
@@ -1011,6 +1010,8 @@ object RunCalypsoE2eDesktopTests : BuildType({
 
 	failureConditions {
 		executionTimeoutMin = 20
+		// With testFailure=true, TeamCity detects test that fail but succeed after a retry as build failures
+		testFailure = false
 	}
 
 	dependencies {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -48,7 +48,7 @@ project {
 	buildType(CheckCodeStyle)
 	buildType(CheckCodeStyleBranch)
 	buildType(BuildDockerImage)
-	buildType(RunCanaryE2eTests)
+	buildType(RunCalypsoE2eDesktopTests)
 
 	params {
 		param("env.NODE_OPTIONS", "--max-old-space-size=32000")
@@ -834,9 +834,10 @@ object CheckCodeStyleBranch : BuildType({
 	}
 })
 
-object RunCanaryE2eTests : BuildType({
-	name = "Canary e2e tests"
-	description = "Run canary e2e tests"
+object RunCalypsoE2eDesktopTests : BuildType({
+	id(RunCanaryE2eTests)
+	name = "Run Calypso e2e tests (desktop)"
+	description = "Run Calypso e2e tests"
 
 	artifactRules = """
 		reports => reports
@@ -874,7 +875,7 @@ object RunCanaryE2eTests : BuildType({
 			dockerRunParameters = "-u %env.UID%"
 		}
 		script {
-			name = "Run e2e tests: Canary (mobile, desktop)"
+			name = "Run e2e tests (desktop)"
 			scriptContent = """
 				#!/bin/bash
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -975,6 +975,7 @@ object RunCalypsoE2eDesktopTests : BuildType({
 			type = "xml-report-plugin"
 			param("xmlReportParsing.reportType", "junit")
 			param("xmlReportParsing.reportDirs", "test/e2e/temp/**/reports/*.xml")
+			param("xmlReportParsing.logInternalSystemError", "true");
 		}
 		perfmon {
 		}
@@ -1010,9 +1011,6 @@ object RunCalypsoE2eDesktopTests : BuildType({
 
 	failureConditions {
 		executionTimeoutMin = 20
-		// This will mute tests that failed but eventually passed. Muted tests
-		// will be run in future builds, but they won't be reported as "failing"
-		supportTestRetry = true
 	}
 
 	dependencies {

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -163,8 +163,10 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 
 				options.addArguments( '--app=https://www.wordpress.com' );
 
+				console.log( 'CHROMERIVER PATH', chromedriver.path );
+
 				// eslint-disable-next-line no-case-declarations
-				const service = new chrome.ServiceBuilder( chromedriver.path )
+				const service = new chrome.ServiceBuilder()
 					.loggingTo( './chromedriver.' + process.pid + '.log' )
 					.enableVerboseLogging()
 					.build();

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -142,7 +142,6 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 				} );
 				options.setProxy( getProxyType() );
 				options.addArguments( '--no-first-run' );
-				options.addArguments( '--disable-dev-shm-usage' );
 				options.addArguments( '--no-sandbox' );
 
 				if ( useCustomUA ) {

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import webdriver from 'selenium-webdriver';
-import chromedriver from 'chromedriver'; // eslint-disable-line no-unused-vars
 import firefox from 'selenium-webdriver/firefox';
 import chrome from 'selenium-webdriver/chrome';
 import config from 'config';
@@ -162,8 +161,6 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 				}
 
 				options.addArguments( '--app=https://www.wordpress.com' );
-
-				console.log( 'CHROMERIVER PATH', chromedriver.path );
 
 				// eslint-disable-next-line no-case-declarations
 				const service = new chrome.ServiceBuilder()


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates build 'Canary e2e tests' to run all Calypso e2e tests, equivalent to the CircleCI build 'ci/wp-e2e-tests-full-desktop'.

Next steps once this is merged and run for a few days:
- [ ] Verify the build is more reliable (and hopefully faster) than the CircleCI counterpart
- [ ] Create a clone of this build for mobile
- [ ] Add @signup tests

 
#### Testing instructions

Check the results of 'Canary e2e tests (Calypso)' in this PR to see it working (name change will take effect once merged)