### PR TITLE
Add new issue template for Task type

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: '[Type] Feature Request'
+labels: "[Type] Feature Request"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,14 @@
+---
+name: Task
+about: Create a task
+title: ''
+labels: "[Type] Task"
+assignees: ''
+
+---
+
+**Task Details**
+<-- Details of the task to be added here. Try to be specific and reasonably sized. -->
+
+**Related to**
+<-- If there are any other GitHub issue(s) that readers should be aware of, include them here. -->


### PR DESCRIPTION
- add a new template via the online GitHub issues template editor for the `Task` type.
