### PR TITLE
Framework: Refactor away from _.noop() - take 2

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-description/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-description/edit.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -29,6 +28,8 @@ import { PanelBody } from '@wordpress/components';
  * Internal dependencies
  */
 import { withSiteOptions } from '../../lib';
+
+const noop = () => {};
 
 function SiteDescriptionEdit( {
 	attributes,

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-title/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-title/edit.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -28,6 +27,8 @@ import { PanelBody } from '@wordpress/components';
  * Internal dependencies
  */
 import { withSiteOptions } from '../../lib';
+
+const noop = () => {};
 
 function SiteTitleEdit( {
 	attributes,

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/template/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/template/edit.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -22,6 +22,8 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 const TemplateEdit = compose(
 	withState( { templateClientId: null } ),

--- a/apps/notifications/src/panel/Notifications.jsx
+++ b/apps/notifications/src/panel/Notifications.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { Provider } from 'react-redux';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,6 +27,7 @@ import './boot/stylesheets/style.scss';
 
 let client;
 
+const noop = () => {};
 const globalData = {};
 
 repliesCache.cleanup();

--- a/apps/notifications/src/panel/templates/image-loader.jsx
+++ b/apps/notifications/src/panel/templates/image-loader.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop } from 'lodash';
 
 /**
  * Module variables
@@ -14,6 +13,7 @@ const LoadStatus = {
 	LOADED: 'LOADED',
 	FAILED: 'FAILED',
 };
+const noop = () => {};
 
 export class ImageLoader extends Component {
 	static propTypes = {

--- a/apps/notifications/src/panel/templates/nav-button.jsx
+++ b/apps/notifications/src/panel/templates/nav-button.jsx
@@ -4,12 +4,13 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Gridicon from './gridicons';
+
+const noop = () => {};
 
 export class NavButton extends Component {
 	static propTypes = {

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -4,7 +4,7 @@
 import { use, select } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
 import { applyFilters } from '@wordpress/hooks';
-import { castArray, noop, find } from 'lodash';
+import { castArray, find } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -15,6 +15,8 @@ import delegateEventTracking from './tracking/delegate-event-tracking';
 
 // Debugger.
 const debug = debugFactory( 'wpcom-block-editor:tracking' );
+
+const noop = () => {};
 
 /**
  * Global handler.

--- a/client/auth/test/login.jsx
+++ b/client/auth/test/login.jsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +16,8 @@ import { identity, noop } from 'lodash';
 import { Auth } from '../login';
 import { makeAuthRequest } from '../login-request';
 import FormButton from 'calypso/components/forms/form-button';
+
+const noop = () => {};
 
 jest.mock( '../login-request', () => ( {
 	makeAuthRequest: require( 'sinon' ).stub(),

--- a/client/blocks/all-sites/index.jsx
+++ b/client/blocks/all-sites/index.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -22,6 +21,8 @@ import { getCurrentUserVisibleSiteCount } from 'calypso/state/current-user/selec
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class AllSites extends Component {
 	static defaultProps = {

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -7,7 +7,7 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { get, identity, includes, noop } from 'lodash';
+import { get, identity, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -57,6 +57,7 @@ import statsBannerImage from 'calypso/assets/images/illustrations/app-banner-sta
 
 const IOS_REGEX = /iPad|iPod|iPhone/i;
 const ANDROID_REGEX = /Android (\d+(\.\d+)?(\.\d+)?)/i;
+const noop = () => {};
 
 export class AppBanner extends Component {
 	static propTypes = {

--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { identity, noop, sample } from 'lodash';
+import { identity, sample } from 'lodash';
 import store from 'store';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -33,6 +33,8 @@ import wordpressLogoImage from 'calypso/assets/images/illustrations/logo-jpc.svg
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 const getRandomPromo = () => {
 	const promoOptions = [

--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -5,13 +5,15 @@ import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import Gridicon from 'calypso/components/gridicon';
 import classNames from 'classnames';
-import { noop, pick } from 'lodash';
+import { pick } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
 import AsyncLoad from 'calypso/components/async-load';
+
+const noop = () => {};
 
 class CalendarButton extends Component {
 	static propTypes = {

--- a/client/blocks/calendar-popover/index.jsx
+++ b/client/blocks/calendar-popover/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { noop, pick } from 'lodash';
+import { pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,6 +19,8 @@ import PostSchedule from 'calypso/components/post-schedule';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class CalendarPopover extends Component {
 	static propTypes = {

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
-import { noop, omitBy } from 'lodash';
+import { omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,6 +18,8 @@ import { getPostTotalCommentsCount } from 'calypso/state/comments/selectors';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 function CommentButton( props ) {
 	const { commentCount, href, onClick, showLabel, tagName, target } = props;

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import classnames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -27,6 +26,8 @@ import PopoverMenuSeparator from 'calypso/components/popover/menu-separator';
  * Style dependencies
  */
 import './comment-actions.scss';
+
+const noop = () => {};
 
 const CommentActions = ( {
 	post,

--- a/client/blocks/comments/comment-approve-action.jsx
+++ b/client/blocks/comments/comment-approve-action.jsx
@@ -4,7 +4,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import classnames from 'classnames';
@@ -18,6 +17,8 @@ import { Button } from '@wordpress/components';
  * Style dependencies
  */
 import './comment-approve-action.scss';
+
+const noop = () => {};
 
 const CommentApproveAction = ( { translate, status, approveComment, unapproveComment } ) => {
 	const isApproved = status === 'approved';

--- a/client/blocks/comments/comment-edit-form.jsx
+++ b/client/blocks/comments/comment-edit-form.jsx
@@ -7,7 +7,6 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { noop } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -24,6 +23,8 @@ import PostCommentFormTextarea from './form-textarea';
  * Style dependencies
  */
 import './comment-edit-form.scss';
+
+const noop = () => {};
 
 class PostCommentForm extends Component {
 	constructor( props ) {

--- a/client/blocks/comments/form-root.jsx
+++ b/client/blocks/comments/form-root.jsx
@@ -1,17 +1,16 @@
 /**
- */
-
-/**
  * External dependencies
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop, some } from 'lodash';
+import { some } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import PostCommentForm from './form';
+
+const noop = () => {};
 
 /*
  * A component for displaying a comment form at the root of a conversation.

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { noop } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -27,6 +26,8 @@ import PostCommentFormTextarea from './form-textarea';
  * Style dependencies
  */
 import './form.scss';
+
+const noop = () => {};
 
 class PostCommentForm extends React.Component {
 	constructor( props ) {

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { get, noop, some, flatMap } from 'lodash';
+import { get, some, flatMap } from 'lodash';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
@@ -36,6 +36,8 @@ import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions'
  * Style dependencies
  */
 import './post-comment.scss';
+
+const noop = () => {};
 
 /**
  * A PostComment is the visual representation for a comment within a tree of comments.

--- a/client/blocks/conversation-follow-button/button.jsx
+++ b/client/blocks/conversation-follow-button/button.jsx
@@ -1,14 +1,12 @@
 /**
- */
-
-/**
  * External dependencies
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
+
+const noop = () => {};
 
 class ConversationFollowButton extends React.Component {
 	static propTypes = {

--- a/client/blocks/conversation-follow-button/index.jsx
+++ b/client/blocks/conversation-follow-button/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { assign, noop } from 'lodash';
+import { assign } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -19,6 +19,8 @@ import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions'
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class ConversationFollowButtonContainer extends Component {
 	static propTypes = {

--- a/client/blocks/conversations/docs/example.jsx
+++ b/client/blocks/conversations/docs/example.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { noop, map, compact } from 'lodash';
+import { map, compact } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,6 +10,8 @@ import { noop, map, compact } from 'lodash';
 import { ConversationCommentList } from 'calypso/blocks/conversations/list';
 import { posts } from 'calypso/blocks/reader-post-card/docs/fixtures';
 import { commentsTree } from 'calypso/blocks/conversations/docs/fixtures';
+
+const noop = () => {};
 
 const ConversationCommentListExample = () => {
 	const post = posts[ 0 ];

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { map, zipObject, fill, size, filter, get, compact, partition, min, noop } from 'lodash';
+import { map, zipObject, fill, size, filter, get, compact, partition, min } from 'lodash';
 
 /**
  * Internal dependencies
@@ -57,6 +57,8 @@ import './list.scss';
  */
 
 const FETCH_NEW_COMMENTS_THRESHOLD = 20;
+const noop = () => {};
+
 export class ConversationCommentList extends React.Component {
 	static propTypes = {
 		post: PropTypes.object.isRequired, // required by PostComment

--- a/client/blocks/daily-post-button/test/index.jsx
+++ b/client/blocks/daily-post-button/test/index.jsx
@@ -7,7 +7,6 @@
  */
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import pageSpy from 'page';
 import { parse } from 'qs';
 import React from 'react';
@@ -27,6 +26,7 @@ jest.mock( 'calypso/reader/stats', () => ( {
 jest.mock( 'calypso/lib/user', () => () => {} );
 jest.mock( 'page', () => require( 'sinon' ).spy() );
 const markPostSeen = jest.fn();
+const noop = () => {};
 
 describe( 'DailyPostButton', () => {
 	const [ sampleUserSite, sampleReadingSite ] = sites;

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -7,7 +7,6 @@ import React, { PureComponent } from 'react';
 import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,6 +35,8 @@ import getRewindState from 'calypso/state/selectors/get-rewind-state';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class DisconnectJetpack extends PureComponent {
 	static propTypes = {

--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { noop, flow } from 'lodash';
+import { flow } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -23,6 +23,7 @@ import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/prefe
 import './style.scss';
 
 const PREFERENCE_PREFIX = 'dismissible-card-';
+const noop = () => {};
 
 class DismissibleCard extends Component {
 	static propTypes = {

--- a/client/blocks/edit-gravatar/test/index.jsx
+++ b/client/blocks/edit-gravatar/test/index.jsx
@@ -7,7 +7,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 
 /**
@@ -27,6 +26,8 @@ jest.mock( 'calypso/lib/oauth-token', () => ( {
 	getToken: () => 'bearerToken',
 } ) );
 jest.mock( 'calypso/lib/user', () => () => {} );
+
+const noop = () => {};
 
 describe( 'EditGravatar', () => {
 	let sandbox;

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { union, includes, noop } from 'lodash';
+import { union, includes } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import page from 'page';
@@ -38,6 +38,9 @@ import getRequest from 'calypso/state/selectors/get-request';
  * Style dependencies
  */
 import './style.scss';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 interface ExternalProps {
 	backUrl: string;

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -6,7 +6,6 @@
  * External dependencies
  */
 import page from 'page';
-import { noop } from 'lodash';
 import React, { ReactChild } from 'react';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
@@ -31,6 +30,9 @@ function renderWithStore( element: ReactChild, initialState: object ) {
 }
 
 global.document = {};
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 function createState( {
 	holds = [],

--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -4,7 +4,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -12,6 +11,8 @@ import Gridicon from 'calypso/components/gridicon';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class FollowButton extends React.Component {
 	static propTypes = {

--- a/client/blocks/follow-button/index.jsx
+++ b/client/blocks/follow-button/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop, omitBy, isUndefined } from 'lodash';
+import { omitBy, isUndefined } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -12,6 +12,8 @@ import { connect } from 'react-redux';
 import FollowButton from './button';
 import { isFollowing } from 'calypso/state/reader/follows/selectors';
 import { follow, unfollow } from 'calypso/state/reader/follows/actions';
+
+const noop = () => {};
 
 class FollowButtonContainer extends Component {
 	static propTypes = {

--- a/client/blocks/gdpr-banner/index.jsx
+++ b/client/blocks/gdpr-banner/index.jsx
@@ -3,7 +3,6 @@
  */
 import classNames from 'classnames';
 import cookie from 'cookie';
-import { noop } from 'lodash';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -24,8 +23,8 @@ import { isWpMobileApp } from 'calypso/lib/mobile-app';
  */
 import './style.scss';
 
+const noop = () => {};
 const SIX_MONTHS = 6 * 30 * 24 * 60 * 60;
-
 const STATUS = {
 	NOT_RENDERED: 'not-rendered',
 	RENDERED: 'rendered',

--- a/client/blocks/get-apps/desktop-download-card.jsx
+++ b/client/blocks/get-apps/desktop-download-card.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -18,6 +18,7 @@ const WINDOWS_LINK = 'https://apps.wordpress.com/d/windows?ref=getapps';
 const MAC_LINK = 'https://apps.wordpress.com/d/osx?ref=getapps';
 const LINUX_TAR_LINK = 'https://apps.wordpress.com/d/linux?ref=getapps';
 const LINUX_DEB_LINK = 'https://apps.wordpress.com/d/linux-deb?ref=getapps';
+const noop = () => {};
 
 class DesktopDownloadCard extends Component {
 	static propTypes = {

--- a/client/blocks/image-editor/image-editor-buttons.jsx
+++ b/client/blocks/image-editor/image-editor-buttons.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -15,6 +14,8 @@ import {
 	getImageEditorFileInfo,
 	imageEditorHasChanges,
 } from 'calypso/state/editor/image-editor/selectors';
+
+const noop = () => {};
 
 class ImageEditorButtons extends Component {
 	static propTypes = {

--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { noop, startsWith } from 'lodash';
+import { startsWith } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -23,6 +23,8 @@ import {
 	setImageEditorImageHasLoaded,
 } from 'calypso/state/editor/image-editor/actions';
 import getImageEditorIsGreaterThanMinimumDimensions from 'calypso/state/selectors/get-image-editor-is-greater-than-minimum-dimensions';
+
+const noop = () => {};
 
 export class ImageEditorCanvas extends Component {
 	static propTypes = {

--- a/client/blocks/image-editor/image-editor-crop.jsx
+++ b/client/blocks/image-editor/image-editor-crop.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { isEqual, noop } from 'lodash';
+import { isEqual } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -25,6 +25,8 @@ import {
 } from 'calypso/state/editor/image-editor/actions';
 import { defaultCrop } from 'calypso/state/editor/image-editor/reducer';
 import getImageEditorOriginalAspectRatio from 'calypso/state/selectors/get-image-editor-original-aspect-ratio';
+
+const noop = () => {};
 
 class ImageEditorCrop extends Component {
 	static propTypes = {

--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { noop, values as objectValues } from 'lodash';
+import { values as objectValues } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import classNames from 'classnames';
@@ -22,6 +22,8 @@ import {
 	setImageEditorAspectRatio,
 } from 'calypso/state/editor/image-editor/actions';
 import getImageEditorIsGreaterThanMinimumDimensions from 'calypso/state/selectors/get-image-editor-is-greater-than-minimum-dimensions';
+
+const noop = () => {};
 
 export class ImageEditorToolbar extends Component {
 	static propTypes = {

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { noop, isEqual, partial } from 'lodash';
+import { isEqual, partial } from 'lodash';
 import path from 'path';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -39,6 +39,8 @@ import { getDefaultAspectRatio } from './utils';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class ImageEditor extends React.Component {
 	static propTypes = {

--- a/client/blocks/image-selector/index.jsx
+++ b/client/blocks/image-selector/index.jsx
@@ -1,12 +1,10 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,6 +21,8 @@ import { setMediaLibrarySelectedItems } from 'calypso/state/media/actions';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export class ImageSelector extends Component {
 	static propTypes = {

--- a/client/blocks/image-selector/test/index.jsx
+++ b/client/blocks/image-selector/test/index.jsx
@@ -6,7 +6,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { noop } from 'lodash';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import React from 'react';
@@ -16,6 +15,8 @@ import sinon from 'sinon';
  * Internal dependencies
  */
 import { ImageSelector } from '../';
+
+const noop = () => {};
 
 jest.mock( 'event', () => {}, { virtual: true } );
 jest.mock( 'calypso/state/ui/media-modal/selectors', () => ( {

--- a/client/blocks/image-selector/test/preview.jsx
+++ b/client/blocks/image-selector/test/preview.jsx
@@ -6,13 +6,14 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { noop } from 'lodash';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import React from 'react';
 import sinon from 'sinon';
 
 import { ImageSelectorPreview } from '../preview';
+
+const noop = () => {};
 
 describe( 'ImageSelectorPreview', () => {
 	const testProps = {

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Fragment, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { debounce, identity, isEmpty, noop } from 'lodash';
+import { debounce, identity, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -34,6 +34,8 @@ import {
 	SUPPORT_TYPE_API_HELP,
 	SUPPORT_TYPE_CONTEXTUAL_HELP,
 } from './constants';
+
+const noop = () => {};
 
 function debounceSpeak( { message = '', priority = 'polite', timeout = 800 } ) {
 	return debounce( () => {

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import { flowRight as compose, noop } from 'lodash';
+import { flowRight as compose } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -26,6 +26,8 @@ import getInlineHelpCurrentlySelectedResult from 'calypso/state/inline-help/sele
 import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-support-types';
 import InlineHelpContactView from 'calypso/blocks/inline-help/inline-help-contact-view';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+const noop = () => {};
 
 class InlineHelpPopover extends Component {
 	static propTypes = {

--- a/client/blocks/keyring-connect-button/index.js
+++ b/client/blocks/keyring-connect-button/index.js
@@ -4,7 +4,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { find, last, noop, some } from 'lodash';
+import { find, last, some } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -22,6 +22,8 @@ import {
 	getKeyringConnectionsByName,
 	isKeyringConnectionsFetching,
 } from 'calypso/state/sharing/keyring/selectors';
+
+const noop = () => {};
 
 class KeyringConnectButton extends Component {
 	static propTypes = {

--- a/client/blocks/like-button/index.jsx
+++ b/client/blocks/like-button/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import { omit, noop } from 'lodash';
+import { omit } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -14,6 +14,8 @@ import LikeButton from './button';
 import { getPostLikeCount } from 'calypso/state/posts/selectors/get-post-like-count';
 import { isLikedPost } from 'calypso/state/posts/selectors/is-liked-post';
 import QueryPostLikes from 'calypso/components/data/query-post-likes';
+
+const noop = () => {};
 
 class LikeButtonContainer extends Component {
 	static propTypes = {

--- a/client/blocks/login/test/login-form.jsx
+++ b/client/blocks/login/test/login-form.jsx
@@ -7,7 +7,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 
 /**
@@ -16,6 +15,8 @@ import React from 'react';
 import FormsButton from 'calypso/components/forms/form-button';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+
+const noop = () => {};
 
 describe( 'LoginForm', () => {
 	let LoginForm;

--- a/client/blocks/nps-survey/docs/example.jsx
+++ b/client/blocks/nps-survey/docs/example.jsx
@@ -5,7 +5,6 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,6 +27,8 @@ import {
 	sendNpsSurveyFeedback,
 } from 'calypso/state/nps-survey/actions';
 import { successNotice } from 'calypso/state/notices/actions';
+
+const noop = () => {};
 
 class NpsSurveyExample extends PureComponent {
 	state = {

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -7,7 +7,7 @@ import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize, getLocaleSlug } from 'i18n-calypso';
-import { isNumber, noop, trim } from 'lodash';
+import { isNumber, trim } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,6 +34,8 @@ import RecommendationSelect from './recommendation-select';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export class NpsSurvey extends PureComponent {
 	static propTypes = {

--- a/client/blocks/privacy-policy-banner/index.jsx
+++ b/client/blocks/privacy-policy-banner/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flowRight as compose, get, identity, noop } from 'lodash';
+import { flowRight as compose, get, identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,6 +23,7 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 const AUTOMATTIC_ENTITY = 'automattic';
 const PRIVACY_POLICY_PREFERENCE = 'privacy_policy';
 const PRIVACY_POLICY_REQUEST_ID = 'privacy-policy';
+const noop = () => {};
 
 const privacyPolicyQuery = {
 	fetch() {

--- a/client/blocks/product-purchase-features-list/business-onboarding.jsx
+++ b/client/blocks/product-purchase-features-list/business-onboarding.jsx
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,6 +13,8 @@ import PurchaseDetail from 'calypso/components/purchase-detail';
  * Image dependencies
  */
 import conciergeImage from 'calypso/assets/images/illustrations/jetpack-concierge.svg';
+
+const noop = () => {};
 
 export default localize( ( { isWpcomPlan, translate, link, onClick = noop } ) => {
 	return (

--- a/client/blocks/product-purchase-features-list/mobile-apps.jsx
+++ b/client/blocks/product-purchase-features-list/mobile-apps.jsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +15,8 @@ import { addQueryArgs } from 'calypso/lib/route';
  * Image dependencies
  */
 import appsImage from 'calypso/assets/images/illustrations/apps.svg';
+
+const noop = () => {};
 
 export default localize( ( { translate, onClick = noop } ) => {
 	return (

--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -17,6 +17,8 @@ import Emojify from 'calypso/components/emojify';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 const ReaderAuthorLink = ( { author, post, siteUrl, children, className, onClick } ) => {
 	const recordAuthorClick = () => {

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { startsWith, noop, get } from 'lodash';
+import { startsWith, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
 
@@ -18,6 +18,8 @@ import safeImageUrl from 'calypso/lib/safe-image-url';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 const ReaderAvatar = ( {
 	author,

--- a/client/blocks/reader-featured-image/index.jsx
+++ b/client/blocks/reader-featured-image/index.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -16,6 +15,8 @@ import resizeImageUrl from 'calypso/lib/resize-image-url';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 const ReaderFeaturedImage = ( {
 	imageUrl,

--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { throttle, constant, noop } from 'lodash';
+import { throttle, constant } from 'lodash';
 import ReactDom from 'react-dom';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
@@ -26,6 +26,8 @@ import playIconImage from 'calypso/assets/images/reader/play-icon.png';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class ReaderFeaturedVideo extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-full-post/unavailable.jsx
+++ b/client/blocks/reader-full-post/unavailable.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
-import { noop, get } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +14,8 @@ import ReaderMain from 'calypso/reader/components/reader-main';
 import DocumentHead from 'calypso/components/data/document-head';
 import BackButton from 'calypso/components/back-button';
 import ExternalLink from 'calypso/components/external-link';
+
+const noop = () => {};
 
 const ReaderFullPostUnavailable = ( { post, onBackClick, translate } ) => {
 	const statusCode = get( post, [ 'error', 'statusCode' ] );

--- a/client/blocks/reader-import-button/index.jsx
+++ b/client/blocks/reader-import-button/index.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
@@ -19,6 +18,8 @@ import { successNotice, errorNotice } from 'calypso/state/notices/actions';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class ReaderImportButton extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-list-item/connected.jsx
+++ b/client/blocks/reader-list-item/connected.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { flowRight as compose, noop } from 'lodash';
+import { flowRight as compose } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -12,6 +12,8 @@ import { connect } from 'react-redux';
 import connectSite from 'calypso/lib/reader-connect-site';
 import ReaderListItem from '.';
 import { isFollowing as isFollowingSelector } from 'calypso/state/reader/follows/selectors';
+
+const noop = () => {};
 
 class ConnectedReaderListItem extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { noop, truncate, get } from 'lodash';
+import { truncate, get } from 'lodash';
 import classnames from 'classnames';
 import ReactDom from 'react-dom';
 import closest from 'component-closest';
@@ -40,6 +40,8 @@ import { canBeMarkedAsSeen, isEligibleForUnseen } from 'calypso/reader/get-helpe
 import { getReaderTeams } from 'calypso/state/teams/selectors';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
+
+const noop = () => {};
 
 class ReaderPostCard extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop, debounce } from 'lodash';
+import { debounce } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -12,6 +12,8 @@ import classnames from 'classnames';
 import AutoDirection from 'calypso/components/auto-direction';
 import Emojify from 'calypso/components/emojify';
 import cssSafeUrl from 'calypso/lib/css-safe-url';
+
+const noop = () => {};
 
 class PostPhoto extends React.Component {
 	state = {

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop, size, map } from 'lodash';
+import { size, map } from 'lodash';
 import page from 'page';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
@@ -45,6 +45,8 @@ import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class ReaderPostOptionsMenu extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-related-card/index.jsx
+++ b/client/blocks/reader-related-card/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import { get, noop, partial } from 'lodash';
+import { get, partial } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -28,6 +28,7 @@ import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
 import './style.scss';
 
 const RELATED_IMAGE_WIDTH = 385; // usual width of featured images in related post card
+const noop = () => {};
 
 function AuthorAndSiteFollow( { post, site, onSiteClick, followSource } ) {
 	const siteUrl = getStreamUrl( post.feed_ID, post.site_ID );

--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { flowRight as compose, noop } from 'lodash';
+import { flowRight as compose } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -12,6 +12,8 @@ import { connect } from 'react-redux';
 import connectSite from 'calypso/lib/reader-connect-site';
 import SubscriptionListItem from '.';
 import { isFollowing as isFollowingSelector } from 'calypso/state/reader/follows/selectors';
+
+const noop = () => {};
 
 class ConnectedSubscriptionListItem extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-visit-link/index.jsx
+++ b/client/blocks/reader-visit-link/index.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +13,8 @@ import ExternalLink from 'calypso/components/external-link';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class ReaderVisitLink extends React.Component {
 	static propTypes = {

--- a/client/blocks/site-address-changer/dialog.jsx
+++ b/client/blocks/site-address-changer/dialog.jsx
@@ -4,7 +4,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -14,6 +13,8 @@ import { Dialog } from '@automattic/components';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+
+const noop = () => {};
 
 class SiteAddressChangerConfirmationDialog extends PureComponent {
 	static propTypes = {

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import { noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -26,6 +25,8 @@ import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class Site extends React.Component {
 	static defaultProps = {

--- a/client/blocks/support-article-dialog/dialog.jsx
+++ b/client/blocks/support-article-dialog/dialog.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import { memoize, noop } from 'lodash';
+import { memoize } from 'lodash';
 import { useTranslate } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -39,6 +39,8 @@ import {
  */
 import './style.scss';
 import './content.scss';
+
+const noop = () => {};
 
 export const SupportArticleDialog = ( {
 	actionIsExternal,

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { includes, filter, map, noop, reduce, union } from 'lodash';
+import { includes, filter, map, reduce, union } from 'lodash';
 import { WindowScroller } from '@automattic/react-virtualized';
 
 /**
@@ -31,6 +31,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 const DEFAULT_TERMS_PER_PAGE = 100;
 const LOAD_OFFSET = 10;
 const ITEM_HEIGHT = 55;
+const noop = () => {};
 
 export class TaxonomyManagerList extends Component {
 	static propTypes = {

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, find, noop, assign } from 'lodash';
+import { get, find, assign } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,6 +30,8 @@ import { recordGoogleEvent, bumpStat } from 'calypso/state/analytics/actions';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class TermFormDialog extends Component {
 	static initialState = {

--- a/client/blocks/term-tree-selector/add-term.jsx
+++ b/client/blocks/term-tree-selector/add-term.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -23,6 +23,8 @@ import { getTerms } from 'calypso/state/terms/selectors';
  * Style dependencies
  */
 import './add-term.scss';
+
+const noop = () => {};
 
 class TermSelectorAddTerm extends Component {
 	static propTypes = {

--- a/client/blocks/video-editor/index.jsx
+++ b/client/blocks/video-editor/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 
@@ -24,6 +24,8 @@ import shouldShowVideoEditorError from 'calypso/state/selectors/should-show-vide
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class VideoEditor extends Component {
 	static propTypes = {

--- a/client/blocks/video-editor/video-editor-controls.jsx
+++ b/client/blocks/video-editor/video-editor-controls.jsx
@@ -4,7 +4,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -12,6 +11,8 @@ import { localize } from 'i18n-calypso';
  */
 import { Button } from '@automattic/components';
 import UploadButton from './video-editor-upload-button';
+
+const noop = () => {};
 
 const VideoEditorControls = ( {
 	isPosterUpdating,

--- a/client/blocks/video-editor/video-editor-upload-button.js
+++ b/client/blocks/video-editor/video-editor-upload-button.js
@@ -4,13 +4,14 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
 import FilePicker from 'calypso/components/file-picker';
+
+const noop = () => {};
 
 class VideoEditorUploadButton extends Component {
 	static propTypes = {

--- a/client/components/back-button/index.jsx
+++ b/client/components/back-button/index.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +15,8 @@ import { Button } from '@automattic/components';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 const BackButton = ( { onClick, translate } ) => {
 	return (

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { noop, size } from 'lodash';
+import { size } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import config from '@automattic/calypso-config';
@@ -38,6 +38,8 @@ import { preventWidows } from 'calypso/lib/formatting';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export class Banner extends Component {
 	static propTypes = {

--- a/client/components/bulk-select/test/index.js
+++ b/client/components/bulk-select/test/index.js
@@ -7,13 +7,15 @@
  */
 import { assert } from 'chai';
 import { mount, shallow } from 'enzyme';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import React from 'react';
 
 /**
  * Internal dependencies
  */
 import { BulkSelect } from '../index';
+
+const noop = () => {};
 
 describe( 'index', () => {
 	test( 'should have BulkSelect class', () => {

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -4,7 +4,6 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { localize, withRtl } from 'i18n-calypso';
-import { noop } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -21,6 +20,7 @@ import BarContainer from './bar-container';
  */
 import './style.scss';
 
+const noop = () => {};
 const isTouch = hasTouch();
 const CHART_PADDING = 20;
 

--- a/client/components/chart/legend.jsx
+++ b/client/components/chart/legend.jsx
@@ -3,13 +3,15 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { find, noop } from 'lodash';
+import { find } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import ChartLegendItem from './legend-item';
+
+const noop = () => {};
 
 class ChartLegend extends React.Component {
 	static propTypes = {

--- a/client/components/close-on-escape/index.jsx
+++ b/client/components/close-on-escape/index.jsx
@@ -2,10 +2,11 @@
  * External dependencies
  */
 
-import { filter, includes, isEmpty, last, noop } from 'lodash';
+import { filter, includes, isEmpty, last } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 
+const noop = () => {};
 const ESC_KEY_CODE = 27;
 let components = [];
 

--- a/client/components/d3-base/test/index.js
+++ b/client/components/d3-base/test/index.js
@@ -7,13 +7,14 @@
  */
 import React from 'react';
 import { assert } from 'chai';
-import { noop } from 'lodash';
 import { shallow, mount } from 'enzyme';
 
 /**
  * Internal dependencies
  */
 import D3Base from '..';
+
+const noop = () => {};
 
 describe( 'D3base', () => {
 	const shallowWithoutLifecycle = ( arg ) => shallow( arg, { disableLifecycleMethods: true } );

--- a/client/components/data/query-atat-eligibility/test/index.jsx
+++ b/client/components/data/query-atat-eligibility/test/index.jsx
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 import { spy } from 'sinon';
 
@@ -12,6 +11,8 @@ import { spy } from 'sinon';
  */
 import { QueryAutomatedTransferEligibility as QueryEligibility, mapDispatchToProps } from '../';
 import { requestEligibility as requestEligibilityAction } from 'calypso/state/automated-transfer/actions';
+
+const noop = () => {};
 
 describe( 'QueryAutomatedTransferEligibility', () => {
 	const siteId = 1337;

--- a/client/components/date-picker/day.jsx
+++ b/client/components/date-picker/day.jsx
@@ -3,7 +3,8 @@
  */
 
 import React from 'react';
-import { noop } from 'lodash';
+
+const noop = () => {};
 
 const handleDayMouseEnter = ( date, modifiers, onMouseEnter = noop ) => ( event ) => {
 	onMouseEnter( date, modifiers, event );

--- a/client/components/date-picker/events-tooltip.jsx
+++ b/client/components/date-picker/events-tooltip.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { noop, map } from 'lodash';
+import { map } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -11,6 +11,8 @@ import { localize } from 'i18n-calypso';
  */
 import Tooltip from 'calypso/components/tooltip';
 import { CalendarEvent } from './event';
+
+const noop = () => {};
 
 class EventsTooltip extends Component {
 	static propTypes = {

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -4,7 +4,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import DayPicker from 'react-day-picker';
-import { noop, merge, map, filter, get, debounce } from 'lodash';
+import { merge, map, filter, get, debounce } from 'lodash';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 
@@ -19,6 +19,8 @@ import DatePickerNavBar from './nav-bar';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class DatePicker extends PureComponent {
 	static propTypes = {

--- a/client/components/date-picker/nav-bar.jsx
+++ b/client/components/date-picker/nav-bar.jsx
@@ -4,8 +4,9 @@
 
 import React from 'react';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 import { translate } from 'i18n-calypso';
+
+const noop = () => {};
 
 const handleMonthClick = ( onClick = noop ) => ( event ) => {
 	event.preventDefault();

--- a/client/components/date-range/header.tsx
+++ b/client/components/date-range/header.tsx
@@ -2,13 +2,15 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
-import { noop } from 'lodash';
 import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 interface Props {
 	onApplyClick: () => void;

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { noop, has } from 'lodash';
+import { has } from 'lodash';
 import { DateUtils } from 'react-day-picker';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -31,6 +31,7 @@ import './style.scss';
  * Module variables
  */
 const NO_DATE_SELECTED_VALUE = null;
+const noop = () => {};
 
 export class DateRange extends Component {
 	static propTypes = {

--- a/client/components/date-range/inputs.tsx
+++ b/client/components/date-range/inputs.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { FunctionComponent, useRef, useCallback } from 'react';
-import { noop } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import { useTranslate } from 'i18n-calypso';
 
@@ -13,6 +12,9 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 type StartOrEnd = 'Start' | 'End';
 

--- a/client/components/date-range/trigger.tsx
+++ b/client/components/date-range/trigger.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
-import { noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import { useTranslate } from 'i18n-calypso';
 import { Moment } from 'moment';
@@ -13,6 +12,9 @@ import { Moment } from 'moment';
 import { Button } from '@automattic/components';
 import ButtonGroup from 'calypso/components/button-group';
 import { ScreenReaderText } from '@automattic/components';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 interface Props {
 	startDate: Date | Moment | null | undefined;

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
@@ -3,13 +3,15 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { Input } from 'calypso/my-sites/domains/components/form';
+
+const noop = () => {};
 
 const EuAddressFieldset = ( props ) => {
 	const { getFieldProps, translate, contactDetailsErrors } = props;

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
@@ -5,7 +5,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { identity, includes, noop } from 'lodash';
+import { identity, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -20,6 +20,8 @@ import UsAddressFieldset from './us-address-fieldset';
 import EuAddressFieldset from './eu-address-fieldset';
 import UkAddressFieldset from './uk-address-fieldset';
 import { Input, HiddenInput } from 'calypso/my-sites/domains/components/form';
+
+const noop = () => {};
 
 export class RegionAddressFieldsets extends Component {
 	static propTypes = {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
@@ -3,13 +3,15 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { Input } from 'calypso/my-sites/domains/components/form';
+
+const noop = () => {};
 
 const UkAddressFieldset = ( props ) => {
 	const { getFieldProps, translate, contactDetailsErrors } = props;

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -11,6 +11,8 @@ import { localize } from 'i18n-calypso';
  */
 import { StateSelect, Input } from 'calypso/my-sites/domains/components/form';
 import { getStateLabelText, getPostCodeLabelText, STATE_SELECT_TEXT } from './utils.js';
+
+const noop = () => {};
 
 const UsAddressFieldset = ( props ) => {
 	const { getFieldProps, translate, countryCode, contactDetailsErrors } = props;

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component, createElement } from 'react';
 import { connect } from 'react-redux';
 import {
-	noop,
 	get,
 	deburr,
 	kebabCase,
@@ -50,6 +49,8 @@ import { getPostCodeLabelText } from './custom-form-fieldsets/utils';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export class ContactDetailsFormFields extends Component {
 	static propTypes = {

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -8,13 +8,15 @@
 import React from 'react';
 import update from 'immutability-helper';
 import { shallow } from 'enzyme';
-import { noop, omit } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { ContactDetailsFormFields } from '../';
 import FormButton from '../../../../components/forms/form-button';
+
+const noop = () => {};
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: ( x ) => x,

--- a/client/components/domains/domain-suggestion/test/index.js
+++ b/client/components/domains/domain-suggestion/test/index.js
@@ -7,13 +7,14 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 
 /**
  * Internal dependencies
  */
 import DomainSuggestion from 'calypso/components/domains/domain-suggestion';
+
+const noop = () => {};
 
 describe( 'Domain Suggestion', () => {
 	describe( 'has attributes', () => {

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { includes, noop, get } from 'lodash';
+import { includes, get } from 'lodash';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { Button } from '@automattic/components';
 
@@ -36,6 +36,8 @@ import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/co
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class MapDomainStep extends React.Component {
 	static propTypes = {

--- a/client/components/domains/register-domain-step/analytics.js
+++ b/client/components/domains/register-domain-step/analytics.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flow, mapKeys, mapValues, snakeCase, startsWith, noop } from 'lodash';
+import { flow, mapKeys, mapValues, snakeCase, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,6 +11,8 @@ import {
 	recordGoogleEvent,
 	recordTracksEvent,
 } from 'calypso/state/analytics/actions';
+
+const noop = () => {};
 
 export const recordMapDomainButtonClick = ( section ) =>
 	composeAnalytics(

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -14,7 +14,6 @@ import {
 	isEmpty,
 	isEqual,
 	mapKeys,
-	noop,
 	pick,
 	pickBy,
 	reject,
@@ -105,6 +104,7 @@ const debug = debugFactory( 'calypso:domains:register-domain-step' );
 // TODO: Enable A/B test handling for M2.1 release
 const isPaginationEnabled = config.isEnabled( 'domains/kracken-ui/pagination' );
 
+const noop = () => {};
 const domains = wpcom.domains();
 
 // max amount of domain suggestions we should fetch/display

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
-import { defaults, get, identity, isEmpty, isString, map, noop, set, uniq } from 'lodash';
+import { defaults, get, identity, isEmpty, isString, map, set, uniq } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,6 +23,7 @@ import FormInputValidation from 'calypso/components/forms/form-input-validation'
 import validateContactDetails from './fr-validate-contact-details';
 import { disableSubmitButton } from './with-contact-details-validation';
 
+const noop = () => {};
 const debug = debugFactory( 'calypso:domains:registrant-extra-info' );
 let defaultRegistrantType;
 

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, isEmpty, noop } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import page from 'page';
 import { stringify } from 'qs';
 import classnames from 'classnames';
@@ -61,6 +61,8 @@ import { withShoppingCart } from '@automattic/shopping-cart';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class TransferDomainStep extends React.Component {
 	static propTypes = {

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, isEmpty, noop } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import page from 'page';
 import { stringify } from 'qs';
@@ -58,6 +58,8 @@ import './style.scss';
  */
 import themesImage from 'calypso/assets/images/illustrations/themes.svg';
 import migratingHostImage from 'calypso/assets/images/illustrations/migrating-host-diy.svg';
+
+const noop = () => {};
 
 class UseYourDomainStep extends React.Component {
 	static propTypes = {

--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { identity, includes, noop, without } from 'lodash';
+import { identity, includes, without } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,6 +21,8 @@ import TranslatableString from 'calypso/components/translatable/proptype';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export class DropZone extends React.Component {
 	static propTypes = {

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -19,6 +18,8 @@ import PopoverMenu from 'calypso/components/popover/menu';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class EllipsisMenu extends Component {
 	static propTypes = {

--- a/client/components/email-verification/email-verification-dialog/index.jsx
+++ b/client/components/email-verification/email-verification-dialog/index.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { get, includes, noop } from 'lodash';
+import { get, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -23,6 +23,8 @@ import {
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class VerifyEmailDialog extends Component {
 	getResendButtonLabel() {

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -4,7 +4,7 @@
 
 import React, { PureComponent } from 'react';
 import ReactDom from 'react-dom';
-import { assign, filter, forEach, forOwn, noop } from 'lodash';
+import { assign, filter, forEach, forOwn } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -13,6 +13,7 @@ import { loadScript } from '@automattic/load-script';
 import { loadjQueryDependentScriptDesktopWrapper } from 'calypso/lib/load-jquery-dependent-script-desktop-wrapper';
 import debugFactory from 'debug';
 
+const noop = () => {};
 const debug = debugFactory( 'calypso:components:embed-container' );
 
 const embedsToLookFor = {

--- a/client/components/file-picker/index.jsx
+++ b/client/components/file-picker/index.jsx
@@ -4,8 +4,10 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { assign, noop } from 'lodash';
+import { assign } from 'lodash';
 import pick from 'component-file-picker';
+
+const noop = () => {};
 
 export default class FilePicker extends React.Component {
 	constructor( props ) {

--- a/client/components/focusable/docs/example.jsx
+++ b/client/components/focusable/docs/example.jsx
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import DocsExample from 'calypso/devdocs/docs-example';
 import Focusable from 'calypso/components/focusable';
+
+const noop = () => {};
 
 export default class FocusableExample extends React.PureComponent {
 	static displayName = 'Focusable';

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -18,6 +17,8 @@ import Gridicon from 'calypso/components/gridicon';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class FoldableCard extends Component {
 	static displayName = 'FoldableCard';

--- a/client/components/forms/clipboard-button/index.jsx
+++ b/client/components/forms/clipboard-button/index.jsx
@@ -6,13 +6,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDom from 'react-dom';
 import Clipboard from 'clipboard';
-import { noop } from 'lodash';
 import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
+
+const noop = () => {};
 
 function ClipboardButton( { className, text, onCopy = noop, ...rest } ) {
 	const buttonRef = React.useRef();

--- a/client/components/forms/counted-textarea/index.jsx
+++ b/client/components/forms/counted-textarea/index.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { localize, translate } from 'i18n-calypso';
 import classNames from 'classnames';
-import { omit, noop } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,6 +17,8 @@ import FormTextarea from 'calypso/components/forms/form-textarea';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export class CountedTextarea extends React.Component {
 	static propTypes = {

--- a/client/components/forms/form-phone-input/index.jsx
+++ b/client/components/forms/form-phone-input/index.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { identity, noop, find } from 'lodash';
+import { identity, find } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -18,6 +18,7 @@ import FormCountrySelect from 'calypso/components/forms/form-country-select';
 import phoneValidation from 'calypso/lib/phone-validation';
 
 const CLEAN_REGEX = /^0|[\s.\-()]+/g;
+const noop = () => {};
 
 export class FormPhoneInput extends React.Component {
 	static propTypes = {

--- a/client/components/forms/form-range/index.jsx
+++ b/client/components/forms/form-range/index.jsx
@@ -4,13 +4,15 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { omit, noop } from 'lodash';
+import { omit } from 'lodash';
 import classnames from 'classnames';
 
 /**
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export default class extends React.Component {
 	static displayName = 'FormRange';

--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -5,7 +5,6 @@
 import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,6 +16,8 @@ import FormButton from 'calypso/components/forms/form-button';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 function FormTextInputWithAction( {
 	className,

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -3,7 +3,6 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -14,6 +13,8 @@ import { ToggleControl } from '@wordpress/components';
  * Internal dependencies
  */
 import Disableable from 'calypso/components/disableable';
+
+const noop = () => {};
 
 export default class FormToggle extends PureComponent {
 	static propTypes = {

--- a/client/components/forms/multi-checkbox/index.tsx
+++ b/client/components/forms/multi-checkbox/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { useCallback, useRef } from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +13,9 @@ import FormLabel from 'calypso/components/forms/form-label';
  * Style dependencies
  */
 import './style.scss';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 type OptionValue = number | string;
 

--- a/client/components/forms/sortable-list/index.jsx
+++ b/client/components/forms/sortable-list/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { assign, findIndex, fromPairs, noop } from 'lodash';
+import { assign, findIndex, fromPairs } from 'lodash';
 import classNames from 'classnames';
 import debugFactory from 'debug';
 import Gridicon from 'calypso/components/gridicon';
@@ -15,6 +15,7 @@ import Gridicon from 'calypso/components/gridicon';
 import { ScreenReaderText } from '@automattic/components';
 import { hasTouch } from 'calypso/lib/touch-detect';
 
+const noop = () => {};
 const debug = debugFactory( 'calypso:forms:sortable-list' );
 
 /**

--- a/client/components/gravatar-caterpillar/index.jsx
+++ b/client/components/gravatar-caterpillar/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop, map, size, takeRight, filter, uniqBy } from 'lodash';
+import { map, size, takeRight, filter, uniqBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +14,8 @@ import Gravatar from 'calypso/components/gravatar';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class GravatarCaterpillar extends React.Component {
 	static propTypes = {

--- a/client/components/gsuite/gsuite-learn-more/index.jsx
+++ b/client/components/gsuite/gsuite-learn-more/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
@@ -16,6 +15,8 @@ import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 const GSuiteLearnMore = ( { onLearnMoreClick, productSlug } ) => {
 	const translate = useTranslate();

--- a/client/components/happiness-support/test/index.jsx
+++ b/client/components/happiness-support/test/index.jsx
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 import { spy } from 'sinon';
 
@@ -19,6 +18,8 @@ import {
 	JETPACK_SUPPORT,
 	SUPPORT_ROOT,
 } from 'calypso/lib/url/support';
+
+const noop = () => {};
 
 describe( 'HappinessSupport', () => {
 	let wrapper;

--- a/client/components/happychat/button.jsx
+++ b/client/components/happychat/button.jsx
@@ -5,7 +5,7 @@ import { isMobile } from '@automattic/viewport';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import page from 'page';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
@@ -22,6 +22,8 @@ import isHappychatConnectionUninitialized from 'calypso/state/happychat/selector
 import { initConnection } from 'calypso/state/happychat/connection/actions';
 import { openChat } from 'calypso/state/happychat/ui/actions';
 import { Button } from '@automattic/components';
+
+const noop = () => {};
 
 export class HappychatButton extends Component {
 	static propTypes = {

--- a/client/components/happychat/test/composer.jsx
+++ b/client/components/happychat/test/composer.jsx
@@ -7,12 +7,13 @@
  */
 import React from 'react';
 import { mount } from 'enzyme';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { Composer } from '../composer';
+
+const noop = () => {};
 
 describe( '<Composer />', () => {
 	describe( 'onChange event ', () => {

--- a/client/components/image-preloader/index.tsx
+++ b/client/components/image-preloader/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { useState, useEffect, useRef } from 'react';
-import { noop } from 'lodash';
 
 /**
  * Constants
@@ -13,6 +12,9 @@ enum LoadStatus {
 	LOADED,
 	FAILED,
 }
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 type ImageEventHandler = ( event: string | Event ) => void;
 

--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { noop } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -24,6 +23,7 @@ import smartSetState from 'calypso/lib/react-smart-set-state';
  */
 import './style.scss';
 
+const noop = () => {};
 const debug = debugFactory( 'calypso:infinite-list' );
 
 export default class InfiniteList extends React.Component {

--- a/client/components/jetpack/backup-card/index.tsx
+++ b/client/components/jetpack/backup-card/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { noop } from 'lodash';
 import React, { useRef, FunctionComponent, useState, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -34,6 +33,9 @@ import cloudIcon from 'calypso/components/jetpack/daily-backup-status/status-car
  * Type dependencies
  */
 import type { Activity } from 'calypso/state/activity-log/types';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 type Props = {
 	activity: Activity;

--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -6,7 +6,6 @@ import { useSelector } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import classnames from 'classnames';
 import { Button } from '@automattic/components';
-import { noop } from 'lodash';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 
 /**
@@ -25,6 +24,9 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
  * Style dependencies
  */
 import './style.scss';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 interface Props {
 	threat: Threat;
@@ -177,7 +179,7 @@ const ThreatItem: React.FC< Props > = ( {
 						target="_blank"
 						rel="noopener noreferrer"
 						tracksEventName="calypso_jetpack_scan_threat_codeable_estimate"
-						onClick={ () => {} }
+						onClick={ noop }
 					>
 						{ translate( 'Get a free estimate' ) }
 					</ExternalLinkWithTracking>

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
 	has,
-	noop,
 	pick,
 	pickBy,
 	without,
@@ -25,6 +24,8 @@ import i18n from 'i18n-calypso';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 function SuggestionsButtonAll( props ) {
 	function click() {

--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Fragment, PureComponent } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { find, isString, noop } from 'lodash';
+import { find, isString } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,6 +19,8 @@ import { getLanguageCodeLabels } from './utils';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export class LanguagePicker extends PureComponent {
 	static propTypes = {

--- a/client/components/legend-item/index.js
+++ b/client/components/legend-item/index.js
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop } from 'lodash';
 
 /**
  * Style dependencies
@@ -13,6 +12,7 @@ import './style.scss';
 export { default as LegendItemPlaceholder } from './placeholder';
 
 const SVG_SIZE = 30;
+const noop = () => {};
 
 class LegendItem extends Component {
 	static propTypes = {

--- a/client/components/line-chart/legend.js
+++ b/client/components/line-chart/legend.js
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,6 +10,7 @@ import { noop } from 'lodash';
 import LegendItem from 'calypso/components/legend-item';
 
 const NUM_SERIES = 3;
+const noop = () => {};
 
 class LineChartLegend extends Component {
 	static propTypes = {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/business-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/business-at-step.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,6 +14,8 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+
+const noop = () => {};
 
 export class BusinessATStep extends Component {
 	static propTypes = {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +15,8 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import userUtils from 'calypso/lib/user/utils';
+
+const noop = () => {};
 
 export class DowngradeStep extends Component {
 	static propTypes = {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/test/business-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/test/business-at-step.jsx
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 import { stub } from 'sinon';
 
@@ -11,6 +10,8 @@ import { stub } from 'sinon';
  * Internal dependencies
  */
 import { BusinessATStep } from '../business-at-step';
+
+const noop = () => {};
 
 describe( 'BusinessATStep', () => {
 	describe( 'rendering translated content', () => {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/test/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/test/upgrade-at-step.jsx
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 import { stub } from 'sinon';
 
@@ -12,6 +11,8 @@ import { stub } from 'sinon';
  */
 import { UpgradeATStep } from '../upgrade-at-step';
 import { Button } from '@automattic/components';
+
+const noop = () => {};
 
 describe( 'UpgradeATStep', () => {
 	const selectedSite = { slug: 'site_slug' };

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upgrade-at-step.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +15,8 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import { Button } from '@automattic/components';
+
+const noop = () => {};
 
 export class UpgradeATStep extends Component {
 	static propTypes = {

--- a/client/components/multiple-choice-question/test/index.js
+++ b/client/components/multiple-choice-question/test/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import React from 'react';
 import renderer from 'react-test-renderer';
 
@@ -9,6 +8,8 @@ import renderer from 'react-test-renderer';
  * Internal dependencies
  */
 import MultipleChoiceQuestion from '../';
+
+const noop = () => {};
 
 describe( 'MultipleChoiceQuestion', () => {
 	test( 'should render with the minimum required properties ( plus extra prop to guarantee order )', () => {

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 // @todo: Convert to import from `components/gridicon`
@@ -33,6 +32,7 @@ const GRIDICONS_WITH_DROP = [
 	'play',
 	'spam',
 ];
+const noop = () => {};
 
 export class Notice extends Component {
 	static defaultProps = {

--- a/client/components/popover/menu-item-clipboard.jsx
+++ b/client/components/popover/menu-item-clipboard.jsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -12,6 +11,8 @@ import Gridicon from 'calypso/components/gridicon';
  * Internal dependencies
  */
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
+
+const noop = () => {};
 
 function PopoverMenuItemClipboard( {
 	children,

--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -5,13 +5,15 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
-import { noop, omit } from 'lodash';
+import { omit } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
 import ExternalLink from 'calypso/components/external-link';
+
+const noop = () => {};
 
 export default class PopoverMenuItem extends Component {
 	static propTypes = {

--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop, flowRight as compose } from 'lodash';
+import { flowRight as compose } from 'lodash';
 import 'moment-timezone'; // monkey patches the existing moment.js
 
 /**
@@ -28,6 +28,8 @@ import {
 	convertHoursToHHMM,
 	convertMinutesToHHMM,
 } from './utils';
+
+const noop = () => {};
 
 class PostScheduleClock extends Component {
 	adjustHour = ( event ) => this.handleKeyDown( event, 'hour' );

--- a/client/components/product-card/action.jsx
+++ b/client/components/product-card/action.jsx
@@ -3,12 +3,13 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
+
+const noop = () => {};
 
 const ProductCardAction = ( { intro, label, onClick, primary, href } ) => (
 	<div className="product-card__action">

--- a/client/components/publicize-message/index.jsx
+++ b/client/components/publicize-message/index.jsx
@@ -6,7 +6,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,6 +20,8 @@ import { recordEditorStat, recordEditorEvent } from 'calypso/state/posts/stats';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class PublicizeMessage extends Component {
 	static propTypes = {

--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -1,12 +1,10 @@
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,6 +17,8 @@ import { preventWidows } from 'calypso/lib/formatting';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export default class PurchaseDetail extends PureComponent {
 	static propTypes = {

--- a/client/components/purchase-detail/test/index.jsx
+++ b/client/components/purchase-detail/test/index.jsx
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 
 /**
@@ -12,6 +11,8 @@ import React from 'react';
 import PurchaseDetail from '..';
 import PurchaseButton from '../purchase-button';
 import TipInfo from '../tip-info';
+
+const noop = () => {};
 
 describe( 'PurchaseDetail', () => {
 	let wrapper;

--- a/client/components/related-posts/index.jsx
+++ b/client/components/related-posts/index.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { noop, times } from 'lodash';
+import { times } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -14,6 +14,8 @@ import { relatedPostsForPost } from 'calypso/state/reader/related-posts/selector
 import { SCOPE_SAME, SCOPE_OTHER } from 'calypso/state/reader/related-posts/utils';
 import RelatedPost from 'calypso/blocks/reader-related-card';
 import QueryReaderRelatedPosts from 'calypso/components/data/query-reader-related-posts';
+
+const noop = () => {};
 
 function RelatedPosts( {
 	siteId,

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -5,7 +5,7 @@ import { isMobile } from '@automattic/viewport';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { debounce, noop, uniqueId } from 'lodash';
+import { debounce, uniqueId } from 'lodash';
 import i18n from 'i18n-calypso';
 
 /**
@@ -26,6 +26,7 @@ import './style.scss';
  * Internal variables
  */
 const SEARCH_DEBOUNCE_MS = 300;
+const noop = () => {};
 
 function keyListener( methodToCall, event ) {
 	switch ( event.key ) {

--- a/client/components/segmented-control/simplified.jsx
+++ b/client/components/segmented-control/simplified.jsx
@@ -3,12 +3,13 @@
  */
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import SegmentedControl from '.';
+
+const noop = () => {};
 
 function SimplifiedSegmentedControl( {
 	options,

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { filter, find, get, noop } from 'lodash';
+import { filter, find, get } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -20,6 +20,8 @@ import TranslatableString from 'calypso/components/translatable/proptype';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class SelectDropdown extends Component {
 	static Item = DropdownItem;

--- a/client/components/seo/meta-title-editor/index.jsx
+++ b/client/components/seo/meta-title-editor/index.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { get, identity, noop } from 'lodash';
+import { get, identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +16,8 @@ import { localize } from 'i18n-calypso';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 const titleTypes = ( translate ) => [
 	{ value: 'frontPage', label: translate( 'Front Page' ) },

--- a/client/components/share-button/index.jsx
+++ b/client/components/share-button/index.jsx
@@ -3,7 +3,6 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +15,8 @@ import services from './services';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export default class ShareButton extends PureComponent {
 	static propTypes = {

--- a/client/components/signup-site-preview/screenshot.tsx
+++ b/client/components/signup-site-preview/screenshot.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import React, { useEffect, useState } from 'react';
 
 /**
@@ -10,6 +9,9 @@ import React, { useEffect, useState } from 'react';
 import Spinner from 'calypso/components/spinner';
 import classNames from 'classnames';
 import photon from 'photon';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 interface Props {
 	defaultViewportDevice: string;

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import classNames from 'classnames';
-import { filter, find, flow, get, includes, isEmpty, noop } from 'lodash';
+import { filter, find, flow, get, includes, isEmpty } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -38,7 +38,7 @@ import { getUrlParts, getUrlFromParts, determineUrlType, format } from 'calypso/
 import './style.scss';
 
 const ALL_SITES = 'ALL_SITES';
-
+const noop = () => {};
 const debug = debugFactory( 'calypso:site-selector' );
 
 class SiteSelector extends Component {

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { noop, get } from 'lodash';
+import { get } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -22,6 +22,8 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export class SitesDropdown extends PureComponent {
 	static propTypes = {

--- a/client/components/sites-dropdown/test/index.js
+++ b/client/components/sites-dropdown/test/index.js
@@ -7,7 +7,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 import sinon from 'sinon';
 
@@ -17,6 +16,8 @@ import sinon from 'sinon';
 import { SitesDropdown } from '..';
 
 jest.mock( 'calypso/lib/user', () => () => {} );
+
+const noop = () => {};
 
 describe( 'index', () => {
 	describe( 'component rendering', () => {

--- a/client/components/sites-popover/index.jsx
+++ b/client/components/sites-popover/index.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -17,6 +16,8 @@ import SiteSelector from 'calypso/components/site-selector';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class SitesPopover extends React.Component {
 	static propTypes = {

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -7,7 +7,6 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import { loadScript } from '@automattic/load-script';
 
 /**
@@ -26,6 +25,7 @@ const appleClientUrl =
 	'https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js';
 const connectUrlPopupFLow =
 	'https://public-api.wordpress.com/connect/?magic=keyring&service=apple&action=request&for=connect';
+const noop = () => {};
 
 class AppleLoginButton extends Component {
 	static propTypes = {

--- a/client/components/social-buttons/facebook.js
+++ b/client/components/social-buttons/facebook.js
@@ -8,7 +8,6 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { loadScript } from '@automattic/load-script';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,6 +19,8 @@ import { isFormDisabled } from 'calypso/state/login/selectors';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class FacebookLoginButton extends Component {
 	// See: https://developers.facebook.com/docs/javascript/reference/FB.init/v2.8

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -7,7 +7,6 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { loadScript } from '@automattic/load-script';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,6 +24,8 @@ let auth2InitDone = false;
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class GoogleLoginButton extends Component {
 	static propTypes = {

--- a/client/components/split-button/index.jsx
+++ b/client/components/split-button/index.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -18,6 +17,8 @@ import PopoverMenu from 'calypso/components/popover/menu';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class SplitButton extends PureComponent {
 	static propTypes = {

--- a/client/components/sub-masterbar-nav/item.jsx
+++ b/client/components/sub-masterbar-nav/item.jsx
@@ -1,16 +1,16 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Gridicon from 'calypso/components/gridicon';
+
+const noop = () => {};
 
 export const Item = ( props ) => {
 	const { isSelected, onClick, label, icon, href } = props;

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -3,7 +3,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,6 +17,8 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class SuggestionSearch extends Component {
 	static propTypes = {

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { get, isEmpty, isEqual, noop, some } from 'lodash';
+import { get, isEmpty, isEqual, some } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 import photon from 'photon';
@@ -26,6 +26,8 @@ import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export class Theme extends Component {
 	static propTypes = {

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { isEqual, isEmpty, noop, times } from 'lodash';
+import { isEqual, isEmpty, times } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -20,6 +20,8 @@ import { getThemesBookmark } from 'calypso/state/themes/themes-ui/selectors';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export class ThemesList extends React.Component {
 	static propTypes = {

--- a/client/components/themes-list/test/index.jsx
+++ b/client/components/themes-list/test/index.jsx
@@ -7,7 +7,7 @@
  */
 import React from 'react';
 import deepFreeze from 'deep-freeze';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { shallow } from 'enzyme';
 
 /**
@@ -16,6 +16,8 @@ import { shallow } from 'enzyme';
 import EmptyContent from 'calypso/components/empty-content';
 import Theme from 'calypso/components/theme';
 import { ThemesList } from '../';
+
+const noop = () => {};
 
 const defaultProps = deepFreeze( {
 	themes: [

--- a/client/components/timezone/index.jsx
+++ b/client/components/timezone/index.jsx
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { map, noop } from 'lodash';
+import { map } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -15,6 +15,8 @@ import FormSelect from 'calypso/components/forms/form-select';
 import QueryTimezones from 'calypso/components/data/query-timezones';
 import getRawOffsets from 'calypso/state/selectors/get-raw-offsets';
 import getTimezones from 'calypso/state/selectors/get-timezones';
+
+const noop = () => {};
 
 class Timezone extends Component {
 	onSelect = ( event ) => {

--- a/client/components/tinymce/plugins/embed/test/dialog.js
+++ b/client/components/tinymce/plugins/embed/test/dialog.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { spy } from 'sinon';
 
 /**
@@ -14,6 +14,7 @@ import { Dialog } from '@automattic/components';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 
 const testSiteId = 5089392;
+const noop = () => {};
 
 describe( 'EmbedDialog', () => {
 	let EmbedDialog;

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { get, head, map, max, min, noop } from 'lodash';
+import { get, head, map, max, min } from 'lodash';
 import moment from 'moment';
 
 /**
@@ -24,6 +24,7 @@ import { localize } from 'i18n-calypso';
 import 'draft-js/dist/Draft.css';
 import './style.scss';
 
+const noop = () => {};
 const Chip = ( onClick ) => ( props ) => <Token { ...props } onClick={ onClick } />;
 
 export class TitleFormatEditor extends Component {

--- a/client/components/token-field/token-input.jsx
+++ b/client/components/token-field/token-input.jsx
@@ -3,12 +3,14 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { omit, noop } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import FormTextInput from 'calypso/components/forms/form-text-input';
+
+const noop = () => {};
 
 class TokenInput extends React.PureComponent {
 	static propTypes = {

--- a/client/components/track-input-changes/index.jsx
+++ b/client/components/track-input-changes/index.jsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { assign, noop } from 'lodash';
+import { assign } from 'lodash';
+
+const noop = () => {};
 
 export default class TrackInputChanges extends Component {
 	static displayName = 'TrackInputChanges';

--- a/client/components/vertical-nav/docs/example.jsx
+++ b/client/components/vertical-nav/docs/example.jsx
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import VerticalNav from '../index';
 import VerticalNavItem from '../item/index';
+
+const noop = () => {};
 
 VerticalNav.displayName = 'VerticalNav';
 VerticalNavItem.displayName = 'VerticalNavItem';

--- a/client/components/vertical-nav/item/index.jsx
+++ b/client/components/vertical-nav/item/index.jsx
@@ -4,7 +4,6 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -17,6 +16,8 @@ import Gridicon from 'calypso/components/gridicon';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class VerticalNavItem extends Component {
 	static propTypes = {

--- a/client/components/virtual-list/index.jsx
+++ b/client/components/virtual-list/index.jsx
@@ -7,7 +7,9 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { AutoSizer, List } from '@automattic/react-virtualized';
-import { debounce, noop, range } from 'lodash';
+import { debounce, range } from 'lodash';
+
+const noop = () => {};
 
 export class VirtualList extends Component {
 	static propTypes = {

--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -6,7 +6,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,6 +20,8 @@ import WebPreviewContent from './content';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export class WebPreviewModal extends Component {
 	static propTypes = {

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import debugModule from 'debug';
-import { noop, isFunction } from 'lodash';
+import { isFunction } from 'lodash';
 import page from 'page';
 import { v4 as uuid } from 'uuid';
 import { addQueryArgs } from 'calypso/lib/route';
@@ -29,6 +29,7 @@ import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 
 const debug = debugModule( 'calypso:web-preview' );
+const noop = () => {};
 
 export class WebPreviewContent extends Component {
 	previewId = uuid();

--- a/client/components/wizard-progress-bar/index.jsx
+++ b/client/components/wizard-progress-bar/index.jsx
@@ -4,7 +4,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,6 +14,8 @@ import { Button, CompactCard, ProgressBar } from '@automattic/components';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class WizardProgressBar extends Component {
 	static propTypes = {

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,6 +11,8 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { setSection } from 'calypso/state/ui/actions';
 import { setLocale } from 'calypso/state/ui/language/actions';
 import { isTranslatedIncompletely } from 'calypso/lib/i18n-utils/utils';
+
+const noop = () => {};
 
 export function makeLayoutMiddleware( LayoutComponent ) {
 	return ( context, next ) => {

--- a/client/devdocs/design/wordpress-components-gallery/base-control.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/base-control.tsx
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { BaseControl, TextareaControl } from '@wordpress/components';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 const BaseControlExample = () => (
 	<BaseControl id="textarea-1" label="Text" help="Enter some text">

--- a/client/devdocs/design/wordpress-components-gallery/disabled.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/disabled.tsx
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { Disabled, SelectControl, TextControl, TextareaControl } from '@wordpress/components';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 const DisabledExample = () => {
 	return (

--- a/client/devdocs/docs-example/test/index.jsx
+++ b/client/devdocs/docs-example/test/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 
 /**
@@ -10,6 +9,8 @@ import React from 'react';
  */
 import DocsExample, { DocsExampleToggle } from '../index';
 import { Button } from '@automattic/components';
+
+const noop = () => {};
 
 describe( 'DocsExample', () => {
 	const props = {

--- a/client/extensions/woocommerce/app/order/create.js
+++ b/client/extensions/woocommerce/app/order/create.js
@@ -3,7 +3,7 @@
  */
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { get, isEmpty, noop, omit } from 'lodash';
+import { get, isEmpty, omit } from 'lodash';
 import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
 import page from 'page';
@@ -36,6 +36,8 @@ import OrderDetails from './order-details';
 import { ProtectFormGuard } from 'calypso/lib/protect-form';
 import { recordTrack } from 'woocommerce/lib/analytics';
 import { sendOrderInvoice } from 'woocommerce/state/sites/orders/send-invoice/actions';
+
+const noop = () => {};
 
 class Order extends Component {
 	componentDidMount() {

--- a/client/extensions/woocommerce/app/order/order-activity-log/events.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log/events.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { keys, last, noop, sortBy } from 'lodash';
+import { keys, last, sortBy } from 'lodash';
 import moment from 'moment';
 
 /**
@@ -17,6 +17,8 @@ import {
 } from 'woocommerce/state/sites/orders/activity-log/selectors';
 import OrderEvent from './event';
 import OrderEventsByDay from './day';
+
+const noop = () => {};
 
 function getSortedEvents( events ) {
 	const eventsByDay = {};

--- a/client/extensions/woocommerce/app/order/order-customer/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-customer/dialog.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import emailValidator from 'email-validator';
-import { find, get, isEmpty, noop } from 'lodash';
+import { find, get, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -45,6 +45,7 @@ const defaultAddress = {
 	last_name: '',
 	phone: '',
 };
+const noop = () => {};
 
 class CustomerAddressDialog extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/app/order/order-details/row-total.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-total.js
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { noop, snakeCase } from 'lodash';
+import { snakeCase } from 'lodash';
 import { localize } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
 
@@ -14,6 +14,8 @@ import formatCurrency from '@automattic/format-currency';
 import PriceInput from 'woocommerce/components/price-input';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
+
+const noop = () => {};
 
 class OrderTotalRow extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
-import { every, find, findIndex, get, isNaN, noop } from 'lodash';
+import { every, find, findIndex, get, isNaN } from 'lodash';
 import formatCurrency from '@automattic/format-currency';
 
 /**
@@ -36,6 +36,8 @@ import OrderTotalRow from './row-total';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
+
+const noop = () => {};
 
 class OrderDetailsTable extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/app/products/product-form-images.js
+++ b/client/extensions/woocommerce/app/products/product-form-images.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
-import { isNumber, noop } from 'lodash';
+import { isNumber } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +16,8 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import MediaImage from 'calypso/my-sites/media-library/media-image';
 import ProductImageUploader from 'woocommerce/components/product-image-uploader';
 import Spinner from 'calypso/components/spinner';
+
+const noop = () => {};
 
 class ProductFormImages extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/app/promotions/promotion-header.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-header.js
@@ -5,7 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
-import { isObject, noop } from 'lodash';
+import { isObject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,6 +13,8 @@ import { isObject, noop } from 'lodash';
 import ActionHeader from 'woocommerce/components/action-header';
 import { Button } from '@automattic/components';
 import { getLink } from 'woocommerce/lib/nav-utils';
+
+const noop = () => {};
 
 function renderTrashButton( onTrash, isBusy, label ) {
 	return (

--- a/client/extensions/woocommerce/app/settings/payments/stripe/payment-method-stripe-placeholder-dialog.js
+++ b/client/extensions/woocommerce/app/settings/payments/stripe/payment-method-stripe-placeholder-dialog.js
@@ -4,12 +4,13 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { Dialog } from '@automattic/components';
+
+const noop = () => {};
 
 const PaymentMethodStripePlaceholderDialog = ( { translate } ) => {
 	const buttons = [

--- a/client/extensions/woocommerce/components/compact-tinymce/index.js
+++ b/client/extensions/woocommerce/components/compact-tinymce/index.js
@@ -4,7 +4,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { assign, noop, uniqueId, forEach } from 'lodash';
+import { assign, uniqueId, forEach } from 'lodash';
 import classNames from 'classnames';
 import { ReactReduxContext } from 'react-redux';
 
@@ -22,6 +22,8 @@ import { wpautop } from 'calypso/lib/formatting';
 import wplinkPlugin from 'calypso/components/tinymce/plugins/wplink/plugin';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import { isLocaleRtl } from 'calypso/lib/i18n-utils';
+
+const noop = () => {};
 
 class CompactTinyMCE extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/components/d3/base/test/index.js
+++ b/client/extensions/woocommerce/components/d3/base/test/index.js
@@ -8,12 +8,13 @@
 import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import D3Base from '../index';
+
+const noop = () => {};
 
 describe( 'D3base', () => {
 	const shallowWithoutLifecycle = ( arg ) => shallow( arg, { disableLifecycleMethods: true } );

--- a/client/extensions/woocommerce/components/dashboard-widget/index.js
+++ b/client/extensions/woocommerce/components/dashboard-widget/index.js
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
-import { isUndefined, noop } from 'lodash';
+import { isUndefined } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -17,6 +17,8 @@ import { localize } from 'i18n-calypso';
 import { Card } from '@automattic/components';
 import Popover from 'calypso/components/popover';
 import Tooltip from 'calypso/components/tooltip';
+
+const noop = () => {};
 
 class DashboardWidget extends Component {
 	constructor( props ) {

--- a/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
+++ b/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
@@ -6,13 +6,15 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
-import { noop, omit } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+
+const noop = () => {};
 
 class FormClickToEditInput extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/components/form-dimensions-input/index.jsx
+++ b/client/extensions/woocommerce/components/form-dimensions-input/index.jsx
@@ -8,7 +8,6 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,6 +17,8 @@ import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-w
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getDimensionsUnitSetting } from 'woocommerce/state/sites/settings/products/selectors';
 import { fetchSettingsProducts } from 'woocommerce/state/sites/settings/products/actions';
+
+const noop = () => {};
 
 class FormDimensionsInput extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/components/form-weight-input/index.js
+++ b/client/extensions/woocommerce/components/form-weight-input/index.js
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +15,8 @@ import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-w
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getWeightUnitSetting } from 'woocommerce/state/sites/settings/products/selectors';
 import { fetchSettingsProducts } from 'woocommerce/state/sites/settings/products/actions';
+
+const noop = () => {};
 
 class FormWeightInput extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { head, noop, trim, uniqueId } from 'lodash';
+import { head, trim, uniqueId } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 
@@ -20,6 +20,8 @@ import FilePicker from 'calypso/components/file-picker';
 import getMediaErrors from 'calypso/state/selectors/get-media-errors';
 import { filterItemsByMimePrefix } from 'calypso/lib/media/utils';
 import { addWoocommerceProductImage } from 'calypso/state/media/thunks';
+
+const noop = () => {};
 
 class ProductImageUploader extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/components/product-search/row.js
+++ b/client/extensions/woocommerce/components/product-search/row.js
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { filter, find, get, intersection, noop, reduce, uniqBy, values } from 'lodash';
+import { filter, find, get, intersection, reduce, uniqBy, values } from 'lodash';
 import { localize } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
 
@@ -25,6 +25,8 @@ import { getVariationsForProduct } from 'woocommerce/state/sites/product-variati
 import { areVariationsSelected, isProductSelected, isVariableProduct } from './utils';
 import ProductVariations from './variations';
 import ImageThumb from 'woocommerce/components/image-thumb';
+
+const noop = () => {};
 
 class ProductSearchRow extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/lib/analytics/test/tracks-utils.js
+++ b/client/extensions/woocommerce/lib/analytics/test/tracks-utils.js
@@ -3,12 +3,13 @@
  */
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { recordTrack } from '../tracks-utils';
+
+const noop = () => {};
 
 describe( 'recordTrack', () => {
 	it( 'should be a function', () => {

--- a/client/extensions/woocommerce/state/data-layer/product-categories/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-categories/test/index.js
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { spy, match } from 'sinon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,6 +30,8 @@ import {
 	deleteProductCategory,
 } from 'woocommerce/state/sites/product-categories/actions';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+
+const noop = () => {};
 
 describe( 'handlers', () => {
 	describe( '#fetch()', () => {

--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-/**
  * Internal dependencies
  */
 import {
@@ -26,6 +22,8 @@ import {
 	WOOCOMMERCE_ORDERS_REQUEST_FAILURE,
 	WOOCOMMERCE_ORDERS_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
+
+const noop = () => {};
 
 export const deleteOrder = ( site, orderId ) => {
 	return {

--- a/client/extensions/woocommerce/state/sites/orders/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/test/actions.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,6 +30,8 @@ import {
 	WOOCOMMERCE_ORDERS_REQUEST_FAILURE,
 	WOOCOMMERCE_ORDERS_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
+
+const noop = () => {};
 
 describe( 'actions', () => {
 	describe( '#fetchOrders()', () => {

--- a/client/extensions/woocommerce/state/sites/product-categories/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/actions.js
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,6 +19,8 @@ import {
 	WOOCOMMERCE_PRODUCT_CATEGORY_UPDATE,
 	WOOCOMMERCE_PRODUCT_CATEGORY_DELETE,
 } from 'woocommerce/state/action-types';
+
+const noop = () => {};
 
 describe( 'actions', () => {
 	describe( '#fetchProductCategories()', () => {

--- a/client/extensions/woocommerce/state/sites/settings/general/test/handlers.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/test/handlers.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { fetchSettingsGeneral } from '../actions';
@@ -14,6 +9,8 @@ import {
 } from '../handlers';
 import { WPCOM_HTTP_REQUEST } from 'calypso/state/action-types';
 import { WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE } from 'woocommerce/state/action-types';
+
+const noop = () => {};
 
 const settingsData = [
 	{

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -15,7 +15,6 @@ import {
 	isBoolean,
 	isEqual,
 	map,
-	noop,
 	pick,
 	sumBy,
 	uniqBy,
@@ -110,6 +109,7 @@ import {
 
 const PRINTING_FAILED_NOTICE_ID = 'label-image-download-failed';
 const PRINTING_IN_PROGRESS_NOTICE_ID = 'label-image-download-printing';
+const noop = () => {};
 
 export const fetchLabelsData = ( orderId, siteId ) => ( dispatch ) => {
 	dispatch( {

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { get, has, isInteger, noop } from 'lodash';
+import { get, has, isInteger } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,6 +32,8 @@ import { REASON_BLOCK_EDITOR_JETPACK_REQUIRES_SSO } from 'calypso/state/desktop/
 import { notifyDesktopCannotOpenEditor } from 'calypso/state/desktop/actions';
 import { requestSite } from 'calypso/state/sites/actions';
 import { stopEditingPost } from 'calypso/state/editor/actions';
+
+const noop = () => {};
 
 function determinePostType( context ) {
 	if ( context.path.startsWith( '/post/' ) ) {

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -3,7 +3,6 @@
  */
 import React, { ReactElement } from 'react';
 import { useTranslate } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,6 +28,9 @@ interface Props {
 	revokedAt: string | null;
 	onCopyLicense?: () => void;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 export default function LicenseDetails( {
 	licenseKey,

--- a/client/jetpack-connect/install-step.jsx
+++ b/client/jetpack-connect/install-step.jsx
@@ -3,7 +3,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -17,6 +16,7 @@ import JetpackExampleActivate from './example-components/jetpack-activate';
 import JetpackExampleConnect from './example-components/jetpack-connect';
 
 const NEW_INSTRUCTIONS_JETPACK_VERSION = '4.2.0';
+const noop = () => {};
 
 class JetpackInstallStep extends Component {
 	static propTypes = {

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -13,7 +13,7 @@ import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { flowRight, get, includes, noop } from 'lodash';
+import { flowRight, get, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { Button, Card } from '@wordpress/components';
 
@@ -56,6 +56,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import wooDnaConfig from './woo-dna-config';
 
 const debug = debugFactory( 'calypso:jetpack-connect:authorize-form' );
+const noop = () => {};
 
 export class JetpackSignup extends Component {
 	static propTypes = {

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -5,7 +5,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +15,8 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import Spinner from 'calypso/components/spinner';
 import SuggestionSearch from 'calypso/components/suggestion-search';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+
+const noop = () => {};
 
 class JetpackConnectSiteUrlInput extends Component {
 	static propTypes = {

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -7,7 +7,7 @@
  */
 import deepFreeze from 'deep-freeze';
 import React from 'react';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { shallow } from 'enzyme';
 
 /**
@@ -15,6 +15,7 @@ import { shallow } from 'enzyme';
  */
 import { JetpackAuthorize } from '../authorize';
 
+const noop = () => {};
 const CLIENT_ID = 98765;
 const SITE_SLUG = 'an.example.site';
 const DEFAULT_PROPS = deepFreeze( {

--- a/client/jetpack-connect/test/signup.js
+++ b/client/jetpack-connect/test/signup.js
@@ -7,7 +7,7 @@
  */
 import deepFreeze from 'deep-freeze';
 import React from 'react';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { shallow } from 'enzyme';
 
 /**
@@ -16,6 +16,7 @@ import { shallow } from 'enzyme';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import { JetpackSignup } from '../signup.js';
 
+const noop = () => {};
 const CLIENT_ID = 98765;
 const SITE_SLUG = 'an.example.site';
 const DEFAULT_PROPS = deepFreeze( {

--- a/client/layout/error.jsx
+++ b/client/layout/error.jsx
@@ -3,7 +3,6 @@
  */
 import debug from 'debug';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import React from 'react';
 
 /**
@@ -18,7 +17,7 @@ import { setSection } from 'calypso/state/ui/section/actions';
  * Module variables
  */
 const log = debug( 'calypso:layout' );
-
+const noop = () => {};
 const LoadingErrorMessage = localize( ( { translate } ) => (
 	<EmptyContent
 		illustration="/calypso/images/illustrations/error.svg"

--- a/client/layout/guided-tours/utils.js
+++ b/client/layout/guided-tours/utils.js
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
-import { overEvery as and, negate as not, noop } from 'lodash';
+import { overEvery as and, negate as not } from 'lodash';
+
+const noop = () => {};
 
 export { and, not, noop };

--- a/client/layout/guided-tours/wait.js
+++ b/client/layout/guided-tours/wait.js
@@ -1,9 +1,4 @@
-/**
- * External dependencies
- */
-
-import { noop } from 'lodash';
-
+const noop = () => {};
 const WAIT_INITIAL = 1; // initial wait in milliseconds
 const WAIT_MULTIPLIER = 2;
 const WAIT_MAX = 2048; // give up waiting when delay has grown to ~4 seconds

--- a/client/layout/masterbar/item.jsx
+++ b/client/layout/masterbar/item.jsx
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import { isFunction, noop } from 'lodash';
+import { isFunction } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import TranslatableString from 'calypso/components/translatable/proptype';
+
+const noop = () => {};
 
 class MasterbarItem extends Component {
 	static propTypes = {

--- a/client/layout/sidebar/expandable-heading.jsx
+++ b/client/layout/sidebar/expandable-heading.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import Gridicon from 'calypso/components/gridicon';
-import { noop } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -13,6 +12,8 @@ import Count from 'calypso/components/count';
 import MaterialIcon from 'calypso/components/material-icon';
 import SidebarHeading from 'calypso/layout/sidebar/heading';
 import TranslatableString from 'calypso/components/translatable/proptype';
+
+const noop = () => {};
 
 const ExpandableSidebarHeading = ( {
 	title,

--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -5,7 +5,7 @@
 import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get, isNumber, noop } from 'lodash';
+import { get, isNumber } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -24,6 +24,7 @@ import { getSiteSlug } from 'calypso/state/sites/selectors';
  * Module variables
  */
 const debug = debugFactory( 'calypso:analytics:PageViewTracker' );
+const noop = () => {};
 
 export class PageViewTracker extends React.Component {
 	static displayName = 'PageViewTracker';

--- a/client/lib/jetpack/use-track-callback.ts
+++ b/client/lib/jetpack/use-track-callback.ts
@@ -3,13 +3,15 @@
  */
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 const useTrackCallback = ( callback: Function = noop, eventName: string, eventProps = {} ) => {
 	const dispatch = useDispatch();

--- a/client/lib/mshots/index.js
+++ b/client/lib/mshots/index.js
@@ -1,7 +1,4 @@
-/**
- * External dependencies
- */
-import { noop } from 'lodash';
+const noop = () => {};
 
 export async function loadmShotsPreview( options = {} ) {
 	const { maxRetries = 1, retryTimeout = 1000 } = options;

--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-
 import debugModule from 'debug';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,7 +23,7 @@ import localStorageBypass from 'calypso/lib/local-storage-bypass';
 
 const debug = debugModule( 'calypso:support-user' );
 const STORAGE_KEY = 'boot_support_user';
-
+const noop = () => {};
 const isEnabled = () => config.isEnabled( 'support-user' );
 
 let _setReduxStore = noop;

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import { connect } from 'react-redux';
 import page from 'page';
 
@@ -24,6 +23,8 @@ import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
  * Style dependencies
  */
 import './confirm-dialog.scss';
+
+const noop = () => {};
 
 class AccountCloseConfirmDialog extends React.Component {
 	state = {

--- a/client/me/account/close-link.jsx
+++ b/client/me/account/close-link.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 import { CompactCard } from '@automattic/components';
 
@@ -11,6 +10,8 @@ import { CompactCard } from '@automattic/components';
  * Style dependencies
  */
 import './close-link.scss';
+
+const noop = () => {};
 
 class AccountSettingsCloseLink extends React.Component {
 	render() {

--- a/client/me/notification-settings/blogs-settings/index.jsx
+++ b/client/me/notification-settings/blogs-settings/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { find, noop } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,7 +22,7 @@ import Placeholder from './placeholder';
 import './style.scss';
 
 const createPlaceholder = () => <Placeholder />;
-
+const noop = () => {};
 const getItemRef = ( { ID } ) => `blog-${ ID }`;
 
 class BlogsSettings extends Component {

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
@@ -33,7 +32,7 @@ const PurchasesWrapper = ( { title = null, children } ) => {
 		</React.Fragment>
 	);
 };
-
+const noop = () => {};
 const userHasNoSites = ( state ) => getCurrentUserSiteCount( state ) <= 0;
 
 function noSites( context, analyticsPath ) {

--- a/client/my-sites/activity/activity-log-banner/index.jsx
+++ b/client/my-sites/activity/activity-log-banner/index.jsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,6 +15,8 @@ import Gridicon from 'calypso/components/gridicon';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class ActivityLogBanner extends Component {
 	static propTypes = {

--- a/client/my-sites/backup/rewind-flow/download.tsx
+++ b/client/my-sites/backup/rewind-flow/download.tsx
@@ -4,7 +4,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import React, { FunctionComponent, useCallback, useState } from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,6 +21,9 @@ import QueryRewindBackupStatus from 'calypso/components/data/query-rewind-backup
 import RewindConfigEditor from './rewind-config-editor';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 interface Props {
 	backupDisplayDate: string;

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import classNames from 'classnames';
-import { get, includes, isEqual, isUndefined, noop } from 'lodash';
+import { get, includes, isEqual, isUndefined } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,6 +36,7 @@ const commentActions = {
 	spam: [ 'approve', 'delete' ],
 	trash: [ 'approve', 'spam', 'delete' ],
 };
+const noop = () => {};
 
 export class CommentActions extends Component {
 	static propTypes = {

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
-import { get, noop, pick } from 'lodash';
+import { get, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,6 +34,8 @@ import { removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSiteComment } from 'calypso/state/comments/selectors';
 import getSiteSetting from 'calypso/state/selectors/get-site-setting';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const noop = () => {};
 
 export class CommentEdit extends Component {
 	static propTypes = {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -4,7 +4,7 @@
 import page from 'page';
 import React from 'react';
 import i18n from 'i18n-calypso';
-import { get, noop, some, startsWith, uniq } from 'lodash';
+import { get, some, startsWith, uniq } from 'lodash';
 import { removeQueryArgs } from '@wordpress/url';
 
 /**
@@ -84,6 +84,7 @@ const getStore = ( context ) => ( {
  * Module vars
  */
 const sitesPageTitleForAnalytics = 'Sites';
+const noop = () => {};
 
 /*
  * The main navigation of My Sites consists of a component with

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -4,7 +4,7 @@
 import page from 'page';
 import { translate } from 'i18n-calypso';
 import React from 'react';
-import { get, includes, map, noop } from 'lodash';
+import { get, includes, map } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -40,6 +40,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { canUserPurchaseGSuite } from 'calypso/lib/gsuite';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
+const noop = () => {};
 const domainsAddHeader = ( context, next ) => {
 	context.getSiteSelectionHeaderText = () => {
 		return translate( 'Select a site to add a domain' );

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { find, findIndex, get, identity, noop, times, isEmpty } from 'lodash';
+import { find, findIndex, get, identity, times, isEmpty } from 'lodash';
 import page from 'page';
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -58,6 +58,8 @@ import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
  */
 import './style.scss';
 import 'calypso/my-sites/domains/style.scss';
+
+const noop = () => {};
 
 export class List extends React.Component {
 	static propTypes = {

--- a/client/my-sites/domains/domain-management/list/test/index.js
+++ b/client/my-sites/domains/domain-management/list/test/index.js
@@ -9,7 +9,6 @@ import deepFreeze from 'deep-freeze';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { shallow, mount } from 'enzyme';
-import { noop } from 'lodash';
 import { ShoppingCartProvider, getEmptyResponseCart } from '@automattic/shopping-cart';
 
 /**
@@ -17,6 +16,8 @@ import { ShoppingCartProvider, getEmptyResponseCart } from '@automattic/shopping
  */
 import { List as DomainList } from '..';
 import { createReduxStore } from 'calypso/state';
+
+const noop = () => {};
 
 jest.mock( 'calypso/lib/wp', () => ( {
 	undocumented: () => ( {

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 import url from 'url';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop, get } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,6 +24,8 @@ import { getEditorUrl } from 'calypso/state/selectors/get-editor-url';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class Draft extends Component {
 	static propTypes = {

--- a/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,6 +16,8 @@ import PromoCardPrice from 'calypso/components/promo-section/promo-card/price';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class EmailProviderDetails extends React.Component {
 	static propTypes = {

--- a/client/my-sites/google-my-business/select-location/button.js
+++ b/client/my-sites/google-my-business/select-location/button.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -17,6 +16,8 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { enhanceWithSiteType, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { enhanceWithLocationCounts } from 'calypso/my-sites/google-my-business/utils';
 import { withEnhancers } from 'calypso/state/utils';
+
+const noop = () => {};
 
 class GoogleMyBusinessSelectLocationButton extends Component {
 	static propTypes = {

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -4,7 +4,6 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -49,6 +48,7 @@ import './style.scss';
 const FILEZILLA_URL = 'https://filezilla-project.org/';
 const SFTP_URL = 'sftp.wp.com';
 const SFTP_PORT = 22;
+const noop = () => {};
 
 export const SftpCard = ( {
 	translate,

--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -6,13 +6,14 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import Page from 'page';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Notice from 'calypso/components/notice';
 import { Button } from '@automattic/components';
+
+const noop = () => {};
 
 class ImporterError extends React.PureComponent {
 	static displayName = 'ImporterError';

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { includes, isEmpty, noop, flowRight, has, trim, sortBy } from 'lodash';
+import { includes, isEmpty, flowRight, has, trim, sortBy } from 'lodash';
 import url from 'url'; // eslint-disable-line no-restricted-imports
 import moment from 'moment';
 
@@ -46,6 +46,8 @@ import {
  * Style dependencies
  */
 import './site-importer-input-pane.scss';
+
+const noop = () => {};
 
 class SiteImporterInputPane extends React.Component {
 	static displayName = 'SiteImporterSitePreview';

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -6,7 +6,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { includes, noop, truncate } from 'lodash';
+import { includes, truncate } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -27,6 +27,8 @@ import { ProgressBar } from '@automattic/components';
  * Style dependencies
  */
 import './uploading-pane.scss';
+
+const noop = () => {};
 
 class UploadingPane extends React.PureComponent {
 	static displayName = 'SiteSettingsUploadingPane';

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { groupBy, head, isEmpty, map, noop, size, values } from 'lodash';
+import { groupBy, head, isEmpty, map, size, values } from 'lodash';
 import PropTypes from 'prop-types';
 import page from 'page';
 import classnames from 'classnames';
@@ -44,6 +44,8 @@ import { localizeUrl } from 'calypso/lib/i18n-utils';
  * Style dependencies
  */
 import './content.scss';
+
+const noop = () => {};
 
 export class MediaLibraryContent extends React.Component {
 	static propTypes = {

--- a/client/my-sites/media-library/drop-zone.jsx
+++ b/client/my-sites/media-library/drop-zone.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 
@@ -16,6 +15,8 @@ import DropZone from 'calypso/components/drop-zone';
 import { userCan } from 'calypso/lib/site/utils';
 import { clearMediaItemErrors } from 'calypso/state/media/actions';
 import { addMedia } from 'calypso/state/media/thunks';
+
+const noop = () => {};
 
 class MediaLibraryDropZone extends React.Component {
 	static displayName = 'MediaLibraryDropZone';

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -4,7 +4,7 @@
 
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { identity, includes, noop, union } from 'lodash';
+import { identity, includes, union } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -22,6 +22,8 @@ import DataSource from './data-source';
 // the site icon editor, where we want to disable them because the editor
 // can't handle the large images.
 const largeImageSources = [ 'pexels', 'google_photos' ];
+
+const noop = () => {};
 
 export class MediaLibraryFilterBar extends Component {
 	static propTypes = {

--- a/client/my-sites/media-library/list-item.tsx
+++ b/client/my-sites/media-library/list-item.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEqual, noop } from 'lodash';
+import { isEqual } from 'lodash';
 import React from 'react';
 import classNames from 'classnames';
 
@@ -21,6 +21,9 @@ import EditorMediaModalGalleryHelp from 'calypso/post-editor/media-modal/gallery
  * Style dependencies
  */
 import './list-item.scss';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 // TODO: move to lib/media/utils once it gets typed.
 interface MediaObject {

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRtl } from 'i18n-calypso';
-import { clone, filter, findIndex, min, noop } from 'lodash';
+import { clone, filter, findIndex, min } from 'lodash';
 import ReactDom from 'react-dom';
 import React from 'react';
 
@@ -22,6 +22,8 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { setMediaLibrarySelectedItems } from 'calypso/state/media/actions';
 import isFetchingNextPage from 'calypso/state/selectors/is-fetching-next-page';
+
+const noop = () => {};
 
 export class MediaLibraryList extends React.Component {
 	static displayName = 'MediaLibraryList';

--- a/client/my-sites/media-library/test/content.jsx
+++ b/client/my-sites/media-library/test/content.jsx
@@ -7,13 +7,14 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { MediaLibraryContent } from 'calypso/my-sites/media-library/content';
 import { ValidationErrors } from 'calypso/lib/media/constants';
+
+const noop = () => {};
 
 const googleConnection = {
 	service: 'google_photos',

--- a/client/my-sites/media-library/test/data-source.jsx
+++ b/client/my-sites/media-library/test/data-source.jsx
@@ -7,7 +7,6 @@
  */
 import { expect } from 'chai';
 import { mount } from 'enzyme';
-import { noop } from 'lodash';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
@@ -17,6 +16,8 @@ import { Provider as ReduxProvider } from 'react-redux';
 import MediaLibraryDataSource from 'calypso/my-sites/media-library/data-source';
 import { createReduxStore } from 'calypso/state';
 import { setStore } from 'calypso/state/redux-store';
+
+const noop = () => {};
 
 // we need to check the correct children are rendered, so this mocks the
 // PopoverMenu component with one that simply renders the children

--- a/client/my-sites/media-library/upload-button.jsx
+++ b/client/my-sites/media-library/upload-button.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { noop, uniq } from 'lodash';
+import { uniq } from 'lodash';
 import classNames from 'classnames';
 import page from 'page';
 
@@ -24,6 +24,8 @@ import { addMedia } from 'calypso/state/media/thunks';
  * Style dependencies
  */
 import './upload-button.scss';
+
+const noop = () => {};
 
 export class MediaLibraryUploadButton extends React.Component {
 	static propTypes = {

--- a/client/my-sites/media-library/upload-url.jsx
+++ b/client/my-sites/media-library/upload-url.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { noop } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
@@ -23,6 +22,8 @@ import { addMedia } from 'calypso/state/media/thunks';
  * Style dependencies
  */
 import './upload-url.scss';
+
+const noop = () => {};
 
 class MediaLibraryUploadUrl extends Component {
 	static propTypes = {

--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import classNames from 'classnames';
@@ -26,6 +26,8 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class BlogPostsPage extends React.Component {
 	static propTypes = {

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import pageRouter from 'page';
 import { connect } from 'react-redux';
-import { flow, get, includes, noop, partial } from 'lodash';
+import { flow, get, includes, partial } from 'lodash';
 import { saveAs } from 'browser-filesaver';
 import classNames from 'classnames';
 
@@ -51,6 +51,7 @@ import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import config from '@automattic/calypso-config';
 
 const recordEvent = partial( recordGoogleEvent, 'Pages' );
+const noop = () => {};
 
 function sleep( ms ) {
 	return new Promise( ( r ) => setTimeout( r, ms ) );

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import wrapWithClickOutside from 'react-click-outside';
-import { noop } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -16,6 +15,8 @@ import SiteSelector from 'calypso/components/site-selector';
 import { hasTouch } from 'calypso/lib/touch-detect';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+
+const noop = () => {};
 
 class SitePicker extends React.Component {
 	static displayName = 'SitePicker';

--- a/client/my-sites/plan-compare-card/index.jsx
+++ b/client/my-sites/plan-compare-card/index.jsx
@@ -1,24 +1,23 @@
 /**
  * External dependencies
  */
-
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
-
 import { Button, Card, Ribbon } from '@automattic/components';
 
 /**
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class PlanCompareCard extends React.Component {
 	static propTypes = {

--- a/client/my-sites/plan-features-comparison/actions.jsx
+++ b/client/my-sites/plan-features-comparison/actions.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
@@ -19,6 +18,7 @@ import { isMonthly, PLAN_P2_FREE } from 'calypso/lib/plans/constants';
 import { getPlanClass, planLevelsMatch } from 'calypso/lib/plans';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
+const noop = () => {};
 const PlanFeaturesComparisonActions = ( props ) => {
 	return (
 		<div className="plan-features-comparison__actions">

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -6,7 +6,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
-import { compact, get, map, noop, reduce } from 'lodash';
+import { compact, get, map, reduce } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -85,6 +85,8 @@ import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export class PlanFeaturesComparison extends Component {
 	render() {

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -4,7 +4,7 @@
 
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
@@ -19,6 +19,7 @@ import { isMonthly, PLAN_P2_FREE } from 'calypso/lib/plans/constants';
 import { getPlanClass, planLevelsMatch } from 'calypso/lib/plans';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
+const noop = () => {};
 const PlanFeaturesActions = ( props ) => {
 	return (
 		<div className="plan-features__actions">

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -6,7 +6,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
-import { compact, get, findIndex, last, map, noop, reduce } from 'lodash';
+import { compact, get, findIndex, last, map, reduce } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
@@ -86,6 +86,8 @@ import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export class PlanFeatures extends Component {
 	render() {

--- a/client/my-sites/post-type-list/post-thumbnail.jsx
+++ b/client/my-sites/post-type-list/post-thumbnail.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,6 +15,8 @@ import safeImageUrl from 'calypso/lib/safe-image-url';
 import { getNormalizedPost } from 'calypso/state/posts/selectors';
 import { getEditorPath } from 'calypso/state/editor/selectors';
 import { canCurrentUserEditPost } from 'calypso/state/posts/selectors/can-current-user-edit-post';
+
+const noop = () => {};
 
 function PostTypeListPostThumbnail( { onClick, thumbnail, postLink } ) {
 	const classes = classnames( 'post-type-list__post-thumbnail-wrapper', {

--- a/client/my-sites/site-settings/site-tools/link.jsx
+++ b/client/my-sites/site-settings/site-tools/link.jsx
@@ -5,12 +5,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { CompactCard } from '@automattic/components';
+
+const noop = () => {};
 
 const SiteToolsLink = ( { description, href, isWarning, onClick, title } ) => {
 	const titleClasses = classNames( 'site-tools__section-title', {

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop, intersection } from 'lodash';
+import { intersection } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -13,6 +13,8 @@ import Gridicon from 'calypso/components/gridicon';
  */
 import i18n from 'i18n-calypso';
 import { allowedSearchWelcomeTaxonomies, taxonomyToGridicon } from './taxonomies-config.js';
+
+const noop = () => {};
 
 class MagicSearchWelcome extends React.Component {
 	constructor( props ) {

--- a/client/my-sites/woocommerce/lib/analytics/test/tracks-utils.js
+++ b/client/my-sites/woocommerce/lib/analytics/test/tracks-utils.js
@@ -3,12 +3,13 @@
  */
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { recordTrack } from '../tracks-utils';
+
+const noop = () => {};
 
 describe( 'recordTrack', () => {
 	it( 'should be a function', () => {

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { flowRight, get, includes, noop } from 'lodash';
+import { flowRight, get, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 import url from 'url';
 import Gridicon from 'calypso/components/gridicon';
@@ -30,6 +30,8 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSiteOption, isJetpackModuleActive, isJetpackSite } from 'calypso/state/sites/selectors';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
+
+const noop = () => {};
 
 export class EditorMediaModalDetailItem extends Component {
 	static propTypes = {

--- a/client/post-editor/media-modal/detail/detail-preview-image.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-image.jsx
@@ -4,7 +4,6 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -13,6 +12,8 @@ import classNames from 'classnames';
 import Spinner from 'calypso/components/spinner';
 import MediaImage from 'calypso/my-sites/media-library/media-image';
 import { url, isItemBeingUploaded } from 'calypso/lib/media/utils';
+
+const noop = () => {};
 
 export default class EditorMediaModalDetailPreviewImage extends Component {
 	static propTypes = {

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { get, invoke, noop } from 'lodash';
+import { get, invoke } from 'lodash';
 import classNames from 'classnames';
 import debug from 'debug';
 import wpcomProxyRequest from 'wpcom-proxy-request';
@@ -19,6 +19,7 @@ import { loadScript, removeScriptCallback } from '@automattic/load-script';
  */
 const log = debug( 'calypso:post-editor:videopress' );
 const videoPressUrl = 'https://wordpress.com/wp-content/plugins/video/assets/js/next/videopress.js';
+const noop = () => {};
 
 class EditorMediaModalDetailPreviewVideoPress extends Component {
 	static propTypes = {

--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { noop, partial } from 'lodash';
+import { partial } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,6 +21,8 @@ import { setEditorMediaModalView } from 'calypso/state/editor/actions';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class EditorMediaModalDetailBase extends React.Component {
 	static propTypes = {

--- a/client/post-editor/media-modal/gallery/edit.jsx
+++ b/client/post-editor/media-modal/gallery/edit.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { map, noop, sortBy } from 'lodash';
+import { map, sortBy } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -14,6 +14,8 @@ import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import SortableList from 'calypso/components/forms/sortable-list';
 import EditorMediaModalGalleryEditItem from './edit-item';
+
+const noop = () => {};
 
 class EditorMediaModalGalleryEdit extends React.Component {
 	static propTypes = {

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { assign, fromPairs, includes, noop, times } from 'lodash';
+import { assign, fromPairs, includes, times } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -15,6 +15,8 @@ import SelectDropdown from 'calypso/components/select-dropdown';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import { GalleryColumnedTypes, GallerySizeableTypes } from 'calypso/lib/media/constants';
 import { isModuleActive } from 'calypso/lib/site/utils';
+
+const noop = () => {};
 
 export class EditorMediaModalGalleryFields extends React.Component {
 	static propTypes = {

--- a/client/post-editor/media-modal/gallery/index.jsx
+++ b/client/post-editor/media-modal/gallery/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { noop, assign, omitBy, some, isEqual, partial } from 'lodash';
+import { assign, omitBy, some, isEqual, partial } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,6 +25,8 @@ import getMediaItem from 'calypso/state/media/thunks/get-media-item';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class EditorMediaModalGallery extends React.Component {
 	static propTypes = {

--- a/client/post-editor/media-modal/gallery/preview.jsx
+++ b/client/post-editor/media-modal/gallery/preview.jsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,6 +13,8 @@ import SegmentedControl from 'calypso/components/segmented-control';
 import EditorMediaModalGalleryEdit from './edit';
 import EditorMediaModalGalleryPreviewShortcode from './preview-shortcode';
 import EditorMediaModalGalleryPreviewIndividual from './preview-individual';
+
+const noop = () => {};
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -13,7 +13,6 @@ import {
 	isEmpty,
 	identity,
 	includes,
-	noop,
 	partial,
 	some,
 	values,
@@ -53,6 +52,8 @@ import { withAnalytics, bumpStat, recordGoogleEvent } from 'calypso/state/analyt
  * Style dependencies
  */
 import './index.scss';
+
+const noop = () => {};
 
 function areMediaActionsDisabled( modalView, mediaItems, isParentReady ) {
 	return (

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { values, noop, some, every, flow, partial, pick } from 'lodash';
+import { values, some, every, flow, partial, pick } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 
@@ -21,6 +21,8 @@ import { setEditorMediaModalView } from 'calypso/state/editor/actions';
 import { ModalViews } from 'calypso/state/ui/media-modal/constants';
 import { withAnalytics, bumpStat, recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { Button } from '@automattic/components';
+
+const noop = () => {};
 
 class MediaModalSecondaryActions extends Component {
 	static propTypes = {

--- a/client/reader/components/reader-infinite-stream/index.jsx
+++ b/client/reader/components/reader-infinite-stream/index.jsx
@@ -11,7 +11,7 @@ import {
 	WindowScroller,
 } from '@automattic/react-virtualized';
 
-import { debounce, noop, get, pickBy } from 'lodash';
+import { debounce, get, pickBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,6 +22,8 @@ import { recordTracksRailcarRender } from 'calypso/reader/stats';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class ReaderInfiniteStream extends Component {
 	static propTypes = {

--- a/client/reader/following-manage/search-followed.jsx
+++ b/client/reader/following-manage/search-followed.jsx
@@ -4,12 +4,13 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal Dependencies
  */
 import SearchCard from 'calypso/components/search-card';
+
+const noop = () => {};
 
 class FollowingManageSearchFollowed extends Component {
 	static propTypes = {

--- a/client/reader/following-manage/sort-controls.jsx
+++ b/client/reader/following-manage/sort-controls.jsx
@@ -3,13 +3,14 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import FormSelect from 'calypso/components/forms/form-select';
+
+const noop = () => {};
 
 class FollowingManageSortControls extends React.Component {
 	static propTypes = {

--- a/client/reader/search-stream/search-stream-header.jsx
+++ b/client/reader/search-stream/search-stream-header.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { noop, values } from 'lodash';
+import { values } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -13,6 +13,7 @@ import NavTabs from 'calypso/components/section-nav/tabs';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 
+const noop = () => {};
 export const SEARCH_TYPES = { POSTS: 'posts', SITES: 'sites' };
 
 class SearchStreamHeader extends Component {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -5,7 +5,7 @@ import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import { findLast, noop, times } from 'lodash';
+import { findLast, times } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -57,7 +57,7 @@ import './style.scss';
 
 const GUESSED_POST_HEIGHT = 600;
 const HEADER_OFFSET_TOP = 46;
-
+const noop = () => {};
 const pagesByKey = new Map();
 
 class ReaderStream extends React.Component {

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { noop, filter, get, flatMap } from 'lodash';
+import { filter, get, flatMap } from 'lodash';
 import classnames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -21,6 +21,8 @@ import { getStream } from 'calypso/state/reader/streams/selectors';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class UpdateNotice extends React.PureComponent {
 	static propTypes = {

--- a/client/server/pages/test/analytics.js
+++ b/client/server/pages/test/analytics.js
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import events from 'events';
-import { noop } from 'lodash';
 import sinon from 'sinon';
 
 /**
@@ -14,6 +13,7 @@ import { logSectionResponse } from 'calypso/server/pages/analytics';
 import { useFakeTimers } from 'calypso/test-helpers/use-sinon';
 
 const TWO_SECONDS = 2000;
+const noop = () => {};
 
 describe( 'index', () => {
 	describe( 'logSectionResponse middleware', () => {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -9,6 +8,8 @@ import { translate } from 'i18n-calypso';
  */
 import { isEnabled } from '@automattic/calypso-config';
 import { addQueryArgs } from 'calypso/lib/route';
+
+const noop = () => {};
 
 export function generateFlows( {
 	getSiteDestination = noop,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import i18n from 'i18n-calypso';
 
 /**
@@ -23,6 +22,8 @@ import {
 	TYPE_BUSINESS,
 	TYPE_ECOMMERCE,
 } from 'calypso/lib/plans/constants';
+
+const noop = () => {};
 
 export function generateSteps( {
 	addPlanToCart = noop,

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -3,7 +3,6 @@
  */
 import { shallow } from 'enzyme';
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +15,7 @@ jest.mock( 'calypso/signup/utils', () => ( {
 	getFilteredSteps: jest.fn(),
 } ) );
 
+const noop = () => {};
 const signupUtils = require( 'calypso/signup/utils' );
 const { getStepUrl, getFilteredSteps } = signupUtils;
 

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { noop, includes } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -50,6 +50,8 @@ import SiteVerticalsSuggestionSearch from 'calypso/components/site-verticals-sug
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class AboutStep extends Component {
 	constructor( props ) {

--- a/client/signup/steps/plans-atomic-store/test/index.jsx
+++ b/client/signup/steps/plans-atomic-store/test/index.jsx
@@ -11,7 +11,7 @@ jest.mock( 'i18n-calypso', () => ( {
  */
 import { shallow } from 'enzyme';
 import React from 'react';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,6 +38,7 @@ import {
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from 'calypso/lib/plans/constants';
 
+const noop = () => {};
 const props = {
 	translate: identity,
 	stepName: 'Step name',

--- a/client/signup/steps/plans/test/index.jsx
+++ b/client/signup/steps/plans/test/index.jsx
@@ -6,7 +6,7 @@ jest.mock( 'calypso/my-sites/plan-features', () => 'plan-features' );
  */
 import { shallow } from 'enzyme';
 import React from 'react';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,6 +33,7 @@ import {
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from 'calypso/lib/plans/constants';
 
+const noop = () => {};
 const props = {
 	siteGoals: '',
 	stepName: 'Step name',

--- a/client/signup/steps/site-picker/test/site-picker-submit.jsx
+++ b/client/signup/steps/site-picker/test/site-picker-submit.jsx
@@ -11,7 +11,6 @@ jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
  */
 import { shallow } from 'enzyme';
 import React from 'react';
-import { noop } from 'lodash';
 
 jest.mock( 'i18n-calypso', () => ( {
 	translate: ( str ) => str,
@@ -43,6 +42,7 @@ import {
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from 'calypso/lib/plans/constants';
 
+const noop = () => {};
 const props = {
 	goToStep: jest.fn(),
 	submitSignupStep: noop,

--- a/client/signup/steps/site-style/test/index.js
+++ b/client/signup/steps/site-style/test/index.js
@@ -7,12 +7,14 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { SiteStyleStep } from '../';
+
+const noop = () => {};
 
 describe( '<SiteStyleStep />', () => {
 	const defaultProps = {

--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { identity, noop } from 'lodash';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -17,6 +17,8 @@ import ThemesList from 'calypso/components/themes-list';
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 class SignupThemesList extends Component {
 	static propTypes = {

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -10,12 +10,13 @@ import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import ReactDOM from 'react-dom';
 import sinon from 'sinon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { UserStep as User } from '../';
+
+const noop = () => {};
 
 jest.mock( 'calypso/blocks/signup-form', () => require( 'calypso/components/empty-component' ) );
 jest.mock( 'calypso/lib/abtest', () => ( {

--- a/client/state/analytics/test/middleware.js
+++ b/client/state/analytics/test/middleware.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,6 +25,8 @@ import { spy as mockGA } from 'calypso/lib/analytics/ga';
 import { spy as mockPageView } from 'calypso/lib/analytics/page-view';
 import { spy as mockTracks } from 'calypso/lib/analytics/tracks';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
+
+const noop = () => {};
 
 jest.mock( 'calypso/lib/analytics/page-view', () => {
 	const pageViewSpy = require( 'sinon' ).spy();

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import deterministicStringify from 'fast-json-stable-stringify';
-import { get, identity, merge, noop } from 'lodash';
+import { get, identity, merge } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -13,6 +13,8 @@ import warn from '@wordpress/warning';
  * Internal dependencies
  */
 import { keyedReducer } from 'calypso/state/utils';
+
+const noop = () => {};
 
 /**
  * Returns response data from an HTTP request success action if available

--- a/client/state/data-layer/wpcom/activity-log/delete-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/delete-credentials/index.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- *
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
@@ -17,6 +11,8 @@ import {
 import { transformApi } from 'calypso/state/data-layer/wpcom/sites/rewind/api-transformer';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 export const request = ( action ) =>
 	http(

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,6 +12,8 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { receiveSiteChecklist } from 'calypso/state/checklist/actions';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 export const CHECKLIST_KNOWN_TASKS = {
 	START_SITE_SETUP: 'start_site_setup',

--- a/client/state/data-layer/wpcom/domains/transfer/index.js
+++ b/client/state/data-layer/wpcom/domains/transfer/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -35,6 +34,8 @@ import {
 	getDomainTransferCodeError,
 	getNoticeOptions,
 } from './notices';
+
+const noop = () => {};
 
 /**
  * Generates actions to save the domain IPS tag at OpenSRS

--- a/client/state/data-layer/wpcom/help/search/index.js
+++ b/client/state/data-layer/wpcom/help/search/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
@@ -11,6 +6,8 @@ import { HELP_LINKS_REQUEST } from 'calypso/state/action-types';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { receiveHelpLinks } from 'calypso/state/help/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 /**
  * Dispatches a request to fetch help links that match a certain search query

--- a/client/state/data-layer/wpcom/i18n/language-names/index.js
+++ b/client/state/data-layer/wpcom/i18n/language-names/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
@@ -12,6 +7,8 @@ import { I18N_LANGUAGE_NAMES_REQUEST } from 'calypso/state/action-types';
 import { receiveLanguageNames } from 'calypso/state/i18n/language-names/actions';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 /**
  * @module state/data-layer/wpcom/i18n/language-names

--- a/client/state/data-layer/wpcom/jetpack-blogs/product-install-status/index.js
+++ b/client/state/data-layer/wpcom/jetpack-blogs/product-install-status/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
@@ -13,6 +8,8 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { JETPACK_PRODUCT_INSTALL_STATUS_REQUEST } from 'calypso/state/action-types';
 import { receiveJetpackProductInstallStatus } from 'calypso/state/jetpack-product-install/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 /**
  * Request the current Jetpack product install status.

--- a/client/state/data-layer/wpcom/jetpack-blogs/product-install/index.js
+++ b/client/state/data-layer/wpcom/jetpack-blogs/product-install/index.js
@@ -1,15 +1,12 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { JETPACK_PRODUCT_INSTALL_REQUEST } from 'calypso/state/action-types';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 /**
  * Start the Jetpack product install process.

--- a/client/state/data-layer/wpcom/locale-guess/index.js
+++ b/client/state/data-layer/wpcom/locale-guess/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
@@ -12,6 +7,8 @@ import { I18N_LOCALE_SUGGESTIONS_REQUEST } from 'calypso/state/action-types';
 import { receiveLocaleSuggestions } from 'calypso/state/i18n/locale-suggestions/actions';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 /**
  * @module state/data-layer/wpcom/locale-guess

--- a/client/state/data-layer/wpcom/logstash/index.js
+++ b/client/state/data-layer/wpcom/logstash/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
@@ -11,6 +6,8 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { LOGSTASH } from 'calypso/state/action-types';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 const logToLogstash = ( action ) =>
 	http( {

--- a/client/state/data-layer/wpcom/marketing/index.js
+++ b/client/state/data-layer/wpcom/marketing/index.js
@@ -3,10 +3,11 @@
  */
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
-import { noop } from 'lodash';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 
 import { MARKETING_CLICK_UPGRADE_NUDGE } from 'calypso/state/action-types';
+
+const noop = () => {};
 
 export const notifyUpgradeNudgeClick = ( action ) =>
 	http(

--- a/client/state/data-layer/wpcom/me/connected-applications/index.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
@@ -14,6 +9,8 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { receiveConnectedApplications } from 'calypso/state/connected-applications/actions';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 export const apiTransformer = ( data ) => data.connected_applications;
 

--- a/client/state/data-layer/wpcom/me/settings/profile-links/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
@@ -13,6 +8,8 @@ import { receiveUserProfileLinks } from 'calypso/state/profile-links/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 
 import 'calypso/state/profile-links/init';
+
+const noop = () => {};
 
 /**
  * Dispatches a request to fetch profile links of the current user

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
@@ -14,6 +9,8 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { receiveApplicationPasswords } from 'calypso/state/application-passwords/actions';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 export const apiTransformer = ( data ) => data.application_passwords;
 

--- a/client/state/data-layer/wpcom/posts/revisions/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { POST_REVISIONS_REQUEST } from 'calypso/state/action-types';
@@ -11,6 +6,8 @@ import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { receivePostRevisions } from 'calypso/state/posts/revisions/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 /**
  * Dispatches returned post revisions

--- a/client/state/data-layer/wpcom/read/following/mine/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/test/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import freeze from 'deep-freeze';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,6 +22,7 @@ import { READER_FOLLOWS_SYNC_START } from 'calypso/state/reader/action-types';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { receiveFollows, follow, syncComplete } from 'calypso/state/reader/follows/actions';
 
+const noop = () => {};
 const successfulApiResponse = freeze( {
 	number: 2,
 	page: 1,

--- a/client/state/data-layer/wpcom/read/lists/index.js
+++ b/client/state/data-layer/wpcom/read/lists/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,6 +29,8 @@ import {
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { navigate } from 'calypso/state/ui/actions';
 import { DEFAULT_NOTICE_DURATION } from 'calypso/state/notices/constants';
+
+const noop = () => {};
 
 registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 	[ READER_LIST_CREATE ]: [

--- a/client/state/data-layer/wpcom/read/lists/items/index.js
+++ b/client/state/data-layer/wpcom/read/lists/items/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
@@ -11,6 +6,8 @@ import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { READER_LIST_ITEMS_REQUEST } from 'calypso/state/reader/action-types';
 import { receiveReaderListItems } from 'calypso/state/reader/lists/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 registerHandlers( 'state/data-layer/wpcom/read/lists/items/index.js', {
 	[ READER_LIST_ITEMS_REQUEST ]: [

--- a/client/state/data-layer/wpcom/read/recommendations/sites/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/index.js
@@ -1,9 +1,4 @@
 /**
- * External Dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal Dependencies
  */
 import { READER_RECOMMENDED_SITES_REQUEST } from 'calypso/state/reader/action-types';
@@ -13,6 +8,8 @@ import { receiveRecommendedSites } from 'calypso/state/reader/recommended-sites/
 import { decodeEntities } from 'calypso/lib/formatting';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 export const requestRecommendedSites = ( action ) => {
 	const { seed = 1, number = 10, offset = 0 } = action.payload;

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/delete/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { READER_UNSUBSCRIBE_TO_NEW_POST_NOTIFICATIONS } from 'calypso/state/reader/action-types';
@@ -15,6 +10,8 @@ import { bypassDataLayer } from 'calypso/state/data-layer/utils';
 import { subscribeToNewPostNotifications } from 'calypso/state/reader/follows/actions';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 export function fromApi( response ) {
 	const isUnsubscribed = !! ( response && response.subscribed === false );

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/new/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { READER_SUBSCRIBE_TO_NEW_POST_NOTIFICATIONS } from 'calypso/state/reader/action-types';
@@ -15,6 +10,8 @@ import { bypassDataLayer } from 'calypso/state/data-layer/utils';
 import { unsubscribeToNewPostNotifications } from 'calypso/state/reader/follows/actions';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 export function fromApi( response ) {
 	const isSubscribed = !! ( response && response.subscribed );

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { random, map, includes, get, noop } from 'lodash';
+import { random, map, includes, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -20,6 +20,8 @@ import { keyForPost } from 'calypso/reader/post-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import XPostHelper from 'calypso/reader/xpost-helper';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 /**
  * Pull the suffix off of a stream key

--- a/client/state/data-layer/wpcom/sites/gutenberg/index.js
+++ b/client/state/data-layer/wpcom/sites/gutenberg/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { has, noop } from 'lodash';
+import { has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,6 +18,8 @@ import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { replaceHistory } from 'calypso/state/ui/actions';
 
 import 'calypso/state/gutenberg-iframe-eligible/init';
+
+const noop = () => {};
 
 const fetchGutenbergOptInData = ( action ) =>
 	http(

--- a/client/state/data-layer/wpcom/sites/homepage/index.js
+++ b/client/state/data-layer/wpcom/sites/homepage/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,6 +13,7 @@ import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { bypassDataLayer } from 'calypso/state/data-layer/utils';
 import { updateSiteFrontPage } from 'calypso/state/sites/actions';
 
+const noop = () => {};
 const getIsPageOnFront = ( show_on_front ) => {
 	if ( 'page' === show_on_front ) {
 		return true;

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -1,9 +1,4 @@
 /**
- * External Dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
@@ -14,6 +9,8 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { JITM_DISMISS, JITM_FETCH } from 'calypso/state/action-types';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 /**
  * Existing libraries do not escape decimal encoded entities that php encodes, this handles that.

--- a/client/state/data-layer/wpcom/sites/mailchimp/index.js
+++ b/client/state/data-layer/wpcom/sites/mailchimp/index.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import {
@@ -18,6 +12,8 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 export const handleMailchimpListsList = dispatchRequest( {
 	fetch: ( action ) =>

--- a/client/state/data-layer/wpcom/sites/memberships/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/index.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import {
@@ -21,6 +15,8 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 export const membershipProductFromApi = ( product ) => ( {
 	ID: parseInt( product.id || product.connected_account_product_id ),

--- a/client/state/data-layer/wpcom/sites/memberships/subscriptions/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/subscriptions/index.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import {
@@ -16,6 +10,8 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 export const handleSubscribedMembershipsList = dispatchRequest( {
 	fetch: ( action ) =>

--- a/client/state/data-layer/wpcom/sites/post-types/index.js
+++ b/client/state/data-layer/wpcom/sites/post-types/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
@@ -12,6 +7,8 @@ import { POST_TYPES_REQUEST } from 'calypso/state/action-types';
 import { receivePostTypes } from 'calypso/state/post-types/actions';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 const handlePostTypesRequest = dispatchRequest( {
 	fetch: ( action ) =>

--- a/client/state/data-layer/wpcom/sites/users/index.js
+++ b/client/state/data-layer/wpcom/sites/users/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { get, isUndefined, map, noop, omit, omitBy } from 'lodash';
+import { get, isUndefined, map, omit, omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,6 +13,8 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { receivePostRevisionAuthors } from 'calypso/state/posts/revisions/authors/actions';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 export const DEFAULT_PER_PAGE = 10;
 

--- a/client/state/data-layer/wpcom/timezones/index.js
+++ b/client/state/data-layer/wpcom/timezones/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fromPairs, map, mapValues, noop } from 'lodash';
+import { fromPairs, map, mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,6 +12,8 @@ import { TIMEZONES_REQUEST } from 'calypso/state/action-types';
 import { timezonesReceive } from 'calypso/state/timezones/actions';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 /**
  * Converts an value/label pairs from API into object whose

--- a/client/state/data-layer/wpcom/wordads/settings/index.js
+++ b/client/state/data-layer/wpcom/wordads/settings/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -19,6 +18,8 @@ import {
 } from 'calypso/state/wordads/settings/actions';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const noop = () => {};
 
 const fromApi = ( data ) => {
 	if ( ! data.hasOwnProperty( 'settings' ) ) {

--- a/client/state/happychat/middleware-calypso.js
+++ b/client/state/happychat/middleware-calypso.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { has, noop } from 'lodash';
+import { has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -47,6 +47,8 @@ import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/action
 import { getHelpSelectedSiteId } from 'calypso/state/help/selectors';
 import getSectionName from 'calypso/state/ui/selectors/get-section-name';
 import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
+
+const noop = () => {};
 
 const getRouteSetMessage = ( state, path ) => {
 	return `Looking at https://wordpress.com${ path }`;

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,6 +24,7 @@ import buildConnection from 'calypso/lib/happychat/connection-async';
 import isHappychatClientConnected from 'calypso/state/happychat/selectors/is-happychat-client-connected';
 import isHappychatChatAssigned from 'calypso/state/happychat/selectors/is-happychat-chat-assigned';
 
+const noop = () => {};
 const eventMessage = {
 	HAPPYCHAT_BLUR: 'Stopped looking at Happychat',
 	HAPPYCHAT_FOCUS: 'Started looking at Happychat',

--- a/client/state/media/thunks/upload-media.js
+++ b/client/state/media/thunks/upload-media.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, noop, zip } from 'lodash';
+import { castArray, zip } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +14,8 @@ import {
 import { requestMediaStorage } from 'calypso/state/sites/media-storage/actions';
 import { createTransientMediaItems } from 'calypso/state/media/thunks/create-transient-media-items';
 import { isFileList } from 'calypso/state/media/utils/is-file-list';
+
+const noop = () => {};
 
 /**
  * Add media items serially (one at a time) but dispatch creation

--- a/client/state/sites/domains/actions.js
+++ b/client/state/sites/domains/actions.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { map, noop } from 'lodash';
+import { map } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -29,6 +29,7 @@ import 'calypso/state/data-layer/wpcom/domains/privacy/index.js';
  */
 const debug = debugFactory( 'calypso:state:sites:domains:actions' );
 const wpcom = wp.undocumented();
+const noop = () => {};
 
 /**
  * Action creator function

--- a/client/state/test/index.js
+++ b/client/state/test/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { createReduxStore } from '../';
@@ -11,6 +6,8 @@ import { getCurrentUser, getCurrentUserId } from 'calypso/state/current-user/sel
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
 jest.mock( 'calypso/lib/user', () => () => {} );
+
+const noop = () => {};
 
 describe( 'index', () => {
 	describe( 'createReduxStore', () => {

--- a/client/state/test/persistence.js
+++ b/client/state/test/persistence.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { DESERIALIZE, SERIALIZE } from 'calypso/state/action-types';
@@ -12,6 +7,8 @@ import reducer from 'calypso/state/reducer';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
 jest.mock( 'calypso/lib/user', () => () => {} );
+
+const noop = () => {};
 
 describe( 'persistence', () => {
 	test( 'initial state should serialize and deserialize without errors or warnings', () => {

--- a/client/test-helpers/use-sinon/index.js
+++ b/client/test-helpers/use-sinon/index.js
@@ -2,7 +2,9 @@
  * External dependencies
  */
 import sinon from 'sinon';
-import { isFunction, noop } from 'lodash';
+import { isFunction } from 'lodash';
+
+const noop = () => {};
 
 /**
  * Use sinon's fake time controls

--- a/packages/components/src/suggestions/index.tsx
+++ b/packages/components/src/suggestions/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
-import { find, groupBy, isEqual, partition, property, noop } from 'lodash';
+import { find, groupBy, isEqual, partition, property } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -15,6 +15,9 @@ import Item from './item';
  * Style depenedencies
  */
 import './style.scss';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 type Suggestion = { label: string; category?: string };
 

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { FunctionComponent, useState, useEffect, Fragment } from 'react';
 import { useSelect } from '@wordpress/data';
-import { noop, times } from 'lodash';
+import { times } from 'lodash';
 import { Button, TextControl, Notice } from '@wordpress/components';
 import { Icon, search } from '@wordpress/icons';
 import { getNewRailcarId, recordTrainTracksRender } from '@automattic/calypso-analytics';
@@ -37,6 +37,9 @@ import type { SUGGESTION_ITEM_TYPE } from './suggestion-item';
  * Style dependencies
  */
 import './style.scss';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
 type DomainGroup = 'sub-domain' | 'professional';

--- a/packages/page-template-modal/src/components/block-iframe-preview.js
+++ b/packages/page-template-modal/src/components/block-iframe-preview.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { each, filter, get, castArray, debounce, noop } from 'lodash';
+import { each, filter, get, castArray, debounce } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -23,6 +23,8 @@ import { compose, withSafeTimeout } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
 import CustomBlockPreview from './block-preview';
+
+const noop = () => {};
 
 // Debounce time applied to the on resize window event.
 const DEBOUNCE_TIMEOUT = 300;

--- a/packages/page-template-modal/src/components/template-selector-control.js
+++ b/packages/page-template-modal/src/components/template-selector-control.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, noop, map } from 'lodash';
+import { isEmpty, map } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -16,6 +16,8 @@ import { memo } from '@wordpress/element';
  */
 import TemplateSelectorItem from './template-selector-item';
 import replacePlaceholders from '../utils/replace-placeholders';
+
+const noop = () => {};
 
 export const TemplateSelectorControl = ( {
 	label,

--- a/packages/plans-grid/src/segmented-control/simplified.jsx
+++ b/packages/plans-grid/src/segmented-control/simplified.jsx
@@ -3,12 +3,13 @@
  */
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import SegmentedControl from '.';
+
+const noop = () => {};
 
 function SimplifiedSegmentedControl( {
 	options,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `noop` is essentially an empty function. This PR replaces all the usage of `noop` with an empty arrow function.

This is take 2, take 1 was in #50654. There we directly replaced the usages inline, but here we're creating inline constants to avoid unnecessary re-renders.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify Calypso builds.
* Verify all tests pass.

#### Notes

Lint errors are expected. Just make sure we're not introducing new ones.