### PR TITLE
New Onboarding: Fix broken back button when landing from external pages.

### DIFF
--- a/client/landing/gutenboarding/hooks/use-last-location.ts
+++ b/client/landing/gutenboarding/hooks/use-last-location.ts
@@ -18,6 +18,6 @@ export default function useLastLocation(): { goLastLocation: () => void } {
 	};
 
 	return {
-		goLastLocation: goLastLocation,
+		goLastLocation,
 	};
 }

--- a/client/landing/gutenboarding/hooks/use-last-location.ts
+++ b/client/landing/gutenboarding/hooks/use-last-location.ts
@@ -11,7 +11,7 @@ import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 export default function useLastLocation(): { goLastLocation: () => void } {
 	const history = useHistory();
 
-	const lastLocation = useSelect( ( select ) => select( ONBOARD_STORE ).getLastLocation() );
+	const lastLocation = useSelect( ( select ) => select( ONBOARD_STORE ).getLastLocation(), [] );
 
 	const goLastLocation = ( fallbackLocation = '/' ) => {
 		history.push( lastLocation || fallbackLocation );

--- a/client/landing/gutenboarding/hooks/use-last-location.ts
+++ b/client/landing/gutenboarding/hooks/use-last-location.ts
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useHistory } from 'react-router-dom';
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
+
+export default function useLastLocation(): { goLastLocation: () => void } {
+	const history = useHistory();
+
+	const lastLocation = useSelect( ( select ) => select( ONBOARD_STORE ).getLastLocation() );
+
+	const goLastLocation = ( fallbackLocation = '/' ) => {
+		history.push( lastLocation || fallbackLocation );
+	};
+
+	return {
+		goLastLocation: goLastLocation,
+	};
+}

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import * as React from 'react';
-import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 import DomainPicker from '@automattic/domain-picker';
@@ -22,6 +21,7 @@ import { useLocale } from '@automattic/i18n-utils';
  */
 import { useTrackStep } from '../../hooks/use-track-step';
 import useStepNavigation from '../../hooks/use-step-navigation';
+import useLastLocation from '../../hooks/use-last-location';
 import { trackEventWithFlow } from '../../lib/analytics';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { DOMAIN_SUGGESTIONS_STORE } from '../../stores/domain-suggestions';
@@ -44,8 +44,8 @@ interface Props {
 const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 	const { __ } = useI18n();
 	const locale = useLocale();
-	const history = useHistory();
 	const { goBack, goNext } = useStepNavigation();
+	const { goLastLocation } = useLastLocation();
 
 	const domain = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDomain() );
 
@@ -76,13 +76,13 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 		selected_domain: selectedDomainRef.current,
 	} ) );
 
-	const handleBack = () => ( isModal ? history.goBack() : goBack() );
+	const handleBack = () => ( isModal ? goLastLocation() : goBack() );
 	const handleNext = () => {
 		trackEventWithFlow( 'calypso_newsite_domain_select', {
 			domain_name: selectedDomainRef.current,
 		} );
 		if ( isModal ) {
-			history.goBack();
+			goLastLocation();
 		} else {
 			goNext();
 		}

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -3,7 +3,7 @@
  */
 import * as React from 'react';
 import { Redirect, Switch, Route, useLocation } from 'react-router-dom';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import type { BlockEditProps } from '@wordpress/blocks';
 
 /**
@@ -20,6 +20,7 @@ import {
 	usePath,
 	useNewQueryParam,
 	useAnchorFmParams,
+	useStepRouteParam,
 } from '../path';
 import { usePrevious } from '../hooks/use-previous';
 import DesignSelector from './design-selector';
@@ -115,6 +116,28 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 
 		return redirectToLatestStep;
 	}
+
+	// Remember the last accessed route path
+	const location = useLocation();
+	const step = useStepRouteParam();
+	const { setLastLocation } = useDispatch( STORE_KEY );
+
+	React.useEffect( () => {
+		if (
+			// When location.key is undefined, this means user has just entered gutenboarding from url.
+			location.key !== undefined &&
+			// When step exists, and step is not any from the modals
+			step &&
+			! [
+				Step.DomainsModal as string,
+				Step.PlansModal as string,
+				Step.LanguageModal as string,
+			].includes( step )
+		) {
+			// Remember last location
+			setLastLocation( location.pathname );
+		}
+	}, [ location, step, setLastLocation ] );
 
 	return (
 		<div className="onboarding-block">

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -123,16 +123,13 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 	const { setLastLocation } = useDispatch( STORE_KEY );
 
 	React.useEffect( () => {
+		const modalSteps: StepType[] = [ Step.DomainsModal, Step.PlansModal, Step.LanguageModal ];
 		if (
 			// When location.key is undefined, this means user has just entered gutenboarding from url.
 			location.key !== undefined &&
 			// When step exists, and step is not any from the modals
 			step &&
-			! [
-				Step.DomainsModal as string,
-				Step.PlansModal as string,
-				Step.LanguageModal as string,
-			].includes( step )
+			! modalSteps.includes( step )
 		) {
 			// Remember last location
 			setLastLocation( location.pathname );

--- a/client/landing/gutenboarding/onboarding-block/language/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/language/index.tsx
@@ -12,6 +12,7 @@ import LanguagePicker, { createLanguageGroups } from '@automattic/language-picke
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import useLastLocation from '../../hooks/use-last-location';
 
 /**
  * Internal dependencies
@@ -49,11 +50,12 @@ const LanguageStep: React.FunctionComponent< Props > = ( { previousStep } ) => {
 
 	const history = useHistory();
 	const makePath = usePath();
+	const { goLastLocation } = useLastLocation();
 
 	const goBack = ( lang = '' ) => {
 		staticPreviousStep.current
 			? history.push( makePath( Step[ staticPreviousStep.current ], lang ) )
-			: history.goBack();
+			: goLastLocation();
 	};
 
 	return (

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -16,6 +16,7 @@ import type { Plans } from '@automattic/data-stores';
  */
 import { useTrackStep } from '../../hooks/use-track-step';
 import useStepNavigation from '../../hooks/use-step-navigation';
+import useLastLocation from '../../hooks/use-last-location';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { PLANS_STORE } from '../../stores/plans';
 import { Step, usePath } from '../../path';
@@ -31,6 +32,7 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 	const history = useHistory();
 	const makePath = usePath();
 	const { goBack, goNext } = useStepNavigation();
+	const { goLastLocation } = useLastLocation();
 
 	const [ billingPeriod, setBillingPeriod ] = React.useState< Plans.PlanBillingPeriod >();
 
@@ -70,7 +72,7 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 
 	const [ planUpdated, setPlanUpdated ] = React.useState( false );
 
-	const handleBack = () => ( isModal ? history.goBack() : goBack() );
+	const handleBack = () => ( isModal ? goLastLocation() : goBack() );
 	const handlePlanSelect = async ( planProductId: number | undefined ) => {
 		// When picking a free plan, if there is a paid domain selected, it's changed automatically to a free domain
 		if ( isPlanProductFree( planProductId ) && ! domain?.is_free ) {
@@ -88,7 +90,7 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 	React.useEffect( () => {
 		if ( planUpdated ) {
 			if ( isModal ) {
-				history.goBack();
+				goLastLocation();
 			} else {
 				goNext();
 			}

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -167,6 +167,11 @@ export const setIsRedirecting = ( isRedirecting: boolean ) => ( {
 	isRedirecting,
 } );
 
+export const setLastLocation = ( path: string ) => ( {
+	type: 'SET_LAST_LOCATION' as const,
+	path,
+} );
+
 export const setPlanProductId = ( planProductId: number | undefined ) => ( {
 	type: 'SET_PLAN_PRODUCT_ID' as const,
 	planProductId,
@@ -233,6 +238,7 @@ export type OnboardAction = ReturnType<
 	| typeof setHasUsedDomainsStep
 	| typeof setHasUsedPlansStep
 	| typeof setIsRedirecting
+	| typeof setLastLocation
 	| typeof setPlanProductId
 	| typeof setRandomizedDesigns
 	| typeof setSelectedDesign

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -29,6 +29,7 @@ registerStore< State >( STORE_KEY, {
 		'domainSearch',
 		'hasUsedDomainsStep',
 		'hasUsedPlansStep',
+		'lastLocation',
 		'pageLayouts',
 		'planProductId',
 		'randomizedDesigns',

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -226,6 +226,16 @@ const hasOnboardingStarted: Reducer< boolean, OnboardAction > = ( state = false,
 	return state;
 };
 
+const lastLocation: Reducer< string, OnboardAction > = ( state = '', action ) => {
+	if ( action.type === 'SET_LAST_LOCATION' ) {
+		return action.path;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return '';
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	domain,
 	domainSearch,
@@ -245,6 +255,7 @@ const reducer = combineReducers( {
 	wasVerticalSkipped,
 	randomizedDesigns,
 	hasOnboardingStarted,
+	lastLocation,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -6,6 +6,7 @@ import { isGoodDefaultDomainQuery } from '@automattic/domain-picker';
 
 export const getIsRedirecting = ( state: State ) => state.isRedirecting;
 export const getPlanProductId = ( state: State ) => state.planProductId;
+export const getLastLocation = ( state: State ) => state.lastLocation;
 export const getRandomizedDesigns = ( state: State ) => state.randomizedDesigns;
 export const getSelectedDesign = ( state: State ) => state.selectedDesign;
 export const getSelectedDomain = ( state: State ) => state.domain;


### PR DESCRIPTION
## Changes proposed in this Pull Request

The "Go Back" button breaks when landing through the url to the following path:
- /new/language-modal
- /new/plans-modal
- /new/domains-modal

This PR fixes this by storing the last route location in the data store `lastLocation` when route changes in when user go through the onboarding flow.

## Testing instructions

**Pro Tip:** You can add the following line to the dev tools live expression watcher to see what values it holds:

```
JSON.parse(localStorage.getItem('WP_ONBOARD'))['automattic/onboard'].lastLocation
```

### Test 1: Pressing **Go Back** should go back to fallback step `/` name step when fresh.

* Enter `/new?fresh`.
* **Open a new tab** and go to any of these 3 urls:
    - [x] `/new/language-modal`
    - [x] `/new/plans-modal`
    - [x] `/new/domains-modal`
* Click on **Go Back** button.
* It should go to the `/` name step.


### Test 2: Pressing **Go Back** should go back to previous step where user left off.

* Enter `/new` and feel free to stop at any step (domain step, design step, feature picker step, plan step, etc.).
* Open up any of the following modal by clicking on their respective header buttons.
   * [x] Domain modal _(through the domain button on the top left)_.
   * [x] Plans modal _(through the plans button on the top right)_.
   * [x] Language modal _(through the language button on the top right)_. 
* **Open a new tab** and go to any of these 3 urls:
    - [x] `/new/language-modal`
    - [x] `/new/plans-modal`
    - [x] `/new/domains-modal`
* Click on **Go Back** button.
* It should go to the previous step where the user left off.

Fixes #49360
