### PR TITLE
Anchor: Correct the Quick Link bump stats key.

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -257,7 +257,7 @@ const trackAnchorPodcastAction = ( isStaticHomePage ) =>
 		recordTracksEvent( 'calypso_customer_home_my_site_anchor_podcast_click', {
 			is_static_home_page: isStaticHomePage,
 		} ),
-		bumpStat( 'calypso_customer_home', 'my_site_design_logo' )
+		bumpStat( 'calypso_customer_home', 'my_site_anchor_podcast' )
 	);
 
 const addEmailAction = ( siteSlug, isStaticHomePage ) =>


### PR DESCRIPTION
A My Home Quick Link for Anchor was recently added in https://github.com/Automattic/wp-calypso/pull/50733/, but we missed updating the key for the bump stats. This PR corrects that key.

<img width="700" alt="Screen Shot 2021-03-10 at 2 19 46 PM" src="https://user-images.githubusercontent.com/349751/110705805-c2a64780-81ab-11eb-8d20-4e7ddff09dd4.png">


**Testing Instructions**
* On calypso.live or a local dev install, load My Home for a site.
* Click the "Create a podcast with Anchor" Quick Link to the right.
* Load the stat in MC (`/s/calypso_customer_home/`).
* Verify you see some results.