### PR TITLE
Hosting, Rewind: remove trivial serialize tests of reducers with no persistence

### DIFF
--- a/client/state/hosting/test/reducer.js
+++ b/client/state/hosting/test/reducer.js
@@ -7,11 +7,7 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import reducer, { sftpUsers } from '../reducer';
-import {
-	HOSTING_SFTP_USERS_SET,
-	HOSTING_SFTP_USER_UPDATE,
-	SERIALIZE,
-} from 'calypso/state/action-types';
+import { HOSTING_SFTP_USERS_SET, HOSTING_SFTP_USER_UPDATE } from 'calypso/state/action-types';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -43,13 +39,6 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).toEqual( [ 4, 5, 6 ] );
-		} );
-
-		test( 'should persist state', () => {
-			const previousState = deepFreeze( [ 1, 2, 3 ] );
-			const state = sftpUsers( previousState, { type: SERIALIZE } );
-
-			expect( state ).toEqual( [ 1, 2, 3 ] );
 		} );
 
 		test( 'should update existing users', () => {

--- a/client/state/rewind/backups/test/reducer.js
+++ b/client/state/rewind/backups/test/reducer.js
@@ -7,7 +7,7 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import reducer from '../reducer';
-import { REWIND_BACKUPS_SET, SERIALIZE } from 'calypso/state/action-types';
+import { REWIND_BACKUPS_SET } from 'calypso/state/action-types';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -38,12 +38,5 @@ describe( 'reducer', () => {
 		} );
 
 		expect( state ).toEqual( [ 4, 5, 6 ] );
-	} );
-
-	test( 'should persist state', () => {
-		const previousState = deepFreeze( [ 1, 2, 3 ] );
-		const state = reducer( previousState, { type: SERIALIZE } );
-
-		expect( state ).toEqual( [ 1, 2, 3 ] );
 	} );
 } );


### PR DESCRIPTION
Removes trivial serialization tests from two reducers that don't have persistence enabled. These tests simply test that a reducer returns unchanged `state` on unhandled action.

Spinoff from #50222.