### PR TITLE
Fix decline button in upsell nudge can't redirect full url.

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -8,6 +8,7 @@ import page from 'page';
 import { pick } from 'lodash';
 import { withShoppingCart, createRequestCartProduct } from '@automattic/shopping-cart';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
+import { isURL } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -273,7 +274,13 @@ export class UpsellNudge extends React.Component {
 			clearSignupDestinationCookie();
 		}
 
-		page.redirect( url );
+		// If url starts with http, use browser redirect.
+		// If url is a route, use page router.
+		if ( isURL( url ) ) {
+			window.location.href = url;
+		} else {
+			page.redirect( url );
+		}
 	};
 
 	handleClickAccept = ( buttonAction ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When clicking Decline button in upsell nudge, if the redirect url is a full url `http(s)://foo/bar` instead of a route path `/foo/bar`, it fails to redirect.

#### Testing instructions

Test this once https://github.com/Automattic/wp-calypso/pull/50521 is merged.

* On a Free site, open up iframed block editor.
* Add a premium block.
* Click **Upgrade plan**.
* Checkout with a **Personal** or **Premium** plan.
* When you see the upsell nudge, click **Decline**.
* It should redirect back to the block editor.

Related to #50461
