### PR TITLE
Framework: Refactor away from lodash isFinite

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -395,6 +395,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/drop': 'error',
 		'you-dont-need-lodash-underscore/ends-with': 'error',
 		'you-dont-need-lodash-underscore/entries': 'error',
+		'you-dont-need-lodash-underscore/is-finite': 'error',
 		'you-dont-need-lodash-underscore/is-null': 'error',
 		'you-dont-need-lodash-underscore/reduce-right': 'error',
 		'you-dont-need-lodash-underscore/reverse': 'error',

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -3,7 +3,7 @@
  */
 import classNames from 'classnames';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { isFinite, isNumber } from 'lodash';
+import { isNumber } from 'lodash';
 import React, { createElement, ReactNode } from 'react';
 import { Button, ProductIcon } from '@automattic/components';
 
@@ -92,7 +92,7 @@ const DisplayPrice = ( {
 		);
 	}
 
-	const isDiscounted = isFinite( discountedPrice );
+	const isDiscounted = Number.isFinite( discountedPrice );
 
 	return (
 		<div className="jetpack-product-card__price">

--- a/client/extensions/woocommerce/state/data-layer/orders/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { isFinite, omitBy } from 'lodash';
+import { omitBy } from 'lodash';
 import { translate } from 'i18n-calypso';
 import { stringify } from 'qs';
 
@@ -91,7 +91,7 @@ export function receivedOrder( action, { data } ) {
 
 export function sendOrder( action ) {
 	const { siteId, orderId, order } = action;
-	if ( isFinite( orderId ) ) {
+	if ( Number.isFinite( orderId ) ) {
 		return request( siteId, action ).post( `orders/${ orderId }`, order );
 	}
 	return request( siteId, action ).post( 'orders', order );

--- a/client/extensions/woocommerce/state/sites/orders/reducer.js
+++ b/client/extensions/woocommerce/state/sites/orders/reducer.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-
-import { isFinite, keyBy, omit } from 'lodash';
+import { keyBy, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -84,9 +83,10 @@ export function isQueryLoading( state = {}, action ) {
 	switch ( action.type ) {
 		case WOOCOMMERCE_ORDERS_REQUEST:
 		case WOOCOMMERCE_ORDERS_REQUEST_SUCCESS:
-		case WOOCOMMERCE_ORDERS_REQUEST_FAILURE:
+		case WOOCOMMERCE_ORDERS_REQUEST_FAILURE: {
 			const query = getSerializedOrdersQuery( action.query );
 			return Object.assign( {}, state, { [ query ]: WOOCOMMERCE_ORDERS_REQUEST === action.type } );
+		}
 		default:
 			return state;
 	}
@@ -102,7 +102,9 @@ export function isQueryLoading( state = {}, action ) {
  * @returns {object}        Updated state
  */
 export function isUpdating( state = {}, action ) {
-	const orderId = isFinite( action.orderId ) ? action.orderId : JSON.stringify( action.orderId );
+	const orderId = Number.isFinite( action.orderId )
+		? action.orderId
+		: JSON.stringify( action.orderId );
 	switch ( action.type ) {
 		case WOOCOMMERCE_ORDER_UPDATE:
 		case WOOCOMMERCE_ORDER_UPDATE_SUCCESS:
@@ -147,10 +149,11 @@ export function items( state = {}, action ) {
  */
 export function queries( state = {}, action ) {
 	switch ( action.type ) {
-		case WOOCOMMERCE_ORDERS_REQUEST_SUCCESS:
+		case WOOCOMMERCE_ORDERS_REQUEST_SUCCESS: {
 			const idList = action.orders.map( ( order ) => order.id );
 			const query = getSerializedOrdersQuery( action.query );
 			return Object.assign( {}, state, { [ query ]: idList } );
+		}
 		default:
 			return state;
 	}
@@ -165,9 +168,10 @@ export function queries( state = {}, action ) {
  */
 export function total( state = 1, action ) {
 	switch ( action.type ) {
-		case WOOCOMMERCE_ORDERS_REQUEST_SUCCESS:
+		case WOOCOMMERCE_ORDERS_REQUEST_SUCCESS: {
 			const query = getSerializedOrdersQuery( omit( action.query, 'page' ) );
 			return Object.assign( {}, state, { [ query ]: action.total } );
+		}
 		default:
 			return state;
 	}

--- a/client/extensions/woocommerce/state/sites/orders/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { filter, get, isFinite, omit, sumBy } from 'lodash';
+import { filter, get, omit, sumBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -120,7 +120,7 @@ export const isOrderLoading = ( state, orderId, siteId = getSelectedSiteId( stat
  * @returns {boolean} Whether this order is currently being updated on the server
  */
 export const isOrderUpdating = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
-	if ( ! isFinite( orderId ) ) {
+	if ( ! Number.isFinite( orderId ) ) {
 		orderId = JSON.stringify( orderId );
 	}
 	const isUpdating = get( state, [
@@ -139,7 +139,7 @@ export const isOrderUpdating = ( state, orderId, siteId = getSelectedSiteId( sta
  * @param {object} state Whole Redux state tree
  * @param {object} [query] Query used to fetch orders. Can contain page, status, etc. If not provided, defaults to first page, all orders.
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
- * @returns {Array|false} List of orders, or false if there was an error
+ * @returns {Array|boolean} List of orders, or false if there was an error
  */
 export const getOrders = ( state, query = {}, siteId = getSelectedSiteId( state ) ) => {
 	if ( ! areOrdersLoaded( state, query, siteId ) ) {

--- a/client/extensions/woocommerce/state/sites/orders/utils.js
+++ b/client/extensions/woocommerce/state/sites/orders/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forEach, isEmpty, isFinite, omit, omitBy } from 'lodash';
+import { forEach, isEmpty, omit, omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -56,7 +56,7 @@ export function removeTemporaryIds( order ) {
 	for ( const type of [ 'line_items', 'fee_lines', 'coupon_lines', 'shipping_lines' ] ) {
 		if ( order[ type ] ) {
 			newOrder[ type ] = order[ type ].map( ( item ) => {
-				if ( ! isFinite( item.id ) ) {
+				if ( ! Number.isFinite( item.id ) ) {
 					return omit( item, 'id' );
 				}
 				return item;
@@ -84,7 +84,7 @@ export function transformOrderForApi( order ) {
 		'total_tax',
 	];
 	forEach( totalsAndTaxes, ( key ) => {
-		if ( isFinite( order[ key ] ) || order[ key ] ) {
+		if ( Number.isFinite( order[ key ] ) || order[ key ] ) {
 			order[ key ] = getCurrencyFormatString( order[ key ], order.currency );
 		}
 	} );
@@ -92,22 +92,22 @@ export function transformOrderForApi( order ) {
 	const transformOrderData = ( data, strings = [], prices = [], integers = [], floats = [] ) => {
 		return data.map( ( line ) => {
 			forEach( strings, ( key ) => {
-				if ( isFinite( line[ key ] ) || line[ key ] ) {
+				if ( Number.isFinite( line[ key ] ) || line[ key ] ) {
 					line[ key ] = line[ key ].toString();
 				}
 			} );
 			forEach( prices, ( key ) => {
-				if ( isFinite( line[ key ] ) || line[ key ] ) {
+				if ( Number.isFinite( line[ key ] ) || line[ key ] ) {
 					line[ key ] = getCurrencyFormatString( line[ key ], order.currency );
 				}
 			} );
 			forEach( integers, ( key ) => {
-				if ( isFinite( line[ key ] ) || line[ key ] ) {
+				if ( Number.isFinite( line[ key ] ) || line[ key ] ) {
 					line[ key ] = parseInt( line[ key ] );
 				}
 			} );
 			forEach( floats, ( key ) => {
-				if ( isFinite( line[ key ] ) || line[ key ] ) {
+				if ( Number.isFinite( line[ key ] ) || line[ key ] ) {
 					line[ key ] = getCurrencyFormatDecimal( line[ key ], order.currency );
 				}
 			} );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -10,7 +10,6 @@ import {
 	includes,
 	isEmpty,
 	isEqual,
-	isFinite,
 	isNil,
 	map,
 	mapValues,
@@ -270,7 +269,7 @@ const getPackagesErrors = ( values ) =>
 			errors.box_id = translate( 'Please select a package' );
 		}
 
-		const isInvalidDimension = ( dimension ) => ! isFinite( dimension ) || 0 >= dimension;
+		const isInvalidDimension = ( dimension ) => ! Number.isFinite( dimension ) || 0 >= dimension;
 
 		if ( isInvalidDimension( pckg.weight ) ) {
 			errors.weight = translate( 'Invalid weight' );

--- a/client/my-sites/plans/jetpack-plans/records-details/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/records-details/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useTranslate, numberFormat } from 'i18n-calypso';
-import { isFinite } from 'lodash';
 import React, { FunctionComponent, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -71,7 +70,7 @@ const RecordsDetails: FunctionComponent< Props > = ( { productSlug } ) => {
 		return null;
 	}
 
-	const isDiscounted = isFinite( discountedPrice );
+	const isDiscounted = Number.isFinite( discountedPrice );
 	const recordCount = searchProduct?.price_tier_usage_quantity;
 	const translations = getJetpackProducts().find( ( p ) => p.slugs.includes( productSlug ) ) as
 		| ProductTranslations


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `isFinite` is essentially fully natively supported by `Number.isFinite`. This PR replaces the usage, and adds an ESLint rule to warn against using `isFinite` from lodash.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Try to `import { isFinite } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass.