### PR TITLE
Domains: Make card heights equal in "How to use your domain" page

### DIFF
--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -5,6 +5,7 @@
 }
 
 .site-or-domain__choice {
+	display: flex;
 	margin: 10px;
 	min-width: 230px;
 	max-width: 300px;
@@ -12,7 +13,13 @@
 	transition: box-shadow 100ms ease-in-out;
 	cursor: pointer;
 
-	a, svg {
+	a {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+	}
+
+	svg {
 		display: block;
 		width: 100%;
 	}
@@ -48,6 +55,7 @@
 }
 
 .site-or-domain__choice-text {
+	flex-grow: 1;
 	color: var( --color-neutral-70 );
 }
 

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -52,6 +52,7 @@
 
 .site-or-domain__choice-image {
 	display: none;
+	width: 100%;
 }
 
 .site-or-domain__choice-text {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After the wording update in #50385, card heights became unequal in the "Choose how you want to use your domain" page. This PR makes the cards' height equal, independently of the text that is contained inside them.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Access `domains/` and search for any domain name (e.g. "leotaba123")
2. Choose any resulting domain (e.g. "leotaba123.com")
3. The cards in the "Choose how you want to use your domain" page should have the same height

Before:

<img width="778" alt="Screen Shot 2021-02-24 at 14 49 52" src="https://user-images.githubusercontent.com/5324818/109058876-4cd9b080-76c2-11eb-9390-628936ab66b8.png">

After:

<img width="773" alt="Screen Shot 2021-02-24 at 16 41 48" src="https://user-images.githubusercontent.com/5324818/109058892-519e6480-76c2-11eb-8c8e-7284f3d1f2fe.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
