### PR TITLE
Page layout picker: Fix broken web fonts in page layout picker large preview

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -554,3 +554,4 @@ View the commit history here: https://github.com/Automattic/wp-calypso/commits/t
 
 = 0.1 =
 * Initial Release
+

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -554,4 +554,3 @@ View the commit history here: https://github.com/Automattic/wp-calypso/commits/t
 
 = 0.1 =
 * Initial Release
-

--- a/packages/page-template-modal/src/components/block-iframe-preview.js
+++ b/packages/page-template-modal/src/components/block-iframe-preview.js
@@ -46,19 +46,27 @@ const copyStylesToIframe = ( srcDocument, targetiFrameDocument ) => {
 		body: document.createDocumentFragment(), // eslint-disable-line no-undef
 	};
 
-	each( Object.keys( targetDOMFragment ), ( domReference ) => {
-		return each(
-			filter( srcDocument[ domReference ].children, ( { localName } ) =>
-				// Only return specific style-related Nodes
-				styleNodes.includes( localName )
-			),
-			( targetNode ) => {
-				// Clone the original node and append to the appropriate Fragement
-				const deep = true;
-				targetDOMFragment[ domReference ].appendChild( targetNode.cloneNode( deep ) );
-			}
-		);
-	} );
+	// To avoid loading too many styles in the iframe that could potentially break
+	// global styles, only copy over the styles that target the editor.
+	const visualStyles = srcDocument.querySelectorAll( '.edit-post-visual-editor style' );
+	if ( visualStyles ) {
+		visualStyles.forEach( ( targetNode ) => {
+			// Clone the original node and append to the appropriate Fragment.
+			const deep = true;
+			targetDOMFragment.body.appendChild( targetNode.cloneNode( deep ) );
+		} );
+	}
+
+	each(
+		filter( srcDocument.head.children, ( node ) => {
+			return styleNodes.includes( node.localName );
+		} ),
+		( targetNode ) => {
+			// Clone the original node and append to the appropriate Fragment.
+			const deep = true;
+			targetDOMFragment.head.appendChild( targetNode.cloneNode( deep ) );
+		}
+	);
 
 	// Consolidate updates to iframe DOM
 	targetiFrameDocument.head.appendChild( targetDOMFragment.head );


### PR DESCRIPTION
In the page layout picker, the existing code that looks to copy over styles to the iframe no longer targets the correct style tags, causing the preview to miss crucial style tags for rendering the web fonts from Global Styles correctly.

This change targets getting the styles from where they're inserted in the visual editor in Gutenberg, which is as children of the `.edit-post-visual-editor` node (the relevant line in Gutenberg is [here](https://github.com/WordPress/gutenberg/blob/db8da1521b2a602753231bb6b90420c2ae552376/packages/edit-post/src/components/visual-editor/index.js#L62)).

This fixes the rendering issue reported in https://github.com/Automattic/wp-calypso/issues/49742.

#### Changes proposed in this Pull Request

* In the page layout picker, target only the `style` tags within the post body that we require to adequately style the preview, to avoid CSS conflicts that broke web fonts in the preview.
* Note: the whitespace change in the `readme.txt` file is just to trigger an ETK build. I'll remove the whitespace change before merging.

#### Screenshot

Before:

![image](https://user-images.githubusercontent.com/14988353/108440396-258c7900-72a7-11eb-8bd7-1e56ab05161e.png)

After:

![image](https://user-images.githubusercontent.com/14988353/108440403-29b89680-72a7-11eb-8041-d6d7da3b0fcd.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this change in your sandbox (D57313-code) and set your sandboxed test site to use a theme that uses custom fonts / Global styles, e.g. Balasana, Maywood, or Barnsbury
* Go to add a new page, and browse through the layouts and compare against the reported issue (#49742) — the styles should look much closer to how the layout looks when inserted in the editor.
* Insert a layout.
* From the top right in the editor, go to Global Styles and update the fonts for the site, and hit the publish button within the Global Styles plugin.
* Go to add a new page and ensure the preview renders with the global styles correctly.
* Switch your site to a theme that doesn't use Global Styles, e.g. Twenty Twenty or Twenty Twenty One, and ensure the preview renders correctly (or at least better than in the reported issue)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/49742
