### PR TITLE
Add regression test to warn us that not all patterns might be loading

### DIFF
--- a/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
+++ b/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
@@ -104,6 +104,25 @@ describe( `[${ host }] Experimental features we depend on are available (${ scre
 				);
 			}
 		);
+
+		// Regression test for https://github.com/Automattic/wp-calypso/pull/48940.
+		// At the time I write this, the default block patterns in the test site /
+		// theme used to test this (edge and non-edge) amount to 10. When activated,
+		// it goes up to 96. Testing if total is > 10 would be too brittle and too
+		// close to the default baseline number. That's why we actually test if the
+		// number is >= the current total number. I assume it's more likely that more
+		// patterns will be added than removed. This also means if we see a dramatic
+		// change in the number to the lower end, then something is probably wrong.
+		step( `number of block patterns loaded should be greater than the default`, async function () {
+			const expectedExperimentalBlockPatternsLength = 96;
+			const __experimentalBlockPatternsLength = await driver.executeScript(
+				`return window.wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns.length`
+			);
+			assert(
+				__experimentalBlockPatternsLength >= expectedExperimentalBlockPatternsLength,
+				`Number of loaded block patterns does not seem right (expected: >= ${ expectedExperimentalBlockPatternsLength }, actual: ${ __experimentalBlockPatternsLength })`
+			);
+		} );
 	} );
 
 	after( async () => {

--- a/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
+++ b/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
@@ -108,13 +108,13 @@ describe( `[${ host }] Experimental features we depend on are available (${ scre
 		// Regression test for https://github.com/Automattic/wp-calypso/pull/48940.
 		// At the time I write this, the default block patterns in the test site /
 		// theme used to test this (edge and non-edge) amount to 10. When activated,
-		// it goes up to 96. Testing if total is > 10 would be too brittle and too
-		// close to the default baseline number. That's why we actually test if the
-		// number is >= the current total number. I assume it's more likely that more
+		// it goes up to >100. Testing if total is > 10 would be too brittle and too
+		// close to the default baseline number. 50 seems to be a good threshold,
+		// also to avoid potential false-negatives. I assume it's more likely that more
 		// patterns will be added than removed. This also means if we see a dramatic
 		// change in the number to the lower end, then something is probably wrong.
 		step( `number of block patterns loaded should be greater than the default`, async function () {
-			const expectedExperimentalBlockPatternsLength = 96;
+			const expectedExperimentalBlockPatternsLength = 50;
 			const __experimentalBlockPatternsLength = await driver.executeScript(
 				`return window.wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns.length`
 			);


### PR DESCRIPTION
Add regression test to warn us if the number of loaded block patterns gets lower than a specific threshold _(captured when all patterns are loading, more details below)_ which could mean ETK patterns are not loading.

I'm taking a more conservative approach of failing if the number of block patterns gets lower than a threshold that I captured from the two test sites where this test runs against _(considering the Gutenberg versions being used at this time for edge / production)_. This means that if one block pattern is removed, this test will fail. I don't think block patterns tend to get removed though, but I might be wrong. This also means that we don't run the risk of missing any cases where block patterns might not be loading, and it covers the scenario in the bug we experienced with Gutenberg 9.7.2.

Regression test for https://github.com/Automattic/wp-calypso/issues/50684.

#### Changes proposed in this Pull Request

* New E2E test.

#### Testing instructions

The test should pass.

Related to: https://github.com/Automattic/wp-calypso/pull/48940. 
