### PR TITLE
chore(packages): [@automattic/format-currency] Add missing dependency

### DIFF
--- a/packages/format-currency/package.json
+++ b/packages/format-currency/package.json
@@ -33,5 +33,8 @@
 		"build": "transpile",
 		"prepack": "yarn run clean && yarn run build"
 	},
+	"peerDependencies": {
+		"react": "^16.8"
+	},
 	"types": "types"
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add missing `peerDependency` on `react`. Should fix:

```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/format-currency/package.json
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/format-currency/package.json:29:19: Unmet transitive peer dependency on react@^16.8, via i18n-calypso@^5.0.0
➤ YN0000: └ Completed in 0s 302ms

```

#### Testing instructions

Run `npx @yarnpkg/doctor packages/format-currency/ ` and verify the error is gone.