### PR TITLE
Nav Unification: duplicate selectors to support Classic Bright in Calypso while keeping IE11 fallback intact

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -1,4 +1,4 @@
-:root {
+.classic-bright-colors {
 	/* Theme Properties */
 	--color-primary: var( --studio-blue-50 );
 	--color-primary-rgb: var( --studio-blue-50-rgb );
@@ -342,4 +342,16 @@
 	--color-sidebar-submenu-text: var( --studio-blue-70 );
 	--color-sidebar-submenu-hover-text: var( --color-accent );
 	--color-sidebar-submenu-selected-text: var( --color-accent );
+}
+
+// We need :root to be a standalone selector for postcss-custom-properties to be able to
+// generate the IE11 fallback colors (see Calypso issue 50231 for details).
+:root {
+	@extend .classic-bright-colors;
+}
+
+// We need this selector too in order to overwrite the dark default styles in Nav Unification.
+// TODO: reduce this and the above to one selector once Nav Unification has been rolled out.
+.color-scheme.is-classic-bright .is-nav-unification {
+	@extend .classic-bright-colors;
 }

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -1,4 +1,4 @@
-.classic-bright-colors {
+:root {
 	/* Theme Properties */
 	--color-primary: var( --studio-blue-50 );
 	--color-primary-rgb: var( --studio-blue-50-rgb );
@@ -344,14 +344,348 @@
 	--color-sidebar-submenu-selected-text: var( --color-accent );
 }
 
-// We need :root to be a standalone selector for postcss-custom-properties to be able to
-// generate the IE11 fallback colors (see Calypso issue 50231 for details).
-:root {
-	@extend .classic-bright-colors;
-}
-
-// We need this selector too in order to overwrite the dark default styles in Nav Unification.
-// TODO: reduce this and the above to one selector once Nav Unification has been rolled out.
 .color-scheme.is-classic-bright .is-nav-unification {
-	@extend .classic-bright-colors;
+	/* Theme Properties */
+	--color-primary: var( --studio-blue-50 );
+	--color-primary-rgb: var( --studio-blue-50-rgb );
+	--color-primary-dark: var( --studio-blue-70 );
+	--color-primary-dark-rgb: var( --studio-blue-70-rgb );
+	--color-primary-light: var( --studio-blue-30 );
+	--color-primary-light-rgb: var( --studio-blue-30-rgb );
+	--color-primary-0: var( --studio-blue-0 );
+	--color-primary-0-rgb: var( --studio-blue-0-rgb );
+	--color-primary-5: var( --studio-blue-5 );
+	--color-primary-5-rgb: var( --studio-blue-5-rgb );
+	--color-primary-10: var( --studio-blue-10 );
+	--color-primary-10-rgb: var( --studio-blue-10-rgb );
+	--color-primary-20: var( --studio-blue-20 );
+	--color-primary-20-rgb: var( --studio-blue-20-rgb );
+	--color-primary-30: var( --studio-blue-30 );
+	--color-primary-30-rgb: var( --studio-blue-30-rgb );
+	--color-primary-40: var( --studio-blue-40 );
+	--color-primary-40-rgb: var( --studio-blue-40-rgb );
+	--color-primary-50: var( --studio-blue-50 );
+	--color-primary-50-rgb: var( --studio-blue-50-rgb );
+	--color-primary-60: var( --studio-blue-60 );
+	--color-primary-60-rgb: var( --studio-blue-60-rgb );
+	--color-primary-70: var( --studio-blue-70 );
+	--color-primary-70-rgb: var( --studio-blue-70-rgb );
+	--color-primary-80: var( --studio-blue-80 );
+	--color-primary-80-rgb: var( --studio-blue-80-rgb );
+	--color-primary-90: var( --studio-blue-90 );
+	--color-primary-90-rgb: var( --studio-blue-90-rgb );
+	--color-primary-100: var( --studio-blue-100 );
+	--color-primary-100-rgb: var( --studio-blue-100-rgb );
+
+	--color-accent: var( --studio-pink-50 );
+	--color-accent-rgb: var( --studio-pink-50-rgb );
+	--color-accent-dark: var( --studio-pink-70 );
+	--color-accent-dark-rgb: var( --studio-pink-70-rgb );
+	--color-accent-light: var( --studio-pink-30 );
+	--color-accent-light-rgb: var( --studio-pink-30-rgb );
+	--color-accent-0: var( --studio-pink-0 );
+	--color-accent-0-rgb: var( --studio-pink-0-rgb );
+	--color-accent-5: var( --studio-pink-5 );
+	--color-accent-5-rgb: var( --studio-pink-5-rgb );
+	--color-accent-10: var( --studio-pink-10 );
+	--color-accent-10-rgb: var( --studio-pink-10-rgb );
+	--color-accent-20: var( --studio-pink-20 );
+	--color-accent-20-rgb: var( --studio-pink-20-rgb );
+	--color-accent-30: var( --studio-pink-30 );
+	--color-accent-30-rgb: var( --studio-pink-30-rgb );
+	--color-accent-40: var( --studio-pink-40 );
+	--color-accent-40-rgb: var( --studio-pink-40-rgb );
+	--color-accent-50: var( --studio-pink-50 );
+	--color-accent-50-rgb: var( --studio-pink-50-rgb );
+	--color-accent-60: var( --studio-pink-60 );
+	--color-accent-60-rgb: var( --studio-pink-60-rgb );
+	--color-accent-70: var( --studio-pink-70 );
+	--color-accent-70-rgb: var( --studio-pink-70-rgb );
+	--color-accent-80: var( --studio-pink-80 );
+	--color-accent-80-rgb: var( --studio-pink-80-rgb );
+	--color-accent-90: var( --studio-pink-90 );
+	--color-accent-90-rgb: var( --studio-pink-90-rgb );
+	--color-accent-100: var( --studio-pink-100 );
+	--color-accent-100-rgb: var( --studio-pink-100-rgb );
+
+	--color-neutral: var( --studio-gray-50 );
+	--color-neutral-rgb: var( --studio-gray-50-rgb );
+	--color-neutral-dark: var( --studio-gray-70 );
+	--color-neutral-dark-rgb: var( --studio-gray-70-rgb );
+	--color-neutral-light: var( --studio-gray-30 );
+	--color-neutral-light-rgb: var( --studio-gray-30-rgb );
+	--color-neutral-0: var( --studio-gray-0 );
+	--color-neutral-0-rgb: var( --studio-gray-0-rgb );
+	--color-neutral-5: var( --studio-gray-5 );
+	--color-neutral-5-rgb: var( --studio-gray-5-rgb );
+	--color-neutral-10: var( --studio-gray-10 );
+	--color-neutral-10-rgb: var( --studio-gray-10-rgb );
+	--color-neutral-20: var( --studio-gray-20 );
+	--color-neutral-20-rgb: var( --studio-gray-20-rgb );
+	--color-neutral-30: var( --studio-gray-30 );
+	--color-neutral-30-rgb: var( --studio-gray-30-rgb );
+	--color-neutral-40: var( --studio-gray-40 );
+	--color-neutral-40-rgb: var( --studio-gray-40-rgb );
+	--color-neutral-50: var( --studio-gray-50 );
+	--color-neutral-50-rgb: var( --studio-gray-50-rgb );
+	--color-neutral-60: var( --studio-gray-60 );
+	--color-neutral-60-rgb: var( --studio-gray-60-rgb );
+	--color-neutral-70: var( --studio-gray-70 );
+	--color-neutral-70-rgb: var( --studio-gray-70-rgb );
+	--color-neutral-80: var( --studio-gray-80 );
+	--color-neutral-80-rgb: var( --studio-gray-80-rgb );
+	--color-neutral-90: var( --studio-gray-90 );
+	--color-neutral-90-rgb: var( --studio-gray-90-rgb );
+	--color-neutral-100: var( --studio-gray-100 );
+	--color-neutral-100-rgb: var( --studio-gray-100-rgb );
+
+	--color-success: var( --studio-green-50 );
+	--color-success-rgb: var( --studio-green-50-rgb );
+	--color-success-dark: var( --studio-green-70 );
+	--color-success-dark-rgb: var( --studio-green-70-rgb );
+	--color-success-light: var( --studio-green-30 );
+	--color-success-light-rgb: var( --studio-green-30-rgb );
+	--color-success-0: var( --studio-green-0 );
+	--color-success-0-rgb: var( --studio-green-0-rgb );
+	--color-success-5: var( --studio-green-5 );
+	--color-success-5-rgb: var( --studio-green-5-rgb );
+	--color-success-10: var( --studio-green-10 );
+	--color-success-10-rgb: var( --studio-green-10-rgb );
+	--color-success-20: var( --studio-green-20 );
+	--color-success-20-rgb: var( --studio-green-20-rgb );
+	--color-success-30: var( --studio-green-30 );
+	--color-success-30-rgb: var( --studio-green-30-rgb );
+	--color-success-40: var( --studio-green-40 );
+	--color-success-40-rgb: var( --studio-green-40-rgb );
+	--color-success-50: var( --studio-green-50 );
+	--color-success-50-rgb: var( --studio-green-50-rgb );
+	--color-success-60: var( --studio-green-60 );
+	--color-success-60-rgb: var( --studio-green-60-rgb );
+	--color-success-70: var( --studio-green-70 );
+	--color-success-70-rgb: var( --studio-green-70-rgb );
+	--color-success-80: var( --studio-green-80 );
+	--color-success-80-rgb: var( --studio-green-80-rgb );
+	--color-success-90: var( --studio-green-90 );
+	--color-success-90-rgb: var( --studio-green-90-rgb );
+	--color-success-100: var( --studio-green-100 );
+	--color-success-100-rgb: var( --studio-green-100-rgb );
+
+	--color-warning: var( --studio-yellow-50 );
+	--color-warning-rgb: var( --studio-yellow-50-rgb );
+	--color-warning-dark: var( --studio-yellow-70 );
+	--color-warning-dark-rgb: var( --studio-yellow-70-rgb );
+	--color-warning-light: var( --studio-yellow-30 );
+	--color-warning-light-rgb: var( --studio-yellow-30-rgb );
+	--color-warning-0: var( --studio-yellow-0 );
+	--color-warning-0-rgb: var( --studio-yellow-0-rgb );
+	--color-warning-5: var( --studio-yellow-5 );
+	--color-warning-5-rgb: var( --studio-yellow-5-rgb );
+	--color-warning-10: var( --studio-yellow-10 );
+	--color-warning-10-rgb: var( --studio-yellow-10-rgb );
+	--color-warning-20: var( --studio-yellow-20 );
+	--color-warning-20-rgb: var( --studio-yellow-20-rgb );
+	--color-warning-30: var( --studio-yellow-30 );
+	--color-warning-30-rgb: var( --studio-yellow-30-rgb );
+	--color-warning-40: var( --studio-yellow-40 );
+	--color-warning-40-rgb: var( --studio-yellow-40-rgb );
+	--color-warning-50: var( --studio-yellow-50 );
+	--color-warning-50-rgb: var( --studio-yellow-50-rgb );
+	--color-warning-60: var( --studio-yellow-60 );
+	--color-warning-60-rgb: var( --studio-yellow-60-rgb );
+	--color-warning-70: var( --studio-yellow-70 );
+	--color-warning-70-rgb: var( --studio-yellow-70-rgb );
+	--color-warning-80: var( --studio-yellow-80 );
+	--color-warning-80-rgb: var( --studio-yellow-80-rgb );
+	--color-warning-90: var( --studio-yellow-90 );
+	--color-warning-90-rgb: var( --studio-yellow-90-rgb );
+	--color-warning-100: var( --studio-yellow-100 );
+	--color-warning-100-rgb: var( --studio-yellow-100-rgb );
+
+	--color-error: var( --studio-red-50 );
+	--color-error-rgb: var( --studio-red-50-rgb );
+	--color-error-dark: var( --studio-red-70 );
+	--color-error-dark-rgb: var( --studio-red-70-rgb );
+	--color-error-light: var( --studio-red-30 );
+	--color-error-light-rgb: var( --studio-red-30-rgb );
+	--color-error-0: var( --studio-red-0 );
+	--color-error-0-rgb: var( --studio-red-0-rgb );
+	--color-error-5: var( --studio-red-5 );
+	--color-error-5-rgb: var( --studio-red-5-rgb );
+	--color-error-10: var( --studio-red-10 );
+	--color-error-10-rgb: var( --studio-red-10-rgb );
+	--color-error-20: var( --studio-red-20 );
+	--color-error-20-rgb: var( --studio-red-20-rgb );
+	--color-error-30: var( --studio-red-30 );
+	--color-error-30-rgb: var( --studio-red-30-rgb );
+	--color-error-40: var( --studio-red-40 );
+	--color-error-40-rgb: var( --studio-red-40-rgb );
+	--color-error-50: var( --studio-red-50 );
+	--color-error-50-rgb: var( --studio-red-50-rgb );
+	--color-error-60: var( --studio-red-60 );
+	--color-error-60-rgb: var( --studio-red-60-rgb );
+	--color-error-70: var( --studio-red-70 );
+	--color-error-70-rgb: var( --studio-red-70-rgb );
+	--color-error-80: var( --studio-red-80 );
+	--color-error-80-rgb: var( --studio-red-80-rgb );
+	--color-error-90: var( --studio-red-90 );
+	--color-error-90-rgb: var( --studio-red-90-rgb );
+	--color-error-100: var( --studio-red-100 );
+	--color-error-100-rgb: var( --studio-red-100-rgb );
+
+	--color-surface: var( --studio-white );
+	--color-surface-rgb: var( --studio-white-rgb );
+	--color-surface-backdrop: var( --studio-gray-0 );
+	--color-surface-backdrop-rgb: var( --studio-gray-0-rgb );
+
+	--color-text: var( --studio-gray-80 );
+	--color-text-rgb: var( --studio-gray-80-rgb );
+	--color-text-subtle: var( --studio-gray-50 );
+	--color-text-subtle-rgb: var( --studio-gray-50-rgb );
+	--color-text-inverted: var( --studio-white );
+	--color-text-inverted-rgb: var( --studio-white-rgb );
+
+	--color-border: var( --color-neutral-20 );
+	--color-border-rgb: var( --color-neutral-20-rgb );
+	--color-border-subtle: var( --color-neutral-5 );
+	--color-border-subtle-rgb: var( --color-neutral-5-rgb );
+	--color-border-shadow: var( --color-neutral-0 );
+	--color-border-shadow-rgb: var( --color-neutral-0-rgb );
+	--color-border-inverted: var( --studio-white );
+	--color-border-inverted-rgb: var( --studio-white-rgb );
+
+	--color-link: var( --studio-blue-50 );
+	--color-link-rgb: var( --studio-blue-50-rgb );
+	--color-link-dark: var( --studio-blue-70 );
+	--color-link-dark-rgb: var( --studio-blue-70-rgb );
+	--color-link-light: var( --studio-blue-30 );
+	--color-link-light-rgb: var( --studio-blue-30-rgb );
+	--color-link-0: var( --studio-blue-0 );
+	--color-link-0-rgb: var( --studio-blue-0-rgb );
+	--color-link-5: var( --studio-blue-5 );
+	--color-link-5-rgb: var( --studio-blue-5-rgb );
+	--color-link-10: var( --studio-blue-10 );
+	--color-link-10-rgb: var( --studio-blue-10-rgb );
+	--color-link-20: var( --studio-blue-20 );
+	--color-link-20-rgb: var( --studio-blue-20-rgb );
+	--color-link-30: var( --studio-blue-30 );
+	--color-link-30-rgb: var( --studio-blue-30-rgb );
+	--color-link-40: var( --studio-blue-40 );
+	--color-link-40-rgb: var( --studio-blue-40-rgb );
+	--color-link-50: var( --studio-blue-50 );
+	--color-link-50-rgb: var( --studio-blue-50-rgb );
+	--color-link-60: var( --studio-blue-60 );
+	--color-link-60-rgb: var( --studio-blue-60-rgb );
+	--color-link-70: var( --studio-blue-70 );
+	--color-link-70-rgb: var( --studio-blue-70-rgb );
+	--color-link-80: var( --studio-blue-80 );
+	--color-link-80-rgb: var( --studio-blue-80-rgb );
+	--color-link-90: var( --studio-blue-90 );
+	--color-link-90-rgb: var( --studio-blue-90-rgb );
+	--color-link-100: var( --studio-blue-100 );
+	--color-link-100-rgb: var( --studio-blue-100-rgb );
+
+	/* Component Properties */
+	--color-plan-free: var( --studio-gray-30 );
+	--color-plan-blogger: var( --studio-celadon-30 );
+	--color-plan-personal: var( --studio-blue-30 );
+	--color-plan-premium: var( --studio-yellow-30 );
+	--color-plan-business: var( --studio-orange-30 );
+	--color-plan-ecommerce: var( --studio-purple-30 );
+	--color-premium-domain: var( --studio-wordpress-blue-60 );
+
+	--color-jetpack-plan-free: var( --studio-blue-30 );
+	--color-jetpack-plan-personal: var( --studio-yellow-30 );
+	--color-jetpack-plan-premium: var( --studio-jetpack-green-30 );
+	--color-jetpack-plan-professional: var( --studio-purple-30 );
+
+	--color-masterbar-background: var( --studio-blue-60 );
+	--color-masterbar-border: var( --studio-blue-70 );
+	--color-masterbar-text: var( --studio-white );
+	--color-masterbar-item-hover-background: var( --studio-blue-70 );
+	--color-masterbar-item-active-background: var( --studio-blue-90 );
+	--color-masterbar-item-new-editor-background: var( --studio-gray-50 );
+	--color-masterbar-item-new-editor-hover-background: var( --studio-gray-40 );
+	--color-masterbar-unread-dot-background: var( --color-accent-20 );
+	--color-masterbar-toggle-drafts-editor-background: var( --studio-gray-40 );
+	--color-masterbar-toggle-drafts-editor-hover-background: var( --studio-gray-40 );
+	--color-masterbar-toggle-drafts-editor-border: var( --studio-gray-10 );
+
+	--color-jetpack-masterbar-background: var( --studio-white );
+	--color-jetpack-masterbar-border: var( --studio-gray-5 );
+	--color-jetpack-masterbar-text: var( --studio-gray-50 );
+	--color-jetpack-masterbar-item-hover-background: var( --studio-gray-5 );
+	--color-jetpack-masterbar-item-active-background: var( --studio-gray-20 );
+
+	--color-sidebar-background: var( --color-surface );
+	--color-sidebar-background-rgb: var( --studio-white-rgb );
+	--color-sidebar-border: var( --studio-gray-5 );
+	--color-sidebar-text: var( --studio-gray-80 );
+	--color-sidebar-text-rgb: var( --studio-gray-80-rgb );
+	--color-sidebar-text-alternative: var( --studio-gray-50 );
+	--color-sidebar-gridicon-fill: var( --studio-gray-50 );
+	--color-sidebar-menu-selected-background: var( --studio-blue-5 );
+	--color-sidebar-menu-selected-background-rgb: var( --studio-blue-5-rgb );
+	--color-sidebar-menu-selected-text: var( --studio-blue-70 );
+	--color-sidebar-menu-selected-text-rgb: var( --studio-blue-70-rgb );
+	--color-sidebar-menu-hover-background: var( --studio-gray-5 );
+	--color-sidebar-menu-hover-background-rgb: var( --studio-gray-5-rgb );
+	--color-sidebar-menu-hover-text: var( --studio-gray-90 );
+
+	--color-jetpack-onboarding-text: var( --studio-white );
+	--color-jetpack-onboarding-text-rgb: var( --studio-white-rgb );
+	--color-jetpack-onboarding-background: var( --studio-blue-100 );
+	--color-jetpack-onboarding-background-rgb: var( --studio-blue-100-rgb );
+
+	/* Brand Color Properties */
+	--color-automattic: var( --studio-blue-40 );
+	--color-jetpack: var( --studio-jetpack-green );
+	--color-simplenote: var( --studio-simplenote-blue );
+	--color-woocommerce: var( --studio-woocommerce-purple );
+	--color-wordpress-com: var( --studio-wordpress-blue );
+	--color-wordpress-org: #585c60;
+
+	--color-blogger: #ff5722;
+	--color-eventbrite: #ff8000;
+	--color-facebook: #39579a;
+	--color-godaddy: #5ea95a;
+	--color-google-plus: #df4a32;
+	--color-instagram: #d93174;
+	--color-linkedin: #0976b4;
+	--color-medium: #12100e;
+	--color-pinterest: #cc2127;
+	--color-pocket: #ee4256;
+	--color-print: #f8f8f8;
+	--color-reddit: #5f99cf;
+	--color-skype: #00aff0;
+	--color-stumbleupon: #eb4924;
+	--color-squarespace: #222;
+	--color-telegram: #0088cc;
+	--color-tumblr: #35465c;
+	--color-twitter: #55acee;
+	--color-whatsapp: #43d854;
+	--color-wix: #faad4d;
+
+	--color-email: var( --studio-gray-0 );
+	--color-podcasting: #9b4dd5;
+
+	/* WP Admin */
+	--color-wp-admin-button-background: #008ec2;
+	--color-wp-admin-button-border: #006799;
+
+	/* WP Admin Default Theme */
+	--theme-text-color: #ffffff; /* Direct from wp-admin */
+	--theme-text-color-rgb: 255, 255, 255;
+	--theme-base-color: #23282d; /* Direct from wp-admin */
+	--theme-base-color-rgb: 35, 40, 45;
+	--theme-submenu-background-color: #131619; /* darken( $base-color, 7% ) */
+	--theme-icon-color: #e1eaf2; /* hsl( hue( $base-color ), 7%, 95% )*/
+	--theme-highlight-color: #0073aa; /* Direct from wp-admin */
+	--theme-highlight-color-rgb: 0, 115, 170;
+	--theme-notification-color: #d54e21; /* Direct from wp-admin */
+
+	/* Sidebar Submenu - Nav Unification */
+	--color-sidebar-submenu-background: var( --studio-blue-0 );
+	--color-sidebar-submenu-text: var( --studio-blue-70 );
+	--color-sidebar-submenu-hover-text: var( --color-accent );
+	--color-sidebar-submenu-selected-text: var( --color-accent );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* duplicate selectors for the default styles so Classic Bright works in Calypso in the Context of Nav Unification
* retain Classic Bright as the fallback color scheme for IE 11

This is a temporary fix, we'll be able to remove this once Nav Unification has been rolled out for all users. For all details that make this necessary please see https://github.com/Automattic/wp-calypso/issues/50231

Fixes https://github.com/Automattic/wp-calypso/issues/50231

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the calypso.live link in Chrome
* Confirm that you can choose Classic Bright in /me/account and you see the bright colors (not the Classic Dark ones)
* Visit the calypso.live link in IE11
* Confirm that the Classic Bright styles are present (and the issue in https://github.com/Automattic/wp-calypso/issues/50231 doesn't show anymore)

