### PR TITLE
Help: Add "Contact support" to header as experiment

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -336,7 +336,7 @@ class Help extends React.PureComponent {
 						subHeaderText={ translate( 'Get help with your WordPress.com site' ) }
 						align="left"
 					/>
-					<Experiment name="calypso-help-contact-button">
+					<Experiment name="calypso_help_contact_button">
 						<Variation name="show-header-button">
 							<div className="help__contact-us-header-button">
 								<Button onClick={ this.trackContactUsClick }>

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -336,7 +336,7 @@ class Help extends React.PureComponent {
 						subHeaderText={ translate( 'Get help with your WordPress.com site' ) }
 						align="left"
 					/>
-					<Experiment name="help-add-header-button">
+					<Experiment name="calypso-help-contact-button">
 						<Variation name="show-header-button">
 							<div className="help__contact-us-header-button">
 								<Button onClick={ this.trackContactUsClick }>

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -337,7 +337,7 @@ class Help extends React.PureComponent {
 						align="left"
 					/>
 					<Experiment name="calypso_help_contact_button">
-						<Variation name="show-header-button">
+						<Variation name="treatment">
 							<div className="help__contact-us-header-button">
 								<Button onClick={ this.trackContactUsClick }>
 									{ translate( 'Contact support' ) }

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -344,7 +344,7 @@ class Help extends React.PureComponent {
 								</Button>
 							</div>
 						</Variation>
-						<DefaultVariation name="default" />
+						<DefaultVariation name="control" />
 					</Experiment>
 				</div>
 				<HelpSearch onSearch={ this.setIsSearching } />

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -20,6 +20,7 @@ import Main from 'calypso/components/main';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { getCurrentUserId, isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
 import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id.js';
@@ -28,6 +29,7 @@ import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { getUserPurchases, isFetchingUserPurchases } from 'calypso/state/purchases/selectors';
 import { planHasFeature } from 'calypso/lib/plans';
 import { FEATURE_BUSINESS_ONBOARDING } from 'calypso/lib/plans/constants';
+import Experiment, { DefaultVariation, Variation } from 'calypso/components/experiment';
 
 /**
  * Style dependencies
@@ -295,6 +297,10 @@ class Help extends React.PureComponent {
 		} );
 	};
 
+	trackContactUsClick = () => {
+		recordTracksEvent( 'calypso_help_header_button_click' );
+	};
+
 	getPlaceholders = () => (
 		<Main className="help" wideLayout>
 			<MeSidebarNavigation />
@@ -312,7 +318,7 @@ class Help extends React.PureComponent {
 	};
 
 	render() {
-		const { isEmailVerified, userId, isLoading } = this.props;
+		const { isEmailVerified, userId, isLoading, translate } = this.props;
 
 		if ( isLoading ) {
 			return this.getPlaceholders();
@@ -322,6 +328,25 @@ class Help extends React.PureComponent {
 			<Main className="help" wideLayout>
 				<PageViewTracker path="/help" title="Help" />
 				<MeSidebarNavigation />
+
+				<div className="help__heading">
+					<FormattedHeader
+						brandFont
+						headerText={ translate( 'Support' ) }
+						subHeaderText={ translate( 'Get help with your WordPress.com site' ) }
+						align="left"
+					/>
+					<Experiment name="help-add-header-button">
+						<Variation name="show-header-button">
+							<div className="help__contact-us-header-button">
+								<Button onClick={ this.trackContactUsClick }>
+									{ translate( 'Contact support' ) }
+								</Button>
+							</div>
+						</Variation>
+						<DefaultVariation name="default" />
+					</Experiment>
+				</div>
 				<HelpSearch onSearch={ this.setIsSearching } />
 				{ ! this.state.isSearching && (
 					<div className="help__inner-wrapper">

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -8,6 +8,10 @@
 		margin-right: 12px;
 	}
 
+	.formatted-header__subtitle {
+		margin-bottom: 0;
+	}
+
 	.help__contact-us-header-button {
 		margin: auto;
 		margin-right: 0;

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -1,6 +1,19 @@
 @import '~@wordpress/base-styles/breakpoints';
 @import '~@wordpress/base-styles/mixins';
 
+.help__heading {
+	display: flex;
+
+	.formatted-header {
+		margin-right: 12px;
+	}
+
+	.help__contact-us-header-button {
+		margin: auto;
+		margin-right: 0;
+	}
+}
+
 .help .upwork-banner {
 	margin: 10px 10px 20px;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a "Contact support" button to the header as an experiment, to make sure we don't increase support load.

**Treatment**

<img width="1118" alt="Screen Shot 2021-02-23 at 10 54 40 AM" src="https://user-images.githubusercontent.com/2124984/108869797-8973b200-75c5-11eb-8881-675e9eae8dff.png">

**Control**

<img width="1101" alt="Screen Shot 2021-02-23 at 10 53 32 AM" src="https://user-images.githubusercontent.com/2124984/108869826-91cbed00-75c5-11eb-98d5-47af2eb03a8f.png">


#### Testing instructions

* Switch to this PR and navigate to `/help`
* Log into Abacus and select the `calypso_help_contact_button` experiment.
* Use the bookmarklets to switch between treatment and control variations. `treatment` should show the Contact support button, `control` should not:

<img width="521" alt="Screen Shot 2021-02-23 at 10 52 21 AM" src="https://user-images.githubusercontent.com/2124984/108869853-985a6480-75c5-11eb-9c79-85aa9460ef3a.png">


See pbxNRc-Ir-p2