### PR TITLE
Help: Fix "Contact support" button for test

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -339,7 +339,7 @@ class Help extends React.PureComponent {
 					<Experiment name="calypso_help_contact_button">
 						<Variation name="treatment">
 							<div className="help__contact-us-header-button">
-								<Button onClick={ this.trackContactUsClick }>
+								<Button onClick={ this.trackContactUsClick } href="/help/contact/">
 									{ translate( 'Contact support' ) }
 								</Button>
 							</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I never added a `href` to the support button so it didn't...do anything. 🤦 
* Adds the correct `href` prop so clicking on the button takes you to the support page for the treatment variation for the test introduced in #50384

<img width="1147" alt="Screen Shot 2021-03-01 at 3 43 26 PM" src="https://user-images.githubusercontent.com/2124984/109556768-3a39ef80-7aa5-11eb-95fc-1f3b305db2a9.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/help` and make sure you're running the `treatment` test variation from Abacus (`calypso_help_contact_button`) 
* Click on the button. It should go to `/help/contact/`