### PR TITLE
Remove references to IE11 from active e2e documentation.

### DIFF
--- a/test/e2e/docs/running-tests.md
+++ b/test/e2e/docs/running-tests.md
@@ -124,7 +124,6 @@ Canary tests are triggered _**automatically**_ on all PRs and merges.
 Canary suites include:
 
 - chrome canary
-- internet explorer
 - safari
 - woocommerce
 
@@ -152,7 +151,6 @@ _All times are in UTC._
 | --------------------- | ---------------------------- | -------------------------- |
 | WordPress.com         | Each `wp-calypso` deployment | -                          |
 |                       | Every 6 hours                | 00:00, 06:00, 12:00, 18:00 |
-| Internet Explorer     | ?                            | ?                          |
 | Jetpack               | Every 12 hours               | 01:00, 13:00               |
 | Jetpack Bleeding Edge | Every 12 hours               | 07:00, 19:00               |
 | WooCommerce           | Every 12 hours               | 11:00, 23:00               |


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- supporting the deprecation of IE11, e2e documentation will remove references to IE11.

Note that I have inquired with team-calypso on their timeline for IE11 deprecation, as there are IE11 related codepaths in the `test/e2e` directory and those likely need to be removed at the end of everything. 

#### Testing instructions