### PR TITLE
Framework: Refactor away from lodash isNil

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -396,6 +396,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/ends-with': 'error',
 		'you-dont-need-lodash-underscore/entries': 'error',
 		'you-dont-need-lodash-underscore/is-finite': 'error',
+		'you-dont-need-lodash-underscore/is-nil': 'error',
 		'you-dont-need-lodash-underscore/is-null': 'error',
 		'you-dont-need-lodash-underscore/reduce-right': 'error',
 		'you-dont-need-lodash-underscore/reverse': 'error',

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { noop, isNil, has } from 'lodash';
+import { noop, has } from 'lodash';
 import { DateUtils } from 'react-day-picker';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -10,6 +10,7 @@ import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import moment from 'moment';
+import { isNullish } from '@automattic/js-utils';
 
 /**
  * Internal dependencies
@@ -81,14 +82,14 @@ export class DateRange extends Component {
 			has( this.props, 'lastSelectableDate' ) && this.props.moment( this.props.lastSelectableDate );
 
 		// Clamp start/end dates to ranges (if specified)
-		let startDate = isNil( this.props.selectedStartDate )
+		let startDate = isNullish( this.props.selectedStartDate )
 			? NO_DATE_SELECTED_VALUE
 			: this.clampDateToRange( this.props.moment( this.props.selectedStartDate ), {
 					dateFrom: firstSelectableDate,
 					dateTo: lastSelectableDate,
 			  } );
 
-		let endDate = isNil( this.props.selectedEndDate )
+		let endDate = isNullish( this.props.selectedEndDate )
 			? NO_DATE_SELECTED_VALUE
 			: this.clampDateToRange( this.props.moment( this.props.selectedEndDate ), {
 					dateFrom: firstSelectableDate,

--- a/client/components/forms/form-radio/index.jsx
+++ b/client/components/forms/form-radio/index.jsx
@@ -4,14 +4,14 @@
 
 import React from 'react';
 import classnames from 'classnames';
-import { isNil } from 'lodash';
+import { isNullish } from '@automattic/js-utils';
 
 import './style.scss';
 
 const FormRadio = ( { className, label, ...otherProps } ) => (
 	<>
 		<input { ...otherProps } type="radio" className={ classnames( className, 'form-radio' ) } />
-		{ ! isNil( label ) && <span className="form-radio__label">{ label }</span> }
+		{ ! isNullish( label ) && <span className="form-radio__label">{ label }</span> }
 	</>
 );
 

--- a/client/extensions/woocommerce/state/data-layer/ui/shipping-zones/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/shipping-zones/index.js
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-
 import { translate } from 'i18n-calypso';
-import { find, flatten, isEmpty, isNil, map, omit, some, startsWith, xor } from 'lodash';
+import { find, flatten, isEmpty, map, omit, some, startsWith, xor } from 'lodash';
+import { isNullish } from '@automattic/js-utils';
 
 /**
  * Internal dependencies
@@ -221,7 +221,7 @@ const getZoneMethodUpdateSteps = ( siteId, zoneId, method, state ) => {
 
 	const isNew = 'number' !== typeof id;
 	const wasEnabled = ! isNew && getShippingZoneMethod( state, id, siteId ).enabled;
-	const enabledChanged = ! isNil( enabled ) && wasEnabled !== enabled;
+	const enabledChanged = ! isNullish( enabled ) && wasEnabled !== enabled;
 	const isWcsMethod = startsWith( realMethodType, 'wc_services' );
 	// The WCS method needs to be updated in 2 steps: "enable/disable" toggle uses the normal endpoint, rest of the props use a custom one
 	const methodPropsToUpdate = isWcsMethod ? {} : { ...extraMethodProps };
@@ -284,7 +284,7 @@ const getZoneMethodCreateSteps = ( siteId, zoneId, method, defaultOrder, state )
 			...omit( method, '_originalId' ),
 			order: originalMethod.order,
 		};
-		if ( isNil( method.enabled ) ) {
+		if ( isNullish( method.enabled ) ) {
 			// If the user didn't change the "Enabled" toggle, use the value from the original method
 			method.enabled = originalMethod.enabled;
 		}

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/reducer.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/reducer.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { find, findIndex, isEmpty, isEqual, isNil, omit, reject } from 'lodash';
+import { find, findIndex, isEmpty, isEqual, omit, reject } from 'lodash';
+import { isNullish } from '@automattic/js-utils';
 
 /**
  * Internal dependencies
@@ -133,7 +134,7 @@ function handleZoneMethodClose( state ) {
 	if ( currentlyEditingChangedType ) {
 		const method = find( state[ bucket ], { id: currentlyEditingId } );
 		let originalId = currentlyEditingId;
-		if ( method && ! isNil( method._originalId ) ) {
+		if ( method && ! isNullish( method._originalId ) ) {
 			originalId = method._originalId;
 		}
 
@@ -148,7 +149,7 @@ function handleZoneMethodClose( state ) {
 				{
 					...currentlyEditingChanges,
 					// If the "Enabled" toggle hasn't been modified in the current changes, use the value from the old method
-					enabled: isNil( currentlyEditingChanges.enabled )
+					enabled: isNullish( currentlyEditingChanges.enabled )
 						? method && method.enabled
 						: currentlyEditingChanges.enabled,
 					id: nextCreateId( state ),

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/selectors.js
@@ -7,7 +7,6 @@ import {
 	intersection,
 	isEmpty,
 	isNumber,
-	isNil,
 	map,
 	merge,
 	mergeWith,
@@ -15,6 +14,7 @@ import {
 	startsWith,
 	isArray,
 } from 'lodash';
+import { isNullish } from '@automattic/js-utils';
 
 /**
  * Internal dependencies
@@ -79,8 +79,8 @@ const getShippingZoneMethodsEdits = ( state, zoneId, siteId ) => {
 
 const sortShippingZoneMethods = ( state, siteId, methods ) => {
 	return methods.sort( ( a, b ) => {
-		const aId = isNil( a._originalId ) ? a.id : a._originalId;
-		const bId = isNil( b._originalId ) ? b.id : b._originalId;
+		const aId = isNullish( a._originalId ) ? a.id : a._originalId;
+		const bId = isNullish( b._originalId ) ? b.id : b._originalId;
 
 		if ( isNumber( aId ) ) {
 			// Both IDs are numbers (come from the server), so compare their "order" property
@@ -122,7 +122,7 @@ const overlayShippingZoneMethods = ( state, zone, siteId, extraEdits ) => {
 	// Compute the "enabled" prop for all the methods. If a method hasn't been explicitly disabled (enabled===false), then it's enabled
 	const allMethods = [ ...methods, ...creates ].map( ( method ) => {
 		let enabled = method.enabled;
-		if ( isNil( enabled ) && 'number' === typeof method._originalId ) {
+		if ( isNullish( enabled ) && 'number' === typeof method._originalId ) {
 			// If the "enabled" prop hasn't been modified, use the value from the original method
 			enabled = getShippingZoneMethod( state, method._originalId, siteId ).enabled;
 		}
@@ -233,7 +233,7 @@ export const getCurrentlyOpenShippingZoneMethod = (
 		return null;
 	}
 
-	const enabled = isNil( zone.methods.currentlyEditingChanges.enabled )
+	const enabled = isNullish( zone.methods.currentlyEditingChanges.enabled )
 		? false !== openMethod.enabled
 		: false !== zone.methods.currentlyEditingChanges.enabled;
 

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -10,7 +10,6 @@ import {
 	includes,
 	isEmpty,
 	isEqual,
-	isNil,
 	map,
 	mapValues,
 	omit,
@@ -20,6 +19,7 @@ import {
 	uniq,
 	zipObject,
 } from 'lodash';
+import { isNullish } from '@automattic/js-utils';
 import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
@@ -373,14 +373,14 @@ export const getCustomsErrors = (
 				itemErrors.description = translate( 'This field is required' );
 			}
 			if ( ! customs.ignoreWeightValidation[ productId ] ) {
-				if ( isNil( itemData.weight ) || '' === itemData.weight ) {
+				if ( isNullish( itemData.weight ) || '' === itemData.weight ) {
 					itemErrors.weight = translate( 'This field is required' );
 				} else if ( ! ( parseFloat( itemData.weight ) > 0 ) ) {
 					itemErrors.weight = translate( 'Weight must be greater than zero' );
 				}
 			}
 			if ( ! customs.ignoreValueValidation[ productId ] ) {
-				if ( isNil( itemData.value ) || '' === itemData.value ) {
+				if ( isNullish( itemData.value ) || '' === itemData.value ) {
 					itemErrors.value = translate( 'This field is required' );
 				} else if ( ! ( parseFloat( itemData.value ) > 0 ) ) {
 					itemErrors.value = translate( 'Declared value must be greater than zero' );
@@ -497,7 +497,7 @@ export const isCustomsFormStepSubmitted = (
 	return ! some(
 		usedProductIds.map(
 			( productId ) =>
-				isNil( form.customs.items[ productId ].tariffNumber ) ||
+				isNullish( form.customs.items[ productId ].tariffNumber ) ||
 				form.customs.ignoreWeightValidation[ productId ] ||
 				form.customs.ignoreValueValidation[ productId ]
 		)

--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
 		"@automattic/domain-picker": "^1.0.0-alpha.0",
 		"@automattic/format-currency": "^1.0.0-alpha.0",
 		"@automattic/i18n-utils": "^1.0.0",
+		"@automattic/js-utils": "^1.0.0",
 		"@automattic/language-picker": "^1.0.0",
 		"@automattic/languages": "^1.0.0",
 		"@automattic/lasagna": "^0.6.1",

--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { isEmpty, mapValues, omit, pickBy, without, isNil, merge, isEqual } from 'lodash';
+import { isEmpty, mapValues, omit, pickBy, without, merge, isEqual } from 'lodash';
+import { isNullish } from '@automattic/js-utils';
 
 /**
  * Internal dependencies
@@ -355,7 +356,9 @@ export const transientItems = ( state = {}, action ) => {
 			 * in this reducer, if none of the received media were previously
 			 * transient, we can skip this work.
 			 */
-			const justSavedMedia = savedMedia.filter( ( mediaItem ) => ! isNil( mediaItem.transientId ) );
+			const justSavedMedia = savedMedia.filter(
+				( mediaItem ) => ! isNullish( mediaItem.transientId )
+			);
 
 			if ( justSavedMedia.length === 0 ) {
 				return state;

--- a/client/state/selectors/get-media-item.js
+++ b/client/state/selectors/get-media-item.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import isNil from 'lodash/isNil';
+import { isNullish } from '@automattic/js-utils';
 
 /**
  * Internal dependencies
@@ -22,7 +22,7 @@ import getMediaQueryManager from 'calypso/state/selectors/get-media-query-manage
 
 export default function getMediaItem( state, siteId, mediaId ) {
 	const transientMediaItem = getTransientMediaItem( state, siteId, mediaId );
-	if ( ! isNil( transientMediaItem ) ) {
+	if ( ! isNullish( transientMediaItem ) ) {
 		// if a transient media item existed by this ID then that means the item isn't saved yet
 		// so we should continue to use the transient item
 		return transientMediaItem;

--- a/packages/js-utils/CHANGELOG.md
+++ b/packages/js-utils/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## 1.0.0
 
-Add `uniqueBy`
+- Add `uniqueBy`
+- Add `isNullish`

--- a/packages/js-utils/src/index.ts
+++ b/packages/js-utils/src/index.ts
@@ -1,1 +1,2 @@
+export { default as isNullish } from './is-nullish';
 export { default as uniqueBy } from './unique-by';

--- a/packages/js-utils/src/is-nullish.ts
+++ b/packages/js-utils/src/is-nullish.ts
@@ -1,4 +1,4 @@
-function isNullish( value: any ): boolean {
+function isNullish( value: any ): value is null | undefined {
 	if ( typeof value === 'undefined' ) {
 		return true;
 	}

--- a/packages/js-utils/src/is-nullish.ts
+++ b/packages/js-utils/src/is-nullish.ts
@@ -1,0 +1,13 @@
+function isNullish( value: any ): boolean {
+	if ( typeof value === 'undefined' ) {
+		return true;
+	}
+
+	if ( value === null ) {
+		return true;
+	}
+
+	return false;
+}
+
+export default isNullish;

--- a/packages/js-utils/src/test/is-nullish.js
+++ b/packages/js-utils/src/test/is-nullish.js
@@ -1,0 +1,43 @@
+/**
+ * Internal dependencies
+ */
+import isNullish from '../is-nullish';
+
+describe( 'isNullish()', () => {
+	test( 'should return false for false', () => {
+		expect( isNullish( false ) ).toEqual( false );
+	} );
+
+	test( 'should return false for 0', () => {
+		expect( isNullish( 0 ) ).toEqual( false );
+	} );
+
+	test( 'should return false for an empty object', () => {
+		expect( isNullish( {} ) ).toEqual( false );
+	} );
+
+	test( 'should return false for an empty array', () => {
+		expect( isNullish( [] ) ).toEqual( false );
+	} );
+
+	test( 'should return false for NaN', () => {
+		expect( isNullish( NaN ) ).toEqual( false );
+	} );
+
+	test( 'should return true for undefined', () => {
+		expect( isNullish( undefined ) ).toEqual( true );
+	} );
+
+	test( 'should return true for an undefined variable', () => {
+		let a;
+		expect( isNullish( a ) ).toEqual( true );
+	} );
+
+	test( 'should return true for a null', () => {
+		expect( isNullish( null ) ).toEqual( true );
+	} );
+
+	test( 'should return true for void 0', () => {
+		expect( isNullish( void 0 ) ).toEqual( true );
+	} );
+} );

--- a/packages/page-template-modal/package.json
+++ b/packages/page-template-modal/package.json
@@ -28,6 +28,7 @@
 		"src"
 	],
 	"dependencies": {
+		"@automattic/js-utils": "^1.0.0",
 		"@wordpress/api-fetch": "^3.21.1",
 		"@wordpress/block-editor": "^5.2.1",
 		"@wordpress/blocks": "^6.25.1",

--- a/packages/page-template-modal/src/components/template-selector-item.js
+++ b/packages/page-template-modal/src/components/template-selector-item.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { isNil } from 'lodash';
 import classnames from 'classnames';
+import { isNullish } from '@automattic/js-utils';
 
 const TemplateSelectorItem = ( props ) => {
 	const {
@@ -17,7 +17,7 @@ const TemplateSelectorItem = ( props ) => {
 		isSelected,
 	} = props;
 
-	if ( isNil( id ) || isNil( title ) || isNil( value ) ) {
+	if ( isNullish( id ) || isNullish( title ) || isNullish( value ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Introduce a new `isNullish` helper function to our `js-utils` package.
* Refactor all instances of `isNil` to `isNullish`.
* Deprecate Lodash's `isNil`.

In case you're wondering why something as simple as this needs a separate function: it can get quite repetitive to do a `typeof value === 'undefined' || typeof === null`, especially when done inline. So it can be convenient to have it as a simple function.

If you're curious why we-re going with `isNullish` - we believe `nullish` makes more sense and is more common than `nil`.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Go to `/devdocs/design/form-fields` and verify all the labels behave the same way as before.
* Go to `/devdocs/design/date-range` and verify that when no dates are selected, the component still behaves the same way.
* Try to `import { isNil } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass.