### PR TITLE
Plans: Add the page header from Calypso Green to Calypso Blue

### DIFF
--- a/client/my-sites/plans/jetpack-plans/plans-header.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-header.tsx
@@ -8,6 +8,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { preventWidows } from 'calypso/lib/formatting';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Notice from 'calypso/components/notice';
@@ -22,8 +23,14 @@ const StandardPlansHeader = () => (
 	<>
 		<FormattedHeader headerText={ translate( 'Plans' ) } align="left" brandFont />
 		<PlansNavigation path={ '/plans' } />
+		<h2 className="jetpack-plans__pricing-header">
+			{ preventWidows(
+				translate( 'Security, performance, and marketing tools made for WordPress' )
+			) }
+		</h2>
 	</>
 );
+
 const ConnectFlowPlansHeader = () => (
 	<>
 		<div className="jetpack-plans__heading">

--- a/client/my-sites/plans/jetpack-plans/style.scss
+++ b/client/my-sites/plans/jetpack-plans/style.scss
@@ -15,3 +15,17 @@
 .jetpack-plans__heading {
 	padding: 1rem 0;
 }
+
+.jetpack-plans__pricing-header {
+	margin-top: 3rem;
+	padding: 0 1rem;
+	max-width: none;
+
+	text-align: center;
+	font-weight: 700;
+	font-size: $font-title-large;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		font-size: $font-headline-small;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Relates to `1196108640073826-as-1199946500089747`.

* Add a header to the Calypso Blue **Plans** page for Jetpack sites, so that it matches the appearance of Calypso Green.

#### Testing instructions

* In Calypso Blue, open the Plans page for a self-hosted Jetpack site.
* Verify that the following header text is displayed at the top of the page, under the navigation panel:
  * "Security, performance, and marketing tools made for WordPress"
* Verify the following characteristics of the header:
  * it is centered;
  * its margin and padding are proportional to its location/size on the page;
  * its font size is slightly larger for desktop screens (36px) and slightly smaller for mobile screens (32px); and
  * when the text wraps onto multiple lines, each line contains at least two words (i.e., no "widows").
* Verify that no changes are visible in any of the other experiences (Calypso Green, Jetpack Connect)

#### Reference screenshot

##### Mobile

<img width="654" alt="image" src="https://user-images.githubusercontent.com/670067/110538653-e1dca080-80e9-11eb-9a63-19f3f004ec6c.png">

##### Desktop

<img width="1074" alt="image" src="https://user-images.githubusercontent.com/670067/110538575-cbcee000-80e9-11eb-8671-e9e359a737c9.png">