### PR TITLE
[WordAds]: Fix typo in activation error

### DIFF
--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -142,7 +142,7 @@ class AdsWrapper extends Component {
 						classname="ads__activate-notice"
 						status="is-warning"
 						showDismiss={ false }
-						text={ translate( 'Your site cannot participate in WordAds program.' ) }
+						text={ translate( 'Your site cannot participate in the WordAds program.' ) }
 					/>
 				) }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a typo in the WordAds activation error message.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Attempt to activate WordAds on an ineligible site. The error message should read "Your site cannot participate in the WordAds program."

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
