### PR TITLE
Move Sparkline chart to SVG

### DIFF
--- a/client/blocks/stats-sparkline/index.jsx
+++ b/client/blocks/stats-sparkline/index.jsx
@@ -30,33 +30,39 @@ const StatsSparklineChart = ( { className, hourlyViews, height = DEFAULT_HEIGHT 
 	const chartWidth = 2 * hourlyViews.length - 1; // 1px bars with 1px space in between
 
 	return (
-		<svg
+		<div
 			className={ classnames( 'stats-sparkline', className ) }
 			title={ title }
-			width={ chartWidth }
-			height={ chartHeight }
-			viewBox={ `0 0 ${ chartWidth } ${ chartHeight }` }
+			style={ { height: chartHeight + 'px', width: chartWidth + 'px' } }
 		>
-			{ hourlyViews.map( ( value, i ) => {
-				// for zero value, we show a baseline bar with 1px height
-				let lineHeight = 1;
+			<svg
+				width={ chartWidth }
+				height={ chartHeight }
+				viewBox={ `0 0 ${ chartWidth } ${ chartHeight }` }
+			>
+				{ hourlyViews.map( ( value, i ) => {
+					// for zero value, we show a baseline bar with 1px height
+					let lineHeight = 1;
 
-				if ( highestViews > 0 ) {
-					lineHeight = ( value / highestViews ) * chartHeight;
-				}
+					// if the chart is all zeros, show just the flat baseline
+					if ( highestViews > 0 ) {
+						// fill the remaining height with the bar scaled according to the value
+						lineHeight += ( value / highestViews ) * ( chartHeight - 1 );
+					}
 
-				return (
-					<rect
-						x={ i * 2 }
-						y={ chartHeight - lineHeight }
-						height={ lineHeight }
-						width={ 1 }
-						key={ i }
-						className="stats-sparkline__bar"
-					/>
-				);
-			} ) }
-		</svg>
+					return (
+						<rect
+							x={ i * 2 }
+							y={ chartHeight - lineHeight }
+							height={ lineHeight }
+							width={ 1 }
+							key={ i }
+							className="stats-sparkline__bar"
+						/>
+					);
+				} ) }
+			</svg>
+		</div>
 	);
 };
 const StatsSparkline = ( { className, siteId } ) => {

--- a/client/blocks/stats-sparkline/index.jsx
+++ b/client/blocks/stats-sparkline/index.jsx
@@ -30,29 +30,33 @@ const StatsSparklineChart = ( { className, hourlyViews, height = DEFAULT_HEIGHT 
 	const chartWidth = 2 * hourlyViews.length - 1; // 1px bars with 1px space in between
 
 	return (
-		<div
+		<svg
 			className={ classnames( 'stats-sparkline', className ) }
 			title={ title }
-			style={ { height: chartHeight + 'px', width: chartWidth + 'px' } }
+			width={ chartWidth }
+			height={ chartHeight }
+			viewBox={ `0 0 ${ chartWidth } ${ chartHeight }` }
 		>
 			{ hourlyViews.map( ( value, i ) => {
 				// for zero value, we show a baseline bar with 1px height
-				let scale = 1 / chartHeight;
-				// if the chart is all zeros, show just the flat baseline
+				let lineHeight = 1;
+
 				if ( highestViews > 0 ) {
-					// fill the remaining height with the bar scaled according to the value
-					scale += ( value / highestViews ) * ( 1 - 1 / chartHeight );
+					lineHeight = ( value / highestViews ) * chartHeight;
 				}
 
 				return (
-					<div
+					<rect
+						x={ i * 2 }
+						y={ chartHeight - lineHeight }
+						height={ lineHeight }
+						width={ 1 }
 						key={ i }
 						className="stats-sparkline__bar"
-						style={ { transform: `scaleY(${ scale })` } }
 					/>
 				);
 			} ) }
-		</div>
+		</svg>
 	);
 };
 const StatsSparkline = ( { className, siteId } ) => {

--- a/client/blocks/stats-sparkline/style.scss
+++ b/client/blocks/stats-sparkline/style.scss
@@ -4,14 +4,5 @@
 }
 
 .stats-sparkline__bar {
-	display: inline-block;
-	background-color: var( --color-stats-sparkline );
-	width: 1px;
-	height: 100%;
-	transform-origin: 0% 100%;
-	margin-left: 1px;
-
-	&:first-child {
-		margin-left: 0;
-	}
+	fill: var( --color-stats-sparkline );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This a quick follow up for https://github.com/Automattic/wp-calypso/pull/49988 with a slight improvement to the sparkline chart.

It looks exactly the same but is powered by SVG.

Before:
<img width="200" src="https://user-images.githubusercontent.com/17054134/108372779-7183e300-71ff-11eb-94e9-172899cd729b.png" >


After:
<img width="200" src="https://user-images.githubusercontent.com/17054134/108372871-8a8c9400-71ff-11eb-9aef-acfdaf0041f5.png" >



#### Testing instructions

1. Using calypso.live (https://calypso.live/?branch=update/svg-spike-chart) compare it against wordpress.com. They should look the same.

#### Note
The CSS custom properties are not being compiled into hardcoded values. But the same thing is happening on `trunk` so this is not a regression. 
