### PR TITLE
Checkout: Add notice when redirecting due to an empty cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-redirect-if-cart-empty.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-redirect-if-cart-empty.ts
@@ -25,8 +25,10 @@ export default function useRedirectIfCartEmpty< T >(
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 	const displayRedirectNotice = useCallback( () => {
-		reduxDispatch( infoNotice( translate( 'You have no items in your cart' ) ) );
-	}, [] );
+		reduxDispatch(
+			infoNotice( translate( 'You have no items in your cart' ), { displayOnNextPage: true } )
+		);
+	}, [ reduxDispatch, translate ] );
 	useEffect( () => {
 		if ( didRedirect.current || doNotRedirect ) {
 			return;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-redirect-if-cart-empty.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-redirect-if-cart-empty.ts
@@ -1,14 +1,17 @@
 /**
  * External dependencies
  */
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import page from 'page';
 import debugFactory from 'debug';
+import { useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
+import { infoNotice } from 'calypso/state/notices/actions';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-redirect-if-cart-empty' );
 
@@ -19,6 +22,11 @@ export default function useRedirectIfCartEmpty< T >(
 	createUserAndSiteBeforeTransaction: boolean
 ): boolean {
 	const didRedirect = useRef< boolean >( false );
+	const translate = useTranslate();
+	const reduxDispatch = useDispatch();
+	const displayRedirectNotice = useCallback( () => {
+		reduxDispatch( infoNotice( translate( 'You have no items in your cart' ) ) );
+	}, [] );
 	useEffect( () => {
 		if ( didRedirect.current || doNotRedirect ) {
 			return;
@@ -26,6 +34,11 @@ export default function useRedirectIfCartEmpty< T >(
 		if ( items.length === 0 ) {
 			didRedirect.current = true;
 			debug( 'cart is empty and not still loading; redirecting...' );
+
+			// Note that this will only be displayed if `page` is used. If there's an
+			// actual redirect (using `window.location`), the notice will not show
+			// up, but it's better than nothing.
+			displayRedirectNotice();
 
 			debug( 'Before redirect, first clear redirect url cookie' );
 			clearSignupDestinationCookie();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When checkout loads and the shopping cart is empty (and there are no errors being displayed), we redirect to the plans page.  This is intended mostly to cover the case where all products have been deleted from the cart and we redirect away, but it will also occur if trying to load checkout in any other situation.

Even though we won't redirect if there are errors, sometimes there can be other reasons why the cart will be empty even though it shouldn't be (eg: something redirected to checkout but failed to successfully add a product to the cart first). In these cases, the UX is pretty confusing because the redirect has no explanation.

This PR hopes to improve that experience slightly by adding a calypso notification that will be displayed on the next page when the redirect occurs.

<img width="869" alt="Screen Shot 2021-02-24 at 3 53 17 PM" src="https://user-images.githubusercontent.com/2036909/109064471-7392e980-76b8-11eb-8d80-d654d1a94ebf.png">

#### Testing instructions

- Visit checkout with an empty cart or visit checkout and remove all the products from your cart.
- Verify that you are redirected to the plans page.
- Verify that you see a notice that says that your cart is empty.