### PR TITLE
Framework: Refactor away from _.isNaN() 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -420,6 +420,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/inject': 'error',
 		'you-dont-need-lodash-underscore/is-array': 'error',
 		'you-dont-need-lodash-underscore/is-finite': 'error',
+		'you-dont-need-lodash-underscore/is-nan': 'error',
 		'you-dont-need-lodash-underscore/is-nil': 'error',
 		'you-dont-need-lodash-underscore/is-null': 'error',
 		'you-dont-need-lodash-underscore/last-index-of': 'error',

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/controls.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/controls.js
@@ -4,7 +4,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'calypso/components/gridicon';
-import { isNaN } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 
@@ -51,7 +50,7 @@ class InventoryControls extends Component {
 
 	setValue = ( name ) => ( event ) => {
 		const value = parseInt( event.target.value );
-		this.setState( { [ name ]: isNaN( value ) ? 0 : value } );
+		this.setState( { [ name ]: Number.isNaN( value ) ? 0 : value } );
 	};
 
 	increaseValue = ( name ) => () => {
@@ -232,8 +231,8 @@ export default connect(
 
 		return {
 			isLoaded,
-			lowStockThreshold: isNaN( lowStockThreshold ) ? 0 : lowStockThreshold,
-			noStockThreshold: isNaN( noStockThreshold ) ? 0 : noStockThreshold,
+			lowStockThreshold: Number.isNaN( lowStockThreshold ) ? 0 : lowStockThreshold,
+			noStockThreshold: Number.isNaN( noStockThreshold ) ? 0 : noStockThreshold,
 			notifyLowStockEnabled,
 			notifyNoStockEnabled,
 			site,

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
-import { every, find, findIndex, get, isNaN } from 'lodash';
+import { every, find, findIndex, get } from 'lodash';
 import formatCurrency from '@automattic/format-currency';
 
 /**
@@ -104,7 +104,7 @@ class OrderDetailsTable extends Component {
 		const { order } = this.props;
 		// Name is `quantity-x`, where x is the ID of the item
 		let id = event.target.name.split( '-' )[ 1 ];
-		if ( ! isNaN( parseInt( id ) ) ) {
+		if ( ! Number.isNaN( parseInt( id ) ) ) {
 			id = parseInt( id );
 		}
 		const item = find( order.line_items, { id } );
@@ -389,7 +389,7 @@ class OrderDetailsTable extends Component {
 						currency={ order.currency }
 						label={ translate( 'Shipping' ) }
 						initialValue={ initialShippingValue }
-						value={ isNaN( currentShippingValue ) ? '' : currentShippingValue }
+						value={ Number.isNaN( currentShippingValue ) ? '' : currentShippingValue }
 						taxValue={ getOrderShippingTax( order ) }
 						showTax={ showTax }
 						isEditable={ isEditing }

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import page from 'page';
-import { each, isNaN, startsWith } from 'lodash';
+import { each, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ const mapPendingStatusToUnapproved = ( status ) => ( 'pending' === status ? 'una
 
 const sanitizeInt = ( number ) => {
 	const integer = parseInt( number, 10 );
-	return ! isNaN( integer ) && integer > 0 ? integer : false;
+	return ! Number.isNaN( integer ) && integer > 0 ? integer : false;
 };
 
 const sanitizeQueryAction = ( action ) => {

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
-import { flowRight, isEqual, isObjectLike, keys, omit, pick, isNaN } from 'lodash';
+import { flowRight, isEqual, isObjectLike, keys, omit, pick } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
@@ -190,7 +190,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 			const { name, value } = event.currentTarget;
 			// Attempt to cast numeric fields value to int
 			const parsedValue = parseInt( value, 10 );
-			this.props.updateFields( { [ name ]: isNaN( parsedValue ) ? value : parsedValue } );
+			this.props.updateFields( { [ name ]: Number.isNaN( parsedValue ) ? value : parsedValue } );
 		};
 
 		handleToggle = ( name ) => () => {

--- a/client/state/selectors/get-current-plan-purchase-id.js
+++ b/client/state/selectors/get-current-plan-purchase-id.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isNaN } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
@@ -24,7 +19,7 @@ export default function getCurrentPlanPurchaseId( state, siteId ) {
 	const result = getCurrentPlan( state, siteId )?.id ?? null;
 
 	// getCurrentPlan uses an "assembler" which may have NaN in the `id`.
-	if ( isNaN( result ) ) {
+	if ( Number.isNaN( result ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `isNaN` is essentially fully natively supported by `Number.isNaN`. This PR replaces the usage, and adds an ESLint rule to warn against using `isNaN` from lodash. 

Noting that this is intentionally using `Number.isNaN` and not the good old `isNan()` - quoting [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN#description):

> In comparison to the global isNaN() function, Number.isNaN() doesn't suffer the problem of forcefully converting the parameter to a number. This means it is now safe to pass values that would normally convert to NaN, but aren't actually the same value as NaN. This also means that only values of the type number, that are also NaN, return true.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Try to `import { isNaN } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass.