### PR TITLE
Makes Collapse menu in sidebar translatable.

### DIFF
--- a/client/my-sites/sidebar-unified/collapse-sidebar.jsx
+++ b/client/my-sites/sidebar-unified/collapse-sidebar.jsx
@@ -18,6 +18,7 @@ import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import { getSidebarIsCollapsed } from 'calypso/state/ui/selectors';
 import { collapseSidebar, expandSidebar } from 'calypso/state/ui/actions';
+import TranslatableString from 'calypso/components/translatable/proptype';
 
 export const CollapseSidebar = ( { title, icon } ) => {
 	const reduxDispatch = useDispatch();
@@ -55,7 +56,7 @@ export const CollapseSidebar = ( { title, icon } ) => {
 };
 
 CollapseSidebar.propTypes = {
-	title: PropTypes.string.isRequired,
+	title: TranslatableString.isRequired,
 	icon: PropTypes.string.isRequired,
 };
 

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -12,6 +12,7 @@
  */
 import React, { Fragment, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -124,7 +125,11 @@ export const MySitesSidebarUnified = ( { path } ) => {
 						/>
 					);
 				} ) }
-				<CollapseSidebar key="collapse" title="Collapse menu" icon="dashicons-admin-collapse" />
+				<CollapseSidebar
+					key="collapse"
+					title={ translate( 'Collapse menu' ) }
+					icon="dashicons-admin-collapse"
+				/>
 			</Sidebar>
 			<AsyncLoad require="calypso/blocks/nav-unification-modal" placeholder={ null } />
 			<AsyncLoad


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Makes Collapse menu in sidebar translatable.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set your site language to Espanol `https://wordpress.com/me/account`
* Inspect the "Collapse menu" item, it should read `Cerrar menú` -> Not working currently https://github.com/Automattic/wp-calypso/pull/50443#issuecomment-785213769

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #50373
