### PR TITLE
Do not imply Happiness accepts ToS in support sessions

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -521,6 +521,12 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	text-align: center;
 }
 
+.is-support-session .jetpack-connect__tos-link {
+	// We should not have the appearance of ToS acceptance on behalf of users.
+	// Using visibility:hidden rather than display:none to avoid unintentional layout changes.
+	visibility: hidden;
+}
+
 .jetpack-connect__tos-link-text {
 	white-space: nowrap;
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -521,10 +521,13 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	text-align: center;
 }
 
-.is-support-session .jetpack-connect__tos-link {
-	// We should not have the appearance of ToS acceptance on behalf of users.
-	// Using visibility:hidden rather than display:none to avoid unintentional layout changes.
-	visibility: hidden;
+.is-support-session {
+	.jetpack-connect__sso,
+	.jetpack-connect__authorize-form {
+		.jetpack-connect__tos-link {
+			display: none;
+		}
+	}
 }
 
 .jetpack-connect__tos-link-text {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While in a support session, we cannot accept ToS on behalf of users, and we'd like the UI to stop suggesting we can.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Prep

* Find or create a WoA test site with one primary test user and one non-primary test user (both Jetpack-connected users)
* Click on the calypso.live link in the comments below and remember the host name

##### For testing the Authorize form

* Create a support session for a test user who owns a WoA test site
* Navigate that site's wp-admin to login via SSO
* Disconnect the blog from Jetpack
* Refresh wp-admin to see the Jetpack reconnect banner, and reconnect Jetpack
* Once you're directed to the `wordpress.com/jetpack/connect/authorize` URL, observe that the ToS notice is visible
* Replace the host `wordpress.com` with the Calypso live hostname and request the page. Note that there is no ToS notice.

##### For testing the SSO form

* Create a support session for the non-primary user
* Navigate the test site's wp-admin to login via SSO
* Since the blog was disconnected from Jetpack, you will be prompted to SSO rather than automatically logged in via SSO
* The base of the URL should be `wordpress.com/jetpack/sso`. Confirm that and observe that the ToS notice is visible.
* Replace the host `wordpress.com` with the Calypso live hostname and request the page. Note that there is no ToS notice.
