### PR TITLE
Nav Unification: Disable Calypsoify with the 'from' parameter

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -31,7 +31,7 @@ export default function SidebarItem( props ) {
 		const { search } = getUrlParts( url );
 		if ( ! search.includes( 'from=' ) ) {
 			// `from` param is used by WP Admin on Atomic sites for disabling Nav Unification in that context. Can be removed after rolling Nav Unification out to 100% of users.
-			url = addQueryArgs( { from: 'calypso-old-menu' }, url );
+			url = addQueryArgs( { from: 'calypso-old-menu', calypsoify: 0 }, url );
 		}
 	}
 

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -945,7 +945,10 @@ export class MySitesSidebar extends Component {
 		}
 
 		// `from` param is used by WP Admin on Atomic sites for disabling Nav Unification in that context. Can be removed after rolling Nav Unification out to 100% of users.
-		let adminUrl = addQueryArgs( { from: 'calypso-old-menu' }, site.options.admin_url );
+		let adminUrl = addQueryArgs(
+			{ from: 'calypso-old-menu', calypsoify: 0 },
+			site.options.admin_url
+		);
 
 		if ( this.props.isJetpack && ! this.props.isAtomicSite && ! this.props.isVip ) {
 			const urlParts = getUrlParts( site.options.admin_url + 'admin.php' );


### PR DESCRIPTION
Going to `wp-admin` on a site with Calypsoify enabled, turns it off.
With #50839 we added a `from` parameter, which prevented that from
happening.

#### Changes proposed in this Pull Request

This PR explicitly disables Calypsoify by adding an additional query
parameter to the URL as we add the `from` parameter.

#### Testing instructions

* Using a non a8c account
* Open the block editor on a site, and then return to Calypso
* Click on one of the external links is the side nav, such as Feedback or WP-Admin
* You should end up in a Calypsoified version of that admin screen
* With this PR, those external links should have `calypsoify=0` added.
* Following them should take you to the normal wp-admin screen
