### PR TITLE
Components: Turn Card into function component and forward refs

### DIFF
--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -30,6 +30,7 @@ jest.mock( 'i18n-calypso', () => ( {
  */
 import React from 'react';
 import { shallow } from 'enzyme';
+import { Card, Button } from '@automattic/components';
 
 /**
  * Internal dependencies
@@ -50,13 +51,13 @@ describe( 'Banner basic tests', () => {
 
 	test( 'should render Card if dismissPreferenceName is null', () => {
 		const comp = shallow( <Banner { ...props } dismissPreferenceName={ null } /> );
-		expect( comp.find( 'Card' ) ).toHaveLength( 1 );
+		expect( comp.find( Card ) ).toHaveLength( 1 );
 		expect( comp.find( 'DismissibleCard' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render DismissibleCard if dismissPreferenceName is defined', () => {
 		const comp = shallow( <Banner { ...props } dismissPreferenceName={ 'banner-test' } /> );
-		expect( comp.find( 'Card' ) ).toHaveLength( 0 );
+		expect( comp.find( Card ) ).toHaveLength( 0 );
 		expect( comp.find( 'DismissibleCard' ) ).toHaveLength( 1 );
 	} );
 
@@ -72,12 +73,12 @@ describe( 'Banner basic tests', () => {
 
 	test( 'should render a <Button /> when callToAction is specified', () => {
 		const comp = shallow( <Banner { ...props } callToAction={ 'Buy something!' } /> );
-		expect( comp.find( 'ForwardRef(Button)' ) ).toHaveLength( 1 );
+		expect( comp.find( Button ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should not render a <Button /> when callToAction is not specified', () => {
 		const comp = shallow( <Banner { ...props } /> );
-		expect( comp.find( 'ForwardRef(Button)' ) ).toHaveLength( 0 );
+		expect( comp.find( Button ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should have .is-jetpack class and JetpackLogo if jetpack prop is defined', () => {
@@ -142,46 +143,46 @@ describe( 'Banner basic tests', () => {
 
 	test( 'should render Card with href if href prop is passed', () => {
 		const comp = shallow( <Banner { ...props } href={ '/' } /> );
-		expect( comp.find( 'Card' ) ).toHaveLength( 1 );
-		expect( comp.find( 'Card' ).props().href ).toBe( '/' );
+		expect( comp.find( Card ) ).toHaveLength( 1 );
+		expect( comp.find( Card ).props().href ).toBe( '/' );
 	} );
 
 	test( 'should render Card with no href if href prop is passed but disableHref is true', () => {
 		const comp = shallow( <Banner { ...props } href={ '/' } disableHref={ true } /> );
-		expect( comp.find( 'Card' ) ).toHaveLength( 1 );
-		expect( comp.find( 'Card' ).props().href ).toBeNull();
+		expect( comp.find( Card ) ).toHaveLength( 1 );
+		expect( comp.find( Card ).props().href ).toBeNull();
 	} );
 
 	test( 'should render Card with href if href prop is passed but disableHref is true and forceHref is true', () => {
 		const comp = shallow(
 			<Banner { ...props } href={ '/' } disableHref={ true } forceHref={ true } />
 		);
-		expect( comp.find( 'Card' ) ).toHaveLength( 1 );
-		expect( comp.find( 'Card' ).props().href ).toBe( '/' );
+		expect( comp.find( Card ) ).toHaveLength( 1 );
+		expect( comp.find( Card ).props().href ).toBe( '/' );
 	} );
 
 	test( 'should render Card with no href and CTA button with href if href prop is passed and callToAction is also passed', () => {
 		const comp = shallow( <Banner { ...props } href={ '/' } callToAction="Go WordPress!" /> );
-		expect( comp.find( 'Card' ) ).toHaveLength( 1 );
-		expect( comp.find( 'Card' ).props().href ).toBeNull();
-		expect( comp.find( 'Card' ).props().onClick ).toBeNull();
+		expect( comp.find( Card ) ).toHaveLength( 1 );
+		expect( comp.find( Card ).props().href ).toBeNull();
+		expect( comp.find( Card ).props().onClick ).toBeNull();
 
-		expect( comp.find( 'ForwardRef(Button)' ) ).toHaveLength( 1 );
-		expect( comp.find( 'ForwardRef(Button)' ).props().href ).toBe( '/' );
-		expect( comp.find( 'ForwardRef(Button)' ).props().children ).toBe( 'Go\xA0WordPress!' ); //preventwidows adds \xA0 non-breaking space;
-		expect( comp.find( 'ForwardRef(Button)' ).props().onClick ).toBe( comp.instance().handleClick );
+		expect( comp.find( Button ) ).toHaveLength( 1 );
+		expect( comp.find( Button ).props().href ).toBe( '/' );
+		expect( comp.find( Button ).props().children ).toBe( 'Go\xA0WordPress!' ); //preventwidows adds \xA0 non-breaking space;
+		expect( comp.find( Button ).props().onClick ).toBe( comp.instance().handleClick );
 	} );
 
 	test( 'should render Card with href and CTA button with no href if href prop is passed and callToAction is also passed and forceHref is true', () => {
 		const comp = shallow(
 			<Banner { ...props } href={ '/' } callToAction="Go WordPress!" forceHref={ true } />
 		);
-		expect( comp.find( 'Card' ) ).toHaveLength( 1 );
-		expect( comp.find( 'Card' ).props().href ).toBe( '/' );
-		expect( comp.find( 'Card' ).props().onClick ).toBe( comp.instance().handleClick );
+		expect( comp.find( Card ) ).toHaveLength( 1 );
+		expect( comp.find( Card ).props().href ).toBe( '/' );
+		expect( comp.find( Card ).props().onClick ).toBe( comp.instance().handleClick );
 
-		expect( comp.find( 'ForwardRef(Button)' ) ).toHaveLength( 1 );
-		expect( comp.find( 'ForwardRef(Button)' ).props().href ).toBeUndefined();
-		expect( comp.find( 'ForwardRef(Button)' ).props().children ).toBe( 'Go\xA0WordPress!' ); //preventWidows adds \xA0 non-breaking space;
+		expect( comp.find( Button ) ).toHaveLength( 1 );
+		expect( comp.find( Button ).props().href ).toBeUndefined();
+		expect( comp.find( Button ).props().children ).toBe( 'Go\xA0WordPress!' ); //preventWidows adds \xA0 non-breaking space;
 	} );
 } );

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Theme rendering with default display buttonContents should match snapshot 1`] = `
-<Memo(ForwardRef(Card))
+<Memo(Card)
   className="theme is-actionable"
   data-e2e-theme="twenty-seventeen"
   onClick={[Function]}
@@ -51,5 +51,5 @@ exports[`Theme rendering with default display buttonContents should match snapsh
       />
     </div>
   </div>
-</Memo(ForwardRef(Card))>
+</Memo(Card)>
 `;

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Theme rendering with default display buttonContents should match snapshot 1`] = `
-<Card
+<Memo(ForwardRef(Card))
   className="theme is-actionable"
   data-e2e-theme="twenty-seventeen"
   onClick={[Function]}
@@ -51,5 +51,5 @@ exports[`Theme rendering with default display buttonContents should match snapsh
       />
     </div>
   </div>
-</Card>
+</Memo(ForwardRef(Card))>
 `;

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -55,7 +55,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
           }
         }
       />
-      <Memo(ForwardRef(Card))
+      <Memo(Card)
         className="jetpack-connect__logged-in-card"
       >
         <Connect(Gravatar)
@@ -86,7 +86,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
             Approve
           </ForwardRef(Button)>
         </LoggedOutFormFooter>
-      </Memo(ForwardRef(Card))>
+      </Memo(Card)>
       <LoggedOutFormLinks>
         <LoggedOutFormLinkItem
           href="http://an.example.site/wp-admin/admin.php?page=jetpack"

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -55,7 +55,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
           }
         }
       />
-      <Card
+      <Memo(ForwardRef(Card))
         className="jetpack-connect__logged-in-card"
       >
         <Connect(Gravatar)
@@ -86,7 +86,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
             Approve
           </ForwardRef(Button)>
         </LoggedOutFormFooter>
-      </Card>
+      </Memo(ForwardRef(Card))>
       <LoggedOutFormLinks>
         <LoggedOutFormLinkItem
           href="http://an.example.site/wp-admin/admin.php?page=jetpack"

--- a/client/me/pending-payments/test/pending-list-item.js
+++ b/client/me/pending-payments/test/pending-list-item.js
@@ -27,7 +27,7 @@ describe( 'PendingListItem', () => {
 
 	const assertions = [
 		// Check nesting
-		'Card.pending-payments__list-item .pending-payments__list-item-wrapper .pending-payments__list-item-details',
+		'Memo(ForwardRef(Card)).pending-payments__list-item .pending-payments__list-item-wrapper .pending-payments__list-item-details',
 		'.pending-payments__list-item-details .pending-payments__list-item-title',
 		'.pending-payments__list-item-details .pending-payments__list-item-product',
 		'.pending-payments__list-item-details .pending-payments__list-item-payment',

--- a/client/me/pending-payments/test/pending-list-item.js
+++ b/client/me/pending-payments/test/pending-list-item.js
@@ -27,7 +27,7 @@ describe( 'PendingListItem', () => {
 
 	const assertions = [
 		// Check nesting
-		'Memo(ForwardRef(Card)).pending-payments__list-item .pending-payments__list-item-wrapper .pending-payments__list-item-details',
+		'Memo(Card).pending-payments__list-item .pending-payments__list-item-wrapper .pending-payments__list-item-details',
 		'.pending-payments__list-item-details .pending-payments__list-item-title',
 		'.pending-payments__list-item-details .pending-payments__list-item-product',
 		'.pending-payments__list-item-details .pending-payments__list-item-payment',

--- a/client/my-sites/people/people-invite-details/test/index.jsx
+++ b/client/my-sites/people/people-invite-details/test/index.jsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import moment from 'moment';
 import { shallow } from 'enzyme';
+import { Card } from '@automattic/components';
 
 const mockGoBack = jest.fn();
 jest.mock( 'page', () => ( { back: mockGoBack } ) );
@@ -152,7 +153,7 @@ describe( 'PeopleInviteDetails', () => {
 
 		// Verify that a placeholder is rendered while waiting for `page.back`
 		// to take effect.
-		const placeholderContainer = inviteDetails.find( 'Card' );
+		const placeholderContainer = inviteDetails.find( Card );
 		expect( placeholderContainer ).toHaveLength( 1 );
 		expect( placeholderContainer.children() ).toHaveLength( 1 );
 		const placeholder = placeholderContainer.childAt( 0 );

--- a/packages/components/src/card/index.tsx
+++ b/packages/components/src/card/index.tsx
@@ -78,4 +78,7 @@ const Card = < T extends TagName = 'div' >(
 	);
 };
 
-export default React.memo( React.forwardRef( Card ) );
+const ForwardedRefCard = React.forwardRef( Card );
+ForwardedRefCard.displayName = 'ForwardRef(Card)';
+
+export default React.memo( ForwardedRefCard );

--- a/packages/components/src/card/index.tsx
+++ b/packages/components/src/card/index.tsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons'; // eslint-disable-line no-restricted-imports
-import type { ElementType, ComponentProps, ReactNode } from 'react';
+import type { ElementType, ComponentProps, ReactNode, Ref } from 'react';
 
 /**
  * Style dependencies
@@ -30,53 +30,52 @@ type ElementProps< P, T extends TagName > = P &
 
 export type Props< T extends TagName > = ElementProps< OwnProps, T >;
 
-class Card< T extends TagName = 'div' > extends PureComponent< Props< T > > {
-	render(): JSX.Element {
-		const {
-			children,
-			className,
-			compact,
-			displayAsLink,
-			highlight,
-			tagName = 'div',
-			href,
-			target,
-			...props
-		} = this.props;
+const Card = < T extends TagName = 'div' >(
+	{
+		children,
+		className,
+		compact,
+		displayAsLink,
+		highlight,
+		tagName = 'div',
+		href,
+		target,
+		...props
+	}: Props< T >,
+	forwardedRef: Ref< any > // eslint-disable-line @typescript-eslint/no-explicit-any
+) => {
+	const elementClass = classNames(
+		'card',
+		className,
+		{
+			'is-card-link': displayAsLink || href,
+			'is-clickable': props.onClick,
+			'is-compact': compact,
+			'is-highlight': highlight,
+		},
+		highlight ? 'is-' + highlight : false
+	);
 
-		const elementClass = classNames(
-			'card',
-			className,
-			{
-				'is-card-link': displayAsLink || href,
-				'is-clickable': this.props.onClick,
-				'is-compact': compact,
-				'is-highlight': highlight,
-			},
-			highlight ? 'is-' + highlight : false
-		);
-
-		return href ? (
-			<a { ...props } href={ href } target={ target } className={ elementClass }>
-				<Gridicon className="card__link-indicator" icon={ target ? 'external' : 'chevron-right' } />
+	return href ? (
+		<a { ...props } href={ href } target={ target } className={ elementClass } ref={ forwardedRef }>
+			<Gridicon className="card__link-indicator" icon={ target ? 'external' : 'chevron-right' } />
+			{ children }
+		</a>
+	) : (
+		React.createElement(
+			tagName,
+			{ ...props, className: elementClass, ref: forwardedRef },
+			<>
+				{ displayAsLink && (
+					<Gridicon
+						className="card__link-indicator"
+						icon={ target ? 'external' : 'chevron-right' }
+					/>
+				) }
 				{ children }
-			</a>
-		) : (
-			React.createElement(
-				tagName,
-				{ ...props, className: elementClass },
-				<>
-					{ displayAsLink && (
-						<Gridicon
-							className="card__link-indicator"
-							icon={ target ? 'external' : 'chevron-right' }
-						/>
-					) }
-					{ children }
-				</>
-			)
-		);
-	}
-}
+			</>
+		)
+	);
+};
 
-export default Card;
+export default React.memo( React.forwardRef( Card ) );

--- a/packages/components/src/card/index.tsx
+++ b/packages/components/src/card/index.tsx
@@ -72,6 +72,6 @@ const Card = < T extends TagName = 'div' >(
 };
 
 const ForwardedRefCard = React.forwardRef( Card );
-ForwardedRefCard.displayName = 'ForwardRef(Card)';
+ForwardedRefCard.displayName = 'Card';
 
 export default React.memo( ForwardedRefCard );

--- a/packages/components/src/card/index.tsx
+++ b/packages/components/src/card/index.tsx
@@ -62,19 +62,12 @@ const Card = < T extends TagName = 'div' >(
 			{ children }
 		</a>
 	) : (
-		React.createElement(
-			tagName,
-			{ ...props, className: elementClass, ref: forwardedRef },
-			<>
-				{ displayAsLink && (
-					<Gridicon
-						className="card__link-indicator"
-						icon={ target ? 'external' : 'chevron-right' }
-					/>
-				) }
-				{ children }
-			</>
-		)
+		React.createElement( tagName, { ...props, className: elementClass, ref: forwardedRef }, [
+			displayAsLink && (
+				<Gridicon className="card__link-indicator" icon={ target ? 'external' : 'chevron-right' } />
+			),
+			children,
+		] )
 	);
 };
 

--- a/packages/components/src/card/test/__snapshots__/index.js.snap
+++ b/packages/components/src/card/test/__snapshots__/index.js.snap
@@ -49,28 +49,28 @@ exports[`Card should render children 1`] = `
 `;
 
 exports[`CompactCard should have \`compact\` prop 1`] = `
-<Card
+<Memo(ForwardRef(Card))
   compact={true}
 />
 `;
 
 exports[`CompactCard should have custom class of \`test__ace\` 1`] = `
-<Card
+<Memo(ForwardRef(Card))
   className="test__ace"
   compact={true}
 />
 `;
 
 exports[`CompactCard should render children 1`] = `
-<Card
+<Memo(ForwardRef(Card))
   compact={true}
 >
   This is a compact card
-</Card>
+</Memo(ForwardRef(Card))>
 `;
 
 exports[`CompactCard should use the card component 1`] = `
-<Card
+<Memo(ForwardRef(Card))
   compact={true}
 />
 `;

--- a/packages/components/src/card/test/__snapshots__/index.js.snap
+++ b/packages/components/src/card/test/__snapshots__/index.js.snap
@@ -49,28 +49,28 @@ exports[`Card should render children 1`] = `
 `;
 
 exports[`CompactCard should have \`compact\` prop 1`] = `
-<Memo(ForwardRef(Card))
+<Memo(Card)
   compact={true}
 />
 `;
 
 exports[`CompactCard should have custom class of \`test__ace\` 1`] = `
-<Memo(ForwardRef(Card))
+<Memo(Card)
   className="test__ace"
   compact={true}
 />
 `;
 
 exports[`CompactCard should render children 1`] = `
-<Memo(ForwardRef(Card))
+<Memo(Card)
   compact={true}
 >
   This is a compact card
-</Memo(ForwardRef(Card))>
+</Memo(Card)>
 `;
 
 exports[`CompactCard should use the card component 1`] = `
-<Memo(ForwardRef(Card))
+<Memo(Card)
   compact={true}
 />
 `;

--- a/packages/components/src/card/test/index.js
+++ b/packages/components/src/card/test/index.js
@@ -80,7 +80,7 @@ describe( 'CompactCard', () => {
 	// test for card component
 	test( 'should use the card component', () => {
 		const compactCard = shallow( <CompactCard /> );
-		expect( compactCard.find( 'Card' ) ).toHaveLength( 1 );
+		expect( compactCard.find( Card ) ).toHaveLength( 1 );
 		expect( compactCard ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Turn `Card` into a function component and forward refs.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This changes no internal logic, but to be safe test all the card components that show up in the `/devdocs/blocks`.
