### PR TITLE
ETK Exclude asset.php in CI diff

### DIFF
--- a/.teamcity/_self/builds/WPComPlugins_EditorToolkit.kt
+++ b/.teamcity/_self/builds/WPComPlugins_EditorToolkit.kt
@@ -112,7 +112,8 @@ object WPComPlugins_EditorToolKit : BuildType({
 				sed -i -e "/^\s\* Version:/c\ * Version: %build.number%" -e "/^define( 'A8C_ETK_PLUGIN_VERSION'/c\define( 'A8C_ETK_PLUGIN_VERSION', '%build.number%' );" ./editing-toolkit-plugin/full-site-editing-plugin.php ../../etk-release-build/full-site-editing-plugin.php
 				sed -i -e "/^Stable tag:\s/c\Stable tag: %build.number%" ./editing-toolkit-plugin/readme.txt ../../etk-release-build/readme.txt
 
-				if ! diff -rq ./editing-toolkit-plugin/ ../../etk-release-build/ ; then
+				# Note: we exclude asset changes because we only really care if the build files (JS/CSS) change. That file is basically just metadata.
+				if ! diff -rq --exclude="*.asset.php" ./editing-toolkit-plugin/ ../../etk-release-build/ ; then
 					echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
 					curl -X POST -H "Content-Type: text/plain" --data "etk-release-build" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/
 				else


### PR DESCRIPTION
#### Changes proposed in this Pull Request
- Exclude asset.php file when diffing to detect changed plugin versions.

I noticed that occasionally, the ETK build in TeamCity will be marked as a "changed" build, but the only changed files are asset.php files. I believe this can happen when a change is made to a package ETK depends on (which modifies the asset file), but the change doesn't actually affect the bundled code in ETK.

We really only care about changes which affect bundled code, so I don't want to mark those builds for release (nor do I want to notify those authors they need to deploy changes which have no effect.)

#### Testing instructions
1. build the plugin locally (yarn build from etk directory)
2. duplicate the `editing-toolkit-plugin` directory
3. make a change in any `dist/*.asset.php` file.
4. make a change to any non-asset file.
5. run `diff -r --exclude="*.asset.php" ./editing-toolkit-plugin $your_etk_copy_here`
6. no changes in asset file should be reported.
7. your change to the other file should be reported.
