### PR TITLE
Show standard dialog when cancelling Titan email on Atomic sites

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -328,7 +328,7 @@ class RemovePurchase extends Component {
 			return this.renderDomainDialog();
 		}
 
-		if ( isDomainMapping( purchase ) || isDomainTransfer( purchase ) ) {
+		if ( isDomainMapping( purchase ) || isDomainTransfer( purchase ) || isTitanMail( purchase ) ) {
 			return this.renderPlanDialog();
 		}
 
@@ -343,7 +343,7 @@ class RemovePurchase extends Component {
 			);
 		}
 
-		if ( this.props.isAtomicSite && ! isJetpackSearch( purchase ) && ! isTitanMail( purchase ) ) {
+		if ( this.props.isAtomicSite && ! isJetpackSearch( purchase ) ) {
 			return this.renderAtomicDialog( purchase );
 		}
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -29,6 +29,7 @@ import {
 	isJetpackProduct,
 	isPlan,
 	isJetpackSearch,
+	isTitanMail,
 } from 'calypso/lib/products-values';
 import { purchasesRoot } from '../paths';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -342,7 +343,7 @@ class RemovePurchase extends Component {
 			);
 		}
 
-		if ( this.props.isAtomicSite && ! isJetpackSearch( purchase ) ) {
+		if ( this.props.isAtomicSite && ! isJetpackSearch( purchase ) && ! isTitanMail( purchase ) ) {
 			return this.renderAtomicDialog( purchase );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change ensures that we allow cancellation of Email/Titan Mail subscriptions on Atomic sites -- without this fix, we showed an Atomic-related dialog that doesn't allow the user to cancel the subscription.

#### Testing instructions

* Ensure that you have an Atomic site with a domain and an Email subscription.
* Verify that you can go to Upgrades > Purchases for the site (or /me/purchases) and can cancel the subscription