### PR TITLE
Legacy experiments: Remove cartNudgeUpdateToPremium

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -10,15 +10,6 @@
 /**************************************************************************************************/
 
 export default {
-	cartNudgeUpdateToPremium: {
-		datestamp: '20180917',
-		variations: {
-			test: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	pageBuilderMVP: {
 		datestamp: '20190419',
 		variations: {


### PR DESCRIPTION
Removes an unused legacy experiment.

Part of the work on pbmo2S-Bv-p2 and under the issue 495-gh-Automattic/experimentation-platform

#### Testing instructions

No significant code changes so no testing should be necessary.
