### PR TITLE
Fix post Jetpack Connect redirection

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card/button.tsx
+++ b/client/components/jetpack/card/jetpack-free-card/button.tsx
@@ -82,7 +82,10 @@ const JetpackFreeCardButton: FC< JetpackFreeCardButtonProps > = ( {
 	const { site: url, ...restQueryArgs } = urlQueryArgs;
 	const startHref =
 		isJetpackCloud() && ! isSiteinContext
-			? addQueryArgs( { url, ...restQueryArgs }, `https://wordpress.com${ JPC_PATH_BASE }` )
+			? addQueryArgs(
+					{ url, ...restQueryArgs, plan: PLAN_JETPACK_FREE },
+					`https://wordpress.com${ JPC_PATH_BASE }`
+			  )
 			: wpAdminUrl || jetpackAdminUrlFromQuery || JPC_PATH_BASE;
 
 	return (

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -33,9 +33,11 @@ import {
 import { login } from 'calypso/lib/paths';
 import { parseAuthorizationQuery } from './utils';
 import {
+	clearPlan,
 	isCalypsoStartedConnection,
 	persistMobileRedirect,
 	retrieveMobileRedirect,
+	retrievePlan,
 	storePlan,
 } from './persistence-utils';
 import { startAuthorizeStep } from 'calypso/state/jetpack-connect/actions';
@@ -46,6 +48,7 @@ import { isCurrentPlanPaid, isJetpackSite } from 'calypso/state/sites/selectors'
 import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PLAN_JETPACK_PREMIUM,
@@ -111,8 +114,14 @@ export function offerResetRedirects( context, next ) {
 		return externalRedirect( CALYPSO_PLANS_PAGE + selectedSite.slug );
 	}
 
-	// If selected site has a Free plan, redirect to URL passed as query param or wpadmin
-	if ( selectedSite.plan.is_free ) {
+	// If the user previously selected Jetpack Free, redirect them to their wp-admin page
+	const storedPlan = retrievePlan();
+	clearPlan();
+	if ( storedPlan === PLAN_JETPACK_FREE ) {
+		debug(
+			'controller: offerResetRedirects -> redirecting to wp-admin because the user got here by clicking Jetpack Free',
+			context.params
+		);
 		externalRedirect( context.query.redirect || selectedSite.options.admin_url );
 		return;
 	}

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -21,7 +21,7 @@ import { addQueryArgs, externalRedirect } from 'calypso/lib/route';
 import { checkUrl, dismissUrl } from 'calypso/state/jetpack-connect/actions';
 import { getConnectingSite, getJetpackSiteByUrl } from 'calypso/state/jetpack-connect/selectors';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
-import { clearPlan, retrieveMobileRedirect, retrievePlan } from './persistence-utils';
+import { clearPlan, retrieveMobileRedirect, retrievePlan, storePlan } from './persistence-utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import HelpButton from './help-button';
 import JetpackConnectNotices from './jetpack-connect-notices';
@@ -50,6 +50,14 @@ const jetpackConnection = ( WrappedComponent ) => {
 			redirecting: false,
 			waitingForSites: true,
 		};
+
+		componentDidMount() {
+			const { queryArgs } = this.props;
+			// If a plan was passed as a query parameter, store it in local storage
+			if ( queryArgs && queryArgs.plan ) {
+				storePlan( queryArgs.plan );
+			}
+		}
 
 		renderFooter = () => {
 			const { translate } = this.props;
@@ -90,11 +98,10 @@ const jetpackConnection = ( WrappedComponent ) => {
 				if ( currentPlan ) {
 					if ( currentPlan === PLAN_JETPACK_FREE ) {
 						debug( `Redirecting to wpadmin` );
-						externalRedirect( this.props.siteHomeUrl + JETPACK_ADMIN_PATH );
-					} else {
-						debug( `Redirecting to checkout with ${ currentPlan } plan retrieved from cookies` );
-						this.redirect( 'checkout', url, currentPlan, queryArgs );
+						return externalRedirect( this.props.siteHomeUrl + JETPACK_ADMIN_PATH );
 					}
+					debug( `Redirecting to checkout with ${ currentPlan } plan retrieved from cookies` );
+					this.redirect( 'checkout', url, currentPlan, queryArgs );
 				} else {
 					debug( 'Redirecting to plans_selection' );
 					this.redirect( 'plans_selection', url );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the Jetpack Free button pass a query parameter that contains the `jetpack_free` slug. This slug is then grabbed by the Jetpack Connection flow and used to determine whether the user should be redirected to wp-admin or to the plans page. If Jetpack Connect sees the `plan=jetpack_free` query parameter, then it knows that the user came from the plans page and clicked the Jetpack Free button, therefore, it knows that the user must be redirected to wp-admin, instead of back to the plans page once more.

#### Testing instructions

Prerequisite: self-hosted Jetpack site.

* Download this PR and run both Calypsos with `yarn start` and `yarn start-jetpack-cloud-p`.

**Case 1: user coming from the pricing page (from a click on the Jetpack Free card)**
* Visit `http://jetpack.cloud.localhost:3001/pricing`.
* Click on Jetpack Free.
* Verify that you are redirected to `https://wordpress.com/jetpack/connect?plan=jetpack_free`.
* Replace `https://wordpress.com` with `http://calypso.localhost:3000` and refresh the page.
* Enter the site of your self-hosted Jetpack site.
* Verify that you are redirected to your site's wp-admin page.

**Case 2: user coming from wp-admin or other sources**
* Visit `https://calypso.localhost:3000/jetpack/connect` (no `plan` query parameter this time).
* Enter the site of your self-hosted Jetpack site.
* Verify that you are redirected to the pricing page.

**To gain more confidence about this PR, repeat Case 2 but coming from wp-admin's Jetpack setup process. You might have to change some URLs from `wordpress.com` to `calypso.localhost:3000`.

Related to 1164141197617539-as-1200018368210202.

#### Demo

#### Bug demonstration – pay attention to how the user is taken from Jetpack Connect to wp-admin, when it should've been taken to the Pricing page.
https://user-images.githubusercontent.com/3418513/110017787-5cca4380-7d05-11eb-852e-9b993feb43ba.mp4

#### Fix demonstration – user coming from the Pricing page after clicking the Jetpack Free card.
https://user-images.githubusercontent.com/3418513/110017848-6ce22300-7d05-11eb-85e1-b975cc5acaf9.mp4

#### Fix demonstration – user coming from Jetpack Connect being redirected to the Pricing page.
https://user-images.githubusercontent.com/3418513/110017939-85ead400-7d05-11eb-8a4c-82afed351a1d.mp4


