### PR TITLE
Revert "ETK: run build more frequently and only publish artifacts when it has changed."

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -141,7 +141,7 @@ function load_common_module() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_common_module' );
 
 /**
- * Load Editor Site Launch
+ * Load Editor Site Launch.
  */
 function load_editor_site_launch() {
 	require_once __DIR__ . '/editor-site-launch/index.php';


### PR DESCRIPTION
Reverts Automattic/wp-calypso#50252

Why: builds start failing when downloading a dependency which doesn't exist. Since we introduced builds as a dependency all ETK builds will fail until there is a successful build on trunk with a dependency.... which is not possible since they all fail without dependencies. Will try an alternative approach.