### PR TITLE
Partner Portal: Add license list pagination UI

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -31,12 +31,13 @@ export function partnerKeyContext( context: PageJS.Context, next: () => void ): 
 }
 
 export function partnerPortalContext( context: PageJS.Context, next: () => void ): void {
-	const { s: search, sort_field, sort_direction } = context.query;
+	const { s: search, sort_field, sort_direction, page } = context.query;
 	const filter = valueToEnum< LicenseFilter >(
 		LicenseFilter,
 		context.params.state,
 		LicenseFilter.NotRevoked
 	);
+	const currentPage = parseInt( page ) || 1;
 	const sortField = valueToEnum< LicenseSortField >(
 		LicenseSortField,
 		sort_field,
@@ -54,6 +55,7 @@ export function partnerPortalContext( context: PageJS.Context, next: () => void 
 		<Licenses
 			filter={ filter }
 			search={ search || '' }
+			currentPage={ currentPage }
 			sortDirection={ sortDirection }
 			sortField={ sortField }
 		/>

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -30,6 +30,7 @@ import LicensePreview, {
 	LicensePreviewPlaceholder,
 } from 'calypso/jetpack-cloud/sections/partner-portal/license-preview';
 import Gridicon from 'calypso/components/gridicon';
+import Pagination from 'calypso/components/pagination';
 import { addQueryArgs } from 'calypso/lib/route';
 
 /**
@@ -48,6 +49,7 @@ const LicenseTransition = ( props: React.PropsWithChildren< LicenseTransitionPro
 interface Props {
 	filter: LicenseFilter;
 	search: string;
+	currentPage: number;
 	sortField: LicenseSortField;
 	sortDirection: LicenseSortDirection;
 }
@@ -55,6 +57,7 @@ interface Props {
 export default function LicenseList( {
 	filter,
 	search,
+	currentPage,
 	sortField,
 	sortDirection,
 }: Props ): ReactElement {
@@ -73,6 +76,13 @@ export default function LicenseList( {
 		}
 
 		const queryParams = { sort_field: field, sort_direction: direction };
+		const currentPath = window.location.pathname + window.location.search;
+
+		page( addQueryArgs( queryParams, currentPath ) );
+	};
+
+	const setPage = ( pageNumber: number ): void => {
+		const queryParams = { page: pageNumber };
 		const currentPath = window.location.pathname + window.location.search;
 
 		page( addQueryArgs( queryParams, currentPath ) );
@@ -150,6 +160,18 @@ export default function LicenseList( {
 							/>
 						</LicenseTransition>
 					) ) }
+
+				{ showLicenses && (
+					<LicenseTransition>
+						<Pagination
+							className="license-list__pagination"
+							page={ currentPage }
+							perPage={ 10 }
+							total={ 50 }
+							pageClick={ setPage }
+						/>
+					</LicenseTransition>
+				) }
 
 				{ isFetching && (
 					<LicenseTransition>

--- a/client/jetpack-cloud/sections/partner-portal/license-list/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/style.scss
@@ -35,6 +35,10 @@
 			}
 		}
 	}
+
+	&__pagination {
+		margin: 64px 0;
+	}
 }
 
 @keyframes license-list__transition-enter {

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -21,6 +21,7 @@ import LicenseStateFilter from 'calypso/jetpack-cloud/sections/partner-portal/li
 interface Props {
 	filter: LicenseFilter;
 	search: string;
+	currentPage: number;
 	sortField: LicenseSortField;
 	sortDirection: LicenseSortDirection;
 }
@@ -28,6 +29,7 @@ interface Props {
 export default function Licenses( {
 	filter,
 	search,
+	currentPage,
 	sortDirection,
 	sortField,
 }: Props ): ReactElement {
@@ -44,6 +46,7 @@ export default function Licenses( {
 			<LicenseList
 				filter={ filter }
 				search={ search }
+				currentPage={ currentPage }
 				sortDirection={ sortDirection }
 				sortField={ sortField }
 			/>


### PR DESCRIPTION
Context:
* Project thread: pbtFPC-Um-p2
* i4 designs: pbtFPC-103-p2

#### Changes proposed in this Pull Request

* Adds pagination at the bottom of the license list (the item count and the items per page are hardcoded, and will be changed in another PR)

_Note: this PR only adds the UI. We will still work on its functionality, so it won't paginate the list at this point_

#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key, if prompted.
* Check the pagination at the bottom of the licenses list, it will show 5 pages, and it changes the `page` param in the URL when you click on a page item.
