### PR TITLE
Refactor the Basic Post test case.

### DIFF
--- a/test/e2e/specs/wp-calypso-gutenberg-blocks-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-blocks-spec.js
@@ -31,7 +31,7 @@ before( async function () {
 describe( `[${ host }] Calypso Gutenberg Editor: Blocks (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
 
-	describe( 'Can see monetization blocks @canary @parallel', function () {
+	describe( 'Can see monetization blocks in block inserter @canary @parallel', function () {
 		step( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );

--- a/test/e2e/specs/wp-calypso-gutenberg-blocks-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-blocks-spec.js
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import assert from 'assert';
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import LoginFlow from '../lib/flows/login-flow.js';
+
+import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
+
+import * as driverManager from '../lib/driver-manager';
+import * as dataHelper from '../lib/data-helper';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+const host = dataHelper.getJetpackHost();
+const gutenbergUser =
+	process.env.GUTENBERG_EDGE === 'true' ? 'gutenbergSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
+
+let driver;
+
+before( async function () {
+	this.timeout( startBrowserTimeoutMS );
+	driver = await driverManager.startBrowser();
+} );
+
+describe( `[${ host }] Calypso Gutenberg Editor: Blocks (${ screenSize })`, function () {
+	this.timeout( mochaTimeOut );
+
+	describe( 'Can see monetization blocks @canary @parallel', function () {
+		step( 'Can log in', async function () {
+			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			return await this.loginFlow.loginAndStartNewPost( null, true );
+		} );
+
+		step( 'Can see the Earn blocks', async function () {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.openBlockInserterAndSearch( 'earn' );
+			const shownItems = await gEditorComponent.getShownBlockInserterItems();
+
+			[
+				'Donations',
+				'OpenTable',
+				'Payments',
+				'Pay with PayPal',
+				'Pricing Table',
+			].forEach( ( block ) =>
+				assert.ok(
+					shownItems.includes( block ),
+					`Block inserter doesn't show the ${ block } block`
+				)
+			);
+
+			await gEditorComponent.closeBlockInserter();
+		} );
+
+		step( 'Can see the Grow blocks', async function () {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.openBlockInserterAndSearch( 'grow' );
+			const shownItems = await gEditorComponent.getShownBlockInserterItems();
+
+			[
+				'Business Hours',
+				'Calendly',
+				'Form',
+				'Contact Info',
+				'Mailchimp',
+				'Revue',
+				'Subscription Form',
+				'Premium Content',
+				'Click to Tweet',
+				'Logos',
+				'Contact Form',
+				'RSVP Form',
+				'Registration Form',
+				'Appointment Form',
+				'Feedback Form',
+				'WhatsApp Button',
+			].forEach( ( block ) =>
+				assert.ok(
+					shownItems.includes( block ),
+					`Block inserter doesn't show the ${ block } block`
+				)
+			);
+
+			await gEditorComponent.closeBlockInserter();
+		} );
+	} );
+} );

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -279,59 +279,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'Can see the Earn blocks', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-				await gEditorComponent.openBlockInserterAndSearch( 'earn' );
-				const shownItems = await gEditorComponent.getShownBlockInserterItems();
-
-				[
-					'Donations',
-					'OpenTable',
-					'Payments',
-					'Pay with PayPal',
-					'Pricing Table',
-				].forEach( ( block ) =>
-					assert.ok(
-						shownItems.includes( block ),
-						`Block inserter doesn't show the ${ block } block`
-					)
-				);
-
-				await gEditorComponent.closeBlockInserter();
-			} );
-
-			step( 'Can see the Grow blocks', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-				await gEditorComponent.openBlockInserterAndSearch( 'grow' );
-				const shownItems = await gEditorComponent.getShownBlockInserterItems();
-
-				[
-					'Business Hours',
-					'Calendly',
-					'Form',
-					'Contact Info',
-					'Mailchimp',
-					'Revue',
-					'Subscription Form',
-					'Premium Content',
-					'Click to Tweet',
-					'Logos',
-					'Contact Form',
-					'RSVP Form',
-					'Registration Form',
-					'Appointment Form',
-					'Feedback Form',
-					'WhatsApp Button',
-				].forEach( ( block ) =>
-					assert.ok(
-						shownItems.includes( block ),
-						`Block inserter doesn't show the ${ block } block`
-					)
-				);
-
-				await gEditorComponent.closeBlockInserter();
-			} );
-
 			step( 'Can publish and view content', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.publish( { visit: true } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- split the verification of certain blocks being visible to a new test file, named `wp-calypso-gutenberg-blocks-spec.js`.
- define the new file as canary and parallel test.

#### Testing instructions

Run and check CircleCI results.

Run locally with:
```
mocha specs/wp-calypso-gutenberg-blocks-spec.js
```

Relates to #50546.