### PR TITLE
Fix MainDashboardButton incorrect undefined checking.

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -584,7 +584,7 @@ function handleCloseEditor( calypsoPort ) {
 		} );
 	}
 
-	if ( typeof MainDashboardButton !== 'undefined' ) {
+	if ( ! MainDashboardButton ) {
 		return;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Incorrect undefined checking of MainDashboardButton causes block editor to fail loading on atomic sites linked to WPCOM (Does not apply to atomic sites created through WPCOM).

Phab patch D57277-code

#### Testing instructions

* Create an atomic ephemeral site (you can uncheck install Gutenberg plugin).
* Link it to your WPCOM account.
* Run `yarn dev --sync` on `apps/wpcom-block-editor`.
* Sandbox `widgets.wp.com`
* Open your atomic site's iframed block editor.
* It should not fail.

Fixes #50228