### PR TITLE
Plans: Wrap subheading in a translate function.

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -136,9 +136,9 @@ class Plans extends React.Component {
 							<FormattedHeader
 								brandFont
 								headerText={ translate( 'Plans' ) }
-								subHeaderText={
+								subHeaderText={ translate(
 									'See and compare the features available on each WordPress.com plan.'
-								}
+								) }
 								align="left"
 							/>
 							<div id="plans" className="plans plans__has-sidebar">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes mistake introduced in #50045, wrap Plans `subHeaderText` copy in a translate function so it's available for i18n.

<img width="1124" alt="Screen Shot 2021-02-25 at 9 12 06 AM" src="https://user-images.githubusercontent.com/2124984/109165495-9d482100-7749-11eb-8d9e-15464a3ff685.png">


#### Testing instructions

* Switch to this PR, navigate to `/plans`
* Make sure the copy is present and that nothing breaks. There are no visual changes.
