### PR TITLE
ci(lint): Fail eslint build if the number of errors goes up

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -15,7 +15,6 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
-import jetbrains.buildServer.configs.kotlin.v2019_2.ArtifactDependency.lastSuccessful
 
 /*
 The settings script is an entry point for defining a TeamCity

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -13,7 +13,9 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.githubConnec
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.ArtifactDependency.lastSuccessful
 
 /*
 The settings script is an entry point for defining a TeamCity

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -13,6 +13,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.githubConnec
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions
 
 /*
 The settings script is an entry point for defining a TeamCity
@@ -701,6 +702,15 @@ object CheckCodeStyle : BuildType({
 
 	failureConditions {
 		executionTimeoutMin = 20
+		nonZeroExitCode = false
+		failOnMetricChange {
+			metric = BuildFailureOnMetric.MetricType.INSPECTION_ERROR_COUNT
+			units = BuildFailureOnMetric.MetricUnit.DEFAULT_UNIT
+			comparison = BuildFailureOnMetric.MetricComparison.MORE
+			compareTo = build {
+				buildRule = lastSuccessful()
+			}
+		}
 	}
 
 	features {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change the eslint build that runs in `trunk` to fail only if the number of errors goes up.

Before this change, the build "Check code style" will fail if there are lint errors (specifically, if `yarn eslint` returns a non 0 value). After this change, the build will ignore the exit status and fail if the number of errors is higher than the previous successful build.

Note this doesn't affect branches, only the build we run in `trunk` every 24h.
