### PR TITLE
E2E: Wait for the Publish button to not be disabled

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -22,15 +22,15 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		super( driver, By.css( '.edit-post-header' ), url );
 		this.editorType = editorType;
 
-		this.publishSelector = By.css(
-			'.editor-post-publish-panel__header-publish-button button.editor-post-publish-button'
+		this.editoriFrameSelector = By.css( '.calypsoify.is-iframe iframe' );
+		this.publishHeaderSelector = By.css( '.editor-post-publish-panel__header' );
+		this.prePublishButtonSelector = By.css( '.editor-post-publish-panel__toggle' );
+		this.publishButtonSelector = By.css(
+			'.editor-post-publish-panel__header-publish-button button.editor-post-publish-button[aria-disabled="false"]'
 		);
 		this.publishingSpinnerSelector = By.css(
 			'.editor-post-publish-panel__content .components-spinner'
 		);
-		this.prePublishButtonSelector = By.css( '.editor-post-publish-panel__toggle' );
-		this.publishHeaderSelector = By.css( '.editor-post-publish-panel__header' );
-		this.editoriFrameSelector = By.css( '.calypsoify.is-iframe iframe' );
 	}
 
 	static async Expect( driver, editorType ) {
@@ -68,10 +68,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async publish( { visit = false, closePanel = true } = {} ) {
 		await driverHelper.clickWhenClickable( this.driver, this.prePublishButtonSelector );
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishHeaderSelector );
-		await this.driver.sleep( 1000 );
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishSelector );
-		await driverHelper.clickWhenClickable( this.driver, this.publishSelector );
+		await driverHelper.clickWhenClickable( this.driver, this.publishButtonSelector );
 		await driverHelper.waitTillNotPresent( this.driver, this.publishingSpinnerSelector );
 
 		if ( closePanel ) {
@@ -606,7 +603,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			By.css( '.editor-post-publish-panel__link' ),
 			publishDate
 		);
-		await driverHelper.clickWhenClickable( this.driver, this.publishSelector );
+		await driverHelper.clickWhenClickable( this.driver, this.publishButtonSelector );
 		await driverHelper.waitTillNotPresent( this.driver, this.publishingSpinnerSelector );
 		await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,
@@ -629,7 +626,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async submitForReview() {
 		await driverHelper.clickWhenClickable( this.driver, this.prePublishButtonSelector );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishHeaderSelector );
-		return await driverHelper.clickWhenClickable( this.driver, this.publishSelector );
+		return await driverHelper.clickWhenClickable( this.driver, this.publishButtonSelector );
 	}
 
 	async closeEditor() {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -24,7 +24,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		this.editoriFrameSelector = By.css( '.calypsoify.is-iframe iframe' );
 		this.publishHeaderSelector = By.css( '.editor-post-publish-panel__header' );
-		this.prePublishButtonSelector = By.css( '.editor-post-publish-panel__toggle' );
+		this.prePublishButtonSelector = By.css(
+			'.editor-post-publish-panel__toggle[aria-disabled="false"]'
+		);
 		this.publishButtonSelector = By.css(
 			'.editor-post-publish-panel__header-publish-button button.editor-post-publish-button[aria-disabled="false"]'
 		);

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -264,59 +264,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				await gEditorComponent.enterText( blogPostQuote );
 			} );
 
-			step( 'Can see the Earn blocks', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-				await gEditorComponent.openBlockInserterAndSearch( 'earn' );
-				const shownItems = await gEditorComponent.getShownBlockInserterItems();
-
-				[
-					'Donations',
-					'OpenTable',
-					'Payments',
-					'Pay with PayPal',
-					'Pricing Table',
-				].forEach( ( block ) =>
-					assert.ok(
-						shownItems.includes( block ),
-						`Block inserter doesn't show the ${ block } block`
-					)
-				);
-
-				await gEditorComponent.closeBlockInserter();
-			} );
-
-			step( 'Can see the Grow blocks', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-				await gEditorComponent.openBlockInserterAndSearch( 'grow' );
-				const shownItems = await gEditorComponent.getShownBlockInserterItems();
-
-				[
-					'Business Hours',
-					'Calendly',
-					'Form',
-					'Contact Info',
-					'Mailchimp',
-					'Revue',
-					'Subscription Form',
-					'Premium Content',
-					'Click to Tweet',
-					'Logos',
-					'Contact Form',
-					'RSVP Form',
-					'Registration Form',
-					'Appointment Form',
-					'Feedback Form',
-					'WhatsApp Button',
-				].forEach( ( block ) =>
-					assert.ok(
-						shownItems.includes( block ),
-						`Block inserter doesn't show the ${ block } block`
-					)
-				);
-
-				await gEditorComponent.closeBlockInserter();
-			} );
-
 			step( 'Can publish and view content', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.publish( { visit: true } );

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -264,6 +264,59 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				await gEditorComponent.enterText( blogPostQuote );
 			} );
 
+			step( 'Can see the Earn blocks', async function () {
+				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				await gEditorComponent.openBlockInserterAndSearch( 'earn' );
+				const shownItems = await gEditorComponent.getShownBlockInserterItems();
+
+				[
+					'Donations',
+					'OpenTable',
+					'Payments',
+					'Pay with PayPal',
+					'Pricing Table',
+				].forEach( ( block ) =>
+					assert.ok(
+						shownItems.includes( block ),
+						`Block inserter doesn't show the ${ block } block`
+					)
+				);
+
+				await gEditorComponent.closeBlockInserter();
+			} );
+
+			step( 'Can see the Grow blocks', async function () {
+				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				await gEditorComponent.openBlockInserterAndSearch( 'grow' );
+				const shownItems = await gEditorComponent.getShownBlockInserterItems();
+
+				[
+					'Business Hours',
+					'Calendly',
+					'Form',
+					'Contact Info',
+					'Mailchimp',
+					'Revue',
+					'Subscription Form',
+					'Premium Content',
+					'Click to Tweet',
+					'Logos',
+					'Contact Form',
+					'RSVP Form',
+					'Registration Form',
+					'Appointment Form',
+					'Feedback Form',
+					'WhatsApp Button',
+				].forEach( ( block ) =>
+					assert.ok(
+						shownItems.includes( block ),
+						`Block inserter doesn't show the ${ block } block`
+					)
+				);
+
+				await gEditorComponent.closeBlockInserter();
+			} );
+
 			step( 'Can publish and view content', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.publish( { visit: true } );


### PR DESCRIPTION
This should fix some flakiness around publishing posts. When the editor performs autosave, the Publish buttons get disabled until the save request is done. These buttons are not technically `disabled` though (meaning they're still clickable), as only the `aria-disabled` attribute is being set. As a result, the `clickWhenClickable()` helper clicks a "disabled" button, then nothing happens and the test fails. The `clickWhenClickable()` helper does not address these kinds of situations (doesn't check whether an element is disabled in any way), so we're fixing this issue by using a more explicit selector and waiting for the button to not be disabled. Whether `clickWhenClickable()` should address these kinds of situations can be discussed in a follow-up PR.

Also, I'm reverting the scripted click hack as the fix from https://github.com/Automattic/wp-calypso/pull/39205 doesn't seem to be necessary anymore.