### PR TITLE
Framework: Refactor away from _.noop()

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-description/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-description/edit.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -105,7 +104,7 @@ function SiteDescriptionEdit( {
 				identifier="content"
 				onChange={ updateValue }
 				onReplace={ insertDefaultBlock }
-				onSplit={ noop }
+				onSplit={ () => {} }
 				placeholder={ __( 'Add a Site Description', 'full-site-editing' ) }
 				style={ {
 					backgroundColor: backgroundColor.color,

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-title/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-title/edit.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -87,7 +86,7 @@ function SiteTitleEdit( {
 				identifier="content"
 				onChange={ updateValue }
 				onReplace={ insertDefaultBlock }
-				onSplit={ noop }
+				onSplit={ () => {} }
 				placeholder={ __( 'Add a Site Title', 'full-site-editing' ) }
 				style={ {
 					color: textColor.color,

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/template/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/template/edit.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -169,7 +169,7 @@ const TemplateEdit = compose(
 									clientId={ templateBlock.clientId }
 									isSelected={ false }
 									name={ templateBlock.name }
-									setAttributes={ noop }
+									setAttributes={ () => {} }
 								/>
 							</div>
 						</Disabled>

--- a/apps/notifications/src/panel/Notifications.jsx
+++ b/apps/notifications/src/panel/Notifications.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { Provider } from 'react-redux';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -56,7 +55,7 @@ export class Notifications extends PureComponent {
 		isShowing: false,
 		isVisible: false,
 		locale: 'en',
-		receiveMessage: noop,
+		receiveMessage: () => {},
 	};
 
 	UNSAFE_componentWillMount() {

--- a/apps/notifications/src/panel/templates/image-loader.jsx
+++ b/apps/notifications/src/panel/templates/image-loader.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop } from 'lodash';
 
 /**
  * Module variables
@@ -60,8 +59,8 @@ export class ImageLoader extends Component {
 			return;
 		}
 
-		this.image.onload = noop;
-		this.image.onerror = noop;
+		this.image.onload = () => {};
+		this.image.onerror = () => {};
 		delete this.image;
 	};
 

--- a/apps/notifications/src/panel/templates/nav-button.jsx
+++ b/apps/notifications/src/panel/templates/nav-button.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,7 +32,7 @@ export class NavButton extends Component {
 			<button
 				className={ classNames( className, { disabled: ! isEnabled } ) }
 				disabled={ ! isEnabled }
-				onClick={ isEnabled ? this.navigate : noop }
+				onClick={ isEnabled ? this.navigate : () => {} }
 			>
 				<Gridicon icon={ iconName } size={ 18 } />
 			</button>

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -4,7 +4,7 @@
 import { use, select } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
 import { applyFilters } from '@wordpress/hooks';
-import { castArray, noop, find } from 'lodash';
+import { castArray, find } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -86,7 +86,7 @@ const ensureBlockObject = ( block ) => {
  * @param {object}   parentBlock       parent block. optional.
  * @returns {void}
  */
-function trackBlocksHandler( blocks, eventName, propertiesHandler = noop, parentBlock ) {
+function trackBlocksHandler( blocks, eventName, propertiesHandler = () => {}, parentBlock ) {
 	const castBlocks = castArray( blocks );
 	if ( ! castBlocks || ! castBlocks.length ) {
 		return;

--- a/client/auth/test/login.jsx
+++ b/client/auth/test/login.jsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -66,7 +66,9 @@ describe( 'LoginTest', () => {
 	test( 'submits login form', () => {
 		return new Promise( ( done ) => {
 			page.setState( { login: 'user', password: 'pass', auth_code: 'otp' }, function () {
-				page.find( 'form' ).simulate( 'submit', { preventDefault: noop, stopPropagation: noop } );
+				page
+					.find( 'form' )
+					.simulate( 'submit', { preventDefault: () => {}, stopPropagation: () => {} } );
 
 				expect( makeAuthRequest ).to.have.been.calledOnce;
 				expect( makeAuthRequest.calledWith( 'user', 'pass', 'otp' ) ).to.be.true;

--- a/client/blocks/all-sites/index.jsx
+++ b/client/blocks/all-sites/index.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -25,7 +24,7 @@ import './style.scss';
 
 class AllSites extends Component {
 	static defaultProps = {
-		onSelect: noop,
+		onSelect: () => {},
 		href: null,
 		isSelected: false,
 		isHighlighted: false,

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -7,7 +7,7 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { get, identity, includes, noop } from 'lodash';
+import { get, identity, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -71,9 +71,9 @@ export class AppBanner extends Component {
 	};
 
 	static defaultProps = {
-		saveDismissTime: noop,
+		saveDismissTime: () => {},
 		translate: identity,
-		recordAppBannerOpen: noop,
+		recordAppBannerOpen: () => {},
 		userAgent: typeof window !== 'undefined' ? window.navigator.userAgent : '',
 	};
 

--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { identity, noop, sample } from 'lodash';
+import { identity, sample } from 'lodash';
 import store from 'store';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -219,7 +219,7 @@ export class AppPromo extends React.Component {
 
 AppPromo.defaultProps = {
 	translate: identity,
-	recordTracksEvent: noop,
+	recordTracksEvent: () => {},
 	saveDismissal: () => store.set( 'desktop_promo_disabled', true ),
 	getPromoLink,
 };

--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import Gridicon from 'calypso/components/gridicon';
 import classNames from 'classnames';
-import { noop, pick } from 'lodash';
+import { pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -42,10 +42,10 @@ class CalendarButton extends Component {
 		icon: 'calendar',
 		type: 'button',
 		popoverPosition: 'bottom',
-		onDateChange: noop,
-		onDayMouseEnter: noop,
-		onDayMouseLeave: noop,
-		onClose: noop,
+		onDateChange: () => {},
+		onDayMouseEnter: () => {},
+		onDayMouseLeave: () => {},
+		onClose: () => {},
 	};
 
 	state = { showPopover: false };

--- a/client/blocks/calendar-popover/index.jsx
+++ b/client/blocks/calendar-popover/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { noop, pick } from 'lodash';
+import { pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -48,9 +48,9 @@ class CalendarPopover extends Component {
 
 	static defaultProps = {
 		timezoneValue: '',
-		onDateChange: noop,
-		onDayMouseEnter: noop,
-		onDayMouseLeave: noop,
+		onDateChange: () => {},
+		onDayMouseEnter: () => {},
+		onDayMouseLeave: () => {},
 	};
 
 	state = {

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
-import { noop, omitBy } from 'lodash';
+import { omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -61,7 +61,7 @@ CommentButton.propTypes = {
 CommentButton.defaultProps = {
 	commentCount: 0,
 	href: null,
-	onClick: noop,
+	onClick: () => {},
 	showLabel: true,
 	size: 24,
 	tagName: 'li',

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import classnames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -135,7 +134,7 @@ const CommentActions = ( {
 };
 
 CommentActions.defaultProps = {
-	onReadMore: noop,
+	onReadMore: () => {},
 };
 
 const mapDispatchToProps = ( dispatch, ownProps ) => {

--- a/client/blocks/comments/comment-approve-action.jsx
+++ b/client/blocks/comments/comment-approve-action.jsx
@@ -4,7 +4,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import classnames from 'classnames';
@@ -43,8 +42,8 @@ CommentApproveAction.propTypes = {
 };
 
 CommentApproveAction.defaultProps = {
-	approveComment: noop,
-	unapproveComment: noop,
+	approveComment: () => {},
+	unapproveComment: () => {},
 };
 
 export default localize( CommentApproveAction );

--- a/client/blocks/comments/comment-edit-form.jsx
+++ b/client/blocks/comments/comment-edit-form.jsx
@@ -7,7 +7,6 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { noop } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -194,7 +193,7 @@ PostCommentForm.propTypes = {
 };
 
 PostCommentForm.defaultProps = {
-	onCommentSubmit: noop,
+	onCommentSubmit: () => {},
 };
 
 const mapDispatchToProps = ( dispatch ) => bindActionCreators( { editComment }, dispatch );

--- a/client/blocks/comments/form-root.jsx
+++ b/client/blocks/comments/form-root.jsx
@@ -1,12 +1,9 @@
 /**
- */
-
-/**
  * External dependencies
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop, some } from 'lodash';
+import { some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,7 +18,7 @@ const PostCommentFormRoot = ( {
 	commentText,
 	activeReplyCommentId,
 	commentsTree,
-	onUpdateCommentText = noop,
+	onUpdateCommentText = () => {},
 } ) => {
 	// Are we displaying the comment form elsewhere? If so, don't render the root form.
 	if (

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { noop } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -243,7 +242,7 @@ PostCommentForm.propTypes = {
 };
 
 PostCommentForm.defaultProps = {
-	onCommentSubmit: noop,
+	onCommentSubmit: () => {},
 };
 
 export default connect(

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { get, noop, some, flatMap } from 'lodash';
+import { get, some, flatMap } from 'lodash';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
@@ -91,12 +91,12 @@ class PostComment extends React.PureComponent {
 	};
 
 	static defaultProps = {
-		onReplyClick: noop,
+		onReplyClick: () => {},
 		errors: [],
 		depth: 1,
 		maxDepth: Infinity,
 		maxChildrenToShow: 5,
-		onCommentSubmit: noop,
+		onCommentSubmit: () => {},
 		showNestingReplyArrow: false,
 		showReadMoreInActions: false,
 		hidePingbacksAndTrackbacks: false,

--- a/client/blocks/conversation-follow-button/button.jsx
+++ b/client/blocks/conversation-follow-button/button.jsx
@@ -1,12 +1,8 @@
 /**
- */
-
-/**
  * External dependencies
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -19,7 +15,7 @@ class ConversationFollowButton extends React.Component {
 
 	static defaultProps = {
 		isFollowing: false,
-		onFollowToggle: noop,
+		onFollowToggle: () => {},
 		tagName: 'button',
 	};
 

--- a/client/blocks/conversation-follow-button/index.jsx
+++ b/client/blocks/conversation-follow-button/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { assign, noop } from 'lodash';
+import { assign } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -31,7 +31,7 @@ class ConversationFollowButtonContainer extends Component {
 	};
 
 	static defaultProps = {
-		onFollowToggle: noop,
+		onFollowToggle: () => {},
 	};
 
 	handleFollowToggle = ( isRequestingFollow ) => {

--- a/client/blocks/conversations/docs/example.jsx
+++ b/client/blocks/conversations/docs/example.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { noop, map, compact } from 'lodash';
+import { map, compact } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,7 +26,7 @@ const ConversationCommentListExample = () => {
 				post={ post }
 				enableCaterpillar={ false }
 				shouldRequestComments={ false }
-				setActiveReply={ noop }
+				setActiveReply={ () => {} }
 			/>
 		</div>
 	);

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { map, zipObject, fill, size, filter, get, compact, partition, min, noop } from 'lodash';
+import { map, zipObject, fill, size, filter, get, compact, partition, min } from 'lodash';
 
 /**
  * Internal dependencies
@@ -68,7 +68,7 @@ export class ConversationCommentList extends React.Component {
 	static defaultProps = {
 		enableCaterpillar: true,
 		shouldRequestComments: true,
-		setActiveReply: noop,
+		setActiveReply: () => {},
 	};
 
 	state = {

--- a/client/blocks/daily-post-button/test/index.jsx
+++ b/client/blocks/daily-post-button/test/index.jsx
@@ -7,7 +7,6 @@
  */
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import pageSpy from 'page';
 import { parse } from 'qs';
 import React from 'react';
@@ -88,7 +87,7 @@ describe( 'DailyPostButton', () => {
 					markPostSeen={ markPostSeen }
 				/>
 			);
-			dailyPostButton.simulate( 'click', { preventDefault: noop } );
+			dailyPostButton.simulate( 'click', { preventDefault: () => {} } );
 			assert.isTrue( pageSpy.calledWithMatch( /post\/apps.wordpress.com?/ ) );
 		} );
 
@@ -107,7 +106,7 @@ describe( 'DailyPostButton', () => {
 			);
 			return new Promise( ( resolve ) => {
 				dailyPostButton.instance().renderSitesPopover = resolve;
-				dailyPostButton.simulate( 'click', { preventDefault: noop } );
+				dailyPostButton.simulate( 'click', { preventDefault: () => {} } );
 			} );
 		} );
 	} );

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -7,7 +7,6 @@ import React, { PureComponent } from 'react';
 import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -63,8 +62,8 @@ class DisconnectJetpack extends PureComponent {
 
 	static defaultProps = {
 		showTitle: true,
-		onDisconnectClick: noop,
-		onStayConnectedClick: noop,
+		onDisconnectClick: () => {},
+		onStayConnectedClick: () => {},
 	};
 
 	trackReadMoreClick = () => {

--- a/client/blocks/dismissible-card/README.md
+++ b/client/blocks/dismissible-card/README.md
@@ -38,7 +38,7 @@ Any addition classes to pass to the card component.
 <table>
 	<tr><td>Type</td><td>Function</td></tr>
 	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>lodash/noop</code></td></tr>
+	<tr><td>Default</td><td><code>() => {}</code></td></tr>
 </table>
 
 This function will fire when a user clicks on the cross icon

--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { noop, flow } from 'lodash';
+import { flow } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -36,7 +36,7 @@ class DismissibleCard extends Component {
 	};
 
 	static defaultProps = {
-		onClick: noop,
+		onClick: () => {},
 	};
 
 	render() {

--- a/client/blocks/edit-gravatar/test/index.jsx
+++ b/client/blocks/edit-gravatar/test/index.jsx
@@ -7,7 +7,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 
 /**
@@ -44,19 +43,19 @@ describe( 'EditGravatar', () => {
 
 	describe( 'component rendering', () => {
 		test( 'displays a Gravatar', () => {
-			const wrapper = shallow( <EditGravatar translate={ noop } user={ user } /> );
+			const wrapper = shallow( <EditGravatar translate={ () => {} } user={ user } /> );
 			expect( wrapper.find( Gravatar ).length ).to.equal( 1 );
 		} );
 
 		test( 'contains a file picker that accepts images', () => {
-			const wrapper = shallow( <EditGravatar translate={ noop } user={ user } /> );
+			const wrapper = shallow( <EditGravatar translate={ () => {} } user={ user } /> );
 			const filePicker = wrapper.find( FilePicker );
 			expect( filePicker.length ).to.equal( 1 );
 			expect( filePicker.prop( 'accept' ) ).to.equal( 'image/*' );
 		} );
 
 		test( 'does not display the image editor by default', () => {
-			const wrapper = shallow( <EditGravatar translate={ noop } user={ user } /> );
+			const wrapper = shallow( <EditGravatar translate={ () => {} } user={ user } /> );
 			expect( wrapper.find( ImageEditor ).length ).to.equal( 0 );
 		} );
 
@@ -64,7 +63,7 @@ describe( 'EditGravatar', () => {
 			test( 'does not contain a drop zone for unverified users', () => {
 				const wrapper = shallow(
 					<EditGravatar
-						translate={ noop }
+						translate={ () => {} }
 						user={ {
 							email_verified: false,
 						} }
@@ -76,7 +75,7 @@ describe( 'EditGravatar', () => {
 			test( 'contains a drop zone for verified users', () => {
 				const wrapper = shallow(
 					<EditGravatar
-						translate={ noop }
+						translate={ () => {} }
 						user={ {
 							email_verified: true,
 						} }
@@ -91,7 +90,7 @@ describe( 'EditGravatar', () => {
 		describe( 'accepted file type', () => {
 			test( 'displays the image editor with square allowed aspect ratio', () => {
 				const wrapper = shallow(
-					<EditGravatar translate={ noop } user={ user } recordReceiveImageEvent={ noop } />
+					<EditGravatar translate={ () => {} } user={ user } recordReceiveImageEvent={ () => {} } />
 				);
 				const files = [
 					{
@@ -115,9 +114,9 @@ describe( 'EditGravatar', () => {
 				const wrapper = shallow(
 					<EditGravatar
 						receiveGravatarImageFailed={ receiveGravatarImageFailedSpy }
-						translate={ noop }
+						translate={ () => {} }
 						user={ user }
-						recordReceiveImageEvent={ noop }
+						recordReceiveImageEvent={ () => {} }
 					/>
 				);
 				const files = [
@@ -136,7 +135,7 @@ describe( 'EditGravatar', () => {
 
 	describe( 'after editing image', () => {
 		const imageEditorProps = {
-			resetAllImageEditorState: noop,
+			resetAllImageEditorState: () => {},
 		};
 		const files = [
 			{
@@ -150,11 +149,11 @@ describe( 'EditGravatar', () => {
 			const wrapper = shallow(
 				<EditGravatar
 					receiveGravatarImageFailed={ receiveGravatarImageFailedSpy }
-					resetAllImageEditorState={ noop }
-					translate={ noop }
+					resetAllImageEditorState={ () => {} }
+					translate={ () => {} }
 					uploadGravatar={ uploadGravatarSpy }
 					user={ user }
-					recordReceiveImageEvent={ noop }
+					recordReceiveImageEvent={ () => {} }
 				/>
 			);
 
@@ -173,11 +172,11 @@ describe( 'EditGravatar', () => {
 			const wrapper = shallow(
 				<EditGravatar
 					receiveGravatarImageFailed={ receiveGravatarImageFailedSpy }
-					resetAllImageEditorState={ noop }
-					translate={ noop }
+					resetAllImageEditorState={ () => {} }
+					translate={ () => {} }
 					uploadGravatar={ uploadGravatarSpy }
 					user={ user }
-					recordReceiveImageEvent={ noop }
+					recordReceiveImageEvent={ () => {} }
 				/>
 			);
 
@@ -193,7 +192,7 @@ describe( 'EditGravatar', () => {
 	describe( 'unverified user', () => {
 		test( 'shows email verification dialog when clicked', () => {
 			const wrapper = shallow(
-				<EditGravatar translate={ noop } user={ user } recordClickButtonEvent={ noop } />
+				<EditGravatar translate={ () => {} } user={ user } recordClickButtonEvent={ () => {} } />
 			);
 			// Enzyme requires simulate() to be called directly on the element with the click handler
 			const clickableWrapper = wrapper.find( '.edit-gravatar > div' ).first();

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { union, includes, noop } from 'lodash';
+import { union, includes } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import page from 'page';
@@ -202,7 +202,8 @@ function siteRequiresGoingPublic( holds: string[] ) {
 }
 
 EligibilityWarnings.defaultProps = {
-	onProceed: noop,
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	onProceed: () => {},
 };
 
 const mapStateToProps = ( state: object, ownProps: ExternalProps ) => {

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -6,7 +6,6 @@
  * External dependencies
  */
 import page from 'page';
-import { noop } from 'lodash';
 import React, { ReactChild } from 'react';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
@@ -67,7 +66,8 @@ describe( '<EligibilityWarnings>', () => {
 		} );
 
 		const { container } = renderWithStore(
-			<EligibilityWarnings backUrl="" onProceed={ noop } />,
+			// eslint-disable-next-line @typescript-eslint/no-empty-function
+			<EligibilityWarnings backUrl="" onProceed={ () => {} } />,
 			state
 		);
 
@@ -83,7 +83,8 @@ describe( '<EligibilityWarnings>', () => {
 		} );
 
 		const { container } = renderWithStore(
-			<EligibilityWarnings backUrl="" onProceed={ noop } />,
+			// eslint-disable-next-line @typescript-eslint/no-empty-function
+			<EligibilityWarnings backUrl="" onProceed={ () => {} } />,
 			state
 		);
 
@@ -96,7 +97,8 @@ describe( '<EligibilityWarnings>', () => {
 		} );
 
 		const { getByTestId, getByText } = renderWithStore(
-			<EligibilityWarnings backUrl="" onProceed={ noop } />,
+			// eslint-disable-next-line @typescript-eslint/no-empty-function
+			<EligibilityWarnings backUrl="" onProceed={ () => {} } />,
 			state
 		);
 
@@ -118,7 +120,8 @@ describe( '<EligibilityWarnings>', () => {
 		} );
 
 		const { getByText } = renderWithStore(
-			<EligibilityWarnings backUrl="" onProceed={ noop } />,
+			// eslint-disable-next-line @typescript-eslint/no-empty-function
+			<EligibilityWarnings backUrl="" onProceed={ () => {} } />,
 			state
 		);
 
@@ -142,7 +145,8 @@ describe( '<EligibilityWarnings>', () => {
 		} );
 
 		const { container } = renderWithStore(
-			<EligibilityWarnings backUrl="" onProceed={ noop } />,
+			// eslint-disable-next-line @typescript-eslint/no-empty-function
+			<EligibilityWarnings backUrl="" onProceed={ () => {} } />,
 			state
 		);
 

--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -4,7 +4,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -26,7 +25,7 @@ class FollowButton extends React.Component {
 
 	static defaultProps = {
 		following: false,
-		onFollowToggle: noop,
+		onFollowToggle: () => {},
 		iconSize: 20,
 		tagName: 'button',
 		disabled: false,

--- a/client/blocks/follow-button/index.jsx
+++ b/client/blocks/follow-button/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop, omitBy, isUndefined } from 'lodash';
+import { omitBy, isUndefined } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -25,7 +25,7 @@ class FollowButtonContainer extends Component {
 	};
 
 	static defaultProps = {
-		onFollowToggle: noop,
+		onFollowToggle: () => {},
 	};
 
 	handleFollowToggle = ( following ) => {

--- a/client/blocks/gdpr-banner/index.jsx
+++ b/client/blocks/gdpr-banner/index.jsx
@@ -3,7 +3,6 @@
  */
 import classNames from 'classnames';
 import cookie from 'cookie';
-import { noop } from 'lodash';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -113,8 +112,8 @@ GdprBanner.propTypes = {
 };
 
 GdprBanner.defaultProps = {
-	recordCookieBannerOk: noop,
-	recordCookieBannerView: noop,
+	recordCookieBannerOk: () => {},
+	recordCookieBannerView: () => {},
 };
 
 const mapDispatchToProps = {

--- a/client/blocks/get-apps/desktop-download-card.jsx
+++ b/client/blocks/get-apps/desktop-download-card.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -30,10 +30,10 @@ class DesktopDownloadCard extends Component {
 
 	static defaultProps = {
 		translate: identity,
-		trackWindowsClick: noop,
-		trackMacClick: noop,
-		trackLinuxTarClick: noop,
-		trackLinuxDebClick: noop,
+		trackWindowsClick: () => {},
+		trackMacClick: () => {},
+		trackLinuxTarClick: () => {},
+		trackLinuxDebClick: () => {},
 	};
 
 	getDescription( platform ) {

--- a/client/blocks/image-editor/image-editor-buttons.jsx
+++ b/client/blocks/image-editor/image-editor-buttons.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -30,10 +29,10 @@ class ImageEditorButtons extends Component {
 	static defaultProps = {
 		src: '',
 		hasChanges: false,
-		resetImageEditorState: noop,
-		onDone: noop,
-		onCancel: noop,
-		onReset: noop,
+		resetImageEditorState: () => {},
+		onDone: () => {},
+		onCancel: () => {},
+		onReset: () => {},
 		doneButtonText: '',
 	};
 

--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { noop, startsWith } from 'lodash';
+import { startsWith } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -58,9 +58,9 @@ export class ImageEditorCanvas extends Component {
 			cropWidthRatio: 1,
 			cropHeightRatio: 1,
 		},
-		setImageEditorCropBounds: noop,
-		setImageEditorImageHasLoaded: noop,
-		onLoadError: noop,
+		setImageEditorCropBounds: () => {},
+		setImageEditorImageHasLoaded: () => {},
+		onLoadError: () => {},
 		isImageLoaded: false,
 		showCrop: true,
 	};

--- a/client/blocks/image-editor/image-editor-crop.jsx
+++ b/client/blocks/image-editor/image-editor-crop.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { isEqual, noop } from 'lodash';
+import { isEqual } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -59,8 +59,8 @@ class ImageEditorCrop extends Component {
 			bottomBound: 100,
 			rightBound: 100,
 		},
-		imageEditorCrop: noop,
-		imageEditorComputedCrop: noop,
+		imageEditorCrop: () => {},
+		imageEditorComputedCrop: () => {},
 		minCropSize: {
 			width: 50,
 			height: 50,

--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { noop, values as objectValues } from 'lodash';
+import { values as objectValues } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import classNames from 'classnames';
@@ -35,11 +35,11 @@ export class ImageEditorToolbar extends Component {
 	};
 
 	static defaultProps = {
-		imageEditorRotateCounterclockwise: noop,
-		imageEditorFlip: noop,
-		setImageEditorAspectRatio: noop,
+		imageEditorRotateCounterclockwise: () => {},
+		imageEditorFlip: () => {},
+		setImageEditorAspectRatio: () => {},
 		allowedAspectRatios: objectValues( AspectRatios ),
-		onShowNotice: noop,
+		onShowNotice: () => {},
 		isAspectRatioDisabled: false,
 	};
 

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { noop, isEqual, partial } from 'lodash';
+import { isEqual, partial } from 'lodash';
 import path from 'path';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -63,13 +63,13 @@ class ImageEditor extends React.Component {
 
 	static defaultProps = {
 		media: null,
-		onDone: noop,
+		onDone: () => {},
 		onCancel: null,
-		onReset: noop,
+		onReset: () => {},
 		isImageLoaded: false,
 		defaultAspectRatio: AspectRatios.FREE,
 		allowedAspectRatios: AspectRatiosValues,
-		setImageEditorDefaultAspectRatio: noop,
+		setImageEditorDefaultAspectRatio: () => {},
 	};
 
 	state = {

--- a/client/blocks/image-selector/index.jsx
+++ b/client/blocks/image-selector/index.jsx
@@ -6,7 +6,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -47,7 +46,7 @@ export class ImageSelector extends Component {
 		compact: false,
 		isDropZoneVisible: false,
 		maxWidth: 450,
-		onAddImage: noop,
+		onAddImage: () => {},
 	};
 
 	state = {

--- a/client/blocks/image-selector/test/index.jsx
+++ b/client/blocks/image-selector/test/index.jsx
@@ -6,7 +6,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { noop } from 'lodash';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import React from 'react';
@@ -38,11 +37,11 @@ jest.mock( 'calypso/state/selectors/get-current-locale-slug', () => () => 'en' )
 
 describe( 'ImageSelector', () => {
 	const testProps = {
-		onImageChange: noop,
-		onImageSelected: noop,
-		onRemoveImage: noop,
+		onImageChange: () => {},
+		onImageSelected: () => {},
+		onRemoveImage: () => {},
 		imageIds: [],
-		setMediaLibrarySelectedItems: noop,
+		setMediaLibrarySelectedItems: () => {},
 	};
 	const store = {
 		getState: () => ( {

--- a/client/blocks/image-selector/test/preview.jsx
+++ b/client/blocks/image-selector/test/preview.jsx
@@ -6,7 +6,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { noop } from 'lodash';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import React from 'react';
@@ -16,11 +15,11 @@ import { ImageSelectorPreview } from '../preview';
 
 describe( 'ImageSelectorPreview', () => {
 	const testProps = {
-		onImageChange: noop,
-		onImageSelected: noop,
-		onRemoveImage: noop,
+		onImageChange: () => {},
+		onImageSelected: () => {},
+		onRemoveImage: () => {},
 		imageIds: [],
-		setMediaLibrarySelectedItems: noop,
+		setMediaLibrarySelectedItems: () => {},
 		translate: () => {},
 		getMediaItem: ( siteId, itemId ) => require( './fixtures' ).DUMMY_MEDIA[ itemId ],
 	};

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Fragment, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { debounce, identity, isEmpty, noop } from 'lodash';
+import { debounce, identity, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -53,7 +53,7 @@ function HelpSearchResults( {
 	hasPurchases,
 	isSearching = false,
 	onSelect,
-	onAdminSectionSelect = noop,
+	onAdminSectionSelect = () => {},
 	searchQuery = '',
 	searchResults = [],
 	sectionName,

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import { flowRight as compose, noop } from 'lodash';
+import { flowRight as compose } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -34,7 +34,7 @@ class InlineHelpPopover extends Component {
 	};
 
 	static defaultProps = {
-		onClose: noop,
+		onClose: () => {},
 	};
 
 	state = {

--- a/client/blocks/keyring-connect-button/index.js
+++ b/client/blocks/keyring-connect-button/index.js
@@ -4,7 +4,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { find, last, noop, some } from 'lodash';
+import { find, last, some } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -41,8 +41,8 @@ class KeyringConnectButton extends Component {
 	};
 
 	static defaultProps = {
-		onClick: noop,
-		onConnect: noop,
+		onClick: () => {},
+		onConnect: () => {},
 		forceReconnect: false,
 		primary: false,
 	};

--- a/client/blocks/like-button/index.jsx
+++ b/client/blocks/like-button/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import { omit, noop } from 'lodash';
+import { omit } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -28,7 +28,7 @@ class LikeButtonContainer extends Component {
 	};
 
 	static defaultProps = {
-		onLikeToggle: noop,
+		onLikeToggle: () => {},
 	};
 
 	handleLikeToggle = ( liked ) => {

--- a/client/blocks/login/test/login-form.jsx
+++ b/client/blocks/login/test/login-form.jsx
@@ -7,7 +7,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 
 /**
@@ -27,7 +26,7 @@ describe( 'LoginForm', () => {
 	describe( 'component rendering', () => {
 		test( 'displays a login form', () => {
 			const wrapper = shallow(
-				<LoginForm translate={ noop } socialAccountLink={ { isLinking: false } } />
+				<LoginForm translate={ () => {} } socialAccountLink={ { isLinking: false } } />
 			);
 			expect( wrapper.find( FormTextInput ).length ).to.equal( 1 );
 			expect( wrapper.find( FormPasswordInput ).length ).to.equal( 1 );

--- a/client/blocks/nps-survey/docs/example.jsx
+++ b/client/blocks/nps-survey/docs/example.jsx
@@ -5,7 +5,6 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -81,7 +80,7 @@ class NpsSurveyExample extends PureComponent {
 						successNotice={ this.props.successNotice }
 						isBusinessUser={ this.state.isBusinessUser }
 						hasAvailableConciergeSession={ this.state.hasAvailableConciergeSession }
-						recordTracksEvent={ noop }
+						recordTracksEvent={ () => {} }
 					/>
 				) }
 				{ ! this.state.isClosed && this.renderOptions() }

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -7,7 +7,7 @@ import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize, getLocaleSlug } from 'i18n-calypso';
-import { isNumber, noop, trim } from 'lodash';
+import { isNumber, trim } from 'lodash';
 
 /**
  * Internal dependencies
@@ -82,7 +82,7 @@ export class NpsSurvey extends PureComponent {
 		if ( ! this.props.hasAnswered ) {
 			this.props.submitNpsSurveyWithNoScore( this.props.name );
 		}
-		this.onClose( noop );
+		this.onClose( () => {} );
 	};
 
 	handleTextBoxChange = ( event ) => {
@@ -107,7 +107,7 @@ export class NpsSurvey extends PureComponent {
 	};
 
 	handlePromotionClose = () => {
-		this.onClose( noop );
+		this.onClose( () => {} );
 	};
 
 	handleLinkClick = ( event ) => {
@@ -115,7 +115,7 @@ export class NpsSurvey extends PureComponent {
 			url: event.target.href,
 			type: event.target.dataset.type,
 		} );
-		this.onClose( noop );
+		this.onClose( () => {} );
 	};
 
 	showThanksNotice = () => {

--- a/client/blocks/privacy-policy-banner/index.jsx
+++ b/client/blocks/privacy-policy-banner/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flowRight as compose, get, identity, noop } from 'lodash';
+import { flowRight as compose, get, identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,7 +32,7 @@ const privacyPolicyQuery = {
 				method: 'GET',
 				path: '/privacy-policy',
 				apiNamespace: 'wpcom/v2',
-				onSuccess: noop,
+				onSuccess: () => {},
 			} ),
 			{
 				fromApi: () => ( data ) => [

--- a/client/blocks/product-purchase-features-list/business-onboarding.jsx
+++ b/client/blocks/product-purchase-features-list/business-onboarding.jsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,7 +15,7 @@ import PurchaseDetail from 'calypso/components/purchase-detail';
  */
 import conciergeImage from 'calypso/assets/images/illustrations/jetpack-concierge.svg';
 
-export default localize( ( { isWpcomPlan, translate, link, onClick = noop } ) => {
+export default localize( ( { isWpcomPlan, translate, link, onClick = () => {} } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail

--- a/client/blocks/product-purchase-features-list/mobile-apps.jsx
+++ b/client/blocks/product-purchase-features-list/mobile-apps.jsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,7 +16,7 @@ import { addQueryArgs } from 'calypso/lib/route';
  */
 import appsImage from 'calypso/assets/images/illustrations/apps.svg';
 
-export default localize( ( { translate, onClick = noop } ) => {
+export default localize( ( { translate, onClick = () => {} } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail

--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -64,7 +64,7 @@ ReaderAuthorLink.propTypes = {
 };
 
 ReaderAuthorLink.defaultProps = {
-	onClick: noop,
+	onClick: () => {},
 };
 
 export default ReaderAuthorLink;

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { startsWith, noop, get } from 'lodash';
+import { startsWith, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
 
@@ -119,7 +119,7 @@ ReaderAvatar.propTypes = {
 };
 
 ReaderAvatar.defaultProps = {
-	onClick: noop,
+	onClick: () => {},
 };
 
 export default localize( ReaderAvatar );

--- a/client/blocks/reader-featured-image/index.jsx
+++ b/client/blocks/reader-featured-image/index.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -60,7 +59,7 @@ ReaderFeaturedImage.propTypes = {
 };
 
 ReaderFeaturedImage.defaultProps = {
-	onClick: noop,
+	onClick: () => {},
 	imageWidth: 250,
 };
 

--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { throttle, constant, noop } from 'lodash';
+import { throttle, constant } from 'lodash';
 import ReactDom from 'react-dom';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
@@ -43,7 +43,7 @@ class ReaderFeaturedVideo extends React.Component {
 
 	static defaultProps = {
 		allowPlaying: true,
-		onThumbnailClick: noop,
+		onThumbnailClick: () => {},
 		className: '',
 	};
 

--- a/client/blocks/reader-full-post/unavailable.jsx
+++ b/client/blocks/reader-full-post/unavailable.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
-import { noop, get } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -76,7 +76,7 @@ ReaderFullPostUnavailable.propTypes = {
 };
 
 ReaderFullPostUnavailable.defaultProps = {
-	onBackClick: noop,
+	onBackClick: () => {},
 };
 
 export default localize( ReaderFullPostUnavailable );

--- a/client/blocks/reader-import-button/index.jsx
+++ b/client/blocks/reader-import-button/index.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
@@ -28,7 +27,7 @@ class ReaderImportButton extends React.Component {
 
 	static defaultProps = {
 		borderless: true,
-		onProgress: noop,
+		onProgress: () => {},
 	};
 
 	state = { disabled: false };

--- a/client/blocks/reader-list-item/connected.jsx
+++ b/client/blocks/reader-list-item/connected.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { flowRight as compose, noop } from 'lodash';
+import { flowRight as compose } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -30,8 +30,8 @@ class ConnectedReaderListItem extends React.Component {
 	};
 
 	static defaultProps = {
-		onShouldMeasure: noop,
-		onComponentMountWithNewRailcar: noop,
+		onShouldMeasure: () => {},
+		onComponentMountWithNewRailcar: () => {},
 		showNotificationSettings: true,
 		showLastUpdatedDate: true,
 	};

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { noop, truncate, get } from 'lodash';
+import { truncate, get } from 'lodash';
 import classnames from 'classnames';
 import ReactDom from 'react-dom';
 import closest from 'component-closest';
@@ -62,8 +62,8 @@ class ReaderPostCard extends React.Component {
 	};
 
 	static defaultProps = {
-		onClick: noop,
-		onCommentClick: noop,
+		onClick: () => {},
+		onCommentClick: () => {},
 		isSelected: false,
 		showSiteName: true,
 	};
@@ -269,7 +269,7 @@ class ReaderPostCard extends React.Component {
 		}
 
 		const followUrl = feed ? feed.feed_URL : post.site_URL;
-		const onClick = ! isPhotoPost && ! compact ? this.handleCardClick : noop;
+		const onClick = ! isPhotoPost && ! compact ? this.handleCardClick : () => {};
 		return (
 			<Card className={ classes } onClick={ onClick } tagName="article">
 				{ ! compact && postByline }

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop, debounce } from 'lodash';
+import { debounce } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -150,7 +150,7 @@ PostPhoto.propTypes = {
 };
 
 PostPhoto.defaultProps = {
-	onClick: noop,
+	onClick: () => {},
 };
 
 export default PostPhoto;

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop, size, map } from 'lodash';
+import { size, map } from 'lodash';
 import page from 'page';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
@@ -64,7 +64,7 @@ class ReaderPostOptionsMenu extends React.Component {
 	};
 
 	static defaultProps = {
-		onBlock: noop,
+		onBlock: () => {},
 		position: 'top left',
 		showFollow: true,
 		showVisitPost: true,

--- a/client/blocks/reader-related-card/index.jsx
+++ b/client/blocks/reader-related-card/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import { get, noop, partial } from 'lodash';
+import { get, partial } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -102,8 +102,8 @@ export function RelatedPostCard( {
 	post,
 	site,
 	siteId,
-	onPostClick = noop,
-	onSiteClick = noop,
+	onPostClick = () => {},
+	onSiteClick = () => {},
 	followSource,
 } ) {
 	if ( ! post || post._state === 'minimal' || post._state === 'pending' ) {

--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { flowRight as compose, noop } from 'lodash';
+import { flowRight as compose } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -30,8 +30,8 @@ class ConnectedSubscriptionListItem extends React.Component {
 	};
 
 	static defaultProps = {
-		onShouldMeasure: noop,
-		onComponentMountWithNewRailcar: noop,
+		onShouldMeasure: () => {},
+		onComponentMountWithNewRailcar: () => {},
 		showNotificationSettings: true,
 		showLastUpdatedDate: true,
 	};

--- a/client/blocks/reader-visit-link/index.jsx
+++ b/client/blocks/reader-visit-link/index.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,7 +23,7 @@ class ReaderVisitLink extends React.Component {
 
 	static defaultProps = {
 		iconSize: 24,
-		onClick: noop,
+		onClick: () => {},
 	};
 
 	render() {

--- a/client/blocks/site-address-changer/dialog.jsx
+++ b/client/blocks/site-address-changer/dialog.jsx
@@ -4,7 +4,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -27,8 +26,8 @@ class SiteAddressChangerConfirmationDialog extends PureComponent {
 	};
 
 	static defaultProps = {
-		onClose: noop,
-		onConfirm: noop,
+		onClose: () => {},
+		onConfirm: () => {},
 		currentDomainSuffix: '.wordpress.com',
 		newDomainSuffix: '.wordpress.com',
 	};

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import { noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -28,10 +27,10 @@ import './style.scss';
 class Site extends React.Component {
 	static defaultProps = {
 		// onSelect callback
-		onSelect: noop,
+		onSelect: () => {},
 		// mouse event callbacks
-		onMouseEnter: noop,
-		onMouseLeave: noop,
+		onMouseEnter: () => {},
+		onMouseLeave: () => {},
 
 		// Set a href attribute to the anchor
 		href: null,

--- a/client/blocks/support-article-dialog/dialog.jsx
+++ b/client/blocks/support-article-dialog/dialog.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import { memoize, noop } from 'lodash';
+import { memoize } from 'lodash';
 import { useTranslate } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -83,7 +83,7 @@ export const SupportArticleDialog = ( {
 						href={ actionUrl }
 						target={ actionIsExternal ? '_blank' : undefined }
 						primary
-						onClick={ () => ( actionIsExternal ? noop() : closeSupportArticleDialog() ) }
+						onClick={ () => ( actionIsExternal ? ( () => {} )() : closeSupportArticleDialog() ) }
 					>
 						{ actionLabel } { actionIsExternal && <Gridicon icon="external" size={ 12 } /> }
 					</Button>

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { includes, filter, map, noop, reduce, union } from 'lodash';
+import { includes, filter, map, reduce, union } from 'lodash';
 import { WindowScroller } from '@automattic/react-virtualized';
 
 /**
@@ -46,8 +46,8 @@ export class TaxonomyManagerList extends Component {
 	static defaultProps = {
 		loading: true,
 		terms: [],
-		onNextPage: noop,
-		onTermClick: noop,
+		onNextPage: () => {},
+		onTermClick: () => {},
 	};
 
 	state = {

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, find, noop, assign } from 'lodash';
+import { get, find, assign } from 'lodash';
 
 /**
  * Internal dependencies
@@ -60,8 +60,8 @@ class TermFormDialog extends Component {
 	};
 
 	static defaultProps = {
-		onClose: noop,
-		onSuccess: noop,
+		onClose: () => {},
+		onSuccess: () => {},
 		showDescriptionInput: false,
 		showDialog: false,
 	};
@@ -89,7 +89,7 @@ class TermFormDialog extends Component {
 
 	onTopLevelChange = () => {
 		// Only validate the form when **enabling** the top level toggle.
-		const performValidation = ! this.state.isTopLevel ? this.isValid : noop;
+		const performValidation = ! this.state.isTopLevel ? this.isValid : () => {};
 		this.setState(
 			( { isTopLevel } ) => ( {
 				isTopLevel: ! isTopLevel,

--- a/client/blocks/term-tree-selector/add-term.jsx
+++ b/client/blocks/term-tree-selector/add-term.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -34,7 +34,7 @@ class TermSelectorAddTerm extends Component {
 	};
 
 	static defaultProps = {
-		onSuccess: noop,
+		onSuccess: () => {},
 	};
 
 	state = {

--- a/client/blocks/video-editor/index.jsx
+++ b/client/blocks/video-editor/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 
@@ -39,8 +39,8 @@ class VideoEditor extends Component {
 	};
 
 	static defaultProps = {
-		onCancel: noop,
-		onUpdatePoster: noop,
+		onCancel: () => {},
+		onUpdatePoster: () => {},
 	};
 
 	state = {

--- a/client/blocks/video-editor/video-editor-controls.jsx
+++ b/client/blocks/video-editor/video-editor-controls.jsx
@@ -4,7 +4,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -64,9 +63,9 @@ VideoEditorControls.propTypes = {
 VideoEditorControls.defaultProps = {
 	isPosterUpdating: false,
 	isVideoLoading: true,
-	onSelectFrame: noop,
-	onUploadImage: noop,
-	onUploadImageClick: noop,
+	onSelectFrame: () => {},
+	onUploadImage: () => {},
+	onUploadImageClick: () => {},
 };
 
 export default localize( VideoEditorControls );

--- a/client/blocks/video-editor/video-editor-upload-button.js
+++ b/client/blocks/video-editor/video-editor-upload-button.js
@@ -4,7 +4,6 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,8 +20,8 @@ class VideoEditorUploadButton extends Component {
 
 	static defaultProps = {
 		isPosterUpdating: false,
-		onClick: noop,
-		onUploadImage: noop,
+		onClick: () => {},
+		onUploadImage: () => {},
 	};
 
 	uploadImage = ( files ) => {

--- a/client/components/action-card/README.md
+++ b/client/components/action-card/README.md
@@ -18,7 +18,7 @@ function render() {
 			buttonPrimary={ true }
 			buttonHref="https://wordpress.com"
 			buttonTarget="_blank"
-			buttonOnClick={ noop }
+			buttonOnClick={ () => {} }
 			buttonDisabled={ false }
 		/>
 	);

--- a/client/components/back-button/index.jsx
+++ b/client/components/back-button/index.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,7 +32,7 @@ BackButton.propTypes = {
 };
 
 BackButton.defaultProps = {
-	onClick: noop,
+	onClick: () => {},
 };
 
 export default localize( BackButton );

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { noop, size } from 'lodash';
+import { size } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import config from '@automattic/calypso-config';
@@ -85,8 +85,8 @@ export class Banner extends Component {
 		compact: false,
 		horizontal: false,
 		jetpack: false,
-		onClick: noop,
-		onDismiss: noop,
+		onClick: () => {},
+		onDismiss: () => {},
 		primaryButton: true,
 		showIcon: true,
 		tracksImpressionName: 'calypso_banner_cta_impression',

--- a/client/components/bulk-select/test/index.js
+++ b/client/components/bulk-select/test/index.js
@@ -7,7 +7,7 @@
  */
 import { assert } from 'chai';
 import { mount, shallow } from 'enzyme';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import React from 'react';
 
 /**
@@ -22,7 +22,7 @@ describe( 'index', () => {
 				translate={ identity }
 				selectedElements={ 0 }
 				totalElements={ 3 }
-				onToggle={ noop }
+				onToggle={ () => {} }
 			/>
 		);
 		assert.equal( 1, bulkSelect.find( '.bulk-select' ).length );
@@ -34,7 +34,7 @@ describe( 'index', () => {
 				translate={ identity }
 				selectedElements={ 0 }
 				totalElements={ 3 }
-				onToggle={ noop }
+				onToggle={ () => {} }
 			/>
 		);
 		assert.equal( 0, bulkSelect.find( '.is-checked' ).length );
@@ -46,7 +46,7 @@ describe( 'index', () => {
 				translate={ identity }
 				selectedElements={ 3 }
 				totalElements={ 3 }
-				onToggle={ noop }
+				onToggle={ () => {} }
 			/>
 		);
 		assert.equal( 1, bulkSelect.find( '.is-checked' ).length );
@@ -58,7 +58,7 @@ describe( 'index', () => {
 				translate={ identity }
 				selectedElements={ 2 }
 				totalElements={ 3 }
-				onToggle={ noop }
+				onToggle={ () => {} }
 			/>
 		);
 		assert.equal( 0, bulkSelect.find( '.is-checked' ).length );
@@ -70,7 +70,7 @@ describe( 'index', () => {
 				translate={ identity }
 				selectedElements={ 2 }
 				totalElements={ 3 }
-				onToggle={ noop }
+				onToggle={ () => {} }
 			/>
 		);
 		assert.equal( 1, bulkSelect.find( '.bulk-select__some-checked-icon' ).length );
@@ -82,7 +82,7 @@ describe( 'index', () => {
 				translate={ identity }
 				selectedElements={ 2 }
 				totalElements={ 3 }
-				onToggle={ noop }
+				onToggle={ () => {} }
 				ariaLabel="Select All"
 			/>
 		);
@@ -95,7 +95,7 @@ describe( 'index', () => {
 				translate={ identity }
 				selectedElements={ 2 }
 				totalElements={ 3 }
-				onToggle={ noop }
+				onToggle={ () => {} }
 			/>
 		);
 		// There is no prop readOnly, so this is undefined

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -4,7 +4,6 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { localize, withRtl } from 'i18n-calypso';
-import { noop } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -215,7 +214,7 @@ Chart.propTypes = {
 };
 
 Chart.defaultProps = {
-	barClick: noop,
+	barClick: () => {},
 	isPlaceholder: false,
 	minBarWidth: 15,
 	minTouchBarWidth: 42,

--- a/client/components/chart/legend.jsx
+++ b/client/components/chart/legend.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { find, noop } from 'lodash';
+import { find } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -23,7 +23,7 @@ class ChartLegend extends React.Component {
 	static defaultProps = {
 		activeCharts: [],
 		availableCharts: [],
-		clickHandler: noop,
+		clickHandler: () => {},
 		tabs: [],
 	};
 

--- a/client/components/close-on-escape/README.md
+++ b/client/components/close-on-escape/README.md
@@ -43,7 +43,7 @@ function render() {
 <table>
 	<tr><td>Type</td><td>function</td></tr>
 	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>noop</code></td></tr>
+	<tr><td>Default</td><td><code>() => {}</code></td></tr>
 </table>
 
 The function to be called when <kbd>esc</kbd> is pressed.

--- a/client/components/close-on-escape/index.jsx
+++ b/client/components/close-on-escape/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { filter, includes, isEmpty, last, noop } from 'lodash';
+import { filter, includes, isEmpty, last } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 
@@ -62,7 +62,7 @@ CloseOnEscape.propTypes = {
 };
 
 CloseOnEscape.defaultProps = {
-	onEscape: noop,
+	onEscape: () => {},
 };
 
 export default CloseOnEscape;

--- a/client/components/d3-base/test/index.js
+++ b/client/components/d3-base/test/index.js
@@ -7,7 +7,6 @@
  */
 import React from 'react';
 import { assert } from 'chai';
-import { noop } from 'lodash';
 import { shallow, mount } from 'enzyme';
 
 /**
@@ -19,7 +18,9 @@ describe( 'D3base', () => {
 	const shallowWithoutLifecycle = ( arg ) => shallow( arg, { disableLifecycleMethods: true } );
 
 	test( 'should have d3-base CSS class', () => {
-		const base = shallowWithoutLifecycle( <D3Base drawChart={ noop } getParams={ noop } /> );
+		const base = shallowWithoutLifecycle(
+			<D3Base drawChart={ () => {} } getParams={ () => {} } />
+		);
 
 		assert.lengthOf( base.find( '.d3-base' ), 1 );
 	} );
@@ -27,7 +28,7 @@ describe( 'D3base', () => {
 	test( 'should render an svg', () => {
 		const getParams = () => ( { width: 100, height: 100 } );
 
-		const base = mount( <D3Base drawChart={ noop } getParams={ getParams } /> );
+		const base = mount( <D3Base drawChart={ () => {} } getParams={ getParams } /> );
 
 		assert.lengthOf( base.render().find( 'svg' ), 1 );
 	} );

--- a/client/components/data/query-atat-eligibility/test/index.jsx
+++ b/client/components/data/query-atat-eligibility/test/index.jsx
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 import { spy } from 'sinon';
 
@@ -17,7 +16,7 @@ describe( 'QueryAutomatedTransferEligibility', () => {
 	const siteId = 1337;
 
 	test( 'should mount as null', () => {
-		const wrapped = shallow( <QueryEligibility { ...{ requestEligibility: noop, siteId } } /> );
+		const wrapped = shallow( <QueryEligibility { ...{ requestEligibility: () => {}, siteId } } /> );
 
 		expect( wrapped.equals( null ) ).to.be.true;
 	} );

--- a/client/components/date-picker/day.jsx
+++ b/client/components/date-picker/day.jsx
@@ -1,15 +1,13 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-import { noop } from 'lodash';
 
-const handleDayMouseEnter = ( date, modifiers, onMouseEnter = noop ) => ( event ) => {
+const handleDayMouseEnter = ( date, modifiers, onMouseEnter = () => {} ) => ( event ) => {
 	onMouseEnter( date, modifiers, event );
 };
 
-const handleDayMouseLeave = ( date, modifiers, onMouseLeave = noop ) => ( event ) => {
+const handleDayMouseLeave = ( date, modifiers, onMouseLeave = () => {} ) => ( event ) => {
 	onMouseLeave( date, modifiers, event );
 };
 

--- a/client/components/date-picker/events-tooltip.jsx
+++ b/client/components/date-picker/events-tooltip.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { noop, map } from 'lodash';
+import { map } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -59,7 +59,7 @@ class EventsTooltip extends Component {
 				className="date-picker__events-tooltip"
 				context={ this.props.context }
 				isVisible={ show }
-				onClose={ noop }
+				onClose={ () => {} }
 			>
 				<span>{ title }</span>
 				<hr className="date-picker__division" />

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -4,7 +4,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import DayPicker from 'react-day-picker';
-import { noop, merge, map, filter, get, debounce } from 'lodash';
+import { merge, map, filter, get, debounce } from 'lodash';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 
@@ -71,13 +71,13 @@ class DatePicker extends PureComponent {
 		fromMonth: null,
 		locale: 'en',
 		selectedDay: null,
-		onMonthChange: noop,
-		onSelectDay: noop,
-		onDayMouseEnter: noop,
-		onDayMouseLeave: noop,
-		onDayTouchStart: noop,
-		onDayTouchEnd: noop,
-		onDayTouchMove: noop,
+		onMonthChange: () => {},
+		onSelectDay: () => {},
+		onDayMouseEnter: () => {},
+		onDayMouseLeave: () => {},
+		onDayTouchStart: () => {},
+		onDayTouchEnd: () => {},
+		onDayTouchMove: () => {},
 		rootClassNames: {},
 	};
 

--- a/client/components/date-picker/nav-bar.jsx
+++ b/client/components/date-picker/nav-bar.jsx
@@ -4,10 +4,9 @@
 
 import React from 'react';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 import { translate } from 'i18n-calypso';
 
-const handleMonthClick = ( onClick = noop ) => ( event ) => {
+const handleMonthClick = ( onClick = () => {} ) => ( event ) => {
 	event.preventDefault();
 	onClick();
 };

--- a/client/components/date-range/header.tsx
+++ b/client/components/date-range/header.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
-import { noop } from 'lodash';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -18,8 +17,10 @@ interface Props {
 }
 
 const DateRangeHeader: FunctionComponent< Props > = ( {
-	onCancelClick = noop,
-	onApplyClick = noop,
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	onCancelClick = () => {},
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	onApplyClick = () => {},
 	cancelButtonText,
 	applyButtonText,
 } ) => {

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { noop, has } from 'lodash';
+import { has } from 'lodash';
 import { DateUtils } from 'react-day-picker';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -61,8 +61,8 @@ export class DateRange extends Component {
 	};
 
 	static defaultProps = {
-		onDateSelect: noop,
-		onDateCommit: noop,
+		onDateSelect: () => {},
+		onDateCommit: () => {},
 		isCompact: false,
 		focusedMonth: null,
 		showTriggerClear: true,

--- a/client/components/date-range/inputs.tsx
+++ b/client/components/date-range/inputs.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { FunctionComponent, useRef, useCallback } from 'react';
-import { noop } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import { useTranslate } from 'i18n-calypso';
 
@@ -25,6 +24,9 @@ interface Props {
 	onInputBlur: ( value: string | null | undefined, startOrEnd: StartOrEnd ) => void;
 	onInputChange: ( value: string | null | undefined, startOrEnd: StartOrEnd ) => void;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 const DateRangeInputs: FunctionComponent< Props > = ( {
 	onInputFocus = noop,

--- a/client/components/date-range/trigger.tsx
+++ b/client/components/date-range/trigger.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
-import { noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import { useTranslate } from 'i18n-calypso';
 import { Moment } from 'moment';
@@ -28,8 +27,8 @@ interface Props {
 }
 
 const DateRangeTrigger: FunctionComponent< Props > = ( {
-	onTriggerClick = noop,
-	onClearClick = noop,
+	onTriggerClick = () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+	onClearClick = () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
 	isCompact = false,
 	showClearBtn = true,
 	startDate,

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -36,7 +36,7 @@ EuAddressFieldset.propTypes = {
 };
 
 EuAddressFieldset.defaultProps = {
-	getFieldProps: noop,
+	getFieldProps: () => {},
 	translate: identity,
 };
 

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
@@ -5,7 +5,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { identity, includes, noop } from 'lodash';
+import { identity, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -37,7 +37,7 @@ export class RegionAddressFieldsets extends Component {
 	};
 
 	static defaultProps = {
-		getFieldProps: noop,
+		getFieldProps: () => {},
 		translate: identity,
 		countryCode: 'US',
 		shouldAutoFocusAddressField: false,
@@ -71,7 +71,7 @@ export class RegionAddressFieldsets extends Component {
 			<div>
 				<div>
 					<Input
-						ref={ shouldAutoFocusAddressField ? this.inputRefCallback : noop }
+						ref={ shouldAutoFocusAddressField ? this.inputRefCallback : () => {} }
 						label={ translate( 'Address' ) }
 						maxLength={ 40 }
 						{ ...getFieldProps( 'address-1', {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -36,7 +36,7 @@ UkAddressFieldset.propTypes = {
 };
 
 UkAddressFieldset.defaultProps = {
-	getFieldProps: noop,
+	getFieldProps: () => {},
 	translate: identity,
 };
 export default localize( UkAddressFieldset );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -48,7 +48,7 @@ UsAddressFieldset.propTypes = {
 
 UsAddressFieldset.defaultProps = {
 	countryCode: 'US',
-	getFieldProps: noop,
+	getFieldProps: () => {},
 	translate: identity,
 };
 

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component, createElement } from 'react';
 import { connect } from 'react-redux';
 import {
-	noop,
 	get,
 	deburr,
 	kebabCase,
@@ -91,8 +90,8 @@ export class ContactDetailsFormFields extends Component {
 			...CONTACT_DETAILS_FORM_FIELDS.map( ( field ) => ( { [ field ]: '' } ) )
 		),
 		needsFax: false,
-		getIsFieldDisabled: noop,
-		onContactDetailsChange: noop,
+		getIsFieldDisabled: () => {},
+		onContactDetailsChange: () => {},
 		onValidate: null,
 		onSanitize: null,
 		labelTexts: {},

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import update from 'immutability-helper';
 import { shallow } from 'enzyme';
-import { noop, omit } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -50,7 +50,7 @@ describe( 'ContactDetailsFormFields', () => {
 				name: 'Brazil',
 			},
 		],
-		onSubmit: noop,
+		onSubmit: () => {},
 	};
 
 	describe( 'default fields', () => {
@@ -173,7 +173,9 @@ describe( 'ContactDetailsFormFields', () => {
 		} );
 
 		test( 'should render cancel button when `onCancel` method prop passed', () => {
-			const wrapper = shallow( <ContactDetailsFormFields { ...defaultProps } onCancel={ noop } /> );
+			const wrapper = shallow(
+				<ContactDetailsFormFields { ...defaultProps } onCancel={ () => {} } />
+			);
 
 			expect( wrapper.find( '.contact-details-form-fields__cancel-button' ) ).toHaveLength( 1 );
 		} );

--- a/client/components/domains/domain-suggestion/test/index.js
+++ b/client/components/domains/domain-suggestion/test/index.js
@@ -7,7 +7,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 
 /**
@@ -23,7 +22,7 @@ describe( 'Domain Suggestion', () => {
 					buttonContent="Click Me"
 					domain="example.com"
 					isAdded={ false }
-					onButtonClick={ noop }
+					onButtonClick={ () => {} }
 					priceRule="PRICE"
 				/>
 			);

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { includes, noop, get } from 'lodash';
+import { includes, get } from 'lodash';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { Button } from '@automattic/components';
 
@@ -52,7 +52,7 @@ class MapDomainStep extends React.Component {
 	};
 
 	static defaultProps = {
-		onSave: noop,
+		onSave: () => {},
 		initialQuery: '',
 	};
 

--- a/client/components/domains/register-domain-step/analytics.js
+++ b/client/components/domains/register-domain-step/analytics.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flow, mapKeys, mapValues, snakeCase, startsWith, noop } from 'lodash';
+import { flow, mapKeys, mapValues, snakeCase, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -161,7 +161,7 @@ let searchQueue = [];
 let searchStackTimer = null;
 let lastSearchTimestamp = null;
 let searchCount = 0;
-let recordSearchFormSubmitWithDispatch = noop;
+let recordSearchFormSubmitWithDispatch = () => {};
 
 export function resetSearchCount() {
 	searchCount = 0;

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -14,7 +14,6 @@ import {
 	isEmpty,
 	isEqual,
 	mapKeys,
-	noop,
 	pick,
 	pickBy,
 	reject,
@@ -164,13 +163,13 @@ class RegisterDomainStep extends React.Component {
 		includeDotBlogSubdomain: false,
 		includeWordPressDotCom: false,
 		isDomainOnly: false,
-		onAddDomain: noop,
-		onAddMapping: noop,
-		onDomainsAvailabilityChange: noop,
-		onSave: noop,
+		onAddDomain: () => {},
+		onAddMapping: () => {},
+		onDomainsAvailabilityChange: () => {},
+		onSave: () => {},
 		vendor: getSuggestionsVendor(),
 		showExampleSuggestions: false,
-		onSkip: noop,
+		onSkip: () => {},
 		showSkipButton: false,
 	};
 
@@ -733,7 +732,7 @@ class RegisterDomainStep extends React.Component {
 		this.repeatSearch( { pageNumber: 1 } );
 	};
 
-	onSearchChange = ( searchQuery, callback = noop ) => {
+	onSearchChange = ( searchQuery, callback = () => {} ) => {
 		if ( ! this._isMounted ) {
 			return;
 		}
@@ -787,7 +786,7 @@ class RegisterDomainStep extends React.Component {
 					availableTlds: filteredAvailableTlds,
 				} );
 			} )
-			.catch( noop );
+			.catch( () => {} );
 	};
 
 	fetchDomainPricePromise = ( domain ) => {

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
-import { defaults, get, identity, isEmpty, isString, map, noop, set, uniq } from 'lodash';
+import { defaults, get, identity, isEmpty, isString, map, set, uniq } from 'lodash';
 
 /**
  * Internal dependencies
@@ -69,7 +69,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 
 	static defaultProps = {
 		isVisible: true,
-		onSubmit: noop,
+		onSubmit: () => {},
 	};
 
 	sanitizeFunctions = {

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, isEmpty, noop } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import page from 'page';
 import { stringify } from 'qs';
 import classnames from 'classnames';
@@ -81,7 +81,7 @@ class TransferDomainStep extends React.Component {
 
 	static defaultProps = {
 		analyticsSection: 'domains',
-		onSave: noop,
+		onSave: () => {},
 	};
 
 	state = this.getDefaultState();

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, isEmpty, noop } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import page from 'page';
 import { stringify } from 'qs';
@@ -80,7 +80,7 @@ class UseYourDomainStep extends React.Component {
 
 	static defaultProps = {
 		analyticsSection: 'domains',
-		onSave: noop,
+		onSave: () => {},
 	};
 
 	state = this.getDefaultState();

--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { identity, includes, noop, without } from 'lodash';
+import { identity, includes, without } from 'lodash';
 
 /**
  * Internal dependencies
@@ -39,9 +39,9 @@ export class DropZone extends React.Component {
 
 	static defaultProps = {
 		className: null,
-		onDrop: noop,
+		onDrop: () => {},
 		onVerifyValidTransfer: () => true,
-		onFilesDrop: noop,
+		onFilesDrop: () => {},
 		fullScreen: false,
 		icon: <Gridicon icon="cloud-upload" size={ 48 } />,
 		translate: identity,

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -32,8 +31,8 @@ class EllipsisMenu extends Component {
 	};
 
 	static defaultProps = {
-		onClick: noop,
-		onToggle: noop,
+		onClick: () => {},
+		onToggle: () => {},
 	};
 
 	state = {

--- a/client/components/email-verification/email-verification-dialog/index.jsx
+++ b/client/components/email-verification/email-verification-dialog/index.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { get, includes, noop } from 'lodash';
+import { get, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -124,7 +124,7 @@ VerifyEmailDialog.propTypes = {
 };
 
 VerifyEmailDialog.defaultProps = {
-	onClose: noop,
+	onClose: () => {},
 };
 
 export default connect(

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -4,7 +4,7 @@
 
 import React, { PureComponent } from 'react';
 import ReactDom from 'react-dom';
-import { assign, filter, forEach, forOwn, noop } from 'lodash';
+import { assign, filter, forEach, forOwn } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -115,12 +115,12 @@ function embedFacebook( domNode ) {
 		return;
 	}
 
-	loadAndRun( 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.2', noop );
+	loadAndRun( 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.2', () => {} );
 }
 
 function embedReddit( domNode ) {
 	debug( 'processing reddit for ', domNode );
-	loadAndRun( 'https://embed.redditmedia.com/widgets/platform.js', noop );
+	loadAndRun( 'https://embed.redditmedia.com/widgets/platform.js', () => {} );
 }
 
 let tumblrLoader;

--- a/client/components/file-picker/index.jsx
+++ b/client/components/file-picker/index.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { assign, noop } from 'lodash';
+import { assign } from 'lodash';
 import pick from 'component-file-picker';
 
 export default class FilePicker extends React.Component {
@@ -41,6 +41,6 @@ FilePicker.defaultProps = {
 	multiple: false,
 	directory: false,
 	accept: null,
-	onClick: noop,
-	onPick: noop,
+	onClick: () => {},
+	onPick: () => {},
 };

--- a/client/components/focusable/docs/example.jsx
+++ b/client/components/focusable/docs/example.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,7 +16,7 @@ export default class FocusableExample extends React.PureComponent {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<DocsExample>
-				<Focusable onClick={ noop }>
+				<Focusable onClick={ () => {} }>
 					<p>
 						This keyboard-accessible component can contain other elements as children, including{ ' ' }
 						<code>p</code>
@@ -29,7 +28,7 @@ export default class FocusableExample extends React.PureComponent {
 					An example of real use is in the Language Picker, which can be considered a "complex
 					button."
 				</p>
-				<Focusable onClick={ noop } className="language-picker">
+				<Focusable onClick={ () => {} } className="language-picker">
 					<div className="language-picker__icon" aria-hidden>
 						<div className="language-picker__icon-inner">en</div>
 					</div>

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -40,8 +39,8 @@ class FoldableCard extends Component {
 	};
 
 	static defaultProps = {
-		onOpen: noop,
-		onClose: noop,
+		onOpen: () => {},
+		onClose: () => {},
 		cardKey: '',
 		icon: 'chevron-down',
 		expanded: false,

--- a/client/components/forms/clipboard-button/README.md
+++ b/client/components/forms/clipboard-button/README.md
@@ -30,7 +30,7 @@ The text to copy to the user's clipboard upon clicking the button.
 <table>
 	<tr><td>Type</td><td>Function</td></tr>
 	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>lodash/noop</code></td></tr>
+	<tr><td>Default</td><td><code>() => {}</code></td></tr>
 </table>
 
 Function to invoke after the text has been copied to the user's clipboard. This will not be triggered if the a prompt is shown in place of direct clipboard copy, in cases where the browser does not grant clipboard access.

--- a/client/components/forms/clipboard-button/index.jsx
+++ b/client/components/forms/clipboard-button/index.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDom from 'react-dom';
 import Clipboard from 'clipboard';
-import { noop } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -14,7 +13,7 @@ import classNames from 'classnames';
  */
 import { Button } from '@automattic/components';
 
-function ClipboardButton( { className, text, onCopy = noop, ...rest } ) {
+function ClipboardButton( { className, text, onCopy = () => {}, ...rest } ) {
 	const buttonRef = React.useRef();
 
 	const textCallback = React.useRef();

--- a/client/components/forms/counted-textarea/index.jsx
+++ b/client/components/forms/counted-textarea/index.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { localize, translate } from 'i18n-calypso';
 import classNames from 'classnames';
-import { omit, noop } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,7 +33,7 @@ export class CountedTextarea extends React.Component {
 		value: '',
 		placeholder: '',
 		countPlaceholderLength: false,
-		onChange: noop,
+		onChange: () => {},
 		showRemainingCharacters: false,
 		translate,
 	};

--- a/client/components/forms/form-phone-input/index.jsx
+++ b/client/components/forms/form-phone-input/index.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { identity, noop, find } from 'lodash';
+import { identity, find } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -35,7 +35,7 @@ export class FormPhoneInput extends React.Component {
 		isDisabled: false,
 		countrySelectProps: {},
 		phoneInputProps: {},
-		onChange: noop,
+		onChange: () => {},
 		translate: identity,
 	};
 

--- a/client/components/forms/form-range/index.jsx
+++ b/client/components/forms/form-range/index.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { omit, noop } from 'lodash';
+import { omit } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -20,7 +20,7 @@ export default class extends React.Component {
 	};
 
 	static defaultProps = {
-		onChange: noop,
+		onChange: () => {},
 	};
 
 	rangeRef = React.createRef();

--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -5,7 +5,6 @@
 import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,11 +21,11 @@ function FormTextInputWithAction( {
 	className,
 	action,
 	inputRef,
-	onFocus = noop,
-	onBlur = noop,
-	onKeyDown = noop,
-	onChange = noop,
-	onAction = noop,
+	onFocus = () => {},
+	onBlur = () => {},
+	onKeyDown = () => {},
+	onChange = () => {},
+	onAction = () => {},
 	defaultValue = '',
 	disabled,
 	isError,

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -3,7 +3,6 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -27,7 +26,7 @@ export default class FormToggle extends PureComponent {
 	static defaultProps = {
 		checked: false,
 		disabled: false,
-		onChange: noop,
+		onChange: () => {},
 	};
 
 	render() {

--- a/client/components/forms/multi-checkbox/index.tsx
+++ b/client/components/forms/multi-checkbox/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { useCallback, useRef } from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -42,7 +41,7 @@ export default function MultiCheckbox( props: Props & DivProps ) {
 		checked,
 		defaultChecked = [] as OptionValue[],
 		disabled = false,
-		onChange = noop,
+		onChange = () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
 		name = 'multiCheckbox',
 		options,
 		...otherProps

--- a/client/components/forms/sortable-list/index.jsx
+++ b/client/components/forms/sortable-list/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { assign, findIndex, fromPairs, noop } from 'lodash';
+import { assign, findIndex, fromPairs } from 'lodash';
 import classNames from 'classnames';
 import debugFactory from 'debug';
 import Gridicon from 'calypso/components/gridicon';
@@ -32,7 +32,7 @@ class SortableList extends React.Component {
 	static defaultProps = {
 		direction: 'horizontal',
 		allowDrag: true,
-		onChange: noop,
+		onChange: () => {},
 	};
 
 	state = {

--- a/client/components/gravatar-caterpillar/index.jsx
+++ b/client/components/gravatar-caterpillar/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop, map, size, takeRight, filter, uniqBy } from 'lodash';
+import { map, size, takeRight, filter, uniqBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -59,7 +59,7 @@ class GravatarCaterpillar extends React.Component {
 }
 
 GravatarCaterpillar.defaultProps = {
-	onClick: noop,
+	onClick: () => {},
 	maxGravatarsToDisplay: 10,
 };
 

--- a/client/components/gsuite/gsuite-learn-more/index.jsx
+++ b/client/components/gsuite/gsuite-learn-more/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
@@ -55,7 +54,7 @@ GSuiteLearnMore.propTypes = {
 };
 
 GSuiteLearnMore.defaultProps = {
-	onLearnMoreClick: noop,
+	onLearnMoreClick: () => {},
 };
 
 export default GSuiteLearnMore;

--- a/client/components/happiness-support/test/index.jsx
+++ b/client/components/happiness-support/test/index.jsx
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 import { spy } from 'sinon';
 
@@ -25,7 +24,9 @@ describe( 'HappinessSupport', () => {
 	const translate = ( content ) => `Translated: ${ content }`;
 
 	beforeEach( () => {
-		wrapper = shallow( <HappinessSupport translate={ translate } recordTracksEvent={ noop } /> );
+		wrapper = shallow(
+			<HappinessSupport translate={ translate } recordTracksEvent={ () => {} } />
+		);
 	} );
 
 	test( 'should render translated heading content', () => {
@@ -50,7 +51,11 @@ describe( 'HappinessSupport', () => {
 
 	test( 'should render a support button with link to SUPPORT_ROOT if it is not for JetPack', () => {
 		wrapper = shallow(
-			<HappinessSupport translate={ translate } recordTracksEvent={ noop } isJetpack={ false } />
+			<HappinessSupport
+				translate={ translate }
+				recordTracksEvent={ () => {} }
+				isJetpack={ false }
+			/>
 		);
 		expect(
 			wrapper.find( 'ForwardRef(Button).happiness-support__support-button' ).props().href
@@ -59,7 +64,7 @@ describe( 'HappinessSupport', () => {
 
 	test( 'should render a support button with link to JETPACK_SUPPORT if it is for JetPack', () => {
 		wrapper = shallow(
-			<HappinessSupport translate={ translate } recordTracksEvent={ noop } isJetpack={ true } />
+			<HappinessSupport translate={ translate } recordTracksEvent={ () => {} } isJetpack={ true } />
 		);
 		expect( wrapper.find( 'ForwardRef(Button)' ).last().prop( 'href' ) ).to.equal(
 			JETPACK_SUPPORT
@@ -70,7 +75,11 @@ describe( 'HappinessSupport', () => {
 		expect( wrapper.find( '.happiness-support' ).hasClass( 'is-placeholder' ) ).to.be.false;
 
 		wrapper = shallow(
-			<HappinessSupport translate={ translate } recordTracksEvent={ noop } isPlaceholder={ true } />
+			<HappinessSupport
+				translate={ translate }
+				recordTracksEvent={ () => {} }
+				isPlaceholder={ true }
+			/>
 		);
 		expect( wrapper.find( '.happiness-support' ).hasClass( 'is-placeholder' ) ).to.be.true;
 	} );
@@ -79,7 +88,7 @@ describe( 'HappinessSupport', () => {
 		wrapper = shallow(
 			<HappinessSupport
 				translate={ translate }
-				recordTracksEvent={ noop }
+				recordTracksEvent={ () => {} }
 				showLiveChatButton={ true }
 			/>
 		);
@@ -89,7 +98,7 @@ describe( 'HappinessSupport', () => {
 	describe( 'LiveChat button', () => {
 		const props = {
 			translate,
-			recordTracksEvent: noop,
+			recordTracksEvent: () => {},
 		};
 
 		beforeEach( () => {
@@ -174,7 +183,7 @@ describe( 'HappinessSupport', () => {
 		const selector = 'ForwardRef(Button).happiness-support__contact-button';
 		const props = {
 			translate,
-			recordTracksEvent: noop,
+			recordTracksEvent: () => {},
 		};
 
 		test( 'should be rendered unless LiveChat button shows up', () => {

--- a/client/components/happychat/button.jsx
+++ b/client/components/happychat/button.jsx
@@ -5,7 +5,7 @@ import { isMobile } from '@automattic/viewport';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import page from 'page';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
@@ -41,13 +41,13 @@ export class HappychatButton extends Component {
 	static defaultProps = {
 		allowMobileRedirect: false,
 		borderless: true,
-		getAuth: noop,
-		initConnection: noop,
+		getAuth: () => {},
+		initConnection: () => {},
 		isChatActive: false,
 		isChatAvailable: false,
 		isConnectionUninitialized: false,
-		onClick: noop,
-		openChat: noop,
+		onClick: () => {},
+		openChat: () => {},
 		translate: identity,
 	};
 

--- a/client/components/happychat/test/composer.jsx
+++ b/client/components/happychat/test/composer.jsx
@@ -7,7 +7,6 @@
  */
 import React from 'react';
 import { mount } from 'enzyme';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,7 +25,7 @@ describe( '<Composer />', () => {
 					onSetCurrentMessage={ onSetCurrentMessage }
 					onSendTyping={ onSendTyping }
 					onSendNotTyping={ onSendNotTyping }
-					translate={ noop }
+					translate={ () => {} }
 				/>
 			);
 			wrapper.find( 'textarea' ).simulate( 'change', { target: { value: 'hey' } } );
@@ -45,7 +44,7 @@ describe( '<Composer />', () => {
 					onSetCurrentMessage={ onSetCurrentMessage }
 					onSendTyping={ onSendTyping }
 					onSendNotTyping={ onSendNotTyping }
-					translate={ noop }
+					translate={ () => {} }
 				/>
 			);
 			wrapper.find( 'textarea' ).simulate( 'change', { target: { value: '' } } );
@@ -64,7 +63,7 @@ describe( '<Composer />', () => {
 					message={ 'hey' }
 					onSendMessage={ onSendMessage }
 					onSendNotTyping={ onSendNotTyping }
-					translate={ noop }
+					translate={ () => {} }
 				/>
 			);
 			wrapper.find( 'textarea' ).simulate( 'keydown', { which: 13, preventDefault: () => {} } );
@@ -80,7 +79,7 @@ describe( '<Composer />', () => {
 					message={ '' }
 					onSendMessage={ onSendMessage }
 					onSendNotTyping={ onSendNotTyping }
-					translate={ noop }
+					translate={ () => {} }
 				/>
 			);
 			wrapper.find( 'textarea' ).simulate( 'keydown', { which: 13, preventDefault: () => {} } );

--- a/client/components/image-preloader/index.tsx
+++ b/client/components/image-preloader/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { useState, useEffect, useRef } from 'react';
-import { noop } from 'lodash';
 
 /**
  * Constants
@@ -55,8 +54,8 @@ export default function ImagePreloader( props: Props & ImgProps ) {
 				return;
 			}
 
-			image.current.onload = noop;
-			image.current.onerror = noop;
+			image.current.onload = () => {}; // eslint-disable-line @typescript-eslint/no-empty-function
+			image.current.onerror = () => {}; // eslint-disable-line @typescript-eslint/no-empty-function
 			image.current = null;
 		}
 

--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { noop } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -43,7 +42,7 @@ export default class InfiniteList extends React.Component {
 
 	static defaultProps = {
 		itemsPerRow: 1,
-		renderTrailingItems: noop,
+		renderTrailingItems: () => {},
 	};
 
 	lastScrollTop = -1;

--- a/client/components/jetpack/backup-card/index.tsx
+++ b/client/components/jetpack/backup-card/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { noop } from 'lodash';
 import React, { useRef, FunctionComponent, useState, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -68,10 +67,12 @@ const BackupCard: FunctionComponent< Props > = ( {
 	const onRestoreButtonLeave = useCallback( () => setTooltipVisibility( false ), [
 		setTooltipVisibility,
 	] );
-	const onDownloadClick = useTrackCallback( noop, 'calypso_jetpack_backup_download', {
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	const onDownloadClick = useTrackCallback( () => {}, 'calypso_jetpack_backup_download', {
 		rewind_id: rewindId,
 	} );
-	const onRestoreClick = useTrackCallback( noop, 'calypso_jetpack_backup_restore', {
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	const onRestoreClick = useTrackCallback( () => {}, 'calypso_jetpack_backup_restore', {
 		rewind_id: rewindId,
 	} );
 

--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -6,7 +6,6 @@ import { useSelector } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import classnames from 'classnames';
 import { Button } from '@automattic/components';
-import { noop } from 'lodash';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 
 /**
@@ -126,7 +125,8 @@ const ThreatItem: React.FC< Props > = ( {
 			? { section: currentRoute.includes( '/scan/history' ) ? 'History' : 'Scanner' }
 			: {};
 	}, [ currentRoute ] );
-	const onOpenTrackEvent = useTrackCallback( noop, 'calypso_jetpack_scan_threat_itemtoggle', {
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	const onOpenTrackEvent = useTrackCallback( () => {}, 'calypso_jetpack_scan_threat_itemtoggle', {
 		threat_signature: threat.signature,
 		...currentRouteProp,
 	} );
@@ -177,6 +177,7 @@ const ThreatItem: React.FC< Props > = ( {
 						target="_blank"
 						rel="noopener noreferrer"
 						tracksEventName="calypso_jetpack_scan_threat_codeable_estimate"
+						// eslint-disable-next-line @typescript-eslint/no-empty-function
 						onClick={ () => {} }
 					>
 						{ translate( 'Get a free estimate' ) }

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
 	has,
-	noop,
 	pick,
 	pickBy,
 	without,
@@ -46,7 +45,7 @@ class KeyedSuggestions extends React.Component {
 	};
 
 	static defaultProps = {
-		suggest: noop,
+		suggest: () => {},
 		terms: {},
 		input: '',
 	};

--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Fragment, PureComponent } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { find, isString, noop } from 'lodash';
+import { find, isString } from 'lodash';
 
 /**
  * Internal dependencies
@@ -35,8 +35,8 @@ export class LanguagePicker extends PureComponent {
 	static defaultProps = {
 		languages: [],
 		valueKey: 'value',
-		onChange: noop,
-		onClick: noop,
+		onChange: () => {},
+		onClick: () => {},
 		showEmpathyModeControl: config.isEnabled( 'i18n/empathy-mode' ),
 		empathyMode: false,
 		useFallbackForIncompleteLanguages: false,

--- a/client/components/legend-item/index.js
+++ b/client/components/legend-item/index.js
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop } from 'lodash';
 
 /**
  * Style dependencies
@@ -27,8 +26,8 @@ class LegendItem extends Component {
 	};
 
 	static defaultProps = {
-		onMouseOver: noop,
-		onMouseOut: noop,
+		onMouseOver: () => {},
+		onMouseOut: () => {},
 	};
 
 	handleMouseOver = () => {

--- a/client/components/line-chart/legend.js
+++ b/client/components/line-chart/legend.js
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,7 +19,7 @@ class LineChartLegend extends Component {
 
 	static defaultProps = {
 		fillArea: false,
-		onDataSeriesSelected: noop,
+		onDataSeriesSelected: () => {},
 	};
 
 	handleMouseOver = ( dataSeriesIndex ) => {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/business-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/business-at-step.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,7 +22,7 @@ export class BusinessATStep extends Component {
 	};
 
 	static defaultProps = {
-		translate: noop,
+		translate: () => {},
 	};
 
 	onClickPluginSupport = () => {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,7 +25,7 @@ export class DowngradeStep extends Component {
 	};
 
 	static defaultProps = {
-		translate: noop,
+		translate: () => {},
 	};
 
 	onClick = () => {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/test/business-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/test/business-at-step.jsx
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 import { stub } from 'sinon';
 
@@ -18,7 +17,9 @@ describe( 'BusinessATStep', () => {
 		const translate = ( content ) => `Translated: ${ content }`;
 
 		beforeEach( () => {
-			wrapper = shallow( <BusinessATStep recordTracksEvent={ noop } translate={ translate } /> );
+			wrapper = shallow(
+				<BusinessATStep recordTracksEvent={ () => {} } translate={ translate } />
+			);
 		} );
 
 		test( 'should render translated heading content', () => {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/test/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/test/upgrade-at-step.jsx
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 import { stub } from 'sinon';
 
@@ -23,7 +22,7 @@ describe( 'UpgradeATStep', () => {
 		beforeEach( () => {
 			wrapper = shallow(
 				<UpgradeATStep
-					recordTracksEvent={ noop }
+					recordTracksEvent={ () => {} }
 					translate={ translate }
 					selectedSite={ selectedSite }
 				/>
@@ -52,7 +51,11 @@ describe( 'UpgradeATStep', () => {
 
 	test( 'should render button with link to business plan checkout', () => {
 		const wrapper = shallow(
-			<UpgradeATStep recordTracksEvent={ noop } translate={ noop } selectedSite={ selectedSite } />
+			<UpgradeATStep
+				recordTracksEvent={ () => {} }
+				translate={ () => {} }
+				selectedSite={ selectedSite }
+			/>
 		);
 
 		expect( wrapper.find( Button ).props().href ).to.equal(
@@ -65,7 +68,7 @@ describe( 'UpgradeATStep', () => {
 		const wrapper = shallow(
 			<UpgradeATStep
 				recordTracksEvent={ recordTracksEvent }
-				translate={ noop }
+				translate={ () => {} }
 				selectedSite={ selectedSite }
 			/>
 		);

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upgrade-at-step.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,7 +24,7 @@ export class UpgradeATStep extends Component {
 	};
 
 	static defaultProps = {
-		translate: noop,
+		translate: () => {},
 	};
 
 	onClick = () => {

--- a/client/components/multiple-choice-question/test/index.js
+++ b/client/components/multiple-choice-question/test/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import React from 'react';
 import renderer from 'react-test-renderer';
 
@@ -22,7 +21,7 @@ describe( 'MultipleChoiceQuestion', () => {
 						{ id: 'test-answer-3', answerText: 'Test Answer Three', doNotShuffle: true },
 						{ id: 'test-answer-4', answerText: 'Test Answer Four', doNotShuffle: true },
 					] }
-					onAnswerChange={ noop }
+					onAnswerChange={ () => {} }
 				/>
 			)
 			.toJSON();

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 // @todo: Convert to import from `components/gridicon`
@@ -41,7 +40,7 @@ export class Notice extends Component {
 		icon: null,
 		isCompact: false,
 		isLoading: false,
-		onDismissClick: noop,
+		onDismissClick: () => {},
 		status: null,
 		text: null,
 	};

--- a/client/components/popover/menu-item-clipboard.jsx
+++ b/client/components/popover/menu-item-clipboard.jsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -17,7 +16,7 @@ function PopoverMenuItemClipboard( {
 	children,
 	className,
 	text,
-	onCopy = noop,
+	onCopy = () => {},
 	icon = 'clipboard',
 	...rest
 } ) {

--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
-import { noop, omit } from 'lodash';
+import { omit } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -28,7 +28,7 @@ export default class PopoverMenuItem extends Component {
 	static defaultProps = {
 		isSelected: false,
 		focusOnHover: true,
-		onMouseOver: noop,
+		onMouseOver: () => {},
 		itemComponent: 'button',
 	};
 

--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop, flowRight as compose } from 'lodash';
+import { flowRight as compose } from 'lodash';
 import 'moment-timezone'; // monkey patches the existing moment.js
 
 /**
@@ -249,7 +249,7 @@ PostScheduleClock.propTypes = {
 };
 
 PostScheduleClock.defaultProps = {
-	onChange: noop,
+	onChange: () => {},
 };
 
 export default compose(

--- a/client/components/product-card/action.jsx
+++ b/client/components/product-card/action.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,7 +33,7 @@ ProductCardAction.propTypes = {
 
 ProductCardAction.defaultProps = {
 	href: null,
-	onClick: noop,
+	onClick: () => {},
 	primary: true,
 };
 

--- a/client/components/publicize-message/index.jsx
+++ b/client/components/publicize-message/index.jsx
@@ -6,7 +6,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,7 +37,7 @@ class PublicizeMessage extends Component {
 		message: '',
 		acceptableLength: 280,
 		requireCount: false,
-		onChange: noop,
+		onChange: () => {},
 		preFilledMessage: '',
 	};
 

--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -6,7 +6,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,7 +37,7 @@ export default class PurchaseDetail extends PureComponent {
 	};
 
 	static defaultProps = {
-		onClick: noop,
+		onClick: () => {},
 		primaryButton: false,
 	};
 

--- a/client/components/purchase-detail/test/index.jsx
+++ b/client/components/purchase-detail/test/index.jsx
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 
 /**
@@ -60,6 +59,7 @@ describe( 'PurchaseDetail', () => {
 	} );
 
 	test( 'should render a <PurchaseButton> with given info unless the body text is passed', () => {
+		const noop = () => {};
 		const buttonProps = {
 			isSubmitting: false,
 			href: 'https://wordpress.com/test/url',

--- a/client/components/related-posts/index.jsx
+++ b/client/components/related-posts/index.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { noop, times } from 'lodash';
+import { times } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -22,8 +22,8 @@ function RelatedPosts( {
 	title,
 	scope,
 	className = '',
-	onPostClick = noop,
-	onSiteClick = noop,
+	onPostClick = () => {},
+	onSiteClick = () => {},
 } ) {
 	let listItems;
 

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -5,7 +5,7 @@ import { isMobile } from '@automattic/viewport';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { debounce, noop, uniqueId } from 'lodash';
+import { debounce, uniqueId } from 'lodash';
 import i18n from 'i18n-calypso';
 
 /**
@@ -77,11 +77,11 @@ class Search extends Component {
 		autoFocus: false,
 		disabled: false,
 		describedBy: null,
-		onSearchChange: noop,
-		onSearchOpen: noop,
-		onSearchClose: noop,
-		onKeyDown: noop,
-		onClick: noop,
+		onSearchChange: () => {},
+		onSearchOpen: () => {},
+		onSearchClose: () => {},
+		onKeyDown: () => {},
+		onClick: () => {},
 		//undefined value for overlayStyling is an optimization that will
 		//disable overlay scrolling calculation when no overlay is provided.
 		overlayStyling: undefined,

--- a/client/components/segmented-control/simplified.jsx
+++ b/client/components/segmented-control/simplified.jsx
@@ -3,7 +3,6 @@
  */
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,7 +12,7 @@ import SegmentedControl from '.';
 function SimplifiedSegmentedControl( {
 	options,
 	initialSelected = options[ 0 ].value,
-	onSelect = noop,
+	onSelect = () => {},
 	...props
 } ) {
 	const [ selected, setSelected ] = useState( initialSelected );

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { filter, find, get, noop } from 'lodash';
+import { filter, find, get } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -50,8 +50,8 @@ class SelectDropdown extends Component {
 
 	static defaultProps = {
 		options: [],
-		onSelect: noop,
-		onToggle: noop,
+		onSelect: () => {},
+		onToggle: () => {},
 		style: {},
 	};
 

--- a/client/components/seo/meta-title-editor/index.jsx
+++ b/client/components/seo/meta-title-editor/index.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { get, identity, noop } from 'lodash';
+import { get, identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -61,7 +61,7 @@ export class MetaTitleEditor extends Component {
 
 	static defaultProps = {
 		disabled: false,
-		onChange: noop,
+		onChange: () => {},
 		translate: identity,
 	};
 

--- a/client/components/share-button/index.jsx
+++ b/client/components/share-button/index.jsx
@@ -3,7 +3,6 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,7 +29,7 @@ export default class ShareButton extends PureComponent {
 	static defaultProps = {
 		size: 48,
 		defaultMessage: '',
-		onClick: noop,
+		onClick: () => {},
 		color: true,
 	};
 

--- a/client/components/signup-site-preview/screenshot.tsx
+++ b/client/components/signup-site-preview/screenshot.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import React, { useEffect, useState } from 'react';
 
 /**
@@ -25,7 +24,7 @@ export default function SignupSitePreviewScreenshot( {
 	setWrapperHeight,
 	scrolling,
 	screenshotUrl,
-	onPreviewClick = noop,
+	onPreviewClick = () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
 	translate,
 }: Props ) {
 	const [ isLoading, setIsLoading ] = useState( true );

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import classNames from 'classnames';
-import { filter, find, flow, get, includes, isEmpty, noop } from 'lodash';
+import { filter, find, flow, get, includes, isEmpty } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -72,8 +72,8 @@ class SiteSelector extends Component {
 		indicator: false,
 		hideSelected: false,
 		selected: null,
-		onClose: noop,
-		onSiteSelect: noop,
+		onClose: () => {},
+		onSiteSelect: () => {},
 		groups: false,
 		autoFocus: false,
 	};

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { noop, get } from 'lodash';
+import { get } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -39,8 +39,8 @@ export class SitesDropdown extends PureComponent {
 
 	static defaultProps = {
 		showAllSites: false,
-		onClose: noop,
-		onSiteSelect: noop,
+		onClose: () => {},
+		onSiteSelect: () => {},
 		isPlaceholder: false,
 		hasMultipleSites: false,
 	};

--- a/client/components/sites-dropdown/test/index.js
+++ b/client/components/sites-dropdown/test/index.js
@@ -7,7 +7,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 import sinon from 'sinon';
 
@@ -85,7 +84,7 @@ describe( 'index', () => {
 			const fakeContext = {
 				setState: setStateSpy,
 				props: {
-					onClose: noop,
+					onClose: () => {},
 				},
 			};
 
@@ -98,7 +97,7 @@ describe( 'index', () => {
 		test( 'should run the component `onClose` hook, when it is provided', () => {
 			const onCloseSpy = sinon.spy();
 			const fakeContext = {
-				setState: noop,
+				setState: () => {},
 				props: {
 					onClose: onCloseSpy,
 				},

--- a/client/components/sites-popover/index.jsx
+++ b/client/components/sites-popover/index.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -32,7 +31,7 @@ class SitesPopover extends React.Component {
 
 	static defaultProps = {
 		visible: false,
-		onClose: noop,
+		onClose: () => {},
 		position: 'bottom left',
 		groups: false,
 		siteQuerystring: false,

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -7,7 +7,6 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import { loadScript } from '@automattic/load-script';
 
 /**
@@ -39,7 +38,7 @@ class AppleLoginButton extends Component {
 	};
 
 	static defaultProps = {
-		onClick: noop,
+		onClick: () => {},
 		scope: 'name email',
 		uxMode: 'popup',
 	};

--- a/client/components/social-buttons/facebook.js
+++ b/client/components/social-buttons/facebook.js
@@ -8,7 +8,6 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { loadScript } from '@automattic/load-script';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -42,7 +41,7 @@ class FacebookLoginButton extends Component {
 		status: false,
 		xfbml: true,
 		scope: 'public_profile,email',
-		onClick: noop,
+		onClick: () => {},
 	};
 
 	constructor( props ) {

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -7,7 +7,6 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { loadScript } from '@automattic/load-script';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,7 +42,7 @@ class GoogleLoginButton extends Component {
 	static defaultProps = {
 		scope: 'https://www.googleapis.com/auth/userinfo.profile',
 		fetchBasicProfile: true,
-		onClick: noop,
+		onClick: () => {},
 	};
 
 	state = {

--- a/client/components/split-button/README.md
+++ b/client/components/split-button/README.md
@@ -26,7 +26,7 @@ export default function MyComponent( { onMenuItemClick } ) {
 <table>
 	<tr><td>Type</td><td><code>PropTypes.node</code></td></tr>
     <tr><td>Required</td><td>Yes</td></tr>
-	<tr><td>Default</td><td><code>noop</code></td></tr>
+	<tr><td>Default</td><td><code>() => {}</code></td></tr>
 </table>
 
 Text or icon for the main button.
@@ -66,7 +66,7 @@ Whether the button has modified styling to warn users (delete, remove, etc).es
 <table>
 	<tr><td>Type</td><td>Function</td></tr>
 	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>noop</code></td></tr>
+	<tr><td>Default</td><td><code>() => {}</code></td></tr>
 </table>
 
 Callback that will be invoked when menu button is clicked.
@@ -77,7 +77,7 @@ Will be passed the click event.
 <table>
 	<tr><td>Type</td><td>Function</td></tr>
 	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>noop</code></td></tr>
+	<tr><td>Default</td><td><code>() => {}</code></td></tr>
 </table>
 
 Callback that will be invoked when menu is toggled.

--- a/client/components/split-button/index.jsx
+++ b/client/components/split-button/index.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -38,8 +37,8 @@ class SplitButton extends PureComponent {
 	};
 
 	static defaultProps = {
-		onClick: noop,
-		onToggle: noop,
+		onClick: () => {},
+		onToggle: () => {},
 		label: '',
 		icon: '',
 		position: 'bottom left',

--- a/client/components/sub-masterbar-nav/item.jsx
+++ b/client/components/sub-masterbar-nav/item.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -41,7 +40,7 @@ Item.propTypes = {
 
 Item.defaultProps = {
 	isSelected: false,
-	onClick: noop,
+	onClick: () => {},
 	icon: 'star',
 };
 

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -3,7 +3,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,8 +39,8 @@ class SuggestionSearch extends Component {
 	static defaultProps = {
 		id: '',
 		placeholder: '',
-		onChange: noop,
-		onSelect: noop,
+		onChange: () => {},
+		onSelect: () => {},
 		suggestions: [],
 		value: '',
 		autoFocus: false,

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { get, isEmpty, isEqual, noop, some } from 'lodash';
+import { get, isEmpty, isEqual, some } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 import photon from 'photon';
@@ -82,7 +82,7 @@ export class Theme extends Component {
 	static defaultProps = {
 		isPlaceholder: false,
 		buttonContents: {},
-		onMoreButtonClick: noop,
+		onMoreButtonClick: () => {},
 		actionLabel: '',
 		active: false,
 	};

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { isEqual, isEmpty, noop, times } from 'lodash';
+import { isEqual, isEmpty, times } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -47,7 +47,7 @@ export class ThemesList extends React.Component {
 	static defaultProps = {
 		loading: false,
 		themes: [],
-		fetchNextPage: noop,
+		fetchNextPage: () => {},
 		placeholderCount: DEFAULT_THEME_QUERY.number,
 		optionsGenerator: () => [],
 		getActionLabel: () => '',

--- a/client/components/themes-list/test/index.jsx
+++ b/client/components/themes-list/test/index.jsx
@@ -7,7 +7,7 @@
  */
 import React from 'react';
 import deepFreeze from 'deep-freeze';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { shallow } from 'enzyme';
 
 /**
@@ -32,9 +32,9 @@ const defaultProps = deepFreeze( {
 	],
 	lastPage: true,
 	loading: false,
-	fetchNextPage: noop,
-	getButtonOptions: noop,
-	onScreenshotClick: noop,
+	fetchNextPage: () => {},
+	getButtonOptions: () => {},
+	onScreenshotClick: () => {},
 	translate: identity,
 } );
 

--- a/client/components/timeline/README.md
+++ b/client/components/timeline/README.md
@@ -74,14 +74,14 @@ export default class extends React.Component {
 					icon="checkmark"
 					iconBackground="success"
 					actionLabel="Delete domain"
-					onActionClick={ noop }
+					onActionClick={ () => {} }
 				/>
 				<TimelineEvent
 					date={ new Date( '11 February 2021' ) }
 					detail="You have Auto-renew enabled which means your domain will automatically be renewed for you every year."
 					icon="sync"
 					actionLabel="Disable Auto-renew"
-					onActionClick={ noop }
+					onActionClick={ () => {} }
 				/>
 				<TimelineEvent
 					date={ new Date( '14 March 2021' ) }
@@ -90,7 +90,7 @@ export default class extends React.Component {
 					iconBackground="warning"
 					actionLabel="Enable Auto-renew"
 					actionIsPrimary
-					onActionClick={ noop }
+					onActionClick={ () => {} }
 				/>
 				<TimelineEvent
 					date={ new Date( '18 April 2021' ) }
@@ -118,7 +118,7 @@ export default class extends React.Component {
 					actionLabel="Watch out!"
 					actionIsScary
 					actionIsPrimary
-					onActionClick={ noop }
+					onActionClick={ () => {} }
 				/>
 			</Timeline>
 		);

--- a/client/components/timeline/docs/example.jsx
+++ b/client/components/timeline/docs/example.jsx
@@ -3,7 +3,6 @@
  */
 
 import React, { PureComponent } from 'react';
-import { noop } from 'lodash-es';
 
 /**
  * Internal dependencies
@@ -23,14 +22,14 @@ class TimelineExample extends PureComponent {
 					icon="checkmark"
 					iconBackground="success"
 					actionLabel="Delete domain"
-					onActionClick={ noop }
+					onActionClick={ () => {} }
 				/>
 				<TimelineEvent
 					date={ new Date( '11 February 2021' ) }
 					detail="You have Auto-renew enabled which means your domain will automatically be renewed for you every year."
 					icon="sync"
 					actionLabel="Disable Auto-renew"
-					onActionClick={ noop }
+					onActionClick={ () => {} }
 				/>
 				<TimelineEvent
 					date={ new Date( '14 March 2021' ) }
@@ -39,7 +38,7 @@ class TimelineExample extends PureComponent {
 					iconBackground="warning"
 					actionLabel="Enable Auto-renew"
 					actionIsPrimary
-					onActionClick={ noop }
+					onActionClick={ () => {} }
 				/>
 				<TimelineEvent
 					date={ new Date( '28 April 2021' ) }
@@ -67,7 +66,7 @@ class TimelineExample extends PureComponent {
 					actionLabel="Watch out!"
 					actionIsScary
 					actionIsPrimary
-					onActionClick={ noop }
+					onActionClick={ () => {} }
 				/>
 			</Timeline>
 		);

--- a/client/components/timezone/index.jsx
+++ b/client/components/timezone/index.jsx
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { map, noop } from 'lodash';
+import { map } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -75,7 +75,7 @@ class Timezone extends Component {
 }
 
 Timezone.defaultProps = {
-	onSelect: noop,
+	onSelect: () => {},
 	includeManualOffsets: true,
 };
 

--- a/client/components/tinymce/plugins/embed/test/dialog.js
+++ b/client/components/tinymce/plugins/embed/test/dialog.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { spy } from 'sinon';
 
 /**
@@ -34,8 +34,8 @@ describe( 'EmbedDialog', () => {
 			<EmbedDialog
 				embedUrl={ url }
 				siteId={ testSiteId }
-				onCancel={ noop }
-				onUpdate={ noop }
+				onCancel={ () => {} }
+				onUpdate={ () => {} }
 				translate={ identity }
 			/>
 		);
@@ -53,8 +53,8 @@ describe( 'EmbedDialog', () => {
 			<EmbedDialog
 				embedUrl={ originalUrl }
 				siteId={ testSiteId }
-				onCancel={ noop }
-				onUpdate={ noop }
+				onCancel={ () => {} }
+				onUpdate={ () => {} }
 				translate={ identity }
 			/>
 		);
@@ -84,7 +84,7 @@ describe( 'EmbedDialog', () => {
 			<EmbedDialog
 				embedUrl={ originalUrl }
 				siteId={ testSiteId }
-				onCancel={ noop }
+				onCancel={ () => {} }
 				onUpdate={ onUpdate }
 				translate={ identity }
 			/>
@@ -102,7 +102,7 @@ describe( 'EmbedDialog', () => {
 		const mockChangeEvent = {
 			target: { value: newUrl },
 		};
-		const noopSpy = spy( noop );
+		const noopSpy = spy( () => {} );
 		let currentUrl = originalUrl;
 		const onUpdate = ( url ) => {
 			currentUrl = url;
@@ -135,8 +135,8 @@ describe( 'EmbedDialog', () => {
 				<EmbedDialog
 					embedUrl={ url }
 					siteId={ testSiteId }
-					onCancel={ noop }
-					onUpdate={ noop }
+					onCancel={ () => {} }
+					onUpdate={ () => {} }
 					translate={ identity }
 				/>
 			);

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { get, head, map, max, min, noop } from 'lodash';
+import { get, head, map, max, min } from 'lodash';
 import moment from 'moment';
 
 /**
@@ -74,7 +74,7 @@ export class TitleFormatEditor extends Component {
 			new CompositeDecorator( [
 				{
 					strategy: this.renderTokens,
-					component: Chip( disabled ? noop : this.removeToken ),
+					component: Chip( disabled ? () => {} : this.removeToken ),
 				},
 			] )
 		);
@@ -247,7 +247,7 @@ export class TitleFormatEditor extends Component {
 						<span
 							key={ name }
 							className="title-format-editor__button"
-							onClick={ disabled ? noop : this.addToken( title, name ) }
+							onClick={ disabled ? () => {} : this.addToken( title, name ) }
 						>
 							{ title }
 						</span>
@@ -258,7 +258,7 @@ export class TitleFormatEditor extends Component {
 					<Editor
 						readOnly={ disabled }
 						editorState={ editorState }
-						onChange={ disabled ? noop : this.updateEditor }
+						onChange={ disabled ? () => {} : this.updateEditor }
 						placeholder={ placeholder }
 						ref={ this.storeEditorReference }
 					/>

--- a/client/components/token-field/token-input.jsx
+++ b/client/components/token-field/token-input.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { omit, noop } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,8 +23,8 @@ class TokenInput extends React.PureComponent {
 	static defaultProps = {
 		disabled: false,
 		hasFocus: false,
-		onChange: noop,
-		onBlur: noop,
+		onChange: () => {},
+		onBlur: () => {},
 		placeholder: '',
 		value: '',
 	};

--- a/client/components/track-input-changes/index.jsx
+++ b/client/components/track-input-changes/index.jsx
@@ -4,7 +4,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { assign, noop } from 'lodash';
+import { assign } from 'lodash';
 
 export default class TrackInputChanges extends Component {
 	static displayName = 'TrackInputChanges';
@@ -14,7 +14,7 @@ export default class TrackInputChanges extends Component {
 	};
 
 	static defaultProps = {
-		onNewValue: noop,
+		onNewValue: () => {},
 	};
 
 	UNSAFE_componentWillMount() {

--- a/client/components/vertical-nav/docs/example.jsx
+++ b/client/components/vertical-nav/docs/example.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,7 +26,7 @@ VerticalNavExample.defaultProps = {
 			<VerticalNavItem path="https://google.com" external key="1">
 				Google
 			</VerticalNavItem>
-			<VerticalNavItem path="/posts" onClick={ noop } key="2">
+			<VerticalNavItem path="/posts" onClick={ () => {} } key="2">
 				Posts
 			</VerticalNavItem>
 			<VerticalNavItem isPlaceholder key="3" />

--- a/client/components/vertical-nav/item/index.jsx
+++ b/client/components/vertical-nav/item/index.jsx
@@ -4,7 +4,6 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -29,7 +28,7 @@ class VerticalNavItem extends Component {
 	static defaultProps = {
 		external: false,
 		isPlaceholder: false,
-		onClick: noop,
+		onClick: () => {},
 	};
 
 	placeholder = () => {

--- a/client/components/virtual-list/index.jsx
+++ b/client/components/virtual-list/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { AutoSizer, List } from '@automattic/react-virtualized';
-import { debounce, noop, range } from 'lodash';
+import { debounce, range } from 'lodash';
 
 export class VirtualList extends Component {
 	static propTypes = {
@@ -29,8 +29,8 @@ export class VirtualList extends Component {
 		items: [],
 		lastPage: 0,
 		loading: false,
-		getRowHeight: noop,
-		renderRow: noop,
+		getRowHeight: () => {},
+		renderRow: () => {},
 		perPage: 100,
 		loadOffset: 10,
 		query: {},

--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -6,7 +6,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -80,9 +79,9 @@ export class WebPreviewModal extends Component {
 		editUrl: null,
 		previewUrl: null,
 		previewMarkup: null,
-		onLoad: noop,
-		onClose: noop,
-		onEdit: noop,
+		onLoad: () => {},
+		onClose: () => {},
+		onEdit: () => {},
 		hasSidebar: false,
 		overridePost: null,
 	};

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import debugModule from 'debug';
-import { noop, isFunction } from 'lodash';
+import { isFunction } from 'lodash';
 import page from 'page';
 import { v4 as uuid } from 'uuid';
 import { addQueryArgs } from 'calypso/lib/route';
@@ -415,11 +415,11 @@ WebPreviewContent.defaultProps = {
 	editUrl: null,
 	previewUrl: null,
 	previewMarkup: null,
-	onLoad: noop,
-	onLocationUpdate: noop,
-	onClose: noop,
-	onEdit: noop,
-	onDeviceUpdate: noop,
+	onLoad: () => {},
+	onLocationUpdate: () => {},
+	onClose: () => {},
+	onEdit: () => {},
+	onDeviceUpdate: () => {},
 	hasSidebar: false,
 	isModalWindow: false,
 	overridePost: null,

--- a/client/components/wizard-progress-bar/index.jsx
+++ b/client/components/wizard-progress-bar/index.jsx
@@ -4,7 +4,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,8 +27,8 @@ class WizardProgressBar extends Component {
 	};
 
 	static defaultProps = {
-		nextButtonClick: noop,
-		previousButtonClick: noop,
+		nextButtonClick: () => {},
+		previousButtonClick: () => {},
 	};
 
 	renderNextButton() {

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,7 +35,7 @@ export function makeLayoutMiddleware( LayoutComponent ) {
 }
 
 export function setSectionMiddleware( section ) {
-	return ( context, next = noop ) => {
+	return ( context, next = () => {} ) => {
 		// save the section in context
 		context.section = section;
 

--- a/client/devdocs/design/wordpress-components-gallery/base-control.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/base-control.tsx
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { BaseControl, TextareaControl } from '@wordpress/components';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 const BaseControlExample = () => (
 	<BaseControl id="textarea-1" label="Text" help="Enter some text">

--- a/client/devdocs/design/wordpress-components-gallery/disabled.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/disabled.tsx
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { Disabled, SelectControl, TextControl, TextareaControl } from '@wordpress/components';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 const DisabledExample = () => {
 	return (

--- a/client/devdocs/docs-example/test/index.jsx
+++ b/client/devdocs/docs-example/test/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 
 /**
@@ -27,7 +26,7 @@ describe( 'DocsExample', () => {
 	} );
 
 	test( 'should render the toggle button', () => {
-		const propsWithToggle = { ...props, toggleHandler: noop, toggleText: 'My Test Example' };
+		const propsWithToggle = { ...props, toggleHandler: () => {}, toggleText: 'My Test Example' };
 		const docsExample = shallow(
 			<DocsExample { ...propsWithToggle }>{ childrenFixture }</DocsExample>
 		);
@@ -38,7 +37,7 @@ describe( 'DocsExample', () => {
 
 describe( 'DocsExampleToggle', () => {
 	const props = {
-		onClick: noop,
+		onClick: () => {},
 		text: 'Toggle me baby!',
 	};
 

--- a/client/extensions/woocommerce/app/order/create.js
+++ b/client/extensions/woocommerce/app/order/create.js
@@ -3,7 +3,7 @@
  */
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { get, isEmpty, noop, omit } from 'lodash';
+import { get, isEmpty, omit } from 'lodash';
 import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
 import page from 'page';
@@ -86,7 +86,7 @@ class Order extends Component {
 			);
 		};
 
-		this.props.sendOrderInvoice( siteId, orderId, onSuccess, noop );
+		this.props.sendOrderInvoice( siteId, orderId, onSuccess, () => {} );
 	};
 
 	// Saves changes to the remote site via API

--- a/client/extensions/woocommerce/app/order/order-activity-log/events.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log/events.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { keys, last, noop, sortBy } from 'lodash';
+import { keys, last, sortBy } from 'lodash';
 import moment from 'moment';
 
 /**
@@ -94,7 +94,7 @@ class OrderEvents extends Component {
 		const placeholderClassName = 'is-placeholder';
 		return (
 			<div className={ placeholderClassName }>
-				<OrderEventsByDay count={ 0 } date="" isOpen={ true } index={ 1 } onClick={ noop }>
+				<OrderEventsByDay count={ 0 } date="" isOpen={ true } index={ 1 } onClick={ () => {} }>
 					<OrderEvent />
 				</OrderEventsByDay>
 			</div>

--- a/client/extensions/woocommerce/app/order/order-customer/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-customer/dialog.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import emailValidator from 'email-validator';
-import { find, get, isEmpty, noop } from 'lodash';
+import { find, get, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -83,10 +83,10 @@ class CustomerAddressDialog extends Component {
 
 	static defaultProps = {
 		address: defaultAddress,
-		closeDialog: noop,
+		closeDialog: () => {},
 		isBilling: false,
 		isVisible: false,
-		updateAddress: noop,
+		updateAddress: () => {},
 	};
 
 	state = {};

--- a/client/extensions/woocommerce/app/order/order-details/row-total.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-total.js
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { noop, snakeCase } from 'lodash';
+import { snakeCase } from 'lodash';
 import { localize } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
 
@@ -32,8 +32,8 @@ class OrderTotalRow extends Component {
 	static defaultProps = {
 		currency: 'USD',
 		isEditable: false,
-		onBlur: noop,
-		onChange: noop,
+		onBlur: () => {},
+		onChange: () => {},
 	};
 
 	renderEditable = () => {

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
-import { every, find, findIndex, get, isNaN, noop } from 'lodash';
+import { every, find, findIndex, get, isNaN } from 'lodash';
 import formatCurrency from '@automattic/format-currency';
 
 /**
@@ -58,7 +58,7 @@ class OrderDetailsTable extends Component {
 
 	static defaultProps = {
 		isEditing: false,
-		onChange: noop,
+		onChange: () => {},
 	};
 
 	shouldShowTax = () => {

--- a/client/extensions/woocommerce/app/products/product-form-images.js
+++ b/client/extensions/woocommerce/app/products/product-form-images.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
-import { isNumber, noop } from 'lodash';
+import { isNumber } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,8 +32,8 @@ class ProductFormImages extends Component {
 	};
 
 	static defaultProps = {
-		onUpload: noop,
-		onRemove: noop,
+		onUpload: () => {},
+		onRemove: () => {},
 	};
 
 	constructor( props ) {

--- a/client/extensions/woocommerce/app/promotions/promotion-header.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-header.js
@@ -5,7 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
-import { isObject, noop } from 'lodash';
+import { isObject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,6 +13,8 @@ import { isObject, noop } from 'lodash';
 import ActionHeader from 'woocommerce/components/action-header';
 import { Button } from '@automattic/components';
 import { getLink } from 'woocommerce/lib/nav-utils';
+
+const noop = () => {};
 
 function renderTrashButton( onTrash, isBusy, label ) {
 	return (

--- a/client/extensions/woocommerce/app/settings/payments/stripe/payment-method-stripe-placeholder-dialog.js
+++ b/client/extensions/woocommerce/app/settings/payments/stripe/payment-method-stripe-placeholder-dialog.js
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,7 +12,7 @@ import { Dialog } from '@automattic/components';
 
 const PaymentMethodStripePlaceholderDialog = ( { translate } ) => {
 	const buttons = [
-		{ action: 'cancel', disabled: true, label: translate( 'Cancel' ), onClick: noop },
+		{ action: 'cancel', disabled: true, label: translate( 'Cancel' ), onClick: () => {} },
 	];
 
 	return (

--- a/client/extensions/woocommerce/components/compact-tinymce/index.js
+++ b/client/extensions/woocommerce/components/compact-tinymce/index.js
@@ -4,7 +4,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { assign, noop, uniqueId, forEach } from 'lodash';
+import { assign, uniqueId, forEach } from 'lodash';
 import classNames from 'classnames';
 import { ReactReduxContext } from 'react-redux';
 
@@ -35,7 +35,7 @@ class CompactTinyMCE extends Component {
 		height: 250,
 		className: '',
 		initialValue: '',
-		onContentsChange: noop,
+		onContentsChange: () => {},
 	};
 
 	reduxStore = null;

--- a/client/extensions/woocommerce/components/d3/base/test/index.js
+++ b/client/extensions/woocommerce/components/d3/base/test/index.js
@@ -8,7 +8,6 @@
 import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,12 +18,14 @@ describe( 'D3base', () => {
 	const shallowWithoutLifecycle = ( arg ) => shallow( arg, { disableLifecycleMethods: true } );
 
 	test( 'should have d3Base class', () => {
-		const base = shallowWithoutLifecycle( <D3Base drawChart={ noop } getParams={ noop } /> );
+		const base = shallowWithoutLifecycle(
+			<D3Base drawChart={ () => {} } getParams={ () => {} } />
+		);
 		assert.lengthOf( base.find( '.d3-base' ), 1 );
 	} );
 
 	test( 'should render an svg', () => {
-		const base = mount( <D3Base drawChart={ noop } getParams={ noop } /> );
+		const base = mount( <D3Base drawChart={ () => {} } getParams={ () => {} } /> );
 		assert.lengthOf( base.render().find( 'svg' ), 1 );
 	} );
 
@@ -32,7 +33,7 @@ describe( 'D3base', () => {
 		const drawChart = ( svg ) => {
 			return svg.append( 'circle' );
 		};
-		const base = mount( <D3Base drawChart={ drawChart } getParams={ noop } /> );
+		const base = mount( <D3Base drawChart={ drawChart } getParams={ () => {} } /> );
 		assert.lengthOf( base.render().find( 'circle' ), 1 );
 	} );
 

--- a/client/extensions/woocommerce/components/dashboard-widget/index.js
+++ b/client/extensions/woocommerce/components/dashboard-widget/index.js
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
-import { isUndefined, noop } from 'lodash';
+import { isUndefined } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -135,7 +135,7 @@ DashboardWidget.propTypes = {
 DashboardWidget.defaultProps = {
 	imagePosition: 'top',
 	imageFlush: false,
-	onSettingsClose: noop,
+	onSettingsClose: () => {},
 	width: 'full',
 };
 

--- a/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
+++ b/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
-import { noop, omit } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,7 +25,7 @@ class FormClickToEditInput extends Component {
 	};
 
 	static defaultProps = {
-		onChange: noop,
+		onChange: () => {},
 		placeholder: '',
 		value: '',
 		disabled: false,

--- a/client/extensions/woocommerce/components/form-dimensions-input/index.jsx
+++ b/client/extensions/woocommerce/components/form-dimensions-input/index.jsx
@@ -8,7 +8,6 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -35,7 +34,7 @@ class FormDimensionsInput extends Component {
 	static defaultProps = {
 		value: '',
 		className: '',
-		onChange: noop,
+		onChange: () => {},
 		noWrap: false,
 	};
 

--- a/client/extensions/woocommerce/components/form-weight-input/index.js
+++ b/client/extensions/woocommerce/components/form-weight-input/index.js
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,7 +27,7 @@ class FormWeightInput extends Component {
 	static defaultProps = {
 		value: '',
 		className: '',
-		onChange: noop,
+		onChange: () => {},
 		noWrap: false,
 	};
 

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { head, noop, trim, uniqueId } from 'lodash';
+import { head, trim, uniqueId } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 
@@ -39,11 +39,11 @@ class ProductImageUploader extends Component {
 	static defaultProps = {
 		multiple: true,
 		compact: false,
-		onSelect: noop,
-		onUpload: noop,
-		onError: noop,
-		onFinish: noop,
-		addWoocommerceProductImage: noop,
+		onSelect: () => {},
+		onUpload: () => {},
+		onError: () => {},
+		onFinish: () => {},
+		addWoocommerceProductImage: () => {},
 	};
 
 	UNSAFE_componentWillMount() {

--- a/client/extensions/woocommerce/components/product-search/row.js
+++ b/client/extensions/woocommerce/components/product-search/row.js
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { filter, find, get, intersection, noop, reduce, uniqBy, values } from 'lodash';
+import { filter, find, get, intersection, reduce, uniqBy, values } from 'lodash';
 import { localize } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
 
@@ -35,7 +35,7 @@ class ProductSearchRow extends Component {
 	};
 
 	static defaultProps = {
-		onChange: noop,
+		onChange: () => {},
 		singular: false,
 	};
 

--- a/client/extensions/woocommerce/lib/analytics/test/tracks-utils.js
+++ b/client/extensions/woocommerce/lib/analytics/test/tracks-utils.js
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,7 +19,7 @@ describe( 'recordTrack', () => {
 			recordTracksEvent: spy(),
 		};
 
-		expect( recordTrack( tracksSpy, noop ) ).to.be.a( 'function' );
+		expect( recordTrack( tracksSpy, () => {} ) ).to.be.a( 'function' );
 	} );
 
 	it( 'should call tracks to record an event with properties', () => {
@@ -42,7 +41,7 @@ describe( 'recordTrack', () => {
 
 		recordTrack(
 			tracksSpy,
-			noop,
+			() => {},
 			tracksStore
 		)( 'calypso_woocommerce_tracks_utils_test', eventProps );
 
@@ -64,7 +63,7 @@ describe( 'recordTrack', () => {
 		};
 
 		recordTrack(
-			{ recordTracksEvent: noop },
+			{ recordTracksEvent: () => {} },
 			debugSpy,
 			tracksStore
 		)( 'calypso_woocommerce_tracks_utils_test', eventProps );

--- a/client/extensions/woocommerce/state/data-layer/product-categories/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-categories/test/index.js
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { spy, match } from 'sinon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -314,7 +313,12 @@ describe( 'handlers', () => {
 			};
 
 			const category = { id: 2, name: 'Category 1', slug: 'category-1' };
-			const action = deleteProductCategory( 123, category, noop, noop );
+			const action = deleteProductCategory(
+				123,
+				category,
+				() => {},
+				() => {}
+			);
 
 			handleProductCategoryDelete( store, action );
 

--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-/**
  * Internal dependencies
  */
 import {
@@ -120,8 +116,8 @@ export const updateOrder = ( siteId, orderId, order ) => {
 export const saveOrder = (
 	siteId,
 	{ id: orderId, ...order },
-	onSuccess = noop,
-	onFailure = noop
+	onSuccess = () => {},
+	onFailure = () => {}
 ) => {
 	order = transformOrderForApi( removeTemporaryIds( order ) );
 	return {

--- a/client/extensions/woocommerce/state/sites/orders/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/test/actions.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,6 +32,8 @@ import {
 } from 'woocommerce/state/action-types';
 
 describe( 'actions', () => {
+	const noop = () => {};
+
 	describe( '#fetchOrders()', () => {
 		const siteId = '123';
 

--- a/client/extensions/woocommerce/state/sites/product-categories/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/actions.js
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,6 +21,8 @@ import {
 } from 'woocommerce/state/action-types';
 
 describe( 'actions', () => {
+	const noop = () => {};
+
 	describe( '#fetchProductCategories()', () => {
 		const siteId = '123';
 

--- a/client/extensions/woocommerce/state/sites/settings/general/test/handlers.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/test/handlers.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { fetchSettingsGeneral } from '../actions';
@@ -49,7 +44,7 @@ describe( 'handlers', () => {
 			const dispatch = jest.fn();
 			const action = fetchSettingsGeneral( siteId );
 
-			handleSettingsGeneral( action, noop )( dispatch, getState );
+			handleSettingsGeneral( action, () => {} )( dispatch, getState );
 			expect( dispatch ).toHaveBeenCalledWith(
 				expect.objectContaining( {
 					type: WPCOM_HTTP_REQUEST,

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -15,7 +15,6 @@ import {
 	isBoolean,
 	isEqual,
 	map,
-	noop,
 	pick,
 	sumBy,
 	uniqBy,
@@ -727,7 +726,7 @@ const handleLabelPurchaseError = ( orderId, siteId, dispatch, getState, error ) 
 	dispatch( NoticeActions.errorNotice( error.toString() ) );
 	//re-request the rates on failure to avoid attempting repurchase of the same shipment id
 	dispatch( clearAvailableRates( orderId, siteId ) );
-	tryGetLabelRates( orderId, siteId, dispatch, getState, noop );
+	tryGetLabelRates( orderId, siteId, dispatch, getState, () => {} );
 };
 
 const getPDFFileName = ( orderId, isReprint = false ) => {

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { get, has, isInteger, noop } from 'lodash';
+import { get, has, isInteger } from 'lodash';
 
 /**
  * Internal dependencies
@@ -133,7 +133,7 @@ export const authenticate = ( context, next ) => {
 
 	// Shows the editor placeholder while doing the redirection.
 	context.primary = <Placeholder />;
-	makeLayout( context, noop );
+	makeLayout( context, () => {} );
 	render( context );
 
 	// We could use `window.location.href` to generate the return URL but there are some potential race conditions that

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -3,7 +3,6 @@
  */
 import React, { ReactElement } from 'react';
 import { useTranslate } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,7 +36,7 @@ export default function LicenseDetails( {
 	issuedAt,
 	attachedAt,
 	revokedAt,
-	onCopyLicense = noop,
+	onCopyLicense = () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
 }: Props ): ReactElement {
 	const translate = useTranslate();
 	const licenseState = getLicenseState( attachedAt, revokedAt );

--- a/client/jetpack-connect/install-step.jsx
+++ b/client/jetpack-connect/install-step.jsx
@@ -3,7 +3,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -28,7 +27,7 @@ class JetpackInstallStep extends Component {
 
 	static defaultProps = {
 		currentUrl: '',
-		onClick: noop,
+		onClick: () => {},
 	};
 
 	confirmJetpackInstalled = ( event ) => {

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -13,7 +13,7 @@ import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { flowRight, get, includes, noop } from 'lodash';
+import { flowRight, get, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { Button, Card } from '@wordpress/components';
 
@@ -153,7 +153,7 @@ export class JetpackSignup extends Component {
 		} );
 	}
 
-	handleSubmitSignup = ( _, userData, analyticsData, afterSubmit = noop ) => {
+	handleSubmitSignup = ( _, userData, analyticsData, afterSubmit = () => {} ) => {
 		debug( 'submitting new account', userData );
 		this.setState( { isCreatingAccount: true }, () =>
 			this.props

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -5,7 +5,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,12 +32,12 @@ class JetpackConnectSiteUrlInput extends Component {
 
 	static defaultProps = {
 		candidateSites: [],
-		onChange: noop,
+		onChange: () => {},
 		url: '',
 		autoFocus: true,
 	};
 
-	focusInput = noop;
+	focusInput = () => {};
 
 	refInput = ( formInputComponent ) => {
 		this.focusInput = () => formInputComponent.focus();

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -7,7 +7,7 @@
  */
 import deepFreeze from 'deep-freeze';
 import React from 'react';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { shallow } from 'enzyme';
 
 /**
@@ -28,7 +28,7 @@ const DEFAULT_PROPS = deepFreeze( {
 		timestamp: 1509368045859,
 		userAlreadyConnected: false,
 	},
-	authorize: noop,
+	authorize: () => {},
 	authQuery: {
 		authApproved: false,
 		blogname: 'Example Blog',
@@ -54,8 +54,8 @@ const DEFAULT_PROPS = deepFreeze( {
 	isAlreadyOnSitesList: false,
 	isFetchingAuthorizationSite: false,
 	isFetchingSites: false,
-	recordTracksEvent: noop,
-	retryAuth: noop,
+	recordTracksEvent: () => {},
+	retryAuth: () => {},
 	siteSlug: SITE_SLUG,
 	translate: identity,
 	user: {

--- a/client/jetpack-connect/test/signup.js
+++ b/client/jetpack-connect/test/signup.js
@@ -7,7 +7,7 @@
  */
 import deepFreeze from 'deep-freeze';
 import React from 'react';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { shallow } from 'enzyme';
 
 /**
@@ -46,9 +46,9 @@ const DEFAULT_PROPS = deepFreeze( {
 		state: '1',
 		userEmail: `email@${ SITE_SLUG }`,
 	},
-	createAccount: noop,
+	createAccount: () => {},
 	path: '/jetpack/connect/authorize',
-	recordTracksEvent: noop,
+	recordTracksEvent: () => {},
 	translate: identity,
 } );
 

--- a/client/layout/error.jsx
+++ b/client/layout/error.jsx
@@ -3,7 +3,6 @@
  */
 import debug from 'debug';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import React from 'react';
 
 /**
@@ -48,6 +47,6 @@ export function show( context, chunkName ) {
 	bumpStat( 'calypso_chunk_error', chunkName );
 	context.store.dispatch( setSection( false, { section: false } ) );
 	context.primary = <LoadingErrorMessage />;
-	makeLayout( context, noop );
+	makeLayout( context, () => {} );
 	clientRender( context );
 }

--- a/client/layout/guided-tours/utils.js
+++ b/client/layout/guided-tours/utils.js
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
-import { overEvery as and, negate as not, noop } from 'lodash';
+import { overEvery as and, negate as not } from 'lodash';
+
+const noop = () => {};
 
 export { and, not, noop };

--- a/client/layout/guided-tours/wait.js
+++ b/client/layout/guided-tours/wait.js
@@ -1,14 +1,8 @@
-/**
- * External dependencies
- */
-
-import { noop } from 'lodash';
-
 const WAIT_INITIAL = 1; // initial wait in milliseconds
 const WAIT_MULTIPLIER = 2;
 const WAIT_MAX = 2048; // give up waiting when delay has grown to ~4 seconds
 
-const wait = ( { condition, consequence, delay = 0, onError = noop } ) => {
+const wait = ( { condition, consequence, delay = 0, onError = () => {} } ) => {
 	if ( condition() ) {
 		consequence();
 		return;

--- a/client/layout/masterbar/item.jsx
+++ b/client/layout/masterbar/item.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import { isFunction, noop } from 'lodash';
+import { isFunction } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import TranslatableString from 'calypso/components/translatable/proptype';
 
@@ -23,7 +23,7 @@ class MasterbarItem extends Component {
 
 	static defaultProps = {
 		icon: '',
-		onClick: noop,
+		onClick: () => {},
 		hasUnseen: false,
 	};
 

--- a/client/layout/sidebar/expandable-heading.jsx
+++ b/client/layout/sidebar/expandable-heading.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import Gridicon from 'calypso/components/gridicon';
-import { noop } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -66,7 +65,7 @@ ExpandableSidebarHeading.propTypes = {
 };
 
 ExpandableSidebarHeading.defaultProps = {
-	onClick: noop,
+	onClick: () => {},
 };
 
 export default ExpandableSidebarHeading;

--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -5,7 +5,7 @@
 import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get, isNumber, noop } from 'lodash';
+import { get, isNumber } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -65,7 +65,7 @@ export class PageViewTracker extends React.Component {
 		const {
 			delay = 0,
 			path,
-			recorder = noop,
+			recorder = () => {},
 			hasSelectedSiteLoaded,
 			title,
 			properties,

--- a/client/lib/jetpack/use-track-callback.ts
+++ b/client/lib/jetpack/use-track-callback.ts
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,7 +10,8 @@ import { noop } from 'lodash';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 
-const useTrackCallback = ( callback: Function = noop, eventName: string, eventProps = {} ) => {
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const useTrackCallback = ( callback: Function = () => {}, eventName: string, eventProps = {} ) => {
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
 	const trackedCallback = React.useCallback(

--- a/client/lib/mshots/index.js
+++ b/client/lib/mshots/index.js
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import { noop } from 'lodash';
-
 export async function loadmShotsPreview( options = {} ) {
 	const { maxRetries = 1, retryTimeout = 1000 } = options;
 	const url = options.url || '';
@@ -49,5 +44,5 @@ export async function loadmShotsPreview( options = {} ) {
 }
 
 export function prefetchmShotsPreview( url ) {
-	loadmShotsPreview( { url, maxRetries: 0 } ).catch( noop );
+	loadmShotsPreview( { url, maxRetries: 0 } ).catch( () => {} );
 }

--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -3,7 +3,6 @@
  */
 
 import debugModule from 'debug';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,7 +27,7 @@ const STORAGE_KEY = 'boot_support_user';
 
 const isEnabled = () => config.isEnabled( 'support-user' );
 
-let _setReduxStore = noop;
+let _setReduxStore = () => {};
 const reduxStoreReady = new Promise( ( resolve ) => {
 	if ( ! isEnabled() ) {
 		return;

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import { connect } from 'react-redux';
 import page from 'page';
 
@@ -209,7 +208,7 @@ class AccountCloseConfirmDialog extends React.Component {
 }
 
 AccountCloseConfirmDialog.defaultProps = {
-	onConfirm: noop,
+	onConfirm: () => {},
 };
 
 export default connect(

--- a/client/me/account/close-link.jsx
+++ b/client/me/account/close-link.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 import { CompactCard } from '@automattic/components';
 
@@ -16,7 +15,7 @@ class AccountSettingsCloseLink extends React.Component {
 	render() {
 		const { translate } = this.props;
 		const href = '/me/account/close';
-		const onClick = noop;
+		const onClick = () => {};
 		return (
 			<CompactCard href={ href } onClick={ onClick } className="account__settings-close">
 				<div>

--- a/client/me/notification-settings/blogs-settings/index.jsx
+++ b/client/me/notification-settings/blogs-settings/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { find, noop } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -74,7 +74,7 @@ class BlogsSettings extends Component {
 			<InfiniteList
 				items={ sites }
 				lastPage={ true }
-				fetchNextPage={ noop }
+				fetchNextPage={ () => {} }
 				fetchingNextPage={ false }
 				guessedItemHeight={ 69 }
 				getItemRef={ getItemRef }

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
@@ -50,7 +49,7 @@ function noSites( context, analyticsPath ) {
 	} );
 
 	context.primary = <NoSitesWrapper />;
-	makeLayout( context, noop );
+	makeLayout( context, () => {} );
 	clientRender( context );
 }
 

--- a/client/my-sites/activity/activity-log-banner/index.jsx
+++ b/client/my-sites/activity/activity-log-banner/index.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,7 +29,7 @@ class ActivityLogBanner extends Component {
 
 	static defaultProps = {
 		isDismissable: false,
-		onDismissClick: noop,
+		onDismissClick: () => {},
 		status: null,
 		title: '',
 	};

--- a/client/my-sites/backup/rewind-flow/download.tsx
+++ b/client/my-sites/backup/rewind-flow/download.tsx
@@ -4,7 +4,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import React, { FunctionComponent, useCallback, useState } from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -184,7 +183,8 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 					}
 			  );
 
-	const trackFileDownload = useTrackCallback( noop, 'calypso_jetpack_backup_file_download' );
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	const trackFileDownload = useTrackCallback( () => {}, 'calypso_jetpack_backup_file_download' );
 	const renderReady = () => (
 		<>
 			<div className="rewind-flow__header">

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import classNames from 'classnames';
-import { get, includes, isEqual, isUndefined, noop } from 'lodash';
+import { get, includes, isEqual, isUndefined } from 'lodash';
 
 /**
  * Internal dependencies
@@ -52,7 +52,7 @@ export class CommentActions extends Component {
 	};
 
 	static defaultProps = {
-		updateLastUndo: noop,
+		updateLastUndo: () => {},
 	};
 
 	shouldComponentUpdate = ( nextProps ) => ! isEqual( this.props, nextProps );

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
-import { get, noop, pick } from 'lodash';
+import { get, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -75,7 +75,7 @@ export class CommentEdit extends Component {
 
 	setAuthorUrlValue = ( event ) => this.setState( { authorUrl: event.target.value } );
 
-	setCommentContentValue = ( event, callback = noop ) =>
+	setCommentContentValue = ( event, callback = () => {} ) =>
 		this.setState( { commentContent: event.target.value }, callback );
 
 	setCommentDateValue = ( commentDate ) =>

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -4,7 +4,7 @@
 import page from 'page';
 import React from 'react';
 import i18n from 'i18n-calypso';
-import { get, noop, some, startsWith, uniq } from 'lodash';
+import { get, some, startsWith, uniq } from 'lodash';
 import { removeQueryArgs } from '@wordpress/url';
 
 /**
@@ -113,7 +113,7 @@ export function renderEmptySites( context ) {
 
 	context.primary = React.createElement( NoSitesMessage );
 
-	makeLayout( context, noop );
+	makeLayout( context, () => {} );
 	clientRender( context );
 }
 
@@ -150,7 +150,7 @@ export function renderNoVisibleSites( context ) {
 		secondaryActionURL: `${ onboardingUrl }?ref=calypso-nosites`,
 	} );
 
-	makeLayout( context, noop );
+	makeLayout( context, () => {} );
 	clientRender( context );
 }
 
@@ -159,7 +159,7 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 
 	reactContext.secondary = createNavigation( reactContext );
 
-	makeLayout( reactContext, noop );
+	makeLayout( reactContext, () => {} );
 	clientRender( reactContext );
 }
 

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -4,7 +4,7 @@
 import page from 'page';
 import { translate } from 'i18n-calypso';
 import React from 'react';
-import { get, includes, map, noop } from 'lodash';
+import { get, includes, map } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -259,7 +259,7 @@ const jetpackNoDomainsWarning = ( context, next ) => {
 			</Main>
 		);
 
-		makeLayout( context, noop );
+		makeLayout( context, () => {} );
 		clientRender( context );
 	} else {
 		next();

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { find, findIndex, get, identity, noop, times, isEmpty } from 'lodash';
+import { find, findIndex, get, identity, times, isEmpty } from 'lodash';
 import page from 'page';
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -71,9 +71,9 @@ export class List extends React.Component {
 
 	static defaultProps = {
 		translate: identity,
-		enablePrimaryDomainMode: noop,
-		disablePrimaryDomainMode: noop,
-		changePrimary: noop,
+		enablePrimaryDomainMode: () => {},
+		disablePrimaryDomainMode: () => {},
+		changePrimary: () => {},
 	};
 
 	state = {
@@ -447,7 +447,7 @@ export class List extends React.Component {
 				domainDetails={ domain }
 				site={ selectedSite }
 				isManagingAllSites={ false }
-				onClick={ settingPrimaryDomain ? noop : this.goToEditDomainRoot }
+				onClick={ settingPrimaryDomain ? () => {} : this.goToEditDomainRoot }
 				isBusy={ settingPrimaryDomain && index === primaryDomainIndex }
 				isChecked={ changePrimaryDomainModeEnabled && index === primaryDomainIndex }
 				busyMessage={ this.props.translate( 'Setting Primary Domain…', {

--- a/client/my-sites/domains/domain-management/list/test/index.js
+++ b/client/my-sites/domains/domain-management/list/test/index.js
@@ -9,7 +9,6 @@ import deepFreeze from 'deep-freeze';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { shallow, mount } from 'enzyme';
-import { noop } from 'lodash';
 import { ShoppingCartProvider, getEmptyResponseCart } from '@automattic/shopping-cart';
 
 /**
@@ -71,8 +70,8 @@ describe( 'index', () => {
 		},
 		sitePlans: {},
 		userCanManageOptions: true,
-		successNotice: noop,
-		errorNotice: noop,
+		successNotice: () => {},
+		errorNotice: () => {},
 	} );
 
 	function renderWithProps( props = defaultProps ) {

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 import url from 'url';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop, get } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -39,7 +39,7 @@ class Draft extends Component {
 	};
 
 	static defaultProps = {
-		onTitleClick: noop,
+		onTitleClick: () => {},
 		selected: false,
 		showAuthor: false,
 	};

--- a/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -35,7 +34,7 @@ class EmailProviderDetails extends React.Component {
 	};
 
 	static defaultProps = {
-		onButtonClick: noop,
+		onButtonClick: () => {},
 	};
 
 	renderFeatures() {

--- a/client/my-sites/google-my-business/select-location/button.js
+++ b/client/my-sites/google-my-business/select-location/button.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -29,7 +28,7 @@ class GoogleMyBusinessSelectLocationButton extends Component {
 	};
 
 	static defaultProps = {
-		onSelected: noop,
+		onSelected: () => {},
 	};
 
 	connectLocation = () => {

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -4,7 +4,6 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -106,7 +105,11 @@ export const SftpCard = ( {
 			return (
 				<>
 					<div className="sftp-card__copy-field sftp-card__password-field">
-						<FormTextInput className="sftp-card__copy-input" value={ password } onChange={ noop } />
+						<FormTextInput
+							className="sftp-card__copy-input"
+							value={ password }
+							onChange={ () => {} }
+						/>
 						<ClipboardButton className="sftp-card__copy-button" text={ password } compact>
 							{ translate( 'Copy', { context: 'verb' } ) }
 						</ClipboardButton>
@@ -208,7 +211,11 @@ export const SftpCard = ( {
 				<FormFieldset className="sftp-card__info-field">
 					<FormLabel>{ translate( 'URL' ) }</FormLabel>
 					<div className="sftp-card__copy-field">
-						<FormTextInput className="sftp-card__copy-input" value={ SFTP_URL } onChange={ noop } />
+						<FormTextInput
+							className="sftp-card__copy-input"
+							value={ SFTP_URL }
+							onChange={ () => {} }
+						/>
 						<ClipboardButton className="sftp-card__copy-button" text={ SFTP_URL } compact>
 							{ translate( 'Copy', { context: 'verb' } ) }
 						</ClipboardButton>
@@ -218,7 +225,7 @@ export const SftpCard = ( {
 						<FormTextInput
 							className="sftp-card__copy-input"
 							value={ SFTP_PORT }
-							onChange={ noop }
+							onChange={ () => {} }
 						/>
 						<ClipboardButton
 							className="sftp-card__copy-button"
@@ -230,7 +237,11 @@ export const SftpCard = ( {
 					</div>
 					<FormLabel>{ translate( 'Username' ) }</FormLabel>
 					<div className="sftp-card__copy-field">
-						<FormTextInput className="sftp-card__copy-input" value={ username } onChange={ noop } />
+						<FormTextInput
+							className="sftp-card__copy-input"
+							value={ username }
+							onChange={ () => {} }
+						/>
 						<ClipboardButton className="sftp-card__copy-button" text={ username } compact>
 							{ translate( 'Copy', { context: 'verb' } ) }
 						</ClipboardButton>

--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import Page from 'page';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,7 +16,7 @@ import { Button } from '@automattic/components';
 class ImporterError extends React.PureComponent {
 	static displayName = 'ImporterError';
 	static defaultProps = {
-		retryImport: noop,
+		retryImport: () => {},
 	};
 
 	static propTypes = {

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { includes, isEmpty, noop, flowRight, has, trim, sortBy } from 'lodash';
+import { includes, isEmpty, flowRight, has, trim, sortBy } from 'lodash';
 import url from 'url'; // eslint-disable-line no-restricted-imports
 import moment from 'moment';
 
@@ -62,7 +62,7 @@ class SiteImporterInputPane extends React.Component {
 		fromSite: PropTypes.string,
 	};
 
-	static defaultProps = { description: null, onStartImport: noop };
+	static defaultProps = { description: null, onStartImport: () => {} };
 
 	state = {
 		siteURLInput: this.props.fromSite || '',

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -6,7 +6,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { includes, noop, truncate } from 'lodash';
+import { includes, truncate } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -161,7 +161,7 @@ class UploadingPane extends React.PureComponent {
 							onChange={ this.initiateFromForm }
 						/>
 					) }
-					<DropZone onFilesDrop={ isReadyForImport ? this.initiateFromDrop : noop } />
+					<DropZone onFilesDrop={ isReadyForImport ? this.initiateFromDrop : () => {} } />
 				</div>
 				<ImporterActionButtonContainer>
 					<ImporterCloseButton

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { groupBy, head, isEmpty, map, noop, size, values } from 'lodash';
+import { groupBy, head, isEmpty, map, size, values } from 'lodash';
 import PropTypes from 'prop-types';
 import page from 'page';
 import classnames from 'classnames';
@@ -65,7 +65,7 @@ export class MediaLibraryContent extends React.Component {
 
 	static defaultProps = {
 		mediaValidationErrors: Object.freeze( {} ),
-		onAddMedia: noop,
+		onAddMedia: () => {},
 		source: '',
 	};
 

--- a/client/my-sites/media-library/drop-zone.jsx
+++ b/client/my-sites/media-library/drop-zone.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 
@@ -30,7 +29,7 @@ class MediaLibraryDropZone extends React.Component {
 
 	static defaultProps = {
 		fullScreen: true,
-		onAddMedia: noop,
+		onAddMedia: () => {},
 		trackStats: true,
 	};
 

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -4,7 +4,7 @@
 
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { identity, includes, noop, union } from 'lodash';
+import { identity, includes, union } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -44,9 +44,9 @@ export class MediaLibraryFilterBar extends Component {
 	static defaultProps = {
 		filter: '',
 		basePath: '/media',
-		onFilterChange: noop,
-		onSourceChange: noop,
-		onSearch: noop,
+		onFilterChange: () => {},
+		onSourceChange: () => {},
+		onSearch: () => {},
 		translate: identity,
 		source: '',
 		post: false,

--- a/client/my-sites/media-library/list-item.tsx
+++ b/client/my-sites/media-library/list-item.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEqual, noop } from 'lodash';
+import { isEqual } from 'lodash';
 import React from 'react';
 import classNames from 'classnames';
 
@@ -49,8 +49,8 @@ export default class MediaLibraryListItem extends React.Component< Props & DivPr
 	static defaultProps = {
 		maxImageWidth: 450,
 		selectedIndex: -1,
-		onToggle: noop,
-		onEditItem: noop,
+		onToggle: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+		onEditItem: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
 	};
 
 	shouldComponentUpdate( nextProps: Props ) {

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRtl } from 'i18n-calypso';
-import { clone, filter, findIndex, min, noop } from 'lodash';
+import { clone, filter, findIndex, min } from 'lodash';
 import ReactDom from 'react-dom';
 import React from 'react';
 
@@ -50,10 +50,10 @@ export class MediaLibraryList extends React.Component {
 		rowPadding: 10,
 		mediaHasNextPage: false,
 		isFetchingNextPage: false,
-		mediaOnFetchNextPage: noop,
+		mediaOnFetchNextPage: () => {},
 		single: false,
 		scrollable: false,
-		onEditItem: noop,
+		onEditItem: () => {},
 	};
 
 	state = {};

--- a/client/my-sites/media-library/test/content.jsx
+++ b/client/my-sites/media-library/test/content.jsx
@@ -7,7 +7,6 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,7 +30,7 @@ function getMediaContent( props ) {
 	return shallow(
 		<MediaLibraryContent
 			mediaValidationErrorTypes={ [] }
-			translate={ noop }
+			translate={ () => {} }
 			site={ { ID: 1 } }
 			{ ...props }
 		/>

--- a/client/my-sites/media-library/test/data-source.jsx
+++ b/client/my-sites/media-library/test/data-source.jsx
@@ -7,7 +7,6 @@
  */
 import { expect } from 'chai';
 import { mount } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
@@ -40,7 +39,7 @@ describe( 'MediaLibraryDataSource', () => {
 				<ReduxProvider store={ store }>
 					<MediaLibraryDataSource
 						source={ '' }
-						onSourceChange={ noop }
+						onSourceChange={ () => {} }
 						ignorePermissions={ true }
 					/>
 				</ReduxProvider>
@@ -56,7 +55,7 @@ describe( 'MediaLibraryDataSource', () => {
 				<ReduxProvider store={ store }>
 					<MediaLibraryDataSource
 						source={ '' }
-						onSourceChange={ noop }
+						onSourceChange={ () => {} }
 						disabledSources={ [ 'pexels' ] }
 						ignorePermissions={ true }
 					/>

--- a/client/my-sites/media-library/upload-button.jsx
+++ b/client/my-sites/media-library/upload-button.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { noop, uniq } from 'lodash';
+import { uniq } from 'lodash';
 import classNames from 'classnames';
 import page from 'page';
 
@@ -34,7 +34,7 @@ export class MediaLibraryUploadButton extends React.Component {
 	};
 
 	static defaultProps = {
-		onAddMedia: noop,
+		onAddMedia: () => {},
 		type: 'button',
 		href: null,
 	};

--- a/client/my-sites/media-library/upload-url.jsx
+++ b/client/my-sites/media-library/upload-url.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { noop } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
@@ -34,8 +33,8 @@ class MediaLibraryUploadUrl extends Component {
 	};
 
 	static defaultProps = {
-		onAddMedia: noop,
-		onClose: noop,
+		onAddMedia: () => {},
+		onClose: () => {},
 	};
 
 	state = {

--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import classNames from 'classnames';
@@ -35,7 +35,7 @@ class BlogPostsPage extends React.Component {
 
 	static defaultProps = {
 		translate: identity,
-		recordCalloutClick: noop,
+		recordCalloutClick: () => {},
 	};
 
 	getPostsPageLink() {

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import pageRouter from 'page';
 import { connect } from 'react-redux';
-import { flow, get, includes, noop, partial } from 'lodash';
+import { flow, get, includes, partial } from 'lodash';
 import { saveAs } from 'browser-filesaver';
 import classNames from 'classnames';
 
@@ -88,7 +88,7 @@ class Page extends Component {
 	};
 
 	static defaultProps = {
-		onShadowStatusChange: noop,
+		onShadowStatusChange: () => {},
 		showPublishedStatus: false,
 	};
 

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import wrapWithClickOutside from 'react-click-outside';
-import { noop } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -28,7 +27,7 @@ class SitePicker extends React.Component {
 	};
 
 	static defaultProps = {
-		onClose: noop,
+		onClose: () => {},
 	};
 
 	state = {

--- a/client/my-sites/plan-compare-card/index.jsx
+++ b/client/my-sites/plan-compare-card/index.jsx
@@ -6,7 +6,6 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -32,7 +31,7 @@ class PlanCompareCard extends React.Component {
 	};
 
 	static defaultProps = {
-		onClick: noop,
+		onClick: () => {},
 		currentPlan: true,
 		popularRibbon: false,
 	};

--- a/client/my-sites/plan-features-comparison/actions.jsx
+++ b/client/my-sites/plan-features-comparison/actions.jsx
@@ -4,7 +4,7 @@
 
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
@@ -43,7 +43,7 @@ const PlanFeaturesActionsButton = ( {
 	isPopular,
 	isInSignup,
 	isLaunchPage,
-	onUpgradeClick = noop,
+	onUpgradeClick = () => {},
 	planName,
 	planType,
 	primaryUpgrade = false,

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -6,7 +6,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
-import { compact, get, map, noop, reduce } from 'lodash';
+import { compact, get, map, reduce } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -273,7 +273,7 @@ export class PlanFeaturesComparison extends Component {
 			siteIsPrivateAndGoingAtomic,
 		} = singlePlanProperties;
 
-		if ( ownPropsOnUpgradeClick && ownPropsOnUpgradeClick !== noop && cartItemForPlan ) {
+		if ( ownPropsOnUpgradeClick && cartItemForPlan ) {
 			ownPropsOnUpgradeClick( cartItemForPlan );
 			return;
 		}
@@ -498,7 +498,7 @@ PlanFeaturesComparison.defaultProps = {
 	isJetpack: false,
 	selectedSiteSlug: '',
 	siteId: null,
-	onUpgradeClick: noop,
+	onUpgradeClick: () => {},
 };
 
 export const isPrimaryUpgradeByPlanDelta = ( currentPlan, plan ) =>

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -4,7 +4,7 @@
 
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
@@ -43,7 +43,7 @@ const PlanFeaturesActionsButton = ( {
 	isPopular,
 	isInSignup,
 	isLaunchPage,
-	onUpgradeClick = noop,
+	onUpgradeClick = () => {},
 	planName,
 	planType,
 	primaryUpgrade = false,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -6,7 +6,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
-import { compact, get, findIndex, last, map, noop, reduce } from 'lodash';
+import { compact, get, findIndex, last, map, reduce } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
@@ -518,7 +518,7 @@ export class PlanFeatures extends Component {
 			siteIsPrivateAndGoingAtomic,
 		} = singlePlanProperties;
 
-		if ( ownPropsOnUpgradeClick && ownPropsOnUpgradeClick !== noop && cartItemForPlan ) {
+		if ( ownPropsOnUpgradeClick && cartItemForPlan ) {
 			ownPropsOnUpgradeClick( cartItemForPlan );
 			return;
 		}
@@ -801,7 +801,7 @@ PlanFeatures.defaultProps = {
 	isJetpack: false,
 	selectedSiteSlug: '',
 	siteId: null,
-	onUpgradeClick: noop,
+	onUpgradeClick: () => {},
 };
 
 export const isPrimaryUpgradeByPlanDelta = ( currentPlan, plan ) =>

--- a/client/my-sites/post-type-list/post-thumbnail.jsx
+++ b/client/my-sites/post-type-list/post-thumbnail.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -44,7 +44,7 @@ PostTypeListPostThumbnail.propTypes = {
 };
 
 PostTypeListPostThumbnail.defaultProps = {
-	onClick: noop,
+	onClick: () => {},
 };
 
 export default connect( ( state, ownProps ) => {

--- a/client/my-sites/site-settings/site-tools/link.jsx
+++ b/client/my-sites/site-settings/site-tools/link.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,7 +36,7 @@ SiteToolsLink.propTypes = {
 
 SiteToolsLink.defaultProps = {
 	isWarning: false,
-	onClick: noop,
+	onClick: () => {},
 };
 
 export default SiteToolsLink;

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop, intersection } from 'lodash';
+import { intersection } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -150,7 +150,7 @@ MagicSearchWelcome.propTypes = {
 MagicSearchWelcome.defaultProps = {
 	taxonomies: [],
 	topSearches: [],
-	suggestionsCallback: noop,
+	suggestionsCallback: () => {},
 };
 
 export default MagicSearchWelcome;

--- a/client/my-sites/woocommerce/lib/analytics/test/tracks-utils.js
+++ b/client/my-sites/woocommerce/lib/analytics/test/tracks-utils.js
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,7 +19,7 @@ describe( 'recordTrack', () => {
 			recordTracksEvent: spy(),
 		};
 
-		expect( recordTrack( tracksSpy, noop ) ).to.be.a( 'function' );
+		expect( recordTrack( tracksSpy, () => {} ) ).to.be.a( 'function' );
 	} );
 
 	it( 'should call tracks to record an event with properties', () => {
@@ -34,7 +33,7 @@ describe( 'recordTrack', () => {
 			c: '3',
 		};
 
-		recordTrack( tracksSpy, noop )( 'calypso_woocommerce_tracks_utils_test', eventProps );
+		recordTrack( tracksSpy, () => {} )( 'calypso_woocommerce_tracks_utils_test', eventProps );
 
 		expect( tracksSpy.recordTracksEvent ).to.have.been.calledWith(
 			'calypso_woocommerce_tracks_utils_test',
@@ -47,7 +46,7 @@ describe( 'recordTrack', () => {
 
 		const eventProps = { a: 1 };
 
-		recordTrack( { recordTracksEvent: noop }, debugSpy )(
+		recordTrack( { recordTracksEvent: () => {} }, debugSpy )(
 			'calypso_woocommerce_tracks_utils_test',
 			eventProps
 		);

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { flowRight, get, includes, noop } from 'lodash';
+import { flowRight, get, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 import url from 'url';
 import Gridicon from 'calypso/components/gridicon';
@@ -46,10 +46,10 @@ export class EditorMediaModalDetailItem extends Component {
 	static defaultProps = {
 		hasPreviousItem: false,
 		hasNextItem: false,
-		onShowPreviousItem: noop,
-		onShowNextItem: noop,
-		onEdit: noop,
-		onRestore: noop,
+		onShowPreviousItem: () => {},
+		onShowNextItem: () => {},
+		onEdit: () => {},
+		onRestore: () => {},
 	};
 
 	/**

--- a/client/post-editor/media-modal/detail/detail-preview-image.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-image.jsx
@@ -4,7 +4,6 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -22,7 +21,7 @@ export default class EditorMediaModalDetailPreviewImage extends Component {
 	};
 
 	static defaultProps = {
-		onLoad: noop,
+		onLoad: () => {},
 	};
 
 	constructor( props ) {

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { get, invoke, noop } from 'lodash';
+import { get, invoke } from 'lodash';
 import classNames from 'classnames';
 import debug from 'debug';
 import wpcomProxyRequest from 'wpcom-proxy-request';
@@ -32,9 +32,9 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 
 	static defaultProps = {
 		isPlaying: false,
-		onPause: noop,
-		onScriptLoadError: noop,
-		onVideoLoaded: noop,
+		onPause: () => {},
+		onScriptLoadError: () => {},
+		onVideoLoaded: () => {},
 	};
 
 	componentDidMount() {

--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { noop, partial } from 'lodash';
+import { partial } from 'lodash';
 
 /**
  * Internal dependencies
@@ -35,7 +35,7 @@ class EditorMediaModalDetailBase extends React.Component {
 
 	static defaultProps = {
 		selectedIndex: 0,
-		onSelectedIndexChange: noop,
+		onSelectedIndexChange: () => {},
 	};
 
 	componentDidMount() {

--- a/client/post-editor/media-modal/gallery/edit.jsx
+++ b/client/post-editor/media-modal/gallery/edit.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { map, noop, sortBy } from 'lodash';
+import { map, sortBy } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -24,7 +24,7 @@ class EditorMediaModalGalleryEdit extends React.Component {
 
 	static defaultProps = {
 		settings: Object.freeze( {} ),
-		onUpdateSetting: noop,
+		onUpdateSetting: () => {},
 	};
 
 	onOrderChanged = ( order ) => {

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { assign, fromPairs, includes, noop, times } from 'lodash';
+import { assign, fromPairs, includes, times } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -26,7 +26,7 @@ export class EditorMediaModalGalleryFields extends React.Component {
 
 	static defaultProps = {
 		settings: Object.freeze( {} ),
-		onUpdateSetting: noop,
+		onUpdateSetting: () => {},
 		numberOfItems: 0,
 	};
 

--- a/client/post-editor/media-modal/gallery/index.jsx
+++ b/client/post-editor/media-modal/gallery/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { noop, assign, omitBy, some, isEqual, partial } from 'lodash';
+import { assign, omitBy, some, isEqual, partial } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,7 +36,7 @@ class EditorMediaModalGallery extends React.Component {
 	};
 
 	static defaultProps = {
-		onUpdateSettings: noop,
+		onUpdateSettings: () => {},
 	};
 
 	state = {

--- a/client/post-editor/media-modal/gallery/preview.jsx
+++ b/client/post-editor/media-modal/gallery/preview.jsx
@@ -5,7 +5,6 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,9 +28,9 @@ class EditorMediaModalGalleryPreview extends Component {
 
 	static defaultProps = {
 		settings: Object.freeze( {} ),
-		onUpdateSetting: noop,
+		onUpdateSetting: () => {},
 		invalidItemDropped: false,
-		onDismissInvalidItemDropped: noop,
+		onDismissInvalidItemDropped: () => {},
 	};
 
 	state = {

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -13,7 +13,6 @@ import {
 	isEmpty,
 	identity,
 	includes,
-	noop,
 	partial,
 	some,
 	values,
@@ -96,12 +95,12 @@ export class EditorMediaModal extends Component {
 
 	static defaultProps = {
 		visible: false,
-		onClose: noop,
+		onClose: () => {},
 		isBackdropVisible: true,
 		isParentReady: () => true,
 		labels: Object.freeze( {} ),
-		setView: noop,
-		resetView: noop,
+		setView: () => {},
+		resetView: () => {},
 		translate: identity,
 		view: ModalViews.LIST,
 		galleryViewEnabled: true,
@@ -109,8 +108,8 @@ export class EditorMediaModal extends Component {
 		deleteMedia: () => {},
 		disableLargeImageSources: false,
 		disabledDataSources: [],
-		onImageEditorDoneHook: noop,
-		onRestoreMediaHook: noop,
+		onImageEditorDoneHook: () => {},
+		onRestoreMediaHook: () => {},
 	};
 
 	constructor( props ) {

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { values, noop, some, every, flow, partial, pick } from 'lodash';
+import { values, some, every, flow, partial, pick } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 
@@ -35,7 +35,7 @@ class MediaModalSecondaryActions extends Component {
 
 	static defaultProps = {
 		disabled: false,
-		onDelete: noop,
+		onDelete: () => {},
 	};
 
 	getButtons() {
@@ -76,7 +76,7 @@ class MediaModalSecondaryActions extends Component {
 				icon: 'trash',
 				className: 'editor-media-modal__delete',
 				disabled: isButtonDisabled,
-				onClick: isButtonDisabled ? noop : onDelete,
+				onClick: isButtonDisabled ? () => {} : onDelete,
 			} );
 		}
 

--- a/client/reader/components/reader-infinite-stream/index.jsx
+++ b/client/reader/components/reader-infinite-stream/index.jsx
@@ -11,7 +11,7 @@ import {
 	WindowScroller,
 } from '@automattic/react-virtualized';
 
-import { debounce, noop, get, pickBy } from 'lodash';
+import { debounce, get, pickBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,7 +36,7 @@ class ReaderInfiniteStream extends Component {
 	};
 
 	static defaultProps = {
-		windowScrollerRef: noop,
+		windowScrollerRef: () => {},
 		minHeight: 70,
 		hasNextPage: () => false,
 	};

--- a/client/reader/following-manage/search-followed.jsx
+++ b/client/reader/following-manage/search-followed.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -18,7 +17,7 @@ class FollowingManageSearchFollowed extends Component {
 	};
 
 	static defaultProps = {
-		onSearch: noop,
+		onSearch: () => {},
 	};
 
 	render() {

--- a/client/reader/following-manage/sort-controls.jsx
+++ b/client/reader/following-manage/sort-controls.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -18,7 +17,7 @@ class FollowingManageSortControls extends React.Component {
 	};
 
 	static defaultProps = {
-		onSortChange: noop,
+		onSortChange: () => {},
 		sortOrder: 'date-followed',
 	};
 

--- a/client/reader/search-stream/search-stream-header.jsx
+++ b/client/reader/search-stream/search-stream-header.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { noop, values } from 'lodash';
+import { values } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -23,7 +23,7 @@ class SearchStreamHeader extends Component {
 		onSelection: PropTypes.func,
 	};
 	static defaultProps = {
-		onSelection: noop,
+		onSelection: () => {},
 		selected: SEARCH_TYPES.posts,
 	};
 

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -5,7 +5,7 @@ import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import { findLast, noop, times } from 'lodash';
+import { findLast, times } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -87,7 +87,7 @@ class ReaderStream extends React.Component {
 		showPostHeader: true,
 		suppressSiteNameLink: false,
 		showFollowInHeader: false,
-		onUpdatesShown: noop,
+		onUpdatesShown: () => {},
 		className: '',
 		showDefaultEmptyContentIfMissing: true,
 		showPrimaryFollowButtonOnCards: true,

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { noop, filter, get, flatMap } from 'lodash';
+import { filter, get, flatMap } from 'lodash';
 import classnames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -29,7 +29,7 @@ class UpdateNotice extends React.PureComponent {
 		cappedUnreadCount: PropTypes.string,
 	};
 
-	static defaultProps = { onClick: noop };
+	static defaultProps = { onClick: () => {} };
 
 	render() {
 		const { count, cappedUnreadCount, translate } = this.props;

--- a/client/server/pages/test/analytics.js
+++ b/client/server/pages/test/analytics.js
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import events from 'events';
-import { noop } from 'lodash';
 import sinon from 'sinon';
 
 /**
@@ -28,7 +27,7 @@ describe( 'index', () => {
 			request2 = { context: {} };
 			response = new events.EventEmitter();
 			response2 = new events.EventEmitter();
-			next = noop;
+			next = () => {};
 		} );
 
 		describe( 'when rendering a section', () => {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -11,12 +10,12 @@ import { isEnabled } from '@automattic/calypso-config';
 import { addQueryArgs } from 'calypso/lib/route';
 
 export function generateFlows( {
-	getSiteDestination = noop,
-	getRedirectDestination = noop,
-	getSignupDestination = noop,
-	getLaunchDestination = noop,
-	getThankYouNoSiteDestination = noop,
-	getChecklistThemeDestination = noop,
+	getSiteDestination = () => {},
+	getRedirectDestination = () => {},
+	getSignupDestination = () => {},
+	getLaunchDestination = () => {},
+	getThankYouNoSiteDestination = () => {},
+	getChecklistThemeDestination = () => {},
 } = {} ) {
 	const flows = {
 		account: {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import i18n from 'i18n-calypso';
 
 /**
@@ -25,23 +24,23 @@ import {
 } from 'calypso/lib/plans/constants';
 
 export function generateSteps( {
-	addPlanToCart = noop,
-	addDomainUpsellToCart = noop,
-	createAccount = noop,
-	createSite = noop,
-	createWpForTeamsSite = noop,
-	createSiteOrDomain = noop,
-	createSiteWithCart = noop,
-	currentPage = noop,
-	setThemeOnSite = noop,
-	addDomainToCart = noop,
-	launchSiteApi = noop,
-	isPlanFulfilled = noop,
-	isFreePlansDomainUpsellFulfilled = noop,
-	isDomainFulfilled = noop,
-	isSiteTypeFulfilled = noop,
-	isSiteTopicFulfilled = noop,
-	maybeRemoveStepForUserlessCheckout = noop,
+	addPlanToCart = () => {},
+	addDomainUpsellToCart = () => {},
+	createAccount = () => {},
+	createSite = () => {},
+	createWpForTeamsSite = () => {},
+	createSiteOrDomain = () => {},
+	createSiteWithCart = () => {},
+	currentPage = () => {},
+	setThemeOnSite = () => {},
+	addDomainToCart = () => {},
+	launchSiteApi = () => {},
+	isPlanFulfilled = () => {},
+	isFreePlansDomainUpsellFulfilled = () => {},
+	isDomainFulfilled = () => {},
+	isSiteTypeFulfilled = () => {},
+	isSiteTopicFulfilled = () => {},
+	maybeRemoveStepForUserlessCheckout = () => {},
 } = {} ) {
 	return {
 		survey: {

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -3,7 +3,6 @@
  */
 import { shallow } from 'enzyme';
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,8 +29,8 @@ describe( 'NavigationLink', () => {
 			'test:step2': { stepName: 'test:step2', stepSectionName: 'test:section2', wasSkipped: false },
 			'test:step3': { stepName: 'test:step3', stepSectionName: 'test:section3', wasSkipped: false },
 		},
-		recordTracksEvent: noop,
-		submitSignupStep: noop,
+		recordTracksEvent: () => {},
+		submitSignupStep: () => {},
 		goToNextStep: jest.fn(),
 		translate: ( str ) => `translated:${ str }`,
 	};

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { noop, includes } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -73,7 +73,7 @@ class AboutStep extends Component {
 		this._isMounted = true;
 		this.formStateController = new formState.Controller( {
 			fieldNames: [ 'siteTitle', 'siteGoals', 'siteTopic' ],
-			validatorFunction: noop,
+			validatorFunction: () => {},
 			onNewState: this.setFormState,
 			hideFieldErrorsOnChange: true,
 			initialState: {

--- a/client/signup/steps/plans-atomic-store/test/index.jsx
+++ b/client/signup/steps/plans-atomic-store/test/index.jsx
@@ -11,7 +11,7 @@ jest.mock( 'i18n-calypso', () => ( {
  */
 import { shallow } from 'enzyme';
 import React from 'react';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,9 +43,9 @@ const props = {
 	stepName: 'Step name',
 	stepSectionName: 'Step section name',
 	signupDependencies: { domainItem: null },
-	submitSignupStep: noop,
-	goToNextStep: noop,
-	recordTracksEvent: noop,
+	submitSignupStep: () => {},
+	goToNextStep: () => {},
+	recordTracksEvent: () => {},
 };
 
 describe( 'PlansAtomicStoreStep basic tests', () => {

--- a/client/signup/steps/plans/test/index.jsx
+++ b/client/signup/steps/plans/test/index.jsx
@@ -6,7 +6,7 @@ jest.mock( 'calypso/my-sites/plan-features', () => 'plan-features' );
  */
 import { shallow } from 'enzyme';
 import React from 'react';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,10 +38,10 @@ const props = {
 	stepName: 'Step name',
 	stepSectionName: 'Step section name',
 	signupDependencies: { domainItem: null },
-	saveSignupStep: noop,
-	submitSignupStep: noop,
-	goToNextStep: noop,
-	recordTracksEvent: noop,
+	saveSignupStep: () => {},
+	submitSignupStep: () => {},
+	goToNextStep: () => {},
+	recordTracksEvent: () => {},
 	translate: identity,
 };
 

--- a/client/signup/steps/site-picker/test/site-picker-submit.jsx
+++ b/client/signup/steps/site-picker/test/site-picker-submit.jsx
@@ -11,7 +11,6 @@ jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
  */
 import { shallow } from 'enzyme';
 import React from 'react';
-import { noop } from 'lodash';
 
 jest.mock( 'i18n-calypso', () => ( {
 	translate: ( str ) => str,
@@ -45,7 +44,7 @@ import {
 
 const props = {
 	goToStep: jest.fn(),
-	submitSignupStep: noop,
+	submitSignupStep: () => {},
 	selectedSite: {
 		ID: 1,
 	},

--- a/client/signup/steps/site-style/test/index.js
+++ b/client/signup/steps/site-style/test/index.js
@@ -7,7 +7,7 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,12 +30,12 @@ describe( '<SiteStyleStep />', () => {
 		],
 		siteStyle: 'default',
 		siteType: 'professional',
-		setSiteStyle: noop,
-		submitSiteStyle: noop,
-		submitSignupStep: noop,
-		saveSignupStep: noop,
-		goToNextStep: noop,
-		recordTracksEvent: noop,
+		setSiteStyle: () => {},
+		submitSiteStyle: () => {},
+		submitSignupStep: () => {},
+		saveSignupStep: () => {},
+		goToNextStep: () => {},
+		recordTracksEvent: () => {},
 		translate: identity,
 	};
 
@@ -64,7 +64,7 @@ describe( '<SiteStyleStep />', () => {
 	test( 'should call `submitSiteStyle()` from `handleSubmit()`', () => {
 		const wrapper = shallow( <SiteStyleStep { ...defaultProps } siteStyle="eyesore" /> );
 		const submitSiteStyle = jest.spyOn( wrapper.instance(), 'submitSiteStyle' );
-		wrapper.instance().handleSubmit( { preventDefault: noop } );
+		wrapper.instance().handleSubmit( { preventDefault: () => {} } );
 		expect( submitSiteStyle ).toHaveBeenCalledWith( 'eyesore', 'pub/hipster', 'nicer' );
 	} );
 
@@ -78,7 +78,7 @@ describe( '<SiteStyleStep />', () => {
 		expect( firstInputField.props.checked ).toBe( true );
 
 		const submitSiteStyle = jest.spyOn( wrapper.instance(), 'submitSiteStyle' );
-		wrapper.instance().handleSubmit( { preventDefault: noop } );
+		wrapper.instance().handleSubmit( { preventDefault: () => {} } );
 		// check that we pass the default site option onSubmit
 		expect( submitSiteStyle ).toHaveBeenCalledWith(
 			defaultProps.styleOptions[ 0 ].id,

--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -31,7 +31,7 @@ class SignupThemesList extends Component {
 		surveyQuestion: null,
 		designType: null,
 		quantity: 3,
-		handleScreenshotClick: noop,
+		handleScreenshotClick: () => {},
 		translate: identity,
 	};
 
@@ -65,9 +65,9 @@ class SignupThemesList extends Component {
 		return (
 			<div className="signup-themes-list">
 				<ThemesList
-					getButtonOptions={ noop }
+					getButtonOptions={ () => {} }
 					onScreenshotClick={ this.props.handleScreenshotClick }
-					onMoreButtonClick={ noop }
+					onMoreButtonClick={ () => {} }
 					getActionLabel={ getActionLabel }
 					themes={ themes }
 				/>

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -10,7 +10,6 @@ import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import ReactDOM from 'react-dom';
 import sinon from 'sinon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -48,7 +47,7 @@ describe( '#signupStep User', () => {
 		testElement = React.createElement( User, {
 			subHeaderText: 'first subheader message',
 			flowName: 'userAsFirstStepInFlow',
-			saveSignupStep: noop,
+			saveSignupStep: () => {},
 		} );
 		rendered = TestUtils.renderIntoDocument( testElement );
 
@@ -59,7 +58,7 @@ describe( '#signupStep User', () => {
 		testElement = React.createElement( User, {
 			subHeaderText: 'test subheader message',
 			flowName: 'someOtherFlow',
-			saveSignupStep: noop,
+			saveSignupStep: () => {},
 		} );
 		rendered = TestUtils.renderIntoDocument( testElement );
 
@@ -79,7 +78,7 @@ describe( '#signupStep User', () => {
 			const element = React.createElement( User, {
 				subHeaderText: 'test subheader message',
 				flowName: 'someOtherFlow',
-				saveSignupStep: noop,
+				saveSignupStep: () => {},
 			} );
 			component = ReactDOM.render( element, node );
 		} );
@@ -92,7 +91,7 @@ describe( '#signupStep User', () => {
 			const testProps = {
 				subHeaderText: 'My test message',
 				flowName: 'userAsFirstStepInFlow',
-				saveSignupStep: noop,
+				saveSignupStep: () => {},
 			};
 
 			expect( spyComponentProps.calledOnce ).to.equal( false );
@@ -107,7 +106,7 @@ describe( '#signupStep User', () => {
 			const testProps = {
 				subHeaderText: 'My test message',
 				flowName: 'another test message test',
-				saveSignupStep: noop,
+				saveSignupStep: () => {},
 			};
 
 			expect( spyComponentProps.calledOnce ).to.equal( false );

--- a/client/state/analytics/test/middleware.js
+++ b/client/state/analytics/test/middleware.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -81,7 +80,7 @@ jest.mock( 'calypso/lib/analytics/hotjar', () => ( {
 	addHotJarScript: require( 'sinon' ).spy(),
 } ) );
 
-const dispatch = analyticsMiddleware()( noop );
+const dispatch = analyticsMiddleware()( () => {} );
 
 describe( 'middleware', () => {
 	describe( 'analytics dispatching', () => {

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import deterministicStringify from 'fast-json-stable-stringify';
-import { get, identity, merge, noop } from 'lodash';
+import { get, identity, merge } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -211,11 +211,11 @@ export const dispatchRequest = requestDispatcher( trackRequests );
  */
 function createRequestAction( options, action ) {
 	const {
-		fetch = noop,
-		onSuccess = noop,
-		onError = noop,
-		onProgress = noop,
-		onStreamRecord = noop,
+		fetch = () => {},
+		onSuccess = () => {},
+		onError = () => {},
+		onProgress = () => {},
+		onStreamRecord = () => {},
 		fromApi = identity,
 	} = options;
 

--- a/client/state/data-layer/wpcom/activity-log/delete-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/delete-credentials/index.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- *
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
@@ -60,7 +54,7 @@ registerHandlers( 'state/data-layer/wpcom/sites/rewind/credentials/delete', {
 		dispatchRequest( {
 			fetch: request,
 			onSuccess: success,
-			onError: noop,
+			onError: () => {},
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -87,7 +87,7 @@ export const receiveChecklistSuccess = ( action, receivedChecklist ) => {
 const dispatchChecklistRequest = dispatchRequest( {
 	fetch: fetchChecklist,
 	onSuccess: receiveChecklistSuccess,
-	onError: noop,
+	onError: () => {},
 	fromApi,
 } );
 
@@ -108,7 +108,7 @@ export const updateChecklistTask = ( action ) =>
 const dispatchChecklistTaskUpdate = dispatchRequest( {
 	fetch: updateChecklistTask,
 	onSuccess: receiveChecklistSuccess,
-	onError: noop,
+	onError: () => {},
 	fromApi,
 } );
 

--- a/client/state/data-layer/wpcom/domains/transfer/index.js
+++ b/client/state/data-layer/wpcom/domains/transfer/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -248,7 +247,7 @@ registerHandlers( 'state/data-layer/wpcom/domains/transfer/index.js', {
 		dispatchRequest( {
 			fetch: declineDomainTransfer,
 			onSuccess: declineDomainTransferSuccess,
-			onError: noop,
+			onError: () => {},
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/help/search/index.js
+++ b/client/state/data-layer/wpcom/help/search/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
@@ -46,7 +41,7 @@ registerHandlers( 'state/data-layer/wpcom/help/search/index.js', {
 		dispatchRequest( {
 			fetch: requestHelpLinks,
 			onSuccess: handleRequestSuccess,
-			onError: noop,
+			onError: () => {},
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/i18n/language-names/index.js
+++ b/client/state/data-layer/wpcom/i18n/language-names/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
@@ -44,7 +39,7 @@ export const addLanguageNames = ( action, data ) => [ receiveLanguageNames( data
 export const dispatchPlansRequest = dispatchRequest( {
 	fetch: fetchLanguageNames,
 	onSuccess: addLanguageNames,
-	onError: noop,
+	onError: () => {},
 } );
 
 registerHandlers( 'state/data-layer/wpcom/i18n/language-names/index.js', {

--- a/client/state/data-layer/wpcom/jetpack-blogs/product-install-status/index.js
+++ b/client/state/data-layer/wpcom/jetpack-blogs/product-install-status/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
@@ -45,7 +40,7 @@ registerHandlers( 'state/data-layer/wpcom/jetpack-blogs/product-install-status',
 		dispatchRequest( {
 			fetch: requestJetpackProductInstallStatus,
 			onSuccess: handleRequestSuccess,
-			onError: noop,
+			onError: () => {},
 			fromApi: makeJsonSchemaParser( schema ),
 		} ),
 	],

--- a/client/state/data-layer/wpcom/jetpack-blogs/product-install/index.js
+++ b/client/state/data-layer/wpcom/jetpack-blogs/product-install/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
@@ -35,8 +30,8 @@ registerHandlers( 'state/data-layer/wpcom/jetpack-blogs/product-install', {
 	[ JETPACK_PRODUCT_INSTALL_REQUEST ]: [
 		dispatchRequest( {
 			fetch: startJetpackProductInstall,
-			onSuccess: noop,
-			onError: noop,
+			onSuccess: () => {},
+			onError: () => {},
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/locale-guess/index.js
+++ b/client/state/data-layer/wpcom/locale-guess/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
@@ -45,7 +40,7 @@ export const addLocaleSuggestions = ( action, data ) => receiveLocaleSuggestions
 export const dispatchPlansRequest = dispatchRequest( {
 	fetch: fetchLocaleSuggestions,
 	onSuccess: addLocaleSuggestions,
-	onError: noop,
+	onError: () => {},
 } );
 
 registerHandlers( 'state/data-layer/wpcom/locale-guess/index.js', {

--- a/client/state/data-layer/wpcom/logstash/index.js
+++ b/client/state/data-layer/wpcom/logstash/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
@@ -21,5 +16,7 @@ const logToLogstash = ( action ) =>
 	} );
 
 registerHandlers( 'state/data-layer/wpcom/logstash/index.js', {
-	[ LOGSTASH ]: [ dispatchRequest( { fetch: logToLogstash, onSuccess: noop, onError: noop } ) ],
+	[ LOGSTASH ]: [
+		dispatchRequest( { fetch: logToLogstash, onSuccess: () => {}, onError: () => {} } ),
+	],
 } );

--- a/client/state/data-layer/wpcom/marketing/index.js
+++ b/client/state/data-layer/wpcom/marketing/index.js
@@ -3,7 +3,6 @@
  */
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
-import { noop } from 'lodash';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 
 import { MARKETING_CLICK_UPGRADE_NUDGE } from 'calypso/state/action-types';
@@ -25,8 +24,8 @@ registerHandlers( 'state/data-layer/wpcom/marketing/index.js', {
 	[ MARKETING_CLICK_UPGRADE_NUDGE ]: [
 		dispatchRequest( {
 			fetch: notifyUpgradeNudgeClick,
-			onSuccess: noop,
-			onError: noop,
+			onSuccess: () => {},
+			onError: () => {},
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/me/connected-applications/index.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
@@ -47,7 +42,7 @@ registerHandlers( 'state/data-layer/wpcom/me/connected-applications/index.js', {
 		dispatchRequest( {
 			fetch: requestConnectedApplications,
 			onSuccess: handleRequestSuccess,
-			onError: noop,
+			onError: () => {},
 			fromApi: makeJsonSchemaParser( schema, apiTransformer, {} ),
 		} ),
 	],

--- a/client/state/data-layer/wpcom/me/settings/profile-links/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
@@ -46,7 +41,7 @@ registerHandlers( 'state/data-layer/wpcom/me/settings/profile-links/index.js', {
 		dispatchRequest( {
 			fetch: requestUserProfileLinks,
 			onSuccess: handleRequestSuccess,
-			onError: noop,
+			onError: () => {},
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
@@ -48,7 +43,7 @@ registerHandlers( 'state/data-layer/wpcom/me/two-step/application-passwords/inde
 		dispatchRequest( {
 			fetch: requestApplicationPasswords,
 			onSuccess: handleRequestSuccess,
-			onError: noop,
+			onError: () => {},
 			fromApi: makeJsonSchemaParser( schema, apiTransformer ),
 		} ),
 	],

--- a/client/state/data-layer/wpcom/posts/revisions/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { POST_REVISIONS_REQUEST } from 'calypso/state/action-types';
@@ -48,7 +43,7 @@ export const fetchPostRevisionsDiffs = ( action ) => {
 const dispatchPostRevisionsDiffsRequest = dispatchRequest( {
 	fetch: fetchPostRevisionsDiffs,
 	onSuccess: receiveSuccess,
-	onError: noop,
+	onError: () => {},
 } );
 
 registerHandlers( 'state/data-layer/wpcom/posts/revisions/index.js', {

--- a/client/state/data-layer/wpcom/read/following/mine/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/test/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import freeze from 'deep-freeze';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -101,7 +100,7 @@ describe( 'get follow subscriptions', () => {
 		test( 'should stop the sync process if it hits an empty page', () => {
 			const startSyncAction = { type: READER_FOLLOWS_SYNC_START };
 			const action = syncReaderFollowsPage(); // no feeds
-			const ignoredDispatch = noop;
+			const ignoredDispatch = () => {};
 			const dispatch = jest.fn();
 
 			syncReaderFollows( { dispatch: ignoredDispatch }, startSyncAction );
@@ -128,7 +127,7 @@ describe( 'get follow subscriptions', () => {
 		test( 'should catch a feed followed during the sync', () => {
 			const startSyncAction = { type: READER_FOLLOWS_SYNC_START };
 			const action = syncReaderFollowsPage(); // no feeds
-			const ignoredDispatch = noop;
+			const ignoredDispatch = () => {};
 			const dispatch = jest.fn();
 
 			syncReaderFollows( { dispatch: ignoredDispatch }, startSyncAction );

--- a/client/state/data-layer/wpcom/read/lists/index.js
+++ b/client/state/data-layer/wpcom/read/lists/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -154,7 +153,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 					action
 				),
 			onSuccess: ( action, apiResponse ) => receiveLists( apiResponse?.lists ),
-			onError: () => noop,
+			onError: () => () => {},
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/lists/items/index.js
+++ b/client/state/data-layer/wpcom/read/lists/items/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
@@ -27,7 +22,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/items/index.js', {
 				),
 			onSuccess: ( action, apiResponse ) =>
 				receiveReaderListItems( apiResponse.list_ID, apiResponse.items ),
-			onError: () => noop,
+			onError: () => () => {},
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/recommendations/sites/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/index.js
@@ -1,9 +1,4 @@
 /**
- * External Dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal Dependencies
  */
 import { READER_RECOMMENDED_SITES_REQUEST } from 'calypso/state/reader/action-types';
@@ -44,7 +39,7 @@ registerHandlers( 'state/data-layer/wpcom/read/recommendations/sites/index.js', 
 		dispatchRequest( {
 			fetch: requestRecommendedSites,
 			onSuccess: addRecommendedSites,
-			onError: noop,
+			onError: () => {},
 			fromApi,
 		} ),
 	],

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/delete/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { READER_UNSUBSCRIBE_TO_NEW_POST_NOTIFICATIONS } from 'calypso/state/reader/action-types';
@@ -54,7 +49,7 @@ registerHandlers( 'state/data-layer/wpcom/read/sites/notification-subscriptions/
 	[ READER_UNSUBSCRIBE_TO_NEW_POST_NOTIFICATIONS ]: [
 		dispatchRequest( {
 			fetch: requestNotificationUnsubscription,
-			onSuccess: noop,
+			onSuccess: () => {},
 			onError: receiveNotificationUnsubscriptionError,
 			fromApi,
 		} ),

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/new/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { READER_SUBSCRIBE_TO_NEW_POST_NOTIFICATIONS } from 'calypso/state/reader/action-types';
@@ -52,7 +47,7 @@ registerHandlers( 'state/data-layer/wpcom/read/sites/notification-subscriptions/
 	[ READER_SUBSCRIBE_TO_NEW_POST_NOTIFICATIONS ]: [
 		dispatchRequest( {
 			fetch: requestNotificationSubscription,
-			onSuccess: noop,
+			onSuccess: () => {},
 			onError: receiveNotificationSubscriptionError,
 			fromApi,
 		} ),

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { random, map, includes, get, noop } from 'lodash';
+import { random, map, includes, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -261,7 +261,7 @@ registerHandlers( 'state/data-layer/wpcom/read/streams/index.js', {
 		dispatchRequest( {
 			fetch: requestPage,
 			onSuccess: handlePage,
-			onError: noop,
+			onError: () => {},
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/sites/gutenberg/index.js
+++ b/client/state/data-layer/wpcom/sites/gutenberg/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { has, noop } from 'lodash';
+import { has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,7 +40,7 @@ const setGutenbergOptInData = (
 const dispatchFetchGutenbergOptInData = dispatchRequest( {
 	fetch: fetchGutenbergOptInData,
 	onSuccess: setGutenbergOptInData,
-	onError: noop,
+	onError: () => {},
 } );
 
 const updateSelectedEditor = ( action ) =>
@@ -76,7 +76,7 @@ const setSelectedEditorAndRedirect = ( { siteId, redirectUrl }, { editor_web: ed
 const dispatchUpdateSelectedEditor = dispatchRequest( {
 	fetch: updateSelectedEditor,
 	onSuccess: setSelectedEditorAndRedirect,
-	onError: noop,
+	onError: () => {},
 } );
 
 registerHandlers( 'state/data-layer/wpcom/sites/gutenberg/index.js', {

--- a/client/state/data-layer/wpcom/sites/homepage/index.js
+++ b/client/state/data-layer/wpcom/sites/homepage/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -58,7 +58,7 @@ registerHandlers( 'state/data-layer/wpcom/sites/homepage/index.js', {
 		dispatchRequest( {
 			fetch: updateSiteFrontPageRequest,
 			onSuccess: setSiteFrontPage,
-			onError: noop,
+			onError: () => {},
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -1,9 +1,4 @@
 /**
- * External Dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
@@ -139,8 +134,8 @@ registerHandlers( 'state/data-layer/wpcom/sites/jitm/index.js', {
 	[ JITM_DISMISS ]: [
 		dispatchRequest( {
 			fetch: doDismissJITM,
-			onSuccess: noop,
-			onError: noop,
+			onSuccess: () => {},
+			onError: () => {},
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/sites/mailchimp/index.js
+++ b/client/state/data-layer/wpcom/sites/mailchimp/index.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import {
@@ -36,7 +30,7 @@ export const handleMailchimpListsList = dispatchRequest( {
 		siteId,
 		lists,
 	} ),
-	onError: noop,
+	onError: () => {},
 } );
 
 export const handleMailchimpSettingsList = dispatchRequest( {
@@ -56,7 +50,7 @@ export const handleMailchimpSettingsList = dispatchRequest( {
 		siteId,
 		settings,
 	} ),
-	onError: noop,
+	onError: () => {},
 } );
 
 registerHandlers(

--- a/client/state/data-layer/wpcom/sites/memberships/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/index.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import {
@@ -54,7 +48,7 @@ export const handleMembershipProductsList = dispatchRequest( {
 		siteId,
 		products,
 	} ),
-	onError: noop,
+	onError: () => {},
 } );
 
 export const handleMembershipGetEarnings = dispatchRequest( {
@@ -72,7 +66,7 @@ export const handleMembershipGetEarnings = dispatchRequest( {
 		siteId,
 		earnings,
 	} ),
-	onError: noop,
+	onError: () => {},
 } );
 
 export const handleMembershipGetSubscribers = dispatchRequest( {
@@ -90,7 +84,7 @@ export const handleMembershipGetSubscribers = dispatchRequest( {
 		siteId,
 		subscribers,
 	} ),
-	onError: noop,
+	onError: () => {},
 } );
 
 export const handleMembershipGetSettings = dispatchRequest( {
@@ -108,7 +102,7 @@ export const handleMembershipGetSettings = dispatchRequest( {
 		siteId,
 		data,
 	} ),
-	onError: noop,
+	onError: () => {},
 } );
 
 registerHandlers( 'state/data-layer/wpcom/sites/memberships/index.js', {

--- a/client/state/data-layer/wpcom/sites/memberships/subscriptions/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/subscriptions/index.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import {
@@ -31,7 +25,7 @@ export const handleSubscribedMembershipsList = dispatchRequest( {
 		subscriptions,
 		total,
 	} ),
-	onError: noop,
+	onError: () => {},
 } );
 
 registerHandlers( 'state/data-layer/wpcom/sites/memberships/subscriptions/index.js', {

--- a/client/state/data-layer/wpcom/sites/post-types/index.js
+++ b/client/state/data-layer/wpcom/sites/post-types/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
@@ -23,7 +18,7 @@ const handlePostTypesRequest = dispatchRequest( {
 			action
 		),
 	onSuccess: ( action, data ) => receivePostTypes( action.siteId, data.post_types ),
-	onError: noop,
+	onError: () => {},
 } );
 
 registerHandlers( 'state/data-layer/wpcom/sites/post-types/index.js', {

--- a/client/state/data-layer/wpcom/sites/users/index.js
+++ b/client/state/data-layer/wpcom/sites/users/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { get, isUndefined, map, noop, omit, omitBy } from 'lodash';
+import { get, isUndefined, map, omit, omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -84,7 +84,7 @@ export const receivePostRevisionAuthorsSuccess = ( action, users ) => ( dispatch
 const dispatchPostRevisionAuthorsRequest = dispatchRequest( {
 	fetch: fetchPostRevisionAuthors,
 	onSuccess: receivePostRevisionAuthorsSuccess,
-	onError: noop,
+	onError: () => {},
 } );
 
 registerHandlers( 'state/data-layer/wpcom/sites/users/index.js', {

--- a/client/state/data-layer/wpcom/timezones/index.js
+++ b/client/state/data-layer/wpcom/timezones/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fromPairs, map, mapValues, noop } from 'lodash';
+import { fromPairs, map, mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -61,7 +61,7 @@ registerHandlers( 'state/data-layer/wpcom/timezones/index.js', {
 		dispatchRequest( {
 			fetch: fetchTimezones,
 			onSuccess: addTimezones,
-			onError: noop,
+			onError: () => {},
 			fromApi,
 		} ),
 	],

--- a/client/state/data-layer/wpcom/wordads/settings/index.js
+++ b/client/state/data-layer/wpcom/wordads/settings/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -114,7 +113,7 @@ registerHandlers( 'state/data-layer/wpcom/wordads/settings/index.js', {
 		dispatchRequest( {
 			fetch: requestWordadsSettings,
 			onSuccess: receiveWordadsSettings,
-			onError: noop,
+			onError: () => {},
 			fromApi,
 		} ),
 	],

--- a/client/state/happychat/middleware-calypso.js
+++ b/client/state/happychat/middleware-calypso.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { has, noop } from 'lodash';
+import { has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -191,7 +191,7 @@ export default ( store ) => ( next ) => ( action ) => {
 		case ROUTE_SET:
 			isHappychatClientConnected( state ) && isHappychatChatAssigned( state )
 				? dispatch( sendEvent( getRouteSetMessage( state, action.path ) ) )
-				: noop;
+				: () => {};
 			break;
 	}
 	return next( action );

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -75,7 +75,7 @@ export const socketMiddleware = ( connection = null ) => {
 				isHappychatChatAssigned( state ) &&
 				eventMessage[ action.type ]
 					? store.dispatch( sendEvent( eventMessage[ action.type ] ) )
-					: noop;
+					: () => {};
 				break;
 		}
 

--- a/client/state/media/thunks/upload-media.js
+++ b/client/state/media/thunks/upload-media.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, noop, zip } from 'lodash';
+import { castArray, zip } from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,8 +40,8 @@ export const uploadMedia = (
 	files,
 	site,
 	uploader,
-	onItemUploaded = noop,
-	onItemFailure = noop
+	onItemUploaded = () => {},
+	onItemFailure = () => {}
 ) => async ( dispatch ) => {
 	// https://stackoverflow.com/questions/25333488/why-isnt-the-filelist-object-an-array
 	files = isFileList( files ) ? Array.from( files ) : castArray( files );

--- a/client/state/sites/domains/actions.js
+++ b/client/state/sites/domains/actions.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { map, noop } from 'lodash';
+import { map } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -155,7 +155,7 @@ export function disableDomainPrivacy( siteId, domain ) {
 	};
 }
 
-export const setPrimaryDomain = ( siteId, domainName, onComplete = noop ) => ( dispatch ) => {
+export const setPrimaryDomain = ( siteId, domainName, onComplete = () => {} ) => ( dispatch ) => {
 	debug( 'setPrimaryDomain', siteId, domainName );
 	return wpcom.setPrimaryDomain( siteId, domainName, ( error, data ) => {
 		if ( error ) {

--- a/client/state/test/index.js
+++ b/client/state/test/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { createReduxStore } from '../';
@@ -48,7 +43,7 @@ describe( 'index', () => {
 
 		describe( 'invalid data', () => {
 			test( 'ignores non-existent keys', () => {
-				const consoleErrorSpy = jest.spyOn( console, 'error' ).mockImplementation( noop );
+				const consoleErrorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
 				expect( consoleErrorSpy ).not.toHaveBeenCalled();
 				const reduxStoreNoArgs = createReduxStore().getState();
 				const reduxStoreBadData = createReduxStore( { some: { bad: { stuff: true } } } ).getState();

--- a/client/state/test/persistence.js
+++ b/client/state/test/persistence.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { DESERIALIZE, SERIALIZE } from 'calypso/state/action-types';
@@ -15,8 +10,8 @@ jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'persistence', () => {
 	test( 'initial state should serialize and deserialize without errors or warnings', () => {
-		const consoleErrorSpy = jest.spyOn( global.console, 'error' ).mockImplementation( noop );
-		const consoleWarnSpy = jest.spyOn( global.console, 'warn' ).mockImplementation( noop );
+		const consoleErrorSpy = jest.spyOn( global.console, 'error' ).mockImplementation( () => {} );
+		const consoleWarnSpy = jest.spyOn( global.console, 'warn' ).mockImplementation( () => {} );
 
 		const initialState = createReduxStore().getState();
 		reducer( reducer( initialState, { type: SERIALIZE } ).root(), { type: DESERIALIZE } );

--- a/client/test-helpers/use-sinon/index.js
+++ b/client/test-helpers/use-sinon/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import sinon from 'sinon';
-import { isFunction, noop } from 'lodash';
+import { isFunction } from 'lodash';
 
 /**
  * Use sinon's fake time controls
@@ -18,6 +18,9 @@ import { isFunction, noop } from 'lodash';
  * @param  {Function} clockCallback  A function invoked with the clock created by sinon
  * @deprecated Use Jest's timer mocks instead (https://facebook.github.io/jest/docs/timer-mocks.html)
  */
+
+const noop = () => {};
+
 export function useFakeTimers( now = 0, clockCallback = noop ) {
 	let clock;
 

--- a/packages/components/src/suggestions/index.tsx
+++ b/packages/components/src/suggestions/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
-import { find, groupBy, isEqual, partition, property, noop } from 'lodash';
+import { find, groupBy, isEqual, partition, property } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -45,7 +45,7 @@ interface State {
 class Suggestions extends Component< Props, State > {
 	static defaultProps = {
 		query: '',
-		onSuggestionItemMount: noop,
+		onSuggestionItemMount: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
 	};
 
 	state = {

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { FunctionComponent, useState, useEffect, Fragment } from 'react';
 import { useSelect } from '@wordpress/data';
-import { noop, times } from 'lodash';
+import { times } from 'lodash';
 import { Button, TextControl, Notice } from '@wordpress/components';
 import { Icon, search } from '@wordpress/icons';
 import { getNewRailcarId, recordTrainTracksRender } from '@automattic/calypso-analytics';
@@ -123,11 +123,11 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	onExistingSubdomainSelect,
 	quantity = PAID_DOMAINS_TO_SHOW,
 	quantityExpanded = PAID_DOMAINS_TO_SHOW_EXPANDED,
-	onDomainSearchBlur = noop,
+	onDomainSearchBlur = () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
 	analyticsFlowId,
 	analyticsUiAlgo,
 	initialDomainSearch = '',
-	onSetDomainSearch = noop,
+	onSetDomainSearch = () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
 	currentDomain,
 	isCheckingDomainAvailability,
 	existingSubdomain,

--- a/packages/page-template-modal/src/components/block-iframe-preview.js
+++ b/packages/page-template-modal/src/components/block-iframe-preview.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { each, filter, get, castArray, debounce, noop } from 'lodash';
+import { each, filter, get, castArray, debounce } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -91,7 +91,7 @@ const BlockFramePreview = ( {
 	viewportWidth,
 	blocks,
 	settings,
-	setTimeout = noop,
+	setTimeout = () => {},
 	title,
 } ) => {
 	const frameContainerRef = useRef();

--- a/packages/page-template-modal/src/components/template-selector-control.js
+++ b/packages/page-template-modal/src/components/template-selector-control.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, noop, map } from 'lodash';
+import { isEmpty, map } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -27,7 +27,7 @@ export const TemplateSelectorControl = ( {
 	blocksByTemplates = {},
 	theme = 'maywood',
 	locale = 'en',
-	onTemplateSelect = noop,
+	onTemplateSelect = () => {},
 	siteInformation = {},
 	selectedTemplate,
 } ) => {

--- a/packages/plans-grid/src/segmented-control/simplified.jsx
+++ b/packages/plans-grid/src/segmented-control/simplified.jsx
@@ -3,7 +3,6 @@
  */
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,7 +12,7 @@ import SegmentedControl from '.';
 function SimplifiedSegmentedControl( {
 	options,
 	initialSelected = options[ 0 ].value,
-	onSelect = noop,
+	onSelect = () => {},
 	...props
 } ) {
 	const [ selected, setSelected ] = useState( initialSelected );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `noop` is essentially an empty function. This PR replaces all the usage of `noop` with an empty arrow function.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify Calypso builds.
* Verify all tests pass.

#### Notes
Lint errors are expected. Just make sure we're not introducing new ones.