### PR TITLE
fix(account): adjust `top` value for site selector search field

### DIFF
--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -24,6 +24,10 @@
 	width: 100%;
 }
 
+.account__settings-form .sites-dropdown .site-selector .search {
+	top: 57px;
+}
+
 .account__link-destination .components-toggle-control__label {
 	color: var( --color-text-subtle );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adjust `top` value for the site selector search field in the account settings age

#### Testing instructions

* Follow the instructions in #50219 and make sure the bug is fixed
* Make sure other usages are not affected by this change

Fixes #50219
