### PR TITLE
Disable the IE11 canary configuration on CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1091,13 +1091,13 @@ workflows:
       #          requires:
       #            - wait-calypso-live
       #          test-flags: '-C -S $CIRCLE_SHA1'
-      - test-e2e-canary:
-          name: test-e2e-canary-ie
-          requires:
-            - wait-calypso-live
-          test-flags: '-z -S $CIRCLE_SHA1'
-          test-target: 'IE11'
-          slack-webhook: '$SLACK_IE'
+      # - test-e2e-canary:
+      #     name: test-e2e-canary-ie
+      #     requires:
+      #       - wait-calypso-live
+      #     test-flags: '-z -S $CIRCLE_SHA1'
+      #     test-target: 'IE11'
+      #     slack-webhook: '$SLACK_IE'
       - test-e2e-canary:
           name: test-e2e-canary-safari
           requires:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* comment out the CircleCI configuration for IE11 canary.

We have taken this step as IE11 canary is permafailing and as discussed in p9oQ9f-rp-p2#comment-766, it is acceptable to discontinue IE11 testing support immediately.

#### Testing instructions
