### PR TITLE
Editor Checkout: fix loading cart data when upgrading for Premium blocks

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -122,7 +122,7 @@ interface Props {
 	locale: string | undefined;
 	checkoutOnSuccessCallback?: () => void;
 	isFocusedLaunch?: boolean;
-	cartData: RequestCart;
+	cartData?: RequestCart;
 	redirectTo?: string;
 }
 

--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -27,12 +27,6 @@ import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopp
  */
 import './style.scss';
 
-export interface CheckoutModalOptions {
-	cartData?: RequestCart;
-	redirectTo?: string;
-	isFocusedLaunch?: boolean;
-}
-
 const wpcom = wp.undocumented();
 
 function fetchStripeConfigurationWpcom( args: Record< string, unknown > ) {
@@ -121,13 +115,15 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 	) : null;
 };
 
-interface Props extends CheckoutModalOptions {
+interface Props {
 	site: SiteData | null;
 	onClose: () => void;
 	isOpen: boolean;
 	locale: string | undefined;
 	checkoutOnSuccessCallback?: () => void;
 	isFocusedLaunch?: boolean;
+	cartData: RequestCart;
+	redirectTo?: string;
 }
 
 EditorCheckoutModal.defaultProps = {

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -8,6 +8,8 @@ import { map, partial, pickBy, isArray, flowRight } from 'lodash';
 /* eslint-disable no-restricted-imports */
 import url from 'url';
 import { localize, LocalizeProps } from 'i18n-calypso';
+import type { RequestCart } from '@automattic/shopping-cart';
+
 /**
  * Internal dependencies
  */
@@ -57,7 +59,6 @@ import { REASON_BLOCK_EDITOR_UNKOWN_IFRAME_LOAD_FAILURE } from 'calypso/state/de
 import { setMediaLibrarySelectedItems } from 'calypso/state/media/actions';
 import { fetchMediaItem, getMediaItem } from 'calypso/state/media/thunks';
 import Iframe from './iframe';
-import type { CheckoutModalOptions } from 'calypso/blocks/editor-checkout-modal';
 
 /**
  * Types
@@ -85,6 +86,11 @@ interface Props {
 	fseParentPageId: T.PostId;
 	parentPostId: T.PostId;
 	stripeConnectSuccess: 'gutenberg' | null;
+}
+
+interface CheckoutModalOptions extends RequestCart {
+	redirectTo?: string;
+	isFocusedLaunch?: boolean;
 }
 
 interface State {
@@ -719,6 +725,7 @@ class CalypsoifyIframe extends Component<
 
 		const isUsingClassicBlock = !! classicBlockEditorId;
 		const isCheckoutOverlayEnabled = config.isEnabled( 'post-editor/checkout-overlay' );
+		const { redirectTo, isFocusedLaunch, ...cartData } = checkoutModalOptions || {};
 
 		return (
 			<Fragment>
@@ -763,9 +770,9 @@ class CalypsoifyIframe extends Component<
 						onClose={ this.closeCheckoutModal }
 						placeholder={ null }
 						isOpen={ isCheckoutModalVisible }
-						cartData={ checkoutModalOptions?.cartData }
-						redirectTo={ checkoutModalOptions?.redirectTo }
-						isFocusedLaunch={ checkoutModalOptions?.isFocusedLaunch }
+						cartData={ cartData }
+						redirectTo={ redirectTo }
+						isFocusedLaunch={ isFocusedLaunch }
 					/>
 				) }
 				<AsyncLoad


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* [Latest updates](https://github.com/Automattic/wp-calypso/pull/48452/files#diff-94cbcc079892f7f8fb113398707b6a9b6394766e051b1f2c28f98334ad25015f) to the way data is passed into `EditorCheckoutModal` weren't compatible to the way Premium Blocks are updating cart. This PR is fixing it.

#### Testing instructions

* Go to editor for a free site and add a Premium Block
* Upgrade that block
* Checkout modal should appear with the corresponding plan loaded

Related to #50450
