### PR TITLE
MediaLibrary: remove unused onEditItem prop

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -60,7 +60,6 @@ export class MediaLibraryContent extends React.Component {
 		scrollable: PropTypes.bool,
 		onAddMedia: PropTypes.func,
 		onMediaScaleChange: PropTypes.func,
-		onEditItem: PropTypes.func,
 		postId: PropTypes.number,
 		isConnected: PropTypes.bool,
 	};
@@ -398,7 +397,6 @@ export class MediaLibraryContent extends React.Component {
 					thumbnailType={ this.getThumbnailType() }
 					single={ this.props.single }
 					scrollable={ this.props.scrollable }
-					onEditItem={ this.props.onEditItem }
 				/>
 			</MediaListData>
 		);

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -59,7 +59,6 @@ class MediaLibrary extends Component {
 		onSourceChange: PropTypes.func,
 		onSearch: PropTypes.func,
 		onScaleChange: PropTypes.func,
-		onEditItem: PropTypes.func,
 		fullScreenDropZone: PropTypes.bool,
 		containerWidth: PropTypes.number,
 		single: PropTypes.bool,
@@ -200,7 +199,6 @@ class MediaLibrary extends Component {
 					onMediaScaleChange={ this.props.onScaleChange }
 					onSourceChange={ this.props.onSourceChange }
 					onDeleteItem={ this.props.onDeleteItem }
-					onEditItem={ this.props.onEditItem }
 					onViewDetails={ this.props.onViewDetails }
 					postId={ this.props.postId }
 					mediaValidationErrors={ this.props.site ? this.props.mediaValidationErrors : undefined }

--- a/client/my-sites/media-library/list-item.tsx
+++ b/client/my-sites/media-library/list-item.tsx
@@ -22,9 +22,6 @@ import EditorMediaModalGalleryHelp from 'calypso/post-editor/media-modal/gallery
  */
 import './list-item.scss';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
-
 // TODO: move to lib/media/utils once it gets typed.
 interface MediaObject {
 	transient?: boolean;
@@ -42,7 +39,6 @@ interface Props {
 	showGalleryHelp?: boolean;
 	selectedIndex?: number;
 	onToggle?: ( media: Media | undefined, shiftKey: boolean ) => void;
-	onEditItem?: any; // Unused. Appears to have been left here for compatibility reasons.
 	style?: React.CSSProperties;
 }
 
@@ -52,8 +48,6 @@ export default class MediaLibraryListItem extends React.Component< Props & DivPr
 	static defaultProps = {
 		maxImageWidth: 450,
 		selectedIndex: -1,
-		onToggle: noop,
-		onEditItem: noop,
 	};
 
 	shouldComponentUpdate( nextProps: Props ) {
@@ -73,11 +67,11 @@ export default class MediaLibraryListItem extends React.Component< Props & DivPr
 		}
 	};
 
-	renderItem = () => {
+	renderItem() {
 		let component;
 
 		if ( ! this.props.media ) {
-			return;
+			return null;
 		}
 
 		switch ( getMimePrefix( this.props.media ) as string ) {
@@ -96,7 +90,7 @@ export default class MediaLibraryListItem extends React.Component< Props & DivPr
 		}
 
 		return React.createElement( component, this.props );
-	};
+	}
 
 	render() {
 		let title;
@@ -110,7 +104,6 @@ export default class MediaLibraryListItem extends React.Component< Props & DivPr
 			showGalleryHelp,
 			selectedIndex,
 			onToggle,
-			onEditItem,
 			style,
 			...otherProps
 		} = this.props;

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -44,7 +44,6 @@ export class MediaLibraryList extends React.Component {
 		mediaOnFetchNextPage: PropTypes.func,
 		single: PropTypes.bool,
 		scrollable: PropTypes.bool,
-		onEditItem: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -55,7 +54,6 @@ export class MediaLibraryList extends React.Component {
 		mediaOnFetchNextPage: noop,
 		single: false,
 		scrollable: false,
-		onEditItem: noop,
 	};
 
 	state = {};
@@ -179,7 +177,6 @@ export class MediaLibraryList extends React.Component {
 				showGalleryHelp={ showGalleryHelp }
 				selectedIndex={ selectedIndex }
 				onToggle={ this.toggleItem }
-				onEditItem={ this.props.onEditItem }
 			/>
 		);
 	};

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -91,13 +91,6 @@ class Media extends Component {
 		page( redirect );
 	};
 
-	openDetailsModalForASingleImage = ( image ) => {
-		this.setState( {
-			currentDetail: 0,
-			selectedItems: [ image ],
-		} );
-	};
-
 	openDetailsModalForAllSelected = () => {
 		const { selectedItems } = this.props;
 
@@ -417,7 +410,6 @@ class Media extends Component {
 						single={ false }
 						filter={ this.props.filter }
 						source={ this.state.source }
-						onEditItem={ this.openDetailsModalForASingleImage }
 						onViewDetails={ this.openDetailsModalForAllSelected }
 						onDeleteItem={ this.handleDeleteMediaEvent }
 						onSourceChange={ this.handleSourceChange }

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -5,24 +5,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import {
-	findIndex,
-	flow,
-	get,
-	head,
-	isEmpty,
-	identity,
-	includes,
-	partial,
-	some,
-	values,
-} from 'lodash';
+import { flow, get, head, isEmpty, identity, includes, partial, some, values } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import MediaLibrary from 'calypso/my-sites/media-library';
-import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { bumpStat as mcBumpStat } from 'calypso/lib/analytics/mc';
 import { recordEditorEvent, recordEditorStat } from 'calypso/state/posts/stats';
 import MediaModalGallery from './gallery';
@@ -397,32 +385,6 @@ export class EditorMediaModal extends Component {
 		this.props.onClose();
 	};
 
-	editItem = ( item ) => {
-		const { site, selectedItems, single } = this.props;
-		if ( ! site ) {
-			return;
-		}
-
-		// Append item to set of selected items if not already selected.
-		let items = selectedItems;
-		if ( ! items.some( ( selected ) => selected.ID === item.ID ) ) {
-			if ( single ) {
-				items = [ item ];
-			} else {
-				items = items.concat( item );
-			}
-			this.props.setMediaLibrarySelectedItems( site.ID, items );
-		}
-
-		// Find and set detail selected index for the edited item
-		this.setDetailSelectedIndex( findIndex( items, { ID: item.ID } ) );
-
-		mcBumpStat( 'editor_media_actions', 'edit_button_contextual' );
-		gaRecordEvent( 'Media', 'Clicked Contextual Edit Button' );
-
-		this.props.setView( ModalViews.DETAIL );
-	};
-
 	getFirstEnabledFilter() {
 		if ( this.props.enabledFilters ) {
 			return head( this.props.enabledFilters );
@@ -565,7 +527,6 @@ export class EditorMediaModal extends Component {
 						onScaleChange={ this.onScaleChange }
 						onSourceChange={ this.onSourceChange }
 						onSearch={ this.onSearch }
-						onEditItem={ this.editItem }
 						fullScreenDropZone={ false }
 						single={ this.props.single }
 						onDeleteItem={ this.deleteMedia }


### PR DESCRIPTION
Removes an unused `onEditItem` callback from from `MediaLibraryListItem` and all the prop drilling all the way up to `MediaLibrary`.

The only usage of this callback was removed exactly 4 years ago in #11933. Since then, the only way to edit an image is the toolbar Edit button that's shown after selecting one or more images:

<img width="642" alt="Screenshot 2021-03-08 at 7 27 43" src="https://user-images.githubusercontent.com/664258/110283145-e3ba3d00-7fdf-11eb-8be9-1747ae1fc7c5.png">

That's handled by the `onViewDetails` callback that continues to exist.

I also eliminated usage of `noop` from `MediaLibraryListItem` by removing a default value for the `onToggle` prop. All usages (there's one) checks for its presence before calling it. And the prop is never used by the `ListItemImage`-ish sub-components even though it's passed to them.