### PR TITLE
Adding Anchor.fm announcement to ETK Whats New

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/style.scss
@@ -130,9 +130,12 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 }
 .whats-new__visual {
 	height: 40%;
-	padding: 25px;
+	padding: 25px 25px 0 25px;
 	background: #1581d8;
 	text-align: center;
+	display: flex;
+	flex-direction: column;
+	flex: 1;
 
 	@media ( min-width: $wpcom-modal-breakpoint ) {
 		height: auto;
@@ -144,11 +147,12 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 	/* Gray / Gray 90 */
 	color: #1d2327;
 
-	font-size: 24px;
-	line-height: 1.19;
+	font-size: 40px;
+	line-height: 1;
+	margin: 0;
 
 	@media ( min-width: $wpcom-modal-breakpoint ) {
-		font-size: 24px;
+		font-size: 40px;
 	}
 
 	// TODO: remove this hack once the welcome editor deals better with
@@ -165,6 +169,7 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 .whats-new__description p {
 	font-size: 15px;
 	line-height: 22px;
+	margin-top:10px;
 
 	/* Gray / Gray 60 */
 	color: #50575e;
@@ -178,7 +183,7 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 .whats-new__image {
 	max-width: 100%;
 	height: auto;
-	flex: 1;
+	margin-top: auto;
 	align-self: center;
 
 	&.align-bottom {

--- a/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
@@ -18,6 +18,7 @@ import './style.scss';
 const blockPatternsImage = 'https://s0.wp.com/i/whats-new/block-patterns.png';
 const dragDropImage = 'https://s0.wp.com/i/whats-new/drag-drop.png';
 const singlePageSiteImage = 'https://s0.wp.com/i/whats-new/single-page-website.png';
+const anchorFmImage = 'https://s0.wp.com/i/whats-new/single-page-website.png';
 
 function WhatsNewMenuItem() {
 	const { toggleWhatsNew } = useDispatch( 'automattic/whats-new' );
@@ -108,6 +109,27 @@ function getWhatsNewPages() {
 				/* translators: the embed is a link */
 				__(
 					'<p>Introducing our freshly-launched Blank Canvas theme, which is optimized for single-page websites.</p><p><Link>Learn more</Link></p>',
+					'full-site-editing'
+				),
+				{
+					Link: (
+						<a
+							href="https://wordpress.com/blog/2021/01/25/building-single-page-websites-on-wordpress-com/"
+							target="_blank"
+							rel="noreferrer"
+						/>
+					),
+					p: <p />,
+				}
+			),
+		},
+		{
+			imgSrc: anchorFmImage,
+			heading: __( 'Create podcast episodes automatically', 'full-site-editing' ),
+			description: createInterpolateElement(
+				/* translators: the embed is a link */
+				__(
+					'<p>Instantly convert any page or post’s text into an Anchor podcast. This new text-to-speech feature automatically transforms your written words into speech – no voice recording required.</p><p><Link>Learn more</Link></p>',
 					'full-site-editing'
 				),
 				{

--- a/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
@@ -18,7 +18,7 @@ import './style.scss';
 const blockPatternsImage = 'https://s0.wp.com/i/whats-new/block-patterns.png';
 const dragDropImage = 'https://s0.wp.com/i/whats-new/drag-drop.png';
 const singlePageSiteImage = 'https://s0.wp.com/i/whats-new/single-page-website.png';
-const anchorFmImage = 'https://s0.wp.com/i/whats-new/single-page-website.png';
+const anchorFmImage = 'https://s0.wp.com/i/whats-new/convert-to-audio.jpg';
 
 function WhatsNewMenuItem() {
 	const { toggleWhatsNew } = useDispatch( 'automattic/whats-new' );
@@ -135,7 +135,7 @@ function getWhatsNewPages() {
 				{
 					Link: (
 						<a
-							href="https://wordpress.com/blog/2021/01/25/building-single-page-websites-on-wordpress-com/"
+							href="https://wordpress.com/support/create-anchor-podcast/"
 							target="_blank"
 							rel="noreferrer"
 						/>


### PR DESCRIPTION
Per the request at pbBQWj-G0-p2, this PR adds a new What's New slide to highlight the Anchor.fm partnership.

Here's a screenshot of the copy laid into the slide:
<img width="729" alt="Screen Shot 2021-02-23 at 10 50 34 AM" src="https://user-images.githubusercontent.com/35781181/108871666-5f22f400-75c7-11eb-882b-bcf17ede68f1.png">


#### Testing instructions

* Checkout this PR.
* Sandbox a test site
* Run `yarn dev --sync` in the `apps` directory
* Load the Gutenberg editor in the sandboxed test site
* Click the sidebar icon to expand the menu
* Click the What's New link in the sidebar and navigate through the slides.
