### PR TITLE
Fix gutenboarding not redirecting to customer site home after hitting browser back button on checkout page.

### DIFF
--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -124,9 +124,10 @@ function waitForSelectedSite(): Promise< Site | undefined > {
 		unsubscribe = subscribe( () => {
 			const resolvedSelectedSite = select( SITE_STORE ).getSite( selectedSite );
 			if ( resolvedSelectedSite ) {
-				resolve( resolvedSelectedSite );
+				return resolve( resolvedSelectedSite );
 			}
 
+			// For some reason, this still holds the value true after the request is resolved.
 			if ( ! select( 'core/data' ).isResolving( SITE_STORE, 'getSite', [ selectedSite ] ) ) {
 				resolve( undefined );
 			}

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -58,9 +58,11 @@ window.AppBoot = async () => {
 	// Add accessible-focus listener.
 	accessibleFocus();
 
-	try {
-		checkAndRedirectIfSiteWasCreatedRecently();
-	} catch {}
+	// If site was recently created, redirect to customer site home.
+	const shouldRedirect = await checkAndRedirectIfSiteWasCreatedRecently();
+	if ( shouldRedirect ) {
+		return;
+	}
 
 	// Update list of randomized designs in the gutenboarding session store
 	ensureRandomizedDesignsAreUpToDate();
@@ -105,7 +107,7 @@ async function checkAndRedirectIfSiteWasCreatedRecently() {
 				const diffMinutes = diff / 1000 / 60;
 				if ( diffMinutes < 10 && diffMinutes >= 0 ) {
 					window.location.replace( `/home/${ selectedSiteDetails.ID }` );
-					return;
+					return true;
 				}
 			}
 		}

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -122,14 +122,10 @@ function waitForSelectedSite(): Promise< Site | undefined > {
 			return resolve( undefined );
 		}
 		unsubscribe = subscribe( () => {
-			const resolvedSelectedSite = select( SITE_STORE ).getSite( selectedSite );
-			if ( resolvedSelectedSite ) {
-				return resolve( resolvedSelectedSite );
-			}
-
-			// For some reason, this still holds the value true after the request is resolved.
-			if ( ! select( 'core/data' ).isResolving( SITE_STORE, 'getSite', [ selectedSite ] ) ) {
-				resolve( undefined );
+			if (
+				select( 'core/data' ).hasFinishedResolution( SITE_STORE, 'getSite', [ selectedSite ] )
+			) {
+				resolve( select( SITE_STORE ).getSite( selectedSite ) );
 			}
 		} );
 		select( SITE_STORE ).getSite( selectedSite );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix user not redirected to customer site home after hitting browser back button on checkout page.

#### Testing instructions

**Test if it redirects when clicking back**
* Go through the `/new` flow.
* Pick a paid plan.
* Once landed at checkout step, press the **browser back button**.
    * [x] You should see `/new/create-site` on the address bar first.
    * [x] You should not see the intent gathering step.
    * [x] Then, it should redirect to customer site home.

**Test if onboard store is reset when re-entering `/new`**
* Re-enter `/new` again.
* Run `JSON.parse(localStorage.getItem('WP_ONBOARD'))["automattic/onboard"].selectedSite` in the console.
    * [x] It should return `undefined`.

Related to #49565
