### PR TITLE
chore(packages): [@automattic/page-template-modal] Add missing dependencies

### DIFF
--- a/packages/page-template-modal/package.json
+++ b/packages/page-template-modal/package.json
@@ -44,7 +44,12 @@
 		"lodash": "^4.17.20"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^7.0.0"
+		"@automattic/calypso-build": "^7.0.0",
+		"enzyme": "^3.11.0",
+		"jest": "^26.4.0",
+		"react": "^16.12.0",
+		"react-dom": "^16.12.0",
+		"webpack": "^5.13.0"
 	},
 	"peerDependencies": {
 		"react": "^16.8"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds missing dependencies. It should fix

```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/page-template-modal/package.json
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/page-template-modal/package.json:47:32: Unmet transitive peer dependency on enzyme@^3.11.0, via @automattic/calypso-build@^7.0.0
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/page-template-modal/package.json:47:32: Unmet transitive peer dependency on jest@>=26.4.0, via @automattic/calypso-build@^7.0.0
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/page-template-modal/package.json:47:32: Unmet transitive peer dependency on react@^16.0.0, via @automattic/calypso-build@^7.0.0
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/page-template-modal/package.json:47:32: Unmet transitive peer dependency on react-dom@^16.0.0, via @automattic/calypso-build@^7.0.0
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/page-template-modal/package.json:47:32: Unmet transitive peer dependency on webpack@^5.13.0, via @automattic/calypso-build@^7.0.0
➤ YN0000: └ Completed in 0s 359ms

```

#### Testing instructions

Run npx `@yarnpkg/doctor packages/page-template-modal` and verify the above error is gone