### PR TITLE
ESLint: Add you-dont-need-lodash-underscore rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,6 @@ module.exports = {
 		'plugin:prettier/recommended',
 		'prettier/react',
 		'plugin:md/prettier',
-		'plugin:you-dont-need-lodash-underscore/compatible',
 		'plugin:@wordpress/eslint-plugin/i18n',
 	],
 	overrides: [
@@ -213,7 +212,7 @@ module.exports = {
 		// this is when Webpack last built the bundle
 		BUILD_TIMESTAMP: true,
 	},
-	plugins: [ 'import' ],
+	plugins: [ 'import', 'you-dont-need-lodash-underscore' ],
 	settings: {
 		react: {
 			version: reactVersion,
@@ -390,5 +389,17 @@ module.exports = {
 
 		// Disabled, because in packages we are using globally defined `__i18n_text_domain__` constant at compile time
 		'@wordpress/i18n-text-domain': 'off',
+
+		// Disable Lodash methods that we've already migrated away from, see p4TIVU-9Bf-p2 for more details.
+		'you-dont-need-lodash-underscore/bind': 'error',
+		'you-dont-need-lodash-underscore/drop': 'error',
+		'you-dont-need-lodash-underscore/ends-with': 'error',
+		'you-dont-need-lodash-underscore/entries': 'error',
+		'you-dont-need-lodash-underscore/is-null': 'error',
+		'you-dont-need-lodash-underscore/reduce-right': 'error',
+		'you-dont-need-lodash-underscore/reverse': 'error',
+		'you-dont-need-lodash-underscore/split': 'error',
+		'you-dont-need-lodash-underscore/to-lower': 'error',
+		'you-dont-need-lodash-underscore/to-upper': 'error',
 	},
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
 		'plugin:prettier/recommended',
 		'prettier/react',
 		'plugin:md/prettier',
+		'plugin:you-dont-need-lodash-underscore/compatible',
 		'plugin:@wordpress/eslint-plugin/i18n',
 	],
 	overrides: [

--- a/package.json
+++ b/package.json
@@ -244,6 +244,7 @@
 		"eslint-plugin-prettier": "^3.1.4",
 		"eslint-plugin-react": "^7.21.5",
 		"eslint-plugin-react-hooks": "^4.0.5",
+		"eslint-plugin-you-dont-need-lodash-underscore": "^6.11.0",
 		"eslint-plugin-wpcalypso": "^5.1.0",
 		"exports-loader": "^0.7.0",
 		"fake-indexeddb": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11513,6 +11513,13 @@ eslint-plugin-react@^7.20.0, eslint-plugin-react@^7.21.5:
     resolve "^1.18.1"
     string.prototype.matchall "^4.0.2"
 
+eslint-plugin-you-dont-need-lodash-underscore@^6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-you-dont-need-lodash-underscore/-/eslint-plugin-you-dont-need-lodash-underscore-6.11.0.tgz#56ac259495cdee7b778165660e89dd1513dba0ac"
+  integrity sha512-cIprUmcACzxBg5rUrrCMbyAI3O0jYsB80+9PGq8XsvRTrxDSIzLitNhBetu9erb3TDxyW6OPseyOZzfQdR8oow==
+  dependencies:
+    kebab-case "^1.0.0"
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -16881,6 +16888,11 @@ jwt-decode@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
   integrity sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=
+
+kebab-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/kebab-case/-/kebab-case-1.0.0.tgz#3f9e4990adcad0c686c0e701f7645868f75f91eb"
+  integrity sha1-P55JkK3K0MaGwOcB92RYaPdfkes=
 
 keymaster@^1.6.2:
   version "1.6.2"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We've been meaning to deprecate lodash for a while. This PR gets it a step further by adding the compatible `you-dont-need-lodash-underscore` ESLint rules. This means, rules in which the native implementation is perfectly compatible with the lodash ones are set to error, the rest are set to warn.

This is only a first step towards deprecating Lodash in Calypso. Its usage is currently widespread, and we can't just deprecate all of it. By starting with the methods that have an excellent native implementation we're ensuring not only that folks will be aware that they can use the native methods for new code, but they'll also be tempted to refactor existing ones. In terms of the lodash functions that don't have a 1:1 correlation to a native method, but can alternatively be approached or have to be additionally safeguarded, we'll still be showing an eslint warning. On top of the opportunity to address those as developers touch files where they occur, those will also educate the Calypso developer community.

The next step would be to start extracting some of those utilities into a separate package, with TS support, and fully modular. https://github.com/Automattic/wp-calypso/pull/50263 is already doing that for `uniqueBy`. Such utilities will help us have full control over the code and will eventually allow us to remove all of Lodash.

#### Testing instructions

* Checkout this branch.
* Attempt using one of the following from `lodash` in your code:
  * `bind`
  * `drop`
  * `endsWith`
  * `entries`
  * `isNull`
  * `reduceRight`
  * `reverse`
  * `split`
  * `toLower`
  * `toUpper`
* Verify you're getting eslint warnings/errors as expected. 
* Attempt using any other Lodash method.
* Verify you're not getting eslint warnings/errors.
