### PR TITLE
Partner Portal: Add a quick and dirty way for users to switch between keys

### DIFF
--- a/client/components/data/query-jetpack-partner-portal-license-counts/index.ts
+++ b/client/components/data/query-jetpack-partner-portal-license-counts/index.ts
@@ -2,19 +2,22 @@
  * External dependencies
  */
 import { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { fetchLicenseCounts } from 'calypso/state/partner-portal/licenses/actions';
+import { getActivePartnerKeyId } from 'calypso/state/partner-portal/partner/selectors';
 
 export default function QueryJetpackPartnerPortalLicenseCounts() {
 	const dispatch = useDispatch();
+	const activeKeyId = useSelector( getActivePartnerKeyId );
 
 	useEffect( () => {
+		// Key switching for requests is already done for us - we use keyId just to re-trigger the request.
 		dispatch( fetchLicenseCounts() );
-	}, [ dispatch ] );
+	}, [ dispatch, activeKeyId ] );
 
 	return null;
 }

--- a/client/components/data/query-jetpack-partner-portal-licenses/index.ts
+++ b/client/components/data/query-jetpack-partner-portal-licenses/index.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -13,6 +13,7 @@ import {
 	LicenseSortDirection,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { fetchLicenses } from 'calypso/state/partner-portal/licenses/actions';
+import { getActivePartnerKeyId } from 'calypso/state/partner-portal/partner/selectors';
 
 interface Props {
 	filter: LicenseFilter;
@@ -30,10 +31,12 @@ export default function QueryJetpackPartnerPortalLicenses( {
 	page,
 }: Props ) {
 	const dispatch = useDispatch();
+	const activeKeyId = useSelector( getActivePartnerKeyId );
 
 	useEffect( () => {
+		// Key switching for requests is already done for us - we use keyId just to re-trigger the request.
 		dispatch( fetchLicenses( filter, search, sortField, sortDirection, page ) );
-	}, [ dispatch, filter, search, sortField, sortDirection, page ] );
+	}, [ dispatch, activeKeyId, filter, search, sortField, sortDirection, page ] );
 
 	return null;
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -17,6 +18,17 @@ import {
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import LicenseStateFilter from 'calypso/jetpack-cloud/sections/partner-portal/license-state-filter';
+import SelectDropdown from 'calypso/components/select-dropdown';
+import {
+	getActivePartnerKeyId,
+	getCurrentPartner,
+} from 'calypso/state/partner-portal/partner/selectors';
+import { setActivePartnerKey } from 'calypso/state/partner-portal/partner/actions';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 interface Props {
 	filter: LicenseFilter;
@@ -34,12 +46,37 @@ export default function Licenses( {
 	sortField,
 }: Props ): ReactElement {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const partner = useSelector( getCurrentPartner );
+	const activeKeyId = useSelector( getActivePartnerKeyId );
+	const onKeySelect = useCallback( ( option ) => {
+		dispatch( setActivePartnerKey( parseInt( option.value ) ) );
+	}, [] );
+
+	const options =
+		partner &&
+		partner.keys.map( ( key ) => ( {
+			value: key.id.toString(),
+			label: key.name,
+		} ) );
+
+	options?.unshift( { label: translate( 'Partner Key' ) as string, value: '', isLabel: true } );
 
 	return (
 		<Main wideLayout={ true } className="licenses">
 			<DocumentHead title={ translate( 'Licenses' ) } />
 
-			<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>
+			<div className="licenses__header">
+				<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>
+				{ options && options.length > 2 && (
+					<SelectDropdown
+						initialSelected={ activeKeyId.toString() }
+						options={ options }
+						onSelect={ onKeySelect }
+						compact
+					/>
+				) }
+			</div>
 
 			<LicenseStateFilter filter={ filter } search={ search } />
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
@@ -1,0 +1,10 @@
+.licenses {
+	&__header {
+		display: flex;
+		align-items: center;
+
+		> * + * {
+			margin-left: 24px;
+		}
+	}
+}


### PR DESCRIPTION
Context:
* Project thread: pbtFPC-Um-p2
* i4 designs: pbtFPC-103-p2

#### Changes proposed in this Pull Request

* In the Partner Portal, add a dropdown to switch between keys on the fly when the user has multiple keys.

#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key, if prompted.
* Make sure the key selection dropdown appears and lists all of your active keys.
* Disable all but one of your keys and make sure the dropdown does not appear after refreshing.

![Screenshot 2021-03-03 at 21 08 59](https://user-images.githubusercontent.com/22746396/109858609-af075800-7c64-11eb-9383-bc012efc5a3a.png)