### PR TITLE
Partner Portal: Change from 'url' to 'addQueryArgs' to build the sorting URL

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -4,8 +4,6 @@
 import React, { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
-import { pick } from 'lodash';
-import url from 'url'; // eslint-disable-line no-restricted-imports
 import page from 'page';
 import classnames from 'classnames';
 
@@ -26,6 +24,7 @@ import LicensePreview, {
 } from 'calypso/jetpack-cloud/sections/partner-portal/license-preview';
 import Gridicon from 'calypso/components/gridicon';
 import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { addQueryArgs } from 'calypso/lib/route';
 
 /**
  * Style dependencies
@@ -53,15 +52,6 @@ export default function LicenseList( {
 	const isFetching = useSelector( isFetchingLicenses );
 	const licenses = useSelector( getPaginatedLicenses ) as PaginatedItems< License >;
 
-	const buildSortingUrl = ( field: string, direction: string ): string => {
-		const parsedUrl = pick( url.parse( window.location.href, true ), 'pathname', 'query' );
-
-		return url.format( {
-			...parsedUrl,
-			query: { ...parsedUrl.query, sort_field: field, sort_direction: direction },
-		} );
-	};
-
 	const setSortingConfig = ( newSortField: string ): void => {
 		let newSortDirection = 'asc';
 
@@ -69,7 +59,10 @@ export default function LicenseList( {
 			newSortDirection = sortDirection === 'asc' ? 'desc' : 'asc';
 		}
 
-		page( buildSortingUrl( newSortField, newSortDirection ) );
+		const queryParams = { sort_direction: newSortDirection, sort_field: newSortField };
+		const currentPath = window.location.pathname + window.location.search;
+
+		page( addQueryArgs( queryParams, currentPath ) );
 	};
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* It changes the approach on building the new URL when we click to sort the license list. Uses `addQueryArgs` from `'calypso/lib/route'` instead of Node package `url`.

#### Testing instructions


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key, if prompted.
* Make sure you can click through each sortable column and it changes the URL as it did before.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #50180 
