### PR TITLE
Checkout: remove priceMonthly from available product variant

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -37,7 +37,6 @@ export interface AvailableProductVariant {
 	priceFullBeforeDiscount: number;
 	priceFull: number;
 	priceFinal: number;
-	priceMonthly: number;
 }
 
 export type GetProductVariants = ( productSlug: WPCOMProductSlug ) => WPCOMProductVariant[];

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
@@ -51,15 +51,17 @@ export const computeFullAndMonthlyPricesForPlan = (
  * @param {object} planObject Plan object returned by getPlan() from lib/plans
  */
 function computePricesForWpComPlan( state, planObject ) {
-	const priceFull = getPlanRawPrice( state, planObject.getProductId(), false );
+	const priceFull = getPlanRawPrice( state, planObject.getProductId(), false ) || 0;
 	const isMonthly = planObject.term === TERM_MONTHLY;
 	const monthlyPlanObject = isMonthly
 		? planObject
 		: getPlan( getMonthlyPlanByYearly( planObject.getStoreSlug() ) );
 	const priceMonthly = monthlyPlanObject
-		? getPlanRawPrice( state, monthlyPlanObject.getProductId(), true )
+		? getPlanRawPrice( state, monthlyPlanObject.getProductId(), true ) || 0
 		: 0;
-	const priceFullBeforeDiscount = priceMonthly * getBillingMonthsForTerm( planObject.term );
+	const priceFullBeforeDiscount = priceMonthly
+		? priceMonthly * getBillingMonthsForTerm( planObject.term )
+		: priceFull;
 
 	return {
 		priceFullBeforeDiscount,

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
@@ -41,7 +41,6 @@ export const computeFullAndMonthlyPricesForPlan = (
 			getPlanPrice( state, siteId, planObject, false ) - credits - couponDiscount,
 			0,
 		] ),
-		priceMonthly: getPlanPrice( state, siteId, planObject, true ),
 	};
 };
 
@@ -66,6 +65,5 @@ function computePricesForWpComPlan( state, planObject ) {
 		priceFullBeforeDiscount,
 		priceFull,
 		priceFinal: priceFull,
-		priceMonthly,
 	};
 }

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -130,7 +130,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#computeFullAndMonthlyPricesForPlan()', () => {
-		test( 'Should return shape { priceFull, priceMonthly }', () => {
+		test( 'Should return shape { priceFull }', () => {
 			getPlanDiscountedRawPrice.mockImplementation( ( a, b, c, { isMonthly } ) =>
 				isMonthly ? 10 : 120
 			);
@@ -141,7 +141,6 @@ describe( 'selectors', () => {
 				priceFullBeforeDiscount: 150,
 				priceFull: 120,
 				priceFinal: 120,
-				priceMonthly: 10,
 			} );
 		} );
 
@@ -151,7 +150,6 @@ describe( 'selectors', () => {
 				priceFullBeforeDiscount: 150,
 				priceFull: 120,
 				priceFinal: 60,
-				priceMonthly: 10, // The monthly price is without discounts applied
 			} );
 		} );
 	} );
@@ -186,7 +184,7 @@ describe( 'selectors', () => {
 			getPlan.mockImplementation( ( slug ) => testPlans[ slug ] );
 		} );
 
-		test( 'Should return list of shapes { priceFull, priceFullBeforeDiscount, priceMonthly, plan, product, planSlug }', () => {
+		test( 'Should return list of shapes { priceFull, priceFullBeforeDiscount, plan, product, planSlug }', () => {
 			const state = {
 				productsList: {
 					items: {
@@ -204,7 +202,6 @@ describe( 'selectors', () => {
 					priceFullBeforeDiscount: 150,
 					priceFull: 120,
 					priceFinal: 120,
-					priceMonthly: 10,
 				},
 				{
 					planSlug: 'plan2',
@@ -213,7 +210,6 @@ describe( 'selectors', () => {
 					priceFullBeforeDiscount: 150,
 					priceFull: 240,
 					priceFinal: 240,
-					priceMonthly: 20,
 				},
 			] );
 		} );
@@ -238,7 +234,6 @@ describe( 'selectors', () => {
 					priceFullBeforeDiscount: 150,
 					priceFull: 120,
 					priceFinal: 60,
-					priceMonthly: 10,
 				},
 				{
 					planSlug: 'plan2',
@@ -247,7 +242,6 @@ describe( 'selectors', () => {
 					priceFullBeforeDiscount: 150,
 					priceFull: 240,
 					priceFinal: 120,
-					priceMonthly: 20,
 				},
 			] );
 		} );
@@ -270,7 +264,6 @@ describe( 'selectors', () => {
 					priceFullBeforeDiscount: 150,
 					priceFinal: 120,
 					priceFull: 120,
-					priceMonthly: 10,
 				},
 			] );
 		} );
@@ -292,7 +285,6 @@ describe( 'selectors', () => {
 					priceFullBeforeDiscount: 150,
 					priceFull: 120,
 					priceFinal: 120,
-					priceMonthly: 10,
 				},
 			] );
 		} );
@@ -326,7 +318,6 @@ describe( 'selectors', () => {
 					priceFullBeforeDiscount: 150,
 					priceFull: 120,
 					priceFinal: 120,
-					priceMonthly: 10,
 				},
 			] );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes the `priceMonthly` property from the product variant data that's passed around checkout for use by the variant selector because it is not used anywhere.

The only place where it is used is when it's created, and there it's only used to calculate the full price (eg: the annual price) before discounts. (This actually seems like a strange behavior to me, but there's a lot I don't grok about the product variant prices.) Therefore this leaves the variable in that location only, making it an implementation detail.

It also makes sure that if there is no monthly version of a product (for example, the Blogger plan), the product price and discount are correctly set.

Before for a plan without a monthly option:

<img width="506" alt="Screen Shot 2021-03-05 at 11 10 23 AM" src="https://user-images.githubusercontent.com/2036909/110142286-006a3100-7da4-11eb-971a-b14e1c50c6a8.png">

After for a plan without a monthly option:

<img width="501" alt="Screen Shot 2021-03-05 at 11 11 50 AM" src="https://user-images.githubusercontent.com/2036909/110142310-04964e80-7da4-11eb-9931-5bd5da205aa2.png">

Before and after for a plan that does have a monthly option:

<img width="504" alt="Screen Shot 2021-03-05 at 11 17 25 AM" src="https://user-images.githubusercontent.com/2036909/110142759-81c1c380-7da4-11eb-8b96-5c4f7a0dcf05.png">


#### Testing instructions

- Use a site with no plan.
- Visit a URL like `/checkout/example.com/blogger` (replacing `example.com` with your site URL).
- Click "Edit" on the first step to view the product variant selector.
- Verify that the product variants do not include a monthly option and that they have no crossed-out prices.
- Repeat the above steps with a URL like `/checkout/example.com/premium` and verify that there _is_ a monthly option listed.