### PR TITLE
[do not merge until code freeze] Change ETK version to dev in dev environments

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'A8C_ETK_PLUGIN_VERSION', '2.21' );
+define( 'A8C_ETK_PLUGIN_VERSION', 'dev' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -33,6 +33,13 @@ namespace A8C\FSE;
  *
  * Can be used in cache keys to invalidate caches on plugin update.
  *
+ * Note: this constant is updated via TeamCity continuous integration. That
+ * change is not copied back to VCS, so we use "dev" here to indicate that the
+ * version in wp-calypso is for development.
+ *
+ * On WordPress.com, the version here should show up in the "info" section of
+ * the "more options" menu in Gutenberg.
+ *
  * @var string
  */
 define( 'A8C_ETK_PLUGIN_VERSION', 'dev' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In dev environments, the ETK version will now say "dev". THe other alternative is having it be the legacy version number after we change to using the build number for the version. I think this would be quite useful for dev environments, especially with the watch-and-sync command. This has no effect on code deployed to production, as the team city build artifact changes this version constant, and that artifact is the item which is deployed.

#### Testing instructions


Related to #
