### PR TITLE
Launch: Fix logic to compute redirectToWpcomPath origin

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
@@ -15,7 +15,13 @@ export const redirectParentWindow = ( url: string ): void => {
 };
 
 export const redirectToWpcomPath = ( url: string ): void => {
-	const origin = new URL( getCurrentLaunchFlowUrl() )?.origin || 'https://wordpress.com';
+	let origin = 'https://wordpress.com';
+
+	try {
+		origin = new URL( window?.calypsoifyGutenberg?.currentCalypsoUrl || '' ).origin;
+	} catch {
+		// do nothing, since origin already has a fallback value
+	}
 
 	const path = url.startsWith( '/' ) ? url : `/${ url }`;
 	redirectParentWindow( `${ origin }${ path }` );


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Fix the logic for computing the `origin` in the `redirectToWpcomPath` function

## Testing instructions

### Setup

* Create a site with `/start` and add it to the sandbox (do not launch it)
* Enable Focused Launch flow A/B testing experiment

### Test in Calypso

* Click "Launch" in the block editor on Calypso
* Click on "View all domains"
* Click on "Use a domain I own"
    - [ ] You should be redirected correctly to the domain transfer launch flow
* Click on the back link on the top left of the page
    - [ ] You should be redirected to the block editor
* Open Focused Launch modal again, and pick free subdomain and a _paid_ plan
* Click Launch
    - [ ] You should be redirected to the correct checkout page

### Test in WP Admin

Repeat steps above, but from the WP Admin block editor instead

Related to #50242
