### PR TITLE
Push Notifications state: use withPersistence for custom de/serialization

### DIFF
--- a/client/state/push-notifications/reducer.js
+++ b/client/state/push-notifications/reducer.js
@@ -8,11 +8,10 @@ import { omit } from 'lodash';
  * Internal dependencies
  */
 import { withStorageKey } from '@automattic/state-utils';
-import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation, withPersistence } from 'calypso/state/utils';
 import { settingsSchema, systemSchema } from './schema';
 
 import {
-	DESERIALIZE,
 	PUSH_NOTIFICATIONS_API_READY,
 	PUSH_NOTIFICATIONS_AUTHORIZE,
 	PUSH_NOTIFICATIONS_BLOCK,
@@ -21,21 +20,15 @@ import {
 	PUSH_NOTIFICATIONS_RECEIVE_UNREGISTER_DEVICE,
 	PUSH_NOTIFICATIONS_TOGGLE_ENABLED,
 	PUSH_NOTIFICATIONS_TOGGLE_UNBLOCK_INSTRUCTIONS,
-	SERIALIZE,
 } from 'calypso/state/action-types';
+
 const debug = debugFactory( 'calypso:push-notifications' );
 
 // If you change this, also change the corresponding test
 const UNPERSISTED_SYSTEM_NODES = [ 'apiReady', 'authorized', 'authorizationLoaded', 'blocked' ];
-const system = withSchemaValidation( systemSchema, ( state = {}, action ) => {
+
+const systemReducer = ( state = {}, action ) => {
 	switch ( action.type ) {
-		// System state is not persisted
-		case DESERIALIZE:
-			return omit( state, UNPERSISTED_SYSTEM_NODES );
-
-		case SERIALIZE:
-			return omit( state, UNPERSISTED_SYSTEM_NODES );
-
 		case PUSH_NOTIFICATIONS_API_READY: {
 			debug( 'API is ready' );
 			return Object.assign( {}, state, {
@@ -95,7 +88,15 @@ const system = withSchemaValidation( systemSchema, ( state = {}, action ) => {
 	}
 
 	return state;
-} );
+};
+
+const system = withSchemaValidation(
+	systemSchema,
+	withPersistence( systemReducer, {
+		serialize: ( state ) => omit( state, UNPERSISTED_SYSTEM_NODES ),
+		deserialize: ( persisted ) => omit( persisted, UNPERSISTED_SYSTEM_NODES ),
+	} )
+);
 
 // If you change this, also change the corresponding test
 const UNPERSISTED_SETTINGS_NODES = [
@@ -103,16 +104,8 @@ const UNPERSISTED_SETTINGS_NODES = [
 	'showingUnblockInstructions',
 ];
 
-const settings = withSchemaValidation( settingsSchema, ( state = { enabled: false }, action ) => {
+const settingsReducer = ( state = { enabled: false }, action ) => {
 	switch ( action.type ) {
-		case DESERIALIZE: {
-			return omit( state, UNPERSISTED_SETTINGS_NODES );
-		}
-
-		case SERIALIZE: {
-			return omit( state, UNPERSISTED_SETTINGS_NODES );
-		}
-
 		case PUSH_NOTIFICATIONS_TOGGLE_ENABLED: {
 			return Object.assign( {}, state, {
 				enabled: ! state.enabled,
@@ -133,7 +126,15 @@ const settings = withSchemaValidation( settingsSchema, ( state = { enabled: fals
 	}
 
 	return state;
-} );
+};
+
+const settings = withSchemaValidation(
+	settingsSchema,
+	withPersistence( settingsReducer, {
+		serialize: ( state ) => omit( state, UNPERSISTED_SETTINGS_NODES ),
+		deserialize: ( persisted ) => omit( persisted, UNPERSISTED_SETTINGS_NODES ),
+	} )
+);
 
 const combinedReducer = combineReducers( {
 	settings,


### PR DESCRIPTION
Rewrite (de)serialization handlers (they omit certain fields) to `withPersistence`.

Spinoff from #50222.