### PR TITLE
Jetpack Magic Links: Carry over magic link user account email address to magic link flow pages.

### DIFF
--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -26,7 +26,10 @@ import LoggedOutForm from 'calypso/components/logged-out-form';
 import Notice from 'calypso/components/notice';
 import { CHECK_YOUR_EMAIL_PAGE } from 'calypso/state/login/magic-login/constants';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { getRedirectToOriginal } from 'calypso/state/login/selectors';
+import {
+	getRedirectToOriginal,
+	getLastCheckedUsernameOrEmail,
+} from 'calypso/state/login/selectors';
 import { hideMagicLoginRequestNotice } from 'calypso/state/login/magic-login/actions';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { sendEmailLogin } from 'calypso/state/auth/actions';
@@ -185,6 +188,7 @@ const mapState = ( state ) => {
 		showCheckYourEmail: getMagicLoginCurrentView( state ) === CHECK_YOUR_EMAIL_PAGE,
 		emailRequested: getMagicLoginRequestedEmailSuccessfully( state ),
 		userEmail:
+			getLastCheckedUsernameOrEmail( state ) ||
 			getCurrentQueryArguments( state ).email_address ||
 			getInitialQueryArguments( state ).email_address,
 	};


### PR DESCRIPTION
### Changes proposed in this Pull Request

In the Jetpack Login form, if you try to enter a Magic Link enabled account (It was initially created using Magic Link), the email address you enter does not get carried over to the magic link login flow pages.

Here's an example:
![Screen Capture on 2021-03-04 at 14-06-35 (1)](https://user-images.githubusercontent.com/11078128/110150275-10d2d980-7dad-11eb-82e5-fbcde190cc89.gif)


### Testing instructions

1. First you have to have a WordPress.com account that was created using Magic Link signup. If you have run and tested PR #50203 , then you should have created WordPress.com account using Magic Links. You'll need to use that sign-up email address for this PR.  If you have not run and tested PR #50203 , then you'll need to run it and follow the instructions resulting in creating a WordPress.com account using Magic Links.
2. Download and run this PR in Calypso blue.
3. Open an incognito window (Google Chrome or Firefox are good browser choices).
4. Create a Jurassic Ninja site or get a self-hosted site.
5. Initiate Jetpack's setup flow.
6. Make sure that you're redirected to /log-in/jetpack (we don't want to go through the in-place connection flow).
7. Copy your browser URL and paste it in a new tab. 
8. Change the url to `https://calypso.localhost:3000`
9. The login form should be pre-filled with the default jurassic ninja email address, something like, `oskosk+jurassicninja+new+site+created@gmail.com`
10. Change this email field to your WordPress.com account that was created using Magic Links.
11. Click "Continue".
12. Verify you end up on `/log-in/jetpack/link` and the correct email address is displayed where it says, "We just emailed a link to <yourWPcomEmailAddressHere>. Please check your inbox and click the link to log in."  See image:
![Markup 2021-03-05 at 12 47 20](https://user-images.githubusercontent.com/11078128/110153621-4ed1fc80-7db1-11eb-902e-7c9c8ed6d26f.png)

To see the undesired behavior, start at step 7 above, but do not change the url to `calypso.localhost:3000`. Stay on 'wordpress.com` and complete the steps.

Fixes 1199916399796129-as-1200012641361232

#### Here's a screencast of the fixed/desired behavior:

![Screen Capture on 2021-03-05 at 12-56-35](https://user-images.githubusercontent.com/11078128/110154620-75446780-7db2-11eb-9254-27efcb65e499.gif)
