### PR TITLE
ETK: Allow .zip download to be uploaded as wordpress plugin

### DIFF
--- a/.teamcity/_self/builds/WPComPlugins_EditorToolkit.kt
+++ b/.teamcity/_self/builds/WPComPlugins_EditorToolkit.kt
@@ -18,7 +18,7 @@ object WPComPlugins_EditorToolKit : BuildType({
 		artifacts(AbsoluteId("calypso_WPComPlugins_EditorToolKit")) {
 			buildRule = tag("etk-release-build", "+:trunk")
 			artifactRules = """
-				+:editing-toolkit.zip!** => etk-release-build
+				+:apps/editing-toolkit/editing-toolkit-plugin => etk-release-build
 			""".trimIndent()
 		}
 	}
@@ -129,7 +129,6 @@ object WPComPlugins_EditorToolKit : BuildType({
 					EOM
 
 				echo
-				zip -r ../../../editing-toolkit.zip .
 			"""
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 		}

--- a/.teamcity/_self/builds/WPComPlugins_EditorToolkit.kt
+++ b/.teamcity/_self/builds/WPComPlugins_EditorToolkit.kt
@@ -18,7 +18,7 @@ object WPComPlugins_EditorToolKit : BuildType({
 		artifacts(AbsoluteId("calypso_WPComPlugins_EditorToolKit")) {
 			buildRule = tag("etk-release-build", "+:trunk")
 			artifactRules = """
-				+:apps/editing-toolkit/editing-toolkit-plugin => etk-release-build
+				+:./apps/editing-toolkit/editing-toolkit-plugin => etk-release-build
 			""".trimIndent()
 		}
 	}

--- a/.teamcity/_self/builds/WPComPlugins_EditorToolkit.kt
+++ b/.teamcity/_self/builds/WPComPlugins_EditorToolkit.kt
@@ -12,14 +12,12 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 object WPComPlugins_EditorToolKit : BuildType({
 	name = "Editor ToolKit"
 
-	artifactRules = "editing-toolkit.zip"
+	artifactRules = "./apps/editing-toolkit/editing-toolkit-plugin"
 
 	dependencies {
 		artifacts(AbsoluteId("calypso_WPComPlugins_EditorToolKit")) {
 			buildRule = tag("etk-release-build", "+:trunk")
-			artifactRules = """
-				+:./apps/editing-toolkit/editing-toolkit-plugin => etk-release-build
-			""".trimIndent()
+			artifactRules = "+:editing-toolkit.zip!** => etk-release-build"
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
When downloading the artifact directly from TeamCity, it is not uploadable as a plugin to a WordPress instance. (Currently, you have to unzip the download, and then rezip the output.) I have a hunch that we don't need to zip the artifact ourselves; maybe TeamCity will do that for us.

#### Testing instructions
1.  `install-plugin.sh` should continue working
2. artifact download should be uploadable to WordPress as a plugin.
