### PR TITLE
Fix flakey e2e test: Basic Public Post

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -69,10 +69,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async publish( { visit = false, closePanel = true } = {} ) {
 		await driverHelper.clickWhenClickable( this.driver, this.prePublishButtonSelector );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishHeaderSelector );
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishSelector );
 		await this.driver.sleep( 1000 );
-		const button = await this.driver.findElement( this.publishSelector );
-		await this.driver.executeScript( 'arguments[0].click();', button );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishSelector );
+		await driverHelper.clickWhenClickable( this.driver, this.publishSelector );
 		await driverHelper.waitTillNotPresent( this.driver, this.publishingSpinnerSelector );
 
 		if ( closePanel ) {

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -245,7 +245,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe.only( 'Basic Public Post @canary @parallel', function () {
+	describe( 'Basic Public Post @canary @parallel', function () {
 		describe( 'Publish a New Post', function () {
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote =

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -245,7 +245,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe.skip( 'Basic Public Post @canary @parallel', function () {
+	describe.only( 'Basic Public Post @canary @parallel', function () {
 		describe( 'Publish a New Post', function () {
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote =


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Make the Basic Public Post test more reliable.

- instead of using arbitrary script to click on the button, use the `clickWhenClickable` function.
- call `waitTillPresentAndDisplayed` for the publish button.

#### Testing instructions

Check CircleCi results:
- https://app.circleci.com/pipelines/github/Automattic/wp-e2e-tests-for-branches/59814/workflows/0796394e-1925-4629-ae7c-2e289cf4978e/jobs/145259/parallel-runs/2?filterBy=ALL
- https://app.circleci.com/pipelines/github/Automattic/wp-e2e-tests-for-branches/59813/workflows/2875f3ec-7b97-4fc7-b200-c97e947ab307/jobs/145258/parallel-runs/2?filterBy=ALL