### PR TITLE
ESLint: Deprecate _.dropRight

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -402,6 +402,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/contains': 'error',
 		'you-dont-need-lodash-underscore/detect': 'error',
 		'you-dont-need-lodash-underscore/drop': 'error',
+		'you-dont-need-lodash-underscore/drop-right': 'error',
 		'you-dont-need-lodash-underscore/ends-with': 'error',
 		'you-dont-need-lodash-underscore/entries': 'error',
 		'you-dont-need-lodash-underscore/extend-own': 'error',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR deprecates usage of lodash's `dropRight`. We removed all its usage a while ago, but not we're also disallowing usage of it. A follow-up to #50368.

If you want to find out why we're moving away from Lodash, also see p4TIVU-9Bf-p2.

#### Testing instructions

* Attempt to `import { dropRight } from 'lodash'`
* Verify you're getting an ESLint error.
