### PR TITLE
Anchor Gutenboarding: Style-preview step now sends anchor_podcast param to backend

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -13,6 +13,7 @@ import { STORE_KEY } from '../../stores/onboard';
 import type { Viewport } from './types';
 import { useFontPairings } from '../../fonts';
 import type { FontPair } from '../../constants';
+import { useAnchorFmParams } from '../../../gutenboarding/path';
 
 function getFontsLoadingHTML( effectiveFontPairings: readonly FontPair[] ) {
 	const baseURL = 'https://fonts.googleapis.com/css2';
@@ -61,6 +62,7 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 	const { selectedDesign, selectedFonts, siteTitle } = useSelect( ( select ) =>
 		select( STORE_KEY ).getState()
 	);
+	const { anchorFmPodcastId } = useAnchorFmParams();
 
 	const iframe = React.useRef< HTMLIFrameElement >( null );
 	const effectiveFontPairings = useFontPairings();
@@ -80,6 +82,9 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 					...( selectedFonts && {
 						font_headings: selectedFonts.headings,
 						font_base: selectedFonts.base,
+					} ),
+					...( anchorFmPodcastId && {
+						anchor_podcast: anchorFmPodcastId,
 					} ),
 				} );
 


### PR DESCRIPTION
* **See 496-gh-Automattic/dotcom-manage for an overview of all parts of this changeset**

#### Changes proposed in this Pull Request

* (Current behavior) In gutenboarding, the style-preview step sends XHR requests to the backend with URLs like: https://public-api.wordpress.com/rest/v1/template/demo/spearhead/riley/?language=en&site_title=Helpdesk%20Miles%20the%20Podcast&font_headings=Raleway&font_base=Cabin to generate HTML previews
* (New behavior) If using anchor flavored gutenboarding, also include an `anchor_podcast` parameter of the podcast ID, so the HTML preview can be customized for the podcast.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D57540-code
* Visit http://calypso.localhost:3000/new?anchor_podcast=85988fc
* Go through the setup steps, but don't make a new site
* On the font pairing step, the logo of this podcast should now appear on both the Gilbert and Riley themes, instead of the "On the Fork" logo
![2021-02-23_15-06](https://user-images.githubusercontent.com/937354/108909258-f305b780-75e9-11eb-89c3-c81c4e3e6500.png)

#### Note

* Ideally we replace both the logo and the "Feeling Lost?" title for Gilbert and Riley as well as all future podcast starter themes.  This might require coordinated changes between Calypso, WPCOM and the starter sites themselves.

Related to 496-gh-Automattic/dotcom-manage