### PR TITLE
ci(test): Create an explicit browserslist env for tests (Take 2)

### DIFF
--- a/client/my-sites/backup/backup-date-picker/test/index.jsx
+++ b/client/my-sites/backup/backup-date-picker/test/index.jsx
@@ -12,24 +12,24 @@ const mockIsEnabled = () => true;
  */
 jest.mock( 'i18n-calypso', () => ( {
 	...jest.requireActual( 'i18n-calypso' ),
-	useTranslate: jest.fn( mockUseTranslate ),
+	useTranslate: jest.fn(),
 } ) );
 jest.mock( 'react-redux', () => ( {
 	...jest.requireActual( 'react-redux' ),
-	useSelector: jest.fn( mockUseSelector ),
-	useDispatch: jest.fn( mockUseDispatch ),
+	useSelector: jest.fn(),
+	useDispatch: jest.fn(),
 } ) );
 jest.mock( '@automattic/calypso-config', () => ( {
 	__esModule: true,
 	default: jest.requireActual( '@automattic/calypso-config' ),
-	isEnabled: jest.fn( mockIsEnabled ),
+	isEnabled: jest.fn(),
 } ) );
 jest.mock( 'calypso/state/ui/selectors/get-selected-site-id' );
 jest.mock( 'calypso/state/selectors/get-site-gmt-offset' );
 jest.mock( 'calypso/state/selectors/get-site-timezone-value' );
 jest.mock( '../hooks', () => ( {
 	...jest.requireActual( '../hooks' ),
-	useCanGoToDate: jest.fn( mockUseCanGoToDate ),
+	useCanGoToDate: jest.fn(),
 } ) );
 
 /**

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
 		],
 		"server": [
 			"current node"
+		],
+		"test": [
+			"current node"
 		]
 	},
 	"engines": {

--- a/packages/webpack-config-flag-plugin/test/__snapshots__/index.js.snap
+++ b/packages/webpack-config-flag-plugin/test/__snapshots__/index.js.snap
@@ -1,10 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`webpack-config-flag-plugin should produce expected output: Output bundle should match snapshot 1`] = `
-"(window[\\"webpackChunk\\"] = window[\\"webpackChunk\\"] || []).push([[\\"main\\"],{
+"(() => {
+var exports = {};
+exports.id = \\"main\\";
+exports.ids = [\\"main\\"];
+exports.modules = {
 
 /***/ \\"./main.js\\":
-/***/ (function(__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
+/***/ ((__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) => {
 
 \\"use strict\\";
 
@@ -25,7 +29,7 @@ function isEnabled( flag ) {
 	return 'argh';
 }
 
-/* harmony default export */ var config = ({ isEnabled });
+/* harmony default export */ const config = ({ isEnabled });
 
 ;// CONCATENATED MODULE: ./default-import/config/module.js
 
@@ -413,6 +417,12 @@ if ( isEnabled( 'bar' ) ) {
 
 /***/ })
 
-},
-0,[[\\"./main.js\\",\\"runtime~main\\"]]]);"
+};
+;
+
+// load runtime
+var __webpack_require__ = require(\\"./runtime~main.js\\");
+__webpack_require__.C(exports);
+return __webpack_require__.X([], \\"./main.js\\");
+})();"
 `;

--- a/packages/webpack-config-flag-plugin/test/__snapshots__/index.js.snap
+++ b/packages/webpack-config-flag-plugin/test/__snapshots__/index.js.snap
@@ -423,6 +423,6 @@ if ( isEnabled( 'bar' ) ) {
 // load runtime
 var __webpack_require__ = require(\\"./runtime~main.js\\");
 __webpack_require__.C(exports);
-return __webpack_require__.X([], \\"./main.js\\");
+var __webpack_exports__ = __webpack_require__.X([], \\"./main.js\\");
 })();"
 `;

--- a/packages/webpack-inline-constant-exports-plugin/test/__snapshots__/index.js.snap
+++ b/packages/webpack-inline-constant-exports-plugin/test/__snapshots__/index.js.snap
@@ -1,10 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`webpack-inline-constant-exports-plugin should produce expected output: Output bundle should match snapshot 1`] = `
-"(window[\\"webpackChunk\\"] = window[\\"webpackChunk\\"] || []).push([[\\"main\\"],{
+"(() => {
+var exports = {};
+exports.id = \\"main\\";
+exports.ids = [\\"main\\"];
+exports.modules = {
 
 /***/ \\"./index.js\\":
-/***/ (function() {
+/***/ (() => {
 
 \\"use strict\\";
 
@@ -15,7 +19,7 @@ exports[`webpack-inline-constant-exports-plugin should produce expected output: 
  */
 const BLOGGER = 'BLOGGER_PLAN';
 const PREMIUM = 'PREMIUM_PLAN';
-/* harmony default export */ var plans = ([ BLOGGER, PREMIUM ]);
+/* harmony default export */ const plans = ([ BLOGGER, PREMIUM ]);
 
 ;// CONCATENATED MODULE: ./paths.js
 /*
@@ -51,6 +55,12 @@ console.log( FOO );
 
 /***/ })
 
-},
-0,[[\\"./index.js\\",\\"runtime~main\\"]]]);"
+};
+;
+
+// load runtime
+var __webpack_require__ = require(\\"./runtime~main.js\\");
+__webpack_require__.C(exports);
+return __webpack_require__.X([], \\"./index.js\\");
+})();"
 `;

--- a/packages/webpack-inline-constant-exports-plugin/test/__snapshots__/index.js.snap
+++ b/packages/webpack-inline-constant-exports-plugin/test/__snapshots__/index.js.snap
@@ -61,6 +61,6 @@ console.log( FOO );
 // load runtime
 var __webpack_require__ = require(\\"./runtime~main.js\\");
 __webpack_require__.C(exports);
-return __webpack_require__.X([], \\"./index.js\\");
+var __webpack_exports__ = __webpack_require__.X([], \\"./index.js\\");
 })();"
 `;


### PR DESCRIPTION
Reintroduces #50880.

It got reverted in #50891 due a bad merge: `trunk` had a newer version of `webpack` which was not compatible with the change I made to some jest snapshots, resulting in a broken `trunk`.
