### PR TITLE
Domains: Show the required root A records for mapping

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -73,6 +73,7 @@ export const MANAGE_PURCHASES_AUTOMATIC_RENEWAL = `${ root }/manage-purchases/#a
 export const MANAGE_PURCHASES_FAQ_CANCELLING = `${ root }/manage-purchases/#faq-cancelling-your-plans-and-domains`;
 export const MAP_EXISTING_DOMAIN = `${ root }/domains/map-existing-domain`;
 export const MAP_EXISTING_DOMAIN_UPDATE_DNS = `${ root }/domains/map-existing-domain#2-ask-your-domain-provider-to-update-your-dns-settings`;
+export const MAP_EXISTING_DOMAIN_UPDATE_A_RECORDS = `${ root }/domains/map-existing-domain/#using-a-records`;
 export const MAP_SUBDOMAIN = `${ root }/domains/map-subdomain`;
 export const MAP_DOMAIN_CHANGE_NAME_SERVERS = `${ root }/domains/map-existing-domain/#change-your-domains-name-servers`;
 export const MOVE_DOMAIN = `${ root }/domains/#move-a-domain-name`;

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -95,7 +95,7 @@ class MappedDomainType extends React.Component {
 				<div>
 					<p>{ setupInstructionsMessage }</p>
 					{ this.renderRecommendedSetupMessage( primaryMessage ) }
-					{ this.renderARecordsMappingMessage() }
+					{ domain.aRecordsRequiredForMapping && this.renderARecordsMappingMessage() }
 				</div>
 				<div className="mapped-domain-type__small-message">{ secondaryMessage }</div>
 			</React.Fragment>
@@ -122,10 +122,6 @@ class MappedDomainType extends React.Component {
 
 	renderARecordsMappingMessage() {
 		const { domain, translate } = this.props;
-
-		if ( ! domain.aRecordsRequiredForMapping ) {
-			return null;
-		}
 
 		const advancedSetupUsingARecordsTitle = translate( 'Advanced setup using root A records' );
 		const aRecordsSetupMessage = translate(

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -36,7 +36,7 @@ import PendingGSuiteTosNotice from 'calypso/my-sites/domains/components/domain-w
 import FoldableFAQ from 'calypso/components/foldable-faq';
 
 class MappedDomainType extends React.Component {
-	renderSettingUpNameservers() {
+	renderSettingUpNameserversAndARecords() {
 		const { domain, translate } = this.props;
 		if ( this.props.isJetpackSite && ! this.props.isSiteAutomatedTransfer ) {
 			return null;
@@ -245,7 +245,7 @@ class MappedDomainType extends React.Component {
 						purchase={ purchase }
 						domain={ domain }
 					/>
-					{ this.renderSettingUpNameservers() }
+					{ this.renderSettingUpNameserversAndARecords() }
 					{ this.renderPendingGSuiteTosNotice() }
 					<ExpiringSoon
 						selectedSite={ selectedSite }

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -33,6 +33,7 @@ import DomainManagementNavigationEnhanced from '../navigation/enhanced';
 import { DomainExpiryOrRenewal, WrapDomainStatusButtons } from './helpers';
 import { hasPendingGSuiteUsers } from 'calypso/lib/gsuite';
 import PendingGSuiteTosNotice from 'calypso/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice';
+import FoldableFAQ from 'calypso/components/foldable-faq';
 
 class MappedDomainType extends React.Component {
 	renderSettingUpNameservers() {
@@ -50,6 +51,7 @@ class MappedDomainType extends React.Component {
 		);
 		let primaryMessage;
 		let secondaryMessage;
+		let thirdMessage;
 
 		if ( isSubdomain( domain.name ) ) {
 			primaryMessage = translate(
@@ -83,19 +85,36 @@ class MappedDomainType extends React.Component {
 					args: { domainName: domain.name },
 				}
 			);
+
+			if ( domain.aRecordsRequiredForMapping ) {
+				thirdMessage = (
+					<FoldableFAQ id="advanced-mapping-setup" question="Advanced setup using root A records">
+						<p>Use this to set it up:</p>
+						<ul>
+							{ domain.aRecordsRequiredForMapping.map( ( aRecord, index ) => {
+								return <li key={ index }>{ aRecord }</li>;
+							} ) }
+						</ul>
+					</FoldableFAQ>
+				);
+			}
 		}
 
 		return (
 			<React.Fragment>
 				<div>
-					<p>{ primaryMessage }</p>
-					{ ! isSubdomain( domain.name ) && (
-						<ul className="mapped-domain-type__name-server-list">
-							{ WPCOM_DEFAULT_NAMESERVERS.map( ( nameServer ) => {
-								return <li key={ nameServer }>{ nameServer }</li>;
-							} ) }
-						</ul>
-					) }
+					<p>Use these instructions to set up your domain mapping.</p>
+					<FoldableFAQ id="recommended-mapping-setup" question="Recommended setup" expanded>
+						<p>{ primaryMessage }</p>
+						{ ! isSubdomain( domain.name ) && (
+							<ul className="mapped-domain-type__name-server-list">
+								{ WPCOM_DEFAULT_NAMESERVERS.map( ( nameServer ) => {
+									return <li key={ nameServer }>{ nameServer }</li>;
+								} ) }
+							</ul>
+						) }
+					</FoldableFAQ>
+					{ thirdMessage }
 				</div>
 				<div className="mapped-domain-type__small-message">{ secondaryMessage }</div>
 			</React.Fragment>

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -90,8 +90,23 @@ class MappedDomainType extends React.Component {
 			'Follow these instructions to set up your domain mapping.'
 		);
 
+		return (
+			<React.Fragment>
+				<div>
+					<p>{ setupInstructionsMessage }</p>
+					{ this.renderRecommendedSetupMessage( primaryMessage ) }
+					{ this.renderARecordsMappingMessage() }
+				</div>
+				<div className="mapped-domain-type__small-message">{ secondaryMessage }</div>
+			</React.Fragment>
+		);
+	}
+
+	renderRecommendedSetupMessage( primaryMessage ) {
+		const { domain, translate } = this.props;
+
 		const recommendedSetupTitle = translate( 'Recommended setup' );
-		const recommendedSetupMessage = (
+		return (
 			<FoldableFAQ id="recommended-mapping-setup" question={ recommendedSetupTitle } expanded>
 				<p>{ primaryMessage }</p>
 				{ ! isSubdomain( domain.name ) && (
@@ -103,34 +118,28 @@ class MappedDomainType extends React.Component {
 				) }
 			</FoldableFAQ>
 		);
+	}
 
-		let aRecordsMappingMessage;
-		if ( domain.aRecordsRequiredForMapping ) {
-			const advancedSetupUsingARecordsTitle = translate( 'Advanced setup using root A records' );
-			const aRecordsSetupMessage = translate(
-				"If you have already set up your domain's DNS records in its own provider and just want to point it to WordPress.com, use these IP addresses as your root A records:"
-			);
-			aRecordsMappingMessage = (
-				<FoldableFAQ id="advanced-mapping-setup" question={ advancedSetupUsingARecordsTitle }>
-					<p>{ aRecordsSetupMessage }</p>
-					<ul className="mapped-domain-type__name-server-list">
-						{ domain.aRecordsRequiredForMapping.map( ( aRecord ) => {
-							return <li key={ aRecord }>{ aRecord }</li>;
-						} ) }
-					</ul>
-				</FoldableFAQ>
-			);
+	renderARecordsMappingMessage() {
+		const { domain, translate } = this.props;
+
+		if ( ! domain.aRecordsRequiredForMapping ) {
+			return null;
 		}
 
+		const advancedSetupUsingARecordsTitle = translate( 'Advanced setup using root A records' );
+		const aRecordsSetupMessage = translate(
+			"If you have already set up your domain's DNS records in its own provider and just want to point it to WordPress.com, use these IP addresses as your root A records:"
+		);
 		return (
-			<React.Fragment>
-				<div>
-					<p>{ setupInstructionsMessage }</p>
-					{ recommendedSetupMessage }
-					{ aRecordsMappingMessage }
-				</div>
-				<div className="mapped-domain-type__small-message">{ secondaryMessage }</div>
-			</React.Fragment>
+			<FoldableFAQ id="advanced-mapping-setup" question={ advancedSetupUsingARecordsTitle }>
+				<p>{ aRecordsSetupMessage }</p>
+				<ul className="mapped-domain-type__name-server-list">
+					{ domain.aRecordsRequiredForMapping.map( ( aRecord ) => {
+						return <li key={ aRecord }>{ aRecord }</li>;
+					} ) }
+				</ul>
+			</FoldableFAQ>
 		);
 	}
 

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -51,7 +51,6 @@ class MappedDomainType extends React.Component {
 		);
 		let primaryMessage;
 		let secondaryMessage;
-		let thirdMessage;
 
 		if ( isSubdomain( domain.name ) ) {
 			primaryMessage = translate(
@@ -85,36 +84,50 @@ class MappedDomainType extends React.Component {
 					args: { domainName: domain.name },
 				}
 			);
+		}
 
-			if ( domain.aRecordsRequiredForMapping ) {
-				thirdMessage = (
-					<FoldableFAQ id="advanced-mapping-setup" question="Advanced setup using root A records">
-						<p>Use this to set it up:</p>
-						<ul>
-							{ domain.aRecordsRequiredForMapping.map( ( aRecord, index ) => {
-								return <li key={ index }>{ aRecord }</li>;
-							} ) }
-						</ul>
-					</FoldableFAQ>
-				);
-			}
+		const setupInstructionsMessage = translate(
+			'Follow these instructions to set up your domain mapping.'
+		);
+
+		const recommendedSetupTitle = translate( 'Recommended setup' );
+		const recommendedSetupMessage = (
+			<FoldableFAQ id="recommended-mapping-setup" question={ recommendedSetupTitle } expanded>
+				<p>{ primaryMessage }</p>
+				{ ! isSubdomain( domain.name ) && (
+					<ul className="mapped-domain-type__name-server-list">
+						{ WPCOM_DEFAULT_NAMESERVERS.map( ( nameServer ) => {
+							return <li key={ nameServer }>{ nameServer }</li>;
+						} ) }
+					</ul>
+				) }
+			</FoldableFAQ>
+		);
+
+		let aRecordsMappingMessage;
+		if ( domain.aRecordsRequiredForMapping ) {
+			const advancedSetupUsingARecordsTitle = translate( 'Advanced setup using root A records' );
+			const aRecordsSetupMessage = translate(
+				"If you have already set up your domain's DNS records in its own provider and just want to point it to WordPress.com, use these IP addresses as your root A records:"
+			);
+			aRecordsMappingMessage = (
+				<FoldableFAQ id="advanced-mapping-setup" question={ advancedSetupUsingARecordsTitle }>
+					<p>{ aRecordsSetupMessage }</p>
+					<ul className="mapped-domain-type__name-server-list">
+						{ domain.aRecordsRequiredForMapping.map( ( aRecord ) => {
+							return <li key={ aRecord }>{ aRecord }</li>;
+						} ) }
+					</ul>
+				</FoldableFAQ>
+			);
 		}
 
 		return (
 			<React.Fragment>
 				<div>
-					<p>Use these instructions to set up your domain mapping.</p>
-					<FoldableFAQ id="recommended-mapping-setup" question="Recommended setup" expanded>
-						<p>{ primaryMessage }</p>
-						{ ! isSubdomain( domain.name ) && (
-							<ul className="mapped-domain-type__name-server-list">
-								{ WPCOM_DEFAULT_NAMESERVERS.map( ( nameServer ) => {
-									return <li key={ nameServer }>{ nameServer }</li>;
-								} ) }
-							</ul>
-						) }
-					</FoldableFAQ>
-					{ thirdMessage }
+					<p>{ setupInstructionsMessage }</p>
+					{ recommendedSetupMessage }
+					{ aRecordsMappingMessage }
 				</div>
 				<div className="mapped-domain-type__small-message">{ secondaryMessage }</div>
 			</React.Fragment>

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -40,6 +40,7 @@ import { hasPendingGSuiteUsers } from 'calypso/lib/gsuite';
 import PendingGSuiteTosNotice from 'calypso/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice';
 import FoldableFAQ from 'calypso/components/foldable-faq';
 import Notice from 'calypso/components/notice';
+
 class MappedDomainType extends React.Component {
 	renderSettingUpNameserversAndARecords() {
 		const { domain, translate } = this.props;

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -49,10 +49,14 @@ class MappedDomainType extends React.Component {
 		const learnMoreLink = ( linksTo ) => (
 			<a href={ linksTo } target="_blank" rel="noopener noreferrer" />
 		);
+		let setupInstructionsMessage;
 		let primaryMessage;
 		let secondaryMessage;
 
 		if ( isSubdomain( domain.name ) ) {
+			setupInstructionsMessage = translate(
+				'Follow these instructions to set up your subdomain mapping:'
+			);
 			primaryMessage = translate(
 				'Your subdomain mapping has not been set up. You need to create the correct CNAME or NS records at your current DNS provider. {{learnMoreLink}}Learn how to do that in our support guide for mapping subdomains{{/learnMoreLink}}.',
 				{
@@ -71,8 +75,11 @@ class MappedDomainType extends React.Component {
 				}
 			);
 		} else {
+			setupInstructionsMessage = translate(
+				'Follow these instructions to set up your domain mapping:'
+			);
 			primaryMessage = translate(
-				'Your domain mapping has not been set up. You need to update your name servers at the company where you purchased the domain to:',
+				'In order to connect your domain to WordPress.com, log into your account at your domain registrar and update the name servers of your domain to use the following values:',
 				{
 					context: 'Notice for mapped domain notice with NS records pointing to somewhere else',
 				}
@@ -89,7 +96,7 @@ class MappedDomainType extends React.Component {
 		return (
 			<React.Fragment>
 				<div>
-					<p>{ translate( 'Follow these instructions to set up your domain mapping:' ) }</p>
+					<p>{ setupInstructionsMessage }</p>
 					{ this.renderRecommendedSetupMessage( primaryMessage ) }
 					{ domain.aRecordsRequiredForMapping && this.renderARecordsMappingMessage() }
 				</div>
@@ -124,7 +131,7 @@ class MappedDomainType extends React.Component {
 
 		const advancedSetupUsingARecordsTitle = translate( 'Advanced setup using root A records' );
 		const aRecordsSetupMessage = translate(
-			"If you have already set up your domain's DNS records in its own provider and just want to point it to WordPress.com, use these IP addresses as your root A records:"
+			'We recommend using WordPress.com’s name servers to map your domain, but if you prefer you can use different name servers and manage the configuration of your domain yourself. If you do that, you can point your domain to WordPress.com by defining the following IP addresses as root A records:'
 		);
 		return (
 			<FoldableFAQ id="advanced-mapping-setup" question={ advancedSetupUsingARecordsTitle }>

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -58,7 +58,10 @@ class MappedDomainType extends React.Component {
 
 		if ( isSubdomain( domain.name ) ) {
 			setupInstructionsMessage = translate(
-				'You need to follow these instructions to set up your subdomain mapping:'
+				'You need to follow these instructions to finish connecting the %(domainName)s subdomain to your WordPress.com site:',
+				{
+					args: { domainName: domain.name },
+				}
 			);
 			primaryMessage = translate(
 				'Please create the correct CNAME or NS records at your current DNS provider. {{learnMoreLink}}Learn how to do that in our support guide for mapping subdomains{{/learnMoreLink}}.',

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -39,7 +39,7 @@ import { DomainExpiryOrRenewal, WrapDomainStatusButtons } from './helpers';
 import { hasPendingGSuiteUsers } from 'calypso/lib/gsuite';
 import PendingGSuiteTosNotice from 'calypso/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice';
 import FoldableFAQ from 'calypso/components/foldable-faq';
-
+import Notice from 'calypso/components/notice';
 class MappedDomainType extends React.Component {
 	renderSettingUpNameserversAndARecords() {
 		const { domain, translate } = this.props;
@@ -63,7 +63,6 @@ class MappedDomainType extends React.Component {
 				'Your subdomain mapping has not been set up. You need to create the correct CNAME or NS records at your current DNS provider. {{learnMoreLink}}Learn how to do that in our support guide for mapping subdomains{{/learnMoreLink}}.',
 				{
 					components: {
-						strong: <strong />,
 						link: this.renderLinkTo( MAP_SUBDOMAIN ),
 					},
 					args: { domainName: domain.name },
@@ -78,13 +77,19 @@ class MappedDomainType extends React.Component {
 			);
 		} else {
 			setupInstructionsMessage = translate(
-				'Follow these instructions to set up your domain mapping:'
+				'You need to follow these instructions to finish connecting the %(domainName)s domain to your WordPress.com site:',
+				{
+					args: { domainName: domain.name },
+				}
 			);
 			primaryMessage = translate(
-				'In order to connect your domain to WordPress.com, please log into your account at your domain registrar and update the name servers of your domain to use the following values, as detailed in {{link}}these instructions{{/link}}:',
+				'Please log into your account at your domain registrar and {{strong}}update the name servers{{/strong}} of your domain to use the following values, as detailed in {{link}}these instructions{{/link}}:',
 				{
 					comment: 'Notice for mapped domain notice with NS records pointing to somewhere else',
-					components: { link: this.renderLinkTo( MAP_DOMAIN_CHANGE_NAME_SERVERS ) },
+					components: {
+						strong: <strong />,
+						link: this.renderLinkTo( MAP_DOMAIN_CHANGE_NAME_SERVERS ),
+					},
 				}
 			);
 			secondaryMessage = translate(
@@ -137,14 +142,20 @@ class MappedDomainType extends React.Component {
 		const { domain, translate } = this.props;
 
 		const advancedSetupUsingARecordsTitle = translate( 'Advanced setup using root A records' );
+		const aRecordMappingWarning = translate(
+			'If you map a domain using A records rather than WordPress.com name servers, you will need to manage your domain’s DNS records yourself for any other services you are using with your domain, including email forwarding or email hosting (i.e. with Google Workspace or Titan)'
+		);
 		const aRecordsSetupMessage = translate(
-			'We recommend using WordPress.com’s name servers to map your domain, but if you prefer you can use different name servers and manage the configuration of your domain yourself. To point your domain to WordPress.com, please add the following IP addresses as root A records using {{link}}these instructions{{/link}}:',
+			'Please set the following IP addresses as root A records using {{link}}these instructions{{/link}}:',
 			{
 				components: { link: this.renderLinkTo( MAP_EXISTING_DOMAIN_UPDATE_A_RECORDS ) },
 			}
 		);
 		return (
 			<FoldableFAQ id="advanced-mapping-setup" question={ advancedSetupUsingARecordsTitle }>
+				<Notice status="is-warning" showDismiss={ false }>
+					{ aRecordMappingWarning }
+				</Notice>
 				<p>{ aRecordsSetupMessage }</p>
 				<ul className="mapped-domain-type__name-server-list">
 					{ domain.aRecordsRequiredForMapping.map( ( aRecord ) => {

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -70,7 +70,7 @@ class MappedDomainType extends React.Component {
 						link: generateLinkTo( MAP_SUBDOMAIN ),
 					},
 					args: { domainName: domain.name },
-					context: 'Notice for mapped subdomain that has DNS records need to set up',
+					comment: 'Notice for mapped subdomain that has DNS records need to set up',
 				}
 			);
 			secondaryMessage = translate(
@@ -86,7 +86,7 @@ class MappedDomainType extends React.Component {
 			primaryMessage = translate(
 				'In order to connect your domain to WordPress.com, please log into your account at your domain registrar and update the name servers of your domain to use the following values, as detailed in {{link}}these instructions{{/link}}:',
 				{
-					context: 'Notice for mapped domain notice with NS records pointing to somewhere else',
+					comment: 'Notice for mapped domain notice with NS records pointing to somewhere else',
 					components: { link: generateLinkTo( MAP_DOMAIN_CHANGE_NAME_SERVERS ) },
 				}
 			);

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -66,7 +66,6 @@ class MappedDomainType extends React.Component {
 					components: {
 						learnMoreLink: this.renderLinkTo( MAP_SUBDOMAIN ),
 					},
-					args: { domainName: domain.name },
 					comment: 'Notice for mapped subdomain that has DNS records need to set up',
 				}
 			);

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -98,7 +98,7 @@ class MappedDomainType extends React.Component {
 
 		return (
 			<React.Fragment>
-				<div>
+				<div className="mapped-domain-type__main-content">
 					<p>{ setupInstructionsMessage }</p>
 					{ this.renderRecommendedSetupMessage( primaryMessage ) }
 					{ domain.aRecordsRequiredForMapping && this.renderARecordsMappingMessage() }

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -51,7 +51,7 @@ class MappedDomainType extends React.Component {
 			return null;
 		}
 
-		const learnMoreLink = ( linksTo ) => (
+		const generateLinkTo = ( linksTo ) => (
 			<a href={ linksTo } target="_blank" rel="noopener noreferrer" />
 		);
 		let setupInstructionsMessage;
@@ -67,7 +67,7 @@ class MappedDomainType extends React.Component {
 				{
 					components: {
 						strong: <strong />,
-						learnMoreLink: learnMoreLink( MAP_SUBDOMAIN ),
+						link: generateLinkTo( MAP_SUBDOMAIN ),
 					},
 					args: { domainName: domain.name },
 					context: 'Notice for mapped subdomain that has DNS records need to set up',
@@ -84,16 +84,16 @@ class MappedDomainType extends React.Component {
 				'Follow these instructions to set up your domain mapping:'
 			);
 			primaryMessage = translate(
-				'In order to connect your domain to WordPress.com, please log into your account at your domain registrar and update the name servers of your domain to use the following values, as per {{learnMoreLink}}these instructions{{/learnMoreLink}}:',
+				'In order to connect your domain to WordPress.com, please log into your account at your domain registrar and update the name servers of your domain to use the following values, as per {{link}}these instructions{{/link}}:',
 				{
 					context: 'Notice for mapped domain notice with NS records pointing to somewhere else',
-					components: { learnMoreLink: learnMoreLink( MAP_DOMAIN_CHANGE_NAME_SERVERS ) },
+					components: { link: generateLinkTo( MAP_DOMAIN_CHANGE_NAME_SERVERS ) },
 				}
 			);
 			secondaryMessage = translate(
 				"Please note that it can take up to 72 hours for your changes to become available. If you're still not seeing your site loading at %(domainName)s, please wait a few more hours, clear your browser cache, and try again. {{learnMoreLink}}Learn all about mapping an existing domain in our support docs{{/learnMoreLink}}.",
 				{
-					components: { learnMoreLink: learnMoreLink( MAP_EXISTING_DOMAIN ) },
+					components: { learnMoreLink: generateLinkTo( MAP_EXISTING_DOMAIN ) },
 					args: { domainName: domain.name },
 				}
 			);

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -84,7 +84,7 @@ class MappedDomainType extends React.Component {
 				'Follow these instructions to set up your domain mapping:'
 			);
 			primaryMessage = translate(
-				'In order to connect your domain to WordPress.com, please log into your account at your domain registrar and update the name servers of your domain to use the following values, as per {{link}}these instructions{{/link}}:',
+				'In order to connect your domain to WordPress.com, please log into your account at your domain registrar and update the name servers of your domain to use the following values, as detailed in {{link}}these instructions{{/link}}:',
 				{
 					context: 'Notice for mapped domain notice with NS records pointing to somewhere else',
 					components: { link: generateLinkTo( MAP_DOMAIN_CHANGE_NAME_SERVERS ) },

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -51,9 +51,6 @@ class MappedDomainType extends React.Component {
 			return null;
 		}
 
-		const generateLinkTo = ( linksTo ) => (
-			<a href={ linksTo } target="_blank" rel="noopener noreferrer" />
-		);
 		let setupInstructionsMessage;
 		let primaryMessage;
 		let secondaryMessage;
@@ -67,7 +64,7 @@ class MappedDomainType extends React.Component {
 				{
 					components: {
 						strong: <strong />,
-						link: generateLinkTo( MAP_SUBDOMAIN ),
+						link: this.renderLinkTo( MAP_SUBDOMAIN ),
 					},
 					args: { domainName: domain.name },
 					comment: 'Notice for mapped subdomain that has DNS records need to set up',
@@ -87,13 +84,13 @@ class MappedDomainType extends React.Component {
 				'In order to connect your domain to WordPress.com, please log into your account at your domain registrar and update the name servers of your domain to use the following values, as detailed in {{link}}these instructions{{/link}}:',
 				{
 					comment: 'Notice for mapped domain notice with NS records pointing to somewhere else',
-					components: { link: generateLinkTo( MAP_DOMAIN_CHANGE_NAME_SERVERS ) },
+					components: { link: this.renderLinkTo( MAP_DOMAIN_CHANGE_NAME_SERVERS ) },
 				}
 			);
 			secondaryMessage = translate(
 				"Please note that it can take up to 72 hours for your changes to become available. If you're still not seeing your site loading at %(domainName)s, please wait a few more hours, clear your browser cache, and try again. {{learnMoreLink}}Learn all about mapping an existing domain in our support docs{{/learnMoreLink}}.",
 				{
-					components: { learnMoreLink: generateLinkTo( MAP_EXISTING_DOMAIN ) },
+					components: { learnMoreLink: this.renderLinkTo( MAP_EXISTING_DOMAIN ) },
 					args: { domainName: domain.name },
 				}
 			);
@@ -109,6 +106,10 @@ class MappedDomainType extends React.Component {
 				<div className="mapped-domain-type__small-message">{ secondaryMessage }</div>
 			</React.Fragment>
 		);
+	}
+
+	renderLinkTo( url ) {
+		return <a href={ url } target="_blank" rel="noopener noreferrer" />;
 	}
 
 	renderRecommendedSetupMessage( primaryMessage ) {
@@ -135,14 +136,11 @@ class MappedDomainType extends React.Component {
 	renderARecordsMappingMessage() {
 		const { domain, translate } = this.props;
 
-		const generateLinkTo = ( href ) => (
-			<a href={ href } target="_blank" rel="noopener noreferrer" />
-		);
 		const advancedSetupUsingARecordsTitle = translate( 'Advanced setup using root A records' );
 		const aRecordsSetupMessage = translate(
 			'We recommend using WordPress.com’s name servers to map your domain, but if you prefer you can use different name servers and manage the configuration of your domain yourself. To point your domain to WordPress.com, please add the following IP addresses as root A records using {{link}}these instructions{{/link}}:',
 			{
-				components: { link: generateLinkTo( MAP_EXISTING_DOMAIN_UPDATE_A_RECORDS ) },
+				components: { link: this.renderLinkTo( MAP_EXISTING_DOMAIN_UPDATE_A_RECORDS ) },
 			}
 		);
 		return (

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -58,10 +58,10 @@ class MappedDomainType extends React.Component {
 
 		if ( isSubdomain( domain.name ) ) {
 			setupInstructionsMessage = translate(
-				'Follow these instructions to set up your subdomain mapping:'
+				'You need to follow these instructions to set up your subdomain mapping:'
 			);
 			primaryMessage = translate(
-				'Your subdomain mapping has not been set up. You need to create the correct CNAME or NS records at your current DNS provider. {{learnMoreLink}}Learn how to do that in our support guide for mapping subdomains{{/learnMoreLink}}.',
+				'Please create the correct CNAME or NS records at your current DNS provider. {{learnMoreLink}}Learn how to do that in our support guide for mapping subdomains{{/learnMoreLink}}.',
 				{
 					components: {
 						learnMoreLink: this.renderLinkTo( MAP_SUBDOMAIN ),

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -64,7 +64,7 @@ class MappedDomainType extends React.Component {
 				'Your subdomain mapping has not been set up. You need to create the correct CNAME or NS records at your current DNS provider. {{learnMoreLink}}Learn how to do that in our support guide for mapping subdomains{{/learnMoreLink}}.',
 				{
 					components: {
-						link: this.renderLinkTo( MAP_SUBDOMAIN ),
+						learnMoreLink: this.renderLinkTo( MAP_SUBDOMAIN ),
 					},
 					args: { domainName: domain.name },
 					comment: 'Notice for mapped subdomain that has DNS records need to set up',

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -86,14 +86,10 @@ class MappedDomainType extends React.Component {
 			);
 		}
 
-		const setupInstructionsMessage = translate(
-			'Follow these instructions to set up your domain mapping.'
-		);
-
 		return (
 			<React.Fragment>
 				<div>
-					<p>{ setupInstructionsMessage }</p>
+					<p>{ translate( 'Follow these instructions to set up your domain mapping:' ) }</p>
 					{ this.renderRecommendedSetupMessage( primaryMessage ) }
 					{ domain.aRecordsRequiredForMapping && this.renderARecordsMappingMessage() }
 				</div>
@@ -105,9 +101,12 @@ class MappedDomainType extends React.Component {
 	renderRecommendedSetupMessage( primaryMessage ) {
 		const { domain, translate } = this.props;
 
-		const recommendedSetupTitle = translate( 'Recommended setup' );
 		return (
-			<FoldableFAQ id="recommended-mapping-setup" question={ recommendedSetupTitle } expanded>
+			<FoldableFAQ
+				id="recommended-mapping-setup"
+				question={ translate( 'Recommended setup' ) }
+				expanded
+			>
 				<p>{ primaryMessage }</p>
 				{ ! isSubdomain( domain.name ) && (
 					<ul className="mapped-domain-type__name-server-list">

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -17,7 +17,12 @@ import { WPCOM_DEFAULT_NAMESERVERS } from 'calypso/state/domains/nameservers/con
 import AutoRenewToggle from 'calypso/me/purchases/manage-purchase/auto-renew-toggle';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { isSubdomain, resolveDomainStatus } from 'calypso/lib/domains';
-import { MAP_EXISTING_DOMAIN, MAP_SUBDOMAIN } from 'calypso/lib/url/support';
+import {
+	MAP_DOMAIN_CHANGE_NAME_SERVERS,
+	MAP_EXISTING_DOMAIN,
+	MAP_EXISTING_DOMAIN_UPDATE_A_RECORDS,
+	MAP_SUBDOMAIN,
+} from 'calypso/lib/url/support';
 import RenewButton from 'calypso/my-sites/domains/domain-management/edit/card/renew-button';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -79,9 +84,10 @@ class MappedDomainType extends React.Component {
 				'Follow these instructions to set up your domain mapping:'
 			);
 			primaryMessage = translate(
-				'In order to connect your domain to WordPress.com, log into your account at your domain registrar and update the name servers of your domain to use the following values:',
+				'In order to connect your domain to WordPress.com, please log into your account at your domain registrar and update the name servers of your domain to use the following values, as per {{learnMoreLink}}these instructions{{/learnMoreLink}}:',
 				{
 					context: 'Notice for mapped domain notice with NS records pointing to somewhere else',
+					components: { learnMoreLink: learnMoreLink( MAP_DOMAIN_CHANGE_NAME_SERVERS ) },
 				}
 			);
 			secondaryMessage = translate(
@@ -129,9 +135,15 @@ class MappedDomainType extends React.Component {
 	renderARecordsMappingMessage() {
 		const { domain, translate } = this.props;
 
+		const generateLinkTo = ( href ) => (
+			<a href={ href } target="_blank" rel="noopener noreferrer" />
+		);
 		const advancedSetupUsingARecordsTitle = translate( 'Advanced setup using root A records' );
 		const aRecordsSetupMessage = translate(
-			'We recommend using WordPress.com’s name servers to map your domain, but if you prefer you can use different name servers and manage the configuration of your domain yourself. If you do that, you can point your domain to WordPress.com by defining the following IP addresses as root A records:'
+			'We recommend using WordPress.com’s name servers to map your domain, but if you prefer you can use different name servers and manage the configuration of your domain yourself. To point your domain to WordPress.com, please add the following IP addresses as root A records using {{link}}these instructions{{/link}}:',
+			{
+				components: { link: generateLinkTo( MAP_EXISTING_DOMAIN_UPDATE_A_RECORDS ) },
+			}
 		);
 		return (
 			<FoldableFAQ id="advanced-mapping-setup" question={ advancedSetupUsingARecordsTitle }>

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -150,6 +150,10 @@
 			margin-bottom: 0.5em;
 		}
 
+		.mapped-domain-type__main-content {
+			padding-bottom: 0;
+		}
+
 		.mapped-domain-type__small-message {
 			font-size: $font-body-small;
 		}
@@ -160,6 +164,10 @@
 			padding-bottom: 1.5em;
 			> p:last-child {
 				margin-bottom: 0;
+			}
+
+			> div:last-of-type .foldable-faq__answer {
+				border-bottom: 0;
 			}
 		}
 

--- a/client/state/sites/domains/assembler.js
+++ b/client/state/sites/domains/assembler.js
@@ -26,6 +26,7 @@ export const createSiteDomainObject = ( domain ) => {
 	}
 
 	return {
+		aRecordsRequiredForMapping: domain.a_records_required_for_mapping,
 		autoRenewalDate: String( domain.auto_renewal_date ),
 		adminEmail: domain.admin_email,
 		autoRenewing: Boolean( domain.auto_renewing ),

--- a/client/state/sites/domains/test/fixture/index.js
+++ b/client/state/sites/domains/test/fixture/index.js
@@ -19,6 +19,7 @@ export const SUBSCRIPTION_ID_SECOND = null;
 
 // testing primary-domain
 export const DOMAIN_PRIMARY = {
+	aRecordsRequiredForMapping: undefined,
 	autoRenewalDate: '2017-02-07T00:00:00+00:00',
 	autoRenewing: true,
 	adminEmail: null,
@@ -90,6 +91,7 @@ export const DOMAIN_PRIMARY = {
 
 // testing not-primary-domain
 export const DOMAIN_NOT_PRIMARY = {
+	aRecordsRequiredForMapping: undefined,
 	autoRenewalDate: '',
 	autoRenewing: false,
 	adminEmail: null,

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -131,6 +131,7 @@ export interface Cart {
 }
 
 export interface Domain {
+	a_records_required_for_mapping?: string[];
 	primary_domain: boolean;
 	blog_id: number;
 	subscription_id?: any;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As explained in #50660, when mapping a domain, you get a nudge in Calypso to update the DNS records to point to our nameservers. However, it's also possible to just update the root A records. We mention this option in our support docs, but not in the UI.

This PR updates the mapped domain settings page to show the A records as an advanced setup option. The recommended configuration - changing the name servers to ours - is shown open by default, with the advanced setup closed.

Before:

<img width="554" alt="Screen Shot 2021-03-04 at 16 28 25" src="https://user-images.githubusercontent.com/5324818/110018985-abc4a880-7d06-11eb-924f-1efe8f0841a7.png">

After:

<img width="589" alt="Screen Shot 2021-03-10 at 16 33 30" src="https://user-images.githubusercontent.com/5324818/110686724-7f090900-81be-11eb-9226-b577717b3651.png">

With the advanced instructions open:

<img width="590" alt="Screen Shot 2021-03-10 at 16 34 05" src="https://user-images.githubusercontent.com/5324818/110686751-87614400-81be-11eb-8b5c-f75ec2611ae6.png">

#### Testing instructions

- You need to apply the D57929-code patch on the backend and sandbox public-api.

- Add a domain mapping to a site
- In Calypso, go to “Upgrades > Domains”
- Select the domain mapping
- It should show the updated instructions with advanced setup

- Depending on the type of site domain mapping is added to, different A records should be shown in the instructions:
    - Atomic sites should show their corresponding IP addresses
    - Simple sites should show the default IP addresses (*.24 and *.25)
    - Subdomains should not show the A records instructions because they should be mapped with CNAME records

Fixes #50660