### PR TITLE
Framework: Refactor away from _.join() 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -411,6 +411,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/is-finite': 'error',
 		'you-dont-need-lodash-underscore/is-nil': 'error',
 		'you-dont-need-lodash-underscore/is-null': 'error',
+		'you-dont-need-lodash-underscore/join': 'error',
 		'you-dont-need-lodash-underscore/last-index-of': 'error',
 		'you-dont-need-lodash-underscore/pad-end': 'error',
 		'you-dont-need-lodash-underscore/pad-start': 'error',

--- a/client/landing/domains/registrant-verification/index.jsx
+++ b/client/landing/domains/registrant-verification/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { get, join } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -62,7 +62,7 @@ class RegistrantVerificationPage extends Component {
 	getVerificationSuccessState = ( domains ) => {
 		const { translate } = this.props;
 
-		const verifiedDomains = join( domains, ', ' );
+		const verifiedDomains = domains.join( ', ' );
 
 		return {
 			title: translate( 'Success!' ),

--- a/client/my-sites/checkout/composite-checkout/components/domain-registration-hsts.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-registration-hsts.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { isEmpty, join, merge, reduce } from 'lodash';
+import { isEmpty, merge, reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -42,7 +42,7 @@ class DomainRegistrationHsts extends React.PureComponent {
 			[]
 		);
 
-		return join( hstsTlds, ', ' );
+		return hstsTlds.join( ', ' );
 	};
 
 	render() {

--- a/client/state/data-layer/wpcom/domains/validation-schemas/index.js
+++ b/client/state/data-layer/wpcom/domains/validation-schemas/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, join, flatMap } from 'lodash';
+import { get, flatMap } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,7 +27,7 @@ export const fetch = ( action ) =>
 		{
 			apiVersion: '1',
 			method: 'GET',
-			path: `/domains/validation-schemas/${ join( get( action, 'tlds', [] ), ',' ) }`,
+			path: `/domains/validation-schemas/${ get( action, 'tlds', [] ).join( ',' ) }`,
 		},
 		action
 	);
@@ -44,9 +44,10 @@ export const onSuccess = ( action, schemas ) => addValidationSchemas( schemas );
 /**
  * Create an error notice action when the request fails
  *
- * @param   {object} tlds   Originating action with the original list of requested tlds
- * @param   {object} error  Error information (query path, error message etc).
- * @returns {[Action]}      An array of mc and tracks analytics events, one each per tld
+ * @param   {object}      action Action object
+ * @param   {Array}  action.tlds Originating action with the original list of requested tlds
+ * @param   {object}       error Error information (query path, error message etc).
+ * @returns {[object]}             An array of mc and tracks analytics events, one each per tld
  */
 export const onError = ( { tlds }, error ) =>
 	composeAnalytics(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `join` is essentially fully natively supported by `Array.join`. This PR replaces the usage, and adds an ESLint rule to warn against using `join` from lodash.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* cc @Automattic/cobalt for verifying changes look good on the domains side of things (this only touches domains code). I took a thorough look and the usages are safe IMHO, but pinging just in case.
* Try to `import { join } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass.