### PR TITLE
Update copy on WPAdmin account toggle

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -1064,7 +1064,18 @@ class Account extends React.Component {
 									onChange={ this.toggleLinkDestination }
 								>
 									{ translate(
-										'Enabling this will replace your dashboard pages with more advanced wp-admin equivalents when possible. Learn more.'
+										'Enabling this will replace your dashboard pages with more advanced wp-admin equivalents when possible. {{a}}Learn more{{/a}}.',
+										{
+											components: {
+												a: (
+													<a
+														href="https://support.wordpress.com"
+														target="_blank"
+														rel="noopener noreferrer"
+													/>
+												),
+											},
+										}
 									) }
 								</FormToggle>
 							</FormFieldset>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -1057,14 +1057,14 @@ class Account extends React.Component {
 						{ config.isEnabled( 'nav-unification' ) && (
 							<FormFieldset className="account__link-destination">
 								<FormLabel id="account__link_destination" htmlFor="link_destination">
-									{ translate( 'Dashboard appearance' ) }
+									{ translate( 'Show advanced dashboard pages' ) }
 								</FormLabel>
 								<FormToggle
 									checked={ !! this.getUserSetting( linkDestinationKey ) }
 									onChange={ this.toggleLinkDestination }
 								>
 									{ translate(
-										'Replace all dashboard pages with WP Admin equivalents when possible.'
+										'Enabling this will replace your dashboard pages with more advanced wp-admin equivalents when possible. Learn more.'
 									) }
 								</FormToggle>
 							</FormFieldset>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -1064,19 +1064,14 @@ class Account extends React.Component {
 									onChange={ this.toggleLinkDestination }
 								>
 									{ translate(
-										'Enabling this will replace your dashboard pages with more advanced wp-admin equivalents when possible. {{a}}Learn more{{/a}}.',
-										{
-											components: {
-												a: (
-													<a
-														href="https://support.wordpress.com"
-														target="_blank"
-														rel="noopener noreferrer"
-													/>
-												),
-											},
-										}
+										'Enabling this will replace your dashboard pages with more advanced wp-admin equivalents when possible.'
 									) }
+
+									i18n.translate( 'I feel {{a}}very{{/a}} strongly about this.', {
+										components: {
+											a: <a />
+										}
+									} );
 								</FormToggle>
 							</FormFieldset>
 						) }

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -1057,14 +1057,20 @@ class Account extends React.Component {
 						{ config.isEnabled( 'nav-unification' ) && (
 							<FormFieldset className="account__link-destination">
 								<FormLabel id="account__link_destination" htmlFor="link_destination">
-									{ translate( 'Show advanced dashboard pages' ) }
+									{ translate( 'Dashboard appearance' ) }
 								</FormLabel>
 								<FormToggle
 									checked={ !! this.getUserSetting( linkDestinationKey ) }
 									onChange={ this.toggleLinkDestination }
 								>
 									{ translate(
-										'Enabling this will replace your dashboard pages with more advanced wp-admin equivalents when possible.'
+										'{{spanlead}}Show advanced dashboard pages.{{/spanlead}} {{spanextra}}Enabling this will replace your dashboard pages with more advanced wp-admin equivalents when possible.{{/spanextra}}',
+										{
+											components: {
+												spanlead: <span className="account__link-destination-label-lead" />,
+												spanextra: <span className="account__link-destination-label-extra" />,
+											},
+										}
 									) }
 								</FormToggle>
 							</FormFieldset>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -1066,12 +1066,6 @@ class Account extends React.Component {
 									{ translate(
 										'Enabling this will replace your dashboard pages with more advanced wp-admin equivalents when possible.'
 									) }
-
-									i18n.translate( 'I feel {{a}}very{{/a}} strongly about this.', {
-										components: {
-											a: <a />
-										}
-									} );
 								</FormToggle>
 							</FormFieldset>
 						) }

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -28,6 +28,23 @@
 	top: 57px;
 }
 
-.account__link-destination .components-toggle-control__label {
-	color: var( --color-text-subtle );
+.account__link-destination {
+	.components-base-control__field {
+		align-items: flex-start;
+		margin-top: 0.5em;
+	}
+
+	.components-toggle-control__label {
+		color: var( --color-text-subtle );
+
+		span {
+			display: block;
+		}
+	}
+
+	.account__link-destination-label-extra {
+		font-style: italic;
+		margin-top: 0.1em;
+	}
 }
+


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/50202


#### Changes proposed in this Pull Request

* Update copy on WPAdmin toggle under Account Settings to better reflect intent of toggle.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live link.
* Go to Account section `/me/account`.
* See new copy on toggle.

##### Please note

* The PR doesn't match the design because the design isn't inline with the current Calypso interface.
* I've omitted the support docs link as we don't yet have the link available.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

