### PR TITLE
Domain Suggestions: Externalize getSuggestionsVendor().

### DIFF
--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -15,7 +15,7 @@ import { getDomainSuggestionsVendor } from '@automattic/domain-picker';
  * @returns {string} Vendor string to pass as part of the domain suggestions query.
  */
 export const getSuggestionsVendor = ( options = {} ) => {
-	// If the isPremium property is not explicitly given
+	// If the isPremium property is explicitly given
 	// and premium domain purchases is enabled, set isPremium to true.
 	if ( options.isPremium !== undefined && config.isEnabled( 'domains/premium-domain-purchases' ) ) {
 		options.isPremium = true;

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import config from '@automattic/calypso-config';
+import { getDomainSuggestionsVendor } from '@automattic/domain-picker';
 
 /**
  * Get the suggestions vendor
@@ -9,15 +10,16 @@ import config from '@automattic/calypso-config';
  * @param {object} [options={}] Options to determine the suggestion vendor
  * @param {boolean} [options.isSignup=false] Flag to indicate that we're in a signup context
  * @param {boolean} [options.isDomainOnly=false] Flag to indicate that we're in a domain-only context
+ * @param {boolean} [options.isPremium=false] Flag to show premium domains.
  *
  * @returns {string} Vendor string to pass as part of the domain suggestions query.
  */
 export const getSuggestionsVendor = ( options = {} ) => {
-	if ( options?.isSignup && ! options?.isDomainOnly ) {
-		return 'variation4_front';
+	// If the isPremium property is not explicitly given
+	// and premium domain purchases is enabled, set isPremium to true.
+	if ( options.isPremium !== undefined && config.isEnabled( 'domains/premium-domain-purchases' ) ) {
+		options.isPremium = true;
 	}
-	if ( config.isEnabled( 'domains/premium-domain-purchases' ) ) {
-		return 'variation8_front';
-	}
-	return 'variation2_front';
+
+	return getDomainSuggestionsVendor( options );
 };

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -15,10 +15,9 @@ import { getDomainSuggestionsVendor } from '@automattic/domain-picker';
  * @returns {string} Vendor string to pass as part of the domain suggestions query.
  */
 export const getSuggestionsVendor = ( options = {} ) => {
-	// If the isPremium property is explicitly given
-	// and premium domain purchases is enabled, set isPremium to true.
-	if ( options.isPremium !== undefined && config.isEnabled( 'domains/premium-domain-purchases' ) ) {
-		options.isPremium = true;
+	// If the isPremium prop is not given, fallback to the value set in config.
+	if ( typeof options.isPremium === 'undefined' ) {
+		options.isPremium = config.isEnabled( 'domains/premium-domain-purchases' );
 	}
 
 	return getDomainSuggestionsVendor( options );

--- a/packages/domain-picker/src/index.tsx
+++ b/packages/domain-picker/src/index.tsx
@@ -7,6 +7,10 @@ export type { Props } from './domain-picker';
 export { ITEM_TYPE_RADIO, ITEM_TYPE_BUTTON } from './domain-picker/suggestion-item';
 export type { SUGGESTION_ITEM_TYPE } from './domain-picker/suggestion-item';
 
-export { mockDomainSuggestion, isGoodDefaultDomainQuery } from './utils';
+export {
+	mockDomainSuggestion,
+	isGoodDefaultDomainQuery,
+	getDomainSuggestionsVendor,
+} from './utils';
 export { useDomainSuggestions } from './hooks';
 export { DOMAIN_QUERY_MINIMUM_LENGTH } from './constants';

--- a/packages/domain-picker/src/utils.ts
+++ b/packages/domain-picker/src/utils.ts
@@ -61,10 +61,10 @@ type DomainSuggestionsVendor = 'variation2_front' | 'variation4_front' | 'variat
 export function getDomainSuggestionsVendor(
 	options: DomainSuggestionsVendorOptions = {}
 ): DomainSuggestionsVendor {
-	if ( options?.isSignup && ! options?.isDomainOnly ) {
+	if ( options.isSignup && ! options.isDomainOnly ) {
 		return 'variation4_front';
 	}
-	if ( options?.isPremium ) {
+	if ( options.isPremium ) {
 		return 'variation8_front';
 	}
 	return 'variation2_front';

--- a/packages/domain-picker/src/utils.ts
+++ b/packages/domain-picker/src/utils.ts
@@ -40,3 +40,32 @@ export function isGoodDefaultDomainQuery( domainQuery: string ): boolean {
 		.replace( /[\u0300-\u036f]/g, '' )
 		.match( /[a-z0-9-.\s]/i );
 }
+
+/**
+ * Get the suggestions vendor
+ *
+ * @param {object} [options={}] Options to determine the suggestion vendor
+ * @param {boolean} [options.isSignup=false] Flag to indicate that we're in a signup context
+ * @param {boolean} [options.isDomainOnly=false] Flag to indicate that we're in a domain-only context
+ * @param {boolean} [options.isPremium=false] Flag to show premium domains.
+ *
+ * @returns {string} Vendor string to pass as part of the domain suggestions query.
+ */
+interface DomainSuggestionsVendorOptions {
+	isSignup?: boolean;
+	isDomainOnly?: boolean;
+	isPremium?: boolean;
+}
+type DomainSuggestionsVendor = 'variation2_front' | 'variation4_front' | 'variation8_front';
+
+export function getDomainSuggestionsVendor(
+	options: DomainSuggestionsVendorOptions = {}
+): DomainSuggestionsVendor {
+	if ( options?.isSignup && ! options?.isDomainOnly ) {
+		return 'variation4_front';
+	}
+	if ( options?.isPremium ) {
+		return 'variation8_front';
+	}
+	return 'variation2_front';
+}


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR:
- Introduces `getDomainSuggestionsVendor()` in `@automattic/domain-picker` package an
- Update existing `getSuggestionsVendor()` in `client/lib/domain/suggestions` to reuse `getDomainSuggestionsVendor()`.
- Added `DomainSuggestionsVendorOptions` and `DomainSuggestionsVendor` types.

This PR is just the first step. Once externalized, then we can fix the incorrect use of vendor strings https://github.com/Automattic/wp-calypso/issues/47105 in another PR.

## Testing instructions

**Test `/start` domain search:**

* Go to `/start/domains`.
* Open up network panel, filter it to XHR, look for API calls to `suggestions`.
* Enter a domain search string.
* You should see `variation4_front`.

**Test `/new` domain search:**

* Go to `/new/domains`.
* Open up network panel, filter it to XHR, look for API calls to `suggestions`.
* Enter a domain search string.
* You should see `variation4_front`.

**Test other places:**

* Go to:
    * **Site Home > Upgrades > Domains > Add a domain to this site**
    * **Site Home > Stats > Insights**
* Open up network panel, filter it to XHR, look for API calls to `suggestions`.
* Enter a domain search string. (only for `/domains/add`)
* You should see `variation2_front`.

## Screenshot

![image](https://user-images.githubusercontent.com/1287077/109961742-a0fc1a80-7cea-11eb-98ec-3cf022621cfc.png)

Fixes #47101
