### PR TITLE
Disable flaky insert embeds test

### DIFF
--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1213,7 +1213,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe( 'Insert embeds: @parallel', function () {
+	// Skip reason: https://github.com/Automattic/wp-calypso/issues/50336
+	describe.skip( 'Insert embeds: @parallel', function () {
 		step( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disables the flaky test: https://github.com/Automattic/wp-calypso/issues/50336

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A