### PR TITLE
ETK: run build more frequently and only publish artifacts when it has changed.

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1212,6 +1212,16 @@ object WPComPlugins_EditorToolKit : BuildType({
 
 	artifactRules = "editing-toolkit.zip"
 
+	dependencies {
+		artifacts(AbsoluteId("calypso_WPComPlugins_EditorToolKit")) {
+			buildRule = lastSuccessful("+:trunk")
+			artifactRules = """
+				+:editing-toolkit.zip!** => editing-toolkit-last-build
+				-:editing-toolkit.zip!build_meta.txt
+			""".trimIndent()
+		}
+	}
+
 	buildNumberPattern = "%build.prefix%.%build.counter%"
 	params {
 		param("build.prefix", "3")
@@ -1224,12 +1234,10 @@ object WPComPlugins_EditorToolKit : BuildType({
 
 	triggers {
 		vcs {
-			triggerRules = "+:apps/editing-toolkit/**"
 			branchFilter = """
 				+:*
 				-:pull*
 			""".trimIndent()
-
 		}
 	}
 
@@ -1322,24 +1330,29 @@ object WPComPlugins_EditorToolKit : BuildType({
 				export NODE_ENV="production"
 
 				cd apps/editing-toolkit
-
-				# Update plugin version in the plugin file.
-				sed -i -e "/^\s\* Version:/c\ * Version: %build.number%" -e "/^define( 'A8C_ETK_PLUGIN_VERSION'/c\define( 'A8C_ETK_PLUGIN_VERSION', '%build.number%' );" ./editing-toolkit-plugin/full-site-editing-plugin.php
-
-				# Update plugin stable tag in readme.txt.
-				sed -i -e "/^Stable tag:\s/c\Stable tag: %build.number%" ./editing-toolkit-plugin/readme.txt
-
 				yarn build
-				cd editing-toolkit-plugin/
 
-				# Metadata file with info for the download script.
-				tee build_meta.txt <<-EOM
-					commit_hash=%build.vcs.number%
-					commit_url=https://github.com/Automattic/wp-calypso/commit/%build.vcs.number%
-					build_number=%build.number%
-					EOM
+				# Update plugin version in the plugin file and readme.txt.
+				# Note: we also update the latest build from trunk to this version to restore idempotence
+				sed -i -e "/^\s\* Version:/c\ * Version: %build.number%" -e "/^define( 'A8C_ETK_PLUGIN_VERSION'/c\define( 'A8C_ETK_PLUGIN_VERSION', '%build.number%' );" ./editing-toolkit-plugin/full-site-editing-plugin.php ../../editing-toolkit-last-build/full-site-editing-plugin.php
+				sed -i -e "/^Stable tag:\s/c\Stable tag: %build.number%" ./editing-toolkit-plugin/readme.txt ../../editing-toolkit-last-build/readme.txt
 
-				zip -r ../../../editing-toolkit.zip .
+				if diff -rq ./editing-toolkit-plugin/ ../../editing-toolkit-last-build/ ; then
+					echo "The build matches trunk. Therefore, this build has no effect."
+				else
+					echo "The build is different from trunk."
+					cd editing-toolkit-plugin/
+
+					# Metadata file with info for the download script.
+					tee build_meta.txt <<-EOM
+						commit_hash=%build.vcs.number%
+						commit_url=https://github.com/Automattic/wp-calypso/commit/%build.vcs.number%
+						build_number=%build.number%
+						EOM
+
+					zip -r ../../../editing-toolkit.zip .
+				fi
+
 			""".trimIndent()
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 			dockerPull = true


### PR DESCRIPTION
### Changes proposed in this Pull Request

This also turns on the build for all files in the repo. This is because we want builds to be available for changes to packages and components which are used in ETK.

Context: when a change does not affect the editing toolkit plugin, we shouldn't be doing much with it. For example, we wouldn't want to ping the authors regardin deployment steps. I also think it would be preferable to not publish artifacts in that case.

This is an attempt at accomplishing that in a round about way. Basically, the current build for a branch has a dependency on the last successful trunk build. The goal is to see if the current build has changed compared to that, if this is even possible in TC.

This sceenshot is a test run where there were no code differences between trunk and this branch.
<img width="1697" alt="Screen Shot 2021-02-18 at 5 20 20 PM" src="https://user-images.githubusercontent.com/6265975/108444499-95e7bb80-720f-11eb-9e48-eb44977db0cb.png">

And this run is when I modified the package `@automattic/page-template-modal`. So basically, we are able to detect changes to the final build in the bash script.

<img width="1697" alt="Screen Shot 2021-02-18 at 5 44 40 PM" src="https://user-images.githubusercontent.com/6265975/108445364-1c50cd00-7211-11eb-8d30-082474e9dc6a.png">

For now, I've used this functionality to _only_ publish an artifact if there are changes. So, while the build will run on every commit, it will only publish an artifact when there are changes. This is good because otherwise, `install-plugin.sh --release` would download the latest successful build, which would be associated with a commit totally separate from ETK. Even though it's just the metadata which would be different (the actual code would be the same by definition), ideally we keep the metadata lined up. (Which lets us link back to the GH commit from the wpcom commit.)

Some more ideas I have:
- Remove the GH commit status check if there are _no_ changes. Could we somehow do this by canceling the build while it is in progress?
- Ping people in slack if there _are_ changes and the commit is on `trunk`

### How it works
1. The build sets a dependency on the latest successful artifact published for the `trunk` branch. In effect, this ought to be the latest published version.
2. TeamCity downloads that artifact to `~/editing-toolkit-last-build`, but excludes the `build-meta.txt` file. (This file will always be different between builds.)
3. When we update the plugin version to the build number, we also update the plugin version in the "last build" copy too. This (along with excluding the build meta) restores idempotence. After this point, the builds should only be different if actual code is different.
4. We run `diff -rq` between the local build and the downloaded artifact, which tells us if the directories are at all different. We check the exit status of that command to determine what to do.

#### Testing instructions
TeamCity

Related to #
