### PR TITLE
Signup domain step fixes: Blank screen and UI fix

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -461,8 +461,9 @@ class RegisterDomainStep extends React.Component {
 							onSearchChange={ this.onSearchChange }
 							placeholder={ this.getPlaceholderText() }
 							ref={ this.bindSearchCardReference }
-						/>
-						{ this.renderSearchFilters() }
+						>
+							{ this.renderSearchFilters() }
+						</Search>
 					</CompactCard>
 				</StickyPanel>
 				{ availabilityMessage && (

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -23,11 +23,6 @@
 			animation: shake 0.5s both;
 			box-shadow: 0 0 0 1px var( --color-neutral-light ), 0 2px 4px var( --color-neutral-10 );
 		}
-
-		// Add some padding to account for the filter button.
-		body.is-section-signup & {
-			padding-right: 72px;
-		}
 	}
 
 	&.disabled {

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -7,17 +7,9 @@
 	height: 51px; // same as .search
 	z-index: z-index( 'root', '.search' );
 
-	// Move the filter so its "inside" the
-	// search input
-	body.is-section-signup & {
-		position: absolute;
-		top: 0;
-		right: 0;
-	}
-
 	.button {
 		align-items: center;
-		border-radius: 0 3px 3px 0;
+		border-radius: 0 3px 3px 0; /* stylelint-disable-line */
 		display: flex;
 		flex-direction: column;
 		font-weight: normal;

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -378,6 +378,7 @@ class Search extends Component {
 					{ this.props.overlayStyling && this.renderStylingDiv() }
 				</div>
 				{ this.closeButton() }
+				{ this.props.children }
 			</div>
 		);
 	}

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -207,6 +207,11 @@ class DomainSearch extends Component {
 
 	render() {
 		const { selectedSite, selectedSiteSlug, translate, isManagingAllDomains } = this.props;
+
+		if ( ! selectedSite ) {
+			return null;
+		}
+
 		const classes = classnames( 'main-column', {
 			'domain-search-page-wrapper': this.state.domainRegistrationAvailable,
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a bug that causes the "Add new site" flow to blank screen with a JS error if the user previously visited the add domains page.


![Kapture 2021-02-22 at 20 31 30](https://user-images.githubusercontent.com/1269602/108726065-057de380-754d-11eb-85f1-4740a6b71967.gif)

* Fixes a UI issue with the cross icon in the signup domains search field, seen in Japanese locale.


**BEFORE**

<img width="1156" alt="Screenshot 2021-02-22 at 7 31 43 PM" src="https://user-images.githubusercontent.com/1269602/108718922-f2ffac00-7544-11eb-902e-711eba5a945f.png">

**AFTER**

<img width="1118" alt="Screenshot 2021-02-22 at 7 32 18 PM" src="https://user-images.githubusercontent.com/1269602/108718950-fa26ba00-7544-11eb-8b8d-3493521e2522.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test case 1 - fix blank screen bug**

* In a non-EN locale, create a new site and visit the add domain page at /domains/add/{SITE_SLUG}
* Next click on the "Add new site" option from the sidebar. 
* Verify that the add new site flow opens the domain step with no JS errors.

**Test case 2 - test UI bug**

* Go through the signup flow in `ja` locale /start/ja and confirm that the domain search input box UI does not have the cross icon overlapping on the filters UI.
* Verify that the UI in mobile and tablet views is fine.
* Go through the signup flow in another locale, such as `en` or `de` and confirm that the UI looks fine.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
