### PR TITLE
Billing: allow subscription management for disconnected Jetpack products and plans

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -353,9 +353,6 @@ class PurchaseItem extends Component {
 			isJetpack,
 		} = this.props;
 
-		let onClick;
-		let href;
-
 		const classes = classNames( 'purchase-item', {
 			'purchase-item--disconnected': isDisconnectedSite,
 		} );
@@ -370,6 +367,9 @@ class PurchaseItem extends Component {
 				</>
 			);
 		}
+
+		let onClick;
+		let href;
 
 		if ( ! isPlaceholder && getManagePurchaseUrlFor ) {
 			// A "disconnected" Jetpack site's purchases may be managed.

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -6,14 +6,13 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { some } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import AsyncLoad from 'calypso/components/async-load';
 import { getSite } from 'calypso/state/sites/selectors';
-import { isJetpackPlan } from 'calypso/lib/products-values';
+import { isJetpackPlan, isJetpackProduct } from 'calypso/lib/products-values';
 import { JETPACK_PLANS } from 'calypso/lib/plans/constants';
 import { JETPACK_PRODUCTS_LIST } from 'calypso/lib/products-values/constants';
 import QuerySites from 'calypso/components/data/query-sites';
@@ -35,8 +34,6 @@ const PurchasesSite = ( {
 	slug,
 	showSite = false,
 } ) => {
-	const isJetpack = ! isPlaceholder && some( purchases, ( purchase ) => isJetpackPlan( purchase ) );
-
 	if ( isPlaceholder ) {
 		return <PurchaseItem isPlaceholder />;
 	}
@@ -60,7 +57,7 @@ const PurchasesSite = ( {
 					slug={ slug }
 					isDisconnectedSite={ ! site }
 					purchase={ purchase }
-					isJetpack={ isJetpack }
+					isJetpack={ isJetpackPlan( purchase ) || isJetpackProduct( purchase ) }
 					site={ site }
 					showSite={ showSite }
 					name={ name }


### PR DESCRIPTION
The purchases list logic to determine if a purchase for a disconnected site was Jetpack was failing. This checks the purchase against both Jetpack plans and products.

Fixes: Automattic/payments-shilling#159

**Before:**
<img width="1073" alt="Screen Shot 2021-02-23 at 2 58 55 PM" src="https://user-images.githubusercontent.com/942359/108900500-ade08600-75e7-11eb-9d1d-ce9eb46c8a28.png">

**After:**
<img width="1063" alt="Screen Shot 2021-02-23 at 2 58 29 PM" src="https://user-images.githubusercontent.com/942359/108900527-b638c100-75e7-11eb-84bd-0665c42658cf.png">

**To test:**
- create a Jetpack site on jurassic.ninja
- connect an account and purchase a plan or product
- visit /me/purchases and make sure that the purchase shows up in your list of purchases
- deactivate jetpack from the plugins list
- visit /me/purchases and make sure that the purchase still shows up, with a disconnected notice, and that you're able to click the link to manage the purchase
