### PR TITLE
Nav Unification: Disable for Jetpack sites

### DIFF
--- a/client/state/selectors/is-nav-unification-enabled.js
+++ b/client/state/selectors/is-nav-unification-enabled.js
@@ -8,10 +8,19 @@ import cookie from 'cookie';
  */
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 
 export default ( state ) => {
 	// Disable if explicitly requested by the `?disable-nav-unification` query param.
 	if ( new URL( document.location ).searchParams.has( 'disable-nav-unification' ) ) {
+		return false;
+	}
+
+	// Disabled for Jetpack sites.
+	const siteId = getSelectedSiteId( state );
+	if ( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Disables the Nav Unification for Jetpack sites as per p1HpG7-bjx-p2#comment-45118.

#### Testing instructions

- Load Calypso using an a8c account.
- Make sure the Nav Unification is enabled for Simple and Atomic sites.
- Switch to a Jetpack site.
- Make sure the Nav Unification is disabled.

Follows up https://github.com/Automattic/wp-calypso/pull/50711.
Fixes https://github.com/Automattic/wp-calypso/issues/50704.