### PR TITLE
Revert "Nav Unification: add selector for Classic Bright to default c…

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -1,5 +1,4 @@
-:root,
-.color-scheme.is-classic-bright .is-nav-unification {
+:root {
 	/* Theme Properties */
 	--color-primary: var( --studio-blue-50 );
 	--color-primary-rgb: var( --studio-blue-50-rgb );


### PR DESCRIPTION
…olor scheme (#49710)"

This reverts commit d3ca9f5ebbf83d1cad0ad380617012ff39b17fa2.

Context: p1613644049033400-slack-C7YPUHBB2

At least IE11 and the notifications panel for non-calypso environments (not currently deployed though) are visually broken since d3ca9f5ebbf83d1cad0ad380617012ff39b17fa2. It seems like it's missing the fallback values for the CSS custom properties which are usually applied for browsers which don't support them.

<img width="549" alt="Screenshot 2021-02-18 at 14 39 49" src="https://user-images.githubusercontent.com/9202899/108365144-2960c280-71f7-11eb-9142-016fdfbf61e9.png">

### Testing instructions

1. Open Calypso with IE11 and verify it's visually broken in prod currently
2. Open [calypso.live](https://calypso.live/?branch=fix/revert-d3ca9f5ebbf83d1cad0ad380617012ff39b17fa2) with IE11 and verify it's not visually broken anymore
