### PR TITLE
E2E: Remove 'errorDisplayed' assertions

### DIFF
--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -70,13 +70,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.enterImageAltText( fileDetails );
 			await gEditorComponent.closeSidebar();
-
-			const errorShown = await gEditorComponent.errorDisplayed();
-			return assert.strictEqual(
-				errorShown,
-				false,
-				'There is an error shown on the Gutenberg editor page!'
-			);
 		} );
 
 		/* Skip until sharing is added in Gutenberg editor
@@ -271,13 +264,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			step( 'Can enter page title and content and set to password protected', async function () {
 				let gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
 				await gHeaderComponent.enterTitle( pageTitle );
-
-				const errorShown = await gHeaderComponent.errorDisplayed();
-				assert.strictEqual(
-					errorShown,
-					false,
-					'There is an error shown on the Gutenberg editor page!'
-				);
 
 				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 				await gSidebarComponent.chooseDocumentSettings();
@@ -544,9 +530,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 
 			const gPaymentComponent = await SimplePaymentsBlockComponent.Expect( driver, blockId );
 			await gPaymentComponent.insertPaymentButtonDetails( paymentButtonDetails );
-
-			const errorShown = await gEditorComponent.errorDisplayed();
-			assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
 
 			await gEditorComponent.enterTitle( pageTitle );
 			await gEditorComponent.ensureSaved();

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -79,13 +79,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.enterImageAltText( fileDetails );
 			await gEditorComponent.closeSidebar();
-
-			const errorShown = await gEditorComponent.errorDisplayed();
-			return assert.strictEqual(
-				errorShown,
-				false,
-				'There is an error shown on the Gutenberg editor page!'
-			);
 		} );
 
 		step( 'Expand Categories and Tags', async function () {
@@ -270,13 +263,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				await gEditorComponent.initEditor();
 				await gEditorComponent.enterTitle( blogPostTitle );
 				await gEditorComponent.enterText( blogPostQuote );
-
-				const errorShown = await gEditorComponent.errorDisplayed();
-				return assert.strictEqual(
-					errorShown,
-					false,
-					'There is an error shown on the Gutenberg editor page!'
-				);
 			} );
 
 			step( 'Can see the Earn blocks', async function () {
@@ -363,9 +349,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.enterTitle( blogPostTitle );
 			await gEditorComponent.enterText( blogPostQuote );
-
-			const errorShown = await gEditorComponent.errorDisplayed();
-			return assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
 		} );
 
 		step( 'Can publish and view content', async function () {
@@ -412,13 +395,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.enterTitle( blogPostTitle );
 				await gEditorComponent.enterText( blogPostQuote );
-
-				const errorShown = await gEditorComponent.errorDisplayed();
-				return assert.strictEqual(
-					errorShown,
-					false,
-					'There is an error shown on the editor page!'
-				);
 			} );
 
 			step(
@@ -596,13 +572,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			step( 'Can enter post title and content and set to password protected', async function () {
 				let gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.enterTitle( blogPostTitle );
-
-				const errorShown = await gEditorComponent.errorDisplayed();
-				assert.strictEqual(
-					errorShown,
-					false,
-					'There is an error shown on the Gutenberg editor page!'
-				);
 
 				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 				await gSidebarComponent.chooseDocumentSettings();
@@ -905,12 +874,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.enterTitle( originalBlogPostTitle );
 				await gEditorComponent.enterText( blogPostQuote );
-				const errorShown = await gEditorComponent.errorDisplayed();
-				return assert.strictEqual(
-					errorShown,
-					false,
-					'There is an error shown on the editor page!'
-				);
 			} );
 
 			step( 'Can publish the post', async function () {
@@ -985,10 +948,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 					'Can set the new title and update it, and link to the updated post',
 					async function () {
 						const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-
 						await gEditorComponent.enterTitle( updatedBlogPostTitle );
-						const errorShown = await gEditorComponent.errorDisplayed();
-						assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
+
 						return await gEditorComponent.update( { visit: true } );
 					}
 				);
@@ -1032,9 +993,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				await gEditorComponent.enterTitle( originalBlogPostTitle );
 				await gEditorComponent.insertContactForm( contactEmail, subject );
 				await gEditorComponent.ensureSaved();
-
-				const errorShown = await gEditorComponent.errorDisplayed();
-				assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
 
 				const contactFormDisplayedInEditor = await gEditorComponent.contactFormDisplayedInEditor();
 				assert.strictEqual(
@@ -1088,9 +1046,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			const gPaymentComponent = await SimplePaymentsBlockComponent.Expect( driver, blockId );
 			await gPaymentComponent.insertPaymentButtonDetails( paymentButtonDetails );
-
-			const errorShown = await gEditorComponent.errorDisplayed();
-			assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
 
 			await gEditorComponent.enterTitle( blogPostTitle );
 			await gEditorComponent.ensureSaved();
@@ -1185,13 +1140,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
 				await gHeaderComponent.enterTitle( originalBlogPostTitle );
 				await gHeaderComponent.enterText( blogPostQuote );
-
-				const errorShown = await gHeaderComponent.errorDisplayed();
-				return assert.strictEqual(
-					errorShown,
-					false,
-					'There is an error shown on the Gutenberg editor page!'
-				);
 			} );
 
 			step( 'Can publish the post', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -127,11 +127,6 @@ function verifyBlockInEditor( Block ) {
 		assert( blockDisplayed, `The block "${ Block.blockName }" was not found in the editor.` );
 	} );
 
-	step( 'Block does not error in the editor', async function () {
-		const errorDisplayed = await editor.errorDisplayed();
-		assert( ! errorDisplayed, `The block "${ Block.blockName }" errored in the editor.` );
-	} );
-
 	step( 'Block does not invalidate', async function () {
 		const hasInvalidBlocks = await editor.hasInvalidBlocks();
 		assert( ! hasInvalidBlocks, `The block "${ Block.blockName }" is invalid.` );

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -484,14 +484,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			await myHomePage.updateHomepageFromSiteSetup();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.initEditor();
-
-			const errorShown = await gEditorComponent.errorDisplayed();
-			assert.strictEqual(
-				errorShown,
-				false,
-				'There is a block editor error when editing the homepage'
-			);
-
 			const hasInvalidBlocks = await gEditorComponent.hasInvalidBlocks();
 			assert.strictEqual(
 				hasInvalidBlocks,
@@ -1113,13 +1105,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			await myHomePage.updateHomepageFromSiteSetup();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.initEditor();
-
-			const errorShown = await gEditorComponent.errorDisplayed();
-			assert.strictEqual(
-				errorShown,
-				false,
-				'There is a block editor error when editing the homepage'
-			);
 
 			const hasInvalidBlocks = await gEditorComponent.hasInvalidBlocks();
 			assert.strictEqual(


### PR DESCRIPTION
These assertions are costly time-wise and don't seem to bring much value. Every time the `errorDisplayed()` is called, it waits until a full timeout ([20 seconds](https://github.com/Automattic/wp-calypso/blob/9c09ecd6a73306b5de97fec57cbaca15f36082be/test/e2e/config/default.json#L3)) is reached, and only then, if the error boundary element is not displayed, continues the suite. I don't think we need to be checking this because, if the Editor errors, the suite will not be able to continue anyway and will fail either on the current or the next step. 

Editor error:
![image](https://user-images.githubusercontent.com/1451471/109515375-4b83fb80-7aa7-11eb-8735-4fe528382c69.png)
