### PR TITLE
Domain Search: Use shopping cart manager for adding personal plan from query string

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -39,9 +39,6 @@ import JetpackManageErrorPage from 'calypso/my-sites/jetpack-manage-error-page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { canUserPurchaseGSuite } from 'calypso/lib/gsuite';
-import { addItem } from 'calypso/lib/cart/actions';
-import { planItem } from 'calypso/lib/cart-values/cart-items';
-import { PLAN_PERSONAL } from 'calypso/lib/plans/constants';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 const domainsAddHeader = ( context, next ) => {
@@ -70,11 +67,6 @@ const domainSearch = ( context, next ) => {
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {
 		window.scrollTo( 0, 0 );
-	}
-
-	if ( 'upgrade' === context.query.ref ) {
-		addItem( planItem( PLAN_PERSONAL, {} ) );
-		return page.replace( context.pathname );
 	}
 
 	context.primary = (

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -144,6 +144,7 @@ class DomainSearch extends Component {
 		this.props.shoppingCartManager.addProductsToCart( [
 			fillInSingleCartItemAttributes( planItem( PLAN_PERSONAL, {} ), this.props.productsList ),
 		] );
+		page.replace( this.props.context.pathname );
 	}
 
 	addDomain( suggestion ) {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -26,6 +26,7 @@ import {
 	domainMapping,
 	domainTransfer,
 	domainRegistration,
+	planItem,
 	updatePrivacyForDomain,
 } from 'calypso/lib/cart-values/cart-items';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
@@ -48,6 +49,7 @@ import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import NewDomainsRedirectionNoticeUpsell from 'calypso/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
 import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
+import { PLAN_PERSONAL } from 'calypso/lib/plans/constants';
 
 /**
  * Style dependencies
@@ -126,12 +128,22 @@ class DomainSearch extends Component {
 
 	componentDidMount() {
 		this.isMounted = true;
+
+		if ( 'upgrade' === this.props.context.query.ref ) {
+			this.addPersonalPlan();
+		}
 	}
 
 	checkSiteIsUpgradeable( props ) {
 		if ( props.selectedSite && ! props.isSiteUpgradeable ) {
 			page.redirect( '/domains/add' );
 		}
+	}
+
+	addPersonalPlan() {
+		this.props.shoppingCartManager.addProductsToCart( [
+			fillInSingleCartItemAttributes( planItem( PLAN_PERSONAL, {} ), this.props.productsList ),
+		] );
 	}
 
 	addDomain( suggestion ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The domain search page controller contains a block of code that will add the Personal plan to the cart if the URL contains the query string `?ref=upgrade`. This code uses the deprecated `CartStore`. As part of removing that store (see https://github.com/Automattic/wp-calypso/issues/24019), this PR moves that logic into the `DomainSearch` component itself and converts it to use the `@automattic/shopping-cart` package (which that component is already using).

#### Testing instructions

- Use a site that has no plan.
- Verify that your cart is empty.
- Visit the domain search URL with `ref=upgrade` in your query string. Something like: http://calypso.localhost:3000/domains/add/example.com?ref=upgrade
- Verify that the query string vanishes from the URL.
- Visit checkout directly without clicking anything. Something like: http://calypso.localhost:3000/checkout/example.com
- Verify that you see the Personal plan in your cart.