### PR TITLE
Domains: Make the free domain explainer banner non-dismissable

### DIFF
--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -77,8 +77,6 @@ class FreeDomainExplainer extends React.Component {
 				className="free-domain-explainer"
 				callToAction={ translate( 'Review our plans to get started' ) }
 				description={ this.getDescription() }
-				dismissPreferenceName="free-domain-explainer"
-				dismissTemporary
 				horizontal
 				title={ title }
 				primaryButton={ false }


### PR DESCRIPTION
Props to @niranjan-uma-shankar for noticing the issue. Introduced in #49470.

Seems that the `DismissableCard` is not working correctly in the context
of a fresh signup. The remote preferences are not present and there's
nothing to trigger fetching them. Only on refresh, the proper context is
set and the banner appears.

To alleviate these issues and to make the context of the `Free` pricing
on this screen, let's simply make the banner non-dismissable.

#### Testing instructions

Go to wordpress.com/start in a private window. Sign up as a new user. On the domains step, you should see the banner:

<img width="993" alt="Screenshot 2021-03-01 at 17 42 20" src="https://user-images.githubusercontent.com/3392497/109536398-94db4780-7ab5-11eb-9efc-227baadbb833.png">

It should not be dismissable. It should persist on refresh.

Mobile view:
![Screen Shot 2021-03-02 at 17 42 32](https://user-images.githubusercontent.com/3392497/109536437-a15fa000-7ab5-11eb-9394-ecc3899cf105.png)


See also #49470 for other cases that are impacted.