### PR TITLE
Billing: Show auto-renew toggle for any renewable product

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -139,6 +139,23 @@ class AutoRenewDisablingDialog extends Component {
 							'%(expiryDate)s is a date string, e.g. May 14, 2020',
 					}
 				);
+			default:
+				return translate(
+					'By canceling auto-renewal, your %(productName)s plan for %(siteDomain)s will expire on %(expiryDate)s. ' +
+						"When it does, you'll lose access to key features you may be using on your site. " +
+						'To avoid that, turn auto-renewal back on or manually renew your plan before the expiration date.',
+					{
+						args: {
+							productName: purchase.productName,
+							siteDomain,
+							expiryDate,
+						},
+						comment:
+							'%(productName)s is the name of a WordPress.com product. ' +
+							'%(siteDomain)s is a domain name, e.g. example.com, example.wordpress.com. ' +
+							'%(expiryDate)s is a date string, e.g. May 14, 2020',
+					}
+				);
 		}
 	}
 

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -141,9 +141,9 @@ class AutoRenewDisablingDialog extends Component {
 				);
 			default:
 				return translate(
-					'By canceling auto-renewal, your %(productName)s plan for %(siteDomain)s will expire on %(expiryDate)s. ' +
+					'By canceling auto-renewal, your %(productName)s subscription for %(siteDomain)s will expire on %(expiryDate)s. ' +
 						"When it does, you'll lose access to key features you may be using on your site. " +
-						'To avoid that, turn auto-renewal back on or manually renew your plan before the expiration date.',
+						'To avoid that, turn auto-renewal back on or manually renew your subscription before the expiration date.',
 					{
 						args: {
 							productName: purchase.productName,

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -27,12 +27,9 @@ import {
 import {
 	isDomainRegistration,
 	isDomainTransfer,
-	isGSuiteOrGoogleWorkspace,
 	isConciergeSession,
 	isJetpackPlan,
 	isJetpackProduct,
-	isPlan,
-	isTitanMail,
 	getProductFromSlug,
 } from 'calypso/lib/products-values';
 import { getPlan } from 'calypso/lib/plans';
@@ -365,13 +362,7 @@ function PurchaseMetaExpiration( {
 		return null;
 	}
 
-	if (
-		( isDomainRegistration( purchase ) ||
-			isPlan( purchase ) ||
-			isGSuiteOrGoogleWorkspace( purchase ) ||
-			isTitanMail( purchase ) ) &&
-		! isExpired( purchase )
-	) {
+	if ( isRenewable( purchase ) && ! isExpired( purchase ) ) {
 		const dateSpan = <span className="manage-purchase__detail-date-span" />;
 		const subsRenewText = isAutorenewalEnabled
 			? translate( 'Auto-renew is ON' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently the "auto-renew" toggle on the subscription management page is only shown for specific products that are covered by the component.

This PR modifies the code so that the toggle is shown for any product that can be renewed.

Fixes 142-gh-Automattic/payments-shilling

Before:

<img width="142" alt="Screen Shot 2021-02-19 at 5 21 47 PM" src="https://user-images.githubusercontent.com/2036909/108569030-348c1f00-72d9-11eb-88d6-31d2dfe3dcbb.png">

After:

<img width="144" alt="Screen Shot 2021-02-19 at 5 21 24 PM" src="https://user-images.githubusercontent.com/2036909/108569040-38b83c80-72d9-11eb-9b85-76220f8af81b.png">


#### Testing instructions

- Use a Jetpack site (you can use jurassic.ninja).
- Purchase a Jetpack product (not a Plan. I used Jetpack Search).
- Turn off auto-renew for that product on the back-end.
- Visit the Manage Purchase page for the product.
- Verify that you can see the auto-renew toggle and that it shows auto-renew as disabled.
- Click the toggle and verify that it changes to enabled.
- Click the toggle again.
- Verify that you see a generic warning that the product will be removed and that the text makes sense.
- Click to accept the warning.
- Verify that the toggle changes to disabled.