### PR TITLE
Updates "included in paid plans" text for domain transfer

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -212,7 +212,7 @@ class TransferDomainStep extends React.Component {
 			);
 		} else if ( domainsWithPlansOnlyButNoPlan ) {
 			domainProductPriceText = translate(
-				'One additional year of domain registration included in paid plans.'
+				'One additional year of domain registration included in annual paid plans.'
 			);
 		} else if ( domainProductSalePrice ) {
 			domainProductPriceText = translate( 'Sale price is %(cost)s', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This updates the text to `One additional year of domain registration included in annual paid plans.` from `One additional year of domain registration included in paid plans.` on the domain transfer screen.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start/free or /start/<monthly-plan>
* Create an account
* On the domains step click "Already own a domain".
* Click on "Transfer your domain".
* Check the text on the right top.

<img width="1920" alt="Screenshot 2021-03-08 at 3 11 32 PM" src="https://user-images.githubusercontent.com/5436027/110310735-decdab80-8028-11eb-84d7-50e152697a5b.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #50433
