### PR TITLE
Checkout: Fix fatal error when renewing a Blogger plan

### DIFF
--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
@@ -57,7 +57,9 @@ function computePricesForWpComPlan( state, planObject ) {
 	const monthlyPlanObject = isMonthly
 		? planObject
 		: getPlan( getMonthlyPlanByYearly( planObject.getStoreSlug() ) );
-	const priceMonthly = getPlanRawPrice( state, monthlyPlanObject.getProductId(), true );
+	const priceMonthly = monthlyPlanObject
+		? getPlanRawPrice( state, monthlyPlanObject.getProductId(), true )
+		: 0;
 	const priceFullBeforeDiscount = priceMonthly * getBillingMonthsForTerm( planObject.term );
 
 	return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Following https://github.com/Automattic/wp-calypso/pull/50383 it is impossible to renew one of the legacy Blogger plans -- you get a "Sorry, there was an error loading this page" error if you try to put it in the shopping cart.

That seems to be because there is no monthly version of the Blogger plan.

Props to @sirbrillig for helping figure out the fix here.

#### Testing instructions

On a site with a legacy Blogger plan, go to the Manage Purchase page and click "Renew Now" to put it in the shopping cart.

Before this pull request, you get an error message.  After this pull request, it works and you can renew it.