### PR TITLE
Jetpack Connect: add busy state to the button while isFetching

### DIFF
--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -54,7 +54,7 @@ class JetpackConnectSiteUrlInput extends Component {
 	}
 
 	handleKeyPress = ( event ) => {
-		if ( 13 === event.keyCode && ! this.isFormSubmitDisabled() ) {
+		if ( 13 === event.keyCode && ! this.isFormSubmitDisabled() && ! this.isFormSubmitBusy() ) {
 			this.props.onSubmit();
 		}
 	};
@@ -80,10 +80,16 @@ class JetpackConnectSiteUrlInput extends Component {
 	}
 
 	isFormSubmitDisabled() {
-		const { isError, isFetching, url } = this.props;
+		const { isError, url } = this.props;
 		const hasError = isError && 'notExists' !== isError;
 
-		return ! url || isFetching || hasError;
+		return ! url || hasError;
+	}
+
+	isFormSubmitBusy() {
+		const { isFetching } = this.props;
+
+		return isFetching;
 	}
 
 	renderTermsOfServiceLink() {
@@ -166,6 +172,7 @@ class JetpackConnectSiteUrlInput extends Component {
 						className="jetpack-connect__connect-button"
 						primary
 						disabled={ this.isFormSubmitDisabled() }
+						busy={ this.isFormSubmitBusy() }
 						onClick={ onSubmit }
 					>
 						{ this.renderButtonLabel() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds busy state to the form button while isFetching is true.
* Improves button contrast and legibility as a side-effect.

#### Testing instructions

* Fire up this PR.
* Go to http://calypso.localhost:3000/jetpack/connect
* Enter a site URL.
* Confirm that you see the busy state and that the current behavior doesn't break.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/110353682-3ff87d80-802f-11eb-9f35-93688b93d5d7.png) | ![image](https://user-images.githubusercontent.com/390760/110353690-42f36e00-802f-11eb-9275-6f82b97b165d.png)


Fixes https://github.com/Automattic/wp-calypso/issues/31550 reported by @simison 
