### PR TITLE
Testimonials: Add a custom subheading to the Testimonials post type header area

### DIFF
--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -32,6 +33,7 @@ function Types( {
 	userCanEdit,
 	statusSlug,
 	showPublishedStatus,
+	translate,
 } ) {
 	return (
 		<Main wideLayout>
@@ -42,6 +44,11 @@ function Types( {
 				brandFont
 				className="types__page-heading"
 				headerText={ get( postType, 'label', '' ) }
+				subHeaderText={
+					get( postType, 'label', '' ) === 'Testimonials'
+						? translate( 'Create and manage all the testimonials on your site.' )
+						: ''
+				}
 				align="left"
 			/>
 			{ userCanEdit &&
@@ -86,4 +93,4 @@ export default connect( ( state, ownProps ) => {
 		postTypeSupported: isPostTypeSupported( state, siteId, ownProps.query.type ),
 		userCanEdit: canCurrentUser( state, siteId, capability ),
 	};
-} )( Types );
+} )( localize( Types ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As part of the Wayfinder project (adding subHeadings to main pages in Calypso) this adds `subHeaderText` for sites on WP.com. 
* Check the post type label and if it matches, print the header text.
* We don't necessarily want to add this content in Jetpack itself because this is only for WP.com sites. 

**Before**

<img width="1115" alt="Screen Shot 2021-02-24 at 2 33 02 PM" src="https://user-images.githubusercontent.com/2124984/109055450-3543fd00-76ad-11eb-8dd6-fc24da8406cc.png">


**After**

<img width="1130" alt="Screen Shot 2021-02-24 at 2 04 36 PM" src="https://user-images.githubusercontent.com/2124984/109052085-3c690c00-76a9-11eb-8a20-019b949f60f8.png">


#### Testing instructions

* Switch to this PR
* Enable testimonials on your site from Settings -> Writing
* View the Testimonials page; you should see the subheader text there.
* Other post types (ie. Portfolios) should not have any subheading.

Related to #
