### PR TITLE
Nav Unification: Update fallback menu for Jetpack sites

### DIFF
--- a/client/my-sites/sidebar-unified/static-data/jetpack-fallback-menu.js
+++ b/client/my-sites/sidebar-unified/static-data/jetpack-fallback-menu.js
@@ -51,22 +51,6 @@ export default function jetpackMenu( { siteDomain } ) {
 			title: translate( 'Posts' ),
 			type: 'menu-item',
 			url: `/posts/${ siteDomain }`,
-			children: [
-				{
-					parent: 'edit.php',
-					slug: 'edit-php',
-					title: translate( 'All Posts' ),
-					type: 'submenu-item',
-					url: `/posts/${ siteDomain }`,
-				},
-				{
-					parent: 'edit.php',
-					slug: 'post-new-php',
-					title: translate( 'Add New' ),
-					type: 'submenu-item',
-					url: `/post/${ siteDomain }`,
-				},
-			],
 		},
 		{
 			icon: 'dashicons-admin-media',
@@ -81,22 +65,6 @@ export default function jetpackMenu( { siteDomain } ) {
 			title: translate( 'Pages' ),
 			type: 'menu-item',
 			url: `/pages/${ siteDomain }`,
-			children: [
-				{
-					parent: 'edit.php?post_type=page',
-					slug: 'edit-phppost_typepage',
-					title: translate( 'All Pages' ),
-					type: 'submenu-item',
-					url: `/pages/${ siteDomain }`,
-				},
-				{
-					parent: 'edit.php?post_type=page',
-					slug: 'post-new-phppost_typepage',
-					title: translate( 'Add New' ),
-					type: 'submenu-item',
-					url: `/page/${ siteDomain }`,
-				},
-			],
 		},
 		{
 			icon: 'dashicons-admin-comments',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates the fallback menu used for Jetpack sites so it's aligned with the latest changes we introduced for the dynamic menu in https://github.com/Automattic/jetpack/pull/18921, in which we removed most of the submenus.

Before | After
--- | ---
![Feb-26-2021 11-13-55](https://user-images.githubusercontent.com/1233880/109290833-6ac12580-7828-11eb-8ee7-f9094e112850.gif) | ![Feb-26-2021 11-44-35](https://user-images.githubusercontent.com/1233880/109290859-73b1f700-7828-11eb-8770-a820f0e7053b.gif)

#### Testing instructions

- Switch to a Jetpack site and go to Posts.
- Delete the IndexedDB database and reload the page.
- Make sure there are no submenus flashing up.

Part of https://github.com/Automattic/wp-calypso/issues/50225.
