### PR TITLE
ExPlat: Implement ProvideExperimentData

### DIFF
--- a/client/lib/explat/index.ts
+++ b/client/lib/explat/index.ts
@@ -23,4 +23,4 @@ const exPlatClient = createExPlatClient( {
 
 export const { loadExperimentAssignment, dangerouslyGetExperimentAssignment } = exPlatClient;
 const exPlatClientReactHelpers = createExPlatClientReactHelpers( exPlatClient );
-export const { useExperiment, Experiment } = exPlatClientReactHelpers;
+export const { useExperiment, Experiment, ProvideExperimentData } = exPlatClientReactHelpers;

--- a/packages/explat-client-react-helpers/src/index.tsx
+++ b/packages/explat-client-react-helpers/src/index.tsx
@@ -44,19 +44,16 @@ export default function createExPlatClientReactHelpers(
 ): ExPlatClientReactHelpers {
 	const useExperiment = ( experimentName: string ): [ boolean, ExperimentAssignment | null ] => {
 		const [ previousExperimentName ] = useState( experimentName );
-		const [ isLoading, setIsLoading ] = useState< boolean >( true );
-		const [
-			experimentAssignment,
-			setExperimentAssignment,
-		] = useState< ExperimentAssignment | null >( null );
+		const [ state, setState ] = useState< [ boolean, ExperimentAssignment | null ] >( [
+			true,
+			null,
+		] );
 
 		useEffect( () => {
 			let isSubscribed = true;
 			exPlatClient.loadExperimentAssignment( experimentName ).then( ( experimentAssignment ) => {
 				if ( isSubscribed ) {
-					// The order here is important as React can rerender in between these two
-					setExperimentAssignment( experimentAssignment );
-					setIsLoading( false );
+					setState( [ false, experimentAssignment ] );
 				}
 			} );
 			return () => {
@@ -77,7 +74,7 @@ export default function createExPlatClientReactHelpers(
 			exPlatClient.config.logError( { message } );
 		}
 
-		return [ isLoading, experimentAssignment ];
+		return state;
 	};
 
 	const Experiment = ( {

--- a/packages/explat-client-react-helpers/src/index.tsx
+++ b/packages/explat-client-react-helpers/src/index.tsx
@@ -25,6 +25,15 @@ interface ExPlatClientReactHelpers {
 		name: string;
 		children: { default: React.ReactNode; treatment: React.ReactNode; loading: React.ReactNode };
 	} ) => JSX.Element;
+
+	/**
+	 * Inject experiment data into a child component.
+	 * Use when hooks aren't available.
+	 */
+	ProvideExperimentData : ( props: {
+		children: (isLoading: boolean, experimentAssignment: ExperimentAssignment | null) => JSX.Element;
+		name: string;
+	}) => JSX.Element 
 }
 
 export default function createExPlatClientReactHelpers(
@@ -42,6 +51,7 @@ export default function createExPlatClientReactHelpers(
 			let isSubscribed = true;
 			exPlatClient.loadExperimentAssignment( experimentName ).then( ( experimentAssignment ) => {
 				if ( isSubscribed ) {
+					// The order here is important as React can rerender in between these two
 					setExperimentAssignment( experimentAssignment );
 					setIsLoading( false );
 				}
@@ -83,8 +93,20 @@ export default function createExPlatClientReactHelpers(
 		return <>{ children.treatment }</>;
 	};
 
+	const ProvideExperimentData = ({
+		children,
+		name: experimentName,
+	}: {
+		children: (isLoading: boolean, experimentAssignment: ExperimentAssignment | null) => JSX.Element;
+		name: string;
+	}) : JSX.Element => {
+		const [ isLoading, experimentAssignment ] = useExperiment( experimentName );
+		return children(isLoading, experimentAssignment)
+	}
+
 	return {
 		useExperiment,
 		Experiment,
+		ProvideExperimentData,
 	};
 }

--- a/packages/explat-client-react-helpers/src/index.tsx
+++ b/packages/explat-client-react-helpers/src/index.tsx
@@ -30,10 +30,13 @@ interface ExPlatClientReactHelpers {
 	 * Inject experiment data into a child component.
 	 * Use when hooks aren't available.
 	 */
-	ProvideExperimentData : ( props: {
-		children: (isLoading: boolean, experimentAssignment: ExperimentAssignment | null) => JSX.Element;
+	ProvideExperimentData: ( props: {
+		children: (
+			isLoading: boolean,
+			experimentAssignment: ExperimentAssignment | null
+		) => JSX.Element;
 		name: string;
-	}) => JSX.Element 
+	} ) => JSX.Element;
 }
 
 export default function createExPlatClientReactHelpers(
@@ -93,16 +96,19 @@ export default function createExPlatClientReactHelpers(
 		return <>{ children.treatment }</>;
 	};
 
-	const ProvideExperimentData = ({
+	const ProvideExperimentData = ( {
 		children,
 		name: experimentName,
 	}: {
-		children: (isLoading: boolean, experimentAssignment: ExperimentAssignment | null) => JSX.Element;
+		children: (
+			isLoading: boolean,
+			experimentAssignment: ExperimentAssignment | null
+		) => JSX.Element;
 		name: string;
-	}) : JSX.Element => {
+	} ): JSX.Element => {
 		const [ isLoading, experimentAssignment ] = useExperiment( experimentName );
-		return children(isLoading, experimentAssignment)
-	}
+		return children( isLoading, experimentAssignment );
+	};
 
 	return {
 		useExperiment,

--- a/packages/explat-client-react-helpers/src/test/index.tsx
+++ b/packages/explat-client-react-helpers/src/test/index.tsx
@@ -174,10 +174,8 @@ describe( 'ProvideExperimentData', () => {
 		capture.mockReset();
 		const experimentAssignment = { ...validExperimentAssignment, variationName: null };
 		await actReact( async () => controllablePromise1.resolve( experimentAssignment ) );
-		// In testing I capture two rerenders: [true, experimentAssignment], [false, experimentAssignment]
-		// React can't guarentee us that this will always happen so will just check the last render
 		await waitFor( () => {
-			expect( capture.mock.calls.length ).toBeGreaterThan( 1 );
+			expect( capture.mock.calls.length ).toBe( 1 );
 		} );
 		expect( capture.mock.calls[ capture.mock.calls.length - 1 ] ).toEqual( [
 			false,

--- a/packages/explat-client-react-helpers/src/test/index.tsx
+++ b/packages/explat-client-react-helpers/src/test/index.tsx
@@ -161,27 +161,27 @@ describe( 'ProvideExperimentData', () => {
 			typeof exPlatClient.loadExperimentAssignment
 		> ).mockImplementationOnce( () => controllablePromise1.promise );
 
-		const capture = jest.fn()
-		const { container, rerender } = render(
+		const capture = jest.fn();
+		render(
 			<ProvideExperimentData name="experiment_a">
-				{(isLoading, experimentAssignment) => (
-					<>
-					{ capture(isLoading, experimentAssignment)}
-					</>
+				{ ( isLoading, experimentAssignment ) => (
+					<>{ capture( isLoading, experimentAssignment ) }</>
 				) }
 			</ProvideExperimentData>
 		);
-		expect(capture.mock.calls.length).toBe(1)
-		expect(capture.mock.calls[capture.mock.calls.length - 1]).toEqual([true, null])
-		capture.mockReset()
-		const experimentAssignment = { ...validExperimentAssignment, variationName: null }
-		await actReact( async () =>
-			controllablePromise1.resolve( experimentAssignment )
-		);
+		expect( capture.mock.calls.length ).toBe( 1 );
+		expect( capture.mock.calls[ capture.mock.calls.length - 1 ] ).toEqual( [ true, null ] );
+		capture.mockReset();
+		const experimentAssignment = { ...validExperimentAssignment, variationName: null };
+		await actReact( async () => controllablePromise1.resolve( experimentAssignment ) );
 		// In testing I capture two rerenders: [true, experimentAssignment], [false, experimentAssignment]
-		// React can't guarentee us that this will always happen so we are doing this:
-		await waitFor( () => { expect(capture.mock.calls.length).toBeGreaterThan(1) })
-		// And checking the last experiment
-		expect(capture.mock.calls[capture.mock.calls.length - 1]).toEqual([false, experimentAssignment])
-	})
-})
+		// React can't guarentee us that this will always happen so will just check the last render
+		await waitFor( () => {
+			expect( capture.mock.calls.length ).toBeGreaterThan( 1 );
+		} );
+		expect( capture.mock.calls[ capture.mock.calls.length - 1 ] ).toEqual( [
+			false,
+			experimentAssignment,
+		] );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `<ProvideExperimentData>`

This allows accessing `useExperiment` functionality in traditional class components.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Added unit test

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 593-gh-Automattic/experimentation-platform