### PR TITLE
Checkout: Remove CartStore from checkout

### DIFF
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -39,7 +39,6 @@ export default function CheckoutSystemDecider( {
 	redirectTo,
 	isLoggedOutCart,
 	isNoSiteCart,
-	cart: otherCart,
 } ) {
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
@@ -80,23 +79,14 @@ export default function CheckoutSystemDecider( {
 		[ reduxDispatch ]
 	);
 
-	// We have to monitor the old cart manager in case it's waiting on a
-	// requested change. To prevent race conditions, we will return undefined in
-	// that case, which will cause the ShoppingCartProvider to enter a loading
-	// state. We have to use null because CalypsoShoppingCartProvider assumes
-	// undefined means to try for its own cartKey.
-	const waitForOtherCartUpdates =
-		otherCart?.hasPendingServerUpdates || ! otherCart?.hasLoadedFromServer;
 	const cartKey = useMemo(
 		() =>
-			waitForOtherCartUpdates
-				? null
-				: getCartKey( {
-						selectedSite,
-						isLoggedOutCart,
-						isNoSiteCart,
-				  } ),
-		[ waitForOtherCartUpdates, selectedSite, isLoggedOutCart, isNoSiteCart ]
+			getCartKey( {
+				selectedSite,
+				isLoggedOutCart,
+				isNoSiteCart,
+			} ),
+		[ selectedSite, isLoggedOutCart, isNoSiteCart ]
 	);
 	debug( 'cartKey is', cartKey );
 
@@ -110,16 +100,13 @@ export default function CheckoutSystemDecider( {
 		}
 	}
 
-	const getCart = isLoggedOutCart || isNoSiteCart ? () => Promise.resolve( otherCart ) : undefined;
-	debug( 'getCart being controlled by', { isLoggedOutCart, isNoSiteCart, otherCart } );
-
 	return (
 		<>
 			<CheckoutErrorBoundary
 				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
 				onError={ logCheckoutError }
 			>
-				<CalypsoShoppingCartProvider cartKey={ cartKey } getCart={ getCart }>
+				<CalypsoShoppingCartProvider cartKey={ cartKey }>
 					<StripeHookProvider
 						fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
 						locale={ locale }

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -7,6 +7,7 @@ import debugFactory from 'debug';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
+import { getEmptyResponseCart } from '@automattic/shopping-cart';
 
 /**
  * Internal Dependencies
@@ -25,6 +26,8 @@ import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 // Aliasing wpcom functions explicitly bound to wpcom is required here;
 // otherwise we get `this is not defined` errors.
 const wpcom = wp.undocumented();
+
+const emptyCart = getEmptyResponseCart();
 
 const debug = debugFactory( 'calypso:checkout-system-decider' );
 
@@ -100,13 +103,17 @@ export default function CheckoutSystemDecider( {
 		}
 	}
 
+	// If we do not have a site or user, we cannot fetch the initial cart from
+	// the server, so we'll just mock it as an empty cart here.
+	const getCart = isLoggedOutCart || isNoSiteCart ? () => Promise.resolve( emptyCart ) : undefined;
+
 	return (
 		<>
 			<CheckoutErrorBoundary
 				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
 				onError={ logCheckoutError }
 			>
-				<CalypsoShoppingCartProvider cartKey={ cartKey }>
+				<CalypsoShoppingCartProvider cartKey={ cartKey } getCart={ getCart }>
 					<StripeHookProvider
 						fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
 						locale={ locale }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -232,6 +232,8 @@ export default function CompositeCheckout( {
 		isJetpackNotAtomic,
 		isPrivate,
 		siteSlug,
+		isLoggedOutCart,
+		isNoSiteCart,
 	} );
 
 	const {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -59,25 +59,17 @@ export default function usePrepareProductsForCart( {
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
 } ): PreparedProductsForCart {
-	const initializePreparedProductsState = (
-		initialState: PreparedProductsForCart
-	): PreparedProductsForCart => ( {
-		...initialState,
-		isLoading: !! productAliasFromUrl,
-	} );
-	const [ state, dispatch ] = useReducer(
-		preparedProductsReducer,
-		initialPreparedProductsState,
-		initializePreparedProductsState
-	);
+	const [ state, dispatch ] = useReducer( preparedProductsReducer, initialPreparedProductsState );
 
 	debug(
 		'preparing products for cart from url string',
 		productAliasFromUrl,
 		'and purchase id',
 		originalPurchaseId,
-		'and signup variables',
-		{ isLoggedOutCart, isNoSiteCart }
+		'and isLoggedOutCart',
+		isLoggedOutCart,
+		'and isNoSiteCart',
+		isNoSiteCart
 	);
 
 	useFetchProductsIfNotLoaded();
@@ -89,6 +81,8 @@ export default function usePrepareProductsForCart( {
 		isLoggedOutCart,
 		isNoSiteCart,
 	} );
+	debug( 'isLoading', state.isLoading );
+	debug( 'handler is', addHandler );
 
 	// Only one of these should ever operate. The others should bail if they
 	// think another hook will handle the data.
@@ -109,6 +103,7 @@ export default function usePrepareProductsForCart( {
 		dispatch,
 		addHandler,
 	} );
+	useNothingToAdd( { addHandler, dispatch } );
 
 	// Do not strip products from url until the URL has been parsed
 	const areProductsRetrievedFromUrl = ! state.isLoading && ! isInEditor;
@@ -176,6 +171,23 @@ function chooseAddHandler( {
 	}
 
 	return 'doNotAdd';
+}
+
+function useNothingToAdd( {
+	dispatch,
+	addHandler,
+}: {
+	dispatch: ( action: PreparedProductsAction ) => void;
+	addHandler: AddHandler;
+} ) {
+	useEffect( () => {
+		if ( addHandler !== 'doNotAdd' ) {
+			return;
+		}
+
+		debug( 'nothing to add' );
+		dispatch( { type: 'PRODUCTS_ADD', products: [] } );
+	}, [ addHandler, dispatch ] );
 }
 
 function useAddProductsFromLocalStorage( {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -216,7 +216,7 @@ function useAddProductsFromLocalStorage( {
 			return;
 		}
 
-		const productsForCart = getCartFromLocalStorage().map( ( product ) =>
+		const productsForCart: RequestCartProduct[] = getCartFromLocalStorage().map( ( product ) =>
 			fillInSingleCartItemAttributes( product, products )
 		);
 

--- a/client/my-sites/checkout/composite-checkout/lib/get-cart-from-local-storage.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-cart-from-local-storage.ts
@@ -4,7 +4,8 @@
 import type { RequestCartProduct } from '@automattic/shopping-cart';
 
 // Used by signup; see https://github.com/Automattic/wp-calypso/pull/44206
-export default function getCartFromLocalStorage(): RequestCartProduct[] {
+// These products are likely missing product_id.
+export default function getCartFromLocalStorage(): Partial< RequestCartProduct >[] {
 	try {
 		return JSON.parse( window.localStorage.getItem( 'shoppingCart' ) || '[]' );
 	} catch ( err ) {

--- a/client/my-sites/checkout/composite-checkout/lib/get-cart-from-local-storage.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-cart-from-local-storage.ts
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import type { RequestCartProduct } from '@automattic/shopping-cart';
+
+// Used by signup; see https://github.com/Automattic/wp-calypso/pull/44206
+export default function getCartFromLocalStorage(): RequestCartProduct[] {
+	try {
+		return JSON.parse( window.localStorage.getItem( 'shoppingCart' ) || '[]' );
+	} catch ( err ) {
+		return [];
+	}
+}

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -21,7 +21,6 @@ import { canUserPurchaseGSuite } from 'calypso/lib/gsuite';
 import { getRememberedCoupon } from 'calypso/lib/cart/actions';
 import { setSectionMiddleware } from 'calypso/controller';
 import { sites } from 'calypso/my-sites/controller';
-import CartData from 'calypso/components/data/cart';
 import userFactory from 'calypso/lib/user';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import {
@@ -93,20 +92,18 @@ export function checkout( context, next ) {
 	}
 
 	context.primary = (
-		<CartData>
-			<CheckoutSystemDecider
-				productAliasFromUrl={ product }
-				purchaseId={ purchaseId }
-				selectedFeature={ feature }
-				couponCode={ couponCode }
-				isComingFromUpsell={ !! context.query.upgrade }
-				plan={ plan }
-				selectedSite={ selectedSite }
-				redirectTo={ context.query.redirect_to }
-				isLoggedOutCart={ isLoggedOutCart }
-				isNoSiteCart={ isNoSiteCart }
-			/>
-		</CartData>
+		<CheckoutSystemDecider
+			productAliasFromUrl={ product }
+			purchaseId={ purchaseId }
+			selectedFeature={ feature }
+			couponCode={ couponCode }
+			isComingFromUpsell={ !! context.query.upgrade }
+			plan={ plan }
+			selectedSite={ selectedSite }
+			redirectTo={ context.query.redirect_to }
+			isLoggedOutCart={ isLoggedOutCart }
+			isNoSiteCart={ isNoSiteCart }
+		/>
 	);
 
 	next();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As a final piece to remove the deprecated CartStore (see https://github.com/Automattic/wp-calypso/issues/24019) we need to remove the `CartData` wrapper around `CheckoutSystemDecider`. That wrapper was added to guard against race conditions where other parts of calypso might be using the CartStore to modify the cart and the new checkout (specifically the `CalypsoShoppingCartProvider`) needed to wait until those transactions completed before initializing. Since no other parts of calypso still use CartStore to modify the cart, this race condition guard can be removed.

However, after the guard was put in place, it was also used in https://github.com/Automattic/wp-calypso/pull/44206 as a mechanism to inject cart items from localStorage as the initial cart. This was done so that siteless and registrationless signup could prepare items to be added to the cart before the shopping-cart endpoint would allow adding those items. The way this works (if I understand it correctly) is that signup writes the temporary items to localStorage and those items are then read by the CartStore into its internal cache which it then posts to the shopping-cart endpoint (every 20 seconds, endlessly, I believe). `CheckoutSystemDecider` then replaces the `CalypsoShoppingCartProvider` fetcher with a hard-coded Promise that resolves to the updated card from the CartStore, so that when checkout goes to pull in the initial copy of the cart, it receives the products written by signup instead.

This strategy has a problem as we try to migrate it away from using CartStore. The cart items written to localStorage (and indeed the rest of the cart) are missing many required properties set by the shopping-cart endpoint (they do not match the `ResponseCartProduct` type), and therefore cannot be safely used in checkout without a round-trip to the endpoint first. Since this PR removes `CartData` from checkout, that round-trip no longer occurs anywhere. 

However, we have a mechanism already that handles this sort of situation when checkout loads, `usePrepareProductsForCart`, which currently takes products from the URL and adds them to the cart. To that end, I think it makes more sense to read them from localStorage directly inside this hook. This PR does just that.

#### Testing instructions

To test the `no-user` flow:

- Start logged-out of WordPress.com
- Visit `/start/onboarding-registrationless/domains`
- Enter text to search for a domain name and click to select one from the results.
- You should see a plans page. Click to select a plan.
- Verify that you are redirected to checkout and that both the plan and domain you chose are in the cart.

I'm not sure how to test the `no-site` flow. Ping @Automattic/martech for help there.