### PR TITLE
Partner Portal: Add license list pagination data layer

### DIFF
--- a/client/components/data/query-jetpack-partner-portal-licenses/index.ts
+++ b/client/components/data/query-jetpack-partner-portal-licenses/index.ts
@@ -19,6 +19,7 @@ interface Props {
 	search: string;
 	sortField: LicenseSortField;
 	sortDirection: LicenseSortDirection;
+	page: number;
 }
 
 export default function QueryJetpackPartnerPortalLicenses( {
@@ -26,12 +27,13 @@ export default function QueryJetpackPartnerPortalLicenses( {
 	search,
 	sortField,
 	sortDirection,
+	page,
 }: Props ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		dispatch( fetchLicenses( filter, search, sortField, sortDirection ) );
-	}, [ dispatch, filter, search, sortField, sortDirection ] );
+		dispatch( fetchLicenses( filter, search, sortField, sortDirection, page ) );
+	}, [ dispatch, filter, search, sortField, sortDirection, page ] );
 
 	return null;
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -57,7 +57,7 @@ function setSortingConfig(
 		direction = LicenseSortDirection.Ascending;
 	}
 
-	const queryParams = { sort_field: newSortField, sort_direction: direction };
+	const queryParams = { sort_field: newSortField, sort_direction: direction, page: 1 };
 	const currentPath = window.location.pathname + window.location.search;
 
 	page( addQueryArgs( queryParams, currentPath ) );

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -29,6 +29,7 @@ import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/licen
 import LicensePreview, {
 	LicensePreviewPlaceholder,
 } from 'calypso/jetpack-cloud/sections/partner-portal/license-preview';
+import { LICENSES_PER_PAGE } from 'calypso/state/partner-portal/licenses/constants';
 import Gridicon from 'calypso/components/gridicon';
 import Pagination from 'calypso/components/pagination';
 import { addQueryArgs } from 'calypso/lib/route';
@@ -121,6 +122,7 @@ export default function LicenseList( {
 	const isFetching = useSelector( isFetchingLicenses );
 	const licenses = useSelector( getPaginatedLicenses ) as PaginatedItems< License >;
 	const showLicenses = hasFetched && ! isFetching && !! licenses;
+	const showPagination = showLicenses && licenses.totalPages > 1;
 	const showNoResults = hasFetched && ! isFetching && licenses && licenses.items.length === 0;
 
 	return (
@@ -130,6 +132,7 @@ export default function LicenseList( {
 				search={ search }
 				sortField={ sortField }
 				sortDirection={ sortDirection }
+				page={ currentPage }
 			/>
 
 			<LicenseListItem header className="license-list__header">
@@ -186,18 +189,6 @@ export default function LicenseList( {
 						</LicenseTransition>
 					) ) }
 
-				{ showLicenses && (
-					<LicenseTransition>
-						<Pagination
-							className="license-list__pagination"
-							page={ currentPage }
-							perPage={ 10 }
-							total={ 50 }
-							pageClick={ setPage }
-						/>
-					</LicenseTransition>
-				) }
-
 				{ isFetching && (
 					<LicenseTransition>
 						<LicensePreviewPlaceholder />
@@ -209,6 +200,17 @@ export default function LicenseList( {
 						<Card className="license-list__message" compact>
 							<p>{ translate( 'No licenses found.' ) }</p>
 						</Card>
+					</LicenseTransition>
+				) }
+				{ showPagination && (
+					<LicenseTransition>
+						<Pagination
+							className="license-list__pagination"
+							page={ currentPage }
+							perPage={ LICENSES_PER_PAGE }
+							total={ licenses.totalItems }
+							pageClick={ setPage }
+						/>
 					</LicenseTransition>
 				) }
 			</TransitionGroup>

--- a/client/state/partner-portal/licenses/actions.ts
+++ b/client/state/partner-portal/licenses/actions.ts
@@ -18,6 +18,7 @@ import {
 	LicenseCounts,
 	PaginatedItems,
 } from 'calypso/state/partner-portal/types';
+import { LICENSES_PER_PAGE } from 'calypso/state/partner-portal/licenses/constants';
 import {
 	LicenseFilter,
 	LicenseSortDirection,
@@ -38,7 +39,8 @@ export function fetchLicenses(
 	filter: LicenseFilter,
 	search: string,
 	sortField: LicenseSortField,
-	sortDirection: LicenseSortDirection
+	sortDirection: LicenseSortDirection,
+	page: number
 ): HttpAction {
 	return createHttpAction( {
 		type: JETPACK_PARTNER_PORTAL_LICENSES_REQUEST,
@@ -46,6 +48,8 @@ export function fetchLicenses(
 		search,
 		sortField,
 		sortDirection,
+		page: page,
+		perPage: LICENSES_PER_PAGE,
 	} );
 }
 

--- a/client/state/partner-portal/licenses/constants.ts
+++ b/client/state/partner-portal/licenses/constants.ts
@@ -1,1 +1,1 @@
-export const LICENSES_PER_PAGE = 1;
+export const LICENSES_PER_PAGE = 50;

--- a/client/state/partner-portal/licenses/constants.ts
+++ b/client/state/partner-portal/licenses/constants.ts
@@ -1,0 +1,1 @@
+export const LICENSES_PER_PAGE = 1;

--- a/client/state/partner-portal/licenses/handlers.ts
+++ b/client/state/partner-portal/licenses/handlers.ts
@@ -80,10 +80,11 @@ export function fetchLicensesHandler( action: HttpAction ): AnyAction {
 			path: '/jetpack-licensing/licenses',
 			query: {
 				// Do not apply filters during search as search takes over (matches Calypso Blue Post search behavior).
-				...( action.search ? { search: action.search } : { filter: action.filter } ),
+				...( action.search
+					? { search: action.search }
+					: { filter: action.filter, page: action.page } ),
 				sort_field: action.sortField,
 				sort_direction: action.sortDirection,
-				page: action.page,
 				per_page: action.perPage,
 			},
 		},

--- a/client/state/partner-portal/licenses/handlers.ts
+++ b/client/state/partner-portal/licenses/handlers.ts
@@ -83,6 +83,8 @@ export function fetchLicensesHandler( action: HttpAction ): AnyAction {
 				...( action.search ? { search: action.search } : { filter: action.filter } ),
 				sort_field: action.sortField,
 				sort_direction: action.sortDirection,
+				page: action.page,
+				per_page: action.perPage,
 			},
 		},
 		action

--- a/client/state/partner-portal/licenses/test/actions.js
+++ b/client/state/partner-portal/licenses/test/actions.js
@@ -16,6 +16,7 @@ import {
 	LicenseSortDirection,
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { LICENSES_PER_PAGE } from 'calypso/state/partner-portal/licenses/constants';
 
 jest.mock( 'calypso/state/partner-portal/partner/selectors', () => ( {
 	getActivePartnerKey: () => ( { oauth2_token: 'fake_oauth2_token' } ),
@@ -31,7 +32,8 @@ describe( 'actions', () => {
 					LicenseState.Detached,
 					'bar',
 					LicenseSortField.IssuedAt,
-					LicenseSortDirection.Descending
+					LicenseSortDirection.Descending,
+					2
 				)
 			).toEqual( {
 				type: JETPACK_PARTNER_PORTAL_LICENSES_REQUEST,
@@ -40,6 +42,8 @@ describe( 'actions', () => {
 				fetcher: 'wpcomJetpackLicensing',
 				sortField: LicenseSortField.IssuedAt,
 				sortDirection: LicenseSortDirection.Descending,
+				page: 2,
+				perPage: LICENSES_PER_PAGE,
 			} );
 		} );
 	} );

--- a/client/state/partner-portal/licenses/test/handlers.js
+++ b/client/state/partner-portal/licenses/test/handlers.js
@@ -99,6 +99,8 @@ describe( 'handlers', () => {
 				search: 'foo',
 				sortField: LicenseSortField.IssuedAt,
 				sortDirection: LicenseSortDirection.Descending,
+				page: 2,
+				perPage: 3,
 				fetcher: 'wpcomJetpackLicensing',
 			};
 			const expected = {
@@ -112,6 +114,7 @@ describe( 'handlers', () => {
 					search: action.search,
 					sort_field: 'issued_at',
 					sort_direction: 'desc',
+					per_page: 3,
 				},
 				formData: undefined,
 				onSuccess: action,

--- a/client/state/partner-portal/licenses/test/handlers.js
+++ b/client/state/partner-portal/licenses/test/handlers.js
@@ -31,6 +31,8 @@ describe( 'handlers', () => {
 				search: '',
 				sortField: LicenseSortField.IssuedAt,
 				sortDirection: LicenseSortDirection.Descending,
+				page: 2,
+				perPage: 3,
 				fetcher: 'wpcomJetpackLicensing',
 			};
 			const expected = {
@@ -43,6 +45,8 @@ describe( 'handlers', () => {
 					filter: 'not_revoked',
 					sort_field: 'issued_at',
 					sort_direction: 'desc',
+					page: 2,
+					per_page: 3,
 				},
 				formData: undefined,
 				onSuccess: action,
@@ -139,6 +143,41 @@ describe( 'handlers', () => {
 					filter: 'revoked',
 					sort_field: 'revoked_at',
 					sort_direction: 'asc',
+				},
+				formData: undefined,
+				onSuccess: action,
+				onFailure: action,
+				onProgress: action,
+				onStreamRecord: action,
+				options: { options: { fetcher: action.fetcher } },
+			};
+
+			expect( fetchLicensesHandler( action ) ).toEqual( expected );
+		} );
+
+		test( 'should return an http request action with pagination params', () => {
+			const { fetchLicensesHandler } = handlers;
+			const action = {
+				type: 'TEST_ACTION',
+				filter: LicenseFilter.Revoked,
+				search: '',
+				sortField: LicenseSortField.RevokedAt,
+				sortDirection: LicenseSortDirection.Ascending,
+				page: 2,
+				perPage: 3,
+			};
+			const expected = {
+				type: WPCOM_HTTP_REQUEST,
+				body: undefined,
+				method: 'GET',
+				path: '/jetpack-licensing/licenses',
+				query: {
+					apiNamespace: 'wpcom/v2',
+					filter: 'revoked',
+					sort_field: 'revoked_at',
+					sort_direction: 'asc',
+					page: 2,
+					per_page: 3,
 				},
 				formData: undefined,
 				onSuccess: action,


### PR DESCRIPTION
Context:
* Project thread: pbtFPC-Um-p2
* i4 designs: pbtFPC-103-p2

#### Changes proposed in this Pull Request

* Add functional license list pagination to the Partner Portal

#### Testing instructions

* If you do not have a partner key with licenses, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key, if prompted.
* You will see a list of your licenses
* If you have at least 2 licenses, change the value of `LICENSES_PER_PAGE` to a number that will make the pagination have more than one page.
* If the number of licenses you have is less than `LICENSES_PER_PAGE`, it should not show the pagination
* Check the functionality works by clicking on the pagination buttons

![image](https://user-images.githubusercontent.com/5714212/108915537-c793c480-760b-11eb-9e20-f53caafb8fcc.png)

