### PR TITLE
Design picker: add Blank Canvas to available-designs-config

### DIFF
--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -1,6 +1,20 @@
 {
 	"featured": [
 		{
+			"title": "Start with an empty page",
+			"slug": "blank-canvas",
+			"template": "blank-canvas",
+			"theme": "blank-canvas",
+			"fonts": {
+				"headings": "Playfair Display",
+				"base": "Fira Sans"
+			},
+			"categories": [ "featured" ],
+			"is_premium": false,
+			"is_fse": false,
+			"features": []
+		},
+		{
 			"title": "Seedlet",
 			"slug": "seedlet-blocks",
 			"template": "seedlet-blocks",
@@ -12,6 +26,7 @@
 			"categories": [ "featured" ],
 			"is_premium": false,
 			"is_fse": true,
+			"is_alpha": true,
 			"features": []
 		},
 		{

--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -12,6 +12,7 @@
 			"categories": [ "featured" ],
 			"is_premium": false,
 			"is_fse": false,
+			"is_alpha": true,
 			"features": []
 		},
 		{
@@ -26,7 +27,6 @@
 			"categories": [ "featured" ],
 			"is_premium": false,
 			"is_fse": true,
-			"is_alpha": true,
 			"features": []
 		},
 		{


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/51979

- Adds "blank canvas" prototype design, hidden behind alpha-flag.
- Doesn't ensure it's location or appearance otherwise, but that should be fairly straightforward to add.

Test: https://calypso.live/new/design?branch=add/design-picker-blank-canvas

<img width="854" alt="image" src="https://user-images.githubusercontent.com/87168/108330602-741e1280-71d6-11eb-8825-cd73cad6fe3e.png">
