### PR TITLE
chore(packages): [@automattic/onboarding] Add missing dependencies

### DIFF
--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -34,6 +34,7 @@
 		"@automattic/data-stores": "^1.0.0-alpha.1",
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
 		"@wordpress/components": "^12.0.1",
+		"@wordpress/data": "^4.26.1",
 		"@wordpress/icons": "^2.9.0",
 		"classnames": "^2.2.6",
 		"react-router-dom": "^5.1.2"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add missing dependencies to `@automattic/onboarding`. It should fix:


```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/onboarding/package.json
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/onboarding/package.json:34:30: Unmet transitive peer dependency on @wordpress/data@^4, via @automattic/data-stores@^1.0.0-alpha.1
➤ YN0000: └ Completed in 0s 386ms
```

#### Testing instructions

Run `npx @yarnpkg/doctor packages/onboarding` and verify the error above is gone.