### PR TITLE
Checkout: Hide refund text when purchase is free

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -136,6 +136,7 @@ function CheckoutSummaryFeaturesList( props ) {
 	);
 	const { hasMonthlyPlan = false } = props;
 
+	const showRefundText = responseCart.total_cost > 0;
 	let refundText = translate( 'Money back guarantee' );
 
 	let refundDays = 0;
@@ -178,10 +179,12 @@ function CheckoutSummaryFeaturesList( props ) {
 					{ ...props }
 				/>
 			</CheckoutSummaryFeaturesListItem>
-			<CheckoutSummaryFeaturesListItem>
-				<WPCheckoutCheckIcon />
-				{ refundText }
-			</CheckoutSummaryFeaturesListItem>
+			{ showRefundText && (
+				<CheckoutSummaryFeaturesListItem>
+					<WPCheckoutCheckIcon />
+					{ refundText }
+				</CheckoutSummaryFeaturesListItem>
+			) }
 		</CheckoutSummaryFeaturesListWrapper>
 	);
 }


### PR DESCRIPTION
This hides the "money back guarantee" text from the Checkout sidebar when the total_cost of the cart is $0.

Fixes: #50049

Before:
![Screen Shot 2021-03-08 at 1 54 39 PM](https://user-images.githubusercontent.com/942359/110368488-192e4d00-8017-11eb-8c77-eda4031ef5fe.png)

After: 
<img width="1543" alt="Screen Shot 2021-03-08 at 1 55 28 PM" src="https://user-images.githubusercontent.com/942359/110368515-221f1e80-8017-11eb-8b66-dc02f14a61d5.png">

**To test:**
- add an item to your cart and either have credits to cover the cost or a 100% coupon
- verify that the refund text isn't visible in the Checkout sidebar