### PR TITLE
Checkout: Do not override coupon with Jetpack default if already applied

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -107,8 +107,11 @@ const wpcomGetStoredCards = (): StoredCard[] => wpcom.getStoredCards();
 // Can be safely removed after 2021-03-03 when the FRESHPACK coupon expires
 import moment from 'moment';
 import { isJetpackProductSlug, isJetpackPlanSlug } from 'calypso/lib/products-values';
-const useMaybeGetFRESHPACKCode = ( products: RequestCartProduct[] ) =>
+const useMaybeGetFRESHPACKCode = ( products: RequestCartProduct[], isCouponApplied: boolean ) =>
 	useMemo( () => {
+		if ( isCouponApplied ) {
+			return undefined;
+		}
 		const includesJetpackItems = products
 			.map( ( p ) => p.product_slug )
 			.some( ( slug ) => isJetpackProductSlug( slug ) || isJetpackPlanSlug( slug ) );
@@ -122,7 +125,7 @@ const useMaybeGetFRESHPACKCode = ( products: RequestCartProduct[] ) =>
 		const endDate = moment.utc( '2021-03-04' );
 
 		return moment().isBefore( endDate ) ? 'FRESHPACK' : undefined;
-	}, [ products ] );
+	}, [ products, isCouponApplied ] );
 
 export default function CompositeCheckout( {
 	siteSlug,
@@ -245,7 +248,10 @@ export default function CompositeCheckout( {
 		addProductsToCart,
 	} = useShoppingCart();
 
-	const maybeFRESHPACKCode = useMaybeGetFRESHPACKCode( productsForCart );
+	const maybeFRESHPACKCode = useMaybeGetFRESHPACKCode(
+		productsForCart,
+		couponStatus === 'applied'
+	);
 
 	const isInitialCartLoading = useAddProductsFromUrl( {
 		isLoadingCart,

--- a/packages/shopping-cart/src/use-shopping-cart-reducer.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-reducer.ts
@@ -152,7 +152,10 @@ function shoppingCartReducer(
 
 		case 'ADD_COUPON': {
 			const newCoupon = action.couponToAdd;
-			if ( couponStatus === 'applied' || couponStatus === 'pending' ) {
+			if (
+				( couponStatus === 'applied' || couponStatus === 'pending' ) &&
+				newCoupon === state.responseCart.coupon
+			) {
 				debug( `coupon status is '${ couponStatus }'; not submitting again` );
 				return state;
 			}


### PR DESCRIPTION
If the cart already has a coupon applied when checkout loads, there's no need to replace it with the jetpack default coupon.

#### Testing instructions

**Prerequisite:** If you have any free credits on WordPress.com, remove them from your account.

1. In Calypso Blue, select a self-hosted Jetpack site.
3. On the **Plans** page, click on a Jetpack product or plan to purchase it.
4. When you reach the checkout page, verify that the `FRESHPACK` coupon has already been applied to your shopping cart and its discount line item is visible.
5. Click "Edit" to modify your cart.
6. Click to remove the coupon from your cart.
7. Add a different coupon to your cart (you'll have to find another valid coupon which is beyond the scope of these instructions but ping me if you need help).
8. Click "Apply" to apply the new coupon.
9. Leave checkout and repeat step 2.
10. Verify that the coupon you added in step 6 is still applied and that the `FRESHPACK` coupon is not applied.