### PR TITLE
Carry over user email from login to sign up form

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -444,6 +444,7 @@ class Login extends Component {
 			disableAutoFocus,
 			locale,
 			userEmail,
+			handleUsernameChange,
 		} = this.props;
 
 		if ( socialConnect ) {
@@ -487,6 +488,7 @@ class Login extends Component {
 				isGutenboarding={ isGutenboarding }
 				locale={ locale }
 				userEmail={ userEmail }
+				handleUsernameChange={ handleUsernameChange }
 			/>
 		);
 	}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -13,13 +13,13 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import config from '@automattic/calypso-config';
-import { addQueryArgs } from '@wordpress/url';
 import Divider from './divider';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormsButton from 'calypso/components/forms/form-button';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import { addQueryArgs } from 'calypso/lib/url';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -518,9 +518,12 @@ export class LoginForm extends Component {
 											components: {
 												newAccountLink: (
 													<a
-														href={ addQueryArgs( signupUrl, {
-															user_email: this.state.usernameOrEmail,
-														} ) }
+														href={ addQueryArgs(
+															{
+																user_email: this.state.usernameOrEmail,
+															},
+															signupUrl
+														) }
 													/>
 												),
 											},

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -65,6 +65,7 @@ export class LoginForm extends Component {
 		isFormDisabled: PropTypes.bool,
 		isLoggedIn: PropTypes.bool.isRequired,
 		loginUser: PropTypes.func.isRequired,
+		handleUsernameChange: PropTypes.func,
 		oauth2Client: PropTypes.object,
 		onSuccess: PropTypes.func.isRequired,
 		privateSite: PropTypes.bool,
@@ -96,8 +97,12 @@ export class LoginForm extends Component {
 		} );
 	}
 
-	componentDidUpdate( prevProps ) {
-		const { disableAutoFocus, requestError } = this.props;
+	componentDidUpdate( prevProps, prevState ) {
+		const { disableAutoFocus, requestError, handleUsernameChange } = this.props;
+
+		if ( handleUsernameChange && prevState.usernameOrEmail !== this.state.usernameOrEmail ) {
+			handleUsernameChange( this.state.usernameOrEmail );
+		}
 
 		if ( prevProps.requestError || ! requestError ) {
 			return;

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import config from '@automattic/calypso-config';
+import { addQueryArgs } from '@wordpress/url';
 import Divider from './divider';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
@@ -515,7 +516,13 @@ export class LoginForm extends Component {
 										' Would you like to {{newAccountLink}}create a new account{{/newAccountLink}}?',
 										{
 											components: {
-												newAccountLink: <a href={ signupUrl } />,
+												newAccountLink: (
+													<a
+														href={ addQueryArgs( signupUrl, {
+															user_email: this.state.usernameOrEmail,
+														} ) }
+													/>
+												),
 											},
 										}
 									) }

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -183,8 +183,8 @@ const mapState = ( state ) => {
 		showCheckYourEmail: getMagicLoginCurrentView( state ) === CHECK_YOUR_EMAIL_PAGE,
 		emailRequested: getMagicLoginRequestedEmailSuccessfully( state ),
 		userEmail:
-			getInitialQueryArguments( state ).email_address ||
-			getCurrentQueryArguments( state ).email_address,
+			getCurrentQueryArguments( state ).email_address ||
+			getInitialQueryArguments( state ).email_address,
 	};
 };
 

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -14,6 +14,8 @@ import { localize } from 'i18n-calypso';
 import AutomatticLogo from 'calypso/components/automattic-logo';
 import DocumentHead from 'calypso/components/data/document-head';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
 import TranslatorInvite from 'calypso/components/translator-invite';
@@ -58,6 +60,16 @@ export class Login extends React.Component {
 
 	static defaultProps = { isJetpack: false, isGutenboarding: false, isLoginView: true };
 
+	state = {
+		usernameOrEmail: '',
+	};
+
+	constructor( props ) {
+		super();
+
+		this.state.usernameOrEmail = props.emailQueryParam ?? '';
+	}
+
 	componentDidMount() {
 		this.recordPageView( this.props );
 	}
@@ -96,6 +108,10 @@ export class Login extends React.Component {
 	recordBackToWpcomLinkClick = () => {
 		this.props.recordTracksEvent( 'calypso_login_back_to_wpcom_link_click' );
 	};
+
+	handleUsernameChange( usernameOrEmail ) {
+		this.setState( { usernameOrEmail } );
+	}
 
 	renderI18nSuggestions() {
 		const { locale, path, isLoginView } = this.props;
@@ -215,6 +231,7 @@ export class Login extends React.Component {
 						twoFactorAuthType={ twoFactorAuthType }
 						isGutenboarding={ isGutenboarding }
 						signupUrl={ signupUrl }
+						usernameOrEmail={ this.state.usernameOrEmail }
 					/>
 				) }
 				{ isLoginView && <TranslatorInvite path={ path } /> }
@@ -236,6 +253,7 @@ export class Login extends React.Component {
 				fromSite={ fromSite }
 				footer={ footer }
 				locale={ locale }
+				handleUsernameChange={ this.handleUsernameChange.bind( this ) }
 			/>
 		);
 	}
@@ -269,6 +287,9 @@ export default connect(
 		locale: getCurrentLocaleSlug( state ),
 		oauth2Client: getCurrentOAuth2Client( state ),
 		isLoginView: ! props.twoFactorAuthType && ! props.socialConnect,
+		emailQueryParam:
+			getCurrentQueryArguments( state ).email_address ||
+			getInitialQueryArguments( state ).email_address,
 	} ),
 	{
 		recordPageView: withEnhancers( recordPageView, [ enhanceWithSiteType ] ),

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -43,6 +43,7 @@ export class LoginLinks extends React.Component {
 		translate: PropTypes.func.isRequired,
 		twoFactorAuthType: PropTypes.string,
 		isGutenboarding: PropTypes.bool.isRequired,
+		usernameOrEmail: PropTypes.string,
 	};
 
 	recordBackToWpcomLinkClick = () => {
@@ -73,19 +74,21 @@ export class LoginLinks extends React.Component {
 		this.props.recordTracksEvent( 'calypso_login_magic_login_request_click' );
 		this.props.resetMagicLoginRequestForm();
 
+		const { locale, currentRoute, isGutenboarding, query, usernameOrEmail } = this.props;
 		const loginParameters = {
 			isNative: true,
-			locale: this.props.locale,
+			locale: locale,
 			twoFactorAuthType: 'link',
 		};
-		const emailAddress = get( this.props, [ 'query', 'email_address' ] );
+		const emailAddress = usernameOrEmail || query?.email_address;
+
 		if ( emailAddress ) {
 			loginParameters.emailAddress = emailAddress;
 		}
 
-		if ( this.props.currentRoute === '/log-in/jetpack' ) {
+		if ( currentRoute === '/log-in/jetpack' ) {
 			loginParameters.twoFactorAuthType = 'jetpack/link';
-		} else if ( this.props.isGutenboarding ) {
+		} else if ( isGutenboarding ) {
 			loginParameters.twoFactorAuthType = 'new/link';
 		}
 
@@ -284,6 +287,7 @@ export class LoginLinks extends React.Component {
 			pathname,
 			query,
 			translate,
+			usernameOrEmail,
 		} = this.props;
 
 		const signupUrl = getSignupUrl(
@@ -301,7 +305,12 @@ export class LoginLinks extends React.Component {
 
 		return (
 			<a
-				href={ signupUrl }
+				href={ addQueryArgs(
+					{
+						user_email: usernameOrEmail,
+					},
+					signupUrl
+				) }
 				key="sign-up-link"
 				onClick={ this.recordSignUpLinkClick }
 				rel="external"

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -217,31 +217,17 @@ export class LoginLinks extends React.Component {
 			return null;
 		}
 
-		// The email address from the URL (if present) is added to the login
-		// parameters in this.handleMagicLoginLinkClick(). But it's left out
-		// here deliberately, to ensure that if someone copies this link to
-		// paste somewhere else, their email address isn't included in it.
-		const loginParameters = {
-			isNative: true,
-			locale: this.props.locale,
-			twoFactorAuthType: 'link',
-		};
-
-		if ( this.props.currentRoute === '/log-in/jetpack' ) {
-			loginParameters.twoFactorAuthType = 'jetpack/link';
-		} else if ( this.props.isGutenboarding ) {
-			loginParameters.twoFactorAuthType = 'new/link';
-		}
-
+		// Using a `button` here because page.js seems to add an onClick handler
+		// to `a` tags with internal links, which prevents the onClick handler
+		// below from being called.
 		return (
-			<a
-				href={ login( loginParameters ) }
+			<button
 				key="magic-login-link"
 				data-e2e-link="magic-login-link"
 				onClick={ this.handleMagicLoginLinkClick }
 			>
 				{ this.props.translate( 'Email me a login link' ) }
-			</a>
+			</button>
 		);
 	}
 

--- a/test/e2e/lib/pages/login-page.js
+++ b/test/e2e/lib/pages/login-page.js
@@ -102,7 +102,7 @@ export default class LoginPage extends AsyncBaseContainer {
 	async requestMagicLink( emailAddress ) {
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( 'a[data-e2e-link="magic-login-link"]' )
+			By.css( '[data-e2e-link="magic-login-link"]' )
 		);
 		await this.driver.sleep( 500 );
 		await driverHelper.setWhenSettable(


### PR DESCRIPTION
### Changes proposed in this Pull Request

In this PR, we make sure that the email a user enters in the login form is carried over the signup form when they decide to create a new account.

Fixes 1199916399796129-as-1199960628695527

### Testing instructions

- Download the PR and run Calypso
- Open a private browser window
- Visit a self-hosted Jetpack site that is not connected to Jetpack yet
- Activate Jetpack
- You should be redirected to the Jetpack login page in wordpress.com
- Copy the URL and replace the hostname by `calypso.localhost:3000`
- Enter an email you know is not associated to an account
- Click on _Would you like to create a new account?_
- Verify that the sign up form is prefilled with the email address you've just entered
- Do the same check with the _Email me a login link_ and _Create a new account_ buttons below

### Screenshots


_Before_
See video in attached issue.

_After_

https://user-images.githubusercontent.com/1620183/109317547-cf758380-781a-11eb-89e7-67ab988296d9.mov

