### PR TITLE
Plans data-store: improve unit tests 

### DIFF
--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -50,7 +50,7 @@ export function register(): typeof STORE_KEY {
 			resolvers,
 			actions,
 			controls: controls as any,
-			reducer: reducer as any,
+			reducer,
 			selectors,
 		} );
 	}

--- a/packages/data-stores/src/plans/mock/apis/features.ts
+++ b/packages/data-stores/src/plans/mock/apis/features.ts
@@ -1,0 +1,54 @@
+/**
+ * Internal dependencies
+ */
+import type { FeaturesByType } from '../../types';
+
+// Individual Features
+export const API_FEATURE_CUSTOM_DOMAIN = {
+	id: 'custom-domain',
+	name: 'Free domain for One Year',
+	description:
+		'Get a free domain for one year. Premium domains not included. Your domain will renew at its regular price.',
+};
+export const API_FEATURE_LIVE_SUPPORT = {
+	id: 'support-live',
+	name: 'Live chat support',
+	description:
+		'High quality support to help you get your website up and running and working how you want it.',
+};
+export const API_FEATURE_PRIORITY_SUPPORT = {
+	id: 'priority-support',
+	name: '24/7 Priority live chat support',
+	description: 'Receive faster support from our WordPress experts - weekends included.',
+};
+export const API_FEATURE_RECURRING_PAYMENTS = {
+	id: 'recurring-payments',
+	name: 'Sell subscriptions (recurring payments)',
+	description: 'Accept one-time, monthly or annual payments on your website.',
+};
+export const API_FEATURE_WORDADS = {
+	id: 'wordads',
+	name: 'WordAds',
+	description: 'Put your site to work and earn through ad revenue.',
+};
+
+// Feature groups (by type)
+export const API_FEATURES_BY_TYPE_GENERAL: FeaturesByType = {
+	id: 'general',
+	name: null,
+	features: [
+		API_FEATURE_CUSTOM_DOMAIN.id,
+		API_FEATURE_LIVE_SUPPORT.id,
+		API_FEATURE_PRIORITY_SUPPORT.id,
+	],
+};
+export const API_FEATURES_BY_TYPE_COMMERCE: FeaturesByType = {
+	id: 'commerce',
+	name: 'Commerce',
+	features: [ API_FEATURE_RECURRING_PAYMENTS.id ],
+};
+export const API_FEATURES_BY_TYPE_MARKETING: FeaturesByType = {
+	id: 'marketing',
+	name: 'Marketing',
+	features: [ API_FEATURE_WORDADS.id ],
+};

--- a/packages/data-stores/src/plans/mock/apis/plans.ts
+++ b/packages/data-stores/src/plans/mock/apis/plans.ts
@@ -1,25 +1,16 @@
 /**
  * Internal dependencies
  */
+import * as MockData from '../';
 import type {
-	Plan,
-	PlanProduct,
-	FeaturesByType,
-	PlanSimplifiedFeature,
 	PricedAPIPlanFree,
 	PricedAPIPlanPaidAnnually,
 	PricedAPIPlanPaidMonthly,
 	DetailsAPIResponse,
 	APIPlanDetail,
-} from '../types';
+} from '../../types';
 
 /**
- * This file contains mock data for the plans data-store unit tests.
- * There 2 main sections:
- * - APIs: mocks of the data returned by the REST APIs
- * - Data-store objects: mocks of the objects that are created by the
- *   data-store's resolvers when reading/transforming plan APIs data
- *
  * For the sake of testing, only a few plans are mocked:
  * - Free plan
  * - Premium plan (annually and monthly billed)
@@ -30,7 +21,6 @@ import type {
 // (allow us to use real-ish APIs data without TypeScript complaining about
 // extra props that are otherwise ignored in this data-store)
 //==============================================================================
-
 interface MockPricedAPIPlanFree extends PricedAPIPlanFree {
 	[ key: string ]: unknown;
 }
@@ -48,62 +38,8 @@ interface MockPricedAPIPlanPaidMonthly extends PricedAPIPlanPaidMonthly {
 	[ key: string ]: unknown;
 }
 
-//==============================================================================
-// APIs
-//==============================================================================
-
-// Individual Features
-export const MOCK_FEATURE_CUSTOM_DOMAIN = {
-	id: 'custom-domain',
-	name: 'Free domain for One Year',
-	description:
-		'Get a free domain for one year. Premium domains not included. Your domain will renew at its regular price.',
-};
-export const MOCK_FEATURE_LIVE_SUPPORT = {
-	id: 'support-live',
-	name: 'Live chat support',
-	description:
-		'High quality support to help you get your website up and running and working how you want it.',
-};
-export const MOCK_FEATURE_PRIORITY_SUPPORT = {
-	id: 'priority-support',
-	name: '24/7 Priority live chat support',
-	description: 'Receive faster support from our WordPress experts - weekends included.',
-};
-export const MOCK_FEATURE_RECURRING_PAYMENTS = {
-	id: 'recurring-payments',
-	name: 'Sell subscriptions (recurring payments)',
-	description: 'Accept one-time, monthly or annual payments on your website.',
-};
-export const MOCK_FEATURE_WORDADS = {
-	id: 'wordads',
-	name: 'WordAds',
-	description: 'Put your site to work and earn through ad revenue.',
-};
-
-// Feature groups (by type)
-export const MOCK_FEATURES_BY_TYPE_GENERAL: FeaturesByType = {
-	id: 'general',
-	name: null,
-	features: [
-		MOCK_FEATURE_CUSTOM_DOMAIN.id,
-		MOCK_FEATURE_LIVE_SUPPORT.id,
-		MOCK_FEATURE_PRIORITY_SUPPORT.id,
-	],
-};
-export const MOCK_FEATURES_BY_TYPE_COMMERCE: FeaturesByType = {
-	id: 'commerce',
-	name: 'Commerce',
-	features: [ MOCK_FEATURE_RECURRING_PAYMENTS.id ],
-};
-export const MOCK_FEATURES_BY_TYPE_MARKETING: FeaturesByType = {
-	id: 'marketing',
-	name: 'Marketing',
-	features: [ MOCK_FEATURE_WORDADS.id ],
-};
-
 // All plans details (from APIs)
-export const MOCK_PLAN_DETAILS_API: MockDetailsAPIResponse = {
+export const API_PLAN_DETAILS: MockDetailsAPIResponse = {
 	groups: [
 		{
 			slug: 'personal',
@@ -151,8 +87,8 @@ export const MOCK_PLAN_DETAILS_API: MockDetailsAPIResponse = {
 				'Build a unique website with advanced design tools, CSS editing, lots of space for audio and video, and the ability to monetize your site with ads.',
 			features: [ 'custom-domain', 'support-live', 'recurring-payments', 'wordads' ],
 			highlighted_features: [
-				MOCK_FEATURE_CUSTOM_DOMAIN.name,
-				MOCK_FEATURE_LIVE_SUPPORT.name,
+				MockData.API_FEATURE_CUSTOM_DOMAIN.name,
+				MockData.API_FEATURE_LIVE_SUPPORT.name,
 				'Premium plan highlighted feature',
 			],
 			storage: '13 GB',
@@ -160,22 +96,22 @@ export const MOCK_PLAN_DETAILS_API: MockDetailsAPIResponse = {
 		},
 	],
 	features_by_type: [
-		MOCK_FEATURES_BY_TYPE_GENERAL,
-		MOCK_FEATURES_BY_TYPE_COMMERCE,
-		MOCK_FEATURES_BY_TYPE_MARKETING,
+		MockData.API_FEATURES_BY_TYPE_GENERAL,
+		MockData.API_FEATURES_BY_TYPE_COMMERCE,
+		MockData.API_FEATURES_BY_TYPE_MARKETING,
 	],
 	features: [
-		MOCK_FEATURE_CUSTOM_DOMAIN,
-		MOCK_FEATURE_LIVE_SUPPORT,
-		MOCK_FEATURE_PRIORITY_SUPPORT,
-		MOCK_FEATURE_RECURRING_PAYMENTS,
-		MOCK_FEATURE_WORDADS,
+		MockData.API_FEATURE_CUSTOM_DOMAIN,
+		MockData.API_FEATURE_LIVE_SUPPORT,
+		MockData.API_FEATURE_PRIORITY_SUPPORT,
+		MockData.API_FEATURE_RECURRING_PAYMENTS,
+		MockData.API_FEATURE_WORDADS,
 	],
 };
 
 // Individual plan (from APIs)
 
-export const MOCK_PLAN_PRICE_APIS_FREE: MockPricedAPIPlanFree = {
+export const API_PLAN_PRICE_FREE: MockPricedAPIPlanFree = {
 	product_id: 1,
 	product_name: 'WordPress.com Free',
 	meta: null,
@@ -240,7 +176,7 @@ export const MOCK_PLAN_PRICE_APIS_FREE: MockPricedAPIPlanFree = {
 	],
 };
 
-export const MOCK_PLAN_PRICE_APIS_PREMIUM_ANNUALLY: MockPricedAPIPlanPaidAnnually = {
+export const API_PLAN_PRICE_PREMIUM_ANNUALLY: MockPricedAPIPlanPaidAnnually = {
 	product_id: 1003,
 	product_name: 'WordPress.com Premium',
 	meta: null,
@@ -346,7 +282,7 @@ export const MOCK_PLAN_PRICE_APIS_PREMIUM_ANNUALLY: MockPricedAPIPlanPaidAnnuall
 	],
 };
 
-export const MOCK_PLAN_PRICE_APIS_PREMIUM_MONTHLY: MockPricedAPIPlanPaidMonthly = {
+export const API_PLAN_PRICE_PREMIUM_MONTHLY: MockPricedAPIPlanPaidMonthly = {
 	product_id: 1013,
 	product_name: 'WordPress.com Premium',
 	meta: null,
@@ -402,104 +338,4 @@ export const MOCK_PLAN_PRICE_APIS_PREMIUM_MONTHLY: MockPricedAPIPlanPaidMonthly 
 	raw_price: 14,
 	tagline: null,
 	currency_code: 'EUR',
-};
-
-//==============================================================================
-// Data-store objects
-//==============================================================================
-
-// Plans
-export const MOCK_PLAN_FREE: Plan = {
-	description: 'Mock free plan',
-	features: [
-		{
-			name: 'Free plan highlighted feature',
-			requiresAnnuallyBilledPlan: false,
-		},
-	],
-	storage: '3 GB',
-	title: 'Free',
-	featuresSlugs: {
-		subdomain: true,
-	},
-	isFree: true,
-	isPopular: false,
-	periodAgnosticSlug: 'free',
-	productIds: [ 1 ],
-};
-export const MOCK_PLAN_PREMIUM: Plan = {
-	description: 'Mock premium plan',
-	features: [
-		{
-			name: MOCK_FEATURE_CUSTOM_DOMAIN.name,
-			requiresAnnuallyBilledPlan: true,
-		},
-		{
-			name: MOCK_FEATURE_LIVE_SUPPORT.name,
-			requiresAnnuallyBilledPlan: true,
-		},
-		{
-			name: 'Premium plan highlighted feature',
-			requiresAnnuallyBilledPlan: false,
-		},
-	],
-	storage: '13 GB',
-	title: 'Premium',
-	featuresSlugs: {
-		'custom-domain': true,
-		'support-live': true,
-		'recurring-payments': true,
-		wordads: true,
-	},
-	isFree: false,
-	isPopular: true,
-	periodAgnosticSlug: 'premium',
-	productIds: [ 1003, 1013 ],
-};
-
-// Plan products
-export const MOCK_PLAN_PRODUCT_FREE: PlanProduct = {
-	productId: 1,
-	billingPeriod: 'ANNUALLY',
-	periodAgnosticSlug: 'free',
-	storeSlug: 'free_plan',
-	rawPrice: 0,
-	pathSlug: 'free',
-	price: '€0',
-	annualPrice: '€0',
-};
-export const MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY: PlanProduct = {
-	productId: 1003,
-	billingPeriod: 'ANNUALLY',
-	periodAgnosticSlug: 'premium',
-	storeSlug: 'value_bundle',
-	rawPrice: 96,
-	pathSlug: 'premium',
-	price: '€8',
-	annualPrice: '€96',
-	annualDiscount: 43,
-};
-export const MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY: PlanProduct = {
-	productId: 1013,
-	billingPeriod: 'MONTHLY',
-	periodAgnosticSlug: 'premium',
-	storeSlug: 'value_bundle_monthly',
-	rawPrice: 14,
-	price: '€14',
-	annualPrice: '€168',
-	annualDiscount: 43,
-};
-
-// Plan "simplified" features
-export const MOCK_SIMPLIFIED_FEATURE_CUSTOM_DOMAIN: PlanSimplifiedFeature = {
-	name: MOCK_FEATURE_CUSTOM_DOMAIN.name,
-	requiresAnnuallyBilledPlan: true,
-};
-export const MOCK_SIMPLIFIED_FEATURE_LIVE_SUPPORT: PlanSimplifiedFeature = {
-	name: MOCK_FEATURE_LIVE_SUPPORT.name,
-	requiresAnnuallyBilledPlan: true,
-};
-export const MOCK_SIMPLIFIED_FEATURE_PRIORITY_SUPPORT: PlanSimplifiedFeature = {
-	name: MOCK_FEATURE_PRIORITY_SUPPORT.name,
-	requiresAnnuallyBilledPlan: false,
 };

--- a/packages/data-stores/src/plans/mock/index.ts
+++ b/packages/data-stores/src/plans/mock/index.ts
@@ -1,0 +1,5 @@
+export * from './apis/features';
+export * from './apis/plans';
+export * from './store/features';
+export * from './store/plans';
+export * from './store/products';

--- a/packages/data-stores/src/plans/mock/store/features.ts
+++ b/packages/data-stores/src/plans/mock/store/features.ts
@@ -1,0 +1,46 @@
+/**
+ * Internal dependencies
+ */
+import * as MockData from '../';
+import type { PlanSimplifiedFeature, PlanFeature } from '../../types';
+
+// Plan "simplified" features
+export const STORE_SIMPLIFIED_FEATURE_CUSTOM_DOMAIN: PlanSimplifiedFeature = {
+	name: MockData.API_FEATURE_CUSTOM_DOMAIN.name,
+	requiresAnnuallyBilledPlan: true,
+};
+export const STORE_SIMPLIFIED_FEATURE_LIVE_SUPPORT: PlanSimplifiedFeature = {
+	name: MockData.API_FEATURE_LIVE_SUPPORT.name,
+	requiresAnnuallyBilledPlan: true,
+};
+export const STORE_SIMPLIFIED_FEATURE_PRIORITY_SUPPORT: PlanSimplifiedFeature = {
+	name: MockData.API_FEATURE_PRIORITY_SUPPORT.name,
+	requiresAnnuallyBilledPlan: false,
+};
+
+// Plan features
+export const STORE_PLAN_FEATURE_CUSTOM_DOMAIN: PlanFeature = {
+	...MockData.API_FEATURE_CUSTOM_DOMAIN,
+	type: 'checkbox',
+	requiresAnnuallyBilledPlan: true,
+};
+export const STORE_PLAN_FEATURE_LIVE_SUPPORT: PlanFeature = {
+	...MockData.API_FEATURE_LIVE_SUPPORT,
+	type: 'checkbox',
+	requiresAnnuallyBilledPlan: true,
+};
+export const STORE_PLAN_FEATURE_PRIORITY_SUPPORT: PlanFeature = {
+	...MockData.API_FEATURE_PRIORITY_SUPPORT,
+	type: 'checkbox',
+	requiresAnnuallyBilledPlan: true,
+};
+export const STORE_PLAN_FEATURE_RECURRING_PAYMENTS: PlanFeature = {
+	...MockData.API_FEATURE_RECURRING_PAYMENTS,
+	type: 'checkbox',
+	requiresAnnuallyBilledPlan: false,
+};
+export const STORE_PLAN_FEATURE_WORDADS: PlanFeature = {
+	...MockData.API_FEATURE_WORDADS,
+	type: 'checkbox',
+	requiresAnnuallyBilledPlan: false,
+};

--- a/packages/data-stores/src/plans/mock/store/plans.ts
+++ b/packages/data-stores/src/plans/mock/store/plans.ts
@@ -1,0 +1,53 @@
+/**
+ * Internal dependencies
+ */
+import * as MockData from '../';
+import type { Plan } from '../../types';
+
+export const STORE_PLAN_FREE: Plan = {
+	description: 'Mock free plan',
+	features: [
+		{
+			name: 'Free plan highlighted feature',
+			requiresAnnuallyBilledPlan: false,
+		},
+	],
+	storage: '3 GB',
+	title: 'Free',
+	featuresSlugs: {
+		subdomain: true,
+	},
+	isFree: true,
+	isPopular: false,
+	periodAgnosticSlug: 'free',
+	productIds: [ 1 ],
+};
+export const STORE_PLAN_PREMIUM: Plan = {
+	description: 'Mock premium plan',
+	features: [
+		{
+			name: MockData.API_FEATURE_CUSTOM_DOMAIN.name,
+			requiresAnnuallyBilledPlan: true,
+		},
+		{
+			name: MockData.API_FEATURE_LIVE_SUPPORT.name,
+			requiresAnnuallyBilledPlan: true,
+		},
+		{
+			name: 'Premium plan highlighted feature',
+			requiresAnnuallyBilledPlan: false,
+		},
+	],
+	storage: '13 GB',
+	title: 'Premium',
+	featuresSlugs: {
+		'custom-domain': true,
+		'support-live': true,
+		'recurring-payments': true,
+		wordads: true,
+	},
+	isFree: false,
+	isPopular: true,
+	periodAgnosticSlug: 'premium',
+	productIds: [ 1003, 1013 ],
+};

--- a/packages/data-stores/src/plans/mock/store/products.ts
+++ b/packages/data-stores/src/plans/mock/store/products.ts
@@ -1,0 +1,37 @@
+/**
+ * Internal dependencies
+ */
+import type { PlanProduct } from '../../types';
+
+// Plan products
+export const STORE_PRODUCT_FREE: PlanProduct = {
+	productId: 1,
+	billingPeriod: 'ANNUALLY',
+	periodAgnosticSlug: 'free',
+	storeSlug: 'free_plan',
+	rawPrice: 0,
+	pathSlug: 'free',
+	price: '€0',
+	annualPrice: '€0',
+};
+export const STORE_PRODUCT_PREMIUM_ANNUALLY: PlanProduct = {
+	productId: 1003,
+	billingPeriod: 'ANNUALLY',
+	periodAgnosticSlug: 'premium',
+	storeSlug: 'value_bundle',
+	rawPrice: 96,
+	pathSlug: 'premium',
+	price: '€8',
+	annualPrice: '€96',
+	annualDiscount: 43,
+};
+export const STORE_PRODUCT_PREMIUM_MONTHLY: PlanProduct = {
+	productId: 1013,
+	billingPeriod: 'MONTHLY',
+	periodAgnosticSlug: 'premium',
+	storeSlug: 'value_bundle_monthly',
+	rawPrice: 14,
+	price: '€14',
+	annualPrice: '€168',
+	annualDiscount: 43,
+};

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -164,5 +164,5 @@ export const isPlanFree = ( _: State, planSlug?: PlanSlug ): boolean => {
 	return planSlug === TIMELESS_PLAN_FREE;
 };
 
-export const isPlanProductFree = ( _: State, planProductId: number | undefined ): boolean =>
+export const isPlanProductFree = ( _: State, planProductId?: number ): boolean =>
 	planProductId === FREE_PLAN_PRODUCT_ID;

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -164,5 +164,5 @@ export const isPlanFree = ( _: State, planSlug?: PlanSlug ): boolean => {
 	return planSlug === TIMELESS_PLAN_FREE;
 };
 
-export const isPlanProductFree = ( _: State, planProductId?: number ): boolean =>
+export const isPlanProductFree = ( _: State, planProductId: number | undefined ): boolean =>
 	planProductId === FREE_PLAN_PRODUCT_ID;

--- a/packages/data-stores/src/plans/test-utils/index.ts
+++ b/packages/data-stores/src/plans/test-utils/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import type { PlanFeature } from '../types';
+
+export const buildPlanFeaturesDict = (
+	planFeatures: PlanFeature[]
+): Record< string, PlanFeature > =>
+	planFeatures.reduce(
+		( dict, feature ) => ( {
+			...dict,
+			[ feature.id ]: feature,
+		} ),
+		{}
+	);

--- a/packages/data-stores/src/plans/test/actions.ts
+++ b/packages/data-stores/src/plans/test/actions.ts
@@ -8,57 +8,67 @@ import { buildPlanFeaturesDict } from '../test-utils';
 const MOCK_LOCALE = 'test-locale';
 
 describe( 'Plans action creators', () => {
-	test( 'setFeatures', () => {
-		const mockFeatures = buildPlanFeaturesDict( [
-			MockData.STORE_PLAN_FEATURE_CUSTOM_DOMAIN,
-			MockData.STORE_PLAN_FEATURE_LIVE_SUPPORT,
-			MockData.STORE_PLAN_FEATURE_WORDADS,
-		] );
+	describe( 'setFeatures', () => {
+		it( 'should create the correct action object', () => {
+			const mockFeatures = buildPlanFeaturesDict( [
+				MockData.STORE_PLAN_FEATURE_CUSTOM_DOMAIN,
+				MockData.STORE_PLAN_FEATURE_LIVE_SUPPORT,
+				MockData.STORE_PLAN_FEATURE_WORDADS,
+			] );
 
-		expect( Actions.setFeatures( mockFeatures, MOCK_LOCALE ) ).toEqual( {
-			type: 'SET_FEATURES',
-			features: mockFeatures,
-			locale: MOCK_LOCALE,
+			expect( Actions.setFeatures( mockFeatures, MOCK_LOCALE ) ).toEqual( {
+				type: 'SET_FEATURES',
+				features: mockFeatures,
+				locale: MOCK_LOCALE,
+			} );
 		} );
 	} );
 
-	test( 'setFeaturesByType', () => {
-		const features = [
-			MockData.API_FEATURES_BY_TYPE_GENERAL,
-			MockData.API_FEATURES_BY_TYPE_COMMERCE,
-			MockData.API_FEATURES_BY_TYPE_MARKETING,
-		];
-		expect( Actions.setFeaturesByType( features, MOCK_LOCALE ) ).toEqual( {
-			type: 'SET_FEATURES_BY_TYPE',
-			featuresByType: features,
-			locale: MOCK_LOCALE,
+	describe( 'setFeaturesByType', () => {
+		it( 'should create the correct action object', () => {
+			const features = [
+				MockData.API_FEATURES_BY_TYPE_GENERAL,
+				MockData.API_FEATURES_BY_TYPE_COMMERCE,
+				MockData.API_FEATURES_BY_TYPE_MARKETING,
+			];
+			expect( Actions.setFeaturesByType( features, MOCK_LOCALE ) ).toEqual( {
+				type: 'SET_FEATURES_BY_TYPE',
+				featuresByType: features,
+				locale: MOCK_LOCALE,
+			} );
 		} );
 	} );
 
-	test( 'setPlans', () => {
-		const plans = [ MockData.STORE_PLAN_FREE, MockData.STORE_PLAN_PREMIUM ];
-		expect( Actions.setPlans( plans, MOCK_LOCALE ) ).toEqual( {
-			type: 'SET_PLANS',
-			plans,
-			locale: MOCK_LOCALE,
+	describe( 'setPlans', () => {
+		it( 'should create the correct action object', () => {
+			const plans = [ MockData.STORE_PLAN_FREE, MockData.STORE_PLAN_PREMIUM ];
+			expect( Actions.setPlans( plans, MOCK_LOCALE ) ).toEqual( {
+				type: 'SET_PLANS',
+				plans,
+				locale: MOCK_LOCALE,
+			} );
 		} );
 	} );
 
-	test( 'setPlanProducts', () => {
-		const planProducts = [
-			MockData.STORE_PRODUCT_FREE,
-			MockData.STORE_PRODUCT_PREMIUM_ANNUALLY,
-			MockData.STORE_PRODUCT_PREMIUM_MONTHLY,
-		];
-		expect( Actions.setPlanProducts( planProducts ) ).toEqual( {
-			type: 'SET_PLAN_PRODUCTS',
-			products: planProducts,
+	describe( 'setPlanProducts', () => {
+		it( 'should create the correct action object', () => {
+			const planProducts = [
+				MockData.STORE_PRODUCT_FREE,
+				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY,
+				MockData.STORE_PRODUCT_PREMIUM_MONTHLY,
+			];
+			expect( Actions.setPlanProducts( planProducts ) ).toEqual( {
+				type: 'SET_PLAN_PRODUCTS',
+				products: planProducts,
+			} );
 		} );
 	} );
 
-	test( 'resetPlan', () => {
-		expect( Actions.resetPlan() ).toEqual( {
-			type: 'RESET_PLAN',
+	describe( 'resetPlan', () => {
+		it( 'should create the correct action object', () => {
+			expect( Actions.resetPlan() ).toEqual( {
+				type: 'RESET_PLAN',
+			} );
 		} );
 	} );
 } );

--- a/packages/data-stores/src/plans/test/actions.ts
+++ b/packages/data-stores/src/plans/test/actions.ts
@@ -5,7 +5,7 @@ import * as Actions from '../actions';
 import * as MockData from '../mock';
 import { buildPlanFeaturesDict } from '../test-utils';
 
-const TEST_LOCALE = 'test-locale';
+const MOCK_LOCALE = 'test-locale';
 
 describe( 'Plans action creators', () => {
 	test( 'setFeatures', () => {
@@ -15,10 +15,10 @@ describe( 'Plans action creators', () => {
 			MockData.STORE_PLAN_FEATURE_WORDADS,
 		] );
 
-		expect( Actions.setFeatures( mockFeatures, TEST_LOCALE ) ).toEqual( {
+		expect( Actions.setFeatures( mockFeatures, MOCK_LOCALE ) ).toEqual( {
 			type: 'SET_FEATURES',
 			features: mockFeatures,
-			locale: TEST_LOCALE,
+			locale: MOCK_LOCALE,
 		} );
 	} );
 
@@ -28,19 +28,19 @@ describe( 'Plans action creators', () => {
 			MockData.API_FEATURES_BY_TYPE_COMMERCE,
 			MockData.API_FEATURES_BY_TYPE_MARKETING,
 		];
-		expect( Actions.setFeaturesByType( features, TEST_LOCALE ) ).toEqual( {
+		expect( Actions.setFeaturesByType( features, MOCK_LOCALE ) ).toEqual( {
 			type: 'SET_FEATURES_BY_TYPE',
 			featuresByType: features,
-			locale: TEST_LOCALE,
+			locale: MOCK_LOCALE,
 		} );
 	} );
 
 	test( 'setPlans', () => {
 		const plans = [ MockData.STORE_PLAN_FREE, MockData.STORE_PLAN_PREMIUM ];
-		expect( Actions.setPlans( plans, TEST_LOCALE ) ).toEqual( {
+		expect( Actions.setPlans( plans, MOCK_LOCALE ) ).toEqual( {
 			type: 'SET_PLANS',
 			plans,
-			locale: TEST_LOCALE,
+			locale: MOCK_LOCALE,
 		} );
 	} );
 

--- a/packages/data-stores/src/plans/test/actions.ts
+++ b/packages/data-stores/src/plans/test/actions.ts
@@ -1,0 +1,82 @@
+/**
+ * Internal dependencies
+ */
+import { setFeatures, setFeaturesByType, setPlans, setPlanProducts, resetPlan } from '../actions';
+import {
+	MOCK_FEATURES_BY_TYPE_GENERAL,
+	MOCK_FEATURES_BY_TYPE_COMMERCE,
+	MOCK_FEATURES_BY_TYPE_MARKETING,
+	MOCK_PLAN_FREE,
+	MOCK_PLAN_PREMIUM,
+	MOCK_PLAN_PRODUCT_FREE,
+	MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY,
+	MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY,
+} from '../mock/mock-constants';
+
+// TODO: consider splitting files in mock/ folder
+// and exporting everything through index file
+
+// TODO: consider extracting to mock/
+const TEST_LOCALE = 'test-locale';
+const TEST_FEATURE = {
+	id: 'test-id',
+	description: 'test-description',
+	name: 'test-name',
+	requiresAnnuallyBilledPlan: true,
+	type: 'test-type',
+	data: [ false, 'test' ],
+};
+
+describe( 'Plans action creators', () => {
+	test( 'SET_FEATURES', () => {
+		const mockFeatures = {
+			test: TEST_FEATURE,
+		};
+
+		expect( setFeatures( mockFeatures, TEST_LOCALE ) ).toEqual( {
+			type: 'SET_FEATURES',
+			features: mockFeatures,
+			locale: TEST_LOCALE,
+		} );
+	} );
+
+	test( 'SET_FEATURES_BY_TYPE', () => {
+		const features = [
+			MOCK_FEATURES_BY_TYPE_GENERAL,
+			MOCK_FEATURES_BY_TYPE_COMMERCE,
+			MOCK_FEATURES_BY_TYPE_MARKETING,
+		];
+		expect( setFeaturesByType( features, TEST_LOCALE ) ).toEqual( {
+			type: 'SET_FEATURES_BY_TYPE',
+			featuresByType: features,
+			locale: TEST_LOCALE,
+		} );
+	} );
+
+	test( 'SET_PLANS', () => {
+		const plans = [ MOCK_PLAN_FREE, MOCK_PLAN_PREMIUM ];
+		expect( setPlans( plans, TEST_LOCALE ) ).toEqual( {
+			type: 'SET_PLANS',
+			plans,
+			locale: TEST_LOCALE,
+		} );
+	} );
+
+	test( 'SET_PLAN_PRODUCTS', () => {
+		const planProducts = [
+			MOCK_PLAN_PRODUCT_FREE,
+			MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY,
+			MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY,
+		];
+		expect( setPlanProducts( planProducts ) ).toEqual( {
+			type: 'SET_PLAN_PRODUCTS',
+			products: planProducts,
+		} );
+	} );
+
+	test( 'RESET_PLAN', () => {
+		expect( resetPlan() ).toEqual( {
+			type: 'RESET_PLAN',
+		} );
+	} );
+} );

--- a/packages/data-stores/src/plans/test/actions.ts
+++ b/packages/data-stores/src/plans/test/actions.ts
@@ -1,81 +1,63 @@
 /**
  * Internal dependencies
  */
-import { setFeatures, setFeaturesByType, setPlans, setPlanProducts, resetPlan } from '../actions';
-import {
-	MOCK_FEATURES_BY_TYPE_GENERAL,
-	MOCK_FEATURES_BY_TYPE_COMMERCE,
-	MOCK_FEATURES_BY_TYPE_MARKETING,
-	MOCK_PLAN_FREE,
-	MOCK_PLAN_PREMIUM,
-	MOCK_PLAN_PRODUCT_FREE,
-	MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY,
-	MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY,
-} from '../mock/mock-constants';
+import * as Actions from '../actions';
+import * as MockData from '../mock';
+import { buildPlanFeaturesDict } from '../test-utils';
 
-// TODO: consider splitting files in mock/ folder
-// and exporting everything through index file
-
-// TODO: consider extracting to mock/
 const TEST_LOCALE = 'test-locale';
-const TEST_FEATURE = {
-	id: 'test-id',
-	description: 'test-description',
-	name: 'test-name',
-	requiresAnnuallyBilledPlan: true,
-	type: 'test-type',
-	data: [ false, 'test' ],
-};
 
 describe( 'Plans action creators', () => {
-	test( 'SET_FEATURES', () => {
-		const mockFeatures = {
-			test: TEST_FEATURE,
-		};
+	test( 'setFeatures', () => {
+		const mockFeatures = buildPlanFeaturesDict( [
+			MockData.STORE_PLAN_FEATURE_CUSTOM_DOMAIN,
+			MockData.STORE_PLAN_FEATURE_LIVE_SUPPORT,
+			MockData.STORE_PLAN_FEATURE_WORDADS,
+		] );
 
-		expect( setFeatures( mockFeatures, TEST_LOCALE ) ).toEqual( {
+		expect( Actions.setFeatures( mockFeatures, TEST_LOCALE ) ).toEqual( {
 			type: 'SET_FEATURES',
 			features: mockFeatures,
 			locale: TEST_LOCALE,
 		} );
 	} );
 
-	test( 'SET_FEATURES_BY_TYPE', () => {
+	test( 'setFeaturesByType', () => {
 		const features = [
-			MOCK_FEATURES_BY_TYPE_GENERAL,
-			MOCK_FEATURES_BY_TYPE_COMMERCE,
-			MOCK_FEATURES_BY_TYPE_MARKETING,
+			MockData.API_FEATURES_BY_TYPE_GENERAL,
+			MockData.API_FEATURES_BY_TYPE_COMMERCE,
+			MockData.API_FEATURES_BY_TYPE_MARKETING,
 		];
-		expect( setFeaturesByType( features, TEST_LOCALE ) ).toEqual( {
+		expect( Actions.setFeaturesByType( features, TEST_LOCALE ) ).toEqual( {
 			type: 'SET_FEATURES_BY_TYPE',
 			featuresByType: features,
 			locale: TEST_LOCALE,
 		} );
 	} );
 
-	test( 'SET_PLANS', () => {
-		const plans = [ MOCK_PLAN_FREE, MOCK_PLAN_PREMIUM ];
-		expect( setPlans( plans, TEST_LOCALE ) ).toEqual( {
+	test( 'setPlans', () => {
+		const plans = [ MockData.STORE_PLAN_FREE, MockData.STORE_PLAN_PREMIUM ];
+		expect( Actions.setPlans( plans, TEST_LOCALE ) ).toEqual( {
 			type: 'SET_PLANS',
 			plans,
 			locale: TEST_LOCALE,
 		} );
 	} );
 
-	test( 'SET_PLAN_PRODUCTS', () => {
+	test( 'setPlanProducts', () => {
 		const planProducts = [
-			MOCK_PLAN_PRODUCT_FREE,
-			MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY,
-			MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY,
+			MockData.STORE_PRODUCT_FREE,
+			MockData.STORE_PRODUCT_PREMIUM_ANNUALLY,
+			MockData.STORE_PRODUCT_PREMIUM_MONTHLY,
 		];
-		expect( setPlanProducts( planProducts ) ).toEqual( {
+		expect( Actions.setPlanProducts( planProducts ) ).toEqual( {
 			type: 'SET_PLAN_PRODUCTS',
 			products: planProducts,
 		} );
 	} );
 
-	test( 'RESET_PLAN', () => {
-		expect( resetPlan() ).toEqual( {
+	test( 'resetPlan', () => {
+		expect( Actions.resetPlan() ).toEqual( {
 			type: 'RESET_PLAN',
 		} );
 	} );

--- a/packages/data-stores/src/plans/test/reducer.ts
+++ b/packages/data-stores/src/plans/test/reducer.ts
@@ -9,13 +9,13 @@ import { buildPlanFeaturesDict } from '../test-utils';
 const MOCK_LOCALE = 'test-locale';
 
 describe( 'Plans reducer', () => {
-	describe( 'Plans', () => {
-		it( 'defaults to no plans info', () => {
+	describe( 'plans', () => {
+		it( 'should default to no plans info', () => {
 			const { plans } = reducer( undefined, { type: 'NOOP' } );
 			expect( plans ).toEqual( {} );
 		} );
 
-		it( 'replaces old plans with new plans', () => {
+		it( 'should replace old plans with new plans', () => {
 			let state = reducer( undefined, setPlans( [ MockData.STORE_PLAN_FREE ], MOCK_LOCALE ) );
 
 			state = reducer(
@@ -36,13 +36,13 @@ describe( 'Plans reducer', () => {
 		} );
 	} );
 
-	describe( 'Features By Type', () => {
-		it( 'defaults to no featuresByType info', () => {
+	describe( 'featuresByType', () => {
+		it( 'should default to no featuresByType info', () => {
 			const { featuresByType } = reducer( undefined, { type: 'NOOP' } );
 			expect( featuresByType ).toEqual( {} );
 		} );
 
-		it( 'replaces old featuresByType info with new featuresByType info', () => {
+		it( 'should replace old featuresByType info with new featuresByType info', () => {
 			const state = reducer(
 				undefined,
 				setFeaturesByType(
@@ -62,13 +62,13 @@ describe( 'Plans reducer', () => {
 		} );
 	} );
 
-	describe( 'Features', () => {
-		it( 'defaults to no feature info', () => {
+	describe( 'features', () => {
+		it( 'should default to no feature info', () => {
 			const { features } = reducer( undefined, { type: 'NOOP' } );
 			expect( features ).toEqual( {} );
 		} );
 
-		it( 'replaces old features with new features', () => {
+		it( 'should replace old features with new features', () => {
 			const state = reducer(
 				undefined,
 				setFeatures(

--- a/packages/data-stores/src/plans/test/reducer.ts
+++ b/packages/data-stores/src/plans/test/reducer.ts
@@ -6,7 +6,7 @@ import { setPlans, setFeaturesByType, setFeatures, setPlanProducts } from '../ac
 import * as MockData from '../mock';
 import { buildPlanFeaturesDict } from '../test-utils';
 
-const TEST_LOCALE = 'test-locale';
+const MOCK_LOCALE = 'test-locale';
 
 describe( 'Plans reducer', () => {
 	describe( 'Plans', () => {
@@ -16,7 +16,7 @@ describe( 'Plans reducer', () => {
 		} );
 
 		it( 'replaces old plans with new plans', () => {
-			let state = reducer( undefined, setPlans( [ MockData.STORE_PLAN_FREE ], TEST_LOCALE ) );
+			let state = reducer( undefined, setPlans( [ MockData.STORE_PLAN_FREE ], MOCK_LOCALE ) );
 
 			state = reducer(
 				state,
@@ -29,10 +29,10 @@ describe( 'Plans reducer', () => {
 
 			const newFreePlan = { ...MockData.STORE_PLAN_FREE, title: 'new free' };
 
-			const { plans } = reducer( state, setPlans( [ newFreePlan ], TEST_LOCALE ) );
+			const { plans } = reducer( state, setPlans( [ newFreePlan ], MOCK_LOCALE ) );
 
-			expect( plans[ TEST_LOCALE ][ 0 ].title ).toBe( newFreePlan.title );
-			expect( plans[ TEST_LOCALE ][ 1 ] ).toBeUndefined();
+			expect( plans[ MOCK_LOCALE ][ 0 ].title ).toBe( newFreePlan.title );
+			expect( plans[ MOCK_LOCALE ][ 1 ] ).toBeUndefined();
 		} );
 	} );
 
@@ -47,16 +47,16 @@ describe( 'Plans reducer', () => {
 				undefined,
 				setFeaturesByType(
 					[ MockData.API_FEATURES_BY_TYPE_GENERAL, MockData.API_FEATURES_BY_TYPE_COMMERCE ],
-					TEST_LOCALE
+					MOCK_LOCALE
 				)
 			);
 
 			const { featuresByType } = reducer(
 				state,
-				setFeaturesByType( [ MockData.API_FEATURES_BY_TYPE_MARKETING ], TEST_LOCALE )
+				setFeaturesByType( [ MockData.API_FEATURES_BY_TYPE_MARKETING ], MOCK_LOCALE )
 			);
 
-			expect( featuresByType[ TEST_LOCALE ] ).toEqual( [
+			expect( featuresByType[ MOCK_LOCALE ] ).toEqual( [
 				MockData.API_FEATURES_BY_TYPE_MARKETING,
 			] );
 		} );
@@ -76,7 +76,7 @@ describe( 'Plans reducer', () => {
 						MockData.STORE_PLAN_FEATURE_CUSTOM_DOMAIN,
 						MockData.STORE_PLAN_FEATURE_LIVE_SUPPORT,
 					] ),
-					TEST_LOCALE
+					MOCK_LOCALE
 				)
 			);
 
@@ -84,15 +84,15 @@ describe( 'Plans reducer', () => {
 				state,
 				setFeatures(
 					buildPlanFeaturesDict( [ MockData.STORE_PLAN_FEATURE_PRIORITY_SUPPORT ] ),
-					TEST_LOCALE
+					MOCK_LOCALE
 				)
 			);
 
 			expect(
-				features[ TEST_LOCALE ][ MockData.STORE_PLAN_FEATURE_PRIORITY_SUPPORT.id ].name
+				features[ MOCK_LOCALE ][ MockData.STORE_PLAN_FEATURE_PRIORITY_SUPPORT.id ].name
 			).toBe( MockData.STORE_SIMPLIFIED_FEATURE_PRIORITY_SUPPORT.name );
 			expect(
-				features[ TEST_LOCALE ][ MockData.STORE_PLAN_FEATURE_CUSTOM_DOMAIN.id ]
+				features[ MOCK_LOCALE ][ MockData.STORE_PLAN_FEATURE_CUSTOM_DOMAIN.id ]
 			).toBeUndefined();
 		} );
 	} );

--- a/packages/data-stores/src/plans/test/reducer.ts
+++ b/packages/data-stores/src/plans/test/reducer.ts
@@ -3,21 +3,10 @@
  */
 import reducer from '../reducer';
 import { setPlans, setFeaturesByType, setFeatures, setPlanProducts } from '../actions';
-import { PLAN_FREE, PLAN_PREMIUM } from '../constants';
-import {
-	MOCK_PLAN_FREE,
-	MOCK_PLAN_PRODUCT_FREE,
-	MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY,
-	MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY,
-	MOCK_FEATURES_BY_TYPE_GENERAL,
-	MOCK_FEATURES_BY_TYPE_COMMERCE,
-	MOCK_FEATURES_BY_TYPE_MARKETING,
-	MOCK_SIMPLIFIED_FEATURE_CUSTOM_DOMAIN,
-	MOCK_SIMPLIFIED_FEATURE_LIVE_SUPPORT,
-	MOCK_SIMPLIFIED_FEATURE_PRIORITY_SUPPORT,
-} from '../mock/mock-constants';
+import * as MockData from '../mock';
+import { buildPlanFeaturesDict } from '../test-utils';
 
-const LOCALE_EN = 'en';
+const TEST_LOCALE = 'test-locale';
 
 describe( 'Plans reducer', () => {
 	describe( 'Plans', () => {
@@ -27,23 +16,23 @@ describe( 'Plans reducer', () => {
 		} );
 
 		it( 'replaces old plans with new plans', () => {
-			let state = reducer( undefined, setPlans( [ MOCK_PLAN_FREE ], LOCALE_EN ) );
+			let state = reducer( undefined, setPlans( [ MockData.STORE_PLAN_FREE ], TEST_LOCALE ) );
 
 			state = reducer(
 				state,
 				setPlanProducts( [
-					MOCK_PLAN_PRODUCT_FREE,
-					MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY,
-					MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY,
+					MockData.STORE_PRODUCT_FREE,
+					MockData.STORE_PRODUCT_PREMIUM_ANNUALLY,
+					MockData.STORE_PRODUCT_PREMIUM_MONTHLY,
 				] )
 			);
 
-			const newFreePlan = { ...MOCK_PLAN_FREE, title: 'new free' };
+			const newFreePlan = { ...MockData.STORE_PLAN_FREE, title: 'new free' };
 
-			const { plans } = reducer( state, setPlans( [ newFreePlan ], LOCALE_EN ) );
+			const { plans } = reducer( state, setPlans( [ newFreePlan ], TEST_LOCALE ) );
 
-			expect( plans[ LOCALE_EN ][ 0 ].title ).toBe( newFreePlan.title );
-			expect( plans[ LOCALE_EN ][ 1 ] ).toBeUndefined();
+			expect( plans[ TEST_LOCALE ][ 0 ].title ).toBe( newFreePlan.title );
+			expect( plans[ TEST_LOCALE ][ 1 ] ).toBeUndefined();
 		} );
 	} );
 
@@ -57,17 +46,19 @@ describe( 'Plans reducer', () => {
 			const state = reducer(
 				undefined,
 				setFeaturesByType(
-					[ MOCK_FEATURES_BY_TYPE_GENERAL, MOCK_FEATURES_BY_TYPE_COMMERCE ],
-					LOCALE_EN
+					[ MockData.API_FEATURES_BY_TYPE_GENERAL, MockData.API_FEATURES_BY_TYPE_COMMERCE ],
+					TEST_LOCALE
 				)
 			);
 
 			const { featuresByType } = reducer(
 				state,
-				setFeaturesByType( [ MOCK_FEATURES_BY_TYPE_MARKETING ], LOCALE_EN )
+				setFeaturesByType( [ MockData.API_FEATURES_BY_TYPE_MARKETING ], TEST_LOCALE )
 			);
 
-			expect( featuresByType[ LOCALE_EN ] ).toEqual( [ MOCK_FEATURES_BY_TYPE_MARKETING ] );
+			expect( featuresByType[ TEST_LOCALE ] ).toEqual( [
+				MockData.API_FEATURES_BY_TYPE_MARKETING,
+			] );
 		} );
 	} );
 
@@ -81,23 +72,28 @@ describe( 'Plans reducer', () => {
 			const state = reducer(
 				undefined,
 				setFeatures(
-					{
-						[ PLAN_FREE ]: MOCK_SIMPLIFIED_FEATURE_CUSTOM_DOMAIN,
-						[ PLAN_PREMIUM ]: MOCK_SIMPLIFIED_FEATURE_LIVE_SUPPORT,
-					},
-					LOCALE_EN
+					buildPlanFeaturesDict( [
+						MockData.STORE_PLAN_FEATURE_CUSTOM_DOMAIN,
+						MockData.STORE_PLAN_FEATURE_LIVE_SUPPORT,
+					] ),
+					TEST_LOCALE
 				)
 			);
 
 			const { features } = reducer(
 				state,
-				setFeatures( { [ PLAN_FREE ]: MOCK_SIMPLIFIED_FEATURE_PRIORITY_SUPPORT }, LOCALE_EN )
+				setFeatures(
+					buildPlanFeaturesDict( [ MockData.STORE_PLAN_FEATURE_PRIORITY_SUPPORT ] ),
+					TEST_LOCALE
+				)
 			);
 
-			expect( features[ LOCALE_EN ][ PLAN_FREE ].name ).toBe(
-				MOCK_SIMPLIFIED_FEATURE_PRIORITY_SUPPORT.name
-			);
-			expect( features[ LOCALE_EN ][ PLAN_PREMIUM ] ).toBeUndefined();
+			expect(
+				features[ TEST_LOCALE ][ MockData.STORE_PLAN_FEATURE_PRIORITY_SUPPORT.id ].name
+			).toBe( MockData.STORE_SIMPLIFIED_FEATURE_PRIORITY_SUPPORT.name );
+			expect(
+				features[ TEST_LOCALE ][ MockData.STORE_PLAN_FEATURE_CUSTOM_DOMAIN.id ]
+			).toBeUndefined();
 		} );
 	} );
 } );

--- a/packages/data-stores/src/plans/test/resolvers.ts
+++ b/packages/data-stores/src/plans/test/resolvers.ts
@@ -7,13 +7,17 @@ import { buildPlanFeaturesDict } from '../test-utils';
 
 import type { PricedAPIPlan } from '../types';
 
-// Don't need to mock specific functions for any tests, but mocking
-// module because it accesses the `document` global.
-jest.mock( 'wpcom-proxy-request', () => ( {
-	__esModule: true,
+jest.mock( '../../wpcom-request-controls', () => ( {
+	wpcomRequest: ( request ) => ( {
+		type: 'WPCOM_REQUEST',
+		request,
+	} ),
+	fetchAndParse: ( resource, options ) => ( {
+		type: 'FETCH_AND_PARSE',
+		resource,
+		options,
+	} ),
 } ) );
-
-// const TEST_LOCALE = 'test-locale';
 
 describe( 'getSupportedPlans', () => {
 	it( 'calls setFeatures, setFeaturesByType, and setPlans after fetching plans', () => {

--- a/packages/data-stores/src/plans/test/resolvers.ts
+++ b/packages/data-stores/src/plans/test/resolvers.ts
@@ -13,11 +13,11 @@ jest.mock( 'wpcom-proxy-request', () => ( {
 	__esModule: true,
 } ) );
 
-// const TEST_LOCALE = 'test-locale';
+const MOCK_LOCALE = 'test-locale';
 
 describe( 'getSupportedPlans', () => {
 	it( 'calls setFeatures, setFeaturesByType, and setPlans after fetching plans', () => {
-		const iter = getSupportedPlans();
+		const iter = getSupportedPlans( MOCK_LOCALE );
 
 		// Prepare stricter iterator types
 		type IteratorReturnType = ReturnType< typeof iter.next >;
@@ -29,7 +29,7 @@ describe( 'getSupportedPlans', () => {
 			request: {
 				apiVersion: '1.5',
 				path: '/plans',
-				query: 'locale=en',
+				query: `locale=${ MOCK_LOCALE }`,
 			},
 			type: 'WPCOM_REQUEST',
 		} );
@@ -42,7 +42,7 @@ describe( 'getSupportedPlans', () => {
 		];
 		expect( ( iter.next as PlanPriceApiDataIterator )( planPriceApiData ).value ).toEqual( {
 			type: 'FETCH_AND_PARSE',
-			resource: 'https://public-api.wordpress.com/wpcom/v2/plans/details?locale=en',
+			resource: `https://public-api.wordpress.com/wpcom/v2/plans/details?locale=${ MOCK_LOCALE }`,
 			options: {
 				credentials: 'omit',
 				mode: 'cors',
@@ -54,7 +54,7 @@ describe( 'getSupportedPlans', () => {
 			body: MockData.API_PLAN_DETAILS,
 		};
 		expect( ( iter.next as PlanDetailsApiDataIterator )( planDetailsApiData ).value ).toEqual( {
-			locale: 'en',
+			locale: MOCK_LOCALE,
 			type: 'SET_PLANS',
 			plans: [ MockData.STORE_PLAN_FREE, MockData.STORE_PLAN_PREMIUM ],
 		} );
@@ -70,7 +70,7 @@ describe( 'getSupportedPlans', () => {
 		} );
 
 		expect( iter.next().value ).toEqual( {
-			locale: 'en',
+			locale: MOCK_LOCALE,
 			type: 'SET_FEATURES',
 			features: buildPlanFeaturesDict( [
 				MockData.STORE_PLAN_FEATURE_CUSTOM_DOMAIN,
@@ -82,7 +82,7 @@ describe( 'getSupportedPlans', () => {
 		} );
 
 		expect( iter.next().value ).toEqual( {
-			locale: 'en',
+			locale: MOCK_LOCALE,
 			type: 'SET_FEATURES_BY_TYPE',
 			featuresByType: [
 				MockData.API_FEATURES_BY_TYPE_GENERAL,

--- a/packages/data-stores/src/plans/test/resolvers.ts
+++ b/packages/data-stores/src/plans/test/resolvers.ts
@@ -15,6 +15,10 @@ jest.mock( 'wpcom-proxy-request', () => ( {
 
 const MOCK_LOCALE = 'test-locale';
 
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
+
 describe( 'Plans resolvers', () => {
 	describe( 'getSupportedPlans', () => {
 		it( 'should fetch APIs data and set features and plans data', () => {
@@ -90,6 +94,21 @@ describe( 'Plans resolvers', () => {
 					MockData.API_FEATURES_BY_TYPE_COMMERCE,
 					MockData.API_FEATURES_BY_TYPE_MARKETING,
 				],
+			} );
+		} );
+
+		it( 'should default to english locale', () => {
+			const englishLocale = 'en';
+			const iter = getSupportedPlans();
+
+			// request to prices endpoint
+			expect( iter.next().value ).toEqual( {
+				request: {
+					apiVersion: '1.5',
+					path: '/plans',
+					query: `locale=${ englishLocale }`,
+				},
+				type: 'WPCOM_REQUEST',
 			} );
 		} );
 	} );

--- a/packages/data-stores/src/plans/test/resolvers.ts
+++ b/packages/data-stores/src/plans/test/resolvers.ts
@@ -15,80 +15,82 @@ jest.mock( 'wpcom-proxy-request', () => ( {
 
 const MOCK_LOCALE = 'test-locale';
 
-describe( 'getSupportedPlans', () => {
-	it( 'calls setFeatures, setFeaturesByType, and setPlans after fetching plans', () => {
-		const iter = getSupportedPlans( MOCK_LOCALE );
+describe( 'Plans resolvers', () => {
+	describe( 'getSupportedPlans', () => {
+		it( 'should fetch APIs data and set features and plans data', () => {
+			const iter = getSupportedPlans( MOCK_LOCALE );
 
-		// Prepare stricter iterator types
-		type IteratorReturnType = ReturnType< typeof iter.next >;
-		type PlanPriceApiDataIterator = ( planPriceData: PricedAPIPlan[] ) => IteratorReturnType;
-		type PlanDetailsApiDataIterator = ( { body: DetailsAPIResponse } ) => IteratorReturnType;
+			// Prepare stricter iterator types
+			type IteratorReturnType = ReturnType< typeof iter.next >;
+			type PlanPriceApiDataIterator = ( planPriceData: PricedAPIPlan[] ) => IteratorReturnType;
+			type PlanDetailsApiDataIterator = ( { body: DetailsAPIResponse } ) => IteratorReturnType;
 
-		// request to prices endpoint
-		expect( iter.next().value ).toEqual( {
-			request: {
-				apiVersion: '1.5',
-				path: '/plans',
-				query: `locale=${ MOCK_LOCALE }`,
-			},
-			type: 'WPCOM_REQUEST',
-		} );
+			// request to prices endpoint
+			expect( iter.next().value ).toEqual( {
+				request: {
+					apiVersion: '1.5',
+					path: '/plans',
+					query: `locale=${ MOCK_LOCALE }`,
+				},
+				type: 'WPCOM_REQUEST',
+			} );
 
-		// request to plan details/features endpoint
-		const planPriceApiData = [
-			MockData.API_PLAN_PRICE_FREE,
-			MockData.API_PLAN_PRICE_PREMIUM_ANNUALLY,
-			MockData.API_PLAN_PRICE_PREMIUM_MONTHLY,
-		];
-		expect( ( iter.next as PlanPriceApiDataIterator )( planPriceApiData ).value ).toEqual( {
-			type: 'FETCH_AND_PARSE',
-			resource: `https://public-api.wordpress.com/wpcom/v2/plans/details?locale=${ MOCK_LOCALE }`,
-			options: {
-				credentials: 'omit',
-				mode: 'cors',
-			},
-		} );
+			// request to plan details/features endpoint
+			const planPriceApiData = [
+				MockData.API_PLAN_PRICE_FREE,
+				MockData.API_PLAN_PRICE_PREMIUM_ANNUALLY,
+				MockData.API_PLAN_PRICE_PREMIUM_MONTHLY,
+			];
+			expect( ( iter.next as PlanPriceApiDataIterator )( planPriceApiData ).value ).toEqual( {
+				type: 'FETCH_AND_PARSE',
+				resource: `https://public-api.wordpress.com/wpcom/v2/plans/details?locale=${ MOCK_LOCALE }`,
+				options: {
+					credentials: 'omit',
+					mode: 'cors',
+				},
+			} );
 
-		// setPlans call
-		const planDetailsApiData = {
-			body: MockData.API_PLAN_DETAILS,
-		};
-		expect( ( iter.next as PlanDetailsApiDataIterator )( planDetailsApiData ).value ).toEqual( {
-			locale: MOCK_LOCALE,
-			type: 'SET_PLANS',
-			plans: [ MockData.STORE_PLAN_FREE, MockData.STORE_PLAN_PREMIUM ],
-		} );
+			// setPlans call
+			const planDetailsApiData = {
+				body: MockData.API_PLAN_DETAILS,
+			};
+			expect( ( iter.next as PlanDetailsApiDataIterator )( planDetailsApiData ).value ).toEqual( {
+				locale: MOCK_LOCALE,
+				type: 'SET_PLANS',
+				plans: [ MockData.STORE_PLAN_FREE, MockData.STORE_PLAN_PREMIUM ],
+			} );
 
-		// setPlanProducts call
-		expect( iter.next().value ).toEqual( {
-			type: 'SET_PLAN_PRODUCTS',
-			products: [
-				MockData.STORE_PRODUCT_FREE,
-				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY,
-				MockData.STORE_PRODUCT_PREMIUM_MONTHLY,
-			],
-		} );
+			// setPlanProducts call
+			expect( iter.next().value ).toEqual( {
+				type: 'SET_PLAN_PRODUCTS',
+				products: [
+					MockData.STORE_PRODUCT_FREE,
+					MockData.STORE_PRODUCT_PREMIUM_ANNUALLY,
+					MockData.STORE_PRODUCT_PREMIUM_MONTHLY,
+				],
+			} );
 
-		expect( iter.next().value ).toEqual( {
-			locale: MOCK_LOCALE,
-			type: 'SET_FEATURES',
-			features: buildPlanFeaturesDict( [
-				MockData.STORE_PLAN_FEATURE_CUSTOM_DOMAIN,
-				MockData.STORE_PLAN_FEATURE_LIVE_SUPPORT,
-				MockData.STORE_PLAN_FEATURE_PRIORITY_SUPPORT,
-				MockData.STORE_PLAN_FEATURE_RECURRING_PAYMENTS,
-				MockData.STORE_PLAN_FEATURE_WORDADS,
-			] ),
-		} );
+			expect( iter.next().value ).toEqual( {
+				locale: MOCK_LOCALE,
+				type: 'SET_FEATURES',
+				features: buildPlanFeaturesDict( [
+					MockData.STORE_PLAN_FEATURE_CUSTOM_DOMAIN,
+					MockData.STORE_PLAN_FEATURE_LIVE_SUPPORT,
+					MockData.STORE_PLAN_FEATURE_PRIORITY_SUPPORT,
+					MockData.STORE_PLAN_FEATURE_RECURRING_PAYMENTS,
+					MockData.STORE_PLAN_FEATURE_WORDADS,
+				] ),
+			} );
 
-		expect( iter.next().value ).toEqual( {
-			locale: MOCK_LOCALE,
-			type: 'SET_FEATURES_BY_TYPE',
-			featuresByType: [
-				MockData.API_FEATURES_BY_TYPE_GENERAL,
-				MockData.API_FEATURES_BY_TYPE_COMMERCE,
-				MockData.API_FEATURES_BY_TYPE_MARKETING,
-			],
+			expect( iter.next().value ).toEqual( {
+				locale: MOCK_LOCALE,
+				type: 'SET_FEATURES_BY_TYPE',
+				featuresByType: [
+					MockData.API_FEATURES_BY_TYPE_GENERAL,
+					MockData.API_FEATURES_BY_TYPE_COMMERCE,
+					MockData.API_FEATURES_BY_TYPE_MARKETING,
+				],
+			} );
 		} );
 	} );
 } );

--- a/packages/data-stores/src/plans/test/resolvers.ts
+++ b/packages/data-stores/src/plans/test/resolvers.ts
@@ -7,17 +7,13 @@ import { buildPlanFeaturesDict } from '../test-utils';
 
 import type { PricedAPIPlan } from '../types';
 
-jest.mock( '../../wpcom-request-controls', () => ( {
-	wpcomRequest: ( request ) => ( {
-		type: 'WPCOM_REQUEST',
-		request,
-	} ),
-	fetchAndParse: ( resource, options ) => ( {
-		type: 'FETCH_AND_PARSE',
-		resource,
-		options,
-	} ),
+// Don't need to mock specific functions for any tests, but mocking
+// module because it accesses the `document` global.
+jest.mock( 'wpcom-proxy-request', () => ( {
+	__esModule: true,
 } ) );
+
+// const TEST_LOCALE = 'test-locale';
 
 describe( 'getSupportedPlans', () => {
 	it( 'calls setFeatures, setFeaturesByType, and setPlans after fetching plans', () => {

--- a/packages/data-stores/src/plans/test/resolvers.ts
+++ b/packages/data-stores/src/plans/test/resolvers.ts
@@ -2,25 +2,8 @@
  * Internal dependencies
  */
 import { getSupportedPlans } from '../resolvers';
-import {
-	MOCK_PLAN_PRICE_APIS_FREE,
-	MOCK_PLAN_PRICE_APIS_PREMIUM_ANNUALLY,
-	MOCK_PLAN_PRICE_APIS_PREMIUM_MONTHLY,
-	MOCK_PLAN_DETAILS_API,
-	MOCK_PLAN_FREE,
-	MOCK_PLAN_PREMIUM,
-	MOCK_PLAN_PRODUCT_FREE,
-	MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY,
-	MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY,
-	MOCK_FEATURE_CUSTOM_DOMAIN,
-	MOCK_FEATURE_LIVE_SUPPORT,
-	MOCK_FEATURE_PRIORITY_SUPPORT,
-	MOCK_FEATURE_RECURRING_PAYMENTS,
-	MOCK_FEATURE_WORDADS,
-	MOCK_FEATURES_BY_TYPE_GENERAL,
-	MOCK_FEATURES_BY_TYPE_COMMERCE,
-	MOCK_FEATURES_BY_TYPE_MARKETING,
-} from '../mock/mock-constants';
+import * as MockData from '../mock';
+import { buildPlanFeaturesDict } from '../test-utils';
 
 import type { PricedAPIPlan } from '../types';
 
@@ -29,6 +12,8 @@ import type { PricedAPIPlan } from '../types';
 jest.mock( 'wpcom-proxy-request', () => ( {
 	__esModule: true,
 } ) );
+
+// const TEST_LOCALE = 'test-locale';
 
 describe( 'getSupportedPlans', () => {
 	it( 'calls setFeatures, setFeaturesByType, and setPlans after fetching plans', () => {
@@ -51,9 +36,9 @@ describe( 'getSupportedPlans', () => {
 
 		// request to plan details/features endpoint
 		const planPriceApiData = [
-			MOCK_PLAN_PRICE_APIS_FREE,
-			MOCK_PLAN_PRICE_APIS_PREMIUM_ANNUALLY,
-			MOCK_PLAN_PRICE_APIS_PREMIUM_MONTHLY,
+			MockData.API_PLAN_PRICE_FREE,
+			MockData.API_PLAN_PRICE_PREMIUM_ANNUALLY,
+			MockData.API_PLAN_PRICE_PREMIUM_MONTHLY,
 		];
 		expect( ( iter.next as PlanPriceApiDataIterator )( planPriceApiData ).value ).toEqual( {
 			type: 'FETCH_AND_PARSE',
@@ -66,56 +51,43 @@ describe( 'getSupportedPlans', () => {
 
 		// setPlans call
 		const planDetailsApiData = {
-			body: MOCK_PLAN_DETAILS_API,
+			body: MockData.API_PLAN_DETAILS,
 		};
 		expect( ( iter.next as PlanDetailsApiDataIterator )( planDetailsApiData ).value ).toEqual( {
 			locale: 'en',
 			type: 'SET_PLANS',
-			plans: [ MOCK_PLAN_FREE, MOCK_PLAN_PREMIUM ],
+			plans: [ MockData.STORE_PLAN_FREE, MockData.STORE_PLAN_PREMIUM ],
 		} );
 
 		// setPlanProducts call
 		expect( iter.next().value ).toEqual( {
 			type: 'SET_PLAN_PRODUCTS',
 			products: [
-				MOCK_PLAN_PRODUCT_FREE,
-				MOCK_PLAN_PRODUCT_PREMIUM_ANNUALLY,
-				MOCK_PLAN_PRODUCT_PREMIUM_MONTHLY,
+				MockData.STORE_PRODUCT_FREE,
+				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY,
+				MockData.STORE_PRODUCT_PREMIUM_MONTHLY,
 			],
 		} );
 
 		expect( iter.next().value ).toEqual( {
 			locale: 'en',
 			type: 'SET_FEATURES',
-			features: [
-				MOCK_FEATURE_CUSTOM_DOMAIN,
-				MOCK_FEATURE_LIVE_SUPPORT,
-				MOCK_FEATURE_PRIORITY_SUPPORT,
-				MOCK_FEATURE_RECURRING_PAYMENTS,
-				MOCK_FEATURE_WORDADS,
-			].reduce(
-				( dict, feature ) => ( {
-					...dict,
-					[ feature.id ]: {
-						...feature,
-						type: 'checkbox',
-						requiresAnnuallyBilledPlan:
-							feature.id === MOCK_FEATURE_CUSTOM_DOMAIN.id ||
-							feature.id === MOCK_FEATURE_LIVE_SUPPORT.id ||
-							feature.id === MOCK_FEATURE_PRIORITY_SUPPORT.id,
-					},
-				} ),
-				{}
-			),
+			features: buildPlanFeaturesDict( [
+				MockData.STORE_PLAN_FEATURE_CUSTOM_DOMAIN,
+				MockData.STORE_PLAN_FEATURE_LIVE_SUPPORT,
+				MockData.STORE_PLAN_FEATURE_PRIORITY_SUPPORT,
+				MockData.STORE_PLAN_FEATURE_RECURRING_PAYMENTS,
+				MockData.STORE_PLAN_FEATURE_WORDADS,
+			] ),
 		} );
 
 		expect( iter.next().value ).toEqual( {
 			locale: 'en',
 			type: 'SET_FEATURES_BY_TYPE',
 			featuresByType: [
-				MOCK_FEATURES_BY_TYPE_GENERAL,
-				MOCK_FEATURES_BY_TYPE_COMMERCE,
-				MOCK_FEATURES_BY_TYPE_MARKETING,
+				MockData.API_FEATURES_BY_TYPE_GENERAL,
+				MockData.API_FEATURES_BY_TYPE_COMMERCE,
+				MockData.API_FEATURES_BY_TYPE_MARKETING,
 			],
 		} );
 	} );

--- a/packages/data-stores/src/plans/test/selectors.ts
+++ b/packages/data-stores/src/plans/test/selectors.ts
@@ -12,11 +12,6 @@ import { buildPlanFeaturesDict } from '../test-utils';
 import { TIMELESS_PLAN_ECOMMERCE, TIMELESS_PLAN_FREE, FREE_PLAN_PRODUCT_ID } from '../constants';
 import type { State } from '../reducer';
 
-// Mocks
-jest.mock( '@wordpress/deprecated', () => {
-	return jest.fn();
-} );
-
 // Test data
 const TEST_LOCALE_1 = 'test-locale-1';
 const TEST_LOCALE_2 = 'test-locale-2';
@@ -54,6 +49,10 @@ const mockState: State = {
 	planProducts: testPlanProducts,
 };
 
+// Mocks
+jest.mock( '@wordpress/deprecated', () => {
+	return jest.fn();
+} );
 // Tests
 describe( 'Plans selectors', () => {
 	it( 'getFeatures', () => {

--- a/packages/data-stores/src/plans/test/selectors.ts
+++ b/packages/data-stores/src/plans/test/selectors.ts
@@ -1,0 +1,142 @@
+/**
+ * External dependencies
+ */
+import * as deprecate from '@wordpress/deprecated';
+
+/**
+ * Internal dependencies
+ */
+import * as Selectors from '../selectors';
+import * as MockData from '../mock';
+import { buildPlanFeaturesDict } from '../test-utils';
+import { TIMELESS_PLAN_ECOMMERCE, TIMELESS_PLAN_FREE, FREE_PLAN_PRODUCT_ID } from '../constants';
+import type { State } from '../reducer';
+
+// Mocks
+jest.mock( '@wordpress/deprecated', () => {
+	return jest.fn();
+} );
+
+// Test data
+const TEST_LOCALE_1 = 'test-locale-1';
+const TEST_LOCALE_2 = 'test-locale-2';
+
+const testFeatures = {
+	[ TEST_LOCALE_1 ]: buildPlanFeaturesDict( [
+		MockData.STORE_PLAN_FEATURE_CUSTOM_DOMAIN,
+		MockData.STORE_PLAN_FEATURE_LIVE_SUPPORT,
+	] ),
+	[ TEST_LOCALE_2 ]: buildPlanFeaturesDict( [
+		MockData.STORE_PLAN_FEATURE_PRIORITY_SUPPORT,
+		MockData.STORE_PLAN_FEATURE_RECURRING_PAYMENTS,
+	] ),
+};
+const testFeaturesByType = {
+	[ TEST_LOCALE_1 ]: [
+		MockData.API_FEATURES_BY_TYPE_GENERAL,
+		MockData.API_FEATURES_BY_TYPE_COMMERCE,
+	],
+	[ TEST_LOCALE_2 ]: [
+		MockData.API_FEATURES_BY_TYPE_GENERAL,
+		MockData.API_FEATURES_BY_TYPE_MARKETING,
+	],
+};
+const testPlans = {
+	[ TEST_LOCALE_1 ]: [ MockData.STORE_PLAN_FREE, MockData.STORE_PLAN_PREMIUM ],
+	[ TEST_LOCALE_2 ]: [ MockData.STORE_PLAN_FREE ],
+};
+const testPlanProducts = [ MockData.STORE_PRODUCT_FREE, MockData.STORE_PRODUCT_PREMIUM_ANNUALLY ];
+
+const mockState: State = {
+	features: testFeatures,
+	featuresByType: testFeaturesByType,
+	plans: testPlans,
+	planProducts: testPlanProducts,
+};
+
+// Tests
+describe( 'Plans selectors', () => {
+	it( 'getFeatures', () => {
+		expect( Selectors.getFeatures( mockState, TEST_LOCALE_1 ) ).toEqual(
+			testFeatures[ TEST_LOCALE_1 ]
+		);
+		expect( Selectors.getFeatures( mockState, TEST_LOCALE_2 ) ).toEqual(
+			testFeatures[ TEST_LOCALE_2 ]
+		);
+		expect( Selectors.getFeatures( mockState, 'non-existing' ) ).toEqual( {} );
+	} );
+
+	it( 'getFeaturesByType', () => {
+		expect( Selectors.getFeaturesByType( mockState, TEST_LOCALE_1 ) ).toEqual(
+			testFeaturesByType[ TEST_LOCALE_1 ]
+		);
+		expect( Selectors.getFeaturesByType( mockState, TEST_LOCALE_2 ) ).toEqual(
+			testFeaturesByType[ TEST_LOCALE_2 ]
+		);
+		expect( Selectors.getFeaturesByType( mockState, 'non-existing' ) ).toEqual( [] );
+	} );
+
+	it( 'getPlanByProductId', () => {
+		expect( 1 ).toBeTruthy();
+	} );
+
+	it( 'getPlanProductById', () => {
+		expect( 1 ).toBeTruthy();
+	} );
+
+	it( 'getPlanByPeriodAgnosticSlug', () => {
+		expect( 1 ).toBeTruthy();
+	} );
+
+	it( 'getDefaultPaidPlan', () => {
+		expect( 1 ).toBeTruthy();
+	} );
+
+	it( 'getDefaultFreePlan', () => {
+		expect( 1 ).toBeTruthy();
+	} );
+
+	it( 'getSupportedPlans', () => {
+		expect( Selectors.getSupportedPlans( mockState, TEST_LOCALE_1 ) ).toEqual(
+			testPlans[ TEST_LOCALE_1 ]
+		);
+		expect( Selectors.getSupportedPlans( mockState, TEST_LOCALE_2 ) ).toEqual(
+			testPlans[ TEST_LOCALE_2 ]
+		);
+		expect( Selectors.getSupportedPlans( mockState, 'non-existing' ) ).toEqual( [] );
+	} );
+
+	it( 'getPlansProducts', () => {
+		expect( Selectors.getPlansProducts( mockState ) ).toEqual( testPlanProducts );
+	} );
+
+	it( 'getPrices', () => {
+		expect( 1 ).toBeTruthy();
+	} );
+
+	it( 'getPlanByPath', () => {
+		expect( 1 ).toBeTruthy();
+	} );
+
+	it( 'getPlanProduct', () => {
+		expect( 1 ).toBeTruthy();
+	} );
+
+	it( 'isPlanEcommerce', () => {
+		expect( Selectors.isPlanEcommerce( mockState, TIMELESS_PLAN_ECOMMERCE ) ).toBe( true );
+		expect( Selectors.isPlanEcommerce( mockState, TIMELESS_PLAN_FREE ) ).toBe( false );
+		expect( Selectors.isPlanEcommerce( mockState ) ).toBe( false );
+	} );
+
+	it( 'isPlanFree', () => {
+		expect( Selectors.isPlanFree( mockState, TIMELESS_PLAN_ECOMMERCE ) ).toBe( false );
+		expect( Selectors.isPlanFree( mockState, TIMELESS_PLAN_FREE ) ).toBe( true );
+		expect( Selectors.isPlanFree( mockState ) ).toBe( false );
+	} );
+
+	it( 'isPlanProductFree', () => {
+		expect( Selectors.isPlanProductFree( mockState, FREE_PLAN_PRODUCT_ID ) ).toBe( true );
+		expect( Selectors.isPlanProductFree( mockState, 2 ) ).toBe( false );
+		expect( Selectors.isPlanProductFree( mockState ) ).toBe( false );
+	} );
+} );

--- a/packages/data-stores/src/plans/test/selectors.ts
+++ b/packages/data-stores/src/plans/test/selectors.ts
@@ -16,7 +16,7 @@ import type { State } from '../reducer';
 const TEST_LOCALE_1 = 'test-locale-1';
 const TEST_LOCALE_2 = 'test-locale-2';
 
-const testFeatures = {
+const mockFeatures = {
 	[ TEST_LOCALE_1 ]: buildPlanFeaturesDict( [
 		MockData.STORE_PLAN_FEATURE_CUSTOM_DOMAIN,
 		MockData.STORE_PLAN_FEATURE_LIVE_SUPPORT,
@@ -26,7 +26,7 @@ const testFeatures = {
 		MockData.STORE_PLAN_FEATURE_RECURRING_PAYMENTS,
 	] ),
 };
-const testFeaturesByType = {
+const mockFeaturesByType = {
 	[ TEST_LOCALE_1 ]: [
 		MockData.API_FEATURES_BY_TYPE_GENERAL,
 		MockData.API_FEATURES_BY_TYPE_COMMERCE,
@@ -36,17 +36,17 @@ const testFeaturesByType = {
 		MockData.API_FEATURES_BY_TYPE_MARKETING,
 	],
 };
-const testPlans = {
+const mockPlans = {
 	[ TEST_LOCALE_1 ]: [ MockData.STORE_PLAN_FREE, MockData.STORE_PLAN_PREMIUM ],
 	[ TEST_LOCALE_2 ]: [ MockData.STORE_PLAN_FREE ],
 };
-const testPlanProducts = [ MockData.STORE_PRODUCT_FREE, MockData.STORE_PRODUCT_PREMIUM_ANNUALLY ];
+const mockPlanProducts = [ MockData.STORE_PRODUCT_FREE, MockData.STORE_PRODUCT_PREMIUM_ANNUALLY ];
 
 const mockState: State = {
-	features: testFeatures,
-	featuresByType: testFeaturesByType,
-	plans: testPlans,
-	planProducts: testPlanProducts,
+	features: mockFeatures,
+	featuresByType: mockFeaturesByType,
+	plans: mockPlans,
+	planProducts: mockPlanProducts,
 };
 
 // Mocks
@@ -57,20 +57,20 @@ jest.mock( '@wordpress/deprecated', () => {
 describe( 'Plans selectors', () => {
 	it( 'getFeatures', () => {
 		expect( Selectors.getFeatures( mockState, TEST_LOCALE_1 ) ).toEqual(
-			testFeatures[ TEST_LOCALE_1 ]
+			mockFeatures[ TEST_LOCALE_1 ]
 		);
 		expect( Selectors.getFeatures( mockState, TEST_LOCALE_2 ) ).toEqual(
-			testFeatures[ TEST_LOCALE_2 ]
+			mockFeatures[ TEST_LOCALE_2 ]
 		);
 		expect( Selectors.getFeatures( mockState, 'non-existing' ) ).toEqual( {} );
 	} );
 
 	it( 'getFeaturesByType', () => {
 		expect( Selectors.getFeaturesByType( mockState, TEST_LOCALE_1 ) ).toEqual(
-			testFeaturesByType[ TEST_LOCALE_1 ]
+			mockFeaturesByType[ TEST_LOCALE_1 ]
 		);
 		expect( Selectors.getFeaturesByType( mockState, TEST_LOCALE_2 ) ).toEqual(
-			testFeaturesByType[ TEST_LOCALE_2 ]
+			mockFeaturesByType[ TEST_LOCALE_2 ]
 		);
 		expect( Selectors.getFeaturesByType( mockState, 'non-existing' ) ).toEqual( [] );
 	} );
@@ -97,16 +97,16 @@ describe( 'Plans selectors', () => {
 
 	it( 'getSupportedPlans', () => {
 		expect( Selectors.getSupportedPlans( mockState, TEST_LOCALE_1 ) ).toEqual(
-			testPlans[ TEST_LOCALE_1 ]
+			mockPlans[ TEST_LOCALE_1 ]
 		);
 		expect( Selectors.getSupportedPlans( mockState, TEST_LOCALE_2 ) ).toEqual(
-			testPlans[ TEST_LOCALE_2 ]
+			mockPlans[ TEST_LOCALE_2 ]
 		);
 		expect( Selectors.getSupportedPlans( mockState, 'non-existing' ) ).toEqual( [] );
 	} );
 
 	it( 'getPlansProducts', () => {
-		expect( Selectors.getPlansProducts( mockState ) ).toEqual( testPlanProducts );
+		expect( Selectors.getPlansProducts( mockState ) ).toEqual( mockPlanProducts );
 	} );
 
 	it( 'getPrices', () => {

--- a/packages/data-stores/src/plans/test/selectors.ts
+++ b/packages/data-stores/src/plans/test/selectors.ts
@@ -13,32 +13,32 @@ import { TIMELESS_PLAN_ECOMMERCE, TIMELESS_PLAN_FREE, FREE_PLAN_PRODUCT_ID } fro
 import type { State } from '../reducer';
 
 // Test data
-const TEST_LOCALE_1 = 'test-locale-1';
-const TEST_LOCALE_2 = 'test-locale-2';
+const MOCK_LOCALE_1 = 'test-locale-1';
+const MOCK_LOCALE_2 = 'test-locale-2';
 
 const mockFeatures = {
-	[ TEST_LOCALE_1 ]: buildPlanFeaturesDict( [
+	[ MOCK_LOCALE_1 ]: buildPlanFeaturesDict( [
 		MockData.STORE_PLAN_FEATURE_CUSTOM_DOMAIN,
 		MockData.STORE_PLAN_FEATURE_LIVE_SUPPORT,
 	] ),
-	[ TEST_LOCALE_2 ]: buildPlanFeaturesDict( [
+	[ MOCK_LOCALE_2 ]: buildPlanFeaturesDict( [
 		MockData.STORE_PLAN_FEATURE_PRIORITY_SUPPORT,
 		MockData.STORE_PLAN_FEATURE_RECURRING_PAYMENTS,
 	] ),
 };
 const mockFeaturesByType = {
-	[ TEST_LOCALE_1 ]: [
+	[ MOCK_LOCALE_1 ]: [
 		MockData.API_FEATURES_BY_TYPE_GENERAL,
 		MockData.API_FEATURES_BY_TYPE_COMMERCE,
 	],
-	[ TEST_LOCALE_2 ]: [
+	[ MOCK_LOCALE_2 ]: [
 		MockData.API_FEATURES_BY_TYPE_GENERAL,
 		MockData.API_FEATURES_BY_TYPE_MARKETING,
 	],
 };
 const mockPlans = {
-	[ TEST_LOCALE_1 ]: [ MockData.STORE_PLAN_FREE, MockData.STORE_PLAN_PREMIUM ],
-	[ TEST_LOCALE_2 ]: [ MockData.STORE_PLAN_FREE ],
+	[ MOCK_LOCALE_1 ]: [ MockData.STORE_PLAN_FREE, MockData.STORE_PLAN_PREMIUM ],
+	[ MOCK_LOCALE_2 ]: [ MockData.STORE_PLAN_FREE ],
 };
 const mockPlanProducts = [ MockData.STORE_PRODUCT_FREE, MockData.STORE_PRODUCT_PREMIUM_ANNUALLY ];
 
@@ -65,38 +65,38 @@ jest.mock( '@wordpress/data', () => ( {
 // Tests
 describe( 'Plans selectors', () => {
 	it( 'getFeatures', () => {
-		expect( Selectors.getFeatures( mockState, TEST_LOCALE_1 ) ).toEqual(
-			mockFeatures[ TEST_LOCALE_1 ]
+		expect( Selectors.getFeatures( mockState, MOCK_LOCALE_1 ) ).toEqual(
+			mockFeatures[ MOCK_LOCALE_1 ]
 		);
-		expect( Selectors.getFeatures( mockState, TEST_LOCALE_2 ) ).toEqual(
-			mockFeatures[ TEST_LOCALE_2 ]
+		expect( Selectors.getFeatures( mockState, MOCK_LOCALE_2 ) ).toEqual(
+			mockFeatures[ MOCK_LOCALE_2 ]
 		);
 		expect( Selectors.getFeatures( mockState, 'non-existing' ) ).toEqual( {} );
 	} );
 
 	it( 'getFeaturesByType', () => {
-		expect( Selectors.getFeaturesByType( mockState, TEST_LOCALE_1 ) ).toEqual(
-			mockFeaturesByType[ TEST_LOCALE_1 ]
+		expect( Selectors.getFeaturesByType( mockState, MOCK_LOCALE_1 ) ).toEqual(
+			mockFeaturesByType[ MOCK_LOCALE_1 ]
 		);
-		expect( Selectors.getFeaturesByType( mockState, TEST_LOCALE_2 ) ).toEqual(
-			mockFeaturesByType[ TEST_LOCALE_2 ]
+		expect( Selectors.getFeaturesByType( mockState, MOCK_LOCALE_2 ) ).toEqual(
+			mockFeaturesByType[ MOCK_LOCALE_2 ]
 		);
 		expect( Selectors.getFeaturesByType( mockState, 'non-existing' ) ).toEqual( [] );
 	} );
 
 	it( 'getPlanByProductId', () => {
 		// Product Id not defined
-		expect( Selectors.getPlanByProductId( mockState, undefined, TEST_LOCALE_1 ) ).toBeUndefined();
+		expect( Selectors.getPlanByProductId( mockState, undefined, MOCK_LOCALE_1 ) ).toBeUndefined();
 
 		// Non existing product
-		expect( Selectors.getPlanByProductId( mockState, -1, TEST_LOCALE_1 ) ).toBeUndefined();
+		expect( Selectors.getPlanByProductId( mockState, -1, MOCK_LOCALE_1 ) ).toBeUndefined();
 
 		// Existing Product (free)
 		expect(
 			Selectors.getPlanByProductId(
 				mockState,
 				MockData.STORE_PRODUCT_FREE.productId,
-				TEST_LOCALE_1
+				MOCK_LOCALE_1
 			)
 		).toEqual( MockData.STORE_PLAN_FREE );
 
@@ -105,7 +105,7 @@ describe( 'Plans selectors', () => {
 			Selectors.getPlanByProductId(
 				mockState,
 				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.productId,
-				TEST_LOCALE_1
+				MOCK_LOCALE_1
 			)
 		).toEqual( MockData.STORE_PLAN_PREMIUM );
 
@@ -114,7 +114,7 @@ describe( 'Plans selectors', () => {
 			Selectors.getPlanByProductId(
 				mockState,
 				MockData.STORE_PRODUCT_PREMIUM_MONTHLY.productId,
-				TEST_LOCALE_1
+				MOCK_LOCALE_1
 			)
 		).toEqual( MockData.STORE_PLAN_PREMIUM );
 
@@ -123,7 +123,7 @@ describe( 'Plans selectors', () => {
 			Selectors.getPlanByProductId(
 				mockState,
 				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.productId,
-				TEST_LOCALE_2
+				MOCK_LOCALE_2
 			)
 		).toBeUndefined();
 	} );
@@ -154,12 +154,12 @@ describe( 'Plans selectors', () => {
 	it( 'getPlanByPeriodAgnosticSlug', () => {
 		// Plan slug is undefined
 		expect(
-			Selectors.getPlanByPeriodAgnosticSlug( mockState, undefined, TEST_LOCALE_1 )
+			Selectors.getPlanByPeriodAgnosticSlug( mockState, undefined, MOCK_LOCALE_1 )
 		).toBeUndefined();
 
 		// A plan that doesn't exist in the mock APIs
 		expect(
-			Selectors.getPlanByPeriodAgnosticSlug( mockState, 'ecommerce', TEST_LOCALE_1 )
+			Selectors.getPlanByPeriodAgnosticSlug( mockState, 'ecommerce', MOCK_LOCALE_1 )
 		).toBeUndefined();
 
 		// A plan that exists in the store, for locale 1
@@ -167,7 +167,7 @@ describe( 'Plans selectors', () => {
 			Selectors.getPlanByPeriodAgnosticSlug(
 				mockState,
 				MockData.STORE_PLAN_PREMIUM.periodAgnosticSlug,
-				TEST_LOCALE_1
+				MOCK_LOCALE_1
 			)
 		).toEqual( MockData.STORE_PLAN_PREMIUM );
 
@@ -176,7 +176,7 @@ describe( 'Plans selectors', () => {
 			Selectors.getPlanByPeriodAgnosticSlug(
 				mockState,
 				MockData.STORE_PLAN_FREE.periodAgnosticSlug,
-				TEST_LOCALE_2
+				MOCK_LOCALE_2
 			)
 		).toEqual( MockData.STORE_PLAN_FREE );
 
@@ -185,36 +185,36 @@ describe( 'Plans selectors', () => {
 			Selectors.getPlanByPeriodAgnosticSlug(
 				mockState,
 				MockData.STORE_PLAN_PREMIUM.periodAgnosticSlug,
-				TEST_LOCALE_2
+				MOCK_LOCALE_2
 			)
 		).toBeUndefined();
 	} );
 
 	it( 'getDefaultPaidPlan', () => {
 		// The store has the default paid plan for the selected locale
-		expect( Selectors.getDefaultPaidPlan( mockState, TEST_LOCALE_1 ) ).toEqual(
+		expect( Selectors.getDefaultPaidPlan( mockState, MOCK_LOCALE_1 ) ).toEqual(
 			MockData.STORE_PLAN_PREMIUM
 		);
 
 		// The store doesn't have the default paid plan for the selected locale
-		expect( Selectors.getDefaultPaidPlan( mockState, TEST_LOCALE_2 ) ).toBeUndefined();
+		expect( Selectors.getDefaultPaidPlan( mockState, MOCK_LOCALE_2 ) ).toBeUndefined();
 	} );
 
 	it( 'getDefaultFreePlan', () => {
-		expect( Selectors.getDefaultFreePlan( mockState, TEST_LOCALE_1 ) ).toEqual(
+		expect( Selectors.getDefaultFreePlan( mockState, MOCK_LOCALE_1 ) ).toEqual(
 			MockData.STORE_PLAN_FREE
 		);
-		expect( Selectors.getDefaultFreePlan( mockState, TEST_LOCALE_2 ) ).toEqual(
+		expect( Selectors.getDefaultFreePlan( mockState, MOCK_LOCALE_2 ) ).toEqual(
 			MockData.STORE_PLAN_FREE
 		);
 	} );
 
 	it( 'getSupportedPlans', () => {
-		expect( Selectors.getSupportedPlans( mockState, TEST_LOCALE_1 ) ).toEqual(
-			mockPlans[ TEST_LOCALE_1 ]
+		expect( Selectors.getSupportedPlans( mockState, MOCK_LOCALE_1 ) ).toEqual(
+			mockPlans[ MOCK_LOCALE_1 ]
 		);
-		expect( Selectors.getSupportedPlans( mockState, TEST_LOCALE_2 ) ).toEqual(
-			mockPlans[ TEST_LOCALE_2 ]
+		expect( Selectors.getSupportedPlans( mockState, MOCK_LOCALE_2 ) ).toEqual(
+			mockPlans[ MOCK_LOCALE_2 ]
 		);
 		expect( Selectors.getSupportedPlans( mockState, 'non-existing' ) ).toEqual( [] );
 	} );
@@ -229,8 +229,8 @@ describe( 'Plans selectors', () => {
 			[ MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.storeSlug ]:
 				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.price,
 		};
-		expect( Selectors.getPrices( mockState, TEST_LOCALE_1 ) ).toEqual( expectedPrices );
-		expect( Selectors.getPrices( mockState, TEST_LOCALE_2 ) ).toEqual( expectedPrices );
+		expect( Selectors.getPrices( mockState, MOCK_LOCALE_1 ) ).toEqual( expectedPrices );
+		expect( Selectors.getPrices( mockState, MOCK_LOCALE_2 ) ).toEqual( expectedPrices );
 
 		// Make sure function is correctly flagged as deprecated
 		const expectedCallArguments = [
@@ -246,17 +246,17 @@ describe( 'Plans selectors', () => {
 
 	it( 'getPlanByPath', () => {
 		// Plan path (product slug) is undefined
-		expect( Selectors.getPlanByPath( mockState, undefined, TEST_LOCALE_1 ) ).toBeUndefined();
+		expect( Selectors.getPlanByPath( mockState, undefined, MOCK_LOCALE_1 ) ).toBeUndefined();
 
 		// Plan path (product slug) exists, but not currently in the store
-		expect( Selectors.getPlanByPath( mockState, 'ecommerce', TEST_LOCALE_1 ) ).toBeUndefined();
+		expect( Selectors.getPlanByPath( mockState, 'ecommerce', MOCK_LOCALE_1 ) ).toBeUndefined();
 
 		// Plan path (product slug) exists and there's a matching plan for the locale
 		expect(
 			Selectors.getPlanByPath(
 				mockState,
 				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.pathSlug,
-				TEST_LOCALE_1
+				MOCK_LOCALE_1
 			)
 		).toEqual( MockData.STORE_PLAN_PREMIUM );
 
@@ -265,7 +265,7 @@ describe( 'Plans selectors', () => {
 			Selectors.getPlanByPath(
 				mockState,
 				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.pathSlug,
-				TEST_LOCALE_2
+				MOCK_LOCALE_2
 			)
 		).toBeUndefined();
 	} );

--- a/packages/data-stores/src/plans/test/selectors.ts
+++ b/packages/data-stores/src/plans/test/selectors.ts
@@ -62,265 +62,346 @@ jest.mock( '@wordpress/data', () => ( {
 	} ),
 } ) );
 
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
+
 // Tests
 describe( 'Plans selectors', () => {
-	it( 'getFeatures', () => {
-		expect( Selectors.getFeatures( mockState, MOCK_LOCALE_1 ) ).toEqual(
-			mockFeatures[ MOCK_LOCALE_1 ]
-		);
-		expect( Selectors.getFeatures( mockState, MOCK_LOCALE_2 ) ).toEqual(
-			mockFeatures[ MOCK_LOCALE_2 ]
-		);
-		expect( Selectors.getFeatures( mockState, 'non-existing' ) ).toEqual( {} );
+	describe( 'getFeatures', () => {
+		it( 'should select the right list of features for an given locale', () => {
+			expect( Selectors.getFeatures( mockState, MOCK_LOCALE_1 ) ).toEqual(
+				mockFeatures[ MOCK_LOCALE_1 ]
+			);
+			expect( Selectors.getFeatures( mockState, MOCK_LOCALE_2 ) ).toEqual(
+				mockFeatures[ MOCK_LOCALE_2 ]
+			);
+		} );
+
+		it( 'should return an empty object if the given locale does not exist in the store', () => {
+			expect( Selectors.getFeatures( mockState, 'non-existing' ) ).toEqual( {} );
+		} );
 	} );
 
-	it( 'getFeaturesByType', () => {
-		expect( Selectors.getFeaturesByType( mockState, MOCK_LOCALE_1 ) ).toEqual(
-			mockFeaturesByType[ MOCK_LOCALE_1 ]
-		);
-		expect( Selectors.getFeaturesByType( mockState, MOCK_LOCALE_2 ) ).toEqual(
-			mockFeaturesByType[ MOCK_LOCALE_2 ]
-		);
-		expect( Selectors.getFeaturesByType( mockState, 'non-existing' ) ).toEqual( [] );
+	describe( 'getFeaturesByType', () => {
+		it( 'should select the right list of features by type for an given locale', () => {
+			expect( Selectors.getFeaturesByType( mockState, MOCK_LOCALE_1 ) ).toEqual(
+				mockFeaturesByType[ MOCK_LOCALE_1 ]
+			);
+			expect( Selectors.getFeaturesByType( mockState, MOCK_LOCALE_2 ) ).toEqual(
+				mockFeaturesByType[ MOCK_LOCALE_2 ]
+			);
+		} );
+
+		it( 'should return an empty array if the given locale does not exist in the store', () => {
+			expect( Selectors.getFeaturesByType( mockState, 'non-existing' ) ).toEqual( [] );
+		} );
 	} );
 
-	it( 'getPlanByProductId', () => {
-		// Product Id not defined
-		expect( Selectors.getPlanByProductId( mockState, undefined, MOCK_LOCALE_1 ) ).toBeUndefined();
+	describe( 'getPlanByProductId', () => {
+		it( 'should return undefined if the product ID is undefined', () => {
+			expect( Selectors.getPlanByProductId( mockState, undefined, MOCK_LOCALE_1 ) ).toBeUndefined();
+		} );
 
-		// Non existing product
-		expect( Selectors.getPlanByProductId( mockState, -1, MOCK_LOCALE_1 ) ).toBeUndefined();
+		it( 'should return undefined if the product ID is not associated to any products', () => {
+			expect( Selectors.getPlanByProductId( mockState, -1, MOCK_LOCALE_1 ) ).toBeUndefined();
+		} );
 
-		// Existing Product (free)
-		expect(
-			Selectors.getPlanByProductId(
-				mockState,
-				MockData.STORE_PRODUCT_FREE.productId,
-				MOCK_LOCALE_1
-			)
-		).toEqual( MockData.STORE_PLAN_FREE );
+		it( 'should select the right product for a given correct product ID', () => {
+			// Free
+			expect(
+				Selectors.getPlanByProductId(
+					mockState,
+					MockData.STORE_PRODUCT_FREE.productId,
+					MOCK_LOCALE_1
+				)
+			).toEqual( MockData.STORE_PLAN_FREE );
 
-		// Existing Product (annually billed)
-		expect(
-			Selectors.getPlanByProductId(
-				mockState,
-				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.productId,
-				MOCK_LOCALE_1
-			)
-		).toEqual( MockData.STORE_PLAN_PREMIUM );
+			// Paid (annually billed)
+			expect(
+				Selectors.getPlanByProductId(
+					mockState,
+					MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.productId,
+					MOCK_LOCALE_1
+				)
+			).toEqual( MockData.STORE_PLAN_PREMIUM );
 
-		// Existing Product (monthly billed)
-		expect(
-			Selectors.getPlanByProductId(
-				mockState,
-				MockData.STORE_PRODUCT_PREMIUM_MONTHLY.productId,
-				MOCK_LOCALE_1
-			)
-		).toEqual( MockData.STORE_PLAN_PREMIUM );
+			// Paid (monthly billed)
+			expect(
+				Selectors.getPlanByProductId(
+					mockState,
+					MockData.STORE_PRODUCT_PREMIUM_MONTHLY.productId,
+					MOCK_LOCALE_1
+				)
+			).toEqual( MockData.STORE_PLAN_PREMIUM );
+		} );
 
-		// Existing Product, but not for the locale
-		expect(
-			Selectors.getPlanByProductId(
-				mockState,
-				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.productId,
-				MOCK_LOCALE_2
-			)
-		).toBeUndefined();
+		it( 'should return undefined if the product ID does not exist for the given locale', () => {
+			expect(
+				Selectors.getPlanByProductId(
+					mockState,
+					MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.productId,
+					MOCK_LOCALE_2
+				)
+			).toBeUndefined();
+		} );
 	} );
 
-	it( 'getPlanProductById', () => {
-		// Product Id not defined
-		expect( Selectors.getPlanProductById( mockState, undefined ) ).toBeUndefined();
+	describe( 'getPlanProductById', () => {
+		it( 'should return undefined if the product ID is undefined', () => {
+			expect( Selectors.getPlanProductById( mockState, undefined ) ).toBeUndefined();
+		} );
 
-		// Non existing product
-		expect( Selectors.getPlanProductById( mockState, -1 ) ).toBeUndefined();
+		it( 'should return undefined if the product ID is not associated to any products', () => {
+			// Non existing product
+			expect( Selectors.getPlanProductById( mockState, -1 ) ).toBeUndefined();
+		} );
 
-		// Existing Product (free)
-		expect(
-			Selectors.getPlanProductById( mockState, MockData.STORE_PRODUCT_FREE.productId )
-		).toEqual( MockData.STORE_PRODUCT_FREE );
+		it( 'should select the right product for a given correct product ID', () => {
+			// Free
+			expect(
+				Selectors.getPlanProductById( mockState, MockData.STORE_PRODUCT_FREE.productId )
+			).toEqual( MockData.STORE_PRODUCT_FREE );
 
-		// Existing Product (annually billed)
-		expect(
-			Selectors.getPlanProductById( mockState, MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.productId )
-		).toEqual( MockData.STORE_PRODUCT_PREMIUM_ANNUALLY );
+			// Paid (annually billed)
+			expect(
+				Selectors.getPlanProductById( mockState, MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.productId )
+			).toEqual( MockData.STORE_PRODUCT_PREMIUM_ANNUALLY );
+		} );
 
-		// Existing Product, but not in store (monthly billed)
-		expect(
-			Selectors.getPlanProductById( mockState, MockData.STORE_PRODUCT_PREMIUM_MONTHLY.productId )
-		).toBeUndefined();
+		it( 'should return undefined if the product ID does not match any products in the store', () => {
+			// Existing Product, but not in store (monthly billed)
+			expect(
+				Selectors.getPlanProductById( mockState, MockData.STORE_PRODUCT_PREMIUM_MONTHLY.productId )
+			).toBeUndefined();
+		} );
 	} );
 
-	it( 'getPlanByPeriodAgnosticSlug', () => {
-		// Plan slug is undefined
-		expect(
-			Selectors.getPlanByPeriodAgnosticSlug( mockState, undefined, MOCK_LOCALE_1 )
-		).toBeUndefined();
+	describe( 'getPlanByPeriodAgnosticSlug', () => {
+		it( 'should return undefined if the plan slug is undefined', () => {
+			expect(
+				Selectors.getPlanByPeriodAgnosticSlug( mockState, undefined, MOCK_LOCALE_1 )
+			).toBeUndefined();
+		} );
 
-		// A plan that doesn't exist in the mock APIs
-		expect(
-			Selectors.getPlanByPeriodAgnosticSlug( mockState, 'ecommerce', MOCK_LOCALE_1 )
-		).toBeUndefined();
+		it( 'should return undefined if the plan slug does not match any plans in the store', () => {
+			expect(
+				Selectors.getPlanByPeriodAgnosticSlug( mockState, 'ecommerce', MOCK_LOCALE_1 )
+			).toBeUndefined();
+		} );
 
-		// A plan that exists in the store, for locale 1
-		expect(
-			Selectors.getPlanByPeriodAgnosticSlug(
-				mockState,
-				MockData.STORE_PLAN_PREMIUM.periodAgnosticSlug,
-				MOCK_LOCALE_1
-			)
-		).toEqual( MockData.STORE_PLAN_PREMIUM );
+		it( 'should select the right plan for a given, correct plan slug and locale', () => {
+			// Locale 1
+			expect(
+				Selectors.getPlanByPeriodAgnosticSlug(
+					mockState,
+					MockData.STORE_PLAN_PREMIUM.periodAgnosticSlug,
+					MOCK_LOCALE_1
+				)
+			).toEqual( MockData.STORE_PLAN_PREMIUM );
 
-		// A plan that exists in the store, for locale 2
-		expect(
-			Selectors.getPlanByPeriodAgnosticSlug(
-				mockState,
-				MockData.STORE_PLAN_FREE.periodAgnosticSlug,
-				MOCK_LOCALE_2
-			)
-		).toEqual( MockData.STORE_PLAN_FREE );
+			// Locale 2
+			expect(
+				Selectors.getPlanByPeriodAgnosticSlug(
+					mockState,
+					MockData.STORE_PLAN_FREE.periodAgnosticSlug,
+					MOCK_LOCALE_2
+				)
+			).toEqual( MockData.STORE_PLAN_FREE );
+		} );
 
-		// Plan exists in the store, but not for locale 2
-		expect(
-			Selectors.getPlanByPeriodAgnosticSlug(
-				mockState,
-				MockData.STORE_PLAN_PREMIUM.periodAgnosticSlug,
-				MOCK_LOCALE_2
-			)
-		).toBeUndefined();
+		it( 'should return undefined if the plan slug does not match any plans in the store for the given locale', () => {
+			expect(
+				Selectors.getPlanByPeriodAgnosticSlug(
+					mockState,
+					MockData.STORE_PLAN_PREMIUM.periodAgnosticSlug,
+					MOCK_LOCALE_2
+				)
+			).toBeUndefined();
+		} );
 	} );
 
-	it( 'getDefaultPaidPlan', () => {
-		// The store has the default paid plan for the selected locale
-		expect( Selectors.getDefaultPaidPlan( mockState, MOCK_LOCALE_1 ) ).toEqual(
-			MockData.STORE_PLAN_PREMIUM
-		);
+	describe( 'getDefaultPaidPlan', () => {
+		it( 'should select the correct default paid plan for the given locale', () => {
+			expect( Selectors.getDefaultPaidPlan( mockState, MOCK_LOCALE_1 ) ).toEqual(
+				MockData.STORE_PLAN_PREMIUM
+			);
+		} );
 
-		// The store doesn't have the default paid plan for the selected locale
-		expect( Selectors.getDefaultPaidPlan( mockState, MOCK_LOCALE_2 ) ).toBeUndefined();
+		it( 'should return undefined if the default paid plan is not available in the store for a given locale', () => {
+			expect( Selectors.getDefaultPaidPlan( mockState, MOCK_LOCALE_2 ) ).toBeUndefined();
+		} );
 	} );
 
-	it( 'getDefaultFreePlan', () => {
-		expect( Selectors.getDefaultFreePlan( mockState, MOCK_LOCALE_1 ) ).toEqual(
-			MockData.STORE_PLAN_FREE
-		);
-		expect( Selectors.getDefaultFreePlan( mockState, MOCK_LOCALE_2 ) ).toEqual(
-			MockData.STORE_PLAN_FREE
-		);
+	describe( 'getDefaultFreePlan', () => {
+		it( 'should select the correct default free plan for the given locale', () => {
+			expect( Selectors.getDefaultFreePlan( mockState, MOCK_LOCALE_1 ) ).toEqual(
+				MockData.STORE_PLAN_FREE
+			);
+			expect( Selectors.getDefaultFreePlan( mockState, MOCK_LOCALE_2 ) ).toEqual(
+				MockData.STORE_PLAN_FREE
+			);
+		} );
 	} );
 
-	it( 'getSupportedPlans', () => {
-		expect( Selectors.getSupportedPlans( mockState, MOCK_LOCALE_1 ) ).toEqual(
-			mockPlans[ MOCK_LOCALE_1 ]
-		);
-		expect( Selectors.getSupportedPlans( mockState, MOCK_LOCALE_2 ) ).toEqual(
-			mockPlans[ MOCK_LOCALE_2 ]
-		);
-		expect( Selectors.getSupportedPlans( mockState, 'non-existing' ) ).toEqual( [] );
+	describe( 'getSupportedPlans', () => {
+		it( 'should select the supported plans for a given locale', () => {
+			expect( Selectors.getSupportedPlans( mockState, MOCK_LOCALE_1 ) ).toEqual(
+				mockPlans[ MOCK_LOCALE_1 ]
+			);
+			expect( Selectors.getSupportedPlans( mockState, MOCK_LOCALE_2 ) ).toEqual(
+				mockPlans[ MOCK_LOCALE_2 ]
+			);
+		} );
+
+		it( 'should return an empty list if the given locale does not exist in the store', () => {
+			expect( Selectors.getSupportedPlans( mockState, 'non-existing' ) ).toEqual( [] );
+		} );
 	} );
 
-	it( 'getPlansProducts', () => {
-		expect( Selectors.getPlansProducts( mockState ) ).toEqual( mockPlanProducts );
+	describe( 'getPlansProducts', () => {
+		it( 'should select all of the plans products from the store', () => {
+			expect( Selectors.getPlansProducts( mockState ) ).toEqual( mockPlanProducts );
+		} );
 	} );
 
-	it( 'getPrices', () => {
-		const expectedPrices = {
-			[ MockData.STORE_PRODUCT_FREE.storeSlug ]: MockData.STORE_PRODUCT_FREE.price,
-			[ MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.storeSlug ]:
-				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.price,
-		};
-		expect( Selectors.getPrices( mockState, MOCK_LOCALE_1 ) ).toEqual( expectedPrices );
-		expect( Selectors.getPrices( mockState, MOCK_LOCALE_2 ) ).toEqual( expectedPrices );
+	describe( 'getPrices', () => {
+		it( 'should select the prices for each plan product for a given locale', () => {
+			const expectedPrices = {
+				[ MockData.STORE_PRODUCT_FREE.storeSlug ]: MockData.STORE_PRODUCT_FREE.price,
+				[ MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.storeSlug ]:
+					MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.price,
+			};
+			expect( Selectors.getPrices( mockState, MOCK_LOCALE_1 ) ).toEqual( expectedPrices );
+			expect( Selectors.getPrices( mockState, MOCK_LOCALE_2 ) ).toEqual( expectedPrices );
+		} );
 
-		// Make sure function is correctly flagged as deprecated
-		const expectedCallArguments = [
-			'getPrices',
-			{
+		it( 'should be marked as deprecated', () => {
+			Selectors.getPrices( mockState, MOCK_LOCALE_1 );
+
+			expect( deprecate ).toHaveBeenCalled();
+			expect( deprecate ).toHaveBeenCalledWith( 'getPrices', {
 				alternative: 'getPlanProduct().price',
-			},
-		];
-		expect( deprecate ).toHaveBeenCalledTimes( 2 );
-		expect( deprecate ).toHaveBeenNthCalledWith( 1, ...expectedCallArguments );
-		expect( deprecate ).toHaveBeenNthCalledWith( 2, ...expectedCallArguments );
+			} );
+		} );
 	} );
 
-	it( 'getPlanByPath', () => {
-		// Plan path (product slug) is undefined
-		expect( Selectors.getPlanByPath( mockState, undefined, MOCK_LOCALE_1 ) ).toBeUndefined();
+	describe( 'getPlanByPath', () => {
+		it( 'should return undefined if the plan slug is undefined', () => {
+			expect( Selectors.getPlanByPath( mockState, undefined, MOCK_LOCALE_1 ) ).toBeUndefined();
+		} );
 
-		// Plan path (product slug) exists, but not currently in the store
-		expect( Selectors.getPlanByPath( mockState, 'ecommerce', MOCK_LOCALE_1 ) ).toBeUndefined();
+		it( 'should return undefined if the plan slug does not match any plans in the store', () => {
+			expect( Selectors.getPlanByPath( mockState, 'ecommerce', MOCK_LOCALE_1 ) ).toBeUndefined();
+		} );
 
-		// Plan path (product slug) exists and there's a matching plan for the locale
-		expect(
-			Selectors.getPlanByPath(
-				mockState,
-				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.pathSlug,
-				MOCK_LOCALE_1
-			)
-		).toEqual( MockData.STORE_PLAN_PREMIUM );
+		it( 'should select the correct plan for the given locale', () => {
+			expect(
+				Selectors.getPlanByPath(
+					mockState,
+					MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.pathSlug,
+					MOCK_LOCALE_1
+				)
+			).toEqual( MockData.STORE_PLAN_PREMIUM );
+		} );
 
-		// Plan path (product slug) exists but there isn't a matching plan for the locale
-		expect(
-			Selectors.getPlanByPath(
-				mockState,
-				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.pathSlug,
-				MOCK_LOCALE_2
-			)
-		).toBeUndefined();
+		it( 'should return undefined if the plan slug does not match any plans in the store for the given locale', () => {
+			expect(
+				Selectors.getPlanByPath(
+					mockState,
+					MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.pathSlug,
+					MOCK_LOCALE_2
+				)
+			).toBeUndefined();
+		} );
 	} );
 
-	it( 'getPlanProduct', () => {
-		// undefined plan slug
-		expect( Selectors.getPlanProduct( mockState, undefined, 'ANNUALLY' ) ).toBeUndefined();
+	describe( 'getPlanProduct', () => {
+		it( 'should return undefined if the plan slug is undefined', () => {
+			expect( Selectors.getPlanProduct( mockState, undefined, 'ANNUALLY' ) ).toBeUndefined();
+		} );
 
-		// undefined billing period
-		expect(
-			Selectors.getPlanProduct( mockState, MockData.STORE_PLAN_FREE.periodAgnosticSlug, undefined )
-		).toBeUndefined();
+		it( 'should return undefined if the billing period is undefined', () => {
+			expect(
+				Selectors.getPlanProduct(
+					mockState,
+					MockData.STORE_PLAN_FREE.periodAgnosticSlug,
+					undefined
+				)
+			).toBeUndefined();
+		} );
 
-		// free plan (regardless of the billing period)
-		expect(
-			Selectors.getPlanProduct( mockState, MockData.STORE_PLAN_FREE.periodAgnosticSlug, 'ANNUALLY' )
-		).toEqual( MockData.STORE_PRODUCT_FREE );
-		expect(
-			Selectors.getPlanProduct( mockState, MockData.STORE_PLAN_FREE.periodAgnosticSlug, 'MONTHLY' )
-		).toEqual( MockData.STORE_PRODUCT_FREE );
+		it( 'should select the free plan if the plan slug matches the free plan (regardless of the billing period)', () => {
+			expect(
+				Selectors.getPlanProduct(
+					mockState,
+					MockData.STORE_PLAN_FREE.periodAgnosticSlug,
+					'ANNUALLY'
+				)
+			).toEqual( MockData.STORE_PRODUCT_FREE );
+			expect(
+				Selectors.getPlanProduct(
+					mockState,
+					MockData.STORE_PLAN_FREE.periodAgnosticSlug,
+					'MONTHLY'
+				)
+			).toEqual( MockData.STORE_PRODUCT_FREE );
+		} );
 
-		// paid plan, annually billed is correctly found in the store
-		expect(
-			Selectors.getPlanProduct(
-				mockState,
-				MockData.STORE_PLAN_PREMIUM.periodAgnosticSlug,
-				'ANNUALLY'
-			)
-		).toEqual( MockData.STORE_PRODUCT_PREMIUM_ANNUALLY );
+		it( 'should select the correct paid plan given the billing period', () => {
+			expect(
+				Selectors.getPlanProduct(
+					mockState,
+					MockData.STORE_PLAN_PREMIUM.periodAgnosticSlug,
+					'ANNUALLY'
+				)
+			).toEqual( MockData.STORE_PRODUCT_PREMIUM_ANNUALLY );
+		} );
 
-		// periodAgnosticSlug is not free, monthly doesn't exist in the store
-		expect(
-			Selectors.getPlanProduct(
-				mockState,
-				MockData.STORE_PLAN_PREMIUM.periodAgnosticSlug,
-				'MONTHLY'
-			)
-		).toBeUndefined();
+		it( 'should return undefined if there is not math in the store for the given plan slug and billing period', () => {
+			expect(
+				Selectors.getPlanProduct(
+					mockState,
+					MockData.STORE_PLAN_PREMIUM.periodAgnosticSlug,
+					'MONTHLY'
+				)
+			).toBeUndefined();
+		} );
 	} );
 
-	it( 'isPlanEcommerce', () => {
-		expect( Selectors.isPlanEcommerce( mockState, TIMELESS_PLAN_ECOMMERCE ) ).toBe( true );
-		expect( Selectors.isPlanEcommerce( mockState, TIMELESS_PLAN_FREE ) ).toBe( false );
-		expect( Selectors.isPlanEcommerce( mockState ) ).toBe( false );
+	describe( 'isPlanEcommerce', () => {
+		it( 'should return true if the eCommerce plan slug is passed', () => {
+			expect( Selectors.isPlanEcommerce( mockState, TIMELESS_PLAN_ECOMMERCE ) ).toBe( true );
+		} );
+		it( 'should return false if the free plan slug is passed', () => {
+			expect( Selectors.isPlanEcommerce( mockState, TIMELESS_PLAN_FREE ) ).toBe( false );
+		} );
+		it( 'should return false if the plan slug is undefined', () => {
+			expect( Selectors.isPlanEcommerce( mockState ) ).toBe( false );
+		} );
 	} );
 
-	it( 'isPlanFree', () => {
-		expect( Selectors.isPlanFree( mockState, TIMELESS_PLAN_ECOMMERCE ) ).toBe( false );
-		expect( Selectors.isPlanFree( mockState, TIMELESS_PLAN_FREE ) ).toBe( true );
-		expect( Selectors.isPlanFree( mockState ) ).toBe( false );
+	describe( 'isPlanFree', () => {
+		it( 'should return false if the eCommerce plan slug is passed', () => {
+			expect( Selectors.isPlanFree( mockState, TIMELESS_PLAN_ECOMMERCE ) ).toBe( false );
+		} );
+		it( 'should return true if the free plan slug is passed', () => {
+			expect( Selectors.isPlanFree( mockState, TIMELESS_PLAN_FREE ) ).toBe( true );
+		} );
+		it( 'should return false if the plan slug is undefined', () => {
+			expect( Selectors.isPlanFree( mockState ) ).toBe( false );
+		} );
 	} );
 
-	it( 'isPlanProductFree', () => {
-		expect( Selectors.isPlanProductFree( mockState, FREE_PLAN_PRODUCT_ID ) ).toBe( true );
-		expect( Selectors.isPlanProductFree( mockState, 2 ) ).toBe( false );
-		expect( Selectors.isPlanProductFree( mockState ) ).toBe( false );
+	describe( 'isPlanProductFree', () => {
+		it( 'should return true if the free plan product ID is passed', () => {
+			expect( Selectors.isPlanProductFree( mockState, FREE_PLAN_PRODUCT_ID ) ).toBe( true );
+		} );
+		it( 'should return false if a product ID not associated to the free plan is passed', () => {
+			expect( Selectors.isPlanProductFree( mockState, 2 ) ).toBe( false );
+		} );
+		it( 'should return false if the product ID is undefined', () => {
+			expect( Selectors.isPlanProductFree( mockState ) ).toBe( false );
+		} );
 	} );
 } );

--- a/packages/data-stores/src/plans/test/selectors.ts
+++ b/packages/data-stores/src/plans/test/selectors.ts
@@ -53,6 +53,15 @@ const mockState: State = {
 jest.mock( '@wordpress/deprecated', () => {
 	return jest.fn();
 } );
+jest.mock( '@wordpress/data', () => ( {
+	// Mocking `select` allows unit tests to run in isolation for selectors,
+	// without the corresponding resolvers being called
+	select: () => ( {
+		getPlansProducts: () => mockPlanProducts,
+		getSupportedPlans: ( locale ) => mockPlans[ locale ] ?? [],
+	} ),
+} ) );
+
 // Tests
 describe( 'Plans selectors', () => {
 	it( 'getFeatures', () => {

--- a/packages/data-stores/src/plans/test/selectors.ts
+++ b/packages/data-stores/src/plans/test/selectors.ts
@@ -85,23 +85,128 @@ describe( 'Plans selectors', () => {
 	} );
 
 	it( 'getPlanByProductId', () => {
-		expect( 1 ).toBeTruthy();
+		// Product Id not defined
+		expect( Selectors.getPlanByProductId( mockState, undefined, TEST_LOCALE_1 ) ).toBeUndefined();
+
+		// Non existing product
+		expect( Selectors.getPlanByProductId( mockState, -1, TEST_LOCALE_1 ) ).toBeUndefined();
+
+		// Existing Product (free)
+		expect(
+			Selectors.getPlanByProductId(
+				mockState,
+				MockData.STORE_PRODUCT_FREE.productId,
+				TEST_LOCALE_1
+			)
+		).toEqual( MockData.STORE_PLAN_FREE );
+
+		// Existing Product (annually billed)
+		expect(
+			Selectors.getPlanByProductId(
+				mockState,
+				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.productId,
+				TEST_LOCALE_1
+			)
+		).toEqual( MockData.STORE_PLAN_PREMIUM );
+
+		// Existing Product (monthly billed)
+		expect(
+			Selectors.getPlanByProductId(
+				mockState,
+				MockData.STORE_PRODUCT_PREMIUM_MONTHLY.productId,
+				TEST_LOCALE_1
+			)
+		).toEqual( MockData.STORE_PLAN_PREMIUM );
+
+		// Existing Product, but not for the locale
+		expect(
+			Selectors.getPlanByProductId(
+				mockState,
+				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.productId,
+				TEST_LOCALE_2
+			)
+		).toBeUndefined();
 	} );
 
 	it( 'getPlanProductById', () => {
-		expect( 1 ).toBeTruthy();
+		// Product Id not defined
+		expect( Selectors.getPlanProductById( mockState, undefined ) ).toBeUndefined();
+
+		// Non existing product
+		expect( Selectors.getPlanProductById( mockState, -1 ) ).toBeUndefined();
+
+		// Existing Product (free)
+		expect(
+			Selectors.getPlanProductById( mockState, MockData.STORE_PRODUCT_FREE.productId )
+		).toEqual( MockData.STORE_PRODUCT_FREE );
+
+		// Existing Product (annually billed)
+		expect(
+			Selectors.getPlanProductById( mockState, MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.productId )
+		).toEqual( MockData.STORE_PRODUCT_PREMIUM_ANNUALLY );
+
+		// Existing Product, but not in store (monthly billed)
+		expect(
+			Selectors.getPlanProductById( mockState, MockData.STORE_PRODUCT_PREMIUM_MONTHLY.productId )
+		).toBeUndefined();
 	} );
 
 	it( 'getPlanByPeriodAgnosticSlug', () => {
-		expect( 1 ).toBeTruthy();
+		// Plan slug is undefined
+		expect(
+			Selectors.getPlanByPeriodAgnosticSlug( mockState, undefined, TEST_LOCALE_1 )
+		).toBeUndefined();
+
+		// A plan that doesn't exist in the mock APIs
+		expect(
+			Selectors.getPlanByPeriodAgnosticSlug( mockState, 'ecommerce', TEST_LOCALE_1 )
+		).toBeUndefined();
+
+		// A plan that exists in the store, for locale 1
+		expect(
+			Selectors.getPlanByPeriodAgnosticSlug(
+				mockState,
+				MockData.STORE_PLAN_PREMIUM.periodAgnosticSlug,
+				TEST_LOCALE_1
+			)
+		).toEqual( MockData.STORE_PLAN_PREMIUM );
+
+		// A plan that exists in the store, for locale 2
+		expect(
+			Selectors.getPlanByPeriodAgnosticSlug(
+				mockState,
+				MockData.STORE_PLAN_FREE.periodAgnosticSlug,
+				TEST_LOCALE_2
+			)
+		).toEqual( MockData.STORE_PLAN_FREE );
+
+		// Plan exists in the store, but not for locale 2
+		expect(
+			Selectors.getPlanByPeriodAgnosticSlug(
+				mockState,
+				MockData.STORE_PLAN_PREMIUM.periodAgnosticSlug,
+				TEST_LOCALE_2
+			)
+		).toBeUndefined();
 	} );
 
 	it( 'getDefaultPaidPlan', () => {
-		expect( 1 ).toBeTruthy();
+		// The store has the default paid plan for the selected locale
+		expect( Selectors.getDefaultPaidPlan( mockState, TEST_LOCALE_1 ) ).toEqual(
+			MockData.STORE_PLAN_PREMIUM
+		);
+
+		// The store doesn't have the default paid plan for the selected locale
+		expect( Selectors.getDefaultPaidPlan( mockState, TEST_LOCALE_2 ) ).toBeUndefined();
 	} );
 
 	it( 'getDefaultFreePlan', () => {
-		expect( 1 ).toBeTruthy();
+		expect( Selectors.getDefaultFreePlan( mockState, TEST_LOCALE_1 ) ).toEqual(
+			MockData.STORE_PLAN_FREE
+		);
+		expect( Selectors.getDefaultFreePlan( mockState, TEST_LOCALE_2 ) ).toEqual(
+			MockData.STORE_PLAN_FREE
+		);
 	} );
 
 	it( 'getSupportedPlans', () => {
@@ -119,15 +224,86 @@ describe( 'Plans selectors', () => {
 	} );
 
 	it( 'getPrices', () => {
-		expect( 1 ).toBeTruthy();
+		const expectedPrices = {
+			[ MockData.STORE_PRODUCT_FREE.storeSlug ]: MockData.STORE_PRODUCT_FREE.price,
+			[ MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.storeSlug ]:
+				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.price,
+		};
+		expect( Selectors.getPrices( mockState, TEST_LOCALE_1 ) ).toEqual( expectedPrices );
+		expect( Selectors.getPrices( mockState, TEST_LOCALE_2 ) ).toEqual( expectedPrices );
+
+		// Make sure function is correctly flagged as deprecated
+		const expectedCallArguments = [
+			'getPrices',
+			{
+				alternative: 'getPlanProduct().price',
+			},
+		];
+		expect( deprecate ).toHaveBeenCalledTimes( 2 );
+		expect( deprecate ).toHaveBeenNthCalledWith( 1, ...expectedCallArguments );
+		expect( deprecate ).toHaveBeenNthCalledWith( 2, ...expectedCallArguments );
 	} );
 
 	it( 'getPlanByPath', () => {
-		expect( 1 ).toBeTruthy();
+		// Plan path (product slug) is undefined
+		expect( Selectors.getPlanByPath( mockState, undefined, TEST_LOCALE_1 ) ).toBeUndefined();
+
+		// Plan path (product slug) exists, but not currently in the store
+		expect( Selectors.getPlanByPath( mockState, 'ecommerce', TEST_LOCALE_1 ) ).toBeUndefined();
+
+		// Plan path (product slug) exists and there's a matching plan for the locale
+		expect(
+			Selectors.getPlanByPath(
+				mockState,
+				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.pathSlug,
+				TEST_LOCALE_1
+			)
+		).toEqual( MockData.STORE_PLAN_PREMIUM );
+
+		// Plan path (product slug) exists but there isn't a matching plan for the locale
+		expect(
+			Selectors.getPlanByPath(
+				mockState,
+				MockData.STORE_PRODUCT_PREMIUM_ANNUALLY.pathSlug,
+				TEST_LOCALE_2
+			)
+		).toBeUndefined();
 	} );
 
 	it( 'getPlanProduct', () => {
-		expect( 1 ).toBeTruthy();
+		// undefined plan slug
+		expect( Selectors.getPlanProduct( mockState, undefined, 'ANNUALLY' ) ).toBeUndefined();
+
+		// undefined billing period
+		expect(
+			Selectors.getPlanProduct( mockState, MockData.STORE_PLAN_FREE.periodAgnosticSlug, undefined )
+		).toBeUndefined();
+
+		// free plan (regardless of the billing period)
+		expect(
+			Selectors.getPlanProduct( mockState, MockData.STORE_PLAN_FREE.periodAgnosticSlug, 'ANNUALLY' )
+		).toEqual( MockData.STORE_PRODUCT_FREE );
+		expect(
+			Selectors.getPlanProduct( mockState, MockData.STORE_PLAN_FREE.periodAgnosticSlug, 'MONTHLY' )
+		).toEqual( MockData.STORE_PRODUCT_FREE );
+
+		// paid plan, annually billed is correctly found in the store
+		expect(
+			Selectors.getPlanProduct(
+				mockState,
+				MockData.STORE_PLAN_PREMIUM.periodAgnosticSlug,
+				'ANNUALLY'
+			)
+		).toEqual( MockData.STORE_PRODUCT_PREMIUM_ANNUALLY );
+
+		// periodAgnosticSlug is not free, monthly doesn't exist in the store
+		expect(
+			Selectors.getPlanProduct(
+				mockState,
+				MockData.STORE_PLAN_PREMIUM.periodAgnosticSlug,
+				'MONTHLY'
+			)
+		).toBeUndefined();
 	} );
 
 	it( 'isPlanEcommerce', () => {

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -79,7 +79,7 @@ export interface PricedAPIPlanPaidMonthly extends PricedAPIPlan {
 }
 
 export type PlanFeature = {
-	id?: string;
+	id: string;
 	description?: string;
 	name: string;
 	requiresAnnuallyBilledPlan: boolean;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Refactor mock data:
  - split into smaller files, divided by data type (e.g. APIs vs Store)
  - removed `MOCK_` prefix
  - slightly changed naming convention
* Add some missing mock data
* Refactored existing tests, mainly to accommodate for the new mock data naming conventions (and now using the `MockData` namespace for accessing all mock variables)
* Added unit tests for action creators
* Added unit tests for selectors

### Testing instructions

#### Manual tests

- [ ] I left some comments below on the most interesting bits of code
- [ ] Check if there's any missing test case, or if any tests could be testing for the wrong result

#### Automated tests

- [ ] `./node_modules/.bin/jest -c=test/packages/jest.config.js packages/data-stores/src/plans` — all tests passing
- [ ] `./node_modules/.bin/jest -c=test/packages/jest.config.js --coverage --collectCoverageFrom='["src/plans/*.ts", "!src/plans/{index,types}.ts"]' packages/data-stores/src/plans` — 100% coverage on all files


### Screenshots

### Before

<img width="876" alt="Screenshot 2021-02-26 at 16 11 54" src="https://user-images.githubusercontent.com/1083581/109317819-69eeba80-784d-11eb-986d-9e3bf0664e47.png">

### After

<img width="879" alt="Screenshot 2021-02-26 at 16 09 51" src="https://user-images.githubusercontent.com/1083581/109317511-11b7b880-784d-11eb-8b7d-7ee968db13d2.png">

Closes #49920 