### PR TITLE
Refactor logic that turns Nav Unification on

### DIFF
--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -10,7 +10,7 @@
  * IMPORTANT: When adding to this file please also add the source file in a comment.
  */
 
-.theme-default .is-nav-unification { // excludes theme-jetpack-cloud.
+.theme-default.is-nav-unification { // excludes theme-jetpack-cloud.
 	// breakpoint used in wp-admin
 	@media only screen and ( min-width: 782px ) {
 		// client/assets/stylesheets/shared/_variables.scss
@@ -175,7 +175,7 @@
 
 // Ensure sidebar is visually separate from the content in the Contrast color scheme
 // client/layout/style.scss
-.theme-default.is-contrast .is-nav-unification {
+.theme-default.is-contrast.is-nav-unification {
 	.layout__secondary {
 		outline: 1px solid var( --color-sidebar-border );
 	}

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -128,7 +128,7 @@
 	// breakpoint used in wp-admin
 	@media only screen and ( max-width: 782px ) {
 		// client/layout/style.scss
-		&.layout.focus-content .layout__secondary {
+		.layout.focus-content .layout__secondary {
 			transform: translateX( -100% );
 			padding: 71px 24px 24px;
 		}

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -20,6 +20,8 @@ import { getSite, getSiteSlug, isSitePreviewable } from 'calypso/state/sites/sel
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import isAtomicAndEditingToolkitPluginDeactivated from 'calypso/state/selectors/is-atomic-and-editing-toolkit-plugin-deactivated';
+import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
+
 /**
  * Style dependencies
  */
@@ -159,7 +161,7 @@ class Site extends React.Component {
 						<div className="site__title">{ site.title }</div>
 						<div className="site__domain">
 							{ /* eslint-disable-next-line no-nested-ternary */ }
-							{ isEnabled( 'nav-unification' ) && ! isEnabled( 'jetpack-cloud' )
+							{ this.props.isNavUnificationEnabled && ! isEnabled( 'jetpack-cloud' )
 								? site.domain
 								: this.props.homeLink
 								? translate( 'View %(domain)s', {
@@ -216,6 +218,7 @@ function mapStateToProps( state, ownProps ) {
 			state,
 			siteId
 		),
+		isNavUnificationEnabled: isNavUnificationEnabled( state ),
 	};
 }
 

--- a/client/components/mobile-back-to-sidebar/index.jsx
+++ b/client/components/mobile-back-to-sidebar/index.jsx
@@ -9,16 +9,20 @@ import Gridicon from 'calypso/components/gridicon';
 /**
  * Internal Dependencies
  */
-import config from '@automattic/calypso-config';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-function MobileBackToSidebar( { children, toggleSidebar } ) {
-	if ( config.isEnabled( 'nav-unification' ) ) {
+function MobileBackToSidebar( {
+	children,
+	toggleSidebar,
+	isNavUnificationEnabled: isUnifiedNavEnabled,
+} ) {
+	if ( isUnifiedNavEnabled ) {
 		return null;
 	}
 
@@ -30,6 +34,9 @@ function MobileBackToSidebar( { children, toggleSidebar } ) {
 	);
 }
 
-export default connect( null, { toggleSidebar: () => setLayoutFocus( 'sidebar' ) } )(
-	MobileBackToSidebar
-);
+export default connect(
+	( state ) => ( {
+		isNavUnificationEnabled: isNavUnificationEnabled( state ),
+	} ),
+	{ toggleSidebar: () => setLayoutFocus( 'sidebar' ) }
+)( MobileBackToSidebar );

--- a/client/components/sidebar-navigation/index.jsx
+++ b/client/components/sidebar-navigation/index.jsx
@@ -13,14 +13,20 @@ import Gridicon from 'calypso/components/gridicon';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import config from '@automattic/calypso-config';
+import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-function SidebarNavigation( { sectionTitle, children, toggleSidebar } ) {
-	if ( config.isEnabled( 'nav-unification' ) && ! config.isEnabled( 'jetpack-cloud' ) ) {
+function SidebarNavigation( {
+	sectionTitle,
+	children,
+	toggleSidebar,
+	isNavUnificationEnabled: isUnifiedNavEnabled,
+} ) {
+	if ( isUnifiedNavEnabled && ! config.isEnabled( 'jetpack-cloud' ) ) {
 		return null;
 	}
 
@@ -42,6 +48,11 @@ SidebarNavigation.propTypes = {
 	toggleSidebar: PropTypes.func.isRequired,
 };
 
-export default connect( null, {
-	toggleSidebar: () => setLayoutFocus( 'sidebar' ),
-} )( SidebarNavigation );
+export default connect(
+	( state ) => ( {
+		isNavUnificationEnabled: isNavUnificationEnabled( state ),
+	} ),
+	{
+		toggleSidebar: () => setLayoutFocus( 'sidebar' ),
+	}
+)( SidebarNavigation );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -45,9 +45,9 @@ import { withCurrentRoute } from 'calypso/components/route';
 import QueryExperiments from 'calypso/components/data/query-experiments';
 import Experiment from 'calypso/components/experiment';
 import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
-import { getReaderTeams } from 'calypso/state/teams/selectors';
-import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
+import { getShouldShowAppBanner, handleScroll } from './utils';
+import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 
 /**
  * Style dependencies
@@ -55,7 +55,6 @@ import { isWpMobileApp } from 'calypso/lib/mobile-app';
 // goofy import for environment badge, which is SSR'd
 import 'calypso/components/environment-badge/style.scss';
 import './style.scss';
-import { getShouldShowAppBanner, handleScroll } from './utils';
 
 const scrollCallback = ( e ) => handleScroll( e );
 
@@ -74,11 +73,6 @@ class Layout extends Component {
 		shouldShowAppBanner: PropTypes.bool,
 	};
 
-	UNSAFE_componentWillMount() {
-		// This is temporary helper function until we have rolled out to 100% of customers.
-		this.isNavUnificationEnabled();
-	}
-
 	componentDidMount() {
 		if ( ! config.isEnabled( 'me/account/color-scheme-picker' ) ) {
 			return;
@@ -93,7 +87,7 @@ class Layout extends Component {
 	}
 
 	componentWillUnmount() {
-		if ( config.isEnabled( 'nav-unification' ) ) {
+		if ( this.props.isNavUnificationEnabled ) {
 			window.removeEventListener( 'scroll', scrollCallback );
 			window.removeEventListener( 'resize', scrollCallback );
 		}
@@ -101,13 +95,9 @@ class Layout extends Component {
 
 	componentDidUpdate( prevProps ) {
 		// This code should be removed when the nav-unification project has been rolled out to 100% of the customers.
-		if ( config.isEnabled( 'nav-unification' ) ) {
+		if ( this.props.isNavUnificationEnabled ) {
 			window.addEventListener( 'scroll', scrollCallback );
 			window.addEventListener( 'resize', scrollCallback );
-		}
-		if ( prevProps.teams !== this.props.teams ) {
-			// This is temporary helper function until we have rolled out to 100% of customers.
-			this.isNavUnificationEnabled();
 		}
 		if ( ! config.isEnabled( 'me/account/color-scheme-picker' ) ) {
 			return;
@@ -162,28 +152,6 @@ class Layout extends Component {
 		);
 	}
 
-	// This is temporary helper function until we have rolled out to 100% of customers.
-	isNavUnificationEnabled() {
-		if ( ! this.props.teams.length ) {
-			return;
-		}
-
-		// Having the feature enabled by default in all environments, will let anyone use ?disable-nav-unification to temporary disable it.
-		// We still have the feature disabled in production as safety mechanism for all customers.
-		if ( new URL( document.location ).searchParams.has( 'disable-nav-unification' ) ) {
-			return;
-		}
-
-		// Leave the feature enabled for all a12s.
-		if ( isAutomatticTeamMember( this.props.teams ) ) {
-			// Force enable even in Production.
-			return config.enable( 'nav-unification' );
-		}
-
-		// Disable the feature for all customers and non a12s accounts.
-		return config.disable( 'nav-unification' );
-	}
-
 	render() {
 		const sectionClass = classnames( 'layout', `focus-${ this.props.currentLayoutFocus }`, {
 			[ 'is-group-' + this.props.sectionGroup ]: this.props.sectionGroup,
@@ -202,15 +170,16 @@ class Layout extends Component {
 				config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
 				isWooOAuth2Client( this.props.oauth2Client ) &&
 				this.props.wccomFrom,
-			'is-nav-unification': config.isEnabled( 'nav-unification' ),
 		} );
 
 		const optionalBodyProps = () => {
-			const optionalProps = {};
-
-			if ( this.props.isNewLaunchFlow || this.props.isCheckoutFromGutenboarding ) {
-				optionalProps.bodyClass = 'is-new-launch-flow';
-			}
+			const optionalProps = {
+				bodyClass: classnames( {
+					'is-new-launch-flow':
+						this.props.isNewLaunchFlow || this.props.isCheckoutFromGutenboarding,
+					'is-nav-unification': this.props.isNavUnificationEnabled,
+				} ),
+			};
 
 			return optionalProps;
 		};
@@ -368,7 +337,7 @@ export default compose(
 			shouldQueryAllSites: currentRoute && currentRoute !== '/jetpack/connect/authorize',
 			isNewLaunchFlow,
 			isCheckoutFromGutenboarding,
-			teams: getReaderTeams( state ),
+			isNavUnificationEnabled: isNavUnificationEnabled( state ),
 		};
 	} )
 )( Layout );

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -39,6 +39,7 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { hasUnseen } from 'calypso/state/reader-ui/seen-posts/selectors';
 import getPreviousPath from 'calypso/state/selectors/get-previous-path.js';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 
 class MasterbarLoggedIn extends React.Component {
 	static propTypes = {
@@ -54,7 +55,7 @@ class MasterbarLoggedIn extends React.Component {
 	};
 
 	handleLayoutFocus = ( currentSection ) => {
-		if ( ! config.isEnabled( 'nav-unification' ) ) {
+		if ( ! this.props.isNavUnificationEnabled ) {
 			this.props.setNextLayoutFocus( 'sidebar' );
 		} else if ( currentSection !== this.props.section ) {
 			// When current section is not focused then open the sidebar.
@@ -164,7 +165,7 @@ class MasterbarLoggedIn extends React.Component {
 			: getStatsPathForTab( 'day', siteSlug );
 
 		let mySitesUrl = domainOnlySite ? domainManagementList( siteSlug ) : homeUrl;
-		if ( config.isEnabled( 'nav-unification' ) && 'sites' === section ) {
+		if ( this.props.isNavUnificationEnabled && 'sites' === section ) {
 			mySitesUrl = '';
 		}
 		return (
@@ -296,6 +297,7 @@ export default connect(
 			previousPath: getPreviousPath( state ),
 			isJetpackNotAtomic: isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ),
 			currentLayoutFocus: getCurrentLayoutFocus( state ),
+			isNavUnificationEnabled: isNavUnificationEnabled( state ),
 		};
 	},
 	{ setNextLayoutFocus, recordTracksEvent, updateSiteMigrationMeta }

--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -4,6 +4,7 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useState, useRef, useLayoutEffect } from 'react';
+import { useSelector } from 'react-redux';
 import { get, uniqueId } from 'lodash';
 
 /**
@@ -14,7 +15,7 @@ import ExpandableSidebarHeading from './expandable-heading';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
 import { hasTouch } from 'calypso/lib/touch-detect';
 import HoverIntent from 'calypso/lib/hover-intent';
-import config from '@automattic/calypso-config';
+import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 
 const isTouch = hasTouch();
 
@@ -62,6 +63,7 @@ export const ExpandableSidebarMenu = ( {
 	const menu = React.createRef(); // Needed for HoverIntent.
 	const submenu = useRef();
 	const [ submenuHovered, setSubmenuHovered ] = useState( false );
+	const isUnifiedMenuEnabled = useSelector( isNavUnificationEnabled );
 
 	if ( submenu.current ) {
 		// Sets flyout to expand towards bottom.
@@ -80,7 +82,7 @@ export const ExpandableSidebarMenu = ( {
 	} );
 
 	const onEnter = () => {
-		if ( disableFlyout || expanded || isTouch || ! config.isEnabled( 'nav-unification' ) ) {
+		if ( disableFlyout || expanded || isTouch || ! isUnifiedMenuEnabled ) {
 			return;
 		}
 
@@ -89,7 +91,7 @@ export const ExpandableSidebarMenu = ( {
 
 	const onLeave = () => {
 		// Remove "hovered" state even if menu is expanded.
-		if ( isTouch || ! config.isEnabled( 'nav-unification' ) ) {
+		if ( isTouch || ! isUnifiedMenuEnabled ) {
 			return;
 		}
 

--- a/client/lib/features-helper/feature-list.js
+++ b/client/lib/features-helper/feature-list.js
@@ -15,7 +15,7 @@ const enabledClass = 'features-helper__feature-item-enabled';
 const disabledClass = 'features-helper__feature-item-disabled';
 
 export const FeatureList = React.memo( () => {
-	const currentXLProjects = [ 'nav-unification' ];
+	const currentXLProjects = [];
 	const enabledFeatures = config.enabledFeatures();
 	return (
 		<>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -71,6 +71,7 @@ import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import getUnsavedUserSettings from 'calypso/state/selectors/get-unsaved-user-settings';
 import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 
 export const noticeId = 'me-settings-notice';
 const noticeOptions = {
@@ -1054,7 +1055,7 @@ class Account extends React.Component {
 
 						{ this.props.canDisplayCommunityTranslator && this.communityTranslator() }
 
-						{ config.isEnabled( 'nav-unification' ) && (
+						{ this.props.isNavUnificationEnabled && (
 							<FormFieldset className="account__link-destination">
 								<FormLabel id="account__link_destination" htmlFor="link_destination">
 									{ translate( 'Dashboard appearance' ) }
@@ -1118,6 +1119,7 @@ export default compose(
 			unsavedUserSettings: getUnsavedUserSettings( state ),
 			visibleSiteCount: getCurrentUserVisibleSiteCount( state ),
 			onboardingUrl: getOnboardingUrl( state ),
+			isNavUnificationEnabled: isNavUnificationEnabled( state ),
 		} ),
 		{
 			bumpStat,

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -23,6 +23,7 @@ import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { hasAllSitesList } from 'calypso/state/sites/selectors';
 import { expandSidebar } from 'calypso/state/ui/actions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 
 /**
  * Style dependencies
@@ -39,10 +40,11 @@ class CurrentSite extends Component {
 		forceAllSitesView: PropTypes.bool,
 		sidebarIsCollapsed: PropTypes.bool,
 		expandSidebar: PropTypes.func.isRequired,
+		isNavUnificationEnabled: PropTypes.bool.isRequired,
 	};
 
 	switchSites = ( event ) => {
-		if ( isEnabled( 'nav-unification' ) && this.props.sidebarIsCollapsed ) {
+		if ( this.props.isNavUnificationEnabled && this.props.sidebarIsCollapsed ) {
 			this.props.expandSidebar();
 		}
 		event.preventDefault();
@@ -78,7 +80,7 @@ class CurrentSite extends Component {
 					tabIndex="0"
 					aria-hidden="true"
 					onClick={ () => {
-						return isEnabled( 'nav-unification' ) && this.props.sidebarIsCollapsed
+						return this.props.isNavUnificationEnabled && this.props.sidebarIsCollapsed
 							? this.props.expandSidebar()
 							: null;
 					} }
@@ -86,7 +88,7 @@ class CurrentSite extends Component {
 					{ this.props.siteCount > 1 && (
 						<span className="current-site__switch-sites">
 							<Button borderless onClick={ this.switchSites }>
-								{ isEnabled( 'nav-unification' ) ? (
+								{ this.props.isNavUnificationEnabled ? (
 									// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 									<span className="gridicon dashicons-before dashicons-arrow-left-alt2"></span>
 								) : (
@@ -140,6 +142,7 @@ export default connect(
 		siteCount: getCurrentUserSiteCount( state ),
 		hasAllSitesList: hasAllSitesList( state ),
 		sidebarIsCollapsed: getSidebarIsCollapsed( state ),
+		isNavUnificationEnabled: isNavUnificationEnabled( state ),
 	} ),
 	{
 		recordGoogleEvent,

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -3,6 +3,7 @@
  */
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -10,6 +11,7 @@ import React from 'react';
 import config from '@automattic/calypso-config';
 import SitePicker from 'calypso/my-sites/picker';
 import AsyncLoad from 'calypso/components/async-load';
+import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 
 class MySitesNavigation extends React.Component {
 	static displayName = 'MySitesNavigation';
@@ -29,7 +31,7 @@ class MySitesNavigation extends React.Component {
 		let asyncSidebar = null;
 		if ( config.isEnabled( 'jetpack-cloud' ) ) {
 			asyncSidebar = <AsyncLoad require="calypso/components/jetpack/sidebar" { ...asyncProps } />;
-		} else if ( config.isEnabled( 'nav-unification' ) ) {
+		} else if ( this.props.isNavUnificationEnabled ) {
 			asyncSidebar = <AsyncLoad require="calypso/my-sites/sidebar-unified" { ...asyncProps } />;
 		} else {
 			asyncSidebar = <AsyncLoad require="calypso/my-sites/sidebar" { ...asyncProps } />;
@@ -48,4 +50,6 @@ class MySitesNavigation extends React.Component {
 	}
 }
 
-export default MySitesNavigation;
+export default connect( ( state ) => ( {
+	isNavUnificationEnabled: isNavUnificationEnabled( state ),
+} ) )( MySitesNavigation );

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -27,7 +27,7 @@
 	--color-sidebar-submenu-selected-background: transparent;
 	--color-sidebar-submenu-selected-text: white;
 
-	.is-sidebar-collapsed:not( .is-section-reader ):not( .is-section-me ) & {
+	&.is-sidebar-collapsed:not( .is-section-reader ):not( .is-section-me ) {
 		--sidebar-width-max: 36px;
 		--sidebar-width-min: 36px;
 	}
@@ -99,14 +99,14 @@ $font-size: rem( 14px );
 		}
 
 		// Apply hover and focus effects only to tabbable items assuming they are links.
-		.sidebar__heading:not([tabindex="-1"]),
+		.sidebar__heading:not( [tabindex='-1'] ),
 		.sidebar__menu-link {
 			&:hover,
 			&:focus {
 				background-color: var( --color-sidebar-menu-hover-background );
 				color: var( --color-sidebar-menu-hover-text );
 				box-shadow: inset 4px 0 0 0 currentColor;
- 				transition: box-shadow .1s linear;
+ 				transition: box-shadow 0.1s linear;
 			}
 		}
 
@@ -353,7 +353,7 @@ $font-size: rem( 14px );
 		padding: 10px 0 10px 8px;
 	}
 
-	.is-sidebar-collapsed & {
+	&.is-sidebar-collapsed {
 		.dashicons-admin-collapse::before {
 			transform: rotate( 180deg );
 		}
@@ -481,7 +481,7 @@ $font-size: rem( 14px );
 
 	// Reader specific styles
 	// client/reader/sidebar/style.scss
-	.is-section-reader & {
+	&.is-section-reader {
 		.sidebar__menu .count {
 			background: transparent;
 			color: var( --color-sidebar-menu-text );
@@ -523,8 +523,8 @@ $font-size: rem( 14px );
 		// TODO: For prototype only, this prevents the sidebar from being scrollable.
 		// In wp-admin there's custom JS to a) position the sidebar based on the scroll
 		// position and b) position the flyout menu based on available screen space.
-		&.focus-content,
-		&.focus-sidebar {
+		.focus-content,
+		.focus-sidebar {
 			.sidebar,
 			.layout__secondary {
 				z-index: z-index( 'root', '.is-nav-unification .layout__secondary' );
@@ -572,7 +572,7 @@ $font-size: rem( 14px );
 @media screen and ( max-width: 782px ) {
 	// client/layout/sidebar/style.scss
 	.is-nav-unification {
-		&.focus-content .layout__content {
+		.focus-content .layout__content {
 			padding: 71px 24px 24px;
 			transition: padding 0.15s ease-in-out;
 		}
@@ -648,7 +648,7 @@ $font-size: rem( 14px );
 			min-height: initial;
 		}
 
-		&.focus-content .layout__content {
+		.focus-content .layout__content {
 			padding: 47px 0 0;
 		}
 

--- a/client/state/selectors/is-nav-unification-enabled.js
+++ b/client/state/selectors/is-nav-unification-enabled.js
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies
+ */
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+
+export default ( state ) => {
+	// Having the feature enabled by default in all environments, will let anyone use ?disable-nav-unification to temporary disable it.
+	// We still have the feature disabled in production as safety mechanism for all customers.
+	if ( new URL( document.location ).searchParams.has( 'disable-nav-unification' ) ) {
+		return false;
+	}
+
+	// Disabled for Jetpack sites.
+	const siteId = getSelectedSiteId( state );
+	if ( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) {
+		return false;
+	}
+
+	// Enable nav-unification for all a12s.
+	if ( isAutomatticTeamMember( getReaderTeams( state ) ) ) {
+		return true;
+	}
+
+	// Enable for E2E tests checking Nav Unification.
+	if ( process.env.FLAGS === 'nav-unification' ) {
+		return true;
+	}
+
+	// Disabled by default.
+	return false;
+};

--- a/client/state/selectors/is-nav-unification-enabled.js
+++ b/client/state/selectors/is-nav-unification-enabled.js
@@ -8,8 +8,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 
 export default ( state ) => {
-	// Having the feature enabled by default in all environments, will let anyone use ?disable-nav-unification to temporary disable it.
-	// We still have the feature disabled in production as safety mechanism for all customers.
+	// Disable if explicitly requested by the `?disable-nav-unification` query param.
 	if ( new URL( document.location ).searchParams.has( 'disable-nav-unification' ) ) {
 		return false;
 	}

--- a/client/state/selectors/is-nav-unification-enabled.js
+++ b/client/state/selectors/is-nav-unification-enabled.js
@@ -8,19 +8,10 @@ import cookie from 'cookie';
  */
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 
 export default ( state ) => {
 	// Disable if explicitly requested by the `?disable-nav-unification` query param.
 	if ( new URL( document.location ).searchParams.has( 'disable-nav-unification' ) ) {
-		return false;
-	}
-
-	// Disabled for Jetpack sites.
-	const siteId = getSelectedSiteId( state );
-	if ( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) {
 		return false;
 	}
 

--- a/client/state/selectors/is-nav-unification-enabled.js
+++ b/client/state/selectors/is-nav-unification-enabled.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import cookie from 'cookie';
+
+/**
  * Internal dependencies
  */
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
@@ -25,7 +30,9 @@ export default ( state ) => {
 	}
 
 	// Enable for E2E tests checking Nav Unification.
-	if ( process.env.FLAGS === 'nav-unification' ) {
+	// @see https://github.com/Automattic/wp-calypso/pull/50144.
+	const cookies = cookie.parse( document.cookie );
+	if ( cookies.flags && cookies.flags.includes( 'nav-unification' ) ) {
 		return true;
 	}
 

--- a/client/state/teams/selectors/get-reader-teams.js
+++ b/client/state/teams/selectors/get-reader-teams.js
@@ -12,5 +12,5 @@ import 'calypso/state/teams/init';
  */
 
 export default function getReaderTeams( state ) {
-	return state.teams.items;
+	return state.teams?.items || [];
 }

--- a/config/client.json
+++ b/config/client.json
@@ -23,7 +23,6 @@
 	"hotjar_enabled",
 	"jetpack_support_blog",
 	"mc_analytics_enabled",
-	"nav-unification",
 	"oauth_client_id",
 	"oauth_response_type",
 	"oauth_url",

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -98,7 +98,6 @@
 		"me/my-profile": true,
 		"me/next-steps": true,
 		"me/notifications": true,
-		"nav-unification": false,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,
 		"paladin": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -77,7 +77,6 @@
 		"me/account/color-scheme-picker": true,
 		"me/my-profile": true,
 		"me/notifications": true,
-		"nav-unification": false,
 		"oauth": true,
 		"p2/p2-plus": true,
 		"plans/personal-plan": true,

--- a/config/development.json
+++ b/config/development.json
@@ -133,7 +133,6 @@
 		"me/notifications": true,
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,
-		"nav-unification": false,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,
 		"network-connection": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -94,7 +94,6 @@
 		"me/account/color-scheme-picker": true,
 		"me/my-profile": true,
 		"me/notifications": true,
-		"nav-unification": false,
 		"network-connection": true,
 		"p2/p2-plus": true,
 		"perfmon": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -50,7 +50,6 @@
 		"layout/nps-survey-notice": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
-		"nav-unification": false,
 		"oauth": true,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -47,7 +47,6 @@
 		"layout/nps-survey-notice": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
-		"nav-unification": false,
 		"oauth": false,
 		"purchases/new-payment-methods": true,
 		"site-indicator": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -48,7 +48,6 @@
 		"layout/nps-survey-notice": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
-		"nav-unification": false,
 		"oauth": true,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,

--- a/config/production.json
+++ b/config/production.json
@@ -99,7 +99,6 @@
 		"me/notifications": true,
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,
-		"nav-unification": false,
 		"nps-survey/devdocs": false,
 		"nps-survey/dev-trigger": false,
 		"p2/p2-plus": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -101,7 +101,6 @@
 		"memberships": true,
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,
-		"nav-unification": false,
 		"nps-survey/devdocs": false,
 		"nps-survey/dev-trigger": false,
 		"p2/p2-plus": true,

--- a/config/test.json
+++ b/config/test.json
@@ -82,7 +82,6 @@
 		"me/my-profile": true,
 		"me/notifications": true,
 		"memberships": true,
-		"nav-unification": false,
 		"network-connection": true,
 		"perfmon": false,
 		"plans/personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -110,7 +110,6 @@
 		"memberships": true,
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,
-		"nav-unification": false,
 		"network-connection": true,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_aquatic.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_aquatic.scss
@@ -1,5 +1,5 @@
 .color-scheme.is-aquatic,
-.color-scheme.is-aquatic .is-nav-unification {
+.color-scheme.is-aquatic.is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-blue-50 );
 	--color-primary-rgb: var( --studio-blue-50-rgb );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
@@ -23,7 +23,7 @@ Used studio-blue for the primary+accent.
 */
 
 .color-scheme.is-blue,
-.color-scheme.is-blue .is-nav-unification {
+.color-scheme.is-blue.is-nav-unification {
 	/* Variables used in Calypso blue */
 	--theme-text-color: #ffffff; /* Direct from wp-admin */
 	--theme-text-color-rgb: 255, 255, 255; /* Manual conversion */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-blue.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-blue.scss
@@ -1,5 +1,5 @@
 .color-scheme.is-classic-blue,
-.color-scheme.is-classic-blue .is-nav-unification {
+.color-scheme.is-classic-blue.is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-blue-50 );
 	--color-primary-rgb: var( --studio-blue-50-rgb );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
@@ -1,5 +1,5 @@
 .color-scheme.is-classic-dark,
-.color-scheme.is-classic-dark .is-nav-unification {
+.color-scheme.is-classic-dark.is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-gray-90 );
 	--color-primary-rgb: var( --studio-gray-90-rgb );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_coffee.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_coffee.scss
@@ -21,7 +21,7 @@ The wp-admin highlight color hue is 27, while studio-orange ranges from 25 to 35
 */
 
 .color-scheme.is-coffee,
-.color-scheme.is-coffee .is-nav-unification {
+.color-scheme.is-coffee.is-nav-unification {
 	/* Variables used in Calypso Coffee */
 	--theme-text-color: #ffffff; /* Direct from wp-admin */
 	--theme-text-color-rgb: 255, 255, 255; /* Manual conversion */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_contrast.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_contrast.scss
@@ -1,5 +1,5 @@
 .color-scheme.is-contrast,
-.color-scheme.is-contrast .is-nav-unification {
+.color-scheme.is-contrast.is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-gray-80 );
 	--color-primary-rgb: var( --studio-gray-80-rgb );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -344,7 +344,7 @@
 	--color-sidebar-submenu-selected-text: var( --color-accent );
 }
 
-.color-scheme.is-classic-bright .is-nav-unification {
+.color-scheme.is-classic-bright.is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-blue-50 );
 	--color-primary-rgb: var( --studio-blue-50-rgb );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_ectoplasm.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_ectoplasm.scss
@@ -33,7 +33,7 @@ Created this definition in color-studio to generate 0-100 shades:
 */
 
 .color-scheme.is-ectoplasm,
-.color-scheme.is-ectoplasm .is-nav-unification {
+.color-scheme.is-ectoplasm.is-nav-unification {
 	/* Variables used in Calypso Ectoplasm */
 	--theme-text-color: #ffffff; /* Direct from wp-admin */
 	--theme-text-color-rgb: 255, 255, 255; /* Manual conversion */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
@@ -38,7 +38,7 @@ Primary+Accent is studio blue.
 
 
 .color-scheme.is-light,
-.color-scheme.is-light .is-nav-unification {
+.color-scheme.is-light.is-nav-unification {
 	/* Variables used in Calypso Light */
 	--theme-text-color: #333333; /* Direct from wp-admin */
 	--theme-text-color-rgb: 51, 51, 51; /* Manual conversion */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
@@ -31,7 +31,7 @@ Created this definition in color-studio to generate 0-100 shades:
 */
 
 .color-scheme.is-midnight,
-.color-scheme.is-midnight .is-nav-unification {
+.color-scheme.is-midnight.is-nav-unification {
 	/* Variables used in Calypso Midnight */
 	--theme-text-color: #ffffff; /* Direct from wp-admin */
 	--theme-text-color-rgb: 255, 255, 255; /* Manual conversion */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
@@ -21,7 +21,7 @@ Used studio-blue for the primary+accent.
 */
 
 .color-scheme.is-modern,
-.color-scheme.is-modern .is-nav-unification {
+.color-scheme.is-modern.is-nav-unification {
 	/* Variables used in Calypso Modern */
 	--theme-text-color: #ffffff; /* Direct from wp-admin */
 	--theme-text-color-rgb: 255, 255, 255; /* Manual conversion */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_nightfall.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_nightfall.scss
@@ -1,5 +1,5 @@
 .color-scheme.is-nightfall,
-.color-scheme.is-nightfall .is-nav-unification {
+.color-scheme.is-nightfall.is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-gray-90 );
 	--color-primary-rgb: var( --studio-gray-90-rgb );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_ocean.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_ocean.scss
@@ -26,7 +26,7 @@ opinion.  Celadon seems to match the ocean colors better.
 */
 
 .color-scheme.is-ocean,
-.color-scheme.is-ocean .is-nav-unification {
+.color-scheme.is-ocean.is-nav-unification {
 	/* Variables used in Calypso Ectoplasm */
 	--theme-text-color: #ffffff; /* Direct from wp-admin */
 	--theme-text-color-rgb: 255, 255, 255; /* Manual conversion */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_powder-snow.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_powder-snow.scss
@@ -1,5 +1,5 @@
 .color-scheme.is-powder-snow,
-.color-scheme.is-powder-snow .is-nav-unification {
+.color-scheme.is-powder-snow.is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-gray-90 );
 	--color-primary-rgb: var( --studio-gray-90-rgb );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sakura.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sakura.scss
@@ -1,5 +1,5 @@
 .color-scheme.is-sakura,
-.color-scheme.is-sakura .is-nav-unification {
+.color-scheme.is-sakura.is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-celadon-50 );
 	--color-primary-rgb: var( --studio-celadon-50-rgb );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
@@ -24,7 +24,7 @@ Well use studio-orange for both the primary and accent colors
 */
 
 .color-scheme.is-sunrise,
-.color-scheme.is-sunrise .is-nav-unification {
+.color-scheme.is-sunrise.is-nav-unification {
 	/* Variables used in Calypso Sunrise */
 	--theme-text-color: #ffffff; /* Direct from wp-admin */
 	--theme-text-color-rgb: 255, 255, 255; /* Manual conversion */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sunset.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sunset.scss
@@ -1,5 +1,5 @@
 .color-scheme.is-sunset,
-.color-scheme.is-sunset .is-nav-unification {
+.color-scheme.is-sunset.is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-red-50 );
 	--color-primary-rgb: var( --studio-red-50-rgb );

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,7 +29,6 @@
 	],
 	"types": "dist/types",
 	"dependencies": {
-		"@automattic/calypso-config": "^1.0.0-alpha.0",
 		"@babel/runtime": "^7.12.5",
 		"classnames": "^2.2.6",
 		"gridicons": "^3.3.1",

--- a/packages/components/src/dialog/index.jsx
+++ b/packages/components/src/dialog/index.jsx
@@ -5,8 +5,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'react-modal';
 import classnames from 'classnames';
-// eslint-disable-next-line import/no-extraneous-dependencies, no-restricted-imports
-import config from '@automattic/calypso-config';
 
 /**
  * Style dependencies
@@ -100,6 +98,7 @@ class Dialog extends Component {
 			isBackdropVisible,
 			className,
 			baseClassName,
+			overlayClassName,
 			isFullScreen,
 			shouldCloseOnEsc,
 		} = this.props;
@@ -107,10 +106,9 @@ class Dialog extends Component {
 		// Previous implementation used a `<Card />`, styling still relies on the 'card' class being present
 		const dialogClassName = classnames( baseClassName, 'card', additionalClassNames );
 
-		const backdropClassName = classnames( baseClassName + '__backdrop', {
+		const backdropClassName = classnames( baseClassName + '__backdrop', overlayClassName, {
 			'is-full-screen': isFullScreen,
 			'is-hidden': ! isBackdropVisible,
-			'is-nav-unification': config.isEnabled( 'nav-unification' ),
 		} );
 
 		const contentClassName = classnames( baseClassName + '__content', className );

--- a/packages/components/src/dialog/index.jsx
+++ b/packages/components/src/dialog/index.jsx
@@ -98,7 +98,6 @@ class Dialog extends Component {
 			isBackdropVisible,
 			className,
 			baseClassName,
-			overlayClassName,
 			isFullScreen,
 			shouldCloseOnEsc,
 		} = this.props;
@@ -106,7 +105,7 @@ class Dialog extends Component {
 		// Previous implementation used a `<Card />`, styling still relies on the 'card' class being present
 		const dialogClassName = classnames( baseClassName, 'card', additionalClassNames );
 
-		const backdropClassName = classnames( baseClassName + '__backdrop', overlayClassName, {
+		const backdropClassName = classnames( baseClassName + '__backdrop', {
 			'is-full-screen': isFullScreen,
 			'is-hidden': ! isBackdropVisible,
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Refactors the logic that determines whether Nav Unification should be enabled, in preparation for a potential disable for Jetpack sites.

The previous `isNavUnificationEnabled` function in the `Layout` component had some issues since it was relying on the `config` package, but changes to the feature flags don't trigger a re-render, causing the nav unification to remain active when switching from a Simple/Atomic site to a Jetpack site, and keeping it inactive when switching from a Jetpack site to a Simple/Atomic sites.

To work around that I moved the logic to a state selector that forces a re-render in every component using it. The `nav-unification` feature flag is no longer needed after that, so I completely removed it.

Changes done to the color schemes are needed because now we add the `is-nav-unification` class to the `body` element rather than to the `Layout` component. That way we can keep the `Dialog` component decoupled from the state selector (effectively allowing us to revert https://github.com/Automattic/wp-calypso/pull/48873).

#### Testing instructions

- Load Calypso using an a8c account.
- Make sure the Nav Unification is enabled.
- Do a smoke test across different sections (Me, Reader, etc) and make sure there are no regressions, especiailly with different color schemes or when a dialog shows up.
- Add a `?disable-nav-unification` query param to the URL.
- Make sure the Nav Unification is disabled.
- Load Calypso using a non-a8c account now.
- Make sure the Nav Unification is disabled for all sites.

Required by https://github.com/Automattic/wp-calypso/issues/50704
