### PR TITLE
Fix Jetpack magic link form scrollbar

### DIFF
--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -70,6 +70,10 @@
 	button {
 		width: 100%;
 	}
+
+	.form-button:last-child {
+		margin-right: 0;
+	}
 }
 
 .magic-login__footer {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR prevents the magic link form from showing a horizontal scrollbar. The cause of the issue is a right margin applied to the submit button of the form.

Fixes 1199916399796129-as-1199980559605755

### Testing instructions

- Download the PR and run Calypso
- Open a private browser window
- Visit `/log-in/jetpack/link`
- Make sure the form doesn't show any scrollbar

_Note: some browsers hide scrollbars until you interact with the content, so you might need to point your mouse cursor on the submit button and try to scroll horizontally_

### Screenshots

![screenshot](https://user-images.githubusercontent.com/1620183/109028889-46cadc00-7690-11eb-87cc-e8ea40c38f08.png)