### PR TITLE
Stats: refuse to deserialize or receive invalid data

### DIFF
--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -86,7 +86,7 @@ export const items = withSchemaValidation( itemSchema, ( state = {}, action ) =>
 					...state[ siteId ],
 					[ statType ]: {
 						...get( state, [ siteId, statType ] ),
-						[ queryKey ]: data,
+						[ queryKey ]: data || null,
 					},
 				},
 			};

--- a/client/state/stats/lists/schema.js
+++ b/client/state/stats/lists/schema.js
@@ -7,10 +7,11 @@ export const itemSchema = {
 				'^[A-Za-z]+$': {
 					type: 'object',
 					patternProperties: {
-						'^\\{[^\\}]*\\}$': {
+						'^\\[.*\\]$': {
 							type: 'object',
 						},
 					},
+					additionalProperties: false,
 				},
 			},
 			additionalProperties: false,

--- a/client/state/stats/lists/test/reducer.js
+++ b/client/state/stats/lists/test/reducer.js
@@ -180,10 +180,36 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( original );
 		} );
 
-		test( 'should not load invalid persisted state', () => {
+		test( 'should not load persisted state with invalid statType', () => {
 			const original = deepFreeze( {
 				2916284: {
 					'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': streakResponse,
+				},
+			} );
+			const state = deserialize( items, original );
+
+			expect( state ).to.eql( {} );
+		} );
+
+		test( 'should not load persisted state with invalid query', () => {
+			const original = deepFreeze( {
+				2916284: {
+					statsStreak: {
+						'query-withou-square-brackets': streakResponse,
+					},
+				},
+			} );
+			const state = deserialize( items, original );
+
+			expect( state ).to.eql( {} );
+		} );
+
+		test( 'should not load persisted state with non-object data', () => {
+			const original = deepFreeze( {
+				2916284: {
+					statsStreak: {
+						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': '',
+					},
 				},
 			} );
 			const state = deserialize( items, original );
@@ -210,6 +236,24 @@ describe( 'reducer', () => {
 				2916284: {
 					statsStreak: {
 						'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': streakResponse,
+					},
+				},
+			} );
+		} );
+
+		test( 'should receive invalid stats as null', () => {
+			const state = items( undefined, {
+				type: SITE_STATS_RECEIVE,
+				siteId: 2916284,
+				statType: 'statsStreak',
+				query: streakQuery,
+				data: '',
+			} );
+
+			expect( state ).to.eql( {
+				2916284: {
+					statsStreak: {
+						'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': null,
 					},
 				},
 			} );
@@ -291,7 +335,7 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		test( 'should should not change another statTypes property', () => {
+		test( 'should not change another statTypes property', () => {
 			const original = deepFreeze( {
 				2916284: {
 					statsStreak: {


### PR DESCRIPTION
Folks have been occasionally getting a Calypso WSOD because `treeSelect` received a key that can't be stored in a `WeakMap`. Report from @WunderBart:

<img width="968" alt="Screenshot 2021-02-18 at 14 03 18" src="https://user-images.githubusercontent.com/664258/108492997-1a851900-72a6-11eb-8162-79cd794ff3be.png">

I got the error some time ago, too, and confirmed it happens when there is invalid stats data in state:
```
{
  stats: {
    lists: {
      items: {
        123456: {
          statsInsights: {
            '[]': ''
          }
        }
      }
    }
  }
}
```

That leaf value should be an object, never an empty string. I don't know how that value could get there. By inspecting the `stats/insights` endpoint source, I confirmed that it always returns an object with stats, or an error, never anything else. But it's a fact that it happens 🙂 

I'm fixing this by improving the schema that validates the serialized stats data: allow only `[...]` keys as `query`, and force the leaf values to be objects.

Before this patch, the `query` property keys were matched against `{...}` and that doesn't make sense: we don't use and never used curly brackets there.

A second fix is to default the state value to `null` when it's anything falsy, e.g., the empty string.
