### PR TITLE
i18n: Replace static translate calls with useTranslate hook

### DIFF
--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { ReactElement, FunctionComponent } from 'react';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { addQueryArgs } from '@wordpress/url';
 import { Button } from '@automattic/components';
@@ -32,24 +32,28 @@ import './style.scss';
 
 const JetpackBackupErrorSVG = '/calypso/images/illustrations/jetpack-cloud-backup-error.svg';
 
-const BackupMultisiteBody: FunctionComponent = () => (
-	<PromoCard
-		title={ preventWidows( translate( 'WordPress multi-sites are not supported' ) ) }
-		image={ { path: JetpackBackupErrorSVG } }
-		isPrimary
-	>
-		<p>
-			{ preventWidows(
-				translate(
-					"We're sorry, Jetpack Backup is not compatible with multisite WordPress installations at this time."
-				)
-			) }
-		</p>
-	</PromoCard>
-);
+const BackupMultisiteBody: FunctionComponent = () => {
+	const translate = useTranslate();
+	return (
+		<PromoCard
+			title={ preventWidows( translate( 'WordPress multi-sites are not supported' ) ) }
+			image={ { path: JetpackBackupErrorSVG } }
+			isPrimary
+		>
+			<p>
+				{ preventWidows(
+					translate(
+						"We're sorry, Jetpack Backup is not compatible with multisite WordPress installations at this time."
+					)
+				) }
+			</p>
+		</PromoCard>
+	);
+};
 
 const BackupVPActiveBody: FunctionComponent = () => {
 	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_backup_vaultpress_click' );
+	const translate = useTranslate();
 	return (
 		<PromoCard
 			title={ preventWidows( translate( 'Your backups are powered by VaultPress' ) ) }
@@ -78,6 +82,7 @@ const BackupUpsellBody: FunctionComponent = () => {
 	const isAdmin = useSelector(
 		( state ) => siteId && canCurrentUser( state, siteId, 'manage_options' )
 	);
+	const translate = useTranslate();
 	return (
 		<PromoCard
 			title={ preventWidows( translate( 'Get time travel for your site with Jetpack Backup' ) ) }
@@ -128,6 +133,7 @@ const BackupUpsellBody: FunctionComponent = () => {
 };
 
 export default function WPCOMUpsellPage( { reason }: { reason: string } ): ReactElement {
+	const translate = useTranslate();
 	let body;
 	switch ( reason ) {
 		case 'multisite_not_supported':

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { ReactElement } from 'react';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 
 /**
@@ -34,24 +34,24 @@ import './style.scss';
 
 const trackEventName = 'calypso_jetpack_backup_business_upsell';
 
-const promos: PromoSectionProps = {
-	promos: [
-		{
-			title: translate( 'Activity Log' ),
-			body: translate(
-				'A complete record of everything that happens on your site, with history that spans over 30 days.'
-			),
-			image: <Gridicon icon="history" className="backup__upsell-icon" />,
-		},
-	],
-};
-
 export default function WPCOMUpsellPage(): ReactElement {
 	const onUpgradeClick = useTrackCallback( undefined, trackEventName );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId );
 	const isAdmin = useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) );
 	const { product_slug: planSlug } = useSelector( ( state ) => getSitePlan( state, siteId ) );
+	const translate = useTranslate();
+	const promos: PromoSectionProps = {
+		promos: [
+			{
+				title: translate( 'Activity Log' ),
+				body: translate(
+					'A complete record of everything that happens on your site, with history that spans over 30 days.'
+				),
+				image: <Gridicon icon="history" className="backup__upsell-icon" />,
+			},
+		],
+	};
 
 	return (
 		<Main className="backup__main backup__wpcom-upsell">

--- a/client/my-sites/jetpack-search/upsell.tsx
+++ b/client/my-sites/jetpack-search/upsell.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { ReactElement } from 'react';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 
 /**
@@ -27,6 +27,7 @@ import JetpackSearchSVG from 'calypso/assets/images/illustrations/jetpack-search
 export default function JetpackSearchUpsell(): ReactElement {
 	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_search_upsell' );
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	const translate = useTranslate();
 
 	return (
 		<Main className="jetpack-search">

--- a/client/my-sites/scan/wpcom-scan-upsell.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { ReactElement, FunctionComponent } from 'react';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { Button } from '@automattic/components';
 
@@ -32,24 +32,28 @@ import JetpackScanSVG from 'calypso/assets/images/illustrations/jetpack-scan.svg
 import VaultPressLogo from 'calypso/assets/images/jetpack/vaultpress-logo.svg';
 import './style.scss';
 
-const ScanMultisiteBody: FunctionComponent = () => (
-	<PromoCard
-		title={ preventWidows( translate( 'WordPress multi-sites are not supported' ) ) }
-		image={ <SecurityIcon icon="info" /> }
-		isPrimary
-	>
-		<p>
-			{ preventWidows(
-				translate(
-					"We're sorry, Jetpack Scan is not compatible with multisite WordPress installations at this time."
-				)
-			) }
-		</p>
-	</PromoCard>
-);
+const ScanMultisiteBody: FunctionComponent = () => {
+	const translate = useTranslate();
+	return (
+		<PromoCard
+			title={ preventWidows( translate( 'WordPress multi-sites are not supported' ) ) }
+			image={ <SecurityIcon icon="info" /> }
+			isPrimary
+		>
+			<p>
+				{ preventWidows(
+					translate(
+						"We're sorry, Jetpack Scan is not compatible with multisite WordPress installations at this time."
+					)
+				) }
+			</p>
+		</PromoCard>
+	);
+};
 
 const ScanVPActiveBody: FunctionComponent = () => {
 	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_scan_vaultpress_click' );
+	const translate = useTranslate();
 	return (
 		<PromoCard
 			title={ preventWidows( translate( 'Your site has VaultPress' ) ) }
@@ -85,6 +89,7 @@ const ScanUpsellBody: FunctionComponent = () => {
 	const isAdmin = useSelector(
 		( state ) => siteId && canCurrentUser( state, siteId, 'manage_options' )
 	);
+	const translate = useTranslate();
 
 	return (
 		<PromoCard
@@ -126,6 +131,7 @@ const ScanUpsellBody: FunctionComponent = () => {
 };
 
 export default function WPCOMScanUpsellPage( { reason }: { reason?: string } ): ReactElement {
+	const translate = useTranslate();
 	let body;
 	switch ( reason ) {
 		case 'multisite_not_supported':

--- a/client/my-sites/scan/wpcom-upsell.tsx
+++ b/client/my-sites/scan/wpcom-upsell.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { ReactElement } from 'react';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 
 /**
@@ -29,25 +29,26 @@ import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import JetpackScanSVG from 'calypso/assets/images/illustrations/jetpack-scan.svg';
 import './style.scss';
 
-const promos = [
-	{
-		title: translate( 'Jetpack Backup' ),
-		body: translate(
-			'Granular control over your site, with the ability ' +
-				'to restore it to any previous state, and export it at any time.'
-		),
-		image: <Gridicon icon="cloud-upload" className="scan__upsell-icon" />,
-	},
-	{
-		title: translate( 'Activity Log' ),
-		body: translate(
-			'A complete record of everything that happens on your site, with history that spans over 30 days.'
-		),
-		image: <Gridicon icon="history" className="scan__upsell-icon" />,
-	},
-];
-
 export default function WPCOMScanUpsellPage(): ReactElement {
+	const translate = useTranslate();
+	const promos = [
+		{
+			title: translate( 'Jetpack Backup' ),
+			body: translate(
+				'Granular control over your site, with the ability ' +
+					'to restore it to any previous state, and export it at any time.'
+			),
+			image: <Gridicon icon="cloud-upload" className="scan__upsell-icon" />,
+		},
+		{
+			title: translate( 'Activity Log' ),
+			body: translate(
+				'A complete record of everything that happens on your site, with history that spans over 30 days.'
+			),
+			image: <Gridicon icon="history" className="scan__upsell-icon" />,
+		},
+	];
+
 	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_scan_business_upsell' );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace static `translate` calls with `useTranslate` hook to get components subscribed to i18n `change` events and re-render when needed.

**Before:**
![image](https://user-images.githubusercontent.com/2722412/109140123-f40f2400-7764-11eb-8613-f32e9aa507d1.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/109140149-fa050500-7764-11eb-9d55-78d3cca380c6.png)


#### Testing instructions

* Review code changes
* Change UI to a Mag-16 language and go to `/backup`, `/jetpack-search` and `/scan`
* Confirm the affected upsell sections are rendering with

Related to 215-gh-Automattic/i18n-issues
