### PR TITLE
Fixing new google analytics card design to work properly with atomic

### DIFF
--- a/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
+++ b/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
@@ -209,7 +209,7 @@ export function CloudflareAnalyticsSettings( {
 						<div className="analytics site-settings__analytics">
 							<FormToggle
 								checked={ isCloudflareEnabled }
-								disabled={ isRequestingSettings || isSavingSettings }
+								disabled={ isRequestingSettings || isSavingSettings || ! enableForm }
 								onChange={ () => handleFormToggle( ! isCloudflareEnabled ) }
 							>
 								{ translate( 'Add Cloudflare' ) }

--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -1,0 +1,297 @@
+/**
+ * External dependencies
+ */
+import React, { useState, useEffect } from 'react';
+import { find } from 'lodash';
+
+import { CompactCard } from '@automattic/components';
+import ExternalLink from 'calypso/components/external-link';
+import SupportInfo from 'calypso/components/support-info';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import FormToggle from 'calypso/components/forms/form-toggle';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextValidation from 'calypso/components/forms/form-input-validation';
+import FormAnalyticsStores from '../form-analytics-stores';
+import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import googleIllustration from 'calypso/assets/images/illustrations/google-analytics-logo.svg';
+import { FEATURE_GOOGLE_ANALYTICS } from 'calypso/lib/plans/constants';
+import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import {
+	OPTIONS_JETPACK_SECURITY,
+	PRODUCT_UPSELLS_BY_FEATURE,
+} from 'calypso/my-sites/plans/jetpack-plans/constants';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const validateGoogleAnalyticsCode = ( code ) =>
+	! code || code.match( /^(UA-\d+-\d+)|(G-[A-Z0-9]+)$/i );
+const GoogleAnalyticsJetpackForm = ( {
+	fields,
+	updateFields,
+	isRequestingSettings,
+	isSavingSettings,
+	enableForm,
+	eventTracker,
+	handleSubmitForm,
+	path,
+	translate,
+	trackTracksEvent,
+	uniqueEventTracker,
+	showUpgradeNudge,
+	site,
+	siteId,
+	sitePlugins,
+	jetpackModuleActive,
+} ) => {
+	const [ isCodeValid, setIsCodeValid ] = useState( true );
+	const [ loggedGoogleAnalyticsModified, setLoggedGoogleAnalyticsModified ] = useState( false );
+	const [ displayForm, setDisplayForm ] = useState( false );
+
+	const isSubmitButtonDisabled =
+		isRequestingSettings || isSavingSettings || ! isCodeValid || ! enableForm;
+	const upsellHref = `/checkout/${ site.slug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_GOOGLE_ANALYTICS ] }`;
+	const analyticsSupportUrl = 'https://jetpack.com/support/google-analytics/';
+	const placeholderText = isRequestingSettings ? translate( 'Loading' ) : '';
+	const nudgeTitle = translate( 'Connect your site to Google Analytics' );
+	const wooCommercePlugin = find( sitePlugins, { slug: 'woocommerce' } );
+	const wooCommerceActive = wooCommercePlugin ? wooCommercePlugin.active : false;
+
+	useEffect( () => {
+		if ( jetpackModuleActive ) {
+			setDisplayForm( true );
+		} else {
+			setDisplayForm( false );
+		}
+	}, [ jetpackModuleActive ] );
+
+	const handleFieldChange = ( key, value, callback = () => {} ) => {
+		const updatedFields = Object.assign( {}, fields.wga || {}, {
+			[ key ]: value,
+		} );
+		updateFields( { wga: updatedFields }, callback );
+	};
+
+	const recordSupportLinkClick = () => {
+		trackTracksEvent( 'calypso_traffic_settings_google_support_click' );
+	};
+
+	const handleCodeChange = ( event ) => {
+		const code = event.target.value.trim();
+		setIsCodeValid( validateGoogleAnalyticsCode( code ) );
+		handleFieldChange( 'code', code );
+	};
+	const handleToggleChange = ( key ) => {
+		const value = fields.wga ? ! fields.wga[ key ] : false;
+
+		recordTracksEvent( 'calypso_google_analytics_setting_changed', { key, path } );
+
+		handleFieldChange( key, value );
+	};
+
+	const handleAnonymizeChange = () => {
+		handleToggleChange( 'anonymize_ip' );
+	};
+
+	const handleFieldFocus = () => {
+		trackTracksEvent( 'calypso_google_analytics_key_field_focused', { path } );
+		eventTracker( 'Focused Analytics Key Field' )();
+	};
+
+	const handleFieldKeypress = () => {
+		if ( ! loggedGoogleAnalyticsModified ) {
+			trackTracksEvent( 'calypso_google_analytics_key_field_modified', { path } );
+			setLoggedGoogleAnalyticsModified( true );
+		}
+		uniqueEventTracker( 'Typed In Analytics Key Field' )();
+	};
+
+	const renderForm = () => {
+		const plan = OPTIONS_JETPACK_SECURITY;
+
+		const nudge = (
+			<UpsellNudge
+				description={ translate(
+					"Monitor your site's views, clicks, and other important metrics"
+				) }
+				event={ 'google_analytics_settings' }
+				feature={ FEATURE_GOOGLE_ANALYTICS }
+				plan={ plan }
+				href={ upsellHref }
+				showIcon={ true }
+				title={ nudgeTitle }
+			/>
+		);
+		return (
+			<form id="analytics" onSubmit={ handleSubmitForm }>
+				<QueryJetpackModules siteId={ siteId } />
+
+				<SettingsSectionHeader
+					disabled={ isSubmitButtonDisabled }
+					isSaving={ isSavingSettings }
+					onButtonClick={ handleSubmitForm }
+					showButton
+					title={ translate( 'Google' ) }
+				/>
+
+				<CompactCard>
+					<div className="analytics site-settings__analytics">
+						<div className="analytics site-settings__analytics-illustration">
+							<img src={ googleIllustration } alt="" />
+						</div>
+						<div className="analytics site-settings__analytics-text">
+							<p className="analytics site-settings__analytics-title">
+								{ translate( 'Google Analytics' ) }
+							</p>
+							<p>
+								{ translate(
+									'A free analytics tool that offers additional insights into your site.'
+								) }
+							</p>
+							<p>
+								<a
+									onClick={ recordSupportLinkClick }
+									href={ analyticsSupportUrl }
+									target="_blank"
+									rel="noreferrer"
+								>
+									{ translate( 'Learn more' ) }
+								</a>
+							</p>
+						</div>
+					</div>
+					{ displayForm && (
+						<div>
+							<FormFieldset>
+								<FormLabel htmlFor="wgaCode">
+									{ translate( 'Google Analytics Measurement ID', { context: 'site setting' } ) }
+								</FormLabel>
+								<FormTextInput
+									name="wgaCode"
+									id="wgaCode"
+									value={ fields.wga ? fields.wga.code : '' }
+									onChange={ handleCodeChange }
+									placeholder={ placeholderText }
+									disabled={ isRequestingSettings || ! enableForm }
+									onFocus={ handleFieldFocus }
+									onKeyPress={ handleFieldKeypress }
+									isError={ ! isCodeValid }
+								/>
+								{ ! isCodeValid && (
+									<FormTextValidation
+										isError={ true }
+										text={ translate( 'Invalid Google Analytics Measurement ID.' ) }
+									/>
+								) }
+								<ExternalLink
+									icon
+									href="https://support.google.com/analytics/answer/1032385?hl=en"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									{ translate( 'Where can I find my Measurement ID?' ) }
+								</ExternalLink>
+							</FormFieldset>
+							<FormFieldset>
+								<FormToggle
+									checked={ fields.wga ? Boolean( fields.wga.anonymize_ip ) : false }
+									disabled={ isRequestingSettings || ! enableForm }
+									onChange={ handleAnonymizeChange }
+								>
+									{ translate( 'Anonymize IP addresses' ) }
+								</FormToggle>
+								<FormSettingExplanation>
+									{ translate(
+										'Enabling this option is mandatory in certain countries due to national ' +
+											'privacy laws.'
+									) }
+									<ExternalLink
+										icon
+										href="https://support.google.com/analytics/answer/2763052"
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										{ translate( 'Learn more' ) }
+									</ExternalLink>
+								</FormSettingExplanation>
+							</FormFieldset>
+							{ wooCommerceActive && (
+								<FormAnalyticsStores fields={ fields } handleToggleChange={ handleToggleChange } />
+							) }
+							<p>
+								{ translate(
+									'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} ' +
+										'with different insights into your traffic. WordPress.com stats and Google Analytics ' +
+										'use different methods to identify and track activity on your site, so they will ' +
+										'normally show slightly different totals for your visits, views, etc.',
+									{
+										components: {
+											a: <a href={ '/stats/' + site.domain } />,
+										},
+									}
+								) }
+							</p>
+							<p>
+								{ translate(
+									'Learn more about using {{a}}Google Analytics with WordPress.com{{/a}}.',
+									{
+										components: {
+											a: (
+												<a
+													href={ localizeUrl( analyticsSupportUrl ) }
+													target="_blank"
+													rel="noopener noreferrer"
+												/>
+											),
+										},
+									}
+								) }
+							</p>
+						</div>
+					) }
+				</CompactCard>
+				{ showUpgradeNudge && site && site.plan ? (
+					nudge
+				) : (
+					<CompactCard>
+						<div className="analytics site-settings__analytics">
+							<FormFieldset>
+								<SupportInfo
+									text={ translate(
+										'Reports help you track the path visitors take' +
+											' through your site, and goal conversion lets you' +
+											' measure how visitors complete specific tasks.'
+									) }
+									link="https://jetpack.com/support/google-analytics/"
+								/>
+								<JetpackModuleToggle
+									siteId={ siteId }
+									moduleSlug="google-analytics"
+									label={ translate( 'Add Google' ) }
+									disabled={ isRequestingSettings || isSavingSettings }
+								/>
+							</FormFieldset>
+						</div>
+					</CompactCard>
+				) }
+				<div className="analytics site-settings__analytics-spacer" />
+			</form>
+		);
+	};
+
+	// we need to check that site has loaded first... a placeholder would be better,
+	// but returning null is better than a fatal error for now
+	if ( ! site ) {
+		return null;
+	}
+	return renderForm();
+};
+export default GoogleAnalyticsJetpackForm;

--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -135,7 +135,7 @@ const GoogleAnalyticsJetpackForm = ( {
 						</div>
 					</div>
 					{ displayForm && (
-						<div>
+						<div className="analytics site-settings__analytics-form-content">
 							<FormFieldset>
 								<FormLabel htmlFor="wgaCode">
 									{ translate( 'Google Analytics Measurement ID', { context: 'site setting' } ) }

--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { find } from 'lodash';
 
 import { CompactCard } from '@automattic/components';
@@ -32,35 +32,32 @@ import {
  */
 import './style.scss';
 
-const validateGoogleAnalyticsCode = ( code ) =>
-	! code || code.match( /^(UA-\d+-\d+)|(G-[A-Z0-9]+)$/i );
 const GoogleAnalyticsJetpackForm = ( {
+	displayForm,
+	enableForm,
 	fields,
-	updateFields,
+	handleCodeChange,
+	handleFieldChange,
+	handleFieldFocus,
+	handleFieldKeypress,
+	handleSubmitForm,
+	isCodeValid,
 	isRequestingSettings,
 	isSavingSettings,
-	enableForm,
-	eventTracker,
-	handleSubmitForm,
+	isSubmitButtonDisabled,
+	jetpackModuleActive,
 	path,
-	translate,
-	trackTracksEvent,
-	uniqueEventTracker,
+	placeholderText,
+	recordSupportLinkClick,
+	setDisplayForm,
 	showUpgradeNudge,
 	site,
 	siteId,
 	sitePlugins,
-	jetpackModuleActive,
+	translate,
 } ) => {
-	const [ isCodeValid, setIsCodeValid ] = useState( true );
-	const [ loggedGoogleAnalyticsModified, setLoggedGoogleAnalyticsModified ] = useState( false );
-	const [ displayForm, setDisplayForm ] = useState( false );
-
-	const isSubmitButtonDisabled =
-		isRequestingSettings || isSavingSettings || ! isCodeValid || ! enableForm;
 	const upsellHref = `/checkout/${ site.slug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_GOOGLE_ANALYTICS ] }`;
 	const analyticsSupportUrl = 'https://jetpack.com/support/google-analytics/';
-	const placeholderText = isRequestingSettings ? translate( 'Loading' ) : '';
 	const nudgeTitle = translate( 'Connect your site to Google Analytics' );
 	const wooCommercePlugin = find( sitePlugins, { slug: 'woocommerce' } );
 	const wooCommerceActive = wooCommercePlugin ? wooCommercePlugin.active : false;
@@ -71,47 +68,16 @@ const GoogleAnalyticsJetpackForm = ( {
 		} else {
 			setDisplayForm( false );
 		}
-	}, [ jetpackModuleActive ] );
+	}, [ jetpackModuleActive, setDisplayForm ] );
 
-	const handleFieldChange = ( key, value, callback = () => {} ) => {
-		const updatedFields = Object.assign( {}, fields.wga || {}, {
-			[ key ]: value,
-		} );
-		updateFields( { wga: updatedFields }, callback );
-	};
-
-	const recordSupportLinkClick = () => {
-		trackTracksEvent( 'calypso_traffic_settings_google_support_click' );
-	};
-
-	const handleCodeChange = ( event ) => {
-		const code = event.target.value.trim();
-		setIsCodeValid( validateGoogleAnalyticsCode( code ) );
-		handleFieldChange( 'code', code );
-	};
 	const handleToggleChange = ( key ) => {
 		const value = fields.wga ? ! fields.wga[ key ] : false;
-
 		recordTracksEvent( 'calypso_google_analytics_setting_changed', { key, path } );
-
 		handleFieldChange( key, value );
 	};
 
 	const handleAnonymizeChange = () => {
 		handleToggleChange( 'anonymize_ip' );
-	};
-
-	const handleFieldFocus = () => {
-		trackTracksEvent( 'calypso_google_analytics_key_field_focused', { path } );
-		eventTracker( 'Focused Analytics Key Field' )();
-	};
-
-	const handleFieldKeypress = () => {
-		if ( ! loggedGoogleAnalyticsModified ) {
-			trackTracksEvent( 'calypso_google_analytics_key_field_modified', { path } );
-			setLoggedGoogleAnalyticsModified( true );
-		}
-		uniqueEventTracker( 'Typed In Analytics Key Field' )();
 	};
 
 	const renderForm = () => {

--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -1,0 +1,248 @@
+/**
+ * External dependencies
+ */
+import React, { useState, useEffect } from 'react';
+
+import { CompactCard } from '@automattic/components';
+import ExternalLink from 'calypso/components/external-link';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import FormToggle from 'calypso/components/forms/form-toggle';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextValidation from 'calypso/components/forms/form-input-validation';
+import googleIllustration from 'calypso/assets/images/illustrations/google-analytics-logo.svg';
+import { FEATURE_GOOGLE_ANALYTICS, TYPE_PREMIUM } from 'calypso/lib/plans/constants';
+import { findFirstSimilarPlanKey } from 'calypso/lib/plans';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const validateGoogleAnalyticsCode = ( code ) =>
+	! code || code.match( /^(UA-\d+-\d+)|(G-[A-Z0-9]+)$/i );
+const GoogleAnalyticsSimpleForm = ( {
+	fields,
+	updateFields,
+	isRequestingSettings,
+	isSavingSettings,
+	enableForm,
+	eventTracker,
+	handleSubmitForm,
+	path,
+	translate,
+	trackTracksEvent,
+	uniqueEventTracker,
+	showUpgradeNudge,
+	site,
+} ) => {
+	const [ isCodeValid, setIsCodeValid ] = useState( true );
+	const [ isGoogleEnabled, setIsGoogleEnabled ] = useState( false );
+	const [ loggedGoogleAnalyticsModified, setLoggedGoogleAnalyticsModified ] = useState( false );
+
+	const isSubmitButtonDisabled =
+		isRequestingSettings || isSavingSettings || ! isCodeValid || ! enableForm;
+	const analyticsSupportUrl = 'https://wordpress.com/support/google-analytics/';
+	const placeholderText = isRequestingSettings ? translate( 'Loading' ) : '';
+	const nudgeTitle = translate(
+		'Connect your site to Google Analytics in seconds with the Premium plan'
+	);
+
+	useEffect( () => {
+		if ( fields?.wga?.code ) {
+			setIsGoogleEnabled( true );
+		} else {
+			setIsGoogleEnabled( false );
+		}
+	}, [ fields ] );
+
+	const handleFieldChange = ( value, callback = () => {} ) => {
+		const updatedFields = Object.assign( {}, fields.wga || {}, {
+			code: value,
+		} );
+		updateFields( { wga: updatedFields }, callback );
+	};
+
+	const recordSupportLinkClick = () => {
+		trackTracksEvent( 'calypso_traffic_settings_google_support_click' );
+	};
+
+	const handleCodeChange = ( event ) => {
+		const code = event.target.value.trim();
+		setIsCodeValid( validateGoogleAnalyticsCode( code ) );
+		handleFieldChange( code );
+	};
+
+	const handleFieldFocus = () => {
+		trackTracksEvent( 'calypso_google_analytics_key_field_focused', { path } );
+		eventTracker( 'Focused Analytics Key Field' )();
+	};
+
+	const handleFieldKeypress = () => {
+		if ( ! loggedGoogleAnalyticsModified ) {
+			trackTracksEvent( 'calypso_google_analytics_key_field_modified', { path } );
+			setLoggedGoogleAnalyticsModified( true );
+		}
+		uniqueEventTracker( 'Typed In Analytics Key Field' )();
+	};
+
+	const handleFormToggle = () => {
+		if ( isGoogleEnabled ) {
+			setIsGoogleEnabled( false );
+			handleFieldChange( '', () => {
+				handleSubmitForm();
+			} );
+		} else {
+			setIsGoogleEnabled( true );
+		}
+	};
+
+	const renderForm = () => {
+		const plan = findFirstSimilarPlanKey( site.plan.product_slug, {
+			type: TYPE_PREMIUM,
+		} );
+
+		const nudge = (
+			<UpsellNudge
+				description={ translate(
+					"Add your unique Measurement ID to monitor your site's performance in Google Analytics."
+				) }
+				event={ 'google_analytics_settings' }
+				feature={ FEATURE_GOOGLE_ANALYTICS }
+				plan={ plan }
+				showIcon={ true }
+				title={ nudgeTitle }
+			/>
+		);
+		return (
+			<form id="analytics" onSubmit={ handleSubmitForm }>
+				<SettingsSectionHeader
+					disabled={ isSubmitButtonDisabled }
+					isSaving={ isSavingSettings }
+					onButtonClick={ handleSubmitForm }
+					showButton
+					title={ translate( 'Google' ) }
+				/>
+
+				<CompactCard>
+					<div className="analytics site-settings__analytics">
+						<div className="analytics site-settings__analytics-illustration">
+							<img src={ googleIllustration } alt="" />
+						</div>
+						<div className="analytics site-settings__analytics-text">
+							<p className="analytics site-settings__analytics-title">
+								{ translate( 'Google Analytics' ) }
+							</p>
+							<p>
+								{ translate(
+									'A free analytics tool that offers additional insights into your site.'
+								) }
+							</p>
+							<p>
+								<a
+									onClick={ recordSupportLinkClick }
+									href={ analyticsSupportUrl }
+									target="_blank"
+									rel="noreferrer"
+								>
+									{ translate( 'Learn more' ) }
+								</a>
+							</p>
+						</div>
+					</div>
+					{ isGoogleEnabled && (
+						<div>
+							<FormFieldset>
+								<FormLabel htmlFor="wgaCode">
+									{ translate( 'Google Analytics Measurement ID', { context: 'site setting' } ) }
+								</FormLabel>
+								<FormTextInput
+									name="wgaCode"
+									id="wgaCode"
+									value={ fields.wga ? fields.wga.code : '' }
+									onChange={ handleCodeChange }
+									placeholder={ placeholderText }
+									disabled={ isRequestingSettings || ! enableForm }
+									onFocus={ handleFieldFocus }
+									onKeyPress={ handleFieldKeypress }
+									isError={ ! isCodeValid }
+								/>
+								{ ! isCodeValid && (
+									<FormTextValidation
+										isError={ true }
+										text={ translate( 'Invalid Google Analytics Measurement ID.' ) }
+									/>
+								) }
+								<ExternalLink
+									icon
+									href="https://support.google.com/analytics/answer/1032385?hl=en"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									{ translate( 'Where can I find my Measurement ID?' ) }
+								</ExternalLink>
+							</FormFieldset>
+							<p>
+								{ translate(
+									'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} ' +
+										'with different insights into your traffic. WordPress.com stats and Google Analytics ' +
+										'use different methods to identify and track activity on your site, so they will ' +
+										'normally show slightly different totals for your visits, views, etc.',
+									{
+										components: {
+											a: <a href={ '/stats/' + site.domain } />,
+										},
+									}
+								) }
+							</p>
+							<p>
+								{ translate(
+									'Learn more about using {{a}}Google Analytics with WordPress.com{{/a}}.',
+									{
+										components: {
+											a: (
+												<a
+													href={ localizeUrl( analyticsSupportUrl ) }
+													target="_blank"
+													rel="noopener noreferrer"
+												/>
+											),
+										},
+									}
+								) }
+							</p>
+						</div>
+					) }
+				</CompactCard>
+				{ showUpgradeNudge && site && site.plan ? (
+					nudge
+				) : (
+					<CompactCard>
+						<div className="analytics site-settings__analytics">
+							<FormToggle
+								checked={ isGoogleEnabled }
+								disabled={ isRequestingSettings || isSavingSettings }
+								onChange={ () => handleFormToggle( ! isGoogleEnabled ) }
+							>
+								{ translate( 'Add Google' ) }
+							</FormToggle>
+						</div>
+					</CompactCard>
+				) }
+				<div className="analytics site-settings__analytics-spacer" />
+			</form>
+		);
+	};
+
+	// we need to check that site has loaded first... a placeholder would be better,
+	// but returning null is better than a fatal error for now
+	if ( ! site ) {
+		return null;
+	}
+	return renderForm();
+};
+
+export default GoogleAnalyticsSimpleForm;

--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -120,7 +120,7 @@ const GoogleAnalyticsSimpleForm = ( {
 						</div>
 					</div>
 					{ displayForm && (
-						<div>
+						<div className="analytics site-settings__analytics-form-content">
 							<FormFieldset>
 								<FormLabel htmlFor="wgaCode">
 									{ translate( 'Google Analytics Measurement ID', { context: 'site setting' } ) }

--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 
 import { CompactCard } from '@automattic/components';
 import ExternalLink from 'calypso/components/external-link';
@@ -22,81 +22,47 @@ import { localizeUrl } from 'calypso/lib/i18n-utils';
  */
 import './style.scss';
 
-const validateGoogleAnalyticsCode = ( code ) =>
-	! code || code.match( /^(UA-\d+-\d+)|(G-[A-Z0-9]+)$/i );
 const GoogleAnalyticsSimpleForm = ( {
+	displayForm,
+	enableForm,
 	fields,
-	updateFields,
+	handleCodeChange,
+	handleFieldChange,
+	handleFieldFocus,
+	handleFieldKeypress,
+	handleSubmitForm,
+	isCodeValid,
 	isRequestingSettings,
 	isSavingSettings,
-	enableForm,
-	eventTracker,
-	handleSubmitForm,
-	path,
-	translate,
-	trackTracksEvent,
-	uniqueEventTracker,
+	isSubmitButtonDisabled,
+	placeholderText,
+	recordSupportLinkClick,
+	setDisplayForm,
 	showUpgradeNudge,
 	site,
+	translate,
 } ) => {
-	const [ isCodeValid, setIsCodeValid ] = useState( true );
-	const [ isGoogleEnabled, setIsGoogleEnabled ] = useState( false );
-	const [ loggedGoogleAnalyticsModified, setLoggedGoogleAnalyticsModified ] = useState( false );
-
-	const isSubmitButtonDisabled =
-		isRequestingSettings || isSavingSettings || ! isCodeValid || ! enableForm;
 	const analyticsSupportUrl = 'https://wordpress.com/support/google-analytics/';
-	const placeholderText = isRequestingSettings ? translate( 'Loading' ) : '';
 	const nudgeTitle = translate(
 		'Connect your site to Google Analytics in seconds with the Premium plan'
 	);
 
 	useEffect( () => {
 		if ( fields?.wga?.code ) {
-			setIsGoogleEnabled( true );
+			setDisplayForm( true );
 		} else {
-			setIsGoogleEnabled( false );
+			setDisplayForm( false );
 		}
-	}, [ fields ] );
-
-	const handleFieldChange = ( value, callback = () => {} ) => {
-		const updatedFields = Object.assign( {}, fields.wga || {}, {
-			code: value,
-		} );
-		updateFields( { wga: updatedFields }, callback );
-	};
-
-	const recordSupportLinkClick = () => {
-		trackTracksEvent( 'calypso_traffic_settings_google_support_click' );
-	};
-
-	const handleCodeChange = ( event ) => {
-		const code = event.target.value.trim();
-		setIsCodeValid( validateGoogleAnalyticsCode( code ) );
-		handleFieldChange( code );
-	};
-
-	const handleFieldFocus = () => {
-		trackTracksEvent( 'calypso_google_analytics_key_field_focused', { path } );
-		eventTracker( 'Focused Analytics Key Field' )();
-	};
-
-	const handleFieldKeypress = () => {
-		if ( ! loggedGoogleAnalyticsModified ) {
-			trackTracksEvent( 'calypso_google_analytics_key_field_modified', { path } );
-			setLoggedGoogleAnalyticsModified( true );
-		}
-		uniqueEventTracker( 'Typed In Analytics Key Field' )();
-	};
+	}, [ fields, setDisplayForm ] );
 
 	const handleFormToggle = () => {
-		if ( isGoogleEnabled ) {
-			setIsGoogleEnabled( false );
-			handleFieldChange( '', () => {
+		if ( displayForm ) {
+			setDisplayForm( false );
+			handleFieldChange( 'code', '', () => {
 				handleSubmitForm();
 			} );
 		} else {
-			setIsGoogleEnabled( true );
+			setDisplayForm( true );
 		}
 	};
 
@@ -153,7 +119,7 @@ const GoogleAnalyticsSimpleForm = ( {
 							</p>
 						</div>
 					</div>
-					{ isGoogleEnabled && (
+					{ displayForm && (
 						<div>
 							<FormFieldset>
 								<FormLabel htmlFor="wgaCode">
@@ -223,9 +189,9 @@ const GoogleAnalyticsSimpleForm = ( {
 					<CompactCard>
 						<div className="analytics site-settings__analytics">
 							<FormToggle
-								checked={ isGoogleEnabled }
+								checked={ displayForm }
 								disabled={ isRequestingSettings || isSavingSettings }
-								onChange={ () => handleFormToggle( ! isGoogleEnabled ) }
+								onChange={ () => handleFormToggle( ! displayForm ) }
 							>
 								{ translate( 'Add Google' ) }
 							</FormToggle>

--- a/client/my-sites/site-settings/analytics/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics.jsx
@@ -1,350 +1,34 @@
 /**
  * External dependencies
  */
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
-import { find, flowRight, partialRight, pick } from 'lodash';
+import { flowRight, partialRight, pick } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { hasSiteAnalyticsFeature } from '../utils';
 import wrapSettingsForm from '../wrap-settings-form';
-import { CompactCard } from '@automattic/components';
-import ExternalLink from 'calypso/components/external-link';
-import SupportInfo from 'calypso/components/support-info';
-import UpsellNudge from 'calypso/blocks/upsell-nudge';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import { getPlugins } from 'calypso/state/plugins/installed/selectors';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormLabel from 'calypso/components/forms/form-label';
-import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormTextValidation from 'calypso/components/forms/form-input-validation';
-import FormAnalyticsStores from '../form-analytics-stores';
-import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
-import googleIllustration from 'calypso/assets/images/illustrations/google-analytics-logo.svg';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { FEATURE_GOOGLE_ANALYTICS, TYPE_PREMIUM, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
-import { findFirstSimilarPlanKey } from 'calypso/lib/plans';
-import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
-import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
-import {
-	OPTIONS_JETPACK_SECURITY,
-	PRODUCT_UPSELLS_BY_FEATURE,
-} from 'calypso/my-sites/plans/jetpack-plans/constants';
+import GoogleAnalyticsJetpackForm from './form-google-analytics-jetpack';
+import GoogleAnalyticsSimpleForm from './form-google-analytics-simple';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const validateGoogleAnalyticsCode = ( code ) =>
-	! code || code.match( /^(UA-\d+-\d+)|(G-[A-Z0-9]+)$/i );
-export const GoogleAnalyticsForm = ( {
-	fields,
-	updateFields,
-	isRequestingSettings,
-	isSavingSettings,
-	enableForm,
-	eventTracker,
-	handleSubmitForm,
-	path,
-	translate,
-	trackTracksEvent,
-	uniqueEventTracker,
-	showUpgradeNudge,
-	siteIsJetpack,
-	site,
-	siteId,
-	sitePlugins,
-} ) => {
-	const [ isCodeValid, setIsCodeValid ] = useState( true );
-	const [ isGoogleEnabled, setIsGoogleEnabled ] = useState( false );
-	const [ loggedGoogleAnalyticsModified, setLoggedGoogleAnalyticsModified ] = useState( false );
-
-	const isSubmitButtonDisabled =
-		isRequestingSettings || isSavingSettings || ! isCodeValid || ! enableForm;
-	const upsellHref = siteIsJetpack
-		? `/checkout/${ site.slug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_GOOGLE_ANALYTICS ] }`
-		: null;
-	const analyticsSupportUrl = siteIsJetpack
-		? 'https://jetpack.com/support/google-analytics/'
-		: 'https://wordpress.com/support/google-analytics/';
-	const placeholderText = isRequestingSettings ? translate( 'Loading' ) : '';
-	const nudgeTitle = siteIsJetpack
-		? translate( 'Connect your site to Google Analytics' )
-		: translate( 'Connect your site to Google Analytics in seconds with the Premium plan' );
-	const wooCommercePlugin = find( sitePlugins, { slug: 'woocommerce' } );
-	const wooCommerceActive = wooCommercePlugin ? wooCommercePlugin.active : false;
-
-	useEffect( () => {
-		if ( fields?.wga?.code ) {
-			setIsGoogleEnabled( true );
-		} else {
-			setIsGoogleEnabled( false );
-		}
-	}, [ fields ] );
-
-	const handleFieldChange = ( value, callback = () => {} ) => {
-		const updatedFields = Object.assign( {}, fields.wga || {}, {
-			code: value,
-		} );
-		updateFields( { wga: updatedFields }, callback );
-	};
-
-	const recordSupportLinkClick = () => {
-		trackTracksEvent( 'calypso_traffic_settings_google_support_click' );
-	};
-
-	const handleCodeChange = ( event ) => {
-		const code = event.target.value.trim();
-		setIsCodeValid( validateGoogleAnalyticsCode( code ) );
-		handleFieldChange( code );
-	};
-	const handleToggleChange = ( key ) => {
-		const value = fields.wga ? ! fields.wga[ key ] : false;
-
-		recordTracksEvent( 'calypso_google_analytics_setting_changed', { key, path } );
-
-		handleFieldChange( key, value );
-	};
-
-	const handleAnonymizeChange = () => {
-		this.handleToggleChange( 'anonymize_ip' );
-	};
-
-	const handleFieldFocus = () => {
-		trackTracksEvent( 'calypso_google_analytics_key_field_focused', { path } );
-		eventTracker( 'Focused Analytics Key Field' )();
-	};
-
-	const handleFieldKeypress = () => {
-		if ( ! loggedGoogleAnalyticsModified ) {
-			trackTracksEvent( 'calypso_google_analytics_key_field_modified', { path } );
-			setLoggedGoogleAnalyticsModified( true );
-		}
-		uniqueEventTracker( 'Typed In Analytics Key Field' )();
-	};
-
-	const handleFormToggle = () => {
-		if ( isGoogleEnabled ) {
-			setIsGoogleEnabled( false );
-			handleFieldChange( '', () => {
-				handleSubmitForm();
-			} );
-		} else {
-			setIsGoogleEnabled( true );
-		}
-	};
-
-	const renderForm = () => {
-		const plan = siteIsJetpack
-			? OPTIONS_JETPACK_SECURITY
-			: findFirstSimilarPlanKey( site.plan.product_slug, {
-					type: TYPE_PREMIUM,
-					...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
-			  } );
-
-		const nudge = (
-			<UpsellNudge
-				description={
-					siteIsJetpack
-						? translate( "Monitor your site's views, clicks, and other important metrics" )
-						: translate(
-								"Add your unique Measurement ID to monitor your site's performance in Google Analytics."
-						  )
-				}
-				event={ 'google_analytics_settings' }
-				feature={ FEATURE_GOOGLE_ANALYTICS }
-				plan={ plan }
-				href={ upsellHref }
-				showIcon={ true }
-				title={ nudgeTitle }
-			/>
-		);
-		return (
-			<form id="analytics" onSubmit={ handleSubmitForm }>
-				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
-
-				<SettingsSectionHeader
-					disabled={ isSubmitButtonDisabled }
-					isSaving={ isSavingSettings }
-					onButtonClick={ handleSubmitForm }
-					showButton
-					title={ translate( 'Google' ) }
-				/>
-
-				<CompactCard>
-					<div className="analytics site-settings__analytics">
-						<div className="analytics site-settings__analytics-illustration">
-							<img src={ googleIllustration } alt="" />
-						</div>
-						<div className="analytics site-settings__analytics-text">
-							<p className="analytics site-settings__analytics-title">
-								{ translate( 'Google Analytics' ) }
-							</p>
-							<p>
-								{ translate(
-									'A free analytics tool that offers additional insights into your site.'
-								) }
-							</p>
-							<p>
-								<a
-									onClick={ recordSupportLinkClick }
-									href={ analyticsSupportUrl }
-									target="_blank"
-									rel="noreferrer"
-								>
-									{ translate( 'Learn more' ) }
-								</a>
-							</p>
-						</div>
-					</div>
-					{ isGoogleEnabled && (
-						<div>
-							{ siteIsJetpack && (
-								<FormFieldset>
-									<SupportInfo
-										text={ translate(
-											'Reports help you track the path visitors take' +
-												' through your site, and goal conversion lets you' +
-												' measure how visitors complete specific tasks.'
-										) }
-										link="https://jetpack.com/support/google-analytics/"
-									/>
-									<JetpackModuleToggle
-										siteId={ siteId }
-										moduleSlug="google-analytics"
-										label={ translate(
-											'Track your WordPress site statistics with Google Analytics.'
-										) }
-										disabled={ isRequestingSettings || isSavingSettings }
-									/>
-								</FormFieldset>
-							) }
-
-							<FormFieldset>
-								<FormLabel htmlFor="wgaCode">
-									{ translate( 'Google Analytics Measurement ID', { context: 'site setting' } ) }
-								</FormLabel>
-								<FormTextInput
-									name="wgaCode"
-									id="wgaCode"
-									value={ fields.wga ? fields.wga.code : '' }
-									onChange={ handleCodeChange }
-									placeholder={ placeholderText }
-									disabled={ isRequestingSettings || ! enableForm }
-									onFocus={ handleFieldFocus }
-									onKeyPress={ handleFieldKeypress }
-									isError={ ! isCodeValid }
-								/>
-								{ ! isCodeValid && (
-									<FormTextValidation
-										isError={ true }
-										text={ translate( 'Invalid Google Analytics Measurement ID.' ) }
-									/>
-								) }
-								<ExternalLink
-									icon
-									href="https://support.google.com/analytics/answer/1032385?hl=en"
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									{ translate( 'Where can I find my Measurement ID?' ) }
-								</ExternalLink>
-							</FormFieldset>
-							{ siteIsJetpack && (
-								<FormFieldset>
-									<FormToggle
-										checked={ fields.wga ? Boolean( fields.wga.anonymize_ip ) : false }
-										disabled={ isRequestingSettings || ! enableForm }
-										onChange={ handleAnonymizeChange }
-									>
-										{ translate( 'Anonymize IP addresses' ) }
-									</FormToggle>
-									<FormSettingExplanation>
-										{ translate(
-											'Enabling this option is mandatory in certain countries due to national ' +
-												'privacy laws.'
-										) }
-										<ExternalLink
-											icon
-											href="https://support.google.com/analytics/answer/2763052"
-											target="_blank"
-											rel="noopener noreferrer"
-										>
-											{ translate( 'Learn more' ) }
-										</ExternalLink>
-									</FormSettingExplanation>
-								</FormFieldset>
-							) }
-							{ siteIsJetpack && wooCommerceActive && (
-								<FormAnalyticsStores fields={ fields } handleToggleChange={ handleToggleChange } />
-							) }
-							<p>
-								{ translate(
-									'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} ' +
-										'with different insights into your traffic. WordPress.com stats and Google Analytics ' +
-										'use different methods to identify and track activity on your site, so they will ' +
-										'normally show slightly different totals for your visits, views, etc.',
-									{
-										components: {
-											a: <a href={ '/stats/' + site.domain } />,
-										},
-									}
-								) }
-							</p>
-							<p>
-								{ translate(
-									'Learn more about using {{a}}Google Analytics with WordPress.com{{/a}}.',
-									{
-										components: {
-											a: (
-												<a
-													href={ localizeUrl( analyticsSupportUrl ) }
-													target="_blank"
-													rel="noopener noreferrer"
-												/>
-											),
-										},
-									}
-								) }
-							</p>
-						</div>
-					) }
-				</CompactCard>
-				{ showUpgradeNudge && site && site.plan ? (
-					nudge
-				) : (
-					<CompactCard>
-						<div className="analytics site-settings__analytics">
-							<FormToggle
-								checked={ isGoogleEnabled }
-								disabled={ isRequestingSettings || isSavingSettings }
-								onChange={ () => handleFormToggle( ! isGoogleEnabled ) }
-							>
-								{ translate( 'Add Google' ) }
-							</FormToggle>
-						</div>
-					</CompactCard>
-				) }
-				<div className="analytics site-settings__analytics-spacer" />
-			</form>
-		);
-	};
-
-	// we need to check that site has loaded first... a placeholder would be better,
-	// but returning null is better than a fatal error for now
-	if ( ! site ) {
-		return null;
+export const GoogleAnalyticsForm = ( props ) => {
+	if ( props.siteIsJetpack ) {
+		return <GoogleAnalyticsJetpackForm { ...props } />;
 	}
-	return renderForm();
+	return <GoogleAnalyticsSimpleForm { ...props } />;
 };
 
 const mapStateToProps = ( state ) => {
@@ -365,6 +49,7 @@ const mapStateToProps = ( state ) => {
 		siteId,
 		siteIsJetpack,
 		sitePlugins,
+		jetpackModuleActive,
 	};
 };
 

--- a/client/my-sites/site-settings/analytics/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { flowRight, partialRight, pick } from 'lodash';
 
@@ -24,11 +24,75 @@ import GoogleAnalyticsSimpleForm from './form-google-analytics-simple';
  */
 import './style.scss';
 
+const validateGoogleAnalyticsCode = ( code ) =>
+	! code || code.match( /^(UA-\d+-\d+)|(G-[A-Z0-9]+)$/i );
 export const GoogleAnalyticsForm = ( props ) => {
+	const {
+		isRequestingSettings,
+		isSavingSettings,
+		enableForm,
+		translate,
+		fields,
+		updateFields,
+		trackTracksEvent,
+		eventTracker,
+		uniqueEventTracker,
+		path,
+	} = props;
+	const [ isCodeValid, setIsCodeValid ] = useState( true );
+	const [ loggedGoogleAnalyticsModified, setLoggedGoogleAnalyticsModified ] = useState( false );
+	const [ displayForm, setDisplayForm ] = useState( false );
+	const isSubmitButtonDisabled =
+		isRequestingSettings || isSavingSettings || ! isCodeValid || ! enableForm;
+	const placeholderText = isRequestingSettings ? translate( 'Loading' ) : '';
+
+	const handleFieldChange = ( key, value, callback = () => {} ) => {
+		const updatedFields = Object.assign( {}, fields.wga || {}, {
+			[ key ]: value,
+		} );
+		updateFields( { wga: updatedFields }, callback );
+	};
+
+	const handleCodeChange = ( event ) => {
+		const code = event.target.value.trim();
+		setIsCodeValid( validateGoogleAnalyticsCode( code ) );
+		handleFieldChange( 'code', code );
+	};
+
+	const recordSupportLinkClick = () => {
+		trackTracksEvent( 'calypso_traffic_settings_google_support_click' );
+	};
+
+	const handleFieldFocus = () => {
+		trackTracksEvent( 'calypso_google_analytics_key_field_focused', { path } );
+		eventTracker( 'Focused Analytics Key Field' )();
+	};
+
+	const handleFieldKeypress = () => {
+		if ( ! loggedGoogleAnalyticsModified ) {
+			trackTracksEvent( 'calypso_google_analytics_key_field_modified', { path } );
+			setLoggedGoogleAnalyticsModified( true );
+		}
+		uniqueEventTracker( 'Typed In Analytics Key Field' )();
+	};
+
+	const newProps = {
+		...props,
+		displayForm,
+		handleCodeChange,
+		handleFieldChange,
+		handleFieldFocus,
+		handleFieldKeypress,
+		isCodeValid,
+		isSubmitButtonDisabled,
+		placeholderText,
+		recordSupportLinkClick,
+		setDisplayForm,
+	};
 	if ( props.siteIsJetpack ) {
-		return <GoogleAnalyticsJetpackForm { ...props } />;
+		return <GoogleAnalyticsJetpackForm { ...newProps } />;
 	}
-	return <GoogleAnalyticsSimpleForm { ...props } />;
+	return <GoogleAnalyticsSimpleForm { ...newProps } />;
 };
 
 const mapStateToProps = ( state ) => {

--- a/client/my-sites/site-settings/analytics/style.scss
+++ b/client/my-sites/site-settings/analytics/style.scss
@@ -31,3 +31,6 @@
 .site-settings__analytics-spacer {
 	margin-bottom: 16px;
 }
+.site-settings__analytics-form-content {
+	margin-top: 24px;
+}

--- a/client/my-sites/site-settings/analytics/style.scss
+++ b/client/my-sites/site-settings/analytics/style.scss
@@ -2,6 +2,10 @@
 	display: flex;
 	flex-direction: row;
 	align-items: flex-start;
+	.support-info {
+		position: absolute;
+		right: 24px;
+	}
 }
 
 .site-settings__analytics-text {
@@ -18,7 +22,7 @@
 }
 
 .site-settings__analytics-illustration {
-	width: 10%;
+	width: 50px;
 	img {
 		width: 100%;
 	}

--- a/client/my-sites/site-settings/test/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-google-analytics.jsx
@@ -28,7 +28,8 @@ import { OPTIONS_JETPACK_SECURITY } from 'calypso/my-sites/plans/jetpack-plans/c
 /**
  * Internal dependencies
  */
-import { GoogleAnalyticsForm } from '../analytics/form-google-analytics';
+import GoogleAnalyticsSimpleForm from '../analytics/form-google-analytics-simple';
+import GoogleAnalyticsJetpackForm from '../analytics/form-google-analytics-jetpack';
 
 const props = {
 	site: {
@@ -43,17 +44,25 @@ const props = {
 };
 
 describe( 'GoogleAnalyticsForm basic tests', () => {
-	test( 'should not blow up and have proper CSS class', () => {
-		const comp = shallow( <GoogleAnalyticsForm { ...props } /> );
+	test( 'simple form should not blow up and have proper CSS class', () => {
+		const comp = shallow( <GoogleAnalyticsSimpleForm { ...props } /> );
 		expect( comp.find( '#analytics' ) ).toHaveLength( 1 );
 	} );
-	test( 'should not show upgrade nudge if disabled', () => {
-		const comp = shallow( <GoogleAnalyticsForm { ...props } showUpgradeNudge={ false } /> );
+	test( 'jetpack form should not blow up and have proper CSS class', () => {
+		const comp = shallow( <GoogleAnalyticsJetpackForm { ...props } /> );
+		expect( comp.find( '#analytics' ) ).toHaveLength( 1 );
+	} );
+	test( 'simple form should not show upgrade nudge if disabled', () => {
+		const comp = shallow( <GoogleAnalyticsSimpleForm { ...props } showUpgradeNudge={ false } /> );
+		expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 0 );
+	} );
+	test( 'jetpack form should not show upgrade nudge if disabled', () => {
+		const comp = shallow( <GoogleAnalyticsJetpackForm { ...props } showUpgradeNudge={ false } /> );
 		expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 0 );
 	} );
 } );
 
-describe( 'UpsellNudge should get appropriate plan constant', () => {
+describe( 'UpsellNudge should get appropriate plan constant for both forms', () => {
 	const myProps = {
 		...props,
 		showUpgradeNudge: true,
@@ -62,11 +71,7 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 	[ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL ].forEach( ( product_slug ) => {
 		test( `Business 1 year for (${ product_slug })`, () => {
 			const comp = shallow(
-				<GoogleAnalyticsForm
-					{ ...myProps }
-					siteIsJetpack={ false }
-					site={ { plan: { product_slug } } }
-				/>
+				<GoogleAnalyticsSimpleForm { ...myProps } site={ { plan: { product_slug } } } />
 			);
 			expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
 			expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ).props().plan ).toBe(
@@ -78,11 +83,7 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 	[ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS ].forEach( ( product_slug ) => {
 		test( `Business 2 year for (${ product_slug })`, () => {
 			const comp = shallow(
-				<GoogleAnalyticsForm
-					{ ...myProps }
-					siteIsJetpack={ false }
-					site={ { plan: { product_slug } } }
-				/>
+				<GoogleAnalyticsSimpleForm { ...myProps } site={ { plan: { product_slug } } } />
 			);
 			expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
 			expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ).props().plan ).toBe(
@@ -95,11 +96,7 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 		( product_slug ) => {
 			test( `Jetpack Security for (${ product_slug })`, () => {
 				const comp = shallow(
-					<GoogleAnalyticsForm
-						{ ...myProps }
-						siteIsJetpack={ true }
-						site={ { plan: { product_slug } } }
-					/>
+					<GoogleAnalyticsJetpackForm { ...myProps } site={ { plan: { product_slug } } } />
 				);
 				expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
 				expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ).props().plan ).toBe(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes the redesigned Google Analytics settings card (https://github.com/Automattic/wp-calypso/pull/49629) to adjust its behavior for atomic sites on WPCOM.
* Atomic sites differ slightly from simple sites in their handling of the Google Analytics plugin; it is a Jetpack module which needs to be actively enabled or disabled, rather than simply setting or removing the tracking code value. 
* Additionally, atomic sites offer a toggle on the settings card for enabling or disabling the option to anonymize IPs when tracking analytics.

(A/N - originally all Jetpack and non-Jetpack code for this card were in the same component; with the switch to a card design where the form is shown and hidden based on a toggle, the state management for handling both these cases at once got pretty gnarly, hence the approach in this PR which splits them into a Jetpack and non-Jetpack component. Open to suggestions if another approach seems preferable but I think this works cleanly enough.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If necessary, create a new WPCOM site with Business or Ecommerce plan and a plugin enabled to make it Atomic.
* Navigate to `Tools->Marketing->Traffic`.
* Verify that you can enable and disable Google Analytics, enter a tracking code, and see it reflected in your site's header code.
* Verify that you can perform the same actions with a simple site, but that the form appears differently.

Simple site:
![image](https://user-images.githubusercontent.com/13437011/109065567-67575e00-76b1-11eb-87e4-de0dbf1f6ea6.png)


Atomic site:
![image](https://user-images.githubusercontent.com/13437011/109065518-51e23400-76b1-11eb-9d28-235788a4b423.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1614032820004200-slack-C01HV13S295