### PR TITLE
Removing duplicate feature definition

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1585,12 +1585,6 @@ export const FEATURES_LIST = {
 		getDescription: () => i18n.translate( 'Make your P2 more memorable using your own domain.' ),
 	},
 
-	[ constants.FEATURE_HOSTING ]: {
-		getSlug: () => constants.FEATURE_HOSTING,
-		getTitle: () => i18n.translate( 'Best-in-class hosting' ),
-		getDescription: () => {},
-	},
-
 	[ constants.FEATURE_SFTP_DATABASE ]: {
 		getSlug: () => constants.FEATURE_SFTP_DATABASE,
 		getTitle: () => i18n.translate( 'SFTP (SSH File Transfer Protocol) and Database Access' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes a duplicate feature entry for `FEATURE_HOSTING` from `features-list`

<img width="760" alt="Screen Shot 2021-03-05 at 1 52 15 PM" src="https://user-images.githubusercontent.com/35781181/110160465-0ec34780-7dba-11eb-8c79-f0b2c0445487.png">


#### Testing instructions

* Checkout this PR and start Calypso
* Navigate to the Plans page
* Confirm that the tooltip description for "Best-in-class hosting" populates as expected.

Related to #
* 50266