### PR TITLE
Home Screen Task List: Anchor sites launch immediately

### DIFF
--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -23,10 +23,11 @@ export const launchSiteOrRedirectToLaunchSignupFlow = ( siteId ) => ( dispatch, 
 		return;
 	}
 
-	if (
-		isCurrentPlanPaid( getState(), siteId ) &&
-		getDomainsBySiteId( getState(), siteId ).length > 1
-	) {
+	const isAnchorPodcast = getSiteOption( getState(), siteId, 'anchor_podcast' );
+	const isPaidWithDomain =
+		isCurrentPlanPaid( getState(), siteId ) && getDomainsBySiteId( getState(), siteId ).length > 1;
+
+	if ( isPaidWithDomain || isAnchorPodcast ) {
 		dispatch( launchSite( siteId ) );
 		return;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When a site created by Anchor.fm flavored gutenboarding presses the "Launch" button on the home screen task list, the site will launch immediately instead of asking for upsells.

#### Testing instructions

* Create an Anchor.fm site from gutenboarding. For example, visit the http://calypso.localhost:3000/new?anchor_podcast=1808c24 URL with a new account and go through the process.
* Go to calypso home and locate the launch section of the site setup checklist.
* Clicking launch should launch the site immediately instead of asking you about domains and plans.

![2021-02-22_13-45](https://user-images.githubusercontent.com/937354/108761640-b6b45780-7514-11eb-94c3-a0cefed9a508.png)

Related to 492-gh-Automattic/dotcom-manage

