### PR TITLE
Framework: Refactor away from _.fromPairs()

### DIFF
--- a/client/components/forms/sortable-list/index.jsx
+++ b/client/components/forms/sortable-list/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { assign, findIndex, fromPairs } from 'lodash';
+import { assign, findIndex } from 'lodash';
 import classNames from 'classnames';
 import debugFactory from 'debug';
 import Gridicon from 'calypso/components/gridicon';
@@ -287,7 +287,7 @@ class SortableList extends React.Component {
 					'is-draggable': isDraggable,
 				} );
 
-				events = fromPairs(
+				events = Object.fromEntries(
 					events.map( function ( event ) {
 						return [ event, this[ event ].bind( null, index ) ];
 					}, this )

--- a/client/components/title-format-editor/parser.js
+++ b/client/components/title-format-editor/parser.js
@@ -1,15 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	compact,
-	flowRight as compose,
-	fromPairs,
-	get,
-	map,
-	matchesProperty,
-	reduce,
-} from 'lodash';
+import { compact, flowRight as compose, get, map, matchesProperty, reduce } from 'lodash';
 import { convertFromRaw, convertToRaw } from 'draft-js';
 
 /*
@@ -214,7 +206,7 @@ export const toEditor = ( format, tokens ) => {
 
 	return convertFromRaw( {
 		blocks: [ blocks ],
-		entityMap: fromPairs(
+		entityMap: Object.fromEntries(
 			map( entityGuide, ( name, key ) => [
 				key, // entity key is position in list
 				{

--- a/client/layout/guided-tours/tour-branching.js
+++ b/client/layout/guided-tours/tour-branching.js
@@ -3,7 +3,7 @@
  */
 
 import { Children } from 'react';
-import { fromPairs, flatMap, identity, isFunction } from 'lodash';
+import { flatMap, identity, isFunction } from 'lodash';
 
 /*
  * Transforms a React `Children` object into an array. The children of a `Step` are
@@ -81,5 +81,7 @@ const branching = ( element ) => {
 export const tourBranching = ( tourTree ) => {
 	const steps = childrenToArray( tourTree.props.children );
 
-	return fromPairs( steps.map( ( step ) => [ step.props.name, fromPairs( branching( step ) ) ] ) );
+	return Object.fromEntries(
+		steps.map( ( step ) => [ step.props.name, Object.fromEntries( branching( step ) ) ] )
+	);
 };

--- a/client/lib/query-manager/key.js
+++ b/client/lib/query-manager/key.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { sortBy, toPairs, fromPairs, omitBy } from 'lodash';
+import { sortBy, toPairs, omitBy } from 'lodash';
 
 /**
  * QueryKey manages the serialization and deserialization of a query key for
@@ -77,6 +77,6 @@ export default class QueryKey {
 	 * @returns {object}     Query object
 	 */
 	static parse( key ) {
-		return this.omit( fromPairs( JSON.parse( key ) ) );
+		return this.omit( Object.fromEntries( JSON.parse( key ) ) );
 	}
 }

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { assign, fromPairs, includes, times } from 'lodash';
+import { assign, includes, times } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -85,7 +85,7 @@ export class EditorMediaModalGalleryFields extends React.Component {
 
 	getColumnOptions = () => {
 		const max = Math.min( this.props.numberOfItems, 9 );
-		return fromPairs( times( max, ( n ) => [ n + 1, ( n + 1 ).toString() ] ) );
+		return Object.fromEntries( times( max, ( n ) => [ n + 1, ( n + 1 ).toString() ] ) );
 	};
 
 	updateRandomOrder = ( event ) => {

--- a/client/state/data-layer/wpcom/timezones/index.js
+++ b/client/state/data-layer/wpcom/timezones/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fromPairs, map, mapValues } from 'lodash';
+import { map, mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,7 +27,7 @@ const noop = () => {};
  * @returns {ValueLabelMap} object whose keys are timezone values, values are timezone labels
  */
 const timezonePairsToMap = ( pairs ) =>
-	fromPairs( map( pairs, ( { label, value } ) => [ value, label ] ) );
+	Object.fromEntries( map( pairs, ( { label, value } ) => [ value, label ] ) );
 
 /**
  * Normalize data gotten from the REST API making them more Calypso friendly.

--- a/client/state/http/index.js
+++ b/client/state/http/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fromPairs, identity, toPairs } from 'lodash';
+import { identity, toPairs } from 'lodash';
 
 /**
  * Internal dependencies
@@ -60,7 +60,7 @@ export const httpHandler = async ( { dispatch }, action ) => {
 		return;
 	}
 
-	const fetchHeaders = fromPairs( headers );
+	const fetchHeaders = Object.fromEntries( headers );
 	fetchHeaders.Accept = 'application/json';
 
 	const contentType = ( fetchHeaders[ 'Content-Type' ] || '' ).split( ';' )[ 0 ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `fromPairs` is essentially fully natively supported by `Object.fromEntries`. This PR replaces the usage.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Manually audit the code and verify we won't end up with `null` / `undefined` argument being passed to `Object.fromEntries()`. 
* Verify all tests pass.

#### Notes

ESLint errors are expected, just make sure they're pre-existing.