### PR TITLE
Components: Remove proptype limitation from ButtonGroup

### DIFF
--- a/client/components/button-group/index.jsx
+++ b/client/components/button-group/index.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-
-import React, { PureComponent } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 
 /**
@@ -10,27 +9,13 @@ import classNames from 'classnames';
  */
 import './style.scss';
 
-class ButtonGroup extends PureComponent {
-	static propTypes = {
-		children( props ) {
-			let error = null;
-			React.Children.forEach( props.children, ( child ) => {
-				if ( child && ( ! child.props || child.props.type !== 'button' ) ) {
-					error = new Error( 'All children elements should be a Button.' );
-				}
-			} );
-			return error;
-		},
-	};
+const ButtonGroup = ( { busy, children, className, primary } ) => {
+	const buttonGroupClasses = classNames( 'button-group', className, {
+		'is-busy': busy,
+		'is-primary': primary,
+	} );
 
-	render() {
-		const buttonGroupClasses = classNames( 'button-group', this.props.className, {
-			'is-busy': this.props.busy,
-			'is-primary': this.props.primary,
-		} );
-
-		return <span className={ buttonGroupClasses }>{ this.props.children }</span>;
-	}
-}
+	return <span className={ buttonGroupClasses }>{ children }</span>;
+};
 
 export default ButtonGroup;

--- a/client/components/button-group/index.jsx
+++ b/client/components/button-group/index.jsx
@@ -18,4 +18,4 @@ const ButtonGroup = ( { busy, children, className, primary } ) => {
 	return <span className={ buttonGroupClasses }>{ children }</span>;
 };
 
-export default ButtonGroup;
+export default React.memo( ButtonGroup );

--- a/client/components/button-group/test/index.js
+++ b/client/components/button-group/test/index.js
@@ -30,19 +30,4 @@ describe( 'ButtonGroup', () => {
 		const buttonGroup = shallow( <ButtonGroup busy /> );
 		expect( buttonGroup.find( '.is-busy' ) ).toHaveLength( 1 );
 	} );
-
-	test( 'should throw an error if any of the children is not a <Button>', () => {
-		const consoleErrorSpy = jest.spyOn( global.console, 'error' ).mockImplementation();
-
-		shallow(
-			<ButtonGroup>
-				<div id="test">test</div>
-			</ButtonGroup>
-		);
-
-		expect( consoleErrorSpy ).toHaveBeenCalledWith(
-			expect.stringContaining( 'All children elements should be a Button.' )
-		);
-		consoleErrorSpy.mockRestore();
-	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While working on #50982 I found that when opening a gallery in a post, the following notice is displayed:

![](https://cldup.com/heZmQScDli.png)

I believe this "button only" limitation is unnecessary - any button component can be a perfectly valid one, while wrapped in a HoC or a hook. That's our case, and that's why we're seeing that error:

![](https://cldup.com/TEKk9-lFsp.png)

This PR removes that limitation, and refactors the component to a simple functional one.

In a next step, we might want to refactor to use the `ButtonGroup` from `@wordpress/components`.

#### Testing instructions

* Open a post where you have a gallery with several images.
* Verify that when the media modal opens, you don't see the error anymore.
* Verify the media modal header looks and behaves like before.