### PR TITLE
Localize URL: Don't rewrite wordpress.com URLs that point to Calypso

### DIFF
--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -98,7 +98,17 @@ const urlLocalizationMapping: UrlLocalizationMapping = {
 		url.pathname = url.pathname.replace( /\/help\//, '/support/' );
 		return prefixLocalizedUrlPath( supportSiteLocales )( url, localeSlug );
 	},
-	'wordpress.com': prefixLocalizedUrlPath( magnificentNonEnLocales ),
+	'wordpress.com': ( url: URL, localeSlug: Locale ) => {
+		// Don't rewrite checkout and me URLs.
+		if ( /^\/(checkout|me)(\/|$)/.test( url.pathname ) ) {
+			return url;
+		}
+		// Don't rewrite Calypso URLs that have the URL at the end.
+		if ( /\/([a-z0-9-]+\.)+[a-z]{2,}(\/|$)/.test( url.pathname ) ) {
+			return url;
+		}
+		return prefixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
+	},
 };
 
 export function localizeUrl( fullUrl: string, locale: Locale, isLoggedIn = true ): string {
@@ -120,6 +130,7 @@ export function localizeUrl( fullUrl: string, locale: Locale, isLoggedIn = true 
 	url.hostname = '';
 
 	if ( ! url.pathname.endsWith( '.php' ) ) {
+		// Essentially a trailingslashit.
 		url.pathname = ( url.pathname + '/' ).replace( /\/+$/, '/' );
 	}
 
@@ -130,7 +141,7 @@ export function localizeUrl( fullUrl: string, locale: Locale, isLoggedIn = true 
 	}
 
 	if ( '/' + locale + '/' === firstPathSegment ) {
-		return url.href;
+		return fullUrl;
 	}
 
 	// Lookup is checked back to front.

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -104,7 +104,7 @@ const urlLocalizationMapping: UrlLocalizationMapping = {
 			return url;
 		}
 		// Don't rewrite Calypso URLs that have the URL at the end.
-		if ( /\/([a-z0-9-]+\.)+[a-z]{2,}(\/|$)/.test( url.pathname ) ) {
+		if ( /\/([a-z0-9-]+\.)+[a-z]{2,}\/?$/.test( url.pathname ) ) {
 			return url;
 		}
 		return prefixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -111,6 +111,53 @@ describe( '#localizeUrl', () => {
 		expect( localizeUrl( 'https://en.wordpress.com/', 'en' ) ).toEqual( 'https://wordpress.com/' );
 	} );
 
+	test( 'calypso standard URLs', () => {
+		expect( localizeUrl( 'https://wordpress.com/checkout/', 'en' ) ).toEqual(
+			'https://wordpress.com/checkout/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/checkout/', 'es' ) ).toEqual(
+			'https://wordpress.com/checkout/'
+		);
+		expect(
+			localizeUrl( 'https://wordpress.com/checkout/offer-quickstart-session/', 'en' )
+		).toEqual( 'https://wordpress.com/checkout/offer-quickstart-session/' );
+		expect(
+			localizeUrl( 'https://wordpress.com/checkout/offer-quickstart-session/', 'es' )
+		).toEqual( 'https://wordpress.com/checkout/offer-quickstart-session/' );
+
+		expect( localizeUrl( 'https://wordpress.com/me', 'en' ) ).toEqual(
+			'https://wordpress.com/me/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/me', 'es' ) ).toEqual(
+			'https://wordpress.com/me/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/me/', 'en' ) ).toEqual(
+			'https://wordpress.com/me/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/me/', 'es' ) ).toEqual(
+			'https://wordpress.com/me/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/me/account', 'en' ) ).toEqual(
+			'https://wordpress.com/me/account/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/me/account', 'es' ) ).toEqual(
+			'https://wordpress.com/me/account/'
+		);
+
+		expect( localizeUrl( 'https://wordpress.com/home/test.wordpress.com', 'en' ) ).toEqual(
+			'https://wordpress.com/home/test.wordpress.com/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/home/test.wordpress.com', 'es' ) ).toEqual(
+			'https://wordpress.com/home/test.wordpress.com/'
+		);
+		expect(
+			localizeUrl( 'https://wordpress.com/not-really-a-calypso-path/test.blog', 'en' )
+		).toEqual( 'https://wordpress.com/not-really-a-calypso-path/test.blog/' );
+		expect(
+			localizeUrl( 'https://wordpress.com/not-really-a-calypso-path/test.blog', 'es' )
+		).toEqual( 'https://wordpress.com/not-really-a-calypso-path/test.blog/' );
+	} );
+
 	test( 'blog url', () => {
 		expect( localizeUrl( 'https://en.blog.wordpress.com/', 'en' ) ).toEqual(
 			'https://wordpress.com/blog/'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* URLs like https://wordpress.com/checkout/offer-quickstart-session/ that go through `localizeUrl()` should not get a locale inserted since they belong to Calypso.

#### Testing instructions

* Unit tests: `cd packages/i18n-utils; yarn test`

See p1615295603002600-slack-i18n