### PR TITLE
Onboarding: Pollard should be using blank-canvas

### DIFF
--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -332,7 +332,7 @@
 			"title": "Balan",
 			"slug": "balan",
 			"template": "balan",
-			"theme": "mayland",
+			"theme": "blank-canvas",
 			"preview": "static",
 			"fonts": {
 				"headings": "Rubik",

--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -346,7 +346,7 @@
 			"title": "Pollard",
 			"slug": "pollard",
 			"template": "pollard",
-			"theme": "mayland",
+			"theme": "blank-canvas",
 			"preview": "static",
 			"fonts": {
 				"headings": "Cabin",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

@ollierozdarz noticed that the background for Pollard didn't have the pleasing apricot background color, preferred by pastel connoisseurs everywhere.

This was because we were previewing the design using Mayland, which has a white background.

Updating to `blank-canvas` restores order. Apricot-lovers unite!

Furthermore, [Balan was also updated to use Blank Canvas](https://github.com/Automattic/wp-calypso/issues/50970)!

This PR changes both designs to use `blank-canvas`.

See https://github.com/Automattic/wp-calypso/issues/50970 for before and after. Example:

**Before**
<img width="1064" alt="Screen Shot 2021-03-11 at 3 29 22 pm" src="https://user-images.githubusercontent.com/6458278/110736046-15046880-827f-11eb-9fe5-394c74965080.png">


**After**
<img width="971" alt="Screen Shot 2021-03-11 at 3 29 32 pm" src="https://user-images.githubusercontent.com/6458278/110736052-16359580-827f-11eb-9f01-d9d0aec52dcd.png">

#### Testing instructions

Fire up the branch and check that the Pollard and Balan designs have the correct backgrounds in both the screenshots and the demos.

Create a site and check the resulting site preview.

Resolves: https://github.com/Automattic/wp-calypso/issues/50970