### PR TITLE
Update styles of the asterisk notes in pricing page

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -90,12 +90,11 @@
 		content: '*';
 	}
 
-	text-align: center;
 	color: var( --color-neutral-light );
 
-	font-size: $font-title-medium;
-	letter-spacing: -0.95px;
-	line-height: $font-headline-large;
+	font-size: $font-body;
+	line-height: 2;
+	text-align: center;
 }
 
 .product-grid__more.is-detached {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the styles of the asterisk notes in the pricing page.

### Testing instructions

- Download this PR and run Calypso or cloud
- Visit the plans/pricing page
- Check that the asterisk notes look like the capture below

### Screenshots

_Below_
<img width="1080" alt="Screen Shot 2021-03-09 at 10 20 19 AM" src="https://user-images.githubusercontent.com/1620183/110495093-2b18fa00-80c2-11eb-9036-18622dcfdbea.png">

_After_
<img width="1086" alt="Screen Shot 2021-03-09 at 10 19 54 AM" src="https://user-images.githubusercontent.com/1620183/110495137-3704bc00-80c2-11eb-8bd3-f6047793f104.png">

