### PR TITLE
Show all cart errors that occur in Titan quantity selection page

### DIFF
--- a/client/my-sites/email/titan-mail-quantity-selection/index.jsx
+++ b/client/my-sites/email/titan-mail-quantity-selection/index.jsx
@@ -120,12 +120,7 @@ class TitanMailQuantitySelection extends React.Component {
 			] )
 			.then( () => {
 				const { errors } = this.props?.cart?.messages;
-				const errorCodesToDisplayLocally = [ 'invalid-quantity', 'missing_quantity_data' ];
-				if (
-					errors &&
-					errors.length &&
-					errors.filter( ( error ) => errorCodesToDisplayLocally.includes( error.code ) ).length
-				) {
+				if ( errors && errors.length ) {
 					// Stay on the page to show the relevant error
 					return;
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR simplifies the existing logic in the Titan quantity selection page to show _any error_ that occurs while adding Titan to the shopping cart.

#### Testing instructions

It's simplest to test this alongside D57965-code, which introduces a new error code for the Titan product, but you can also simulate this by returning an error from a modified version of the shopping cart endpoint on a sandbox.

* Try to add Email for a domain that should return an error from the shopping cart end point, and verify that the error is displayed on the quantity selection page.