### PR TITLE
Partner Portal: Adjust license filter terms used to match i4.1 designs

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -10,7 +10,11 @@ import type PageJS from 'page';
  */
 import { addQueryArgs } from 'calypso/lib/route';
 import { getActivePartnerKey } from 'calypso/state/partner-portal/partner/selectors';
-import { valueToEnum } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import {
+	publicToInternalLicenseFilter,
+	publicToInternalLicenseSortField,
+	valueToEnum,
+} from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import Header from './header';
 import JetpackComFooter from 'calypso/jetpack-cloud/sections/pricing/jpcom-footer';
 import PartnerPortalSidebar from 'calypso/jetpack-cloud/sections/partner-portal/sidebar';
@@ -32,17 +36,9 @@ export function partnerKeyContext( context: PageJS.Context, next: () => void ): 
 
 export function partnerPortalContext( context: PageJS.Context, next: () => void ): void {
 	const { s: search, sort_field, sort_direction, page } = context.query;
-	const filter = valueToEnum< LicenseFilter >(
-		LicenseFilter,
-		context.params.state,
-		LicenseFilter.NotRevoked
-	);
+	const filter = publicToInternalLicenseFilter( context.params.filter, LicenseFilter.NotRevoked );
 	const currentPage = parseInt( page ) || 1;
-	const sortField = valueToEnum< LicenseSortField >(
-		LicenseSortField,
-		sort_field,
-		LicenseSortField.IssuedAt
-	);
+	const sortField = publicToInternalLicenseSortField( sort_field, LicenseSortField.IssuedAt );
 	const sortDirection = valueToEnum< LicenseSortDirection >(
 		LicenseSortDirection,
 		sort_direction,

--- a/client/jetpack-cloud/sections/partner-portal/index.ts
+++ b/client/jetpack-cloud/sections/partner-portal/index.ts
@@ -18,7 +18,7 @@ export default function () {
 	page( `/partner-portal/partner-key`, controller.partnerKeyContext, makeLayout, clientRender );
 
 	page(
-		`/partner-portal/:state(detached|attached|revoked)?`,
+		`/partner-portal/:filter(unassigned|assigned|revoked)?`,
 		controller.requirePartnerKeyContext,
 		controller.partnerPortalContext,
 		makeLayout,

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -70,14 +70,14 @@ export default function LicenseDetails( {
 
 				{ licenseState === LicenseState.Attached && (
 					<li className="license-details__list-item">
-						<h4 className="license-details__label">{ translate( 'Attached on' ) }</h4>
+						<h4 className="license-details__label">{ translate( 'Assigned on' ) }</h4>
 						<FormattedDate date={ attachedAt } format="LLL" />
 					</li>
 				) }
 
 				{ licenseState === LicenseState.Detached && (
 					<li className="license-details__list-item">
-						<h4 className="license-details__label">{ translate( 'Attached on' ) }</h4>
+						<h4 className="license-details__label">{ translate( 'Assigned on' ) }</h4>
 						<Gridicon icon="minus" />
 					</li>
 				) }

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -33,6 +33,7 @@ import { LICENSES_PER_PAGE } from 'calypso/state/partner-portal/licenses/constan
 import Gridicon from 'calypso/components/gridicon';
 import Pagination from 'calypso/components/pagination';
 import { addQueryArgs } from 'calypso/lib/route';
+import { internalToPublicLicenseSortField } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 
 /**
  * Style dependencies
@@ -57,7 +58,11 @@ function setSortingConfig(
 		direction = LicenseSortDirection.Ascending;
 	}
 
-	const queryParams = { sort_field: newSortField, sort_direction: direction, page: 1 };
+	const queryParams = {
+		sort_field: internalToPublicLicenseSortField( newSortField ),
+		sort_direction: direction,
+		page: 1,
+	};
 	const currentPath = window.location.pathname + window.location.search;
 
 	page( addQueryArgs( queryParams, currentPath ) );
@@ -152,7 +157,7 @@ export default function LicenseList( {
 						currentSortField={ sortField }
 						currentSortDirection={ sortDirection }
 					>
-						{ translate( 'Attached on' ) }
+						{ translate( 'Assigned on' ) }
 					</SortButton>
 				) }
 

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -86,7 +86,7 @@ export default function LicensePreview( {
 						{ licenseState === LicenseState.Detached && (
 							<span className="license-preview__tag license-preview__tag--is-detached">
 								<Gridicon icon="info-outline" size={ 18 } />
-								{ translate( 'Detached' ) }
+								{ translate( 'Unassigned' ) }
 							</span>
 						) }
 
@@ -112,7 +112,7 @@ export default function LicensePreview( {
 
 				{ filter !== LicenseFilter.Revoked ? (
 					<div>
-						<div className="license-preview__label">{ translate( 'Attached on:' ) }</div>
+						<div className="license-preview__label">{ translate( 'Assigned on:' ) }</div>
 
 						{ licenseState === LicenseState.Attached && (
 							<FormattedDate date={ attachedAt } format="YYYY-MM-DD" />
@@ -190,7 +190,7 @@ export function LicensePreviewPlaceholder(): ReactElement {
 				</div>
 
 				<div>
-					<div className="license-preview__label">{ translate( 'Attached on:' ) }</div>
+					<div className="license-preview__label">{ translate( 'Assigned on:' ) }</div>
 
 					<div />
 				</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
@@ -19,6 +19,7 @@ import Search from 'calypso/components/search';
 import UrlSearch from 'calypso/lib/url-search';
 import QueryJetpackPartnerPortalLicenseCounts from 'calypso/components/data/query-jetpack-partner-portal-license-counts';
 import { getLicenseCounts } from 'calypso/state/partner-portal/licenses/selectors';
+import { internalToPublicLicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 
 /**
  * Style dependencies
@@ -44,11 +45,11 @@ function LicenseStateFilter( { filter, search, doSearch }: Props ): ReactElement
 		},
 		{
 			key: LicenseFilter.Detached,
-			label: translate( 'Detached' ),
+			label: translate( 'Unassigned' ),
 		},
 		{
 			key: LicenseFilter.Attached,
-			label: translate( 'Attached' ),
+			label: translate( 'Assigned' ),
 		},
 		{
 			key: LicenseFilter.Revoked,
@@ -58,7 +59,7 @@ function LicenseStateFilter( { filter, search, doSearch }: Props ): ReactElement
 		...navItem,
 		count: counts[ navItem.key ] || 0,
 		selected: filter === navItem.key,
-		path: basePath + ( LicenseFilter.NotRevoked !== navItem.key ? navItem.key : '' ),
+		path: basePath + internalToPublicLicenseFilter( navItem.key ),
 		children: navItem.label,
 	} ) );
 

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import {
+	LicenseFilter,
+	LicenseSortField,
+	LicenseState,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 
 /**
  * Get the state of a license based on its properties.
@@ -45,4 +49,83 @@ export function valueToEnum< T >(
 	fallback: unknown
 ): T {
 	return Object.values( enumType ).includes( value ) ? ( value as T ) : ( fallback as T );
+}
+
+const internalFilterMap = {
+	[ LicenseFilter.NotRevoked ]: '',
+	[ LicenseFilter.Attached ]: 'assigned',
+	[ LicenseFilter.Detached ]: 'unassigned',
+} as { [ key: string ]: string };
+
+const publicFilterMap = {
+	[ internalFilterMap[ LicenseFilter.Attached ] ]: LicenseFilter.Attached,
+	[ internalFilterMap[ LicenseFilter.Detached ] ]: LicenseFilter.Detached,
+} as { [ key: string ]: LicenseFilter };
+
+/**
+ * Convert a public license filter to its internal representation.
+ * Public filter differences are entirely cosmetic.
+ *
+ * @param {string} publicFilter Public filter value (e.g. "assigned").
+ * @param {LicenseFilter} fallback Filter to return if publicFilter is invalid.
+ * @returns {LicenseFilter} Internal filter.
+ */
+export function publicToInternalLicenseFilter(
+	publicFilter: string,
+	fallback: LicenseFilter
+): LicenseFilter {
+	return valueToEnum< LicenseFilter >(
+		LicenseFilter,
+		publicFilterMap[ publicFilter ] || publicFilter,
+		fallback
+	);
+}
+
+/**
+ * Convert an internal license filter to its public representation.
+ * Public filter differences are entirely cosmetic.
+ *
+ * @param {LicenseFilter} internalFilter Internal filter (e.g. LicenseFilter.Attached).
+ * @returns {string} Public filter.
+ */
+export function internalToPublicLicenseFilter( internalFilter: LicenseFilter ): string {
+	return internalFilterMap[ internalFilter ] || internalFilter;
+}
+
+const internalSortFieldMap = {
+	[ LicenseSortField.AttachedAt ]: 'assigned_on',
+} as { [ key: string ]: string };
+
+const publicSortFieldMap = {
+	[ internalSortFieldMap[ LicenseSortField.AttachedAt ] ]: LicenseSortField.AttachedAt,
+} as { [ key: string ]: LicenseSortField };
+
+/**
+ * Convert a public license sort field to its internal representation.
+ * Public sort field differences are entirely cosmetic.
+ *
+ * @param {string} publicSortField Public sort field value (e.g. "assigned_on").
+ * @param {LicenseSortField} fallback Sort field to return if publicSortField is invalid.
+ * @returns {LicenseSortField} Internal sort field.
+ */
+export function publicToInternalLicenseSortField(
+	publicSortField: string,
+	fallback: LicenseSortField
+): LicenseSortField {
+	return valueToEnum< LicenseSortField >(
+		LicenseSortField,
+		publicSortFieldMap[ publicSortField ] || publicSortField,
+		fallback
+	);
+}
+
+/**
+ * Convert an internal license sort field to its public representation.
+ * Public sort field differences are entirely cosmetic.
+ *
+ * @param {LicenseSortField} internalSortField Internal sort field (e.g. LicenseSortField.AttachedAt).
+ * @returns {string} Public sort field.
+ */
+export function internalToPublicLicenseSortField( internalSortField: LicenseSortField ): string {
+	return internalSortFieldMap[ internalSortField ] || internalSortField;
 }


### PR DESCRIPTION
Context:
* Project thread: pbtFPC-Um-p2
* i4.1 designs: pbtFPC-1co-p2

#### Changes proposed in this Pull Request

* Adjust Attached/Detached to Assigned/Unassigned matching i4.1 designs.

#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key, if prompted.
* Make sure filters and license labels match the new terms where applicable.
* Click through the list filters to make sure they work as expected and the resulting window location matches the new terms.

![Screenshot 2021-03-03 at 15 39 35](https://user-images.githubusercontent.com/22746396/109813953-ab5cdc80-7c36-11eb-94ba-aab05614b433.png)
