### PR TITLE
ETK: Add typecheck in TC

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -378,6 +378,7 @@ object RunAllUnitTests : BuildType({
 
 				# Run type checks
 				yarn tsc --build packages/tsconfig.json
+				yarn tsc --build apps/editing-toolkit/tsconfig.json
 				yarn tsc --project client/landing/gutenboarding
 			""".trimIndent()
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/src/premium-block-patterns.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/src/premium-block-patterns.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
@@ -27,7 +27,7 @@ interface ExperimentalBlockPattern {
 	description: string;
 	isPremium: boolean;
 	name: string;
-	title: React.ReactNode;
+	title: ReactNode;
 	viewportWidth: number;
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/src/premium-block-patterns.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/src/premium-block-patterns.tsx
@@ -27,7 +27,7 @@ interface ExperimentalBlockPattern {
 	description: string;
 	isPremium: boolean;
 	name: string;
-	title: string | JSX.Element;
+	title: React.ReactNode;
 	viewportWidth: number;
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/src/premium-block-patterns.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/src/premium-block-patterns.tsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
+import type { EditorSettings } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -16,13 +17,17 @@ interface PatternTitleProps {
 	description?: string;
 }
 
+interface ExperimentalEditorSettings extends EditorSettings {
+	__experimentalBlockPatterns: ExperimentalBlockPattern[];
+}
+
 interface ExperimentalBlockPattern {
 	categories: string[];
 	content: string;
 	description: string;
 	isPremium: boolean;
 	name: string;
-	title: string;
+	title: string | JSX.Element;
 	viewportWidth: number;
 }
 
@@ -40,12 +45,16 @@ export const PatternTitleContainer: React.FunctionComponent< PatternTitleProps >
 export const PremiumBlockPatterns: React.FunctionComponent = () => {
 	const { __experimentalBlockPatterns } = useSelect( ( select ) =>
 		select( 'core/block-editor' ).getSettings()
+	) as ExperimentalEditorSettings;
+	const {
+		updateSettings,
+	}: { updateSettings: ( settings: Partial< ExperimentalEditorSettings > ) => void } = useDispatch(
+		'core/block-editor'
 	);
-	const { updateSettings } = useDispatch( 'core/block-editor' );
 
 	if ( __experimentalBlockPatterns ) {
 		let shouldUpdateBlockPatterns = false;
-		const updatedPatterns: Array = [];
+		const updatedPatterns: ExperimentalBlockPattern[] = [];
 
 		__experimentalBlockPatterns.forEach( ( originalPattern: ExperimentalBlockPattern ) => {
 			const pattern = { ...originalPattern };

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { hasQueryArg } from '@wordpress/url';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
 import { doAction, hasAction } from '@wordpress/hooks';
 import { LaunchContext } from '@automattic/launch';
-import { LocaleProvider } from '@automattic/i18n-utils';
+import { LocaleProvider, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -47,7 +47,7 @@ registerPlugin( 'a8c-editor-site-launch', {
 		}
 
 		return (
-			<LocaleProvider localeSlug={ window.wpcomEditorSiteLaunch?.locale }>
+			<LocaleProvider localeSlug={ window.wpcomEditorSiteLaunch?.locale ?? i18nDefaultLocaleSlug }>
 				<LaunchContext.Provider
 					value={ {
 						siteId: window._currentSiteId,

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/item.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/item.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { Button, SVG, Circle } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import classnames from 'classnames';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import classnames from 'classnames';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-progress/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-progress/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Title, SubTitle, ActionButtons, NextButton } from '@automattic/onboarding';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-step/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import DomainPicker, { mockDomainSuggestion } from '@automattic/domain-picker';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import classnames from 'classnames';
 import { ThemeProvider } from 'emotion-theming';
 import { createInterpolateElement } from '@wordpress/element';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { TextControl, Tip } from '@wordpress/components';
 import { Title, SubTitle, ActionButtons, BackButton, NextButton } from '@automattic/onboarding';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import PlansGrid from '@automattic/plans-grid';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, createPortal, useState } from '@wordpress/element';
 import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/edit-post';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -14,7 +14,7 @@ import WpcomBlockEditorNavSidebar from './components/nav-sidebar';
 import ToggleSidebarButton from './components/toggle-sidebar-button';
 
 const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > ) =>
-	originalRegisterPlugin( name, settings as any );
+	originalRegisterPlugin( name, settings as PluginSettings );
 
 if ( typeof MainDashboardButton !== 'undefined' ) {
 	registerPlugin( 'a8c-full-site-editing-nav-sidebar', {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { get } from 'lodash';
 import { Button as OriginalButton } from '@wordpress/components';
 import { applyFilters } from '@wordpress/hooks';
@@ -35,14 +36,14 @@ export default function CreatePage( { postType }: Props ) {
 		'a8c.WpcomBlockEditorNavSidebar.createPostLabel',
 		defaultLabel,
 		postType.slug
-	);
+	) as string;
 
 	const defaultUrl = addQueryArgs( 'post-new.php', { post_type: postType.slug } );
 	const url = applyFilters(
 		'a8c.WpcomBlockEditorNavSidebar.createPostUrl',
 		defaultUrl,
 		postType.slug
-	);
+	) as string;
 
 	const trackEvent = () => {
 		recordTracksEvent( `calypso_editor_sidebar_item_add`, { post_type: postType.slug } );
@@ -50,7 +51,9 @@ export default function CreatePage( { postType }: Props ) {
 
 	return (
 		<Button
-			target={ applyFilters( 'a8c.WpcomBlockEditorNavSidebar.linkTarget', undefined ) }
+			target={
+				applyFilters( 'a8c.WpcomBlockEditorNavSidebar.linkTarget', undefined ) as string | undefined
+			}
 			isPrimary
 			className="wpcom-block-editor-nav-sidebar-create-page"
 			href={ url }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
@@ -18,7 +18,7 @@ import './style.scss';
 const Button = ( {
 	children,
 	...rest
-}: OriginalButton.Props & { icon?: any; iconSize?: number } ) => (
+}: OriginalButton.Props & { icon?: unknown; iconSize?: number } ) => (
 	<OriginalButton { ...rest }>{ children }</OriginalButton>
 );
 
@@ -26,7 +26,7 @@ interface Props {
 	postType: { slug: string };
 }
 
-export default function CreatePage( { postType }: Props ) {
+export default function CreatePage( { postType }: Props ): JSX.Element {
 	const defaultLabel = get(
 		postType,
 		[ 'labels', 'add_new_item' ],

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import classNames from 'classnames';
 import { Button } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
@@ -38,7 +39,7 @@ const NavItem = forwardRef< HTMLLIElement, NavItemProps >(
 			defaultEditUrl,
 			item.id,
 			postType.slug
-		);
+		) as string;
 		const trackEvent = () => {
 			recordTracksEvent( 'calypso_editor_sidebar_item_edit', { post_type: postType.slug } );
 		};
@@ -49,7 +50,11 @@ const NavItem = forwardRef< HTMLLIElement, NavItemProps >(
 					className={ buttonClasses }
 					href={ editUrl }
 					onClick={ trackEvent }
-					target={ applyFilters( 'a8c.WpcomBlockEditorNavSidebar.linkTarget', undefined ) }
+					target={
+						applyFilters( 'a8c.WpcomBlockEditorNavSidebar.linkTarget', undefined ) as
+							| string
+							| undefined
+					}
 				>
 					<div className={ titleClasses } title={ item.title?.raw }>
 						{ item.title?.raw ||

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { forwardRef, useLayoutEffect, useRef, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -102,14 +103,20 @@ function WpcomBlockEditorNavSidebar() {
 	// `closeLabel` can be overridden in the same way to correctly label where the user will
 	// be taken to after closing the editor.
 	const defaultCloseUrl = addQueryArgs( 'edit.php', { post_type: postType.slug } );
-	const closeUrl = applyFilters( 'a8c.WpcomBlockEditorNavSidebar.closeUrl', defaultCloseUrl );
+	const closeUrl = applyFilters(
+		'a8c.WpcomBlockEditorNavSidebar.closeUrl',
+		defaultCloseUrl
+	) as string;
 
 	const defaultCloseLabel = get(
 		postType,
 		[ 'labels', 'all_items' ],
 		__( 'Back', 'full-site-editing' )
 	);
-	const closeLabel = applyFilters( 'a8c.WpcomBlockEditorNavSidebar.closeLabel', defaultCloseLabel );
+	const closeLabel = applyFilters(
+		'a8c.WpcomBlockEditorNavSidebar.closeLabel',
+		defaultCloseLabel
+	) as string;
 
 	const handleClose = ( e: React.MouseEvent ) => {
 		if ( hasAction( 'a8c.wpcom-block-editor.closeEditor' ) ) {
@@ -124,7 +131,7 @@ function WpcomBlockEditorNavSidebar() {
 		'a8c.WpcomBlockEditorNavSidebar.listHeading',
 		defaultListHeading,
 		postType.slug
-	);
+	) as string;
 
 	const dialogDescription =
 		postType.slug === 'page'
@@ -296,7 +303,7 @@ function useNavItems(): Record< string, Post[] > {
 			.join( ',' );
 		const currentPostId = getCurrentPostId();
 		const currentPostType = getCurrentPostType();
-		const items: Post[] =
+		const items =
 			select( 'core' ).getEntityRecords( 'postType', currentPostType, {
 				_fields: 'id,status,title',
 				exclude: [ currentPostId, ...POST_IDS_TO_EXCLUDE ],

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -328,7 +328,7 @@ function useNavItems(): NavItemRecord {
 		} as Post;
 		const [ drafts, recent ] = partition( items, { status: 'draft' } );
 
-		return { current: [ current ], drafts, recent } as NavItemRecord;
+		return { current: [ current ], drafts, recent };
 	} );
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -18,11 +18,11 @@ import './style.scss';
 const Button = ( {
 	children,
 	...rest
-}: OriginalButton.Props & { icon?: any; iconSize?: number; showTooltip?: boolean } ) => (
+}: OriginalButton.Props & { icon?: unknown; iconSize?: number; showTooltip?: boolean } ) => (
 	<OriginalButton { ...rest }>{ children }</OriginalButton>
 );
 
-export default function ToggleSidebarButton() {
+export default function ToggleSidebarButton(): JSX.Element {
 	const { toggleSidebar } = useDispatch( STORE_KEY );
 	const isSidebarOpen = useSelect( ( select ) => select( STORE_KEY ).isSidebarOpened() );
 	const isSidebarClosing = useSelect( ( select ) => select( STORE_KEY ).isSidebarClosing() );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { Button as OriginalButton } from '@wordpress/components';
 import { wordpress } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';

--- a/apps/editing-toolkit/tsconfig.json
+++ b/apps/editing-toolkit/tsconfig.json
@@ -6,6 +6,7 @@
 		"isolatedModules": true,
 		"noEmit": true,
 
+		"jsx": "react",
 		"allowJs": true,
 		"checkJs": false,
 
@@ -22,15 +23,13 @@
 
 		/* Module Resolution Options */
 		"moduleResolution": "node",
+		"allowSyntheticDefaultImports": true,
 
 		/* This needs to be false so our types are possible to consume without setting this */
 		"esModuleInterop": false,
 
 		// Some type helpers from our webpack/
-		"types": [ "fse", "jest" ],
-		"typeRoots": [ "./typings", "./node_modules/@types", "../../node_modules/@types" ],
-		// Preserve JSX, allows compatibility with wp-element jsx babel transforms
-		"jsx": "preserve"
+		"typeRoots": [ "./typings", "./node_modules/@types", "../../node_modules/@types" ]
 	},
 	"exclude": [ "node_modules" ],
 	"references": [
@@ -38,7 +37,6 @@
 		{ "path": "../../packages/calypso-analytics" },
 		{ "path": "../../packages/composite-checkout" },
 		{ "path": "../../packages/domain-picker" },
-		{ "path": "../../packages/format-currency" },
 		{ "path": "../../packages/onboarding" },
 		{ "path": "../../packages/launch" },
 		{ "path": "../../packages/plans-grid" },

--- a/apps/editing-toolkit/tsconfig.json
+++ b/apps/editing-toolkit/tsconfig.json
@@ -29,7 +29,8 @@
 		"esModuleInterop": false,
 
 		// Some type helpers from our webpack/
-		"typeRoots": [ "./typings", "./node_modules/@types", "../../node_modules/@types" ]
+		"typeRoots": [ "./typings", "./node_modules/@types", "../../node_modules/@types" ],
+		"types": [ "jest", "@emotion/core" ]
 	},
 	"exclude": [ "node_modules" ],
 	"references": [

--- a/apps/editing-toolkit/typings/index.d.ts
+++ b/apps/editing-toolkit/typings/index.d.ts
@@ -21,4 +21,3 @@ interface Window {
 		manageReusableBlocksUrl?: string;
 	};
 }
-

--- a/apps/editing-toolkit/typings/index.d.ts
+++ b/apps/editing-toolkit/typings/index.d.ts
@@ -21,3 +21,4 @@ interface Window {
 		manageReusableBlocksUrl?: string;
 	};
 }
+

--- a/packages/format-currency/tsconfig.json
+++ b/packages/format-currency/tsconfig.json
@@ -1,8 +1,0 @@
-{
-	"extends": "@automattic/calypso-build/tsconfig",
-	"exclude": [ "node_modules" ],
-	"compilerOptions": {
-		"allowJs": true,
-		"composite": true
-	}
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Resolves #50334. We were not running a typescript build for ETK, so this adds one to catch major errors. Also solves some TS lint problems which didn't yet get reported in CI.

#### Testing instructions
test on your wpocm sandbox with `install-plugin.sh etk add/typecheck-etk`

- [x] unit tests should pass
- [x] static analysis + lint should pass
- [x] builds should pass
- [x] smoke test ETK on wpcom 