### PR TITLE
Signup: check for siteSlug in setSelectedSiteForSignup method

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -311,13 +311,13 @@ export default {
 	setSelectedSiteForSignup( { store: signupStore, query }, next ) {
 		const { getState, dispatch } = signupStore;
 		const signupDependencies = getSignupDependencyStore( getState() );
-
 		const siteSlug = signupDependencies?.siteSlug || query?.siteSlug;
 		const siteId = getSiteId( getState(), siteSlug );
+
 		if ( siteId ) {
 			dispatch( setSelectedSiteId( siteId ) );
 			next();
-		} else {
+		} else if ( siteSlug ) {
 			// Fetch the site by siteSlug and then try to select again
 			dispatch( requestSite( siteSlug ) ).then( () => {
 				let freshSiteId = getSiteId( getState(), siteSlug );
@@ -332,6 +332,7 @@ export default {
 					next();
 				}
 			} );
+		} else {
 			next();
 		}
 	},


### PR DESCRIPTION
### Changes proposed in this Pull Request

This commit checks for the existence of `siteSlug` in the `setSelectedSiteForSignup()` signup controller method, then calls next() if there is none.

Without it, we see an an error on `/start` since the `siteSlug` isn't available to be passed to the Promise.

<img width="765" alt="Screen Shot 2021-02-25 at 8 23 01 pm" src="https://user-images.githubusercontent.com/6458278/109137616-7de2df80-77ad-11eb-8166-eb853b33b35e.png">

### Testing instructions

1. Sign up for a new site at `/start` (make sure you're in the control group of the current launch flow experiment `focused_launch_flow_v2` assuming it's still running) ensuring that your WordPress subdomain is long, e.g., `asdfasdfawedq24wrgthtgrfwfeq3e435trygdfsvdwe3r453t4rgfvsdfae3333`
2. Go to the home screen of your site.
3. Select the launch task. You should be sent to the launch flow at `/start/launch-site/domains-launch`
4. Continue through the launch flow

Repeat for good measure!

- [ ] You shouldn't see the above error message in the console during `/start`
- [ ] You should be able to launch your site as expected
- [ ] It shouldn't affect subsequent site creation + launch flows

Fixes https://github.com/Automattic/wp-calypso/issues/50431