### PR TITLE
Remove lodash references from Calypso Green

### DIFF
--- a/client/components/jetpack/backup-card/index.tsx
+++ b/client/components/jetpack/backup-card/index.tsx
@@ -3,7 +3,7 @@
  */
 import classNames from 'classnames';
 import React, { useRef, FunctionComponent, useState, useCallback } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -11,6 +11,7 @@ import { useSelector } from 'react-redux';
 import { Button } from '@automattic/components';
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ActivityActor, { SIZE_S } from 'calypso/components/activity-card/activity-actor';
 import ActivityDescription from 'calypso/components/activity-card/activity-description';
 import ActivityMedia from 'calypso/components/activity-card/activity-media';
@@ -18,7 +19,6 @@ import Badge from 'calypso/components/badge';
 import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Tooltip from 'calypso/components/tooltip';
-import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -52,6 +52,7 @@ const BackupCard: FunctionComponent< Props > = ( {
 } ) => {
 	const { activityTs, activityTitle, rewindId } = activity;
 
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const getDisplayDate = useGetDisplayDate();
 	const moment = useLocalizedMoment();
@@ -70,12 +71,24 @@ const BackupCard: FunctionComponent< Props > = ( {
 	const onRestoreButtonLeave = useCallback( () => setTooltipVisibility( false ), [
 		setTooltipVisibility,
 	] );
-	const onDownloadClick = useTrackCallback( noop, 'calypso_jetpack_backup_download', {
-		rewind_id: rewindId,
-	} );
-	const onRestoreClick = useTrackCallback( noop, 'calypso_jetpack_backup_restore', {
-		rewind_id: rewindId,
-	} );
+	const onDownloadClick = useCallback(
+		() =>
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_backup_download', {
+					rewind_id: rewindId,
+				} )
+			),
+		[ dispatch, rewindId ]
+	);
+	const onRestoreClick = useCallback(
+		() =>
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_backup_restore', {
+					rewind_id: rewindId,
+				} )
+			),
+		[ dispatch, rewindId ]
+	);
 
 	return (
 		<Card

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -3,7 +3,6 @@
  */
 import classNames from 'classnames';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { isNumber } from 'lodash';
 import React, { createElement, ReactNode } from 'react';
 import { Button, ProductIcon } from '@automattic/components';
 
@@ -191,8 +190,8 @@ const JetpackProductCard: React.FC< Props > = ( {
 	aboveButtonText = null,
 }: Props ) => {
 	const translate = useTranslate();
-	const parsedHeadingLevel = isNumber( headingLevel )
-		? Math.min( Math.max( Math.floor( headingLevel ), 1 ), 6 )
+	const parsedHeadingLevel = Number.isFinite( headingLevel )
+		? Math.min( Math.max( Math.floor( headingLevel as number ), 1 ), 6 )
 		: 2;
 
 	return (

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useTranslate } from 'i18n-calypso';
-import { get } from 'lodash';
 import React from 'react';
 import { useSelector } from 'react-redux';
 
@@ -49,7 +48,7 @@ const BackupSuccessful = ( { backup, deltas, selectedDate } ) => {
 	} );
 	const isToday = selectedDate.isSame( today, 'day' );
 
-	const meta = get( backup, 'activityDescription[2].children[0]', '' );
+	const meta = backup?.activityDescription?.[ 2 ]?.children?.[ 0 ] ?? '';
 
 	// We should only showing the summarized ActivityCard for Real-time sites when the latest backup is not a full backup
 	const showBackupDetails =

--- a/client/components/jetpack/scan-badge/index.tsx
+++ b/client/components/jetpack/scan-badge/index.tsx
@@ -3,7 +3,6 @@
  */
 import React, { FunctionComponent } from 'react';
 import { useTranslate } from 'i18n-calypso';
-import { isNumber } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,11 +18,13 @@ interface Props {
 
 const ScanBadge: FunctionComponent< Props > = ( { numberOfThreatsFound, progress } ) => {
 	const translate = useTranslate();
-	if ( ! numberOfThreatsFound && ! isNumber( progress ) ) {
+	const hasProgressPercentage = Number.isFinite( progress );
+
+	if ( ! numberOfThreatsFound && ! hasProgressPercentage ) {
 		return null;
 	}
 
-	if ( isNumber( progress ) ) {
+	if ( hasProgressPercentage ) {
 		return (
 			<Badge type="success">
 				{ translate( '%(number)d %', {

--- a/client/components/jetpack/server-credentials-form/index.jsx
+++ b/client/components/jetpack/server-credentials-form/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -51,7 +50,7 @@ const ServerCredentialsForm = ( {
 				<FormSelect
 					name="protocol"
 					id="protocol-type"
-					value={ get( form, 'protocol', 'ssh' ) }
+					value={ form?.protocol?.ssh }
 					onChange={ handleFieldChange }
 					disabled={ formIsSubmitting }
 				>
@@ -69,7 +68,7 @@ const ServerCredentialsForm = ( {
 						name="host"
 						id="host-address"
 						placeholder={ translate( 'YourGroovyDomain.com' ) }
-						value={ get( form, 'host', '' ) }
+						value={ form?.host ?? '' }
 						onChange={ handleFieldChange }
 						disabled={ formIsSubmitting }
 						isError={ !! formErrors.host }
@@ -83,7 +82,7 @@ const ServerCredentialsForm = ( {
 						name="port"
 						id="server-port"
 						placeholder="22"
-						value={ get( form, 'port', '' ) }
+						value={ form?.port ?? '' }
 						onChange={ handleFieldChange }
 						disabled={ formIsSubmitting }
 						isError={ !! formErrors.port }
@@ -101,7 +100,7 @@ const ServerCredentialsForm = ( {
 						name="user"
 						id="server-username"
 						placeholder={ translate( 'username' ) }
-						value={ get( form, 'user', '' ) }
+						value={ form?.user ?? '' }
 						onChange={ handleFieldChange }
 						disabled={ formIsSubmitting }
 						isError={ !! formErrors.user }
@@ -119,7 +118,7 @@ const ServerCredentialsForm = ( {
 						name="pass"
 						id="server-password"
 						placeholder={ translate( 'password' ) }
-						value={ get( form, 'pass', '' ) }
+						value={ form?.pass ?? '' }
 						onChange={ handleFieldChange }
 						disabled={ formIsSubmitting }
 						isError={ !! formErrors.pass }
@@ -138,7 +137,7 @@ const ServerCredentialsForm = ( {
 					name="path"
 					id="wordpress-path"
 					placeholder="/public_html/wordpress-site/"
-					value={ get( form, 'path', '' ) }
+					value={ form?.path ?? '' }
 					onChange={ handleFieldChange }
 					disabled={ formIsSubmitting }
 					isError={ !! formErrors.path }
@@ -151,7 +150,7 @@ const ServerCredentialsForm = ( {
 				<FormTextArea
 					name="kpri"
 					id="private-key"
-					value={ get( form, 'kpri', '' ) }
+					value={ form?.kpri ?? '' }
 					onChange={ handleFieldChange }
 					disabled={ formIsSubmitting }
 					className="server-credentials-form__private-key"

--- a/client/components/jetpack/server-credentials-wizard-dialog/index.tsx
+++ b/client/components/jetpack/server-credentials-wizard-dialog/index.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import classnames from 'classnames';
-import { isEmpty } from 'lodash';
 import { Dialog } from '@automattic/components';
 
 /**
@@ -46,9 +45,10 @@ const ServerCredentialsWizardDialog = ( {
 	children,
 }: Props ) => {
 	const siteId = useSelector( getSelectedSiteId );
-	const userNeedsCredentials = useSelector( ( state ) =>
-		isEmpty( getJetpackCredentials( state, siteId, 'main' ) )
-	);
+	const userNeedsCredentials = useSelector( ( state ) => {
+		const creds = getJetpackCredentials( state, siteId, 'main' );
+		return ! creds || Object.keys( creds ).length === 0;
+	} );
 
 	const showServerCredentialsForm = React.useMemo(
 		() => userNeedsCredentials && ! skipServerCredentials,

--- a/client/components/jetpack/sidebar/index.jsx
+++ b/client/components/jetpack/sidebar/index.jsx
@@ -4,7 +4,6 @@
 import { connect } from 'react-redux';
 import { format as formatUrl, getUrlParts, getUrlFromParts } from 'calypso/lib/url';
 import { localize } from 'i18n-calypso';
-import { memoize } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
@@ -38,13 +37,13 @@ class JetpackCloudSidebar extends Component {
 		threats: PropTypes.array,
 	};
 
-	onNavigate = memoize( ( menuItem ) => () => {
+	onGetHelp = () => {
 		this.props.dispatchRecordTracksEvent( 'calypso_jetpack_sidebar_menu_click', {
-			menu_item: menuItem,
+			menu_item: 'Jetpack Cloud / Support',
 		} );
 
 		window.scrollTo( 0, 0 );
-	} );
+	};
 
 	render() {
 		const { translate, jetpackAdminUrl, path } = this.props;
@@ -66,7 +65,7 @@ class JetpackCloudSidebar extends Component {
 							link="https://jetpack.com/support"
 							materialIcon="help"
 							materialIconStyle="filled"
-							onNavigate={ this.onNavigate( 'Jetpack Cloud / Support' ) }
+							onNavigate={ this.onGetHelp }
 						/>
 						<SidebarItem
 							label={ translate( 'WP Admin', {

--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import classnames from 'classnames';
 import { Button } from '@automattic/components';
@@ -13,21 +13,17 @@ import ExternalLinkWithTracking from 'calypso/components/external-link/with-trac
  */
 import LogItem from '../log-item';
 import ThreatDescription from '../threat-description';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import ThreatItemHeader from 'calypso/components/jetpack/threat-item-header';
 import ThreatItemSubheader from 'calypso/components/jetpack/threat-item-subheader';
 import { Threat } from 'calypso/components/jetpack/threat-item/types';
 import { getThreatFix } from 'calypso/components/jetpack/threat-item/utils';
-import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
-
 interface Props {
 	threat: Threat;
 	isPlaceholder: boolean;
@@ -53,6 +49,8 @@ const ThreatItem: React.FC< Props > = ( {
 	isFixing,
 	contactSupportUrl,
 } ) => {
+	const dispatch = useDispatch();
+
 	/**
 	 * Render a CTA button. Currently, this button is rendered three
 	 * times: in the details section, and in the `summary` and `extendSummary`
@@ -97,22 +95,20 @@ const ThreatItem: React.FC< Props > = ( {
 								'the offending code, theme, or plugin from your site.'
 						) }
 					</p>
-					{
-						'current' === threat.status && (
-							<p className="threat-description__section-text">
-								{ translate(
-									'If you need more help to resolve this threat, we recommend {{strong}}Codeable{{/strong}}, a trusted freelancer marketplace of highly vetted WordPress experts. ' +
-										'They have identified a select group of security experts to help with these projects. ' +
-										'Pricing ranges from $70-120/hour, and you can get a free estimate with no obligation to hire.',
-									{
-										components: {
-											strong: <strong />,
-										},
-									}
-								) }
-							</p>
-						)
-					}
+					{ 'current' === threat.status && (
+						<p className="threat-description__section-text">
+							{ translate(
+								'If you need more help to resolve this threat, we recommend {{strong}}Codeable{{/strong}}, a trusted freelancer marketplace of highly vetted WordPress experts. ' +
+									'They have identified a select group of security experts to help with these projects. ' +
+									'Pricing ranges from $70-120/hour, and you can get a free estimate with no obligation to hire.',
+								{
+									components: {
+										strong: <strong />,
+									},
+								}
+							) }
+						</p>
+					) }
 				</>
 			);
 		}
@@ -132,10 +128,16 @@ const ThreatItem: React.FC< Props > = ( {
 			? { section: currentRoute.includes( '/scan/history' ) ? 'History' : 'Scanner' }
 			: {};
 	}, [ currentRoute ] );
-	const onOpenTrackEvent = useTrackCallback( noop, 'calypso_jetpack_scan_threat_itemtoggle', {
-		threat_signature: threat.signature,
-		...currentRouteProp,
-	} );
+	const onOpenTrackEvent = React.useCallback(
+		() =>
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_scan_threat_itemtoggle', {
+					threat_signature: threat.signature,
+					...currentRouteProp,
+				} )
+			),
+		[ dispatch, threat, currentRouteProp ]
+	);
 
 	if ( isPlaceholder ) {
 		return <ThreatItemPlaceholder />;
@@ -183,7 +185,6 @@ const ThreatItem: React.FC< Props > = ( {
 						target="_blank"
 						rel="noopener noreferrer"
 						tracksEventName="calypso_jetpack_scan_threat_codeable_estimate"
-						onClick={ noop }
 					>
 						{ translate( 'Get a free estimate' ) }
 					</ExternalLinkWithTracking>

--- a/client/components/jetpack/with-server-credentials-form/index.jsx
+++ b/client/components/jetpack/with-server-credentials-form/index.jsx
@@ -5,7 +5,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,7 +36,7 @@ function mergeFormWithCredentials( form, credentials, siteSlug ) {
 		newForm.path = credentials.abspath || newForm.path;
 	}
 	// Populate the host field with the site slug if needed
-	newForm.host = isEmpty( newForm.host ) && siteSlug ? siteSlug.split( '::' )[ 0 ] : newForm.host;
+	newForm.host = ! newForm.host && siteSlug ? siteSlug.split( '::' )[ 0 ] : newForm.host;
 	return newForm;
 }
 
@@ -120,9 +119,9 @@ function withServerCredentialsForm( WrappedComponent ) {
 				! payload.path && requirePath && { path: translate( 'Please enter a server path.' ) }
 			);
 
-			return isEmpty( errors )
-				? this.props.updateCredentials( siteId, payload )
-				: this.setState( { formErrors: errors } );
+			return errors && Object.keys( errors ).length > 0
+				? this.setState( { formErrors: errors } )
+				: this.props.updateCredentials( siteId, payload );
 		};
 
 		handleDelete = () => this.props.deleteCredentials( this.props.siteId, this.props.role );

--- a/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
@@ -4,7 +4,6 @@
 import React, { ReactElement } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -63,7 +62,7 @@ function LicenseStateFilter( { filter, search, doSearch }: Props ): ReactElement
 		children: navItem.label,
 	} ) );
 
-	const selectedItem = find( navItems, 'selected' ) || navItems[ 0 ];
+	const selectedItem = navItems.find( ( i ) => i.selected ) || navItems[ 0 ];
 
 	return (
 		<SectionNav

--- a/client/jetpack-cloud/sections/partner-portal/select-partner-key/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/select-partner-key/index.tsx
@@ -7,7 +7,6 @@ import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { getQueryArg } from '@wordpress/url';
 import page from 'page';
-import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -37,7 +36,7 @@ export default function SelectPartnerKey(): ReactElement | null {
 	const hasFetched = useSelector( hasFetchedPartner );
 	const isFetching = useSelector( isFetchingPartner );
 	const partner = useSelector( getCurrentPartner );
-	const keys = get( partner, 'keys', [] ) as PartnerKey[];
+	const keys = ( partner?.keys || [] ) as PartnerKey[];
 	const showKeys = hasFetched && ! isFetching && keys.length > 0;
 	const showError = hasFetched && ! isFetching && keys.length === 0;
 

--- a/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
@@ -3,7 +3,6 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { memoize } from 'lodash';
 import { localize, translate as TranslateType } from 'i18n-calypso';
 
 /**
@@ -30,15 +29,14 @@ interface Props {
 	dispatchRecordTracksEvent: typeof recordTracksEvent;
 	translate: typeof TranslateType;
 }
-
 class PartnerPortalSidebar extends Component< Props > {
-	onNavigate = memoize( ( menuItem ) => () => {
+	onNavigate = ( menuItem: string ) => () => {
 		this.props.dispatchRecordTracksEvent( 'calypso_jetpack_sidebar_menu_click', {
 			menu_item: menuItem,
 		} );
 
 		window.scrollTo( 0, 0 );
-	} );
+	};
 
 	render() {
 		const { translate, path } = this.props;
@@ -54,7 +52,7 @@ class PartnerPortalSidebar extends Component< Props > {
 								comment: 'Jetpack sidebar navigation item',
 							} ) }
 							link="/partner-portal"
-							onNavigate={ this.onNavigate }
+							onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal / Licenses' ) }
 							selected={ itemLinkMatches( [ '/partner-portal' ], path ) }
 						/>
 					</SidebarMenu>

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/form.ts
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/form.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isEmpty } from 'lodash';
 import { TranslateResult, translate } from 'i18n-calypso';
 
 export enum FormMode {
@@ -81,7 +80,7 @@ export const mergeFoundCredentials = ( foundCredentials: Credentials, formState:
 export const validate = ( formState: FormState, mode: FormMode ): FormErrors => {
 	const formErrors: FormErrors = {};
 	// user checking
-	if ( isEmpty( formState.user ) ) {
+	if ( ! formState.user ) {
 		formErrors.user = {
 			message: translate( 'Please enter your server username.' ),
 			waitForInteraction: true,
@@ -96,7 +95,7 @@ export const validate = ( formState: FormState, mode: FormMode ): FormErrors => 
 		};
 	}
 	// host checking
-	if ( isEmpty( formState.host ) ) {
+	if ( ! formState.host ) {
 		formErrors.host = {
 			message: translate( 'Please enter a valid server address.' ),
 			waitForInteraction: true,
@@ -110,14 +109,14 @@ export const validate = ( formState: FormState, mode: FormMode ): FormErrors => 
 		};
 	}
 
-	if ( FormMode.Password === mode && isEmpty( formState.pass ) ) {
+	if ( FormMode.Password === mode && ! formState.pass ) {
 		formErrors.pass = {
 			message: translate( 'Please enter your server password.' ),
 			waitForInteraction: true,
 		};
 	}
 
-	if ( FormMode.PrivateKey === mode && isEmpty( formState.kpri ) ) {
+	if ( FormMode.PrivateKey === mode && ! formState.kpri ) {
 		formErrors.kpri = {
 			message: translate( 'Please enter your private key.' ),
 			waitForInteraction: true,

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/index.tsx
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-import { isEmpty } from 'lodash';
 import { useSelector, useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import React, { FunctionComponent, useMemo, useState, useEffect } from 'react';
+import React, { FunctionComponent, useCallback, useMemo, useState, useEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -96,7 +95,7 @@ const AdvancedCredentials: FunctionComponent< Props > = ( { action, host, role }
 		getJetpackCredentials( state, siteId, role )
 	) as FormState & { abspath: string };
 
-	const hasCredentials = ! isEmpty( credentials );
+	const hasCredentials = credentials && Object.keys( credentials ).length > 0;
 
 	const statusState = useMemo( (): StatusState => {
 		if ( isRequestingCredentials ) {
@@ -202,21 +201,22 @@ const AdvancedCredentials: FunctionComponent< Props > = ( { action, host, role }
 		}
 	}, [ currentStep, dispatch, host ] );
 
+	const disableForm = 'pending' === formSubmissionStatus;
+	const formHasErrors = formErrors && Object.keys( formErrors ).length > 0;
+
 	const handleDeleteCredentials = () => {
 		dispatch( recordTracksEvent( 'calypso_jetpack_advanced_credentials_flow_credentials_delete' ) );
 
 		dispatch( deleteCredentials( siteId, role ) );
 	};
 
-	const handleUpdateCredentials = () => {
-		if ( ! isEmpty( formErrors ) ) {
+	const handleUpdateCredentials = useCallback( () => {
+		if ( formHasErrors ) {
 			return;
 		}
 		dispatch( recordTracksEvent( 'calypso_jetpack_advanced_credentials_flow_credentials_update' ) );
 		dispatch( updateCredentials( siteId, { role, ...formState }, true, false ) );
-	};
-
-	const disableForm = 'pending' === formSubmissionStatus;
+	}, [ formHasErrors, dispatch, siteId, role, formState ] );
 
 	const renderUnconnectedButtons = () => (
 		<>
@@ -234,11 +234,7 @@ const AdvancedCredentials: FunctionComponent< Props > = ( { action, host, role }
 				<Gridicon icon="arrow-left" size={ 18 } />
 				{ translate( 'Change host' ) }
 			</Button>
-			<Button
-				primary
-				onClick={ handleUpdateCredentials }
-				disabled={ ! isEmpty( formErrors ) || disableForm }
-			>
+			<Button primary onClick={ handleUpdateCredentials } disabled={ disableForm || formHasErrors }>
 				{ translate( 'Test and save credentials' ) }
 			</Button>
 		</>
@@ -249,10 +245,7 @@ const AdvancedCredentials: FunctionComponent< Props > = ( { action, host, role }
 			<Button scary disabled={ disableForm } onClick={ handleDeleteCredentials }>
 				{ translate( 'Delete credentials' ) }
 			</Button>
-			<Button
-				onClick={ handleUpdateCredentials }
-				disabled={ ! isEmpty( formErrors ) || disableForm }
-			>
+			<Button onClick={ handleUpdateCredentials } disabled={ disableForm || formHasErrors }>
 				{ translate( 'Update credentials' ) }
 			</Button>
 		</>

--- a/client/jetpack-cloud/sections/settings/main.jsx
+++ b/client/jetpack-cloud/sections/settings/main.jsx
@@ -4,7 +4,6 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { localize, useTranslate } from 'i18n-calypso';
-import { isEmpty } from 'lodash';
 import { Card } from '@automattic/components';
 
 /**
@@ -124,7 +123,7 @@ const SettingsPage = () => {
 
 	const isInitialized =
 		backupState.state !== 'uninitialized' || scanState?.state !== 'provisioning';
-	const isConnected = ! isEmpty( credentials );
+	const isConnected = credentials && Object.keys( credentials ).length > 0;
 
 	const hasBackup = backupState?.state !== 'unavailable';
 	const hasScan = scanState?.state !== 'unavailable';

--- a/client/state/selectors/get-jetpack-credentials.js
+++ b/client/state/selectors/get-jetpack-credentials.js
@@ -1,13 +1,8 @@
 /**
- * External Dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import 'calypso/state/jetpack/init';
 
 export default function getJetpackCredentials( state, siteId, role ) {
-	return get( state, [ 'jetpack', 'credentials', 'items', siteId, role ], {} );
+	return state?.jetpack?.credentials?.items?.[ siteId ]?.[ role ] || {};
 }


### PR DESCRIPTION
Related to `p4TIVU-9Bf-p2`. Seeks to remove all references to the lodash library from components that are part of Calypso Green.

Tagging Infinity for Partner Portal changes, and Voyager for all the rest.

#### Changes proposed in this Pull Request

* Remove imports and function calls to the lodash library from all code files inside `client/jetpack-cloud` and `client/components/jetpack`, replacing with standard React or JavaScript function calls.

#### Testing instructions

There are a lot of steps here, but they're all pretty small. I would advise looking closely at the code itself to get a better idea of what's changed and how risky (or not-risky) the changes are.

**NOTE:** For all test steps, keep the console window open and ensure that no unexpected console errors show up. All behavior should match production.

##### Plans/Pricing

* (All test variations) Verify that all product card heading font sizes match production

##### Log-in

* Verify that the "landing" behavior/logic still behaves the same as in production:
  * If the selected site has Scan and not Backup, land on the Scan page; otherwise, land on the Backup page/upsell.
  * If the selected site is not eligible to use Calypso Green (e.g., Atomic, multi-site, non-Jetpack site), they're re-directed to `/`.

##### Sidebar

* Verify that Scan progress is rendered correctly beside the Scan menu item (or not rendered at all, if no Scan is running).
* Verify that the following Tracks event correctly fires when clicking the 'Get Help' menu item:
  * `calypso_jetpack_sidebar_menu_click` (params: `menu_item: 'Jetpack Cloud / Support'` )

##### Backup

* Verify that the following Tracks events are correctly fired:
  * `calypso_jetpack_backup_download` (when clicking the Download button on a backup activity; with parameter `rewind_id` corresponding to the activity's Rewind ID)
  * `calypso_jetpack_backup_restore` (same as above, but when clicking the Restore button on a backup activity)
* Verify that the "successful" backup status card looks the same as production for both Daily and Real-time.

##### Scan

* Verify that the following Tracks event is correctly fired when opening the details of a threat item:
  * `calypso_jetpack_scan_threat_itemtoggle` (params: `threat_signature`, `section: 'Scanner'`)

##### Settings (Credentials wizard *enabled*)

* Verify that the credentials wizard launches correctly (same as in production) when no credentials are present.
* Verify that error messages still display as expected for problems with form values (make sure to test both Password and Private Key modes).
* Verify that valid credentials are correctly saved, and that errors are correctly displayed when saving invalid credentials.
* Verify that the save button is disabled when errors are present on the form.

##### Settings (Credentials wizard *disabled*)

**TIP:** You can disable the credentials wizard by specifying `?flags=-jetpack/server-credentials-advanced-flow` in your browser's address bar.

* Verify that the page looks and behaves correctly when no credentials are present (e.g., form is immediately visible instead of collapsed, header shows red "disconnected" message, etc.).
* Verify that saved credentials are displayed the same as in production if they exist, and that blank values are shown in form fields where no value is specified.
* Verify that the **Server address** field is auto-populated with a value taken from the site slug if no value is specified.
* Verify that errors are still correctly shown when there's an error on the form, and that valid credentials are saved correctly.

##### Partner Portal

* Verify that tab navigation on the Licenses page still looks and behaves as normal, specifically with respect to which tab is currently selected.
* Verify that the Select Partner Key component still functions as expected (i.e., without errors) when no keys are present.
* Verify that the following Tracks event correctly fires when clicking the Licenses menu item in the sidebar. NOTE: This is new behavior, as it was there previously but wasn't firing.
  * `calypso_jetpack_sidebar_menu_click` (params: `menu_item: 'Jetpack Cloud / Partner Portal / Licenses'`)