### PR TITLE
Change Desktop Sign Up flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -766,7 +766,7 @@ jobs:
           name: Persist Mac Executable
           command: |
             # If this isn't a full artifact build, ensure to persist the built application for inspection
-            if ls desktop/release/*.zip &>/dev/null
+            if ! ls desktop/release/*.zip &>/dev/null
             then
               ditto -ck --rsrc --sequesterRsrc desktop/release/mac desktop/release/mac.app.zip
             fi
@@ -774,7 +774,7 @@ jobs:
           when: always
           name: Clean Up
           command: |
-            rm -rf desktop/release/mac/WordPress.com.app
+            rm -rf desktop/release/mac
             rm -rf desktop/release/mac-arm64
       - store_artifacts:
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -774,7 +774,7 @@ jobs:
           when: always
           name: Clean Up
           command: |
-            rm -rf desktop/release/mac
+            rm -rf desktop/release/mac/WordPress.com.app
             rm -rf desktop/release/mac-arm64
       - store_artifacts:
           when: always

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -135,7 +135,7 @@ export function generateFlows( {
 			steps: [ 'user' ],
 			destination: getSignupDestination,
 			description: 'Signup flow for desktop app',
-			lastModified: '2021-03-09',
+			lastModified: '2021-03-26',
 			showRecaptcha: true,
 		},
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -135,7 +135,7 @@ export function generateFlows( {
 			steps: [ 'user', 'about', 'themes', 'domains', 'plans' ],
 			destination: getSignupDestination,
 			description: 'Signup flow for desktop app',
-			lastModified: '2020-08-11',
+			lastModified: '2021-03-09',
 			showRecaptcha: true,
 		},
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -132,7 +132,7 @@ export function generateFlows( {
 		},
 
 		desktop: {
-			steps: [ 'about', 'themes', 'domains', 'plans', 'user' ],
+			steps: [ 'user', 'about', 'themes', 'domains', 'plans' ],
 			destination: getSignupDestination,
 			description: 'Signup flow for desktop app',
 			lastModified: '2020-08-11',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -132,7 +132,7 @@ export function generateFlows( {
 		},
 
 		desktop: {
-			steps: [ 'user', 'about', 'themes', 'domains', 'plans' ],
+			steps: [ 'user' ],
 			destination: getSignupDestination,
 			description: 'Signup flow for desktop app',
 			lastModified: '2021-03-09',

--- a/client/state/selectors/get-onboarding-url.js
+++ b/client/state/selectors/get-onboarding-url.js
@@ -17,6 +17,12 @@ import config from '@automattic/calypso-config';
 const GUTENBOARDING_LOCALES = [ 'en', 'en-gb' ];
 
 export default function getOnboardingUrl( state ) {
+	const isDesktopApp = config.isEnabled( 'desktop' );
+
+	if ( isDesktopApp ) {
+		return `https://wordpress.com/new`;
+	}
+
 	if ( isJetpackCloud() ) {
 		return config( 'jetpack_connect_url' );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes: https://github.com/Automattic/wp-calypso/issues/50399

Changes were made to the site creation flow in a way that breaks the desktop app. This PR allows for account creation without creating a site. It also sends users to the web to create a site since the site creation flow in the app is broken.

#### Testing instructions

* Grab the Desktop build from this PR
* Sign up for a new account
* Click the create site button
