### PR TITLE
Comments: remove extendAction usage

### DIFF
--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 import { each, get, includes, isEqual, isUndefined, map } from 'lodash';
-import { extendAction } from '@automattic/state-utils';
 
 /**
  * Internal dependencies
@@ -351,32 +350,26 @@ const mapStateToProps = ( state, { commentsPage, siteId } ) => {
 const mapDispatchToProps = ( dispatch, { siteId, commentsListQuery } ) => ( {
 	changeStatus: ( postId, commentId, status, analytics = { alsoUnlike: false } ) =>
 		dispatch(
-			extendAction(
-				withAnalytics(
-					composeAnalytics(
-						recordTracksEvent( 'calypso_comment_management_change_status', {
-							also_unlike: analytics.alsoUnlike,
-							previous_status: analytics.previousStatus,
-							status,
-						} ),
-						bumpStat( 'calypso_comment_management', 'comment_status_changed_to_' + status )
-					),
-					changeCommentStatus( siteId, postId, commentId, status )
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_change_status', {
+						also_unlike: analytics.alsoUnlike,
+						previous_status: analytics.previousStatus,
+						status,
+					} ),
+					bumpStat( 'calypso_comment_management', 'comment_status_changed_to_' + status )
 				),
-				{ meta: { comment: { commentsListQuery: commentsListQuery } } }
+				changeCommentStatus( siteId, postId, commentId, status, commentsListQuery )
 			)
 		),
 	deletePermanently: ( postId, commentId ) =>
 		dispatch(
-			extendAction(
-				withAnalytics(
-					composeAnalytics(
-						recordTracksEvent( 'calypso_comment_management_delete' ),
-						bumpStat( 'calypso_comment_management', 'comment_deleted' )
-					),
-					deleteComment( siteId, postId, commentId, { showSuccessNotice: true } )
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_delete' ),
+					bumpStat( 'calypso_comment_management', 'comment_deleted' )
 				),
-				{ meta: { comment: { commentsListQuery: commentsListQuery } } }
+				deleteComment( siteId, postId, commentId, { showSuccessNotice: true }, commentsListQuery )
 			)
 		),
 	recordBulkAction: ( action, count, fromList, view = 'site' ) =>

--- a/client/state/comments/ui/reducer.js
+++ b/client/state/comments/ui/reducer.js
@@ -61,9 +61,7 @@ export const queries = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case COMMENTS_CHANGE_STATUS:
 		case COMMENTS_DELETE: {
-			const query = action.refreshCommentListQuery
-				? action.refreshCommentListQuery
-				: get( action, 'meta.comment.commentsListQuery' );
+			const query = action.refreshCommentListQuery;
 			if ( ! query ) {
 				return state;
 			}

--- a/client/state/comments/ui/test/reducer.js
+++ b/client/state/comments/ui/test/reducer.js
@@ -195,7 +195,7 @@ describe( 'reducer', () => {
 				siteId,
 				commentId: 4,
 				status: 'unapproved',
-				meta: { comment: { commentsListQuery: { page: 1, status: 'approved', order: 'ASC' } } },
+				refreshCommentListQuery: { page: 1, status: 'approved', order: 'ASC' },
 			} );
 			expect( query ).toEqual( { site: { 'approved?order=ASC': { 1: [ 1, 3, 5 ] } } } );
 		} );


### PR DESCRIPTION
Usage of `extendAction` from comments state can be removed, because the `changeCommentStatus` and `deleteComment` actions both have a `refreshCommentsListQuery` param and field that serves exactly the same purpose as `meta.comment.commentsListQuery`.

So this PR removes the `meta.comment.commentsListQuery` capability in favor of `refreshCommentsListQuery`.

Related to #50124.

The code was added in #21155 by @gwwar during Lannister's work on comments. May I ask for review if you still have recollections?
