### PR TITLE
E2E: Don't run GB upgrade edge specs when non-edge part fails

### DIFF
--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -217,23 +217,23 @@ describe( `[${ host }, ${ screenSize }] Test Gutenberg upgrade against most popu
 				} );
 
 				verifyBlockInPublishedPage( Block );
-			} );
 
-			describe( `Test the same block on a corresponding edge site`, function () {
-				step( `Start a new post`, async function () {
-					const loginFlow = new LoginFlow( driver, 'gutenbergUpgradeEdgeUser' );
+				describe( `Test the same block on a corresponding edge site`, function () {
+					step( `Start a new post`, async function () {
+						const loginFlow = new LoginFlow( driver, 'gutenbergUpgradeEdgeUser' );
 
-					// No need to log in again as the edge site is owned by the same user.
-					editor = await startNewPost( loginFlow );
+						// No need to log in again as the edge site is owned by the same user.
+						editor = await startNewPost( loginFlow );
+					} );
+
+					step( 'Load the block via markup copied from the non-edge site', async function () {
+						await editor.setBlocksCode( currentGutenbergBlocksCode );
+					} );
+
+					verifyBlockInEditor( Block );
+
+					verifyBlockInPublishedPage( Block );
 				} );
-
-				step( 'Load the block via markup copied from the non-edge site', async function () {
-					await editor.setBlocksCode( currentGutenbergBlocksCode );
-				} );
-
-				verifyBlockInEditor( Block );
-
-				verifyBlockInPublishedPage( Block );
 			} );
 		} );
 	} );


### PR DESCRIPTION
This edge testing part should be nested because we don't want to run it unless the non-edge one passes. The main profit here is reduced running time, because when the non-edge upgrade suite part fails it will immediately bail instead of moving to the edge section and failing again. Also, less error noise I guess :)  