### PR TITLE
E2E: Refactor clickWhenClickable() helper

### DIFF
--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -411,24 +411,20 @@ export function logPerformance( driver ) {
 }
 
 export async function ensureMobileMenuOpen( driver ) {
-	const self = this;
-	const mobileHeaderSelector = by.css( '.section-nav__mobile-header' );
-	await waitTillPresentAndDisplayed( driver, mobileHeaderSelector );
-	return driver
-		.findElement( mobileHeaderSelector )
-		.isDisplayed()
-		.then( ( mobileDisplayed ) => {
-			if ( mobileDisplayed ) {
-				driver
-					.findElement( by.css( '.section-nav' ) )
-					.getAttribute( 'class' )
-					.then( ( classNames ) => {
-						if ( classNames.includes( 'is-open' ) === false ) {
-							self.clickWhenClickable( driver, mobileHeaderSelector );
-						}
-					} );
-			}
-		} );
+	const mobileHeaderLocator = by.css( '.section-nav__mobile-header' );
+	const menuLocator = by.css( '.section-nav' );
+	const openMenuLocator = by.css( '.section-nav.is-open' );
+
+	await waitTillPresentAndDisplayed( driver, menuLocator );
+	const menuElement = await driver.findElement( menuLocator );
+	const isMenuOpen = await menuElement
+		.getAttribute( 'class' )
+		.then( ( classNames ) => classNames.includes( 'is-open' ) );
+
+	if ( ! isMenuOpen ) {
+		await clickWhenClickable( driver, mobileHeaderLocator );
+		await waitTillPresentAndDisplayed( driver, openMenuLocator );
+	}
 }
 
 export function waitForInfiniteListLoad( driver, elementSelector, { numElements = 10 } = {} ) {

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -37,29 +37,31 @@ export async function clickWhenClickable( driver, locator, timeout = explicitWai
 		return driver.wait( condition, timeout );
 	}
 
-	// Wait for the element to be located
-	const element = await wait( until.elementLocated( locator ) );
-	// Wait for the element to be visible
-	await wait( until.elementIsVisible( element ) );
-	// Wait for the element to not be disabled
-	await wait( until.elementIsEnabled( element ) );
-	// Wait for the element to not be aria-disabled
-	await wait( elementIsAriaEnabled( element ) );
-
 	try {
-		// Highlight & click the element
-		await highlightElement( driver, element );
-		await element.click();
-	} catch ( error ) {
-		// Flaky response back from IE, so assume success and hope for the best
-		if ( global.browserName === 'Internet Explorer' ) {
-			console.log( "WARNING: IE claims the click action failed, but we're proceeding anyway!" );
-		} else {
-			throw error;
-		}
-	}
+		const element = await wait( until.elementLocated( locator ) );
 
-	return element;
+		await wait( until.elementIsEnabled( element ) );
+		await wait( elementIsAriaEnabled( element ) );
+		await highlightElement( driver, element );
+
+		try {
+			await element.click();
+		} catch ( error ) {
+			// Flaky response back from IE, so assume success and hope for the best
+			if ( global.browserName === 'Internet Explorer' ) {
+				console.log( "WARNING: IE claims the click action failed, but we're proceeding anyway!" );
+			} else {
+				throw error;
+			}
+		}
+
+		return element;
+	} catch ( error ) {
+		const locatorStr = typeof locator === 'function' ? 'by function()' : locator + '';
+		error.message = 'Could not click element ' + locatorStr + '\n' + error.message;
+
+		throw error;
+	}
 }
 
 export function waitTillFocused( driver, selector, pollingOverride, waitOverride ) {

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -40,9 +40,9 @@ export async function clickWhenClickable( driver, locator, timeout = explicitWai
 	try {
 		const element = await wait( until.elementLocated( locator ) );
 
+		await highlightElement( driver, element );
 		await wait( until.elementIsEnabled( element ) );
 		await wait( elementIsAriaEnabled( element ) );
-		await highlightElement( driver, element );
 
 		try {
 			await element.click();

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -411,6 +411,10 @@ export function logPerformance( driver ) {
 }
 
 export async function ensureMobileMenuOpen( driver ) {
+	if ( process.env.BROWSERSIZE !== 'mobile' ) {
+		return null;
+	}
+
 	const mobileHeaderLocator = by.css( '.section-nav__mobile-header' );
 	const menuLocator = by.css( '.section-nav' );
 	const openMenuLocator = by.css( '.section-nav.is-open' );

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -527,7 +527,7 @@ export async function selectElementByText( driver, selector, text ) {
 		const allElements = await driver.findElements( selector );
 		return await webdriver.promise.filter( allElements, getInnerTextMatcherFunction( text ) );
 	};
-	return await this.clickWhenClickable( driver, element, null, `while looking for '${ text }'` );
+	return await this.clickWhenClickable( driver, element );
 }
 
 export async function verifyTextPresent( driver, selector, text ) {


### PR DESCRIPTION
#### Changes proposed in this pull request
- Refactored `DriverHelper.clickWhenClickable()` to make sure that element is enabled before clicking. This should address some [general flakiness where a clicked element is (initially) disabled](https://github.com/Automattic/wp-calypso/pull/50653) (due to i.e. pending request).
- The above revealed an issue with the `ensureMobileMenuOpen` helper, where the `findElement` & `clickWhenClickable` methods weren't called via `await` and, as a result, returning an unreliable state of the menu. This PR fixes that.

#### Testing instructions
Specs should pass :)