### PR TITLE
Connection state: simplify reducer and its tests

### DIFF
--- a/client/state/application/reducer.js
+++ b/client/state/application/reducer.js
@@ -3,9 +3,9 @@
  */
 import { withStorageKey } from '@automattic/state-utils';
 import { CONNECTION_LOST, CONNECTION_RESTORED } from 'calypso/state/action-types';
-import { combineReducers, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers } from 'calypso/state/utils';
 
-export const connectionState = withoutPersistence( ( state = 'CHECKING', action ) => {
+const connectionState = ( state = 'CHECKING', action ) => {
 	switch ( action.type ) {
 		case CONNECTION_LOST:
 			return 'OFFLINE';
@@ -14,7 +14,6 @@ export const connectionState = withoutPersistence( ( state = 'CHECKING', action 
 	}
 
 	return state;
-} );
+};
 
-const combinedReducer = combineReducers( { connectionState } );
-export default withStorageKey( 'application', combinedReducer );
+export default withStorageKey( 'application', combineReducers( { connectionState } ) );

--- a/client/state/application/test/reducer.js
+++ b/client/state/application/test/reducer.js
@@ -1,51 +1,25 @@
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
-import { connectionState } from '../reducer';
-import {
-	CONNECTION_LOST,
-	CONNECTION_RESTORED,
-	SERIALIZE,
-	DESERIALIZE,
-} from 'calypso/state/action-types';
+import reducer from '../reducer';
+import { CONNECTION_LOST, CONNECTION_RESTORED } from 'calypso/state/action-types';
 
 describe( 'state/application reducer', () => {
 	describe( '#connectionState()', () => {
-		test( 'should default to CHECKING when no arguments provided', () => {
-			expect( connectionState( undefined, {} ) ).to.equal( 'CHECKING' );
+		test( 'should default to CHECKING as initial state', () => {
+			expect( reducer( undefined, { type: 'INIT' } ) ).toEqual( { connectionState: 'CHECKING' } );
 		} );
 
 		test( 'should be ONLINE when action CONNECTION_RESTORED dispatched', () => {
-			expect( connectionState( undefined, { type: CONNECTION_RESTORED } ) ).to.equal( 'ONLINE' );
+			expect( reducer( undefined, { type: CONNECTION_RESTORED } ) ).toEqual( {
+				connectionState: 'ONLINE',
+			} );
 		} );
 
 		test( 'should be OFFLINE when action CONNECTION_LOST dispatched', () => {
-			expect( connectionState( undefined, { type: CONNECTION_LOST } ) ).to.equal( 'OFFLINE' );
-		} );
-
-		test( 'never persists online state', () => {
-			const state = connectionState( 'ONLINE', { type: SERIALIZE } );
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'never persists offline state', () => {
-			const state = connectionState( 'OFFLINE', { type: SERIALIZE } );
-			expect( state ).to.be.undefined;
-		} );
-
-		test( 'always uses initialState, even if given offline', () => {
-			const state = connectionState( 'OFFLINE', { type: DESERIALIZE } );
-			expect( state ).to.eql( 'CHECKING' );
-		} );
-
-		test( 'always uses initialState, even if given online', () => {
-			const state = connectionState( 'ONLINE', { type: DESERIALIZE } );
-			expect( state ).to.eql( 'CHECKING' );
+			expect( reducer( undefined, { type: CONNECTION_LOST } ) ).toEqual( {
+				connectionState: 'OFFLINE',
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
Removes `withoutPersistence` wrapper and tests that test serialization behavior. Also updates the tests so that the module only needs to export one reducer, not multiple sub-reducers.