### PR TITLE
Fix: broken back function in domain only flow

### DIFF
--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize, getLocaleSlug } from 'i18n-calypso';
-import { get, findLast, findIndex } from 'lodash';
+import { get } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import classnames from 'classnames';
 
@@ -24,7 +24,6 @@ import { getABTestVariation } from 'calypso/lib/abtest';
  * Style dependencies
  */
 import './style.scss';
-import * as previousStepsUptoCurrent from '@wordpress/rich-text';
 
 export class NavigationLink extends Component {
 	static propTypes = {

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -24,6 +24,7 @@ import { getABTestVariation } from 'calypso/lib/abtest';
  * Style dependencies
  */
 import './style.scss';
+import * as previousStepsUptoCurrent from '@wordpress/rich-text';
 
 export class NavigationLink extends Component {
 	static propTypes = {
@@ -53,14 +54,14 @@ export class NavigationLink extends Component {
 	 * @returns {object} The previous step object
 	 */
 	getPreviousStep() {
-		const { flowName, signupProgress, stepName } = this.props;
+		const { flowName, signupProgress, stepName: currentStepName } = this.props;
 
-		let steps = getFilteredSteps( flowName, signupProgress );
-		steps = steps.slice(
-			0,
-			findIndex( steps, ( step ) => step.stepName === stepName )
-		);
-		const previousStep = findLast( steps, ( step ) => ! step.wasSkipped );
+		const stepsThatBelongToTheCurrentFlow = getFilteredSteps( flowName, signupProgress );
+
+		const [ previousStep ] = stepsThatBelongToTheCurrentFlow
+			.filter( ( step ) => step.stepName !== currentStepName )
+			.filter( ( step ) => ! step.wasSkipped )
+			.slice( -1 );
 
 		return previousStep || { stepName: null };
 	}

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -46,22 +46,6 @@ export class NavigationLink extends Component {
 		allowBackFirstStep: false,
 	};
 
-	/**
-	 * Returns the last step in a signup progress , skipping over steps with the
-	 * `wasSkipped` property.
-	 *
-	 * @param signUpProgress current corted, ompleted steps in a flow
-	 * @param currentStepName current step name
-	 * @returns {object} The previous step object
-	 */
-	getLastKnownStep( signUpProgress, currentStepName ) {
-		const [ lastKnownStepInFlow ] = signUpProgress
-			.filter( ( step ) => step.stepName !== currentStepName )
-			.filter( ( step ) => ! step.wasSkipped )
-			.slice( -1 );
-		return lastKnownStepInFlow;
-	}
-
 	getPreviousStep( flowName, signupProgress, currentStepName ) {
 		let previousStep = { stepName: null };
 
@@ -70,7 +54,10 @@ export class NavigationLink extends Component {
 		}
 
 		//Progressed steps will be filtered and sorted in relation to the steps definition of the current flow
-		const filteredProgressedSteps = getFilteredSteps( flowName, signupProgress );
+		//Skipped steps are also filtered out
+		const filteredProgressedSteps = getFilteredSteps( flowName, signupProgress ).filter(
+			( step ) => ! step.wasSkipped
+		);
 		if ( filteredProgressedSteps.length === 0 ) {
 			return previousStep;
 		}
@@ -78,7 +65,7 @@ export class NavigationLink extends Component {
 		//Get the previous step according to the step definition
 		const previousStepName = getPreviousStepName( flowName, currentStepName );
 
-		//Find previous step in current relevant progress
+		//Find previous step in current relevant filtered progress
 		const previousStepFromProgress = filteredProgressedSteps.find(
 			( step ) => step.stepName === previousStepName
 		);
@@ -86,7 +73,10 @@ export class NavigationLink extends Component {
 			previousStep = previousStepFromProgress;
 		} else {
 			//If no previous step found in progress, go to the last step of the progress that belongs to the current flow
-			previousStep = this.getLastKnownStep( filteredProgressedSteps, currentStepName );
+			const [ lastKnownStepInFlow ] = filteredProgressedSteps
+				.filter( ( step ) => step.stepName !== currentStepName )
+				.slice( -1 );
+			previousStep = lastKnownStepInFlow;
 		}
 
 		return previousStep;

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -13,11 +13,13 @@ import Gridicon from 'calypso/components/gridicon';
 jest.mock( 'calypso/signup/utils', () => ( {
 	getStepUrl: jest.fn(),
 	getFilteredSteps: jest.fn(),
+	getPreviousStepName: jest.fn(),
+	isFirstStepInFlow: jest.fn(),
 } ) );
 
 const noop = () => {};
 const signupUtils = require( 'calypso/signup/utils' );
-const { getStepUrl, getFilteredSteps } = signupUtils;
+const { getStepUrl, getFilteredSteps, getPreviousStepName, isFirstStepInFlow } = signupUtils;
 
 describe( 'NavigationLink', () => {
 	const props = {
@@ -37,6 +39,8 @@ describe( 'NavigationLink', () => {
 	};
 
 	beforeEach( () => {
+		getPreviousStepName.mockReturnValue( 'test:step1' );
+		isFirstStepInFlow.mockReturnValue( false );
 		getFilteredSteps.mockReturnValue( Object.values( props.signupProgress ) );
 	} );
 
@@ -89,6 +93,8 @@ describe( 'NavigationLink', () => {
 
 		// when it is the first step
 		getStepUrl.mockReset();
+		getPreviousStepName.mockReturnValue( 'test:step1' );
+		isFirstStepInFlow.mockReturnValue( true );
 		getFilteredSteps.mockReturnValue( [
 			{ stepName: 'test:step1', stepSectionName: 'test:section1', wasSkipped: false },
 		] );

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -148,7 +148,7 @@ describe( 'NavigationLink', () => {
 		expect( previousStep.stepName ).toBe( 'test:step2' );
 	} );
 
-	test( 'getPreviousStep() When in unknown step should return last step in progress which belong to the current flow', () => {
+	test( 'getPreviousStep() When current steps is unknown, step should return last step in progress which belong to the current flow', () => {
 		const navigationLink = new NavigationLink();
 		const { flowName, signupProgress } = props;
 
@@ -179,27 +179,47 @@ describe( 'NavigationLink', () => {
 		const { flowName } = props;
 
 		const singupProgressWithOnlyStepsThatDoNotBelongToThisFlow = {
-			'some-random-step': {
-				stepName: 'test:step4',
-				stepSectionName: 'test:section4',
+			'test:some-random-step': {
+				stepName: 'test:some-random-step',
+				stepSectionName: 'test:some-random-step:section',
 				wasSkipped: false,
 			},
-			'another-random-step': {
-				stepName: 'test:step4',
-				stepSectionName: 'test:section4',
+			'test:some-other-random-step': {
+				stepName: 'test:some-other-random-step',
+				stepSectionName: 'test:some-other-random-step',
 				wasSkipped: false,
 			},
 		};
 
+		//This simulates not having relevant steps in current flow
 		getFilteredSteps.mockReturnValue( [] );
+
 		isFirstStepInFlow.mockReturnValue( false );
-		const currentStepName = 'some-other-random-step';
+		const currentStepName = 'test:whatever-current-step';
 		const previousStep = navigationLink.getPreviousStep(
-			// eslint-disable-next-line no-undef
 			flowName,
 			singupProgressWithOnlyStepsThatDoNotBelongToThisFlow,
 			currentStepName
 		);
 		expect( previousStep.stepName ).toBe( null );
+	} );
+
+	test( 'getPreviousStep() When there are skipped steps they should be ignored', () => {
+		const { flowName, signupProgress } = props;
+		const navigationLink = new NavigationLink();
+		const stepsWithSkippedSteps = {
+			'test:step1': { stepName: 'test:step1', stepSectionName: 'test:section1', wasSkipped: false },
+			'test:step2': { stepName: 'test:step2', stepSectionName: 'test:section2', wasSkipped: true },
+			'test:step3': { stepName: 'test:step3', stepSectionName: 'test:section3', wasSkipped: true },
+			'test:step4': { stepName: 'test:step4', stepSectionName: 'test:section4', wasSkipped: false },
+		};
+
+		//According to step definitions the last step would return as mocked here
+		getPreviousStepName.mockReturnValue( 'test:step3' );
+
+		getFilteredSteps.mockReturnValue( Object.values( stepsWithSkippedSteps ) );
+		isFirstStepInFlow.mockReturnValue( false );
+		const previousStep = navigationLink.getPreviousStep( flowName, signupProgress, 'test:step4' );
+		expect( previousStep.stepName ).toBe( 'test:step1' );
 	} );
 } );

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -31,6 +31,11 @@ export function getStepName( parameters ) {
 	return find( pick( parameters, [ 'flowName', 'stepName' ] ), isStepName );
 }
 
+export function isFirstStepInFlow( flowName, stepName ) {
+	const { steps: stepsBelongingToFlow } = flows.getFlow( flowName );
+	return stepsBelongingToFlow.indexOf( stepName ) === 0;
+}
+
 function isStepName( pathFragment ) {
 	return ! isEmpty( steps[ pathFragment ] );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Fixed and refactored getPreviousStep function to outright ignore the current step when considering the previous step

#### Testing instructions

##### Fixed Breaking Test 
- Go to https://wordpress.com/start/domain/domain-only, 
- select a domain and click on the Existing WordPress.com Site. 
- When you click on the back button on that page, 
- it should go back to https://wordpress.com/start/domain/site-or-domain, but it goes back to the domain selection step.

##### Generic testing
- Go to /start
- Go back and forth across any flow/step to see if the back button only takes you to the previous step

Fixes 703-gh-Automattic/martech
Originally reported in pau2Xa-2yq-p2.

