### PR TITLE
people(team): use queries to fetch users and mutations to update/delete/remove a user

### DIFF
--- a/client/data/users/use-delete-user-mutation.js
+++ b/client/data/users/use-delete-user-mutation.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { useCallback } from 'react';
+import { useMutation, useQueryClient } from 'react-query';
+
+/**
+ * Internal dependencies
+ */
+import wp from 'calypso/lib/wp';
+
+function useDeleteUserMutation( siteId ) {
+	const queryClient = useQueryClient();
+	const mutation = useMutation(
+		( { userId, variables } ) =>
+			wp.req.post( `/sites/${ siteId }/users/${ userId }/delete`, variables ),
+		{
+			onSuccess() {
+				queryClient.invalidateQueries( [ 'users', siteId ] );
+			},
+		}
+	);
+
+	const { mutate } = mutation;
+
+	const deleteUser = useCallback(
+		( userId, variables ) => {
+			mutate( { userId, variables } );
+		},
+		[ mutate ]
+	);
+
+	return { deleteUser, ...mutation };
+}
+
+export default useDeleteUserMutation;

--- a/client/data/users/use-update-user-mutation.js
+++ b/client/data/users/use-update-user-mutation.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { useCallback } from 'react';
+import { useMutation, useQueryClient } from 'react-query';
+
+/**
+ * Internal dependencies
+ */
+import wp from 'calypso/lib/wp';
+
+export const cacheKey = ( siteId, login ) => [ 'user', siteId, login ];
+
+function useUpdateUserMutation( siteId, login ) {
+	const queryClient = useQueryClient();
+	const { mutate, ...mutationObj } = useMutation(
+		( { userId, variables } ) => wp.req.post( `/sites/${ siteId }/users/${ userId }`, variables ),
+		{
+			// optimistically update user
+			async onMutate( { variables } ) {
+				await queryClient.cancelQueries( cacheKey( siteId, login ) );
+
+				const previousUser = queryClient.getQueryData( cacheKey( siteId, login ) );
+
+				queryClient.setQueryData( cacheKey( siteId, login ), ( old ) => ( {
+					...old,
+					...variables,
+				} ) );
+
+				return { previousUser };
+			},
+			onError( error, updatedUser, context ) {
+				queryClient.setQueryData( cacheKey( siteId, login ), context.previousUser );
+			},
+			onSuccess( userData ) {
+				queryClient.setQueryData( cacheKey( siteId, login ), userData );
+			},
+		}
+	);
+
+	const updateUser = useCallback(
+		( userId, variables = {} ) => {
+			mutate( { userId, variables } );
+		},
+		[ mutate ]
+	);
+
+	return { updateUser, mutate, ...mutationObj };
+}
+
+export default useUpdateUserMutation;

--- a/client/data/users/use-update-user-mutation.js
+++ b/client/data/users/use-update-user-mutation.js
@@ -8,35 +8,21 @@ import { useMutation, useQueryClient } from 'react-query';
  * Internal dependencies
  */
 import wp from 'calypso/lib/wp';
+import { cacheKey } from './use-user-query';
 
-export const cacheKey = ( siteId, login ) => [ 'user', siteId, login ];
-
-function useUpdateUserMutation( siteId, login ) {
+function useUpdateUserMutation( siteId ) {
 	const queryClient = useQueryClient();
-	const { mutate, ...mutationObj } = useMutation(
+	const mutation = useMutation(
 		( { userId, variables } ) => wp.req.post( `/sites/${ siteId }/users/${ userId }`, variables ),
 		{
-			// optimistically update user
-			async onMutate( { variables } ) {
-				await queryClient.cancelQueries( cacheKey( siteId, login ) );
-
-				const previousUser = queryClient.getQueryData( cacheKey( siteId, login ) );
-
-				queryClient.setQueryData( cacheKey( siteId, login ), ( old ) => ( {
-					...old,
-					...variables,
-				} ) );
-
-				return { previousUser };
-			},
-			onError( error, updatedUser, context ) {
-				queryClient.setQueryData( cacheKey( siteId, login ), context.previousUser );
-			},
-			onSuccess( userData ) {
-				queryClient.setQueryData( cacheKey( siteId, login ), userData );
+			onSuccess( data ) {
+				const { login } = data;
+				queryClient.setQueryData( cacheKey( siteId, login ), data );
 			},
 		}
 	);
+
+	const { mutate } = mutation;
 
 	const updateUser = useCallback(
 		( userId, variables = {} ) => {
@@ -45,7 +31,7 @@ function useUpdateUserMutation( siteId, login ) {
 		[ mutate ]
 	);
 
-	return { updateUser, mutate, ...mutationObj };
+	return { updateUser, ...mutation };
 }
 
 export default useUpdateUserMutation;

--- a/client/data/users/use-update-user-mutation.js
+++ b/client/data/users/use-update-user-mutation.js
@@ -17,7 +17,7 @@ function useUpdateUserMutation( siteId ) {
 		{
 			onSuccess( data ) {
 				const { login } = data;
-				queryClient.setQueryData( cacheKey( siteId, login ), data );
+				queryClient.invalidateQueries( cacheKey( siteId, login ) );
 			},
 		}
 	);

--- a/client/data/users/use-update-user-mutation.js
+++ b/client/data/users/use-update-user-mutation.js
@@ -8,16 +8,15 @@ import { useMutation, useQueryClient } from 'react-query';
  * Internal dependencies
  */
 import wp from 'calypso/lib/wp';
-import { cacheKey } from './use-user-query';
+import { getCacheKey } from './use-user-query';
 
 function useUpdateUserMutation( siteId ) {
 	const queryClient = useQueryClient();
 	const mutation = useMutation(
 		( { userId, variables } ) => wp.req.post( `/sites/${ siteId }/users/${ userId }`, variables ),
 		{
-			onSuccess( data ) {
-				const { login } = data;
-				queryClient.invalidateQueries( cacheKey( siteId, login ) );
+			onSuccess( { login } ) {
+				queryClient.invalidateQueries( getCacheKey( siteId, login ) );
 			},
 		}
 	);

--- a/client/data/users/use-user-query.js
+++ b/client/data/users/use-user-query.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { useQuery } from 'react-query';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'calypso/lib/wp';
+
+const useUserQuery = ( siteId, login, queryOptions = {} ) => {
+	return useQuery(
+		[ 'user', siteId, login ],
+		() => wpcom.req.get( `/sites/${ siteId }/users/login:${ login }` ),
+		queryOptions
+	);
+};
+
+export default useUserQuery;

--- a/client/data/users/use-user-query.js
+++ b/client/data/users/use-user-query.js
@@ -8,9 +8,11 @@ import { useQuery } from 'react-query';
  */
 import wpcom from 'calypso/lib/wp';
 
+export const cacheKey = ( siteId, login ) => [ 'user', siteId, login ];
+
 const useUserQuery = ( siteId, login, queryOptions = {} ) => {
 	return useQuery(
-		[ 'user', siteId, login ],
+		cacheKey( siteId, login ),
 		() => wpcom.req.get( `/sites/${ siteId }/users/login:${ login }` ),
 		queryOptions
 	);

--- a/client/data/users/use-user-query.js
+++ b/client/data/users/use-user-query.js
@@ -8,11 +8,11 @@ import { useQuery } from 'react-query';
  */
 import wpcom from 'calypso/lib/wp';
 
-export const cacheKey = ( siteId, login ) => [ 'user', siteId, login ];
+export const getCacheKey = ( siteId, login ) => [ 'user', siteId, login ];
 
 const useUserQuery = ( siteId, login, queryOptions = {} ) => {
 	return useQuery(
-		cacheKey( siteId, login ),
+		getCacheKey( siteId, login ),
 		() => wpcom.req.get( `/sites/${ siteId }/users/login:${ login }` ),
 		queryOptions
 	);

--- a/client/my-sites/people/contractor-select/index.tsx
+++ b/client/my-sites/people/contractor-select/index.tsx
@@ -15,6 +15,7 @@ import SupportInfo from 'calypso/components/support-info';
 interface Props {
 	checked: boolean;
 	onChange: ( event ) => void;
+	disabled: boolean;
 }
 
 /**
@@ -22,7 +23,7 @@ interface Props {
  */
 import './style.scss';
 
-const ContractorSelect: FunctionComponent< Props > = ( { checked, onChange } ) => {
+const ContractorSelect: FunctionComponent< Props > = ( { checked, onChange, disabled } ) => {
 	const translate = useTranslate();
 
 	return (
@@ -32,6 +33,7 @@ const ContractorSelect: FunctionComponent< Props > = ( { checked, onChange } ) =
 					className="contractor-select__checkbox"
 					onChange={ onChange }
 					checked={ checked }
+					disabled={ disabled }
 				/>
 				<span>
 					{ translate( 'This user is a contractor, freelancer, consultant, or agency.' ) }

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -21,7 +21,6 @@ import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
 import User from 'calypso/components/user';
 import AuthorSelector from 'calypso/blocks/author-selector';
-import { deleteUser } from 'calypso/lib/users/actions';
 import accept from 'calypso/lib/accept';
 import Gravatar from 'calypso/components/gravatar';
 import { localize } from 'i18n-calypso';
@@ -32,6 +31,7 @@ import {
 	requestExternalContributorsRemoval,
 } from 'calypso/state/data-getters';
 import { httpData } from 'calypso/state/data-layer/http-data';
+import withDeleteUser from './with-delete-user';
 
 /**
  * Style dependencies
@@ -168,7 +168,7 @@ class DeleteUser extends React.Component {
 							user.linked_user_ID ? user.linked_user_ID : user.ID
 						);
 					}
-					deleteUser( siteId, user.ID );
+					this.props.deleteUser( user.ID );
 				} else {
 					this.props.recordGoogleEvent(
 						'People',
@@ -183,23 +183,28 @@ class DeleteUser extends React.Component {
 
 	deleteUser = ( event ) => {
 		event.preventDefault();
+
 		const { contributorType, siteId, user } = this.props;
+		const { reassignUser, radioOption } = this.state;
+
 		if ( ! user.ID ) {
 			return;
 		}
 
-		let reassignUserId;
-		if ( this.state.reassignUser && 'reassign' === this.state.radioOption ) {
-			reassignUserId = this.state.reassignUser.ID;
+		const variables = {};
+
+		if ( reassignUser && 'reassign' === radioOption ) {
+			variables.reassign = reassignUser.ID;
 		}
+
 		if ( 'external' === contributorType ) {
 			requestExternalContributorsRemoval(
 				siteId,
 				user.linked_user_ID ? user.linked_user_ID : user.ID
 			);
 		}
-		deleteUser( siteId, user.ID, reassignUserId );
 
+		this.props.deleteUser( user.ID, variables );
 		this.props.recordGoogleEvent( 'People', 'Clicked Remove User on Edit User Single Site' );
 	};
 
@@ -341,5 +346,5 @@ export default localize(
 			};
 		},
 		{ recordGoogleEvent }
-	)( DeleteUser )
+	)( withDeleteUser( DeleteUser ) )
 );

--- a/client/my-sites/people/delete-user/with-delete-user.js
+++ b/client/my-sites/people/delete-user/with-delete-user.js
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import page from 'page';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import useDeleteUserMutation from 'calypso/data/users/use-delete-user-mutation';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+
+const useSuccessNotice = ( isSuccess, user, isMultisite, siteSlug ) => {
+	const showNotice = React.useRef();
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	React.useEffect( () => {
+		showNotice.current = () => {
+			dispatch(
+				successNotice(
+					isMultisite
+						? translate( 'Successfully removed @%(user)s', {
+								args: { user: user.login },
+								context: 'Success message after a user has been modified.',
+						  } )
+						: translate( 'Successfully deleted @%(user)s', {
+								args: { user: user.login },
+								context: 'Success message after a user has been modified.',
+						  } ),
+					{ id: 'delete-user-notice', displayOnNextPage: true }
+				)
+			);
+			page.redirect( `/people/team${ siteSlug ? `/${ siteSlug }` : '' }` );
+		};
+	}, [ dispatch, isMultisite, siteSlug, translate, user.login ] );
+
+	React.useEffect( () => {
+		isSuccess && showNotice.current();
+	}, [ isSuccess ] );
+};
+
+const useErrorNotice = ( isError, user, isMultisite, error ) => {
+	const showNotice = React.useRef();
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	React.useEffect( () => {
+		showNotice.current = ( errorObj ) => {
+			let message;
+			if ( 'user_owns_domain_subscription' === errorObj.error ) {
+				const domains = errorObj.data ?? errorObj.message.split( ',' );
+				message = translate(
+					'@%(user)s owns following domain used on this site: {{strong}}%(domains)s{{/strong}}. This domain will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
+					'@%(user)s owns following domains used on this site: {{strong}}%(domains)s{{/strong}}. These domains will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
+					{
+						count: domains.length,
+						args: {
+							domains: domains.join( ', ' ),
+							user: user.login,
+						},
+						components: {
+							strong: <strong />,
+						},
+					}
+				);
+			} else if ( 'user_has_active_subscriptions' === errorObj.error ) {
+				const productNames = errorObj.data ?? [];
+				message = translate(
+					'@%(user)s owns following product used on this site: {{strong}}%(productNames)s{{/strong}}. This product will have to be transferred to a different site, user, or canceled before removing or deleting @%(user)s.',
+					'@%(user)s owns following products used on this site: {{strong}}%(productNames)s{{/strong}}. These products will have to be transferred to a different site, user, or canceled before removing or deleting @%(user)s.',
+					{
+						count: productNames.length,
+						args: {
+							productNames: productNames.join( ', ' ),
+							user: user.login,
+						},
+						components: {
+							strong: <strong />,
+						},
+					}
+				);
+			} else {
+				message = isMultisite
+					? translate( 'There was an error removing @%(user)s', {
+							args: { user: user.login },
+							context: 'Error message after A site has failed to perform actions on a user.',
+					  } )
+					: translate( 'There was an error deleting @%(user)s', {
+							args: { user: user.login },
+							context: 'Error message after A site has failed to perform actions on a user.',
+					  } );
+			}
+
+			dispatch( errorNotice( message, { id: 'delete-user-notice' } ) );
+		};
+	}, [ dispatch, isMultisite, translate, user.login ] );
+
+	React.useEffect( () => {
+		isError && showNotice.current( error );
+	}, [ isError, error ] );
+};
+
+const withDeleteUser = ( Component ) => ( props ) => {
+	const { siteId, user, isMultisite, siteSlug } = props;
+	const { deleteUser, isSuccess, isError, error } = useDeleteUserMutation( siteId );
+
+	useSuccessNotice( isSuccess, user, isMultisite, siteSlug );
+	useErrorNotice( isError, user, isMultisite, error );
+
+	return <Component { ...props } deleteUser={ deleteUser } />;
+};
+
+export default withDeleteUser;

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -4,7 +4,7 @@
 import React, { Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import debugModule from 'debug';
-import { connect, useDispatch } from 'react-redux';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -25,8 +25,7 @@ import {
 	requestExternalContributorsRemoval,
 } from 'calypso/state/data-getters';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import useUpdateUserMutation from 'calypso/data/users/use-update-user-mutation';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import withUpdateUser from './with-update-user';
 
 /**
  * Style dependencies
@@ -119,7 +118,7 @@ class EditUserForm extends React.Component {
 			? Object.assign( changedSettings, { roles: [ changedSettings.roles ] } )
 			: changedSettings;
 
-		this.props.updateUser( this.state.ID, changedAttributes );
+		this.props.updateUser( user.ID, changedAttributes );
 
 		if ( true === changedSettings.isExternalContributor ) {
 			requestExternalContributorsAddition(
@@ -264,43 +263,6 @@ class EditUserForm extends React.Component {
 		);
 	}
 }
-
-const withUpdateUser = ( Component ) => {
-	return ( props ) => {
-		const { siteId, user, translate } = props;
-		const dispatch = useDispatch();
-		const { updateUser, isSuccess, isError, error } = useUpdateUserMutation( siteId, user?.login );
-
-		React.useEffect( () => {
-			isSuccess &&
-				dispatch(
-					successNotice(
-						translate( 'Successfully updated @%(user)s', {
-							args: { user: user?.login },
-							context: 'Success message after a user has been modified.',
-						} ),
-						{ id: 'update-user-notice' }
-					)
-				);
-		}, [ isSuccess, translate, dispatch, user ] );
-
-		React.useEffect( () => {
-			isError &&
-				error &&
-				dispatch(
-					errorNotice(
-						translate( 'There was an error updating @%(user)s', {
-							args: { user: user?.login },
-							context: 'Error message after A site has failed to perform actions on a user.',
-						} ),
-						{ id: 'update-user-notice' }
-					)
-				);
-		}, [ isError, error, translate, dispatch, user ] );
-
-		return <Component { ...props } updateUser={ updateUser } />;
-	};
-};
 
 export default localize(
 	connect(

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -149,7 +149,7 @@ class EditUserForm extends React.Component {
 	isExternalRole = ( role ) =>
 		[ 'administrator', 'editor', 'author', 'contributor' ].includes( role );
 
-	renderField = ( fieldId ) => {
+	renderField = ( fieldId, isDisabled ) => {
 		let returnField = null;
 		switch ( fieldId ) {
 			case 'roles':
@@ -162,6 +162,7 @@ class EditUserForm extends React.Component {
 							value={ this.state.roles }
 							onChange={ this.handleChange }
 							onFocus={ this.recordFieldFocus( 'roles' ) }
+							disabled={ isDisabled }
 						/>
 						{ ! this.props.isVip &&
 							! this.props.isWPForTeamsSite &&
@@ -169,6 +170,7 @@ class EditUserForm extends React.Component {
 								<ContractorSelect
 									onChange={ this.handleExternalChange }
 									checked={ this.state.isExternalContributor }
+									disabled={ isDisabled }
 								/>
 							) }
 					</Fragment>
@@ -188,6 +190,7 @@ class EditUserForm extends React.Component {
 							value={ this.state.first_name }
 							onChange={ this.handleChange }
 							onFocus={ this.recordFieldFocus( 'first_name' ) }
+							disabled={ isDisabled }
 						/>
 					</FormFieldset>
 				);
@@ -206,6 +209,7 @@ class EditUserForm extends React.Component {
 							value={ this.state.last_name }
 							onChange={ this.handleChange }
 							onFocus={ this.recordFieldFocus( 'last_name' ) }
+							disabled={ isDisabled }
 						/>
 					</FormFieldset>
 				);
@@ -224,6 +228,7 @@ class EditUserForm extends React.Component {
 							value={ this.state.name }
 							onChange={ this.handleChange }
 							onFocus={ this.recordFieldFocus( 'name' ) }
+							disabled={ isDisabled }
 						/>
 					</FormFieldset>
 				);
@@ -251,9 +256,9 @@ class EditUserForm extends React.Component {
 				onSubmit={ this.updateUser }
 				onChange={ this.props.markChanged }
 			>
-				{ editableFields.map( this.renderField ) }
+				{ editableFields.map( ( fieldId ) => this.renderField( fieldId, this.props.isUpdating ) ) }
 				<FormButtonsBar>
-					<FormButton disabled={ ! this.hasUnsavedSettings() }>
+					<FormButton disabled={ ! this.hasUnsavedSettings() || this.props.isUpdating }>
 						{ this.props.translate( 'Save changes', {
 							context: 'Button label that prompts user to save form',
 						} ) }

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import React, { Component, Fragment } from 'react';
+import React, { Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import debugModule from 'debug';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -16,7 +16,6 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
-import { updateUser } from 'calypso/lib/users/actions';
 import RoleSelect from 'calypso/my-sites/people/role-select';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
@@ -26,6 +25,8 @@ import {
 	requestExternalContributorsRemoval,
 } from 'calypso/state/data-getters';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import useUpdateUserMutation from 'calypso/data/users/use-update-user-mutation';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 /**
  * Style dependencies
@@ -37,7 +38,7 @@ import './style.scss';
  */
 const debug = debugModule( 'calypso:my-sites:people:edit-team-member-form' );
 
-class EditUserForm extends Component {
+class EditUserForm extends React.Component {
 	state = this.getStateObject( this.props );
 
 	componentDidUpdate() {
@@ -114,13 +115,11 @@ class EditUserForm extends Component {
 		// Since we store 'roles' in state as a string, but user objects expect
 		// roles to be an array, if we've updated the user's role, we need to
 		// place the role in an array before updating the user.
-		updateUser(
-			siteId,
-			user.ID,
-			changedSettings.roles
-				? Object.assign( changedSettings, { roles: [ changedSettings.roles ] } )
-				: changedSettings
-		);
+		const changedAttributes = changedSettings.roles
+			? Object.assign( changedSettings, { roles: [ changedSettings.roles ] } )
+			: changedSettings;
+
+		this.props.updateUser( this.state.ID, changedAttributes );
 
 		if ( true === changedSettings.isExternalContributor ) {
 			requestExternalContributorsAddition(
@@ -266,6 +265,43 @@ class EditUserForm extends Component {
 	}
 }
 
+const withUpdateUser = ( Component ) => {
+	return ( props ) => {
+		const { siteId, user, translate } = props;
+		const dispatch = useDispatch();
+		const { updateUser, isSuccess, isError, error } = useUpdateUserMutation( siteId, user?.login );
+
+		React.useEffect( () => {
+			isSuccess &&
+				dispatch(
+					successNotice(
+						translate( 'Successfully updated @%(user)s', {
+							args: { user: user?.login },
+							context: 'Success message after a user has been modified.',
+						} ),
+						{ id: 'update-user-notice' }
+					)
+				);
+		}, [ isSuccess, translate, dispatch, user ] );
+
+		React.useEffect( () => {
+			isError &&
+				error &&
+				dispatch(
+					errorNotice(
+						translate( 'There was an error updating @%(user)s', {
+							args: { user: user?.login },
+							context: 'Error message after A site has failed to perform actions on a user.',
+						} ),
+						{ id: 'update-user-notice' }
+					)
+				);
+		}, [ isError, error, translate, dispatch, user ] );
+
+		return <Component { ...props } updateUser={ updateUser } />;
+	};
+};
+
 export default localize(
 	connect(
 		( state, { siteId, user } ) => {
@@ -280,5 +316,5 @@ export default localize(
 		{
 			recordGoogleEvent,
 		}
-	)( EditUserForm )
+	)( withUpdateUser( EditUserForm ) )
 );

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -2,8 +2,7 @@
  * External dependencies
  */
 
-import React, { Component } from 'react';
-import { pick } from 'lodash';
+import React from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
 
@@ -14,171 +13,80 @@ import Main from 'calypso/components/main';
 import HeaderCake from 'calypso/components/header-cake';
 import { Card } from '@automattic/components';
 import PeopleProfile from 'calypso/my-sites/people/people-profile';
-import UsersStore from 'calypso/lib/users/store';
-import { fetchUser } from 'calypso/lib/users/actions';
 import { protectForm } from 'calypso/lib/protect-form';
 import DeleteUser from 'calypso/my-sites/people/delete-user';
-import PeopleNotices from 'calypso/my-sites/people/people-notices';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import PeopleLogStore from 'calypso/lib/people/log-store';
 import { isJetpackSiteMultiSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import EditUserForm from './edit-user-form';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { recordGoogleEvent as recordGoogleEventAction } from 'calypso/state/analytics/actions';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
+import useUserQuery from 'calypso/data/users/use-user-query';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-export class EditTeamMemberForm extends Component {
-	constructor( props ) {
-		super( props );
-		this.state = {
-			user: UsersStore.getUserByLogin( props.siteId, props.userLogin ),
-			removingUser: false,
-		};
-	}
-
-	componentDidMount() {
-		UsersStore.on( 'change', this.refreshUser );
-		PeopleLogStore.on( 'change', this.checkRemoveUser );
-		PeopleLogStore.on( 'change', this.redirectIfError );
-		this.requestUser();
-	}
-
-	componentWillUnmount() {
-		UsersStore.removeListener( 'change', this.refreshUser );
-		PeopleLogStore.removeListener( 'change', this.checkRemoveUser );
-		PeopleLogStore.removeListener( 'change', this.redirectIfError );
-	}
-
-	componentDidUpdate( lastProps ) {
-		if ( lastProps.siteId !== this.props.siteId || lastProps.userLogin !== this.props.userLogin ) {
-			this.requestUser();
-		}
-	}
-
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.siteId !== this.props.siteId || nextProps.userLogin !== this.props.userLogin ) {
-			this.refreshUser( nextProps );
-		}
-	}
-
-	requestUser = () => {
-		if ( this.props.siteId ) {
-			fetchUser( { siteId: this.props.siteId }, this.props.userLogin );
-		}
-	};
-
-	refreshUser = ( props = this.props ) => {
-		const peopleUser = UsersStore.getUserByLogin( props.siteId, props.userLogin );
-
-		this.setState( {
-			user: peopleUser,
-		} );
-	};
-
-	redirectIfError = () => {
-		if ( this.props.siteId ) {
-			const fetchUserError = PeopleLogStore.getErrors(
-				( log ) =>
-					this.props.siteId === log.siteId &&
-					'RECEIVE_USER_FAILED' === log.action &&
-					this.props.userLogin === log.user
-			);
-			if ( fetchUserError.length ) {
-				page.redirect( `/people/team/${ this.props.siteSlug }` );
-			}
-		}
-	};
-
-	checkRemoveUser = () => {
-		if ( ! this.props.siteId ) {
+export const EditTeamMemberForm = ( {
+	siteId,
+	userLogin,
+	isJetpack,
+	isMultisite,
+	markChanged,
+	markSaved,
+	previousRoute,
+	siteSlug,
+	recordGoogleEvent,
+} ) => {
+	const goBack = () => {
+		recordGoogleEvent( 'People', 'Clicked Back Button on User Edit' );
+		if ( previousRoute ) {
+			page.back( previousRoute );
 			return;
 		}
-
-		const removeUserSuccessful = PeopleLogStore.getCompleted( ( log ) => {
-			return (
-				'RECEIVE_DELETE_SITE_USER_SUCCESS' === log.action &&
-				this.props.siteId === log.siteId &&
-				this.props.userLogin === log.user.login
-			);
-		} );
-
-		if ( removeUserSuccessful.length ) {
-			this.props.markSaved();
-			const redirect = this.props.siteSlug ? '/people/team/' + this.props.siteSlug : '/people/team';
-			page.redirect( redirect );
-		}
-
-		const removeUserInProgress = PeopleLogStore.getInProgress(
-			function ( log ) {
-				return (
-					'DELETE_SITE_USER' === log.action &&
-					this.props.siteId === log.siteId &&
-					this.props.userLogin === log.user.login
-				);
-			}.bind( this )
-		);
-
-		if ( !! removeUserInProgress.length !== this.state.removingUser ) {
-			this.setState( {
-				removingUser: ! this.state.removingUser,
-			} );
-		}
-	};
-
-	goBack = () => {
-		this.props.recordGoogleEvent( 'People', 'Clicked Back Button on User Edit' );
-		if ( this.props.previousRoute ) {
-			page.back( this.props.previousRoute );
-			return;
-		}
-		if ( this.props.siteSlug ) {
-			page( '/people/team/' + this.props.siteSlug );
+		if ( siteSlug ) {
+			page( '/people/team/' + siteSlug );
 			return;
 		}
 		page( '/people/team' );
 	};
 
-	renderNotices() {
-		if ( ! this.state.user ) {
-			return;
-		}
-		return <PeopleNotices user={ this.state.user } />;
-	}
+	const { data: user, error, isLoading } = useUserQuery( siteId, userLogin, { retry: false } );
 
-	render() {
-		return (
-			<Main className="edit-team-member-form">
-				<PageViewTracker path="people/edit/:site/:user" title="People > View Team Member" />
-				<HeaderCake onClick={ this.goBack } isCompact />
-				{ this.renderNotices() }
-				<Card className="edit-team-member-form__user-profile">
-					<PeopleProfile siteId={ this.props.siteId } user={ this.state.user } />
-					{ this.state.user && (
-						<EditUserForm
-							user={ this.state.user }
-							disabled={ this.state.removingUser }
-							siteId={ this.props.siteId }
-							isJetpack={ this.props.isJetpack }
-							markChanged={ this.props.markChanged }
-							markSaved={ this.props.markSaved }
-						/>
-					) }
-				</Card>
-				{ this.state.user && (
-					<DeleteUser
-						{ ...pick( this.props, [ 'siteId', 'isJetpack', 'isMultisite' ] ) }
-						user={ this.state.user }
+	React.useEffect( () => {
+		! isLoading && error && page.redirect( `/people/team/${ siteSlug }` );
+	}, [ error, isLoading, siteSlug ] );
+
+	return (
+		<Main className="edit-team-member-form">
+			<PageViewTracker path="people/edit/:site/:user" title="People > View Team Member" />
+			<HeaderCake onClick={ goBack } isCompact />
+			<Card className="edit-team-member-form__user-profile">
+				<PeopleProfile siteId={ siteId } user={ user } />
+				{ user && (
+					<EditUserForm
+						user={ user }
+						disabled={ false } // @TODO added when added mutation to remove user
+						siteId={ siteId }
+						isJetpack={ isJetpack }
+						markChanged={ markChanged }
+						markSaved={ markSaved }
 					/>
 				) }
-			</Main>
-		);
-	}
-}
+			</Card>
+			{ user && (
+				<DeleteUser
+					siteId={ siteId }
+					isJetpack={ isJetpack }
+					isMultisite={ isMultisite }
+					user={ user }
+					siteSlug={ siteSlug }
+				/>
+			) }
+		</Main>
+	);
+};
 
 export default connect(
 	( state ) => {
@@ -192,5 +100,5 @@ export default connect(
 			previousRoute: getPreviousRoute( state ),
 		};
 	},
-	{ recordGoogleEvent }
+	{ recordGoogleEvent: recordGoogleEventAction }
 )( protectForm( EditTeamMemberForm ) );

--- a/client/my-sites/people/edit-team-member-form/with-update-user.js
+++ b/client/my-sites/people/edit-team-member-form/with-update-user.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useDispatch } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import useUpdateUserMutation from 'calypso/data/users/use-update-user-mutation';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { useTranslate } from 'i18n-calypso';
+
+const useSuccessNotice = ( isSuccess, user ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	React.useEffect( () => {
+		isSuccess &&
+			dispatch(
+				successNotice(
+					translate( 'Successfully updated @%(user)s', {
+						args: { user: user?.login },
+						context: 'Success message after a user has been modified.',
+					} ),
+					{ id: 'update-user-notice' }
+				)
+			);
+	}, [ isSuccess, translate, dispatch, user ] );
+};
+
+const useErrorNotice = ( error, user ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	React.useEffect( () => {
+		error &&
+			dispatch(
+				errorNotice(
+					translate( 'There was an error updating @%(user)s', {
+						args: { user: user?.login },
+						context: 'Error message after A site has failed to perform actions on a user.',
+					} ),
+					{ id: 'update-user-notice' }
+				)
+			);
+	}, [ error, translate, dispatch, user ] );
+};
+
+const withUpdateUser = ( Component ) => ( props ) => {
+	const { siteId, user } = props;
+	const { updateUser, isSuccess, error } = useUpdateUserMutation( siteId, user?.login );
+
+	useSuccessNotice( isSuccess, user );
+	useErrorNotice( error, user );
+
+	return <Component { ...props } updateUser={ updateUser } />;
+};
+
+export default withUpdateUser;

--- a/client/my-sites/people/edit-team-member-form/with-update-user.js
+++ b/client/my-sites/people/edit-team-member-form/with-update-user.js
@@ -26,15 +26,18 @@ const useSuccessNotice = ( isSuccess, user ) => {
 					{ id: 'update-user-notice' }
 				)
 			);
-	}, [ isSuccess, translate, dispatch, user ] );
+		// Note: We only want to run this effect in case `isSuccess`
+		// changes and ignore changes to other deps like `user`.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isSuccess ] );
 };
 
-const useErrorNotice = ( error, user ) => {
+const useErrorNotice = ( isError, user ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	React.useEffect( () => {
-		error &&
+		isError &&
 			dispatch(
 				errorNotice(
 					translate( 'There was an error updating @%(user)s', {
@@ -44,7 +47,10 @@ const useErrorNotice = ( error, user ) => {
 					{ id: 'update-user-notice' }
 				)
 			);
-	}, [ error, translate, dispatch, user ] );
+		// Note: We only want to run this effect in case `isError`
+		// changes and ignore changes to other deps like `user`.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isError ] );
 };
 
 const usePendingNotice = ( isPending, user ) => {
@@ -62,15 +68,18 @@ const usePendingNotice = ( isPending, user ) => {
 					{ id: 'update-user-notice' }
 				)
 			);
-	}, [ isPending, translate, dispatch, user ] );
+		// Note: We only want to run this effect in case `isError`
+		// changes and ignore changes to other deps like `user`.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isPending ] );
 };
 
 const withUpdateUser = ( Component ) => ( props ) => {
 	const { siteId, user } = props;
-	const { updateUser, isSuccess, error, isLoading } = useUpdateUserMutation( siteId );
+	const { updateUser, isSuccess, isError, isLoading } = useUpdateUserMutation( siteId );
 
 	useSuccessNotice( isSuccess, user );
-	useErrorNotice( error, user );
+	useErrorNotice( isError, user );
 	usePendingNotice( isLoading, user );
 
 	return <Component { ...props } updateUser={ updateUser } isUpdating={ isLoading } />;

--- a/client/my-sites/people/edit-team-member-form/with-update-user.js
+++ b/client/my-sites/people/edit-team-member-form/with-update-user.js
@@ -8,7 +8,7 @@ import { useDispatch } from 'react-redux';
  * Internal dependencies
  */
 import useUpdateUserMutation from 'calypso/data/users/use-update-user-mutation';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice, plainNotice } from 'calypso/state/notices/actions';
 import { useTranslate } from 'i18n-calypso';
 
 const useSuccessNotice = ( isSuccess, user ) => {
@@ -47,12 +47,31 @@ const useErrorNotice = ( error, user ) => {
 	}, [ error, translate, dispatch, user ] );
 };
 
+const usePendingNotice = ( isPending, user ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	React.useEffect( () => {
+		isPending &&
+			dispatch(
+				plainNotice(
+					translate( 'Updating @%(user)s', {
+						args: { user: user?.login },
+						context: 'In progress message while a site is performing actions on users.',
+					} ),
+					{ id: 'update-user-notice' }
+				)
+			);
+	}, [ isPending, translate, dispatch, user ] );
+};
+
 const withUpdateUser = ( Component ) => ( props ) => {
 	const { siteId, user } = props;
-	const { updateUser, isSuccess, error } = useUpdateUserMutation( siteId, user?.login );
+	const { updateUser, isSuccess, error, isLoading } = useUpdateUserMutation( siteId );
 
 	useSuccessNotice( isSuccess, user );
 	useErrorNotice( error, user );
+	usePendingNotice( isLoading, user );
 
 	return <Component { ...props } updateUser={ updateUser } />;
 };

--- a/client/my-sites/people/edit-team-member-form/with-update-user.js
+++ b/client/my-sites/people/edit-team-member-form/with-update-user.js
@@ -8,7 +8,7 @@ import { useDispatch } from 'react-redux';
  * Internal dependencies
  */
 import useUpdateUserMutation from 'calypso/data/users/use-update-user-mutation';
-import { errorNotice, successNotice, plainNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { useTranslate } from 'i18n-calypso';
 
 const useSuccessNotice = ( isSuccess, user ) => {
@@ -53,34 +53,12 @@ const useErrorNotice = ( isError, user ) => {
 	}, [ isError ] );
 };
 
-const usePendingNotice = ( isPending, user ) => {
-	const dispatch = useDispatch();
-	const translate = useTranslate();
-
-	React.useEffect( () => {
-		isPending &&
-			dispatch(
-				plainNotice(
-					translate( 'Updating @%(user)s', {
-						args: { user: user?.login },
-						context: 'In progress message while a site is performing actions on users.',
-					} ),
-					{ id: 'update-user-notice' }
-				)
-			);
-		// Note: We only want to run this effect in case `isError`
-		// changes and ignore changes to other deps like `user`.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ isPending ] );
-};
-
 const withUpdateUser = ( Component ) => ( props ) => {
 	const { siteId, user } = props;
 	const { updateUser, isSuccess, isError, isLoading } = useUpdateUserMutation( siteId );
 
 	useSuccessNotice( isSuccess, user );
 	useErrorNotice( isError, user );
-	usePendingNotice( isLoading, user );
 
 	return <Component { ...props } updateUser={ updateUser } isUpdating={ isLoading } />;
 };

--- a/client/my-sites/people/edit-team-member-form/with-update-user.js
+++ b/client/my-sites/people/edit-team-member-form/with-update-user.js
@@ -73,7 +73,7 @@ const withUpdateUser = ( Component ) => ( props ) => {
 	useErrorNotice( error, user );
 	usePendingNotice( isLoading, user );
 
-	return <Component { ...props } updateUser={ updateUser } />;
+	return <Component { ...props } updateUser={ updateUser } isUpdating={ isLoading } />;
 };
 
 export default withUpdateUser;

--- a/client/my-sites/people/edit-team-member-form/with-update-user.js
+++ b/client/my-sites/people/edit-team-member-form/with-update-user.js
@@ -12,44 +12,50 @@ import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { useTranslate } from 'i18n-calypso';
 
 const useSuccessNotice = ( isSuccess, user ) => {
+	const showNotice = React.useRef();
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	React.useEffect( () => {
-		isSuccess &&
+		showNotice.current = () => {
 			dispatch(
 				successNotice(
 					translate( 'Successfully updated @%(user)s', {
-						args: { user: user?.login },
+						args: { user: user.login },
 						context: 'Success message after a user has been modified.',
 					} ),
 					{ id: 'update-user-notice' }
 				)
 			);
-		// Note: We only want to run this effect in case `isSuccess`
-		// changes and ignore changes to other deps like `user`.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
+		};
+	}, [ dispatch, translate, user.login ] );
+
+	React.useEffect( () => {
+		isSuccess && showNotice.current();
 	}, [ isSuccess ] );
 };
 
 const useErrorNotice = ( isError, user ) => {
+	const showNotice = React.useRef();
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	React.useEffect( () => {
-		isError &&
+		showNotice.current = () => {
 			dispatch(
 				errorNotice(
 					translate( 'There was an error updating @%(user)s', {
-						args: { user: user?.login },
+						args: { user: user.login },
 						context: 'Error message after A site has failed to perform actions on a user.',
 					} ),
 					{ id: 'update-user-notice' }
 				)
 			);
-		// Note: We only want to run this effect in case `isError`
-		// changes and ignore changes to other deps like `user`.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
+		};
+	}, [ dispatch, translate, user.login ] );
+
+	React.useEffect( () => {
+		isError && showNotice.current();
 	}, [ isError ] );
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* EditTeamMemberForm: use `useUserQuery` to fetch user data
* EditUserForm: use `useUpdateUserMutation` to update user data

#### Testing instructions

Try the following steps for a simple site, an AT site and a Jetpack site because the fields you can change differ on the type of the site.

* Go to `people/team/` and choose on of the people on your team which isn't you
* Attempt to change the role and/or other attributes of that user
* Hit _Save changes_
* Are the changes persisted successfully and shown locally (e.g. role changes)?
* Try the error case and block the request to update a user
* Change the user login in the URL to one which doesn't exist on the chosen site, are you redirected to `/people/team`?
