### PR TITLE
ci(e2e) Do not use async describe blocks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -80,6 +80,7 @@ module.exports = {
 				'mocha/no-exclusive-tests': 'error',
 				'mocha/handle-done-callback': [ 'error', { ignoreSkipped: true } ],
 				'mocha/no-global-tests': 'error',
+				'mocha/no-async-describe': 'error',
 				'no-console': 'off',
 				// Disable all rules from "plugin:jest/recommended", as e2e tests use mocha
 				...Object.keys( require( 'eslint-plugin-jest' ).configs.recommended.rules ).reduce(

--- a/test/e2e/specs/wp-calypso-gutenberg-checkout-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-checkout-spec.js
@@ -130,7 +130,7 @@ describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize
 		} );
 	} );
 
-	describe( 'Can add/remove coupons', async function () {
+	describe( 'Can add/remove coupons', function () {
 		step( 'Can Enter Coupon Code', async function () {
 			const enterCouponCodeButton = await driverHelper.isElementPresent(
 				driver,
@@ -239,7 +239,7 @@ describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize
 		} );
 	} );
 
-	describe( 'Can delete the premium plan', async function () {
+	describe( 'Can delete the premium plan', function () {
 		step( 'Can log in', async function () {
 			const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteFreePlanUser' );
 			return await loginFlow.login();

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
@@ -213,7 +213,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 		} );
 	} );
 
-	describe( 'WPCOM-specific gutter controls: @parallel', async function () {
+	describe( 'WPCOM-specific gutter controls: @parallel', function () {
 		const gutterControlsLocator = By.css(
 			'div[aria-label="Editor settings"] div[aria-label="Gutter"]'
 		);

--- a/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
+++ b/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
@@ -57,7 +57,7 @@ describe( `[${ host }] Experimental features we depend on are available (${ scre
 		return await this.loginFlow.loginAndStartNewPost( null, true );
 	} );
 
-	describe( 'Can find experimental package features', async function () {
+	describe( 'Can find experimental package features', function () {
 		for ( const [ packageName, features ] of Object.entries( EXPERIMENTAL_FEATURES ) ) {
 			// Removes the `@wordpress/` prefix and hyphens from package name
 			// The algorithm WP uses to convert package names to variable names is here: https://github.com/WordPress/gutenberg/blob/a03ea51e11a36d0abeecb4ce4e4cea5ffebdffc5/packages/dependency-extraction-webpack-plugin/lib/util.js#L40-L45

--- a/test/e2e/specs/wp-inline-help-support-search-spec.js
+++ b/test/e2e/specs/wp-inline-help-support-search-spec.js
@@ -29,7 +29,7 @@ before( async function () {
 	driver = await driverManager.startBrowser();
 } );
 
-describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, async function () {
+describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
 	step( 'Login and select a page that is not the My Home page', async function () {

--- a/test/e2e/specs/wp-my-home-support-search-spec.js
+++ b/test/e2e/specs/wp-my-home-support-search-spec.js
@@ -31,7 +31,7 @@ before( async function () {
 	driver = await driverManager.startBrowser();
 } );
 
-describe( `[${ host }] My Home "Get help" support search card: (${ screenSize }) @parallel`, async function () {
+describe( `[${ host }] My Home "Get help" support search card: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
 	step( 'Login and select the My Home page', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable eslint rule `mocha/no-async-describe`
* Fix violations of that rule

Mocha doesn't really support async/Promises in `describe` blocks, this can results in tests being ignored or reported as root tests.

#### Testing instructions

Verify e2e tests pass