### PR TITLE
Wayfinder: Add subHeaderText across Calypso, round 2

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import moment from 'moment';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import Chart from './store-stats-orders-chart';
 import StatsPeriodNavigation from 'calypso/my-sites/stats/stats-period-navigation';
 import DatePicker from 'calypso/my-sites/stats/stats-date-picker';
+import FormattedHeader from 'calypso/components/formatted-header';
 import Module from './store-stats-module';
 import List from './store-stats-list';
 import WidgetList from './store-stats-widget-list';
@@ -46,7 +48,7 @@ class StoreStats extends Component {
 	};
 
 	render() {
-		const { queryDate, selectedDate, siteId, slug, unit, queryParams } = this.props;
+		const { queryDate, selectedDate, siteId, slug, unit, queryParams, translate } = this.props;
 		const endSelectedDate = getEndPeriod( selectedDate, unit );
 		const { orderQuery, referrerQuery } = getQueries( unit, queryDate );
 		const { topListQuery } = getQueries( unit, selectedDate );
@@ -63,6 +65,15 @@ class StoreStats extends Component {
 					<QuerySiteStats statType="statsOrders" siteId={ siteId } query={ orderQuery } />
 				) }
 				<SidebarNavigation />
+				<FormattedHeader
+					brandFont
+					className="store-stats__section-header"
+					headerText={ translate( 'Stats and Insights' ) }
+					align="left"
+					subHeaderText={ translate(
+						'Learn valuable insights about the purchases made on your store.'
+					) }
+				/>
 				<StatsNavigation
 					selectedItem={ 'store' }
 					siteId={ siteId }
@@ -188,4 +199,4 @@ class StoreStats extends Component {
 export default connect( ( state ) => ( {
 	slug: getSelectedSiteSlug( state ),
 	siteId: getSelectedSiteId( state ),
-} ) )( StoreStats );
+} ) )( localize( StoreStats ) );

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -151,6 +151,7 @@ export class List extends React.Component {
 						brandFont
 						className="domain-management__page-heading"
 						headerText={ this.props.translate( 'Site Domains' ) }
+						subHeaderText={ this.props.translate( 'Manage the domains connected to your site.' ) }
 						align="left"
 					/>
 					<div className="domains__header-buttons">

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -202,6 +202,7 @@ class EarningsMain extends Component {
 					brandFont
 					className="earn__page-header"
 					headerText={ translate( 'Earn' ) }
+					subHeaderText={ translate( 'Explore tools to earn money with your site.' ) }
 					align="left"
 				/>
 				{ this.getHeaderCake() }

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -101,6 +101,7 @@ class EmailManagement extends React.Component {
 						brandFont
 						className="email-management__page-heading"
 						headerText={ this.props.translate( 'Email' ) }
+						subHeaderText={ this.props.translate( 'Add a custom email address to your domain.' ) }
 						align="left"
 					/>
 				) }

--- a/client/my-sites/exporter/section-export.jsx
+++ b/client/my-sites/exporter/section-export.jsx
@@ -55,7 +55,7 @@ const SectionExport = ( { isJetpack, canUserExport, site, translate } ) => {
 					brandFont
 					className="exporter__section-header"
 					headerText={ translate( 'Export Content' ) }
-					subHeaderText={ translate( 'Your content on WordPress.com is always yours.' ) }
+					subHeaderText={ translate( 'Back up or move your content to another site or platform.' ) }
 					align="left"
 				/>
 				<ExporterContainer />

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -294,6 +294,7 @@ class SectionImport extends Component {
 					brandFont
 					className="importer__page-heading"
 					headerText={ translate( 'Import Content' ) }
+					subHeaderText={ translate( 'Import content from another website or platform.' ) }
 					align="left"
 				/>
 				<EmailVerificationGate allowUnlaunched>

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -92,8 +92,10 @@ class PeopleInvites extends React.PureComponent {
 				{ siteId && <QuerySiteInvites siteId={ siteId } /> }
 				<SidebarNavigation />
 				<FormattedHeader
+					brandFont
 					className="people-invites__page-heading"
 					headerText={ translate( 'People' ) }
+					subHeaderText={ translate( 'View and manage the invites to your site.' ) }
 					align="left"
 				/>
 				<PeopleSectionNav

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -199,6 +199,9 @@ class CurrentPlan extends Component {
 					brandFont
 					className="current-plan__page-heading"
 					headerText={ translate( 'Plans' ) }
+					subHeaderText={ translate(
+						'Learn about the features included in your WordPress.com plan.'
+					) }
 					align="left"
 				/>
 				{ selectedSiteId && (

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -68,6 +68,9 @@ export function Purchases(): JSX.Element {
 				brandFont
 				className="purchases__page-heading"
 				headerText={ titles.sectionTitle }
+				subHeaderText={ translate(
+					'View, manage, or cancel your WordPress.com plan and other purchases.'
+				) }
 				align="left"
 			/>
 			<PurchasesNavigation sectionTitle={ 'Active Upgrades' } siteSlug={ siteSlug } />

--- a/client/my-sites/site-settings/settings-discussion/main.jsx
+++ b/client/my-sites/site-settings/settings-discussion/main.jsx
@@ -26,6 +26,7 @@ const SiteSettingsDiscussion = ( { site, translate } ) => (
 			brandFont
 			className="settings-discussion__page-heading"
 			headerText={ translate( 'Settings' ) }
+			subHeaderText={ translate( 'Control how people interact with your site through comments.' ) }
 			align="left"
 		/>
 		<SiteSettingsNavigation site={ site } section="discussion" />

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -63,6 +63,7 @@ class SiteSettingsPerformance extends Component {
 					brandFont
 					className="settings-performance__page-heading"
 					headerText={ translate( 'Settings' ) }
+					subHeaderText={ translate( "Explore settings to improve your site's performance." ) }
 					align="left"
 				/>
 				<SiteSettingsNavigation site={ site } section="performance" />

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -70,6 +70,7 @@ const SiteSettingsSecurity = ( {
 				brandFont
 				className="settings-security__page-heading"
 				headerText={ translate( 'Settings' ) }
+				subHeaderText={ translate( "Manage your site's security settings." ) }
 				align="left"
 			/>
 			<SiteSettingsNavigation site={ site } section="security" />

--- a/client/my-sites/site-settings/settings-writing/main.jsx
+++ b/client/my-sites/site-settings/settings-writing/main.jsx
@@ -26,6 +26,9 @@ const SiteSettingsWriting = ( { site, translate } ) => (
 			brandFont
 			className="settings-writing__page-heading"
 			headerText={ translate( 'Settings' ) }
+			subHeaderText={ translate(
+				"Manage categories, tags, and other settings related to your site's content."
+			) }
 			align="left"
 		/>
 		<SiteSettingsNavigation site={ site } section="writing" />

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -60,6 +60,7 @@ const StatsInsights = ( props ) => {
 				brandFont
 				className="stats__section-header"
 				headerText={ translate( 'Stats and Insights' ) }
+				subHeaderText={ translate( "View your site's performance and learn from trends." ) }
 				align="left"
 			/>
 			<StatsNavigation selectedItem={ 'insights' } siteId={ siteId } slug={ siteSlug } />

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -150,8 +150,10 @@ class WordAds extends Component {
 				<PrivacyPolicyBanner />
 				<SidebarNavigation />
 				<FormattedHeader
+					brandFont
 					className="wordads__section-header"
 					headerText={ translate( 'Stats and Insights' ) }
+					subHeaderText={ translate( 'See how ads are performing on your site.' ) }
 					align="left"
 				/>
 				{ ! canAccessAds && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add `subHeaderText` to more `FormattedHeader`s across Calypso, in the following paths:

* /export/SITE
* /stats/insights/SITE
* /store/stats/orders/day/SITE
* /stats/ads/day/SITE
* /plans/my-plan/SITE
* /people/invites/SITE
* /purchases/subscriptions/SITE
* /domains/manage/SITE
* /email/SITE
* /earn/SITE
* /settings/security/SITE
* /settings/performance/SITE
* /settings/writing/SITE
* /settings/discussion/SITE
* /import/SITE

**Visuals (not comprehensive)**

<img width="1102" alt="Screen Shot 2021-03-03 at 11 59 14 AM" src="https://user-images.githubusercontent.com/2124984/110339667-6a7a1480-7ff6-11eb-90f6-d0de41f39d47.png">
<img width="1113" alt="Screen Shot 2021-03-03 at 11 59 21 AM" src="https://user-images.githubusercontent.com/2124984/110339672-6b12ab00-7ff6-11eb-8ea2-10f48df00485.png">
<img width="797" alt="Screen Shot 2021-03-03 at 11 59 39 AM" src="https://user-images.githubusercontent.com/2124984/110339675-6bab4180-7ff6-11eb-813a-4307e61e90f9.png">
<img width="1096" alt="Screen Shot 2021-03-03 at 12 05 54 PM" src="https://user-images.githubusercontent.com/2124984/110339676-6c43d800-7ff6-11eb-8905-f1805aed8dd1.png">
<img width="1131" alt="Screen Shot 2021-03-04 at 4 54 22 PM" src="https://user-images.githubusercontent.com/2124984/110339680-6c43d800-7ff6-11eb-9d30-18b85526b450.png">
<img width="832" alt="Screen Shot 2021-03-12 at 11 37 17 AM" src="https://user-images.githubusercontent.com/2124984/110970001-4f294500-8327-11eb-95b3-89846806d6a2.png">

#### Testing instructions

* Switch to this PR
* Check the above paths in Calypso and note the addition of a subheading beneath each page title. 
* Make sure every string is wrapped in a `translate` function and that there are no spelling errors or other visual errors.