### PR TITLE
Framework: Refactor away from _.isArray()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -408,6 +408,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/foldl': 'error',
 		'you-dont-need-lodash-underscore/foldr': 'error',
 		'you-dont-need-lodash-underscore/inject': 'error',
+		'you-dont-need-lodash-underscore/is-array': 'error',
 		'you-dont-need-lodash-underscore/is-finite': 'error',
 		'you-dont-need-lodash-underscore/is-nil': 'error',
 		'you-dont-need-lodash-underscore/is-null': 'error',

--- a/apps/notifications/src/panel/state/action-middleware/utils.js
+++ b/apps/notifications/src/panel/state/action-middleware/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isArray, mergeWith } from 'lodash';
+import { mergeWith } from 'lodash';
 
 /**
  * Merge handler for lodash.mergeWith
@@ -14,8 +14,13 @@ import { isArray, mergeWith } from 'lodash';
  * they don't exists but when they do, we
  * prefer to concatenate lists instead of
  * overwriting them.
+ *
+ * @param {?Array<Function>} left existing handlers
+ * @param {Array<Function>} right new handlers to add
+ * @returns {Array<Function>} combined handlers
  */
-const concatHandlers = ( left, right ) => ( isArray( left ) ? left.concat( right ) : undefined );
+const concatHandlers = ( left, right ) =>
+	Array.isArray( left ) ? left.concat( right ) : undefined;
 
 export const mergeHandlers = ( ...handlers ) =>
 	handlers.length > 1

--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { assign, isArray, isEmpty } from 'lodash';
+import { assign, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -164,7 +164,7 @@ const welcomeMessage = ( { currentUserEmail, translate } ) => (
 	</div>
 );
 
-const timelineHasContent = ( { timeline } ) => isArray( timeline ) && ! isEmpty( timeline );
+const timelineHasContent = ( { timeline } ) => Array.isArray( timeline ) && ! isEmpty( timeline );
 
 const renderTimeline = ( {
 	timeline,

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useTranslate } from 'i18n-calypso';
-import { get, isArray } from 'lodash';
+import { get } from 'lodash';
 import React from 'react';
 import { useSelector } from 'react-redux';
 
@@ -32,7 +32,7 @@ const BackupSuccessful = ( { backup, deltas, selectedDate } ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const hasRealtimeBackups = useSelector( ( state ) => {
 		const capabilities = getRewindCapabilities( state, siteId );
-		return isArray( capabilities ) && capabilities.includes( 'backup-realtime' );
+		return Array.isArray( capabilities ) && capabilities.includes( 'backup-realtime' );
 	} );
 
 	const moment = useLocalizedMoment();

--- a/client/components/language-picker/utils.js
+++ b/client/components/language-picker/utils.js
@@ -1,10 +1,7 @@
 /**
- */
-
-/**
  * External dependencies
  */
-import { find, get, includes, isArray } from 'lodash';
+import { find, get, includes } from 'lodash';
 import { LANGUAGE_GROUPS, DEFAULT_LANGUAGE_GROUP } from './constants';
 
 /**
@@ -46,7 +43,7 @@ export function getLanguageGroupFromTerritoryId(
 export function getLanguageGroupByLangSlug( langSlug, languages, openInPopular = false ) {
 	const language = find( languages, ( l ) => l.langSlug === langSlug );
 	const territoryId =
-		language && isArray( language.territories ) ? language.territories[ 0 ] : null;
+		language && Array.isArray( language.territories ) ? language.territories[ 0 ] : null;
 	return get( language, 'popular', null ) && openInPopular === true
 		? 'popular'
 		: getLanguageGroupFromTerritoryId( territoryId );

--- a/client/components/text-diff/index.jsx
+++ b/client/components/text-diff/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { isArray, isEmpty, map, partialRight } from 'lodash';
+import { isEmpty, map, partialRight } from 'lodash';
 
 /**
  * Style dependencies
@@ -12,7 +12,7 @@ import { isArray, isEmpty, map, partialRight } from 'lodash';
 import './style.scss';
 
 const addLinesToOperations = ( operations ) => {
-	if ( ! isArray( operations ) || isEmpty( operations ) ) {
+	if ( ! Array.isArray( operations ) || isEmpty( operations ) ) {
 		return operations;
 	}
 	return operations.join( '\n\n' );

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit-dialog.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit-dialog.js
@@ -5,7 +5,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { isArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -54,7 +53,11 @@ class PaymentMethodEdit extends Component {
 
 	renderEditField = ( editField ) => {
 		const { method } = this.props;
-		if ( method.fields && isArray( method.fields ) && method.fields.indexOf( editField ) < 0 ) {
+		if (
+			method.fields &&
+			Array.isArray( method.fields ) &&
+			method.fields.indexOf( editField ) < 0
+		) {
 			return;
 		}
 		const setting = method.settings[ editField ];

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'calypso/components/gridicon';
-import { isArray } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -32,7 +31,7 @@ class ActionHeader extends React.Component {
 	renderBreadcrumbs = () => {
 		const { breadcrumbs } = this.props;
 		let breadcrumbsOutput = breadcrumbs;
-		if ( isArray( breadcrumbs ) ) {
+		if ( Array.isArray( breadcrumbs ) ) {
 			breadcrumbsOutput = breadcrumbs.map( ( crumb, i ) => <span key={ i }>{ crumb }</span> );
 		}
 

--- a/client/extensions/woocommerce/components/product-search/utils.js
+++ b/client/extensions/woocommerce/components/product-search/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { difference, filter, intersection, isArray, uniq } from 'lodash';
+import { difference, filter, intersection, uniq } from 'lodash';
 
 /**
  * Check if a string is found in a product name or attribute option
@@ -35,7 +35,7 @@ export function productContainsString( product, textString ) {
  * @returns {boolean} Whether the product ID exists in the list of values
  */
 export function isProductSelected( value = [], productId ) {
-	if ( isArray( value ) && value.length ) {
+	if ( Array.isArray( value ) && value.length ) {
 		return -1 !== value.indexOf( productId );
 	}
 	return value === productId;
@@ -53,7 +53,7 @@ export function areVariationsSelected( value = [], product ) {
 	if ( ! variations.length ) {
 		return false;
 	}
-	if ( isArray( value ) && value.length ) {
+	if ( Array.isArray( value ) && value.length ) {
 		return !! intersection( value, variations ).length;
 	}
 	return -1 !== variations.indexOf( value );
@@ -77,7 +77,7 @@ export function isVariableProduct( product ) {
  * @returns {Array} Updated list of values
  */
 export function addProductId( value = [], productId ) {
-	if ( isArray( productId ) ) {
+	if ( Array.isArray( productId ) ) {
 		return uniq( [ ...value, ...productId ] );
 	}
 	return uniq( [ ...value, productId ] );
@@ -91,7 +91,7 @@ export function addProductId( value = [], productId ) {
  * @returns {Array} Updated list of values
  */
 export function removeProductId( value = [], productId ) {
-	if ( isArray( productId ) ) {
+	if ( Array.isArray( productId ) ) {
 		return difference( value, productId );
 	}
 	return value.filter( ( id ) => id !== productId );

--- a/client/extensions/woocommerce/state/sites/customers/actions.js
+++ b/client/extensions/woocommerce/state/sites/customers/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isArray } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import {
@@ -31,7 +26,7 @@ export const customersFailure = ( siteId, searchTerm, error = false ) => {
 
 export const customersReceive = ( siteId, searchTerm, customers ) => {
 	// This passed through the API layer successfully, but failed at the remote site.
-	if ( ! isArray( customers ) ) {
+	if ( ! Array.isArray( customers ) ) {
 		return customersFailure( siteId, searchTerm, customers );
 	}
 	return {

--- a/client/extensions/woocommerce/state/sites/data/locations/selectors.js
+++ b/client/extensions/woocommerce/state/sites/data/locations/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { find, filter, flatMap, get, isArray, isEmpty, omit, sortBy } from 'lodash';
+import { find, filter, flatMap, get, isEmpty, omit, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,7 +27,7 @@ const getRawLocations = ( state, siteId = getSelectedSiteId( state ) ) => {
  * @returns {boolean} Whether the locations data tree has been successfully loaded from the server
  */
 export const areLocationsLoaded = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return isArray( getRawLocations( state, siteId ) );
+	return Array.isArray( getRawLocations( state, siteId ) );
 };
 
 /**

--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isArray, noop } from 'lodash';
+import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -75,7 +75,7 @@ export const failOrders = ( siteId, query = {}, error = false ) => {
 
 export const updateOrders = ( siteId, query = {}, orders = [], total = 0 ) => {
 	// This passed through the API layer successfully, but failed at the remote site.
-	if ( ! isArray( orders ) ) {
+	if ( ! Array.isArray( orders ) ) {
 		return failOrders( siteId, query, orders );
 	}
 	return {

--- a/client/extensions/woocommerce/state/sites/payment-methods/selectors.js
+++ b/client/extensions/woocommerce/state/sites/payment-methods/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { find, get, isArray } from 'lodash';
+import { find, get } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -49,7 +49,7 @@ export const getPaymentMethod = ( state, methodId, siteId = getSelectedSiteId( s
  * @returns {boolean} Whether the payment methods list has been successfully loaded from the server
  */
 export const arePaymentMethodsLoaded = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return isArray( getPaymentMethods( state, siteId ) );
+	return Array.isArray( getPaymentMethods( state, siteId ) );
 };
 
 /**

--- a/client/extensions/woocommerce/state/sites/product-categories/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, isArray, omit, some, range, values } from 'lodash';
+import { get, omit, some, range, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,7 +33,7 @@ export function areProductCategoriesLoaded(
 	const categoryState = getRawCategoryState( state, siteId );
 	const cats = categoryState.queries && categoryState.queries[ serializedQuery ];
 
-	return isArray( cats );
+	return Array.isArray( cats );
 }
 
 /**

--- a/client/extensions/woocommerce/state/sites/products/actions.js
+++ b/client/extensions/woocommerce/state/sites/products/actions.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import { isArray } from 'lodash';
-/**
  * Internal dependencies
  */
 import { DEFAULT_QUERY, getNormalizedProductsQuery } from './utils';
@@ -166,7 +162,7 @@ export function fetchProductsFailure( siteId, params ) {
 
 export function productsUpdated( siteId, params, products, totalPages, totalProducts ) {
 	// This passed through the API layer successfully, but failed at the remote site.
-	if ( ! isArray( products ) ) {
+	if ( ! Array.isArray( products ) ) {
 		return {
 			type: WOOCOMMERCE_PRODUCTS_REQUEST_FAILURE,
 			siteId,

--- a/client/extensions/woocommerce/state/sites/request.js
+++ b/client/extensions/woocommerce/state/sites/request.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { omit, mapValues, isArray, isObject } from 'lodash';
+import { omit, mapValues, isObject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,7 +10,7 @@ import { omit, mapValues, isArray, isObject } from 'lodash';
 import wp from 'calypso/lib/wp';
 
 const omitDeep = ( input, props ) => {
-	if ( isArray( input ) ) {
+	if ( Array.isArray( input ) ) {
 		return input.map( ( elem ) => omitDeep( elem, props ) );
 	}
 

--- a/client/extensions/woocommerce/state/sites/reviews/selectors.js
+++ b/client/extensions/woocommerce/state/sites/reviews/selectors.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-
-import { get, omit, isArray } from 'lodash';
+import { get, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,7 +22,7 @@ export const areReviewsLoaded = ( state, query, siteId = getSelectedSiteId( stat
 		[ 'extensions', 'woocommerce', 'sites', siteId, 'reviews', 'queries', serializedQuery ],
 		false
 	);
-	return isArray( reviews );
+	return Array.isArray( reviews );
 };
 
 /**
@@ -51,7 +50,7 @@ export const areReviewsLoading = ( state, query = {}, siteId = getSelectedSiteId
  * @param {object} state Whole Redux state tree
  * @param {object} [query] Query used to fetch reviews. Can contain page, status, etc. If not provided, defaults to first page, all reviews.
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
- * @returns {Array|false} Array of reviews, or false if there was an error
+ * @returns {Array|boolean} Array of reviews, or false if there was an error
  */
 export const getReviews = ( state, query = {}, siteId = getSelectedSiteId( state ) ) => {
 	if ( ! areReviewsLoaded( state, query, siteId ) ) {

--- a/client/extensions/woocommerce/state/sites/settings/general/selectors.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/selectors.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-
-import { find, get, isArray } from 'lodash';
+import { find, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,7 +19,7 @@ const getRawGeneralSettings = ( state, siteId ) => {
  * @returns {boolean} Whether the general settings list has been successfully loaded from the server
  */
 export const areSettingsGeneralLoaded = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return isArray( getRawGeneralSettings( state, siteId ) );
+	return Array.isArray( getRawGeneralSettings( state, siteId ) );
 };
 
 /**

--- a/client/extensions/woocommerce/state/sites/settings/products/selectors.js
+++ b/client/extensions/woocommerce/state/sites/settings/products/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { find, get, isArray } from 'lodash';
+import { find, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,7 +20,7 @@ const getRawProductsSettings = ( state, siteId ) => {
  * @returns {boolean} Whether the products settings list has been successfully loaded from the server
  */
 export const areSettingsProductsLoaded = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return isArray( getRawProductsSettings( state, siteId ) );
+	return Array.isArray( getRawProductsSettings( state, siteId ) );
 };
 
 /**
@@ -64,7 +64,7 @@ export function getDimensionsUnitSetting( state, siteId = getSelectedSiteId( sta
  * @param {object} state Global state tree
  * @param {string} id setting name / id of the products setting you would like the value of
  * @param {number} siteId wpcom site id. If not provided, the Site ID selected in the UI will be used
- * @returns {mixed} value for the products setting returned from the API
+ * @returns {*} value for the products setting returned from the API
  */
 export function getProductsSettingValue( state, id, siteId = getSelectedSiteId( state ) ) {
 	const productsSettings = getRawProductsSettings( state, siteId );

--- a/client/extensions/woocommerce/state/sites/settings/tax/selectors.js
+++ b/client/extensions/woocommerce/state/sites/settings/tax/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { find, get, isArray } from 'lodash';
+import { find, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,7 +15,7 @@ const getRawTaxSettings = ( state, siteId ) => {
 };
 
 export const areTaxSettingsLoaded = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return isArray( getRawTaxSettings( state, siteId ) );
+	return Array.isArray( getRawTaxSettings( state, siteId ) );
 };
 
 export const areTaxSettingsLoading = ( state, siteId = getSelectedSiteId( state ) ) => {

--- a/client/extensions/woocommerce/state/sites/shipping-classes/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-classes/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, isArray } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ const getShippingClassesFromState = ( state, siteId = getSelectedSiteId( state )
  * @returns {boolean} Whether the shipping classes have been successfully loaded from the server
  */
 export const areShippingClassesLoaded = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return isArray( getShippingClassesFromState( state, siteId ) );
+	return Array.isArray( getShippingClassesFromState( state, siteId ) );
 };
 
 /**
@@ -39,5 +39,5 @@ export const areShippingClassesLoading = ( state, siteId = getSelectedSiteId( st
 export const getShippingClassOptions = ( state, siteId = getSelectedSiteId( state ) ) => {
 	const classes = getShippingClassesFromState( state, siteId );
 
-	return isArray( classes ) ? classes : [];
+	return Array.isArray( classes ) ? classes : [];
 };

--- a/client/extensions/woocommerce/state/sites/shipping-methods/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-methods/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { every, filter, find, get, isArray, some, startsWith } from 'lodash';
+import { every, filter, find, get, some, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,7 +40,7 @@ export const getShippingMethods = ( state, siteId = getSelectedSiteId( state ) )
 		siteId,
 		'shippingMethods',
 	] );
-	if ( ! isArray( allMethods ) ) {
+	if ( ! Array.isArray( allMethods ) ) {
 		return allMethods;
 	}
 	const availableMethods = isWcsEnabled( state, siteId )
@@ -58,7 +58,7 @@ export const getShippingMethods = ( state, siteId = getSelectedSiteId( state ) )
  * @returns {boolean} Whether the shipping methods list has been successfully loaded from the server
  */
 export const areShippingMethodsLoaded = ( state, siteId = getSelectedSiteId( state ) ) => {
-	if ( ! isArray( getShippingMethods( state, siteId ) ) ) {
+	if ( ! Array.isArray( getShippingMethods( state, siteId ) ) ) {
 		return false;
 	}
 	const wcsMethods = filter( getShippingMethods( state, siteId ), ( { id } ) =>

--- a/client/extensions/woocommerce/state/sites/shipping-zone-methods/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zone-methods/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { every, find, get, isArray, isObject, some, startsWith } from 'lodash';
+import { every, find, get, isObject, some, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -46,11 +46,11 @@ export const areShippingZoneMethodsLoaded = (
 	siteId = getSelectedSiteId( state )
 ) => {
 	const zones = getAPIShippingZones( state, siteId );
-	if ( ! isArray( zones ) ) {
+	if ( ! Array.isArray( zones ) ) {
 		return false;
 	}
 	const zone = find( zones, { id: zoneId } );
-	if ( ! zone || ! isArray( zone.methodIds ) ) {
+	if ( ! zone || ! Array.isArray( zone.methodIds ) ) {
 		return false;
 	}
 	if ( ! isWcsEnabled( state, siteId ) ) {
@@ -80,7 +80,7 @@ export const areShippingZoneMethodsLoading = (
 	siteId = getSelectedSiteId( state )
 ) => {
 	const zones = getAPIShippingZones( state, siteId );
-	if ( ! isArray( zones ) ) {
+	if ( ! Array.isArray( zones ) ) {
 		return false;
 	}
 	const zone = find( zones, { id: zoneId } );
@@ -90,7 +90,7 @@ export const areShippingZoneMethodsLoading = (
 	if ( LOADING === zone.methodIds ) {
 		return true;
 	}
-	if ( ! isWcsEnabled( state, siteId ) || ! isArray( zone.methodIds ) ) {
+	if ( ! isWcsEnabled( state, siteId ) || ! Array.isArray( zone.methodIds ) ) {
 		return false;
 	}
 	const wcsMethods = zone.methodIds

--- a/client/extensions/woocommerce/state/sites/shipping-zones/reducer.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zones/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { findIndex, isArray } from 'lodash';
+import { findIndex } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -34,7 +34,7 @@ export default withoutPersistence( ( state = null, action ) => {
 	switch ( action.type ) {
 		case WOOCOMMERCE_SHIPPING_ZONE_METHODS_REQUEST: {
 			const { zoneId } = action;
-			if ( ! isArray( state ) ) {
+			if ( ! Array.isArray( state ) ) {
 				return state;
 			}
 			const zoneIndex = findIndex( state, { id: zoneId } );
@@ -50,7 +50,7 @@ export default withoutPersistence( ( state = null, action ) => {
 		}
 		case WOOCOMMERCE_SHIPPING_ZONE_METHODS_REQUEST_SUCCESS: {
 			const { zoneId, data } = action;
-			if ( ! isArray( state ) ) {
+			if ( ! Array.isArray( state ) ) {
 				return state;
 			}
 			const zoneIndex = findIndex( state, { id: zoneId } );
@@ -71,7 +71,7 @@ export default withoutPersistence( ( state = null, action ) => {
 				originatingAction: { zone },
 			} = action;
 			data = processZoneData( data );
-			if ( ! isArray( state ) ) {
+			if ( ! Array.isArray( state ) ) {
 				return state;
 			}
 
@@ -103,7 +103,7 @@ export default withoutPersistence( ( state = null, action ) => {
 			const {
 				originatingAction: { zone },
 			} = action;
-			if ( ! isArray( state ) ) {
+			if ( ! Array.isArray( state ) ) {
 				return state;
 			}
 
@@ -119,7 +119,7 @@ export default withoutPersistence( ( state = null, action ) => {
 				data,
 				originatingAction: { zoneId },
 			} = action;
-			if ( ! isArray( state ) ) {
+			if ( ! Array.isArray( state ) ) {
 				return state;
 			}
 
@@ -145,7 +145,7 @@ export default withoutPersistence( ( state = null, action ) => {
 			const {
 				originatingAction: { zoneId, methodId },
 			} = action;
-			if ( ! isArray( state ) ) {
+			if ( ! Array.isArray( state ) ) {
 				return state;
 			}
 

--- a/client/extensions/woocommerce/state/sites/shipping-zones/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zones/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { every, get, isArray, some } from 'lodash';
+import { every, get, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,7 +36,7 @@ export const getAPIShippingZones = ( state, siteId = getSelectedSiteId( state ) 
 export const areShippingZonesLoaded = ( state, siteId = getSelectedSiteId( state ) ) => {
 	const zones = getAPIShippingZones( state, siteId );
 	return (
-		isArray( zones ) &&
+		Array.isArray( zones ) &&
 		every( zones, ( zone ) => areShippingZoneMethodsLoaded( state, zone.id, siteId ) ) &&
 		every( zones, ( zone ) => areShippingZoneLocationsLoaded( state, zone.id, siteId ) )
 	);
@@ -52,7 +52,7 @@ export const areShippingZonesLoading = ( state, siteId = getSelectedSiteId( stat
 	if ( LOADING === zones ) {
 		return true;
 	}
-	if ( ! isArray( zones ) ) {
+	if ( ! Array.isArray( zones ) ) {
 		return false;
 	}
 	return (

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/selectors.js
@@ -12,7 +12,6 @@ import {
 	mergeWith,
 	pullAll,
 	startsWith,
-	isArray,
 } from 'lodash';
 import { isNullish } from '@automattic/js-utils';
 
@@ -239,7 +238,7 @@ export const getCurrentlyOpenShippingZoneMethod = (
 
 	// Overwrites the default behavior of `merge` while ignoring arrays and focusing on objects.
 	const customizer = ( objValue, srcValue ) => {
-		if ( isArray( objValue ) ) {
+		if ( Array.isArray( objValue ) ) {
 			return srcValue;
 		}
 	};

--- a/client/extensions/woocommerce/woocommerce-services/lib/utils/tree.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/utils/tree.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isArray, isPlainObject, some, values } from 'lodash';
+import { isPlainObject, some, values } from 'lodash';
 
 /**
  * Checks if the given tree-like structure has any non-empty terminal nodes.
@@ -13,7 +13,7 @@ export const hasNonEmptyLeaves = ( tree ) => {
 	if ( ! tree ) {
 		return false;
 	}
-	if ( isArray( tree ) ) {
+	if ( Array.isArray( tree ) ) {
 		return some( tree, hasNonEmptyLeaves );
 	}
 	if ( isPlainObject( tree ) ) {

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -4,7 +4,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { map, partial, pickBy, isArray, flowRight } from 'lodash';
+import { map, partial, pickBy, flowRight } from 'lodash';
 /* eslint-disable no-restricted-imports */
 import url from 'url';
 import { localize, LocalizeProps } from 'i18n-calypso';
@@ -432,7 +432,7 @@ class CalypsoifyIframe extends Component<
 		// Pipes errors in the iFrame context to the Calypso error handler if it exists:
 		if ( EditorActions.LogError === action ) {
 			const { error } = payload;
-			if ( isArray( error ) && error.length > 4 && window.onerror ) {
+			if ( Array.isArray( error ) && error.length > 4 && window.onerror ) {
 				const errorObject = error[ 4 ];
 				error[ 4 ] = errorObject && JSON.parse( errorObject );
 				window.onerror( ...error );

--- a/client/gutenberg/editor/media-utils.js
+++ b/client/gutenberg/editor/media-utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, head, includes, isArray, reduce } from 'lodash';
+import { get, head, includes, reduce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -52,7 +52,7 @@ export const getDisabledDataSources = ( allowedTypes ) => {
 	// its `allowedTypes` prop can be either undefined or an empty array.
 	if (
 		! allowedTypes ||
-		( isArray( allowedTypes ) && ! allowedTypes.length ) ||
+		( Array.isArray( allowedTypes ) && ! allowedTypes.length ) ||
 		includes( allowedTypes, 'image' )
 	) {
 		return [];
@@ -67,7 +67,7 @@ const enabledFiltersMap = {
 };
 
 export const getEnabledFilters = ( allowedTypes ) => {
-	return isArray( allowedTypes ) && allowedTypes.length
+	return Array.isArray( allowedTypes ) && allowedTypes.length
 		? allowedTypes.map( ( type ) => enabledFiltersMap[ type ] )
 		: undefined;
 };

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -7,7 +7,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { every, includes, isArray, keys, reduce, some } from 'lodash';
+import { every, includes, keys, reduce, some } from 'lodash';
 import store from 'store';
 import { getLocaleSlug } from 'i18n-calypso';
 
@@ -133,7 +133,7 @@ ABTest.prototype.init = function ( name, geoLocation ) {
 			// Allow any locales.
 			this.localeTargets = false;
 		} else if (
-			isArray( testConfig.localeTargets ) &&
+			Array.isArray( testConfig.localeTargets ) &&
 			every( testConfig.localeTargets, langSlugIsValid )
 		) {
 			// Allow specific locales.
@@ -148,7 +148,7 @@ ABTest.prototype.init = function ( name, geoLocation ) {
 	this.localeExceptions = false;
 	if (
 		testConfig.localeExceptions &&
-		isArray( testConfig.localeExceptions ) &&
+		Array.isArray( testConfig.localeExceptions ) &&
 		every( testConfig.localeExceptions, langSlugIsValid )
 	) {
 		this.localeExceptions = testConfig.localeExceptions;

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import creditcards from 'creditcards';
-import { capitalize, compact, isArray, isEmpty, mergeWith, union, isString } from 'lodash';
+import { capitalize, compact, isEmpty, mergeWith, union, isString } from 'lodash';
 import i18n from 'i18n-calypso';
 import { isValidPostalCode } from 'calypso/lib/postal-code';
 
@@ -177,7 +177,7 @@ export function paymentFieldRules( paymentDetails, paymentType ) {
  */
 export function mergeValidationRules( ...rulesets ) {
 	return mergeWith( {}, ...rulesets, ( objValue, srcValue ) =>
-		isArray( objValue ) && isArray( srcValue ) ? union( objValue, srcValue ) : undefined
+		Array.isArray( objValue ) && Array.isArray( srcValue ) ? union( objValue, srcValue ) : undefined
 	);
 }
 
@@ -446,7 +446,7 @@ function getConditionalCreditCardRules( { country } ) {
 }
 
 function getValidator( rule ) {
-	if ( isArray( rule ) ) {
+	if ( Array.isArray( rule ) ) {
 		return validators[ rule[ 0 ] ].apply( null, rule.slice( 1 ) );
 	}
 

--- a/client/lib/preferences-helper/preference.js
+++ b/client/lib/preferences-helper/preference.js
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { partial, isArray, isPlainObject } from 'lodash';
+import { partial, isPlainObject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,7 +26,7 @@ class Preference extends Component {
 			</ul>
 		);
 
-		if ( isArray( value ) ) {
+		if ( Array.isArray( value ) ) {
 			preferenceHandler = <ArrayPreference name={ name } value={ value } />;
 		} else if ( isPlainObject( value ) ) {
 			preferenceHandler = <ObjectPreference name={ name } value={ value } />;

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { debounce, isEqual, find, isEmpty, isArray } from 'lodash';
+import { debounce, isEqual, find, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
@@ -198,7 +198,7 @@ export class HelpContactForm extends React.PureComponent {
 			.getQandA( query, site )
 			.then( ( qanda ) =>
 				this.setState( {
-					qanda: isArray( qanda ) ? qanda : [],
+					qanda: Array.isArray( qanda ) ? qanda : [],
 					// only keep sibylClicked true if the user is seeing the same set of questions
 					// we don't want to track "questions -> question click -> different questions -> support click",
 					// so we need to set sibylClicked to false here if the questions have changed

--- a/client/my-sites/backup/hooks.js
+++ b/client/my-sites/backup/hooks.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isArray } from 'lodash';
 import { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -95,7 +94,7 @@ export const useFirstMatchingBackupAttempt = (
 
 	const rewindCapabilities = useSelector( ( state ) => getRewindCapabilities( state, siteId ) );
 	const hasRealtimeBackups =
-		isArray( rewindCapabilities ) && rewindCapabilities.includes( 'backup-realtime' );
+		Array.isArray( rewindCapabilities ) && rewindCapabilities.includes( 'backup-realtime' );
 
 	const filter = hasRealtimeBackups
 		? getRealtimeAttemptFilter( { before, after, sortOrder } )

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -6,7 +6,6 @@ import { useSelector } from 'react-redux';
 import page from 'page';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { isArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -145,7 +144,7 @@ const BackupStatus = ( { selectedDate } ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const rewindCapabilities = useSelector( ( state ) => getRewindCapabilities( state, siteId ) );
 
-	if ( ! isArray( rewindCapabilities ) ) {
+	if ( ! Array.isArray( rewindCapabilities ) ) {
 		return <BackupPlaceholder showDatePicker={ false } />;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/cart-plan-overlaps-owned-product-notice.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/cart-plan-overlaps-owned-product-notice.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useTranslate } from 'i18n-calypso';
-import { isArray } from 'lodash';
 import React, { ReactElement, FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -32,7 +31,7 @@ const CartPlanOverlapsOwnedProductNotice: FunctionComponent< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
-	const purchase = isArray( purchases )
+	const purchase = Array.isArray( purchases )
 		? purchases.find( ( p ) => p.productSlug === product.productSlug )
 		: null;
 	const purchaseId = purchase?.id;

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/site-plan-includes-cart-product-notice.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/site-plan-includes-cart-product-notice.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useTranslate } from 'i18n-calypso';
-import { isArray } from 'lodash';
 import React, { ReactElement, FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -33,7 +32,7 @@ const SitePlanIncludesCartProductNotice: FunctionComponent< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
-	const purchase = isArray( purchases )
+	const purchase = Array.isArray( purchases )
 		? purchases.find( ( p ) => p.productSlug === plan.product_slug )
 		: null;
 	const purchaseId = purchase?.id;

--- a/client/my-sites/marketing/connections/mailchimp-settings.jsx
+++ b/client/my-sites/marketing/connections/mailchimp-settings.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { isArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -97,7 +96,7 @@ const MailchimpSettings = ( {
 			<QueryMailchimpLists siteId={ siteId } />
 			<QueryMailchimpSettings siteId={ siteId } />
 			<p>{ translate( 'What Mailchimp list should subscribers be added to?' ) }</p>
-			{ isArray( mailchimpLists ) && mailchimpLists.length === 0 && (
+			{ Array.isArray( mailchimpLists ) && mailchimpLists.length === 0 && (
 				<Notice
 					status="is-info"
 					text={ translate(

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { translate, TranslateResult, numberFormat } from 'i18n-calypso';
-import { compact, isArray, isObject, isFunction } from 'lodash';
+import { compact, isObject, isFunction } from 'lodash';
 import page from 'page';
 import React, { createElement, Fragment } from 'react';
 import formatCurrency from '@automattic/format-currency';
@@ -528,7 +528,7 @@ export function buildCardFeatureItemFromFeatureKey(
 	let feature;
 	let subFeaturesKeys;
 
-	if ( isArray( featureKey ) ) {
+	if ( Array.isArray( featureKey ) ) {
 		const [ key, subKeys ] = featureKey;
 
 		feature = getFeatureByKey( key );
@@ -569,7 +569,7 @@ export function buildCardFeaturesFromFeatureKeys(
 	variation?: Iterations
 ): SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[] {
 	// Without sections (JetpackPlanCardFeature[])
-	if ( isArray( features ) ) {
+	if ( Array.isArray( features ) ) {
 		return compact(
 			features.map( ( f ) => buildCardFeatureItemFromFeatureKey( f, options, variation ) )
 		);
@@ -665,7 +665,7 @@ export function checkout(
 	products: string | string[],
 	urlQueryArgs: QueryArgs = {}
 ): void {
-	const productsArray = isArray( products ) ? products : [ products ];
+	const productsArray = Array.isArray( products ) ? products : [ products ];
 	const productsString = productsArray.join( ',' );
 
 	// If there is not siteSlug, we need to redirect the user to the site selection

--- a/client/my-sites/site-settings/disconnect-site/confirm.jsx
+++ b/client/my-sites/site-settings/disconnect-site/confirm.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { find, flowRight, isArray } from 'lodash';
+import { find, flowRight } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -53,7 +53,7 @@ class ConfirmDisconnection extends PureComponent {
 		const surveyData = {
 			'why-cancel': {
 				response: find( this.constructor.allowedReasons, ( r ) => r === reason ),
-				text: isArray( text ) ? text.join() : text,
+				text: Array.isArray( text ) ? text.join() : text,
 			},
 			source: {
 				from: 'Calypso',

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { get, isArray, isEqual, mapValues, omit, pickBy, partial } from 'lodash';
+import { get, isEqual, mapValues, omit, pickBy, partial } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -225,7 +225,7 @@ export class SeoForm extends React.Component {
 		// We will pass an empty string in this case.
 		updatedOptions.advanced_seo_title_formats = mapValues(
 			updatedOptions.advanced_seo_title_formats,
-			( format ) => ( isArray( format ) && 0 === format.length ? '' : format )
+			( format ) => ( Array.isArray( format ) && 0 === format.length ? '' : format )
 		);
 
 		this.props.saveSiteSettings( siteId, updatedOptions );

--- a/client/state/action-watchers/utils.js
+++ b/client/state/action-watchers/utils.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-
-import { isArray, mergeWith } from 'lodash';
+import { mergeWith } from 'lodash';
 
 /**
  * Merge handler for lodash.mergeWith
@@ -20,7 +19,8 @@ import { isArray, mergeWith } from 'lodash';
  * @param {Array<Function>} right new handlers to add
  * @returns {Array<Function>} combined handlers
  */
-const concatHandlers = ( left, right ) => ( isArray( left ) ? left.concat( right ) : undefined );
+const concatHandlers = ( left, right ) =>
+	Array.isArray( left ) ? left.concat( right ) : undefined;
 
 export const mergeHandlers = ( ...handlers ) =>
 	handlers.length > 1

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -13,7 +13,6 @@ import {
 	get,
 	zipObject,
 	includes,
-	isArray,
 	values,
 	omit,
 	startsWith,
@@ -230,7 +229,7 @@ const isValidExpansionsAction = ( action ) => {
 	return (
 		siteId &&
 		postId &&
-		isArray( commentIds ) &&
+		Array.isArray( commentIds ) &&
 		includes( values( POST_COMMENT_DISPLAY_TYPES ), displayType )
 	);
 };

--- a/client/state/data-getters/get-request-activity-logs-id.js
+++ b/client/state/data-getters/get-request-activity-logs-id.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isArray, isUndefined, sortBy } from 'lodash';
+import { isUndefined, sortBy } from 'lodash';
 
 const getRequestActivityLogsId = ( siteId, filter ) => {
 	const knownFilterOptions = [
@@ -25,7 +25,9 @@ const getRequestActivityLogsId = ( siteId, filter ) => {
 				return undefined;
 			}
 
-			const cacheKeyValue = String( isArray( optionValue ) ? sortBy( optionValue ) : optionValue );
+			const cacheKeyValue = String(
+				Array.isArray( optionValue ) ? sortBy( optionValue ) : optionValue
+			);
 
 			return `${ opt }=${ cacheKeyValue }`;
 		} )

--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -1,16 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	camelCase,
-	isArray,
-	isObjectLike,
-	isPlainObject,
-	map,
-	reduce,
-	set,
-	snakeCase,
-} from 'lodash';
+import { camelCase, isObjectLike, isPlainObject, map, reduce, set, snakeCase } from 'lodash';
 
 /**
  * Internal dependencies
@@ -35,7 +26,7 @@ export const bypassDataLayer = ( action ) => extendAction( action, doBypassDataL
  * @returns {object} a new object with all keys converted
  */
 export function convertKeysBy( obj, fn ) {
-	if ( isArray( obj ) ) {
+	if ( Array.isArray( obj ) ) {
 		return map( obj, ( v ) => convertKeysBy( v, fn ) );
 	}
 

--- a/client/state/data-layer/wpcom/read/following/mine/utils.js
+++ b/client/state/data-layer/wpcom/read/following/mine/utils.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { isArray, isUndefined, map, omitBy } from 'lodash';
+import { isUndefined, map, omitBy } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -10,7 +10,7 @@ import { toValidId } from 'calypso/reader/id-helpers';
 
 export const isValidApiResponse = ( apiResponse ) => {
 	const hasSubscriptions =
-		apiResponse && apiResponse.subscriptions && isArray( apiResponse.subscriptions );
+		apiResponse && apiResponse.subscriptions && Array.isArray( apiResponse.subscriptions );
 	return hasSubscriptions;
 };
 

--- a/client/state/data-layer/wpcom/read/tags/utils.js
+++ b/client/state/data-layer/wpcom/read/tags/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, compact, concat, isObject, isArray } from 'lodash';
+import { map, compact, concat, isObject } from 'lodash';
 import { decodeEntities } from 'calypso/lib/formatting';
 
 /**
@@ -9,8 +9,8 @@ import { decodeEntities } from 'calypso/lib/formatting';
  * we always pass forward a list
  * Also transform the api response to be something more calypso-friendly
  *
- * @param  {Tag|Tags} apiResponse api response from the tags endpoint
- * @returns {Tags} An object containing all of the normalized tags in the format:
+ * @param  {Object} apiResponse api response from the tags endpoint
+ * @returns {Object} An object containing all of the normalized tags in the format:
  *  [
  *    { id, displayName, url, title, slug },
  *    ...
@@ -25,7 +25,7 @@ export function fromApi( apiResponse ) {
 		concat(
 			[],
 			isObject( apiResponse.tag ) && apiResponse.tag,
-			isArray( apiResponse.tags ) && apiResponse.tags
+			Array.isArray( apiResponse.tags ) && apiResponse.tags
 		)
 	);
 

--- a/client/state/data-layer/wpcom/read/tags/utils.js
+++ b/client/state/data-layer/wpcom/read/tags/utils.js
@@ -10,7 +10,7 @@ import { decodeEntities } from 'calypso/lib/formatting';
  * Also transform the api response to be something more calypso-friendly
  *
  * @param  {Object} apiResponse api response from the tags endpoint
- * @returns {Object} An object containing all of the normalized tags in the format:
+ * @returns {Array} An array containing all of the normalized tags in the format:
  *  [
  *    { id, displayName, url, title, slug },
  *    ...

--- a/client/state/data-layer/wpcom/sites/blog-stickers/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/index.js
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-
 import { translate } from 'i18n-calypso';
-import { isArray } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -31,7 +29,7 @@ export const receiveBlogStickerListError = () =>
 	errorNotice( translate( 'Sorry, we had a problem retrieving blog stickers. Please try again.' ) );
 
 export const receiveBlogStickerList = ( action, response ) =>
-	! response || ! isArray( response )
+	! response || ! Array.isArray( response )
 		? receiveBlogStickerListError( action )
 		: receiveBlogStickers( action.payload.blogId, response );
 

--- a/client/state/data-layer/wpcom/sites/comments-tree/index.js
+++ b/client/state/data-layer/wpcom/sites/comments-tree/index.js
@@ -3,7 +3,7 @@
  */
 
 import { translate } from 'i18n-calypso';
-import { flatMap, flatten, isArray, map } from 'lodash';
+import { flatMap, flatten, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,7 +34,9 @@ export const fetchCommentsTreeForSite = ( action ) => {
 
 const mapPosts = ( commentIds, apiPostId ) => {
 	const postId = parseInt( apiPostId, 10 );
-	const [ topLevelIds, replyIds ] = ! isArray( commentIds[ 0 ] ) ? [ commentIds, [] ] : commentIds;
+	const [ topLevelIds, replyIds ] = ! Array.isArray( commentIds[ 0 ] )
+		? [ commentIds, [] ]
+		: commentIds;
 
 	return flatten( [
 		topLevelIds.map( ( commentId ) => [ commentId, postId, 0 ] ),

--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { uniqWith, isEqual, isArray } from 'lodash';
+import { uniqWith, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -61,7 +61,7 @@ export const link = withSchemaValidation( linkSchema, ( state = [], action ) => 
 			// Append action.link to the state array and prevent duplicate objects.
 			// Works with action.link being a single link object or an array of link objects.
 			return uniqWith(
-				[ ...state, ...( isArray( action.link ) ? action.link : [ action.link ] ) ],
+				[ ...state, ...( Array.isArray( action.link ) ? action.link : [ action.link ] ) ],
 				isEqual
 			);
 	}

--- a/client/state/domains/management/reducer.js
+++ b/client/state/domains/management/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, isArray, merge, omit, stubFalse, stubTrue } from 'lodash';
+import { get, merge, omit, stubFalse, stubTrue } from 'lodash';
 
 /**
  * Internal dependencies
@@ -108,7 +108,7 @@ export const isSaving = withoutPersistence( ( state = {}, action ) => {
 } );
 
 function mergeDomainRegistrantContactDetails( domainState, registrantContactDetails ) {
-	return isArray( domainState )
+	return Array.isArray( domainState )
 		? domainState.map( ( item ) => {
 				if ( item.type === whoisType.REGISTRANT ) {
 					return {
@@ -201,5 +201,5 @@ export default combineReducers( {
  */
 function sanitizeExtra( data ) {
 	const path = data._contactDetailsCache ? [ '_contactDetailsCache', 'extra' ] : 'extra';
-	return data && isArray( get( data, path ) ) ? omit( data, path ) : data;
+	return data && Array.isArray( get( data, path ) ) ? omit( data, path ) : data;
 }

--- a/client/state/reader/feeds/actions.js
+++ b/client/state/reader/feeds/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isArray } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import {
@@ -42,7 +37,7 @@ export function receiveReaderFeedRequestFailure( feedId, error ) {
 }
 
 export function updateFeeds( feeds ) {
-	if ( ! isArray( feeds ) ) {
+	if ( ! Array.isArray( feeds ) ) {
 		feeds = [ feeds ];
 	}
 

--- a/client/state/reader/sites/actions.js
+++ b/client/state/reader/sites/actions.js
@@ -1,9 +1,4 @@
 /**
- * External Dependencies
- */
-import { isArray } from 'lodash';
-
-/**
  * Internal Dependencies
  */
 import {
@@ -42,7 +37,7 @@ export function receiveReaderSiteRequestFailure( action, error ) {
 }
 
 export function updateSites( sites ) {
-	if ( ! isArray( sites ) ) {
+	if ( ! Array.isArray( sites ) ) {
 		sites = [ sites ];
 	}
 	return {

--- a/client/state/rewind/selectors/site-has-realtime-backups.ts
+++ b/client/state/rewind/selectors/site-has-realtime-backups.ts
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isArray } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { AppState } from 'calypso/types';
@@ -11,7 +6,7 @@ import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabiliti
 
 const siteHasRealtimeBackups = ( state: AppState, siteId: number ): boolean => {
 	const capabilities = getRewindCapabilities( state, siteId );
-	return isArray( capabilities ) && capabilities.includes( 'backup-realtime' );
+	return Array.isArray( capabilities ) && capabilities.includes( 'backup-realtime' );
 };
 
 export default siteHasRealtimeBackups;

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, isArray, map, flatten, round } from 'lodash';
+import { get, map, flatten, round } from 'lodash';
 import moment from 'moment';
 
 /**
@@ -76,7 +76,7 @@ export const getSiteStatsPostStreakData = treeSelect(
 		const gmtOffset = query.gmtOffset || 0;
 		const response = {};
 		// ensure streakData.data exists and it is not an array
-		if ( streakData && streakData.data && ! isArray( streakData.data ) ) {
+		if ( streakData && streakData.data && ! Array.isArray( streakData.data ) ) {
 			Object.keys( streakData.data ).forEach( ( timestamp ) => {
 				const postDay = moment.unix( timestamp );
 				const datestamp = postDay.utcOffset( gmtOffset ).format( 'YYYY-MM-DD' );
@@ -135,7 +135,7 @@ export const getSiteStatsNormalizedData = treeSelect(
  */
 export function getSiteStatsCSVData( state, siteId, statType, query ) {
 	const data = getSiteStatsNormalizedData( state, siteId, statType, query );
-	if ( ! data || ! isArray( data ) ) {
+	if ( ! data || ! Array.isArray( data ) ) {
 		return [];
 	}
 

--- a/docs/coding-guidelines/javascript.md
+++ b/docs/coding-guidelines/javascript.md
@@ -332,7 +332,7 @@ If you really must check the type of a value, however, do the following:
 - Number: [`Number.isFinite( value )`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite) for finite numbers only, or `[ Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ].includes( value )` if you'd like to check for infinite numbers. (avoid using Lodash's `isNumber`).
 - Boolean: `value === true || value === false` (don't use Lodash's `isBoolean`, as it's incredibly wasteful).
 - Object: [`isPlainObject( value )`](https://lodash.com/docs#isPlainObject). Try to avoid when possible - we'd like to get rid of Lodash in the long term. In most cases, `typeof value === 'object' && value.constructor === Object` should do the job for plain objects.
-- Array: [`Array.isArray( value )`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray).
+- Array: [`Array.isArray( value )`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray). (avoid using Lodash's `isArray`).
 - null: `value === null`.
 - undefined: `value === undefined`.
 - undefined or null (either): `value == null` or `value === null || value === undefined` (clearer)

--- a/packages/page-template-modal/src/components/template-selector-control.js
+++ b/packages/page-template-modal/src/components/template-selector-control.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, isArray, noop, map } from 'lodash';
+import { isEmpty, noop, map } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -31,7 +31,7 @@ export const TemplateSelectorControl = ( {
 	siteInformation = {},
 	selectedTemplate,
 } ) => {
-	if ( isEmpty( templates ) || ! isArray( templates ) ) {
+	if ( isEmpty( templates ) || ! Array.isArray( templates ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `isArray` is essentially fully natively supported by `Array.isArray`. This PR replaces the usage, and adds an ESLint rule to warn against using `isArray` from lodash. It might look like a big PR, but replacing one with the other is pretty harmless (neither will throw with any value), so no extensive testing is actually necessary.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Try importing `isArray` from `lodash` and verify you're getting an ESLint error.
* Verify all tests pass.

#### Notes

There is one ESLint error in one of the files we're touching, and we're intentionally leaving it be. That needs to be refactored away from `create-react-class` (`react/prefer-es6-class`).