### PR TITLE
i18n: Fix translations on site stats screen

### DIFF
--- a/client/blocks/stats-navigation/constants.js
+++ b/client/blocks/stats-navigation/constants.js
@@ -3,37 +3,65 @@
  */
 import { translate } from 'i18n-calypso';
 
-export const intervals = [
-	{ value: 'day', label: translate( 'Days' ) },
-	{ value: 'week', label: translate( 'Weeks' ) },
-	{ value: 'month', label: translate( 'Months' ) },
-	{ value: 'year', label: translate( 'Years' ) },
-];
+/**
+ * Intervals
+ */
+const day = { value: 'day', label: translate( 'Days' ) };
+const week = { value: 'week', label: translate( 'Weeks' ) };
+const month = { value: 'month', label: translate( 'Months' ) };
+const year = { value: 'year', label: translate( 'Years' ) };
+
+export const intervals = [ day, week, month, year ];
+
+/**
+ * Nav items
+ */
+const traffic = {
+	label: translate( 'Traffic' ),
+	path: '/stats',
+	showIntervals: true,
+};
+const insights = {
+	label: translate( 'Insights' ),
+	path: '/stats/insights',
+	showIntervals: false,
+};
+const store = {
+	label: translate( 'Store' ),
+	path: '/store/stats/orders',
+	showIntervals: true,
+};
+const wordads = {
+	label: 'Ads',
+	path: '/stats/ads',
+	showIntervals: true,
+};
+const googleMyBusiness = {
+	label: translate( 'Google My Business' ),
+	path: '/google-my-business/stats',
+	showIntervals: false,
+};
 
 export const navItems = {
-	traffic: {
-		label: translate( 'Traffic' ),
-		path: '/stats',
-		showIntervals: true,
-	},
-	insights: {
-		label: translate( 'Insights' ),
-		path: '/stats/insights',
-		showIntervals: false,
-	},
-	store: {
-		label: translate( 'Store' ),
-		path: '/store/stats/orders',
-		showIntervals: true,
-	},
-	wordads: {
-		label: 'Ads',
-		path: '/stats/ads',
-		showIntervals: true,
-	},
-	googleMyBusiness: {
-		label: translate( 'Google My Business' ),
-		path: '/google-my-business/stats',
-		showIntervals: false,
-	},
+	traffic,
+	insights,
+	store,
+	wordads,
+	googleMyBusiness,
 };
+
+/**
+ * Define properties with translatable strings getters
+ */
+Object.defineProperty( day, 'label', { get: () => translate( 'Days' ) } );
+Object.defineProperty( week, 'label', { get: () => translate( 'Weeks' ) } );
+Object.defineProperty( month, 'label', { get: () => translate( 'Months' ) } );
+Object.defineProperty( year, 'label', { get: () => translate( 'Years' ) } );
+
+Object.defineProperty( traffic, 'label', { get: () => translate( 'Traffic' ) } );
+Object.defineProperty( insights, 'label', { get: () => translate( 'Insights' ) } );
+Object.defineProperty( store, 'label', { get: () => translate( 'Store' ) } );
+Object.defineProperty( wordads, 'label', { get: () => 'Ads' } );
+Object.defineProperty( googleMyBusiness, 'label', {
+	get: () => translate( 'Google My Business' ),
+} );

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -109,4 +110,4 @@ export default connect( ( state, { siteId } ) => {
 			canCurrentUser( state, siteId, 'manage_options' ),
 		siteId,
 	};
-} )( StatsNavigation );
+} )( localize( StatsNavigation ) );

--- a/client/blocks/stats-navigation/intervals.js
+++ b/client/blocks/stats-navigation/intervals.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -46,4 +47,4 @@ Intervals.defaultProps = {
 	standalone: false,
 };
 
-export default Intervals;
+export default localize( Intervals );

--- a/client/components/chart/legend.jsx
+++ b/client/components/chart/legend.jsx
@@ -4,13 +4,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { find, noop } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import ChartLegendItem from './legend-item';
 
-export default class ChartLegend extends React.Component {
+class ChartLegend extends React.Component {
 	static propTypes = {
 		activeCharts: PropTypes.array,
 		activeTab: PropTypes.object.isRequired,
@@ -38,6 +39,7 @@ export default class ChartLegend extends React.Component {
 			const colorClass = legendColors[ index ];
 			const checked = -1 !== this.props.activeCharts.indexOf( legendItem );
 			const tab = find( this.props.tabs, { attr: legendItem } );
+
 			return (
 				<ChartLegendItem
 					key={ index }
@@ -65,3 +67,5 @@ export default class ChartLegend extends React.Component {
 		);
 	}
 }
+
+export default localize( ChartLegend );

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -60,29 +60,44 @@ const memoizedQuery = memoizeLast( ( period, endOf ) => ( {
 	date: endOf.format( 'YYYY-MM-DD' ),
 } ) );
 
-const CHARTS = [
-	{
-		attr: 'views',
-		legendOptions: [ 'visitors' ],
-		gridicon: 'visible',
-		label: translate( 'Views', { context: 'noun' } ),
-	},
-	{
-		attr: 'visitors',
-		gridicon: 'user',
-		label: translate( 'Visitors', { context: 'noun' } ),
-	},
-	{
-		attr: 'likes',
-		gridicon: 'star',
-		label: translate( 'Likes', { context: 'noun' } ),
-	},
-	{
-		attr: 'comments',
-		gridicon: 'comment',
-		label: translate( 'Comments', { context: 'noun' } ),
-	},
-];
+const CHART_VIEWS = {
+	attr: 'views',
+	legendOptions: [ 'visitors' ],
+	gridicon: 'visible',
+	label: translate( 'Views', { context: 'noun' } ),
+};
+const CHART_VISITORS = {
+	attr: 'visitors',
+	gridicon: 'user',
+	label: translate( 'Visitors', { context: 'noun' } ),
+};
+const CHART_LIKES = {
+	attr: 'likes',
+	gridicon: 'star',
+	label: translate( 'Likes', { context: 'noun' } ),
+};
+const CHART_COMMENTS = {
+	attr: 'comments',
+	gridicon: 'comment',
+	label: translate( 'Comments', { context: 'noun' } ),
+};
+const CHARTS = [ CHART_VIEWS, CHART_VISITORS, CHART_LIKES, CHART_COMMENTS ];
+
+/**
+ * Define chart properties with translatable strings getters
+ */
+Object.defineProperty( CHART_VIEWS, 'label', {
+	get: () => translate( 'Views', { context: 'noun' } ),
+} );
+Object.defineProperty( CHART_VISITORS, 'label', {
+	get: () => translate( 'Visitors', { context: 'noun' } ),
+} );
+Object.defineProperty( CHART_LIKES, 'label', {
+	get: () => translate( 'Likes', { context: 'noun' } ),
+} );
+Object.defineProperty( CHART_COMMENTS, 'label', {
+	get: () => translate( 'Comments', { context: 'noun' } ),
+} );
 
 const getActiveTab = ( chartTab ) => find( CHARTS, { attr: chartTab } ) || CHARTS[ 0 ];
 class StatsSite extends Component {

--- a/client/my-sites/stats/stats-tabs/index.jsx
+++ b/client/my-sites/stats/stats-tabs/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { find } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -17,7 +18,7 @@ import StatTab from './tab';
  */
 import './style.scss';
 
-export default class extends React.Component {
+class StatsTabs extends React.Component {
 	static displayName = 'StatsTabs';
 
 	static propTypes = {
@@ -79,3 +80,5 @@ export default class extends React.Component {
 		);
 	}
 }
+
+export default localize( StatsTabs );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Define constant labels on the stats screen with dynamic getters that would call `translate` every time they are being accessed.
* Wrap chart components with `localize` HOC where it's needed to re-render the component on i18n `change` events.

**Before:**
![image](https://user-images.githubusercontent.com/2722412/109148440-f5dde500-776e-11eb-84db-0e44e4039d63.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/109148459-fb3b2f80-776e-11eb-92df-bac3edf13471.png)

#### Testing instructions

* Review code changes
* Change UI to a Mag-16 language and go to `/stats/day/{site}`
* Confirm nav items, tabs and legend labels are being translated into the selected language.

Related to 216-gh-Automattic/i18n-issues
