### PR TITLE
Cancellation: translate button text

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -802,7 +802,7 @@ class CancelPurchaseForm extends React.Component {
 				primary
 				data-e2e-button="remove"
 			>
-				{ this.props.disableButtons ? 'Removing' : 'Remove It' }
+				{ this.props.disableButtons ? translate( 'Removing' ) : translate( 'Remove It' ) }
 			</Button>
 		);
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -794,6 +794,8 @@ class CancelPurchaseForm extends React.Component {
 			onClick: this.downgradeClick,
 			isPrimary: true,
 		};
+		const removeText = translate( 'Remove It' );
+		const removingText = translate( 'Removing' );
 		const remove = (
 			<Button
 				disabled={ this.props.disableButtons }
@@ -802,7 +804,7 @@ class CancelPurchaseForm extends React.Component {
 				primary
 				data-e2e-button="remove"
 			>
-				{ this.props.disableButtons ? translate( 'Removing' ) : translate( 'Remove It' ) }
+				{ this.props.disableButtons ? removingText : removeText }
 			</Button>
 		);
 


### PR DESCRIPTION
This wraps the "remove it" and "removing" button text in a translate function.

Fixes: #50590

<img width="559" alt="Screen Shot 2021-03-08 at 2 29 45 PM" src="https://user-images.githubusercontent.com/942359/110371287-c0f94a00-801a-11eb-8384-1404516290f8.png">

**To test:**
- Go to /me/purchases
- Select a plan
- Turn off auto-renew with the toggle
- Click "remove {plan}"
- Follow the modal prompt
- Verify that the main CTA of the final step says "Remove it" and when clicked "Removing…"