### PR TITLE
Checkout: Remove CartStore from validation

### DIFF
--- a/client/lib/checkout/README.md
+++ b/client/lib/checkout/README.md
@@ -4,7 +4,7 @@ This module contains functions to validate and mask checkout form fields such as
 
 ## API
 
-### `validatePaymentDetails( paymentDetails )`
+### `validatePaymentDetails( paymentDetails, paymentType )`
 
 Returns an object containing the errors for each field. For example the returned object might look like this:
 

--- a/client/lib/checkout/processor-specific.js
+++ b/client/lib/checkout/processor-specific.js
@@ -10,7 +10,6 @@ import { CPF, CNPJ } from 'cpf_cnpj';
  * Internal dependencies
  */
 import { PAYMENT_PROCESSOR_COUNTRIES_FIELDS } from 'calypso/lib/checkout/constants';
-import CartStore from 'calypso/lib/cart/store';
 import isPaymentMethodEnabled from 'calypso/my-sites/checkout/composite-checkout/lib/is-payment-method-enabled';
 import { translateWpcomPaymentMethodToCheckoutPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
 
@@ -18,13 +17,10 @@ import { translateWpcomPaymentMethodToCheckoutPaymentMethod } from 'calypso/my-s
  * Returns whether we should Ebanx credit card processing for a particular country
  *
  * @param {string} countryCode - a two-letter country code, e.g., 'DE', 'BR'
- * @param {import('@automattic/shopping-cart').ResponseCart} [cart] - The shopping cart
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart - The shopping cart
  * @returns {boolean} Whether the country code requires ebanx payment processing
  */
-export function isEbanxCreditCardProcessingEnabledForCountry( countryCode = '', cart = null ) {
-	if ( ! cart ) {
-		cart = CartStore.get();
-	}
+export function isEbanxCreditCardProcessingEnabledForCountry( countryCode, cart ) {
 	return (
 		! isUndefined( PAYMENT_PROCESSOR_COUNTRIES_FIELDS[ countryCode ] ) &&
 		isPaymentMethodEnabled(

--- a/client/lib/checkout/test/validation.js
+++ b/client/lib/checkout/test/validation.js
@@ -46,14 +46,14 @@ describe( 'validation', () => {
 
 	describe( '#validatePaymentDetails', () => {
 		test( 'should return no errors when card is valid', () => {
-			const result = validatePaymentDetails( validCard );
+			const result = validatePaymentDetails( validCard, 'credit-card' );
 			expect( result ).toEqual( { errors: {} } );
 		} );
 
 		describe( 'validate credit card', () => {
 			test( 'should return error when card has expiration date in the past', () => {
 				const expiredCard = { ...validCard, 'expiration-date': '01/01' };
-				const result = validatePaymentDetails( expiredCard );
+				const result = validatePaymentDetails( expiredCard, 'credit-card' );
 
 				expect( result ).toEqual( {
 					errors: {
@@ -64,7 +64,7 @@ describe( 'validation', () => {
 
 			test( 'should return error when cvv is the wrong length', () => {
 				const invalidCVVCard = { ...validCard, cvv: '12345' };
-				const result = validatePaymentDetails( invalidCVVCard );
+				const result = validatePaymentDetails( invalidCVVCard, 'credit-card' );
 
 				expect( result ).toEqual( {
 					errors: {
@@ -77,7 +77,7 @@ describe( 'validation', () => {
 		describe( 'validate basic non-credit card details', () => {
 			test( 'should return error when card holder name is missing', () => {
 				const invalidCardHolderName = { ...validCard, name: '' };
-				const result = validatePaymentDetails( invalidCardHolderName );
+				const result = validatePaymentDetails( invalidCardHolderName, 'credit-card' );
 
 				expect( result ).toEqual( {
 					errors: {
@@ -88,7 +88,7 @@ describe( 'validation', () => {
 
 			test( 'should return error when Cardholder Name is missing', () => {
 				const invalidCardHolderName = { ...validCard, name: '' };
-				const result = validatePaymentDetails( invalidCardHolderName );
+				const result = validatePaymentDetails( invalidCardHolderName, 'credit-card' );
 
 				expect( result ).toEqual( {
 					errors: {
@@ -99,7 +99,7 @@ describe( 'validation', () => {
 
 			test( 'should return error when Postal Code is missing', () => {
 				const invalidCardPostCode = { ...validCard, 'postal-code': '' };
-				const result = validatePaymentDetails( invalidCardPostCode );
+				const result = validatePaymentDetails( invalidCardPostCode, 'credit-card' );
 
 				expect( result ).toEqual( {
 					errors: {
@@ -114,7 +114,7 @@ describe( 'validation', () => {
 					country: 'US',
 					'postal-code': '1234',
 				};
-				const result = validatePaymentDetails( invalidCardPostCode );
+				const result = validatePaymentDetails( invalidCardPostCode, 'credit-card' );
 
 				expect( result ).toEqual( {
 					errors: {
@@ -131,7 +131,7 @@ describe( 'validation', () => {
 					country: 'US',
 					'postal-code': '90001',
 				};
-				const result = validatePaymentDetails( invalidCardPostCode );
+				const result = validatePaymentDetails( invalidCardPostCode, 'credit-card' );
 
 				expect( result ).not.toEqual( {
 					errors: {
@@ -148,7 +148,7 @@ describe( 'validation', () => {
 					country: 'CA', // redundancy for explicitness
 					'postal-code': '1234',
 				};
-				const result = validatePaymentDetails( invalidCardPostCode );
+				const result = validatePaymentDetails( invalidCardPostCode, 'credit-card' );
 
 				expect( result ).not.toEqual( {
 					errors: {
@@ -162,21 +162,18 @@ describe( 'validation', () => {
 
 		describe( 'validate ebanx non-credit card details', () => {
 			beforeAll( () => {
-				processorSpecificMethods.isEbanxCreditCardProcessingEnabledForCountry = jest
-					.fn()
-					.mockImplementation( () => true );
-				processorSpecificMethods.isValidCPF = jest.fn().mockImplementation( () => true );
+				processorSpecificMethods.isValidCPF = jest.fn().mockImplementation( () => true ); // eslint-disable-line no-import-assign
 			} );
 
 			test( 'should return no errors when details are valid', () => {
-				const result = validatePaymentDetails( validBrazilianEbanxCard );
+				const result = validatePaymentDetails( validBrazilianEbanxCard, 'ebanx' );
 
 				expect( result ).toEqual( { errors: {} } );
 			} );
 
 			test( 'should return error when city is missing', () => {
 				const invalidCity = { ...validBrazilianEbanxCard, city: '' };
-				const result = validatePaymentDetails( invalidCity );
+				const result = validatePaymentDetails( invalidCity, 'ebanx' );
 
 				expect( result ).toEqual( {
 					errors: {
@@ -187,7 +184,7 @@ describe( 'validation', () => {
 
 			test( 'should return error when state is missing', () => {
 				const invalidState = { ...validBrazilianEbanxCard, state: '' };
-				const result = validatePaymentDetails( invalidState );
+				const result = validatePaymentDetails( invalidState, 'ebanx' );
 
 				expect( result ).toEqual( {
 					errors: {
@@ -198,7 +195,7 @@ describe( 'validation', () => {
 
 			test( 'should return error when address-1 is missing', () => {
 				const invalidAddress = { ...validBrazilianEbanxCard, 'address-1': '' };
-				const result = validatePaymentDetails( invalidAddress );
+				const result = validatePaymentDetails( invalidAddress, 'ebanx' );
 
 				expect( result ).toEqual( {
 					errors: {
@@ -209,7 +206,7 @@ describe( 'validation', () => {
 
 			test( 'should return error when street-number is missing', () => {
 				const invalidStNo = { ...validBrazilianEbanxCard, 'street-number': '' };
-				const result = validatePaymentDetails( invalidStNo );
+				const result = validatePaymentDetails( invalidStNo, 'ebanx' );
 
 				expect( result ).toEqual( {
 					errors: {
@@ -220,7 +217,7 @@ describe( 'validation', () => {
 
 			test( 'should return error when phone number is missing', () => {
 				const invalidStPhNo = { ...validBrazilianEbanxCard, 'phone-number': '' };
-				const result = validatePaymentDetails( invalidStPhNo );
+				const result = validatePaymentDetails( invalidStPhNo, 'ebanx' );
 
 				expect( result ).toEqual( {
 					errors: {
@@ -231,7 +228,7 @@ describe( 'validation', () => {
 
 			test( 'should return error when street number is invalid', () => {
 				const invalidStreetNumber = { ...validBrazilianEbanxCard, 'street-number': '0' };
-				const result = validatePaymentDetails( invalidStreetNumber );
+				const result = validatePaymentDetails( invalidStreetNumber, 'ebanx' );
 
 				expect( result ).toEqual( {
 					errors: {
@@ -241,9 +238,9 @@ describe( 'validation', () => {
 			} );
 
 			test( 'should return error when CPF is invalid', () => {
-				processorSpecificMethods.isValidCPF = jest.fn().mockImplementation( () => false );
+				processorSpecificMethods.isValidCPF = jest.fn().mockImplementation( () => false ); // eslint-disable-line no-import-assign
 				const invalidCPF = { ...validBrazilianEbanxCard, document: 'blah' };
-				const result = validatePaymentDetails( invalidCPF );
+				const result = validatePaymentDetails( invalidCPF, 'ebanx' );
 				expect( result ).toEqual( {
 					errors: {
 						document: [

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -343,10 +343,10 @@ validators.validStreetNumber = {
  * property of that object is an array of error strings.
  *
  * @param {object} paymentDetails object containing fieldname/value keypairs
- * @param {string} paymentType credit-card(default)|paypal|id_wallet|p24|brazil-tef|netbanking|token|stripe
+ * @param {string} paymentType credit-card|paypal|id_wallet|p24|brazil-tef|netbanking|token|stripe|ebanx
  * @returns {object} validation errors, if any
  */
-export function validatePaymentDetails( paymentDetails, paymentType = 'credit-card' ) {
+export function validatePaymentDetails( paymentDetails, paymentType ) {
 	const rules = paymentFieldRules( paymentDetails, paymentType ) || {};
 	const errors = Object.keys( rules ).reduce( function ( allErrors, fieldName ) {
 		const field = rules[ fieldName ];

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -141,16 +141,21 @@ export function tokenFieldRules() {
  * Returns a validation ruleset to use for the given payment type
  *
  * @param {object} paymentDetails object containing fieldname/value keypairs
- * @param {string} paymentType credit-card(default)|paypal|id_wallet|p24|brazil-tef|netbanking|token|stripe
+ * @param {string} paymentType credit-card|paypal|id_wallet|p24|brazil-tef|netbanking|token|stripe|ebanx
  * @returns {object|null} the ruleset
  */
 export function paymentFieldRules( paymentDetails, paymentType ) {
 	switch ( paymentType ) {
-		case 'credit-card':
+		case 'ebanx':
 			return mergeValidationRules(
 				getCreditCardFieldRules(),
 				getConditionalCreditCardRules( paymentDetails ),
 				getEbanxCreditCardRules( paymentDetails )
+			);
+		case 'credit-card':
+			return mergeValidationRules(
+				getCreditCardFieldRules(),
+				getConditionalCreditCardRules( paymentDetails )
 			);
 		case 'brazil-tef':
 			return tefPaymentFieldRules();

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -10,7 +10,6 @@ import { isValidPostalCode } from 'calypso/lib/postal-code';
  * Internal dependencies
  */
 import {
-	isEbanxCreditCardProcessingEnabledForCountry,
 	isValidCPF,
 	isValidCNPJ,
 	countrySpecificFieldRules,
@@ -415,11 +414,7 @@ function getErrors( field, value, paymentDetails ) {
 }
 
 function getEbanxCreditCardRules( { country } ) {
-	return (
-		country &&
-		isEbanxCreditCardProcessingEnabledForCountry( country ) &&
-		countrySpecificFieldRules( country )
-	);
+	return country && countrySpecificFieldRules( country );
 }
 
 /**

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
@@ -156,7 +156,8 @@ function isCreditCardFormValid( store, paymentPartner, __ ) {
 				} ).reduce( ( accum, [ key, managedValue ] ) => {
 					accum[ key ] = managedValue?.value;
 					return accum;
-				}, {} )
+				}, {} ),
+				'ebanx'
 			);
 			Object.entries( validationResults.errors ).map( ( [ key, errors ] ) => {
 				errors.map( ( error ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`isEbanxCreditCardProcessingEnabledForCountry` requires getting the available payment methods from the shopping cart. It originally went directly to the `CartStore` to get that list, but as we've migrated away from `CartStore` (see https://github.com/Automattic/wp-calypso/issues/24019), that function has been changed to allow passing in the cart as an argument instead. However, there was still one place which did not pass in the cart: Ebanx form validation.

The `CreditCardPayButton` component, used by the credit card payment method in checkout, calls `validatePaymentDetails`, which then calls `paymentFieldRules`, which in turn uses `isEbanxCreditCardProcessingEnabledForCountry` to determine if the cart merits the additional validation needed for Ebanx fields. However, it only calls this function when the Ebanx form fields are active, so the payment method check in `isEbanxCreditCardProcessingEnabledForCountry` is redundant.

This PR makes the call to `validatePaymentDetails()` require a payment type to be explicitly provided, and adds a new payment type of `ebanx`. This inverts the dependencies so that the validation caller must decide if Ebanx is enabled. It then is able to remove the call to `isEbanxCreditCardProcessingEnabledForCountry` inside the validation.

#### Testing instructions

- Set your currency to `BRL`.
- Visit checkout with a product in your cart.
-  In the contact information step, choose "Brazil" for the country.
- In the final step, choose "Credit or debit card".
- Verify that the form asks for all the Ebanx fields in addition to the credit card fields (Taxpayer Identification Number, Phone, etc.)
- Use an [ebanx test card](https://developer.ebanx.com/docs/resources/testCreditCards/) and [test customer info](https://developer.ebanx.com/docs/resources/testCustomerData/).
- Verify that the payment succeeds and that you are redirected to the thank-you page.