### PR TITLE
chroe(wp-babel-makepot): Add missing dev dependencies

### DIFF
--- a/packages/wp-babel-makepot/package.json
+++ b/packages/wp-babel-makepot/package.json
@@ -38,7 +38,9 @@
 		"lodash.mergewith": "^4.6.2"
 	},
 	"devDependencies": {
+		"i18n-calypso": "^5.0.0",
 		"jest": "^26.4.0",
+		"react": "^16.12.0",
 		"rimraf": "^3.0.0"
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds missing dependencies. It fixes

```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/wp-babel-makepot/package.json
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/wp-babel-makepot/test/examples/translate-2.js:4:1: Undeclared dependency on i18n-calypso
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/wp-babel-makepot/test/examples/typescript-react.tsx:4:1: Undeclared dependency on react
➤ YN0000: └ Completed in 1s 700ms
```

Note that the dependencies are not actually used, they are only required from test files. That's why I added them as dev dependencies.


#### Testing instructions

Run `cd packages/wp-babel-makepot && npx @yarnpkg/doctor` and verify the error above is gone (there may be other errors)
