### PR TITLE
Enable featured category of page layouts

### DIFF
--- a/packages/page-template-modal/src/components/page-template-modal.js
+++ b/packages/page-template-modal/src/components/page-template-modal.js
@@ -274,14 +274,21 @@ export default class PageTemplateModal extends Component {
 		const templateGroups = {};
 		for ( const template of this.props.templates ) {
 			for ( const key in template.categories ) {
-				// Temporarily skip the 'featured' category so that we can expose it at another time.
-				if ( key !== 'featured' && ! ( key in templateGroups ) ) {
+				if ( ! ( key in templateGroups ) ) {
 					templateGroups[ key ] = template.categories[ key ];
 				}
 			}
 		}
 
-		const preferredGroupOrder = [ 'about', 'blog', 'home-page', 'gallery', 'services', 'contact' ];
+		const preferredGroupOrder = [
+			'featured',
+			'about',
+			'blog',
+			'home-page',
+			'gallery',
+			'services',
+			'contact',
+		];
 		return sortGroupNames( preferredGroupOrder, templateGroups );
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Displays the featured category as the first category of the new page template selector 

see #49865

#### Testing instructions
checkout this PR
`yarn dev --sync`

![Screen Shot 2021-02-25 at 11 56 43 AM](https://user-images.githubusercontent.com/22446385/109091670-f2436180-7760-11eb-9c59-c740ec9c8c7e.png)

closes #49865
