### PR TITLE
Themes and Posts State: use withPersistence to serialize QueryManagers

### DIFF
--- a/client/state/utils/schema-utils.js
+++ b/client/state/utils/schema-utils.js
@@ -13,7 +13,8 @@ import warn from '@wordpress/warning';
 /**
  * Internal dependencies
  */
-import { DESERIALIZE, SERIALIZE } from 'calypso/state/action-types';
+import { serialize } from './serialize';
+import { DESERIALIZE } from 'calypso/state/action-types';
 
 export function isValidStateWithSchema( state, schema, debugInfo ) {
 	const validate = validator( schema, {
@@ -59,7 +60,7 @@ function isValidSerializedState( schema, reducer, state ) {
 	// Note that we need to serialize the initial state to make a correct check. For reducers
 	// with custom persistence, the initial state can be arbitrary non-serializable object. We
 	// need to compare two serialized objects.
-	const serializedInitialState = reducer( undefined, { type: SERIALIZE } );
+	const serializedInitialState = serialize( reducer, getInitialState( reducer ) );
 	if ( isEqual( state, serializedInitialState ) ) {
 		return true;
 	}


### PR DESCRIPTION
This PR updates the Themes and Posts reducers, which both use a `*QueryManager` to represent the state, to serialize them using the `withPersistence` helper.

It also removes several instances of `withoutPersistence` from the Themes reducer.

Tip for reviewers: when ignoring whitespaces (`git diff -w`) this diff is much shorter and easier to read.

Spinoff from #50222.

**How to test:**
All the affected functionality is covered by unit tests.
