### PR TITLE
Fix New Onboarding flow when Nav Unification is enabled

### DIFF
--- a/client/layout/body-section-css-class.js
+++ b/client/layout/body-section-css-class.js
@@ -41,12 +41,12 @@ export default function BodySectionCssClass( { group, section, bodyClass } ) {
 			return;
 		}
 
-		bodyClass.forEach( bodyClass, ( className ) => {
+		bodyClass.forEach( ( className ) => {
 			document.body.classList.add( className );
 		} );
 
 		return () => {
-			bodyClass.forEach( bodyClass, ( className ) => {
+			bodyClass.forEach( ( className ) => {
 				document.body.classList.remove( className );
 			} );
 		};

--- a/client/layout/body-section-css-class.js
+++ b/client/layout/body-section-css-class.js
@@ -37,12 +37,19 @@ export default function BodySectionCssClass( { group, section, bodyClass } ) {
 	React.useEffect( addGroupClass( group ), [ group ] );
 	React.useEffect( addSectionClass( section ), [ section ] );
 	React.useEffect( () => {
-		if ( ! bodyClass ) {
+		if ( ! Array.isArray( bodyClass ) || bodyClass.length === 0 ) {
 			return;
 		}
 
-		document.body.classList.add( bodyClass );
-		return () => document.body.classList.remove( bodyClass );
+		bodyClass.forEach( bodyClass, ( className ) => {
+			document.body.classList.add( className );
+		} );
+
+		return () => {
+			bodyClass.forEach( bodyClass, ( className ) => {
+				document.body.classList.remove( className );
+			} );
+		};
 	}, [ bodyClass ] );
 
 	return null;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -173,15 +173,16 @@ class Layout extends Component {
 		} );
 
 		const optionalBodyProps = () => {
-			const optionalProps = {
-				bodyClass: classnames( {
-					'is-new-launch-flow':
-						this.props.isNewLaunchFlow || this.props.isCheckoutFromGutenboarding,
-					'is-nav-unification': this.props.isNavUnificationEnabled,
-				} ),
+			const bodyClass = [];
+			if ( this.props.isNewLaunchFlow || this.props.isCheckoutFromGutenboarding ) {
+				bodyClass.push( 'is-new-launch-flow' );
+			}
+			if ( this.props.isNavUnificationEnabled ) {
+				bodyClass.push( 'is-nav-unification' );
+			}
+			return {
+				bodyClass,
 			};
-
-			return optionalProps;
 		};
 
 		const { shouldShowAppBanner } = this.props;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes a regression introduced in https://github.com/Automattic/wp-calypso/pull/50711 which prevented the new onboarding flow from working as expected when Nav Unification is enabled. 

#### Testing instructions

- See https://github.com/Automattic/wp-calypso/issues/50781.
- Make sure you can complete the flow, and there isn't any white screen.
- Make sure Nav Unification continues to work as expected.

Fixes https://github.com/Automattic/wp-calypso/issues/50781
