### PR TITLE
Gutenboarding: Cleanup isExperimental.

### DIFF
--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -29,7 +29,6 @@ registerStore< State >( STORE_KEY, {
 		'domainSearch',
 		'hasUsedDomainsStep',
 		'hasUsedPlansStep',
-		'isExperimental',
 		'pageLayouts',
 		'planProductId',
 		'randomizedDesigns',

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -14,14 +14,6 @@ import type { FontPair } from '../../constants';
 
 type FeatureId = WPCOMFeatures.FeatureId;
 
-// Returns true if the url has a `?latest`, which is used to enable experimental features
-export function hasExperimentalQueryParam() {
-	if ( typeof window !== 'undefined' ) {
-		return new URLSearchParams( window.location.search ).has( 'latest' );
-	}
-	return false;
-}
-
 const domain: Reducer< DomainSuggestions.DomainSuggestion | undefined, OnboardAction > = (
 	state,
 	action

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -75,16 +75,6 @@ const hasUsedPlansStep: Reducer< boolean, OnboardAction > = ( state = false, act
 	return state;
 };
 
-const isExperimental: Reducer< boolean, OnboardAction > = (
-	state = hasExperimentalQueryParam(),
-	action
-) => {
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return false;
-	}
-	return state;
-};
-
 const isRedirecting: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
 	if ( action.type === 'SET_IS_REDIRECTING' ) {
 		return action.isRedirecting;
@@ -261,7 +251,6 @@ const reducer = combineReducers( {
 	showSignupDialog,
 	planProductId,
 	wasVerticalSkipped,
-	isExperimental,
 	randomizedDesigns,
 	hasOnboardingStarted,
 } );

--- a/packages/data-stores/src/launch/actions.ts
+++ b/packages/data-stores/src/launch/actions.ts
@@ -115,11 +115,6 @@ export const closeFocusedLaunch = () =>
 		type: 'CLOSE_FOCUSED_LAUNCH',
 	} as const );
 
-export const enableExperimental = () =>
-	( {
-		type: 'ENABLE_EXPERIMENTAL',
-	} as const );
-
 export const enableAnchorFm = () =>
 	( {
 		type: 'ENABLE_ANCHOR_FM',
@@ -186,7 +181,6 @@ export type LaunchAction = ReturnOrGeneratorYieldUnion<
 	| typeof unsetPlanProductId
 	| typeof openSidebar
 	| typeof closeSidebar
-	| typeof enableExperimental
 	| typeof enableAnchorFm
 	| typeof setSidebarFullscreen
 	| typeof unsetSidebarFullscreen

--- a/packages/data-stores/src/launch/index.ts
+++ b/packages/data-stores/src/launch/index.ts
@@ -36,7 +36,6 @@ export function register(): typeof STORE_KEY {
 				'planProductId',
 				'planBillingPeriod',
 				'confirmedDomainSelection',
-				'isExperimental',
 				'isAnchorFm',
 				'isSiteTitleStepVisible',
 				'siteTitle',

--- a/packages/data-stores/src/launch/reducer.ts
+++ b/packages/data-stores/src/launch/reducer.ts
@@ -109,14 +109,6 @@ const isSidebarFullscreen: Reducer< boolean, LaunchAction > = ( state = false, a
 	return state;
 };
 
-const isExperimental: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
-	if ( action.type === 'ENABLE_EXPERIMENTAL' ) {
-		return true;
-	}
-
-	return state;
-};
-
 const isAnchorFm: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
 	if ( action.type === 'ENABLE_ANCHOR_FM' ) {
 		return true;
@@ -170,7 +162,6 @@ const reducer = combineReducers( {
 	planProductId,
 	isSidebarOpen,
 	isSidebarFullscreen,
-	isExperimental,
 	isAnchorFm,
 	isFocusedLaunchOpen,
 	isSiteTitleStepVisible,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes `isExperimental` flag 

IIRC the `isExperimental` flag was that it was used for enabling feature picker which is now enabled for all.

#### Testing instructions

* Go to `/new` and the flow should run just fine.

Related to #45273
