### PR TITLE
Site Editor: open published pages in site editor

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -45,6 +45,7 @@ import WebPreview from 'calypso/components/web-preview';
 import { editPost, trashPost } from 'calypso/state/posts/actions';
 import { getEditorPostId } from 'calypso/state/editor/selectors';
 import { protectForm, ProtectedFormProps } from 'calypso/lib/protect-form';
+import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor.js';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import getSiteUrl from 'calypso/state/selectors/get-site-url';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -840,10 +841,19 @@ const mapStateToProps = (
 		queryArgs[ 'in-editor-deprecation-group' ] = 1;
 	}
 
-	const siteAdminUrl =
+	let siteAdminUrl =
 		editorType === 'site'
 			? getSiteAdminUrl( state, siteId, 'admin.php?page=gutenberg-edit-site' )
 			: getSiteAdminUrl( state, siteId, postId ? 'post.php' : 'post-new.php' );
+
+	// Use the site editor to edit already-published pages if site editor is enabled
+	if ( postId && postType === 'page' && isSiteUsingCoreSiteEditor( state, siteId ) ) {
+		siteAdminUrl = getSiteAdminUrl(
+			state,
+			siteId,
+			`admin.php?page=gutenberg-edit-site&postId=${ postId }&postType=page`
+		);
+	}
 
 	const iframeUrl = addQueryArgs( queryArgs, siteAdminUrl );
 

--- a/client/state/selectors/is-site-using-core-site-editor.js
+++ b/client/state/selectors/is-site-using-core-site-editor.js
@@ -12,7 +12,7 @@ import getRawSite from 'calypso/state/selectors/get-raw-site';
  * Checks if a site is using the core Site Editor
  *
  * @param {object} state  Global state tree
- * @param {object} siteId Site ID
+ * @param {number|null} siteId Site ID
  * @returns {boolean} True if the site is using core Site Editor, otherwise false
  */
 export default function isSiteUsingCoreSiteEditor( state, siteId ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Open already-published pages in the Site Editor rather than the Post Editor

#### Testing instructions

* Have an FSE-enabled site (you should see Site Editor in the sidebar) or [create a new one](https://horizon.wordpress.com/new?flags=gutenboarding/site-editor)
* Edit an already-published page
* Should be opened in the Site Editor
* Create a new page
* Should be opened in the Post Editor

#### Notes

The Site Editor does not support creating new pages, and our Starter Page Templates functionality also is only activated in the Post Editor, so we have to use the Post Editor for new pages, for now.

Fixes #50702

