### PR TITLE
Framework: Refactor away from _.repeat()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -398,6 +398,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/is-finite': 'error',
 		'you-dont-need-lodash-underscore/is-null': 'error',
 		'you-dont-need-lodash-underscore/reduce-right': 'error',
+		'you-dont-need-lodash-underscore/repeat': 'error',
 		'you-dont-need-lodash-underscore/reverse': 'error',
 		'you-dont-need-lodash-underscore/split': 'error',
 		'you-dont-need-lodash-underscore/to-lower': 'error',

--- a/client/blocks/comments/docs/post-comment-example.jsx
+++ b/client/blocks/comments/docs/post-comment-example.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { repeat } from 'lodash';
 
 /**
  * Internal dependencies
@@ -49,8 +48,8 @@ const mockMultipleShortLineComment = {
 
 const mockComments = [
 	{ ...mockComment, ID: 0 },
-	{ ...mockComment, ID: 1, content: repeat( mockComment.content, 5 ) },
-	{ ...mockComment, ID: 2, content: repeat( mockComment.content, 5 ) },
+	{ ...mockComment, ID: 1, content: mockComment.content.repeat( 5 ) },
+	{ ...mockComment, ID: 2, content: mockComment.content.repeat( 5 ) },
 	{ ...mockShortComment, ID: 3 },
 	{ ...mockMultipleShortLineComment, ID: 4 },
 ];

--- a/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { omit, repeat } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -104,7 +104,7 @@ describe( 'validateContactDetails', () => {
 
 			test( 'should reject long strings', () => {
 				const testDetails = Object.assign( {}, organizationDetails, {
-					organization: repeat( '0123456789', 11 ),
+					organization: '0123456789'.repeat( 11 ),
 				} );
 
 				const result = validateContactDetails( testDetails );

--- a/client/state/reader/posts/test/normalization-rules.js
+++ b/client/state/reader/posts/test/normalization-rules.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { forEach, repeat } from 'lodash';
+import { forEach } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,7 +34,7 @@ describe( 'normalization-rules', () => {
 						mediaType: 'image',
 						width: 1000,
 					},
-					better_excerpt_no_html: repeat( 'no ', 10 ),
+					better_excerpt_no_html: 'no '.repeat( 10 ),
 				},
 				[ DISPLAY_TYPES.PHOTO_ONLY ]
 			);
@@ -47,7 +47,7 @@ describe( 'normalization-rules', () => {
 						mediaType: 'image',
 						width: 1000,
 					},
-					better_excerpt_no_html: repeat( 'no ', 100 ),
+					better_excerpt_no_html: 'no '.repeat( 100 ),
 				},
 				[ DISPLAY_TYPES.UNCLASSIFIED ]
 			);
@@ -74,7 +74,7 @@ describe( 'normalization-rules', () => {
 							width: 50,
 						},
 					],
-					better_excerpt_no_html: repeat( 'no ', 5 ),
+					better_excerpt_no_html: 'no '.repeat( 5 ),
 				},
 				[ DISPLAY_TYPES.PHOTO_ONLY ]
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `repeat` is essentially fully natively supported by `String.prototype.repeat`. This PR replaces the usage and adds an ESLint rule to warn against using `repeat()` from lodash.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Try to `import { repeat } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass.