### PR TITLE
 Fix tracking the 'core/block-editor' events

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -300,8 +300,9 @@ if (
 	// Intercept dispatch function and add tracking for actions that need it.
 	use( ( registry ) => ( {
 		dispatch: ( namespace ) => {
-			const actions = { ...registry.dispatch( namespace ) };
-			const trackers = REDUX_TRACKING[ namespace ];
+			const namespaceName = typeof namespace === 'object' ? namespace.name : namespace;
+			const actions = { ...registry.dispatch( namespaceName ) };
+			const trackers = REDUX_TRACKING[ namespaceName ];
 
 			if ( trackers ) {
 				Object.keys( trackers ).forEach( ( actionName ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix tracking the 'core/block-editor' events. Since https://github.com/WordPress/gutenberg/pull/28775 namespace is not always a string.

#### Testing instructions

This has been tested by @WunderBart locally. After merging this, the remaining tests here https://github.com/Automattic/wp-calypso/pull/50108 should pass.


Related to https://github.com/Automattic/wp-calypso/pull/50108. Context: p1613662487260800-slack-C02A41GCS.