### PR TITLE
Refactor the Insert embeds test.

### DIFF
--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1213,45 +1213,44 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	// Skip reason: https://github.com/Automattic/wp-calypso/issues/50336
-	describe.skip( 'Insert embeds: @parallel', function () {
+	describe.only( 'Insert embeds: @parallel', function () {
 		step( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
-		step( 'Can insert Embeds block', async function () {
-			const blogPostTitle = dataHelper.randomPhrase();
+		step( 'Can start post', async function () {
+			const blogPostTitle = 'Embeds: ' + dataHelper.randomPhrase();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			await gEditorComponent.enterTitle( 'Embeds: ' + blogPostTitle );
+			await gEditorComponent.enterTitle( blogPostTitle );
+			const title = await gEditorComponent.titleShown();
+			assert.strictEqual( title, blogPostTitle );
+		} );
 
-			this.instagramEditorSelector =
-				'.wp-block-embed iframe[title="Embedded content from instagram.com"]';
-			const blockIdInstagram = await gEditorComponent.addBlock( 'Instagram' );
-			const gEmbedsComponentInstagram = await EmbedsBlockComponent.Expect(
-				driver,
-				blockIdInstagram
-			);
-			await gEmbedsComponentInstagram.embedUrl( 'https://www.instagram.com/p/BlDOZMil933/' );
-			await gEmbedsComponentInstagram.isEmbeddedInEditor( this.instagramEditorSelector );
-
-			this.twitterEditorSelector = '.wp-block-embed iframe[title="Embedded content from twitter"]';
-			const blockIdTwitter = await gEditorComponent.addBlock( 'Twitter' );
-			const gEmbedsComponentTwitter = await EmbedsBlockComponent.Expect( driver, blockIdTwitter );
-			await gEmbedsComponentTwitter.embedUrl(
-				'https://twitter.com/automattic/status/1067120832676327424'
-			);
-			await gEmbedsComponentTwitter.isEmbeddedInEditor( this.twitterEditorSelector );
-
-			this.youtubeEditorSelector =
-				'.wp-block-embed iframe[title="Embedded content from youtube.com"]';
-			const blockIdYouTube = await gEditorComponent.addBlock( 'YouTube' );
-			const gEmbedsComponentYouTube = await EmbedsBlockComponent.Expect( driver, blockIdYouTube );
-			await gEmbedsComponentYouTube.embedUrl( 'https://www.youtube.com/watch?v=xifhQyopjZM' );
-			await gEmbedsComponentYouTube.isEmbeddedInEditor( this.youtubeEditorSelector );
-
-			const errorShown = await gEditorComponent.errorDisplayed();
-			return assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
+		[
+			{
+				name: 'Instagram',
+				url: 'https://www.instagram.com/p/BlDOZMil933/',
+				selector: '.wp-block-embed iframe[title="Embedded content from instagram.com"]',
+			},
+			{
+				name: 'Twitter',
+				url: 'https://twitter.com/automattic/status/1067120832676327424',
+				selector: '.wp-block-embed iframe[title="Embedded content from twitter"]',
+			},
+			{
+				name: 'YouTube',
+				url: 'https://www.youtube.com/watch?v=xifhQyopjZM',
+				selector: '.wp-block-embed iframe[title="Embedded content from youtube.com"]',
+			},
+		].forEach( ( Block ) => {
+			step( `Can insert ${ Block.name } block`, async function () {
+				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				const embedBlock = await gEditorComponent.addBlock( Block.name );
+				const gEmbedsComponent = await EmbedsBlockComponent.Expect( driver, embedBlock );
+				await gEmbedsComponent.embedUrl( Block.url );
+				await gEmbedsComponent.isEmbeddedInEditor( Block.selector );
+			} );
 		} );
 
 		step( 'Can publish and view content', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- separate out steps that insert blog post title into its own step.
- parametrize the insertion of various embed blocks.

The goal of these steps are to make the test run more reliably by separating out individual actions into its own step for better encapsulation.

#### Testing instructions

1. pull the changes to local repo.
2. run the following:
```
node_modules/.bin/mocha specs/wp-calypso-gutenberg-post-editor-spec.js -f "Insert embeds: @parallel"
```

Test results locally:

*Mobile*:
```
  [WPCOM] Calypso Gutenberg Editor: Posts (mobile)
    Insert embeds: @parallel
{} Logging in as e2eflowtestinggutenbergsimple
      ✓ Can log in (33758ms)
      ✓ Can start post (4673ms)
      ✓ Can insert Instagram block (12072ms)
      ✓ Can insert Twitter block (9939ms)
      ✓ Can insert YouTube block (9879ms)
      ✓ Can publish and view content (16093ms)
      ✓ Can see embedded content in our published post (3559ms)

  7 passing (2m)
```

*Desktop*:
```
  [WPCOM] Calypso Gutenberg Editor: Posts (desktop)
    Insert embeds: @parallel
{} Logging in as e2eflowtestinggutenbergsimple
      ✓ Can log in (34309ms)
      ✓ Can start post (4633ms)
      ✓ Can insert Instagram block (11469ms)
      ✓ Can insert Twitter block (10926ms)
      ✓ Can insert YouTube block (10275ms)
      ✓ Can publish and view content (82930ms)
      ✓ Can see embedded content in our published post (3733ms)

  7 passing (3m)
```


This test also appears to be passing on CircleCI as well:
https://app.circleci.com/pipelines/github/Automattic/wp-e2e-tests-for-branches/58942/workflows/cd912065-8e44-47d7-893d-4cdbb242f364/jobs/143483/parallel-runs/2?filterBy=ALL
https://app.circleci.com/pipelines/github/Automattic/wp-e2e-tests-for-branches/58941/workflows/c69b51e1-f6c0-47b6-83d6-069546c28cf1/jobs/143482/parallel-runs/2?filterBy=ALL