### PR TITLE
ABTest: Add social proof header to Jetpack pricing pages

### DIFF
--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -11,6 +11,7 @@ import JetpackComMasterbar from '../jpcom-masterbar';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { preventWidows } from 'calypso/lib/formatting';
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
+import useMaybeSocialProofHeader from 'calypso/my-sites/plans/jetpack-plans/use-maybe-social-proof-header';
 
 /**
  * Style dependencies
@@ -20,6 +21,10 @@ import './style.scss';
 const Header: React.FC< Props > = () => {
 	const translate = useTranslate();
 
+	const headerText =
+		useMaybeSocialProofHeader() ??
+		translate( 'Security, performance, and marketing tools made for WordPress' );
+
 	return (
 		<>
 			<JetpackComMasterbar />
@@ -27,9 +32,7 @@ const Header: React.FC< Props > = () => {
 			<div className="header">
 				<FormattedHeader
 					className="header__main-title"
-					headerText={ preventWidows(
-						translate( 'Security, performance, and marketing tools made for WordPress' )
-					) }
+					headerText={ preventWidows( headerText ) }
 					align="center"
 				/>
 			</div>

--- a/client/jetpack-connect/store-header.tsx
+++ b/client/jetpack-connect/store-header.tsx
@@ -15,6 +15,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-from-query';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
+import useMaybeSocialProofHeader from 'calypso/my-sites/plans/jetpack-plans/use-maybe-social-proof-header';
 
 import './style.scss';
 
@@ -30,6 +31,8 @@ export default function StoreHeader(): React.ReactElement {
 		'add-bottom-margin': ! isStoreLanding,
 	} );
 
+	const headerText = useMaybeSocialProofHeader() ?? translate( 'Explore our Jetpack plans' );
+
 	return (
 		<>
 			<DocumentHead title={ translate( 'Jetpack Connect' ) } />
@@ -43,7 +46,7 @@ export default function StoreHeader(): React.ReactElement {
 			</div>
 			{ isStoreLanding && (
 				<FormattedHeader
-					headerText={ translate( 'Explore our Jetpack plans' ) }
+					headerText={ headerText }
 					subHeaderText={ translate( 'Pick a plan that fits your needs.' ) }
 					brandFont
 				/>

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -60,7 +60,7 @@ export default {
 		allowExistingUsers: false,
 	},
 	jetpackSocialProofHeader: {
-		datestamp: '20210309',
+		datestamp: '20210310',
 		variations: {
 			withoutSocialProof_control: 50,
 			withSocialProof_test: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -59,4 +59,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: false,
 	},
+	jetpackSocialProofHeader: {
+		datestamp: '20210309',
+		variations: {
+			withoutSocialProof_control: 50,
+			withSocialProof_test: 50,
+		},
+		defaultVariation: 'withoutSocialProof_control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/plans/jetpack-plans/iterations.ts
+++ b/client/my-sites/plans/jetpack-plans/iterations.ts
@@ -1,13 +1,16 @@
 /**
  * Internal dependencies
  */
+import { abtest } from 'calypso/lib/abtest';
 import { getUrlParts } from 'calypso/lib/url/url-parts';
 
 /**
  * Iterations
  */
 
-export enum Iterations {}
+export enum Iterations {
+	SPROOF = 'jetpackSocialProofHeader',
+}
 
 const iterationNames: string[] = Object.values( Iterations );
 
@@ -38,8 +41,8 @@ const getCurrentCROIterationName = (): Iterations | null => {
 		}
 	}
 
-	// There are no active iterations right now
-	return null;
+	const showSocialProofHeader = abtest( 'jetpackSocialProofHeader' ) === 'withSocialProof_test';
+	return showSocialProofHeader ? Iterations.SPROOF : null;
 };
 
 type IterationValueFunction< T > = ( key: Iterations | null ) => T | undefined;

--- a/client/my-sites/plans/jetpack-plans/plans-header.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-header.tsx
@@ -18,32 +18,39 @@ import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
 import { PLAN_JETPACK_FREE } from 'calypso/lib/plans/constants';
 import { JETPACK_PRODUCTS_LIST } from 'calypso/lib/products-values/constants';
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
+import useMaybeSocialProofHeader from 'calypso/my-sites/plans/jetpack-plans/use-maybe-social-proof-header';
 
-const StandardPlansHeader = () => (
-	<>
-		<FormattedHeader headerText={ translate( 'Plans' ) } align="left" brandFont />
-		<PlansNavigation path={ '/plans' } />
-		<h2 className="jetpack-plans__pricing-header">
-			{ preventWidows(
-				translate( 'Security, performance, and marketing tools made for WordPress' )
-			) }
-		</h2>
-	</>
-);
+const StandardPlansHeader = () => {
+	const headerText =
+		useMaybeSocialProofHeader() ??
+		translate( 'Security, performance, and marketing tools made for WordPress' );
 
-const ConnectFlowPlansHeader = () => (
-	<>
-		<div className="jetpack-plans__heading">
-			<FormattedHeader
-				headerText={ translate( 'Explore our Jetpack plans' ) }
-				subHeaderText={ translate( "Now that you're set up, pick a plan that fits your needs." ) }
-				align="left"
-				brandFont
-			/>
-		</div>
-		<PlansNavigation path={ '/plans' } />
-	</>
-);
+	return (
+		<>
+			<FormattedHeader headerText={ translate( 'Plans' ) } align="left" brandFont />
+			<PlansNavigation path={ '/plans' } />
+			<h2 className="jetpack-plans__pricing-header">{ preventWidows( headerText ) }</h2>
+		</>
+	);
+};
+
+const ConnectFlowPlansHeader = () => {
+	const headerText = useMaybeSocialProofHeader() ?? translate( 'Explore our Jetpack plans' );
+
+	return (
+		<>
+			<div className="jetpack-plans__heading">
+				<FormattedHeader
+					headerText={ headerText }
+					subHeaderText={ translate( "Now that you're set up, pick a plan that fits your needs." ) }
+					align="left"
+					brandFont
+				/>
+			</div>
+			<PlansNavigation path={ '/plans' } />
+		</>
+	);
+};
 
 const PlansHeader = ( { context }: { context: PageJS.Context } ) => {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );

--- a/client/my-sites/plans/jetpack-plans/plans-header.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-header.tsx
@@ -23,7 +23,7 @@ import useMaybeSocialProofHeader from 'calypso/my-sites/plans/jetpack-plans/use-
 const StandardPlansHeader = () => {
 	const headerText =
 		useMaybeSocialProofHeader() ??
-		translate( 'Security, performance, and marketing tools made for WordPress' );
+		translate( 'Security, performance, and marketing tools made for WordPress' );
 
 	return (
 		<>

--- a/client/my-sites/plans/jetpack-plans/use-maybe-social-proof-header.ts
+++ b/client/my-sites/plans/jetpack-plans/use-maybe-social-proof-header.ts
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+import { useTranslate, numberFormat, TranslateResult } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getForCurrentCROIteration, Iterations } from './iterations';
+
+/**
+ * If the 'jetpackSocialProofHeader' test is active,
+ * and the user is part of the 'withSocialProof_test' variation,
+ * return translated text for a header that uses social proof;
+ * otherwise, return undefined.
+ */
+const useMaybeSocialProofHeader = (): TranslateResult | undefined => {
+	const translate = useTranslate();
+
+	return useMemo( () => {
+		return getForCurrentCROIteration( {
+			[ Iterations.SPROOF ]: translate(
+				'More than %(count)s websites trust Jetpack to protect their site',
+				{ args: { count: numberFormat( 3_119_881, 0 ) } }
+			),
+		} );
+	}, [ translate ] );
+};
+
+export default useMaybeSocialProofHeader;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Relates to `1196108640073826-as-1199946500089747`.

* Establish and launch a new A/B test called `jetpackSocialProofHeader`.
* On Jetpack product pricing pages, when the current user is assigned to the `withSocialProof_test` variation, replace the header above the product grid with a different one as follows (translated per locale):
  * "More than 3,119,881 websites trust Jetpack to protect their site"

#### Testing instructions

##### Checking existence of the test

* In Calypso Blue, open the A/B test helper in the lower-right corner of the page and select **ABTESTS**.
* Verify that `jetpackSocialProofHeader` appears in the list of active tests, with the variations `withoutSocialProof_control` and `withSocialProof_test`.

<img width="227" alt="image" src="https://user-images.githubusercontent.com/670067/110540204-cecad000-80eb-11eb-8f6c-c084ed83bc35.png">

##### Checking test behavior (control group)

* In the A/B test helper described in the section above, select the `withoutSocialProof_control` variation.
* Paying specific attention to Plans and Pricing pages in all experiences, verify that nothing is changed and everything looks and behaves as it does in production.

<img height="200" alt="image" src="https://user-images.githubusercontent.com/670067/110540775-852eb500-80ec-11eb-976d-fd50ef23191d.png"> <img height="200" alt="image" src="https://user-images.githubusercontent.com/670067/110541001-c8892380-80ec-11eb-99ba-15d6f074e4d8.png"> <img height="200" alt="image" src="https://user-images.githubusercontent.com/670067/110540856-9bd50c00-80ec-11eb-983c-ce6ef40937c3.png">

**NOTE:** There's also a possible fourth variation that I'm not sure is reachable anymore. To test this, select a self-hosted Jetpack site with no purchased upgrades (i.e., Jetpack Free only), then load /plans/<site>?source=jetpack-connect-plans. The only major difference in this variation should be the following part of the page, which replaces the "normal" page header for Calypso Blue:

<img width="891" alt="image" src="https://user-images.githubusercontent.com/670067/110636367-c917cd80-8171-11eb-81d4-651766c89782.png">

##### Checking test behavior (test group)

* Load the appropriate Plans/Pricing page in Calypso Blue, Calypso Green, and/or Jetpack Connect.
* In the aforementioned A/B test helper, select the `withSocialProof_test` variation.
* Verify that the page header is replaced with the following copy:
  * "More than 3,119,881 websites trust Jetpack to protect their site"
* Verify the following characteristics of the page header:
  * the number should be properly formatted for the current user's locale; and
  * when the text wraps onto multiple lines, each line contains at least two words (i.e., no "widows").

<img height="200" alt="image" src="https://user-images.githubusercontent.com/670067/110540632-5adcf780-80ec-11eb-9eee-bbe00b3d4aa6.png"> <img height="200" alt="image" src="https://user-images.githubusercontent.com/670067/110540426-194c4c80-80ec-11eb-8229-ae6acf3db3c2.png"> <img height="200" alt="image" src="https://user-images.githubusercontent.com/670067/110540533-397c0b80-80ec-11eb-8d79-3bf8f54ac7b7.png">

**NOTE:** There's also a possible fourth variation that I'm not sure is reachable anymore. To test this, select a self-hosted Jetpack site with no purchased upgrades (i.e., Jetpack Free _only_), then load `/plans/<site>?source=jetpack-connect-plans`. The only major difference in this variation should be the following part of the page, which replaces the "normal" page header for Calypso Blue::

<img height="150" alt="image" src="https://user-images.githubusercontent.com/670067/110636165-91a92100-8171-11eb-807a-88c5df13587c.png">