### PR TITLE
Redux persistence: introduce a withPersistence wrapper

### DIFF
--- a/client/state/automated-transfer/eligibility/reducer.js
+++ b/client/state/automated-transfer/eligibility/reducer.js
@@ -7,7 +7,8 @@ import { property, sortBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE as UPDATE } from 'calypso/state/action-types';
+import { AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE } from 'calypso/state/action-types';
+import { withPersistence } from 'calypso/state/utils';
 
 const initialState = {
 	eligibilityHolds: [],
@@ -15,9 +16,10 @@ const initialState = {
 	lastUpdate: 0,
 };
 
-const eligibilityReducer = ( state = initialState, action ) => {
+// the parent reducer will verify the schema
+export default withPersistence( ( state = initialState, action ) => {
 	switch ( action.type ) {
-		case UPDATE:
+		case AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE:
 			return {
 				eligibilityHolds: sortBy( action.eligibilityHolds ),
 				eligibilityWarnings: sortBy( action.eligibilityWarnings, property( 'name' ) ),
@@ -26,7 +28,4 @@ const eligibilityReducer = ( state = initialState, action ) => {
 	}
 
 	return state;
-};
-eligibilityReducer.hasCustomPersistence = true; // the parent reducer will verify the schema
-
-export default eligibilityReducer;
+} );

--- a/client/state/automated-transfer/reducer.js
+++ b/client/state/automated-transfer/reducer.js
@@ -3,7 +3,12 @@
  */
 import { withStorageKey } from '@automattic/state-utils';
 import eligibility from './eligibility/reducer';
-import { combineReducers, keyedReducer, withSchemaValidation } from 'calypso/state/utils';
+import {
+	combineReducers,
+	keyedReducer,
+	withSchemaValidation,
+	withPersistence,
+} from 'calypso/state/utils';
 import { transferStates } from './constants';
 import { automatedTransfer as schema } from './schema';
 import {
@@ -18,7 +23,7 @@ import {
 	THEME_TRANSFER_STATUS_RECEIVE as TRANSFER_UPDATE,
 } from 'calypso/state/themes/action-types';
 
-export const status = ( state = null, action ) => {
+export const status = withPersistence( ( state = null, action ) => {
 	switch ( action.type ) {
 		case ELIGIBILITY_UPDATE:
 			return state || transferStates.INQUIRING;
@@ -33,8 +38,7 @@ export const status = ( state = null, action ) => {
 	}
 
 	return state;
-};
-status.hasCustomPersistence = true;
+} );
 
 export const fetchingStatus = ( state = false, action ) => {
 	switch ( action.type ) {

--- a/client/state/test/with-persistence.js
+++ b/client/state/test/with-persistence.js
@@ -1,0 +1,63 @@
+/**
+ * Internal dependencies
+ */
+import { withPersistence, serialize, deserialize, combineReducers } from 'calypso/state/utils';
+
+describe( 'withPersistence', () => {
+	const countReducer = ( state = 0, action ) => {
+		switch ( action.type ) {
+			case 'INC':
+				return state + 1;
+			default:
+				return state;
+		}
+	};
+
+	test( 'enables persistence with identity transform', () => {
+		const reducer = combineReducers( { count: withPersistence( countReducer ) } );
+
+		// handles normal actions without disruption
+		expect( reducer( { count: 1 }, { type: 'INC' } ) ).toEqual( { count: 2 } );
+
+		// serializes the state
+		expect( serialize( reducer, { count: 2 } ).root() ).toEqual( { count: 2 } );
+
+		// deserializes the state
+		expect( deserialize( reducer, { count: 3 } ) ).toEqual( { count: 3 } );
+
+		// just make sure that reducer without `withPersistence` indeed has no persistence
+		const reducerWithoutPersistence = combineReducers( { count: countReducer } );
+		expect( serialize( reducerWithoutPersistence, { count: 2 } ) ).toBeUndefined();
+		expect( deserialize( reducerWithoutPersistence, { count: 2 } ) ).toEqual( { count: 0 } );
+	} );
+
+	test( 'enables persistence with custom serialize', () => {
+		const reducer = combineReducers( {
+			count: withPersistence( countReducer, {
+				// never store unlucky numbers
+				serialize: ( state ) => ( state === 13 ? 12 : state ),
+			} ),
+		} );
+
+		// serializes the state with the custom handler
+		expect( serialize( reducer, { count: 13 } ).root() ).toEqual( { count: 12 } );
+
+		// deserializes the state with identity
+		expect( deserialize( reducer, { count: 13 } ) ).toEqual( { count: 13 } );
+	} );
+
+	test( 'enables persistence with custom deserialize', () => {
+		const reducer = combineReducers( {
+			count: withPersistence( countReducer, {
+				// don't load counters that are too small
+				deserialize: ( state ) => ( state > 10 ? state : 0 ),
+			} ),
+		} );
+
+		// serializes the state with identity
+		expect( serialize( reducer, { count: 5 } ).root() ).toEqual( { count: 5 } );
+
+		// deserializes the state with custom handler
+		expect( deserialize( reducer, { count: 5 } ) ).toEqual( { count: 0 } );
+	} );
+} );

--- a/client/state/utils/index.ts
+++ b/client/state/utils/index.ts
@@ -6,6 +6,7 @@ export { isValidStateWithSchema, withSchemaValidation } from './schema-utils';
 export { keyedReducer } from './keyed-reducer';
 export { withEnhancers } from './with-enhancers';
 export { serialize, deserialize } from './serialize';
+export { withPersistence } from './with-persistence';
 export { withoutPersistence } from './without-persistence';
 export { addReducer, combineReducers } from './reducer-utils';
 export { addReducerEnhancer } from './add-reducer-enhancer';

--- a/client/state/utils/with-persistence.js
+++ b/client/state/utils/with-persistence.js
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies
+ */
+import { DESERIALIZE, SERIALIZE } from 'calypso/state/action-types';
+
+export const withPersistence = ( reducer, { serialize, deserialize } = {} ) => {
+	const wrappedReducer = ( state, action ) => {
+		switch ( action.type ) {
+			case SERIALIZE:
+				return serialize ? serialize( state ) : reducer( state, action );
+			case DESERIALIZE:
+				return deserialize ? deserialize( state ) : reducer( state, action );
+			default:
+				return reducer( state, action );
+		}
+	};
+
+	wrappedReducer.hasCustomPersistence = true;
+
+	return wrappedReducer;
+};


### PR DESCRIPTION
Another spinoff from #50222 that introduces a `withPersistence` reducer wrapper that replaces two coding patterns:
- setting a `.hasCustomPersistence` flag on a reducer to signal to `combineReducers` that it shouldn't wrap it with `withoutPersistence`
- reducer handling a `SERIALIZE` and `DESERIALIZE` actions

This is now replaced with:
```js
withPersistence( reducer )
```
or
```js
withPersistence( reducer, {
  serialize: state => state.toJson(),
  deserialize: persisted => State.fromJson( persisted )
} );
```

We still continue to use `hasCustomPersistence` and the two actions internally, but it's now hidden from app code. This allows us to change the internal implementation at any time without affecting the app.

I migrated several reducers to illustrate the point. There are many more reducers that are still not migrated.