### PR TITLE
Signup: add check for siteSlug to prevent JS error in non-launch flows

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -322,7 +322,7 @@ export default {
 			dispatch( requestSite( siteSlug ) ).then( () => {
 				let freshSiteId = getSiteId( getState(), siteSlug );
 
-				if ( ! freshSiteId ) {
+				if ( ! freshSiteId && siteSlug ) {
 					const wpcomStagingFragment = siteSlug.replace( /\b.wordpress.com/, '.wpcomstaging.com' );
 					freshSiteId = getSiteId( getState(), wpcomStagingFragment );
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Prevent the JS error in signup controller during non-launch flows. 

#### Testing instructions
* Go to `/start` and there should be no JS TypeError in browser console

Related to https://github.com/Automattic/wp-calypso/pull/49680
Fixes https://github.com/Automattic/wp-calypso/issues/50431
