### PR TITLE
Checkout: Update specificity of post-purchase upsell nudge style overrides

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -68,7 +68,7 @@ $left-margin: 36px;
 	height: 27px;
 	top: 0;
 	left: -$left-margin;
-	border-radius: 50%;
+	border-radius: 50;
 	background: #008a20;
 	text-align: center;
 

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -119,9 +119,9 @@ $left-margin: 36px;
 /**
  * Checkout Terms
  */
-.checkout__terms,
-.checkout__concierge-refund-policy,
-.checkout__bundled-domain-notice {
+.purchase-modal .checkout__terms,
+.purchase-modal .checkout__concierge-refund-policy,
+.purchase-modal .checkout__bundled-domain-notice {
 	margin: 4px 0;
 	padding-left: $left-margin;
 	position: relative;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The post-purchase upsell nudge page uses the `CheckoutTerms` component (as well as several sub-components) but overrides some of their styles in its stylesheet. However, those overrides are not written to be specific to the upsell nudge so they can leak out into other places which use `CheckoutTerms`.

This PR adds more specificity to the overriding CSS selectors so that the styles will not leak.

#### Screenshots

Checkout before (note some leaked styles):

<img width="571" alt="checkout-before" src="https://user-images.githubusercontent.com/2036909/109214591-064a8b80-7780-11eb-9d6d-b77140f103c4.png">

Checkout after:

<img width="569" alt="checkout-after" src="https://user-images.githubusercontent.com/2036909/109214662-1bbfb580-7780-11eb-8455-23e52bee3c81.png">

Upsell modal before:

<img width="472" alt="modal-before" src="https://user-images.githubusercontent.com/2036909/109214762-3c880b00-7780-11eb-9901-72eec645d893.png">

Upsell modal after:

<img width="469" alt="modal-after" src="https://user-images.githubusercontent.com/2036909/109214782-401b9200-7780-11eb-88c0-cfd575072e26.png">

#### Testing instructions

- With a free site, add a personal plan to your cart and visit checkout.
- Verify that the checkout terms, refund policy, etc. look correct.
- Complete the purchase with a new or existing credit card (but not a 3DS card) and verify that you are redirected to an upsell page.
- Click the "Yes! I want a WordPress Expert" confirmation button. You should see a one-click upsell modal.
- Verify that the checkout terms, refund policy, etc. look correct.

