### PR TITLE
WordAds: Fix WordAds approved Jetpack sites not always able to access Tools > Marketing > Ads

### DIFF
--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -11,7 +11,7 @@ import {
 	isComplete,
 } from 'calypso/lib/products-values';
 
-export function hasWordadsPlan( site ) {
+export function hasWordAdsPlan( site ) {
 	return (
 		isPremium( site.plan ) ||
 		isBusiness( site.plan ) ||
@@ -20,6 +20,16 @@ export function hasWordadsPlan( site ) {
 		isSecurityRealTime( site.plan ) ||
 		isComplete( site.plan )
 	);
+}
+
+/**
+ * Returns true if the site is approved for WordAds.
+ *
+ * @param site Site object
+ * @returns {boolean} true if site is approved for WordAds.
+ */
+export function isWordAdsApproved( site ) {
+	return !! site.options.wordads;
 }
 
 /**
@@ -34,7 +44,7 @@ export function canAccessWordads( site ) {
 			return true;
 		}
 
-		const jetpackPremium = site.jetpack && hasWordadsPlan( site );
+		const jetpackPremium = site.jetpack && hasWordAdsPlan( site );
 		return (
 			site.options &&
 			( site.options.wordads || jetpackPremium ) &&
@@ -53,15 +63,15 @@ export function canAccessAds( site ) {
 }
 
 export function isWordadsInstantActivationEligible( site ) {
-	return hasWordadsPlan( site ) && userCan( 'activate_wordads', site );
+	return hasWordAdsPlan( site ) && userCan( 'activate_wordads', site );
 }
 
 export function isWordadsInstantActivationEligibleButNotOwner( site ) {
-	return hasWordadsPlan( site ) && ! userCan( 'activate_wordads', site );
+	return hasWordAdsPlan( site ) && ! userCan( 'activate_wordads', site );
 }
 
 export function canUpgradeToUseWordAds( site ) {
-	if ( site && ! site.options.wordads && ! hasWordadsPlan( site ) ) {
+	if ( site && ! site.options.wordads && ! hasWordAdsPlan( site ) ) {
 		return true;
 	}
 

--- a/client/my-sites/site-settings/jetpack-ads.jsx
+++ b/client/my-sites/site-settings/jetpack-ads.jsx
@@ -22,12 +22,17 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+	getSelectedSiteSlug,
+} from 'calypso/state/ui/selectors';
 import { hasFeature } from 'calypso/state/sites/plans/selectors';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import { FEATURE_WORDADS_INSTANT, PLAN_JETPACK_SECURITY_DAILY } from 'calypso/lib/plans/constants';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getCustomizerUrl } from 'calypso/state/sites/selectors';
+import { isWordAdsApproved } from 'calypso/lib/ads/utils';
 
 class JetpackAds extends Component {
 	static defaultProps = {
@@ -249,7 +254,13 @@ class JetpackAds extends Component {
 	}
 
 	render() {
-		const { hasWordadsFeature, isSavingSettings, onSubmitForm, translate } = this.props;
+		const {
+			hasWordadsFeature,
+			wordAdsApproved,
+			isSavingSettings,
+			onSubmitForm,
+			translate,
+		} = this.props;
 
 		return (
 			<div>
@@ -261,19 +272,24 @@ class JetpackAds extends Component {
 					title={ translate( 'Ads' ) }
 				/>
 
-				{ hasWordadsFeature ? this.renderSettings() : this.renderUpgradeBanner() }
+				{ hasWordadsFeature || wordAdsApproved
+					? this.renderSettings()
+					: this.renderUpgradeBanner() }
 			</div>
 		);
 	}
 }
 
 export default connect( ( state ) => {
+	const site = getSelectedSite( state );
 	const selectedSiteId = getSelectedSiteId( state );
 	const selectedSiteSlug = getSelectedSiteSlug( state );
 	const hasWordadsFeature = hasFeature( state, selectedSiteId, FEATURE_WORDADS_INSTANT );
+	const wordAdsApproved = isWordAdsApproved( site );
 
 	return {
 		hasWordadsFeature,
+		wordAdsApproved,
 		selectedSiteId,
 		selectedSiteSlug,
 		wordadsModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'wordads' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes Jetpack sites approved for WordAds not always able to access Ads settings at Tools > Marketing > Ads

#### Testing instructions

* Create test Jetpack site and enroll in WordAds
* Remove Jetpack subscription from the site
* Verify that site can still access Tools > Marketing > Ads
