### PR TITLE
ci(e2e): Move browser start inside the describe block

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,6 +81,7 @@ module.exports = {
 				'mocha/handle-done-callback': [ 'error', { ignoreSkipped: true } ],
 				'mocha/no-global-tests': 'error',
 				'mocha/no-async-describe': 'error',
+				'mocha/no-top-level-hooks': 'error',
 				'no-console': 'off',
 				// Disable all rules from "plugin:jest/recommended", as e2e tests use mocha
 				...Object.keys( require( 'eslint-plugin-jest' ).configs.recommended.rules ).reduce(

--- a/test/e2e/lib/mocha-hooks.js
+++ b/test/e2e/lib/mocha-hooks.js
@@ -1,3 +1,5 @@
+/* eslint-disable mocha/no-top-level-hooks */
+
 /**
  * External dependencies
  */

--- a/test/e2e/lib/pages/wp-admin/wp-admin-plugins-page.js
+++ b/test/e2e/lib/pages/wp-admin/wp-admin-plugins-page.js
@@ -20,7 +20,7 @@ export default class WPAdminPluginsPage extends AsyncBaseContainer {
 		);
 		const located = await driverHelper.isElementPresent( this.driver, activateSelector );
 		if ( located === true ) {
-			return await driverHelper.clickWhenClickable( self.driver, activateSelector );
+			return await driverHelper.clickWhenClickable( this.driver, activateSelector );
 		}
 	}
 

--- a/test/e2e/lib/shared-steps/wp-signup-spec.js
+++ b/test/e2e/lib/shared-steps/wp-signup-spec.js
@@ -42,15 +42,15 @@ export const canSeeTheInlineHelpCongratulations = () => {
 	} );
 };
 
-export const canSeeTheOnboardingChecklist = ( driver ) => {
+export const canSeeTheOnboardingChecklist = () => {
 	step( 'Can then see the site setup list', async function () {
 		// dismiss upsell page if displayed
 		try {
-			const upsellPage = await UpsellPage.Expect( driver );
+			const upsellPage = await UpsellPage.Expect( this.driver );
 			await upsellPage.declineOffer();
 		} catch ( e ) {}
 
-		const myHomePage = await MyHomePage.Expect( driver );
+		const myHomePage = await MyHomePage.Expect( this.driver );
 		return assert( await myHomePage.siteSetupListExists(), 'The site setup list does not exist.' );
 	} );
 };

--- a/test/e2e/lib/shared-steps/wp-signup-spec.js
+++ b/test/e2e/lib/shared-steps/wp-signup-spec.js
@@ -42,15 +42,15 @@ export const canSeeTheInlineHelpCongratulations = () => {
 	} );
 };
 
-export const canSeeTheOnboardingChecklist = () => {
+export const canSeeTheOnboardingChecklist = ( driver ) => {
 	step( 'Can then see the site setup list', async function () {
 		// dismiss upsell page if displayed
 		try {
-			const upsellPage = await UpsellPage.Expect( this.driver );
+			const upsellPage = await UpsellPage.Expect( driver );
 			await upsellPage.declineOffer();
 		} catch ( e ) {}
 
-		const myHomePage = await MyHomePage.Expect( this.driver );
+		const myHomePage = await MyHomePage.Expect( driver );
 		return assert( await myHomePage.siteSetupListExists(), 'The site setup list does not exist.' );
 	} );
 };

--- a/test/e2e/scripts/jetpack/wp-jetpack-activate.js
+++ b/test/e2e/scripts/jetpack/wp-jetpack-activate.js
@@ -22,15 +22,14 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
-
-before( function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Jetpack Connection: (${ screenSize }) @jetpack`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = driverManager.startBrowser();
+	} );
 
 	describe( 'Activate Jetpack Plugin:', function () {
 		before( async function () {

--- a/test/e2e/scripts/jetpack/wp-jetpack-deactivate.js
+++ b/test/e2e/scripts/jetpack/wp-jetpack-deactivate.js
@@ -18,15 +18,15 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
-
-before( function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Jetpack Connection Removal: (${ screenSize }) @jetpack`, function () {
 	this.timeout( mochaTimeOut );
+
+	let driver;
+
+	before( function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = driverManager.startBrowser();
+	} );
 
 	describe( 'Deactivate Jetpack Plugin:', function () {
 		before( async function () {

--- a/test/e2e/scripts/jetpack/wp-jetpack-jn-activate.js
+++ b/test/e2e/scripts/jetpack/wp-jetpack-jn-activate.js
@@ -18,8 +18,6 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
-
 // Write url and site credentials into file for further use
 function writeJNCredentials( url, username, password ) {
 	const fileContents = `${ url } ${ username } ${ password }`;
@@ -37,14 +35,15 @@ function writeJNCredentials( url, username, password ) {
 	} );
 }
 
-before( function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = driverManager.startBrowser();
-	return driverManager.clearCookiesAndDeleteLocalStorage( driver );
-} );
-
 describe( `[${ host }] Jurassic Ninja Connection: (${ screenSize }) @jetpack`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+		return driverManager.clearCookiesAndDeleteLocalStorage( driver );
+	} );
 
 	step( 'Can connect from WP Admin', async function () {
 		this.jnFlow = new JetpackConnectFlow( driver, 'jetpackUserJN' );

--- a/test/e2e/specs-i18n/logged-out-redirect-i18n-spec.js
+++ b/test/e2e/specs-i18n/logged-out-redirect-i18n-spec.js
@@ -18,18 +18,16 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 // call run.sh with -I to feed in the mag16
 const locale = driverManager.currentLocale();
 
-let driver;
-
-before( function () {
-	this.timeout( startBrowserTimeoutMS );
-} );
-
 describe( `Logged out homepage redirect test @i18n (${ locale })`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	step( `should redirect to the correct url for wordpress.com (${ locale })`, async function () {
-		driver = await driverManager.startBrowser();
-
 		// No culture here implies 'en'
 		const wpHomePage = await WPHomePage.Visit( driver );
 		await wpHomePage.checkURL( locale );

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -43,15 +43,14 @@ const sandboxCookieValue = config.get( 'storeSandboxCookieValue' );
 const locale = driverManager.currentLocale();
 const siteName = dataHelper.getJetpackSiteName();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `Jetpack Connect: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Connect From wp-admin: @parallel @jetpack @canary', function () {
 		before( async function () {

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -30,15 +30,14 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Jetpack Plans: (${ screenSize }) @jetpack`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Purchase Business Plan:', function () {
 		before( async function () {

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-plugins-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-plugins-spec.js
@@ -22,15 +22,14 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = getJetpackHost();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Jetpack Plugins - Activating a plugin: (${ screenSize }) @jetpack`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	step( 'Can login and select Manage Plugins', async function () {
 		await driverManager.clearCookiesAndDeleteLocalStorage( driver );
@@ -71,6 +70,12 @@ describe( `[${ host }] Jetpack Plugins - Activating a plugin: (${ screenSize }) 
 
 describe( `[${ host }] Jetpack Plugins - Searching a plugin: (${ screenSize }) @jetpack`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	step( 'Can login and select Plugins', async function () {
 		await driverManager.clearCookiesAndDeleteLocalStorage( driver );

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-settings-writing-media-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-settings-writing-media-spec.js
@@ -19,15 +19,14 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Jetpack Settings on Calypso: (${ screenSize }) @jetpack`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	before( async function () {
 		await driverManager.clearCookiesAndDeleteLocalStorage( driver );

--- a/test/e2e/specs-jetpack-calypso/wp-pressable-nux-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-pressable-nux-spec.js
@@ -17,7 +17,6 @@ import PressableNUXFlow from '../lib/flows/pressable-nux-flow';
 import ReaderPage from '../lib/pages/reader-page';
 import SidebarComponent from '../lib/components/sidebar-component';
 import NavBarComponent from '../lib/components/nav-bar-component';
-import JetpackConnectFlow from '../lib/flows/jetpack-connect-flow';
 import LoginFlow from '../lib/flows/login-flow';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
@@ -25,92 +24,85 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
-
 // Disabled due to p1535659602000200-slack-e2e-testing-discuss
 // tl;dr: There is a bug in my.pressable.com which cause some noise/warnings/errors
 // We shouldn't create new Pressable sites for every test.
 // eslint-disable-next-line no-constant-condition
-if ( false ) {
+describe.skip( `[${ host }] Pressable NUX: (${ screenSize })`, function () {
+	this.timeout( mochaTimeOut * 2 );
+	let driver;
 	before( async function () {
 		this.timeout( startBrowserTimeoutMS );
 		driver = await driverManager.startBrowser();
 	} );
 
-	describe( `[${ host }] Pressable NUX: (${ screenSize })`, function () {
-		this.timeout( mochaTimeOut * 2 );
+	describe( 'Connect via Pressable @parallel @jetpack', function () {
+		before( async function () {
+			return await driverManager.ensureNotLoggedIn( driver );
+		} );
 
-		describe( 'Connect via Pressable @parallel @jetpack', function () {
-			before( async function () {
-				return await driverManager.ensureNotLoggedIn( driver );
-			} );
+		step( 'Can log into WordPress.com', async function () {
+			return await new LoginFlow( driver, 'jetpackUser' + host ).login();
+		} );
 
-			step( 'Can log into WordPress.com', async function () {
-				return await new LoginFlow( driver, 'jetpackUser' + host ).login();
-			} );
+		step( 'Can log into Pressable', async function () {
+			const pressableLogonPage = await PressableLogonPage.Visit( driver );
+			return await pressableLogonPage.loginWithWP();
+		} );
 
-			step( 'Can log into Pressable', async function () {
-				const pressableLogonPage = await PressableLogonPage.Visit( driver );
-				return await pressableLogonPage.loginWithWP();
-			} );
+		step( 'Can approve login with WordPress', async function () {
+			const pressableApprovePage = await PressableApprovePage.Expect( driver );
+			return await pressableApprovePage.approve();
+		} );
 
-			step( 'Can approve login with WordPress', async function () {
-				const pressableApprovePage = await PressableApprovePage.Expect( driver );
-				return await pressableApprovePage.approve();
-			} );
+		step( 'Can create new site', async function () {
+			this.siteName = dataHelper.getNewBlogName();
+			this.pressableSitesPage = await PressableSitesPage.Expect( driver );
+			return await this.pressableSitesPage.addNewSite( this.siteName );
+		} );
 
-			step( 'Can create new site', async function () {
-				this.siteName = dataHelper.getNewBlogName();
-				this.pressableSitesPage = await PressableSitesPage.Expect( driver );
-				return await this.pressableSitesPage.addNewSite( this.siteName );
-			} );
+		step( 'Can go to site settings', async function () {
+			return await this.pressableSitesPage.gotoSettings( this.siteName );
+		} );
 
-			step( 'Can go to site settings', async function () {
-				return await this.pressableSitesPage.gotoSettings( this.siteName );
-			} );
+		step( 'Can proceed to Jetpack activation', async function () {
+			const siteSettings = await PressableSiteSettingsPage.Expect( driver );
+			await siteSettings.waitForJetpackPremium();
+			return await siteSettings.activateJetpackPremium();
+		} );
 
-			step( 'Can proceed to Jetpack activation', async function () {
-				const siteSettings = await PressableSiteSettingsPage.Expect( driver );
-				await siteSettings.waitForJetpackPremium();
-				return await siteSettings.activateJetpackPremium();
-			} );
+		step( 'Can approve connection on the authorization page', async function () {
+			const jetpackAuthorizePage = await JetpackAuthorizePage.Expect( driver );
+			return await jetpackAuthorizePage.approveConnection();
+		} );
 
-			step( 'Can approve connection on the authorization page', async function () {
-				const jetpackAuthorizePage = await JetpackAuthorizePage.Expect( driver );
-				return await jetpackAuthorizePage.approveConnection();
-			} );
+		step( 'Can wait for 30 sec until Jetpack Rewind will be ready for configuration', function () {
+			return driver.sleep( 30000 );
+		} );
 
-			step(
-				'Can wait for 30 sec until Jetpack Rewind will be ready for configuration',
-				function () {
-					return driver.sleep( 30000 );
-				}
-			);
+		step( 'Can proceed with Pressable NUX flow', async function () {
+			return await new PressableNUXFlow( driver ).addSiteCredentials();
+		} );
 
-			step( 'Can proceed with Pressable NUX flow', async function () {
-				return await new PressableNUXFlow( driver ).addSiteCredentials();
-			} );
+		step( 'Can open Rewind activity page', async function () {
+			await ReaderPage.Visit( driver );
+			const navBarComponent = await NavBarComponent.Expect( driver );
+			await navBarComponent.clickMySites();
+			const sidebarComponent = await SidebarComponent.Expect( driver );
+			await sidebarComponent.selectSiteSwitcher();
+			await sidebarComponent.searchForSite( this.siteName );
+			await sidebarComponent.selectActivity();
+		} );
 
-			step( 'Can open Rewind activity page', async function () {
-				await ReaderPage.Visit( driver );
-				const navBarComponent = await NavBarComponent.Expect( driver );
-				await navBarComponent.clickMySites();
-				const sidebarComponent = await SidebarComponent.Expect( driver );
-				await sidebarComponent.selectSiteSwitcher();
-				await sidebarComponent.searchForSite( this.siteName );
-				await sidebarComponent.selectActivity();
-			} );
+		// Disabled due to to longer time is required to make a backup.
+		// step( 'Can wait until Rewind backup is completed', function() {
+		// 	const activityPage = new ActivityPage( driver );
+		// 	return activityPage.waitUntilBackupCompleted();
+		// } );
 
-			// Disabled due to to longer time is required to make a backup.
-			// step( 'Can wait until Rewind backup is completed', function() {
-			// 	const activityPage = new ActivityPage( driver );
-			// 	return activityPage.waitUntilBackupCompleted();
-			// } );
-
-			after( async function () {
-				const pressableSitesPage = await PressableSitesPage.Visit( driver );
-				return await pressableSitesPage.deleteFirstSite();
-			} );
+		after( async function () {
+			const pressableSitesPage = await PressableSitesPage.Visit( driver );
+			return await pressableSitesPage.deleteFirstSite();
 		} );
 	} );
-}
+} );

--- a/test/e2e/specs-jetpack/connect-disconnect-spec.js
+++ b/test/e2e/specs-jetpack/connect-disconnect-spec.js
@@ -23,14 +23,15 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const jetpackUser = process.env.JETPACKUSER;
 const user = dataHelper.getAccountConfig( jetpackUser );
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
 
 describe( 'Disconnect wporg site', function () {
+	let driver;
+
+	before( async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
+
 	this.timeout( mochaTimeOut );
 
 	step( 'Can disconnect wporg site', async function () {
@@ -44,6 +45,12 @@ describe( 'Disconnect wporg site', function () {
 
 describe( `Jetpack Connect and Disconnect: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	before( async function () {
 		return await driverManager.ensureNotLoggedIn( driver );

--- a/test/e2e/specs/wp-calypso-gutenberg-blocks-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-blocks-spec.js
@@ -21,15 +21,14 @@ const host = dataHelper.getJetpackHost();
 const gutenbergUser =
 	process.env.GUTENBERG_EDGE === 'true' ? 'gutenbergSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Calypso Gutenberg Editor: Blocks (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Can see monetization blocks in block inserter @canary @parallel', function () {
 		step( 'Can log in', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-checkout-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-checkout-spec.js
@@ -28,16 +28,15 @@ const sandboxCookieValue = config.get( 'storeSandboxCookieValue' );
 
 const currencyValue = 'USD';
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize }) is interactive @parallel`, function () {
 	this.timeout( mochaTimeOut );
 	let editorUrl;
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Can trigger the checkout modal via post editor', function () {
 		step( 'Can log in', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
@@ -23,15 +23,14 @@ const host = dataHelper.getJetpackHost();
 const gutenbergUser =
 	process.env.COBLOCKS_EDGE === 'true' ? 'coBlocksSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Insert a Click to Tweet block: @parallel', function () {
 		step( 'Can log in', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -26,13 +26,6 @@ const host = dataHelper.getJetpackHost();
 const gutenbergUser =
 	process.env.GUTENBERG_EDGE === 'true' ? 'gutenbergSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 function getEventsFiredForBlock( eventsStack, event, block ) {
 	if ( ! eventsStack || ! event || ! block ) {
 		return false;
@@ -49,6 +42,12 @@ function getTotalEventsFiredForBlock( eventsStack, event, block ) {
 
 describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Tracking: @parallel', function () {
 		step( 'Can log in to WPAdmin and create new Post', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -30,15 +30,14 @@ const host = dataHelper.getJetpackHost();
 const gutenbergUser =
 	process.env.GUTENBERG_EDGE === 'true' ? 'gutenbergSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Public Pages: @parallel', function () {
 		let fileDetails;

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -40,15 +40,14 @@ const host = dataHelper.getJetpackHost();
 const gutenbergUser =
 	process.env.GUTENBERG_EDGE === 'true' ? 'gutenbergSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function () {
 		let fileDetails;

--- a/test/e2e/specs/wp-calypso-seo-preview.js
+++ b/test/e2e/specs/wp-calypso-seo-preview.js
@@ -24,16 +24,16 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-	await driverManager.clearCookiesAndDeleteLocalStorage( driver );
-} );
-
 describe( `[${ host }] SEO Preview page: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+		await driverManager.clearCookiesAndDeleteLocalStorage( driver );
+	} );
+
 	describe( 'SEO Preview page:', function () {
 		// Login as Business plan user and open the sidebar
 		step( 'Log In', async function () {

--- a/test/e2e/specs/wp-comments-spec.js
+++ b/test/e2e/specs/wp-comments-spec.js
@@ -21,16 +21,15 @@ const blogPostTitle = dataHelper.randomPhrase();
 const blogPostQuote =
 	'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Comments: (${ screenSize })`, function () {
 	let fileDetails;
+	let driver;
 	this.timeout( mochaTimeoutMS );
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	// Create image file for upload
 	before( async function () {

--- a/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
+++ b/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
@@ -42,15 +42,14 @@ function camelCaseDash( string ) {
 	return string.replace( /-([a-z])/g, ( _, letter ) => letter.toUpperCase() );
 }
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Experimental features we depend on are available (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	step( 'Can log in', async function () {
 		this.loginFlow = new LoginFlow( driver, gutenbergUser );

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -27,15 +27,15 @@ const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( 'Gutenboarding: (' + screenSize + ')', function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
+
 	describe.skip( 'Create new site as existing user @parallel @canary', function () {
 		const siteTitle = dataHelper.randomPhrase();
 		const domainQuery = dataHelper.randomPhrase();

--- a/test/e2e/specs/wp-import-site-spec.js
+++ b/test/e2e/specs/wp-import-site-spec.js
@@ -20,15 +20,14 @@ const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( 'Verify Import Option: (' + screenSize + ') @parallel', function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	step( 'Can log in as default user', async function () {
 		const loginFlow = new LoginFlow( driver );

--- a/test/e2e/specs/wp-inline-help-support-search-spec.js
+++ b/test/e2e/specs/wp-inline-help-support-search-spec.js
@@ -20,17 +20,17 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
 let supportSearchComponent;
 let inlineHelpPopoverComponent;
 
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	step( 'Login and select a page that is not the My Home page', async function () {
 		const loginFlow = new LoginFlow( driver );

--- a/test/e2e/specs/wp-invite-users-spec.js
+++ b/test/e2e/specs/wp-invite-users-spec.js
@@ -37,15 +37,14 @@ const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 const emailClient = new EmailClient( inviteInboxId );
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Inviting new user as an Editor: @parallel @jetpack', function () {
 		const newUserName = 'e2eflowtestingeditora' + new Date().getTime().toString();

--- a/test/e2e/specs/wp-launch-spec.js
+++ b/test/e2e/specs/wp-launch-spec.js
@@ -25,8 +25,7 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const signupInboxId = config.get( 'signupInboxId' );
 
-let driver;
-const createAndActivateAccount = async function ( accountName ) {
+const createAndActivateAccount = async function ( driver, accountName ) {
 	const emailAddress = dataHelper.getEmailAddress( accountName, signupInboxId );
 	const password = config.get( 'passwordForNewTestSignUps' );
 
@@ -39,13 +38,14 @@ const createAndActivateAccount = async function ( accountName ) {
 	await signupFlow.activateAccount();
 };
 
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Launch a free site', function () {
 		const siteName = dataHelper.getNewBlogName();
@@ -79,7 +79,7 @@ describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () 
 		const secondSiteName = dataHelper.getNewBlogName();
 
 		before( 'Create 2 free sites as a new user', async function () {
-			await createAndActivateAccount( accountName );
+			await createAndActivateAccount( driver, accountName );
 			await new CreateSiteFlow( driver, firstSiteName ).createFreeSite();
 			await new CreateSiteFlow( driver, secondSiteName ).createFreeSite();
 		} );

--- a/test/e2e/specs/wp-log-in-out-spec.js
+++ b/test/e2e/specs/wp-log-in-out-spec.js
@@ -32,21 +32,17 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Auth Screen Canary: (${ screenSize }) @parallel @safaricanary`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+		return await driverManager.ensureNotLoggedIn( driver );
+	} );
 
 	describe( 'Loading the log-in screen', function () {
-		before( async function () {
-			return await driverManager.ensureNotLoggedIn( driver );
-		} );
-
 		step( 'Can see the log in screen', async function () {
 			await LoginPage.Visit( driver, LoginPage.getLoginURL() );
 		} );
@@ -55,6 +51,12 @@ describe( `[${ host }] Auth Screen Canary: (${ screenSize }) @parallel @safarica
 
 describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Logging In and Out: @jetpack', function () {
 		before( async function () {
@@ -461,8 +463,11 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 
 describe( `[${ host }] User Agent: (${ screenSize }) @parallel @jetpack`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
 
-	before( async function () {
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
 		await driverManager.ensureNotLoggedIn( driver );
 	} );
 

--- a/test/e2e/specs/wp-manage-domains-spec.js
+++ b/test/e2e/specs/wp-manage-domains-spec.js
@@ -34,15 +34,14 @@ const screenSize = driverManager.currentScreenSize();
 const domainsInboxId = config.get( 'domainsInboxId' );
 const host = dataHelper.getJetpackHost();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Managing Domains: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Adding a domain to an existing site @parallel', function () {
 		const blogName = dataHelper.getNewBlogName();

--- a/test/e2e/specs/wp-media-editor-spec.js
+++ b/test/e2e/specs/wp-media-editor-spec.js
@@ -20,15 +20,14 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Media: Edit Media (${ screenSize }) @parallel @jetpack`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Edit Existing Media:', function () {
 		before( 'Can login and select my site', async function () {

--- a/test/e2e/specs/wp-media-upload-spec.js
+++ b/test/e2e/specs/wp-media-upload-spec.js
@@ -21,15 +21,14 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Editor: Media Upload (${ screenSize }) @parallel @jetpack`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Image Upload:', function () {
 		let gutenbergEditor;

--- a/test/e2e/specs/wp-my-home-support-search-spec.js
+++ b/test/e2e/specs/wp-my-home-support-search-spec.js
@@ -21,18 +21,18 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
 let supportSearchComponent;
 
 const helpCardSelector = By.css( '.help-search' );
 
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] My Home "Get help" support search card: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	step( 'Login and select the My Home page', async function () {
 		const loginFlow = new LoginFlow( driver );

--- a/test/e2e/specs/wp-notifications-spec.js
+++ b/test/e2e/specs/wp-notifications-spec.js
@@ -24,15 +24,14 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Notifications: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	const commentingUser = dataHelper.getAccountConfig( 'commentingUser' )[ 0 ];
 	const comment = dataHelper.randomPhrase() + ' TBD';

--- a/test/e2e/specs/wp-plan-purchase-spec.js
+++ b/test/e2e/specs/wp-plan-purchase-spec.js
@@ -24,15 +24,14 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Plans: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Comparing Plans:  @parallel @jetpack', function () {
 		step( 'Login and Select My Site', async function () {

--- a/test/e2e/specs/wp-reader-spec.js
+++ b/test/e2e/specs/wp-reader-spec.js
@@ -21,15 +21,15 @@ const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( 'Reader: (' + screenSize + ') @parallel', function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
+
 	describe( 'Log in as commenting user', function () {
 		step( 'Can log in as commenting user', async function () {
 			this.loginFlow = new LoginFlow( driver, 'commentingUser' );

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -87,7 +87,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		step( 'Can create a new WordPress site', async function () {
-			await StartPage.Visit( this.driver, StartPage.getStartURL() );
+			await StartPage.Visit( driver, StartPage.getStartURL() );
 		} );
 
 		step( 'Can see the account page and enter account details', async function () {
@@ -130,7 +130,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			}
 		);
 
-		sharedSteps.canSeeTheOnboardingChecklist();
+		sharedSteps.canSeeTheOnboardingChecklist( driver );
 
 		step( 'Can log out and request a magic link', async function () {
 			if ( process.env.HORIZON_TESTS === 'true' ) {
@@ -479,7 +479,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		sharedSteps.canSeeTheOnboardingChecklist();
 
 		step( 'Can update the homepage', async function () {
-			const myHomePage = await MyHomePage.Expect( this.driver );
+			const myHomePage = await MyHomePage.Expect( driver );
 			await myHomePage.updateHomepageFromSiteSetup();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.initEditor();
@@ -1108,7 +1108,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			if ( dataHelper.getTargetType() === 'IE11' ) {
 				return this.skip();
 			}
-			const myHomePage = await MyHomePage.Expect( this.driver );
+			const myHomePage = await MyHomePage.Expect( driver );
 			await myHomePage.updateHomepageFromSiteSetup();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.initEditor();

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -67,15 +67,14 @@ const locale = driverManager.currentLocale();
 const passwordForTestAccounts = config.get( 'passwordForNewTestSignUps' );
 const sandboxCookieValue = config.get( 'storeSandboxCookieValue' );
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	this.driver = driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Sign up for a free WordPress.com site from the Jetpack new site page, and log in via a magic link @signup @email', function () {
 		const blogName = dataHelper.getNewBlogName();

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -73,7 +73,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 	before( 'Start browser', async function () {
 		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
+		this.driver = driver = await driverManager.startBrowser();
 	} );
 
 	describe( 'Sign up for a free WordPress.com site from the Jetpack new site page, and log in via a magic link @signup @email', function () {
@@ -130,7 +130,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			}
 		);
 
-		sharedSteps.canSeeTheOnboardingChecklist( driver );
+		sharedSteps.canSeeTheOnboardingChecklist();
 
 		step( 'Can log out and request a magic link', async function () {
 			if ( process.env.HORIZON_TESTS === 'true' ) {
@@ -237,7 +237,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			}
 		);
 
-		sharedSteps.canSeeTheOnboardingChecklist( driver );
+		sharedSteps.canSeeTheOnboardingChecklist();
 
 		after( 'Can delete our newly created account', async function () {
 			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
@@ -476,7 +476,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		sharedSteps.canSeeTheOnboardingChecklist( driver );
+		sharedSteps.canSeeTheOnboardingChecklist();
 
 		step( 'Can update the homepage', async function () {
 			const myHomePage = await MyHomePage.Expect( driver );
@@ -612,7 +612,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		sharedSteps.canSeeTheOnboardingChecklist( driver );
+		sharedSteps.canSeeTheOnboardingChecklist();
 
 		step( 'Can delete the plan', async function () {
 			return await new DeletePlanFlow( driver ).deletePlan( 'premium' );
@@ -722,7 +722,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		sharedSteps.canSeeTheOnboardingChecklist( driver );
+		sharedSteps.canSeeTheOnboardingChecklist();
 
 		step( 'Can delete the plan', async function () {
 			return await new DeletePlanFlow( driver ).deletePlan( 'personal' );
@@ -1034,7 +1034,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		sharedSteps.canSeeTheOnboardingChecklist( driver );
+		sharedSteps.canSeeTheOnboardingChecklist();
 
 		step( 'Can delete the plan', async function () {
 			return await new DeletePlanFlow( driver ).deletePlan( 'business', {
@@ -1100,7 +1100,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			}
 		);
 
-		sharedSteps.canSeeTheOnboardingChecklist( driver );
+		sharedSteps.canSeeTheOnboardingChecklist();
 
 		step( 'Can update the homepage', async function () {
 			// Skipping if IE11 due to JS errors caused by missing DOMRect polyfill.
@@ -1215,7 +1215,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			}
 		);
 
-		sharedSteps.canSeeTheOnboardingChecklist( driver );
+		sharedSteps.canSeeTheOnboardingChecklist();
 
 		step( 'Can delete site', async function () {
 			const sidebarComponent = await SidebarComponent.Expect( driver );

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -237,7 +237,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			}
 		);
 
-		sharedSteps.canSeeTheOnboardingChecklist();
+		sharedSteps.canSeeTheOnboardingChecklist( driver );
 
 		after( 'Can delete our newly created account', async function () {
 			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
@@ -476,7 +476,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		sharedSteps.canSeeTheOnboardingChecklist();
+		sharedSteps.canSeeTheOnboardingChecklist( driver );
 
 		step( 'Can update the homepage', async function () {
 			const myHomePage = await MyHomePage.Expect( driver );
@@ -612,7 +612,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		sharedSteps.canSeeTheOnboardingChecklist();
+		sharedSteps.canSeeTheOnboardingChecklist( driver );
 
 		step( 'Can delete the plan', async function () {
 			return await new DeletePlanFlow( driver ).deletePlan( 'premium' );
@@ -722,7 +722,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		sharedSteps.canSeeTheOnboardingChecklist();
+		sharedSteps.canSeeTheOnboardingChecklist( driver );
 
 		step( 'Can delete the plan', async function () {
 			return await new DeletePlanFlow( driver ).deletePlan( 'personal' );
@@ -1034,7 +1034,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		sharedSteps.canSeeTheOnboardingChecklist();
+		sharedSteps.canSeeTheOnboardingChecklist( driver );
 
 		step( 'Can delete the plan', async function () {
 			return await new DeletePlanFlow( driver ).deletePlan( 'business', {
@@ -1100,7 +1100,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			}
 		);
 
-		sharedSteps.canSeeTheOnboardingChecklist();
+		sharedSteps.canSeeTheOnboardingChecklist( driver );
 
 		step( 'Can update the homepage', async function () {
 			// Skipping if IE11 due to JS errors caused by missing DOMRect polyfill.
@@ -1215,7 +1215,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			}
 		);
 
-		sharedSteps.canSeeTheOnboardingChecklist();
+		sharedSteps.canSeeTheOnboardingChecklist( driver );
 
 		step( 'Can delete site', async function () {
 			const sidebarComponent = await SidebarComponent.Expect( driver );

--- a/test/e2e/specs/wp-site-editor-spec.js
+++ b/test/e2e/specs/wp-site-editor-spec.js
@@ -19,15 +19,14 @@ const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 const gutenbergUser = 'siteEditorSimpleSiteUser';
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Site Editor (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	step( 'Can log in', async function () {
 		this.loginFlow = new LoginFlow( driver, gutenbergUser );

--- a/test/e2e/specs/wp-ssr-spec.js
+++ b/test/e2e/specs/wp-ssr-spec.js
@@ -16,31 +16,31 @@ import * as driverManager from '../lib/driver-manager';
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 
-let driver;
-
-async function ssrWorksForPage( url ) {
+async function ssrWorksForPage( driver, url ) {
 	await driver.get( url );
 	const layoutSelector = by.css( '#wpcom[data-calypso-ssr="true"]' );
 	assert( await driver.findElement( layoutSelector ) );
 }
 
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-	await driverManager.ensureNotLoggedIn( driver );
-} );
-
 describe( 'Server-side rendering: @canary @parallel', function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+		await driverManager.ensureNotLoggedIn( driver );
+	} );
+
 	step( '/log-in renders on the server', async function () {
-		await ssrWorksForPage( LoginPage.getLoginURL() );
+		await ssrWorksForPage( driver, LoginPage.getLoginURL() );
 	} );
 
 	step( '/themes renders on the server', async function () {
-		await ssrWorksForPage( ThemesPage.getStartURL() );
+		await ssrWorksForPage( driver, ThemesPage.getStartURL() );
 	} );
 
 	step( '/theme/twentytwenty renders on the server', async function () {
-		await ssrWorksForPage( dataHelper.getCalypsoURL( 'theme/twentytwenty' ) );
+		await ssrWorksForPage( driver, dataHelper.getCalypsoURL( 'theme/twentytwenty' ) );
 	} );
 } );

--- a/test/e2e/specs/wp-stats-insights-spec.js
+++ b/test/e2e/specs/wp-stats-insights-spec.js
@@ -19,15 +19,15 @@ const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( 'Stats: (' + screenSize + ') @parallel', function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
+
 	describe( 'Log in as user', function () {
 		step( 'Can log in as user', async function () {
 			this.loginFlow = new LoginFlow( driver );

--- a/test/e2e/specs/wp-theme-multisite-spec.js
+++ b/test/e2e/specs/wp-theme-multisite-spec.js
@@ -26,14 +26,14 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Themes: All sites (${ screenSize })`, function () {
+	let driver;
+
+	before( async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
+
 	describe( 'Preview a theme @parallel', function () {
 		this.timeout( mochaTimeOut );
 

--- a/test/e2e/specs/wp-theme-switch-spec.js
+++ b/test/e2e/specs/wp-theme-switch-spec.js
@@ -26,15 +26,14 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
-
-before( async function () {
-	this.timeout( startBrowserTimeoutMS );
-	driver = await driverManager.startBrowser();
-} );
-
 describe( `[${ host }] Previewing Themes: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
 
 	describe( 'Previewing Themes @parallel @jetpack', function () {
 		step( 'Can login and select themes', async function () {
@@ -68,6 +67,13 @@ describe( `[${ host }] Previewing Themes: (${ screenSize })`, function () {
 // NOTE: test in jetpack env is failing due to some strange issue, when switching to new tab. It fails only in CI
 describe( `[${ host }] Activating Themes: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
+
 	describe( 'Activating Themes:', function () {
 		step( 'Login', async function () {
 			const loginFlow = new LoginFlow( driver );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Moves `before` hook used to start the browser inside the `describe` block.

This should save some resources, as we won't start the browser when the `describe` block is disabled. It will also help TeamCity identify which test is failing when there is a problem running the browser.

To ensure this pattern doesn't regress, I've enabled the [eslint rule `mocha/no-top-level-hooks`](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-top-level-hooks.md)

Note: there are some opportunities to reduce code duplication, as most e2e tests have a very similar setup. I'll address that in an upcoming PR.

#### Testing instructions

Check e2e tests pass (or at least they don't fail trying to start the browser)