### PR TITLE
Update photon version number for publishing

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -171,7 +171,7 @@
 		"path-browserify": "^1.0.0",
 		"percentage-regex": "^3.0.0",
 		"phone": "^2.4.2",
-		"photon": "^3.0.0",
+		"photon": "^4.0.0",
 		"portscanner": "^2.2.0",
 		"prismjs": "^1.17.1",
 		"prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -274,7 +274,7 @@
 		"node-sass-package-importer": "^5.3.2",
 		"npm-merge-driver": "^2.3.5",
 		"npm-run-all": "^4.1.5",
-		"photon": "^3.0.0",
+		"photon": "^4.0.0",
 		"postcss": "^8.2.6",
 		"postcss-cli": "^8.3.1",
 		"postcss-custom-properties": "^11.0.0",

--- a/packages/photon/History.md
+++ b/packages/photon/History.md
@@ -1,6 +1,8 @@
 # History
 
-## 3.0.0 / TBD
+## 4.0.0 / TBD
+
+(Note: version 3 was skipped due to an existing deprecation)
 
 - Drop dependency on `url` npm package.
 - Breaking change: support for URL / URLSearchParams APIs is now required.

--- a/packages/photon/History.md
+++ b/packages/photon/History.md
@@ -2,10 +2,12 @@
 
 ## 4.0.0 / TBD
 
-(Note: version 3 was skipped due to an existing deprecation)
-
 - Drop dependency on `url` npm package.
 - Breaking change: support for URL / URLSearchParams APIs is now required.
+
+## 3.0.0 / 2019-01-08
+
+Deprecated due an existing CORS issue.
 
 ## 2.1.0 / 2019-06-03
 

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "photon",
-	"version": "3.0.0",
+	"version": "4.0.0",
 	"description": "JavaScript library for the WordPress.com Photon image manipulation service",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
`photon@3.0.0` was once published and deprecated due to a bug, before it was added to the monorepo. Afterwards, development continued in the 2.x range.

Since then, there have been breaking changes, so we need to publish to a new major version number. This change switches over to 4.0.0 to enable that publishing, skipping over the deprecated 3.0.0 and its entire major version, to avoid confusion.

Fixes #50627 

#### Changes proposed in this Pull Request

* Update photon version number for publishing

#### Testing instructions

No code changes.
