### PR TITLE
Legacy fse - fix close button margin

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/close-button-override/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/close-button-override/style.scss
@@ -15,7 +15,6 @@
 	display: flex;
 	align-items: center;
 	margin-right: 10px;
-	margin-left: -24px;
 	border: none;
 	border-right: 1px solid #e2e4e7;
 
@@ -76,7 +75,6 @@
 	// provided by .edit-post-header__toolbar from WP. So here we
 	// offset the -24px padding and then restore the 24px padding
 	// for other toolbar buttons that comes after this button.
-	margin-left: -24px;
 	margin-right: 24px;
 
 	// Back button is not displayed in mobile & tablet view.
@@ -89,10 +87,5 @@
 		.close-button-override__label {
 			display: none;
 		}
-	}
-
-	// Overrides < v7.7.
-	@media ( max-width: 599px ) {
-		margin-left: -24px;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes margin for the close button in legacy FSE.

Before:

![Screen Shot 2021-02-18 at 5 53 18 PM](https://user-images.githubusercontent.com/28742426/108432959-312e6000-7213-11eb-9e41-4c2a00565b1a.png)

After:

![Screen Shot 2021-02-18 at 5 55 22 PM](https://user-images.githubusercontent.com/28742426/108432964-355a7d80-7213-11eb-8576-60705e063834.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch this change to your sandbox and test a legacy FSE site.
* Verify the close button appears as expected.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
