### PR TITLE
Gutenboarding: Re-enable language picker on production.

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -15,7 +15,6 @@ import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import DomainPickerButton from '../domain-picker-button';
 import PlansButton from '../plans-button';
 import { useCurrentStep, useIsAnchorFm, usePath, Step } from '../../path';
-import { isEnabled } from '@automattic/calypso-config';
 import Link from '../link';
 
 /**
@@ -53,19 +52,16 @@ const Header: React.FunctionComponent = () => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 	const changeLocaleButton = () => {
-		if ( isEnabled( 'gutenboarding/language-picker' ) ) {
-			return (
-				<div className="gutenboarding__header-section-item gutenboarding__header-section-item--right gutenboarding__header-language-section">
-					<Link to={ makePath( Step.LanguageModal ) }>
-						<span className="gutenboarding__header-site-language-label">
-							{ __( 'Site Language' ) }
-						</span>
-						<span className="gutenboarding__header-site-language-badge">{ locale }</span>
-					</Link>
-				</div>
-			);
-		}
-		return null;
+		return (
+			<div className="gutenboarding__header-section-item gutenboarding__header-section-item--right gutenboarding__header-language-section">
+				<Link to={ makePath( Step.LanguageModal ) }>
+					<span className="gutenboarding__header-site-language-label">
+						{ __( 'Site Language' ) }
+					</span>
+					<span className="gutenboarding__header-site-language-badge">{ locale }</span>
+				</Link>
+			</div>
+		);
 	};
 
 	return (

--- a/config/development.json
+++ b/config/development.json
@@ -68,7 +68,6 @@
 		"google-drive": true,
 		"google-workspace-migration": true,
 		"gutenboarding/alpha-templates": true,
-		"gutenboarding/language-picker": true,
 		"gutenboarding/show-vertical-input": false,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -42,7 +42,6 @@
 		"gdpr-banner": true,
 		"google-my-business": false,
 		"gutenboarding/alpha-templates": true,
-		"gutenboarding/language-picker": true,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
 		"happychat": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -45,7 +45,6 @@
 		"google-my-business": true,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
-		"gutenboarding/language-picker": false,
 		"happychat": true,
 		"help": true,
 		"inline-help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -53,7 +53,6 @@
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
 		"gutenboarding/alpha-templates": true,
-		"gutenboarding/language-picker": false,
 		"happychat": true,
 		"help": true,
 		"home/layout-dev": true,

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -46,12 +46,7 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 		} );
 
 		step( 'Can visit Gutenboarding page and see Onboarding block', async function () {
-			const page = await NewPage.Visit(
-				driver,
-				NewPage.getGutenboardingURL( {
-					query: 'flags=gutenboarding/language-picker',
-				} )
-			);
+			const page = await NewPage.Visit( driver, NewPage.getGutenboardingURL() );
 			const blockExists = await page.waitForBlock();
 			assert( blockExists, 'Onboarding block is not rendered' );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable language picker on production by removing gutenboarding/language-picker feature flag.

Successor of the previous attempt: https://github.com/Automattic/wp-calypso/pull/49674

This time with the temp fix https://github.com/Automattic/wp-calypso/pull/49681 included where lang picker will not display on plans & domains modal.

#### Testing instructions

* Go to /new and you should see the language picker.

