### PR TITLE
Adding Universal Nav slide to ETK Whats New

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
@@ -62,11 +62,11 @@ function getWhatsNewPages() {
 	return [
 		{
 			imgSrc: universalNavImage,
-			heading: __( 'Navigate easier than ever', 'full-site-editing' ),
+			heading: __( 'Easier navigation', 'full-site-editing' ),
 			description: createInterpolateElement(
 				/* translators: the embed is a link */
 				__(
-					'<p>This month all WordPress.com accounts will receive sidebar and menu updates, making it easier than ever to manage your site from the left sidebar.</p><p><Link>Learn more</Link></p>',
+					'<p>This month all WordPress.com accounts will receive sidebar and menu updates, making it easier to manage your site from the left sidebar.</p><p><Link>Learn more</Link></p>',
 					'full-site-editing'
 				),
 				{

--- a/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
@@ -15,7 +15,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import './style.scss';
-const blockPatternsImage = 'https://s0.wp.com/i/whats-new/block-patterns.png';
+const universalNavImage = 'https://s0.wp.com/i/whats-new/universal-nav.png';
 const dragDropImage = 'https://s0.wp.com/i/whats-new/drag-drop.png';
 const singlePageSiteImage = 'https://s0.wp.com/i/whats-new/single-page-website.png';
 const anchorFmImage = 'https://s0.wp.com/i/whats-new/convert-to-audio.jpg';
@@ -61,18 +61,18 @@ function WhatsNewMenuItem() {
 function getWhatsNewPages() {
 	return [
 		{
-			imgSrc: blockPatternsImage,
-			heading: __( 'New block patterns', 'full-site-editing' ),
+			imgSrc: universalNavImage,
+			heading: __( 'Navigate easier than ever', 'full-site-editing' ),
 			description: createInterpolateElement(
 				/* translators: the embed is a link */
 				__(
-					'<p>Choose from hundreds of pre-made patterns for buttons, headers, galleries, and more available via the + button at the top of all pages.</p><p><Link>Learn more</Link></p>',
+					'<p>This month all WordPress.com accounts will receive sidebar and menu updates, making it easier than ever to manage your site from the left sidebar.</p><p><Link>Learn more</Link></p>',
 					'full-site-editing'
 				),
 				{
 					Link: (
 						<a
-							href="https://wordpress.com/support/block-pattern/"
+							href="https://wordpress.com/support/account-settings/#dashboard-appearance"
 							target="_blank"
 							rel="noreferrer"
 						/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a new slide highlighting the Universal nav rollout
* Context in pbAPfg-1ry-p2

Screenshot of the new slide:
<img width="740" alt="Screen Shot 2021-03-10 at 11 44 04 AM" src="https://user-images.githubusercontent.com/35781181/110665011-f4acaf00-8195-11eb-9965-e575b338e54b.png">


#### Testing instructions
* Checkout this PR and run `yarn install`.
* sandbox a test site (update `/etc/hosts` to point the domain for one of your test Simple sites to your sandbox; for example, this entry for one of my sites `192.0.93.101	dsfdsf3.wordpress.com`.
* Install Composer (run `composer install` from Calypso root.
* Sync ETK to your sandbox ( cd into `CALYPSOROOT/apps/editing-toolkit` and run `yarn && yarn dev --sync` from the ETK root)
* `yarn start` Calypso
* Navigate to your sandboxed test site
* Go to the Gutenberg editor and launch the What's New modal from the sidebar nav. (`http://calypso.localhost:3000/post/SITESLUG`)
* The What's New modal is accessed via the small hamburger icon next to the Jetpack logo. Scroll down to the `Tools` section of the menu and click `What's New`
* Click through the slides and confirm that they work as expected.