### PR TITLE
Partner Portal: Remove selected partner key store cache to avoid invalid state

### DIFF
--- a/client/state/partner-portal/partner/reducer.ts
+++ b/client/state/partner-portal/partner/reducer.ts
@@ -12,7 +12,7 @@ import {
 	JETPACK_PARTNER_PORTAL_PARTNER_REQUEST_FAILURE,
 	JETPACK_PARTNER_PORTAL_PARTNER_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
-import { combineReducers, withoutPersistence, withSchemaValidation } from 'calypso/state/utils';
+import { combineReducers, withoutPersistence } from 'calypso/state/utils';
 
 export const initialState = {
 	hasFetched: false,
@@ -49,10 +49,7 @@ export const isFetching = withoutPersistence(
 	}
 );
 
-export const activePartnerKey = withSchemaValidation(
-	{
-		type: 'number',
-	},
+export const activePartnerKey = withoutPersistence(
 	( state = initialState.activePartnerKey, action: AnyAction ) => {
 		switch ( action.type ) {
 			case JETPACK_PARTNER_PORTAL_PARTNER_ACTIVE_PARTNER_KEY_UPDATE:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Stop caching the selected partner key id to avoid an invalid state where a non-existent key (e.g. not fetched yet) is considered active.

#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key.
* Refresh multiple times and make sure that the license listing does not show an error message due to a failed request.