### PR TITLE
Partner Portal: Refactor license sorting component to make it more readable and hoist functions

### DIFF
--- a/client/state/partner-portal/licenses/handlers.ts
+++ b/client/state/partner-portal/licenses/handlers.ts
@@ -160,7 +160,7 @@ export default {
 			fetch: fetchLicenseCountsHandler,
 			onSuccess: receiveLicenseCountsHandler,
 			onError: () => {
-				// TODO this is a failure or relatively low importance - how do we log these?
+				// Failure of low importance we can ignore.
 			},
 		} ),
 	],


### PR DESCRIPTION
Context:
* Project thread: pbtFPC-Um-p2
* i4 designs: pbtFPC-103-p2

#### Changes proposed in this Pull Request

* Refactor sorting button components to be a bit more manageable and avoid a small potential unnecessary render.
* Reword a TODO comment to indicate intention rather than uncertainty.

#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key, if prompted.
* Click through the list sorting headers to make sure they work as expected.