### PR TITLE
Adds test to emphasize the free domain option in the launch flow

### DIFF
--- a/client/signup/steps/domain-upsell/index.jsx
+++ b/client/signup/steps/domain-upsell/index.jsx
@@ -53,7 +53,7 @@ export default function DomainUpsellStep( props ) {
 
 	const isInDomainUpsellEmphasizeFreeTest =
 		'treatment' ===
-		useSelector( ( state ) => getVariationForUser( state, 'domain_upsell_emphasize_free' ) );
+		useSelector( ( state ) => getVariationForUser( state, 'domain_upsell_emphasize_free_v2' ) );
 
 	return (
 		<div
@@ -61,7 +61,7 @@ export default function DomainUpsellStep( props ) {
 				is_in_domain_upsell_emphasize_free_test: isInDomainUpsellEmphasizeFreeTest,
 			} ) }
 		>
-			<Experiment name="domain_upsell_emphasize_free" />
+			<Experiment name="domain_upsell_emphasize_free_v2" />
 			<StepWrapper
 				flowName={ flowName }
 				stepName={ stepName }

--- a/client/signup/steps/domain-upsell/index.jsx
+++ b/client/signup/steps/domain-upsell/index.jsx
@@ -22,14 +22,15 @@ import {
 	getVariationForUser,
 	isLoading as isExperimentLoadingSelector,
 } from 'calypso/state/experiments/selectors';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormRadio from 'calypso/components/forms/form-radio';
+import FormLabel from 'calypso/components/forms/form-label';
+import Experiment from 'calypso/components/experiment';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormRadio from 'calypso/components/forms/form-radio';
-import FormLabel from 'calypso/components/forms/form-label';
 
 export default function DomainUpsellStep( props ) {
 	const translate = useTranslate();
@@ -60,6 +61,7 @@ export default function DomainUpsellStep( props ) {
 				is_in_domain_upsell_emphasize_free_test: isInDomainUpsellEmphasizeFreeTest,
 			} ) }
 		>
+			<Experiment name="domain_upsell_emphasize_free" />
 			<StepWrapper
 				flowName={ flowName }
 				stepName={ stepName }

--- a/client/signup/steps/domain-upsell/style.scss
+++ b/client/signup/steps/domain-upsell/style.scss
@@ -62,4 +62,20 @@
             color: var( --color-neutral-60 );
         }
     }
+
+    &.is_in_domain_upsell_emphasize_free_test {
+        .formatted-header__subtitle {
+            padding-top: 24px;
+        }
+
+        .domain-upsell__buttons {
+            .button {
+                width: 100%;
+            }
+
+            & > :first-child {
+                margin-bottom: 12px;
+            }
+        }
+    }
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: pbxNRc-HM-p2

Emphasizes the free domain option in the domain upsell test of the launch flow.
![image](https://user-images.githubusercontent.com/5436027/108708400-6a2e4380-7537-11eb-92ff-f516aae5d6a9.png)


#### Testing instructions

0. Make sure you are using an English locale
1. Sign up for a free user and site
2. Assign yourself to the `treatment` group
2. Launch the site from the /home menu
3. Select a free domain and plan
4. The domain upsell test should look like the screenshot above (The free domain option has been converted to a button).
5. Confirm that there is no change when assigned to `control`.

A way to skip this is to directly start the launch flow by removing the cart items and going to http://calypso.localhost:3000/start/launch-site/domains-launch?siteSlug=YOURSITE.wordpress.com

