### PR TITLE
Remove the Stale label from list of excluded labels.

### DIFF
--- a/.github/workflows/mark-issue-stale.yml
+++ b/.github/workflows/mark-issue-stale.yml
@@ -16,7 +16,7 @@ jobs:
           # Days before issue is considered stale.
           days-before-issue-stale: 180
           # Exempt issue labels.
-          exempt-issue-labels: '[Pri] High,[Pri] BLOCKER,[Status] Keep Open,[Status] Stale'
+          exempt-issue-labels: '[Pri] High,[Pri] BLOCKER,[Status] Keep Open'
           # Disable auto-close of both issues and PRs.
           days-before-close: -1
           # Get issues in ascending (oldest first) order.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- intention was to eliminate repeated re-processing of the issues already marked as stale in subsequent runs.
- however, this is not what happened; instead the previous change ended up excluing issues that were stale from this action's target, resulting in removal of the stale label.

#### Testing instructions
