### PR TITLE
Redirect users to wpadmin after selecting Jetpack Free

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card/button.tsx
+++ b/client/components/jetpack/card/jetpack-free-card/button.tsx
@@ -9,11 +9,13 @@ import { Button } from '@automattic/components';
 /**
  * Internal dependencies
  */
-import { JPC_PATH_BASE } from 'calypso/jetpack-connect/constants';
+import { storePlan } from 'calypso/jetpack-connect/persistence-utils';
+import { PLAN_JETPACK_FREE } from 'calypso/lib/plans/constants';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { addQueryArgs } from 'calypso/lib/route';
 import { getUrlParts, getUrlFromParts } from 'calypso/lib/url';
+import { JPC_PATH_BASE } from 'calypso/jetpack-connect/constants';
 import getJetpackWpAdminUrl from 'calypso/state/selectors/get-jetpack-wp-admin-url';
 
 /**
@@ -38,6 +40,9 @@ const JetpackFreeCardButton: FC< JetpackFreeCardButtonProps > = ( {
 } ) => {
 	const translate = useTranslate();
 	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
+	const trackCallback = useTrackCallback( undefined, 'calypso_product_jpfree_click', {
+		site_id: siteId || undefined,
+	} );
 	const { site } = urlQueryArgs;
 
 	// If the user is not logged in and there is a site in the URL, we need to construct
@@ -64,9 +69,10 @@ const JetpackFreeCardButton: FC< JetpackFreeCardButtonProps > = ( {
 		}
 	}
 
-	const onClickTrack = useTrackCallback( undefined, 'calypso_product_jpfree_click', {
-		site_id: siteId || undefined,
-	} );
+	const onClickTrack = () => {
+		storePlan( PLAN_JETPACK_FREE );
+		trackCallback();
+	};
 
 	// `siteId` is going to be null if the user is not logged in, so we need to check
 	// if there is a site in the URL also
@@ -78,6 +84,7 @@ const JetpackFreeCardButton: FC< JetpackFreeCardButtonProps > = ( {
 		isJetpackCloud() && ! isSiteinContext
 			? addQueryArgs( { url, ...restQueryArgs }, `https://wordpress.com${ JPC_PATH_BASE }` )
 			: wpAdminUrl || jetpackAdminUrlFromQuery || JPC_PATH_BASE;
+
 	return (
 		<Button primary={ primary } className={ className } href={ startHref } onClick={ onClickTrack }>
 			{ label || translate( 'Start for free' ) }

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -111,6 +111,11 @@ export function offerResetRedirects( context, next ) {
 		return externalRedirect( CALYPSO_PLANS_PAGE + selectedSite.slug );
 	}
 
+	// If selected site has a Free plan, redirect to URL passed as query param or wpadmin
+	if ( selectedSite.plan.is_free ) {
+		externalRedirect( context.query.redirect || selectedSite.options.admin_url );
+	}
+
 	// If current user is not an admin (can't purchase plans), redirect the user to /posts if
 	// the connection was started within Calypso, otherwise redirect the user to wp-admin
 	const canPurchasePlans = selectedSite

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -114,6 +114,7 @@ export function offerResetRedirects( context, next ) {
 	// If selected site has a Free plan, redirect to URL passed as query param or wpadmin
 	if ( selectedSite.plan.is_free ) {
 		externalRedirect( context.query.redirect || selectedSite.options.admin_url );
+		return;
 	}
 
 	// If current user is not an admin (can't purchase plans), redirect the user to /posts if

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 import config from '@automattic/calypso-config';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
+import { JETPACK_ADMIN_PATH } from 'calypso/jetpack-connect/constants';
 import { PLAN_JETPACK_FREE } from 'calypso/lib/plans/constants';
 import versionCompare from 'calypso/lib/version-compare';
 import { addQueryArgs, externalRedirect } from 'calypso/lib/route';
@@ -89,7 +90,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 				if ( currentPlan ) {
 					if ( currentPlan === PLAN_JETPACK_FREE ) {
 						debug( `Redirecting to wpadmin` );
-						externalRedirect( `${ this.props.siteHomeUrl }/wp-admin/` );
+						externalRedirect( this.props.siteHomeUrl + JETPACK_ADMIN_PATH );
 					} else {
 						debug( `Redirecting to checkout with ${ currentPlan } plan retrieved from cookies` );
 						this.redirect( 'checkout', url, currentPlan, queryArgs );

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 import config from '@automattic/calypso-config';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
+import { PLAN_JETPACK_FREE } from 'calypso/lib/plans/constants';
 import versionCompare from 'calypso/lib/version-compare';
 import { addQueryArgs, externalRedirect } from 'calypso/lib/route';
 import { checkUrl, dismissUrl } from 'calypso/state/jetpack-connect/actions';
@@ -86,8 +87,13 @@ const jetpackConnection = ( WrappedComponent ) => {
 				const currentPlan = retrievePlan();
 				clearPlan();
 				if ( currentPlan ) {
-					debug( `Redirecting to checkout with ${ currentPlan } plan retrieved from cookies` );
-					this.redirect( 'checkout', url, currentPlan, queryArgs );
+					if ( currentPlan === PLAN_JETPACK_FREE ) {
+						debug( `Redirecting to wpadmin` );
+						externalRedirect( `${ this.props.siteHomeUrl }/wp-admin/` );
+					} else {
+						debug( `Redirecting to checkout with ${ currentPlan } plan retrieved from cookies` );
+						this.redirect( 'checkout', url, currentPlan, queryArgs );
+					}
 				} else {
 					debug( 'Redirecting to plans_selection' );
 					this.redirect( 'plans_selection', url );


### PR DESCRIPTION
### Changes proposed in this Pull Request

Selecting the Jetpack Free plan in the pricing page leads to a loop by redirecting to the pricing page again eventually. Instead, it should redirect to the site WP admin.

Fixes 1164141197617539-as-1199986228014056

### Testing instructions

- Download the PR and run Calypso
- Make sure you have a self-hosted Jetpack site, with Jetpack not activated
- Visit `http://calypso.localhost:3000/jetpack/connect/store?source=jetpack-connect-plans`
- Select _Jetpack Free_ in the pricing page
- Enter the site URL in the connect page
- Verify that you eventually land in the site WP admin
- Repeat the same steps, this time with Jetpack activated

### Screenshots

_Expected behaviour_
https://user-images.githubusercontent.com/1620183/109329991-369a3480-7829-11eb-9124-5cbf356c8c3b.mov