### PR TITLE
Restore site: update more info to an external link

### DIFF
--- a/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
  */
 import ActivityIcon from '../activity-log-item/activity-icon';
 import { Button, Card } from '@automattic/components';
+import ExternalLink from 'calypso/components/external-link';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import Gridicon from 'calypso/components/gridicon';
@@ -92,14 +93,9 @@ const ActivityLogConfirmDialog = ( {
 					</Button>
 				</div>
 				<div className="activity-log-confirm-dialog__secondary-actions">
-					<Button
-						borderless
-						className="activity-log-confirm-dialog__more-info-link"
-						href={ supportLink }
-					>
-						<Gridicon icon="notice" />
-						<span>{ translate( 'More info' ) }</span>
-					</Button>
+					<ExternalLink icon href={ supportLink } onClick={ () => {} }>
+						{ translate( 'More info' ) }
+					</ExternalLink>
 					<HappychatButton
 						className="activity-log-confirm-dialog__more-info-link"
 						onClick={ happychatEvent }

--- a/client/my-sites/activity/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/activity/activity-log-confirm-dialog/style.scss
@@ -176,6 +176,15 @@
 	}
 }
 
+.activity-log-confirm-dialog__secondary-actions {
+	
+	.external-link {
+		display: inline-block;
+		padding: 8px 8px 0 0;
+		font-size: $font-body-small;
+	}
+}
+
 .activity-log-confirm-dialog__partial-restore-settings {
 	margin-bottom: 1.5rem;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update “More info” on the Restore site dialog to an external link.
* Accessibility: greatly improves the legibility of this element.
* Gets rid of incorrect “notice” icon.

#### Testing instructions

* Fire up this PR.
* Open the Activity Log for any Jetpack site that has a Backup product.
* Click the ellipsis on a _rewindable_ event and select “Restore to this point”.
* Confirm that you see the “More info” link correctly styled as an external link; confirm that it works.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/110361337-c7e28580-8037-11eb-8ab7-82573bdf51e5.png) | ![image](https://user-images.githubusercontent.com/390760/110361383-d4ff7480-8037-11eb-85f5-c0d5b5820c86.png)

