### PR TITLE
Nav Unification: Open wp-admin links on new tabs (Jetpack sites only)

### DIFF
--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -34,6 +34,9 @@ import { getSidebarIsCollapsed } from 'calypso/state/ui/selectors';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
 import { isExternal } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -43,7 +46,11 @@ export const MySitesSidebarUnified = ( { path } ) => {
 	const isAllDomainsView = useDomainsViewStatus();
 	const isRequestingMenu = useSelector( getIsRequestingAdminMenu );
 	const sidebarIsCollapsed = useSelector( getSidebarIsCollapsed );
-	const isHappychatSessionActive = useSelector( ( state ) => hasActiveHappychatSession( state ) );
+	const isHappychatSessionActive = useSelector( hasActiveHappychatSession );
+	const siteId = useSelector( getSelectedSiteId );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
+	const isJetpackNonAtomicSite = isJetpack && ! isSiteAtomic;
 	const [ showDialog, setShowDialog ] = useState( false );
 	const [ externalUrl, setExternalUrl ] = useState();
 
@@ -62,6 +69,10 @@ export const MySitesSidebarUnified = ( { path } ) => {
 	// link on new tab in order to avoid Happy Chat session disconnection.
 	// We return a bool that shows if the logic should terminate here.
 	const continueInCalypso = ( url, event ) => {
+		if ( isJetpackNonAtomicSite ) {
+			return true;
+		}
+
 		if ( isHappychatSessionActive && isExternal( url ) ) {
 			event && event.preventDefault();
 			setExternalUrl( url );

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -30,13 +30,12 @@ import SidebarRegion from 'calypso/layout/sidebar/region';
 import 'calypso/state/admin-menu/init';
 import Spinner from 'calypso/components/spinner';
 import { itemLinkMatches } from '../sidebar/utils';
-import { getSidebarIsCollapsed } from 'calypso/state/ui/selectors';
+import { getSidebarIsCollapsed, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
 import { isExternal } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -69,11 +68,13 @@ export const MySitesSidebarUnified = ( { path } ) => {
 	// link on new tab in order to avoid Happy Chat session disconnection.
 	// We return a bool that shows if the logic should terminate here.
 	const continueInCalypso = ( url, event ) => {
-		if ( isJetpackNonAtomicSite ) {
-			return true;
-		}
-
 		if ( isHappychatSessionActive && isExternal( url ) ) {
+			// Do not show warning modal on Jetpack sites, since all external links are
+			// always opened on new tabs for these sites.
+			if ( isJetpackNonAtomicSite ) {
+				return false;
+			}
+
 			event && event.preventDefault();
 			setExternalUrl( url );
 			setShowDialog( true );
@@ -120,6 +121,8 @@ export const MySitesSidebarUnified = ( { path } ) => {
 								link={ item.url }
 								selected={ isSelected }
 								sidebarCollapsed={ sidebarIsCollapsed }
+								isHappychatSessionActive={ isHappychatSessionActive }
+								isJetpackNonAtomicSite={ isJetpackNonAtomicSite }
 								continueInCalypso={ continueInCalypso }
 								{ ...item }
 							/>
@@ -130,6 +133,8 @@ export const MySitesSidebarUnified = ( { path } ) => {
 						<MySitesSidebarUnifiedItem
 							key={ item.slug }
 							selected={ isSelected }
+							isHappychatSessionActive={ isHappychatSessionActive }
+							isJetpackNonAtomicSite={ isJetpackNonAtomicSite }
 							continueInCalypso={ continueInCalypso }
 							{ ...item }
 						/>

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -9,7 +9,7 @@
  * External dependencies
  */
 import React, { memo } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 
 /**
@@ -22,10 +22,6 @@ import {
 	collapseAllMySitesSidebarSections,
 	expandMySitesSidebarSection,
 } from 'calypso/state/my-sites/sidebar/actions';
-import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
-import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 
 export const MySitesSidebarUnifiedItem = ( {
 	count,
@@ -36,26 +32,16 @@ export const MySitesSidebarUnifiedItem = ( {
 	slug,
 	title,
 	url,
+	isHappychatSessionActive,
+	isJetpackNonAtomicSite,
 	continueInCalypso,
 } ) => {
 	const reduxDispatch = useDispatch();
-	const isHappychatSessionActive = useSelector( hasActiveHappychatSession );
-	const siteId = useSelector( getSelectedSiteId );
-	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
-	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
-	const isJetpackNonAtomicSite = isJetpack && ! isSiteAtomic;
 
 	const onNavigate = () => {
 		reduxDispatch( collapseAllMySitesSidebarSections() );
 		reduxDispatch( expandMySitesSidebarSection( sectionId ) );
 	};
-
-	let forceInternalLink = true;
-	if ( isHappychatSessionActive && ! isJetpackNonAtomicSite ) {
-		forceInternalLink = false;
-	} else if ( isJetpackNonAtomicSite ) {
-		forceInternalLink = false;
-	}
 
 	return (
 		<SidebarItem
@@ -65,7 +51,7 @@ export const MySitesSidebarUnifiedItem = ( {
 			onNavigate={ ( event ) => continueInCalypso( url, event ) && onNavigate() }
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
-			forceInternalLink={ forceInternalLink }
+			forceInternalLink={ ! isHappychatSessionActive && ! isJetpackNonAtomicSite }
 			className={ isSubItem ? 'sidebar__menu-item--child' : 'sidebar__menu-item-parent' }
 		>
 			<MySitesSidebarUnifiedStatsSparkline slug={ slug } />
@@ -80,6 +66,8 @@ MySitesSidebarUnifiedItem.propTypes = {
 	slug: PropTypes.string,
 	title: PropTypes.string,
 	url: PropTypes.string,
+	isHappychatSessionActive: PropTypes.bool.isRequired,
+	isJetpackNonAtomicSite: PropTypes.bool.isRequired,
 	continueInCalypso: PropTypes.func.isRequired,
 };
 

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -23,6 +23,9 @@ import {
 	expandMySitesSidebarSection,
 } from 'calypso/state/my-sites/sidebar/actions';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 
 export const MySitesSidebarUnifiedItem = ( {
 	count,
@@ -36,12 +39,23 @@ export const MySitesSidebarUnifiedItem = ( {
 	continueInCalypso,
 } ) => {
 	const reduxDispatch = useDispatch();
-	const isHappychatSessionActive = useSelector( ( state ) => hasActiveHappychatSession( state ) );
+	const isHappychatSessionActive = useSelector( hasActiveHappychatSession );
+	const siteId = useSelector( getSelectedSiteId );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
+	const isJetpackNonAtomicSite = isJetpack && ! isSiteAtomic;
 
 	const onNavigate = () => {
 		reduxDispatch( collapseAllMySitesSidebarSections() );
 		reduxDispatch( expandMySitesSidebarSection( sectionId ) );
 	};
+
+	let forceInternalLink = true;
+	if ( isHappychatSessionActive && ! isJetpackNonAtomicSite ) {
+		forceInternalLink = false;
+	} else if ( isJetpackNonAtomicSite ) {
+		forceInternalLink = false;
+	}
 
 	return (
 		<SidebarItem
@@ -51,7 +65,7 @@ export const MySitesSidebarUnifiedItem = ( {
 			onNavigate={ ( event ) => continueInCalypso( url, event ) && onNavigate() }
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
-			forceInternalLink={ ! isHappychatSessionActive }
+			forceInternalLink={ forceInternalLink }
 			className={ isSubItem ? 'sidebar__menu-item--child' : 'sidebar__menu-item-parent' }
 		>
 			<MySitesSidebarUnifiedStatsSparkline slug={ slug } />

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -40,6 +40,8 @@ export const MySitesSidebarUnifiedMenu = ( {
 	link,
 	selected,
 	sidebarCollapsed,
+	isHappychatSessionActive,
+	isJetpackNonAtomicSite,
 	continueInCalypso,
 } ) => {
 	const hasAutoExpanded = useRef( false );
@@ -109,6 +111,8 @@ export const MySitesSidebarUnifiedMenu = ( {
 							selected={ isSelected }
 							sectionId={ sectionId }
 							isSubItem={ true }
+							isHappychatSessionActive={ isHappychatSessionActive }
+							isJetpackNonAtomicSite={ isJetpackNonAtomicSite }
 							continueInCalypso={ continueInCalypso }
 						/>
 					);
@@ -127,6 +131,8 @@ MySitesSidebarUnifiedMenu.propTypes = {
 	children: PropTypes.array.isRequired,
 	link: PropTypes.string,
 	sidebarCollapsed: PropTypes.bool,
+	isHappychatSessionActive: PropTypes.bool.isRequired,
+	isJetpackNonAtomicSite: PropTypes.bool.isRequired,
 	continueInCalypso: PropTypes.func.isRequired,
 	/*
 	Example of children shape:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Ensures that all menu items linking to `/wp-admin` URLs are marked as external and opened in new tabs for Jetpack sites.

This improves the nav unification experience for Jetpack sites, since WP Admin is considered a separate area on those sites.

<img width="475" alt="Screen Shot 2021-02-25 at 10 47 39" src="https://user-images.githubusercontent.com/1233880/109135543-7a246e00-7757-11eb-9947-a6f8430f885f.png">

#### Testing instructions

- Spin up a Jetpack site running the `update/admin-menu-jetpack-sites` branch (https://github.com/Automattic/jetpack/pull/18921).
- Use the Calypso live link below, and switch to that Jetpack site.
- Make sure all menus linking to `/wp-admin` URLs (Feedback, Customize, Import, Export, WP Admin) are marked as external and they open pages in a new tab.
- Make sure there are no regression on Simple/Atomic sites (all menus should open in the same tab except when Happychat is active).

Fixes (partially) https://github.com/Automattic/wp-calypso/issues/50438
