### PR TITLE
Disable assets cache

### DIFF
--- a/client/server/middleware/assets.js
+++ b/client/server/middleware/assets.js
@@ -30,15 +30,10 @@ const getChunkById = ( assets, chunkId ) => assets.chunks.find( ( chunk ) => chu
 const groupAssetsByType = ( assets ) => defaults( groupBy( assets, getAssetType ), EMPTY_ASSETS );
 
 export default () => {
-	const cachedAssets = {};
-
 	return ( req, res, next ) => {
 		req.getAssets = () => {
 			const target = req.getTarget();
-			if ( ! cachedAssets[ target ] ) {
-				cachedAssets[ target ] = JSON.parse( fs.readFileSync( getAssetsPath( target ), 'utf8' ) );
-			}
-			return cachedAssets[ target ];
+			return JSON.parse( fs.readFileSync( getAssetsPath( target ), 'utf8' ) );
 		};
 
 		req.getFilesForEntrypoint = ( name ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix for #50316, by disabling the assets cache. If webpack is running, it recompiles the app and produces new chunks, this cache was preventing those new chunks to be loaded in the page.

#### Testing instructions

Validate you can't reproduce #50316 anymore.

#### Context

Fixes #50316
