### PR TITLE
Shopping Cart: Remove is_update property

### DIFF
--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -27,7 +27,6 @@ export interface RequestCart {
 	is_coupon_applied: boolean;
 	temporary: false;
 	extra: string;
-	is_update?: boolean;
 }
 
 export type RequestCartTaxData = null | {

--- a/packages/shopping-cart/src/use-cart-update-and-revalidate.ts
+++ b/packages/shopping-cart/src/use-cart-update-and-revalidate.ts
@@ -50,8 +50,7 @@ export default function useCartUpdateAndRevalidate(
 
 		hookDispatch( { type: 'REQUEST_UPDATED_RESPONSE_CART' } );
 
-		// We need to add is_update so that we don't add a plan automatically when the cart gets updated (DWPO).
-		setServerCart( { ...requestCart, is_update: true } )
+		setServerCart( requestCart )
 			.then( ( response ) => {
 				debug( 'update cart request complete', requestCart, '; updated cart is', response );
 				if ( responseCart !== pendingResponseCart.current ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As of D57928-code, the `is_update` property is no longer used by the shopping-cart endpoint. 

#### Testing instructions

- Add a product to the shopping cart and visit checkout.
- Verify that the cart loads correctly.