### PR TITLE
Signup domains step: Fix alignment for RTL

### DIFF
--- a/client/components/domains/example-domain-browser/index.jsx
+++ b/client/components/domains/example-domain-browser/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
+import i18n from 'i18n-calypso';
 
 /**
  * Style dependencies
@@ -10,6 +11,7 @@ import classNames from 'classnames';
 import './style.scss';
 
 export default function ExampleDomainBrowser( { className } ) {
+	const domainTextXAxisValue = i18n.isRtl() ? '245' : '99';
 	return (
 		<div className={ classNames( 'example-domain-browser', className ) }>
 			<svg width="295" height="102" viewBox="0 0 295 102" xmlns="http://www.w3.org/2000/svg">
@@ -17,7 +19,7 @@ export default function ExampleDomainBrowser( { className } ) {
 				<g fill="none" fillRule="evenodd">
 					<path fill="#D8D8D8" d="M10 0h285v50H0V10C0 4.477 4.477 0 10 0z" />
 					<path fill="#FFF" d="M0 50h295v50H0zM94 9h201v30H94a4 4 0 0 1-4-4V13a4 4 0 0 1 4-4z" />
-					<text x="99" y="29">
+					<text x={ domainTextXAxisValue } y="29">
 						<tspan className="example-domain-browser__protocol">https://</tspan>
 						<tspan className="example-domain-browser__domain">example.com</tspan>
 					</text>

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -3,9 +3,10 @@
 
 .search-filters__dropdown-filters {
 	align-items: center;
-	border-left: 1px solid var( --color-neutral-10 );
 	height: 51px; // same as .search
 	z-index: z-index( 'root', '.search' );
+	/*!rtl:ignore*/
+	border-left: 1px solid var( --color-neutral-10 );
 
 	.button {
 		align-items: center;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The following UI fixes are made for the signup domains step:
* The "example.com" copy alignment is fixed. This is an extension of the changes made in https://github.com/Automattic/wp-calypso/pull/49460.
* The search box border was missing and this is fixed.

**BEFORE**

![image](https://user-images.githubusercontent.com/1269602/110322027-843c4b80-8038-11eb-96e8-ba0120ad2714.png)


![image](https://user-images.githubusercontent.com/1269602/110321994-74bd0280-8038-11eb-8f2d-2c1aa9c76850.png)


**AFTER**

![image](https://user-images.githubusercontent.com/1269602/110321921-5ce57e80-8038-11eb-898d-052064918578.png)


![image](https://user-images.githubusercontent.com/1269602/110321869-45a69100-8038-11eb-9b99-3b1e9e1efb36.png)



#### Testing instructions

1. Signup with an RTL locale, e.g. http://calypso.localhost:3000/start/ar
2. In the domains step, verify that the UI fixes shown in the PR description have taken effect.
3. Start over and signup in an LTR locale and ensure that the signup domains step UI is not changed.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


