### PR TITLE
Cloudflare - Suppress warning message for non-wordpress.com nameservers if user is entering Cloudflare info

### DIFF
--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -26,6 +26,7 @@ import { updateNameservers } from 'calypso/state/domains/nameservers/actions';
 import {
 	WPCOM_DEFAULT_NAMESERVERS,
 	WPCOM_DEFAULT_NAMESERVERS_REGEX,
+	CLOUDFLARE_NAMESERVERS_REGEX,
 } from 'calypso/state/domains/nameservers/constants';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -78,6 +79,16 @@ class NameServers extends React.Component {
 		} );
 	};
 
+	hasCloudflareNameservers = () => {
+		if ( this.state.nameservers.length === 0 ) {
+			return false;
+		}
+
+		return this.state.nameservers.every( ( nameserver ) => {
+			return CLOUDFLARE_NAMESERVERS_REGEX.test( nameserver );
+		} );
+	};
+
 	setStateWhenLoadedFromServer( props ) {
 		const prevNameservers = this.props.nameservers;
 		const nextNameservers = props.nameservers;
@@ -106,6 +117,7 @@ class NameServers extends React.Component {
 
 		if (
 			this.hasWpcomNameservers() ||
+			this.hasCloudflareNameservers() ||
 			this.isPendingTransfer() ||
 			this.needsVerification() ||
 			! this.state.nameservers

--- a/client/state/domains/nameservers/constants.js
+++ b/client/state/domains/nameservers/constants.js
@@ -4,3 +4,5 @@ export const WPCOM_DEFAULT_NAMESERVERS = [
 	'ns3.wordpress.com',
 ];
 export const WPCOM_DEFAULT_NAMESERVERS_REGEX = /^ns[1-4]\.wordpress\.com$/i;
+
+export const CLOUDFLARE_NAMESERVERS_REGEX = /^.*\.ns\.cloudflare\.com$/i;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates front-end logic that determines whether we show a warning to users who are entering custom nameserver info for a mapped domain, indicating that their site may not work properly if they are not using WPCOM nameservers. Due to partnership with Cloudflare, we do not want to show a warning for Cloudflare nameserver values since it is part of the official process we direct users to follow.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site (in production) with a Premium account and redeem a free domain onto it. (Alternatively, use an existing site where this has already been done.)
* Check out this PR to your local dev environment.
* Navigate to http://calypso.localhost:3000/domains/manage/{MAPPED-DOMAIN}/name-servers/{MAPPED-DOMAIN}.
    * Via menuing, this is *Upgrades -> Domains -> (Select Mapped Domain) -> Change Your Name Server and DNS Records*.
* Disable the "Use Wordpress.com Name Servers" toggle.
* Verify that when all values entered in the nameserver boxes match the pattern *\*.ns.cloudflare.com*, the warning regarding valid nameservers disappears.
* Verify that you can submit custom Cloudflare nameserver values without issue.

Ex:

![image](https://user-images.githubusercontent.com/13437011/110387686-9cf03580-8027-11eb-956e-db38eb5a580e.png)
![image](https://user-images.githubusercontent.com/13437011/110387772-bbeec780-8027-11eb-8b2c-79fab4f63bbd.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 520-gh-Automattic/dotcom-manage