### PR TITLE
Checkout: Make cart messages persistent across page loads

### DIFF
--- a/client/my-sites/checkout/cart/cart-messages.jsx
+++ b/client/my-sites/checkout/cart/cart-messages.jsx
@@ -133,7 +133,7 @@ function displayCartMessages( {
 				messages.errors.map( ( error ) => (
 					<p key={ `${ error.code }-${ error.message }` }>{ error.message }</p>
 				) ),
-				{ persistent: true }
+				{ isPersistent: true }
 			)
 		);
 		return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `CartMessages` component displays notices returned by the shopping cart endpoint. Often those notices are displayed on the next page because checkout has various situations where it may redirect you (notably when removing all products from the cart).

In https://github.com/Automattic/wp-calypso/pull/49297, the notices module used by `CartMessages` was converted to use Redux, but there was a regression because the `persistent` property on error notices (which makes notices remain after the page changes) was changed in the Redux version to be `isPersistent` and that was not updated here. However, this regression wasn't apparent because https://github.com/Automattic/wp-calypso/pull/44370 made it so that we would never be redirected away if there were errors. It became a problem because https://github.com/Automattic/wp-calypso/pull/50465 removed that condition.

This PR updates the persistent property so that it works again for errors (success messages are not persistent, but that should be ok since they tend to refer to something on the current page like a coupon being applied).

Fixes https://github.com/Automattic/wp-calypso/issues/50768

<img width="993" alt="Screen Shot 2021-03-05 at 2 11 09 PM" src="https://user-images.githubusercontent.com/2036909/110162385-aaee4e00-7dbc-11eb-9f3e-96b9efb961ee.png">

#### Testing instructions

1. Make sure your cart is empty.
1. Add a domain to the shopping cart.
2. Add G Suite.
3. Remove the domain from the shopping cart.  This will automatically remove G Suite also, thereby emptying the cart.
4. You get redirected to the plans page. Verify that you see a notice about why G Suite was removed from your cart.