### PR TITLE
Framework: Refactor away from _.indexOf()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -407,6 +407,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/extend-own': 'error',
 		'you-dont-need-lodash-underscore/foldl': 'error',
 		'you-dont-need-lodash-underscore/foldr': 'error',
+		'you-dont-need-lodash-underscore/index-of': 'error',
 		'you-dont-need-lodash-underscore/inject': 'error',
 		'you-dont-need-lodash-underscore/is-finite': 'error',
 		'you-dont-need-lodash-underscore/is-nil': 'error',

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -4,7 +4,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { compact, get, indexOf } from 'lodash';
+import { compact, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -41,7 +41,7 @@ class Wizard extends Component {
 		hideNavigation: false,
 	};
 
-	getStepIndex = () => indexOf( this.props.steps, this.props.stepName );
+	getStepIndex = () => this.props.steps.indexOf( this.props.stepName );
 
 	getBackUrl = () => {
 		const stepIndex = this.getStepIndex();

--- a/client/extensions/woocommerce/app/products/product-variation-types-form.js
+++ b/client/extensions/woocommerce/app/products/product-variation-types-form.js
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { find, debounce, isNumber, indexOf } from 'lodash';
+import { find, debounce, isNumber } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -61,7 +60,7 @@ class ProductVariationTypesForm extends Component {
 
 	setAttributeNameError = ( id ) => {
 		const attributeNameErrors = this.state.attributeNameErrors;
-		if ( indexOf( attributeNameErrors, id ) === -1 ) {
+		if ( attributeNameErrors.indexOf( id ) === -1 ) {
 			attributeNameErrors.push( id );
 		}
 		this.setState( { attributeNameErrors } );
@@ -112,7 +111,7 @@ class ProductVariationTypesForm extends Component {
 		const { attributeNames, attributeNameErrors } = this.state;
 
 		const attributeName = ( attributeNames && attributeNames[ attribute.uid ] ) || attribute.name;
-		const duplicateNameIssue = indexOf( attributeNameErrors, attribute.uid ) !== -1;
+		const duplicateNameIssue = attributeNameErrors.indexOf( attribute.uid ) !== -1;
 		const classes = classNames( 'products__variation-types-form-fieldset', {
 			'is-error': duplicateNameIssue,
 		} );

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign, get, includes, indexOf, reject } from 'lodash';
+import { assign, get, includes, reject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -183,7 +183,7 @@ const Flows = {
 			return false;
 		}
 		const flowSteps = flow.steps;
-		const currentStepIndex = indexOf( flowSteps, currentStepName );
+		const currentStepIndex = flowSteps.indexOf( currentStepName );
 		const nextIndex = currentStepIndex + 1;
 		const nextStepName = get( flowSteps, nextIndex );
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -12,7 +12,6 @@ import {
 	find,
 	get,
 	includes,
-	indexOf,
 	isEmpty,
 	isEqual,
 	kebabCase,
@@ -557,7 +556,7 @@ class Signup extends React.Component {
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
 	goToNextStep = ( nextFlowName = this.props.flowName ) => {
 		const flowSteps = flows.getFlow( nextFlowName ).steps;
-		const currentStepIndex = indexOf( flowSteps, this.props.stepName );
+		const currentStepIndex = flowSteps.indexOf( this.props.stepName );
 		const nextStepName = flowSteps[ currentStepIndex + 1 ];
 		const nextProgressItem = get( this.props.progress, nextStepName );
 		const nextStepSection = ( nextProgressItem && nextProgressItem.stepSectionName ) || '';
@@ -594,7 +593,7 @@ class Signup extends React.Component {
 
 	getPositionInFlow() {
 		const { flowName, stepName } = this.props;
-		return indexOf( flows.getFlow( flowName ).steps, stepName );
+		return flows.getFlow( flowName ).steps.indexOf( stepName );
 	}
 
 	getFlowLength() {

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, find, includes, indexOf, isEmpty, pick, sortBy } from 'lodash';
+import { filter, find, includes, isEmpty, pick, sortBy } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -76,12 +76,12 @@ export function getValidPath( parameters ) {
 
 export function getPreviousStepName( flowName, currentStepName ) {
 	const flow = flows.getFlow( flowName );
-	return flow.steps[ indexOf( flow.steps, currentStepName ) - 1 ];
+	return flow.steps[ flow.steps.indexOf( currentStepName ) - 1 ];
 }
 
 export function getNextStepName( flowName, currentStepName ) {
 	const flow = flows.getFlow( flowName );
-	return flow.steps[ indexOf( flow.steps, currentStepName ) + 1 ];
+	return flow.steps[ flow.steps.indexOf( currentStepName ) + 1 ];
 }
 
 export function getFlowSteps( flowName ) {

--- a/client/state/invites/selectors.js
+++ b/client/state/invites/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, find, indexOf, values } from 'lodash';
+import { get, find, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -167,6 +167,6 @@ export function didInviteDeletionSucceed( state, siteId, inviteId ) {
  */
 export function isDeletingAnyInvite( state, siteId ) {
 	return (
-		-1 !== indexOf( values( get( state, [ 'invites', 'deleting', siteId ], {} ) ), 'requesting' )
+		-1 !== values( get( state, [ 'invites', 'deleting', siteId ], {} ) ).indexOf( 'requesting' )
 	);
 }

--- a/client/state/sites/domains/reducer.js
+++ b/client/state/sites/domains/reducer.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { find, indexOf } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,7 +32,7 @@ import { itemsSchema } from './schema';
  * Returns a copy of the domains state object with some modifications
  *
  * @param {object} state - current state
- * @param {int} siteId - site ID
+ * @param {number} siteId - site ID
  * @param {string} domain - domain name
  * @param {object} modifyDomainProperties - object with modified site domain properties
  * @returns {any} - new copy of the state
@@ -40,7 +40,7 @@ import { itemsSchema } from './schema';
 const modifySiteDomainObjectImmutable = ( state, siteId, domain, modifyDomainProperties ) => {
 	// Find the domain we want to update
 	const targetDomain = find( state[ siteId ], { domain: domain } );
-	const domainIndex = indexOf( state[ siteId ], targetDomain );
+	const domainIndex = state[ siteId ].indexOf( targetDomain );
 	// Copy as we shouldn't mutate original state
 	const newDomains = [ ...state[ siteId ] ];
 	// Update privacy


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `indexOf` is essentially fully natively supported by `Array.indexOf`. This PR replaces the usage, and adds an ESLint rule to warn against using `indexOf` from lodash.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify navigation and current step in `/devdocs/design/wizard/second` still works like it did before.
* Go through the signup process and verify it still works well.
* Try to `import { indexOf } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass.