### PR TITLE
Add a "Finish Setup" button to the Titan quantity selection page

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -808,14 +808,16 @@ Undocumented.prototype.getTitanControlPanelAutoLoginURL = function ( emailAccoun
  * Retrieves the URL to embed Titan's control panel in an iframe.
  *
  * @param emailAccountId The email account ID
+ * @param context Optional context enum to launch into a specific part of the control panel
  * @param fn The callback function
  */
-Undocumented.prototype.getTitanControlPanelIframeURL = function ( emailAccountId, fn ) {
+Undocumented.prototype.getTitanControlPanelIframeURL = function ( emailAccountId, context, fn ) {
 	return this.wpcom.req.get(
 		{
 			path: `/emails/titan/${ encodeURIComponent( emailAccountId ) }/control-panel-iframe-url`,
 			apiNamespace: 'wpcom/v2',
 		},
+		{ context },
 		fn
 	);
 };

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -47,7 +47,12 @@ export default {
 	},
 
 	emailManagementManageTitanAccount( pageContext, next ) {
-		pageContext.primary = <TitanManagementIframe domainName={ pageContext.params.domain } />;
+		pageContext.primary = (
+			<TitanManagementIframe
+				domainName={ pageContext.params.domain }
+				context={ pageContext.query.context }
+			/>
+		);
 
 		next();
 	},

--- a/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
@@ -34,7 +34,9 @@ class TitanControlPanelLoginCard extends React.Component {
 	componentDidMount() {
 		this._mounted = true;
 
-		fetchTitanIframeURL( getTitanMailOrderId( this.props.domain ) ).then(
+		const { context, domain } = this.props;
+
+		fetchTitanIframeURL( getTitanMailOrderId( domain ), context ).then(
 			( { error, iframeURL } ) => {
 				if ( error ) {
 					this.props.errorNotice(
@@ -56,19 +58,21 @@ class TitanControlPanelLoginCard extends React.Component {
 			return;
 		}
 
-		const { domain, translate } = this.props;
+		const { context, domain, translate } = this.props;
 		this.setState( { isFetchingAutoLoginLink: true } );
 
-		fetchTitanAutoLoginURL( getTitanMailOrderId( domain ) ).then( ( { error, loginURL } ) => {
-			this.setState( { isFetchingAutoLoginLink: false } );
-			if ( error ) {
-				this.props.errorNotice(
-					error ?? translate( 'An unknown error occurred. Please try again later.' )
-				);
-			} else {
-				window.location.href = loginURL;
+		fetchTitanAutoLoginURL( getTitanMailOrderId( domain ), context ).then(
+			( { error, loginURL } ) => {
+				this.setState( { isFetchingAutoLoginLink: false } );
+				if ( error ) {
+					this.props.errorNotice(
+						error ?? translate( 'An unknown error occurred. Please try again later.' )
+					);
+				} else {
+					window.location.href = loginURL;
+				}
 			}
-		} );
+		);
 	};
 
 	renderAutoLogin() {
@@ -148,6 +152,7 @@ class TitanControlPanelLoginCard extends React.Component {
 }
 
 TitanControlPanelLoginCard.propTypes = {
+	context: PropTypes.string,
 	domain: PropTypes.object.isRequired,
 };
 

--- a/client/my-sites/email/email-management/titan-functions.js
+++ b/client/my-sites/email/email-management/titan-functions.js
@@ -20,13 +20,15 @@ export const fetchTitanAutoLoginURL = ( emailAccountId, context ) => {
 	} );
 };
 
-export const fetchTitanIframeURL = ( emailAccountId ) => {
+export const fetchTitanIframeURL = ( emailAccountId, context ) => {
 	return new Promise( ( resolve ) => {
-		wpcom.undocumented().getTitanControlPanelIframeURL( emailAccountId, ( serverError, result ) => {
-			resolve( {
-				error: serverError?.message,
-				iframeURL: serverError ? null : result.iframe_url,
+		wpcom
+			.undocumented()
+			.getTitanControlPanelIframeURL( emailAccountId, context, ( serverError, result ) => {
+				resolve( {
+					error: serverError?.message,
+					iframeURL: serverError ? null : result.iframe_url,
+				} );
 			} );
-		} );
 	} );
 };

--- a/client/my-sites/email/email-management/titan-management-iframe/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-iframe/index.jsx
@@ -27,6 +27,7 @@ import TitanControlPanelLoginCard from 'calypso/my-sites/email/email-management/
 class TitanManagementIframe extends React.Component {
 	static propTypes = {
 		canManageSite: PropTypes.bool.isRequired,
+		context: PropTypes.string,
 		currentRoute: PropTypes.string,
 		domainName: PropTypes.string.isRequired,
 		hasSiteDomainsLoaded: PropTypes.bool.isRequired,
@@ -35,7 +36,7 @@ class TitanManagementIframe extends React.Component {
 	};
 
 	renderManagementSection() {
-		const { domainName } = this.props;
+		const { context, domainName } = this.props;
 		const selectedDomain = this.props.domains
 			.filter( function ( domain ) {
 				return domain?.name === domainName;
@@ -44,7 +45,7 @@ class TitanManagementIframe extends React.Component {
 		if ( ! selectedDomain ) {
 			return null;
 		}
-		return <TitanControlPanelLoginCard domain={ selectedDomain } />;
+		return <TitanControlPanelLoginCard domain={ selectedDomain } context={ context } />;
 	}
 
 	render() {

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -2,6 +2,11 @@
  * External dependencies
  */
 import { startsWith } from 'lodash';
+import { stringify } from 'qs';
+
+/**
+ * Internal dependencies
+ */
 import { isUnderDomainManagementAll, domainManagementRoot } from 'calypso/my-sites/domains/paths';
 
 export const emailManagementPrefix = '/email';
@@ -50,8 +55,13 @@ export function emailManagementNewGSuiteAccount(
 	return emailManagementEdit( siteName, domainName, 'gsuite/new/' + planType, relativeTo );
 }
 
-export function emailManagementManageTitanAccount( siteName, domainName, relativeTo = null ) {
-	return emailManagementEdit( siteName, domainName, 'titan/manage', relativeTo );
+export function emailManagementManageTitanAccount(
+	siteName,
+	domainName,
+	relativeTo = null,
+	urlParameters = {}
+) {
+	return emailManagementEdit( siteName, domainName, 'titan/manage', relativeTo, urlParameters );
 }
 
 export function emailManagementNewTitanAccount( siteName, domainName, relativeTo = null ) {
@@ -61,9 +71,16 @@ export function emailManagementNewTitanAccount( siteName, domainName, relativeTo
 export function emailManagementTitanControlPanelRedirect(
 	siteName,
 	domainName,
-	relativeTo = null
+	relativeTo = null,
+	urlParameters = {}
 ) {
-	return emailManagementEdit( siteName, domainName, 'titan/control-panel', relativeTo );
+	return emailManagementEdit(
+		siteName,
+		domainName,
+		'titan/control-panel',
+		relativeTo,
+		urlParameters
+	);
 }
 
 export function emailManagement( siteName, domainName, relativeTo = null ) {
@@ -84,7 +101,13 @@ export function emailManagementForwarding( siteName, domainName, relativeTo = nu
 	return emailManagementEdit( siteName, domainName, 'forwarding', relativeTo );
 }
 
-export function emailManagementEdit( siteName, domainName, slug, relativeTo = null ) {
+export function emailManagementEdit(
+	siteName,
+	domainName,
+	slug,
+	relativeTo = null,
+	urlParameters = {}
+) {
 	slug = slug || 'manage';
 
 	// Encodes only real domain names and not parameter placeholders
@@ -94,7 +117,20 @@ export function emailManagementEdit( siteName, domainName, slug, relativeTo = nu
 		domainName = encodeURIComponent( encodeURIComponent( domainName ) );
 	}
 
-	return resolveRootPath( relativeTo ) + '/' + domainName + '/' + slug + '/' + siteName;
+	const urlParameterString = urlParameters
+		? stringify( urlParameters, { addQueryPrefix: true } )
+		: '';
+
+	return (
+		resolveRootPath( relativeTo ) +
+		'/' +
+		domainName +
+		'/' +
+		slug +
+		'/' +
+		siteName +
+		urlParameterString
+	);
 }
 
 export function isUnderEmailManagementAll( path ) {

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { startsWith } from 'lodash';
 import { stringify } from 'qs';
 
 /**
@@ -111,7 +110,7 @@ export function emailManagementEdit(
 	slug = slug || 'manage';
 
 	// Encodes only real domain names and not parameter placeholders
-	if ( ! startsWith( domainName, ':' ) ) {
+	if ( domainName && ! String( domainName ).startsWith( ':' ) ) {
 		// Encodes domain names so addresses with slashes in the path (e.g. used in site redirects) don't break routing.
 		// Note they are encoded twice since page.js decodes the path by default.
 		domainName = encodeURIComponent( encodeURIComponent( domainName ) );

--- a/client/my-sites/email/titan-mail-quantity-selection/index.jsx
+++ b/client/my-sites/email/titan-mail-quantity-selection/index.jsx
@@ -263,7 +263,9 @@ class TitanMailQuantitySelection extends React.Component {
 					) }
 					<Button onClick={ this.handleCreateMailbox } compact>
 						{ translate( 'Finish Setup' ) }
-						{ showExternalFinishSetupLink && <Gridicon icon="external" /> }
+						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+						{ showExternalFinishSetupLink && <Gridicon icon="external" size={ 16 } /> }
+						{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
 					</Button>
 				</span>
 			</CompactCard>

--- a/client/my-sites/email/titan-mail-quantity-selection/style.scss
+++ b/client/my-sites/email/titan-mail-quantity-selection/style.scss
@@ -22,6 +22,18 @@
 	span {
 		display: block;
 		font-size: $font-body-small;
+		line-height: 28px;
+
+		.button {
+			margin-left: 0.5em;
+
+			.gridicon {
+				height: 16px;
+				margin-left: 0.25em;
+				vertical-align: top;
+				width: 16px;
+			}
+		}
 	}
 }
 .titan-mail-quantity-selection__pricing-info {

--- a/client/my-sites/email/titan-mail-quantity-selection/style.scss
+++ b/client/my-sites/email/titan-mail-quantity-selection/style.scss
@@ -22,16 +22,14 @@
 	span {
 		display: block;
 		font-size: $font-body-small;
-		line-height: 28px;
+		line-height: 2em;
 
 		.button {
 			margin-left: 0.5em;
 
 			.gridicon {
-				height: 16px;
 				margin-left: 0.25em;
 				vertical-align: top;
-				width: 16px;
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is mostly intended to finish the client-side support for specifying a `context` when linking to the Titan control panel, which was started in #50198. The specific changes here are:
* Implement client-side `context` support for fetching the URL for the embedded Titan control panel (currently behind the `titan/iframe-control-panel` flag)
* Implement the component logic to support the `context` parameter for the embedded Titan control panel
* Update the helper functions for the email paths to support arbitrary URL parameters (though `context` is the only one supported by the server at the moment)
* Remove a usage of `lodash.startsWith` in the path helper functions
* Add a button the Titan quantity selection page to create mailboxes when the user has unused mailboxes

The visible button here is almost certainly going to change soon. #50197 is likely to land soon, but we also want to wire up additional links to make it easier for users to set their mailboxes up.

<img width="740" alt="Finish setup button in Titan quantity selection UI" src="https://user-images.githubusercontent.com/3376401/109279168-19ae3300-7822-11eb-9697-1d0e8f7a8bfb.png">

#### Testing instructions

If you don't have an Email subscription that has unused mailboxes, buy an Email subscription, but don't set up all of the mailboxes yet.

* For your subscription, navigate to `/email/[email_domain]/manage/[site_slug]`.
* Click on "Add New Mailboxes".
* Update the URL to add `?flags=titan/iframe-control-panel`.
* Verify that the "Finish Setup" button appears and is aligned well. It should _not_ include an icon inside the button.
* Click on "Finish Setup", and verify that the current window navigates to the embedded control panel, and launches the UI for creating a new email. (The actual UI is still being worked on from the Titan side, so the UI may not be at 100%.)
* For your subscription, navigate to `/email/[email_domain]/manage/[site_slug]` again.
* Click on "Add New Mailboxes".
* Update the URL to add `?flags=-titan/iframe-control-panel`.
* Verify that the "Finish Setup" button appears and is aligned well. Verify that the button includes an icon to indicate that the link is external.
* Click on "Finish Setup", and verify that the Titan control panel redirection page opens in a new window, before opening the Titan control panel and showing the email creation dialog.

To test the path changes, navigate around the Email-related sections of your site.