### PR TITLE
Domains: Display a notice when redirecting away from Google Workspace upgrade

### DIFF
--- a/client/components/upgrades/gsuite/index.jsx
+++ b/client/components/upgrades/gsuite/index.jsx
@@ -3,7 +3,7 @@
  */
 import page from 'page';
 import React, { useEffect, useRef } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import { useShoppingCart } from '@automattic/shopping-cart';
 
@@ -21,6 +21,7 @@ import HeaderCake from 'calypso/components/header-cake';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { getProductsList } from 'calypso/state/products-list/selectors/get-products-list';
+import { infoNotice } from 'calypso/state/notices/actions';
 
 export default function GSuiteUpgrade( { domain } ) {
 	const { responseCart: cart, addProductsToCart, isLoading } = useShoppingCart();
@@ -50,14 +51,24 @@ export default function GSuiteUpgrade( { domain } ) {
 		page( `/checkout/${ selectedSiteSlug }` );
 	};
 
+	const translate = useTranslate();
+	const reduxDispatch = useDispatch();
+
+	const didRedirect = useRef( false );
 	useEffect( () => {
+		if ( didRedirect.current === true ) {
+			return;
+		}
 		if ( cart && ! isLoading && ! hasDomainInCart( cart, domain ) ) {
+			didRedirect.current = true;
+			const message = translate(
+				'There is no domain in your cart, so you cannot add an email product.'
+			);
+			reduxDispatch( infoNotice( message, { displayOnNextPage: true } ) );
 			// Should we handle this more gracefully?
 			page( `/domains/add/${ selectedSiteSlug }` );
 		}
-	}, [ cart, domain, selectedSiteSlug, isLoading ] );
-
-	const translate = useTranslate();
+	}, [ cart, domain, selectedSiteSlug, isLoading, translate, reduxDispatch ] );
 
 	const productSlug = config.isEnabled( 'google-workspace-migration' )
 		? GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY

--- a/client/components/upgrades/gsuite/index.jsx
+++ b/client/components/upgrades/gsuite/index.jsx
@@ -62,7 +62,8 @@ export default function GSuiteUpgrade( { domain } ) {
 		if ( cart && ! isLoading && ! hasDomainInCart( cart, domain ) ) {
 			didRedirect.current = true;
 			const message = translate(
-				'There is no domain in your cart, so you cannot add an email product.'
+				'To add email for %(domain)s, you must either own the domain or have it in your shopping cart.',
+				{ args: { domain } }
 			);
 			reduxDispatch( infoNotice( message, { displayOnNextPage: true } ) );
 			// Should we handle this more gracefully?


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Google Workspace upgrade page that's usually displayed between selecting a new domain and reaching checkout has a failsafe mechanism which will redirect back to the domains page if the cart does not contain a domain product. I believe that this might sometimes be triggered incorrectly (see the failing e2e test in https://github.com/Automattic/wp-calypso/pull/50723), but it's hard to know because the redirect is so fast and there's no context given to the user.

This PR adds a notice when the redirect occurs so that there's at least a reason given for ending up on a different page.

Before:

<img width="931" alt="Screen Shot 2021-03-03 at 5 28 38 PM" src="https://user-images.githubusercontent.com/2036909/109881221-e9153180-7c45-11eb-953f-fdbe72c8c565.png">

After:

<img width="928" alt="Screen Shot 2021-03-03 at 5 28 27 PM" src="https://user-images.githubusercontent.com/2036909/109881232-ed414f00-7c45-11eb-92c8-f1bdb854fdb2.png">


#### Testing instructions

- Make sure your cart is empty.
- Visit the Google Workspace upgrade page directly at a URL like `/domains/add/google.com/google-apps/example.com` (the first domain name is the domain you're supposedly adding so it can be anything; the second domain name is your wp.com site).
- Verify that after the page loads you are redirected to the "Site Domains" page which lets you search for a domain.
- Verify that you see a notice message mentioning that there is no domain in your cart.