### PR TITLE
G Suite: Show annual and monthly price on Email Comparison page

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -524,7 +524,7 @@ class ManagePurchase extends Component {
 			);
 		} else if ( isGSuiteOrGoogleWorkspace( purchase ) ) {
 			description = translate(
-				'The best way to create, communicate, and collaborate. An integrated workspace that is simple and easy to use.'
+				'Professional email integrated with Google Meet and other collaboration tools from Google.'
 			);
 
 			if ( purchase.purchaseRenewalQuantity ) {

--- a/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
@@ -21,18 +21,19 @@ const noop = () => {};
 
 class EmailProviderDetails extends React.Component {
 	static propTypes = {
-		title: PropTypes.string.isRequired,
-		description: PropTypes.string.isRequired,
-		image: PropTypes.object.isRequired,
-		features: PropTypes.arrayOf( PropTypes.string ).isRequired,
+		additionalPriceInformation: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
 		badge: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ),
-		formattedPrice: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
-		discount: PropTypes.string,
 		buttonLabel: PropTypes.string,
-		hasPrimaryButton: PropTypes.bool,
 		className: PropTypes.string,
-		onButtonClick: PropTypes.func,
+		description: PropTypes.string.isRequired,
+		discount: PropTypes.string,
+		features: PropTypes.arrayOf( PropTypes.string ).isRequired,
+		formattedPrice: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
+		hasPrimaryButton: PropTypes.bool,
+		image: PropTypes.object.isRequired,
 		isButtonBusy: PropTypes.bool,
+		onButtonClick: PropTypes.func,
+		title: PropTypes.string.isRequired,
 	};
 
 	static defaultProps = {
@@ -47,22 +48,31 @@ class EmailProviderDetails extends React.Component {
 
 	render() {
 		const {
+			additionalPriceInformation,
 			badge,
-			description,
-			image,
-			title,
-			formattedPrice,
-			discount,
 			buttonLabel,
-			hasPrimaryButton,
 			className,
+			description,
+			discount,
+			formattedPrice,
+			hasPrimaryButton,
+			image,
 			isButtonBusy,
+			title,
 		} = this.props;
 
 		return (
 			<PromoCard { ...{ className, title, image, badge } }>
 				<p className="email-provider-details__description">{ description }</p>
+
 				<PromoCardPrice { ...{ formattedPrice, discount } } />
+
+				{ additionalPriceInformation && (
+					<span className="email-provider-details__additional-price-information">
+						{ additionalPriceInformation }
+					</span>
+				) }
+
 				<Button
 					className="email-provider-details__cta"
 					primary={ hasPrimaryButton }
@@ -71,6 +81,7 @@ class EmailProviderDetails extends React.Component {
 				>
 					{ buttonLabel }
 				</Button>
+
 				<div>{ this.renderFeatures() }</div>
 			</PromoCard>
 		);

--- a/client/my-sites/email/email-providers-comparison/email-provider-details/style.scss
+++ b/client/my-sites/email/email-providers-comparison/email-provider-details/style.scss
@@ -33,6 +33,25 @@
 	flex-wrap: wrap;
 }
 
+.email-provider-details__additional-price-information {
+	color: var( --color-text-subtle );
+	display: inline-block;
+	font-size: $font-body-extra-small;
+	font-style: normal;
+	margin-top: 3px;
+}
+
 .email-provider-details__cta {
-	margin: 16px auto 16px 0;
+	margin-top: 16px;
+	margin-right: auto;
+	margin-bottom: 16px;
+
+	.gsuite & {
+		margin-top: 16px;
+	}
+
+	@include breakpoint-deprecated( '>1040px' ) {
+		margin-top: 40px;
+		margin-bottom: 25px;
+	}
 }

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -246,31 +246,16 @@ class EmailProvidersComparison extends React.Component {
 	renderGSuiteDetails( className ) {
 		const { currencyCode, gSuiteProduct, translate } = this.props;
 
-		let title = translate( 'G Suite by Google' );
-		let description = translate(
-			"We've partnered with Google to offer you email, storage, docs, calendars, and more."
-		);
-		let logo = gSuiteLogo;
-		let buttonLabel = translate( 'Add G Suite' );
-
-		if ( config.isEnabled( 'google-workspace-migration' ) ) {
-			title = getGoogleMailServiceFamily();
-			description = translate(
-				'Professional email integrated with Google Meet and other collaboration tools from Google.'
-			);
-			logo = googleWorkspaceIcon;
-			buttonLabel = translate( 'Add %(googleMailService)s', {
-				args: {
-					googleMailService: getGoogleMailServiceFamily(),
-				},
-				comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
-			} );
-		}
+		const logo = config.isEnabled( 'google-workspace-migration' )
+			? googleWorkspaceIcon
+			: gSuiteLogo;
 
 		return (
 			<EmailProviderDetails
-				title={ title }
-				description={ description }
+				title={ getGoogleMailServiceFamily() }
+				description={ translate(
+					'Professional email integrated with Google Meet and other collaboration tools from Google.'
+				) }
 				image={ { path: logo } }
 				features={ [
 					translate( 'Annual billing' ),
@@ -302,7 +287,12 @@ class EmailProvidersComparison extends React.Component {
 					},
 					comment: "Annual price formatted with the currency (e.g. '$99.99')",
 				} ) }
-				buttonLabel={ buttonLabel }
+				buttonLabel={ translate( 'Add %(googleMailService)s', {
+					args: {
+						googleMailService: getGoogleMailServiceFamily(),
+					},
+					comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+				} ) }
 				onButtonClick={ this.goToAddGSuite }
 				className={ classNames( className, 'gsuite' ) }
 			/>

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -25,7 +25,7 @@ import {
 	GSUITE_BASIC_SLUG,
 } from 'calypso/lib/gsuite/constants';
 import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
-import { getAnnualPrice, getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
+import { getAnnualPrice, getGoogleMailServiceFamily, getMonthlyPrice } from 'calypso/lib/gsuite';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -256,7 +256,7 @@ class EmailProvidersComparison extends React.Component {
 		if ( config.isEnabled( 'google-workspace-migration' ) ) {
 			title = getGoogleMailServiceFamily();
 			description = translate(
-				'The best way to create, communicate, and collaborate. An integrated workspace that is simple and easy to use.'
+				'Professional email integrated with Google Meet and other collaboration tools from Google.'
 			);
 			logo = googleWorkspaceIcon;
 			buttonLabel = translate( 'Add %(googleMailService)s', {
@@ -280,9 +280,9 @@ class EmailProvidersComparison extends React.Component {
 					translate( 'Video calls, docs, spreadsheets, and more' ),
 					translate( 'Work from anywhere on any device – even offline' ),
 				] }
-				formattedPrice={ translate( '{{price/}} /user /year', {
+				formattedPrice={ translate( '{{price/}} /user /month', {
 					components: {
-						price: <span>{ getAnnualPrice( gSuiteProduct?.cost ?? null, currencyCode ) }</span>,
+						price: <span>{ getMonthlyPrice( gSuiteProduct?.cost ?? null, currencyCode ) }</span>,
 					},
 					comment: '{{price/}} is the formatted price, e.g. $20',
 				} ) }
@@ -296,6 +296,12 @@ class EmailProvidersComparison extends React.Component {
 						  } )
 						: null
 				}
+				additionalPriceInformation={ translate( '%(price)s billed annually', {
+					args: {
+						price: getAnnualPrice( gSuiteProduct?.cost ?? null, currencyCode ),
+					},
+					comment: "Annual price formatted with the currency (e.g. '$99.99')",
+				} ) }
 				buttonLabel={ buttonLabel }
 				onButtonClick={ this.goToAddGSuite }
 				className={ classNames( className, 'gsuite' ) }


### PR DESCRIPTION
This pull request updates the `Email Comparison` page to show a monthly price in addition to the annual price for G Suite and Google Workspace. It also refines the copy presenting those two products to put more emphasis on emails:

![screenshot](https://user-images.githubusercontent.com/594356/110790523-6b6aaa80-8271-11eb-83ec-b2acbcf19abe.png)

Note I've tried to keep the copy the same length as for email forwardings and Titan, so that the prices stay aligned despite being in different promo cards. I've also aligned the call-to-actions as well as the list of features.

#### Testing instructions

1. Run `git checkout update/gsuite-monthly-price` and start your server, or open a [live branch](https://calypso.live/?branch=update/gsuite-monthly-price)
2. Log into a WordPress.com account that has a domain
3. Open the [`Domains` page](http://calypso.localhost:3000/domains/manage)
4. Click the `Add` button in front of that domain
5. Assert that the page looks like in the screenshot above
6. Add `?flags=-google-workspace-migration` to the url, and reload the page
7. Assert that the page now presents G Suite, and looks similar to the screenshot above