### PR TITLE
Nav Unification: add InlineSupportLink to nav unification toggle

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -41,7 +41,7 @@ import Main from 'calypso/components/main';
 import SitesDropdown from 'calypso/components/sites-dropdown';
 import ColorSchemePicker from 'calypso/blocks/color-scheme-picker';
 import { successNotice, errorNotice, removeNotice } from 'calypso/state/notices/actions';
-import { getLanguage, isLocaleVariant, canBeTranslated } from 'calypso/lib/i18n-utils';
+import { getLanguage, isLocaleVariant, canBeTranslated, localizeUrl } from 'calypso/lib/i18n-utils';
 import isRequestingMissingSites from 'calypso/state/selectors/is-requesting-missing-sites';
 import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -72,6 +72,7 @@ import getUnsavedUserSettings from 'calypso/state/selectors/get-unsaved-user-set
 import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 
 export const noticeId = 'me-settings-notice';
 const noticeOptions = {
@@ -1068,11 +1069,17 @@ class Account extends React.Component {
 										'{{spanlead}}Show advanced dashboard pages.{{/spanlead}} {{spanextra}}Enabling this will replace your dashboard pages with more advanced wp-admin equivalents when possible.{{/spanextra}}',
 										{
 											components: {
-												spanlead: <span className="account__link-destination-label-lead" />,
+												spanlead: <strong className="account__link-destination-label-lead" />,
 												spanextra: <span className="account__link-destination-label-extra" />,
 											},
 										}
 									) }
+									<InlineSupportLink
+										supportPostId={ 80368 }
+										supportLink={ localizeUrl(
+											'https://wordpress.com/support/account-settings/#dashboard-appearance'
+										) }
+									/>
 								</FormToggle>
 							</FormFieldset>
 						) }

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -37,7 +37,7 @@
 	.components-toggle-control__label {
 		color: var( --color-text-subtle );
 
-		span {
+		strong {
 			display: block;
 		}
 	}
@@ -45,6 +45,10 @@
 	.account__link-destination-label-extra {
 		font-style: italic;
 		margin-top: 0.1em;
+	}
+
+	.inline-support-link {
+		margin-left: 4px;
 	}
 }
 


### PR DESCRIPTION
This adds an inline support link to the nav unification "dashboard appearance" toggle.

Fixes #50784

**Before:**
<img width="1068" alt="Screen Shot 2021-03-05 at 9 51 43 AM" src="https://user-images.githubusercontent.com/942359/110132314-09093a00-7d99-11eb-8cb6-23c9a74a826f.png">

**After:**
<img width="994" alt="Screen Shot 2021-03-05 at 9 48 27 AM" src="https://user-images.githubusercontent.com/942359/110132357-132b3880-7d99-11eb-8fcf-3034c202cdae.png">

**On Click:**
![Screen Shot 2021-03-05 at 9 51 17 AM](https://user-images.githubusercontent.com/942359/110132450-2dfdad00-7d99-11eb-8571-713470e8f6cc.png)

**To test:**
- visit Me > Settings > Account Settings
- verify that a "learn more" link is shown beside the dashboard appearance toggle
- click the link
- verify that the inline help modal is opened and scrolled to the appropriate section
- click "visit article"
- verify that the support doc is opened in a new tab and scrolled to the appropriate section

