### PR TITLE
Adds a return param in external urls.

### DIFF
--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -22,6 +22,7 @@ import {
 	collapseAllMySitesSidebarSections,
 	expandMySitesSidebarSection,
 } from 'calypso/state/my-sites/sidebar/actions';
+import { isExternal, addQueryArgs } from 'calypso/lib/url';
 
 export const MySitesSidebarUnifiedItem = ( {
 	count,
@@ -43,11 +44,20 @@ export const MySitesSidebarUnifiedItem = ( {
 		reduxDispatch( expandMySitesSidebarSection( sectionId ) );
 	};
 
+	const getLink = () => {
+		if ( ! isExternal( url ) ) {
+			return url;
+		}
+		// In case of external links, let's add a `return` query arg so that we give
+		// other interfaces ( eg WP Admin ) a chance to return us where we started from.
+		return addQueryArgs( { return: document.location.href }, url );
+	};
+
 	return (
 		<SidebarItem
 			count={ count }
 			label={ title }
-			link={ url }
+			link={ getLink() }
 			onNavigate={ ( event ) => continueInCalypso( url, event ) && onNavigate() }
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a return param in all external urls.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**In trunk** 
1. Go to WordPress.com admin area for a site other than your primary site set in your account settings.
2. Click on Appearance > Customize
3. Exit the Customizer
4. Note that instead of going back to the site you were working on, you're instead brought to your primary site

**In this branch (use calypso.live)** 
1. Go to WordPress.com admin area for a site other than your primary site set in your account settings.
2. Click on Appearance > Customize
3. Exit the Customizer
4. You should land to the page you were before clicking Appearance > Customize

Please turn on "Replace all dashboard pages with WP Admin equivalents when possible." in `https://wordpress.com/me/account` or test on an Atomic site. Otherwise, the customizer opens in react context and going back works already.

There is a WP Admin counterpart here https://github.com/Automattic/jetpack/pull/18961

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #49568
