### PR TITLE
Fixes arrow position when menu is open.

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -266,6 +266,10 @@ $font-size: rem( 14px );
 			}
 		}
 
+		.sidebar__menu.is-togglable.is-toggle-open .sidebar__expandable-arrow {
+			margin-right: 10px;
+		}
+
 		.notice {
 			/* stylelint-disable-next-line scales/font-weight */
 			font-weight: 300;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a margin to the arrow icon in reader when a section is open

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before | After
-------|------
![](https://cln.sh/nwq36R+) | ![](https://cln.sh/rYUY7Q+)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #50929
