### PR TITLE
Jetpack Connect Authorize: use withPersistence for custom deserialization 

### DIFF
--- a/client/state/jetpack-connect/constants.js
+++ b/client/state/jetpack-connect/constants.js
@@ -1,4 +1,4 @@
-export const JETPACK_CONNECT_TTL_SECONDS = 60 * 60; // 1 hours in seconds
+export const JETPACK_CONNECT_TTL_SECONDS = 60 * 60; // 1 hour in seconds
 export const JETPACK_CONNECT_TTL = JETPACK_CONNECT_TTL_SECONDS * 1000; // 1 hour
 export const JETPACK_CONNECT_AUTHORIZE_TTL = 60 * 60 * 1000; // 1 hour
 export const AUTH_ATTEMPS_TTL = 60 * 1000; // 1 minute

--- a/client/state/jetpack-connect/constants.js
+++ b/client/state/jetpack-connect/constants.js
@@ -1,4 +1,4 @@
-export const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 hour
-export const JETPACK_CONNECT_TTL_SECONDS = JETPACK_CONNECT_TTL / 60;
+export const JETPACK_CONNECT_TTL_SECONDS = 60 * 60; // 1 hours in seconds
+export const JETPACK_CONNECT_TTL = JETPACK_CONNECT_TTL_SECONDS * 1000; // 1 hour
 export const JETPACK_CONNECT_AUTHORIZE_TTL = 60 * 60 * 1000; // 1 hour
 export const AUTH_ATTEMPS_TTL = 60 * 1000; // 1 minute

--- a/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
@@ -7,10 +7,10 @@ import { isEmpty } from 'lodash';
  * Internal dependencies
  */
 import { isStale } from '../utils';
-import { withSchemaValidation } from 'calypso/state/utils';
+import { withSchemaValidation, withPersistence } from 'calypso/state/utils';
 import { JETPACK_CONNECT_AUTHORIZE_TTL } from '../constants';
 import { jetpackConnectAuthorizeSchema } from './schema';
-import { DESERIALIZE, SITE_REQUEST_FAILURE } from 'calypso/state/action-types';
+import { SITE_REQUEST_FAILURE } from 'calypso/state/action-types';
 import {
 	JETPACK_CONNECT_AUTHORIZE,
 	JETPACK_CONNECT_AUTHORIZE_LOGIN_COMPLETE,
@@ -77,15 +77,20 @@ function jetpackConnectAuthorize( state = {}, action ) {
 		case JETPACK_CONNECT_COMPLETE_FLOW:
 			return {};
 
-		case DESERIALIZE:
-			if ( isStale( state.timestamp, JETPACK_CONNECT_AUTHORIZE_TTL ) ) {
-				return {};
-			}
-			return state;
-
 		default:
 			return state;
 	}
 }
 
-export default withSchemaValidation( jetpackConnectAuthorizeSchema, jetpackConnectAuthorize );
+export default withSchemaValidation(
+	jetpackConnectAuthorizeSchema,
+	withPersistence( jetpackConnectAuthorize, {
+		deserialize( persisted ) {
+			if ( isStale( persisted.timestamp, JETPACK_CONNECT_AUTHORIZE_TTL ) ) {
+				return {};
+			}
+
+			return persisted;
+		},
+	} )
+);


### PR DESCRIPTION
Use `withPersistence` for custom deserialize handler (one that drops state that's too old) in `state.jetpackConnect.jetpackConnectAuthorize`.

Also fixes an incorrect value of the `JETPACK_CONNECT_TTL_SECONDS` constant. Used to set `maxAge` field of the `jetpack_connect_session_url` cookie.