### PR TITLE
Monthly Plans: update domain step subtitle copy across new onboarding flows

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -54,8 +54,7 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, o
 		'full-site-editing'
 	);
 	const subtitleText =
-		locale === 'en' ||
-		hasTranslation?.( 'Free for the first year with any annual plan.', 'full-site-editing' )
+		locale === 'en' || hasTranslation?.( 'Free for the first year with any annual plan.' )
 			? newSubtitleText
 			: fallbackSubtitleText;
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -3,7 +3,8 @@
  */
 import * as React from 'react';
 import { useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
+import { useLocale } from '@automattic/i18n-utils';
 import DomainPicker, { mockDomainSuggestion } from '@automattic/domain-picker';
 import { Title, SubTitle, ActionButtons, BackButton, NextButton } from '@automattic/onboarding';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
@@ -18,6 +19,10 @@ import { useDomainSelection, useSiteDomains, useDomainSearch } from '@automattic
 import { FLOW_ID } from '../../constants';
 
 const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onNextStep } ) => {
+	const { __, hasTranslation } = useI18n();
+	const locale = useLocale();
+	console.log( locale, document.documentElement.lang );
+
 	const { onDomainSelect, onExistingSubdomainSelect, currentDomain } = useDomainSelection();
 	const { siteSubdomain } = useSiteDomains();
 	const { domainSearch, setDomainSearch } = useDomainSearch();
@@ -41,14 +46,26 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, o
 		} );
 	};
 
+	const fallbackSubtitleText = __(
+		'Free for the first year with any paid plan.',
+		'full-site-editing'
+	);
+	const newSubtitleText = __(
+		'Free for the first year with any annual plan.',
+		'full-site-editing'
+	);
+	const subtitleText =
+		locale === 'en' ||
+		hasTranslation?.( 'Free for the first year with any annual plan.', 'full-site-editing' )
+			? newSubtitleText
+			: fallbackSubtitleText;
+
 	return (
 		<LaunchStepContainer>
 			<div className="nux-launch-step__header">
 				<div>
 					<Title>{ __( 'Choose a domain', 'full-site-editing' ) }</Title>
-					<SubTitle>
-						{ __( 'Free for the first year with any paid plan.', 'full-site-editing' ) }
-					</SubTitle>
+					<SubTitle>{ subtitleText }</SubTitle>
 				</div>
 				<ActionButtons sticky={ false }>
 					<NextButton onClick={ handleNext } disabled={ ! domainSearch } />

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -21,7 +21,6 @@ import { FLOW_ID } from '../../constants';
 const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onNextStep } ) => {
 	const { __, hasTranslation } = useI18n();
 	const locale = useLocale();
-	console.log( locale, document.documentElement.lang );
 
 	const { onDomainSelect, onExistingSubdomainSelect, currentDomain } = useDomainSelection();
 	const { siteSubdomain } = useSiteDomains();
@@ -83,7 +82,7 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, o
 					onExistingSubdomainSelect={ onExistingSubdomainSelect }
 					analyticsUiAlgo="editor_domain_modal"
 					segregateFreeAndPaid
-					locale={ document.documentElement.lang }
+					locale={ locale }
 				/>
 			</div>
 			<div className="nux-launch-step__footer">

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -42,7 +42,7 @@ interface Props {
 }
 
 const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
-	const { __ } = useI18n();
+	const { __, hasTranslation } = useI18n();
 	const locale = useLocale();
 	const history = useHistory();
 	const { goBack, goNext } = useStepNavigation();
@@ -113,11 +113,18 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 		setDomain( suggestion );
 	};
 
+	const fallbackSubtitleText = __( 'Free for the first year with any paid plan.' );
+	const newSubtitleText = __( 'Free for the first year with any annual plan.' );
+	const subtitleText =
+		locale === 'en' || hasTranslation?.( 'Free for the first year with any annual plan.' )
+			? newSubtitleText
+			: fallbackSubtitleText;
+
 	const header = (
 		<div className="domains__header">
 			<div>
 				<Title>{ __( 'Choose a domain' ) }</Title>
-				<SubTitle>{ __( 'Free for the first year with any paid plan.' ) }</SubTitle>
+				<SubTitle>{ subtitleText }</SubTitle>
 			</div>
 			<ActionButtons>
 				<BackButton onClick={ handleBack } />

--- a/packages/launch/src/focused-launch/domain-details/index.tsx
+++ b/packages/launch/src/focused-launch/domain-details/index.tsx
@@ -72,8 +72,7 @@ const DomainDetails: React.FunctionComponent = () => {
 		__i18n_text_domain__
 	);
 	const subtitleText =
-		locale === 'en' ||
-		hasTranslation?.( 'Free for the first year with any annual plan.', __i18n_text_domain__ )
+		locale === 'en' || hasTranslation?.( 'Free for the first year with any annual plan.' )
 			? newSubtitleText
 			: fallbackSubtitleText;
 

--- a/packages/launch/src/focused-launch/domain-details/index.tsx
+++ b/packages/launch/src/focused-launch/domain-details/index.tsx
@@ -6,12 +6,12 @@
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 
-import { __ } from '@wordpress/i18n';
 import DomainPicker, { mockDomainSuggestion, ITEM_TYPE_BUTTON } from '@automattic/domain-picker';
 import { Title, SubTitle } from '@automattic/onboarding';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import type { DomainSuggestions } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
+import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
@@ -27,6 +27,7 @@ const ANALYTICS_UI_LOCATION = 'domain_step';
 
 const DomainDetails: React.FunctionComponent = () => {
 	const { getCurrentLaunchFlowUrl, redirectTo } = React.useContext( LaunchContext );
+	const { __, hasTranslation } = useI18n();
 	const locale = useLocale();
 
 	const { siteSubdomain } = useSiteDomains();
@@ -62,6 +63,20 @@ const DomainDetails: React.FunctionComponent = () => {
 		} );
 	};
 
+	const fallbackSubtitleText = __(
+		'Free for the first year with any paid plan.',
+		__i18n_text_domain__
+	);
+	const newSubtitleText = __(
+		'Free for the first year with any annual plan.',
+		__i18n_text_domain__
+	);
+	const subtitleText =
+		locale === 'en' ||
+		hasTranslation?.( 'Free for the first year with any annual plan.', __i18n_text_domain__ )
+			? newSubtitleText
+			: fallbackSubtitleText;
+
 	return (
 		<div className="focused-launch-container">
 			<div className="focused-launch-details__back-button-wrapper">
@@ -69,9 +84,7 @@ const DomainDetails: React.FunctionComponent = () => {
 			</div>
 			<div className="focused-launch-details__header">
 				<Title>{ __( 'Choose a domain', __i18n_text_domain__ ) }</Title>
-				<SubTitle>
-					{ __( 'Free for the first year with any paid plan.', __i18n_text_domain__ ) }
-				</SubTitle>
+				<SubTitle>{ subtitleText }</SubTitle>
 			</div>
 			<div className="focused-launch-details__body">
 				<DomainPicker

--- a/packages/launch/src/focused-launch/domain-details/test/index.tsx
+++ b/packages/launch/src/focused-launch/domain-details/test/index.tsx
@@ -19,7 +19,9 @@ describe( 'DomainStep', () => {
 		);
 
 		expect( screen.queryByText( /Choose a domain/i ) ).toBeTruthy();
-		expect( screen.queryByText( /Free for the first year with any paid plan/i ) ).toBeTruthy();
+		expect(
+			screen.queryByText( /Free for the first year with any (paid|annual) plan/i )
+		).toBeTruthy();
 	} );
 
 	test( 'Has domain search input', () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Update the domains step subtitle copy from `Free for the first year with any paid plan.` to `Free for the first year with any annual plan.` across all "New Onboarding" flows

### Testing instructions

#### Test in Gutenboarding

- Pull this PR's branch on your local machine or test using the live link: https://calypso.live/new?branch=feat/plans-grid/monthly-prices
- If Run `yarn && yarn start` in the root folder of this repo
- Visit `calyspo.localhost:3000/new`
- Navigate to the domains step
  - [ ] When the locale is EN, the subtitle should read `Free for the first year with any annual plan.`
  - [ ] When the locale is not EN (that can be changed in the WordPress.com account settings), the subtitle should always appear translated (either with the fallback translation, or with the new translation if already available)

#### Test in Focused Launch Flow

- Prepare your sandbox:
  - Make sure you have an active ssh connection to your sandbox
  - Clear your sandbox and pull the latest version from trunk
  - Add an unlaunched site **created via `/start`** to your sandbox
- Assign yourself to the "treatment" group in the `focused_launch_flow_v2` A/B test
- Pull this PR's branch on your local machine and run the project locally:
  - Run `yarn && yarn start` in the root folder
  - After the command above has finished compiling, in a separate terminal window run `cd apps/editing-toolkit && yarn dev --sync`
- Open the block editor (e.g. by visiting `calyspo.localhost:3000/page/UNLAUNCHED_SITE_CREATED_WITH_START.wordpress.com/home`)
- Click on the "Launch" button to open Focused Launch flow
- Click on the "View all domains" link
  - [ ] When the locale is EN, the subtitle should read `Free for the first year with any annual plan.`
  - [ ] When the locale is not EN (that can be changed in the WordPress.com account settings), the subtitle should always appear translated (either with the fallback translation, or with the new translation if already available)

#### Test in Step By Step Launch Flow

- Prepare your sandbox:
  - Make sure you have an active ssh connection to your sandbox
  - Clear your sandbox and pull the latest version from trunk
  - Add an unlaunched site **created via `/new`** and **on a free plan** to your sandbox
- Pull this PR's branch on your local machine and run the project locally:
  - Run `yarn && yarn start` in the root folder
  - After the command above has finished compiling, in a separate terminal window run `cd apps/editing-toolkit && yarn dev --sync`
- Open the block editor (e.g. by visiting `calyspo.localhost:3000/page/UNLAUNCHED_SITE_CREATED_WITH_NEW .wordpress.com/home`)
- Click on the "Launch" button to open Step By Step Launch flow
  - [ ] When the locale is EN, the subtitle should read `Free for the first year with any annual plan.`
  - [ ] When the locale is not EN (that can be changed in the WordPress.com account settings), the subtitle should always appear translated (either with the fallback translation, or with the new translation if already available)

### Screenshot

![image](https://user-images.githubusercontent.com/1083581/109331634-5cd9c780-785d-11eb-9439-c654706be05a.png)



Closes #50534
