### PR TITLE
people(users): use `react-query` (include forms)

### DIFF
--- a/client/data/users/delete-user.js
+++ b/client/data/users/delete-user.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { useMutation } from 'react-query';
+
+/**
+ * Internal dependencies
+ */
+import wp from 'calypso/lib/wp';
+
+function useDeleteUser( siteId ) {
+	const { mutate: deleteUser, ...rest } = useMutation( ( { userId, reassignUserId } ) => {
+		const variables = {};
+		if ( reassignUserId ) {
+			variables.reassign = reassignUserId;
+		}
+		return wp.undocumented().site( siteId ).deleteUser( userId, variables );
+	} );
+
+	return { deleteUser, ...rest };
+}
+
+export default useDeleteUser;

--- a/client/data/users/update-user.js
+++ b/client/data/users/update-user.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { useMutation, useQueryClient } from 'react-query';
+
+/**
+ * Internal dependencies
+ */
+import wp from 'calypso/lib/wp';
+
+export const cacheKey = ( siteId, login ) => [ 'user', siteId, login ];
+
+function useUpdateUser( siteId, login ) {
+	const queryClient = useQueryClient();
+	const { mutate: updateUser, ...rest } = useMutation(
+		( { userId, variables } ) => wp.undocumented().site( siteId ).updateUser( userId, variables ),
+		{
+			// optimistically update user
+			async onMutate( { variables } ) {
+				await queryClient.cancelQueries( cacheKey( siteId, login ) );
+
+				const previousUser = queryClient.getQueryData( cacheKey( siteId, login ) );
+
+				queryClient.setQueryData( cacheKey( siteId, login ), ( old ) => ( {
+					...old,
+					...variables,
+				} ) );
+
+				return { previousUser };
+			},
+			onError( error, updatedUser, context ) {
+				queryClient.setQueryData( cacheKey( siteId, login ), context.previousUser );
+			},
+			onSuccess( userData ) {
+				queryClient.setQueryData( cacheKey( siteId, login ), userData );
+			},
+		}
+	);
+
+	return { updateUser, ...rest };
+}
+
+export default useUpdateUser;

--- a/client/data/users/use-user.js
+++ b/client/data/users/use-user.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { useQuery } from 'react-query';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'calypso/lib/wp';
+
+const useUser = ( siteId, login, queryOptions = {} ) => {
+	return useQuery(
+		[ 'user', siteId, login ],
+		() => wpcom.undocumented().site( siteId ).getUser( login ),
+		queryOptions
+	);
+};
+
+export default useUser;

--- a/client/data/users/use-users.js
+++ b/client/data/users/use-users.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { useInfiniteQuery } from 'react-query';
+import { uniqueBy } from '@automattic/js-utils';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'calypso/lib/wp';
+
+export const DEFAULT_NUMBER = 100;
+export const defaults = {
+	number: DEFAULT_NUMBER,
+	offset: 0,
+};
+
+const extractPages = ( pages = [] ) => pages.flatMap( ( page ) => page.users );
+const compareUnique = ( a, b ) => a.ID === b.ID;
+
+const useUsers = ( fetchOptions = {}, queryOptions = {} ) => {
+	const { search, siteId } = fetchOptions;
+
+	return useInfiniteQuery(
+		[ 'users', siteId, search ],
+		async ( { pageParam = 0 } ) => {
+			const res = await wpcom
+				.site( siteId )
+				.usersList( { ...defaults, ...fetchOptions, offset: pageParam } );
+			return res;
+		},
+		{
+			getNextPageParam: ( lastPage, allPages ) => {
+				if ( lastPage.found <= allPages.length * DEFAULT_NUMBER ) {
+					return;
+				}
+				return allPages.length * DEFAULT_NUMBER;
+			},
+			select: ( data ) => {
+				return {
+					/* @TODO: `uniqueBy` is necessary, because the API can return duplicates */
+					users: uniqueBy( extractPages( data.pages ), compareUnique ),
+					total: data.pages[ 0 ].found,
+					...data,
+				};
+			},
+			...queryOptions,
+		}
+	);
+};
+
+export default useUsers;

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -6,7 +6,8 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { connect } from 'react-redux';
+import page from 'page';
+import { connect, useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -21,7 +22,6 @@ import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
 import User from 'calypso/components/user';
 import AuthorSelector from 'calypso/blocks/author-selector';
-import { deleteUser } from 'calypso/lib/users/actions';
 import accept from 'calypso/lib/accept';
 import Gravatar from 'calypso/components/gravatar';
 import { localize } from 'i18n-calypso';
@@ -32,6 +32,8 @@ import {
 	requestExternalContributorsRemoval,
 } from 'calypso/state/data-getters';
 import { httpData } from 'calypso/state/data-layer/http-data';
+import useDeleteUser from 'calypso/data/users/delete-user';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 /**
  * Style dependencies
@@ -168,7 +170,7 @@ class DeleteUser extends React.Component {
 							user.linked_user_ID ? user.linked_user_ID : user.ID
 						);
 					}
-					deleteUser( siteId, user.ID );
+					this.props.deleteUser( { userId: user.ID } );
 				} else {
 					this.props.recordGoogleEvent(
 						'People',
@@ -198,7 +200,7 @@ class DeleteUser extends React.Component {
 				user.linked_user_ID ? user.linked_user_ID : user.ID
 			);
 		}
-		deleteUser( siteId, user.ID, reassignUserId );
+		this.props.deleteUser( { userId: user.ID, reassignUserId } );
 
 		this.props.recordGoogleEvent( 'People', 'Clicked Remove User on Edit User Single Site' );
 	};
@@ -308,16 +310,87 @@ class DeleteUser extends React.Component {
 
 	render() {
 		// A user should not be able to remove themself.
-		if ( ! this.props.isJetpack && this.props.user.ID === this.props.currentUser.ID ) {
-			return null;
-		}
-		if ( this.props.isJetpack && this.props.user.linked_user_ID === this.props.currentUser.ID ) {
+		const { user, currentUser } = this.props;
+		const isCurrentUser = ( user.linked_user_ID ?? user.ID ) === currentUser.ID;
+
+		if ( isCurrentUser ) {
 			return null;
 		}
 
 		return this.props.isMultisite ? this.renderMultisite() : this.renderSingleSite();
 	}
 }
+
+const withDeleteUser = ( Component ) => {
+	return ( props ) => {
+		const { siteId, user, translate, isMultisite, siteSlug } = props;
+		const { deleteUser, isSuccess, isError, error } = useDeleteUser( siteId );
+		const dispatch = useDispatch();
+
+		React.useEffect( () => {
+			if ( isSuccess ) {
+				dispatch(
+					successNotice(
+						isMultisite
+							? translate( 'Successfully removed @%(user)s', {
+									args: { user: user?.login },
+									context: 'Success message after a user has been modified.',
+							  } )
+							: translate( 'Successfully deleted @%(user)s', {
+									args: { user: user?.login },
+									context: 'Success message after a user has been modified.',
+							  } ),
+						{ id: 'delete-user-notice', displayOnNextPage: true }
+					)
+				);
+				page.redirect( `/people/team${ siteSlug ? `/${ siteSlug }` : '' }` );
+			}
+		}, [ isSuccess, translate, dispatch, user, isMultisite, siteSlug ] );
+
+		React.useEffect( () => {
+			if ( isError ) {
+				if ( 'user_owns_domain_subscription' === error.error ) {
+					const numDomains = error.message.split( ',' ).length;
+					dispatch(
+						errorNotice(
+							translate(
+								'@%(user)s owns following domain used on this site: {{strong}}%(domains)s{{/strong}}. This domain will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
+								'@%(user)s owns following domains used on this site: {{strong}}%(domains)s{{/strong}}. These domains will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
+								{
+									count: numDomains,
+									args: {
+										domains: error.message,
+										user: user.login,
+									},
+									components: {
+										strong: <strong />,
+									},
+								}
+							),
+							{ id: 'delete-user-notice' }
+						)
+					);
+				}
+
+				dispatch(
+					errorNotice(
+						isMultisite
+							? translate( 'There was an error removing @%(user)s', {
+									args: { user: user.login },
+									context: 'Error message after A site has failed to perform actions on a user.',
+							  } )
+							: translate( 'There was an error deleting @%(user)s', {
+									args: { user: user.login },
+									context: 'Error message after A site has failed to perform actions on a user.',
+							  } )
+					)
+				);
+			}
+		}, [ isError, error, translate, dispatch, user, isMultisite ] );
+
+		return <Component { ...props } deleteUser={ deleteUser } />;
+	};
+};
 
 const getContributorType = ( externalContributors, userId ) => {
 	if ( externalContributors.data ) {
@@ -341,5 +414,5 @@ export default localize(
 			};
 		},
 		{ recordGoogleEvent }
-	)( DeleteUser )
+	)( withDeleteUser( DeleteUser ) )
 );

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -2,8 +2,7 @@
  * External dependencies
  */
 
-import React, { Component } from 'react';
-import { pick } from 'lodash';
+import React from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
 
@@ -14,169 +13,77 @@ import Main from 'calypso/components/main';
 import HeaderCake from 'calypso/components/header-cake';
 import { Card } from '@automattic/components';
 import PeopleProfile from 'calypso/my-sites/people/people-profile';
-import UsersStore from 'calypso/lib/users/store';
-import { fetchUser } from 'calypso/lib/users/actions';
 import { protectForm } from 'calypso/lib/protect-form';
 import DeleteUser from 'calypso/my-sites/people/delete-user';
-import PeopleNotices from 'calypso/my-sites/people/people-notices';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import PeopleLogStore from 'calypso/lib/people/log-store';
 import { isJetpackSiteMultiSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import EditUserForm from './edit-user-form';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { recordGoogleEvent as recordGoogleEventAction } from 'calypso/state/analytics/actions';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
+import useUser from 'calypso/data/users/use-user';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-export class EditTeamMemberForm extends Component {
-	constructor( props ) {
-		super( props );
-		this.state = {
-			user: UsersStore.getUserByLogin( props.siteId, props.userLogin ),
-			removingUser: false,
-		};
-	}
-
-	componentDidMount() {
-		UsersStore.on( 'change', this.refreshUser );
-		PeopleLogStore.on( 'change', this.checkRemoveUser );
-		PeopleLogStore.on( 'change', this.redirectIfError );
-		this.requestUser();
-	}
-
-	componentWillUnmount() {
-		UsersStore.removeListener( 'change', this.refreshUser );
-		PeopleLogStore.removeListener( 'change', this.checkRemoveUser );
-		PeopleLogStore.removeListener( 'change', this.redirectIfError );
-	}
-
-	componentDidUpdate( lastProps ) {
-		if ( lastProps.siteId !== this.props.siteId || lastProps.userLogin !== this.props.userLogin ) {
-			this.requestUser();
-		}
-	}
-
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.siteId !== this.props.siteId || nextProps.userLogin !== this.props.userLogin ) {
-			this.refreshUser( nextProps );
-		}
-	}
-
-	requestUser = () => {
-		if ( this.props.siteId ) {
-			fetchUser( { siteId: this.props.siteId }, this.props.userLogin );
-		}
-	};
-
-	refreshUser = ( props = this.props ) => {
-		const peopleUser = UsersStore.getUserByLogin( props.siteId, props.userLogin );
-
-		this.setState( {
-			user: peopleUser,
-		} );
-	};
-
-	redirectIfError = () => {
-		if ( this.props.siteId ) {
-			const fetchUserError = PeopleLogStore.getErrors(
-				( log ) =>
-					this.props.siteId === log.siteId &&
-					'RECEIVE_USER_FAILED' === log.action &&
-					this.props.userLogin === log.user
-			);
-			if ( fetchUserError.length ) {
-				page.redirect( `/people/team/${ this.props.siteSlug }` );
-			}
-		}
-	};
-
-	checkRemoveUser = () => {
-		if ( ! this.props.siteId ) {
+export const EditTeamMemberForm = ( {
+	siteId,
+	userLogin,
+	isJetpack,
+	isMultisite,
+	markChanged,
+	markSaved,
+	previousRoute,
+	siteSlug,
+	recordGoogleEvent,
+} ) => {
+	const goBack = () => {
+		recordGoogleEvent( 'People', 'Clicked Back Button on User Edit' );
+		if ( previousRoute ) {
+			page.back( previousRoute );
 			return;
 		}
-
-		const removeUserSuccessful = PeopleLogStore.getCompleted( ( log ) => {
-			return (
-				'RECEIVE_DELETE_SITE_USER_SUCCESS' === log.action &&
-				this.props.siteId === log.siteId &&
-				this.props.userLogin === log.user.login
-			);
-		} );
-
-		if ( removeUserSuccessful.length ) {
-			this.props.markSaved();
-			const redirect = this.props.siteSlug ? '/people/team/' + this.props.siteSlug : '/people/team';
-			page.redirect( redirect );
-		}
-
-		const removeUserInProgress = PeopleLogStore.getInProgress(
-			function ( log ) {
-				return (
-					'DELETE_SITE_USER' === log.action &&
-					this.props.siteId === log.siteId &&
-					this.props.userLogin === log.user.login
-				);
-			}.bind( this )
-		);
-
-		if ( !! removeUserInProgress.length !== this.state.removingUser ) {
-			this.setState( {
-				removingUser: ! this.state.removingUser,
-			} );
-		}
-	};
-
-	goBack = () => {
-		this.props.recordGoogleEvent( 'People', 'Clicked Back Button on User Edit' );
-		if ( this.props.previousRoute ) {
-			page.back( this.props.previousRoute );
-			return;
-		}
-		if ( this.props.siteSlug ) {
-			page( '/people/team/' + this.props.siteSlug );
+		if ( siteSlug ) {
+			page( '/people/team/' + siteSlug );
 			return;
 		}
 		page( '/people/team' );
 	};
+	const { data: user, error, isLoading } = useUser( siteId, userLogin, { retry: false } );
 
-	renderNotices() {
-		if ( ! this.state.user ) {
-			return;
-		}
-		return <PeopleNotices user={ this.state.user } />;
-	}
+	React.useEffect( () => {
+		! isLoading && error && page.redirect( `/people/team/${ siteSlug }` );
+	}, [ error, isLoading, siteSlug ] );
 
-	render() {
-		return (
-			<Main className="edit-team-member-form">
-				<PageViewTracker path="people/edit/:site/:user" title="People > View Team Member" />
-				<HeaderCake onClick={ this.goBack } isCompact />
-				{ this.renderNotices() }
-				<Card className="edit-team-member-form__user-profile">
-					<PeopleProfile siteId={ this.props.siteId } user={ this.state.user } />
-					<EditUserForm
-						{ ...this.state.user }
-						disabled={ this.state.removingUser }
-						siteId={ this.props.siteId }
-						isJetpack={ this.props.isJetpack }
-						markChanged={ this.props.markChanged }
-						markSaved={ this.props.markSaved }
-					/>
-				</Card>
-				{ this.state.user && (
-					<DeleteUser
-						{ ...pick( this.props, [ 'siteId', 'isJetpack', 'isMultisite' ] ) }
-						user={ this.state.user }
-					/>
-				) }
-			</Main>
-		);
-	}
-}
+	return (
+		<Main className="edit-team-member-form">
+			<PageViewTracker path="people/edit/:site/:user" title="People > View Team Member" />
+			<HeaderCake onClick={ goBack } isCompact />
+			<Card className="edit-team-member-form__user-profile">
+				<PeopleProfile siteId={ siteId } user={ user } />
+				<EditUserForm
+					user={ user }
+					disabled={ false } // @TODO added when added mutation to remove user
+					siteId={ siteId }
+					isJetpack={ isJetpack }
+					markChanged={ markChanged }
+					markSaved={ markSaved }
+				/>
+			</Card>
+			{ user && (
+				<DeleteUser
+					siteId={ siteId }
+					isJetpack={ isJetpack }
+					isMultisite={ isMultisite }
+					user={ user }
+					siteSlug={ siteSlug }
+				/>
+			) }
+		</Main>
+	);
+};
 
 export default connect(
 	( state ) => {
@@ -190,5 +97,5 @@ export default connect(
 			previousRoute: getPreviousRoute( state ),
 		};
 	},
-	{ recordGoogleEvent }
+	{ recordGoogleEvent: recordGoogleEventAction }
 )( protectForm( EditTeamMemberForm ) );

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -3,33 +3,66 @@
  */
 import { localize } from 'i18n-calypso';
 import React from 'react';
+import { useDispatch } from 'react-redux';
+import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 
 /**
  * Internal dependencies
  */
-import SiteUsersFetcher from 'calypso/components/site-users-fetcher';
 import Team from './team';
+import useUsers from 'calypso/data/users/use-users';
 
-class TeamList extends React.Component {
-	static displayName = 'TeamList';
+function TeamList( props ) {
+	const dispatch = useDispatch();
+	const { site, search, translate } = props;
+	const fetchOptions = {
+		siteId: site?.ID,
+		order: 'ASC',
+		order_by: 'display_name',
+	};
 
-	render() {
-		const fetchOptions = {
-			siteId: this.props.site && this.props.site.ID,
-			order: 'ASC',
-			order_by: 'display_name',
-			search: this.props.search ? '*' + this.props.search + '*' : null,
-			search_columns: [ 'display_name', 'user_login' ],
-		};
-
-		Object.freeze( fetchOptions );
-
-		return (
-			<SiteUsersFetcher fetchOptions={ fetchOptions }>
-				<Team { ...this.props } />
-			</SiteUsersFetcher>
-		);
+	if ( search ) {
+		fetchOptions.search = `*${ search }*`;
+		fetchOptions.search_columns = [ 'display_name', 'user_login' ];
 	}
+
+	const {
+		data,
+		isLoading,
+		isFetchingNextPage,
+		hasNextPage,
+		fetchNextPage,
+		error,
+		refetch,
+	} = useUsers( fetchOptions );
+
+	React.useEffect( () => {
+		error &&
+			dispatch(
+				errorNotice( translate( 'There was an error retrieving users' ), {
+					id: 'site-users-notice',
+					button: 'Try again.',
+					onClick: () => {
+						dispatch( removeNotice( 'site-users-notice' ) );
+						refetch();
+					},
+				} )
+			);
+	}, [ dispatch, translate, refetch, error ] );
+
+	return (
+		<Team
+			fetchingUsers={ isLoading }
+			fetchingNextPage={ isFetchingNextPage }
+			totalUsers={ data?.total }
+			users={ data?.users ?? [] }
+			excludedUsers={ [] }
+			fetchOptions={ fetchOptions }
+			fetchNextPage={ fetchNextPage }
+			hasNextPage={ hasNextPage }
+			{ ...props }
+		/>
+	);
 }
 
 export default localize( TeamList );


### PR DESCRIPTION
This PR is branched upon #50262 to make it easier to review. It should be rebased on `trunk` as #50262 gets in.

#### Changes proposed in this Pull Request

* People: migrate users to use `react-query` (also includes forms to update and delete users)

#### Testing instructions

1. Go to the people section of a site and choose _Team_
2. Make sure the list of users shows up
3. If you scroll down on a site with more than 100 users you should see a request for the next page
4. If you switch your active site, make sure you get a fresh list of users and fetching params are reset
5. Try to update and delete a user from the team (also test the error case for these)