### PR TITLE
Update Jetpack magic link form label

### DIFF
--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -149,7 +149,7 @@ class RequestLoginEmailForm extends React.Component {
 						) }
 					</p>
 					<FormLabel htmlFor="usernameOrEmail">
-						{ this.props.translate( 'Email Address' ) }
+						{ this.props.translate( 'Email Address or Username' ) }
 					</FormLabel>
 					<FormFieldset className="magic-login__email-fields">
 						<FormTextInput


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the copy of the magic link form label to mention the username.

### Testing instructions

- Download the PR and run Calypso
- Open a private browser window
- Visit `/log-in/jetpack/link`
- Make sure the label mentions the username

### Screenshots

<img width="496" alt="Screen Shot 2021-02-24 at 11 29 56 AM" src="https://user-images.githubusercontent.com/1620183/109032305-834c0700-7693-11eb-9271-203eaf26b841.png">

