### PR TITLE
Always display homepage title in editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
@@ -1,12 +1,9 @@
 body.hide-homepage-title {
+
+	// Allow homepage title to be edited even when hidden
+	// Lighter color to signify not visible from front page
 	.editor-post-title {
 		opacity: .4;
-	}
-
-	// When the title is hidden in the block editor while editing the homepage,
-	// leave enough space above the first block for the toolbar to show correctly.
-	.block-editor-block-list__layout.is-root-container > .wp-block:first-child {
-		margin-top: 64px;
 	}
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
@@ -1,6 +1,6 @@
 body.hide-homepage-title {
 	.editor-post-title {
-		display: none;
+		opacity: .4;
 	}
 
 	// When the title is hidden in the block editor while editing the homepage,


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Currently the homepage title can not be edited when the `Hide homepage title` option is enabled. This adjusts that to permit the title to show in the editor. While also adjusting the opacity to help users realize it is not visible on the live page.
* Based on the [suggestions in this issue](https://github.com/Automattic/wp-calypso/issues/45127) I removed the `display: none;` and replaced it with a 40% opacity. The pseudo-element would have been nice, but the lack of string translation for I18N would not have been available. I figured making it a little lighter would help users understand it's not meant to be there.

---

## Screenshots

#### Page title while set to HIDDEN

[![Screenshot](https://d.pr/i/wAOv9n+)](https://d.pr/i/wAOv9n)

#### Page title while set to VISIBLE

[![Screenshot](https://d.pr/i/ZphYwH+)](https://d.pr/i/ZphYwH)

#### Current version

[![Screenshot](https://d.pr/i/bWALNg+)](https://d.pr/i/bWALNg)

---

## Related issues
Fixes #45127
