### PR TITLE
Nav Unification: Add param on external URLs for toggling the feature on WP Admin

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -3,6 +3,7 @@
  */
 
 import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
@@ -11,12 +12,13 @@ import { isFunction } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isExternal } from 'calypso/lib/url';
+import { addQueryArgs, isExternal } from 'calypso/lib/url';
 import MaterialIcon from 'calypso/components/material-icon';
 import Count from 'calypso/components/count';
 import { preload } from 'calypso/sections-helper';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
+import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 
 export default function SidebarItem( props ) {
 	const isExternalLink = isExternal( props.link );
@@ -26,6 +28,11 @@ export default function SidebarItem( props ) {
 		'has-unseen': props.hasUnseen,
 	} );
 	const { materialIcon, materialIconStyle, icon, customIcon, count } = props;
+	const isUnifiedMenuEnabled = useSelector( isNavUnificationEnabled );
+	const url =
+		isExternalLink && ! isUnifiedMenuEnabled
+			? addQueryArgs( { from: 'calypso-old-menu' }, props.link ) // `from` param is used by WP Admin on Atomic sites for disabling Nav Unification in that context. Can be removed after rolling Nav Unification out to 100% of users.
+			: props.link;
 
 	let _preloaded = false;
 
@@ -51,7 +58,7 @@ export default function SidebarItem( props ) {
 			<a
 				className="sidebar__menu-link"
 				onClick={ props.onNavigate }
-				href={ props.link }
+				href={ url }
 				target={ showAsExternal ? '_blank' : null }
 				rel={ isExternalLink ? 'noopener noreferrer' : null }
 				onMouseEnter={ itemPreload }

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-
 import React, { useEffect } from 'react';
-import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
@@ -12,13 +10,12 @@ import { isFunction } from 'lodash';
 /**
  * Internal dependencies
  */
-import { addQueryArgs, isExternal } from 'calypso/lib/url';
+import { addQueryArgs, isExternal, getUrlParts } from 'calypso/lib/url';
 import MaterialIcon from 'calypso/components/material-icon';
 import Count from 'calypso/components/count';
 import { preload } from 'calypso/sections-helper';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
-import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 
 export default function SidebarItem( props ) {
 	const isExternalLink = isExternal( props.link );
@@ -28,11 +25,15 @@ export default function SidebarItem( props ) {
 		'has-unseen': props.hasUnseen,
 	} );
 	const { materialIcon, materialIconStyle, icon, customIcon, count } = props;
-	const isUnifiedMenuEnabled = useSelector( isNavUnificationEnabled );
-	const url =
-		isExternalLink && ! isUnifiedMenuEnabled
-			? addQueryArgs( { from: 'calypso-old-menu' }, props.link ) // `from` param is used by WP Admin on Atomic sites for disabling Nav Unification in that context. Can be removed after rolling Nav Unification out to 100% of users.
-			: props.link;
+
+	let url = props.link;
+	if ( isExternalLink ) {
+		const { search } = getUrlParts( url );
+		if ( ! search.includes( 'from=' ) ) {
+			// `from` param is used by WP Admin on Atomic sites for disabling Nav Unification in that context. Can be removed after rolling Nav Unification out to 100% of users.
+			url = addQueryArgs( { from: 'calypso-old-menu' }, url );
+		}
+	}
 
 	let _preloaded = false;
 

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -22,7 +22,6 @@ import {
 	collapseAllMySitesSidebarSections,
 	expandMySitesSidebarSection,
 } from 'calypso/state/my-sites/sidebar/actions';
-import { isExternal, addQueryArgs } from 'calypso/lib/url';
 
 export const MySitesSidebarUnifiedItem = ( {
 	count,
@@ -44,20 +43,11 @@ export const MySitesSidebarUnifiedItem = ( {
 		reduxDispatch( expandMySitesSidebarSection( sectionId ) );
 	};
 
-	const getLink = () => {
-		if ( ! isExternal( url ) ) {
-			return url;
-		}
-		// In case of external links, let's add a `return` query arg so that we give
-		// other interfaces ( eg WP Admin ) a chance to return us where we started from.
-		return addQueryArgs( { return: document.location.href }, url );
-	};
-
 	return (
 		<SidebarItem
 			count={ count }
 			label={ title }
-			link={ getLink() }
+			link={ url }
 			onNavigate={ ( event ) => continueInCalypso( url, event ) && onNavigate() }
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -90,7 +90,7 @@ import { isUnderEmailManagementAll } from 'calypso/my-sites/email/paths';
 import JetpackSidebarMenuItems from 'calypso/components/jetpack/sidebar/menu-items/calypso';
 import InfoPopover from 'calypso/components/info-popover';
 import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
-import { getUrlParts, getUrlFromParts } from 'calypso/lib/url';
+import { getUrlParts, getUrlFromParts, addQueryArgs } from 'calypso/lib/url';
 import { isP2PlusPlan } from 'calypso/lib/plans';
 
 /**
@@ -944,7 +944,8 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		let adminUrl = site.options.admin_url;
+		// `from` param is used by WP Admin on Atomic sites for disabling Nav Unification in that context. Can be removed after rolling Nav Unification out to 100% of users.
+		let adminUrl = addQueryArgs( { from: 'calypso-old-menu' }, site.options.admin_url );
 
 		if ( this.props.isJetpack && ! this.props.isAtomicSite && ! this.props.isVip ) {
 			const urlParts = getUrlParts( site.options.admin_url + 'admin.php' );

--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -7,6 +7,7 @@ import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { ADMIN_MENU_REQUEST } from 'calypso/state/action-types';
 import { receiveAdminMenu } from 'calypso/state/admin-menu/actions';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import { addQueryArgs } from 'calypso/lib/url';
 
 export const requestFetchAdminMenu = ( action ) =>
 	http(
@@ -24,6 +25,16 @@ const sanitizeUrl = ( url, wpAdminUrl ) => {
 	const isSafeWpAdminUrl = new RegExp( `^${ wpAdminUrl?.replace( /^https?:\/\//, '' ) }` ).test(
 		url?.replace( /^https?:\/\//, '' )
 	);
+
+	if ( isSafeWpAdminUrl ) {
+		url = addQueryArgs(
+			{
+				return: document.location.href, // Gives WP Admin a chance to return to where we started from.
+				from: 'calypso-unified-menu', // `from` param is used by WP Admin on Atomic sites for enabling Nav Unification in that context. Can be removed after rolling Nav Unification out to 100% of users.
+			},
+			url
+		);
+	}
 
 	if ( isSafeInternalUrl || isSafeWpAdminUrl ) {
 		return url;

--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -29,8 +29,8 @@ const sanitizeUrl = ( url, wpAdminUrl ) => {
 	if ( isSafeWpAdminUrl ) {
 		url = addQueryArgs(
 			{
-				return: document.location.href, // Gives WP Admin a chance to return to where we started from.
 				from: 'calypso-unified-menu', // `from` param is used by WP Admin on Atomic sites for enabling Nav Unification in that context. Can be removed after rolling Nav Unification out to 100% of users.
+				...( typeof document !== 'undefined' && { return: document.location.href } ), // Gives WP Admin a chance to return to where we started from.
 			},
 			url
 		);

--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -29,8 +29,8 @@ const sanitizeUrl = ( url, wpAdminUrl ) => {
 	if ( isSafeWpAdminUrl ) {
 		url = addQueryArgs(
 			{
+				return: document.location.href, // Gives WP Admin a chance to return to where we started from.
 				from: 'calypso-unified-menu', // `from` param is used by WP Admin on Atomic sites for enabling Nav Unification in that context. Can be removed after rolling Nav Unification out to 100% of users.
-				...( typeof document !== 'undefined' && { return: document.location.href } ), // Gives WP Admin a chance to return to where we started from.
 			},
 			url
 		);

--- a/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
@@ -1,10 +1,15 @@
 /**
+ * @jest-environment jsdom
+ */
+
+/**
  * Internal dependencies
  */
 
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { requestFetchAdminMenu, handleSuccess } from '../';
 import { requestAdminMenu, receiveAdminMenu } from 'calypso/state/admin-menu/actions';
+import { addQueryArgs } from 'calypso/lib/url';
 
 describe( 'requestFetchAdminMenu', () => {
 	test( 'should create the correct http request action', () => {
@@ -70,7 +75,7 @@ describe( 'handlers', () => {
 						slug: 'my-custom-menu-3',
 						title: 'Settings',
 						type: 'submenu-item',
-						url: 'https://example.wordpress.com/wp-admin/settings.php?from=calypso-unified-menu',
+						url: 'https://example.wordpress.com/wp-admin/settings.php',
 					},
 					{
 						parent: 'my-custom-menu-4',
@@ -85,6 +90,13 @@ describe( 'handlers', () => {
 		const sanitizedMenu = [ ...unsafeMenu ];
 		sanitizedMenu[ 0 ].url = '';
 		sanitizedMenu[ 0 ].children[ 0 ].url = '';
+		sanitizedMenu[ 1 ].children[ 0 ].url = addQueryArgs(
+			{
+				return: document.location.href,
+				from: 'calypso-unified-menu',
+			},
+			sanitizedMenu[ 1 ].children[ 0 ].url
+		);
 		sanitizedMenu[ 1 ].children[ 1 ].url = '';
 		const action = receiveAdminMenu( 73738, sanitizedMenu );
 

--- a/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
@@ -70,7 +70,7 @@ describe( 'handlers', () => {
 						slug: 'my-custom-menu-3',
 						title: 'Settings',
 						type: 'submenu-item',
-						url: 'https://example.wordpress.com/wp-admin/settings.php',
+						url: 'https://example.wordpress.com/wp-admin/settings.php?from=calypso-unified-menu',
 					},
 					{
 						parent: 'my-custom-menu-4',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR explores an alternative approach for gradually rolling out Nav Unification on Atomic sites without the caching issues noted in p9o2xV-1hP-p2.

We're adding an additional `from` param to all external URLs in the sidebar menu that indicate whether the user is coming from the new unified menu or the old menu. That way, `wpcomsh` can check that param to update the user option that toggles Nav Unification without waiting for the XMLRPC response to be removed from the cache. See 629-gh-Automattic/wpcomsh.

#### Testing instructions

- With a A8C account, make sure all external links contain a `from=calypso-unified-menu` param.
- With a non-A8C account, make sure all external links contain a `from=calypso-old-menu` param.