### PR TITLE
Fix apiNamespace and apiVersion in JITM REST request

### DIFF
--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -24,7 +24,8 @@ const unescapeDecimalEntities = ( str ) =>
 /**
  * Given an object from the api, prepare it to be consumed by the ui by transforming the shape of the data
  *
- * @param {object} jitms The jitms to display from the api
+ * @param {object} response The response object from the jitms endpoint
+ * @param {object} response.data The jitms to display from the api
  * @returns {object} The transformed data to display
  */
 const transformApiRequest = ( { data: jitms } ) =>
@@ -54,9 +55,8 @@ const transformApiRequest = ( { data: jitms } ) =>
 export const doFetchJITM = ( action ) => {
 	return http(
 		{
-			apiNamespace: 'rest',
 			method: 'GET',
-			path: `/v1.1/jetpack-blogs/${ action.siteId }/rest-api/`,
+			path: `/jetpack-blogs/${ action.siteId }/rest-api/`,
 			query: {
 				path: '/jetpack/v4/jitm',
 				query: JSON.stringify( {
@@ -80,7 +80,6 @@ export const doFetchJITM = ( action ) => {
 export const doDismissJITM = ( action ) =>
 	http(
 		{
-			apiNamespace: 'rest',
 			method: 'POST',
 			path: `/jetpack-blogs/${ action.siteId }/rest-api/`,
 			query: {

--- a/client/state/data-layer/wpcom/sites/jitm/test/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/test/index.js
@@ -15,9 +15,8 @@ describe( 'jitms', () => {
 			expect( doFetchJITM( action ) ).toEqual(
 				http(
 					{
-						apiNamespace: 'rest',
 						method: 'GET',
-						path: `/v1.1/jetpack-blogs/${ siteId }/rest-api/`,
+						path: `/jetpack-blogs/${ siteId }/rest-api/`,
 						query: {
 							path: '/jetpack/v4/jitm',
 							query: JSON.stringify( {
@@ -42,7 +41,6 @@ describe( 'jitms', () => {
 			expect( doDismissJITM( action ) ).toEqual(
 				http(
 					{
-						apiNamespace: 'rest',
 						method: 'POST',
 						path: `/jetpack-blogs/${ siteId }/rest-api/`,
 						query: {


### PR DESCRIPTION
Fixes how `apiNamespace` and `apiVersion` is passed to the JITM REST endpoint. `rest` is not a valid `apiNamespace` for the `wpcom-xhr-request` library and it will use `wp-json` when it sees an invalid namespace. That results in failing requests:

<img width="873" alt="Screenshot 2021-03-10 at 13 03 08" src="https://user-images.githubusercontent.com/664258/110630263-722beb80-81a5-11eb-9cd5-2f251c872824.png">

`rest/v1.1` is the default namespace and we shouldn't pass any `apiNamespace` and `apiVersion` at all.

**How to test:**
Not that the above error happens only when Calypso runs in OAuth mode, with the `wpcom-xhr-request` low-level handler. The default `wpcom-proxy-request` handler, with cookie auth, treats namespaces differently (an inconsistency worth fixing) and works both before and after this patch.

Run Calypso in OAuth mode:
```
ENABLE_FEATURES=oauth yarn start
```
and verify the JITM requests (issued on Calypso load of the Home section) are not failing.