### PR TITLE
ci(e2e): Create video dir concurrently

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -970,7 +970,7 @@ object RunCalypsoE2eDesktopTests : BuildType({
 				set -x
 
 				mkdir -p screenshots
-				find test/e2e/temp -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
+				find test/e2e/temp -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
 
 				mkdir -p logs
 				find test/e2e -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz

--- a/test/e2e/lib/video-recorder.js
+++ b/test/e2e/lib/video-recorder.js
@@ -11,20 +11,6 @@ let file;
 let xvfb;
 let ffVideo;
 
-function createDir( dir ) {
-	dir = path.resolve( dir );
-	if ( fs.existsSync( dir ) ) return dir;
-	try {
-		fs.mkdirSync( dir );
-		return dir;
-	} catch ( error ) {
-		if ( error.code === 'ENOENT' ) {
-			return createDir( path.dirname( dir ) ) && createDir( dir );
-		}
-		throw error;
-	}
-}
-
 function isVideoEnabled() {
 	const video = config.has( 'useTestVideo' )
 		? config.get( 'useTestVideo' )
@@ -69,7 +55,7 @@ export function startVideo() {
 	const dateTime = new Date().toISOString().split( '.' )[ 0 ].replace( /:/g, '-' );
 	const fileName = `${ global.displayNum }-${ dateTime }.mpg`;
 	file = path.resolve( path.join( './screenshots/videos', fileName ) );
-	createDir( path.dirname( file ) );
+	fs.mkdirSync( path.dirname( file ), { recursive: true } );
 	ffVideo = child_process.spawn( ffmpeg.path, [
 		'-f',
 		'x11grab',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Create `videos` dir in a concurrent-friendly way.
* Don't move dirs to the final artifact, only files.