### PR TITLE
Checkout: Prevent replacing to checkout url when checkout is shown in editor.

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -225,6 +225,7 @@ export default function CompositeCheckout( {
 	} = usePrepareProductsForCart( {
 		productAliasFromUrl,
 		purchaseId,
+		isInEditor,
 		isJetpackNotAtomic,
 		isPrivate,
 		siteSlug,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -42,12 +42,14 @@ const initialPreparedProductsState = {
 export default function usePrepareProductsForCart( {
 	productAliasFromUrl,
 	purchaseId: originalPurchaseId,
+	isInEditor,
 	isJetpackNotAtomic,
 	isPrivate,
 	siteSlug,
 }: {
 	productAliasFromUrl: string | null | undefined;
 	purchaseId: string | number | null | undefined;
+	isInEditor?: boolean;
 	isJetpackNotAtomic: boolean;
 	isPrivate: boolean;
 	siteSlug: string | undefined;
@@ -95,7 +97,7 @@ export default function usePrepareProductsForCart( {
 	} );
 
 	// Do not strip products from url until the URL has been parsed
-	const areProductsRetrievedFromUrl = ! state.isLoading;
+	const areProductsRetrievedFromUrl = ! state.isLoading && ! isInEditor;
 	useStripProductsFromUrl( siteSlug, ! areProductsRetrievedFromUrl );
 
 	return state;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When checkout overlay is displayed in block editor, prevent checkout component from replacing the url.

**Technical Changes:**
* The `isInEditor` prop is introduced in the `usePrepareProductsForCart` hook.

#### Testing instructions

* On a Free site, open up iframed block editor.
* Add a premium block.
* Click "Upgrade plan".
* The url on the browser should not change.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/50461 _(this only fixes one part of it)_.
