### PR TITLE
Domain Site Redirect: Use shoppingCartManager to add products in SiteRedirectStep

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -96,7 +96,9 @@ const siteRedirect = ( context, next ) => {
 				title="Domain Search > Site Redirect"
 			/>
 			<DocumentHead title={ translate( 'Redirect a Site' ) } />
-			<SiteRedirect />
+			<CalypsoShoppingCartProvider>
+				<SiteRedirect />
+			</CalypsoShoppingCartProvider>
 		</Main>
 	);
 	next();

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -19,7 +19,6 @@ import {
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import CartData from 'calypso/components/data/cart';
 import DomainSearch from './domain-search';
 import SiteRedirect from './domain-search/site-redirect';
 import MapDomain from 'calypso/my-sites/domains/map-domain';
@@ -97,9 +96,7 @@ const siteRedirect = ( context, next ) => {
 				title="Domain Search > Site Redirect"
 			/>
 			<DocumentHead title={ translate( 'Redirect a Site' ) } />
-			<CartData>
-				<SiteRedirect />
-			</CartData>
+			<SiteRedirect />
 		</Main>
 	);
 	next();

--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -34,7 +34,7 @@ class SiteRedirectStep extends React.Component {
 		selectedSite: PropTypes.object.isRequired,
 	};
 
-	state = { searchQuery: '' };
+	state = { searchQuery: '', isSubmitting: false };
 
 	isMounted = false;
 
@@ -78,6 +78,7 @@ class SiteRedirectStep extends React.Component {
 							className="site-redirect-step__go"
 							type="submit"
 							onClick={ this.recordGoButtonClick }
+							busy={ this.state.isSubmitting }
 						>
 							{ translate( 'Go', {
 								context: 'Upgrades: Label for adding Site Redirect',
@@ -105,6 +106,8 @@ class SiteRedirectStep extends React.Component {
 	handleFormSubmit = ( event ) => {
 		event.preventDefault();
 
+		this.setState( { isSubmitting: true } );
+
 		const domain = this.state.searchQuery;
 
 		this.props.recordFormSubmit( domain );
@@ -113,6 +116,7 @@ class SiteRedirectStep extends React.Component {
 			this.props.errorNotice(
 				this.getValidationErrorMessage( domain, { code: 'already_in_cart' } )
 			);
+			this.setState( { isSubmitting: false } );
 			return;
 		}
 
@@ -122,6 +126,7 @@ class SiteRedirectStep extends React.Component {
 			function ( error ) {
 				if ( error ) {
 					this.props.errorNotice( this.getValidationErrorMessage( domain, error ) );
+					this.setState( { isSubmitting: false } );
 					return;
 				}
 

--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -79,6 +79,7 @@ class SiteRedirectStep extends React.Component {
 							type="submit"
 							onClick={ this.recordGoButtonClick }
 							busy={ this.state.isSubmitting }
+							disabled={ this.state.isSubmitting }
 						>
 							{ translate( 'Go', {
 								context: 'Upgrades: Label for adding Site Redirect',

--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -22,7 +22,6 @@ import DomainProductPrice from 'calypso/components/domains/domain-product-price'
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { withoutHttp } from 'calypso/lib/url';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
-import { getProductsList } from 'calypso/state/products-list/selectors';
 
 /**
  * Style dependencies
@@ -135,7 +134,7 @@ class SiteRedirectStep extends React.Component {
 	addSiteRedirectToCart = ( domain ) => {
 		this.props.shoppingCartManager
 			.addProductsToCart( [
-				fillInSingleCartItemAttributes( siteRedirect( { domain } ), this.props.productsList ),
+				fillInSingleCartItemAttributes( siteRedirect( { domain } ), this.props.products ),
 			] )
 			.then( () => {
 				this.isMounted && page( '/checkout/' + this.props.selectedSite.slug );
@@ -201,16 +200,9 @@ const recordFormSubmit = ( searchBoxValue ) =>
 		searchBoxValue
 	);
 
-export default connect(
-	( state ) => {
-		return {
-			productsList: getProductsList( state ),
-		};
-	},
-	{
-		errorNotice,
-		recordInputFocus,
-		recordGoButtonClick,
-		recordFormSubmit,
-	}
-)( withShoppingCart( localize( SiteRedirectStep ) ) );
+export default connect( null, {
+	errorNotice,
+	recordInputFocus,
+	recordGoButtonClick,
+	recordFormSubmit,
+} )( withShoppingCart( localize( SiteRedirectStep ) ) );

--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -30,7 +30,6 @@ import './site-redirect-step.scss';
 
 class SiteRedirectStep extends React.Component {
 	static propTypes = {
-		cart: PropTypes.object.isRequired,
 		products: PropTypes.object.isRequired,
 		selectedSite: PropTypes.object.isRequired,
 	};

--- a/client/my-sites/domains/domain-search/site-redirect.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect.jsx
@@ -28,7 +28,6 @@ import { getProductsList } from 'calypso/state/products-list/selectors';
 
 class SiteRedirect extends Component {
 	static propTypes = {
-		cart: PropTypes.object.isRequired,
 		selectedSite: PropTypes.object.isRequired,
 		selectedSiteSlug: PropTypes.string.isRequired,
 		isSiteAtomic: PropTypes.bool.isRequired,
@@ -59,7 +58,6 @@ class SiteRedirect extends Component {
 
 	render() {
 		const {
-			cart,
 			selectedSite,
 			selectedSiteAdminUrl,
 			isSiteAtomic,
@@ -87,7 +85,7 @@ class SiteRedirect extends Component {
 					{ translate( 'Redirect a Site' ) }
 				</HeaderCake>
 
-				<SiteRedirectStep cart={ cart } products={ productsList } selectedSite={ selectedSite } />
+				<SiteRedirectStep products={ productsList } selectedSite={ selectedSite } />
 			</Main>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of removing `CartStore` (see https://github.com/Automattic/wp-calypso/issues/24019), this PR replaces the code in `SiteRedirectStep` that adds a redirect product to the cart with functions from `@automattic/shopping-cart`.

![site-redirect-step](https://user-images.githubusercontent.com/2036909/108778622-9ea00080-7533-11eb-984b-23bf19c7640c.gif)


#### Testing instructions

- Visit the site-redirect form at a URL like http://calypso.localhost:3000/domains/add/site-redirect/example.com
- Write a domain name in the form field and press "Go".
- Verify that you are redirected to checkout and that a "Site redirect" product is in your cart.