### PR TITLE
Domain Suggestions: Avoid vendor prop during store registration & types cleanup.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/domain-suggestions.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/domain-suggestions.ts
@@ -3,4 +3,4 @@
  */
 import { DomainSuggestions } from '@automattic/data-stores';
 
-DomainSuggestions.register( { vendor: 'variation2_front' } );
+DomainSuggestions.register();

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
-import DomainPicker from '@automattic/domain-picker';
+import DomainPicker, { getDomainSuggestionsVendor } from '@automattic/domain-picker';
 import type { DomainSuggestions } from '@automattic/data-stores';
 import {
 	Title,
@@ -168,6 +168,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 				analyticsUiAlgo={ isModal ? 'domain_modal' : 'domain_page' }
 				locale={ locale }
 				onUseYourDomainClick={ currentUser ? handleUseYourDomain : undefined }
+				vendor={ getDomainSuggestionsVendor( { isSignup: true } ) }
 			/>
 		</div>
 	);

--- a/client/landing/gutenboarding/stores/domain-suggestions/index.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/index.ts
@@ -2,9 +2,5 @@
  * External dependencies
  */
 import { DomainSuggestions } from '@automattic/data-stores';
-import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 
-export const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register( {
-	/* Returns an ID for the domain suggestions vendor. Passing `{ isSignup: true }` to getSuggestionsVendor returns the signup variant. */
-	vendor: getSuggestionsVendor( { isSignup: true } ),
-} );
+export const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register();

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -37,6 +37,7 @@
 		"@wordpress/api-fetch": "^3.21.1",
 		"@wordpress/data-controls": "^1.20.1",
 		"@wordpress/deprecated": "^2.11.0",
+		"@automattic/domain-picker": "^1.0.0-alpha.0",
 		"@wordpress/url": "^2.21.0",
 		"fast-json-stable-stringify": "^2.1.0",
 		"i18n-calypso": "^5.0.0",

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -37,7 +37,6 @@
 		"@wordpress/api-fetch": "^3.21.1",
 		"@wordpress/data-controls": "^1.20.1",
 		"@wordpress/deprecated": "^2.11.0",
-		"@automattic/domain-picker": "^1.0.0-alpha.0",
 		"@wordpress/url": "^2.21.0",
 		"fast-json-stable-stringify": "^2.1.0",
 		"i18n-calypso": "^5.0.0",

--- a/packages/data-stores/src/domain-suggestions/index.ts
+++ b/packages/data-stores/src/domain-suggestions/index.ts
@@ -10,7 +10,7 @@ import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
-import createSelectors, { Selectors } from './selectors';
+import * as selectors from './selectors';
 import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import { controls } from '../wpcom-request-controls';
 
@@ -19,14 +19,8 @@ export { getFormattedPrice } from './utils';
 export type { State };
 
 let isRegistered = false;
-interface StoreConfiguration {
-	/**
-	 * The default vendor to pass to domain queries.
-	 * Can be overridden in individual queries.
-	 */
-	vendor: string;
-}
-export function register( { vendor }: StoreConfiguration ): typeof STORE_KEY {
+
+export function register(): typeof STORE_KEY {
 	if ( ! isRegistered ) {
 		isRegistered = true;
 		registerStore< State >( STORE_KEY, {
@@ -34,7 +28,7 @@ export function register( { vendor }: StoreConfiguration ): typeof STORE_KEY {
 			controls: controls as any,
 			reducer: reducer as any,
 			resolvers,
-			selectors: createSelectors( vendor ),
+			selectors,
 		} );
 	}
 	return STORE_KEY;
@@ -42,5 +36,5 @@ export function register( { vendor }: StoreConfiguration ): typeof STORE_KEY {
 
 declare module '@wordpress/data' {
 	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof actions >;
-	function select( key: typeof STORE_KEY ): SelectFromMap< Selectors >;
+	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
 }

--- a/packages/data-stores/src/domain-suggestions/reducer.ts
+++ b/packages/data-stores/src/domain-suggestions/reducer.ts
@@ -7,7 +7,7 @@ import { combineReducers } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import type { DomainCategory, DomainAvailability, DomainSuggestionState } from './types';
+import type { DomainCategory, DomainSuggestionState, DomainAvailabilities } from './types';
 import { DataStatus } from './constants';
 import type { Action } from './actions';
 import { stringifyDomainQueryObject } from './utils';
@@ -67,10 +67,7 @@ const categories: Reducer< DomainCategory[], Action > = ( state = [], action ) =
 	return state;
 };
 
-const availability: Reducer< Record< string, DomainAvailability | undefined >, Action > = (
-	state = {},
-	action
-) => {
+const availability: Reducer< DomainAvailabilities, Action > = ( state = {}, action ) => {
 	if ( action.type === 'RECEIVE_DOMAIN_AVAILABILITY' ) {
 		return {
 			...state,

--- a/packages/data-stores/src/domain-suggestions/resolvers.ts
+++ b/packages/data-stores/src/domain-suggestions/resolvers.ts
@@ -17,13 +17,9 @@ import {
 import { fetchAndParse, wpcomRequest } from '../wpcom-request-controls';
 import { getFormattedPrice } from './utils';
 
-import type { Selectors } from './selectors';
-import type { TailParameters } from '../mapped-types';
-import type { DomainSuggestion } from './types';
+import type { DomainSuggestion, DomainSuggestionQuery } from './types';
 
-export const isAvailable = function* isAvailable(
-	domainName: TailParameters< Selectors[ 'isAvailable' ] >[ 0 ]
-) {
+export const isAvailable = function* isAvailable( domainName: string ) {
 	const url = `https://public-api.wordpress.com/rest/v1.3/domains/${ encodeURIComponent(
 		domainName
 	) }/is-available?is_cart_pre_check=true`;
@@ -50,10 +46,7 @@ export function* getCategories() {
 	return receiveCategories( categories.body );
 }
 
-export function* __internalGetDomainSuggestions(
-	// Resolver has the same signature as corresponding selector without the initial state argument
-	queryObject: Parameters< Selectors[ '__internalGetDomainSuggestions' ] >[ 1 ]
-) {
+export function* __internalGetDomainSuggestions( queryObject: DomainSuggestionQuery ) {
 	// If normalized search string (`query`) contains no alphanumerics, endpoint 404s
 	if ( ! queryObject.query ) {
 		return receiveDomainSuggestionsError( 'Empty query' );

--- a/packages/data-stores/src/domain-suggestions/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/selectors.ts
@@ -7,127 +7,80 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import { STORE_KEY, DataStatus } from './constants';
-import type { DomainSuggestionQuery } from './types';
+import type {
+	DomainAvailability,
+	DomainAvailabilities,
+	DomainCategory,
+	DomainSuggestion,
+	DomainSuggestionQuery,
+	DomainSuggestionSelectorOptions,
+} from './types';
 import type { State } from './reducer';
-import { stringifyDomainQueryObject } from './utils';
+import { stringifyDomainQueryObject, normalizeDomainSuggestionQuery } from './utils';
 
-type DomainSuggestionSelectorOptions = Partial< Exclude< DomainSuggestionQuery, 'query' > >;
-
-const createSelectors = ( vendor: string ) => {
-	function getDomainSuggestionVendor() {
-		return vendor;
-	}
-
-	function getCategories( state: State ) {
-		// Sort domain categories by tier, then by title.
-		return [
-			...state.categories
-				.filter( ( { tier } ) => tier !== null )
-				.sort( ( a, b ) => ( a > b ? 1 : -1 ) ),
-			...state.categories
-				.filter( ( { tier } ) => tier === null )
-				.sort( ( a, b ) => a.title.localeCompare( b.title ) ),
-		];
-	}
-
-	function getDomainSuggestions(
-		_state: State,
-		search: string,
-		options: DomainSuggestionSelectorOptions = {}
-	) {
-		const normalizedQuery = normalizeDomainSuggestionQuery( search, options );
-
-		// We need to go through the `select` store to get the resolver action
-		return select( STORE_KEY ).__internalGetDomainSuggestions( normalizedQuery );
-	}
-
-	function getDomainState( state: State ): DataStatus {
-		return state.domainSuggestions.state;
-	}
-
-	function getDomainErrorMessage( state: State ): string | null {
-		return state.domainSuggestions.errorMessage;
-	}
-
-	// TODO: reconcile this function with "Pending" status?
-	// It doesn't seem to be used
-	function isLoadingDomainSuggestions(
-		_state: State,
-		search: string,
-		options: DomainSuggestionSelectorOptions = {}
-	) {
-		const normalizedQuery = normalizeDomainSuggestionQuery( search, options );
-
-		return select( 'core/data' ).isResolving( STORE_KEY, '__internalGetDomainSuggestions', [
-			normalizedQuery,
-		] );
-	}
-
-	/**
-	 * Normalize domain query
-	 *
-	 * It's important to have a consistent, reproduceable representation of a domains query so that the result can be
-	 * stored and retrieved.
-	 *
-	 * @see client/state/domains/suggestions/utils.js
-	 * @see client/components/data/query-domains-suggestions/index.jsx
-	 *
-	 * @param search       Domain search string
-	 * @param queryOptions Optional paramaters for the query
-	 * @returns Normalized query object
-	 */
-	function normalizeDomainSuggestionQuery(
-		search: string,
-		queryOptions: DomainSuggestionSelectorOptions
-	): DomainSuggestionQuery {
-		return {
-			// Defaults
-			include_wordpressdotcom: queryOptions.only_wordpressdotcom || false,
-			include_dotblogsubdomain: false,
-			only_wordpressdotcom: false,
-			quantity: 5,
-			vendor,
-
-			// Merge options
-			...queryOptions,
-
-			// Add the search query
-			query: search.trim().toLocaleLowerCase(),
-		};
-	}
-
-	/**
-	 * Do not use this selector. It is for internal use.
-	 *
-	 * @param state Store state
-	 * @param queryObject Normalized object representing the query
-	 * @returns suggestions
-	 */
-	function __internalGetDomainSuggestions( state: State, queryObject: DomainSuggestionQuery ) {
-		return state.domainSuggestions.data[ stringifyDomainQueryObject( queryObject ) ];
-	}
-
-	function isAvailable( state: State, domainName: string ) {
-		return state.availability[ domainName ];
-	}
-
-	function getDomainAvailabilities( state: State ) {
-		return state.availability;
-	}
-
-	return {
-		getCategories,
-		getDomainSuggestions,
-		getDomainState,
-		getDomainErrorMessage,
-		getDomainSuggestionVendor,
-		isLoadingDomainSuggestions,
-		__internalGetDomainSuggestions,
-		isAvailable,
-		getDomainAvailabilities,
-	};
+export const getCategories = ( state: State ): DomainCategory[] => {
+	// Sort domain categories by tier, then by title.
+	return [
+		...state.categories
+			.filter( ( { tier } ) => tier !== null )
+			.sort( ( a, b ) => ( a > b ? 1 : -1 ) ),
+		...state.categories
+			.filter( ( { tier } ) => tier === null )
+			.sort( ( a, b ) => a.title.localeCompare( b.title ) ),
+	];
 };
 
-export type Selectors = ReturnType< typeof createSelectors >;
+export const getDomainSuggestions = (
+	_state: State,
+	search: string,
+	options: DomainSuggestionSelectorOptions = {}
+): DomainSuggestion[] | undefined => {
+	const normalizedQuery = normalizeDomainSuggestionQuery( search, options );
 
-export default createSelectors;
+	// We need to go through the `select` store to get the resolver action
+	return select( STORE_KEY ).__internalGetDomainSuggestions( normalizedQuery );
+};
+
+export const getDomainState = ( state: State ): DataStatus => {
+	return state.domainSuggestions.state;
+};
+
+export const getDomainErrorMessage = ( state: State ): string | null => {
+	return state.domainSuggestions.errorMessage;
+};
+
+// TODO: reconcile this function with "Pending" status?
+// It doesn't seem to be used
+export const isLoadingDomainSuggestions = (
+	_state: State,
+	search: string,
+	options: DomainSuggestionSelectorOptions = {}
+): boolean => {
+	const normalizedQuery = normalizeDomainSuggestionQuery( search, options );
+
+	return select( 'core/data' ).isResolving( STORE_KEY, '__internalGetDomainSuggestions', [
+		normalizedQuery,
+	] );
+};
+
+/**
+ * Do not use this selector. It is for internal use.
+ *
+ * @param state Store state
+ * @param queryObject Normalized object representing the query
+ * @returns suggestions
+ */
+export const __internalGetDomainSuggestions = (
+	state: State,
+	queryObject: DomainSuggestionQuery
+): DomainSuggestion[] | undefined => {
+	return state.domainSuggestions.data[ stringifyDomainQueryObject( queryObject ) ];
+};
+
+export const isAvailable = ( state: State, domainName: string ): DomainAvailability | undefined => {
+	return state.availability[ domainName ];
+};
+
+export const getDomainAvailabilities = ( state: State ): DomainAvailabilities => {
+	return state.availability;
+};

--- a/packages/data-stores/src/domain-suggestions/test/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/test/selectors.ts
@@ -49,7 +49,7 @@ const apiResponse = [
 ];
 
 beforeAll( () => {
-	store = register( { vendor: 'variation2_front' } );
+	store = register();
 } );
 
 beforeEach( () => {

--- a/packages/data-stores/src/domain-suggestions/types.ts
+++ b/packages/data-stores/src/domain-suggestions/types.ts
@@ -210,6 +210,8 @@ export interface DomainAvailability {
 
 export type TimestampMS = ReturnType< typeof Date.now >;
 
+export type DomainSuggestions = Record< string, DomainSuggestion[] | undefined >;
+
 export interface DomainSuggestionState {
 	/**
 	 * The state of the DomainSuggestions e.g. pending, failure etc
@@ -219,7 +221,7 @@ export interface DomainSuggestionState {
 	/**
 	 * Domain suggestion data typically returned from the API
 	 */
-	data: Record< string, DomainSuggestion[] | undefined >;
+	data: DomainSuggestions;
 
 	/**
 	 * Error message
@@ -236,3 +238,7 @@ export interface DomainSuggestionState {
 	 */
 	pendingSince: TimestampMS | undefined;
 }
+
+export type DomainAvailabilities = Record< string, DomainAvailability | undefined >;
+
+export type DomainSuggestionSelectorOptions = Partial< Exclude< DomainSuggestionQuery, 'query' > >;

--- a/packages/data-stores/src/domain-suggestions/utils.ts
+++ b/packages/data-stores/src/domain-suggestions/utils.ts
@@ -3,10 +3,6 @@
  */
 import deterministicStringify from 'fast-json-stable-stringify';
 import formatCurrency from '@automattic/format-currency';
-// This is commented out due to cyclic package dependency compilation error.
-// Since domain picker passes in the vendor prop it is safe to hardcode this for now.
-// We can re-enable this in a separate PR.
-// import { getDomainSuggestionsVendor } from '@automattic/domain-picker';
 
 /**
  * Internal dependencies
@@ -58,10 +54,6 @@ export function normalizeDomainSuggestionQuery(
 		include_dotblogsubdomain: false,
 		only_wordpressdotcom: false,
 		quantity: 5,
-		// This is commented out due to cyclic package dependency compilation error.
-		// Since domain picker passes in the vendor prop it is safe to hardcode this for now.
-		// We can re-enable this in a separate PR.
-		// vendor: getDomainSuggestionsVendor(),
 		vendor: 'variation2_front',
 
 		// Merge options

--- a/packages/data-stores/src/domain-suggestions/utils.ts
+++ b/packages/data-stores/src/domain-suggestions/utils.ts
@@ -3,11 +3,15 @@
  */
 import deterministicStringify from 'fast-json-stable-stringify';
 import formatCurrency from '@automattic/format-currency';
+// This is commented out due to cyclic package dependency compilation error.
+// Since domain picker passes in the vendor prop it is safe to hardcode this for now.
+// We can re-enable this in a separate PR.
+// import { getDomainSuggestionsVendor } from '@automattic/domain-picker';
 
 /**
  * Internal dependencies
  */
-import type { DomainSuggestionQuery } from './types';
+import type { DomainSuggestionQuery, DomainSuggestionSelectorOptions } from './types';
 
 /**
  * Stable transform to an object key for storage and access.
@@ -29,4 +33,41 @@ export function getFormattedPrice( price: number, currencyCode: string ): string
 	return formatCurrency( price, currencyCode, {
 		stripZeros: true,
 	} ) as string;
+}
+
+/**
+ * Normalize domain query
+ *
+ * It's important to have a consistent, reproduceable representation of a domains query so that the result can be
+ * stored and retrieved.
+ *
+ * @see client/state/domains/suggestions/utils.js
+ * @see client/components/data/query-domains-suggestions/index.jsx
+ *
+ * @param search       Domain search string
+ * @param queryOptions Optional paramaters for the query
+ * @returns Normalized query object
+ */
+export function normalizeDomainSuggestionQuery(
+	search: string,
+	queryOptions: DomainSuggestionSelectorOptions
+): DomainSuggestionQuery {
+	return {
+		// Defaults
+		include_wordpressdotcom: queryOptions.only_wordpressdotcom || false,
+		include_dotblogsubdomain: false,
+		only_wordpressdotcom: false,
+		quantity: 5,
+		// This is commented out due to cyclic package dependency compilation error.
+		// Since domain picker passes in the vendor prop it is safe to hardcode this for now.
+		// We can re-enable this in a separate PR.
+		// vendor: getDomainSuggestionsVendor(),
+		vendor: 'variation2_front',
+
+		// Merge options
+		...queryOptions,
+
+		// Add the search query
+		query: search.trim().toLocaleLowerCase(),
+	};
 }

--- a/packages/domain-picker/src/constants.ts
+++ b/packages/domain-picker/src/constants.ts
@@ -17,10 +17,6 @@ export const DOMAIN_QUERY_MINIMUM_LENGTH = 2;
  */
 export const DOMAIN_SEARCH_DEBOUNCE_INTERVAL = 300;
 
-// TODO: Check domain suggestions store registration discrepancies
-// (see https://github.com/Automattic/wp-calypso/issues/46869)
-export const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register( {
-	vendor: 'variation2_front',
-} );
+export const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register();
 
 export const domainIsAvailableStatus = [ 'available', 'available_premium' ];

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { FunctionComponent, useState, useEffect, Fragment } from 'react';
-import { noop, times } from 'lodash';
+import { times } from 'lodash';
 import { Button, TextControl, Notice } from '@wordpress/components';
 import { Icon, search } from '@wordpress/icons';
 import { getNewRailcarId, recordTrainTracksRender } from '@automattic/calypso-analytics';
@@ -125,11 +125,11 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	onExistingSubdomainSelect,
 	quantity = PAID_DOMAINS_TO_SHOW,
 	quantityExpanded = PAID_DOMAINS_TO_SHOW_EXPANDED,
-	onDomainSearchBlur = noop,
+	onDomainSearchBlur,
 	analyticsFlowId,
 	analyticsUiAlgo,
 	initialDomainSearch = '',
-	onSetDomainSearch = noop,
+	onSetDomainSearch,
 	currentDomain,
 	isCheckingDomainAvailability,
 	existingSubdomain,
@@ -235,7 +235,9 @@ const DomainPicker: FunctionComponent< Props > = ( {
 
 	const handleInputChange = ( searchQuery: string ) => {
 		setDomainSearch( searchQuery );
-		onSetDomainSearch( searchQuery );
+		if ( onSetDomainSearch ) {
+			onSetDomainSearch( searchQuery );
+		}
 	};
 
 	// Force blur to close keyboard when submitting the form using Search button on mobile

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -114,7 +114,7 @@ export interface Props {
 	/** Callback for when a user clicks "Use a domain I own" item */
 	onUseYourDomainClick?: () => void;
 
-	/** Vendor string for domain suggestionts */
+	/** Vendor string for domain suggestions */
 	vendor?: string;
 }
 
@@ -140,7 +140,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	areDependenciesLoading = false,
 	orderSubDomainsLast = false,
 	onUseYourDomainClick,
-	vendor,
+	vendor = getDomainSuggestionsVendor(),
 } ) => {
 	const { __ } = useI18n();
 	const label = __( 'Search for a domain', __i18n_text_domain__ );
@@ -149,9 +149,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	// Keep domain query in local state to allow free editing of the input value while the modal is open
 	const [ domainSearch, setDomainSearch ] = useState< string >( initialDomainSearch );
 	const [ domainCategory, setDomainCategory ] = useState< string | undefined >();
-
-	// If no vendor given, get default vendor.
-	const domainSuggestionVendor = vendor || getDomainSuggestionsVendor();
 
 	const {
 		allDomainSuggestions,
@@ -219,7 +216,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		uiPosition: number,
 		isRecommended: boolean
 	) => {
-		const fetchAlgo = `/domains/search/${ domainSuggestionVendor }/${ analyticsFlowId }${
+		const fetchAlgo = `/domains/search/${ vendor }/${ analyticsFlowId }${
 			domainCategory ? '/' + domainCategory : ''
 		}`;
 

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -2,8 +2,7 @@
  * External dependencies
  */
 import React, { FunctionComponent, useState, useEffect, Fragment } from 'react';
-import { useSelect } from '@wordpress/data';
-import { times } from 'lodash';
+import { noop, times } from 'lodash';
 import { Button, TextControl, Notice } from '@wordpress/components';
 import { Icon, search } from '@wordpress/icons';
 import { getNewRailcarId, recordTrainTracksRender } from '@automattic/calypso-analytics';
@@ -26,20 +25,17 @@ import DomainCategories from '../domain-categories';
 import {
 	PAID_DOMAINS_TO_SHOW,
 	PAID_DOMAINS_TO_SHOW_EXPANDED,
-	DOMAIN_SUGGESTIONS_STORE,
 	domainIsAvailableStatus,
 } from '../constants';
 import { DomainNameExplanationImage } from '../domain-name-explanation/';
 import { ITEM_TYPE_RADIO } from './suggestion-item';
 import type { SUGGESTION_ITEM_TYPE } from './suggestion-item';
+import { getDomainSuggestionsVendor } from '../utils';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
 
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
 type DomainGroup = 'sub-domain' | 'professional';
@@ -117,6 +113,9 @@ export interface Props {
 
 	/** Callback for when a user clicks "Use a domain I own" item */
 	onUseYourDomainClick?: () => void;
+
+	/** Vendor string for domain suggestionts */
+	vendor?: string;
 }
 
 const DomainPicker: FunctionComponent< Props > = ( {
@@ -141,6 +140,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	areDependenciesLoading = false,
 	orderSubDomainsLast = false,
 	onUseYourDomainClick,
+	vendor,
 } ) => {
 	const { __ } = useI18n();
 	const label = __( 'Search for a domain', __i18n_text_domain__ );
@@ -150,9 +150,8 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	const [ domainSearch, setDomainSearch ] = useState< string >( initialDomainSearch );
 	const [ domainCategory, setDomainCategory ] = useState< string | undefined >();
 
-	const domainSuggestionVendor = useSelect( ( select ) =>
-		select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestionVendor()
-	);
+	// If no vendor given, get default vendor.
+	const domainSuggestionVendor = vendor || getDomainSuggestionsVendor();
 
 	const {
 		allDomainSuggestions,

--- a/packages/launch/src/stores.ts
+++ b/packages/launch/src/stores.ts
@@ -10,10 +10,7 @@ const SITE_STORE = Site.register( { client_id: '', client_secret: '' } );
 
 const PLANS_STORE = Plans.register();
 
-// TODO: Check domain suggestions store registration discrepancies between:
-// - client/landing/gutenboarding/stores/domain-suggestions/index.ts
-// - apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/domain-suggestions.ts
-const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register( { vendor: 'variation2_front' } );
+const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register();
 
 const LAUNCH_STORE = Launch.register();
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the need to pass in `vendor` prop when registering domain suggestions data store, e.g.
   * **From:** `DomainSuggestions.register( { vendor: 'variation2_front' } )`.
   * **To:** `DomainSuggestions.register()`.
* Selectors no longer uses `createSelectors()` to hoist the the `vendor` value to create selector functions.
  * In consequence to this, the rest of the changes (mostly in `selectors.ts`) are related to types cleanup, e.g. ensuring selector functions have return types defined, using `export const` like in other selector files for coherence.
  * The function `normalizeDomainSuggestionQuery()` is moved to `utils.ts` since it no longer depends on the hoisted `vendor` value.
* Added `vendor` prop to `<DomainPicker>` component.
   * Due to the size of this PR, passing the right value to the `vendor` prop will be done in another PR. (Edit: Done for Gutenboarding in this PR, for Launch in another PR).

#### Testing instructions

* Test domain picker in Gutenboarding, Step-By-Step Launch & Focused Launch and make sure there are no regressions.


Fixes part of https://github.com/Automattic/wp-calypso/issues/47105
Fixes part of #46869