### PR TITLE
Use slot form for Experiment component

### DIFF
--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -125,13 +125,10 @@ class PagesMain extends React.Component {
 					name={ `explat_test_aa_weekly_calypso_next_client_${ moment
 						.utc()
 						.format( 'GGGG' ) }_week_${ moment.utc().format( 'WW' ) }_v2` }
-				>
-					{ {
-						treatment: null,
-						default: null,
-						loading: null,
-					} }
-				</Experiment>
+					default={ null }
+					treatment={ null }
+					loading={ null }
+				/>
 			</Main>
 		);
 	}

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -125,9 +125,9 @@ class PagesMain extends React.Component {
 					name={ `explat_test_aa_weekly_calypso_next_client_${ moment
 						.utc()
 						.format( 'GGGG' ) }_week_${ moment.utc().format( 'WW' ) }_v2` }
-					default={ null }
-					treatment={ null }
-					loading={ null }
+					defaultExperience={ null }
+					treatmentExperience={ null }
+					loadingExperience={ null }
 				/>
 			</Main>
 		);

--- a/packages/explat-client-react-helpers/src/index.tsx
+++ b/packages/explat-client-react-helpers/src/index.tsx
@@ -23,9 +23,9 @@ interface ExPlatClientReactHelpers {
 	 */
 	Experiment: ( props: {
 		name: string;
-		default: React.ReactNode;
-		treatment: React.ReactNode;
-		loading: React.ReactNode;
+		defaultExperience: React.ReactNode;
+		treatmentExperience: React.ReactNode;
+		loadingExperience: React.ReactNode;
 	} ) => JSX.Element;
 }
 
@@ -70,24 +70,23 @@ export default function createExPlatClientReactHelpers(
 	};
 
 	const Experiment = ( {
-		// As default is a keyword:
-		default: defaultExperience,
-		treatment,
-		loading,
+		defaultExperience,
+		treatmentExperience,
+		loadingExperience,
 		name: experimentName,
 	}: {
-		default: React.ReactNode;
-		treatment: React.ReactNode;
-		loading: React.ReactNode;
+		defaultExperience: React.ReactNode;
+		treatmentExperience: React.ReactNode;
+		loadingExperience: React.ReactNode;
 		name: string;
 	} ): JSX.Element => {
 		const [ isLoading, experimentAssignment ] = useExperiment( experimentName );
 		if ( isLoading ) {
-			return <>{ loading }</>;
+			return <>{ loadingExperience }</>;
 		} else if ( ! experimentAssignment?.variationName ) {
 			return <>{ defaultExperience }</>;
 		}
-		return <>{ treatment }</>;
+		return <>{ treatmentExperience }</>;
 	};
 
 	return {

--- a/packages/explat-client-react-helpers/src/index.tsx
+++ b/packages/explat-client-react-helpers/src/index.tsx
@@ -23,7 +23,9 @@ interface ExPlatClientReactHelpers {
 	 */
 	Experiment: ( props: {
 		name: string;
-		children: { default: React.ReactNode; treatment: React.ReactNode; loading: React.ReactNode };
+		default: React.ReactNode;
+		treatment: React.ReactNode;
+		loading: React.ReactNode;
 	} ) => JSX.Element;
 }
 
@@ -68,19 +70,24 @@ export default function createExPlatClientReactHelpers(
 	};
 
 	const Experiment = ( {
-		children,
+		// As default is a keyword:
+		default: defaultExperience,
+		treatment,
+		loading,
 		name: experimentName,
 	}: {
-		children: { default: React.ReactNode; treatment: React.ReactNode; loading: React.ReactNode };
+		default: React.ReactNode;
+		treatment: React.ReactNode;
+		loading: React.ReactNode;
 		name: string;
 	} ): JSX.Element => {
 		const [ isLoading, experimentAssignment ] = useExperiment( experimentName );
 		if ( isLoading ) {
-			return <>{ children.loading }</>;
+			return <>{ loading }</>;
 		} else if ( ! experimentAssignment?.variationName ) {
-			return <>{ children.default }</>;
+			return <>{ defaultExperience }</>;
 		}
-		return <>{ children.treatment }</>;
+		return <>{ treatment }</>;
 	};
 
 	return {

--- a/packages/explat-client-react-helpers/src/test/index.tsx
+++ b/packages/explat-client-react-helpers/src/test/index.tsx
@@ -122,7 +122,12 @@ describe( 'Experiment', () => {
 		> ).mockImplementationOnce( () => controllablePromise1.promise );
 
 		const { container, rerender } = render(
-			<Experiment name="experiment_a" treatmentExperience="treatment" defaultExperience="default-1" loadingExperience="loading" />
+			<Experiment
+				name="experiment_a"
+				treatmentExperience="treatment"
+				defaultExperience="default-1"
+				loadingExperience="loading"
+			/>
 		);
 		expect( container.textContent ).toBe( 'loading' );
 		await actReact( async () =>

--- a/packages/explat-client-react-helpers/src/test/index.tsx
+++ b/packages/explat-client-react-helpers/src/test/index.tsx
@@ -84,18 +84,18 @@ describe( 'Experiment', () => {
 		const { container, rerender } = render(
 			<Experiment
 				name="experiment_a"
-				treatment="treatment-1"
-				default="default"
-				loading="loading-1"
+				treatmentExperience="treatment-1"
+				defaultExperience="default"
+				loadingExperience="loading-1"
 			/>
 		);
 		expect( container.textContent ).toBe( 'loading-1' );
 		rerender(
 			<Experiment
 				name="experiment_a"
-				treatment="treatment-1"
-				default="default"
-				loading="loading-2"
+				treatmentExperience="treatment-1"
+				defaultExperience="default"
+				loadingExperience="loading-2"
 			/>
 		);
 		expect( container.textContent ).toBe( 'loading-2' );
@@ -104,9 +104,9 @@ describe( 'Experiment', () => {
 		rerender(
 			<Experiment
 				name="experiment_a"
-				treatment="treatment-2"
-				default="default"
-				loading="loading-2"
+				treatmentExperience="treatment-2"
+				defaultExperience="default"
+				loadingExperience="loading-2"
 			/>
 		);
 		expect( container.textContent ).toBe( 'treatment-2' );
@@ -122,7 +122,7 @@ describe( 'Experiment', () => {
 		> ).mockImplementationOnce( () => controllablePromise1.promise );
 
 		const { container, rerender } = render(
-			<Experiment name="experiment_a" treatment="treatment" default="default-1" loading="loading" />
+			<Experiment name="experiment_a" treatmentExperience="treatment" defaultExperience="default-1" loadingExperience="loading" />
 		);
 		expect( container.textContent ).toBe( 'loading' );
 		await actReact( async () =>
@@ -132,9 +132,9 @@ describe( 'Experiment', () => {
 		rerender(
 			<Experiment
 				name="experiment_a"
-				treatment="treatment-2"
-				default="default-2"
-				loading="loading-2"
+				treatmentExperience="treatment-2"
+				defaultExperience="default-2"
+				loadingExperience="loading-2"
 			/>
 		);
 		expect( container.textContent ).toBe( 'default-2' );

--- a/packages/explat-client-react-helpers/src/test/index.tsx
+++ b/packages/explat-client-react-helpers/src/test/index.tsx
@@ -82,35 +82,32 @@ describe( 'Experiment', () => {
 		> ).mockImplementationOnce( () => controllablePromise1.promise );
 
 		const { container, rerender } = render(
-			<Experiment name="experiment_a">
-				{ {
-					treatment: 'treatment-1',
-					default: 'default',
-					loading: 'loading-1',
-				} }
-			</Experiment>
+			<Experiment
+				name="experiment_a"
+				treatment="treatment-1"
+				default="default"
+				loading="loading-1"
+			/>
 		);
 		expect( container.textContent ).toBe( 'loading-1' );
 		rerender(
-			<Experiment name="experiment_a">
-				{ {
-					treatment: 'treatment-1',
-					default: 'default',
-					loading: 'loading-2',
-				} }
-			</Experiment>
+			<Experiment
+				name="experiment_a"
+				treatment="treatment-1"
+				default="default"
+				loading="loading-2"
+			/>
 		);
 		expect( container.textContent ).toBe( 'loading-2' );
 		await actReact( async () => controllablePromise1.resolve( validExperimentAssignment ) );
 		await waitFor( () => expect( container.textContent ).toBe( 'treatment-1' ) );
 		rerender(
-			<Experiment name="experiment_a">
-				{ {
-					treatment: 'treatment-2',
-					default: 'default',
-					loading: 'loading-2',
-				} }
-			</Experiment>
+			<Experiment
+				name="experiment_a"
+				treatment="treatment-2"
+				default="default"
+				loading="loading-2"
+			/>
 		);
 		expect( container.textContent ).toBe( 'treatment-2' );
 	} );
@@ -125,13 +122,7 @@ describe( 'Experiment', () => {
 		> ).mockImplementationOnce( () => controllablePromise1.promise );
 
 		const { container, rerender } = render(
-			<Experiment name="experiment_a">
-				{ {
-					treatment: 'treatment',
-					default: 'default-1',
-					loading: 'loading',
-				} }
-			</Experiment>
+			<Experiment name="experiment_a" treatment="treatment" default="default-1" loading="loading" />
 		);
 		expect( container.textContent ).toBe( 'loading' );
 		await actReact( async () =>
@@ -139,13 +130,12 @@ describe( 'Experiment', () => {
 		);
 		await waitFor( () => expect( container.textContent ).toBe( 'default-1' ) );
 		rerender(
-			<Experiment name="experiment_a">
-				{ {
-					treatment: 'treatment-2',
-					default: 'default-2',
-					loading: 'loading-2',
-				} }
-			</Experiment>
+			<Experiment
+				name="experiment_a"
+				treatment="treatment-2"
+				default="default-2"
+				loading="loading-2"
+			/>
 		);
 		expect( container.textContent ).toBe( 'default-2' );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the `<Experiment>` component to use slots rather than an object child.

See the altered tests for an illustration.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Altered unit tests

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 593-gh-Automattic/experimentation-platform