### PR TITLE
Another take on the "Add a domain" button

### DIFF
--- a/client/my-sites/domains/domain-management/list/add-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/add-domain-button.jsx
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import page from 'page';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { Button } from '@automattic/components';
+import PopoverMenu from 'calypso/components/popover/menu';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import Gridicon from 'calypso/components/gridicon';
+import { composeAnalytics, recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { domainAddNew } from 'calypso/my-sites/domains/paths';
+
+class AddDomainButton extends React.Component {
+	static propTypes = {
+		selectedSiteSlug: PropTypes.string,
+	};
+
+	state = {
+		isAddMenuVisible: false,
+	};
+
+	addDomainButtonRef = React.createRef();
+
+	clickAddDomain = () => {
+		this.props.trackAddDomainClick();
+		page( domainAddNew( this.props.selectedSiteSlug ) );
+	};
+
+	toggleAddMenu = () => {
+		this.setState( ( state ) => {
+			return { isAddMenuVisible: ! state.isAddMenuVisible };
+		} );
+	};
+
+	closeAddMenu = () => {
+		this.setState( { isAddMenuVisible: false } );
+	};
+
+	trackMenuClick = ( reactEvent ) => {
+		this.props.trackAddDomainMenuClick( reactEvent.target.pathname );
+	};
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<React.Fragment>
+				<Button primary compact className="add-domain-button" onClick={ this.toggleAddMenu }>
+					{ translate( 'Add a domain' ) }
+					<Gridicon icon="chevron-down" ref={ this.addDomainButtonRef } />
+				</Button>
+				<PopoverMenu
+					isVisible={ this.state.isAddMenuVisible }
+					onClose={ this.closeAddMenu }
+					context={ this.addDomainButtonRef.current }
+					position="bottom"
+				>
+					{ this.props.selectedSiteSlug && (
+						<PopoverMenuItem onClick={ this.clickAddDomain }>
+							{ translate( 'to this site' ) }
+						</PopoverMenuItem>
+					) }
+					<PopoverMenuItem href="/new" onClick={ this.trackMenuClick }>
+						{ translate( 'to a new site' ) }
+					</PopoverMenuItem>
+					<PopoverMenuItem href="/domains/add" onClick={ this.trackMenuClick }>
+						{ translate( 'to a different site' ) }
+					</PopoverMenuItem>
+					<PopoverMenuItem href="/start/domain" onClick={ this.trackMenuClick }>
+						{ translate( 'without a site' ) }
+					</PopoverMenuItem>
+				</PopoverMenu>
+			</React.Fragment>
+		);
+	}
+}
+
+const trackAddDomainClick = () =>
+	composeAnalytics(
+		recordGoogleEvent( 'Domain Management', 'Clicked "Add Domain" Button in List' ),
+		recordTracksEvent( 'calypso_domain_management_list_add_domain_click' )
+	);
+
+const trackAddDomainMenuClick = ( menuUrl ) =>
+	recordTracksEvent( 'calypso_domain_management_list_add_domain_menu_click', {
+		menu_slug: menuUrl,
+	} );
+
+export default connect(
+	( state ) => {
+		return {
+			selectedSiteSlug: getSelectedSiteSlug( state ),
+		};
+	},
+	() => {
+		return {
+			trackAddDomainClick,
+			trackAddDomainMenuClick,
+		};
+	}
+)( localize( AddDomainButton ) );

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -52,6 +52,10 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import InfoPopover from 'calypso/components/info-popover';
 import ExternalLink from 'calypso/components/external-link';
 import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
+import ButtonGroup from 'calypso/components/button-group';
+import Gridicon from 'calypso/components/gridicon';
+import PopoverMenu from 'calypso/components/popover/menu';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
 
 /**
  * Style dependencies
@@ -82,7 +86,9 @@ export class List extends React.Component {
 		settingPrimaryDomain: false,
 		changePrimaryDomainModeEnabled: false,
 		primaryDomainIndex: -1,
+		addMenuVisible: false,
 	};
+	addDomainButtonRef = React.createRef();
 
 	isLoading() {
 		return this.props.isRequestingSiteDomains && this.props.domains.length === 0;
@@ -265,21 +271,54 @@ export class List extends React.Component {
 		} );
 	};
 
+	toggleAddMenu = () => {
+		this.setState( ( state ) => {
+			return { isAddMenuVisible: ! state.isAddMenuVisible };
+		} );
+	};
+
+	closeAddMenu = () => {
+		this.setState( { isAddMenuVisible: false } );
+	};
+
 	addDomainButton() {
+		const { translate } = this.props;
 		if ( ! config.isEnabled( 'upgrades/domain-search' ) ) {
 			return null;
 		}
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<Button
-				primary
-				compact
-				className="domain-management-list__add-a-domain"
-				onClick={ this.clickAddDomain }
-			>
-				{ this.props.translate( 'Add a domain to this site' ) }
-			</Button>
+			<ButtonGroup>
+				<Button
+					primary
+					compact
+					className="domain-management-list__add-a-domain"
+					onClick={ this.clickAddbDomain }
+				>
+					{ translate( 'Add a domain to this site' ) }
+				</Button>
+				<Button compact primary onClick={ this.toggleAddMenu } ref={ this.addDomainButtonRef }>
+					<Gridicon icon="chevron-down" />
+				</Button>
+				<PopoverMenu
+					isVisible={ this.state.isAddMenuVisible }
+					onClose={ this.closeAddMenu }
+					context={ this.addDomainButtonRef.current }
+					position="bottom left"
+					autoPosition={ true }
+				>
+					<PopoverMenuItem href="/domains/add">
+						{ translate( 'Add a domain to another site' ) }
+					</PopoverMenuItem>
+					<PopoverMenuItem href="/new">
+						{ translate( 'Add a domain to new WordPress.com site' ) }
+					</PopoverMenuItem>
+					<PopoverMenuItem href="/start/domain">
+						{ translate( 'Just buy a domain' ) }
+					</PopoverMenuItem>
+				</PopoverMenu>
+			</ButtonGroup>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -52,10 +52,7 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import InfoPopover from 'calypso/components/info-popover';
 import ExternalLink from 'calypso/components/external-link';
 import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
-import ButtonGroup from 'calypso/components/button-group';
-import Gridicon from 'calypso/components/gridicon';
-import PopoverMenu from 'calypso/components/popover/menu';
-import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import AddDomainButton from 'calypso/my-sites/domains/domain-management/list/add-domain-button';
 
 /**
  * Style dependencies
@@ -88,7 +85,6 @@ export class List extends React.Component {
 		primaryDomainIndex: -1,
 		addMenuVisible: false,
 	};
-	addDomainButtonRef = React.createRef();
 
 	isLoading() {
 		return this.props.isRequestingSiteDomains && this.props.domains.length === 0;
@@ -271,56 +267,12 @@ export class List extends React.Component {
 		} );
 	};
 
-	toggleAddMenu = () => {
-		this.setState( ( state ) => {
-			return { isAddMenuVisible: ! state.isAddMenuVisible };
-		} );
-	};
-
-	closeAddMenu = () => {
-		this.setState( { isAddMenuVisible: false } );
-	};
-
 	addDomainButton() {
-		const { translate } = this.props;
 		if ( ! config.isEnabled( 'upgrades/domain-search' ) ) {
 			return null;
 		}
 
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		return (
-			<ButtonGroup>
-				<Button
-					primary
-					compact
-					className="domain-management-list__add-a-domain"
-					onClick={ this.clickAddbDomain }
-				>
-					{ translate( 'Add a domain to this site' ) }
-				</Button>
-				<Button compact primary onClick={ this.toggleAddMenu } ref={ this.addDomainButtonRef }>
-					<Gridicon icon="chevron-down" />
-				</Button>
-				<PopoverMenu
-					isVisible={ this.state.isAddMenuVisible }
-					onClose={ this.closeAddMenu }
-					context={ this.addDomainButtonRef.current }
-					position="bottom left"
-					autoPosition={ true }
-				>
-					<PopoverMenuItem href="/domains/add">
-						{ translate( 'Add a domain to another site' ) }
-					</PopoverMenuItem>
-					<PopoverMenuItem href="/new">
-						{ translate( 'Add a domain to new WordPress.com site' ) }
-					</PopoverMenuItem>
-					<PopoverMenuItem href="/start/domain">
-						{ translate( 'Just buy a domain' ) }
-					</PopoverMenuItem>
-				</PopoverMenu>
-			</ButtonGroup>
-		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
+		return <AddDomainButton />;
 	}
 
 	setPrimaryDomain( domainName ) {

--- a/test/e2e/lib/pages/domains-page.js
+++ b/test/e2e/lib/pages/domains-page.js
@@ -16,9 +16,16 @@ export default class DomainsPage extends AsyncBaseContainer {
 	}
 
 	async clickAddDomain() {
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '.domain-management-list__add-a-domain' )
-		);
+		return await driverHelper.clickWhenClickable( this.driver, By.css( '.add-domain-button' ) );
+	}
+
+	async clickPopoverItem( name ) {
+		const actionItemSelector = By.css( '.popover__menu-item' );
+		return await driverHelper.selectElementByText( this.driver, actionItemSelector, name );
+	}
+
+	async popOverMenuDisplayed() {
+		const popOverMenuSelector = By.css( '.popover__menu' );
+		return await driverHelper.isEventuallyPresentAndDisplayed( this.driver, popOverMenuSelector );
 	}
 }

--- a/test/e2e/specs/wp-manage-domains-spec.js
+++ b/test/e2e/specs/wp-manage-domains-spec.js
@@ -66,7 +66,9 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 		step( 'Can see the Domains page and choose add a domain', async function () {
 			const domainsPage = await DomainsPage.Expect( driver );
 			await domainsPage.setABTestControlGroupsInLocalStorage();
-			return await domainsPage.clickAddDomain();
+			await domainsPage.clickAddDomain();
+			await domainsPage.popOverMenuDisplayed();
+			return await domainsPage.clickPopoverItem( 'to this site' );
 		} );
 
 		step( 'Can see the domain search component', async function () {

--- a/test/e2e/specs/wp-manage-domains-spec.js
+++ b/test/e2e/specs/wp-manage-domains-spec.js
@@ -140,7 +140,9 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 		step( 'Can see the Domains page and choose add a domain', async function () {
 			const domainsPage = await DomainsPage.Expect( driver );
 			await domainsPage.setABTestControlGroupsInLocalStorage();
-			return await domainsPage.clickAddDomain();
+			await domainsPage.clickAddDomain();
+			await domainsPage.popOverMenuDisplayed();
+			return await domainsPage.clickPopoverItem( 'to this site' );
 		} );
 
 		step( 'Can see the domain search component', async function () {


### PR DESCRIPTION
This is another take on #50674 - instead of introducing a separate screen we might use a popover menu to show the other domain buying options.

After having some discussion with the rest of the team here's what we think will look and work best:
<img width="316" alt="Screenshot 2021-03-17 at 21 34 17" src="https://user-images.githubusercontent.com/1355045/111527440-9c167c80-8768-11eb-98e7-582886038b7d.png">


#### Changes proposed in this Pull Request

* Change the button label to "Add a domain"
* Add a popover menu when you click the button that shows all the possible options
* Add tracking for all the popover menu options

#### Testing instructions

* Open the domains list of your site and click on the arrow next to "Add a domain to this site" button
