### PR TITLE
Reset page title when switching back to cloud landing page

### DIFF
--- a/client/jetpack-cloud/index.js
+++ b/client/jetpack-cloud/index.js
@@ -30,6 +30,11 @@ const selectionPrompt = ( context, next ) => {
 	next();
 };
 
+const clearPageTitle = ( context, next ) => {
+	context.clearPageTitle = true;
+	next();
+};
+
 const redirectToPrimarySiteLanding = ( context ) => {
 	debug( 'controller: redirectToPrimarySiteLanding', context );
 	const state = context.store.getState();
@@ -55,7 +60,15 @@ export const handleOAuthOverride = () => {
 
 export default function () {
 	page( '/landing/:site', siteSelection, landingController, makeLayout, clientRender );
-	page( '/landing', siteSelection, selectionPrompt, sites, makeLayout, clientRender );
+	page(
+		'/landing',
+		siteSelection,
+		selectionPrompt,
+		clearPageTitle,
+		sites,
+		makeLayout,
+		clientRender
+	);
 	page( '/oauth-override', handleOAuthOverride );
 	page( '/', redirectToPrimarySiteLanding );
 }

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -309,6 +309,7 @@ function createSitesComponent( context ) {
 			siteBasePath={ basePath }
 			getSiteSelectionHeaderText={ context.getSiteSelectionHeaderText }
 			fromSite={ context.query.site }
+			clearPageTitle={ context.clearPageTitle }
 		/>
 	);
 }

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -13,6 +13,7 @@ import { Card } from '@automattic/components';
 import Main from 'calypso/components/main';
 import SiteSelector from 'calypso/components/site-selector';
 import VisitSite from 'calypso/blocks/visit-site';
+import DocumentHead from 'calypso/components/data/document-head';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 /**
@@ -23,6 +24,7 @@ import './style.scss';
 class Sites extends Component {
 	static propTypes = {
 		siteBasePath: PropTypes.string.isRequired,
+		clearPageTitle: PropTypes.bool,
 	};
 
 	componentDidMount() {
@@ -139,20 +141,21 @@ class Sites extends Component {
 	}
 
 	render() {
+		const { clearPageTitle, fromSite, siteBasePath } = this.props;
+
 		return (
-			<Main className="sites">
-				<div className="sites__select-header">
-					<h2 className="sites__select-heading">{ this.getHeaderText() }</h2>
-					{ this.props.fromSite && <VisitSite siteSlug={ this.props.fromSite } /> }
-				</div>
-				<Card className="sites__select-wrapper">
-					<SiteSelector
-						filter={ this.filterSites }
-						siteBasePath={ this.props.siteBasePath }
-						groups
-					/>
-				</Card>
-			</Main>
+			<>
+				{ clearPageTitle && <DocumentHead title="" /> }
+				<Main className="sites">
+					<div className="sites__select-header">
+						<h2 className="sites__select-heading">{ this.getHeaderText() }</h2>
+						{ fromSite && <VisitSite siteSlug={ fromSite } /> }
+					</div>
+					<Card className="sites__select-wrapper">
+						<SiteSelector filter={ this.filterSites } siteBasePath={ siteBasePath } groups />
+					</Card>
+				</Main>
+			</>
 		);
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR makes sure the page title is cleared when hitting the `/landing` route.

### Testing instructions

- Download this PR and run cloud
- Visit `/landing`
- Select a site. You should be redirected to the backup section.
- Hit the browser back button
- Check that the masterbar doesn't include any title (see videos below)

### Screenshots

_Before_

https://user-images.githubusercontent.com/1620183/110174086-95355480-7dcd-11eb-9528-c3805fd47eeb.mov



_After_

https://user-images.githubusercontent.com/1620183/110174077-8f3f7380-7dcd-11eb-86d7-122f29684601.mov

