### PR TITLE
Premium Plugins state: use withPersitence, remove key for errors, test Error object

### DIFF
--- a/client/state/plugins/premium/reducer.js
+++ b/client/state/plugins/premium/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { mapValues, omit } from 'lodash';
+import { mapValues, omit, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -73,12 +73,16 @@ const pluginsReducer = ( state = {}, action ) => {
 export const plugins = withSchemaValidation(
 	pluginInstructionSchema,
 	withPersistence( pluginsReducer, {
-		// Save the error state as a string message and omit the `key` field.
+		// - save only selected fields of an error (an `Error` instance is not serializable per se)
+		// - omit the `key` field.
 		serialize: ( state ) =>
 			mapValues( state, ( pluginList ) =>
 				pluginList.map( ( item ) => {
-					if ( item.error != null ) {
-						item = { ...item, error: item.error.toString() };
+					if ( item.error ) {
+						item = {
+							...item,
+							error: pick( item.error, [ 'name', 'code', 'error', 'message' ] ),
+						};
 					}
 					return omit( item, 'key' );
 				} )

--- a/client/state/plugins/premium/reducer.js
+++ b/client/state/plugins/premium/reducer.js
@@ -14,9 +14,8 @@ import {
 	PLUGIN_SETUP_CONFIGURE,
 	PLUGIN_SETUP_FINISH,
 	PLUGIN_SETUP_ERROR,
-	SERIALIZE,
 } from 'calypso/state/action-types';
-import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation, withPersistence } from 'calypso/state/utils';
 import { pluginInstructionSchema } from './schema';
 
 /*
@@ -51,7 +50,7 @@ export function hasRequested( state = {}, action ) {
  * Tracks all known premium plugin objects (plugin meta and install status),
  * indexed by site ID.
  */
-export const plugins = withSchemaValidation( pluginInstructionSchema, ( state = {}, action ) => {
+const pluginsReducer = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case PLUGIN_SETUP_INSTRUCTIONS_RECEIVE:
 			return Object.assign( {}, state, { [ action.siteId ]: action.data } );
@@ -66,20 +65,26 @@ export const plugins = withSchemaValidation( pluginInstructionSchema, ( state = 
 				} );
 			}
 			return state;
-		case SERIALIZE:
-			// Save the error state as a string message.
-			return mapValues( state, ( pluginList ) =>
-				pluginList.map( ( item ) => {
-					if ( item.error !== null ) {
-						return Object.assign( {}, item, { error: item.error.toString() } );
-					}
-					return omit( item, 'key' );
-				} )
-			);
 		default:
 			return state;
 	}
-} );
+};
+
+export const plugins = withSchemaValidation(
+	pluginInstructionSchema,
+	withPersistence( pluginsReducer, {
+		// Save the error state as a string message and omit the `key` field.
+		serialize: ( state ) =>
+			mapValues( state, ( pluginList ) =>
+				pluginList.map( ( item ) => {
+					if ( item.error != null ) {
+						item = { ...item, error: item.error.toString() };
+					}
+					return omit( item, 'key' );
+				} )
+			),
+	} )
+);
 
 /*
  * Tracks the list of premium plugin objects for a single site

--- a/client/state/plugins/premium/reducer.js
+++ b/client/state/plugins/premium/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { mapValues, omit, pick } from 'lodash';
+import { mapValues, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -70,6 +70,14 @@ const pluginsReducer = ( state = {}, action ) => {
 	}
 };
 
+// pick selected properties from the error object and ignore ones that are `undefined`.
+const serializeError = ( error ) =>
+	Object.fromEntries(
+		[ 'name', 'code', 'error', 'message' ]
+			.map( ( k ) => [ k, error[ k ] ] )
+			.filter( ( [ , v ] ) => v !== undefined )
+	);
+
 export const plugins = withSchemaValidation(
 	pluginInstructionSchema,
 	withPersistence( pluginsReducer, {
@@ -81,7 +89,7 @@ export const plugins = withSchemaValidation(
 					if ( item.error ) {
 						item = {
 							...item,
-							error: pick( item.error, [ 'name', 'code', 'error', 'message' ] ),
+							error: serializeError( item.error ),
 						};
 					}
 					return omit( item, 'key' );

--- a/client/state/plugins/premium/test/reducer.js
+++ b/client/state/plugins/premium/test/reducer.js
@@ -218,7 +218,7 @@ describe( 'premium reducer', () => {
 			} );
 		} );
 
-		test( 'should serialize just the error message for errored plugins', () => {
+		test( 'should serialize selected error fields for errored plugins', () => {
 			const originalState = deepFreeze( {
 				'error-site': [
 					{
@@ -237,7 +237,7 @@ describe( 'premium reducer', () => {
 						slug: 'vaultpress',
 						name: 'VaultPress',
 						status: 'done',
-						error: 'Error: Something went wrong.',
+						error: { name: 'Error', message: 'Something went wrong.' },
 					},
 				],
 			} );

--- a/client/state/plugins/premium/test/reducer.js
+++ b/client/state/plugins/premium/test/reducer.js
@@ -218,7 +218,7 @@ describe( 'premium reducer', () => {
 			} );
 		} );
 
-		test( 'should serialize just the error for errored plugins', () => {
+		test( 'should serialize just the error message for errored plugins', () => {
 			const originalState = deepFreeze( {
 				'error-site': [
 					{
@@ -226,7 +226,7 @@ describe( 'premium reducer', () => {
 						name: 'VaultPress',
 						key: 'vp-api-key',
 						status: 'done',
-						error: { name: 'ErrorCode', message: 'Something went wrong.' },
+						error: new Error( 'Something went wrong.' ),
 					},
 				],
 			} );
@@ -236,9 +236,8 @@ describe( 'premium reducer', () => {
 					{
 						slug: 'vaultpress',
 						name: 'VaultPress',
-						key: 'vp-api-key',
 						status: 'done',
-						error: '[object Object]',
+						error: 'Error: Something went wrong.',
 					},
 				],
 			} );


### PR DESCRIPTION
Uses `withPersistence` for custom serialization in `plugins/premium` reducer.

That serialization handler converts an `Error` object to string. It also omits `key` field from the serialized object. This patch extends that omit also to the error state -- that seems to have been the intent from the start. See also #26829.

I also updated the unit test to test a real `Error` object that serializes to something more interesting than `[object Object]`.