### PR TITLE
Partner Portal: Fix mobile styles

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
@@ -6,20 +6,27 @@
 
 	&__list {
 		display: grid;
-		grid-template-columns: repeat( 2, 1fr );
-		grid-column-gap: 32px;
-		grid-row-gap: 32px;
+		grid-template-columns: 1fr;
+		grid-column-gap: 16px;
+		grid-row-gap: 16px;
 		padding: 0;
 		margin: 0;
 		list-style-type: none;
+
+		@include break-xlarge() {
+			grid-template-columns: repeat( 2, 1fr );
+			grid-column-gap: 32px;
+			grid-row-gap: 32px;
+		}
 	}
 
 	&__list-item {
 		font-size: 1rem;
 
 		&--wide {
-			grid-column-start: span 2;
-			white-space: nowrap;
+			@include break-xlarge() {
+				grid-column-start: span 2;
+			}
 		}
 	}
 
@@ -34,7 +41,7 @@
 		background: var( --studio-gray-0 );
 		color: var( --studio-gray-70 );
 		overflow: hidden;
-		text-overflow: ellipsis;
+		word-break: break-all;
 	}
 
 	&__clipboard-button {

--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
@@ -10,17 +10,17 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 
 .license-list-item {
 	display: grid;
-	grid-template-columns: repeat( 3, 1fr );
-	grid-column-gap: 14px;
-	grid-row-gap: 14px;
+	grid-template-columns: 1fr 36px;
 
 	> * {
+		display: none;
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}
 
 	> *:nth-child(#{$column-domain}) {
-		grid-column-end: span 3;
+		grid-column-end: auto;
+		display: block;
 	}
 
 	> *:nth-child(#{$column-actions}) {
@@ -28,7 +28,8 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 	}
 
 	> *:nth-child(#{$column-toggle}) {
-		grid-column-end: span 3;
+		grid-column-end: -1;
+		display: inherit;
 		text-align: center;
 	}
 
@@ -37,6 +38,10 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 		grid-column-gap: 0;
 		grid-row-gap: 0;
 		align-items: center;
+
+		> * {
+			display: block;
+		}
 
 		> * + * {
 			margin-left: 14px;
@@ -49,10 +54,6 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 
 		> *:nth-child(#{$column-domain}) {
 			grid-column-end: auto;
-		}
-
-		> *:nth-child(#{$column-actions}) {
-			display: block;
 		}
 
 		> *:nth-child(#{$column-toggle}) {

--- a/client/jetpack-cloud/sections/partner-portal/license-list/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/style.scss
@@ -1,8 +1,16 @@
+@import '~@wordpress/base-styles/_breakpoints.scss';
+@import '~@wordpress/base-styles/_mixins.scss';
+
 .license-list {
 	&__header {
 		&.card.is-compact {
-			padding-top: 0;
-			padding-bottom: 0;
+			display: none;
+
+			@include break-xlarge() {
+				display: block;
+				padding-top: 0;
+				padding-bottom: 0;
+			}
 		}
 	}
 

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -53,8 +53,7 @@
 		line-height: 1.75rem;
 		color: var( --studio-gray-100 );
 		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+		word-break: break-all;
 
 		span + span {
 			margin-left: 12px;


### PR DESCRIPTION
Context:
* Project thread: pbtFPC-Um-p2
* i4 designs: pbtFPC-103-p2
* Mobile designs: pbtFPC-103-p2#comment-2526

#### Changes proposed in this Pull Request

* It changes the style to cover mobile/smaller screen devices.

#### Testing instructions

* If you do not have a partner key with licenses, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key, if prompted.
* Change the browser to the mobile device view and look if the license list matches the mobile designs in pbtFPC-103-p2#comment-2526 

<img src="https://user-images.githubusercontent.com/5714212/108886574-e2ecd880-75e7-11eb-94bc-7e0d7b5953bb.png" width="400" />
