### PR TITLE
Re-enable stale bot.

### DIFF
--- a/.github/workflows/mark-issue-stale.yml
+++ b/.github/workflows/mark-issue-stale.yml
@@ -24,5 +24,4 @@ jobs:
           # Label to apply when issue is marked stale.
           stale-issue-label: '[Status] Stale'
           # Increase number of operations executed per run.
-          operations-per-run: 750
-          debug-only: true
+          operations-per-run: 650


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- reduce the number of operations to 650 (from 750 in debug mode) to stay under the 1000 operation limit across the repository.
- remove debug-only flag.
