### PR TITLE
Monthly toggle: RTL locales not showing tooltip

### DIFF
--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -242,10 +242,18 @@ const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSig
 
 			&:first-of-type {
 				padding-left: var( --item-padding );
+
+				.rtl & {
+					padding-right: var( --item-padding );
+				}
 			}
 
 			&:last-of-type {
 				padding-right: var( --item-padding );
+
+				.rtl & {
+					padding-left: var( --item-padding );
+				}
 			}
 
 			&:last-of-type .segmented-control__link {
@@ -285,7 +293,8 @@ const StyledPopover = styled( Popover )`
 		transition-duration: 0.01s;
 	}
 
-	&.is-right {
+	&.is-right,
+	.rtl &.is-left {
 		@media ( min-width: 960px ) {
 			display: block;
 		}
@@ -304,6 +313,20 @@ const StyledPopover = styled( Popover )`
 			&::before {
 				border-right-color: var( --color-neutral-100 );
 			}
+		}
+	}
+
+	.rtl &.is-left {
+		.popover__arrow {
+			right: 35px;
+			border-left-color: var( --color-neutral-100 );
+			&::before {
+				border-left-color: var( --color-neutral-100 );
+			}
+		}
+
+		.popover__inner {
+			left: -45px;
 		}
 	}
 

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -352,6 +352,12 @@ const StyledPopover = styled( Popover )`
 		}
 	}
 
+	.rtl &.is-bottom {
+		.popover__arrow {
+			border-right-color: transparent;
+		}
+	}
+
 	.popover__inner {
 		padding: 8px 10px;
 		max-width: 210px;

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -318,7 +318,7 @@ const StyledPopover = styled( Popover )`
 
 	.rtl &.is-left {
 		.popover__arrow {
-			right: 35px;
+			right: 40px;
 			border-left-color: var( --color-neutral-100 );
 			&::before {
 				border-left-color: var( --color-neutral-100 );
@@ -326,7 +326,7 @@ const StyledPopover = styled( Popover )`
 		}
 
 		.popover__inner {
-			left: -45px;
+			left: -50px;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the following issues in the monthly toggle in the signup flow:

* In RTL locales, the monthly toggle is not showing the annual savings tooltip
* There is also a minor padding UI issue in the monthly toggle buttons.

## BEFORE

**DESKTOP**

<img width="769" alt="Screenshot_2021-03-08_at_11_33_32_PM" src="https://user-images.githubusercontent.com/1269602/110371876-94bde780-8073-11eb-8113-9ef2445c3866.png">

**MOBILE**

<img width="296" alt="Screenshot 2021-03-08 at 11 48 17 PM" src="https://user-images.githubusercontent.com/1269602/110480396-76f09100-810c-11eb-96ad-6ecedc1330aa.png">

## AFTER

**DESKTOP** (Tooltip displayed when monthly prices toggle is clicked)

<img width="732" alt="Screenshot 2021-03-08 at 11 39 59 PM" src="https://user-images.githubusercontent.com/1269602/110372360-36453900-8074-11eb-871e-0109eed5e9c1.png">

**MOBILE** (UI of tooltip is fixed)

<img width="367" alt="Screenshot 2021-03-08 at 11 48 56 PM" src="https://user-images.githubusercontent.com/1269602/110480449-840d8000-810c-11eb-859c-dfa847d992fa.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Begin signup at /start/ar
* At the plans step, verify that the monthly prices toggle shows the tooltip when clicking on "Pay monthly", and that the toggle UI has appropriate padding as shown in the screenshot above.
* Verify UI on desktop and mobile web screen sizes.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

