### PR TITLE
Remove Revoke License button

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -9,7 +9,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
-import { Button, Card } from '@automattic/components';
+import { Card } from '@automattic/components';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import Gridicon from 'calypso/components/gridicon';
 import FormattedDate from 'calypso/components/formatted-date';
@@ -95,9 +95,6 @@ export default function LicenseDetails( {
 					{ blogId ? <span>{ blogId }</span> : <Gridicon icon="minus" /> }
 				</li>
 			</ul>
-			<div className="license-details__actions">
-				<Button scary>{ translate( 'Revoke License' ) }</Button>
-			</div>
 		</Card>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the Revoke License button as it will no longer be part of the MPV 1 for the partner portal. This has been moved to the next MVP.

#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run yarn && yarn start-jetpack-cloud.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key, if prompted.
* You should be presented with a list of all of your licenses.
* Make sure that the license details card does not show the Revoke License button. It should look like the screenshot:

![revoke](https://user-images.githubusercontent.com/348248/108757355-5a026e00-750f-11eb-9510-359353b5032a.png)

