### PR TITLE
Refactor post publish e2e flow to use driverhelper

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -67,7 +67,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async publish( { visit = false, closePanel = true } = {} ) {
-		const snackBarNoticeLinkSelector = By.css( '.components-snackbar__content a' );
 		await driverHelper.clickWhenClickable( this.driver, this.prePublishButtonSelector );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishHeaderSelector );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishSelector );
@@ -75,6 +74,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		const button = await this.driver.findElement( this.publishSelector );
 		await this.driver.executeScript( 'arguments[0].click();', button );
 		await driverHelper.waitTillNotPresent( this.driver, this.publishingSpinnerSelector );
+
 		if ( closePanel ) {
 			try {
 				await this.closePublishedPanel();
@@ -82,13 +82,16 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 				console.log( 'Publish panel already closed' );
 			}
 		}
+
 		await this.waitForSuccessViewPostNotice();
+
+		const snackBarNoticeLinkSelector = By.css( '.components-snackbar__content a' );
 		const url = await this.driver.findElement( snackBarNoticeLinkSelector ).getAttribute( 'href' );
 
 		if ( visit ) {
-			const snackbar = await this.driver.findElement( snackBarNoticeLinkSelector );
-			await this.driver.executeScript( 'arguments[0].click();', snackbar );
+			await driverHelper.clickWhenClickable( this.driver, snackBarNoticeLinkSelector );
 		}
+
 		await this.driver.sleep( 1000 );
 		await driverHelper.acceptAlertIfPresent( this.driver );
 		return url;
@@ -528,10 +531,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async closePublishedPanel() {
-		const closeButton = await this.driver.findElement(
+		return await driverHelper.clickWhenClickable(
+			this.driver,
 			By.css( '.editor-post-publish-panel__header button[aria-label="Close panel"]' )
 		);
-		return await this.driver.executeScript( 'arguments[0].click();', closeButton );
 	}
 
 	async ensureSaved() {

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
@@ -63,7 +63,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 			// We need to save the post to get a stable post slug for the block's `url` attribute.
 			// See https://github.com/godaddy-wordpress/coblocks/issues/1663.
 			await gEditorComponent.ensureSaved();
-			return await gEditorComponent.publish( { visit: true, closePanel: false } );
+			return await gEditorComponent.publish( { visit: true } );
 		} );
 
 		step( 'Can see the Click to Tweet block in our published post', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -555,7 +555,9 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 
 		step( 'Can publish and view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			return await gEditorComponent.publish( { visit: true } );
+			// closePanel is set to false because the panel is forcibly dismissed after publishing.
+			// See https://github.com/Automattic/wp-calypso/issues/50302.
+			return await gEditorComponent.publish( { closePanel: false, visit: true } );
 		} );
 
 		step( 'Can see the payment button in our published page', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1099,7 +1099,9 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 		step( 'Can publish and view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			return await gEditorComponent.publish( { visit: true } );
+			// closePanel is set to false because the panel is forcibly dismissed after publishing.
+			// See https://github.com/Automattic/wp-calypso/issues/50302.
+			return await gEditorComponent.publish( { closePanel: false, visit: true } );
 		} );
 
 		step( 'Can see the payment button in our published post', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* instead of executing scripts to click on buttons or links, use the `clickWhenClickable` function.
* update tests with appropriate parameters for `closePanel` where necessary due to existing issues such as #50302.

#### Testing instructions

Pull the changes and from `test/e2e` run:
```
mocha test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
```
Or wait for CircleCI run to complete, and check the run logs for:

```
Insert a payment button into a page
Insert a payment button: @parallel
Insert a Click to Tweet block: @parallel
```