### PR TITLE
G Suite: Add support for purchasing additional Google Workspace licenses

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -491,19 +491,33 @@ export function getGoogleApps( cart ) {
 	return filter( getAllCartItems( cart ), isGSuiteOrExtraLicenseOrGoogleWorkspace );
 }
 
+/**
+ * Creates a new shopping cart item for G Suite or Google Workspace.
+ *
+ * @param {object} properties - list of properties
+ * @returns {CartItemValue} the new item
+ */
 export function googleApps( properties ) {
+	const { domain, meta, product_slug, quantity, new_quantity, users } = properties;
+
+	const domainName = meta ?? domain;
+
 	const productSlug =
-		properties.product_slug ||
+		product_slug ||
 		( config.isEnabled( 'google-workspace-migration' )
 			? GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
 			: GSUITE_BASIC_SLUG );
 
-	return assign( domainItem( productSlug, properties.meta ?? properties.domain ), {
-		extra: { google_apps_users: properties.users },
-		...( productSlug === GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
-			? { quantity: properties.quantity }
-			: {} ),
-	} );
+	const extra = {
+		google_apps_users: users,
+		...( new_quantity ? { new_quantity } : {} ),
+	};
+
+	return {
+		...domainItem( productSlug, domainName ),
+		...( quantity ? { quantity } : {} ),
+		extra,
+	};
 }
 
 export function googleAppsExtraLicenses( properties ) {

--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -10,9 +10,13 @@ import { v4 as uuidv4 } from 'uuid';
  * Internal dependencies
  */
 import { CartItemValue } from 'calypso/lib/cart-values/types';
-import config from '@automattic/calypso-config';
 import { googleApps, googleAppsExtraLicenses } from 'calypso/lib/cart-values/cart-items';
-import { hasGSuiteWithUs } from './has-gsuite-with-us';
+import {
+	getGSuiteMailboxCount,
+	hasGSuiteWithUs,
+	isGoogleWorkspaceProductSlug,
+	isGSuiteProductSlug,
+} from 'calypso/lib/gsuite';
 
 // exporting these in the big export below causes trouble
 export interface GSuiteNewUserField {
@@ -344,16 +348,23 @@ const getItemsForCart = (
 		( groupedUsers ) => groupedUsers.map( transformUserForCart )
 	);
 
-	return map( usersGroupedByDomain, ( groupedUsers: GSuiteProductUser[], domain: string ) => {
-		const domainInfo = find( domains, [ 'name', domain ] );
+	return map( usersGroupedByDomain, ( groupedUsers: GSuiteProductUser[], domainName: string ) => {
+		const properties = { domain: domainName, users: groupedUsers };
 
-		const properties = { domain, users: groupedUsers };
+		const domain = find( domains, [ 'name', domainName ] );
 
-		if ( domainInfo && hasGSuiteWithUs( domainInfo ) ) {
+		const isExtraLicense = domain && hasGSuiteWithUs( domain );
+
+		if ( isGSuiteProductSlug( productSlug ) && isExtraLicense ) {
 			return googleAppsExtraLicenses( properties );
 		}
 
-		if ( config.isEnabled( 'google-workspace-migration' ) ) {
+		if ( isGoogleWorkspaceProductSlug( productSlug ) && isExtraLicense ) {
+			properties[ 'new_quantity' ] = groupedUsers.length;
+			properties[ 'quantity' ] = getGSuiteMailboxCount( domain ) + groupedUsers.length;
+		}
+
+		if ( isGoogleWorkspaceProductSlug( productSlug ) && ! isExtraLicense ) {
 			properties[ 'quantity' ] = groupedUsers.length;
 		}
 

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -39,6 +39,7 @@ export { isFreePlan } from './is-free-plan';
 export { isFreeWordPressComDomain } from './is-free-wordpress-com-domain';
 export {
 	isGoogleWorkspace,
+	isGoogleWorkspaceExtraLicence,
 	isGSuite,
 	isGSuiteOrExtraLicense,
 	isGSuiteOrExtraLicenseOrGoogleWorkspace,

--- a/client/lib/products-values/is-gsuite.js
+++ b/client/lib/products-values/is-gsuite.js
@@ -17,6 +17,25 @@ export function isGoogleWorkspace( product ) {
 	return isGoogleWorkspaceProductSlug( product.product_slug );
 }
 
+/**
+ * Determines whether the provided Google Workspace product is for a user purchasing extra licenses (versus a new account).
+ *
+ * @param {object} product - product object
+ * @returns {boolean} - true if this product is for extra licenses, false otherwise
+ * @see isGoogleWorkspaceExtraLicence() in client/lib/purchases for a function that works on a purchase object
+ */
+export function isGoogleWorkspaceExtraLicence( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	if ( ! isGoogleWorkspaceProductSlug( product.product_slug ) ) {
+		return false;
+	}
+
+	// Checks if the 'new_quantity' property exists as it should only be specified for extra licenses
+	return product?.extra?.new_quantity !== undefined;
+}
+
 export function isGSuite( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -769,3 +769,5 @@ export {
 	shouldAddPaymentSourceInsteadOfRenewingNow,
 	shouldRenderExpiringCreditCard,
 };
+
+export { isGoogleWorkspaceExtraLicence } from './is-google-workspace-extra-license';

--- a/client/lib/purchases/is-google-workspace-extra-license.js
+++ b/client/lib/purchases/is-google-workspace-extra-license.js
@@ -1,0 +1,20 @@
+/**
+ * Internal Dependencies
+ */
+import { isGoogleWorkspaceProductSlug } from 'calypso/lib/gsuite';
+
+/**
+ * Determines whether the provided Google Workspace purchase is for a user purchasing extra licenses (versus a new account).
+ *
+ * @param {object} purchase - purchase object
+ * @returns {boolean} - true if this purchase is for extra licenses, false otherwise
+ * @see isGoogleWorkspaceExtraLicence() in client/lib/product-values for a function that works on a product object
+ */
+export function isGoogleWorkspaceExtraLicence( purchase ) {
+	if ( ! isGoogleWorkspaceProductSlug( purchase.productSlug ) ) {
+		return false;
+	}
+
+	// Checks if the 'newQuantity' property exists as it should only be specified for extra licenses
+	return purchase?.newQuantity !== undefined;
+}

--- a/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
@@ -11,6 +11,7 @@ import { CONTACT, GSUITE_LEARNING_CENTER } from 'calypso/lib/url/support';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import { useSelector } from 'react-redux';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
+import { isGoogleWorkspaceExtraLicence } from 'calypso/lib/purchases';
 import { isGSuiteOrExtraLicenseOrGoogleWorkspace } from 'calypso/lib/products-values';
 import { getGoogleMailServiceFamily, isGSuiteExtraLicenseProductSlug } from 'calypso/lib/gsuite';
 
@@ -18,10 +19,12 @@ const GoogleAppsDetails = ( { purchases } ) => {
 	const email = useSelector( getCurrentUserEmail );
 
 	const purchase = purchases.find( isGSuiteOrExtraLicenseOrGoogleWorkspace );
-	const productName = purchase.productName;
 	const productFamily = getGoogleMailServiceFamily( purchase.productSlug );
 
-	if ( isGSuiteExtraLicenseProductSlug( purchase.productSlug ) ) {
+	if (
+		isGoogleWorkspaceExtraLicence( purchase ) ||
+		isGSuiteExtraLicenseProductSlug( purchase.productSlug )
+	) {
 		return (
 			<PurchaseDetail
 				icon="mail"
@@ -29,7 +32,7 @@ const GoogleAppsDetails = ( { purchases } ) => {
 					'Keep an eye on your email to finish setting up your new email addresses'
 				) }
 				description={ i18n.translate(
-					'We are setting up your new G Suite users but {{strong}}this process can take several minutes' +
+					'We are setting up your new %(productFamily)s users but {{strong}}this process can take several minutes' +
 						'{{/strong}}. We will email you at %(email)s with login information once they are ready but if ' +
 						"you still haven't received anything after a few hours, do not hesitate to {{link}}contact support{{/link}}.",
 					{
@@ -46,13 +49,17 @@ const GoogleAppsDetails = ( { purchases } ) => {
 						},
 						args: {
 							email,
+							productFamily,
 						},
+						comment: '%(productFamily)s can be either "G Suite" or "Google Workspace"',
 					}
 				) }
 				isRequired
 			/>
 		);
 	}
+
+	const productName = purchase.productName;
 
 	return (
 		<PurchaseDetail

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -22,6 +22,7 @@ import {
 	isSiteRedirect,
 	isTitanMail,
 } from 'calypso/lib/products-values';
+import { isGoogleWorkspaceExtraLicence } from 'calypso/lib/purchases';
 import {
 	isGSuiteExtraLicenseProductSlug,
 	isGSuiteOrGoogleWorkspaceProductSlug,
@@ -202,6 +203,15 @@ export class CheckoutThankYouHeader extends PureComponent {
 			);
 		}
 
+		if (
+			isGoogleWorkspaceExtraLicence( primaryPurchase ) ||
+			isGSuiteExtraLicenseProductSlug( primaryPurchase.productSlug )
+		) {
+			return preventWidows(
+				translate( 'You will receive an email confirmation shortly for your purchase.' )
+			);
+		}
+
 		if ( isGSuiteOrGoogleWorkspaceProductSlug( primaryPurchase.productSlug ) ) {
 			return preventWidows(
 				translate(
@@ -216,12 +226,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 							'%(productName)s can be either "G Suite" or "Google Workspace Business Starter"',
 					}
 				)
-			);
-		}
-
-		if ( isGSuiteExtraLicenseProductSlug( primaryPurchase.productSlug ) ) {
-			return preventWidows(
-				translate( 'You will receive an email confirmation shortly for your purchase.' )
 			);
 		}
 

--- a/client/my-sites/checkout/composite-checkout/lib/get-contact-details-type.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-contact-details-type.ts
@@ -13,25 +13,36 @@ import {
 	hasTransferProduct,
 	hasOnlyRenewalItems,
 } from 'calypso/lib/cart-values/cart-items';
-import { isGSuiteOrGoogleWorkspaceProductSlug } from 'calypso/lib/gsuite';
+import { isGoogleWorkspaceExtraLicence } from 'calypso/lib/products-values';
+import { isGoogleWorkspaceProductSlug, isGSuiteProductSlug } from 'calypso/lib/gsuite';
 
 export default function getContactDetailsType( responseCart: ResponseCart ): ContactDetailsType {
 	const hasDomainProduct =
 		hasDomainRegistration( responseCart ) || hasTransferProduct( responseCart );
-	const hasNewGSuite = responseCart.products.some(
-		( product ) => isGSuiteOrGoogleWorkspaceProductSlug( product.product_slug ) // Do not show the G Suite form for extra licenses
-	);
-	const isOnlyRenewals = hasOnlyRenewalItems( responseCart );
-	const isPurchaseFree = responseCart.total_cost_integer === 0;
-	const isFullCredits = doesPurchaseHaveFullCredits( responseCart );
+	const hasOnlyRenewals = hasOnlyRenewalItems( responseCart );
 
-	if ( hasDomainProduct && ! isOnlyRenewals ) {
+	if ( hasDomainProduct && ! hasOnlyRenewals ) {
 		return 'domain';
 	}
 
-	if ( hasNewGSuite && ! isOnlyRenewals ) {
+	// Hides account information form if the user is only purchasing extra licenses for G Suite or Google Workspace
+	const hasNewGSuite = responseCart.products.some( ( product ) => {
+		if ( isGSuiteProductSlug( product.product_slug ) ) {
+			return true;
+		}
+
+		return (
+			isGoogleWorkspaceProductSlug( product.product_slug ) &&
+			! isGoogleWorkspaceExtraLicence( product )
+		);
+	} );
+
+	if ( hasNewGSuite && ! hasOnlyRenewals ) {
 		return 'gsuite';
 	}
+
+	const isPurchaseFree = responseCart.total_cost_integer === 0;
+	const isFullCredits = doesPurchaseHaveFullCredits( responseCart );
 
 	if ( isPurchaseFree && ! isFullCredits ) {
 		return 'none';

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -19,6 +19,7 @@ import {
 	isDomainTransferProduct,
 	isDomainProduct,
 	isDotComPlan,
+	isGoogleWorkspaceExtraLicence,
 	isGSuiteOrGoogleWorkspace,
 	isTitanMail,
 } from 'calypso/lib/products-values';
@@ -201,9 +202,13 @@ function addRegistrationDataToGSuiteItem(
 	item: WPCOMCartItem,
 	contactDetails: DomainContactDetails | null
 ): WPCOMCartItem {
-	if ( ! isGSuiteOrGoogleWorkspaceProductSlug( item.wpcom_meta?.product_slug ) ) {
+	if (
+		! isGSuiteOrGoogleWorkspaceProductSlug( item.wpcom_meta?.product_slug ) ||
+		isGoogleWorkspaceExtraLicence( item.wpcom_meta )
+	) {
 		return item;
 	}
+
 	return {
 		...item,
 		wpcom_meta: {

--- a/client/state/receipts/assembler.js
+++ b/client/state/receipts/assembler.js
@@ -17,6 +17,7 @@ import { flatten } from 'lodash';
  * @property {string} product_type
  * @property {string} product_name
  * @property {string} product_name_short
+ * @property {number} new_quantity
  * @property {string} [registrar_support_url]
  * @property {boolean} [is_email_verified]
  * @property {boolean} [is_root_domain_with_us]
@@ -108,6 +109,7 @@ export function createReceiptObject( data ) {
 				productType: purchase.product_type,
 				productName: purchase.product_name,
 				productNameShort: purchase.product_name_short,
+				newQuantity: purchase.new_quantity,
 				registrarSupportUrl: purchase.registrar_support_url,
 				isEmailVerified: Boolean( purchase.is_email_verified ),
 				isRootDomainWithUs: Boolean( purchase.is_root_domain_with_us ),


### PR DESCRIPTION
This pull request, together with D57935-code, adds support for purchasing extra Google Workspace licenses. Most of the work revolved around handling the `new_quantity` property, and use it to determine when a user is purchasing additional Google Workspace users. That information is mainly used to hide the account information form in the checkout, and display the right copy in the `Thank You` page:

![screenshot](https://user-images.githubusercontent.com/594356/111517919-df1b2480-8755-11eb-8a33-a5ac19b7e0d7.png)

#### Testing instructions

See instructions in D57935-code.