### PR TITLE
Checkout: Move getRememberedCoupon to checkout controller

### DIFF
--- a/client/lib/cart/actions.js
+++ b/client/lib/cart/actions.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { assign } from 'lodash';
-import debugModule from 'debug';
 
 /**
  * Internal dependencies
@@ -22,8 +21,6 @@ import {
 	CART_RELOAD,
 } from './action-types';
 import Dispatcher from 'calypso/dispatcher';
-import { MARKETING_COUPONS_KEY } from 'calypso/lib/analytics/utils';
-import { TRUENAME_COUPONS } from 'calypso/lib/domains';
 
 // We need to load the CartStore to make sure the store is registered with the
 // dispatcher even though it's not used directly here
@@ -32,8 +29,6 @@ import './store';
 /**
  * Constants
  */
-const debug = debugModule( 'calypso:signup:cart' );
-
 export function disableCart() {
 	Dispatcher.handleViewAction( { type: CART_DISABLE } );
 }
@@ -109,70 +104,6 @@ export function removeCoupon() {
 	Dispatcher.handleViewAction( {
 		type: CART_COUPON_REMOVE,
 	} );
-}
-
-export function getRememberedCoupon() {
-	// read coupon list from localStorage, return early if it's not there
-	let coupons = null;
-	try {
-		const couponsJson = window.localStorage.getItem( MARKETING_COUPONS_KEY );
-		coupons = JSON.parse( couponsJson );
-	} catch ( err ) {}
-	if ( ! coupons ) {
-		debug( 'No coupons found in localStorage: ', coupons );
-		return null;
-	}
-	const ALLOWED_COUPON_CODE_LIST = [
-		'ALT',
-		'FBSAVE15',
-		'FIVERR',
-		'FLASHFB20OFF',
-		'FLASHFB50OFF',
-		'GENEA',
-		'KITVISA',
-		'LINKEDIN',
-		'PATREON',
-		'ROCKETLAWYER',
-		'RBC',
-		'SAFE',
-		'SBDC',
-		'TXAM',
-		...TRUENAME_COUPONS,
-	];
-	const THIRTY_DAYS_MILLISECONDS = 30 * 24 * 60 * 60 * 1000;
-	const now = Date.now();
-	debug( 'Found coupons in localStorage: ', coupons );
-
-	// delete coupons if they're older than thirty days; find the most recent one
-	let mostRecentTimestamp = 0;
-	let mostRecentCouponCode = null;
-	Object.keys( coupons ).forEach( ( key ) => {
-		if ( now > coupons[ key ] + THIRTY_DAYS_MILLISECONDS ) {
-			delete coupons[ key ];
-		} else if ( coupons[ key ] > mostRecentTimestamp ) {
-			mostRecentCouponCode = key;
-			mostRecentTimestamp = coupons[ key ];
-		}
-	} );
-
-	// write remembered coupons back to localStorage
-	try {
-		debug( 'Storing coupons in localStorage: ', coupons );
-		window.localStorage.setItem( MARKETING_COUPONS_KEY, JSON.stringify( coupons ) );
-	} catch ( err ) {}
-
-	if (
-		ALLOWED_COUPON_CODE_LIST.includes(
-			mostRecentCouponCode?.includes( '_' )
-				? mostRecentCouponCode.substring( 0, mostRecentCouponCode.indexOf( '_' ) )
-				: mostRecentCouponCode
-		)
-	) {
-		debug( 'returning coupon code:', mostRecentCouponCode );
-		return mostRecentCouponCode;
-	}
-	debug( 'not returning any coupon code.' );
-	return null;
 }
 
 export function setTaxCountryCode( countryCode ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `getRememberedCoupon()` function checks localStorage for a coupon and is only used by the checkout controller, but it is defined inside `lib/cart/actions` which otherwise are functions that interact with the `CartStore`. Since the `CartStore` is being removed soon (see https://github.com/Automattic/wp-calypso/issues/24019), and because it doesn't seem to belong there anyway, this PR moves the function to where it's used.

The data format used by this feature appears to be:

```typescript
type CouponCode = string;
type Timestamp = number;
type RememberedCoupon = Record< CouponCode, Timestamp >;
```

<img width="354" alt="Screen Shot 2021-03-06 at 4 58 32 PM" src="https://user-images.githubusercontent.com/2036909/110221982-36d7a700-7e9d-11eb-8346-16735381d46b.png">


#### Testing instructions

- Visit `/plans` in calypso.
- In your JavaScript console, run `localStorage.setItem('marketing-coupons', '{"FIVERR_AAAA":' + Date.now() + '}');`, replacing `FIVERR_AAAA` with a valid coupon code beginning with `FIVERR_`.
- Add a product to your cart and visit checkout.
- Verify that the coupon code you wrote to localStorage shows up as applied to the cart successfully.