### PR TITLE
ExPlat: Test the number of original function calls from asyncOneAtATime

### DIFF
--- a/packages/explat-client/src/internal/test/timing.ts
+++ b/packages/explat-client/src/internal/test/timing.ts
@@ -62,8 +62,9 @@ describe( 'asyncOneAtATime', () => {
 		await expect( f() ).rejects.toThrowError( 'error-123' );
 	} );
 
-	it( 'it should return the same promise when called multiple times', async () => {
-		const f = Timing.asyncOneAtATime( async () => delayedValue( 123, 1 ) );
+	it( 'it should return the same promise when called multiple times, only calling the original function once', async () => {
+		const origF = jest.fn( async () => delayedValue( 123, 1 ) );
+		const f = Timing.asyncOneAtATime( origF );
 		const a = f();
 		const b = f();
 		const c = f();
@@ -71,27 +72,32 @@ describe( 'asyncOneAtATime', () => {
 		expect( b ).toBe( c );
 		jest.advanceTimersByTime( 2 );
 		await expect( a ).resolves.toBe( 123 );
+		expect( origF.mock.calls.length ).toBe( 1 );
 	} );
 
-	it( 'it should return the same promise when called multiple times (rejection)', async () => {
-		const f = Timing.asyncOneAtATime( async () => {
+	it( 'it should return the same promise when called multiple times (rejection), only calling the original function once', async () => {
+		const origF = jest.fn( async () => {
 			throw new Error( 'error-123' );
 		} );
+		const f = Timing.asyncOneAtATime( origF );
 		const a = f();
 		const b = f();
 		const c = f();
 		expect( a ).toBe( b );
 		expect( b ).toBe( c );
 		await expect( a ).rejects.toThrowError( 'error-123' );
+		expect( origF.mock.calls.length ).toBe( 1 );
 	} );
 
-	it( 'it should return a different promise after the last has resolved', async () => {
-		const f = Timing.asyncOneAtATime( async () => delayedValue( 123, 3 ) );
+	it( 'it should return a different promise after the last has resolved, calling the orignal function twice', async () => {
+		const origF = jest.fn( async () => delayedValue( 123, 3 ) );
+		const f = Timing.asyncOneAtATime( origF );
 		const a = f();
 		const b = f();
 		expect( a ).toBe( b );
 		jest.advanceTimersByTime( 4 );
 		await expect( a ).resolves.toBe( 123 );
+		expect( origF.mock.calls.length ).toBe( 1 );
 
 		jest.advanceTimersByTime( 4 );
 		const c = f();
@@ -100,20 +106,23 @@ describe( 'asyncOneAtATime', () => {
 		expect( c ).toBe( d );
 		jest.advanceTimersByTime( 4 );
 		await expect( c ).resolves.toBe( 123 );
+		expect( origF.mock.calls.length ).toBe( 2 );
 	} );
 
-	it( 'it should return a different promise after the last has resolved (rejection)', async () => {
+	it( 'it should return a different promise after the last has resolved (rejection), calling the original function twice', async () => {
 		let isReject = true;
-		const f = Timing.asyncOneAtATime( async () => {
+		const origF = jest.fn( async () => {
 			if ( isReject ) {
 				throw new Error( 'error-123' );
 			}
 			return 123;
 		} );
+		const f = Timing.asyncOneAtATime( origF );
 		const a = f();
 		const b = f();
 		expect( a ).toBe( b );
 		await expect( a ).rejects.toThrowError( 'error-123' );
+		expect( origF.mock.calls.length ).toBe( 1 );
 
 		isReject = false;
 		const c = f();
@@ -121,5 +130,6 @@ describe( 'asyncOneAtATime', () => {
 		expect( a ).not.toBe( c );
 		expect( c ).toBe( d );
 		await expect( c ).resolves.toBe( 123 );
+		expect( origF.mock.calls.length ).toBe( 2 );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added tests to ensure the original function is called the correct amount of times.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 593-gh-Automattic/experimentation-platform