### PR TITLE
Nav unification: Add informative title classes to account headings

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -128,7 +128,9 @@ class MeSidebar extends React.Component {
 					</div>
 
 					<SidebarMenu>
-						<SidebarHeading>{ translate( 'Profile' ) }</SidebarHeading>
+						<SidebarHeading>
+							<span className="sidebar__informative-title">{ translate( 'Profile' ) }</span>
+						</SidebarHeading>
 
 						<SidebarItem
 							selected={ selected === 'profile' }
@@ -202,7 +204,9 @@ class MeSidebar extends React.Component {
 					</SidebarMenu>
 
 					<SidebarMenu>
-						<SidebarHeading>{ translate( 'Special' ) }</SidebarHeading>
+						<SidebarHeading>
+							<span className="sidebar__informative-title">{ translate( 'Special' ) }</span>
+						</SidebarHeading>
 
 						<SidebarItem
 							selected={ selected === 'get-apps' }

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -82,14 +82,6 @@ $font-size: rem( 14px );
 			color: var( --color-sidebar-text );
 			align-items: center;
 
-			&:hover,
-			&:focus {
-				background-color: var( --color-sidebar-menu-hover-background );
-				color: var( --color-sidebar-menu-hover-text );
-				box-shadow: inset 4px 0 0 0 currentColor;
- 				transition: box-shadow .1s linear;
-			}
-
 			&::after {
 				content: ' ';
 				display: none;
@@ -106,7 +98,24 @@ $font-size: rem( 14px );
 			}
 		}
 
+		// Apply hover and focus effects only to tabbable items assuming they are links.
+		.sidebar__heading:not([tabindex="-1"]),
+		.sidebar__menu-link {
+			&:hover,
+			&:focus {
+				background-color: var( --color-sidebar-menu-hover-background );
+				color: var( --color-sidebar-menu-hover-text );
+				box-shadow: inset 4px 0 0 0 currentColor;
+ 				transition: box-shadow .1s linear;
+			}
+		}
+
+		.sidebar__informative-title {
+			display: block;
+		}
+
 		.sidebar__expandable-title,
+		.sidebar__informative-title,
 		.sidebar__menu-link-text {
 			padding: $sidebar-item-padding;
 			max-height: 34px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As per Daves comment [here](https://github.com/Automattic/wp-calypso/issues/49178#issuecomment-766833245) I've kept the menu items and added some breathing room around them

* Removes hover/focus styles from items that are not links
* Adds spacing around informative headings in me/account section

#### Testing instructions

* Visit generated Calypso live link
* Visit `/me`
* Hovering over "Profile" or "Heading" doesn't highlight them
* Observe spacing around these titles
* Regression check other Calypso link hover states haven't been negatively effected

Before
![Screenshot 2021-02-24 at 14 14 30](https://user-images.githubusercontent.com/8639742/109013654-51469f00-76ab-11eb-9c98-3d10b4fd257b.png)

After
![Screenshot 2021-02-24 at 14 14 42](https://user-images.githubusercontent.com/8639742/109013668-54da2600-76ab-11eb-81fa-a479b639c1a4.png)


Fixes https://github.com/Automattic/wp-calypso/issues/49178
