### PR TITLE
chore(@automattic/shopping-cart): remove unused dependency

### DIFF
--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -44,7 +44,6 @@
 		"@automattic/calypso-polyfills": "^1.0.0",
 		"@testing-library/jest-dom": "^5.9.0",
 		"@testing-library/react": "^10.0.5",
-		"cache-loader": "^4.1.0",
 		"react-dom": "^16.12.0"
 	},
 	"private": true


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Clean unused dependencies. It fixes: 

```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/shopping-cart/package.json
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/shopping-cart/package.json:47:19: Unmet transitive peer dependency on webpack@^4.0.0, via cache-loader@^4.1.0
➤ YN0000: └ Completed in 0s 624ms
```


#### Testing instructions

Run `cd packages/shopping-cart && npx @yarnpkg/doctor` and verify the error above is gone.