### PR TITLE
Update changelog and package.json for data-stores 2.0.0

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -92,7 +92,7 @@
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@automattic/calypso-build": "^7.0.0",
 		"@automattic/composite-checkout": "^1.0.0",
-		"@automattic/data-stores": "^2.0.0-alpha.0",
+		"@automattic/data-stores": "^2.0.0",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",
 		"@automattic/format-currency": "^1.0.0-alpha.0",
 		"@automattic/i18n-utils": "^1.0.0",

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -92,7 +92,7 @@
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@automattic/calypso-build": "^7.0.0",
 		"@automattic/composite-checkout": "^1.0.0",
-		"@automattic/data-stores": "^1.0.0-alpha.1",
+		"@automattic/data-stores": "^2.0.0-alpha.0",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",
 		"@automattic/format-currency": "^1.0.0-alpha.0",
 		"@automattic/i18n-utils": "^1.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -24,7 +24,7 @@
 		"@automattic/components": "^1.0.0-alpha.1",
 		"@automattic/composite-checkout": "^1.0.0",
 		"@automattic/create-calypso-config": "^1.0.0-alpha.0",
-		"@automattic/data-stores": "^1.0.0-alpha.1",
+		"@automattic/data-stores": "^2.0.0-alpha.0",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",
 		"@automattic/explat-client": "^0.0.1",
 		"@automattic/explat-client-react-helpers": "^0.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -24,7 +24,7 @@
 		"@automattic/components": "^1.0.0-alpha.1",
 		"@automattic/composite-checkout": "^1.0.0",
 		"@automattic/create-calypso-config": "^1.0.0-alpha.0",
-		"@automattic/data-stores": "^2.0.0-alpha.0",
+		"@automattic/data-stores": "^2.0.0",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",
 		"@automattic/explat-client": "^0.0.1",
 		"@automattic/explat-client-react-helpers": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
 		"@automattic/calypso-polyfills": "^1.0.0",
 		"@automattic/color-studio": "2.5.0",
 		"@automattic/components": "^1.0.0-alpha.1",
-		"@automattic/data-stores": "^1.0.0-alpha.1",
+		"@automattic/data-stores": "^2.0.0-alpha.0",
 		"@automattic/i18n-utils": "^1.0.0",
 		"@automattic/languages": "^1.0.0",
 		"@automattic/typography": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
 		"@automattic/calypso-polyfills": "^1.0.0",
 		"@automattic/color-studio": "2.5.0",
 		"@automattic/components": "^1.0.0-alpha.1",
-		"@automattic/data-stores": "^2.0.0-alpha.0",
+		"@automattic/data-stores": "^2.0.0",
 		"@automattic/i18n-utils": "^1.0.0",
 		"@automattic/languages": "^1.0.0",
 		"@automattic/typography": "^1.0.0",

--- a/packages/data-stores/CHANGELOG.md
+++ b/packages/data-stores/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.0-alpha.2
+## 2.0.0-alpha.0
 
 - Initial release with stores:
   - Domain Suggestions

--- a/packages/data-stores/CHANGELOG.md
+++ b/packages/data-stores/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0.0-alpha.0
+## 2.0.0
 
 - Initial release with stores:
   - Domain Suggestions

--- a/packages/data-stores/CHANGELOG.md
+++ b/packages/data-stores/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Next
+## 1.0.0-alpha.2
 
 - Initial release with stores:
   - Domain Suggestions

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/data-stores",
-	"version": "2.0.0-alpha.0",
+	"version": "2.0.0",
 	"description": "Calypso Data Stores",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/data-stores",
-	"version": "1.0.0-alpha.2",
+	"version": "2.0.0-alpha.0",
 	"description": "Calypso Data Stores",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/data-stores",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "Calypso Data Stores",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -32,7 +32,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
-		"@automattic/data-stores": "^1.0.0-alpha.1",
+		"@automattic/data-stores": "^2.0.0-alpha.0",
 		"@automattic/onboarding": "^1.0.0",
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
 		"@automattic/i18n-utils": "^1.0.0",

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -32,7 +32,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
-		"@automattic/data-stores": "^2.0.0-alpha.0",
+		"@automattic/data-stores": "^2.0.0",
 		"@automattic/onboarding": "^1.0.0",
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
 		"@automattic/i18n-utils": "^1.0.0",

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -32,7 +32,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
-		"@automattic/data-stores": "^2.0.0-alpha.0",
+		"@automattic/data-stores": "^2.0.0",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",
 		"@automattic/i18n-utils": "^1.0.0",
 		"@automattic/onboarding": "^1.0.0",

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -32,7 +32,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
-		"@automattic/data-stores": "^1.0.0-alpha.1",
+		"@automattic/data-stores": "^2.0.0-alpha.0",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",
 		"@automattic/i18n-utils": "^1.0.0",
 		"@automattic/onboarding": "^1.0.0",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -31,7 +31,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/data-stores": "^2.0.0-alpha.0",
+		"@automattic/data-stores": "^2.0.0",
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
 		"@wordpress/components": "^12.0.1",
 		"@wordpress/data": "^4.26.1",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -31,7 +31,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/data-stores": "^1.0.0-alpha.1",
+		"@automattic/data-stores": "^2.0.0-alpha.0",
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
 		"@wordpress/components": "^12.0.1",
 		"@wordpress/data": "^4.26.1",

--- a/packages/plans-grid/package.json
+++ b/packages/plans-grid/package.json
@@ -31,7 +31,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/data-stores": "^1.0.0-alpha.1",
+		"@automattic/data-stores": "^2.0.0-alpha.0",
 		"@automattic/onboarding": "^1.0.0",
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
 		"@wordpress/components": "^12.0.1",

--- a/packages/plans-grid/package.json
+++ b/packages/plans-grid/package.json
@@ -31,7 +31,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/data-stores": "^2.0.0-alpha.0",
+		"@automattic/data-stores": "^2.0.0",
 		"@automattic/onboarding": "^1.0.0",
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
 		"@wordpress/components": "^12.0.1",


### PR DESCRIPTION
In WooCommerce Blocks we were hoping to make use of the `ReturnOrGeneratorYieldUnion`, `DispatchFromMap`, and `GeneratorReturnType` type definitions, however in the package currently published on npm (`1.0.0-alpha.0`) they don't exist. 

I would like this PR to be merged so I can publish the current package to npm as `2.0.0`

Here is the relevant PR in Blocks where this updated package would be useful: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3913/files#diff-7e630e6f8dfcf5354f81558d9ac0828bf697a9c519747ed6430c88747cfab4dd 

#### Changes proposed in this Pull Request

* Update the version number in the package.json and CHANGELOG.md file in the `@automattic/data-stores` package.
* Update the following packages to use this new version:
  * `@automattic/domain-picker`
  * `@automattic/launch`
  * `@automattic/onboarding`
  * `@automattic/plans-grid`
  * `@automattic/wpcom-editing-toolkit`

The reason all of these packages needed to be updated is because they are currently using `1.0.0-alpha.1`, so when we change the version of `@automattic/data-stores` in this project, they won't be able to resolve it. 