### PR TITLE
Update CSS selector used in canSeeTheOnboardingChecklist

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -71,7 +71,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishSelector );
 		await this.driver.sleep( 1000 );
 		const button = await this.driver.findElement( this.publishSelector );
+		await this.driver.sleep( 1000 );
 		await this.driver.executeScript( 'arguments[0].click();', button );
+		await this.driver.sleep( 1000 );
 		await driverHelper.waitTillNotPresent( this.driver, this.publishingSpinnerSelector );
 		if ( closePanel ) {
 			try {

--- a/test/e2e/lib/pages/signup/upsell-page.js
+++ b/test/e2e/lib/pages/signup/upsell-page.js
@@ -22,7 +22,7 @@ export default class UpsellPage extends AsyncBaseContainer {
 	async declineOffer() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( 'button[data-e2e-button="decline"]' )
+			By.css( 'button.difm-upsell__decline-offer-button' )
 		);
 	}
 }


### PR DESCRIPTION
- change the CSS selector of the Cancel Upsell button that is causing timeout issues.

#### Changes proposed in this Pull Request

The step at `canSeeTheOnboardingChecklist` often causes timeout issues.
This causes the entire suite to be reported as failing which is a false positive.

#### Testing instructions

Run the single test file:
```
node_modules/.bin/mocha specs/wp-signup-spec.js
```