### PR TITLE
Anchor Gutenboarding: Add Hannah starter design

### DIFF
--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -369,6 +369,19 @@
 			"categories": [ "featured" ],
 			"is_premium": false,
 			"features": []
+		},
+		{
+			"title": "Hannah",
+			"slug": "hannah",
+			"template": "hannah",
+			"theme": "mayland",
+			"fonts": {
+				"headings": "Raleway",
+				"base": "Cabin"
+			},
+			"categories": [ "featured" ],
+			"is_premium": false,
+			"features": [ "anchorfm" ]
 		}
 	]
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds Hannah to available designs for podcasting sites

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* ~Apply these diffs: D57710-code D57712-code and sandbox the API~ Diffs have been merged and screenshots generated.
* Start the Anchor Gutenboarding flow (/new?anchor_podcast={podcast-id})
* The "Hannah" design should be an option at the design step, and the correct preview should load at the fonts step (with the podcast-specific logo and title).

<img width="1181" alt="Screen Shot 2021-03-15 at 12 49 01 PM" src="https://user-images.githubusercontent.com/1689238/111189852-e04d2580-858c-11eb-8682-a5b2b50e635c.png">

<img width="1480" alt="Screen Shot 2021-03-10 at 11 33 24 AM" src="https://user-images.githubusercontent.com/1689238/110663482-78659c00-8194-11eb-8085-fe6c37c9429e.png">


* Choose "Hannah" and create the site
* The homepage should look like the Hannah design

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 486-gh-Automattic/dotcom-manage