### PR TITLE
Update wording on auto-renew disable confirmation buttons

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -107,7 +107,7 @@ class AutoRenewDisablingDialog extends Component {
 			case 'atomic':
 				return translate(
 					'By canceling auto-renewal, your %(planName)s plan for %(siteDomain)s will expire on %(expiryDate)s. ' +
-						'When it does, you will lose plugins, themes, design customizations, and possibly some content. ' +
+						'When it expires, plugins, themes and design customizations will be deactivated. ' +
 						'To avoid that, turn auto-renewal back on or manually renew your plan before the expiration date.',
 					{
 						args: {
@@ -239,12 +239,12 @@ class AutoRenewDisablingDialog extends Component {
 		const buttons = [
 			{
 				action: 'close',
-				label: translate( "I'll keep it" ),
+				label: translate( 'Keep auto-renew on' ),
 				onClick: this.closeAndCleanup,
 			},
 			{
 				action: 'confirm',
-				label: translate( 'Confirm cancellation' ),
+				label: translate( 'Turn off auto-renew' ),
 				onClick: this.onClickGeneralConfirm,
 				isPrimary: true,
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* A draft for updating the wording on buttons when confirming the cancelation of auto-renew

#### Testing instructions

* Manage the current plan for a site and toggle 'Auto-renew' to off
* Review the labels on the buttons


Related to #48839 

---

<img width="437" alt="Screen Shot 2021-06-03 at 9 18 28 am" src="https://user-images.githubusercontent.com/1842363/120564024-54d98700-c44d-11eb-8ea7-b52668a6b85e.png">

