### PR TITLE
Marketing Upsell: can't decline offer from Editor Checkout #50461

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
@@ -270,7 +270,7 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 				<Button
 					data-e2e-button="decline"
 					className="business-plan-upgrade-upsell__decline-offer-button"
-					onClick={ handleClickDecline }
+					onClick={ () => handleClickDecline() }
 				>
 					{ translate( "No thanks, I don't need plugins" ) }
 				</Button>

--- a/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/index.jsx
@@ -259,7 +259,7 @@ export class ConciergeQuickstartSession extends PureComponent {
 						<Button
 							data-e2e-button="decline"
 							className="concierge-quickstart-session__decline-offer-button"
-							onClick={ handleClickDecline }
+							onClick={ () => handleClickDecline() }
 						>
 							{ translate( "No thanks, I'll do it on my own" ) }
 						</Button>

--- a/client/my-sites/checkout/upsell-nudge/concierge-support-session/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/concierge-support-session/index.jsx
@@ -207,7 +207,7 @@ export class ConciergeSupportSession extends PureComponent {
 				<Button
 					data-e2e-button="decline"
 					className="concierge-support-session__decline-offer-button"
-					onClick={ handleClickDecline }
+					onClick={ () => handleClickDecline() }
 				>
 					{ translate( 'Skip' ) }
 				</Button>

--- a/client/my-sites/checkout/upsell-nudge/difm-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/difm-upsell/index.jsx
@@ -176,7 +176,7 @@ export class DifmUpsell extends PureComponent {
 				<Button
 					data-e2e-button="decline"
 					className="difm-upsell__decline-offer-button"
-					onClick={ handleClickDecline }
+					onClick={ () => handleClickDecline() }
 				>
 					{ translate( 'No thanks' ) }
 				</Button>

--- a/client/my-sites/checkout/upsell-nudge/premium-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/premium-plan-upgrade-upsell/index.jsx
@@ -233,7 +233,7 @@ export class PremiumPlanUpgradeUpsell extends PureComponent {
 				<Button
 					data-e2e-button="decline"
 					className="premium-plan-upgrade-upsell__decline-offer-button"
-					onClick={ handleClickDecline }
+					onClick={ () => handleClickDecline() }
 				>
 					{ translate( 'No thanks' ) }
 				</Button>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**DO NOT MERGE**

**This is test PR** to try to see what's going on in https://github.com/Automattic/wp-calypso/issues/50461

The `handleClickDecline()` method in the upsell component is not working as expected.

⚠️ I can't track down where exactly the problem is. [getThankYouPageUrl](https://github.com/Automattic/wp-calypso/blob/768e81f9cbd8aec3d7be28d95c9cd728391c716d/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts) isn't returning the expected URL (it is returning the current URL of http://calypso.localhost:3000/checkout/MY_SITE?notice=purchase-success#step2), so `page.redirect()` isn't doing anything

The last relevant change is from https://github.com/Automattic/wp-calypso/commit/768e81f9cbd8aec3d7be28d95c9cd728391c716d#diff-ea2f96cfb7728d99fffeb9644dbda281c9225548684c9acf8b918e396ef0e5dbR209

The PR (so far) has three main changes:

1. Wrapping the `page.redirect` in a try/catch statement. For reasons unknown the `page.redirect()` does nothing, so I'm testing using `window.location.replace`
2. Calling `handleClickDecline()` in an anonymous function, since we're expecting `shouldHideUpsellNudges` as an argument, not the handler event
3. Updating the prop types planDiscountedRawPrice and planRawPrice to `number` due to console complaints from React

#### Testing instructions

See: https://github.com/Automattic/wp-calypso/pull/50460

Also check that the prop errors don't show when you land on the upsell page:
<img width="1022" alt="Screen Shot 2021-02-25 at 12 22 19 pm" src="https://user-images.githubusercontent.com/6458278/109093617-c29a5680-776c-11eb-8a9f-939473a36687.png">


Related to #50461
