### PR TITLE
Checkout: Convert WPCheckout to TypeScript

### DIFF
--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -6,20 +6,20 @@ import { addLocaleToPath, localizeUrl } from 'calypso/lib/i18n-utils';
 import config, { isEnabled } from '@automattic/calypso-config';
 
 export function login( {
-	isJetpack,
-	isGutenboarding,
-	isNative,
-	locale,
-	redirectTo,
-	twoFactorAuthType,
-	socialConnect,
-	emailAddress,
-	socialService,
-	oauth2ClientId,
-	wccomFrom,
-	site,
-	useMagicLink,
-	from,
+	isJetpack = undefined,
+	isGutenboarding = undefined,
+	isNative = undefined,
+	locale = undefined,
+	redirectTo = undefined,
+	twoFactorAuthType = undefined,
+	socialConnect = undefined,
+	emailAddress = undefined,
+	socialService = undefined,
+	oauth2ClientId = undefined,
+	wccomFrom = undefined,
+	site = undefined,
+	useMagicLink = undefined,
+	from = undefined,
 } = {} ) {
 	let url = config( 'login_url' );
 

--- a/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
+++ b/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
@@ -5,6 +5,7 @@ import React, { FunctionComponent, useMemo, useCallback, useState } from 'react'
 import { useSelector, useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import styled from '@emotion/styled';
+import type { RequestCartProduct } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -55,7 +56,7 @@ interface SelectedSite {
 
 interface Props {
 	cart: MockResponseCart;
-	addItemToCart: ( product: object ) => void;
+	addItemToCart: ( product: RequestCartProduct ) => void;
 }
 
 const UpcomingRenewalsReminder: FunctionComponent< Props > = ( { cart, addItemToCart } ) => {

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
@@ -69,7 +69,7 @@ const CheckoutTermsWrapper = styled.div`
 export default function PaymentMethodStep( {
 	activeStepContent,
 }: {
-	activeStepContent: JSX.Element;
+	activeStepContent: React.ReactNode;
 } ): JSX.Element {
 	const { responseCart } = useShoppingCart();
 	const taxLineItem = getTaxLineItem( responseCart );

--- a/client/my-sites/checkout/composite-checkout/components/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/secondary-cart-promotions.tsx
@@ -4,7 +4,7 @@
 import React, { FunctionComponent, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import styled from '@emotion/styled';
-import { ResponseCart } from '@automattic/shopping-cart';
+import type { ResponseCart, RequestCartProduct } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -17,7 +17,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 type PartialCart = Pick< ResponseCart, 'products' >;
 interface Props {
 	responseCart: PartialCart;
-	addItemToCart: () => void;
+	addItemToCart: ( item: RequestCartProduct ) => void;
 }
 
 export interface MockResponseCart extends PartialCart {

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -3,15 +3,10 @@
  */
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import styled from '@emotion/styled';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import type {
-	RemoveProductFromCart,
-	RemoveCouponFromCart,
-	CouponStatus,
-} from '@automattic/shopping-cart';
+import type { RemoveProductFromCart, CouponStatus } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -20,6 +15,7 @@ import joinClasses from './join-classes';
 import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
 import { isDomainRegistration, isDomainTransfer } from 'calypso/lib/products-values';
+import styled from '../lib/styled';
 import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
 import type { GetProductVariants } from '../hooks/product-variants';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -70,8 +66,6 @@ const CouponEnableButton = styled.button`
 export default function WPCheckoutOrderReview( {
 	className,
 	removeProductFromCart,
-	removeCoupon,
-	couponStatus,
 	couponFieldStateProps,
 	getItemVariants,
 	onChangePlanLength,
@@ -80,19 +74,17 @@ export default function WPCheckoutOrderReview( {
 	createUserAndSiteBeforeTransaction,
 }: {
 	className?: string;
-	removeProductFromCart: RemoveProductFromCart;
-	removeCoupon: RemoveCouponFromCart;
-	couponStatus: CouponStatus;
+	removeProductFromCart?: RemoveProductFromCart;
 	couponFieldStateProps: CouponFieldStateProps;
-	getItemVariants: GetProductVariants;
-	onChangePlanLength: OnChangeItemVariant;
+	getItemVariants?: GetProductVariants;
+	onChangePlanLength?: OnChangeItemVariant;
 	siteUrl?: string;
 	isSummary?: boolean;
 	createUserAndSiteBeforeTransaction?: boolean;
 } ): JSX.Element {
 	const translate = useTranslate();
 	const [ isCouponFieldVisible, setCouponFieldVisible ] = useState( false );
-	const { responseCart } = useShoppingCart();
+	const { responseCart, removeCoupon, couponStatus } = useShoppingCart();
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
 
 	const firstDomainItem = responseCart.products.find(
@@ -139,11 +131,9 @@ WPCheckoutOrderReview.propTypes = {
 	isSummary: PropTypes.bool,
 	className: PropTypes.string,
 	removeProductFromCart: PropTypes.func,
-	removeCoupon: PropTypes.func,
 	getItemVariants: PropTypes.func,
 	onChangePlanLength: PropTypes.func,
 	siteUrl: PropTypes.string,
-	couponStatus: PropTypes.string,
 	couponFieldStateProps: PropTypes.object.isRequired,
 };
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -344,6 +344,10 @@ export default function WPCheckout( {
 		[ onEvent ]
 	);
 
+	const validatingButtonText = isCartPendingUpdate
+		? String( translate( 'Updating cart…' ) )
+		: String( translate( 'Please wait…' ) );
+
 	return (
 		<Checkout>
 			<QueryExperiments />
@@ -411,12 +415,8 @@ export default function WPCheckout( {
 					editButtonAriaLabel={ String( translate( 'Edit your order' ) ) }
 					nextStepButtonText={ String( translate( 'Save order' ) ) }
 					nextStepButtonAriaLabel={ String( translate( 'Save your order' ) ) }
-					validatingButtonText={ String(
-						isCartPendingUpdate ? translate( 'Updating cart…' ) : translate( 'Please wait…' )
-					) }
-					validatingButtonAriaLabel={ String(
-						isCartPendingUpdate ? translate( 'Updating cart…' ) : translate( 'Please wait…' )
-					) }
+					validatingButtonText={ validatingButtonText }
+					validatingButtonAriaLabel={ validatingButtonText }
 					formStatus={ formStatus }
 				/>
 				<CheckoutSteps areStepsActive={ ! isOrderReviewActive }>
@@ -455,12 +455,8 @@ export default function WPCheckout( {
 							nextStepButtonAriaLabel={ String(
 								translate( 'Continue with the entered contact details' )
 							) }
-							validatingButtonText={ String(
-								isCartPendingUpdate ? translate( 'Updating cart…' ) : translate( 'Please wait…' )
-							) }
-							validatingButtonAriaLabel={ String(
-								isCartPendingUpdate ? translate( 'Updating cart…' ) : translate( 'Please wait…' )
-							) }
+							validatingButtonText={ validatingButtonText }
+							validatingButtonAriaLabel={ validatingButtonText }
 						/>
 					) }
 					<CheckoutStep
@@ -476,12 +472,8 @@ export default function WPCheckout( {
 						nextStepButtonAriaLabel={ String(
 							translate( 'Continue with the selected payment method' )
 						) }
-						validatingButtonText={ String(
-							isCartPendingUpdate ? translate( 'Updating cart…' ) : translate( 'Please wait…' )
-						) }
-						validatingButtonAriaLabel={ String(
-							isCartPendingUpdate ? translate( 'Updating cart…' ) : translate( 'Please wait…' )
-						) }
+						validatingButtonText={ validatingButtonText }
+						validatingButtonAriaLabel={ validatingButtonText }
 						isCompleteCallback={ () => false }
 					/>
 				</CheckoutSteps>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -31,7 +31,6 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import { updateContactDetailsCache } from 'calypso/state/domains/management/actions';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import { StateSelect } from 'calypso/my-sites/domains/components/form';
 import { getPlan } from 'calypso/lib/plans';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { errorNotice, infoNotice, successNotice } from 'calypso/state/notices/actions';
@@ -213,7 +212,6 @@ export default function CompositeCheckout( {
 	const {
 		couponStatus,
 		applyCoupon,
-		removeCoupon,
 		updateLocation,
 		replaceProductInCart,
 		isLoading: isLoadingCart,
@@ -660,21 +658,14 @@ export default function CompositeCheckout( {
 			>
 				<WPCheckout
 					removeProductFromCart={ removeProductFromCartAndMaybeRedirect }
-					updateLocation={ updateLocation }
-					applyCoupon={ applyCoupon }
-					removeCoupon={ removeCoupon }
-					couponStatus={ couponStatus }
 					changePlanLength={ changePlanLength }
 					siteId={ siteId }
 					siteUrl={ siteSlug }
 					countriesList={ countriesList }
-					StateSelect={ StateSelect }
 					getItemVariants={ getItemVariants }
-					responseCart={ responseCart }
 					addItemToCart={ addItemWithEssentialProperties }
-					isCartPendingUpdate={ isCartPendingUpdate }
 					showErrorMessageBriefly={ showErrorMessageBriefly }
-					isLoggedOutCart={ isLoggedOutCart }
+					isLoggedOutCart={ !! isLoggedOutCart }
 					createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 					infoMessage={ infoMessage }
 				/>

--- a/client/my-sites/checkout/composite-checkout/lib/styled.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/styled.ts
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+import styled, { CreateStyled } from '@emotion/styled';
+import type { Theme } from '@automattic/composite-checkout';
+
+// Use this instead of directly using `styled` from emotion to support
+// TypeScript and the composite-checkout theme
+export default styled as CreateStyled< Theme >;

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -34,5 +34,6 @@ export function getEmptyResponseCart(): ResponseCart {
 		locale: 'en-us',
 		tax: { location: {}, display_taxes: false },
 		is_signup: false,
+		next_domain_is_free: false,
 	};
 }

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -89,6 +89,7 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	messages?: ResponseCartMessages;
 	cart_generated_at_timestamp: number;
 	tax: ResponseCartTaxData;
+	next_domain_is_free: boolean;
 }
 
 export interface ResponseCartTaxData {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Many components in checkout have been converted to TypeScript, but one of the major ones, `WPCheckout`, had not been. Since it lies between the top of checkout (arguably the `CompositeCheckout` component) and most of the interior of checkout, giving it type safety will help many of our other components be type safe as well.

This PR converts the component with as few changes as I was able to make.

#### Testing instructions

This should not cause any changes to behavior. Verify that checkout loads and appears normal.