### PR TITLE
Billing: Remove setting CartStore site id in ManagePurchase

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -103,7 +103,6 @@ import {
 	getCurrentUser,
 	getCurrentUserId,
 } from 'calypso/state/current-user/selectors';
-import CartStore from 'calypso/lib/cart/store';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { hasCustomDomain } from 'calypso/lib/site/utils';
 import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
@@ -160,22 +159,10 @@ class ManagePurchase extends Component {
 		}
 	}
 
-	componentDidMount() {
-		if ( this.props.siteId ) {
-			CartStore.setSelectedSiteId( this.props.siteId );
-		}
-	}
-
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( this.isDataValid() && ! this.isDataValid( nextProps ) ) {
 			page.redirect( this.props.purchaseListUrl );
 			return;
-		}
-	}
-
-	componentDidUpdate( { siteId } ) {
-		if ( this.props.siteId && siteId !== this.props.siteId ) {
-			CartStore.setSelectedSiteId( this.props.siteId );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `ManagePurchase` component caches the currently selected site ID in the `CartStore`. I'm not 100% sure why this is the case, but presumably it was used when later adding products to the cart (renewals, for example). In any case, as most uses of the `CartStore` have been removed (see https://github.com/Automattic/wp-calypso/issues/24019), I suspect this use no longer has any value and remove it here.

#### Testing instructions

Verify that viewing a purchase works as expected.