### PR TITLE
Implement accessible profile dropdown

### DIFF
--- a/client/components/jetpack/masterbar/index.tsx
+++ b/client/components/jetpack/masterbar/index.tsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -16,7 +15,6 @@ import JetpackLogo from 'calypso/components/jetpack-logo';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import ProfileDropdown from 'calypso/components/jetpack/profile-dropdown';
 import { useBreakpoint } from '@automattic/viewport-react';
-import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import AsyncLoad from 'calypso/components/async-load';
 
 /**
@@ -24,26 +22,12 @@ import AsyncLoad from 'calypso/components/async-load';
  */
 import './style.scss';
 
-const useOpenClose = () => {
-	const [ isOpen, setIsOpen ] = React.useState( false );
-	const close = React.useCallback( () => {
-		setIsOpen( false );
-	}, [ setIsOpen ] );
-	const toggle = React.useCallback( () => {
-		setIsOpen( ! isOpen );
-	}, [ isOpen, setIsOpen ] );
-	return { isOpen, close, toggle };
-};
-
-const JetpackCloudMasterBar = () => {
+const JetpackCloudMasterBar: React.FC = () => {
 	const translate = useTranslate();
 	const headerTitle = useSelector( getDocumentHeadTitle );
 	const currentRoute = useSelector( getCurrentRoute );
 	const isNarrow = useBreakpoint( '<660px' );
 	const isExteriorPage = /^\/(?:backup|scan)\/[^/]*$/.test( currentRoute );
-	const { isOpen, close, toggle } = useOpenClose();
-	const trackedToggle = useTrackCallback( toggle, 'calypso_jetpack_masterbar_profile_toggle' );
-	const trackedClose = useTrackCallback( close, 'calypso_jetpack_masterbar_profile_close' );
 
 	return (
 		<Masterbar
@@ -60,18 +44,7 @@ const JetpackCloudMasterBar = () => {
 			</Item>
 			<AsyncLoad require="calypso/components/jetpack/portal-nav" placeholder={ null } />
 			{ headerTitle && <h1 className="masterbar__item-title">{ headerTitle }</h1> }
-			<Item
-				tipTarget="me"
-				url="#" // @todo: add a correct URL
-				onClick={ trackedToggle }
-				icon="user-circle"
-				className={ classnames( 'masterbar__item-me', {
-					'masterbar__item-me--open': isOpen,
-				} ) }
-				tooltip={ translate( 'Log out of Jetpack Cloud' ) }
-			>
-				<ProfileDropdown isOpen={ isOpen } close={ trackedClose } />
-			</Item>
+			<ProfileDropdown />
 		</Masterbar>
 	);
 };

--- a/client/components/jetpack/profile-dropdown/index.tsx
+++ b/client/components/jetpack/profile-dropdown/index.tsx
@@ -47,7 +47,16 @@ const ProfileDropdown: React.FC = () => {
 	useOutsideClickCallback( ref, trackedClose );
 
 	return (
-		<nav className="profile-dropdown__nav" id="user-navigation" ref={ ref }>
+		<nav
+			className="profile-dropdown__nav"
+			id="user-navigation"
+			aria-label={
+				translate( 'User menu', {
+					comment: 'Label used to differentiate navigation landmarks in screen readers',
+				} ) as string
+			}
+			ref={ ref }
+		>
 			<button
 				className="profile-dropdown__button"
 				aria-expanded={ isExpanded }

--- a/client/components/jetpack/profile-dropdown/index.tsx
+++ b/client/components/jetpack/profile-dropdown/index.tsx
@@ -58,16 +58,13 @@ const ProfileDropdown: React.FC = () => {
 					className="profile-dropdown__button-gravatar"
 					user={ user }
 					alt={ translate( 'My Profile' ) }
-					size={ 18 }
+					size={ 24 }
 				/>
 			</button>
 			<ul className="profile-dropdown__list" id="menu-list" hidden={ ! isExpanded }>
 				<li className="profile-dropdown__list-item">
-					<Gravatar className="profile-dropdown__list-gravatar" user={ user } alt="" size={ 64 } />
-					{ translate( 'Logged in as {{username}}%s{{/username}}', {
-						args: user.username,
-						components: { username: <span className="profile-dropdown__username" /> },
-					} ) }
+					<span className="profile-dropdown__display-name">{ user.display_name }</span>
+					<span className="profile-dropdown__username">{ `@${ user.username }` }</span>
 				</li>
 				<li className="profile-dropdown__list-item">
 					<button className="profile-dropdown__logout" onClick={ trackedLogOut }>

--- a/client/components/jetpack/profile-dropdown/index.tsx
+++ b/client/components/jetpack/profile-dropdown/index.tsx
@@ -1,119 +1,81 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
+import useOutsideClickCallback from './use-outside-click-callback';
 import Gravatar from 'calypso/components/gravatar';
 import userUtilities from 'calypso/lib/user/utils';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 
 /**
+ * Type dependencies
+ */
+import type { UserData } from 'calypso/lib/user/user';
+
+/**
  * Style dependencies
  */
 import './style.scss';
 
-/**
- * Hook that executes `callback` is the 'Escape' key is pressed
- * or if the user clicks outside of `ref`.
- *
- * @param ref       Ref to an HTML element
- * @param callback  Function to be executed
- */
-const useCallIfOutOfContext = (
-	ref: React.MutableRefObject< null | HTMLElement >,
-	callback: Function
-) => {
-	const handleEscape = React.useCallback(
-		( event: KeyboardEvent ) => {
-			if ( event.key === 'Escape' ) {
-				callback();
-			}
-		},
-		[ callback ]
-	);
-
-	const handleClick = React.useCallback(
-		( { target } ) => {
-			if ( ref.current && ! ref.current.contains( target ) ) {
-				callback();
-			}
-		},
-		[ ref, callback ]
-	);
-
-	React.useEffect( () => {
-		document.addEventListener( 'keydown', handleEscape );
-		document.addEventListener( 'click', handleClick );
-
-		return () => {
-			document.removeEventListener( 'keydown', handleEscape );
-			document.removeEventListener( 'click', handleClick );
-		};
-	}, [ handleClick, handleEscape ] );
-};
-
-interface Props {
-	isOpen: boolean;
-	close: Function;
-}
-
-const ProfileDropdown: React.FC< Props > = ( { isOpen, close } ) => {
+const ProfileDropdown: React.FC = () => {
 	const translate = useTranslate();
-	const user = useSelector( getCurrentUser );
-	const logOut = ( e: MouseEvent ) => {
-		e.preventDefault();
-		e.stopPropagation();
-		userUtilities.logout();
-	};
-	const trackedLogOut = useTrackCallback( logOut, 'calypso_jetpack_settings_masterbar_logout' );
 	const ref = React.useRef( null );
-	// We don't want to call close if it's already closed because we would
-	// track unnecessary events.
-	const closeOnlyIfIsOpen = React.useCallback( () => {
-		isOpen && close();
-	}, [ close, isOpen ] );
-	useCallIfOutOfContext( ref, closeOnlyIfIsOpen );
+	const [ isExpanded, setExpanded ] = useState( false );
+	const user = useSelector( getCurrentUser ) as UserData;
+
+	const toggle = useCallback( () => setExpanded( ! isExpanded ), [ isExpanded, setExpanded ] );
+	const close = useCallback( () => {
+		if ( isExpanded ) {
+			setExpanded( false );
+		}
+	}, [ isExpanded, setExpanded ] );
+
+	const trackedToggle = useTrackCallback( toggle, 'calypso_jetpack_masterbar_profile_toggle' );
+	const trackedClose = useTrackCallback( close, 'calypso_jetpack_masterbar_profile_close' );
+	const trackedLogOut = useTrackCallback(
+		userUtilities.logout,
+		'calypso_jetpack_settings_masterbar_logout'
+	);
+
+	useOutsideClickCallback( ref, trackedClose );
 
 	return (
-		<div className="profile-dropdown" ref={ ref }>
-			<Gravatar user={ user } alt={ translate( 'My Profile' ) } size={ 18 } />
-			<span className="profile-dropdown__me-label">
-				{ translate( 'My Profile', { context: 'Toolbar, must be shorter than ~12 chars' } ) }
-			</span>
-			{ isOpen && (
-				<div className="profile-dropdown__items">
-					<div className="profile-dropdown__logout-item">
-						<Gravatar
-							className="profile-dropdown__logout-gravatar"
-							user={ user }
-							alt={ translate( 'My Profile' ) }
-							size={ 64 }
-						/>
-						<span className="profile-dropdown__me-label">
-							{ translate( 'My Profile', {
-								context: 'Toolbar, must be shorter than ~12 chars',
-							} ) }
-						</span>
-
-						<div className="profile-dropdown__logout-username">
-							<span>{ user.username }</span>
-							<Button borderless onClick={ trackedLogOut }>
-								{ translate( 'Log out' ) }
-							</Button>
-						</div>
-
-						<div className="profile-dropdown__empty-space"></div>
-					</div>
-				</div>
-			) }
-		</div>
+		<nav className="profile-dropdown__nav" id="user-navigation" ref={ ref }>
+			<button
+				className="profile-dropdown__button"
+				aria-expanded={ isExpanded }
+				aria-controls="menu-list"
+				onClick={ trackedToggle }
+			>
+				<Gravatar
+					className="profile-dropdown__button-gravatar"
+					user={ user }
+					alt={ translate( 'My Profile' ) }
+					size={ 18 }
+				/>
+			</button>
+			<ul className="profile-dropdown__list" id="menu-list" hidden={ ! isExpanded }>
+				<li className="profile-dropdown__list-item">
+					<Gravatar className="profile-dropdown__list-gravatar" user={ user } alt="" size={ 64 } />
+					{ translate( 'Logged in as {{username}}%s{{/username}}', {
+						args: user.username,
+						components: { username: <span className="profile-dropdown__username" /> },
+					} ) }
+				</li>
+				<li className="profile-dropdown__list-item">
+					<button className="profile-dropdown__logout" onClick={ trackedLogOut }>
+						{ translate( 'Log out' ) }
+					</button>
+				</li>
+			</ul>
+		</nav>
 	);
 };
 

--- a/client/components/jetpack/profile-dropdown/style.scss
+++ b/client/components/jetpack/profile-dropdown/style.scss
@@ -21,7 +21,7 @@
 		cursor: pointer;
 
 		&[aria-expanded='true'] {
-			border-left: 1px solid var( --studio-gray-20 );
+			box-shadow: -1px 0 var( --studio-gray-20 );
 		}
 
 		&:hover {

--- a/client/components/jetpack/profile-dropdown/style.scss
+++ b/client/components/jetpack/profile-dropdown/style.scss
@@ -1,55 +1,87 @@
 .profile-dropdown {
-	&__me-label {
-		display: none;
+	&__nav {
+		position: relative;
 	}
 
-	&__items {
-		position: absolute;
-		top: 100%;
-		right: -1px;
-		width: 240px;
-		padding: 8px;
-		background: #fff;
-		border: 1px solid var( --studio-gray-20 );
-	}
-
-	&__logout-item {
+	&__button {
 		display: flex;
+		justify-content: center;
 		align-items: center;
-		height: 80px;
-	}
 
-	&__logout-gravatar.gravatar {
-		position: initial;
-		width: 64px;
-		height: 64px;
-	}
+		min-width: 48px;
+		height: 100%;
 
-	&__logout-username {
-		flex: 1;
-		display: flex;
-		flex-direction: column;
-		align-items: flex-start;
+		cursor: pointer;
 
-		span {
-			max-width: 150px;
-			height: 40px;
-			white-space: nowrap;
-			overflow: hidden;
-			text-overflow: ellipsis;
+		&:hover {
+			img {
+				transform: scale( 1.5, 1.5 );
+			}
 		}
 	}
 
-	&__logout-button {
-		color: var( --color-text-subtle );
+	html.accessible-focus &__button:focus {
+		box-shadow: inset 0 0 0 2px var( --color-primary-light );
 	}
 
-	&__empty-space {
+	&__button-gravatar {
+		transform-origin: center center;
+		transition: all 0.1s ease;
+	}
+
+	&__list {
 		position: absolute;
-		top: -1px;
-		right: 0;
-		height: 1px;
-		width: 54px;
-		background: #fff;
+		right: -1px;
+		top: 100%;
+
+		box-sizing: border-box;
+		width: 260px;
+		margin: 0;
+		padding: 12px 12px 12px 76px;
+
+		background: var( --color-surface );
+		border: 1px solid var( --studio-gray-10 );
+		list-style-type: none;
+
+		font-size: 0.875rem;
+
+		&[hidden] {
+			display: none;
+		}
+	}
+
+	&__list-item {
+		padding: 8px 0;
+	}
+
+	&__list-gravatar {
+		position: absolute;
+		top: 0;
+		left: 0;
+
+		border: 2px solid var( --color-border-inverted );
+
+		transform: translate( -40%, -25% );
+	}
+
+	&__username {
+		font-weight: 700;
+		word-break: break-word;
+	}
+
+	&__logout {
+		color: var( --color-link );
+		text-decoration: underline;
+
+		cursor: pointer;
+
+		&:hover {
+			color: var( --color-link-dark );
+			text-decoration: none;
+		}
+
+		&:focus {
+			box-shadow: 0 0 0 2px var( --color-primary-light );
+		}
 	}
 }

--- a/client/components/jetpack/profile-dropdown/style.scss
+++ b/client/components/jetpack/profile-dropdown/style.scss
@@ -58,7 +58,7 @@
 			0 1px 2px rgba( var( --studio-gray-100-rgb ), 0.1 );
 		list-style-type: none;
 
-		font-size: 0.875rem;
+		font-size: $font-body-small;
 
 		// Required for older browsers
 		&[hidden] {

--- a/client/components/jetpack/profile-dropdown/style.scss
+++ b/client/components/jetpack/profile-dropdown/style.scss
@@ -4,6 +4,7 @@
 	}
 
 	&__button {
+		// Button needs to be above the list to partly hide its top border
 		position: relative;
 		z-index: 1;
 
@@ -11,6 +12,7 @@
 		justify-content: center;
 		align-items: center;
 
+		// Minimum recommended width for touch interactions
 		min-width: 48px;
 		height: 100%;
 
@@ -29,6 +31,8 @@
 		}
 	}
 
+	// Hide focus state right after a user clicked the button. The focus state
+	// is still shown if we know the user is using a keyboard exclusively.
 	html.accessible-focus &__button:focus {
 		box-shadow: inset 0 0 0 2px var( --color-primary-light );
 	}
@@ -55,6 +59,7 @@
 
 		font-size: 0.875rem;
 
+		// Required for older browsers
 		&[hidden] {
 			display: none;
 		}

--- a/client/components/jetpack/profile-dropdown/style.scss
+++ b/client/components/jetpack/profile-dropdown/style.scss
@@ -4,6 +4,9 @@
 	}
 
 	&__button {
+		position: relative;
+		z-index: 1;
+
 		display: flex;
 		justify-content: center;
 		align-items: center;
@@ -11,11 +14,17 @@
 		min-width: 48px;
 		height: 100%;
 
+		background: var( --color-surface );
+
 		cursor: pointer;
+
+		&[aria-expanded='true'] {
+			border-left: 1px solid var( --studio-gray-20 );
+		}
 
 		&:hover {
 			img {
-				transform: scale( 1.5, 1.5 );
+				transform: scale( 1.2, 1.2 );
 			}
 		}
 	}
@@ -32,15 +41,16 @@
 	&__list {
 		position: absolute;
 		right: -1px;
-		top: 100%;
+		top: calc( 100% - 1px );
 
-		box-sizing: border-box;
-		width: 260px;
+		width: 220px;
 		margin: 0;
-		padding: 12px 12px 12px 76px;
+		padding: 0 16px;
 
 		background: var( --color-surface );
-		border: 1px solid var( --studio-gray-10 );
+		border: 1px solid var( --studio-gray-20 );
+		box-shadow: 0 4px 6px rgba( var( --studio-gray-100-rgb ), 0.1 ),
+			0 1px 2px rgba( var( --studio-gray-100-rgb ), 0.1 );
 		list-style-type: none;
 
 		font-size: 0.875rem;
@@ -51,21 +61,19 @@
 	}
 
 	&__list-item {
-		padding: 8px 0;
+		margin: 16px 0;
 	}
 
-	&__list-gravatar {
-		position: absolute;
-		top: 0;
-		left: 0;
+	&__display-name {
+		display: block;
 
-		border: 2px solid var( --color-border-inverted );
+		color: var( --color-text );
 
-		transform: translate( -40%, -25% );
+		font-size: $font-body;
+		font-weight: 700;
 	}
 
 	&__username {
-		font-weight: 700;
 		word-break: break-word;
 	}
 

--- a/client/components/jetpack/profile-dropdown/style.scss
+++ b/client/components/jetpack/profile-dropdown/style.scss
@@ -24,9 +24,10 @@
 			box-shadow: -1px 0 var( --studio-gray-20 );
 		}
 
-		&:hover {
+		&:hover,
+		&:focus {
 			img {
-				transform: scale( 1.2, 1.2 );
+				transform: scale( 1.2 );
 			}
 		}
 	}

--- a/client/components/jetpack/profile-dropdown/use-outside-click-callback.ts
+++ b/client/components/jetpack/profile-dropdown/use-outside-click-callback.ts
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import React, { useCallback, useEffect } from 'react';
+
+/**
+ * Hook that executes `callback` is the 'Escape' key is pressed
+ * or if the user clicks outside of `ref`.
+ *
+ * @param ref       Ref to an HTML element
+ * @param callback  Function to be executed
+ */
+export default function useOutsideClickCallback(
+	ref: React.MutableRefObject< null | HTMLElement >,
+	callback: () => void
+): void {
+	const handleEscape = useCallback(
+		( event: KeyboardEvent ) => {
+			if ( event.key === 'Escape' ) {
+				callback();
+			}
+		},
+		[ callback ]
+	);
+
+	const handleClick = useCallback(
+		( { target } ) => {
+			if ( ref.current && ! ref.current.contains( target ) ) {
+				callback();
+			}
+		},
+		[ ref, callback ]
+	);
+
+	useEffect( () => {
+		document.addEventListener( 'keydown', handleEscape );
+		document.addEventListener( 'click', handleClick );
+
+		return () => {
+			document.removeEventListener( 'keydown', handleEscape );
+			document.removeEventListener( 'click', handleClick );
+		};
+	}, [ handleClick, handleEscape ] );
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes some accessibility issues spotted in the profile menu, in Jetpack cloud.

Fixes 1164141197617539-as-1200050697540261

### Implementation notes

We've fixed a couple of different things:

1. Rewrote the `ProfileDropdown` component so that the markup makes for an accessible experience (see videos below). We've followed the guidelines mentioned in [this article](https://inclusive-components.design/menus-menu-buttons/).
2. Made the _Log out_ button clickable instead of the whole menu (which was confusing and not scalable)
3. Made sure the masterbar elements all had visible focus states
4. Updated the appearance of the menu to reflect the changes made in #50990
5. Updated contrast of interactive elements

`use-outside-click-callback.ts` could probably be extracted in a different folder, and use existing code. I'll address this and add unit tests in a subsequent PR, for readability.

### Testing instructions

- Download the PR and run cloud
- Visit `/landing`

#### Functionalities

Firstly, let's test that the base functionalities of the profile menu work.
- Click your avatar, and check that it opens the menu
- Make sure the menu closes when you click your avatar, click outside of the menu, and hit the Escape key
- Check that you see your display name and username, and the menu looks like the capture below
- Check that you're logged out after clicking the _Log out_ button (and not the whole profile menu)

#### Focus states

The next part is with your keyboard only:
- Reload the page
- Hit `Tab`. The Jetpack logo should have focus, and have a visible focus state.
- Hit `Tab` again. The avatar button should now have focus.
- Press `Enter` to open the menu.
- Press `Tab`, and notice that the _Log out_ button now has focus
- Pressing `Tab` one more time should allow you to leave the menu for the search input
- Finally, press `Shift+Tab` to go backwards and check that all elements have a visible focus state

#### Screen reader

_Note: the following assumes you're using VoiceOver on OSX. Instructions may differ with other screen readers._

If you want to go a step further:
- Activate VoiceOver (`⌘+F5`)
- Open the Web Rotor (`Control+Option+U`). The rotor is a handy way to view the page main features (such as headings, links, etc.) and provides shortcuts for navigating.
- Check that you see `navigation` in the _Landmarks_ section

### Screenshots

#### Appearance
_Before_
<img width="309" alt="Screen Shot 2021-03-11 at 2 52 13 PM" src="https://user-images.githubusercontent.com/1620183/110845994-41b58180-8279-11eb-8f3f-7e3da00c93cf.png">


_After_
<img width="308" alt="Screen Shot 2021-03-11 at 2 43 00 PM" src="https://user-images.githubusercontent.com/1620183/110845012-1bdbad00-8278-11eb-83e9-24efda891e80.png">

#### Focus management
_Before: avatar button doesn't show a focus state when tabbing backwards_

https://user-images.githubusercontent.com/1620183/110846185-7b868800-8279-11eb-9db5-6097b0822559.mov



_After_

https://user-images.githubusercontent.com/1620183/110849005-b807b300-827c-11eb-8cce-9e3945d580a7.mov



#### Screen reader

https://user-images.githubusercontent.com/1620183/110848443-18e2bb80-827c-11eb-8b0c-e315f74e0f7b.mov

