### PR TITLE
Jetpack: update user menu styling in Calypso Green

### DIFF
--- a/client/components/jetpack/masterbar/style.scss
+++ b/client/components/jetpack/masterbar/style.scss
@@ -31,17 +31,18 @@
 	.masterbar__item-title {
 		flex: 1 1 auto;
 		align-self: center;
-
 		padding-left: 16px;
-
 		color: var( --color-neutral-80 );
-
 		text-transform: none;
 	}
 
 	.masterbar__item-me {
-		min-width: 18px;
+		min-width: 24px;
 		flex: 0 0 auto;
+
+		&:hover {
+			background: none;
+		}
 
 		// Calypso's masterbar hides this item content and we need to show it
 		// so we override its display property.
@@ -49,6 +50,11 @@
 			.masterbar__item-content {
 				display: block;
 			}
+		}
+
+		.gravatar {
+			width: 24px;
+			height: 24px;
 		}
 	}
 

--- a/client/components/jetpack/profile-dropdown/index.tsx
+++ b/client/components/jetpack/profile-dropdown/index.tsx
@@ -83,28 +83,29 @@ const ProfileDropdown: React.FC< Props > = ( { isOpen, close } ) => {
 
 	return (
 		<div className="profile-dropdown" ref={ ref }>
-			<Gravatar user={ user } alt={ translate( 'My Profile' ) } size={ 18 } />
+			<Gravatar user={ user } alt={ translate( 'My Profile' ) } size={ 32 } />
 			<span className="profile-dropdown__me-label">
 				{ translate( 'My Profile', { context: 'Toolbar, must be shorter than ~12 chars' } ) }
 			</span>
 			{ isOpen && (
 				<div className="profile-dropdown__items">
 					<div className="profile-dropdown__logout-item">
-						<Gravatar
-							className="profile-dropdown__logout-gravatar"
-							user={ user }
-							alt={ translate( 'My Profile' ) }
-							size={ 64 }
-						/>
 						<span className="profile-dropdown__me-label">
 							{ translate( 'My Profile', {
 								context: 'Toolbar, must be shorter than ~12 chars',
 							} ) }
 						</span>
 
-						<div className="profile-dropdown__logout-username">
-							<span>{ user.username }</span>
-							<Button borderless onClick={ trackedLogOut }>
+						<div className="profile-dropdown__logout-options">
+							<div className="profile-dropdown__logout-username">
+								<strong>{ user.display_name }</strong>
+								<span>{ '@' + user.username }</span>
+							</div>
+							<Button
+								className="profile-dropdown__logout-button"
+								borderless
+								onClick={ trackedLogOut }
+							>
 								{ translate( 'Log out' ) }
 							</Button>
 						</div>

--- a/client/components/jetpack/profile-dropdown/style.scss
+++ b/client/components/jetpack/profile-dropdown/style.scss
@@ -5,18 +5,19 @@
 
 	&__items {
 		position: absolute;
-		top: 100%;
+		top: calc( 100% - 1px );
 		right: -1px;
-		width: 240px;
-		padding: 8px;
-		background: #fff;
+		width: 220px;
+		padding: 8px 16px;
+		background: var( --color-surface );
 		border: 1px solid var( --studio-gray-20 );
+		box-shadow: 0 4px 6px rgba( var( --studio-gray-100-rgb ), 0.1 ),
+					0 1px 2px rgba( var( --studio-gray-100-rgb ), 0.1 );
 	}
 
 	&__logout-item {
 		display: flex;
 		align-items: center;
-		height: 80px;
 	}
 
 	&__logout-gravatar.gravatar {
@@ -25,22 +26,36 @@
 		height: 64px;
 	}
 
-	&__logout-username {
+	&__logout-options {
 		flex: 1;
 		display: flex;
 		flex-direction: column;
 		align-items: flex-start;
+		width: 100%;
+		cursor: default;
+	}
 
-		span {
-			max-width: 150px;
-			height: 40px;
+	&__logout-username {
+		margin: 8px 0;
+		line-height: 24px;
+
+		strong, span {
+			display: block;
+			max-width: 220px;
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
 		}
+
+		strong {
+			font-size: $font-body;
+			color: var( --color-text );
+		}
 	}
 
 	&__logout-button {
+		width: 100%;
+		text-align: left;
 		color: var( --color-text-subtle );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates user menu styling in Calypso Green.
* Removes Gravatar and adds Display name.

#### Testing instructions

* Fire up this PR.
* Run `yarn start-jetpack-cloud` and visit `jetpack.cloud.localhost:3000`.
* Ensure you see the revised user menu and everything works.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/110797113-a4564f80-8270-11eb-8e91-0af809732ed5.png) | ![image](https://user-images.githubusercontent.com/390760/110797121-a6b8a980-8270-11eb-8118-152c7e4b7f36.png)
