### PR TITLE
New onboarding: stop newUsersWithFreePlan A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -51,8 +51,8 @@ export default {
 	newUsersWithFreePlan: {
 		datestamp: '20210107',
 		variations: {
-			newOnboarding: 50,
-			control: 50,
+			newOnboarding: 0,
+			control: 100,
 		},
 		localeTargets: 'any',
 		localeExceptions: [ 'en', 'es' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Stop the experiment started in https://github.com/Automattic/wp-calypso/pull/48193

#### Testing instructions

* Go to `/start/free` and you shouldn't be redirected to `/new/free`
