### PR TITLE
Revert "ci(test): Create an explicit browserlist env for tests"

### DIFF
--- a/client/my-sites/backup/backup-date-picker/test/index.jsx
+++ b/client/my-sites/backup/backup-date-picker/test/index.jsx
@@ -12,24 +12,24 @@ const mockIsEnabled = () => true;
  */
 jest.mock( 'i18n-calypso', () => ( {
 	...jest.requireActual( 'i18n-calypso' ),
-	useTranslate: jest.fn(),
+	useTranslate: jest.fn( mockUseTranslate ),
 } ) );
 jest.mock( 'react-redux', () => ( {
 	...jest.requireActual( 'react-redux' ),
-	useSelector: jest.fn(),
-	useDispatch: jest.fn(),
+	useSelector: jest.fn( mockUseSelector ),
+	useDispatch: jest.fn( mockUseDispatch ),
 } ) );
 jest.mock( '@automattic/calypso-config', () => ( {
 	__esModule: true,
 	default: jest.requireActual( '@automattic/calypso-config' ),
-	isEnabled: jest.fn(),
+	isEnabled: jest.fn( mockIsEnabled ),
 } ) );
 jest.mock( 'calypso/state/ui/selectors/get-selected-site-id' );
 jest.mock( 'calypso/state/selectors/get-site-gmt-offset' );
 jest.mock( 'calypso/state/selectors/get-site-timezone-value' );
 jest.mock( '../hooks', () => ( {
 	...jest.requireActual( '../hooks' ),
-	useCanGoToDate: jest.fn(),
+	useCanGoToDate: jest.fn( mockUseCanGoToDate ),
 } ) );
 
 /**

--- a/package.json
+++ b/package.json
@@ -46,9 +46,6 @@
 		],
 		"server": [
 			"current node"
-		],
-		"test": [
-			"current node"
 		]
 	},
 	"engines": {

--- a/packages/webpack-config-flag-plugin/test/__snapshots__/index.js.snap
+++ b/packages/webpack-config-flag-plugin/test/__snapshots__/index.js.snap
@@ -1,14 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`webpack-config-flag-plugin should produce expected output: Output bundle should match snapshot 1`] = `
-"(() => {
-var exports = {};
-exports.id = \\"main\\";
-exports.ids = [\\"main\\"];
-exports.modules = {
+"(window[\\"webpackChunk\\"] = window[\\"webpackChunk\\"] || []).push([[\\"main\\"],{
 
 /***/ \\"./main.js\\":
-/***/ ((__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) => {
+/***/ (function(__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 
 \\"use strict\\";
 
@@ -29,7 +25,7 @@ function isEnabled( flag ) {
 	return 'argh';
 }
 
-/* harmony default export */ const config = ({ isEnabled });
+/* harmony default export */ var config = ({ isEnabled });
 
 ;// CONCATENATED MODULE: ./default-import/config/module.js
 
@@ -417,12 +413,6 @@ if ( isEnabled( 'bar' ) ) {
 
 /***/ })
 
-};
-;
-
-// load runtime
-var __webpack_require__ = require(\\"./runtime~main.js\\");
-__webpack_require__.C(exports);
-return __webpack_require__.X([], \\"./main.js\\");
-})();"
+},
+0,[[\\"./main.js\\",\\"runtime~main\\"]]]);"
 `;

--- a/packages/webpack-inline-constant-exports-plugin/test/__snapshots__/index.js.snap
+++ b/packages/webpack-inline-constant-exports-plugin/test/__snapshots__/index.js.snap
@@ -1,14 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`webpack-inline-constant-exports-plugin should produce expected output: Output bundle should match snapshot 1`] = `
-"(() => {
-var exports = {};
-exports.id = \\"main\\";
-exports.ids = [\\"main\\"];
-exports.modules = {
+"(window[\\"webpackChunk\\"] = window[\\"webpackChunk\\"] || []).push([[\\"main\\"],{
 
 /***/ \\"./index.js\\":
-/***/ (() => {
+/***/ (function() {
 
 \\"use strict\\";
 
@@ -19,7 +15,7 @@ exports.modules = {
  */
 const BLOGGER = 'BLOGGER_PLAN';
 const PREMIUM = 'PREMIUM_PLAN';
-/* harmony default export */ const plans = ([ BLOGGER, PREMIUM ]);
+/* harmony default export */ var plans = ([ BLOGGER, PREMIUM ]);
 
 ;// CONCATENATED MODULE: ./paths.js
 /*
@@ -55,12 +51,6 @@ console.log( FOO );
 
 /***/ })
 
-};
-;
-
-// load runtime
-var __webpack_require__ = require(\\"./runtime~main.js\\");
-__webpack_require__.C(exports);
-return __webpack_require__.X([], \\"./index.js\\");
-})();"
+},
+0,[[\\"./index.js\\",\\"runtime~main\\"]]]);"
 `;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#50880

It is breaking unit tests in trunk