### PR TITLE
ETK: Add more info to TC build log

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1365,9 +1365,9 @@ object WPComPlugins_EditorToolKit : BuildType({
 				yarn build
 
 				echo
-				prev_release_build_num=${'$'}(grep build_number ../../etk-release-build/readme.txt | sed -e "s/build_number=//")
+				prev_release_build_num=${'$'}(grep build_number ../../etk-release-build/build_meta.txt | sed -e "s/build_number=//")
+				rm ../../etk-release-build/build_meta.txt # Adds a source of randomness which we don't want for comparison.
 				echo "Previous tagged trunk build: ${'$'}prev_release_build_num"
-				rm ../../etk-release-build/readme.txt
 
 				# Update plugin version in the plugin file and readme.txt.
 				# Note: we also update the previous release build to the same version to restore idempotence

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1366,8 +1366,8 @@ object WPComPlugins_EditorToolKit : BuildType({
 				yarn build
 
 				echo
-				echo
-				echo "Previous Tagged Build: ${'$'}( grep build_number ../../etk-release-build/readme.txt | sed -e "s/build_number=//" )" 
+				prev_release_build_num=${'$'}(grep "build_number" "../../etk-release-build/readme.txt" | sed -e "s/build_number=//")
+				echo "Previous tagged trunk build: ${'$'}prev_release_build_num
 
 				# Update plugin version in the plugin file and readme.txt.
 				# Note: we also update the previous release build to the same version to restore idempotence
@@ -1377,11 +1377,11 @@ object WPComPlugins_EditorToolKit : BuildType({
 				if ! diff -rq ./editing-toolkit-plugin/ ../../etk-release-build/ ; then
 					echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
 					curl -X POST -H "Content-Type: text/plain" --data "etk-release-build" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/
+				else
+					echo "The build is not different from the last release build. Therefore, this build has no effect."
 				fi
 
-				echo "The build is different from trunk; creating artifact."
 				cd editing-toolkit-plugin/
-
 				# Metadata file with info for the download script.
 				tee build_meta.txt <<-EOM
 					commit_hash=%build.vcs.number%
@@ -1389,6 +1389,7 @@ object WPComPlugins_EditorToolKit : BuildType({
 					build_number=%build.number%
 					EOM
 
+				echo
 				zip -r ../../../editing-toolkit.zip .
 
 			""".trimIndent()

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1250,7 +1250,6 @@ object WPComPlugins_EditorToolKit : BuildType({
 			buildRule = tag("etk-release-build", "+:trunk")
 			artifactRules = """
 				+:editing-toolkit.zip!** => etk-release-build
-				-:editing-toolkit.zip!build_meta.txt
 			""".trimIndent()
 		}
 	}
@@ -1366,8 +1365,9 @@ object WPComPlugins_EditorToolKit : BuildType({
 				yarn build
 
 				echo
-				prev_release_build_num=${'$'}(grep "build_number" "../../etk-release-build/readme.txt" | sed -e "s/build_number=//")
+				prev_release_build_num=${'$'}(grep build_number ../../etk-release-build/readme.txt | sed -e "s/build_number=//")
 				echo "Previous tagged trunk build: ${'$'}prev_release_build_num"
+				rm ../../etk-release-build/readme.txt
 
 				# Update plugin version in the plugin file and readme.txt.
 				# Note: we also update the previous release build to the same version to restore idempotence

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1365,6 +1365,10 @@ object WPComPlugins_EditorToolKit : BuildType({
 				cd apps/editing-toolkit
 				yarn build
 
+				echo
+				echo
+				echo "Previous Tagged Build: ${'$'}( grep build_number ../../etk-release-build/readme.txt | sed -e "s/build_number=//" )" 
+
 				# Update plugin version in the plugin file and readme.txt.
 				# Note: we also update the previous release build to the same version to restore idempotence
 				sed -i -e "/^\s\* Version:/c\ * Version: %build.number%" -e "/^define( 'A8C_ETK_PLUGIN_VERSION'/c\define( 'A8C_ETK_PLUGIN_VERSION', '%build.number%' );" ./editing-toolkit-plugin/full-site-editing-plugin.php ../../etk-release-build/full-site-editing-plugin.php

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1367,7 +1367,7 @@ object WPComPlugins_EditorToolKit : BuildType({
 
 				echo
 				prev_release_build_num=${'$'}(grep "build_number" "../../etk-release-build/readme.txt" | sed -e "s/build_number=//")
-				echo "Previous tagged trunk build: ${'$'}prev_release_build_num
+				echo "Previous tagged trunk build: ${'$'}prev_release_build_num"
 
 				# Update plugin version in the plugin file and readme.txt.
 				# Note: we also update the previous release build to the same version to restore idempotence

--- a/packages/page-template-modal/src/components/page-template-modal.js
+++ b/packages/page-template-modal/src/components/page-template-modal.js
@@ -117,6 +117,12 @@ export default class PageTemplateModal extends Component {
 		return null;
 	}
 
+	componentDidMount() {
+		if ( this.props.isOpen ) {
+			this.trackCurrentView();
+		}
+	}
+
 	componentDidUpdate( prevProps ) {
 		// Only track when the modal is first displayed
 		// and if it didn't already happen during componentDidMount.

--- a/packages/page-template-modal/src/components/page-template-modal.js
+++ b/packages/page-template-modal/src/components/page-template-modal.js
@@ -117,12 +117,6 @@ export default class PageTemplateModal extends Component {
 		return null;
 	}
 
-	componentDidMount() {
-		if ( this.props.isOpen ) {
-			this.trackCurrentView();
-		}
-	}
-
 	componentDidUpdate( prevProps ) {
 		// Only track when the modal is first displayed
 		// and if it didn't already happen during componentDidMount.


### PR DESCRIPTION
Expectations:
- [x] The first package change commit _should_ show changes only to the SPT bundle.
- [x] The final change should not show changes to anything, and shouldn't be tagged.
- [x] The final commit should also print the build number from the "previous tagged build"

<img width="1847" alt="Screen Shot 2021-02-22 at 1 38 29 PM" src="https://user-images.githubusercontent.com/6265975/108773506-4e18ab00-7513-11eb-8b96-fb34d4b07eae.png">
