### PR TITLE
Partner Portal: Add license sorting data layer

### DIFF
--- a/client/components/data/query-jetpack-partner-portal-licenses/index.ts
+++ b/client/components/data/query-jetpack-partner-portal-licenses/index.ts
@@ -7,20 +7,31 @@ import { useDispatch } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import {
+	LicenseFilter,
+	LicenseSortField,
+	LicenseSortDirection,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { fetchLicenses } from 'calypso/state/partner-portal/licenses/actions';
 
 interface Props {
 	filter: LicenseFilter;
 	search: string;
+	sortField: LicenseSortField;
+	sortDirection: LicenseSortDirection;
 }
 
-export default function QueryJetpackPartnerPortalLicenses( { filter, search }: Props ) {
+export default function QueryJetpackPartnerPortalLicenses( {
+	filter,
+	search,
+	sortField,
+	sortDirection,
+}: Props ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		dispatch( fetchLicenses( filter, search ) );
-	}, [ dispatch, filter, search ] );
+		dispatch( fetchLicenses( filter, search, sortField, sortDirection ) );
+	}, [ dispatch, filter, search, sortField, sortDirection ] );
 
 	return null;
 }

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -10,12 +10,17 @@ import type PageJS from 'page';
  */
 import { addQueryArgs } from 'calypso/lib/route';
 import { getActivePartnerKey } from 'calypso/state/partner-portal/partner/selectors';
-import { stringToLicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import { valueToEnum } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import Header from './header';
 import JetpackComFooter from 'calypso/jetpack-cloud/sections/pricing/jpcom-footer';
 import PartnerPortalSidebar from 'calypso/jetpack-cloud/sections/partner-portal/sidebar';
 import SelectPartnerKey from 'calypso/jetpack-cloud/sections/partner-portal/select-partner-key';
 import Licenses from 'calypso/jetpack-cloud/sections/partner-portal/primary/licenses';
+import {
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 
 export function partnerKeyContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
@@ -26,14 +31,28 @@ export function partnerKeyContext( context: PageJS.Context, next: () => void ): 
 }
 
 export function partnerPortalContext( context: PageJS.Context, next: () => void ): void {
-	const { s: search, sort_field: sortField, sort_direction: sortDirection } = context.query;
-	const licenseFilter = stringToLicenseFilter( context.params.state );
+	const { s: search, sort_field, sort_direction } = context.query;
+	const filter = valueToEnum< LicenseFilter >(
+		LicenseFilter,
+		context.params.state,
+		LicenseFilter.NotRevoked
+	);
+	const sortField = valueToEnum< LicenseSortField >(
+		LicenseSortField,
+		sort_field,
+		LicenseSortField.IssuedAt
+	);
+	const sortDirection = valueToEnum< LicenseSortDirection >(
+		LicenseSortDirection,
+		sort_direction,
+		LicenseSortDirection.Descending
+	);
 
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;
 	context.primary = (
 		<Licenses
-			filter={ licenseFilter }
+			filter={ filter }
 			search={ search || '' }
 			sortDirection={ sortDirection }
 			sortField={ sortField }

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -13,13 +13,17 @@ import CSSTransition from 'react-transition-group/CSSTransition';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import {
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { License, PaginatedItems } from 'calypso/state/partner-portal/types';
 import QueryJetpackPartnerPortalLicenses from 'calypso/components/data/query-jetpack-partner-portal-licenses';
 import {
+	getPaginatedLicenses,
 	hasFetchedLicenses,
 	isFetchingLicenses,
-	getPaginatedLicenses,
 } from 'calypso/state/partner-portal/licenses/selectors';
 import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
 import LicensePreview, {
@@ -44,15 +48,15 @@ const LicenseTransition = ( props: React.PropsWithChildren< LicenseTransitionPro
 interface Props {
 	filter: LicenseFilter;
 	search: string;
-	sortDirection: string;
-	sortField: string;
+	sortField: LicenseSortField;
+	sortDirection: LicenseSortDirection;
 }
 
 export default function LicenseList( {
 	filter,
 	search,
-	sortDirection,
 	sortField,
+	sortDirection,
 }: Props ): ReactElement {
 	const translate = useTranslate();
 	const hasFetched = useSelector( hasFetchedLicenses );
@@ -61,14 +65,14 @@ export default function LicenseList( {
 	const showLicenses = hasFetched && ! isFetching && !! licenses;
 	const showNoResults = hasFetched && ! isFetching && licenses && licenses.items.length === 0;
 
-	const setSortingConfig = ( newSortField: string ): void => {
-		let newSortDirection = 'asc';
+	const setSortingConfig = ( field: LicenseSortField ): void => {
+		let direction = LicenseSortDirection.Descending;
 
-		if ( sortField === newSortField ) {
-			newSortDirection = sortDirection === 'asc' ? 'desc' : 'asc';
+		if ( field === sortField && sortDirection === direction ) {
+			direction = LicenseSortDirection.Ascending;
 		}
 
-		const queryParams = { sort_direction: newSortDirection, sort_field: newSortField };
+		const queryParams = { sort_field: field, sort_direction: direction };
 		const currentPath = window.location.pathname + window.location.search;
 
 		page( addQueryArgs( queryParams, currentPath ) );
@@ -80,37 +84,41 @@ export default function LicenseList( {
 
 			<LicenseListItem header className="license-list__header">
 				<h2>{ translate( 'License state' ) }</h2>
-				<h2 className={ classnames( { 'is-selected': 'issued_at' === sortField } ) }>
-					<button onClick={ () => setSortingConfig( 'issued_at' ) }>
+				<h2 className={ classnames( { 'is-selected': LicenseSortField.IssuedAt === sortField } ) }>
+					<button onClick={ () => setSortingConfig( LicenseSortField.IssuedAt ) }>
 						{ translate( 'Issued on' ) }
 						<Gridicon
 							icon="dropdown"
 							className={ classnames( 'license-list-item__sort-indicator', {
-								[ `is-sort-${ sortDirection }` ]: sortDirection,
+								[ `is-sort-${ sortDirection }` ]: true,
 							} ) }
 						/>
 					</button>
 				</h2>
 				{ filter !== LicenseFilter.Revoked ? (
-					<h2 className={ classnames( { 'is-selected': 'attached_at' === sortField } ) }>
-						<button onClick={ () => setSortingConfig( 'attached_at' ) }>
+					<h2
+						className={ classnames( { 'is-selected': LicenseSortField.AttachedAt === sortField } ) }
+					>
+						<button onClick={ () => setSortingConfig( LicenseSortField.AttachedAt ) }>
 							{ translate( 'Attached on' ) }
 							<Gridicon
 								icon="dropdown"
 								className={ classnames( 'license-list-item__sort-indicator', {
-									[ `is-sort-${ sortDirection }` ]: sortDirection,
+									[ `is-sort-${ sortDirection }` ]: true,
 								} ) }
 							/>
 						</button>
 					</h2>
 				) : (
-					<h2 className={ classnames( { 'is-selected': 'revoked_at' === sortField } ) }>
-						<button onClick={ () => setSortingConfig( 'revoked_at' ) }>
+					<h2
+						className={ classnames( { 'is-selected': LicenseSortField.RevokedAt === sortField } ) }
+					>
+						<button onClick={ () => setSortingConfig( LicenseSortField.RevokedAt ) }>
 							{ translate( 'Revoked on' ) }
 							<Gridicon
 								icon="dropdown"
 								className={ classnames( 'license-list-item__sort-indicator', {
-									[ `is-sort-${ sortDirection }` ]: sortDirection,
+									[ `is-sort-${ sortDirection }` ]: true,
 								} ) }
 							/>
 						</button>

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -80,7 +80,12 @@ export default function LicenseList( {
 
 	return (
 		<div className="license-list">
-			<QueryJetpackPartnerPortalLicenses filter={ filter } search={ search } />
+			<QueryJetpackPartnerPortalLicenses
+				filter={ filter }
+				search={ search }
+				sortField={ sortField }
+				sortDirection={ sortDirection }
+			/>
 
 			<LicenseListItem header className="license-list__header">
 				<h2>{ translate( 'License state' ) }</h2>

--- a/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
@@ -32,7 +32,7 @@ interface Props {
 	getSearchOpen: () => boolean;
 }
 
-function LicenseStateFilter( props: Props ): ReactElement {
+function LicenseStateFilter( { filter, search, doSearch }: Props ): ReactElement {
 	const translate = useTranslate();
 	const counts = useSelector( getLicenseCounts );
 	const basePath = '/partner-portal/';
@@ -57,7 +57,7 @@ function LicenseStateFilter( props: Props ): ReactElement {
 	].map( ( navItem ) => ( {
 		...navItem,
 		count: counts[ navItem.key ] || 0,
-		selected: props.filter === navItem.key,
+		selected: filter === navItem.key,
 		path: basePath + ( LicenseFilter.NotRevoked !== navItem.key ? navItem.key : '' ),
 		children: navItem.label,
 	} ) );
@@ -90,8 +90,8 @@ function LicenseStateFilter( props: Props ): ReactElement {
 			<Search
 				pinned
 				fitsContainer
-				initialValue={ props.search }
-				onSearch={ props.doSearch }
+				initialValue={ search }
+				onSearch={ doSearch }
 				placeholder={ translate( 'Search licenses' ) }
 				delaySearch={ true }
 			/>

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -11,21 +11,25 @@ import Main from 'calypso/components/main';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import LicenseList from 'calypso/jetpack-cloud/sections/partner-portal/license-list';
-import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import {
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import LicenseStateFilter from 'calypso/jetpack-cloud/sections/partner-portal/license-state-filter';
 
 interface Props {
 	filter: LicenseFilter;
 	search: string;
-	sortDirection?: string;
-	sortField?: string;
+	sortDirection: LicenseSortDirection;
+	sortField: LicenseSortField;
 }
 
 export default function Licenses( {
 	filter,
 	search,
-	sortDirection = 'asc',
-	sortField = 'issued_at',
+	sortDirection,
+	sortField,
 }: Props ): ReactElement {
 	const translate = useTranslate();
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -21,8 +21,8 @@ import LicenseStateFilter from 'calypso/jetpack-cloud/sections/partner-portal/li
 interface Props {
 	filter: LicenseFilter;
 	search: string;
-	sortDirection: LicenseSortDirection;
 	sortField: LicenseSortField;
+	sortDirection: LicenseSortDirection;
 }
 
 export default function Licenses( {

--- a/client/jetpack-cloud/sections/partner-portal/types.ts
+++ b/client/jetpack-cloud/sections/partner-portal/types.ts
@@ -10,3 +10,14 @@ export enum LicenseFilter {
 	Attached = 'attached',
 	Revoked = 'revoked',
 }
+
+export enum LicenseSortField {
+	IssuedAt = 'issued_at',
+	AttachedAt = 'attached_at',
+	RevokedAt = 'revoked_at',
+}
+
+export enum LicenseSortDirection {
+	Ascending = 'asc',
+	Descending = 'desc',
+}

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { LicenseFilter, LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 
 /**
  * Get the state of a license based on its properties.
@@ -26,15 +26,23 @@ export function getLicenseState(
 
 	return LicenseState.Detached;
 }
+
 /**
- * Get the state of a license based on a string.
- * If the given string is not a valid LicenseState, it returns `LicenseFilter.NotRevoked`
+ * Convert a value to a the enum member with that value or a fallback.
+ * This is a hack around TypeScript's poor support of enums as types.
  *
- * @param {string?} value The filter string matching the `state` param in the URL
- * @returns {LicenseFilter} State matching one of LicenseFilter values.
+ * @example const enumMember = valueToEnum< SomeEnumType >( SomeEnumType, 'foo', SomeEnumType.SomeMember );
+ *
+ * @template T
+ * @param {Record< string, * >} enumType Enum type to search in.
+ * @param {*} value The enum value we are looking to get the member for.
+ * @param {*} fallback The fallback value in case value is not a member of enumType.
+ * @returns {T} T for value or fallback
  */
-export function stringToLicenseFilter( value?: string ): LicenseFilter {
-	return Object.values( LicenseFilter ).includes( value as LicenseFilter )
-		? ( value as LicenseFilter )
-		: LicenseFilter.NotRevoked;
+export function valueToEnum< T >(
+	enumType: Record< string, unknown >,
+	value: unknown,
+	fallback: unknown
+): T {
+	return Object.values( enumType ).includes( value ) ? ( value as T ) : ( fallback as T );
 }

--- a/client/state/partner-portal/licenses/actions.ts
+++ b/client/state/partner-portal/licenses/actions.ts
@@ -18,7 +18,11 @@ import {
 	LicenseCounts,
 	PaginatedItems,
 } from 'calypso/state/partner-portal/types';
-import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import {
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 
 // Required for modular state.
 import 'calypso/state/partner-portal/init';
@@ -30,11 +34,18 @@ function createHttpAction( action: AnyAction ): HttpAction {
 	};
 }
 
-export function fetchLicenses( filter: LicenseFilter, search: string ): HttpAction {
+export function fetchLicenses(
+	filter: LicenseFilter,
+	search: string,
+	sortField: LicenseSortField,
+	sortDirection: LicenseSortDirection
+): HttpAction {
 	return createHttpAction( {
 		type: JETPACK_PARTNER_PORTAL_LICENSES_REQUEST,
 		filter,
 		search,
+		sortField,
+		sortDirection,
 	} );
 }
 

--- a/client/state/partner-portal/licenses/handlers.ts
+++ b/client/state/partner-portal/licenses/handlers.ts
@@ -81,6 +81,8 @@ export function fetchLicensesHandler( action: HttpAction ): AnyAction {
 			query: {
 				// Do not apply filters during search as search takes over (matches Calypso Blue Post search behavior).
 				...( action.search ? { search: action.search } : { filter: action.filter } ),
+				sort_field: action.sortField,
+				sort_direction: action.sortDirection,
 			},
 		},
 		action

--- a/client/state/partner-portal/licenses/test/actions.js
+++ b/client/state/partner-portal/licenses/test/actions.js
@@ -11,7 +11,11 @@ import {
 	JETPACK_PARTNER_PORTAL_LICENSE_COUNTS_REQUEST,
 	JETPACK_PARTNER_PORTAL_LICENSE_COUNTS_RECEIVE,
 } from 'calypso/state/action-types';
-import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import {
+	LicenseState,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 
 jest.mock( 'calypso/state/partner-portal/partner/selectors', () => ( {
 	getActivePartnerKey: () => ( { oauth2_token: 'fake_oauth2_token' } ),
@@ -22,11 +26,20 @@ describe( 'actions', () => {
 		test( 'should dispatch a request action when called', () => {
 			const { fetchLicenses } = actions;
 
-			expect( fetchLicenses( LicenseState.Detached, 'bar' ) ).toEqual( {
+			expect(
+				fetchLicenses(
+					LicenseState.Detached,
+					'bar',
+					LicenseSortField.IssuedAt,
+					LicenseSortDirection.Descending
+				)
+			).toEqual( {
 				type: JETPACK_PARTNER_PORTAL_LICENSES_REQUEST,
 				filter: LicenseState.Detached,
 				search: 'bar',
 				fetcher: 'wpcomJetpackLicensing',
+				sortField: LicenseSortField.IssuedAt,
+				sortDirection: LicenseSortDirection.Descending,
 			} );
 		} );
 	} );

--- a/client/state/partner-portal/licenses/test/handlers.js
+++ b/client/state/partner-portal/licenses/test/handlers.js
@@ -15,7 +15,11 @@ import {
 	JETPACK_PARTNER_PORTAL_LICENSES_RECEIVE,
 	JETPACK_PARTNER_PORTAL_LICENSE_COUNTS_RECEIVE,
 } from 'calypso/state/action-types';
-import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import {
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 
 describe( 'handlers', () => {
 	describe( '#fetchLicensesHandler()', () => {
@@ -23,8 +27,10 @@ describe( 'handlers', () => {
 			const { fetchLicensesHandler } = handlers;
 			const action = {
 				type: 'TEST_ACTION',
-				filter: LicenseState.NotRevoked,
+				filter: LicenseFilter.NotRevoked,
 				search: '',
+				sortField: LicenseSortField.IssuedAt,
+				sortDirection: LicenseSortDirection.Descending,
 				fetcher: 'wpcomJetpackLicensing',
 			};
 			const expected = {
@@ -34,7 +40,9 @@ describe( 'handlers', () => {
 				path: '/jetpack-licensing/licenses',
 				query: {
 					apiNamespace: 'wpcom/v2',
-					filter: action.filter,
+					filter: 'not_revoked',
+					sort_field: 'issued_at',
+					sort_direction: 'desc',
 				},
 				formData: undefined,
 				onSuccess: action,
@@ -51,8 +59,10 @@ describe( 'handlers', () => {
 			const { fetchLicensesHandler } = handlers;
 			const action = {
 				type: 'TEST_ACTION',
-				filter: LicenseState.Revoked,
+				filter: LicenseFilter.Revoked,
 				search: '',
+				sortField: LicenseSortField.IssuedAt,
+				sortDirection: LicenseSortDirection.Descending,
 				fetcher: 'wpcomJetpackLicensing',
 			};
 			const expected = {
@@ -62,7 +72,9 @@ describe( 'handlers', () => {
 				path: '/jetpack-licensing/licenses',
 				query: {
 					apiNamespace: 'wpcom/v2',
-					filter: action.filter,
+					filter: 'revoked',
+					sort_field: 'issued_at',
+					sort_direction: 'desc',
 				},
 				formData: undefined,
 				onSuccess: action,
@@ -79,8 +91,10 @@ describe( 'handlers', () => {
 			const { fetchLicensesHandler } = handlers;
 			const action = {
 				type: 'TEST_ACTION',
-				filter: LicenseState.Revoked,
+				filter: LicenseFilter.Revoked,
 				search: 'foo',
+				sortField: LicenseSortField.IssuedAt,
+				sortDirection: LicenseSortDirection.Descending,
 				fetcher: 'wpcomJetpackLicensing',
 			};
 			const expected = {
@@ -92,6 +106,39 @@ describe( 'handlers', () => {
 					apiNamespace: 'wpcom/v2',
 					// No filter present intentionally as search overrides it.
 					search: action.search,
+					sort_field: 'issued_at',
+					sort_direction: 'desc',
+				},
+				formData: undefined,
+				onSuccess: action,
+				onFailure: action,
+				onProgress: action,
+				onStreamRecord: action,
+				options: { options: { fetcher: action.fetcher } },
+			};
+
+			expect( fetchLicensesHandler( action ) ).toEqual( expected );
+		} );
+
+		test( 'should return an http request action with sort params', () => {
+			const { fetchLicensesHandler } = handlers;
+			const action = {
+				type: 'TEST_ACTION',
+				filter: LicenseFilter.Revoked,
+				search: '',
+				sortField: LicenseSortField.RevokedAt,
+				sortDirection: LicenseSortDirection.Ascending,
+			};
+			const expected = {
+				type: WPCOM_HTTP_REQUEST,
+				body: undefined,
+				method: 'GET',
+				path: '/jetpack-licensing/licenses',
+				query: {
+					apiNamespace: 'wpcom/v2',
+					filter: 'revoked',
+					sort_field: 'revoked_at',
+					sort_direction: 'asc',
 				},
 				formData: undefined,
 				onSuccess: action,


### PR DESCRIPTION
Blocked by:
- ~#50189~

Context:
* Project thread: pbtFPC-Um-p2
* i4 designs: pbtFPC-103-p2

#### Changes proposed in this Pull Request

* Add live API-driven license list sorting to the Partner Portal.

#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key, if prompted.
* You should be presented with a list of all of your licenses, if any. Test that all the list sorting options work as expected.

![Screenshot 2021-02-18 at 21 07 31](https://user-images.githubusercontent.com/22746396/108408120-5334dc00-722d-11eb-809e-5ad4dd09989e.png)
