### PR TITLE
Updating pricing table copy and adding hosting feature

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -175,8 +175,8 @@ export const FEATURES_LIST = {
 	},
 
 	[ constants.FEATURE_HOSTING ]: {
-		getSlug: () => constants.FEATURE_HOSTING,
-		getTitle: () => i18n.translate( 'Fully hosted site' ),
+		getSlug: () => constants.FEATURE_SITE_HOSTING,
+		getTitle: () => i18n.translate( 'Best-in-class hosting' ),
 		getDescription: () =>
 			i18n.translate(
 				'Site hosting is included with your plan, eliminating additional cost and technical hassle.'

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -175,7 +175,7 @@ export const FEATURES_LIST = {
 	},
 
 	[ constants.FEATURE_HOSTING ]: {
-		getSlug: () => constants.FEATURE_SITE_HOSTING,
+		getSlug: () => constants.FEATURE_HOSTING,
 		getTitle: () => i18n.translate( 'Best-in-class hosting' ),
 		getDescription: () =>
 			i18n.translate(

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -174,6 +174,15 @@ export const FEATURES_LIST = {
 			),
 	},
 
+	[ constants.FEATURE_HOSTING ]: {
+		getSlug: () => constants.FEATURE_HOSTING,
+		getTitle: () => i18n.translate( 'Fully hosted site' ),
+		getDescription: () =>
+			i18n.translate(
+				'Site hosting is included with your plan, eliminating additional cost and technical hassle.'
+			),
+	},
+
 	[ constants.FEATURE_PREMIUM_THEMES ]: {
 		getSlug: () => constants.FEATURE_PREMIUM_THEMES,
 		getTitle: () => i18n.translate( 'Unlimited premium themes' ),
@@ -1047,7 +1056,10 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_PREMIUM_CONTENT_BLOCK ]: {
 		getSlug: () => constants.FEATURE_PREMIUM_CONTENT_BLOCK,
 		getTitle: () => i18n.translate( 'Subscriber-only content' ),
-		getDescription: () => i18n.translate( 'Limit content to paying subscribers.' ),
+		getDescription: () =>
+			i18n.translate(
+				'Create additional, premium content that you can make available to paying subscribers only.'
+			),
 	},
 
 	[ constants.FEATURE_PLAN_SECURITY_DAILY ]: {

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -122,6 +122,7 @@ const getPlanPersonalDetails = () => ( {
 	getPlanCompareFeatures: () => [
 		// pay attention to ordering, shared features should align on /plan page
 		constants.FEATURE_CUSTOM_DOMAIN,
+		constants.FEATURE_HOSTING,
 		constants.FEATURE_JETPACK_ESSENTIAL,
 		constants.FEATURE_EMAIL_SUPPORT,
 		constants.FEATURE_FREE_THEMES,
@@ -192,6 +193,7 @@ const getPlanEcommerceDetails = () => ( {
 			constants.FEATURE_CUSTOM_DOMAIN,
 			isLoggedInMonthlyPricing && constants.FEATURE_LIVE_CHAT_SUPPORT,
 			isLoggedInMonthlyPricing && constants.FEATURE_EMAIL_SUPPORT,
+			constants.FEATURE_HOSTING,
 			constants.FEATURE_JETPACK_ADVANCED,
 			! isLoggedInMonthlyPricing && constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS,
 			constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
@@ -296,6 +298,7 @@ const getPlanPremiumDetails = () => ( {
 			constants.FEATURE_CUSTOM_DOMAIN,
 			isLoggedInMonthlyPricing && constants.FEATURE_LIVE_CHAT_SUPPORT,
 			isLoggedInMonthlyPricing && constants.FEATURE_EMAIL_SUPPORT,
+			constants.FEATURE_HOSTING,
 			constants.FEATURE_JETPACK_ESSENTIAL,
 			! isLoggedInMonthlyPricing && constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
 			constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
@@ -379,6 +382,7 @@ const getPlanBusinessDetails = () => ( {
 			constants.FEATURE_CUSTOM_DOMAIN,
 			isLoggedInMonthlyPricing && constants.FEATURE_LIVE_CHAT_SUPPORT,
 			isLoggedInMonthlyPricing && constants.FEATURE_EMAIL_SUPPORT,
+			constants.FEATURE_HOSTING,
 			constants.FEATURE_JETPACK_ADVANCED,
 			! isLoggedInMonthlyPricing && constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS,
 			constants.FEATURE_UNLIMITED_PREMIUM_THEMES,


### PR DESCRIPTION
This PR updates the Plans features table on `/plan` with the following updates:
* Adds a new entry highlighting that all plans include hosting (a common point of confusion).
* Updates the tooltip copy for the "Subscriber only content" item.

Additional context available in pbBQWj-Gz-p2.

Here's a screenshot of the changes:

<img width="1057" alt="Screen Shot 2021-02-19 at 11 28 03 AM" src="https://user-images.githubusercontent.com/35781181/108532190-96cb2c80-72a5-11eb-9e11-52b5c5cf8df5.png">

#### Testing instructions
* Check out this PR and spin up Calypso.
* Navigate to `/plan/SITESLUG` and confirm the updates are present on all plans.

CC @mktgmolly 