### PR TITLE
ETK: update sync script to reference new wpcom location

### DIFF
--- a/apps/editing-toolkit/bin/wpcom-watch-and-sync.sh
+++ b/apps/editing-toolkit/bin/wpcom-watch-and-sync.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 LOCAL_PATH="./editing-toolkit-plugin/"
-REMOTE_PATH="/home/wpcom/public_html/wp-content/plugins/full-site-editing-plugin/dev"
+REMOTE_PATH="/home/wpcom/public_html/wp-content/plugins/editing-toolkit-plugin/dev"
 REMOTE_SSH="wpcom-sandbox"
 COMMAND="rsync -ahz $LOCAL_PATH $REMOTE_SSH:$REMOTE_PATH"
 echo "Running initial sync"


### PR DESCRIPTION
### Changes proposed in this Pull Request
- point sync script at new location in wpcom. We can merge this now, and it should work fine alongside the legacy prod version.
- 
#### Testing instructions
run `yarn dev --sync` from the editing-toolkit directory. On your sandbox, files should show up under `plugins/editing-toolkit-plugin/dev` 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
