### PR TITLE
o2-blocks (p2-autocomplete): also use site title for keywords

### DIFF
--- a/apps/o2-blocks/src/p2-autocomplete/editor.js
+++ b/apps/o2-blocks/src/p2-autocomplete/editor.js
@@ -22,7 +22,7 @@ const p2s = apiFetch( {
 	path: '/internal/P2s',
 } ).then( ( result ) =>
 	map( result.list, ( p2, subdomain ) => {
-		const keywords = [ subdomain ];
+		const keywords = [ subdomain, p2.title ];
 		const stripped = stripCommonWords( subdomain );
 		if ( subdomain !== stripped ) {
 			keywords.push( stripped );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In addition to the P2 subdomain, use the site title as autocompleter keyword to improve x-post autocomplete experience for large groups of P2s that have the same prefix, e.g. `jetpackp2`, `jetpackcrew`, `jetpackvoyager`, etc., as described in 2153-gh-Automattic/p2

Note: there is currently an existing "common prefix" strip step that is used as a workaround for the above-described problem. Instead of using this and adding `jetpack` as a common prefix, we propose to augment the keywords with the site title instead. This is also to get closer to the standard x-post autocompleter behavior.

#### Testing instructions
1. Apply the diff in code-D58072 to get the build files in your sandbox
2. Visit any internal P2 and trigger the x-post autocompleter.
3. Options presented should make sense.

Related to 2153-gh-Automattic/p2

