### PR TITLE
ci: Do not assume `chromedriver` is in $PATH

### DIFF
--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -4,6 +4,7 @@
 import webdriver from 'selenium-webdriver';
 import firefox from 'selenium-webdriver/firefox';
 import chrome from 'selenium-webdriver/chrome';
+import chromedriver from 'chromedriver';
 import config from 'config';
 import proxy from 'selenium-webdriver/proxy';
 import SauceLabs from 'saucelabs';
@@ -163,7 +164,7 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 				options.addArguments( '--app=https://www.wordpress.com' );
 
 				// eslint-disable-next-line no-case-declarations
-				const service = new chrome.ServiceBuilder()
+				const service = new chrome.ServiceBuilder( chromedriver.path )
 					.loggingTo( './chromedriver.' + process.pid + '.log' )
 					.enableVerboseLogging()
 					.build();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `chromedriver.path` to get the path where chromedriver is actually insatlled. Partial revert of #50208
