### PR TITLE
Media Library: Provide VideoPress Shortcode

### DIFF
--- a/client/post-editor/media-modal/detail/detail-file-info.jsx
+++ b/client/post-editor/media-modal/detail/detail-file-info.jsx
@@ -11,6 +11,7 @@ import classNames from 'classnames';
  */
 import { playtime } from 'calypso/lib/media/utils';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 
 class EditorMediaModalDetailFileInfo extends React.Component {
 	static displayName = 'EditorMediaModalDetailFileInfo';
@@ -84,6 +85,23 @@ class EditorMediaModalDetailFileInfo extends React.Component {
 		);
 	};
 
+	renderVideoPressShortcode = () => {
+		const videopressGuid = this.getItemValue( 'videopress_guid' );
+
+		if ( ! videopressGuid ) {
+			return;
+		}
+
+		return (
+			<tr>
+				<th>{ this.props.translate( 'Shortcode' ) }</th>
+				<td>
+					<ClipboardButtonInput value={ '[wpvideo ' + videopressGuid + ']' } />
+				</td>
+			</tr>
+		);
+	};
+
 	render() {
 		const classes = classNames( 'editor-media-modal-detail__file-info', {
 			'is-loading': ! this.props.item,
@@ -104,6 +122,7 @@ class EditorMediaModalDetailFileInfo extends React.Component {
 					</tr>
 					{ this.renderDimensions() }
 					{ this.renderDuration() }
+					{ this.renderVideoPressShortcode() }
 					<tr>
 						<th>{ this.props.translate( 'Upload Date' ) }</th>
 						<td>{ this.getItemValue( 'date' ) }</td>

--- a/client/post-editor/media-modal/detail/style.scss
+++ b/client/post-editor/media-modal/detail/style.scss
@@ -194,6 +194,10 @@
 
 	span {
 		display: block;
+
+		&.clipboard-button-input {
+			width: inherit;
+		}
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Allows users to easily access the Shortcode necessary to embed their videos in a post

#### Testing instructions

Visit the Media Library and open a video file, then verify that the "Shortcode" is displayed neatly in the corner. It should work if used in a post too.

<img width="984" alt="Screenshot 2021-03-09 at 14 02 28" src="https://user-images.githubusercontent.com/43215253/110482228-590d3700-80e0-11eb-9f54-523e9074b683.png">

Fixes #50867
(By the way, very similar PR in #49500!)

cc @tyxla, @flootr 