### PR TITLE
Nav Unification: Show a warning before navigating away to WP Admin if Happychat is active

### DIFF
--- a/client/layout/sidebar/expandable-heading.jsx
+++ b/client/layout/sidebar/expandable-heading.jsx
@@ -24,6 +24,7 @@ const ExpandableSidebarHeading = ( {
 	materialIconStyle,
 	expanded,
 	menuId,
+	hideExpandableIcon,
 	...props
 } ) => {
 	return (
@@ -46,7 +47,9 @@ const ExpandableSidebarHeading = ( {
 				{ title }
 				{ undefined !== count && <Count count={ count } /> }
 			</span>
-			<MaterialIcon icon="keyboard_arrow_down" className="sidebar__expandable-arrow" />
+			{ ! hideExpandableIcon && (
+				<MaterialIcon icon="keyboard_arrow_down" className="sidebar__expandable-arrow" />
+			) }
 		</SidebarHeading>
 	);
 };
@@ -59,6 +62,7 @@ ExpandableSidebarHeading.propTypes = {
 	icon: PropTypes.string,
 	materialIcon: PropTypes.string,
 	materialIconStyle: PropTypes.string,
+	hideExpandableIcon: PropTypes.bool,
 };
 
 ExpandableSidebarHeading.defaultProps = {

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -20,9 +20,7 @@ import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 
 export default function SidebarItem( props ) {
 	const isExternalLink = isExternal( props.link );
-	const shouldOpenInNewTab = isExternalLink && ! props.forceInternalLink;
-	const showAsExternal =
-		typeof props.showAsExternal !== 'undefined' ? props.showAsExternal : shouldOpenInNewTab;
+	const showAsExternal = isExternalLink && ! props.forceInternalLink;
 	const classes = classnames( props.className, props.tipTarget, {
 		selected: props.selected,
 		'has-unseen': props.hasUnseen,
@@ -54,7 +52,7 @@ export default function SidebarItem( props ) {
 				className="sidebar__menu-link"
 				onClick={ props.onNavigate }
 				href={ props.link }
-				target={ shouldOpenInNewTab ? '_blank' : null }
+				target={ showAsExternal ? '_blank' : null }
 				rel={ isExternalLink ? 'noopener noreferrer' : null }
 				onMouseEnter={ itemPreload }
 			>
@@ -95,7 +93,6 @@ SidebarItem.propTypes = {
 	expandSection: PropTypes.func,
 	preloadSectionName: PropTypes.string,
 	forceInternalLink: PropTypes.bool,
-	showAsExternal: PropTypes.bool,
 	testTarget: PropTypes.string,
 	tipTarget: PropTypes.string,
 	count: PropTypes.number,

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -20,7 +20,9 @@ import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 
 export default function SidebarItem( props ) {
 	const isExternalLink = isExternal( props.link );
-	const showAsExternal = isExternalLink && ! props.forceInternalLink;
+	const shouldOpenInNewTab = isExternalLink && ! props.forceInternalLink;
+	const showAsExternal =
+		typeof props.showAsExternal !== 'undefined' ? props.showAsExternal : shouldOpenInNewTab;
 	const classes = classnames( props.className, props.tipTarget, {
 		selected: props.selected,
 		'has-unseen': props.hasUnseen,
@@ -52,7 +54,7 @@ export default function SidebarItem( props ) {
 				className="sidebar__menu-link"
 				onClick={ props.onNavigate }
 				href={ props.link }
-				target={ showAsExternal ? '_blank' : null }
+				target={ shouldOpenInNewTab ? '_blank' : null }
 				rel={ isExternalLink ? 'noopener noreferrer' : null }
 				onMouseEnter={ itemPreload }
 			>
@@ -93,6 +95,7 @@ SidebarItem.propTypes = {
 	expandSection: PropTypes.func,
 	preloadSectionName: PropTypes.string,
 	forceInternalLink: PropTypes.bool,
+	showAsExternal: PropTypes.bool,
 	testTarget: PropTypes.string,
 	tipTarget: PropTypes.string,
 	count: PropTypes.number,

--- a/client/my-sites/sidebar-unified/external-link-dialog.jsx
+++ b/client/my-sites/sidebar-unified/external-link-dialog.jsx
@@ -9,10 +9,10 @@ import { translate } from 'i18n-calypso';
  */
 import { Dialog } from '@automattic/components';
 
-export const ExternalLinkDialog = ( { closeModalHandler } ) => {
+export const ExternalLinkDialog = ( { isVisible, closeModalHandler } ) => {
 	return (
 		<Dialog
-			isVisible={ true }
+			isVisible={ isVisible }
 			buttons={ [
 				{
 					action: 'cancel',
@@ -31,10 +31,10 @@ export const ExternalLinkDialog = ( { closeModalHandler } ) => {
 		>
 			<p>
 				{ translate(
-					'There is a Chat session in progress. Clicking OK will open this link in a new tab.'
+					'There is a Support Chat session in progress. Clicking OK will open this link in a new tab.'
 				) }
 			</p>
-			<p>{ translate( 'Please come back to this tab to continue.' ) }</p>
+			<p>{ translate( 'Please come back to this tab to continue chatting.' ) }</p>
 		</Dialog>
 	);
 };

--- a/client/my-sites/sidebar-unified/external-link-dialog.jsx
+++ b/client/my-sites/sidebar-unified/external-link-dialog.jsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Dialog } from '@automattic/components';
+
+export const ExternalLinkDialog = ( { closeModalHandler } ) => {
+	return (
+		<Dialog
+			isVisible={ true }
+			buttons={ [
+				{
+					action: 'cancel',
+					label: translate( 'Cancel' ),
+					isPrimary: false,
+					onClick: () => closeModalHandler( false ),
+				},
+				{
+					action: 'ok',
+					label: translate( 'OK' ),
+					isPrimary: true,
+					onClick: () => closeModalHandler( true ),
+				},
+			] }
+			onClose={ () => closeModalHandler( false ) }
+		>
+			<p>
+				{ translate(
+					'There is a Chat session in progress. Clicking OK will open this link in a new tab.'
+				) }
+			</p>
+			<p>{ translate( 'Please come back to this tab to continue.' ) }</p>
+		</Dialog>
+	);
+};
+
+export default ExternalLinkDialog;

--- a/client/my-sites/sidebar-unified/external-link-dialog.jsx
+++ b/client/my-sites/sidebar-unified/external-link-dialog.jsx
@@ -22,7 +22,7 @@ export const ExternalLinkDialog = ( { isVisible, closeModalHandler } ) => {
 				},
 				{
 					action: 'ok',
-					label: translate( 'OK' ),
+					label: translate( 'Continue' ),
 					isPrimary: true,
 					onClick: () => closeModalHandler( true ),
 				},
@@ -31,10 +31,9 @@ export const ExternalLinkDialog = ( { isVisible, closeModalHandler } ) => {
 		>
 			<p>
 				{ translate(
-					'There is a Support Chat session in progress. Clicking OK will open this link in a new tab.'
+					'A support chat session is currently in progress. Click continue to open this link in a new tab.'
 				) }
 			</p>
-			<p>{ translate( 'Please come back to this tab to continue chatting.' ) }</p>
 		</Dialog>
 	);
 };

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -11,7 +11,7 @@
  * External dependencies
  */
 import React, { Fragment, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -33,10 +33,12 @@ import { itemLinkMatches } from '../sidebar/utils';
 import { getSidebarIsCollapsed } from 'calypso/state/ui/selectors';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
 import { isExternal } from 'calypso/lib/url';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './style.scss';
 
 export const MySitesSidebarUnified = ( { path } ) => {
+	const dispatch = useDispatch();
 	const menuItems = useSiteMenuItems();
 	const isAllDomainsView = useDomainsViewStatus();
 	const isRequestingMenu = useSelector( getIsRequestingAdminMenu );
@@ -64,6 +66,11 @@ export const MySitesSidebarUnified = ( { path } ) => {
 			event && event.preventDefault();
 			setExternalUrl( url );
 			setShowDialog( true );
+			dispatch(
+				recordTracksEvent( 'calypso_nav_unification_external_link_dialog_show', {
+					link: url,
+				} )
+			);
 			return false;
 		}
 		return true;
@@ -71,7 +78,14 @@ export const MySitesSidebarUnified = ( { path } ) => {
 
 	const closeModalHandler = ( openUrl ) => {
 		setShowDialog( false );
-		openUrl && window.open( externalUrl );
+		if ( openUrl ) {
+			openUrl && window.open( externalUrl );
+			dispatch(
+				recordTracksEvent( 'calypso_nav_unification_external_link_dialog_continue', {
+					link: externalUrl,
+				} )
+			);
+		}
 	};
 
 	return (

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -116,7 +116,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 			<AsyncLoad
 				require="calypso/my-sites/sidebar-unified/external-link-dialog"
 				isVisible={ showDialog }
-				closeModalHandler={ ( openUrl ) => closeModalHandler( openUrl ) }
+				closeModalHandler={ closeModalHandler }
 			/>
 		</Fragment>
 	);

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -20,7 +20,6 @@ import AsyncLoad from 'calypso/components/async-load';
 import CurrentSite from 'calypso/my-sites/current-site';
 import MySitesSidebarUnifiedItem from './item';
 import MySitesSidebarUnifiedMenu from './menu';
-import ExternalLinkDialog from './external-link-dialog';
 import CollapseSidebar from './collapse-sidebar';
 import useSiteMenuItems from './use-site-menu-items';
 import useDomainsViewStatus from './use-domains-view-status';
@@ -113,11 +112,12 @@ export const MySitesSidebarUnified = ( { path } ) => {
 				} ) }
 				<CollapseSidebar key="collapse" title="Collapse menu" icon="dashicons-admin-collapse" />
 			</Sidebar>
-			<ExternalLinkDialog
+			<AsyncLoad require="calypso/blocks/nav-unification-modal" placeholder={ null } />
+			<AsyncLoad
+				require="calypso/my-sites/sidebar-unified/external-link-dialog"
 				isVisible={ showDialog }
 				closeModalHandler={ ( openUrl ) => closeModalHandler( openUrl ) }
 			/>
-			<AsyncLoad require="calypso/blocks/nav-unification-modal" placeholder={ null } />
 		</Fragment>
 	);
 };

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -79,7 +79,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 	const closeModalHandler = ( openUrl ) => {
 		setShowDialog( false );
 		if ( openUrl ) {
-			openUrl && window.open( externalUrl );
+			window.open( externalUrl );
 			dispatch(
 				recordTracksEvent( 'calypso_nav_unification_external_link_dialog_continue', {
 					link: externalUrl,

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -23,7 +23,6 @@ import {
 	expandMySitesSidebarSection,
 } from 'calypso/state/my-sites/sidebar/actions';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
-import { isExternal } from 'calypso/lib/url';
 
 export const MySitesSidebarUnifiedItem = ( {
 	count,
@@ -52,8 +51,7 @@ export const MySitesSidebarUnifiedItem = ( {
 			onNavigate={ ( event ) => continueInCalypso( url, event ) && onNavigate() }
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
-			forceInternalLink
-			showAsExternal={ isHappychatSessionActive && isExternal( url ) }
+			forceInternalLink={ ! isHappychatSessionActive }
 			className={ isSubItem ? 'sidebar__menu-item--child' : 'sidebar__menu-item-parent' }
 		>
 			<MySitesSidebarUnifiedStatsSparkline slug={ slug } />

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -15,7 +15,6 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import MySitesSidebarUnifiedStatsSparkline from './sparkline';
@@ -35,27 +34,26 @@ export const MySitesSidebarUnifiedItem = ( {
 	slug,
 	title,
 	url,
+	continueInCalypso,
 } ) => {
 	const reduxDispatch = useDispatch();
 	const isHappychatSessionActive = useSelector( ( state ) => hasActiveHappychatSession( state ) );
+
+	const onNavigate = () => {
+		reduxDispatch( collapseAllMySitesSidebarSections() );
+		reduxDispatch( expandMySitesSidebarSection( sectionId ) );
+	};
 
 	return (
 		<SidebarItem
 			count={ count }
 			label={ title }
 			link={ url }
-			onNavigate={ () => {
-				if ( isHappychatSessionActive && isExternal( url ) ) {
-					// TODO
-				}
-
-				reduxDispatch( collapseAllMySitesSidebarSections() );
-				reduxDispatch( expandMySitesSidebarSection( sectionId ) );
-			} }
+			onNavigate={ ( event ) => continueInCalypso( url, event ) && onNavigate() }
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
-			forceInternalLink={ ! isHappychatSessionActive }
-			showAsExternal={ false }
+			forceInternalLink
+			showAsExternal={ isHappychatSessionActive && isExternal( url ) }
 			className={ isSubItem ? 'sidebar__menu-item--child' : 'sidebar__menu-item-parent' }
 		>
 			<MySitesSidebarUnifiedStatsSparkline slug={ slug } />

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -9,7 +9,7 @@
  * External dependencies
  */
 import React, { memo } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
 /**
@@ -23,6 +23,8 @@ import {
 	collapseAllMySitesSidebarSections,
 	expandMySitesSidebarSection,
 } from 'calypso/state/my-sites/sidebar/actions';
+import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
+import { isExternal } from 'calypso/lib/url';
 
 export const MySitesSidebarUnifiedItem = ( {
 	count,
@@ -35,6 +37,7 @@ export const MySitesSidebarUnifiedItem = ( {
 	url,
 } ) => {
 	const reduxDispatch = useDispatch();
+	const isHappychatSessionActive = useSelector( ( state ) => hasActiveHappychatSession( state ) );
 
 	return (
 		<SidebarItem
@@ -42,12 +45,17 @@ export const MySitesSidebarUnifiedItem = ( {
 			label={ title }
 			link={ url }
 			onNavigate={ () => {
+				if ( isHappychatSessionActive && isExternal( url ) ) {
+					// TODO
+				}
+
 				reduxDispatch( collapseAllMySitesSidebarSections() );
 				reduxDispatch( expandMySitesSidebarSection( sectionId ) );
 			} }
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
-			forceInternalLink
+			forceInternalLink={ ! isHappychatSessionActive }
+			showAsExternal={ false }
 			className={ isSubItem ? 'sidebar__menu-item--child' : 'sidebar__menu-item-parent' }
 		>
 			<MySitesSidebarUnifiedStatsSparkline slug={ slug } />

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -66,7 +66,7 @@ MySitesSidebarUnifiedItem.propTypes = {
 	slug: PropTypes.string,
 	title: PropTypes.string,
 	url: PropTypes.string,
-	continueInCalypso: PropTypes.func,
+	continueInCalypso: PropTypes.func.isRequired,
 };
 
 export default memo( MySitesSidebarUnifiedItem );

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -66,6 +66,7 @@ MySitesSidebarUnifiedItem.propTypes = {
 	slug: PropTypes.string,
 	title: PropTypes.string,
 	url: PropTypes.string,
+	continueInCalypso: PropTypes.func,
 };
 
 export default memo( MySitesSidebarUnifiedItem );

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -40,6 +40,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 	link,
 	selected,
 	sidebarCollapsed,
+	continueInCalypso,
 } ) => {
 	const hasAutoExpanded = useRef( false );
 	const reduxDispatch = useDispatch();
@@ -87,7 +88,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 	return (
 		<li>
 			<ExpandableSidebarMenu
-				onClick={ () => onClick() }
+				onClick={ () => continueInCalypso( link ) && onClick() }
 				expanded={ ! sidebarCollapsed && isExpanded }
 				title={ title }
 				customIcon={ <SidebarCustomIcon icon={ icon } /> }
@@ -104,6 +105,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 							selected={ isSelected }
 							sectionId={ sectionId }
 							isSubItem={ true }
+							continueInCalypso={ continueInCalypso }
 						/>
 					);
 				} ) }

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -61,35 +61,39 @@ export const MySitesSidebarUnifiedMenu = ( {
 			hasAutoExpanded.current = true;
 		}
 	}, [ selected, childIsSelected, reduxDispatch, sectionId, sidebarCollapsed ] );
+
+	const onClick = () => {
+		if ( isWithinBreakpoint( '>782px' ) ) {
+			if ( link ) {
+				if ( isExternal( link ) ) {
+					// If the URL is external, page() will fail to replace state between different domains.
+					externalRedirect( link );
+					return;
+				}
+
+				// Only open the page if menu is NOT full-width, otherwise just open / close the section instead of directly redirecting to the section.
+				page( link );
+			}
+
+			if ( ! sidebarCollapsed ) {
+				// Keep only current submenu open.
+				reduxDispatch( collapseAllMySitesSidebarSections() );
+			}
+		}
+
+		reduxDispatch( toggleSection( sectionId ) );
+	};
+
 	return (
 		<li>
 			<ExpandableSidebarMenu
-				onClick={ () => {
-					if ( isWithinBreakpoint( '>782px' ) ) {
-						if ( link ) {
-							if ( isExternal( link ) ) {
-								// If the URL is external, page() will fail to replace state between different domains.
-								externalRedirect( link );
-								return;
-							}
-
-							// Only open the page if menu is NOT full-width, otherwise just open / close the section instead of directly redirecting to the section.
-							page( link );
-						}
-
-						if ( ! sidebarCollapsed ) {
-							// Keep only current submenu open.
-							reduxDispatch( collapseAllMySitesSidebarSections() );
-						}
-					}
-
-					reduxDispatch( toggleSection( sectionId ) );
-				} }
+				onClick={ () => onClick() }
 				expanded={ ! sidebarCollapsed && isExpanded }
 				title={ title }
 				customIcon={ <SidebarCustomIcon icon={ icon } /> }
 				className={ ( selected || childIsSelected ) && 'sidebar__menu--selected' }
 				count={ count }
+				hideExpandableIcon={ true }
 			>
 				{ children.map( ( item ) => {
 					const isSelected = selectedMenuItem?.url === item.url;

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -66,6 +66,10 @@ export const MySitesSidebarUnifiedMenu = ( {
 	const onClick = () => {
 		if ( isWithinBreakpoint( '>782px' ) ) {
 			if ( link ) {
+				if ( ! continueInCalypso( link ) ) {
+					return;
+				}
+
 				if ( isExternal( link ) ) {
 					// If the URL is external, page() will fail to replace state between different domains.
 					externalRedirect( link );
@@ -88,7 +92,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 	return (
 		<li>
 			<ExpandableSidebarMenu
-				onClick={ () => continueInCalypso( link ) && onClick() }
+				onClick={ () => onClick() }
 				expanded={ ! sidebarCollapsed && isExpanded }
 				title={ title }
 				customIcon={ <SidebarCustomIcon icon={ icon } /> }

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -127,7 +127,7 @@ MySitesSidebarUnifiedMenu.propTypes = {
 	children: PropTypes.array.isRequired,
 	link: PropTypes.string,
 	sidebarCollapsed: PropTypes.bool,
-	continueInCalypso: PropTypes.func,
+	continueInCalypso: PropTypes.func.isRequired,
 	/*
 	Example of children shape:
 	[

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -123,6 +123,7 @@ MySitesSidebarUnifiedMenu.propTypes = {
 	children: PropTypes.array.isRequired,
 	link: PropTypes.string,
 	sidebarCollapsed: PropTypes.bool,
+	continueInCalypso: PropTypes.func,
 	/*
 	Example of children shape:
 	[

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -113,7 +113,6 @@ $font-size: rem( 14px );
 
 		.sidebar__expandable-arrow,
 		.gridicons-external {
-			display: none;
 			width: 20px;
 			height: 20px;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We need an "External Link Check" both in the `MySitesSidebarUnifiedItem` and in the `MySitesSidebarUnifiedMenu`. That is why I opted for moving the logic - component to `MySitesSidebarUnified`.

- Adds support for hiding the `sidebar__expandable-arrow` on case per case
- Show a warning when Happychat is active and a customer clicks on a wp-admin link, then open it in new tab.

#### Testing instructions

- Logging into the Staging Happychat HUD (URL available in PCYsg-b99-p2).
- Spin up Calypso locally running this branch.
- Start a chat from the customer side (remember to select a site under a paid plan).
- Click on a WP Admin link.
- A warning is shown in a modal
- Clicking "Continue" opens in new tab
- Clicking "Cancel" dismisses the modal

Tracking Testing Instructions
- After ~ 5minutes of following the above instructions go to tracks tool and search for `calypso_nav_unification_external_link_dialog_%` the results should contain both events: `calypso_nav_unification_external_link_dialog_continue` and `calypso_nav_unification_external_link_dialog_show`.
- The above events should have a `link` prop showing the external Url clicked.

Links Icon | Modal
-------|------
![](https://cln.sh/MWtr7U+) | ![](https://cln.sh/zEoFZO+)

Fixes https://github.com/Automattic/wp-calypso/issues/50235