### PR TITLE
Color Schemes: add back default

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -17,7 +17,7 @@ import LanguagePicker from 'calypso/components/language-picker';
 import SectionHeader from 'calypso/components/section-header';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import { protectForm } from 'calypso/lib/protect-form';
-import config, { isEnabled } from '@automattic/calypso-config';
+import config from '@automattic/calypso-config';
 import languages from '@automattic/languages';
 import { supportsCssCustomProperties } from 'calypso/lib/feature-detection';
 import { Card, Button } from '@automattic/components';
@@ -1093,7 +1093,7 @@ class Account extends React.Component {
 									<ColorSchemePicker
 										temporarySelection
 										defaultSelection={
-											isEnabled( 'nav-unification' ) ? 'classic-dark' : 'classic-bright'
+											this.props.isNavUnificationEnabled ? 'classic-dark' : 'classic-bright'
 										}
 										onSelection={ this.updateColorScheme }
 									/>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -17,7 +17,7 @@ import LanguagePicker from 'calypso/components/language-picker';
 import SectionHeader from 'calypso/components/section-header';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import { protectForm } from 'calypso/lib/protect-form';
-import config from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
 import languages from '@automattic/languages';
 import { supportsCssCustomProperties } from 'calypso/lib/feature-detection';
 import { Card, Button } from '@automattic/components';
@@ -1090,7 +1090,13 @@ class Account extends React.Component {
 									<FormLabel id="account__color_scheme" htmlFor="color_scheme">
 										{ translate( 'Dashboard color scheme' ) }
 									</FormLabel>
-									<ColorSchemePicker temporarySelection onSelection={ this.updateColorScheme } />
+									<ColorSchemePicker
+										temporarySelection
+										defaultSelection={
+											isEnabled( 'nav-unification' ) ? 'classic-dark' : 'classic-bright'
+										}
+										onSelection={ this.updateColorScheme }
+									/>
 								</FormFieldset>
 							) }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add back the Color Schemes default (which got lost in a rebase)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Grab your WP.com USER_ID
* `update_user_attribute( {{USER_ID}}, 'calypso_preferences', array( 'colorScheme' => '' ) )`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
