### PR TITLE
WooCommerce: Use new standalone WooCommerce installation page instead of extension page

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -785,8 +785,8 @@ export class MySitesSidebar extends Component {
 
 		let storeLink = woocommerceUrl;
 		if ( ! isSiteWpcomStore ) {
-			// Navigate to Store UI for installation.
-			storeLink = '/store' + siteSuffix + '?redirect_after_install';
+			// Navigate to installation.
+			storeLink = '/woocommerce-installation' + siteSuffix;
 		}
 
 		return (

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -86,7 +86,7 @@ describe( 'MySitesSidebar', () => {
 			expect( wrapper.props().link ).toEqual( '/store/mysite.com' );
 		} );
 
-		test( 'Should return Calypsoified store menu item if user can use store on this site and the site is an ecommerce plan', () => {
+		test( 'Should return wp-admin menu item if user can use store on this site and the site is an ecommerce plan', () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseCalypsoStore: true,
 				canUserUseWooCommerceCoreStore: true,
@@ -248,7 +248,7 @@ describe( 'MySitesSidebar', () => {
 			);
 		} );
 
-		test( 'Should return WooCommerce menu item linking to Store UI dashboard if site has Business plan, WooCommerce plugin not installed yet, and user can use store', () => {
+		test( 'Should return WooCommerce menu item linking to installation page if site has Business plan, WooCommerce plugin not installed yet, and user can use store', () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseWooCommerceCoreStore: true,
 				...defaultProps,
@@ -266,7 +266,7 @@ describe( 'MySitesSidebar', () => {
 
 			const wrapper = shallow( <WooCommerce /> );
 			expect( wrapper.html() ).not.toEqual( null );
-			expect( wrapper.props().link ).toEqual( '/store/mysite.com?redirect_after_install' );
+			expect( wrapper.props().link ).toEqual( '/woocommerce-installation/mysite.com' );
 		} );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes #50446 by using the new standalone WooCommerce installation page (introduced in #49879) instead of the old, obsolete installation page from `extensions/woocommerce`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start with a Business site without WooCommerce installed
2. Install the Hello Dolly plugin, to convert the site to Atomic
3. Use the `?disable-nav-unification` query arg to disable Nav Unification when accessing Calypso locally
4. Verify that you have disabled Nav Unification. Your Calypso should look something like this (All the disclosure chevrons, as well as the shopping cart icon for "WooCommerce" are tell-tale signs that you are *not* using Nav Unification)...

<img width="1275" alt="Screen Shot 2021-03-01 at 16 39 53" src="https://user-images.githubusercontent.com/2098816/109562807-de736480-7aac-11eb-9b45-f6c75da7d980.png">


5. Click on "WooCommerce"
6. Click "Set up my store!"
7. Verify that the page auto-redirects to the WooCommerce setup wizard after installing the WooCommerce plugin. You should arrive on this page...

<img width="1275" alt="Screen Shot 2021-03-01 at 16 30 20" src="https://user-images.githubusercontent.com/2098816/109562595-96544200-7aac-11eb-809c-f6c6698034bf.png">


