### PR TITLE
Partner Portal: Add a notice when clicking to copy a license

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -3,6 +3,7 @@
  */
 import React, { ReactElement } from 'react';
 import { useTranslate } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,6 +27,7 @@ interface Props {
 	issuedAt: string;
 	attachedAt: string | null;
 	revokedAt: string | null;
+	onCopyLicense?: () => void;
 }
 
 export default function LicenseDetails( {
@@ -35,6 +37,7 @@ export default function LicenseDetails( {
 	issuedAt,
 	attachedAt,
 	revokedAt,
+	onCopyLicense = noop,
 }: Props ): ReactElement {
 	const translate = useTranslate();
 	const licenseState = getLicenseState( attachedAt, revokedAt );
@@ -53,6 +56,7 @@ export default function LicenseDetails( {
 							className="license-details__clipboard-button"
 							borderless
 							compact
+							onCopy={ onCopyLicense }
 						>
 							<Gridicon icon="clipboard" />
 						</ClipboardButton>

--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
@@ -52,6 +52,10 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 			margin-left: 6px;
 		}
 
+		> *:nth-child(#{$column-actions}) {
+			display: block;
+		}
+
 		> *:nth-child(#{$column-domain}) {
 			grid-column-end: auto;
 		}

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { useState, useCallback, ReactElement } from 'react';
+import { useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import { getUrlParts } from 'calypso/lib/url';
 import classnames from 'classnames';
@@ -10,6 +11,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 
+import { infoNotice } from 'calypso/state/notices/actions';
 import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { LicenseState, LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { Button } from '@automattic/components';
@@ -48,6 +50,7 @@ export default function LicensePreview( {
 	filter,
 }: Props ): ReactElement {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const [ isOpen, setOpen ] = useState( false );
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const domain = siteUrl ? getUrlParts( siteUrl ).hostname : '';
@@ -57,6 +60,10 @@ export default function LicensePreview( {
 	const open = useCallback( () => {
 		setOpen( ! isOpen );
 	}, [ isOpen ] );
+
+	const onCopyLicense = () => {
+		dispatch( infoNotice( translate( 'License copied!' ), { duration: 2000 } ) );
+	};
 
 	return (
 		<div
@@ -135,6 +142,7 @@ export default function LicensePreview( {
 							text={ licenseKey }
 							className="license-preview__copy-license-key"
 							compact
+							onCopy={ onCopyLicense }
 						>
 							{ translate( 'Copy License' ) }
 						</ClipboardButton>
@@ -156,6 +164,7 @@ export default function LicensePreview( {
 					issuedAt={ issuedAt }
 					attachedAt={ attachedAt }
 					revokedAt={ revokedAt }
+					onCopyLicense={ onCopyLicense }
 				/>
 			) }
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -61,9 +61,9 @@ export default function LicensePreview( {
 		setOpen( ! isOpen );
 	}, [ isOpen ] );
 
-	const onCopyLicense = () => {
+	const onCopyLicense = useCallback( () => {
 		dispatch( infoNotice( translate( 'License copied!' ), { duration: 2000 } ) );
-	};
+	}, [ dispatch, translate ] );
 
 	return (
 		<div


### PR DESCRIPTION
Context:
* Project thread: pbtFPC-Um-p2
* i4 designs: pbtFPC-103-p2

#### Changes proposed in this Pull Request

* Adds a notice when clicking to copy a license
* Fix the CSS for the copy button (before, it was hidden even on larger screens)

#### Testing instructions

* If you do not have a partner key with a license, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key, if prompted.
* Click to copy a license, a notice will pop up
* Make sure you can see the "Copy license" button

![image](https://user-images.githubusercontent.com/5714212/108906837-1b001580-7600-11eb-9348-8c935c146b96.png)

