### PR TITLE
Switch to newer domain suggestion variation

### DIFF
--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -17,7 +17,7 @@ export const getSuggestionsVendor = ( options = {} ) => {
 		return 'variation4_front';
 	}
 	if ( config.isEnabled( 'domains/premium-domain-purchases' ) ) {
-		return 'variation7_front';
+		return 'variation8_front';
 	}
 	return 'variation2_front';
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switch to latest domain suggestion variation version

see: p1614620749024700-slack-GUV2MM536

#### Testing instructions

* Search for a domain in Calypso or in the domain-only flow and make sure we're calling the suggestion endpoint with `variation8_front` in the browser network tab