### PR TITLE
ci(test): Create an explicit browserlist env for tests

### DIFF
--- a/client/my-sites/backup/backup-date-picker/test/index.jsx
+++ b/client/my-sites/backup/backup-date-picker/test/index.jsx
@@ -12,24 +12,24 @@ const mockIsEnabled = () => true;
  */
 jest.mock( 'i18n-calypso', () => ( {
 	...jest.requireActual( 'i18n-calypso' ),
-	useTranslate: jest.fn( mockUseTranslate ),
+	useTranslate: jest.fn(),
 } ) );
 jest.mock( 'react-redux', () => ( {
 	...jest.requireActual( 'react-redux' ),
-	useSelector: jest.fn( mockUseSelector ),
-	useDispatch: jest.fn( mockUseDispatch ),
+	useSelector: jest.fn(),
+	useDispatch: jest.fn(),
 } ) );
 jest.mock( '@automattic/calypso-config', () => ( {
 	__esModule: true,
 	default: jest.requireActual( '@automattic/calypso-config' ),
-	isEnabled: jest.fn( mockIsEnabled ),
+	isEnabled: jest.fn(),
 } ) );
 jest.mock( 'calypso/state/ui/selectors/get-selected-site-id' );
 jest.mock( 'calypso/state/selectors/get-site-gmt-offset' );
 jest.mock( 'calypso/state/selectors/get-site-timezone-value' );
 jest.mock( '../hooks', () => ( {
 	...jest.requireActual( '../hooks' ),
-	useCanGoToDate: jest.fn( mockUseCanGoToDate ),
+	useCanGoToDate: jest.fn(),
 } ) );
 
 /**

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
 		],
 		"server": [
 			"current node"
+		],
+		"test": [
+			"current node"
 		]
 	},
 	"engines": {

--- a/packages/webpack-config-flag-plugin/test/__snapshots__/index.js.snap
+++ b/packages/webpack-config-flag-plugin/test/__snapshots__/index.js.snap
@@ -1,10 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`webpack-config-flag-plugin should produce expected output: Output bundle should match snapshot 1`] = `
-"(window[\\"webpackChunk\\"] = window[\\"webpackChunk\\"] || []).push([[\\"main\\"],{
+"(() => {
+var exports = {};
+exports.id = \\"main\\";
+exports.ids = [\\"main\\"];
+exports.modules = {
 
 /***/ \\"./main.js\\":
-/***/ (function(__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
+/***/ ((__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) => {
 
 \\"use strict\\";
 
@@ -25,7 +29,7 @@ function isEnabled( flag ) {
 	return 'argh';
 }
 
-/* harmony default export */ var config = ({ isEnabled });
+/* harmony default export */ const config = ({ isEnabled });
 
 ;// CONCATENATED MODULE: ./default-import/config/module.js
 
@@ -413,6 +417,12 @@ if ( isEnabled( 'bar' ) ) {
 
 /***/ })
 
-},
-0,[[\\"./main.js\\",\\"runtime~main\\"]]]);"
+};
+;
+
+// load runtime
+var __webpack_require__ = require(\\"./runtime~main.js\\");
+__webpack_require__.C(exports);
+return __webpack_require__.X([], \\"./main.js\\");
+})();"
 `;

--- a/packages/webpack-inline-constant-exports-plugin/test/__snapshots__/index.js.snap
+++ b/packages/webpack-inline-constant-exports-plugin/test/__snapshots__/index.js.snap
@@ -1,10 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`webpack-inline-constant-exports-plugin should produce expected output: Output bundle should match snapshot 1`] = `
-"(window[\\"webpackChunk\\"] = window[\\"webpackChunk\\"] || []).push([[\\"main\\"],{
+"(() => {
+var exports = {};
+exports.id = \\"main\\";
+exports.ids = [\\"main\\"];
+exports.modules = {
 
 /***/ \\"./index.js\\":
-/***/ (function() {
+/***/ (() => {
 
 \\"use strict\\";
 
@@ -15,7 +19,7 @@ exports[`webpack-inline-constant-exports-plugin should produce expected output: 
  */
 const BLOGGER = 'BLOGGER_PLAN';
 const PREMIUM = 'PREMIUM_PLAN';
-/* harmony default export */ var plans = ([ BLOGGER, PREMIUM ]);
+/* harmony default export */ const plans = ([ BLOGGER, PREMIUM ]);
 
 ;// CONCATENATED MODULE: ./paths.js
 /*
@@ -51,6 +55,12 @@ console.log( FOO );
 
 /***/ })
 
-},
-0,[[\\"./index.js\\",\\"runtime~main\\"]]]);"
+};
+;
+
+// load runtime
+var __webpack_require__ = require(\\"./runtime~main.js\\");
+__webpack_require__.C(exports);
+return __webpack_require__.X([], \\"./index.js\\");
+})();"
 `;


### PR DESCRIPTION
#### Background

When running Babel as part of `webpack` or `jest`, the environment resolution algorithm will try these options in order:

1) Use the env specified in `BROWSERSLIST_ENV`
2) Use the env specified in `NODE_ENV`
3) Use the env `"production"`
4) Use browserslist's default (`> 0.5%, last 2 versions, Firefox ESR, not dead.`).

(From https://github.com/browserslist/browserslist/blob/main/node.js#L67, https://github.com/browserslist/browserslist#configuring-for-different-environments and https://github.com/browserslist/browserslist#queries)

For webpack builds this usually don't matter as we set `BROWSERSLIST_ENV` to an explicit value (either `evergreen` or `defaults`).

However, when running Jest we don't specify any value. Because Jest will set `NODE_ENV` to `test`, it will try to use a browserslist environment with that name. As there is none, it will use the defaults. This is suboptimal because it is not explicit and transpiles code assuming it will run in IE 11 (part of browserslist defaults), when in fact it will run in Node.

#### Changes proposed in this Pull Request

* Introduce a new environment called `test` that targets current Node.
* Fix tests that were relying on transpilation for browsers
* Fix Webpack snapshots used in tests.

#### Testing instructions

Verify unit tests pass