### PR TITLE
Ensure that `errorNotice` is correctly wired into outbound Titan redirect component

### DIFF
--- a/client/my-sites/email/email-management/titan-control-panel-redirect/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-redirect/index.jsx
@@ -37,6 +37,10 @@ class TitanControlPanelRedirect extends React.Component {
 		// Connected props derived from the props above
 		domain: PropTypes.object,
 		siteId: PropTypes.number,
+
+		// Other props added via connect
+		errorNotice: PropTypes.function,
+		translate: PropTypes.function,
 	};
 
 	componentDidMount() {

--- a/client/my-sites/email/email-management/titan-control-panel-redirect/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-redirect/index.jsx
@@ -11,6 +11,7 @@ import React from 'react';
  */
 import { Card } from '@automattic/components';
 import EmptyContent from 'calypso/components/empty-content';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { fetchTitanAutoLoginURL } from 'calypso/my-sites/email/email-management/titan-functions';
 import { getTitanMailOrderId, hasTitanMailWithUs } from 'calypso/lib/titan';
 import { getSelectedDomain } from 'calypso/lib/domains';
@@ -95,15 +96,20 @@ class TitanControlPanelRedirect extends React.Component {
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	const site = getSiteBySlug( state, ownProps.siteSlug );
-	const siteId = site?.ID;
-	return {
-		domain: getSelectedDomain( {
-			domains: getDomainsBySiteId( state, siteId ),
-			selectedDomainName: ownProps.domainName,
-			isSiteRedirect: false,
-		} ),
-		siteId,
-	};
-} )( localize( TitanControlPanelRedirect ) );
+export default connect(
+	( state, ownProps ) => {
+		const site = getSiteBySlug( state, ownProps.siteSlug );
+		const siteId = site?.ID;
+		return {
+			domain: getSelectedDomain( {
+				domains: getDomainsBySiteId( state, siteId ),
+				selectedDomainName: ownProps.domainName,
+				isSiteRedirect: false,
+			} ),
+			siteId,
+		};
+	},
+	{
+		errorNotice,
+	}
+)( localize( TitanControlPanelRedirect ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change ensures that `errorNotice` is wired into `TitanControlPanelRedirect` so it can actually display errors to users.

#### Testing instructions

To test this, you need to be able to load this page in a way that returns an error from the auto-login link API. Some options for triggering that are:
 * Run against a sandboxed back end that you set up to return an error
 * Set up an admin user on a site with a domain and Email configured, where the user doesn't own the domain or the Email subscription, and then follow the link to the Titan Control Panel

For both cases, make sure that the iframed version of the control panel is not in use by adding `?flags=-titan/iframe-control-panel` to the URL.

* Navigate to `/email/[domain]/titan/control-panel/[siteSlug]
* Verify that you see the error message returned from the server in an error notice.