### PR TITLE
Checkout: Inject items directly into payment processor functions

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -89,6 +89,7 @@ import mergeIfObjects from './lib/merge-if-objects';
 import type { ReactStandardAction } from './types/analytics';
 import useCreatePaymentCompleteCallback from './hooks/use-create-payment-complete-callback';
 import useMaybeJetpackIntroCouponCode from './hooks/use-maybe-jetpack-intro-coupon-code';
+import type { PaymentProcessorOptions } from './types/payment-processors';
 
 const { colors } = colorStudio;
 const debug = debugFactory( 'calypso:composite-checkout:composite-checkout' );
@@ -445,7 +446,7 @@ export default function CompositeCheckout( {
 	const includeDomainDetails = contactDetailsType === 'domain';
 	const includeGSuiteDetails = contactDetailsType === 'gsuite';
 	const transactionOptions = { createUserAndSiteBeforeTransaction };
-	const dataForProcessor = useMemo(
+	const dataForProcessor: PaymentProcessorOptions = useMemo(
 		() => ( {
 			includeDomainDetails,
 			includeGSuiteDetails,
@@ -453,6 +454,8 @@ export default function CompositeCheckout( {
 			createUserAndSiteBeforeTransaction,
 			stripeConfiguration,
 			reduxDispatch,
+			items,
+			total,
 		} ),
 		[
 			includeDomainDetails,
@@ -461,6 +464,8 @@ export default function CompositeCheckout( {
 			createUserAndSiteBeforeTransaction,
 			stripeConfiguration,
 			reduxDispatch,
+			items,
+			total,
 		]
 	);
 	const dataForRedirectProcessor = useMemo(

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -36,7 +36,15 @@ const { select } = defaultRegistry;
 export async function genericRedirectProcessor(
 	paymentMethodId,
 	submitData,
-	{ getThankYouUrl, siteSlug, includeDomainDetails, includeGSuiteDetails, reduxDispatch }
+	{
+		getThankYouUrl,
+		siteSlug,
+		includeDomainDetails,
+		includeGSuiteDetails,
+		reduxDispatch,
+		items,
+		total,
+	}
 ) {
 	const { protocol, hostname, port, pathname } = parseUrl(
 		typeof window !== 'undefined' ? window.location.href : 'https://wordpress.com',
@@ -73,6 +81,8 @@ export async function genericRedirectProcessor(
 		paymentMethodId,
 		{
 			...submitData,
+			items,
+			total,
 			successUrl,
 			cancelUrl,
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
@@ -213,7 +213,7 @@ const NetBankingField = styled( Field )`
 
 function NetBankingPayButton( { disabled, onClick, store } ) {
 	const { __ } = useI18n();
-	const [ items, total ] = useLineItems();
+	const [ total ] = useLineItems();
 	const { formStatus } = useFormStatus();
 	const customerName = useSelect( ( select ) => select( 'netbanking' ).getCustomerName() );
 	const fields = useSelect( ( select ) => select( 'netbanking' ).getFields() );
@@ -236,8 +236,6 @@ function NetBankingPayButton( { disabled, onClick, store } ) {
 						...massagedFields,
 						name: customerName?.value,
 						address: massagedFields?.address1,
-						items,
-						total,
 					} );
 				}
 			} }

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
@@ -9,7 +9,6 @@ import { useI18n } from '@automattic/react-i18n';
 import {
 	Button,
 	FormStatus,
-	useLineItems,
 	useFormStatus,
 	registerStore,
 	useSelect,
@@ -17,6 +16,7 @@ import {
 } from '@automattic/composite-checkout';
 import { camelCase } from 'lodash';
 import { useDispatch as useReduxDispatch } from 'react-redux';
+import { useShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -213,7 +213,7 @@ const NetBankingField = styled( Field )`
 
 function NetBankingPayButton( { disabled, onClick, store } ) {
 	const { __ } = useI18n();
-	const [ total ] = useLineItems();
+	const { responseCart } = useShoppingCart();
 	const { formStatus } = useFormStatus();
 	const customerName = useSelect( ( select ) => select( 'netbanking' ).getCustomerName() );
 	const fields = useSelect( ( select ) => select( 'netbanking' ).getFields() );
@@ -243,7 +243,7 @@ function NetBankingPayButton( { disabled, onClick, store } ) {
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
-			<ButtonContents formStatus={ formStatus } total={ total } />
+			<ButtonContents formStatus={ formStatus } total={ responseCart.total_cost_display } />
 		</Button>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
+++ b/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
@@ -3,11 +3,13 @@
  */
 import { useDispatch } from 'react-redux';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
+import type { LineItem } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
  */
 import type { ReactStandardAction } from '../types/analytics';
+import type { WPCOMCartItem } from '../types/checkout-cart';
 
 export interface PaymentProcessorOptions {
 	includeDomainDetails: boolean;
@@ -16,4 +18,6 @@ export interface PaymentProcessorOptions {
 	stripeConfiguration: StripeConfiguration | null;
 	recordEvent: ( action: ReactStandardAction ) => void;
 	reduxDispatch: ReturnType< typeof useDispatch >;
+	items: WPCOMCartItem[];
+	total: LineItem;
 }

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -53,6 +53,7 @@ export type ExistingCardTransactionRequestWithLineItems = Partial< TransactionRe
 			| 'siteId'
 			| 'paymentMethodToken'
 			| 'paymentPartnerProcessorId'
+			| 'paymentMethodType'
 		>
 	>;
 

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -111,7 +111,7 @@ function ExistingCardPayButton( {
 	paymentPartnerProcessorId,
 	activeButtonText = undefined,
 } ) {
-	const [ items, total ] = useLineItems();
+	const [ total ] = useLineItems();
 	const { formStatus } = useFormStatus();
 	const onEvent = useEvents();
 
@@ -122,7 +122,6 @@ function ExistingCardPayButton( {
 				debug( 'submitting existing card payment' );
 				onEvent( { type: 'EXISTING_CARD_TRANSACTION_BEGIN' } );
 				onClick( 'existing-card', {
-					items,
 					name: cardholderName,
 					storedDetailsId,
 					paymentMethodToken,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Checkout's payment processor functions all require a list of line items to be sent to the transactions endpoint. Currently the way that works is that each payment method submit button component collects the items from the `CheckoutProvider` using `useLineItems` and sends them along to the processor function using the `onClick` handler. However, I'd like to remove `useLineItems` because it relies on a data type (`WPCOMCartItem`) which is confusing and will cause us problems as we convert to TypeScript (it's not part of `@automattic/composite-checkout` but hijacks the `CheckoutProvider` to use it, which we cannot easily do using TypeScript).

In this PR we instead inject the line items directly into the payment processor function from within `CompositeCheckout` rather than passing them through `CheckoutProvider` first. This allows us to remove the need to get `items` in each payment method and therefore to remove `useLineItems` within those methods.

To do:

- [ ] Verify that the transactions endpoint really needs the line items. Can't it get them from the shopping cart?
- [ ] Why are we sending `total` to the transactions endpoint? (Is it really being sent? If not, can we remove it from the payment processor functions?)
- [ ] Move `Pay %s` to `activeButtonText` in the existing credit card payment method so we can remove `useLineItems` there. (And/or move that payment method to calypso which needs to happen eventually.)
- [ ] Remove `items` from all other payment method submission functions that use the adapted payment processors. Maybe this PR should just do existing credit cards and do other payment methods in their own PRs?

#### Testing instructions

TBD