### PR TITLE
Remove width constraint on the domain upsell card so that it can stre…

### DIFF
--- a/client/signup/steps/domain-upsell/index.jsx
+++ b/client/signup/steps/domain-upsell/index.jsx
@@ -154,7 +154,7 @@ function RecommendedDomains( props ) {
 	return (
 		<div className="domain-upsell">
 			{ ! productData && ! isLoading && ! hasError && <QuerySecureYourBrand domain={ siteSlug } /> }
-			<Card style={ { maxWidth: '615px' } } className="domain-upsell__card">
+			<Card className="domain-upsell__card">
 				{ isLoading ? (
 					[ ...Array( 3 ) ].map( ( e, i ) => (
 						<div key={ `${ i }` } className="domain-upsell__placeholder">


### PR DESCRIPTION
### What this PR does

On the domain upsell step on the launch site flow, the container width is constrained and the content flows outside the white background.

<img width="1039" alt="Screen Shot 2021-02-25 at 7 57 44 pm" src="https://user-images.githubusercontent.com/6458278/109130062-6b64a800-77a5-11eb-964f-3375abb4adc3.png">

This PR proposes a quick fix that removes the [width constraint](https://github.com/Automattic/wp-calypso/blob/5b4715a51f5690dfcdd692ef2ef78ad4ae5fccae/client/signup/steps/domain-upsell/index.jsx#L157) of 615px

### Testing instructions

1. Sign up for a new site at `/start` (make sure you're in the control group of the current launch flow experiment `focused_launch_flow_v2` assuming it's still running) ensuring that your WordPress subdomain is long, e.g., `asdfasdfawedq24wrgthtgrfwfeq3e435trygdfsvdwe3r453t4rgfvsdfae3333`
2. Go to the home screen of your site.
3. Select the launch task. You should be sent to the launch flow at `/start/launch-site/domains-launch`
4. Skip purchase and continue with your free site address
5. Select a free plan on the plans step

Check that the container stretches to accommodate my long domain

<img width="1073" alt="Screen Shot 2021-02-25 at 8 02 39 pm" src="https://user-images.githubusercontent.com/6458278/109130052-6869b780-77a5-11eb-8b05-d17909991159.png">

Also check with smaller domain names, and in narrow viewports



Fixes #49285
