### PR TITLE
Codeowners: add View Design to block patterns

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,6 +82,7 @@
 /apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse @Automattic/cylon
 /apps/editing-toolkit/editing-toolkit-plugin/posts-list-block @Automattic/ajax
 /apps/editing-toolkit/editing-toolkit-plugin/global-styles @Automattic/cylon @nosolosw
+/apps/editing-toolkit/editing-toolkit-plugin/block-patterns @Automattic/dotcom-view-design
 
 # Editing Toolkit Workflow Files
 /.github/workflows/editing-toolkit-plugin.yml @noahtallen


### PR DESCRIPTION
This adds @Automattic/dotcom-view-design to the codeowners file for the Editing Toolkit's block patterns directory to test notifications for design ownership.