### PR TITLE
Ignores the protocol while sanitizing external urls in sidebar.

### DIFF
--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -21,8 +21,8 @@ export const requestFetchAdminMenu = ( action ) =>
 const sanitizeUrl = ( url, wpAdminUrl ) => {
 	const isSafeInternalUrl = new RegExp( '^/' ).test( url );
 	// The replace function removes the protocol.
-	const isSafeWpAdminUrl = new RegExp( `^${ wpAdminUrl?.replace( /(^\w+:|^)\/\//, '' ) }` ).test(
-		url?.replace( /(^\w+:|^)\/\//, '' )
+	const isSafeWpAdminUrl = new RegExp( `^${ wpAdminUrl?.replace( /^https?:\/\//, '' ) }` ).test(
+		url?.replace( /^https?:\/\//, '' )
 	);
 
 	if ( isSafeInternalUrl || isSafeWpAdminUrl ) {

--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -20,7 +20,11 @@ export const requestFetchAdminMenu = ( action ) =>
 
 const sanitizeUrl = ( url, wpAdminUrl ) => {
 	const isSafeInternalUrl = new RegExp( '^/' ).test( url );
-	const isSafeWpAdminUrl = new RegExp( `^${ wpAdminUrl }` ).test( url );
+	// The replace function removes the protocol.
+	const isSafeWpAdminUrl = new RegExp( `^${ wpAdminUrl?.replace( /(^\w+:|^)\/\//, '' ) }` ).test(
+		url?.replace( /(^\w+:|^)\/\//, '' )
+	);
+
 	if ( isSafeInternalUrl || isSafeWpAdminUrl ) {
 		return url;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ignore the protocol while sanitizing external urls to be used in the sidebar navigation.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* On trunk Go to https://github.com/Automattic/wp-calypso/blob/dcabd91c78a8f8096aa8b3e18a1235bab7a2c055/client/state/data-layer/wpcom/sites/admin-menu/index.js#L60 and replace it with `const wpAdminUrl = "http://[DOMAIN]/wp-admin"`
* Inspect that external links are all empty (they link to home)
* On this branch, external links should appear as expected

Before | After
-------|------
![](https://cln.sh/zQXmVX+) | ![](https://cln.sh/k2ennU+)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #50371
