### PR TITLE
people(viewers): improve query and ViewersList

### DIFF
--- a/client/data/viewers/use-viewers-query.js
+++ b/client/data/viewers/use-viewers-query.js
@@ -18,7 +18,7 @@ const defaults = {
 	number: 100,
 };
 
-const useViewers = ( fetchOptions = {}, queryOptions = {} ) => {
+const useViewersQuery = ( fetchOptions = {}, queryOptions = {} ) => {
 	const { siteId } = fetchOptions;
 
 	return useInfiniteQuery(
@@ -49,4 +49,4 @@ const useViewers = ( fetchOptions = {}, queryOptions = {} ) => {
 	);
 };
 
-export default useViewers;
+export default useViewersQuery;

--- a/client/data/viewers/use-viewers-query.js
+++ b/client/data/viewers/use-viewers-query.js
@@ -12,15 +12,11 @@ import wpcom from 'calypso/lib/wp';
 const extractPages = ( pages = [] ) => pages.flatMap( ( page ) => page.viewers );
 const compareUnique = ( a, b ) => a.ID === b.ID;
 
-const DEFAULT_NUMBER = 100;
 const defaults = {
-	page: 1,
 	number: 100,
 };
 
-const useViewersQuery = ( fetchOptions = {}, queryOptions = {} ) => {
-	const { siteId } = fetchOptions;
-
+const useViewersQuery = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
 	return useInfiniteQuery(
 		[ 'viewers', siteId ],
 		( { pageParam = 1 } ) =>
@@ -31,7 +27,7 @@ const useViewersQuery = ( fetchOptions = {}, queryOptions = {} ) => {
 			} ),
 		{
 			getNextPageParam: ( lastPage, allPages ) => {
-				if ( lastPage.found <= allPages.length * DEFAULT_NUMBER ) {
+				if ( lastPage.found <= allPages.length * defaults.number ) {
 					return;
 				}
 				return allPages.length + 1;

--- a/client/data/viewers/use-viewers-query.js
+++ b/client/data/viewers/use-viewers-query.js
@@ -12,22 +12,16 @@ import wpcom from 'calypso/lib/wp';
 const extractPages = ( pages = [] ) => pages.flatMap( ( page ) => page.viewers );
 const compareUnique = ( a, b ) => a.ID === b.ID;
 
-const defaults = {
-	number: 100,
-};
+const DEFAULT_PER_PAGE = 100;
 
-const useViewersQuery = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
+const useViewersQuery = ( siteId, { number = DEFAULT_PER_PAGE } = {}, queryOptions = {} ) => {
 	return useInfiniteQuery(
 		[ 'viewers', siteId ],
 		( { pageParam = 1 } ) =>
-			wpcom.req.get( `/sites/${ siteId }/viewers`, {
-				...defaults,
-				...fetchOptions,
-				page: pageParam,
-			} ),
+			wpcom.req.get( `/sites/${ siteId }/viewers`, { number, page: pageParam } ),
 		{
 			getNextPageParam: ( lastPage, allPages ) => {
-				if ( lastPage.found <= allPages.length * defaults.number ) {
+				if ( lastPage.found <= allPages.length * number ) {
 					return;
 				}
 				return allPages.length + 1;

--- a/client/data/viewers/use-viewers-query.js
+++ b/client/data/viewers/use-viewers-query.js
@@ -20,6 +20,7 @@ const useViewersQuery = ( siteId, { number = DEFAULT_PER_PAGE } = {}, queryOptio
 		( { pageParam = 1 } ) =>
 			wpcom.req.get( `/sites/${ siteId }/viewers`, { number, page: pageParam } ),
 		{
+			...queryOptions,
 			getNextPageParam: ( lastPage, allPages ) => {
 				if ( lastPage.found <= allPages.length * number ) {
 					return;
@@ -34,7 +35,6 @@ const useViewersQuery = ( siteId, { number = DEFAULT_PER_PAGE } = {}, queryOptio
 					...data,
 				};
 			},
-			...queryOptions,
 		}
 	);
 };

--- a/client/data/viewers/use-viewers.js
+++ b/client/data/viewers/use-viewers.js
@@ -23,13 +23,12 @@ const useViewers = ( fetchOptions = {}, queryOptions = {} ) => {
 
 	return useInfiniteQuery(
 		[ 'viewers', siteId ],
-		async ( { pageParam = 1 } ) => {
-			const res = await wpcom
-				.undocumented()
-				.site( siteId )
-				.getViewers( { ...defaults, ...fetchOptions, page: pageParam } );
-			return res;
-		},
+		( { pageParam = 1 } ) =>
+			wpcom.req.get( `/sites/${ siteId }/viewers`, {
+				...defaults,
+				...fetchOptions,
+				page: pageParam,
+			} ),
 		{
 			getNextPageParam: ( lastPage, allPages ) => {
 				if ( lastPage.found <= allPages.length * DEFAULT_NUMBER ) {

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -131,10 +131,6 @@ UndocumentedSite.prototype.getRoles = function ( callback ) {
 	return this.wpcom.req.get( '/sites/' + this._id + '/roles', {}, callback );
 };
 
-UndocumentedSite.prototype.getViewers = function ( query, callback ) {
-	return this.wpcom.req.get( '/sites/' + this._id + '/viewers', query, callback );
-};
-
 UndocumentedSite.prototype.removeViewer = function ( viewerId, callback ) {
 	return this.wpcom.req.post(
 		{

--- a/client/my-sites/people/viewers-list/index.jsx
+++ b/client/my-sites/people/viewers-list/index.jsx
@@ -24,7 +24,7 @@ const useErrorNotice = ( error, refetch ) => {
 					id: 'site-viewers-notice',
 					button: translate( 'Try again' ),
 					onClick: () => {
-						removeNotice( 'site-viewers-notice' );
+						dispatch( removeNotice( 'site-viewers-notice' ) );
 						refetch();
 					},
 				} )

--- a/client/my-sites/people/viewers-list/index.jsx
+++ b/client/my-sites/people/viewers-list/index.jsx
@@ -24,9 +24,7 @@ const ViewersList = ( { site, label } ) => {
 		hasNextPage,
 		error,
 		refetch,
-	} = useViewersQuery( {
-		siteId: site.ID,
-	} );
+	} = useViewersQuery( site.ID );
 	const { removeViewer } = useRemoveViewer();
 
 	useEffect( () => {

--- a/client/my-sites/people/viewers-list/index.jsx
+++ b/client/my-sites/people/viewers-list/index.jsx
@@ -13,19 +13,9 @@ import useViewersQuery from 'calypso/data/viewers/use-viewers-query';
 import useRemoveViewer from 'calypso/data/viewers/remove-viewer';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 
-const ViewersList = ( { site, label } ) => {
+const useErrorNotice = ( error, refetch ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const {
-		data,
-		isLoading,
-		fetchNextPage,
-		isFetchingNextPage,
-		hasNextPage,
-		error,
-		refetch,
-	} = useViewersQuery( site.ID );
-	const { removeViewer } = useRemoveViewer();
 
 	useEffect( () => {
 		if ( error ) {
@@ -41,6 +31,21 @@ const ViewersList = ( { site, label } ) => {
 			);
 		}
 	}, [ dispatch, error, refetch, translate ] );
+};
+
+const ViewersList = ( { site, label } ) => {
+	const {
+		data,
+		isLoading,
+		fetchNextPage,
+		isFetchingNextPage,
+		hasNextPage,
+		error,
+		refetch,
+	} = useViewersQuery( site.ID );
+	const { removeViewer } = useRemoveViewer();
+
+	useErrorNotice( error, refetch );
 
 	return (
 		<Viewers

--- a/client/my-sites/people/viewers-list/index.jsx
+++ b/client/my-sites/people/viewers-list/index.jsx
@@ -9,7 +9,7 @@ import { useDispatch } from 'react-redux';
  * Internal dependencies
  */
 import Viewers from './viewers';
-import useViewers from 'calypso/data/viewers/use-viewers';
+import useViewersQuery from 'calypso/data/viewers/use-viewers-query';
 import useRemoveViewer from 'calypso/data/viewers/remove-viewer';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 
@@ -24,7 +24,7 @@ const ViewersList = ( { site, label } ) => {
 		hasNextPage,
 		error,
 		refetch,
-	} = useViewers( {
+	} = useViewersQuery( {
 		siteId: site.ID,
 	} );
 	const { removeViewer } = useRemoveViewer();

--- a/client/my-sites/people/viewers-list/index.jsx
+++ b/client/my-sites/people/viewers-list/index.jsx
@@ -20,9 +20,9 @@ const useErrorNotice = ( error, refetch ) => {
 	useEffect( () => {
 		if ( error ) {
 			dispatch(
-				errorNotice( 'There was an error retrieving viewer', {
+				errorNotice( translate( 'There was an error retrieving viewers' ), {
 					id: 'site-viewers-notice',
-					button: 'Try again',
+					button: translate( 'Try again' ),
 					onClick: () => {
 						removeNotice( 'site-viewers-notice' );
 						refetch();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `useViewers`: use `wpcom.req.get` directly (and remove undocumented `getViewers`)
* rename  `useViewers` to `useViewersQuery`
* `useViewersQuery`: make `siteId` argument explicit
* extract `useErrorNotice` from `ViewersList`

#### Testing instructions

Note: Viewers are only visible in the UI for pages which are private. You can access the viewers tab, however, by going to the `/people/viewers/:site` route even it it's not private.  Depending on what sites you have available it may make sense to look for a site with many viewers. 

1. Open a site with viewers on `/people/viewers/:site`
2. Make sure data is fetched correctly
3. Switch your active site, are site & page params reset correctly when fetching viewers for the site you switched to?

follow up to #50330 based on feedback from #50712 

Note: I'll address `removeViewer` in a separate PR.
