### PR TITLE
Focused Launch: show Name your site step for non-EN sites

### DIFF
--- a/packages/data-stores/src/launch/index.ts
+++ b/packages/data-stores/src/launch/index.ts
@@ -39,6 +39,7 @@ export function register(): typeof STORE_KEY {
 				'isExperimental',
 				'isAnchorFm',
 				'isSiteTitleStepVisible',
+				'siteTitle',
 			],
 		} );
 	}

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -90,3 +90,5 @@ export const getFirstIncompleteStep = ( state: State ): LaunchStepType | undefin
 export const getSiteTitle = ( state: State ): string | undefined => state?.siteTitle;
 
 export const getCurrentStep = ( state: State ): string => state.step;
+
+export const getDomainSearch = ( state: State ): string => state.domainSearch;

--- a/packages/domain-picker/src/constants.ts
+++ b/packages/domain-picker/src/constants.ts
@@ -5,6 +5,7 @@ import { DomainSuggestions } from '@automattic/data-stores';
 
 export const PAID_DOMAINS_TO_SHOW = 5;
 export const PAID_DOMAINS_TO_SHOW_EXPANDED = 10;
+export const DOMAIN_QUERY_MINIMUM_LENGTH = 2;
 
 /**
  * Debounce our input + HTTP dependent select changes

--- a/packages/domain-picker/src/hooks/use-domain-suggestions.ts
+++ b/packages/domain-picker/src/hooks/use-domain-suggestions.ts
@@ -9,7 +9,11 @@ import { useDebounce } from 'use-debounce';
 /**
  * Internal dependencies
  */
-import { DOMAIN_SUGGESTIONS_STORE, DOMAIN_SEARCH_DEBOUNCE_INTERVAL } from '../constants';
+import {
+	DOMAIN_SUGGESTIONS_STORE,
+	DOMAIN_SEARCH_DEBOUNCE_INTERVAL,
+	DOMAIN_QUERY_MINIMUM_LENGTH,
+} from '../constants';
 
 type DomainSuggestionsResult = {
 	allDomainSuggestions: DomainSuggestion[] | undefined;
@@ -34,7 +38,7 @@ export function useDomainSuggestions(
 
 	return useSelect(
 		( select ) => {
-			if ( ! domainSearch || domainSearch.length < 2 ) {
+			if ( ! domainSearch || domainSearch.length < DOMAIN_QUERY_MINIMUM_LENGTH ) {
 				return;
 			}
 			const { getDomainSuggestions, getDomainState, getDomainErrorMessage } = select(

--- a/packages/domain-picker/src/index.tsx
+++ b/packages/domain-picker/src/index.tsx
@@ -9,3 +9,4 @@ export type { SUGGESTION_ITEM_TYPE } from './domain-picker/suggestion-item';
 
 export { mockDomainSuggestion, isGoodDefaultDomainQuery } from './utils';
 export { useDomainSuggestions } from './hooks';
+export { DOMAIN_QUERY_MINIMUM_LENGTH } from './constants';

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -547,7 +547,7 @@ const Summary: React.FunctionComponent = () => {
 		showSiteTitleStep,
 	} = useDispatch( LAUNCH_STORE );
 
-	const { title, isValidTitle, updateTitle } = useTitle();
+	const { title, isValidTitle, isDefaultTitle, updateTitle } = useTitle();
 	const { siteSubdomain, hasPaidDomain } = useSiteDomains();
 	const { onDomainSelect, onExistingSubdomainSelect, currentDomain } = useDomainSelection();
 	const { domainSearch, isLoading } = useDomainSearch();
@@ -574,10 +574,10 @@ const Summary: React.FunctionComponent = () => {
 	// step to the user when in this launch flow.
 	// Allow changing site title when it's the default value or when it's an empty string.
 	React.useEffect( () => {
-		if ( ! isSiteTitleStepVisible && ! isValidTitle ) {
+		if ( title !== undefined && ! isSiteTitleStepVisible && isDefaultTitle ) {
 			showSiteTitleStep();
 		}
-	}, [ isValidTitle, showSiteTitleStep, isSiteTitleStepVisible ] );
+	}, [ isDefaultTitle, showSiteTitleStep, isSiteTitleStepVisible, title ] );
 
 	// Launch the site directly if Free plan and subdomain are selected.
 	// Otherwise, show checkout as the next step.

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -574,7 +574,7 @@ const Summary: React.FunctionComponent = () => {
 	// step to the user when in this launch flow.
 	// Allow changing site title when it's the default value or when it's an empty string.
 	React.useEffect( () => {
-		if ( title !== undefined && ! isSiteTitleStepVisible && isDefaultTitle ) {
+		if ( ! isSiteTitleStepVisible && isDefaultTitle ) {
 			showSiteTitleStep();
 		}
 	}, [ isDefaultTitle, showSiteTitleStep, isSiteTitleStepVisible, title ] );

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -34,7 +34,6 @@ import FocusedLaunchSummaryItem, {
 } from './focused-launch-summary-item';
 import { LAUNCH_STORE, SITE_STORE, PLANS_STORE } from '../../stores';
 import LaunchContext from '../../context';
-import { isValidSiteTitle } from '../../utils';
 import { FOCUSED_LAUNCH_FLOW_ID } from '../../constants';
 import type { Plan, PlanProduct } from '../../stores';
 
@@ -548,7 +547,7 @@ const Summary: React.FunctionComponent = () => {
 		showSiteTitleStep,
 	} = useDispatch( LAUNCH_STORE );
 
-	const { title, updateTitle } = useTitle();
+	const { title, isValidTitle, updateTitle } = useTitle();
 	const { siteSubdomain, hasPaidDomain } = useSiteDomains();
 	const { onDomainSelect, onExistingSubdomainSelect, currentDomain } = useDomainSelection();
 	const { domainSearch, isLoading } = useDomainSearch();
@@ -575,10 +574,10 @@ const Summary: React.FunctionComponent = () => {
 	// step to the user when in this launch flow.
 	// Allow changing site title when it's the default value or when it's an empty string.
 	React.useEffect( () => {
-		if ( ! isSiteTitleStepVisible && ! isValidSiteTitle( title ) ) {
+		if ( ! isSiteTitleStepVisible && ! isValidTitle ) {
 			showSiteTitleStep();
 		}
-	}, [ title, showSiteTitleStep, isSiteTitleStepVisible ] );
+	}, [ isValidTitle, showSiteTitleStep, isSiteTitleStepVisible ] );
 
 	// Launch the site directly if Free plan and subdomain are selected.
 	// Otherwise, show checkout as the next step.
@@ -602,8 +601,7 @@ const Summary: React.FunctionComponent = () => {
 		/>
 	);
 
-	const isDomainStepHighlighted =
-		!! selectedPlanProductId || !! hasSelectedDomain || isValidSiteTitle( title );
+	const isDomainStepHighlighted = !! selectedPlanProductId || !! hasSelectedDomain || isValidTitle;
 
 	const renderDomainStep: StepIndexRenderFunction = ( { stepIndex, forwardStepIndex } ) => (
 		<DomainStep

--- a/packages/launch/src/hooks/use-domain-search.ts
+++ b/packages/launch/src/hooks/use-domain-search.ts
@@ -3,7 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useDispatch } from '@wordpress/data';
-import { isGoodDefaultDomainQuery } from '@automattic/domain-picker';
+import { isGoodDefaultDomainQuery, DOMAIN_QUERY_MINIMUM_LENGTH } from '@automattic/domain-picker';
 
 /**
  * Internal dependencies
@@ -27,7 +27,10 @@ export function useDomainSearch(): {
 
 	const { setDomainSearch } = useDispatch( LAUNCH_STORE );
 
-	const nonDefaultTitle = ( title && title.length > 1 && ! isDefaultTitle && title ) || '';
+	const searchQueryFromTitle =
+		typeof title !== 'undefined' && title.length >= DOMAIN_QUERY_MINIMUM_LENGTH && ! isDefaultTitle
+			? title
+			: '';
 
 	// Domain search query is determined by evaluating the following, in order:
 	// 1. existing domain search string saved in Launch store
@@ -35,7 +38,7 @@ export function useDomainSearch(): {
 	// 3. site subdomain name
 	const domainSearch =
 		( existingDomainSearch.trim() ||
-			filterUnsuitableTitles( nonDefaultTitle ) ||
+			filterUnsuitableTitles( searchQueryFromTitle ) ||
 			siteSubdomain?.domain?.split( '.' )[ 0 ] ) ??
 		'';
 

--- a/packages/launch/src/hooks/use-domain-search.ts
+++ b/packages/launch/src/hooks/use-domain-search.ts
@@ -27,7 +27,7 @@ export function useDomainSearch(): {
 
 	const { setDomainSearch } = useDispatch( LAUNCH_STORE );
 
-	const nonDefaultTitle = ( ! isDefaultTitle && title ) || '';
+	const nonDefaultTitle = ( title && title.length > 1 && ! isDefaultTitle && title ) || '';
 
 	// Domain search query is determined by evaluating the following, in order:
 	// 1. existing domain search string saved in Launch store

--- a/packages/launch/src/hooks/use-title.ts
+++ b/packages/launch/src/hooks/use-title.ts
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { useContext, useEffect } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
+import { __ } from '@wordpress/i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useLocale, englishLocales } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -14,6 +15,8 @@ import LaunchContext from '../context';
 
 export function useTitle() {
 	const { siteId } = useContext( LaunchContext );
+
+	const locale = useLocale();
 
 	const existingSiteTitle = useSelect( ( select ) => select( SITE_STORE ).getSiteTitle( siteId ), [
 		siteId,
@@ -29,8 +32,23 @@ export function useTitle() {
 	const title = noLaunchSiteTitle ? existingSiteTitle : launchSiteTitle;
 
 	const DEFAULT_SITE_NAME = __( 'Site Title', __i18n_text_domain__ );
-	const isDefaultTitle = title === DEFAULT_SITE_NAME;
-	const isValidTitle = title !== '' && ! isDefaultTitle;
+	let isDefaultTitle = title === DEFAULT_SITE_NAME;
+	let isValidTitle = title !== '' && ! isDefaultTitle;
+
+	// START of non-EN temporary fix for https://github.com/Automattic/wp-calypso/issues/50269
+	// @TODO: remove this when we'll have a proper way to know if the title is the default one set by the backend
+	if ( englishLocales.indexOf( locale ) === -1 ) {
+		// Since we don't know if DEFAULT_SITE_NAME is matching
+		// the default title set in the backend at site creation,
+		// we consider that any site title that has not been edited during Launch is default
+		// and don't use it to suggest domains
+		isDefaultTitle = ! launchSiteTitle?.trim();
+
+		// With the fix added above for isDefaultTitle, its value will be true even for valid titles
+		// So we should consider valid any non-emtpy title
+		isValidTitle = title !== '';
+	}
+	// END of temporary fix
 
 	useEffect( () => {
 		if ( noLaunchSiteTitle ) {

--- a/packages/launch/src/hooks/use-title.ts
+++ b/packages/launch/src/hooks/use-title.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useContext, useEffect } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
@@ -13,13 +14,23 @@ import LaunchContext from '../context';
 
 export function useTitle() {
 	const { siteId } = useContext( LaunchContext );
-	const title = useSelect( ( select ) => select( SITE_STORE ).getSiteTitle( siteId ) );
-	const launchSiteTitle = useSelect( ( select ) => select( LAUNCH_STORE ) ).getSiteTitle();
-	const setLaunchSiteTitle = useDispatch( LAUNCH_STORE ).setSiteTitle;
+
+	const existingSiteTitle = useSelect( ( select ) => select( SITE_STORE ).getSiteTitle( siteId ), [
+		siteId,
+	] );
+	const launchSiteTitle = useSelect( ( select ) => select( LAUNCH_STORE ).getSiteTitle(), [] );
+
+	const updateTitle = useDispatch( LAUNCH_STORE ).setSiteTitle;
 	const saveSiteTitle = useDispatch( SITE_STORE ).saveSiteTitle;
+
 	const [ debouncedSaveSiteTitle ] = useDebouncedCallback( saveSiteTitle, 1000 );
 
 	const noLaunchSiteTitle = typeof launchSiteTitle === 'undefined';
+	const title = noLaunchSiteTitle ? existingSiteTitle : launchSiteTitle;
+
+	const DEFAULT_SITE_NAME = __( 'Site Title', __i18n_text_domain__ );
+	const isDefaultTitle = title === DEFAULT_SITE_NAME;
+	const isValidTitle = title !== '' && ! isDefaultTitle;
 
 	useEffect( () => {
 		if ( noLaunchSiteTitle ) {
@@ -29,7 +40,9 @@ export function useTitle() {
 	}, [ launchSiteTitle, debouncedSaveSiteTitle, siteId, noLaunchSiteTitle ] );
 
 	return {
-		title: noLaunchSiteTitle ? title : launchSiteTitle,
-		updateTitle: setLaunchSiteTitle,
+		isDefaultTitle,
+		isValidTitle,
+		title,
+		updateTitle,
 	};
 }

--- a/packages/launch/src/hooks/use-title.ts
+++ b/packages/launch/src/hooks/use-title.ts
@@ -31,31 +31,30 @@ export function useTitle() {
 	const noLaunchSiteTitle = typeof launchSiteTitle === 'undefined';
 	const title = noLaunchSiteTitle ? existingSiteTitle : launchSiteTitle;
 
-	const DEFAULT_SITE_NAME = __( 'Site Title', __i18n_text_domain__ );
-	let isDefaultTitle = title === DEFAULT_SITE_NAME;
-	let isValidTitle = title !== '' && ! isDefaultTitle;
-
-	// START of non-EN temporary fix for https://github.com/Automattic/wp-calypso/issues/50269
-	// @TODO: remove this when we'll have a proper way to know if the title is the default one set by the backend
-	if ( englishLocales.indexOf( locale ) === -1 ) {
-		// Since we don't know if DEFAULT_SITE_NAME is matching
-		// the default title set in the backend at site creation,
-		// we consider that any site title that has not been edited during Launch is default
-		// and don't use it to suggest domains
-		isDefaultTitle = ! launchSiteTitle?.trim();
-
-		// With the fix added above for isDefaultTitle, its value will be true even for valid titles
-		// So we should consider valid any non-emtpy title
-		isValidTitle = title !== '';
-	}
-	// END of temporary fix
-
 	useEffect( () => {
 		if ( noLaunchSiteTitle ) {
 			return;
 		}
 		debouncedSaveSiteTitle( siteId, launchSiteTitle );
 	}, [ launchSiteTitle, debouncedSaveSiteTitle, siteId, noLaunchSiteTitle ] );
+
+	const DEFAULT_SITE_NAME = __( 'Site Title', __i18n_text_domain__ );
+	let isDefaultTitle = typeof title !== 'undefined' && title === DEFAULT_SITE_NAME;
+	let isValidTitle = typeof title !== 'undefined' && title !== '' && ! isDefaultTitle;
+
+	// START of non-EN temporary fix for https://github.com/Automattic/wp-calypso/issues/50269
+	// @TODO: remove this when we'll have a proper way to know if the title is the default one set by the backend
+	if ( englishLocales.indexOf( locale ) === -1 ) {
+		// Since we don't know if DEFAULT_SITE_NAME is matching the default title set in the backend during site creation:
+		// 1. isDefaultTitle will be always true when opening Focused Launch for the first time so we append the Name step
+		// 2. we set isDefaultTitle to false for the purpose of suggesting domains only after editing site title in Launch flow
+		isDefaultTitle = ! launchSiteTitle?.trim();
+
+		// With the fix added above for isDefaultTitle, its value will be true even for valid titles
+		// So we should consider valid any non-empty title
+		isValidTitle = typeof title !== 'undefined' && title !== '';
+	}
+	// END of temporary fix
 
 	return {
 		isDefaultTitle,

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -1,22 +1,10 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import type { DomainSuggestions } from '@automattic/data-stores';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 import { Plans as PlansStore } from '@automattic/data-stores';
 import type { Plans } from '@automattic/data-stores';
-
-const DEFAULT_SITE_NAME = __( 'Site Title', __i18n_text_domain__ );
-
-export const isDefaultSiteTitle = ( {
-	currentSiteTitle = '',
-}: {
-	currentSiteTitle: string | undefined;
-} ): boolean => currentSiteTitle === DEFAULT_SITE_NAME;
-
-export const isValidSiteTitle = ( title?: string ): boolean =>
-	title !== '' && ! isDefaultSiteTitle( { currentSiteTitle: title } );
 
 export type PlanProductForFlow = {
 	product_id: number;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Move `isDefaultTitle` and `isValidTitle` to `useTitle` hook
* Call translation function for DEFAULT_SITE_NAME inside `LocaleContext` scope to get the <s>correct</s> translated value. However, this is not enough for plugin translations to match wpcom ones. See p1613984935005400/1613742326.045000-slack-C0KDTA48Y
* Add temporary exceptions for non-EN user language:
  * Always show _Name your site_ step
  * Use site title as domain suggestion query only if it has been edited during Launch flow
  * Consider site title valid (to enable next step and _Launch your site_ button) if there is a non-empty value, regardless of the default site title for that language
* Use site title value to search for domain suggestions only if its length is at least 2 characters  

#### Testing instructions
* In Focused Launch, nothing should change for EN compared to production 
  * Non-default site title longer than 2 characters should be used as a domain search query
  * Site title step should show up in Summary View only if the title is default. After it shows up one time, it will continue to show up after refreshing the page.
  * If site title input is empty or has the default value, _Launch your site_ button should be disabled
* Temporary exceptions for non-EN account language mentioned above should apply

Related to #50269