### PR TITLE
Magic Link: add custom landing page for users coming from Jetpack flow

### DIFF
--- a/client/login/index.node.js
+++ b/client/login/index.node.js
@@ -17,7 +17,12 @@ export default ( router ) => {
 		const lang = getLanguageRouteParam();
 
 		// Only do the basics for layout on the server-side
-		router( `/log-in/link/use/${ lang }`, setLocaleMiddleware, redirectLoggedIn, makeLayout );
+		router(
+			[ `/log-in/link/use/${ lang }`, `/log-in/link/jetpack/use/${ lang }` ],
+			setLocaleMiddleware,
+			redirectLoggedIn,
+			makeLayout
+		);
 	}
 
 	webRouter( router );

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -63,7 +63,7 @@ export default ( router ) => {
 
 	if ( config.isEnabled( 'login/magic-login' ) ) {
 		router(
-			`/log-in/link/use/${ lang }`,
+			[ `/log-in/link/use/${ lang }`, `/log-in/jetpack/link/use/${ lang }` ],
 			redirectLoggedIn,
 			setLocaleMiddleware,
 			setSectionMiddleware( LOGIN_SECTION_DEFINITION ),

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -141,6 +141,10 @@ class MagicLogin extends React.Component {
 	}
 
 	render() {
+		const formProps = {
+			...( this.props.isJetpackLogin ? { flow: 'jetpack' } : {} ),
+		};
+
 		return (
 			<Main
 				className={ classNames( 'magic-login', 'magic-login__request-link', {
@@ -154,7 +158,7 @@ class MagicLogin extends React.Component {
 
 				<GlobalNotices id="notices" />
 
-				<RequestLoginEmailForm />
+				<RequestLoginEmailForm { ...formProps } />
 
 				{ this.renderLinks() }
 			</Main>

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -41,6 +41,7 @@ class RequestLoginEmailForm extends React.Component {
 		requestError: PropTypes.string,
 		showCheckYourEmail: PropTypes.bool,
 		userEmail: PropTypes.string,
+		flow: PropTypes.string,
 
 		// mapped to dispatch
 		sendEmailLogin: PropTypes.func.isRequired,
@@ -87,7 +88,7 @@ class RequestLoginEmailForm extends React.Component {
 		this.props.sendEmailLogin( usernameOrEmail, {
 			redirectTo: this.props.redirectTo,
 			requestLoginEmailFormFlow: true,
-			flow: 'jetpack',
+			...( this.props.flow ? { flow: this.props.flow } : {} ),
 		} );
 	};
 

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -87,6 +87,7 @@ class RequestLoginEmailForm extends React.Component {
 		this.props.sendEmailLogin( usernameOrEmail, {
 			redirectTo: this.props.redirectTo,
 			requestLoginEmailFormFlow: true,
+			flow: 'jetpack',
 		} );
 	};
 

--- a/client/state/auth/actions.js
+++ b/client/state/auth/actions.js
@@ -8,14 +8,14 @@ import 'calypso/state/data-layer/wpcom/auth/send-login-email';
 /**
  * Sends an email with a link that allows a user to login WordPress.com or the native apps
  *
- * @param {string}  email - email to send to
- * @param {object}  options object:
- * {string} redirectTo - url to redirect to after login
- * {boolean} loginFormFlow - if true, dispatches actions associated with passwordless login
- * {boolean} requestLoginEmailFormFlow - if true, dispatches actions associated with email me login
- * {boolean} isMobileAppLogin - if true, will send an email that allows login to the native apps
- * {boolean} showGlobalNotices - if true, displays global notices to user about the email
- *
+ * @param {string} email - email to send to
+ * @param {object} options -
+ * @param {string} options.redirectTo - url to redirect to after login
+ * @param {boolean} options.loginFormFlow - if true, dispatches actions associated with passwordless login
+ * @param {boolean} options.requestLoginEmailFormFlow - if true, dispatches actions associated with email me login
+ * @param {boolean} options.isMobileAppLogin - if true, will send an email that allows login to the native apps
+ * @param {boolean} options.showGlobalNotices - if true, displays global notices to user about the email
+ * @param {string} options.flow - name of the login flow
  * @returns {object} action object
  */
 export const sendEmailLogin = (
@@ -26,6 +26,7 @@ export const sendEmailLogin = (
 		loginFormFlow = false,
 		requestLoginEmailFormFlow = false,
 		isMobileAppLogin = false,
+		flow = null,
 	}
 ) => {
 	//Kind of weird usage, but this is a straight port from undocumented.js for now.
@@ -43,5 +44,6 @@ export const sendEmailLogin = (
 		showGlobalNotices,
 		loginFormFlow,
 		requestLoginEmailFormFlow,
+		flow,
 	};
 };

--- a/client/state/data-layer/wpcom/auth/send-login-email/index.js
+++ b/client/state/data-layer/wpcom/auth/send-login-email/index.js
@@ -35,6 +35,7 @@ export const sendLoginEmail = ( action ) => {
 		loginFormFlow,
 		requestLoginEmailFormFlow,
 		isMobileAppLogin,
+		flow,
 	} = action;
 	const noticeAction = showGlobalNotices
 		? infoNotice( translate( 'Sending email' ), { duration: 4000 } )
@@ -54,7 +55,7 @@ export const sendLoginEmail = ( action ) => {
 			{
 				path: `/auth/send-login-email`,
 				method: 'POST',
-				apiVersion: '1.2',
+				apiVersion: '1.3',
 				body: {
 					client_id: config( 'wpcom_signup_id' ),
 					client_secret: config( 'wpcom_signup_key' ),
@@ -64,6 +65,7 @@ export const sendLoginEmail = ( action ) => {
 					lang_id: lang_id,
 					email: email,
 					...( redirect_to && { redirect_to } ),
+					...( flow && { flow } ),
 				},
 			},
 			{ ...action, infoNoticeId: noticeAction ? noticeAction.notice.noticeId : null }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Related to 1199916399796129-as-1199957083423373

* By default, after clicking a Magic Link email CTA we are sending users back to `/log-in/link/use` which can be confusing for users coming from a Jetpack flow. This revision changes that by taking into account whether the user is coming from a Jetpack flow and sends them to `/log-in/jetpack/link/use` in that case.

#### Testing instructions

This PR requires a change on WPCOM so in order to test it, you will have to the following:

* Apply D57587-code to your sandbox and follow its instructions.

##### Instructions for Calypso
* Download this PR and run Calypso locally (`yarn start` is enough).
* Make sure you're logged out from WordPress.com.
* Open a window (do not use a private window, we need an environment where 3rd party cookies are enabled).
* Visit `http://calypso.localhost:3000/log-in/link`.
* Enter an email address that is linked to a valid WP.com account you own.
* Click the email CTA.
* Verify that you are redirected to `http://calypso.localhost:3000/log-in/link/use` and that the page looks like
![image](https://user-images.githubusercontent.com/3418513/109174883-06d52900-7764-11eb-96de-74b5b903f99e.png)
* Visit `http://calypso.localhost:3000/log-in/jetpack/link`.
* Enter an email address that is linked to a valid WP.com account you own.
* Click the email CTA.
* Verify that you are redirected to `http://calypso.localhost:3000/log-in/jetpack/link/use` and that the page looks like  
![image](https://user-images.githubusercontent.com/3418513/109174855-ff158480-7763-11eb-9cb6-fe77d5d4be68.png)