### PR TITLE
Anchor Gutenboarding: Clear title on pageload including anchor_podcast parameter

### DIFF
--- a/client/landing/gutenboarding/hooks/use-site-title.ts
+++ b/client/landing/gutenboarding/hooks/use-site-title.ts
@@ -22,7 +22,8 @@ export default function useSiteTitle(): void {
 	// When first loading a url including an ?anchor_podcast query param, clear
 	// the title.
 	// This allows the title retrieved from from backend to be applied, since
-	// we only load it over blank titles to prevent wiping out custom titles.
+	// we only apply it over blank titles to prevent wiping out custom titles
+	// set by the user.
 	// This also retains the ability to keep custom titles when reloading the
 	// browser during steps after "acquire-intent".
 	const { search } = useLocation();

--- a/client/landing/gutenboarding/hooks/use-site-title.ts
+++ b/client/landing/gutenboarding/hooks/use-site-title.ts
@@ -19,9 +19,12 @@ export default function useSiteTitle(): void {
 		hasSiteTitle: select( ONBOARD_STORE ).getSelectedSiteTitle().length > 0,
 	} ) );
 
-	// When first loading a url including an ?anchor_podcast query param, clear the title
-	// This stops any pre-saved title in state from interfering, while retaining the ability
-	// to reload the browser in steps after aquire-intent and keep custom titles.
+	// When first loading a url including an ?anchor_podcast query param, clear
+	// the title.
+	// This allows the title retrieved from from backend to be applied, since
+	// we only load it over blank titles to prevent wiping out custom titles.
+	// This also retains the ability to keep custom titles when reloading the
+	// browser during steps after "acquire-intent".
 	const { search } = useLocation();
 	useEffect( () => {
 		const queryAnchorPodcast = new URLSearchParams( search ).get( 'anchor_podcast' );

--- a/client/landing/gutenboarding/hooks/use-site-title.ts
+++ b/client/landing/gutenboarding/hooks/use-site-title.ts
@@ -3,12 +3,14 @@
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import usePodcastTitle from './use-podcast-title';
+import { isAnchorPodcastIdValid } from '../path';
 
 export default function useSiteTitle(): void {
 	const { setSiteTitle } = useDispatch( ONBOARD_STORE );
@@ -16,6 +18,17 @@ export default function useSiteTitle(): void {
 	const { hasSiteTitle } = useSelect( ( select ) => ( {
 		hasSiteTitle: select( ONBOARD_STORE ).getSelectedSiteTitle().length > 0,
 	} ) );
+
+	// When first loading a url including an ?anchor_podcast query param, clear the title
+	// This stops any pre-saved title in state from interfering, while retaining the ability
+	// to reload the browser in steps after aquire-intent and keep custom titles.
+	const { search } = useLocation();
+	useEffect( () => {
+		const queryAnchorPodcast = new URLSearchParams( search ).get( 'anchor_podcast' );
+		if ( isAnchorPodcastIdValid( queryAnchorPodcast ) ) {
+			setSiteTitle( '' );
+		}
+	}, [] ); // Only run on initial mount
 
 	useEffect( () => {
 		if ( podcastTitle && ! hasSiteTitle ) {

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -119,7 +119,7 @@ export function useIsAnchorFm(): boolean {
 	return isAnchorPodcastIdValid( anchorFmPodcastId );
 }
 
-function isAnchorPodcastIdValid( anchorFmPodcastId: string | null ): boolean {
+export function isAnchorPodcastIdValid( anchorFmPodcastId: string | null ): boolean {
 	return Boolean( anchorFmPodcastId && anchorFmPodcastId.match( /^[0-9a-f]{7,8}$/i ) );
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When first loading a url including an ?anchor_podcast query param, clear the title.
* This allows the title retrieved from from backend to be applied, since we only apply it over blank titles to prevent wiping out custom titles set by the user.
* This also retains the ability to keep custom titles when reloading the browser during steps after "acquire-intent".

#### Bug Fixed

* Visit http://calypso.localhost:3000/new?anchor_podcast=22b6608 . It brought me to my already existing "Brave not Perfect" site.
* Visit http://calypso.localhost:3000/new?anchor_podcast=1808c24 . This is a new, completely different podcast, but my acquire intent screen says "Brave Not Perfect". It should be pulling the podcast name, "Styles N Dris" from the backend.

#### Bug in Tension

Fixing the issue in https://github.com/Automattic/wp-calypso/pull/50148/ caused this issue.  We want to be certain by fixing this issue, we are not regressing #50148.

#### Testing instructions

* Create two sites in a row, from podcasts with different titles. (Example URLS)
   * Example URLs
     * http://calypso.localhost:3000/new?anchor_podcast=22b6608 (Brave not perfect)
     * http://calypso.localhost:3000/new?anchor_podcast=9fa55c4 (Tour de Trance)
     * http://calypso.localhost:3000/new?anchor_podcast=1808c24 (Styles and Dris)
   * The second site should have its title loaded into the Acquire Intent screen, instead of loading the title from the first site created
* Ensure the issue in https://github.com/Automattic/wp-calypso/pull/50148/ is still fixed 
  * Visit `/new/?anchor_podcast=22b6608`
  * Check that the podcast title is populated in the site title field.
  * Replace the podcast title with a custom title.
  * Continue to the font pairing step
  * Refresh the browser page
  * Check that the custom title displays both in the font preview and at the top of the page:
* Anything else you can think of

Related to #
