### PR TITLE
ci(e2e): Fix missing `driver` in e2e tests

### DIFF
--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -36,6 +36,7 @@ const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
+let driver;
 let editor;
 let sampleImages;
 
@@ -99,11 +100,10 @@ async function insertBlock( Block ) {
 /**
  * Starts a new post in the editor. User must be logged-in.
  *
- * @param {object} driver WebDriver instance
  * @param {object} loginFlow Instance of the LoginFlow helper.
  * @returns {object} Instance of the GutenbergEditorComponent.
  */
-async function startNewPost( driver, loginFlow ) {
+async function startNewPost( loginFlow ) {
 	await ReaderPage.Visit( driver );
 	await NavBarComponent.Expect( driver );
 
@@ -136,10 +136,9 @@ function verifyBlockInEditor( Block ) {
 /**
  * Re-usable collection of steps for verifying blocks in the frontend/published page.
  *
- * @param {object} driver WebDriver instance
  * @param {Function} Block A block class.
  */
-function verifyBlockInPublishedPage( driver, Block ) {
+function verifyBlockInPublishedPage( Block ) {
 	step( 'Publish page', async function () {
 		await editor.publish( { visit: true } );
 	} );
@@ -159,8 +158,6 @@ function verifyBlockInPublishedPage( driver, Block ) {
 }
 
 describe( `[${ host }, ${ screenSize }] Test Gutenberg upgrade against most popular blocks:`, function () {
-	let driver;
-
 	before( async function () {
 		if ( process.env.GUTENBERG_EDGE === 'true' ) {
 			sampleImages = times( 3, () => mediaHelper.createFile() );
@@ -206,7 +203,7 @@ describe( `[${ host }, ${ screenSize }] Test Gutenberg upgrade against most popu
 					const loginFlow = new LoginFlow( driver, 'gutenbergUpgradeUser' );
 
 					await loginFlow.login();
-					editor = await startNewPost( driver, loginFlow );
+					editor = await startNewPost( loginFlow );
 				} );
 
 				step( `Insert and configure the block`, async function () {
@@ -219,7 +216,7 @@ describe( `[${ host }, ${ screenSize }] Test Gutenberg upgrade against most popu
 					currentGutenbergBlocksCode = await editor.getBlocksCode();
 				} );
 
-				verifyBlockInPublishedPage( driver, Block );
+				verifyBlockInPublishedPage( Block );
 			} );
 
 			describe( `Test the same block on a corresponding edge site`, function () {
@@ -227,7 +224,7 @@ describe( `[${ host }, ${ screenSize }] Test Gutenberg upgrade against most popu
 					const loginFlow = new LoginFlow( driver, 'gutenbergUpgradeEdgeUser' );
 
 					// No need to log in again as the edge site is owned by the same user.
-					editor = await startNewPost( driver, loginFlow );
+					editor = await startNewPost( loginFlow );
 				} );
 
 				step( 'Load the block via markup copied from the non-edge site', async function () {
@@ -236,7 +233,7 @@ describe( `[${ host }, ${ screenSize }] Test Gutenberg upgrade against most popu
 
 				verifyBlockInEditor( Block );
 
-				verifyBlockInPublishedPage( driver, Block );
+				verifyBlockInPublishedPage( Block );
 			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use closures to read `driver` instead of passing it as args.

Turns out that an async `before` is run and awaited only before `it`/`step`, but not before `describe` (see https://github.com/mochajs/mocha/issues/1628).

In this case `verifyBlockInEditor(driver)` is inside a `describe` block, so it runs before the async `before` that creates `driver` completes, passing `undefined` as the function arg.  I broke this in #50655

The tests defined _inside_ `verifyBlockInEditor` do wait for the async `before`. Moving `driver` back to a closure means they will find a populated `driver` when they run.

#### Testing instructions

Run e2e test locally with `cd test/e2e && GUTENBERG_EDGE=true NODE_CONFIG_ENV=test BROWSERSIZE="desktop" node_modules/.bin/mocha ./specs/wp-calypso-gutenberg-upgrade-spec.js`. If you see a passing `Block is displayed in the published page` it means the fix is working.

![image](https://user-images.githubusercontent.com/975703/109872134-4c19bf00-7c6c-11eb-8b9f-74a70b24006d.png)
