### PR TITLE
ExPlat: Make development mode behaviour match production

### DIFF
--- a/client/lib/explat/internals/anon-id.ts
+++ b/client/lib/explat/internals/anon-id.ts
@@ -11,7 +11,7 @@ import {
  * Internal dependencies
  */
 import userUtils from 'calypso/lib/user/utils';
-import { logErrorOrThrowInDevelopmentMode } from './log-error';
+import { logError } from './log-error';
 
 // SSR safety: Fail TypeScript compilation if `window` is used without an explicit undefined check
 declare const window: undefined | ( Window & typeof globalThis );
@@ -47,7 +47,7 @@ const anonIdPollingIntervalMaxAttempts = 100; // 50 * 100 = 5000 = 5 seconds
  */
 export const initializeAnonId = async (): Promise< string | null > => {
 	if ( typeof window === 'undefined' ) {
-		logErrorOrThrowInDevelopmentMode( 'Trying to initialize anonId outside of a browser context.' );
+		logError( { message: 'Trying to initialize anonId outside of a browser context.' } );
 		return null;
 	}
 
@@ -90,14 +90,12 @@ export const initializeAnonId = async (): Promise< string | null > => {
  */
 export const getAnonId = async (): Promise< string | null > => {
 	if ( typeof window === 'undefined' ) {
-		logErrorOrThrowInDevelopmentMode( 'Trying to getAnonId in non browser context.' );
+		logError( { message: 'Trying to getAnonId in non browser context.' } );
 		return null;
 	}
 
 	if ( initializeAnonIdPromise === null ) {
-		logErrorOrThrowInDevelopmentMode(
-			'AnonId initialization should have started before this function call.'
-		);
+		logError( { message: 'AnonId initialization should have started before this function call.' } );
 	}
 
 	try {

--- a/client/lib/explat/internals/log-error.ts
+++ b/client/lib/explat/internals/log-error.ts
@@ -52,11 +52,3 @@ export const logError = (
 		onError( e );
 	}
 };
-
-export const logErrorOrThrowInDevelopmentMode = ( message: string ): void => {
-	if ( isDevelopmentMode ) {
-		throw new Error( message );
-	} else {
-		logError( { message } );
-	}
-};

--- a/client/lib/explat/internals/test/anon-id.ts
+++ b/client/lib/explat/internals/test/anon-id.ts
@@ -11,9 +11,9 @@ import userUtils from 'calypso/lib/user/utils';
 
 import * as AnonId from '../anon-id';
 
-const mockLogErrorOrThrowInDevelopmentMode = jest.fn();
+const mockLogError = jest.fn();
 jest.mock( '../log-error', () => ( {
-	logErrorOrThrowInDevelopmentMode: ( ...args ) => mockLogErrorOrThrowInDevelopmentMode( ...args ),
+	logError: ( ...args ) => mockLogError( ...args ),
 } ) );
 
 jest.mock( 'calypso/lib/wp' );
@@ -48,10 +48,12 @@ describe( 'initializeAnonId', () => {
 	it( 'should return null and log error when run under SSR', async () => {
 		setSsrContext();
 		await expect( AnonId.initializeAnonId() ).resolves.toBe( null );
-		expect( mockLogErrorOrThrowInDevelopmentMode.mock.calls ).toMatchInlineSnapshot( `
+		expect( mockLogError.mock.calls ).toMatchInlineSnapshot( `
 		Array [
 		  Array [
-		    "Trying to initialize anonId outside of a browser context.",
+		    Object {
+		      "message": "Trying to initialize anonId outside of a browser context.",
+		    },
 		  ],
 		]
 	` );
@@ -153,10 +155,12 @@ describe( 'getAnonId', () => {
 	it( 'should return null and log in SSR', async () => {
 		setSsrContext();
 		expect( await AnonId.getAnonId() ).toBeNull();
-		expect( mockLogErrorOrThrowInDevelopmentMode.mock.calls ).toMatchInlineSnapshot( `
+		expect( mockLogError.mock.calls ).toMatchInlineSnapshot( `
 		Array [
 		  Array [
-		    "Trying to getAnonId in non browser context.",
+		    Object {
+		      "message": "Trying to getAnonId in non browser context.",
+		    },
 		  ],
 		]
 	` );

--- a/packages/explat-client-react-helpers/src/index.tsx
+++ b/packages/explat-client-react-helpers/src/index.tsx
@@ -57,11 +57,9 @@ export default function createExPlatClientReactHelpers(
 			experimentName !== previousExperimentName &&
 			! previousExperimentName.startsWith( 'explat_test' )
 		) {
-			const message = '[ExPlat] useExperiment: experimentName should never change between renders!';
-			if ( exPlatClient.config.isDevelopmentMode ) {
-				throw new Error( message );
-			}
-			exPlatClient.config.logError( { message } );
+			exPlatClient.config.logError( {
+				message: '[ExPlat] useExperiment: experimentName should never change between renders!',
+			} );
 		}
 
 		return [ isLoading, experimentAssignment ];

--- a/packages/explat-client/src/create-explat-client.ts
+++ b/packages/explat-client/src/create-explat-client.ts
@@ -134,9 +134,6 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 					experimentName,
 					source: 'loadExperimentAssignment-initialError',
 				} );
-				if ( config.isDevelopmentMode ) {
-					throw initialError;
-				}
 			}
 
 			// Fetching failed and we're not in development mode.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Don't throw in development where we wouldn't in production

@jsnajdr brought up in https://github.com/Automattic/wp-calypso/pull/50618#discussion_r586365198 that it is a good idea to keep development behaviour close to production where we can, and I have come round to this idea. We still use `console.error` in production. It is also nice to not have all those extra tests.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Removed development mode unit tests, production tests stay the same.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 593-gh-Automattic/experimentation-platform