### PR TITLE
Analytics: Load latest `w.js`

### DIFF
--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -44,7 +44,7 @@ let _superProps: any; // Added to all Tracks events.
 let _loadTracksResult = Promise.resolve(); // default value for non-BOM environments.
 
 if ( typeof document !== 'undefined' ) {
-	_loadTracksResult = loadScript( '//stats.wp.com/w2.js?1' );
+	_loadTracksResult = loadScript( '//stats.wp.com/w.js?63' );
 }
 
 function createRandomId( randomBytesLength = 9 ): string {


### PR DESCRIPTION
Fix fetching multiple times the same pixels in some circumstances ( high latency
connection, pixels recorded before `w.js` was loaded ). Those dups were
discarded on the backend, but there is no need to have the extra traffic ;)

This also switches back to `w.js` since `w2.js` was a way of deploying the new
Tracks client only in Calypso, now that `w.js` and `w2.js` are the same file,
there is no need to keep both of them around.

#### Changes proposed in this Pull Request

* sync to use latest `w.js`.

#### Testing instructions

* `w.js` should be loaded in the Network pane, `t.gif` pixels are still triggered as usual.
