### PR TITLE
Checkout: Only redirect away when cart is empty if removing a product

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/empty-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/empty-cart.tsx
@@ -12,6 +12,7 @@ export default function EmptyCart(): JSX.Element {
 			isStepActive={ false }
 			isStepComplete={ true }
 			titleContent={ <EmptyCartTitle /> }
+			completeStepContent={ <EmptyCartExplanation /> }
 		/>
 	);
 }
@@ -19,4 +20,15 @@ export default function EmptyCart(): JSX.Element {
 function EmptyCartTitle(): JSX.Element {
 	const translate = useTranslate();
 	return <>{ String( translate( 'You have no items in your cart' ) ) }</>;
+}
+
+function EmptyCartExplanation(): JSX.Element {
+	const translate = useTranslate();
+	return (
+		<>
+			{ translate(
+				'If you were trying to add something to your cart, there may have been a problem. Try adding it again.'
+			) }
+		</>
+	);
 }

--- a/client/my-sites/checkout/composite-checkout/components/empty-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/empty-cart.tsx
@@ -1,11 +1,30 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { CheckoutStepBody } from '@automattic/composite-checkout';
+import { useSelector, useDispatch } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getPreviousPath from 'calypso/state/selectors/get-previous-path';
 
 export default function EmptyCart(): JSX.Element {
+	const reduxDispatch = useDispatch();
+	const previousPath = useSelector( getPreviousPath );
+	const referrer = window?.document?.referrer ?? '';
+	useEffect( () => {
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_empty_cart', {
+				previous_path: previousPath ?? '',
+				referrer,
+			} )
+		);
+	}, [ reduxDispatch, previousPath, referrer ] );
+
 	return (
 		<CheckoutStepBody
 			stepId="empty-cart"

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -68,7 +68,7 @@ import { translateResponseCartToWPCOMCart } from './lib/translate-cart';
 import useCountryList from './hooks/use-country-list';
 import useCachedDomainContactDetails from './hooks/use-cached-domain-contact-details';
 import useActOnceOnStrings from './hooks/use-act-once-on-strings';
-import useRedirectIfCartEmpty from './hooks/use-redirect-if-cart-empty';
+import useRemoveFromCartAndRedirect from './hooks/use-remove-from-cart-and-redirect';
 import useRecordCheckoutLoaded from './hooks/use-record-checkout-loaded';
 import useRecordCartLoaded from './hooks/use-record-cart-loaded';
 import useAddProductsFromUrl from './hooks/use-add-products-from-url';
@@ -350,7 +350,11 @@ export default function CompositeCheckout( {
 	const {
 		isRemovingProductFromCart,
 		removeProductFromCartAndMaybeRedirect,
-	} = useRedirectIfCartEmpty( siteSlug, siteSlugLoggedOutCart, createUserAndSiteBeforeTransaction );
+	} = useRemoveFromCartAndRedirect(
+		siteSlug,
+		siteSlugLoggedOutCart,
+		createUserAndSiteBeforeTransaction
+	);
 
 	const { storedCards, isLoading: isLoadingStoredCards, error: storedCardsError } = useStoredCards(
 		getStoredCards || wpcomGetStoredCards,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-redirect-if-cart-empty.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-redirect-if-cart-empty.ts
@@ -56,10 +56,10 @@ export default function useRedirectIfCartEmpty(
 			return removeProductFromCart( uuid ).then( ( cart: ResponseCart ) => {
 				if ( cart.products.length === 0 ) {
 					redirectDueToEmptyCart();
+					// Don't turn off isRemovingProductFromCart if we are redirecting so that the loading page remains active.
 					return cart;
 				}
-				// Don't change this if we are redirecting so that the loading page remains active
-				setIsRemovingFromCart( true );
+				setIsRemovingFromCart( false );
 				return cart;
 			} );
 		},

--- a/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
@@ -14,7 +14,7 @@ import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-redirect-if-cart-empty' );
 
-export default function useRedirectIfCartEmpty(
+export default function useRemoveFromCartAndRedirect(
 	siteSlug: string | undefined,
 	siteSlugLoggedOutCart: string | undefined,
 	createUserAndSiteBeforeTransaction: boolean

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -497,12 +497,12 @@ describe( 'CompositeCheckout', () => {
 		expect( page.redirect ).not.toHaveBeenCalled();
 	} );
 
-	it( 'redirects to the plans page if the cart is empty when it loads', async () => {
+	it( 'does not redirect to the plans page if the cart is empty when it loads', async () => {
 		const cartChanges = { products: [] };
 		await act( async () => {
 			render( <MyCheckout cartChanges={ cartChanges } />, container );
 		} );
-		expect( page.redirect ).toHaveBeenCalledWith( '/plans/foo.com' );
+		expect( page.redirect ).not.toHaveBeenCalledWith( '/plans/foo.com' );
 	} );
 
 	it( 'does not redirect if the cart is empty when it loads but the url has a plan alias', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -10,7 +10,7 @@ import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import { Provider as ReduxProvider } from 'react-redux';
 import '@testing-library/jest-dom/extend-expect';
-import { render, act, fireEvent } from '@testing-library/react';
+import { render, act, fireEvent, screen } from '@testing-library/react';
 import { ShoppingCartProvider } from '@automattic/shopping-cart';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 
@@ -47,7 +47,7 @@ const domainProduct = {
 	},
 	free_trial: false,
 	meta: 'foo.cash',
-	product_id: 106,
+	product_id: 6,
 	volume: 1,
 	is_domain_registration: true,
 	item_original_cost_integer: 500,
@@ -70,7 +70,7 @@ const domainTransferProduct = {
 	},
 	free_trial: false,
 	meta: 'foo.cash',
-	product_id: 106,
+	product_id: 6,
 	volume: 1,
 	item_original_cost_integer: 500,
 	item_original_cost_display: 'R$5',
@@ -495,6 +495,57 @@ describe( 'CompositeCheckout', () => {
 		const { getByText } = renderResult;
 		expect( getByText( 'Purchase Details' ) ).toBeInTheDocument();
 		expect( page.redirect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'removes a product from the cart after clicking to remove it', async () => {
+		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+		const removeProductButton = await screen.findByLabelText(
+			'Remove WordPress.com Personal from cart'
+		);
+		expect( screen.getAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 2 );
+		fireEvent.click( removeProductButton );
+		const confirmButton = await screen.findByText( 'Continue' );
+		await act( async () => {
+			fireEvent.click( confirmButton );
+		} );
+		expect( screen.queryAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 0 );
+	} );
+
+	it( 'redirects to the plans page if the cart is empty after removing the last product', async () => {
+		const cartChanges = { products: [ planWithoutDomain ] };
+		await act( async () => {
+			render( <MyCheckout cartChanges={ cartChanges } />, container );
+		} );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+		const removeProductButton = await screen.findByLabelText(
+			'Remove WordPress.com Personal from cart'
+		);
+		fireEvent.click( removeProductButton );
+		const confirmButton = await screen.findByText( 'Continue' );
+		await act( async () => {
+			fireEvent.click( confirmButton );
+		} );
+		expect( page.redirect ).toHaveBeenCalledWith( '/plans/foo.com' );
+	} );
+
+	it( 'does not redirect to the plans page if the cart is empty after removing a product when it is not the last', async () => {
+		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
+		await act( async () => {
+			render( <MyCheckout cartChanges={ cartChanges } />, container );
+		} );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+		const removeProductButton = await screen.findByLabelText( 'Remove foo.cash from cart' );
+		fireEvent.click( removeProductButton );
+		const confirmButton = await screen.findByText( 'Continue' );
+		await act( async () => {
+			fireEvent.click( confirmButton );
+		} );
+		expect( page.redirect ).not.toHaveBeenCalledWith( '/plans/foo.com' );
 	} );
 
 	it( 'does not redirect to the plans page if the cart is empty when it loads', async () => {

--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -29,14 +29,14 @@ This is a React hook that can be used in any child component under [ShoppingCart
 
 The following actions are also properties. Each one returns a Promise that resolves when the cart is next valid (this may be after several queued actions are complete).
 
-- `addProductsToCart: ( products: RequestCartProduct[] ) => Promise<void>`. A function that requests adding new products to the cart. May cause the cart to be replaced instead, depending on the RequestCartProducts (mostly renewals and non-renewals cannot co-exist in the cart at the same time).
-- `removeProductFromCart: ( uuidToRemove: string ) => Promise<void>`. A function that requests removing a product from the cart.
-- `applyCoupon: ( couponId: string ) => Promise<void>`. A function that requests applying a coupon to the cart (only one coupon can be applied at a time).
-- `removeCoupon: () => Promise<void>`. A function that requests removing a coupon to the cart.
-- `updateLocation: ( location: CartLocation ) => Promise<void>`. A function that can be used to change the tax location of the cart.
-- `replaceProductInCart: ( uuidToReplace: string, productPropertiesToChange: Partial< RequestCartProduct > ) => Promise<void>`. A function that can replace one product in the cart with another, retaining the same UUID; useful for changing product variants.
-- `replaceProductsInCart: ( products: RequestCartProduct[] ) => Promise<void>`. A function that replaces all the products in the cart with a new set of products. Can also be used to clear the cart.
-- `reloadFromServer: () => Promise<void>`. A function to throw away the current cart cache and fetch it fresh from the shopping cart API.
+- `addProductsToCart: ( products: RequestCartProduct[] ) => Promise<ResponseCart>`. A function that requests adding new products to the cart. May cause the cart to be replaced instead, depending on the RequestCartProducts (mostly renewals and non-renewals cannot co-exist in the cart at the same time).
+- `removeProductFromCart: ( uuidToRemove: string ) => Promise<ResponseCart>`. A function that requests removing a product from the cart.
+- `applyCoupon: ( couponId: string ) => Promise<ResponseCart>`. A function that requests applying a coupon to the cart (only one coupon can be applied at a time).
+- `removeCoupon: () => Promise<ResponseCart>`. A function that requests removing a coupon to the cart.
+- `updateLocation: ( location: CartLocation ) => Promise<ResponseCart>`. A function that can be used to change the tax location of the cart.
+- `replaceProductInCart: ( uuidToReplace: string, productPropertiesToChange: Partial< RequestCartProduct > ) => Promise<ResponseCart>`. A function that can replace one product in the cart with another, retaining the same UUID; useful for changing product variants.
+- `replaceProductsInCart: ( products: RequestCartProduct[] ) => Promise<ResponseCart>`. A function that replaces all the products in the cart with a new set of products. Can also be used to clear the cart.
+- `reloadFromServer: () => Promise<ResponseCart>`. A function to throw away the current cart cache and fetch it fresh from the shopping cart API.
 
 ## withShoppingCart
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -38,21 +38,25 @@ export interface ShoppingCartManager {
 export type ReplaceProductInCart = (
 	uuidToReplace: string,
 	productPropertiesToChange: Partial< RequestCartProduct >
-) => Promise< void >;
+) => Promise< ResponseCart >;
 
-export type ReloadCartFromServer = () => Promise< void >;
+export type ReloadCartFromServer = () => Promise< ResponseCart >;
 
-export type ReplaceProductsInCart = ( products: MinimalRequestCartProduct[] ) => Promise< void >;
+export type ReplaceProductsInCart = (
+	products: MinimalRequestCartProduct[]
+) => Promise< ResponseCart >;
 
-export type AddProductsToCart = ( products: MinimalRequestCartProduct[] ) => Promise< void >;
+export type AddProductsToCart = (
+	products: MinimalRequestCartProduct[]
+) => Promise< ResponseCart >;
 
-export type RemoveCouponFromCart = () => Promise< void >;
+export type RemoveCouponFromCart = () => Promise< ResponseCart >;
 
-export type ApplyCouponToCart = ( couponId: string ) => Promise< void >;
+export type ApplyCouponToCart = ( couponId: string ) => Promise< ResponseCart >;
 
-export type RemoveProductFromCart = ( uuidToRemove: string ) => Promise< void >;
+export type RemoveProductFromCart = ( uuidToRemove: string ) => Promise< ResponseCart >;
 
-export type UpdateTaxLocationInCart = ( location: CartLocation ) => Promise< void >;
+export type UpdateTaxLocationInCart = ( location: CartLocation ) => Promise< ResponseCart >;
 
 /**
  * The custom hook keeps a cached version of the server cart, as well as a
@@ -109,4 +113,4 @@ export type ShoppingCartState = {
 	queuedActions: ShoppingCartAction[];
 };
 
-export type CartValidCallback = () => void;
+export type CartValidCallback = ( cart: ResponseCart ) => void;

--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -83,7 +83,7 @@ export default function useShoppingCartManager( {
 
 	const dispatchAndWaitForValid = useCallback(
 		( action ) => {
-			return new Promise< void >( ( resolve ) => {
+			return new Promise< ResponseCart >( ( resolve ) => {
 				isMounted.current && hookDispatch( action );
 				cartValidCallbacks.current.push( resolve );
 			} );
@@ -165,7 +165,9 @@ export default function useShoppingCartManager( {
 		debug( `cacheStatus changed to ${ cacheStatus } and cartValidCallbacks exist` );
 		if ( hookState.queuedActions.length === 0 && cacheStatus === 'valid' ) {
 			debug( 'calling cartValidCallbacks' );
-			cartValidCallbacks.current.forEach( ( callback ) => callback() );
+			cartValidCallbacks.current.forEach( ( callback ) =>
+				callback( lastValidResponseCart.current )
+			);
 			cartValidCallbacks.current = [];
 		}
 	}, [ hookState.queuedActions, cacheStatus ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently when checkout finishes rendering at any time, and the cart is empty, and there are no errors, we redirect away. (This is typically to the plans page but may be to somewhere else.)

This behavior is helpful if you are removing the last product from your cart, but can be confusing if it happens when checkout first loads. The latter case should never really happen, but it does if there is a bug somewhere else that might prevent something from being added to the cart correctly. (If checkout itself fails to add a product to the cart, the redirect already does not happen because an error is displayed.)

In this PR we modify the behavior so that the redirect only occurs after removing the last product from the cart, rather than on any given render. Otherwise, you'll be shown the "empty cart" page, which this PR updates to mention that you probably shouldn't be seeing it.

<img width="775" alt="Screen Shot 2021-02-25 at 6 52 27 PM" src="https://user-images.githubusercontent.com/2036909/109234958-baf1a680-779a-11eb-9275-05eeced755d0.png">


#### Testing instructions

- With an empty cart, visit checkout.
- Verify that you see the "empty cart" page and that no redirect occurs.
- Visit `/domains/add/example.com` for your site and add a domain to the cart.
- At the upsell, add an email product to the cart (or in some other way get two products in your cart).
- Visit checkout.
- Verify that you see two products in your cart and that no redirect occurs.
- Click "Edit" on the first step and then remove one of the products from your cart (the email product must be first if the other one is a domain so that they are not both removed).
- Verify that you see one product in your cart and that no redirect occurs.
- Click to remove the last product.
- Verify that the loading page appears and then that you are redirected to the plans page.