### PR TITLE
Redux persistence tests: use serialization helpers

### DIFF
--- a/client/extensions/wp-super-cache/state/plugins/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/plugins/test/reducer.js
@@ -17,8 +17,8 @@ import {
 	WP_SUPER_CACHE_TOGGLE_PLUGIN_SUCCESS,
 } from '../../action-types';
 import { items, requesting, toggling } from '../reducer';
-import { SERIALIZE, DESERIALIZE } from 'calypso/state/action-types';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
+import { serialize, deserialize } from 'calypso/state/utils';
 
 describe( 'reducer', () => {
 	const primarySiteId = 123456;
@@ -227,9 +227,7 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should persist state', () => {
-			const state = items( previousState, {
-				type: SERIALIZE,
-			} );
+			const state = serialize( items, previousState );
 
 			expect( state ).to.eql( {
 				[ primarySiteId ]: primaryPlugins,
@@ -237,9 +235,7 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should load valid persisted state', () => {
-			const state = items( previousState, {
-				type: DESERIALIZE,
-			} );
+			const state = deserialize( items, previousState );
 
 			expect( state ).to.eql( {
 				[ primarySiteId ]: primaryPlugins,
@@ -252,9 +248,7 @@ describe( 'reducer', () => {
 					[ primarySiteId ]: 2,
 				},
 			} );
-			const state = items( previousInvalidState, {
-				type: DESERIALIZE,
-			} );
+			const state = deserialize( items, previousInvalidState );
 
 			expect( state ).to.eql( {} );
 		} );

--- a/client/extensions/wp-super-cache/state/settings/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/settings/test/reducer.js
@@ -21,7 +21,7 @@ import {
 	WP_SUPER_CACHE_SAVE_SETTINGS_SUCCESS,
 } from '../../action-types';
 import reducer, { items, restoring } from '../reducer';
-import { SERIALIZE, DESERIALIZE } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -298,9 +298,7 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should persist state', () => {
-			const state = reducer( previousState, {
-				type: SERIALIZE,
-			} );
+			const state = serialize( reducer, previousState );
 
 			expect( state.root().items ).to.eql( {
 				[ primarySiteId ]: primarySettings,
@@ -308,9 +306,7 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should load valid persisted state', () => {
-			const state = reducer( previousState, {
-				type: DESERIALIZE,
-			} );
+			const state = deserialize( reducer, previousState );
 
 			expect( state.items ).to.eql( {
 				[ primarySiteId ]: primarySettings,
@@ -323,9 +319,7 @@ describe( 'reducer', () => {
 					[ primarySiteId ]: 2,
 				},
 			} );
-			const state = reducer( previousInvalidState, {
-				type: DESERIALIZE,
-			} );
+			const state = deserialize( reducer, previousInvalidState );
 
 			expect( state.items ).to.eql( {} );
 		} );

--- a/client/extensions/wp-super-cache/state/stats/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/stats/test/reducer.js
@@ -17,7 +17,7 @@ import {
 	WP_SUPER_CACHE_GENERATE_STATS_SUCCESS,
 } from '../../action-types';
 import reducer, { generating } from '../reducer';
-import { DESERIALIZE, SERIALIZE } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -236,9 +236,7 @@ describe( 'reducer', () => {
 			} );
 
 			test( 'should persist state', () => {
-				const state = reducer( previousState, {
-					type: SERIALIZE,
-				} );
+				const state = serialize( reducer, previousState );
 
 				expect( state.root().items ).to.eql( {
 					[ primarySiteId ]: primaryStats,
@@ -246,9 +244,7 @@ describe( 'reducer', () => {
 			} );
 
 			test( 'should load valid persisted state', () => {
-				const state = reducer( previousState, {
-					type: DESERIALIZE,
-				} );
+				const state = deserialize( reducer, previousState );
 
 				expect( state.items ).to.eql( {
 					[ primarySiteId ]: primaryStats,
@@ -261,9 +257,7 @@ describe( 'reducer', () => {
 						[ primarySiteId ]: 2,
 					},
 				} );
-				const state = reducer( previousInvalidState, {
-					type: DESERIALIZE,
-				} );
+				const state = deserialize( reducer, previousInvalidState );
 
 				expect( state.items ).to.eql( {} );
 			} );

--- a/client/extensions/wp-super-cache/state/status/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/status/test/reducer.js
@@ -13,7 +13,7 @@ import {
 	WP_SUPER_CACHE_REQUEST_STATUS_FAILURE,
 } from '../../action-types';
 import reducer from '../reducer';
-import { SERIALIZE, DESERIALIZE } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -168,9 +168,7 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should persist state', () => {
-			const state = reducer( previousState, {
-				type: SERIALIZE,
-			} );
+			const state = serialize( reducer, previousState );
 
 			expect( state.root().items ).to.eql( {
 				[ primarySiteId ]: primaryNotices,
@@ -178,9 +176,7 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should load valid persisted state', () => {
-			const state = reducer( previousState, {
-				type: DESERIALIZE,
-			} );
+			const state = deserialize( reducer, previousState );
 
 			expect( state.items ).to.eql( {
 				[ primarySiteId ]: primaryNotices,
@@ -193,9 +189,7 @@ describe( 'reducer', () => {
 					[ primarySiteId ]: 2,
 				},
 			} );
-			const state = reducer( previousInvalidState, {
-				type: DESERIALIZE,
-			} );
+			const state = deserialize( reducer, previousInvalidState );
 
 			expect( state.items ).to.eql( {} );
 		} );

--- a/client/extensions/zoninator/state/zones/test/reducer.js
+++ b/client/extensions/zoninator/state/zones/test/reducer.js
@@ -17,7 +17,7 @@ import {
 	ZONINATOR_UPDATE_ZONES,
 } from '../../action-types';
 import reducer, { requesting, items, saving } from '../reducer';
-import { DESERIALIZE, SERIALIZE } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 
 describe( 'reducer', () => {
 	const primarySiteId = 123456;
@@ -214,9 +214,7 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should persist state', () => {
-			const state = items( previousState, {
-				type: SERIALIZE,
-			} );
+			const state = serialize( items, previousState );
 
 			expect( state ).to.deep.equal( {
 				[ primarySiteId ]: {
@@ -226,9 +224,7 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should load valid persisted state', () => {
-			const state = items( previousState, {
-				type: DESERIALIZE,
-			} );
+			const state = deserialize( items, previousState );
 
 			expect( state ).to.deep.equal( {
 				[ primarySiteId ]: {
@@ -242,9 +238,7 @@ describe( 'reducer', () => {
 				[ primarySiteId ]: 2,
 			} );
 
-			const state = items( previousInvalidState, {
-				type: DESERIALIZE,
-			} );
+			const state = deserialize( items, previousInvalidState );
 
 			expect( state ).to.deep.equal( {} );
 		} );

--- a/client/state/active-promotions/test/reducer.js
+++ b/client/state/active-promotions/test/reducer.js
@@ -21,6 +21,7 @@ import activePromotionsReducer, {
 
 import { WPCOM_RESPONSE } from './fixture';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
+import { serialize, deserialize } from 'calypso/state/utils';
 
 describe( 'reducer', () => {
 	let sandbox;
@@ -73,13 +74,12 @@ describe( 'reducer', () => {
 		test( 'should persist state', () => {
 			const activePromotions = WPCOM_RESPONSE;
 			const initialState = activePromotions;
-			const action = { type: 'SERIALIZE' };
 			const expectedState = activePromotions;
 
 			deepFreeze( initialState );
 			deepFreeze( expectedState );
 
-			const newState = itemsReducer( initialState, action );
+			const newState = serialize( itemsReducer, initialState );
 
 			expect( newState ).to.eql( expectedState );
 		} );
@@ -87,12 +87,11 @@ describe( 'reducer', () => {
 		test( 'should load persisted state', () => {
 			const activePromotions = WPCOM_RESPONSE;
 			const initialState = activePromotions;
-			const action = { type: 'DESERIALIZE' };
 			const expectedState = activePromotions;
 			deepFreeze( initialState );
 			deepFreeze( expectedState );
 
-			const newState = itemsReducer( initialState, action );
+			const newState = deserialize( itemsReducer, initialState );
 
 			expect( newState ).to.eql( expectedState );
 		} );
@@ -101,12 +100,11 @@ describe( 'reducer', () => {
 			// each entry should be `string`
 			const activePromotions = [ 1234 ];
 			const initialState = activePromotions;
-			const action = { type: 'DESERIALIZE' };
 			deepFreeze( initialState );
 			const expectedState = [];
 			deepFreeze( expectedState );
 
-			const newState = itemsReducer( initialState, action );
+			const newState = deserialize( itemsReducer, initialState );
 
 			expect( newState ).to.eql( expectedState );
 		} );

--- a/client/state/admin-menu/test/reducer.js
+++ b/client/state/admin-menu/test/reducer.js
@@ -7,12 +7,8 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import menuFixture from './fixture/menu-fixture';
-import {
-	ADMIN_MENU_RECEIVE,
-	ADMIN_MENU_REQUEST,
-	DESERIALIZE,
-	SERIALIZE,
-} from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
+import { ADMIN_MENU_RECEIVE, ADMIN_MENU_REQUEST } from 'calypso/state/action-types';
 import { menus as menusReducer, requesting as requestingReducer } from '../reducer';
 
 describe( 'reducer', () => {
@@ -72,9 +68,7 @@ describe( 'reducer', () => {
 					123456: menuFixture,
 				} );
 
-				const action = { type: SERIALIZE };
-
-				const serializationResult = menusReducer( initialState, action ).root();
+				const serializationResult = serialize( menusReducer, initialState ).root();
 
 				expect( serializationResult ).toEqual( {
 					123456: menuFixture,
@@ -86,9 +80,7 @@ describe( 'reducer', () => {
 					123456: menuFixture,
 				} );
 
-				const action = { type: DESERIALIZE };
-
-				expect( menusReducer( stateToDeserialize, action ) ).toEqual( {
+				expect( deserialize( menusReducer, stateToDeserialize ) ).toEqual( {
 					123456: menuFixture,
 				} );
 			} );
@@ -127,14 +119,14 @@ describe( 'reducer', () => {
 					// see: https://github.com/Automattic/wp-calypso/blob/02c3a452881ff89fce240c09d16874c0c4e4d429/client/state/utils/schema-utils.js#L14
 					jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
 
-					// This is the state that will be returned for the `DESERIALIZE` action
+					// This is the state that will be returned for the `deserialize` call
 					// if the persisted state fails schema validation
 					const defaultReducerState = deepFreeze( {} );
 
 					// This is the state to be validated against the schema.
 					const stateToDeserialize = deepFreeze( persistedState );
 
-					const state = menusReducer( stateToDeserialize, { type: DESERIALIZE } );
+					const state = deserialize( menusReducer, stateToDeserialize );
 					expect( state ).toEqual( defaultReducerState );
 				}
 			);

--- a/client/state/automated-transfer/test/reducer.js
+++ b/client/state/automated-transfer/test/reducer.js
@@ -6,14 +6,13 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
+import { serialize, deserialize } from 'calypso/state/utils';
 import { transferStates } from '../constants';
 import reducer, { status, fetchingStatus } from '../reducer';
 import {
 	AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE as ELIGIBILITY_UPDATE,
 	AUTOMATED_TRANSFER_STATUS_REQUEST as REQUEST_STATUS,
 	AUTOMATED_TRANSFER_STATUS_REQUEST_FAILURE as REQUEST_STATUS_FAILURE,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
 
 describe( 'state', () => {
@@ -61,12 +60,12 @@ describe( 'state', () => {
 					},
 				};
 
-				const serialized = reducer( AT_STATE, { type: SERIALIZE } ).root();
+				const serialized = serialize( reducer, AT_STATE ).root();
 				expect( serialized[ SITE_ID ] ).to.have.property( 'status' );
 				expect( serialized[ SITE_ID ] ).to.have.property( 'eligibility' );
 				expect( serialized[ SITE_ID ] ).to.not.have.property( 'fetchingStatus' );
 
-				const deserialized = reducer( AT_STATE, { type: DESERIALIZE } );
+				const deserialized = deserialize( reducer, AT_STATE );
 				expect( deserialized[ SITE_ID ] ).to.have.property( 'status' );
 				expect( deserialized[ SITE_ID ] ).to.have.property( 'eligibility' );
 				// The non-persisted property has default value, persisted value is ignored

--- a/client/state/billing-transactions/test/reducer.js
+++ b/client/state/billing-transactions/test/reducer.js
@@ -16,9 +16,8 @@ import {
 	BILLING_TRANSACTIONS_REQUEST,
 	BILLING_TRANSACTIONS_REQUEST_FAILURE,
 	BILLING_TRANSACTIONS_REQUEST_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -127,30 +126,19 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should persist state', () => {
-			const state = items( deepFreeze( billingTransactions ), {
-				type: SERIALIZE,
-			} );
+			const state = serialize( items, deepFreeze( billingTransactions ) );
 
 			expect( state ).to.eql( billingTransactions );
 		} );
 
 		test( 'should load valid persisted state', () => {
-			const state = items( deepFreeze( billingTransactions ), {
-				type: DESERIALIZE,
-			} );
+			const state = deserialize( items, deepFreeze( billingTransactions ) );
 
 			expect( state ).to.eql( billingTransactions );
 		} );
 
 		test( 'should not load invalid persisted state', () => {
-			const state = items(
-				deepFreeze( {
-					example: 'test',
-				} ),
-				{
-					type: DESERIALIZE,
-				}
-			);
+			const state = deserialize( items, deepFreeze( { example: 'test' } ) );
 
 			expect( state ).to.eql( {} );
 		} );

--- a/client/state/country-states/test/reducer.js
+++ b/client/state/country-states/test/reducer.js
@@ -13,9 +13,8 @@ import {
 	COUNTRY_STATES_REQUEST,
 	COUNTRY_STATES_REQUEST_FAILURE,
 	COUNTRY_STATES_REQUEST_SUCCESS,
-	DESERIALIZE,
-	SERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 const originalCountryStates = [
@@ -61,13 +60,13 @@ describe( 'reducer', () => {
 		describe( 'persistence', () => {
 			test( 'persists state', () => {
 				const original = deepFreeze( { us: originalCountryStates } );
-				const state = items( original, { type: SERIALIZE } );
+				const state = serialize( items, original );
 				expect( state ).to.eql( original );
 			} );
 
 			test( 'loads valid persisted state', () => {
 				const original = deepFreeze( { us: originalCountryStates } );
-				const state = items( original, { type: DESERIALIZE } );
+				const state = deserialize( items, original );
 
 				expect( state ).to.eql( original );
 			} );
@@ -78,7 +77,7 @@ describe( 'reducer', () => {
 					AK: 'Alaska',
 					AS: 'American Samoa',
 				} );
-				const state = items( original, { type: DESERIALIZE } );
+				const state = deserialize( items, original );
 				expect( state ).to.eql( {} );
 			} );
 		} );

--- a/client/state/current-user/test/reducer.js
+++ b/client/state/current-user/test/reducer.js
@@ -8,11 +8,10 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import reducer, { id, capabilities, currencyCode } from '../reducer';
+import { serialize, deserialize } from 'calypso/state/utils';
 import {
 	CURRENT_USER_RECEIVE,
-	DESERIALIZE,
 	PLANS_RECEIVE,
-	SERIALIZE,
 	SITE_RECEIVE,
 	SITE_PLANS_FETCH_COMPLETED,
 	SITES_RECEIVE,
@@ -54,34 +53,22 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should validate ID is positive', () => {
-			const state = id( -1, {
-				type: DESERIALIZE,
-			} );
-
+			const state = deserialize( id, -1 );
 			expect( state ).to.equal( null );
 		} );
 
 		test( 'should validate ID is a number', () => {
-			const state = id( 'foobar', {
-				type: DESERIALIZE,
-			} );
-
+			const state = deserialize( id, 'foobar' );
 			expect( state ).to.equal( null );
 		} );
 
 		test( 'returns valid ID', () => {
-			const state = id( 73705554, {
-				type: DESERIALIZE,
-			} );
-
+			const state = deserialize( id, 73705554 );
 			expect( state ).to.equal( 73705554 );
 		} );
 
 		test( 'will SERIALIZE current user', () => {
-			const state = id( 73705554, {
-				type: SERIALIZE,
-			} );
-
+			const state = serialize( id, 73705554 );
 			expect( state ).to.equal( 73705554 );
 		} );
 	} );
@@ -155,23 +142,17 @@ describe( 'reducer', () => {
 		} );
 		test( 'should persist state', () => {
 			const original = 'JPY';
-			const state = currencyCode( original, {
-				type: SERIALIZE,
-			} );
+			const state = serialize( currencyCode, original );
 			expect( state ).to.equal( original );
 		} );
 		test( 'should restore valid persisted state', () => {
 			const original = 'JPY';
-			const state = currencyCode( original, {
-				type: DESERIALIZE,
-			} );
+			const state = deserialize( currencyCode, original );
 			expect( state ).to.equal( original );
 		} );
 		test( 'should ignore invalid persisted state', () => {
 			const original = 1234;
-			const state = currencyCode( original, {
-				type: DESERIALIZE,
-			} );
+			const state = deserialize( currencyCode, original );
 			expect( state ).to.equal( null );
 		} );
 	} );
@@ -297,9 +278,7 @@ describe( 'reducer', () => {
 					manage_options: false,
 				},
 			} );
-			const state = capabilities( original, {
-				type: SERIALIZE,
-			} );
+			const state = serialize( capabilities, original );
 
 			expect( state ).to.equal( original );
 		} );
@@ -310,9 +289,7 @@ describe( 'reducer', () => {
 					manage_options: false,
 				},
 			} );
-			const state = capabilities( original, {
-				type: DESERIALIZE,
-			} );
+			const state = deserialize( capabilities, original );
 
 			expect( state ).to.equal( original );
 		} );
@@ -323,9 +300,7 @@ describe( 'reducer', () => {
 					manage_options: false,
 				},
 			} );
-			const state = capabilities( original, {
-				type: DESERIALIZE,
-			} );
+			const state = deserialize( capabilities, original );
 
 			expect( state ).to.eql( {} );
 		} );

--- a/client/state/domains/suggestions/test/reducer.js
+++ b/client/state/domains/suggestions/test/reducer.js
@@ -13,9 +13,8 @@ import {
 	DOMAINS_SUGGESTIONS_REQUEST,
 	DOMAINS_SUGGESTIONS_REQUEST_FAILURE,
 	DOMAINS_SUGGESTIONS_REQUEST_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -205,7 +204,7 @@ describe( 'reducer', () => {
 						},
 					],
 				} );
-				const state = items( original, { type: SERIALIZE } );
+				const state = serialize( items, original );
 				expect( state ).to.eql( original );
 			} );
 
@@ -226,7 +225,7 @@ describe( 'reducer', () => {
 						},
 					],
 				} );
-				const state = items( original, { type: DESERIALIZE } );
+				const state = deserialize( items, original );
 				expect( state ).to.eql( original );
 			} );
 
@@ -237,7 +236,7 @@ describe( 'reducer', () => {
 						{ cost: '$18.00', product_id: 6, product_slug: 'domain_reg' },
 					],
 				} );
-				const state = items( original, { type: DESERIALIZE } );
+				const state = deserialize( items, original );
 				expect( state ).to.eql( {} );
 			} );
 		} );

--- a/client/state/happiness-engineers/test/reducer.js
+++ b/client/state/happiness-engineers/test/reducer.js
@@ -13,9 +13,8 @@ import {
 	HAPPINESS_ENGINEERS_RECEIVE,
 	HAPPINESS_ENGINEERS_FETCH_FAILURE,
 	HAPPINESS_ENGINEERS_FETCH_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -89,14 +88,14 @@ describe( 'reducer', () => {
 
 		test( 'should persist state', () => {
 			const original = deepFreeze( [ 'test 3' ] );
-			const state = items( original, { type: SERIALIZE } );
+			const state = serialize( items, original );
 
 			expect( state ).to.eql( [ 'test 3' ] );
 		} );
 
 		test( 'should load valid persisted state', () => {
 			const original = deepFreeze( [ 'test 3' ] );
-			const state = items( original, { type: DESERIALIZE } );
+			const state = deserialize( items, original );
 
 			expect( state ).to.eql( [ 'test 3' ] );
 		} );
@@ -105,7 +104,7 @@ describe( 'reducer', () => {
 			const original = deepFreeze( {
 				'test 3': { URL: 'test 3' },
 			} );
-			const state = items( original, { type: DESERIALIZE } );
+			const state = deserialize( items, original );
 
 			expect( state ).to.eql( null );
 		} );

--- a/client/state/happychat/ui/test/index.js
+++ b/client/state/happychat/ui/test/index.js
@@ -7,13 +7,12 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
-	SERIALIZE,
-	DESERIALIZE,
 	HAPPYCHAT_BLUR,
 	HAPPYCHAT_FOCUS,
 	HAPPYCHAT_IO_SEND_MESSAGE_MESSAGE,
 	HAPPYCHAT_SET_CURRENT_MESSAGE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { lostFocusAt, currentMessage } from '../reducer';
 jest.mock( '@wordpress/warning', () => () => {} );
 
@@ -29,17 +28,17 @@ describe( 'reducers', () => {
 			expect( lostFocusAt( undefined, {} ) ).to.be.null;
 		} );
 
-		test( 'SERIALIZEs to Date.now() if state is null', () => {
-			expect( lostFocusAt( null, { type: SERIALIZE } ) ).to.eql( NOW );
+		test( 'serializes to Date.now() if state is null', () => {
+			expect( serialize( lostFocusAt, null ) ).to.eql( NOW );
 		} );
 
-		test( 'DESERIALIZEs a valid value', () => {
-			expect( lostFocusAt( 1, { type: DESERIALIZE } ) ).eql( 1 );
+		test( 'deserializes a valid value', () => {
+			expect( deserialize( lostFocusAt, 1 ) ).eql( 1 );
 		} );
 
-		test( 'does not DESERIALIZEs invalid values', () => {
-			expect( lostFocusAt( {}, { type: DESERIALIZE } ) ).eql( null );
-			expect( lostFocusAt( '1', { type: DESERIALIZE } ) ).eql( null );
+		test( 'does not deserializes invalid values', () => {
+			expect( deserialize( lostFocusAt, {} ) ).eql( null );
+			expect( deserialize( lostFocusAt, '1' ) ).eql( null );
 		} );
 
 		test( 'returns Date.now() on HAPPYCHAT_BLUR actions', () => {

--- a/client/state/happychat/user/test/reducer.js
+++ b/client/state/happychat/user/test/reducer.js
@@ -6,7 +6,8 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { HAPPYCHAT_IO_RECEIVE_INIT, DESERIALIZE } from 'calypso/state/action-types';
+import { deserialize } from 'calypso/state/utils';
+import { HAPPYCHAT_IO_RECEIVE_INIT } from 'calypso/state/action-types';
 import { geoLocation } from '../reducer';
 
 describe( '#geoLocation()', () => {
@@ -31,12 +32,7 @@ describe( '#geoLocation()', () => {
 	} );
 
 	test( 'deserializes correctly', () => {
-		const state = geoLocation(
-			{ country_long: 'Romania', city: 'Timisoara' },
-			{
-				type: DESERIALIZE,
-			}
-		);
+		const state = deserialize( geoLocation, { country_long: 'Romania', city: 'Timisoara' } );
 
 		expect( state ).to.eql( { country_long: 'Romania', city: 'Timisoara' } );
 	} );

--- a/client/state/invites/test/reducer.js
+++ b/client/state/invites/test/reducer.js
@@ -17,9 +17,8 @@ import {
 	INVITES_DELETE_REQUEST,
 	INVITES_DELETE_REQUEST_FAILURE,
 	INVITES_DELETE_REQUEST_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -411,7 +410,7 @@ describe( 'reducer', () => {
 					],
 				},
 			} );
-			const state = items( original, { type: SERIALIZE } );
+			const state = serialize( items, original );
 
 			expect( state ).to.eql( original );
 		} );
@@ -457,7 +456,7 @@ describe( 'reducer', () => {
 					],
 				},
 			} );
-			const state = items( original, { type: DESERIALIZE } );
+			const state = deserialize( items, original );
 
 			expect( state ).to.eql( original );
 		} );
@@ -496,7 +495,7 @@ describe( 'reducer', () => {
 						accepted: [],
 					},
 				} );
-				const state = items( original, { type: DESERIALIZE } );
+				const state = deserialize( items, original );
 
 				expect( state ).to.eql( {} );
 			} );
@@ -529,7 +528,7 @@ describe( 'reducer', () => {
 						],
 					},
 				} );
-				const state = items( original, { type: DESERIALIZE } );
+				const state = deserialize( items, original );
 
 				expect( state ).to.eql( {} );
 			} );
@@ -538,7 +537,7 @@ describe( 'reducer', () => {
 				const original = deepFreeze( {
 					12345: { pending: [] /* accepted: missing */ },
 				} );
-				const state = items( original, { type: DESERIALIZE } );
+				const state = deserialize( items, original );
 
 				expect( state ).to.eql( {} );
 			} );
@@ -547,7 +546,7 @@ describe( 'reducer', () => {
 				const original = deepFreeze( {
 					12345: { pending: [], accepted: [], fileNotFound: [] },
 				} );
-				const state = items( original, { type: DESERIALIZE } );
+				const state = deserialize( items, original );
 
 				expect( state ).to.eql( {} );
 			} );

--- a/client/state/jetpack-connect/reducer/test/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-connect-authorize.js
@@ -14,8 +14,8 @@ import {
 	JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST,
 	JETPACK_CONNECT_QUERY_SET,
 } from 'calypso/state/jetpack-connect/action-types';
-import { DESERIALIZE, SERIALIZE, SITE_REQUEST_FAILURE } from 'calypso/state/action-types';
-
+import { SITE_REQUEST_FAILURE } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( '#jetpackConnectAuthorize()', () => {
@@ -158,9 +158,7 @@ describe( '#jetpackConnectAuthorize()', () => {
 			clientId: 1234,
 			timestamp: 1410647400000,
 		} );
-		const state = jetpackConnectAuthorize( originalState, {
-			type: SERIALIZE,
-		} );
+		const state = serialize( jetpackConnectAuthorize, originalState );
 
 		expect( state ).toEqual( originalState );
 	} );
@@ -170,9 +168,7 @@ describe( '#jetpackConnectAuthorize()', () => {
 			clientId: 1234,
 			timestamp: Infinity, // Ensure timestamp is not expired
 		} );
-		const state = jetpackConnectAuthorize( originalState, {
-			type: DESERIALIZE,
-		} );
+		const state = deserialize( jetpackConnectAuthorize, originalState );
 
 		expect( state ).toEqual( originalState );
 	} );
@@ -182,9 +178,7 @@ describe( '#jetpackConnectAuthorize()', () => {
 			clientId: 1234,
 			timestamp: -Infinity, // Ensure timestamp is expired
 		} );
-		const state = jetpackConnectAuthorize( originalState, {
-			type: DESERIALIZE,
-		} );
+		const state = deserialize( jetpackConnectAuthorize, originalState );
 
 		expect( state ).toEqual( {} );
 	} );

--- a/client/state/jetpack/settings/test/reducer.js
+++ b/client/state/jetpack/settings/test/reducer.js
@@ -8,14 +8,13 @@ import deepFreeze from 'deep-freeze';
  */
 import reducer, { settingsReducer } from '../reducer';
 import {
-	DESERIALIZE,
 	JETPACK_MODULE_ACTIVATE_SUCCESS,
 	JETPACK_MODULE_DEACTIVATE_SUCCESS,
 	JETPACK_MODULES_RECEIVE,
 	JETPACK_SETTINGS_SAVE_SUCCESS,
 	JETPACK_SETTINGS_UPDATE,
-	SERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -275,7 +274,7 @@ describe( 'reducer', () => {
 			const original = deepFreeze( {
 				[ 12345678 ]: settings,
 			} );
-			const state = settingsReducer( original, { type: SERIALIZE } );
+			const state = serialize( settingsReducer, original );
 
 			expect( state.root() ).toEqual( original );
 		} );
@@ -285,7 +284,7 @@ describe( 'reducer', () => {
 				[ 12345678 ]: settings,
 			} );
 
-			const state = settingsReducer( original, { type: DESERIALIZE } );
+			const state = deserialize( settingsReducer, original );
 
 			expect( state ).toEqual( original );
 		} );
@@ -294,7 +293,7 @@ describe( 'reducer', () => {
 			const original = deepFreeze( {
 				[ 12345678 ]: [ 'test' ],
 			} );
-			const state = settingsReducer( original, { type: DESERIALIZE } );
+			const state = deserialize( settingsReducer, original );
 
 			expect( state ).toEqual( {} );
 		} );

--- a/client/state/plans/test/reducer.js
+++ b/client/state/plans/test/reducer.js
@@ -21,6 +21,7 @@ import plansReducer, {
 
 import { WPCOM_RESPONSE } from './fixture';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
+import { serialize, deserialize } from 'calypso/state/utils';
 
 describe( 'reducer', () => {
 	let sandbox;
@@ -69,13 +70,12 @@ describe( 'reducer', () => {
 		test( 'should persist state', () => {
 			const plans = WPCOM_RESPONSE;
 			const initialState = plans;
-			const action = { type: 'SERIALIZE' };
 			const expectedState = plans;
 
 			deepFreeze( initialState );
 			deepFreeze( expectedState );
 
-			const newState = itemsReducer( initialState, action );
+			const newState = serialize( itemsReducer, initialState );
 
 			expect( newState ).to.eql( expectedState );
 		} );
@@ -83,12 +83,11 @@ describe( 'reducer', () => {
 		test( 'should load persisted state', () => {
 			const plans = WPCOM_RESPONSE;
 			const initialState = plans;
-			const action = { type: 'DESERIALIZE' };
 			const expectedState = plans;
 			deepFreeze( initialState );
 			deepFreeze( expectedState );
 
-			const newState = itemsReducer( initialState, action );
+			const newState = deserialize( itemsReducer, initialState );
 
 			expect( newState ).to.eql( expectedState );
 		} );
@@ -97,12 +96,11 @@ describe( 'reducer', () => {
 			// product_id should be `Number`
 			const plans = [ { product_id: '234234' } ];
 			const initialState = plans;
-			const action = { type: 'DESERIALIZE' };
 			deepFreeze( initialState );
 			const expectedState = [];
 			deepFreeze( expectedState );
 
-			const newState = itemsReducer( initialState, action );
+			const newState = deserialize( itemsReducer, initialState );
 
 			expect( newState ).to.eql( expectedState );
 		} );

--- a/client/state/plugins/premium/test/reducer.js
+++ b/client/state/plugins/premium/test/reducer.js
@@ -25,8 +25,8 @@ import {
 	PLUGIN_SETUP_CONFIGURE,
 	PLUGIN_SETUP_FINISH,
 	PLUGIN_SETUP_ERROR,
-	SERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize } from 'calypso/state/utils';
 
 describe( 'premium reducer', () => {
 	describe( 'isRequesting', () => {
@@ -204,7 +204,7 @@ describe( 'premium reducer', () => {
 				],
 			} );
 
-			const nextState = plugins( originalState, { type: SERIALIZE } );
+			const nextState = serialize( plugins, originalState );
 			expect( nextState ).to.deep.eql( {
 				'one.site': [
 					{
@@ -230,7 +230,7 @@ describe( 'premium reducer', () => {
 					},
 				],
 			} );
-			const nextState = plugins( originalState, { type: SERIALIZE } );
+			const nextState = serialize( plugins, originalState );
 			expect( nextState ).eql( {
 				'error-site': [
 					{

--- a/client/state/post-formats/test/reducer.js
+++ b/client/state/post-formats/test/reducer.js
@@ -13,9 +13,8 @@ import {
 	POST_FORMATS_REQUEST,
 	POST_FORMATS_REQUEST_FAILURE,
 	POST_FORMATS_REQUEST_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -178,15 +177,13 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should persist state', () => {
-			const state = items(
+			const state = serialize(
+				items,
 				deepFreeze( {
 					12345678: {
 						status: 'Status',
 					},
-				} ),
-				{
-					type: SERIALIZE,
-				}
+				} )
 			);
 
 			expect( state ).to.eql( {
@@ -197,15 +194,13 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should load valid persisted state', () => {
-			const state = items(
+			const state = deserialize(
+				items,
 				deepFreeze( {
 					12345678: {
 						status: 'Status',
 					},
-				} ),
-				{
-					type: DESERIALIZE,
-				}
+				} )
 			);
 
 			expect( state ).to.eql( {
@@ -216,13 +211,11 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should not load invalid persisted state', () => {
-			const state = items(
+			const state = deserialize(
+				items,
 				deepFreeze( {
 					status: 'Status',
-				} ),
-				{
-					type: DESERIALIZE,
-				}
+				} )
 			);
 
 			expect( state ).to.eql( {} );

--- a/client/state/post-types/taxonomies/test/reducer.js
+++ b/client/state/post-types/taxonomies/test/reducer.js
@@ -14,9 +14,8 @@ import {
 	POST_TYPES_TAXONOMIES_REQUEST,
 	POST_TYPES_TAXONOMIES_REQUEST_SUCCESS,
 	POST_TYPES_TAXONOMIES_REQUEST_FAILURE,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -233,7 +232,7 @@ describe( 'reducer', () => {
 					],
 				},
 			} );
-			const state = items( original, { type: SERIALIZE } );
+			const state = serialize( items, original );
 
 			expect( state ).to.eql( original );
 		} );
@@ -253,7 +252,7 @@ describe( 'reducer', () => {
 					],
 				},
 			} );
-			const state = items( original, { type: DESERIALIZE } );
+			const state = deserialize( items, original );
 
 			expect( state ).to.eql( original );
 		} );
@@ -264,7 +263,7 @@ describe( 'reducer', () => {
 					post: [ true ],
 				},
 			} );
-			const state = items( original, { type: DESERIALIZE } );
+			const state = deserialize( items, original );
 
 			expect( state ).to.eql( {} );
 		} );

--- a/client/state/post-types/test/reducer.js
+++ b/client/state/post-types/test/reducer.js
@@ -8,7 +8,8 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import reducer, { items } from '../reducer';
-import { POST_TYPES_RECEIVE, SERIALIZE, DESERIALIZE } from 'calypso/state/action-types';
+import { POST_TYPES_RECEIVE } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -94,13 +95,13 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should persist state', () => {
-			const state = items(
+			const state = serialize(
+				items,
 				deepFreeze( {
 					2916284: {
 						post: { name: 'post', label: 'Posts' },
 					},
-				} ),
-				{ type: SERIALIZE }
+				} )
 			);
 
 			expect( state.root() ).to.eql( {
@@ -111,13 +112,13 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should load valid persisted state', () => {
-			const state = items(
+			const state = deserialize(
+				items,
 				deepFreeze( {
 					2916284: {
 						post: { name: 'post', label: 'Posts' },
 					},
-				} ),
-				{ type: DESERIALIZE }
+				} )
 			);
 
 			expect( state ).to.eql( {
@@ -128,11 +129,11 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should not load invalid persisted state', () => {
-			const state = items(
+			const state = deserialize(
+				items,
 				deepFreeze( {
 					post: { name: 'post', label: 'Posts' },
-				} ),
-				{ type: DESERIALIZE }
+				} )
 			);
 
 			expect( state ).to.eql( {} );

--- a/client/state/posts/counts/test/reducer.js
+++ b/client/state/posts/counts/test/reducer.js
@@ -18,9 +18,8 @@ import {
 	POST_DELETE,
 	POST_SAVE,
 	POSTS_RECEIVE,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -413,7 +412,7 @@ describe( 'reducer', () => {
 					},
 				},
 			} );
-			const state = counts( original, { type: SERIALIZE } );
+			const state = serialize( counts, original );
 
 			expect( state ).to.eql( original );
 		} );
@@ -431,7 +430,7 @@ describe( 'reducer', () => {
 					},
 				},
 			} );
-			const state = counts( original, { type: DESERIALIZE } );
+			const state = deserialize( counts, original );
 
 			expect( state ).to.eql( original );
 		} );
@@ -449,7 +448,7 @@ describe( 'reducer', () => {
 					},
 				},
 			} );
-			const state = counts( original, { type: DESERIALIZE } );
+			const state = deserialize( counts, original );
 
 			expect( state ).to.eql( {} );
 		} );

--- a/client/state/posts/likes/test/reducer.js
+++ b/client/state/posts/likes/test/reducer.js
@@ -7,7 +7,8 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import reducer, { items, itemReducer } from '../reducer';
-import { POST_LIKES_RECEIVE, SERIALIZE, DESERIALIZE } from 'calypso/state/action-types';
+import { POST_LIKES_RECEIVE } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { addLiker, removeLiker, like, unlike } from '../actions';
 import { useFakeTimers, useSandbox } from 'calypso/test-helpers/use-sinon';
 
@@ -220,7 +221,8 @@ describe( 'reducer', () => {
 
 		test( 'should persist state', () => {
 			const likes = [ { ID: 1, login: 'chicken' } ];
-			const state = items(
+			const state = serialize(
+				items,
 				deepFreeze( {
 					12345678: {
 						50: {
@@ -230,10 +232,7 @@ describe( 'reducer', () => {
 							lastUpdated: 2000,
 						},
 					},
-				} ),
-				{
-					type: SERIALIZE,
-				}
+				} )
 			);
 
 			expect( state.root() ).toEqual( {
@@ -250,7 +249,8 @@ describe( 'reducer', () => {
 
 		test( 'should load valid persisted state', () => {
 			const likes = [ { ID: 1, login: 'chicken' } ];
-			const state = items(
+			const state = deserialize(
+				items,
 				deepFreeze( {
 					12345678: {
 						50: {
@@ -260,10 +260,7 @@ describe( 'reducer', () => {
 							lastUpdated: 4000,
 						},
 					},
-				} ),
-				{
-					type: DESERIALIZE,
-				}
+				} )
 			);
 
 			expect( state ).toEqual( {
@@ -279,13 +276,11 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should not load invalid persisted state', () => {
-			const state = items(
+			const state = deserialize(
+				items,
 				deepFreeze( {
 					status: 'ribs',
-				} ),
-				{
-					type: DESERIALIZE,
-				}
+				} )
 			);
 
 			expect( state ).toEqual( {} );

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -34,9 +34,8 @@ import {
 	POSTS_REQUEST,
 	POSTS_REQUEST_FAILURE,
 	POSTS_REQUEST_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -129,7 +128,7 @@ describe( 'reducer', () => {
 			const original = deepFreeze( {
 				'3d097cb7c5473c169bba0eb8e3c6cb64': [ 2916284, 841 ],
 			} );
-			const state = items( original, { type: SERIALIZE } );
+			const state = serialize( items, original );
 
 			expect( state ).to.eql( original );
 		} );
@@ -138,7 +137,7 @@ describe( 'reducer', () => {
 			const original = deepFreeze( {
 				'3d097cb7c5473c169bba0eb8e3c6cb64': [ 2916284, 841 ],
 			} );
-			const state = items( original, { type: DESERIALIZE } );
+			const state = deserialize( items, original );
 
 			expect( state ).to.eql( original );
 		} );
@@ -152,7 +151,7 @@ describe( 'reducer', () => {
 					title: 'Hello World',
 				},
 			} );
-			const state = items( original, { type: DESERIALIZE } );
+			const state = deserialize( items, original );
 
 			expect( state ).to.eql( {} );
 		} );
@@ -620,7 +619,7 @@ describe( 'reducer', () => {
 				} )
 			);
 
-			const state = queries( original, { type: SERIALIZE } );
+			const state = serialize( queries, original );
 
 			expect( state ).to.eql( {
 				2916284: {
@@ -672,7 +671,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			const state = queries( original, { type: DESERIALIZE } );
+			const state = deserialize( queries, original );
 
 			expect( state ).to.eql( {
 				2916284: new PostQueryManager( {
@@ -699,7 +698,7 @@ describe( 'reducer', () => {
 				2916284: '{INVALID',
 			} );
 
-			const state = queries( original, { type: DESERIALIZE } );
+			const state = deserialize( queries, original );
 
 			expect( state ).to.eql( {} );
 		} );
@@ -1927,7 +1926,7 @@ describe( 'reducer', () => {
 				} )
 			);
 
-			const state = allSitesQueries( original, { type: SERIALIZE } );
+			const state = serialize( allSitesQueries, original );
 
 			expect( state ).to.eql( {
 				data: {
@@ -1975,7 +1974,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			const state = allSitesQueries( original, { type: DESERIALIZE } );
+			const state = deserialize( allSitesQueries, original );
 
 			expect( state ).to.eql(
 				new PostQueryManager(
@@ -2003,7 +2002,7 @@ describe( 'reducer', () => {
 		test( 'should not load invalid persisted state', () => {
 			const original = '{INVALID';
 
-			const state = allSitesQueries( original, { type: DESERIALIZE } );
+			const state = deserialize( allSitesQueries, original );
 
 			expect( state ).to.be.an.instanceof( PostQueryManager );
 			expect( state.data ).to.eql( { items: {}, queries: {} } );

--- a/client/state/products-list/test/reducer.js
+++ b/client/state/products-list/test/reducer.js
@@ -9,12 +9,11 @@ import deepFreeze from 'deep-freeze';
  */
 import reducer, { items, isFetching } from '../reducer';
 import {
-	DESERIALIZE,
 	PRODUCTS_LIST_RECEIVE,
 	PRODUCTS_LIST_REQUEST,
 	PRODUCTS_LIST_REQUEST_FAILURE,
-	SERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -76,7 +75,7 @@ describe( 'reducer', () => {
 						cost_display: '$129',
 					},
 				} );
-				const state = items( original, { type: SERIALIZE } );
+				const state = serialize( items, original );
 				expect( state ).to.eql( original );
 			} );
 
@@ -94,7 +93,7 @@ describe( 'reducer', () => {
 						cost_display: '$129',
 					},
 				} );
-				const state = items( original, { type: DESERIALIZE } );
+				const state = deserialize( items, original );
 				expect( state ).to.eql( original );
 			} );
 
@@ -107,7 +106,7 @@ describe( 'reducer', () => {
 						slug: 'guided_transfer',
 					},
 				} );
-				const state = items( original, { type: DESERIALIZE } );
+				const state = deserialize( items, original );
 				expect( state ).to.eql( {} );
 			} );
 		} );

--- a/client/state/push-notifications/test/reducer.js
+++ b/client/state/push-notifications/test/reducer.js
@@ -8,11 +8,8 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import reducer from '../reducer';
-import {
-	SERIALIZE,
-	DESERIALIZE,
-	PUSH_NOTIFICATIONS_RECEIVE_REGISTER_DEVICE,
-} from 'calypso/state/action-types';
+import { PUSH_NOTIFICATIONS_RECEIVE_REGISTER_DEVICE } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 
 const wpcomSubscription = {
 	ID: '42',
@@ -27,10 +24,9 @@ const wpcomSubscription = {
 
 describe( 'system reducer', () => {
 	test( 'should persist keys', () => {
-		const previousState = { system: { wpcomSubscription: wpcomSubscription } };
+		const previousState = { system: { wpcomSubscription } };
 		deepFreeze( previousState );
-		const action = { type: SERIALIZE };
-		const newState = reducer( previousState, action ).root();
+		const newState = serialize( reducer, previousState ).root();
 
 		expect( newState.system ).to.eql( { wpcomSubscription } );
 	} );
@@ -46,17 +42,15 @@ describe( 'system reducer', () => {
 			},
 		};
 		deepFreeze( previousState );
-		const action = { type: SERIALIZE };
-		const newState = reducer( previousState, action ).root();
+		const newState = serialize( reducer, previousState ).root();
 
 		expect( newState.system ).to.eql( { wpcomSubscription } );
 	} );
 
 	test( 'should restore keys', () => {
-		const previousState = { system: { wpcomSubscription: wpcomSubscription } };
+		const previousState = { system: { wpcomSubscription } };
 		deepFreeze( previousState );
-		const action = { type: DESERIALIZE };
-		const newState = reducer( previousState, action );
+		const newState = deserialize( reducer, previousState );
 
 		expect( newState.system ).to.eql( {
 			wpcomSubscription,
@@ -75,8 +69,7 @@ describe( 'system reducer', () => {
 			},
 		};
 		deepFreeze( previousState );
-		const action = { type: DESERIALIZE };
-		const newState = reducer( previousState, action );
+		const newState = deserialize( reducer, previousState );
 
 		expect( newState.system ).to.eql( {
 			wpcomSubscription: wpcomSubscriptionId,
@@ -107,8 +100,7 @@ describe( 'settings reducer', () => {
 			},
 		};
 		deepFreeze( previousState );
-		const action = { type: SERIALIZE };
-		const newState = reducer( previousState, action ).root();
+		const newState = serialize( reducer, previousState ).root();
 
 		expect( newState.settings ).to.eql( {
 			dismissedNotice: true,
@@ -125,8 +117,7 @@ describe( 'settings reducer', () => {
 			},
 		};
 		deepFreeze( previousState );
-		const action = { type: SERIALIZE };
-		const newState = reducer( previousState, action ).root();
+		const newState = serialize( reducer, previousState ).root();
 
 		expect( newState.settings ).to.eql( {
 			enabled: true,
@@ -142,7 +133,7 @@ describe( 'settings reducer', () => {
 			},
 		};
 		deepFreeze( previousState );
-		const newState = reducer( previousState, { type: DESERIALIZE } );
+		const newState = deserialize( reducer, previousState );
 
 		expect( newState.settings ).to.eql( {
 			dismissedNotice: true,
@@ -159,8 +150,7 @@ describe( 'settings reducer', () => {
 			},
 		};
 		deepFreeze( previousState );
-		const action = { type: DESERIALIZE };
-		const newState = reducer( previousState, action );
+		const newState = deserialize( reducer, previousState );
 
 		expect( newState.settings ).to.eql( {
 			enabled: true,

--- a/client/state/reader/conversations/test/reducer.js
+++ b/client/state/reader/conversations/test/reducer.js
@@ -13,7 +13,7 @@ import {
 	READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
 	READER_POSTS_RECEIVE,
 } from 'calypso/state/reader/action-types';
-import { SERIALIZE, DESERIALIZE } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 
 describe( 'reducer', () => {
 	describe( '#items()', () => {
@@ -106,17 +106,17 @@ describe( 'reducer', () => {
 
 		test( 'will deserialize valid state', () => {
 			const validState = { '123-456': 'M' };
-			expect( items( validState, { type: DESERIALIZE } ) ).toEqual( validState );
+			expect( deserialize( items, validState ) ).toEqual( validState );
 		} );
 
 		test( 'will not deserialize invalid state', () => {
 			const invalidState = { '123-456': 'X' };
-			expect( items( invalidState, { type: DESERIALIZE } ) ).toEqual( {} );
+			expect( deserialize( items, invalidState ) ).toEqual( {} );
 		} );
 
 		test( 'will serialize', () => {
 			const validState = { '123-456': 'M' };
-			expect( items( validState, { type: SERIALIZE } ) ).toEqual( validState );
+			expect( serialize( items, validState ) ).toEqual( validState );
 		} );
 	} );
 } );

--- a/client/state/reader/feeds/test/reducer.js
+++ b/client/state/reader/feeds/test/reducer.js
@@ -14,7 +14,7 @@ import {
 	READER_FEED_REQUEST_FAILURE,
 	READER_FEED_UPDATE,
 } from 'calypso/state/reader/action-types';
-import { SERIALIZE, DESERIALIZE } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { captureConsole } from 'calypso/test-helpers/console';
 
 describe( 'reducer', () => {
@@ -116,7 +116,7 @@ describe( 'reducer', () => {
 
 		test( 'should serialize feed entries', () => {
 			const unvalidatedObject = deepFreeze( { hi: 'there' } );
-			expect( items( unvalidatedObject, { type: SERIALIZE } ) ).to.deep.equal( unvalidatedObject );
+			expect( serialize( items, unvalidatedObject ) ).to.deep.equal( unvalidatedObject );
 		} );
 
 		test( 'should not serialize errors', () => {
@@ -127,7 +127,7 @@ describe( 'reducer', () => {
 					is_error: true,
 				},
 			} );
-			expect( items( stateWithErrors, { type: SERIALIZE } ) ).to.deep.equal( {
+			expect( serialize( items, stateWithErrors ) ).to.deep.equal( {
 				12: { feed_ID: 12 },
 			} );
 		} );
@@ -136,7 +136,7 @@ describe( 'reducer', () => {
 			'should reject deserializing entries it cannot validate',
 			captureConsole( () => {
 				const unvalidatedObject = deepFreeze( { hi: 'there' } );
-				expect( items( unvalidatedObject, { type: DESERIALIZE } ) ).to.deep.equal( {} );
+				expect( deserialize( items, unvalidatedObject ) ).to.deep.equal( {} );
 			} )
 		);
 
@@ -154,7 +154,7 @@ describe( 'reducer', () => {
 					image: 'http://example.com/favicon',
 				},
 			} );
-			expect( items( validState, { type: DESERIALIZE } ) ).to.deep.equal( validState );
+			expect( deserialize( items, validState ) ).to.deep.equal( validState );
 		} );
 
 		test( 'should stash an error object in the map if the request fails', () => {

--- a/client/state/reader/follows/test/reducer.js
+++ b/client/state/reader/follows/test/reducer.js
@@ -27,7 +27,7 @@ import {
 	READER_FOLLOW_ERROR,
 	READER_SITE_REQUEST_SUCCESS,
 } from 'calypso/state/reader/action-types';
-import { SERIALIZE, DESERIALIZE } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 
 const exampleFollow = {
 	is_following: true,
@@ -157,7 +157,7 @@ describe( 'reducer', () => {
 					blog_ID: 125,
 				},
 			} );
-			expect( items( original, { type: SERIALIZE } ) ).toEqual( {
+			expect( serialize( items, original ) ).toEqual( {
 				'dailypost.wordpress.com': {
 					ID: 2,
 					feed_URL: 'http://dailypost.wordpress.com',
@@ -178,7 +178,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( items( original, { type: DESERIALIZE } ) ).toBe( original );
+			expect( deserialize( items, original ) ).toBe( original );
 		} );
 
 		test( 'should return the blank state for bad serialized data', () => {
@@ -190,7 +190,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( items( original, { type: DESERIALIZE } ) ).toEqual( {} );
+			expect( deserialize( items, original ) ).toEqual( {} );
 		} );
 
 		test( 'should update when passed new post email subscription info', () => {

--- a/client/state/reader/sites/test/reducer.js
+++ b/client/state/reader/sites/test/reducer.js
@@ -15,7 +15,7 @@ import {
 	READER_SITE_REQUEST_FAILURE,
 	READER_SITE_UPDATE,
 } from 'calypso/state/reader/action-types';
-import { SERIALIZE, DESERIALIZE } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 
 describe( 'reducer', () => {
 	describe( 'items', () => {
@@ -136,9 +136,7 @@ describe( 'reducer', () => {
 
 		test( 'should serialize site entries', () => {
 			const unvalidatedObject = deepFreeze( { hi: 'there' } );
-			chaiExpect( items( unvalidatedObject, { type: SERIALIZE } ) ).to.deep.equal(
-				unvalidatedObject
-			);
+			chaiExpect( serialize( items, unvalidatedObject ) ).to.deep.equal( unvalidatedObject );
 		} );
 
 		test( 'should not serialize errors', () => {
@@ -149,7 +147,7 @@ describe( 'reducer', () => {
 					is_error: true,
 				},
 			} );
-			chaiExpect( items( stateWithErrors, { type: SERIALIZE } ) ).to.deep.equal( {
+			chaiExpect( serialize( items, stateWithErrors ) ).to.deep.equal( {
 				12: { ID: 12, name: 'yes' },
 			} );
 		} );
@@ -157,7 +155,7 @@ describe( 'reducer', () => {
 		test( 'should reject deserializing entries it cannot validate', () => {
 			const consoleSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
 			const unvalidatedObject = deepFreeze( { hi: 'there' } );
-			chaiExpect( items( unvalidatedObject, { type: DESERIALIZE } ) ).to.deep.equal( {} );
+			chaiExpect( deserialize( items, unvalidatedObject ) ).to.deep.equal( {} );
 			consoleSpy.mockRestore();
 		} );
 
@@ -168,7 +166,7 @@ describe( 'reducer', () => {
 					name: 'Example Dot Com',
 				},
 			} );
-			chaiExpect( items( validState, { type: DESERIALIZE } ) ).to.deep.equal( validState );
+			chaiExpect( deserialize( items, validState ) ).to.deep.equal( validState );
 		} );
 
 		test( 'should stash an error object in the map if the request fails with a 410', () => {

--- a/client/state/reader/watermarks/test/reducer.js
+++ b/client/state/reader/watermarks/test/reducer.js
@@ -3,7 +3,7 @@
  */
 import { viewStream } from '../actions';
 import { watermarks } from '../reducer';
-import { DESERIALIZE, SERIALIZE } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 
 jest.mock( '@wordpress/warning', () => () => {} );
 
@@ -42,16 +42,16 @@ describe( '#watermarks', () => {
 
 	test( 'will skip deserializing invalid marks', () => {
 		const invalidState = { [ streamKey ]: 'invalid' };
-		expect( watermarks( invalidState, { type: DESERIALIZE } ) ).toEqual( {} );
+		expect( deserialize( watermarks, invalidState ) ).toEqual( {} );
 	} );
 
 	test( 'will deserialize valid mark', () => {
 		const validState = { [ streamKey ]: 42 };
-		expect( watermarks( validState, { type: DESERIALIZE } ) ).toEqual( validState );
+		expect( deserialize( watermarks, validState ) ).toEqual( validState );
 	} );
 
 	test( 'will serialize', () => {
 		const validState = { [ streamKey ]: 42 };
-		expect( watermarks( validState, { type: SERIALIZE } ).root() ).toEqual( validState );
+		expect( serialize( watermarks, validState ).root() ).toEqual( validState );
 	} );
 } );

--- a/client/state/secure-your-brand/test/reducer.js
+++ b/client/state/secure-your-brand/test/reducer.js
@@ -19,6 +19,7 @@ import secureYourBrandReducer, {
 } from '../reducer';
 
 import { WPCOM_RESPONSE } from './fixture';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -72,13 +73,12 @@ describe( 'reducer', () => {
 		test( 'should persist state', () => {
 			const secureYourBrand = WPCOM_RESPONSE;
 			const initialState = secureYourBrand;
-			const action = { type: 'SERIALIZE' };
 			const expectedState = secureYourBrand;
 
 			deepFreeze( initialState );
 			deepFreeze( expectedState );
 
-			const newState = itemsReducer( initialState, action );
+			const newState = serialize( itemsReducer, initialState );
 
 			expect( newState ).to.eql( expectedState );
 		} );
@@ -86,12 +86,11 @@ describe( 'reducer', () => {
 		test( 'should load persisted state', () => {
 			const secureYourBrand = WPCOM_RESPONSE;
 			const initialState = secureYourBrand;
-			const action = { type: 'DESERIALIZE' };
 			const expectedState = secureYourBrand;
 			deepFreeze( initialState );
 			deepFreeze( expectedState );
 
-			const newState = itemsReducer( initialState, action );
+			const newState = deserialize( itemsReducer, initialState );
 
 			expect( newState ).to.eql( expectedState );
 		} );
@@ -100,12 +99,11 @@ describe( 'reducer', () => {
 			// each entry should be `string`
 			const secureYourBrand = [ 1234 ];
 			const initialState = secureYourBrand;
-			const action = { type: 'DESERIALIZE' };
 			deepFreeze( initialState );
 			const expectedState = [];
 			deepFreeze( expectedState );
 
-			const newState = itemsReducer( initialState, action );
+			const newState = deserialize( itemsReducer, initialState );
 
 			expect( newState ).to.eql( expectedState );
 		} );

--- a/client/state/sharing/keyring/test/reducer.js
+++ b/client/state/sharing/keyring/test/reducer.js
@@ -16,9 +16,8 @@ import {
 	KEYRING_CONNECTIONS_REQUEST_SUCCESS,
 	PUBLICIZE_CONNECTION_CREATE,
 	PUBLICIZE_CONNECTION_DELETE,
-	DESERIALIZE,
-	SERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducers', () => {
@@ -159,9 +158,7 @@ describe( 'reducers', () => {
 					1: { ID: 1, sites: [ '2916284' ] },
 					2: { ID: 2, sites: [ '77203074' ] },
 				} );
-				const persistedState = items( state, {
-					type: SERIALIZE,
-				} );
+				const persistedState = serialize( items, state );
 				expect( persistedState ).to.eql( state );
 			} );
 
@@ -170,9 +167,7 @@ describe( 'reducers', () => {
 					1: { ID: 1, sites: [ '2916284' ] },
 					2: { ID: 2, sites: [ '77203074' ] },
 				} );
-				const state = items( persistedState, {
-					type: DESERIALIZE,
-				} );
+				const state = deserialize( items, persistedState );
 				expect( state ).to.eql( persistedState );
 			} );
 
@@ -181,9 +176,7 @@ describe( 'reducers', () => {
 					foo: { ID: 1, sites: [ '2916284' ] },
 					bar: { ID: 2, sites: [ '77203074' ] },
 				} );
-				const state = items( persistedState, {
-					type: DESERIALIZE,
-				} );
+				const state = deserialize( items, persistedState );
 				expect( state ).to.eql( {} );
 			} );
 
@@ -192,9 +185,7 @@ describe( 'reducers', () => {
 					1: { ID: 1, sites: 'foo' },
 					2: { ID: 2, sites: [ '77203074' ] },
 				} );
-				const state = items( persistedState, {
-					type: DESERIALIZE,
-				} );
+				const state = deserialize( items, persistedState );
 				expect( state ).to.eql( {} );
 			} );
 		} );

--- a/client/state/sharing/publicize/test/reducer.js
+++ b/client/state/sharing/publicize/test/reducer.js
@@ -19,9 +19,8 @@ import {
 	PUBLICIZE_CONNECTIONS_REQUEST,
 	PUBLICIZE_CONNECTIONS_RECEIVE,
 	PUBLICIZE_CONNECTIONS_REQUEST_FAILURE,
-	DESERIALIZE,
-	SERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -306,7 +305,7 @@ describe( 'reducer', () => {
 					1: { ID: 1, site_ID: 2916284 },
 					2: { ID: 2, site_ID: 2916284 },
 				} );
-				const persistedState = connections( state, { type: SERIALIZE } );
+				const persistedState = serialize( connections, state );
 				expect( persistedState ).to.eql( state );
 			} );
 
@@ -315,9 +314,7 @@ describe( 'reducer', () => {
 					1: { ID: 1, site_ID: 2916284 },
 					2: { ID: 2, site_ID: 2916284 },
 				} );
-				const state = connections( persistedState, {
-					type: DESERIALIZE,
-				} );
+				const state = deserialize( connections, persistedState );
 				expect( state ).to.eql( persistedState );
 			} );
 
@@ -326,9 +323,7 @@ describe( 'reducer', () => {
 					foo: { ID: 1, site_ID: 2916284 },
 					bar: { ID: 2, site_ID: 2916284 },
 				} );
-				const state = connections( persistedState, {
-					type: DESERIALIZE,
-				} );
+				const state = deserialize( connections, persistedState );
 				expect( state ).to.eql( {} );
 			} );
 
@@ -337,9 +332,7 @@ describe( 'reducer', () => {
 					1: { ID: 1, site_ID: 'foo' },
 					2: { ID: 2, site_ID: 2916284 },
 				} );
-				const state = connections( persistedState, {
-					type: DESERIALIZE,
-				} );
+				const state = deserialize( connections, persistedState );
 				expect( state ).to.eql( {} );
 			} );
 		} );

--- a/client/state/sharing/services/test/reducer.js
+++ b/client/state/sharing/services/test/reducer.js
@@ -13,9 +13,8 @@ import {
 	KEYRING_SERVICES_REQUEST,
 	KEYRING_SERVICES_REQUEST_FAILURE,
 	KEYRING_SERVICES_REQUEST_SUCCESS,
-	DESERIALIZE,
-	SERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 const originalKeyringServices = {
@@ -83,21 +82,21 @@ describe( 'reducer', () => {
 		describe( 'persistence', () => {
 			test( 'persists state', () => {
 				const original = deepFreeze( originalKeyringServices );
-				const services = items( original, { type: SERIALIZE } );
+				const services = serialize( items, original );
 
 				expect( services ).to.eql( original );
 			} );
 
 			test( 'loads valid persisted state', () => {
 				const original = deepFreeze( originalKeyringServices );
-				const services = items( original, { type: DESERIALIZE } );
+				const services = deserialize( items, original );
 
 				expect( services ).to.eql( original );
 			} );
 
 			test( 'loads default state when schema does not match', () => {
 				const original = deepFreeze( [ { ID: 'facebook' }, { ID: 'twitter' } ] );
-				const services = items( original, { type: DESERIALIZE } );
+				const services = deserialize( items, original );
 
 				expect( services ).to.eql( {} );
 			} );

--- a/client/state/site-roles/test/reducer.js
+++ b/client/state/site-roles/test/reducer.js
@@ -13,9 +13,8 @@ import {
 	SITE_ROLES_REQUEST,
 	SITE_ROLES_REQUEST_FAILURE,
 	SITE_ROLES_REQUEST_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -148,14 +147,12 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should persist state', () => {
-			const state = items(
+			const state = serialize(
+				items,
 				deepFreeze( {
 					12345678: roles,
 					87654321: altRoles,
-				} ),
-				{
-					type: SERIALIZE,
-				}
+				} )
 			);
 
 			expect( state ).to.eql( {
@@ -165,14 +162,12 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should load valid persisted state', () => {
-			const state = items(
+			const state = deserialize(
+				items,
 				deepFreeze( {
 					12345678: roles,
 					87654321: altRoles,
-				} ),
-				{
-					type: DESERIALIZE,
-				}
+				} )
 			);
 
 			expect( state ).to.eql( {
@@ -182,7 +177,8 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should not load invalid persisted state', () => {
-			const state = items(
+			const state = deserialize(
+				items,
 				deepFreeze( {
 					1234567: [
 						{
@@ -192,10 +188,7 @@ describe( 'reducer', () => {
 							},
 						},
 					],
-				} ),
-				{
-					type: DESERIALIZE,
-				}
+				} )
 			);
 
 			expect( state ).to.eql( {} );

--- a/client/state/site-settings/test/reducer.js
+++ b/client/state/site-settings/test/reducer.js
@@ -18,9 +18,8 @@ import {
 	SITE_SETTINGS_SAVE_FAILURE,
 	SITE_SETTINGS_SAVE_SUCCESS,
 	SITE_SETTINGS_UPDATE,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -274,7 +273,7 @@ describe( 'reducer', () => {
 			const previousState = deepFreeze( {
 				2916284: { default_category: 'cat' },
 			} );
-			const state = items( previousState, { type: SERIALIZE } );
+			const state = serialize( items, previousState );
 
 			expect( state ).to.eql( {
 				2916284: { default_category: 'cat' },
@@ -285,7 +284,7 @@ describe( 'reducer', () => {
 			const previousState = deepFreeze( {
 				2916284: { default_category: 'cat' },
 			} );
-			const state = items( previousState, { type: DESERIALIZE } );
+			const state = deserialize( items, previousState );
 
 			expect( state ).to.eql( {
 				2916284: { default_category: 'cat' },
@@ -296,7 +295,7 @@ describe( 'reducer', () => {
 			const previousInvalidState = deepFreeze( {
 				2454: 2,
 			} );
-			const state = items( previousInvalidState, { type: DESERIALIZE } );
+			const state = deserialize( items, previousInvalidState );
 
 			expect( state ).to.eql( {} );
 		} );

--- a/client/state/sites/domains/test/reducer.js
+++ b/client/state/sites/domains/test/reducer.js
@@ -34,6 +34,7 @@ import {
 	SITE_DOMAINS_REQUEST_SUCCESS,
 	SITE_DOMAINS_REQUEST_FAILURE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
@@ -168,7 +169,7 @@ describe( 'reducer', () => {
 				[ firstSiteId ]: [ firstDomain ],
 				[ secondSiteId ]: [ secondDomain ],
 			} );
-			expect( itemsReducer( state, { type: 'SERIALIZE' } ) ).to.eql( state );
+			expect( serialize( itemsReducer, state ) ).to.eql( state );
 		} );
 
 		test( 'should load persisted state', () => {
@@ -176,14 +177,14 @@ describe( 'reducer', () => {
 				[ firstSiteId ]: [ firstDomain ],
 				[ secondSiteId ]: [ secondDomain ],
 			} );
-			expect( itemsReducer( state, { type: 'DESERIALIZE' } ) ).to.eql( state );
+			expect( deserialize( itemsReducer, state ) ).to.eql( state );
 		} );
 
 		test( 'should not load invalid persisted state', () => {
 			const state = deepFreeze( {
 				[ 77203074 ]: [ { domain: 1234 } ],
 			} );
-			expect( itemsReducer( state, { type: 'DESERIALIZE' } ) ).to.eql( {} );
+			expect( deserialize( itemsReducer, state ) ).to.eql( {} );
 		} );
 	} );
 

--- a/client/state/sites/guided-transfer/test/reducer.js
+++ b/client/state/sites/guided-transfer/test/reducer.js
@@ -9,7 +9,6 @@ import deepFreeze from 'deep-freeze';
  */
 import reducer, { status, isFetching, isSaving } from '../reducer';
 import {
-	DESERIALIZE,
 	GUIDED_TRANSFER_HOST_DETAILS_SAVE,
 	GUIDED_TRANSFER_HOST_DETAILS_SAVE_FAILURE,
 	GUIDED_TRANSFER_HOST_DETAILS_SAVE_SUCCESS,
@@ -17,8 +16,8 @@ import {
 	GUIDED_TRANSFER_STATUS_REQUEST,
 	GUIDED_TRANSFER_STATUS_REQUEST_FAILURE,
 	GUIDED_TRANSFER_STATUS_REQUEST_SUCCESS,
-	SERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -70,7 +69,7 @@ describe( 'reducer', () => {
 						host_details_entered: false,
 					},
 				} );
-				const state = status( original, { type: SERIALIZE } );
+				const state = serialize( status, original );
 				expect( state ).to.eql( original );
 			} );
 
@@ -81,7 +80,7 @@ describe( 'reducer', () => {
 						host_details_entered: false,
 					},
 				} );
-				const state = status( original, { type: DESERIALIZE } );
+				const state = deserialize( status, original );
 				expect( state ).to.eql( original );
 			} );
 
@@ -92,7 +91,7 @@ describe( 'reducer', () => {
 						host_details_entered: false,
 					},
 				} );
-				const state = status( original, { type: DESERIALIZE } );
+				const state = deserialize( status, original );
 				expect( state ).to.eql( {} );
 			} );
 		} );

--- a/client/state/sites/media-storage/test/reducer.js
+++ b/client/state/sites/media-storage/test/reducer.js
@@ -13,9 +13,8 @@ import {
 	SITE_MEDIA_STORAGE_REQUEST,
 	SITE_MEDIA_STORAGE_REQUEST_SUCCESS,
 	SITE_MEDIA_STORAGE_REQUEST_FAILURE,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -126,7 +125,7 @@ describe( 'reducer', () => {
 						storage_used_bytes: 323506,
 					},
 				} );
-				const state = items( original, { type: SERIALIZE } );
+				const state = serialize( items, original );
 				expect( state ).to.eql( original );
 			} );
 
@@ -141,7 +140,7 @@ describe( 'reducer', () => {
 						storage_used_bytes: 323506,
 					},
 				} );
-				const state = items( original, { type: DESERIALIZE } );
+				const state = deserialize( items, original );
 				expect( state ).to.eql( original );
 			} );
 
@@ -156,7 +155,7 @@ describe( 'reducer', () => {
 						storage_used_bytes: 323506,
 					},
 				} );
-				const state = items( original, { type: DESERIALIZE } );
+				const state = deserialize( items, original );
 				expect( state ).to.eql( {} );
 			} );
 		} );

--- a/client/state/sites/sharing-buttons/test/reducer.js
+++ b/client/state/sites/sharing-buttons/test/reducer.js
@@ -17,9 +17,8 @@ import {
 	SHARING_BUTTONS_SAVE_FAILURE,
 	SHARING_BUTTONS_SAVE_SUCCESS,
 	SHARING_BUTTONS_UPDATE,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -234,7 +233,7 @@ describe( 'reducer', () => {
 			const previousState = deepFreeze( {
 				2916284: [ { ID: 'facebook', name: 'Facebook' } ],
 			} );
-			const state = items( previousState, { type: SERIALIZE } );
+			const state = serialize( items, previousState );
 
 			expect( state ).to.eql( {
 				2916284: [ { ID: 'facebook', name: 'Facebook' } ],
@@ -245,7 +244,7 @@ describe( 'reducer', () => {
 			const previousState = deepFreeze( {
 				2916284: [ { ID: 'facebook', name: 'Facebook' } ],
 			} );
-			const state = items( previousState, { type: DESERIALIZE } );
+			const state = deserialize( items, previousState );
 
 			expect( state ).to.eql( {
 				2916284: [ { ID: 'facebook', name: 'Facebook' } ],
@@ -256,7 +255,7 @@ describe( 'reducer', () => {
 			const previousInvalidState = deepFreeze( {
 				2454: 2,
 			} );
-			const state = items( previousInvalidState, { type: DESERIALIZE } );
+			const state = deserialize( items, previousInvalidState );
 
 			expect( state ).to.eql( {} );
 		} );

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -27,9 +27,8 @@ import {
 	SITE_SETTINGS_UPDATE,
 	WORDADS_SITE_APPROVE_REQUEST_SUCCESS,
 	SITE_PLUGIN_UPDATED,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { THEME_ACTIVATE_SUCCESS } from 'calypso/state/themes/action-types';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
@@ -546,7 +545,7 @@ describe( 'reducer', () => {
 					name: 'WordPress.com Example Blog',
 				},
 			} );
-			const state = items( original, { type: SERIALIZE } );
+			const state = serialize( items, original );
 
 			expect( state ).to.eql( original );
 		} );
@@ -558,7 +557,7 @@ describe( 'reducer', () => {
 					name: 'WordPress.com Example Blog',
 				},
 			} );
-			const state = items( original, { type: DESERIALIZE } );
+			const state = deserialize( items, original );
 
 			expect( state ).to.eql( original );
 		} );
@@ -567,7 +566,7 @@ describe( 'reducer', () => {
 			const original = deepFreeze( {
 				2916284: { bad: true },
 			} );
-			const state = items( original, { type: DESERIALIZE } );
+			const state = deserialize( items, original );
 
 			expect( state ).to.be.null;
 		} );
@@ -784,7 +783,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			const state = items( original, { type: DESERIALIZE } );
+			const state = deserialize( items, original );
 			expect( state ).to.eql( original );
 		} );
 
@@ -797,7 +796,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			const state = items( original, { type: DESERIALIZE } );
+			const state = deserialize( items, original );
 			expect( state ).to.be.null;
 		} );
 	} );

--- a/client/state/stats/lists/test/reducer.js
+++ b/client/state/stats/lists/test/reducer.js
@@ -9,12 +9,11 @@ import deepFreeze from 'deep-freeze';
  */
 import reducer, { items, requests } from '../reducer';
 import {
-	DESERIALIZE,
-	SERIALIZE,
 	SITE_STATS_RECEIVE,
 	SITE_STATS_REQUEST,
 	SITE_STATS_REQUEST_FAILURE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 /**
@@ -163,7 +162,7 @@ describe( 'reducer', () => {
 					},
 				},
 			} );
-			const state = items( original, { type: SERIALIZE } );
+			const state = serialize( items, original );
 
 			expect( state ).to.eql( original );
 		} );
@@ -176,7 +175,7 @@ describe( 'reducer', () => {
 					},
 				},
 			} );
-			const state = items( original, { type: DESERIALIZE } );
+			const state = deserialize( items, original );
 
 			expect( state ).to.eql( original );
 		} );
@@ -187,7 +186,7 @@ describe( 'reducer', () => {
 					'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': streakResponse,
 				},
 			} );
-			const state = items( original, { type: DESERIALIZE } );
+			const state = deserialize( items, original );
 
 			expect( state ).to.eql( {} );
 		} );

--- a/client/state/stats/posts/test/reducer.js
+++ b/client/state/stats/posts/test/reducer.js
@@ -13,9 +13,8 @@ import {
 	POST_STATS_REQUEST,
 	POST_STATS_REQUEST_FAILURE,
 	POST_STATS_REQUEST_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -270,7 +269,7 @@ describe( 'reducer', () => {
 					2454: { views: 2 },
 				},
 			} );
-			const state = items( previousState, { type: SERIALIZE } );
+			const state = serialize( items, previousState );
 
 			expect( state ).to.eql( {
 				2916284: {
@@ -285,7 +284,7 @@ describe( 'reducer', () => {
 					2454: { views: 2 },
 				},
 			} );
-			const state = items( previousState, { type: DESERIALIZE } );
+			const state = deserialize( items, previousState );
 
 			expect( state ).to.eql( {
 				2916284: {
@@ -298,7 +297,7 @@ describe( 'reducer', () => {
 			const previousInvalidState = deepFreeze( {
 				2454: { views: 2 },
 			} );
-			const state = items( previousInvalidState, { type: DESERIALIZE } );
+			const state = deserialize( items, previousInvalidState );
 
 			expect( state ).to.eql( {} );
 		} );

--- a/client/state/stored-cards/test/reducer.js
+++ b/client/state/stored-cards/test/reducer.js
@@ -17,9 +17,8 @@ import {
 	STORED_CARDS_DELETE,
 	STORED_CARDS_DELETE_COMPLETED,
 	STORED_CARDS_DELETE_FAILED,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'items', () => {
@@ -163,7 +162,7 @@ describe( 'items', () => {
 		test( 'should persist state', () => {
 			const originalState = deepFreeze( STORED_CARDS_FROM_API );
 
-			const state = items( originalState, { type: SERIALIZE } );
+			const state = serialize( items, originalState );
 
 			expect( state ).to.eql( originalState );
 		} );
@@ -171,7 +170,7 @@ describe( 'items', () => {
 		test( 'should load valid persisted state', () => {
 			const originalState = deepFreeze( STORED_CARDS_FROM_API );
 
-			const state = items( originalState, { type: DESERIALIZE } );
+			const state = deserialize( items, originalState );
 
 			expect( state ).to.eql( originalState );
 		} );
@@ -185,7 +184,7 @@ describe( 'items', () => {
 				},
 			] );
 
-			const state = items( originalState, { type: DESERIALIZE } );
+			const state = deserialize( items, originalState );
 
 			expect( state ).to.eql( [] );
 		} );

--- a/client/state/teams/test/reducer.js
+++ b/client/state/teams/test/reducer.js
@@ -9,7 +9,7 @@ import deepfreeze from 'deep-freeze';
  */
 import { items, isRequesting } from '../reducer';
 import { TEAMS_REQUEST, TEAMS_RECEIVE } from 'calypso/state/teams/action-types';
-import { DESERIALIZE } from 'calypso/state/action-types';
+import { deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 const TEAM1 = { slug: 'team one slug', title: 'team one title' };
@@ -66,13 +66,13 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'deserialize: should succeed with good data', () => {
-			assert.deepEqual( validState, items( validState, { type: DESERIALIZE } ) );
+			assert.deepEqual( validState, deserialize( items, validState ) );
 		} );
 
 		test( 'deserialize: should ignore bad data', () => {
 			let state;
 			try {
-				state = items( invalidState, { type: DESERIALIZE } );
+				state = deserialize( items, invalidState );
 				assert.fail();
 			} catch ( err ) {
 				assert.deepEqual( [], state );

--- a/client/state/terms/test/reducer.js
+++ b/client/state/terms/test/reducer.js
@@ -10,14 +10,13 @@ import deepFreeze from 'deep-freeze';
 import reducer, { queries, queryRequests } from '../reducer';
 import TermQueryManager from 'calypso/lib/query-manager/term';
 import {
-	DESERIALIZE,
 	TERM_REMOVE,
 	TERMS_RECEIVE,
 	TERMS_REQUEST,
 	TERMS_REQUEST_FAILURE,
 	TERMS_REQUEST_SUCCESS,
-	SERIALIZE,
 } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 /**
@@ -254,7 +253,7 @@ describe( 'reducer', () => {
 				} )
 			);
 
-			const state = queries( original, { type: SERIALIZE } );
+			const state = serialize( queries, original );
 
 			expect( state ).to.have.keys( [ '2916284' ] );
 			expect( state[ 2916284 ] ).to.have.keys( [ 'category' ] );
@@ -273,21 +272,18 @@ describe( 'reducer', () => {
 				} )
 			);
 
-			const serialized = queries( original, { type: SERIALIZE } );
-			const state = queries( serialized, { type: DESERIALIZE } );
+			const serialized = serialize( queries, original );
+			const state = deserialize( queries, serialized );
 
 			expect( state ).to.eql( original );
 		} );
 
 		test( 'should not load invalid persisted state', () => {
-			const state = queries(
-				{
-					2916284: {
-						category: '{~!--BROKEN',
-					},
+			const state = deserialize( queries, {
+				2916284: {
+					category: '{~!--BROKEN',
 				},
-				{ type: DESERIALIZE }
-			);
+			} );
 
 			expect( state ).to.eql( {} );
 		} );

--- a/client/state/themes/test/reducer.js
+++ b/client/state/themes/test/reducer.js
@@ -42,7 +42,7 @@ import {
 	RECOMMENDED_THEMES_SUCCESS,
 	RECOMMENDED_THEMES_FAIL,
 } from 'calypso/state/themes/action-types';
-import { SERIALIZE, DESERIALIZE } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 
 const twentysixteen = {
 	id: 'twentysixteen',
@@ -316,7 +316,7 @@ describe( 'reducer', () => {
 				} )
 			);
 
-			const state = queries( original, { type: SERIALIZE } );
+			const state = serialize( queries, original );
 
 			// _timestamp is not part of the data
 			delete state._timestamp;
@@ -361,7 +361,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			const state = queries( original, { type: DESERIALIZE } );
+			const state = deserialize( queries, original );
 
 			expect( state ).toEqual( {
 				2916284: new ThemeQueryManager(
@@ -387,7 +387,7 @@ describe( 'reducer', () => {
 				2916284: '{INVALID',
 			} );
 
-			const state = queries( original, { type: DESERIALIZE } );
+			const state = deserialize( queries, original );
 
 			expect( state ).toEqual( {} );
 		} );
@@ -615,18 +615,12 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'persists state', () => {
-			const state = themeRequestErrors( themeError, {
-				type: SERIALIZE,
-			} );
-
+			const state = serialize( themeRequestErrors, themeError );
 			expect( state ).toEqual( themeError );
 		} );
 
 		test( 'loads persisted state', () => {
-			const state = themeRequestErrors( themeError, {
-				type: DESERIALIZE,
-			} );
-
+			const state = deserialize( themeRequestErrors, themeError );
 			expect( state ).toEqual( themeError );
 		} );
 	} );
@@ -688,8 +682,7 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should persist state', () => {
-			const state = activeThemes( { 2211888: 'twentysixteen' }, { type: SERIALIZE } );
-
+			const state = serialize( activeThemes, { 2211888: 'twentysixteen' } );
 			expect( state ).toEqual( { 2211888: 'twentysixteen' } );
 		} );
 
@@ -698,7 +691,7 @@ describe( 'reducer', () => {
 				2211888: 'twentysixteen',
 			} );
 
-			const state = activeThemes( original, { type: DESERIALIZE } );
+			const state = deserialize( activeThemes, original );
 			expect( state ).toEqual( { 2211888: 'twentysixteen' } );
 		} );
 
@@ -708,7 +701,7 @@ describe( 'reducer', () => {
 				2916284: 1234,
 			} );
 
-			const state = activeThemes( original, { type: DESERIALIZE } );
+			const state = deserialize( activeThemes, original );
 			expect( state ).toEqual( {} );
 		} );
 	} );

--- a/client/state/timezones/test/reducer.js
+++ b/client/state/timezones/test/reducer.js
@@ -10,6 +10,7 @@ import deepFreeze from 'deep-freeze';
 import { timezonesReceive } from '../actions';
 import timezonesReducer, { byContinents, labels, rawOffsets } from '../reducer';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
+import { serialize, deserialize } from 'calypso/state/utils';
 
 describe( 'reducer', () => {
 	let sandbox;
@@ -102,21 +103,20 @@ describe( 'reducer', () => {
 			};
 			deepFreeze( initialState );
 
-			const action = { type: 'DESERIALIZE' };
 			const expectedState = initialState;
-			const newState = rawOffsets( initialState, action );
+			const newState = deserialize( rawOffsets, initialState );
 			expect( newState ).to.eql( expectedState );
 		} );
 
 		test( 'should not load invalid persisted state', () => {
 			const initialStateONE = { rawOffsets: { foo: 'bar' } };
 			deepFreeze( initialStateONE );
-			const newStateONE = rawOffsets( initialStateONE, { type: 'DESERIALIZE' } );
+			const newStateONE = deserialize( rawOffsets, initialStateONE );
 
 			// 'UTC' shouldn't be allowed either.
 			const initialStateTWO = { rawOffsets: { UTC: 'UTC' } };
 			deepFreeze( initialStateTWO );
-			const newStateTWO = rawOffsets( initialStateTWO, { type: 'DESERIALIZE' } );
+			const newStateTWO = deserialize( rawOffsets, initialStateTWO );
 
 			expect( newStateONE ).to.eql( {} );
 			expect( newStateTWO ).to.eql( {} );
@@ -199,16 +199,15 @@ describe( 'reducer', () => {
 			};
 			deepFreeze( initialState );
 
-			const action = { type: 'DESERIALIZE' };
 			const expectedState = initialState;
-			const newState = labels( initialState, action );
+			const newState = deserialize( labels, initialState );
 			expect( newState ).to.eql( expectedState );
 		} );
 
 		test( 'should not load invalid persisted state', () => {
 			const initialStateONE = { labels: { foo: 'bar' } };
 			deepFreeze( initialStateONE );
-			const newStateONE = labels( initialStateONE, { type: 'DESERIALIZE' } );
+			const newStateONE = deserialize( labels, initialStateONE );
 			expect( newStateONE ).to.eql( {} );
 		} );
 	} );
@@ -273,9 +272,8 @@ describe( 'reducer', () => {
 			};
 			deepFreeze( initialState );
 
-			const action = { type: 'SERIALIZE' };
 			const expectedState = initialState;
-			const newState = byContinents( initialState, action );
+			const newState = serialize( byContinents, initialState );
 
 			expect( newState ).to.eql( expectedState );
 		} );
@@ -288,16 +286,15 @@ describe( 'reducer', () => {
 			};
 			deepFreeze( initialState );
 
-			const action = { type: 'DESERIALIZE' };
 			const expectedState = initialState;
-			const newState = byContinents( initialState, action );
+			const newState = deserialize( byContinents, initialState );
 			expect( newState ).to.eql( expectedState );
 		} );
 
 		test( 'should not load invalid persisted state', () => {
 			const initialStateONE = { byContinents: { foo: 'bar' } };
 			deepFreeze( initialStateONE );
-			const newStateONE = byContinents( initialStateONE, { type: 'DESERIALIZE' } );
+			const newStateONE = deserialize( byContinents, initialStateONE );
 			expect( newStateONE ).to.eql( {} );
 		} );
 	} );

--- a/client/state/ui/checkout/test/reducer.js
+++ b/client/state/ui/checkout/test/reducer.js
@@ -1,12 +1,8 @@
 /**
  * Internal dependencies
  */
-import {
-	CHECKOUT_TOGGLE_CART_ON_MOBILE,
-	DESERIALIZE,
-	SECTION_SET,
-	SERIALIZE,
-} from 'calypso/state/action-types';
+import { CHECKOUT_TOGGLE_CART_ON_MOBILE, SECTION_SET } from 'calypso/state/action-types';
+import { serialize, deserialize } from 'calypso/state/utils';
 import reducer, { isShowingCartOnMobile, upgradeIntent } from '../reducer';
 
 describe( 'reducer', () => {
@@ -41,12 +37,12 @@ describe( 'reducer', () => {
 
 	describe( '#upgradeIntent()', () => {
 		test( 'should persist value', () => {
-			const state = upgradeIntent( 'hallows', { type: SERIALIZE } );
+			const state = serialize( upgradeIntent, 'hallows' );
 			expect( state ).toBe( 'hallows' );
 		} );
 
 		test( 'should restore value', () => {
-			const state = upgradeIntent( 'always', { type: DESERIALIZE } );
+			const state = deserialize( upgradeIntent, 'always' );
 			expect( state ).toBe( 'always' );
 		} );
 

--- a/client/state/utils/index.ts
+++ b/client/state/utils/index.ts
@@ -5,6 +5,7 @@ export { extendAction } from './extend-action';
 export { isValidStateWithSchema, withSchemaValidation } from './schema-utils';
 export { keyedReducer } from './keyed-reducer';
 export { withEnhancers } from './with-enhancers';
+export { serialize, deserialize } from './serialize';
 export { withoutPersistence } from './without-persistence';
 export { addReducer, combineReducers } from './reducer-utils';
 export { addReducerEnhancer } from './add-reducer-enhancer';

--- a/client/state/utils/serialize.js
+++ b/client/state/utils/serialize.js
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { SERIALIZE, DESERIALIZE } from 'calypso/state/action-types';
+
+export function serialize( reducer, state ) {
+	return reducer( state, { type: SERIALIZE } );
+}
+
+export function deserialize( reducer, persisted ) {
+	return reducer( persisted, { type: DESERIALIZE } );
+}

--- a/client/state/wordads/settings/test/reducer.js
+++ b/client/state/wordads/settings/test/reducer.js
@@ -7,9 +7,8 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import { items, requests } from '../reducer';
+import { serialize, deserialize } from 'calypso/state/utils';
 import {
-	DESERIALIZE,
-	SERIALIZE,
 	WORDADS_SETTINGS_RECEIVE,
 	WORDADS_SETTINGS_SAVE,
 	WORDADS_SETTINGS_SAVE_FAILURE,
@@ -101,7 +100,7 @@ describe( 'reducer', () => {
 			const previousState = deepFreeze( {
 				2916284: { paypal: 'support@wordpress.com' },
 			} );
-			const state = items( previousState, { type: SERIALIZE } );
+			const state = serialize( items, previousState );
 
 			expect( state ).toEqual( {
 				2916284: { paypal: 'support@wordpress.com' },
@@ -112,7 +111,7 @@ describe( 'reducer', () => {
 			const previousState = deepFreeze( {
 				2916284: { paypal: 'support@wordpress.com' },
 			} );
-			const state = items( previousState, { type: DESERIALIZE } );
+			const state = deserialize( items, previousState );
 
 			expect( state ).toEqual( {
 				2916284: { paypal: 'support@wordpress.com' },
@@ -123,7 +122,7 @@ describe( 'reducer', () => {
 			const previousInvalidState = deepFreeze( {
 				2454: 2,
 			} );
-			const state = items( previousInvalidState, { type: DESERIALIZE } );
+			const state = deserialize( items, previousInvalidState );
 
 			expect( state ).toEqual( {} );
 		} );


### PR DESCRIPTION
Quite big and repetitive, test-only spinoff from #50222.

Abstracts away dispatches of `SERIALIZE` and `DESERIALIZE` actions into helper functions. Instead of:
```js
const persisted = reducer( state, { type: SERIALIZE } );
const state = reducer( persisted, { type: DESERIALIZE } );
```
we now write:
```js
import { serialize, deserialize } from 'calypso/state/utils';

const persisted = serialize( reducer, state );
const state = deserialize( reducer, persisted );
```

Right now they do the action dispatches internally, but the beauty is that after the refactoring in #50222 their implementation will be very different, roughly equivalent to:
```js
const persisted = reducer.serialize( state );
const state = reducer.deserialize( persisted );
```
But the usage will remain exactly the same. The tests are unaware of the implementation details and just test if the reducer implements persistence as expected.