### PR TITLE
Jetpack Backup: Render progress % on page reload

### DIFF
--- a/client/my-sites/backup/rewind-flow/progress-bar.tsx
+++ b/client/my-sites/backup/rewind-flow/progress-bar.tsx
@@ -23,7 +23,7 @@ const RewindFlowProgressBar: FunctionComponent< Props > = ( {
 	entry,
 } ) => {
 	const translate = useTranslate();
-	const filteredPercent = percent !== null ? percent : 0;
+	const filteredPercent = ( Number.isFinite( percent ) ? percent : 0 ) as number;
 
 	return (
 		<div className="rewind-flow__progress-bar">


### PR DESCRIPTION
When a restore is in progress, we display a progress bar. While a restore is ongoing, the progress bar renders correctly, but reloading the page causes the bar to remain empty no matter the progress percentage. This PR fixes the issue.

#### Changes proposed in this Pull Request

Fixes `1164141197617539-as-1200000994370962`.

* Check for a finite number value (with `Number.isFinite`) instead of null when sanitizing the progress bar percentage value.

#### Testing instructions

**Prerequisite:** You'll need admin access to a site with Jetpack Backup, with restores enabled (i.e., saved credentials in Settings), and at least one restoreable backup.

* In either Calypso Blue or Green, select your site and navigate to the **Backup** page.
* Find a backup you can restore from and click **Restore to this point**, then **Confirm restore** to start the restore process.
* Once the restore is in progress and you see a non-zero percentage in the progress bar, refresh your browser.
* Verify that when the page reloads, the "filled" portion of the progress bar is at or above the percentage you saw before, and is not empty.

#### Reference screenshots

##### Before: percentage number is shown, but progress bar is empty

<img width="715" alt="image" src="https://user-images.githubusercontent.com/670067/110381750-847c1d00-801f-11eb-80aa-95469efec4dd.png">

##### After: percentage number is shown and bar fill % matches

<img width="708" alt="image" src="https://user-images.githubusercontent.com/670067/110381660-657d8b00-801f-11eb-815a-a1529d58a326.png">