### PR TITLE
Reader: Use more accurate wording for free domain offer

### DIFF
--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -30,7 +30,7 @@ function renderFreeToPaidPlanNudge( { siteId, siteSlug, translate }, dispatch ) 
 			callToAction={ translate( 'Upgrade' ) }
 			compact
 			href={ '/plans/' + siteSlug }
-			title={ translate( 'Free domain with a plan' ) }
+			title={ translate( 'Free domain with annual plan' ) }
 			onClick={ () => dispatch( clickUpgradeNudge( siteId ) ) }
 			tracksClickName={ 'calypso_upgrade_nudge_cta_click' }
 			tracksImpressionName={ 'calypso_upgrade_nudge_impression' }

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -30,7 +30,7 @@ function renderFreeToPaidPlanNudge( { siteId, siteSlug, translate }, dispatch ) 
 			callToAction={ translate( 'Upgrade' ) }
 			compact
 			href={ '/plans/' + siteSlug }
-			title={ translate( 'Free domain with annual plan' ) }
+			title={ translate( 'Free domain with an annual plan' ) }
 			onClick={ () => dispatch( clickUpgradeNudge( siteId ) ) }
 			tracksClickName={ 'calypso_upgrade_nudge_cta_click' }
 			tracksImpressionName={ 'calypso_upgrade_nudge_impression' }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR replaces the confusing wording "Free domain with a plan" with "Free domain with annual plan" because we don't offer free domain for monthly plans.

Reported in p7DVsv-anF-p2#comment-34653

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You should be a new user who owns _only one_ WordPress.com free site. (not Jetpack or domain-only site)
* Go to `/read` page.
* Make sure the upsell nudge in the sidebar says `Free domain with an annual plan` instead of `Free domain with a plan`.

<img width="286" alt="Following_‹_Reader_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/110638550-0b80ef00-81f2-11eb-9ea1-1fa8fc808a71.png">

For those who review this PR, please take a look at the backend counterpart(D58440-code) too if you have time. 🙏