### PR TITLE
Help: Style Sibyl results differently

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -474,6 +474,7 @@ export class HelpContactForm extends React.PureComponent {
 						helpLinks={ this.state.qanda }
 						iconTypeDescription="book"
 						onClick={ this.trackSibylClick }
+						isSibyl
 					/>
 				) }
 

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -474,7 +474,7 @@ export class HelpContactForm extends React.PureComponent {
 						helpLinks={ this.state.qanda }
 						iconTypeDescription="book"
 						onClick={ this.trackSibylClick }
-						isSibyl
+						compact
 					/>
 				) }
 

--- a/client/me/help/help-results/index.jsx
+++ b/client/me/help/help-results/index.jsx
@@ -34,6 +34,7 @@ export default class extends React.PureComponent {
 							helpLink={ helpLink }
 							iconTypeDescription={ this.props.iconTypeDescription }
 							onClick={ this.props.onClick }
+							compact={ this.props.compact }
 						/>
 					) ) }
 					<a href={ this.props.searchLink } target="__blank">

--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -60,7 +60,7 @@ export default class extends React.PureComponent {
 	};
 
 	render() {
-		const { isSibyl, helpLink } = this.props;
+		const { compact, helpLink } = this.props;
 		return (
 			<a
 				className="help-result"
@@ -69,12 +69,12 @@ export default class extends React.PureComponent {
 				onClick={ this.onClick }
 			>
 				<CompactCard className="help-result__wrapper">
-					{ isSibyl && this.getResultIcon() }
+					{ compact && this.getResultIcon() }
 					<div className="help-result__content-wrapper">
 						<h2 className="help-result__title">{ decodeEntities( helpLink.title ) }</h2>
 						<p className="help-result__description">{ decodeEntities( helpLink.description ) }</p>
 					</div>
-					{ ! isSibyl && (
+					{ ! compact && (
 						<div className="help-result__icon-wrapper">
 							{ this.getResultImage() }
 							{ this.getResultIcon() }

--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -72,7 +72,7 @@ export default class extends React.PureComponent {
 					{ compact && this.getResultIcon() }
 					<div className="help-result__content-wrapper">
 						<h2 className="help-result__title">{ decodeEntities( helpLink.title ) }</h2>
-						<p className="help-result__description">{ decodeEntities( helpLink.description ) }</p>
+						{ ! compact && <p className="help-result__description">{ decodeEntities( helpLink.description ) }</p> }
 					</div>
 					{ ! compact && (
 						<div className="help-result__icon-wrapper">

--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -60,24 +60,26 @@ export default class extends React.PureComponent {
 	};
 
 	render() {
+		const { isSibyl, helpLink } = this.props;
 		return (
 			<a
 				className="help-result"
-				href={ localizeUrl( this.props.helpLink.link ) }
+				href={ localizeUrl( helpLink.link ) }
 				target="__blank"
 				onClick={ this.onClick }
 			>
 				<CompactCard className="help-result__wrapper">
+					{ isSibyl && this.getResultIcon() }
 					<div className="help-result__content-wrapper">
-						<h2 className="help-result__title">{ decodeEntities( this.props.helpLink.title ) }</h2>
-						<p className="help-result__description">
-							{ decodeEntities( this.props.helpLink.description ) }
-						</p>
+						<h2 className="help-result__title">{ decodeEntities( helpLink.title ) }</h2>
+						<p className="help-result__description">{ decodeEntities( helpLink.description ) }</p>
 					</div>
-					<div className="help-result__icon-wrapper">
-						{ this.getResultImage() }
-						{ this.getResultIcon() }
-					</div>
+					{ ! isSibyl && (
+						<div className="help-result__icon-wrapper">
+							{ this.getResultImage() }
+							{ this.getResultIcon() }
+						</div>
+					) }
 				</CompactCard>
 			</a>
 		);

--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -72,7 +72,9 @@ export default class extends React.PureComponent {
 					{ compact && this.getResultIcon() }
 					<div className="help-result__content-wrapper">
 						<h2 className="help-result__title">{ decodeEntities( helpLink.title ) }</h2>
-						{ ! compact && <p className="help-result__description">{ decodeEntities( helpLink.description ) }</p> }
+						{ ! compact && (
+							<p className="help-result__description">{ decodeEntities( helpLink.description ) }</p>
+						) }
 					</div>
 					{ ! compact && (
 						<div className="help-result__icon-wrapper">

--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -11,6 +11,15 @@
 	}
 }
 
+.help-results__header.card.is-compact,
+.help-results__footer.card.is-compact {
+	padding: 16px;
+
+	@include break-medium {
+		padding: 16px 24px;
+	}
+}
+
 .help-result {
 	&:hover {
 		.help-result__wrapper {
@@ -86,18 +95,9 @@
 	margin: 0 0 8px;
 }
 
-/* Compact variation */
+/* Contact form results */
 
-.help-results__header.card.is-compact,
-.help-results__footer.card.is-compact {
-	padding: 16px;
-
-	@include break-medium {
-		padding: 16px 24px;
-	}
-}
-
-.is-compact .help-result__content-wrapper {
+.help-contact-form .help-result__content-wrapper {
 	width: 100%;
 	margin-right: 0;
 
@@ -106,10 +106,11 @@
 	}
 }
 
-.is-compact .help-result__title {
+.help-contact-form .help-result__title {
 	font-weight: 400;
+	margin: 0;
 }
 
-.is-compact .gridicon {
+.help-contact-form .gridicon {
 	margin-right: 16px;
 }

--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -86,12 +86,23 @@
 	margin: 0 0 8px;
 }
 
+/* Compact variation */
+
 .help-results__header.card.is-compact,
 .help-results__footer.card.is-compact {
 	padding: 16px;
 
 	@include break-medium {
 		padding: 16px 24px;
+	}
+}
+
+.is-compact .help-result__content-wrapper {
+	width: 100%;
+	margin-right: 0;
+
+	@include break-medium {
+		max-width: 100%;
 	}
 }
 

--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -11,15 +11,6 @@
 	}
 }
 
-.help-results__header.card.is-compact,
-.help-results__footer.card.is-compact {
-	padding: 16px;
-
-	@include break-medium {
-		padding: 16px 24px;
-	}
-}
-
 .help-result {
 	&:hover {
 		.help-result__wrapper {
@@ -93,4 +84,21 @@
 	font-size: $font-body;
 	line-height: 24px;
 	margin: 0 0 8px;
+}
+
+.help-results__header.card.is-compact,
+.help-results__footer.card.is-compact {
+	padding: 16px;
+
+	@include break-medium {
+		padding: 16px 24px;
+	}
+}
+
+.is-compact .help-result__title {
+	font-weight: 400;
+}
+
+.is-compact .gridicon {
+	margin-right: 16px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a prop so we know we're in the compact/Sibyl context when viewing HelpResults.
* Show the icon on the left rather than the right

**Before**

<img width="789" alt="Screen Shot 2021-03-02 at 4 52 47 PM" src="https://user-images.githubusercontent.com/2124984/109720353-f532bd80-7b77-11eb-8616-0691a5c5e19a.png">

**After**

<img width="777" alt="Screen Shot 2021-03-02 at 4 52 00 PM" src="https://user-images.githubusercontent.com/2124984/109720369-fc59cb80-7b77-11eb-84ef-206384c832f3.png">

#### Testing instructions

* Switch to this PR, navigate to `/help/contact`
* Put a phrase in the Subject/description fields like "site map" or "css" and some Q&A results should appear
* They should be styled like the "After" image above, a more compact style with the icon on the left. 
* Make sure I haven't introduced additional visual bugs or other bugs.

Fixes #50543