### PR TITLE
Checkout: Display introductory offer intervals in the cart line items

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -12,7 +12,7 @@ import {
 	Button,
 } from '@automattic/composite-checkout';
 import type { Theme, LineItem as LineItemType } from '@automattic/composite-checkout';
-import { useTranslate } from 'i18n-calypso';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import type {
@@ -638,6 +638,115 @@ function FirstTermDiscountCallout( {
 	return null;
 }
 
+function IntroductoryOfferCallout( {
+	product,
+}: {
+	product: ResponseCartProduct;
+} ): JSX.Element | null {
+	const translate = useTranslate();
+	let text: TranslateResult = translate( 'Discount for first period' );
+	if ( ! product.introductory_offer_terms?.enabled ) {
+		return null;
+	}
+
+	const intervalUnit = product.introductory_offer_terms.interval_unit;
+	const intervalCount = product.introductory_offer_terms.interval_count;
+
+	if ( product.cost === 0 ) {
+		if ( intervalUnit === 'day' ) {
+			if ( intervalCount === 1 ) {
+				text = translate( 'Free for first day' );
+			} else {
+				text = translate( 'Free for first %(numberOfDays)d days', {
+					args: {
+						numberOfDays: intervalCount,
+					},
+				} );
+			}
+		}
+		if ( intervalUnit === 'week' ) {
+			if ( intervalCount === 1 ) {
+				text = translate( 'Free for first week' );
+			} else {
+				text = translate( 'Free for first %(numberOfWeeks)d weeks', {
+					args: {
+						numberOfWeeks: intervalCount,
+					},
+				} );
+			}
+		}
+		if ( intervalUnit === 'month' ) {
+			if ( intervalCount === 1 ) {
+				text = translate( 'Free for first month' );
+			} else {
+				text = translate( 'Free for first %(numberOfMonths)d months', {
+					args: {
+						numberOfMonths: intervalCount,
+					},
+				} );
+			}
+		}
+		if ( intervalUnit === 'year' ) {
+			if ( intervalCount === 1 ) {
+				text = translate( 'Free for first year' );
+			} else {
+				text = translate( 'Free for first %(numberOfYears)d years', {
+					args: {
+						numberOfYears: intervalCount,
+					},
+				} );
+			}
+		}
+	} else {
+		if ( intervalUnit === 'day' ) {
+			if ( intervalCount === 1 ) {
+				text = translate( 'Discount for first day' );
+			} else {
+				text = translate( 'Discount for first %(numberOfDays)d days', {
+					args: {
+						numberOfDays: intervalCount,
+					},
+				} );
+			}
+		}
+		if ( intervalUnit === 'week' ) {
+			if ( intervalCount === 1 ) {
+				text = translate( 'Discount for first week' );
+			} else {
+				text = translate( 'Discount for first %(numberOfWeeks)d weeks', {
+					args: {
+						numberOfWeeks: intervalCount,
+					},
+				} );
+			}
+		}
+		if ( intervalUnit === 'month' ) {
+			if ( intervalCount === 1 ) {
+				text = translate( 'Discount for first month' );
+			} else {
+				text = translate( 'Discount for first %(numberOfMonths)d months', {
+					args: {
+						numberOfMonths: intervalCount,
+					},
+				} );
+			}
+		}
+		if ( intervalUnit === 'year' ) {
+			if ( intervalCount === 1 ) {
+				text = translate( 'Discount for first year' );
+			} else {
+				text = translate( 'Discount for first %(numberOfYears)d years', {
+					args: {
+						numberOfYears: intervalCount,
+					},
+				} );
+			}
+		}
+	}
+
+	return <DiscountCallout>{ text }</DiscountCallout>;
+}
+
 function DomainDiscountCallout( {
 	product,
 }: {
@@ -781,6 +890,7 @@ function WPLineItem( {
 					<DomainDiscountCallout product={ product } />
 					<FirstTermDiscountCallout product={ product } />
 					<CouponDiscountCallout product={ product } />
+					<IntroductoryOfferCallout product={ product } />
 				</LineItemMeta>
 			) }
 			{ isGSuite && <GSuiteUsersList product={ product } /> }

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -644,11 +644,11 @@ function IntroductoryOfferCallout( {
 	product: ResponseCartProduct;
 } ): JSX.Element | null {
 	const translate = useTranslate();
-	let text = String( translate( 'Discount for first period' ) );
 	if ( ! product.introductory_offer_terms?.enabled ) {
 		return null;
 	}
 
+	let text = String( translate( 'Discount for first period' ) );
 	const intervalUnit = product.introductory_offer_terms.interval_unit;
 	const intervalCount = product.introductory_offer_terms.interval_count;
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -644,7 +644,7 @@ function IntroductoryOfferCallout( {
 	product: ResponseCartProduct;
 } ): JSX.Element | null {
 	const translate = useTranslate();
-	let text = translate( 'Discount for first period' ) as string;
+	let text = String( translate( 'Discount for first period' ) );
 	if ( ! product.introductory_offer_terms?.enabled ) {
 		return null;
 	}
@@ -655,47 +655,55 @@ function IntroductoryOfferCallout( {
 	if ( product.cost === 0 ) {
 		if ( intervalUnit === 'month' ) {
 			if ( intervalCount === 1 ) {
-				text = translate( 'First month free' ) as string;
+				text = String( translate( 'First month free' ) );
 			} else {
-				text = translate( 'First %(numberOfMonths)d months free', {
-					args: {
-						numberOfMonths: intervalCount,
-					},
-				} ) as string;
+				text = String(
+					translate( 'First %(numberOfMonths)d months free', {
+						args: {
+							numberOfMonths: intervalCount,
+						},
+					} )
+				);
 			}
 		}
 		if ( intervalUnit === 'year' ) {
 			if ( intervalCount === 1 ) {
-				text = translate( 'First year free' ) as string;
+				text = String( translate( 'First year free' ) );
 			} else {
-				text = translate( 'First %(numberOfYears)d years free', {
-					args: {
-						numberOfYears: intervalCount,
-					},
-				} ) as string;
+				text = String(
+					translate( 'First %(numberOfYears)d years free', {
+						args: {
+							numberOfYears: intervalCount,
+						},
+					} )
+				);
 			}
 		}
 	} else {
 		if ( intervalUnit === 'month' ) {
 			if ( intervalCount === 1 ) {
-				text = translate( 'Discount for first month' ) as string;
+				text = String( translate( 'Discount for first month' ) );
 			} else {
-				text = translate( 'Discount for first %(numberOfMonths)d months', {
-					args: {
-						numberOfMonths: intervalCount,
-					},
-				} ) as string;
+				text = String(
+					translate( 'Discount for first %(numberOfMonths)d months', {
+						args: {
+							numberOfMonths: intervalCount,
+						},
+					} )
+				);
 			}
 		}
 		if ( intervalUnit === 'year' ) {
 			if ( intervalCount === 1 ) {
-				text = translate( 'Discount for first year' ) as string;
+				text = String( translate( 'Discount for first year' ) );
 			} else {
-				text = translate( 'Discount for first %(numberOfYears)d years', {
-					args: {
-						numberOfYears: intervalCount,
-					},
-				} ) as string;
+				text = String(
+					translate( 'Discount for first %(numberOfYears)d years', {
+						args: {
+							numberOfYears: intervalCount,
+						},
+					} )
+				);
 			}
 		}
 	}

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -652,7 +652,7 @@ function IntroductoryOfferCallout( {
 	const intervalUnit = product.introductory_offer_terms.interval_unit;
 	const intervalCount = product.introductory_offer_terms.interval_count;
 
-	if ( product.cost === 0 ) {
+	if ( product.item_subtotal_integer === 0 ) {
 		if ( intervalUnit === 'month' ) {
 			if ( intervalCount === 1 ) {
 				text = String( translate( 'First month free' ) );

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -653,33 +653,11 @@ function IntroductoryOfferCallout( {
 	const intervalCount = product.introductory_offer_terms.interval_count;
 
 	if ( product.cost === 0 ) {
-		if ( intervalUnit === 'day' ) {
-			if ( intervalCount === 1 ) {
-				text = translate( 'Free for first day' );
-			} else {
-				text = translate( 'Free for first %(numberOfDays)d days', {
-					args: {
-						numberOfDays: intervalCount,
-					},
-				} );
-			}
-		}
-		if ( intervalUnit === 'week' ) {
-			if ( intervalCount === 1 ) {
-				text = translate( 'Free for first week' );
-			} else {
-				text = translate( 'Free for first %(numberOfWeeks)d weeks', {
-					args: {
-						numberOfWeeks: intervalCount,
-					},
-				} );
-			}
-		}
 		if ( intervalUnit === 'month' ) {
 			if ( intervalCount === 1 ) {
-				text = translate( 'Free for first month' );
+				text = translate( 'First month free' );
 			} else {
-				text = translate( 'Free for first %(numberOfMonths)d months', {
+				text = translate( 'First %(numberOfMonths)d months free', {
 					args: {
 						numberOfMonths: intervalCount,
 					},
@@ -688,9 +666,9 @@ function IntroductoryOfferCallout( {
 		}
 		if ( intervalUnit === 'year' ) {
 			if ( intervalCount === 1 ) {
-				text = translate( 'Free for first year' );
+				text = translate( 'First year free' );
 			} else {
-				text = translate( 'Free for first %(numberOfYears)d years', {
+				text = translate( 'First %(numberOfYears)d years free', {
 					args: {
 						numberOfYears: intervalCount,
 					},
@@ -698,28 +676,6 @@ function IntroductoryOfferCallout( {
 			}
 		}
 	} else {
-		if ( intervalUnit === 'day' ) {
-			if ( intervalCount === 1 ) {
-				text = translate( 'Discount for first day' );
-			} else {
-				text = translate( 'Discount for first %(numberOfDays)d days', {
-					args: {
-						numberOfDays: intervalCount,
-					},
-				} );
-			}
-		}
-		if ( intervalUnit === 'week' ) {
-			if ( intervalCount === 1 ) {
-				text = translate( 'Discount for first week' );
-			} else {
-				text = translate( 'Discount for first %(numberOfWeeks)d weeks', {
-					args: {
-						numberOfWeeks: intervalCount,
-					},
-				} );
-			}
-		}
 		if ( intervalUnit === 'month' ) {
 			if ( intervalCount === 1 ) {
 				text = translate( 'Discount for first month' );

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -12,7 +12,7 @@ import {
 	Button,
 } from '@automattic/composite-checkout';
 import type { Theme, LineItem as LineItemType } from '@automattic/composite-checkout';
-import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import type {
@@ -644,7 +644,7 @@ function IntroductoryOfferCallout( {
 	product: ResponseCartProduct;
 } ): JSX.Element | null {
 	const translate = useTranslate();
-	let text: TranslateResult = translate( 'Discount for first period' );
+	let text = translate( 'Discount for first period' ) as string;
 	if ( ! product.introductory_offer_terms?.enabled ) {
 		return null;
 	}
@@ -655,47 +655,47 @@ function IntroductoryOfferCallout( {
 	if ( product.cost === 0 ) {
 		if ( intervalUnit === 'month' ) {
 			if ( intervalCount === 1 ) {
-				text = translate( 'First month free' );
+				text = translate( 'First month free' ) as string;
 			} else {
 				text = translate( 'First %(numberOfMonths)d months free', {
 					args: {
 						numberOfMonths: intervalCount,
 					},
-				} );
+				} ) as string;
 			}
 		}
 		if ( intervalUnit === 'year' ) {
 			if ( intervalCount === 1 ) {
-				text = translate( 'First year free' );
+				text = translate( 'First year free' ) as string;
 			} else {
 				text = translate( 'First %(numberOfYears)d years free', {
 					args: {
 						numberOfYears: intervalCount,
 					},
-				} );
+				} ) as string;
 			}
 		}
 	} else {
 		if ( intervalUnit === 'month' ) {
 			if ( intervalCount === 1 ) {
-				text = translate( 'Discount for first month' );
+				text = translate( 'Discount for first month' ) as string;
 			} else {
 				text = translate( 'Discount for first %(numberOfMonths)d months', {
 					args: {
 						numberOfMonths: intervalCount,
 					},
-				} );
+				} ) as string;
 			}
 		}
 		if ( intervalUnit === 'year' ) {
 			if ( intervalCount === 1 ) {
-				text = translate( 'Discount for first year' );
+				text = translate( 'Discount for first year' ) as string;
 			} else {
 				text = translate( 'Discount for first %(numberOfYears)d years', {
 					args: {
 						numberOfYears: intervalCount,
 					},
-				} );
+				} ) as string;
 			}
 		}
 	}

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -462,7 +462,15 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): i18nCalypso.
 		}
 	}
 
-	return isRenewalItem ? translate( 'Renewal' ) : '';
+	if ( ! isRenewalItem && serverCartItem.months_per_bill_period === 1 ) {
+		return translate( 'Monthly subscription' );
+	}
+
+	if ( isRenewalItem ) {
+		return translate( 'Renewal' );
+	}
+
+	return '';
 }
 
 export function getLabel( serverCartItem: ResponseCartProduct ): string {

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -154,10 +154,18 @@ export interface ResponseCartProduct {
 	included_domain_purchase_amount: number;
 	is_renewal?: boolean;
 	subscription_id?: string;
+	introductory_offer_terms?: IntroductoryOfferTerms;
 
 	// Temporary optional properties for the monthly pricing test
 	related_monthly_plan_cost_display?: string;
 	related_monthly_plan_cost_integer?: number;
+}
+
+export interface IntroductoryOfferTerms {
+	enabled: boolean;
+	interval_unit: string;
+	interval_count: number;
+	reason?: string;
 }
 
 export interface CartLocation {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Display the introductory offer discount/free trial intervals (only yearly and monthly intervals contain specific language) as discount callouts in the line items.
![image](https://user-images.githubusercontent.com/15204776/111353578-0d600d80-864b-11eb-8f85-955369f4ade8.png)


#### Testing instructions
* Follow the same steps described in the test plan of D58043-code to enable an introductory offer for your user.
* When you arrive to the checkout, a discount callout should be displayed in the shopping cart line item like the one in the screenshot above.
