### PR TITLE
Add instrumentation for all menu clicks in the Titan nav menu

### DIFF
--- a/client/my-sites/email/email-management/titan-management-nav/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-nav/index.jsx
@@ -22,6 +22,7 @@ import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import Gridicon from 'calypso/components/gridicon';
 import { isEnabled } from '@automattic/calypso-config';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import titanCalendarIcon from 'calypso/assets/images/email-providers/titan/services/calendar.svg';
 import titanContactsIcon from 'calypso/assets/images/email-providers/titan/services/contacts.svg';
 import titanMailIcon from 'calypso/assets/images/email-providers/titan/services/mail.svg';
@@ -60,6 +61,9 @@ class TitanManagementNav extends React.Component {
 			return (
 				<VerticalNavItem
 					path={ emailManagementManageTitanAccount( selectedSiteSlug, domain.name, currentRoute ) }
+					onClick={ () => {
+						this.recordNavItemClick( 'control_panel' );
+					} }
 				>
 					{ linkTitle }
 				</VerticalNavItem>
@@ -74,6 +78,9 @@ class TitanManagementNav extends React.Component {
 					currentRoute
 				) }
 				external={ true }
+				onClick={ () => {
+					this.recordNavItemClick( 'control_panel' );
+				} }
 			>
 				{ linkTitle }
 			</VerticalNavItem>
@@ -93,6 +100,9 @@ class TitanManagementNav extends React.Component {
 					selectedSiteSlug,
 					domain.titanMailSubscription.subscriptionId
 				) }
+				onClick={ () => {
+					this.recordNavItemClick( 'manage_purchase' );
+				} }
 			>
 				{ translate( 'Update your billing and payment settings' ) }
 			</VerticalNavItem>
@@ -143,6 +153,9 @@ class TitanManagementNav extends React.Component {
 					compact
 					href={ controlPanelUrl }
 					target={ showExternalControlPanelLink ? '_blank' : null }
+					onClick={ () => {
+						this.recordNavItemClick( 'set_up_mailbox' );
+					} }
 				>
 					{ translate( 'Finish Setup' ) }
 					{ showExternalControlPanelLink && <Gridicon icon="external" size={ 16 } /> }
@@ -150,6 +163,15 @@ class TitanManagementNav extends React.Component {
 				{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
 			</CompactCard>
 		);
+	};
+
+	recordNavItemClick = ( clickedItem ) => {
+		const { domain } = this.props;
+
+		recordTracksEvent( 'calypso_email_management_titan_nav_item_click', {
+			clicked_item: clickedItem,
+			domain: domain.name,
+		} );
 	};
 
 	render() {
@@ -175,6 +197,9 @@ class TitanManagementNav extends React.Component {
 				primary
 				compact
 				href={ emailManagementNewTitanAccount( selectedSiteSlug, domain.name, currentRoute ) }
+				onClick={ () => {
+					this.recordNavItemClick( 'add_mailboxes' );
+				} }
 			>
 				{ translate( 'Add New Mailboxes' ) }
 			</Button>
@@ -190,7 +215,14 @@ class TitanManagementNav extends React.Component {
 				>
 					<ul className="titan-management-nav__foldable-card-services">
 						<li>
-							<a href="https://wp.titan.email/mail/" target="_blank" rel="noreferrer noopener">
+							<a
+								href="https://wp.titan.email/mail/"
+								target="_blank"
+								rel="noreferrer noopener"
+								onClick={ () => {
+									this.recordNavItemClick( 'webmail' );
+								} }
+							>
 								<img src={ titanMailIcon } alt={ translate( 'Titan Mail icon' ) } />
 								<strong>
 									{ translate( 'Mail', {
@@ -200,7 +232,14 @@ class TitanManagementNav extends React.Component {
 							</a>
 						</li>
 						<li>
-							<a href="https://wp.titan.email/calendar/" target="_blank" rel="noreferrer noopener">
+							<a
+								href="https://wp.titan.email/calendar/"
+								target="_blank"
+								rel="noreferrer noopener"
+								onClick={ () => {
+									this.recordNavItemClick( 'calendar' );
+								} }
+							>
 								<img src={ titanCalendarIcon } alt={ translate( 'Titan Calendar icon' ) } />
 								<strong>
 									{ translate( 'Calendar', {
@@ -210,7 +249,14 @@ class TitanManagementNav extends React.Component {
 							</a>
 						</li>
 						<li>
-							<a href="https://wp.titan.email/contacts/" target="_blank" rel="noreferrer noopener">
+							<a
+								href="https://wp.titan.email/contacts/"
+								target="_blank"
+								rel="noreferrer noopener"
+								onClick={ () => {
+									this.recordNavItemClick( 'contacts' );
+								} }
+							>
 								<img src={ titanContactsIcon } alt={ translate( 'Titan Contacts icon' ) } />
 								<strong>
 									{ translate( 'Contacts', {

--- a/client/my-sites/email/email-management/titan-management-nav/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-nav/index.jsx
@@ -212,6 +212,9 @@ class TitanManagementNav extends React.Component {
 					header={ header }
 					summary={ summary }
 					expandedSummary={ summary }
+					onOpen={ () => {
+						this.recordNavItemClick( 'quick_links_show' );
+					} }
 				>
 					<ul className="titan-management-nav__foldable-card-services">
 						<li>

--- a/client/my-sites/email/email-management/titan-management-nav/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-nav/index.jsx
@@ -154,7 +154,9 @@ class TitanManagementNav extends React.Component {
 					href={ controlPanelUrl }
 					target={ showExternalControlPanelLink ? '_blank' : null }
 					onClick={ () => {
-						this.recordNavItemClick( 'set_up_mailbox' );
+						recordTracksEvent( 'calypso_email_management_titan_nav_finish_setup_click', {
+							domain: domain.name,
+						} );
 					} }
 				>
 					{ translate( 'Finish Setup' ) }
@@ -198,7 +200,9 @@ class TitanManagementNav extends React.Component {
 				compact
 				href={ emailManagementNewTitanAccount( selectedSiteSlug, domain.name, currentRoute ) }
 				onClick={ () => {
-					this.recordNavItemClick( 'add_mailboxes' );
+					recordTracksEvent( 'calypso_email_management_titan_nav_add_mailbox_click', {
+						domain: domain.name,
+					} );
 				} }
 			>
 				{ translate( 'Add New Mailboxes' ) }

--- a/client/my-sites/email/email-management/titan-management-nav/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-nav/index.jsx
@@ -56,14 +56,13 @@ class TitanManagementNav extends React.Component {
 		const { currentRoute, domain, selectedSiteSlug, translate } = this.props;
 
 		const linkTitle = translate( 'Manage your email settings and accounts' );
+		const controlPanelClickHandler = this.getNavItemClickHandler( 'control_panel' );
 
 		if ( isEnabled( 'titan/iframe-control-panel' ) ) {
 			return (
 				<VerticalNavItem
 					path={ emailManagementManageTitanAccount( selectedSiteSlug, domain.name, currentRoute ) }
-					onClick={ () => {
-						this.recordNavItemClick( 'control_panel' );
-					} }
+					onClick={ controlPanelClickHandler }
 				>
 					{ linkTitle }
 				</VerticalNavItem>
@@ -78,9 +77,7 @@ class TitanManagementNav extends React.Component {
 					currentRoute
 				) }
 				external={ true }
-				onClick={ () => {
-					this.recordNavItemClick( 'control_panel' );
-				} }
+				onClick={ controlPanelClickHandler }
 			>
 				{ linkTitle }
 			</VerticalNavItem>
@@ -100,9 +97,7 @@ class TitanManagementNav extends React.Component {
 					selectedSiteSlug,
 					domain.titanMailSubscription.subscriptionId
 				) }
-				onClick={ () => {
-					this.recordNavItemClick( 'manage_purchase' );
-				} }
+				onClick={ this.getNavItemClickHandler( 'manage_purchase' ) }
 			>
 				{ translate( 'Update your billing and payment settings' ) }
 			</VerticalNavItem>
@@ -167,7 +162,7 @@ class TitanManagementNav extends React.Component {
 		);
 	};
 
-	recordNavItemClick = ( clickedItem ) => {
+	getNavItemClickHandler = ( clickedItem ) => () => {
 		const { domain } = this.props;
 
 		recordTracksEvent( 'calypso_email_management_titan_nav_item_click', {
@@ -216,9 +211,7 @@ class TitanManagementNav extends React.Component {
 					header={ header }
 					summary={ summary }
 					expandedSummary={ summary }
-					onOpen={ () => {
-						this.recordNavItemClick( 'quick_links_show' );
-					} }
+					onOpen={ this.getNavItemClickHandler( 'quick_links_show' ) }
 				>
 					<ul className="titan-management-nav__foldable-card-services">
 						<li>
@@ -226,9 +219,7 @@ class TitanManagementNav extends React.Component {
 								href="https://wp.titan.email/mail/"
 								target="_blank"
 								rel="noreferrer noopener"
-								onClick={ () => {
-									this.recordNavItemClick( 'webmail' );
-								} }
+								onClick={ this.getNavItemClickHandler( 'webmail' ) }
 							>
 								<img src={ titanMailIcon } alt={ translate( 'Titan Mail icon' ) } />
 								<strong>
@@ -243,9 +234,7 @@ class TitanManagementNav extends React.Component {
 								href="https://wp.titan.email/calendar/"
 								target="_blank"
 								rel="noreferrer noopener"
-								onClick={ () => {
-									this.recordNavItemClick( 'calendar' );
-								} }
+								onClick={ this.getNavItemClickHandler( 'calendar' ) }
 							>
 								<img src={ titanCalendarIcon } alt={ translate( 'Titan Calendar icon' ) } />
 								<strong>
@@ -260,9 +249,7 @@ class TitanManagementNav extends React.Component {
 								href="https://wp.titan.email/contacts/"
 								target="_blank"
 								rel="noreferrer noopener"
-								onClick={ () => {
-									this.recordNavItemClick( 'contacts' );
-								} }
+								onClick={ this.getNavItemClickHandler( 'contacts' ) }
 							>
 								<img src={ titanContactsIcon } alt={ translate( 'Titan Contacts icon' ) } />
 								<strong>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In PR #50527, one of the pieces of feedback during the review was that the new "Finish Setup" button didn't have tracking. I forgot to do that before merging, so queued up a separate task to handle that. When I looked more closely, I realised that we don't have _any_ tracking for clicks on this page.
* This PR adds click tracking for all the options on the Titan nav menu
* When the user clicks on the "Add New Mailboxes" CTA, we log a new `calypso_email_management_titan_nav_add_mailbox_click` event with a `domain` property.
* When the user clicks on the "Finish Setup" prompt/button to configure mailboxes, we should log a new `calypso_email_management_titan_nav_finish_setup_click` event with a `domain` property.
* All of the clicks in the nav menu (except for the two called out above) should record a Tracks event called `calypso_email_management_titan_nav_item_click` with props of `domain` and `clicked_item`, where `clicked_item` can be one of:
   - `calendar` - the user clicked on the Calendar link in the foldable quick links section
   - `contacts` - the user clicked on the Contacts link in the foldable quick links section
   - `control_panel` - the user clicked on the link to open the control panel (we log the same data for both the iframed and external links here)
   - `manage_purchase` - the user clicked on the link to manage their purchase/subscription
   - `quick_links_show` - the user expanded the foldable quick links section
   - `webmail` - the user clicked on the Mail link in the foldable quick links section

#### Testing instructions

For a domain that has Email configured, open the screen at `/email/[your.domain]/manage/[your.site]` (which you can also reach via Upgrades -> Domains -> [your.domain] -> Manage your email accounts).
Open your network tab, and ensure that it's configured to keep entries after you navigate (this is called "Preserve log" on Chrome). 
Click on all of the following items in the screen and confirm that you see a request to `t.gif` with the `_en` URL parameter set to `calypso_email_management_titan_nav_item_click`, the `domain` parameter set correctly, and the `clicked_item` parameter set to the correct value for each of the following actions:
* Clicking on the expand chevron to show/expand the quick links section
* Clicking on the Mail item in the quick links section
* Clicking on the Calendar item in the quick links section
* Clicking on the Contacts item in the quick links section
* Clicking on the "Manage your email settings and accounts" menu item
* Clicking on the  "Update your billing and payment settings" menu item

You also need to verify that clicking on the following two items generate the correct events:
1. Click on the "Add New Mailboxes" button - you should see a `calypso_email_management_titan_nav_add_mailbox_click` event triggered with the `domain` specified.
2. Click on the "Finish Setup" button - you should see a `calypso_email_management_titan_nav_finish_setup_click` event with the `domain` specified. (Note that this button should only appear if you have one or more unused mailboxes.)

Related to #50527