### PR TITLE
Patterns API: register patterns in FSE, and use a patterns_source param to specify a different source site

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -30,6 +30,8 @@ class Block_Patterns_From_API {
 
 	/**
 	 * Valid source strings for retrieving patterns.
+	 *
+	 * @var array
 	 */
 	private $valid_patterns_sources = array( 'block_patterns', 'fse_block_patterns' );
 
@@ -40,7 +42,7 @@ class Block_Patterns_From_API {
 	 */
 	private function __construct( $patterns_source ) {
 		// Tells the backend which patterns source site to default to.
-		$this->patterns_source = in_array( $patterns_source, $this->valid_patterns_sources ) ? $patterns_source : 'block_patterns';
+		$this->patterns_source = in_array( $patterns_source, $this->valid_patterns_sources, true ) ? $patterns_source : 'block_patterns';
 
 		$this->patterns_cache_key = sha1(
 			implode(

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -8,7 +8,7 @@
 namespace A8C\FSE;
 
 /**
- * Class B  lock_Patterns_From_API
+ * Class Block_Patterns_From_API
  */
 class Block_Patterns_From_API {
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -29,12 +29,19 @@ class Block_Patterns_From_API {
 	private $patterns_cache_key;
 
 	/**
-	 * Block_Patterns constructor.
+	 * Valid source strings for retrieving patterns.
 	 */
-	private function __construct() {
-		$this->is_site_editor_enabled = function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme();
+	private $valid_patterns_sources = array( 'block_patterns', 'fse_block_patterns' );
+
+	/**
+	 * Block_Patterns constructor.
+	 *
+	 * @param string $patterns_source A string matching a valid source for retrieving patterns.
+	 */
+	private function __construct( $patterns_source ) {
 		// Tells the backend which patterns source site to default to.
-		$this->patterns_source    = $this->is_site_editor_enabled ? 'fse_block_patterns' : 'block_patterns';
+		$this->patterns_source = in_array( $patterns_source, $this->valid_patterns_sources ) ? $patterns_source : 'block_patterns';
+
 		$this->patterns_cache_key = sha1(
 			implode(
 				'_',
@@ -52,11 +59,12 @@ class Block_Patterns_From_API {
 	/**
 	 * Creates instance.
 	 *
+	 * @param string $patterns_source A string matching a valid source for retrieving patterns.
 	 * @return \A8C\FSE\Block_Patterns
 	 */
-	public static function get_instance() {
+	public static function get_instance( $patterns_source ) {
 		if ( null === self::$instance ) {
-			self::$instance = new self();
+			self::$instance = new self( $patterns_source );
 		}
 
 		return self::$instance;

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -33,14 +33,13 @@ class Block_Patterns_From_API {
 	 */
 	private function __construct() {
 		$this->is_site_editor_enabled = function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme();
-
 		// Tells the backend which patterns source site to default to.
 		$this->patterns_source    = $this->is_site_editor_enabled ? 'fse_block_patterns' : 'block_patterns';
 		$this->patterns_cache_key = sha1(
 			implode(
 				'_',
 				array(
-					$this->pattern_source,
+					$this->patterns_source,
 					A8C_ETK_PLUGIN_VERSION,
 					$this->get_block_patterns_locale(),
 				)

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -33,12 +33,14 @@ class Block_Patterns_From_API {
 	 */
 	private function __construct() {
 		$this->is_site_editor_enabled = function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme();
-		$cache_key_prefix             = $this->is_site_editor_enabled ? 'fse_block_patterns' : 'block_patterns';
-		$this->patterns_cache_key     = sha1(
+
+		// Tells the backend which patterns source site to default to.
+		$this->patterns_source    = $this->is_site_editor_enabled ? 'fse_block_patterns' : 'block_patterns';
+		$this->patterns_cache_key = sha1(
 			implode(
 				'_',
 				array(
-					$cache_key_prefix,
+					$this->pattern_source,
 					A8C_ETK_PLUGIN_VERSION,
 					$this->get_block_patterns_locale(),
 				)
@@ -181,9 +183,9 @@ class Block_Patterns_From_API {
 			$request_url = esc_url_raw(
 				add_query_arg(
 					array(
-						'tags'         => 'pattern',
-						'pattern_meta' => 'is_web',
-						'is_fse'       => $this->is_site_editor_enabled,
+						'tags'            => 'pattern',
+						'pattern_meta'    => 'is_web',
+						'patterns_source' => $this->patterns_source,
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->get_block_patterns_locale()
 				)

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -8,7 +8,7 @@
 namespace A8C\FSE;
 
 /**
- * Class Block_Patterns_From_API
+ * Class B  lock_Patterns_From_API
  */
 class Block_Patterns_From_API {
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -32,11 +32,13 @@ class Block_Patterns_From_API {
 	 * Block_Patterns constructor.
 	 */
 	private function __construct() {
-		$this->patterns_cache_key = sha1(
+		$this->is_site_editor_enabled = function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme();
+		$cache_key_prefix             = $this->is_site_editor_enabled ? 'fse_block_patterns' : 'block_patterns';
+		$this->patterns_cache_key     = sha1(
 			implode(
 				'_',
 				array(
-					'block_patterns',
+					$cache_key_prefix,
 					A8C_ETK_PLUGIN_VERSION,
 					$this->get_block_patterns_locale(),
 				)
@@ -181,6 +183,7 @@ class Block_Patterns_From_API {
 					array(
 						'tags'         => 'pattern',
 						'pattern_meta' => 'is_web',
+						'is_fse'       => $this->is_site_editor_enabled,
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->get_block_patterns_locale()
 				)

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -22,13 +22,6 @@ class Block_Patterns_From_API {
 	private static $instance = null;
 
 	/**
-	 * Cache key for patterns array.
-	 *
-	 * @var string
-	 */
-	private $patterns_cache_key;
-
-	/**
 	 * Valid source strings for retrieving patterns.
 	 *
 	 * @var array
@@ -38,22 +31,11 @@ class Block_Patterns_From_API {
 	/**
 	 * Block_Patterns constructor.
 	 *
-	 * @param string $patterns_source A string matching a valid source for retrieving patterns.
+	 * @param array $pattern_sources A array of strings, each of which matches a valid source for retrieving patterns.
 	 */
-	private function __construct( $patterns_source ) {
+	private function __construct( $patterns_sources ) {
 		// Tells the backend which patterns source site to default to.
-		$this->patterns_source = in_array( $patterns_source, $this->valid_patterns_sources, true ) ? $patterns_source : 'block_patterns';
-
-		$this->patterns_cache_key = sha1(
-			implode(
-				'_',
-				array(
-					$this->patterns_source,
-					A8C_ETK_PLUGIN_VERSION,
-					$this->get_block_patterns_locale(),
-				)
-			)
-		);
+		$this->patterns_sources = empty( array_diff( $patterns_sources, $this->valid_patterns_sources ) ) ? $patterns_sources : [ 'block_patterns' ];
 
 		$this->register_patterns();
 	}
@@ -61,12 +43,12 @@ class Block_Patterns_From_API {
 	/**
 	 * Creates instance.
 	 *
-	 * @param string $patterns_source A string matching a valid source for retrieving patterns.
+	 * @param  array $pattern_sources    A array of strings, each of which matches a valid source for retrieving patterns.
 	 * @return \A8C\FSE\Block_Patterns
 	 */
-	public static function get_instance( $patterns_source ) {
+	public static function get_instance( $patterns_sources ) {
 		if ( null === self::$instance ) {
-			self::$instance = new self( $patterns_source );
+			self::$instance = new self( $patterns_sources );
 		}
 
 		return self::$instance;
@@ -85,75 +67,90 @@ class Block_Patterns_From_API {
 			}
 		}
 
-		$pattern_categories = array();
-		$block_patterns     = $this->get_patterns();
-
-		foreach ( (array) $block_patterns as $pattern ) {
-			foreach ( (array) $pattern['categories'] as $slug => $category ) {
-				$pattern_categories[ $slug ] = array( 'label' => $category['title'] );
-			}
-		}
-
-		// Unregister existing categories so that we can insert them in the desired order (alphabetically).
-		$existing_categories = array();
-		foreach ( \WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered() as $existing_category ) {
-			$existing_categories[ $existing_category['name'] ] = $existing_category;
-			unregister_block_pattern_category( $existing_category['name'] );
-		}
-
-		$pattern_categories = array_merge( $pattern_categories, $existing_categories );
-
-		// Order categories alphabetically by their label.
-		uasort(
-			$pattern_categories,
-			function ( $a, $b ) {
-				return strnatcasecmp( $a['label'], $b['label'] );
-			}
-		);
-
-		// Move the Featured category to be the first category.
-		if ( isset( $pattern_categories['featured'] ) ) {
-			$featured_category  = $pattern_categories['featured'];
-			$pattern_categories = array( 'featured' => $featured_category ) + $pattern_categories;
-		}
-
-		// Register categories (and re-register existing categories).
-		foreach ( (array) $pattern_categories as $slug => $category_properties ) {
-			register_block_pattern_category( $slug, $category_properties );
-		}
-
-		foreach ( (array) $block_patterns as $pattern ) {
-			if ( $this->can_register_pattern( $pattern ) ) {
-				$is_premium = isset( $pattern['pattern_meta']['is_premium'] ) ? boolval( $pattern['pattern_meta']['is_premium'] ) : false;
-
-				// Set custom viewport width for the pattern preview with a
-				// default width of 1280 and ensure a safe minimum width of 320.
-				$viewport_width = isset( $pattern['pattern_meta']['viewport_width'] ) ? intval( $pattern['pattern_meta']['viewport_width'] ) : 1280;
-				$viewport_width = $viewport_width < 320 ? 320 : $viewport_width;
-
-				register_block_pattern(
-					self::PATTERN_NAMESPACE . $pattern['name'],
+		// For every pattern source site, fetch the patterns
+		foreach( $this->patterns_sources as $patterns_source ) {
+			$patterns_cache_key = sha1(
+				implode(
+					'_',
 					array(
-						'title'         => $pattern['title'],
-						'description'   => $pattern['description'],
-						'content'       => $pattern['html'],
-						'viewportWidth' => $viewport_width,
-						'categories'    => array_keys(
-							$pattern['categories']
-						),
-						'isPremium'     => $is_premium,
+						$patterns_source,
+						A8C_ETK_PLUGIN_VERSION,
+						$this->get_block_patterns_locale(),
 					)
-				);
+				)
+			);
+
+			$pattern_categories = array();
+			$block_patterns     = $this->get_patterns( $patterns_cache_key, $patterns_source );
+
+			foreach ( (array) $block_patterns as $pattern ) {
+				foreach ( (array) $pattern['categories'] as $slug => $category ) {
+					$pattern_categories[ $slug ] = array( 'label' => $category['title'] );
+				}
+			}
+
+			// Unregister existing categories so that we can insert them in the desired order (alphabetically).
+			$existing_categories = array();
+			foreach ( \WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered() as $existing_category ) {
+				$existing_categories[ $existing_category['name'] ] = $existing_category;
+				unregister_block_pattern_category( $existing_category['name'] );
+			}
+
+			$pattern_categories = array_merge( $pattern_categories, $existing_categories );
+
+			// Order categories alphabetically by their label.
+			uasort(
+				$pattern_categories,
+				function ( $a, $b ) {
+					return strnatcasecmp( $a['label'], $b['label'] );
+				}
+			);
+
+			// Move the Featured category to be the first category.
+			if ( isset( $pattern_categories['featured'] ) ) {
+				$featured_category  = $pattern_categories['featured'];
+				$pattern_categories = array( 'featured' => $featured_category ) + $pattern_categories;
+			}
+
+			// Register categories (and re-register existing categories).
+			foreach ( (array) $pattern_categories as $slug => $category_properties ) {
+				register_block_pattern_category( $slug, $category_properties );
+			}
+
+			foreach ( (array) $block_patterns as $pattern ) {
+				if ( $this->can_register_pattern( $pattern ) ) {
+					$is_premium = isset( $pattern['pattern_meta']['is_premium'] ) ? boolval( $pattern['pattern_meta']['is_premium'] ) : false;
+
+					// Set custom viewport width for the pattern preview with a
+					// default width of 1280 and ensure a safe minimum width of 320.
+					$viewport_width = isset( $pattern['pattern_meta']['viewport_width'] ) ? intval( $pattern['pattern_meta']['viewport_width'] ) : 1280;
+					$viewport_width = $viewport_width < 320 ? 320 : $viewport_width;
+
+					register_block_pattern(
+						self::PATTERN_NAMESPACE . $pattern['name'],
+						array(
+							'title'         => $pattern['title'],
+							'description'   => $pattern['description'],
+							'content'       => $pattern['html'],
+							'viewportWidth' => $viewport_width,
+							'categories'    => array_keys(
+								$pattern['categories']
+							),
+							'isPremium'     => $is_premium,
+						)
+					);
+				}
 			}
 		}
 	}
 
 	/**
 	 * Returns a list of patterns.
-	 *
-	 * @return array
+	 * @param  string $patterns_cache_key Key to store responses to and fetch responses from cache.
+	 * @param  string $patterns_source    Slug for valid patterns source site, e.g., `block_patterns`
+	 * @return array                      The list of translated patterns.
 	 */
-	private function get_patterns() {
+	private function get_patterns( $patterns_cache_key, $patterns_source ) {
 		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
 		if ( $override_source_site ) {
 			// Skip caching and request all patterns from a specified source site.
@@ -185,7 +182,7 @@ class Block_Patterns_From_API {
 			return json_decode( wp_remote_retrieve_body( $response ), true );
 		}
 
-		$block_patterns = wp_cache_get( $this->patterns_cache_key, 'ptk_patterns' );
+		$block_patterns = wp_cache_get( $patterns_cache_key, 'ptk_patterns' );
 
 		// Load fresh data if we don't have any patterns.
 		if ( false === $block_patterns || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE ) ) {
@@ -194,7 +191,7 @@ class Block_Patterns_From_API {
 					array(
 						'tags'            => 'pattern',
 						'pattern_meta'    => 'is_web',
-						'patterns_source' => $this->patterns_source,
+						'patterns_source' => $patterns_source,
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->get_block_patterns_locale()
 				)
@@ -212,7 +209,7 @@ class Block_Patterns_From_API {
 				return array();
 			}
 			$block_patterns = json_decode( wp_remote_retrieve_body( $response ), true );
-			wp_cache_add( $this->patterns_cache_key, $block_patterns, 'ptk_patterns', DAY_IN_SECONDS );
+			wp_cache_add( $patterns_cache_key, $block_patterns, 'ptk_patterns', DAY_IN_SECONDS );
 		}
 
 		return $block_patterns;

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -31,11 +31,11 @@ class Block_Patterns_From_API {
 	/**
 	 * Block_Patterns constructor.
 	 *
-	 * @param array $pattern_sources A array of strings, each of which matches a valid source for retrieving patterns.
+	 * @param array $patterns_sources A array of strings, each of which matches a valid source for retrieving patterns.
 	 */
 	private function __construct( $patterns_sources ) {
 		// Tells the backend which patterns source site to default to.
-		$this->patterns_sources = empty( array_diff( $patterns_sources, $this->valid_patterns_sources ) ) ? $patterns_sources : [ 'block_patterns' ];
+		$this->patterns_sources = empty( array_diff( $patterns_sources, $this->valid_patterns_sources ) ) ? $patterns_sources : array( 'block_patterns' );
 
 		$this->register_patterns();
 	}
@@ -43,7 +43,7 @@ class Block_Patterns_From_API {
 	/**
 	 * Creates instance.
 	 *
-	 * @param  array $pattern_sources    A array of strings, each of which matches a valid source for retrieving patterns.
+	 * @param  array $patterns_sources A array of strings, each of which matches a valid source for retrieving patterns.
 	 * @return \A8C\FSE\Block_Patterns
 	 */
 	public static function get_instance( $patterns_sources ) {
@@ -67,8 +67,8 @@ class Block_Patterns_From_API {
 			}
 		}
 
-		// For every pattern source site, fetch the patterns
-		foreach( $this->patterns_sources as $patterns_source ) {
+		// For every pattern source site, fetch the patterns.
+		foreach ( $this->patterns_sources as $patterns_source ) {
 			$patterns_cache_key = sha1(
 				implode(
 					'_',
@@ -146,8 +146,9 @@ class Block_Patterns_From_API {
 
 	/**
 	 * Returns a list of patterns.
-	 * @param  string $patterns_cache_key Key to store responses to and fetch responses from cache.
-	 * @param  string $patterns_source    Slug for valid patterns source site, e.g., `block_patterns`
+	 *
+	 * @param string $patterns_cache_key Key to store responses to and fetch responses from cache.
+	 * @param string $patterns_source    Slug for valid patterns source site, e.g., `block_patterns`.
 	 * @return array                      The list of translated patterns.
 	 */
 	private function get_patterns( $patterns_cache_key, $patterns_source ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -34,6 +34,8 @@ class Block_Patterns_From_API {
 	 * @param array $patterns_sources A array of strings, each of which matches a valid source for retrieving patterns.
 	 */
 	private function __construct( $patterns_sources ) {
+		$patterns_sources = empty( $patterns_sources ) ? array( 'block_patterns' ) : $patterns_sources;
+
 		// Tells the backend which patterns source site to default to.
 		$this->patterns_sources = empty( array_diff( $patterns_sources, $this->valid_patterns_sources ) ) ? $patterns_sources : array( 'block_patterns' );
 
@@ -46,7 +48,7 @@ class Block_Patterns_From_API {
 	 * @param  array $patterns_sources A array of strings, each of which matches a valid source for retrieving patterns.
 	 * @return \A8C\FSE\Block_Patterns
 	 */
-	public static function get_instance( $patterns_sources ) {
+	public static function get_instance( $patterns_sources = array() ) {
 		if ( null === self::$instance ) {
 			self::$instance = new self( $patterns_sources );
 		}

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -255,9 +255,10 @@ function load_block_patterns_from_api( $current_screen ) {
 		return;
 	}
 
-	$pattern_sources = [ 'block_patterns' ];
+	$pattern_sources = array( 'block_patterns' );
 
-	if ( $is_site_editor ) {
+	// While we're still testing the FSE patterns, limit activation via a filter.
+	if ( $is_site_editor && apply_filters( 'a8c_enable_fse_block_patterns_api', false ) ) {
 		$pattern_sources[] = 'fse_block_patterns';
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -255,10 +255,14 @@ function load_block_patterns_from_api( $current_screen ) {
 		return;
 	}
 
-	$pattern_source = $is_site_editor ? 'fse_block_patterns' : 'block_patterns';
+	$pattern_sources = [ 'block_patterns' ];
+
+	if ( $is_site_editor ) {
+		$pattern_sources[] = 'fse_block_patterns';
+	}
 
 	require_once __DIR__ . '/block-patterns/class-block-patterns-from-api.php';
-	Block_Patterns_From_API::get_instance( $pattern_source );
+	Block_Patterns_From_API::get_instance( $pattern_sources );
 }
 add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -249,12 +249,16 @@ function load_block_patterns_from_api( $current_screen ) {
 		return;
 	}
 
-	if ( ! $current_screen->is_block_editor ) {
+	$is_site_editor = ( function_exists( 'gutenberg_is_edit_site_page' ) && gutenberg_is_edit_site_page( $current_screen->id ) );
+
+	if ( ! $current_screen->is_block_editor && ! $is_site_editor ) {
 		return;
 	}
 
+	$pattern_source = $is_site_editor ? 'fse_block_patterns' : 'block_patterns';
+
 	require_once __DIR__ . '/block-patterns/class-block-patterns-from-api.php';
-	Block_Patterns_From_API::get_instance();
+	Block_Patterns_From_API::get_instance( $pattern_source );
 }
 add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -255,15 +255,15 @@ function load_block_patterns_from_api( $current_screen ) {
 		return;
 	}
 
-	$pattern_sources = array( 'block_patterns' );
+	$patterns_sources = array( 'block_patterns' );
 
 	// While we're still testing the FSE patterns, limit activation via a filter.
 	if ( $is_site_editor && apply_filters( 'a8c_enable_fse_block_patterns_api', false ) ) {
-		$pattern_sources[] = 'fse_block_patterns';
+		$patterns_sources[] = 'fse_block_patterns';
 	}
 
 	require_once __DIR__ . '/block-patterns/class-block-patterns-from-api.php';
-	Block_Patterns_From_API::get_instance( $pattern_sources );
+	Block_Patterns_From_API::get_instance( $patterns_sources );
 }
 add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -249,21 +249,12 @@ function load_block_patterns_from_api( $current_screen ) {
 		return;
 	}
 
-	$is_site_editor = ( function_exists( 'gutenberg_is_edit_site_page' ) && gutenberg_is_edit_site_page( $current_screen->id ) );
-
-	if ( ! $current_screen->is_block_editor && ! $is_site_editor ) {
+	if ( ! $current_screen->is_block_editor ) {
 		return;
 	}
 
-	$patterns_sources = array( 'block_patterns' );
-
-	// While we're still testing the FSE patterns, limit activation via a filter.
-	if ( $is_site_editor && apply_filters( 'a8c_enable_fse_block_patterns_api', false ) ) {
-		$patterns_sources[] = 'fse_block_patterns';
-	}
-
 	require_once __DIR__ . '/block-patterns/class-block-patterns-from-api.php';
-	Block_Patterns_From_API::get_instance( $patterns_sources );
+	Block_Patterns_From_API::get_instance();
 }
 add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR has been split in two to prevent deploy fatals. #50694 (this one) adds the code to handle multiple pattern sources.

https://github.com/Automattic/wp-calypso/pull/51434 passes the pattern sources to Block_Patterns_From_API

So! This PR:

- adds a `patterns_source` query parameter to the API fields so that we can tell the API to return a specific canonical source site. The primary use case is to give us the choice of switching default source sites to return patterns.
- updates the `current_screen` check before registering patterns to also include a check for the site editor (this enables registering patterns for the new site editor)
- adds a further filter check to ensure we only enable the FSE patterns for specific sites. See D59351-code

<img width="700" alt="Screen Shot 2021-03-26 at 12 54 43 pm" src="https://user-images.githubusercontent.com/6458278/112566089-722d1c00-8e32-11eb-9db3-2d16b649aeb5.png">

#### Testing instructions


1. Create a FSE site (e.g. https://horizon.wordpress.com/new?flags=gutenboarding/site-editor)
2. Apply D59351-code and Sandbox your new FSE site.
3. Apply this ETK patch `install-plugin.sh etk update/editing-toolkit-block-patterns-api-with-fse-flag` If the script doesn't apply the [latest commit](https://github.com/Automattic/wp-calypso/pull/50694/commits) try running locally and `yarn dev --sync` from the `apps/editing-toolkit` folder. Also apply the activation code from https://github.com/Automattic/wp-calypso/pull/51434 `install-plugin.sh etk add/fse-block-patterns-to-inserter` 
4. Head over to edit any post or page and then open the patterns inserter.
5. Check that, when editing a post or page, you see the full list of patterns that we usually expect
6. When editing in the site editor (`/site-editor`) you should see the theme's patterns and patterns registered from the FSE source site **as well as** the full complement of patterns. Select the "Headers" category to see the WPCOM FSE patterns.
7. Pause to consider our place in this vast universe.

Related to 223-gh-Automattic/view-design