### PR TITLE
Plan details: remove domain as second argument of hasTranslation() function

### DIFF
--- a/packages/plans-grid/src/plans-details/index.tsx
+++ b/packages/plans-grid/src/plans-details/index.tsx
@@ -58,7 +58,7 @@ const PlansDetails: React.FunctionComponent< Props > = ( { onSelect, locale, bil
 		__i18n_text_domain__
 	);
 	const annualBillingLabel =
-		locale === 'en' || hasTranslation?.( 'Monthly price (billed yearly)', __i18n_text_domain__ )
+		locale === 'en' || hasTranslation?.( 'Monthly price (billed yearly)' )
 			? newAnnualBillingLabel
 			: fallbackAnnualBillingLabel;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `domain` as the second argument of the hasTranslation() function, which makes that function call to always return `false` (see explanation [here](https://github.com/Automattic/wp-calypso/pull/49290#discussion_r586335475))

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/new` and proceed through the steps until you see the plans grid
* Select "Annually" in the toggle
* Scroll at the bottom of the page and check the copy in the last row of the table:
    - [x] When `locale === 'en'` the text should say "Monthly price (billed yearly)"
    - [x] When `locale !== 'en'`, the text should be the translated version of  "Monthly price (billed yearly)" (see the [translation status page](https://translate.wordpress.com/localci/status/automattic/wp-calypso/update/plans-grid-details-signup-label) for which exact copy you should look for, given the locale)

#### Screenshots

![image](https://user-images.githubusercontent.com/1083581/109837018-0990bc00-7c45-11eb-954b-2c52b53e604b.png)


Related to #49290
