### PR TITLE
Jetpack: Scan: Do not show fix estimate if threat is fixed or ignored

### DIFF
--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -95,18 +95,22 @@ const ThreatItem: React.FC< Props > = ( {
 								'the offending code, theme, or plugin from your site.'
 						) }
 					</p>
-					<p className="threat-description__section-text">
-						{ translate(
-							'If you need more help to resolve this threat, we recommend {{strong}}Codeable{{/strong}}, a trusted freelancer marketplace of highly vetted WordPress experts. ' +
-								'They have identified a select group of security experts to help with these projects. ' +
-								'Pricing ranges from $70-120/hour, and you can get a free estimate with no obligation to hire.',
-							{
-								components: {
-									strong: <strong />,
-								},
-							}
-						) }
-					</p>
+					{
+						'current' === threat.status && (
+							<p className="threat-description__section-text">
+								{ translate(
+									'If you need more help to resolve this threat, we recommend {{strong}}Codeable{{/strong}}, a trusted freelancer marketplace of highly vetted WordPress experts. ' +
+										'They have identified a select group of security experts to help with these projects. ' +
+										'Pricing ranges from $70-120/hour, and you can get a free estimate with no obligation to hire.',
+									{
+										components: {
+											strong: <strong />,
+										},
+									}
+								) }
+							</p>
+						)
+					}
 				</>
 			);
 		}
@@ -170,7 +174,7 @@ const ThreatItem: React.FC< Props > = ( {
 						{ translate( 'Ignore threat' ) }
 					</Button>
 				) }
-				{ ! isFixable && (
+				{ ! threat.fixable && 'current' === threat.status && (
 					<ExternalLinkWithTracking
 						className="button is-primary threat-item__codeable-button"
 						href="https://codeable.io/partners/jetpack-scan/"


### PR DESCRIPTION
Currently in production, we show the "Get a free estimate" button, a prompt for users to pay to get a threat fixed, when a threat is already marked as fixed.

<img width="742" alt="Screen Shot 2021-03-04 at 5 23 12 PM" src="https://user-images.githubusercontent.com/1126811/110045441-48d80f00-7d10-11eb-9f9e-593c3765af30.png">


#### Changes proposed in this Pull Request

* Do not show "Get a free estimate" button when a threat is already fixed or ignored

After screenshots:

<img width="736" alt="Screen Shot 2021-03-04 at 5 47 54 PM" src="https://user-images.githubusercontent.com/1126811/110046678-18917000-7d12-11eb-9e63-e55dfa87a291.png">
<img width="735" alt="Screen Shot 2021-03-04 at 5 48 00 PM" src="https://user-images.githubusercontent.com/1126811/110046681-19c29d00-7d12-11eb-872b-783462acadb7.png">
<img width="693" alt="Screen Shot 2021-03-04 at 5 48 12 PM" src="https://user-images.githubusercontent.com/1126811/110046683-1af3ca00-7d12-11eb-901c-4f5efd718b15.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout patch
* Add threat to site with Jetpack threat tester plugin in Github
* Add one or more threats to your site
* Queue a scan of your site
* Wait for scan to complete
* Go to calypso.localhost:3000/scan/$site 
* Ensure that threats show
* Ensure that "Get a free estimate" button shows where the threat is
* Ignore a threat
* Go to "History" tab
* Ensure that the "Get a free estimate" button shows on the ignored threat but no other threats

