### PR TITLE
Plans: Add analytics params to Jetpack CRM call-to-action links

### DIFF
--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -292,7 +292,8 @@ export const EXTERNAL_PRODUCT_CRM_FREE: ( variation: Iterations ) => SelectorPro
 		),
 	},
 	hidePrice: true,
-	externalUrl: 'https://jetpackcrm.com/pricing/',
+	externalUrl:
+		'https://jetpackcrm.com/pricing?utm_source=jetpack&utm_medium=web&utm_campaign=pricing_i4&utm_content=pricing',
 } );
 
 export const EXTERNAL_PRODUCT_CRM_FREE_MONTHLY: ( variation: Iterations ) => SelectorProduct = (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Modify the `externalUrl` property on the Jetpack CRM product object, such that analytics parameters will be included when people click its call-to-action links.

#### Testing instructions

* Open this PR in Calypso Blue, Green, and/or Jetpack Connect.
* Visit the Plans/Pricing page.
* Click the **Get CRM** link in the CRM product card.
* Verify that you're sent to the following URL, parameters included: `https://jetpackcrm.com/pricing?utm_source=jetpack&utm_medium=web&utm_campaign=pricing_i4&utm_content=pricing`