### PR TITLE
chore(test/e2e/): Add missing packages

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -48,7 +48,7 @@ project {
 	buildType(CheckCodeStyle)
 	buildType(CheckCodeStyleBranch)
 	buildType(BuildDockerImage)
-	buildType(RunCanaryE2eTests)
+	buildType(RunBrowserE2eTests)
 
 	params {
 		param("env.NODE_OPTIONS", "--max-old-space-size=32000")
@@ -801,9 +801,10 @@ object CheckCodeStyleBranch : BuildType({
 	}
 })
 
-object RunCanaryE2eTests : BuildType({
-	name = "Canary e2e tests"
-	description = "Run canary e2e tests"
+object RunBrowserE2eTests : BuildType({
+	id("calypso_RunBrowserE2eTests")
+	name = "Browser e2e tests"
+	description = "Run e2e tests in a browser"
 
 	artifactRules = """
 		reports => reports
@@ -841,7 +842,7 @@ object RunCanaryE2eTests : BuildType({
 			dockerRunParameters = "-u %env.UID%"
 		}
 		script {
-			name = "Run e2e tests: Canary (mobile, desktop)"
+			name = "Run e2e tests"
 			scriptContent = """
 				#!/bin/bash
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -891,7 +891,7 @@ object RunCanaryE2eTests : BuildType({
 				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
 
 				# Run the test
-				./run.sh -R -a %E2E_WORKERS% -C -s "mobile,desktop" -u "${'$'}{URL%/}"
+				./run.sh -R -a %E2E_WORKERS% -g -s "mobile,desktop" -u "${'$'}{URL%/}"
 			""".trimIndent()
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 			dockerImage = "%docker_image_e2e%"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -48,7 +48,7 @@ project {
 	buildType(CheckCodeStyle)
 	buildType(CheckCodeStyleBranch)
 	buildType(BuildDockerImage)
-	buildType(RunBrowserE2eTests)
+	buildType(RunCanaryE2eTests)
 
 	params {
 		param("env.NODE_OPTIONS", "--max-old-space-size=32000")
@@ -801,10 +801,9 @@ object CheckCodeStyleBranch : BuildType({
 	}
 })
 
-object RunBrowserE2eTests : BuildType({
-	id("calypso_RunBrowserE2eTests")
-	name = "Browser e2e tests"
-	description = "Run e2e tests in a browser"
+object RunCanaryE2eTests : BuildType({
+	name = "Canary e2e tests"
+	description = "Run canary e2e tests"
 
 	artifactRules = """
 		reports => reports
@@ -842,7 +841,7 @@ object RunBrowserE2eTests : BuildType({
 			dockerRunParameters = "-u %env.UID%"
 		}
 		script {
-			name = "Run e2e tests"
+			name = "Run e2e tests: Canary (mobile, desktop)"
 			scriptContent = """
 				#!/bin/bash
 
@@ -892,7 +891,7 @@ object RunBrowserE2eTests : BuildType({
 				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
 
 				# Run the test
-				./run.sh -R -a %E2E_WORKERS% -g -s "mobile,desktop" -u "${'$'}{URL%/}"
+				./run.sh -R -a %E2E_WORKERS% -C -s "mobile,desktop" -u "${'$'}{URL%/}"
 			""".trimIndent()
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 			dockerImage = "%docker_image_e2e%"

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -37,6 +37,7 @@
 		"esformatter-semicolons": "^1.1.2",
 		"esformatter-special-bangs": "^1.0.1",
 		"esm": "^3.2.25",
+		"execa": "^5.0.0",
 		"ffmpeg-static": "^2.4.0",
 		"fs-extra": "^0.22.1",
 		"grunt": "^1.0.3",

--- a/test/e2e/test/mocha.env.js
+++ b/test/e2e/test/mocha.env.js
@@ -1,10 +1,6 @@
-process.env.SELENIUM_PROMISE_MANAGER = '0';
-
-/**
- * External dependencies (can also be listed in the root package.json)
- */
-// eslint-disable-next-line import/no-extraneous-dependencies
 const execa = require( 'execa' );
+
+process.env.SELENIUM_PROMISE_MANAGER = '0';
 
 // Make sure that chromedriver is installed before running tests
 try {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds missing packages to `test/e2e/package.json`. It fixes:

```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/test/e2e/package.json
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/test/e2e/test/mocha.env.js:7:15: Undeclared dependency on execa
➤ YN0000: └ Completed in 28s 327ms
```

#### Testing instructions

Run `cd test/e2e && npx @yarnpkg/doctor` and verify the error above is gone (there may be other errors related to user scripts prefixed with "pre" or "post")