### PR TITLE
Minor changes to the Stale bot to increase effectiveness.

### DIFF
--- a/.github/workflows/mark-issue-stale.yml
+++ b/.github/workflows/mark-issue-stale.yml
@@ -20,8 +20,8 @@ jobs:
           # Disable auto-close of both issues and PRs.
           days-before-close: -1
           # Get issues in ascending (oldest first) order.
-          ascending: false
+          ascending: true
           # Label to apply when issue is marked stale.
           stale-issue-label: '[Status] Stale'
           # Increase number of operations executed per run.
-          operations-per-run: 180
+          operations-per-run: 2000

--- a/.github/workflows/mark-issue-stale.yml
+++ b/.github/workflows/mark-issue-stale.yml
@@ -2,7 +2,8 @@
 name: 'Mark stale issues'
 on:
   schedule:
-    - cron: '30 0 * * *'
+    # Run every 6 hours at xx:30.
+    - cron: '30 */6 * * *'
 
 jobs:
   stale:
@@ -13,12 +14,14 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue is stale because it has been 180 days with no activity. You can keep the issue open by adding a comment. If you do, please provide additional context and explain why you’d like it to remain open. You can also close the issue yourself — if you do, please add a brief explanation and apply one of relevant issue close labels.'
           # Days before issue is considered stale.
-          days-before-stale: 180
+          days-before-issue-stale: 180
           # Exempt issue labels.
           exempt-issue-labels: '[Pri] High,[Pri] BLOCKER,[Status] Keep Open'
           # Disable auto-close of both issues and PRs.
           days-before-close: -1
           # Get issues in ascending (oldest first) order.
-          ascending: true
+          ascending: false
           # Label to apply when issue is marked stale.
           stale-issue-label: '[Status] Stale'
+          # Increase number of operations executed per run.
+          operations-per-run: 180

--- a/.github/workflows/mark-issue-stale.yml
+++ b/.github/workflows/mark-issue-stale.yml
@@ -25,3 +25,4 @@ jobs:
           stale-issue-label: '[Status] Stale'
           # Increase number of operations executed per run.
           operations-per-run: 2000
+          debug-only: true


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Update frequency at which the stalebot runs to every 6 hours.
- Increase operations per run from 30 to 2000.
- Enable debug mode to verify behavior and guard against API limit busting by the change in number of operations to 2000.

#### Testing instructions

Watch the action run in Repo > Actions > Mark Stale Issues