### PR TITLE
Domains: Ensure enough space for DNS record type

### DIFF
--- a/client/my-sites/domains/domain-management/dns-records/item.scss
+++ b/client/my-sites/domains/domain-management/dns-records/item.scss
@@ -7,7 +7,7 @@
 	position: relative;
 
 	.dns-records__list-type {
-		min-width: 60px;
+		min-width: 65px;
 
 		span {
 			background: var( --color-neutral-light );


### PR DESCRIPTION
Fixes #50823

#### Changes proposed in this Pull Request

Adjust the `min-width` to ensure the DNS record type label does not clip.

#### Testing instructions

Go to `/domains/manage/example.com/dns/example.com` - Domains -> example.com -> Change your nameservers & DNS records -> DNS records.

Before:
<img width="768" alt="Screenshot 2021-03-08 at 17 51 44" src="https://user-images.githubusercontent.com/3392497/110360801-19d6db80-8037-11eb-92d8-d05cf3dcf983.png">

After:
<img width="749" alt="Screenshot 2021-03-08 at 17 49 15" src="https://user-images.githubusercontent.com/3392497/110360813-1f342600-8037-11eb-8c7a-c2f57be6103f.png">

Note the correct alignment of the `CNAME` label. `CNAME` is the longest one, so everything else should fit as well. Make sure to check the mobile view as well.