### PR TITLE
Transform cloud masterbar title in h1

### DIFF
--- a/client/components/jetpack/masterbar/index.jsx
+++ b/client/components/jetpack/masterbar/index.jsx
@@ -59,7 +59,7 @@ const JetpackCloudMasterBar = () => {
 				<JetpackLogo size={ 28 } full={ ! isNarrow || isExteriorPage } />
 			</Item>
 			<AsyncLoad require="calypso/components/jetpack/portal-nav" placeholder={ null } />
-			<Item className="masterbar__item-title">{ headerTitle }</Item>
+			<h1 className="masterbar__item-title">{ headerTitle }</h1>
 			<Item
 				tipTarget="me"
 				url="#" // @todo: add a correct URL

--- a/client/components/jetpack/masterbar/style.scss
+++ b/client/components/jetpack/masterbar/style.scss
@@ -30,17 +30,13 @@
 
 	.masterbar__item-title {
 		flex: 1 1 auto;
+		align-self: center;
+
 		padding-left: 16px;
-		font-size: $font-body;
+
+		color: var( --color-neutral-80 );
 
 		text-transform: none;
-		font-weight: 400;
-
-		.masterbar__item-content {
-			margin-top: 2px;
-			line-height: normal;
-			color: var( --color-neutral-80 );
-		}
 	}
 
 	.masterbar__item-me {


### PR DESCRIPTION
### Changes proposed in this Pull Request

In Jetpack cloud, the masterbar title at the top of the page (see videos below) is implemented as a non clickable link instead of a heading. This is an error regarding accessibility.

This PR integrates the title as a level 1 heading, since it describes the main content of the page.

Fixes 1164141197617539-as-1200025493232650

### Testing instructions

- Download the PR and run cloud
- Visit any page that has a title, such as `/backup/:site`
- Inspect the title and verify it's a `h1` tag
- Verify that it still looks like the title in production

_Note: the following assumes you're using VoiceOver on OSX. Instructions may differ with other screen readers._

If you want to go a step further:
- Activate VoiceOver (`⌘+F5`)
- Open the Web Rotor (`Control+Option+U`). The rotor is a handy way to view the page main features (such as headings, links, etc.) and provides shortcuts for navigating.
- Check that _Backup_ is now shown in the _Headings_ and not the _Links_ section

### Screenshots

_Before_

https://user-images.githubusercontent.com/1620183/110177543-21964600-7dd3-11eb-8139-493d4cc0340d.mov



_After_

https://user-images.githubusercontent.com/1620183/110177551-25c26380-7dd3-11eb-9c0a-4de9c39718e5.mov