### PR TITLE
Media: Deselect only transient media items

### DIFF
--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -27,6 +27,7 @@ import {
 	MEDIA_ITEM_EDIT,
 } from 'calypso/state/action-types';
 import { combineReducers } from 'calypso/state/utils';
+import isTransientMediaId from 'calypso/lib/media/utils/is-transient-media-id';
 import MediaQueryManager from 'calypso/lib/query-manager/media';
 import { ValidationErrors as MediaValidationErrors } from 'calypso/lib/media/constants';
 import { transformSite as transformSiteTransientItems } from 'calypso/state/media/utils/transientItems';
@@ -257,6 +258,12 @@ export const selectedItems = ( state = {}, action ) => {
 		}
 		case MEDIA_ITEM_REQUEST_SUCCESS: {
 			const { mediaId: transientMediaId, siteId } = action;
+
+			// We only want to deselect if it is a transient media item
+			if ( ! isTransientMediaId( transientMediaId ) ) {
+				return state;
+			}
+
 			const media = state[ siteId ] ?? [];
 
 			return {

--- a/client/state/media/test/reducer.js
+++ b/client/state/media/test/reducer.js
@@ -437,6 +437,7 @@ describe( 'reducer', () => {
 		};
 		const anotherSiteId = 87654321;
 		const mediaId = 42;
+		const transientMediaId = 'media-32';
 		const mediaItem = {
 			ID: [ mediaId ],
 		};
@@ -511,11 +512,11 @@ describe( 'reducer', () => {
 
 		test( 'should deselect any transient media item after its corresponding media was successfully uploaded', () => {
 			const state = {
-				[ site.ID ]: [ 1, mediaId, 2 ],
+				[ site.ID ]: [ 1, transientMediaId, 2 ],
 			};
 			const result = selectedItems(
 				deepFreeze( state ),
-				successMediaItemRequest( siteId, mediaId )
+				successMediaItemRequest( siteId, transientMediaId )
 			);
 
 			expect( result ).to.deep.eql( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As reported in #44677, on the initial load of a post that has a gallery, when we attempt to edit the gallery, the selected images in the media upload dialog are lost. Upon a subsequent load of the dialog, selected images are there. 

This seems to be caused by the fact that when we deselect transient media items upon receiving after they have been uploaded, we don't check if they're actually transients. That way, any received items may end up being deselected at any given time 😞 

Luckily, the fix is easy - when deselecting on a media item request success, we should check if the item is a transient media item before deselecting it. This is what this PR does. It also updates a related reducer test.

#### Testing instructions

* Open a post where you have a gallery with several images.
* Click on one of the gallery images, and click the "Media Library" button below.
* Verify that when the dialog opens, the media items are selected.
* Close, reopen, and verify on the second time they're still selected.
* Try uploading a new image in the gallery and verify it gets auto-selected
* Try to break the gallery somehow 😉 
* Verify tests pass.

#### Notes

Fixes #44677
