### PR TITLE
ETK: Update to 2.21

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.20
+ * Version: 2.21
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'A8C_ETK_PLUGIN_VERSION', '2.20' );
+define( 'A8C_ETK_PLUGIN_VERSION', '2.21' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.5
 Tested up to: 5.6
-Stable tag: 2.20
+Stable tag: 2.21
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -40,6 +40,12 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 == Changelog ==
 View the commit history here: https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit
+
+= 2.21 =
+* Focused Launch: redirect to checkout after launch for eCommerce plan in Calypso (https://github.com/Automattic/wp-calypso/pull/50267)
+* Focused Launch: Once there is a plan selected, do not use plan from cart anymore. (https://github.com/Automattic/wp-calypso/pull/50276)
+* Set an order for page layout categories (https://github.com/Automattic/wp-calypso/pull/50110)
+* Focused Launch: show Name your site step for non-EN sites (https://github.com/Automattic/wp-calypso/pull/50311)
 
 = 2.20 =
 * Page layout picker: Fix broken web fonts in page layout picker large preview (https://github.com/Automattic/wp-calypso/pull/50253)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.20.0",
+	"version": "2.21.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Bumps version of Editing Toolkit to 2.21

### [Editing Toolkit changes included in this release](https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit)

- [x] Focused Launch: redirect to checkout after launch for eCommerce plan in Calypso (#50267) @razvanpapadopol 

### Other [changes](https://github.com/Automattic/wp-calypso/commits/trunk/packages) included from the [imported @automattic packages](https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/tsconfig.json#L37-L46) and their imports

- [x] Focused Launch: show Name your site step for non-EN sites (#50311) @razvanpapadopol 
- [x] Focused Launch: Once there is a plan selected, do not use plan from cart anymore. (#50276) @yansern 
- [x] Set an order for page layout categories (#50110) @roo2 

### Testing instructions

1. Load the diff on your sandbox (D57437-code) and confirm that the above changes work correctly
2. When a change has been tested to work correctly, please mark it as checked in the list above
3. Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.
    - [x] Tested on atomic 