### PR TITLE
Customer home: Prevent showing the same notice more than once

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import { flowRight } from 'lodash';
@@ -50,12 +50,14 @@ const Home = ( {
 	const reduxDispatch = useDispatch();
 
 	const shouldShowNotice = canUserUseCustomerHome && layout && noticeType;
+	const lastShownNotice = useRef( null );
 	useEffect( () => {
-		if ( ! shouldShowNotice ) {
+		if ( ! shouldShowNotice || lastShownNotice.current === noticeType ) {
 			return;
 		}
 
 		if ( noticeType === 'difm-success' ) {
+			lastShownNotice.current = noticeType;
 			reduxDispatch( recordTracksEvent( 'calypso_difm_intake_submitted' ) );
 
 			const successMessage = translate( 'Your application has been sent!' );
@@ -64,6 +66,7 @@ const Home = ( {
 		}
 
 		if ( noticeType === 'purchase-success' ) {
+			lastShownNotice.current = noticeType;
 			const successMessage = translate( 'Your purchase has been completed!' );
 			reduxDispatch( successNotice( successMessage ) );
 			return;

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -49,8 +49,9 @@ const Home = ( {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 
+	const shouldShowNotice = canUserUseCustomerHome && layout && noticeType;
 	useEffect( () => {
-		if ( ! canUserUseCustomerHome || ! layout || ! noticeType ) {
+		if ( ! shouldShowNotice ) {
 			return;
 		}
 
@@ -69,7 +70,7 @@ const Home = ( {
 		}
 
 		return;
-	}, [ noticeType, layout, canUserUseCustomerHome, reduxDispatch, translate ] );
+	}, [ shouldShowNotice, translate, reduxDispatch, noticeType ] );
 
 	if ( ! canUserUseCustomerHome ) {
 		const title = translate( 'This page is not available on this site.' );

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -49,7 +49,7 @@ const Home = ( {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 
-	const shouldShowNotice = canUserUseCustomerHome && layout && noticeType;
+	const shouldShowNotice = Boolean( canUserUseCustomerHome && layout && noticeType );
 	const lastShownNotice = useRef( null );
 	useEffect( () => {
 		if ( ! shouldShowNotice || lastShownNotice.current === noticeType ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The customer home page reacts to the `noticeType` prop, which is pulled from the URL query string, displaying one of a few different notices after it renders. However, there are cases where the notice could be displayed more than once. The biggest case is if the `layout` prop changes, but there are also other possible dependency changes which could potentially trigger it.

This PR removes `layout` as a dependency for the notices and also adds an explicit guard to make sure the same notice will not be displayed more than once.

Fixes https://github.com/Automattic/wp-calypso/issues/50432

#### Testing instructions

I'm not actually sure how to trigger the bug. You can see the video in https://github.com/Automattic/wp-calypso/issues/50432 to see it in action.

- Visit customer home with `?notice=purchase-success` at the end of the URL.
- Verify that you see the "Your purchase has been completed" message, but only once.