### PR TITLE
Framework: Refactor away from _.fill()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -414,6 +414,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/ends-with': 'error',
 		'you-dont-need-lodash-underscore/entries': 'error',
 		'you-dont-need-lodash-underscore/extend-own': 'error',
+		'you-dont-need-lodash-underscore/fill': 'error',
 		'you-dont-need-lodash-underscore/foldl': 'error',
 		'you-dont-need-lodash-underscore/foldr': 'error',
 		'you-dont-need-lodash-underscore/index-of': 'error',

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { map, zipObject, fill, size, filter, get, compact, partition, min } from 'lodash';
+import { map, zipObject, size, filter, get, compact, partition, min } from 'lodash';
 
 /**
  * Internal dependencies
@@ -182,11 +182,10 @@ export class ConversationCommentList extends React.Component {
 		const parentIds = compact(
 			map( startingCommentIds, ( id ) => this.getParentId( commentsTree, id ) )
 		);
-		const commentExpansions = fill(
-			Array( startingCommentIds.length ),
+		const commentExpansions = Array( startingCommentIds.length ).fill(
 			POST_COMMENT_DISPLAY_TYPES.excerpt
 		);
-		const parentExpansions = fill( Array( parentIds.length ), POST_COMMENT_DISPLAY_TYPES.excerpt );
+		const parentExpansions = Array( parentIds.length ).fill( POST_COMMENT_DISPLAY_TYPES.excerpt );
 
 		const startingExpanded = zipObject(
 			startingCommentIds.concat( parentIds ),

--- a/client/extensions/woocommerce/state/sites/promotions/reducer.js
+++ b/client/extensions/woocommerce/state/sites/promotions/reducer.js
@@ -5,7 +5,7 @@
 /**
  * External dependencies
  */
-import { fill, find, findIndex } from 'lodash';
+import { find, findIndex } from 'lodash';
 
 /**
  * Internal dependencies
@@ -80,7 +80,7 @@ function couponsUpdated( state, action ) {
 	const { params, totalCoupons } = action;
 
 	if ( undefined !== params.offset ) {
-		const newCoupons = fill( Array( totalCoupons ), null );
+		const newCoupons = Array( totalCoupons ).fill( null );
 
 		if ( state.coupons ) {
 			// Copy over existing coupons from previous state.
@@ -140,7 +140,7 @@ function productsRequestSuccess( state, action ) {
 	const { params, totalProducts } = action;
 
 	if ( undefined !== params.offset ) {
-		const newProducts = fill( Array( totalProducts ), null );
+		const newProducts = Array( totalProducts ).fill( null );
 
 		if ( state.products ) {
 			// Copy over existing products from previous state.

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -6,7 +6,6 @@
 import { translate } from 'i18n-calypso';
 import {
 	every,
-	fill,
 	filter,
 	find,
 	first,
@@ -1028,7 +1027,7 @@ export const purchaseLabel = ( orderId, siteId ) => ( dispatch, getState ) => {
 						carrier_id: rate.carrier_id,
 						service_name: rate.title,
 						products: flatten(
-							pckg.items.map( ( item ) => fill( new Array( item.quantity ), item.product_id ) )
+							pckg.items.map( ( item ) => Array( item.quantity ).fill( item.product_id ) )
 						),
 					};
 				} ),

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	fill,
 	find,
 	flatten,
 	forEach,
@@ -296,7 +295,7 @@ export const getCustomsErrors = (
 		flatten( map( packages, ( pckg ) => map( pckg.items, 'product_id' ) ) )
 	);
 
-	const valuesByProductId = zipObject( usedProductIds, fill( Array( usedProductIds.length ), 0 ) );
+	const valuesByProductId = zipObject( usedProductIds, Array( usedProductIds.length ).fill( 0 ) );
 	forEach( packages, ( pckg ) => {
 		forEach(
 			pckg.items,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `fill` is essentially fully natively supported by `Array.fill`. This PR replaces the usage and adds an ESLint rule to warn against using `fill` from lodash.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Try to `import { fill } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass.