### PR TITLE
Anchor: Remove feature flag in preparation for launch.

### DIFF
--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -10,7 +10,6 @@ import type { ValuesType } from 'utility-types';
 /**
  * Internal dependencies
  */
-import config from '@automattic/calypso-config';
 import { FLOW_ID } from '../gutenboarding/constants';
 
 type PlanPath = Plans.PlanPath;
@@ -236,11 +235,6 @@ function useAnchorParameter( {
 	sanitize,
 }: UseAnchorParameterType ): string | null {
 	const { state: locationState = {}, search } = useLocation< GutenLocationStateType >();
-
-	// Feature flag 'anchor-fm-dev' is required for anchor podcast id to be read
-	if ( ! config.isEnabled( 'anchor-fm-dev' ) ) {
-		return null;
-	}
 
 	// Use location state if available
 	const locationStateParamValue = locationState[ locationStateParamName ];

--- a/client/lib/features-helper/feature-list.js
+++ b/client/lib/features-helper/feature-list.js
@@ -15,7 +15,7 @@ const enabledClass = 'features-helper__feature-item-enabled';
 const disabledClass = 'features-helper__feature-item-disabled';
 
 export const FeatureList = React.memo( () => {
-	const currentXLProjects = [ 'anchor-fm-dev', 'nav-unification' ];
+	const currentXLProjects = [ 'nav-unification' ];
 	const enabledFeatures = config.enabledFeatures();
 	return (
 		<>

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -18,7 +18,6 @@
 	"features": {
 		"ad-tracking": true,
 		"always_use_logout_url": true,
-		"anchor-fm-dev": false,
 		"async-payments": false,
 		"automated-transfer": true,
 		"blogger-plan": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -14,7 +14,6 @@
 	"features": {
 		"ad-tracking": true,
 		"always_use_logout_url": true,
-		"anchor-fm-dev": false,
 		"async-payments": false,
 		"blogger-plan": false,
 		"catch-js-errors": false,

--- a/config/development.json
+++ b/config/development.json
@@ -30,7 +30,6 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
-		"anchor-fm-dev": true,
 		"async-payments": false,
 		"automated-transfer": true,
 		"blogger-plan": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -15,7 +15,6 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
-		"anchor-fm-dev": true,
 		"automated-transfer": true,
 		"async-payments": false,
 		"ad-tracking": false,

--- a/config/production.json
+++ b/config/production.json
@@ -16,7 +16,6 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": true,
-		"anchor-fm-dev": false,
 		"async-payments": false,
 		"automated-transfer": true,
 		"blogger-plan": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -17,7 +17,6 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
-		"anchor-fm-dev": false,
 		"async-payments": false,
 		"automated-transfer": true,
 		"blogger-plan": false,

--- a/config/test.json
+++ b/config/test.json
@@ -27,7 +27,6 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
-		"anchor-fm-dev": false,
 		"async-payments": false,
 		"blogger-plan": false,
 		"calypsoify/plugins": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -18,7 +18,6 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
-		"anchor-fm-dev": true,
 		"async-payments": false,
 		"automated-transfer": true,
 		"blogger-plan": false,


### PR DESCRIPTION
This PR remove the `anchor-fm-dev` feature flag, in preparation for our integration launch on February 22.

This will make the flows live in production, but will not expose the post-publish prompt or My Home entry points. The former is still hidden by a filter exposing it only to proxied requests, and the latter is hidden by the fact that production configs don't have the Home layout dev mode (`home/layout-dev`) enabled (which gates our Anchor card on the back-end).

**Testing Instructions**
* Use the calypso.live link below to open this PR in a logged-out window.
* Go to `/new?anchor_podcast=22b6608` and verify the Anchor signup flow works as expected.
* Find a test site on horizon.wordpress.com that displays the Anchor My Home card (it must have at least three posts published, and dismiss a pile of Home cards first).
* Verify the same site does _not_ display the Anchor card.