### PR TITLE
Add/finish setup link to titan nav menu

### DIFF
--- a/client/lib/titan/index.js
+++ b/client/lib/titan/index.js
@@ -4,4 +4,5 @@ export { getTitanExpiryDate } from './get-titan-expiry-date';
 export { getTitanMailboxPurchaseCost } from './get-titan-mailbox-purchase-cost';
 export { getTitanMailboxRenewalCost } from './get-titan-mailbox-renewal-cost';
 export { getTitanMailOrderId } from './get-titan-mail-order-id';
+export { getTitanProductName } from './get-titan-product-name';
 export { hasTitanMailWithUs } from './has-titan-mail-with-us';

--- a/client/my-sites/email/email-management/titan-management-nav/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-nav/index.jsx
@@ -27,8 +27,11 @@ import titanContactsIcon from 'calypso/assets/images/email-providers/titan/servi
 import titanMailIcon from 'calypso/assets/images/email-providers/titan/services/mail.svg';
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
-import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
-import { getConfiguredTitanMailboxCount, getMaxTitanMailboxCount } from 'calypso/lib/titan';
+import {
+	getConfiguredTitanMailboxCount,
+	getMaxTitanMailboxCount,
+	getTitanProductName,
+} from 'calypso/lib/titan';
 import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/constants';
 
 /**

--- a/client/my-sites/email/email-management/titan-management-nav/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-nav/index.jsx
@@ -194,7 +194,7 @@ class TitanManagementNav extends React.Component {
 								<img src={ titanMailIcon } alt={ translate( 'Titan Mail icon' ) } />
 								<strong>
 									{ translate( 'Mail', {
-										comments: 'This refers to the Email application (i.e. the webmail) of Titan',
+										comment: 'This refers to the Email application (i.e. the webmail) of Titan',
 									} ) }
 								</strong>
 							</a>
@@ -204,7 +204,7 @@ class TitanManagementNav extends React.Component {
 								<img src={ titanCalendarIcon } alt={ translate( 'Titan Calendar icon' ) } />
 								<strong>
 									{ translate( 'Calendar', {
-										comments: 'This refers to the Calendar application of Titan',
+										comment: 'This refers to the Calendar application of Titan',
 									} ) }
 								</strong>
 							</a>
@@ -214,7 +214,7 @@ class TitanManagementNav extends React.Component {
 								<img src={ titanContactsIcon } alt={ translate( 'Titan Contacts icon' ) } />
 								<strong>
 									{ translate( 'Contacts', {
-										comments: 'This refers to the Contacts application of Titan',
+										comment: 'This refers to the Contacts application of Titan',
 									} ) }
 								</strong>
 							</a>

--- a/client/my-sites/email/email-management/titan-management-nav/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-nav/index.jsx
@@ -119,7 +119,7 @@ class TitanManagementNav extends React.Component {
 			  } );
 
 		return (
-			<CompactCard className="titan-management-nav__mailbox-setup-prompt">
+			<CompactCard className="titan-management-nav__mailbox-setup-prompt" highlight="info">
 				<span>
 					<Gridicon icon="info-outline" size={ 18 } />
 					<em>

--- a/client/my-sites/email/email-management/titan-management-nav/style.scss
+++ b/client/my-sites/email/email-management/titan-management-nav/style.scss
@@ -7,6 +7,24 @@
 	}
 }
 
+.titan-management-nav__mailbox-setup-prompt {
+	display: flex;
+
+	span {
+		flex-grow: 1;
+
+		.gridicon {
+			margin-right: 0.25em;
+			vertical-align: text-bottom;
+		}
+	}
+
+	.button .gridicon {
+		margin-left: 0.25em;
+		vertical-align: top;
+	}
+}
+
 .titan-management-nav__foldable-card {
 	margin-bottom: 0;
 
@@ -47,7 +65,7 @@
 
 			&:hover {
 				background-color: #eee;
-				border-radius: 5px;
+				border-radius: 5px; /* stylelint-disable-line scales/radii */
 			}
 
 			img {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR/branch is based on #50515, which implements the client-side wiring needed to launch the Titan control panel in specific contexts.

It also borrows heavily from #50177, but I ended up pulling only the core implementation pieces from that PR to keep it focused on the core improvement. (I do want to take on all the cleanup work, but I'd rather handle that via a dedicated PR.)

I changed some elements from #50177 to make it clearer that the new item is _not_ a standard menu item like the others, as it doesn't support clicking on the row. To achieve that, I made the text italic, added an info icon, and specified the `info` highlight for the card. I also made it clearer when we're linking out to the Titan control panel by adding an external icon to the button.

<img width="1079" alt="finish_setup_item_titan_nav_menu" src="https://user-images.githubusercontent.com/3376401/109823649-cc2a2f80-7c40-11eb-8b82-14cd1ee3c754.png">

#### Testing instructions

Start by identifying a domain with Email that has at least one unused mailbox. If you don't have an Email subscription in that state, purchase Email for a domain and ensure that you don't set up any email addresses via the Titan control panel.

* Navigate to `/email/[domain]/manage/[site_slug]?flags=-titan/iframe-control-panel`
* Verify that you get the "You have _n_ unused mailbox(es)" row with a "Finish Setup" button, and that the button shows the link/action as being external
* Click on the "Finish Setup" button, and verify that you get launched into the Titan control panel in a new window, with the "Create account" dialog box open to set up the email account/mailbox.
* Navigate to `/email/[domain]/manage/[site_slug]?flags=titan/iframe-control-panel`
* Verify that you get the "You have _n_ unused mailbox(es)" row with a "Finish Setup" button, and that the button doesn't show the link/action as being external (i.e. there should be no icon in the button)
* Click on the "Finish Setup" button, and verify that you navigate to the embedded Titan control panel, and that the create account UI is shown. (The embedded UI is still under development, so it may look a bit off/incomplete.)

Related to #50177, #50515
