### PR TITLE
Refactor the Launch a Free Site test to not require a signup.

### DIFF
--- a/test/e2e/lib/flows/launch-site-flow.js
+++ b/test/e2e/lib/flows/launch-site-flow.js
@@ -1,9 +1,17 @@
 /**
+ * External dependencies
+ */
+
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import FindADomainComponent from '../components/find-a-domain-component';
 import PickAPlanPage from '../pages/signup/pick-a-plan-page';
 import MyHomePage from '../pages/my-home-page';
+
+import * as driverHelper from '../driver-helper.js';
 
 export default class LaunchSiteFlow {
 	constructor( driver ) {
@@ -18,6 +26,16 @@ export default class LaunchSiteFlow {
 
 		const pickAPlanPage = await PickAPlanPage.Expect( this.driver );
 		await pickAPlanPage.selectFreePlan();
+
+		// Dismiss the domain upsell if present.
+		const dismissDomainUpsellSelector = By.css( ' .domain-upsell__continue-link button ' );
+		const domainUpsellPresent = await driverHelper.isElementPresent(
+			this.driver,
+			dismissDomainUpsellSelector
+		);
+		if ( domainUpsellPresent ) {
+			return await driverHelper.clickWhenClickable( this.driver, dismissDomainUpsellSelector );
+		}
 
 		return await myHomePage.isSiteLaunched();
 	}

--- a/test/e2e/specs/wp-launch-spec.js
+++ b/test/e2e/specs/wp-launch-spec.js
@@ -10,9 +10,11 @@ import * as driverManager from '../lib/driver-manager.js';
 import * as dataHelper from '../lib/data-helper.js';
 
 import SignUpFlow from '../lib/flows/sign-up-flow.js';
+import LoginFlow from '../lib/flows/login-flow.js';
 import CreateSiteFlow from '../lib/flows/create-site-flow.js';
 import LaunchSiteFlow from '../lib/flows/launch-site-flow.js';
 import DeleteAccountFlow from '../lib/flows/delete-account-flow.js';
+import DeleteSiteFlow from '../lib/flows/delete-site-flow.js';
 import SidebarComponent from '../lib/components/sidebar-component';
 import FindADomainComponent from '../lib/components/find-a-domain-component.js';
 import MyHomePage from '../lib/pages/my-home-page.js';
@@ -46,16 +48,20 @@ before( async function () {
 // https://github.com/Automattic/wp-calypso/issues/50547
 // Potential issue that trigger this failure:
 // https://github.com/Automattic/wp-calypso/issues/50273
-describe.skip( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () {
+describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
 	describe( 'Launch a free site', function () {
-		const accountName = dataHelper.getNewBlogName();
 		const siteName = dataHelper.getNewBlogName();
+		console.log( siteName );
 
-		before( 'Create a site as a new user', async function () {
-			await createAndActivateAccount( accountName );
-			await new CreateSiteFlow( driver, siteName ).createFreeSite();
+		before( 'Can log in', async function () {
+			const loginFlow = new LoginFlow( driver );
+			await loginFlow.login();
+		} );
+
+		step( 'Can create a free site', async function () {
+			return await new CreateSiteFlow( driver, siteName ).createFreeSite();
 		} );
 
 		step( 'Can launch a site', async function () {
@@ -63,11 +69,13 @@ describe.skip( `[${ host }] Launch (${ screenSize }) @signup @parallel`, functio
 		} );
 
 		after( 'Delete the newly created account', async function () {
-			return await new DeleteAccountFlow( driver ).deleteAccount( accountName );
+			const deleteSite = new DeleteSiteFlow( driver );
+			return await deleteSite.deleteSite( siteName + '.wordpress.com' );
+			// return await new DeleteAccountFlow( driver ).deleteAccount( accountName );
 		} );
 	} );
 
-	describe( 'Launch when having multiple sites', function () {
+	describe.skip( 'Launch when having multiple sites', function () {
 		const accountName = dataHelper.getNewBlogName();
 		const firstSiteName = dataHelper.getNewBlogName();
 		const secondSiteName = dataHelper.getNewBlogName();

--- a/test/e2e/specs/wp-launch-spec.js
+++ b/test/e2e/specs/wp-launch-spec.js
@@ -63,7 +63,7 @@ describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () 
 			return await new LaunchSiteFlow( driver ).launchFreeSite();
 		} );
 
-		after( 'Delete the newly created account', async function () {
+		after( 'Delete the newly created site', async function () {
 			const deleteSite = new DeleteSiteFlow( driver );
 			return await deleteSite.deleteSite( siteName + '.wordpress.com' );
 		} );

--- a/test/e2e/specs/wp-launch-spec.js
+++ b/test/e2e/specs/wp-launch-spec.js
@@ -44,14 +44,10 @@ before( async function () {
 	driver = await driverManager.startBrowser();
 } );
 
-// Tracking issue:
-// https://github.com/Automattic/wp-calypso/issues/50547
-// Potential issue that trigger this failure:
-// https://github.com/Automattic/wp-calypso/issues/50273
 describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
-	describe.only( 'Launch a free site', function () {
+	describe( 'Launch a free site', function () {
 		const siteName = dataHelper.getNewBlogName();
 		console.log( siteName );
 
@@ -71,10 +67,13 @@ describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () 
 		after( 'Delete the newly created account', async function () {
 			const deleteSite = new DeleteSiteFlow( driver );
 			return await deleteSite.deleteSite( siteName + '.wordpress.com' );
-			// return await new DeleteAccountFlow( driver ).deleteAccount( accountName );
 		} );
 	} );
 
+	// Tracking issue:
+	// https://github.com/Automattic/wp-calypso/issues/50547
+	// Potential issue that trigger this failure:
+	// https://github.com/Automattic/wp-calypso/issues/50273
 	describe.skip( 'Launch when having multiple sites', function () {
 		const accountName = dataHelper.getNewBlogName();
 		const firstSiteName = dataHelper.getNewBlogName();

--- a/test/e2e/specs/wp-launch-spec.js
+++ b/test/e2e/specs/wp-launch-spec.js
@@ -51,7 +51,7 @@ before( async function () {
 describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
-	describe( 'Launch a free site', function () {
+	describe.only( 'Launch a free site', function () {
 		const siteName = dataHelper.getNewBlogName();
 		console.log( siteName );
 

--- a/test/e2e/specs/wp-launch-spec.js
+++ b/test/e2e/specs/wp-launch-spec.js
@@ -49,7 +49,6 @@ describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () 
 
 	describe( 'Launch a free site', function () {
 		const siteName = dataHelper.getNewBlogName();
-		console.log( siteName );
 
 		before( 'Can log in', async function () {
 			const loginFlow = new LoginFlow( driver );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- use existing LoginFlow to log in as existing user to run the test.
- use existing DeleteSiteFlow in place of DeletAccount flow for cleanup.
- add in path to handle Domain Upsell during site launch phase.

#### Testing instructions

Wait for CircleCI to complete, or pull the changes locally and run:

```
 mocha specs/wp-launch-spec.js
```

Example Runs (isolated to just this test):
- https://app.circleci.com/pipelines/github/Automattic/wp-e2e-tests-for-branches/59836/workflows/50ad9a79-c5b9-4703-a6d6-3dad3e331c6c/jobs/145369/parallel-runs/1?filterBy=ALL
- https://app.circleci.com/pipelines/github/Automattic/wp-e2e-tests-for-branches/59837/workflows/20231f2d-df5e-4e10-84a0-8ca879138180/jobs/145370/parallel-runs/1?filterBy=ALL