### PR TITLE
Temporarily disable the Launch (screensize) test.

### DIFF
--- a/test/e2e/specs/wp-launch-spec.js
+++ b/test/e2e/specs/wp-launch-spec.js
@@ -42,7 +42,11 @@ before( async function () {
 	driver = await driverManager.startBrowser();
 } );
 
-describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () {
+// Tracking issue:
+// https://github.com/Automattic/wp-calypso/issues/50547
+// Potential issue that trigger this failure:
+// https://github.com/Automattic/wp-calypso/issues/50273
+describe.skip( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
 	describe( 'Launch a free site', function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* disables the test suite `Launch` in `wp-launch-spec.js` temporarily as per #50547.

#### Testing instructions

Run e2e tests.

#### Other notes

I have assigned myself to the issue to deal with this test, to rewrite.