### PR TITLE
Hide CTAs in success view when it isn't needed

### DIFF
--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -29,14 +29,20 @@ const Success: React.FunctionComponent = () => {
 		LaunchContext
 	);
 
-	const isSiteLaunching = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunching( siteId ) );
+	const isSiteLaunching = useSelect(
+		( select ) => select( SITE_STORE ).isSiteLaunching( siteId ),
+		[]
+	);
 
 	const locale = useLocale();
 
-	const [ isSelectedPlanPaid, planProductId ] = useSelect( ( select ) => [
-		select( LAUNCH_STORE ).isSelectedPlanPaid(),
-		select( LAUNCH_STORE ).getSelectedPlanProductId(),
-	] );
+	const [ isSelectedPlanPaid, planProductId ] = useSelect(
+		( select ) => [
+			select( LAUNCH_STORE ).isSelectedPlanPaid(),
+			select( LAUNCH_STORE ).getSelectedPlanProductId(),
+		],
+		[]
+	);
 
 	const { unsetModalDismissible, hideModalTitle, closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
 

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -56,7 +56,7 @@ const Success: React.FunctionComponent = () => {
 
 	// if the user has an ecommerce plan or they're using focused launch from wp-admin
 	// they will be automatically redirected to /checkout, in which case the CTAs are not needed
-	const willUserBeRedirectedAutomatically = isEcommercePlan || ! isInIframe;
+	const willUserBeRedirectedAutomatically = ! isInIframe || isEcommercePlan;
 
 	React.useEffect( () => {
 		setDisplayedSiteUrl( `https://${ sitePrimaryDomain?.domain }` );
@@ -101,7 +101,7 @@ const Success: React.FunctionComponent = () => {
 			<SubTitle tagName="h3">
 				{ isSiteLaunching ? subtitleTextLaunching : subtitleTextLaunched }
 			</SubTitle>
-			{ ! isSiteLaunching && (
+			{ ! willUserBeRedirectedAutomatically && ! isSiteLaunching && (
 				<>
 					<div className="focused-launch-success__url-wrapper">
 						<span className="focused-launch-success__url-field">{ displayedSiteUrl }</span>
@@ -124,22 +124,17 @@ const Success: React.FunctionComponent = () => {
 							{ hasCopied ? copyButtonLabelActivated : copyButtonLabelIdle }
 						</ClipboardButton>
 					</div>
+					{ /* @TODO: at the moment this only works when the modal is in the block editor. */ }
+					<NextButton
+						onClick={ continueEditing }
+						className="focused-launch-success__continue-editing-button"
+					>
+						{ __( 'Continue Editing', __i18n_text_domain__ ) }
+					</NextButton>
 
-					{ ! willUserBeRedirectedAutomatically && (
-						<>
-							{ /* @TODO: at the moment this only works when the modal is in the block editor. */ }
-							<NextButton
-								onClick={ continueEditing }
-								className="focused-launch-success__continue-editing-button"
-							>
-								{ __( 'Continue Editing', __i18n_text_domain__ ) }
-							</NextButton>
-
-							<BackButton onClick={ redirectToHome }>
-								{ __( 'Back home', __i18n_text_domain__ ) }
-							</BackButton>
-						</>
-					) }
+					<BackButton onClick={ redirectToHome }>
+						{ __( 'Back home', __i18n_text_domain__ ) }
+					</BackButton>
 				</>
 			) }
 		</div>

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -9,6 +9,8 @@ import { Title, SubTitle, NextButton, BackButton } from '@automattic/onboarding'
 import { Icon, external } from '@wordpress/icons';
 import { ClipboardButton } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { PLANS_STORE } from '../../stores';
+import { useLocale } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -23,14 +25,18 @@ import './style.scss';
 // Success is shown when the site is launched but also while the site is still launching.
 // This view is technically going to be the selected view in the modal even while the user goes through the checkout flow (which is rendered on top of this view).
 const Success: React.FunctionComponent = () => {
-	const { redirectTo, siteId, getCurrentLaunchFlowUrl } = React.useContext( LaunchContext );
+	const { redirectTo, siteId, getCurrentLaunchFlowUrl, isInIframe } = React.useContext(
+		LaunchContext
+	);
 
 	const isSiteLaunching = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunching( siteId ) );
 
-	const isSelectedPlanPaid = useSelect(
-		( select ) => select( LAUNCH_STORE ).isSelectedPlanPaid(),
-		[]
-	);
+	const locale = useLocale();
+
+	const [ isSelectedPlanPaid, planProductId ] = useSelect( ( select ) => [
+		select( LAUNCH_STORE ).isSelectedPlanPaid(),
+		select( LAUNCH_STORE ).getSelectedPlanProductId(),
+	] );
 
 	const { unsetModalDismissible, hideModalTitle, closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
 
@@ -38,6 +44,19 @@ const Success: React.FunctionComponent = () => {
 
 	const [ displayedSiteUrl, setDisplayedSiteUrl ] = React.useState( '' );
 	const [ hasCopied, setHasCopied ] = React.useState( false );
+
+	const isEcommercePlan = useSelect(
+		( select ) => {
+			const plansStore = select( PLANS_STORE );
+			const plan = plansStore.getPlanByProductId( planProductId, locale );
+			return plansStore.isPlanEcommerce( plan?.periodAgnosticSlug );
+		},
+		[ planProductId, locale ]
+	);
+
+	// if the user has an ecommerce plan or they're using focused launch from wp-admin
+	// they will be automatically redirected to /checkout, in which case the CTAs are not needed
+	const willUserBeRedirectedAutomatically = isEcommercePlan || ! isInIframe;
 
 	React.useEffect( () => {
 		setDisplayedSiteUrl( `https://${ sitePrimaryDomain?.domain }` );
@@ -106,17 +125,21 @@ const Success: React.FunctionComponent = () => {
 						</ClipboardButton>
 					</div>
 
-					{ /* @TODO: at the moment this only works when the modal is in the block editor. */ }
-					<NextButton
-						onClick={ continueEditing }
-						className="focused-launch-success__continue-editing-button"
-					>
-						{ __( 'Continue Editing', __i18n_text_domain__ ) }
-					</NextButton>
+					{ ! willUserBeRedirectedAutomatically && (
+						<>
+							{ /* @TODO: at the moment this only works when the modal is in the block editor. */ }
+							<NextButton
+								onClick={ continueEditing }
+								className="focused-launch-success__continue-editing-button"
+							>
+								{ __( 'Continue Editing', __i18n_text_domain__ ) }
+							</NextButton>
 
-					<BackButton onClick={ redirectToHome }>
-						{ __( 'Back home', __i18n_text_domain__ ) }
-					</BackButton>
+							<BackButton onClick={ redirectToHome }>
+								{ __( 'Back home', __i18n_text_domain__ ) }
+							</BackButton>
+						</>
+					) }
 				</>
 			) }
 		</div>

--- a/packages/launch/src/hooks/index.ts
+++ b/packages/launch/src/hooks/index.ts
@@ -7,3 +7,4 @@ export * from './use-title';
 export * from './use-site-domains';
 export * from './use-plans';
 export * from './use-cart';
+export * from './use-will-redirect-after-success';

--- a/packages/launch/src/hooks/use-cart.ts
+++ b/packages/launch/src/hooks/use-cart.ts
@@ -11,7 +11,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { LAUNCH_STORE, SITE_STORE, PLANS_STORE } from '../stores';
 import LaunchContext from '../context';
 import { getDomainProduct, getPlanProductForFlow } from '../utils';
-import { useSiteDomains } from '../hooks';
+import { useSiteDomains, useWillRedirectAfterSuccess } from '../hooks';
 
 type LaunchCart = {
 	goToCheckout: () => Promise< void >; // used in gutenboarding-launch
@@ -20,7 +20,7 @@ type LaunchCart = {
 };
 
 export function useCart(): LaunchCart {
-	const { siteId, flow, openCheckout, isInIframe } = React.useContext( LaunchContext );
+	const { siteId, flow, openCheckout } = React.useContext( LaunchContext );
 
 	const locale = useLocale();
 
@@ -49,6 +49,8 @@ export function useCart(): LaunchCart {
 
 	const [ isCartUpdating, setIsCartUpdating ] = React.useState( false );
 
+	const willRedirectAfterSuccess = useWillRedirectAfterSuccess();
+
 	const addProductsToCart = async () => {
 		if ( isCartUpdating ) {
 			return;
@@ -75,7 +77,7 @@ export function useCart(): LaunchCart {
 	};
 
 	const goToCheckoutAndLaunch = async () => {
-		if ( ! isInIframe || isEcommercePlan ) {
+		if ( willRedirectAfterSuccess ) {
 			// We launch the site first and then open Checkout in these cases:
 			// - Focused Launch is loaded outside Calypso iframe (in wp-admin)
 			// - eCommerce plan is selected so Checkout will handle thank-you redirect after purchase

--- a/packages/launch/src/hooks/use-will-redirect-after-success.ts
+++ b/packages/launch/src/hooks/use-will-redirect-after-success.ts
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { useSelect } from '@wordpress/data';
+import { useLocale } from '@automattic/i18n-utils';
+
+/**
+ * Internal dependencies
+ */
+import { LAUNCH_STORE } from '../stores';
+import { PLANS_STORE } from '../stores';
+import LaunchContext from '../context';
+
+/**
+ * When the user has an ecommerce plan or they're using focused launch in wp-admin
+ * they will be automatically redirected to /checkout after site launch.
+ * This hook returns true when this is the case
+ *
+ * @returns boolean
+ */
+export function useWillRedirectAfterSuccess(): boolean {
+	const { isInIframe } = React.useContext( LaunchContext );
+
+	const locale = useLocale();
+
+	const planProductId = useSelect(
+		( select ) => select( LAUNCH_STORE ).getSelectedPlanProductId(),
+		[]
+	);
+
+	const isEcommercePlan = useSelect(
+		( select ) => {
+			const plansStore = select( PLANS_STORE );
+			const plan = plansStore.getPlanByProductId( planProductId, locale );
+			return plansStore.isPlanEcommerce( plan?.periodAgnosticSlug );
+		},
+		[ planProductId, locale ]
+	);
+
+	return ! isInIframe || isEcommercePlan;
+}

--- a/packages/launch/src/hooks/use-will-redirect-after-success.ts
+++ b/packages/launch/src/hooks/use-will-redirect-after-success.ts
@@ -8,8 +8,7 @@ import { useLocale } from '@automattic/i18n-utils';
 /**
  * Internal dependencies
  */
-import { LAUNCH_STORE } from '../stores';
-import { PLANS_STORE } from '../stores';
+import { LAUNCH_STORE, PLANS_STORE } from '../stores';
 import LaunchContext from '../context';
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR hides the CTA buttons when we automatically redirect after success.
* It also hides the URL and the copy button because it can be frustrating to try and use them, only for them to disappear after a second.

#### Demo videos

https://user-images.githubusercontent.com/17054134/109955241-90e03d00-7ce2-11eb-97fc-63aef28d8850.mov


https://user-images.githubusercontent.com/17054134/109955263-95a4f100-7ce2-11eb-8bd2-3f27fd734b55.mov


https://user-images.githubusercontent.com/17054134/109955269-976eb480-7ce2-11eb-99b4-40adbb95111e.mov


https://user-images.githubusercontent.com/17054134/109955274-989fe180-7ce2-11eb-8957-ec41ec53da81.mov


#### Testing instructions

1. Create a free unlaunched site using `/start`.
2. Let's say its called http://test123.wordpress.com.
3. Sandbox this site.
4. In Calypso, run `yarn start`, in `apps/editing-toolkit` run `yarn dev --sync`.

### Calypso - free plan and domain

5. Go to http://calypso.localhost:3000/page/test123.wordpress.com/5.
6. Pick a free plan and a free domain.
7. Launch. You should see "Continue editing" button.

### Calypso - premium plan
(you need a new site)

5. Go to http://calypso.localhost:3000/page/test123.wordpress.com/5.
6. Click Launch.
7. Pick a premium plan and a free domain.
8. Launch. You should be taken to checkout without seeing success view.

### wp-admin - premium plan
(you need a new site)

5. Go to http://test123.wordpress.com/wp-admin/post-new.php.
6. Click Launch.
7. Pick a premium plan and a free domain.
8. Launch. Success view shouldn't have any buttons.

### wp-admin or calypso - Ecommerce
(you need a new site)

5. Go to http://test123.wordpress.com/wp-admin/post-new.php.
6. Click Launch.
7. Pick an ecommerce plan and a free domain.
8. Launch. Success view shouldn't have any buttons.



Fixes https://github.com/Automattic/wp-calypso/issues/50541
