### PR TITLE
people(team): use `react-query` to fetch data

### DIFF
--- a/client/data/users/use-users-query.js
+++ b/client/data/users/use-users-query.js
@@ -18,7 +18,7 @@ export const defaults = {
 const extractPages = ( pages = [] ) => pages.flatMap( ( page ) => page.users );
 const compareUnique = ( a, b ) => a.ID === b.ID;
 
-const useUsers = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
+const useUsersQuery = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
 	const { search } = fetchOptions;
 
 	return useInfiniteQuery(
@@ -51,4 +51,4 @@ const useUsers = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
 	);
 };
 
-export default useUsers;
+export default useUsersQuery;

--- a/client/data/users/use-users.js
+++ b/client/data/users/use-users.js
@@ -23,12 +23,12 @@ const useUsers = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
 
 	return useInfiniteQuery(
 		[ 'users', siteId, search ],
-		async ( { pageParam = 0 } ) => {
-			const res = await wpcom
-				.site( siteId )
-				.usersList( { ...defaults, ...fetchOptions, offset: pageParam } );
-			return res;
-		},
+		( { pageParam = 0 } ) =>
+			wpcom.req.get( `/sites/${ siteId }/users`, {
+				...defaults,
+				...fetchOptions,
+				offset: pageParam,
+			} ),
 		{
 			enabled: !! siteId,
 			getNextPageParam: ( lastPage, allPages ) => {

--- a/client/data/users/use-users.js
+++ b/client/data/users/use-users.js
@@ -9,17 +9,17 @@ import { uniqueBy } from '@automattic/js-utils';
  */
 import wpcom from 'calypso/lib/wp';
 
-export const DEFAULT_NUMBER = 100;
 export const defaults = {
-	number: DEFAULT_NUMBER,
-	offset: 0,
+	number: 100,
+	order: 'ASC',
+	order_by: 'display_name',
 };
 
 const extractPages = ( pages = [] ) => pages.flatMap( ( page ) => page.users );
 const compareUnique = ( a, b ) => a.ID === b.ID;
 
-const useUsers = ( fetchOptions = {}, queryOptions = {} ) => {
-	const { search, siteId } = fetchOptions;
+const useUsers = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
+	const { search } = fetchOptions;
 
 	return useInfiniteQuery(
 		[ 'users', siteId, search ],
@@ -30,11 +30,13 @@ const useUsers = ( fetchOptions = {}, queryOptions = {} ) => {
 			return res;
 		},
 		{
+			enabled: !! siteId,
 			getNextPageParam: ( lastPage, allPages ) => {
-				if ( lastPage.found <= allPages.length * DEFAULT_NUMBER ) {
+				const n = fetchOptions.number ?? defaults.number;
+				if ( lastPage.found <= allPages.length * n ) {
 					return;
 				}
-				return allPages.length * DEFAULT_NUMBER;
+				return allPages.length * n;
 			},
 			select: ( data ) => {
 				return {

--- a/client/data/users/use-users.js
+++ b/client/data/users/use-users.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { useInfiniteQuery } from 'react-query';
+import { uniqueBy } from '@automattic/js-utils';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'calypso/lib/wp';
+
+export const DEFAULT_NUMBER = 100;
+export const defaults = {
+	number: DEFAULT_NUMBER,
+	offset: 0,
+};
+
+const extractPages = ( pages = [] ) => pages.flatMap( ( page ) => page.users );
+const compareUnique = ( a, b ) => a.ID === b.ID;
+
+const useUsers = ( fetchOptions = {}, queryOptions = {} ) => {
+	const { search, siteId } = fetchOptions;
+
+	return useInfiniteQuery(
+		[ 'users', siteId, search ],
+		async ( { pageParam = 0 } ) => {
+			const res = await wpcom
+				.site( siteId )
+				.usersList( { ...defaults, ...fetchOptions, offset: pageParam } );
+			return res;
+		},
+		{
+			getNextPageParam: ( lastPage, allPages ) => {
+				if ( lastPage.found <= allPages.length * DEFAULT_NUMBER ) {
+					return;
+				}
+				return allPages.length * DEFAULT_NUMBER;
+			},
+			select: ( data ) => {
+				return {
+					/* @TODO: `uniqueBy` is necessary, because the API can return duplicates */
+					users: uniqueBy( extractPages( data.pages ), compareUnique ),
+					total: data.pages[ 0 ].found,
+					...data,
+				};
+			},
+			...queryOptions,
+		}
+	);
+};
+
+export default useUsers;

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
@@ -14,16 +14,9 @@ import useUsers from 'calypso/data/users/use-users';
 
 function TeamList( props ) {
 	const dispatch = useDispatch();
-	const { site, search, translate } = props;
-	const fetchOptions = {
-		siteId: site?.ID,
-		order: 'ASC',
-		order_by: 'display_name',
-	};
+	const translate = useTranslate();
 
-	if ( search ) {
-		fetchOptions.search = `*${ search }*`;
-		fetchOptions.search_columns = [ 'display_name', 'user_login' ];
+	const { site, search } = props;
 	}
 
 	const {
@@ -65,4 +58,4 @@ function TeamList( props ) {
 	);
 }
 
-export default localize( TeamList );
+export default TeamList;

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -17,7 +17,12 @@ function TeamList( props ) {
 	const translate = useTranslate();
 
 	const { site, search } = props;
-	}
+	const fetchOptions = search
+		? {
+				search: `*${ search }*`,
+				search_columns: [ 'display_name', 'user_login' ],
+		  }
+		: {};
 
 	const {
 		data,
@@ -27,7 +32,7 @@ function TeamList( props ) {
 		fetchNextPage,
 		error,
 		refetch,
-	} = useUsers( fetchOptions );
+	} = useUsers( site.ID, fetchOptions );
 
 	React.useEffect( () => {
 		error &&

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -3,33 +3,66 @@
  */
 import { localize } from 'i18n-calypso';
 import React from 'react';
+import { useDispatch } from 'react-redux';
+import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 
 /**
  * Internal dependencies
  */
-import SiteUsersFetcher from 'calypso/components/site-users-fetcher';
 import Team from './team';
+import useUsers from 'calypso/data/users/use-users';
 
-class TeamList extends React.Component {
-	static displayName = 'TeamList';
+function TeamList( props ) {
+	const dispatch = useDispatch();
+	const { site, search, translate } = props;
+	const fetchOptions = {
+		siteId: site?.ID,
+		order: 'ASC',
+		order_by: 'display_name',
+	};
 
-	render() {
-		const fetchOptions = {
-			siteId: this.props.site && this.props.site.ID,
-			order: 'ASC',
-			order_by: 'display_name',
-			search: this.props.search ? '*' + this.props.search + '*' : null,
-			search_columns: [ 'display_name', 'user_login' ],
-		};
-
-		Object.freeze( fetchOptions );
-
-		return (
-			<SiteUsersFetcher fetchOptions={ fetchOptions }>
-				<Team { ...this.props } />
-			</SiteUsersFetcher>
-		);
+	if ( search ) {
+		fetchOptions.search = `*${ search }*`;
+		fetchOptions.search_columns = [ 'display_name', 'user_login' ];
 	}
+
+	const {
+		data,
+		isLoading,
+		isFetchingNextPage,
+		hasNextPage,
+		fetchNextPage,
+		error,
+		refetch,
+	} = useUsers( fetchOptions );
+
+	React.useEffect( () => {
+		error &&
+			dispatch(
+				errorNotice( translate( 'There was an error retrieving users' ), {
+					id: 'site-users-notice',
+					button: 'Try again.',
+					onClick: () => {
+						dispatch( removeNotice( 'site-users-notice' ) );
+						refetch();
+					},
+				} )
+			);
+	}, [ dispatch, translate, refetch, error ] );
+
+	return (
+		<Team
+			fetchingUsers={ isLoading }
+			fetchingNextPage={ isFetchingNextPage }
+			totalUsers={ data?.total }
+			users={ data?.users ?? [] }
+			excludedUsers={ [] }
+			fetchOptions={ fetchOptions }
+			fetchNextPage={ fetchNextPage }
+			hasNextPage={ hasNextPage }
+			{ ...props }
+		/>
+	);
 }
 
 export default localize( TeamList );

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -23,6 +23,7 @@ function TeamList( props ) {
 				search_columns: [ 'display_name', 'user_login' ],
 		  }
 		: {};
+	const listKey = [ 'team', site.ID, search ].join( '-' );
 
 	const {
 		data,
@@ -50,12 +51,12 @@ function TeamList( props ) {
 
 	return (
 		<Team
+			listKey={ listKey }
 			fetchingUsers={ isLoading }
 			fetchingNextPage={ isFetchingNextPage }
 			totalUsers={ data?.total }
 			users={ data?.users ?? [] }
 			excludedUsers={ [] }
-			fetchOptions={ fetchOptions }
 			fetchNextPage={ fetchNextPage }
 			hasNextPage={ hasNextPage }
 			{ ...props }

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -3,6 +3,7 @@
  */
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 
@@ -70,5 +71,10 @@ function TeamList( props ) {
 		/>
 	);
 }
+
+TeamList.propTypes = {
+	site: PropTypes.object.isRequired,
+	search: PropTypes.string,
+};
 
 export default TeamList;

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -35,8 +35,7 @@ const useErrorNotice = ( error, refetch ) => {
 	}, [ dispatch, translate, error, refetch ] );
 };
 
-function TeamList( props ) {
-	const { site, search } = props;
+function TeamList( { site, search } ) {
 	const fetchOptions = search
 		? {
 				search: `*${ search }*`,
@@ -67,7 +66,8 @@ function TeamList( props ) {
 			excludedUsers={ [] }
 			fetchNextPage={ fetchNextPage }
 			hasNextPage={ hasNextPage }
-			{ ...props }
+			site={ site }
+			search={ search }
 		/>
 	);
 }

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -11,7 +11,7 @@ import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
  * Internal dependencies
  */
 import Team from './team';
-import useUsers from 'calypso/data/users/use-users';
+import useUsersQuery from 'calypso/data/users/use-users-query';
 
 const useErrorNotice = ( error, refetch ) => {
 	const dispatch = useDispatch();
@@ -52,7 +52,7 @@ function TeamList( { site, search } ) {
 		fetchNextPage,
 		error,
 		refetch,
-	} = useUsers( site.ID, fetchOptions );
+	} = useUsersQuery( site.ID, fetchOptions );
 
 	useErrorNotice( error, refetch );
 

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -12,10 +12,29 @@ import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import Team from './team';
 import useUsers from 'calypso/data/users/use-users';
 
-function TeamList( props ) {
+const useErrorNotice = ( error, refetch ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
+	React.useEffect( () => {
+		if ( ! error ) {
+			return;
+		}
+
+		dispatch(
+			errorNotice( translate( 'There was an error retrieving users' ), {
+				id: 'site-users-notice',
+				button: 'Try again.',
+				onClick: () => {
+					dispatch( removeNotice( 'site-users-notice' ) );
+					refetch();
+				},
+			} )
+		);
+	}, [ dispatch, translate, error, refetch ] );
+};
+
+function TeamList( props ) {
 	const { site, search } = props;
 	const fetchOptions = search
 		? {
@@ -35,19 +54,7 @@ function TeamList( props ) {
 		refetch,
 	} = useUsers( site.ID, fetchOptions );
 
-	React.useEffect( () => {
-		error &&
-			dispatch(
-				errorNotice( translate( 'There was an error retrieving users' ), {
-					id: 'site-users-notice',
-					button: 'Try again.',
-					onClick: () => {
-						dispatch( removeNotice( 'site-users-notice' ) );
-						refetch();
-					},
-				} )
-			);
-	}, [ dispatch, translate, refetch, error ] );
+	useErrorNotice( error, refetch );
 
 	return (
 		<Team

--- a/client/my-sites/people/team-list/team.jsx
+++ b/client/my-sites/people/team-list/team.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import deterministicStringify from 'fast-json-stable-stringify';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -34,7 +33,7 @@ class Team extends React.Component {
 		const {
 			site,
 			users,
-			fetchOptions,
+			listKey,
 			search,
 			fetchingUsers,
 			fetchingNextPage,
@@ -43,9 +42,6 @@ class Team extends React.Component {
 			fetchNextPage,
 			translate,
 		} = this.props;
-
-		const { number, offset, ...keyProps } = fetchOptions;
-		const key = deterministicStringify( keyProps );
 
 		let people;
 		let headerText;
@@ -64,7 +60,7 @@ class Team extends React.Component {
 			);
 		}
 
-		if ( ! users.length && fetchOptions.search && ! fetchingUsers ) {
+		if ( ! users.length && search && ! fetchingUsers ) {
 			return (
 				<NoResults
 					image="/calypso/images/people/mystery-person.svg"
@@ -96,7 +92,7 @@ class Team extends React.Component {
 
 			people = (
 				<InfiniteList
-					key={ key }
+					key={ listKey }
 					items={ users }
 					className="team-list__infinite is-people"
 					ref={ this.infiniteList }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* People: migrate team to use `useUsers` custom hook based on ReactQuery


#### Testing instructions

1. Go to the people section of a site and choose _Team_
2. Make sure the list of users shows up
3. If you scroll down on a site with more than 100 users you should see a request for the next page
4. If you switch your active site, make sure you get a fresh list of users and fetching params are reset
5. Try to filter the list by adding a search param (click the search icon on the top right)

Related to #24150

