### PR TITLE
Framework: Refactor away from _.inRange()

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { debounce, get, flow, inRange, isEmpty } from 'lodash';
+import { debounce, get, flow, isEmpty } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 
@@ -105,7 +105,8 @@ export class SiteAddressChanger extends Component {
 		}
 
 		if (
-			! inRange( domainFieldValue.length, SUBDOMAIN_LENGTH_MINIMUM, SUBDOMAIN_LENGTH_MAXIMUM )
+			domainFieldValue.length < SUBDOMAIN_LENGTH_MINIMUM ||
+			domainFieldValue.length > SUBDOMAIN_LENGTH_MAXIMUM
 		) {
 			validationProperties = {
 				showValidationMessage: domainFieldValue.length > SUBDOMAIN_LENGTH_MAXIMUM,

--- a/client/lib/importer/url-validation.js
+++ b/client/lib/importer/url-validation.js
@@ -4,7 +4,7 @@
 import url from 'url';
 import { isURL } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
-import { inRange, trim } from 'lodash';
+import { trim } from 'lodash';
 
 const parseUrl = function ( value = '' ) {
 	const rawUrl = trim( value );
@@ -16,7 +16,8 @@ const parseUrl = function ( value = '' ) {
 
 const hasTld = function ( hostname ) {
 	// Min length of hostname with TLD is 4 characters, e.g. "a.co".
-	return hostname.length > 3 && inRange( hostname.lastIndexOf( '.' ), 1, hostname.length - 2 );
+	const lastDotIndex = hostname.lastIndexOf( '.' );
+	return hostname.length > 3 && lastDotIndex >= 1 && lastDotIndex < hostname.length - 2;
 };
 
 export function validateImportUrl( value ) {

--- a/client/my-sites/plan-features/scroller.jsx
+++ b/client/my-sites/plan-features/scroller.jsx
@@ -4,7 +4,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'calypso/components/gridicon';
-import { inRange, range, round } from 'lodash';
+import { range, round } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -16,6 +16,8 @@ const MIN_CELL_WIDTH = 240; // px
 const SIDE_PANE_RATIO = 0.12; // 12% of full width
 const MIN_PLAN_OPACITY = 0.4;
 const NO_SCROLL_PADDING = 20; // will appear when plans show up without scrolling
+
+const inRange = ( value, min, max ) => value >= min && value < max;
 
 export default class PlanFeaturesScroller extends PureComponent {
 	static propTypes = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `inRange` is essentially easy to be replaced by native functionality (a `x >= min && x < max` condition). This PR replaces the usage.

Noting that we're intentionally fixing a bug with the subdomain minimum allowed characters - previously the validation was claiming to allow between 4 and 50 characters (inclusive) but it was not allowing exactly 50 characters of length. This is due to the fact that `_.inRange()` includes the `min` but not the `max`.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Go to `/domains/manage/:site/change-site-address/:domain` with a simple `.wordpress.com` site.
* Try inputting a 50 character subdomain.
* Verify you're no longer getting a validation error.