### PR TITLE
Focused Launch: redirect to checkout after launch with eCommerce plan

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
@@ -47,8 +47,12 @@ export const openCheckout = (
 	const isFocusedLaunchFlow = window?.wpcomEditorSiteLaunch?.launchFlow === FOCUSED_LAUNCH_FLOW;
 	const urlWithoutArgs = getCurrentLaunchFlowUrl().split( '?' )[ 0 ];
 
-	// only in focused launch, open checkout modal assuming the cart is already updated
-	if ( hasAction( HOOK_OPEN_CHECKOUT_MODAL ) && isFocusedLaunchFlow ) {
+	// Use Checkout Modal as a progressive enhancement if:
+	// - we are in Calypso, within the iframed editor where HOOK_OPEN_CHECKOUT_MODAL exists
+	// - we are in Focused Launch flow
+	// - selected plan is not eCommerce
+	if ( hasAction( HOOK_OPEN_CHECKOUT_MODAL ) && isFocusedLaunchFlow && ! isEcommerce ) {
+		// open Checkout Modal without passing cartData, assuming the cart is already updated
 		doAction( HOOK_OPEN_CHECKOUT_MODAL, {
 			checkoutOnSuccessCallback: onSuccessCallback,
 			isFocusedLaunch: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Redirect to `/checkout` after launching the site with eCommerce plan selected. The behavior should be the same as in wp-admin.

#### Testing instructions
* Create a site using `/start`
* Sync ETK and sandbox site
* Select eCommerce plan in Focused Launch
* After launching the site you should be redirected to `/checkout`

Related to https://github.com/Automattic/wp-calypso/issues/46943#issuecomment-782028475
> For Calypso, user is redirected back to the block editor, user did not get redirected to the store setup. Atomic transfer did happen though, because the subdomain becomes *.wpcomstaging.com. For WP-Admin, atomic transfer & store setup works as usual.