### PR TITLE
Updating text on Cloudflare CDN marketing card to indicate that it is only usable by sites with a custom domain

### DIFF
--- a/client/my-sites/site-settings/cloudflare.js
+++ b/client/my-sites/site-settings/cloudflare.js
@@ -83,7 +83,9 @@ const Cloudflare = () => {
 									{ translate( 'Cloudflare CDN ' ) }
 								</p>
 								<p>
-									{ translate( 'An alternative to Jetpack CDN, with security-focused plans.' ) }
+									{ translate(
+										'An alternative to Jetpack CDN, with security-focused plans available for sites with a custom domain enabled.'
+									) }
 								</p>
 								<p>
 									<a

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -548,10 +548,9 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 
 .site-settings__cloudflare-text {
 	margin-left: 20px;
-	line-height: 2rem;
 
 	p {
-		margin: 0;
+		margin: 0 0 0.5rem;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the text content of the Cloudflare CDN marketing card slightly.

OLD:
![image](https://user-images.githubusercontent.com/13437011/109723793-31fcb580-7b74-11eb-9eb9-e74eaddd1279.png)

NEW:
![image](https://user-images.githubusercontent.com/13437011/109724985-1692aa00-7b76-11eb-9fc4-ed209d3fff4c.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR or open it on calypso.live
* Navigate to /settings/performance/{site-domain} for any WPCOM site.
    * Note that if you are testing on calypso.live, you will have to add `?flags=cloudflare` to the end of the URL to enable the relevant feature flag.
* Verify that the Cloudflare card displays updated text copy.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pbAPfg-1he-p2#comment-2614