### PR TITLE
ETK: Tag build for release only when there are changes

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1212,6 +1212,16 @@ object WPComPlugins_EditorToolKit : BuildType({
 
 	artifactRules = "editing-toolkit.zip"
 
+	dependencies {
+		artifacts(AbsoluteId("calypso_WPComPlugins_EditorToolKit")) {
+			buildRule = lastSuccessful("+:trunk")
+			artifactRules = """
+				+:editing-toolkit.zip!** => editing-toolkit-last-build
+				-:editing-toolkit.zip!build_meta.txt
+			""".trimIndent()
+		}
+	}
+
 	buildNumberPattern = "%build.prefix%.%build.counter%"
 	params {
 		param("build.prefix", "3")
@@ -1224,12 +1234,10 @@ object WPComPlugins_EditorToolKit : BuildType({
 
 	triggers {
 		vcs {
-			triggerRules = "+:apps/editing-toolkit/**"
 			branchFilter = """
 				+:*
 				-:pull*
 			""".trimIndent()
-
 		}
 	}
 
@@ -1322,24 +1330,29 @@ object WPComPlugins_EditorToolKit : BuildType({
 				export NODE_ENV="production"
 
 				cd apps/editing-toolkit
-
-				# Update plugin version in the plugin file.
-				sed -i -e "/^\s\* Version:/c\ * Version: %build.number%" -e "/^define( 'A8C_ETK_PLUGIN_VERSION'/c\define( 'A8C_ETK_PLUGIN_VERSION', '%build.number%' );" ./editing-toolkit-plugin/full-site-editing-plugin.php
-
-				# Update plugin stable tag in readme.txt.
-				sed -i -e "/^Stable tag:\s/c\Stable tag: %build.number%" ./editing-toolkit-plugin/readme.txt
-
 				yarn build
-				cd editing-toolkit-plugin/
 
-				# Metadata file with info for the download script.
-				tee build_meta.txt <<-EOM
-					commit_hash=%build.vcs.number%
-					commit_url=https://github.com/Automattic/wp-calypso/commit/%build.vcs.number%
-					build_number=%build.number%
-					EOM
+				# Update plugin version in the plugin file and readme.txt.
+				# Note: we also update the latest build from trunk to this version to restore idempotence
+				sed -i -e "/^\s\* Version:/c\ * Version: %build.number%" -e "/^define( 'A8C_ETK_PLUGIN_VERSION'/c\define( 'A8C_ETK_PLUGIN_VERSION', '%build.number%' );" ./editing-toolkit-plugin/full-site-editing-plugin.php ../../editing-toolkit-last-build/full-site-editing-plugin.php
+				sed -i -e "/^Stable tag:\s/c\Stable tag: %build.number%" ./editing-toolkit-plugin/readme.txt ../../editing-toolkit-last-build/readme.txt
 
-				zip -r ../../../editing-toolkit.zip .
+				if diff -rq ./editing-toolkit-plugin/ ../../editing-toolkit-last-build/ ; then
+					echo "The build matches trunk. Therefore, this build has no effect."
+				else
+					echo "The build is different from trunk."
+					cd editing-toolkit-plugin/
+
+					# Metadata file with info for the download script.
+					tee build_meta.txt <<-EOM
+						commit_hash=%build.vcs.number%
+						commit_url=https://github.com/Automattic/wp-calypso/commit/%build.vcs.number%
+						build_number=%build.number%
+						EOM
+
+					zip -r ../../../editing-toolkit.zip .
+				fi
+
 			""".trimIndent()
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 			dockerPull = true

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -141,7 +141,7 @@ function load_common_module() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_common_module' );
 
 /**
- * Load Editor Site Launch
+ * Load Editor Site Launch.
  */
 function load_editor_site_launch() {
 	require_once __DIR__ . '/editor-site-launch/index.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -141,7 +141,7 @@ function load_common_module() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_common_module' );
 
 /**
- * Load Editor Site Launch.
+ * Load Editor Site Launch
  */
 function load_editor_site_launch() {
 	require_once __DIR__ . '/editor-site-launch/index.php';


### PR DESCRIPTION
See #50252 for more context.

The problem with that approach was that the build would succeed without publishing an artifact. This creates an infinite loop of failure because every new build would try to get the build from the previous successful build. When there is no artifact there, the build fails. This means it becomes impossible to get a passing build.

This approach relies on tags instead: when a build artifact is different from the latest tagged build on trunk, then it tags the artifact for the branch. The build runs for every commit, but we now have a way to tell which commits should actually be deployed. (thanks @scinos for brainstorming this solution with me!)

I've updated `install-plugin.sh` in D57392-code to only download tagged builds when working with the branch argument.

Essentially, this now makes sure of the following:
- For release or trunk installations, only the most recent "changed" version is downloaded. This means that builds which do not affect ETK will be ignored. (And thus we get better metadata for the installation.)
- For branch installations, the script should now fail if the branch does not modify the ETK artifact. It should always work if the branch does change the ETK artifact.

it is possible to get around this behavior using the `--build` flag in the install script.