### PR TITLE
Focused Launch: Once there is a plan selected, do not use plan from cart anymore.

### DIFF
--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -46,11 +46,30 @@ const FocusedLaunch: React.FunctionComponent = () => {
 	const planProductIdFromCart = usePlanProductIdFromCart();
 	const { setPlanProductId } = useDispatch( LAUNCH_STORE );
 
+	// Once there is a selected plan, do not retrieve plan from from cart anymore.
+	const canUsePlanProductIdFromCart = React.useRef( false );
 	React.useEffect( () => {
-		if ( ! selectedPlanProductId && planProductIdFromCart && ! hasPaidPlan ) {
+		if ( selectedPlanProductId ) {
+			canUsePlanProductIdFromCart.current = true;
+		}
+	}, [ selectedPlanProductId ] );
+
+	React.useEffect( () => {
+		if (
+			! selectedPlanProductId &&
+			planProductIdFromCart &&
+			! hasPaidPlan &&
+			! canUsePlanProductIdFromCart.current
+		) {
 			setPlanProductId( planProductIdFromCart );
 		}
-	}, [ selectedPlanProductId, planProductIdFromCart, setPlanProductId, hasPaidPlan ] );
+	}, [
+		selectedPlanProductId,
+		planProductIdFromCart,
+		setPlanProductId,
+		hasPaidPlan,
+		canUsePlanProductIdFromCart,
+	] );
 
 	// The user may have previously used the launch flow to pick a paid plan,
 	// but they may have then purchased that paid plan or other plan before deciding to continue Launch flow.

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -47,10 +47,10 @@ const FocusedLaunch: React.FunctionComponent = () => {
 	const { setPlanProductId } = useDispatch( LAUNCH_STORE );
 
 	// Once there is a selected plan, do not retrieve plan from from cart anymore.
-	const canUsePlanProductIdFromCart = React.useRef( false );
+	const canUsePlanProductIdFromCart = React.useRef( true );
 	React.useEffect( () => {
 		if ( selectedPlanProductId ) {
-			canUsePlanProductIdFromCart.current = true;
+			canUsePlanProductIdFromCart.current = false;
 		}
 	}, [ selectedPlanProductId ] );
 
@@ -59,7 +59,7 @@ const FocusedLaunch: React.FunctionComponent = () => {
 			! selectedPlanProductId &&
 			planProductIdFromCart &&
 			! hasPaidPlan &&
-			! canUsePlanProductIdFromCart.current
+			canUsePlanProductIdFromCart.current
 		) {
 			setPlanProductId( planProductIdFromCart );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Do not fallback to plan from cart once a plan has been selected.

#### Testing instructions
* Create a site via `/start`.
  * `yarn dev --sync` and sandbox your site.
* Go to **Site Home > Upgrades**, select **Personal Plan**, click **Upgrade**, then abandon checkout.
* Go to Focused Launch.
  * [ ] **Personal Plan** should be the pre-selected plan.
* Click on **View all plans** and selected another paid plan.
  * Go back to summary view  and select **Free plan**.
* Click on a custom domain.
  * [ ] The **Free plan** should be deselected.

Fixes #50272
