### PR TITLE
AnchorFM: use Focused Launch flow

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
@@ -93,6 +93,11 @@ function enqueue_launch_flow_script_and_style( $site_launch_options ) {
 			return;
 	}
 
+	$anchor_podcast = $site_launch_options['anchor_podcast'];
+	if ( ! empty( $anchor_podcast ) ) {
+		$script_name = 'focused-launch';
+	}
+
 	$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/' . $script_name . '.asset.php';
 	$script_dependencies = isset( $asset_file['dependencies'] ) ? $asset_file['dependencies'] : array();
 	$script_file         = 'dist/' . $script_name . '.js';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
@@ -93,6 +93,7 @@ function enqueue_launch_flow_script_and_style( $site_launch_options ) {
 			return;
 	}
 
+	// @TODO: remove this once $launch_flow value is 'focused-launch' for AnchorFM sites
 	$anchor_podcast = $site_launch_options['anchor_podcast'];
 	if ( ! empty( $anchor_podcast ) ) {
 		$script_name = 'focused-launch';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
@@ -28,7 +28,7 @@ registerPlugin( 'a8c-editor-editor-focused-launch', {
 			[ currentSiteId ]
 		);
 
-		const { isFocusedLaunchOpen } = useSelect(
+		const { isFocusedLaunchOpen, isAnchorFm } = useSelect(
 			( select ) => select( LAUNCH_STORE ).getState(),
 			[]
 		);
@@ -60,7 +60,7 @@ registerPlugin( 'a8c-editor-editor-focused-launch', {
 				siteId={ currentSiteId }
 				getCurrentLaunchFlowUrl={ getCurrentLaunchFlowUrl }
 				isInIframe={ inIframe() }
-				isLaunchImmediately={ shouldLaunch }
+				isLaunchImmediately={ shouldLaunch || isAnchorFm }
 			/>
 		) : null;
 	},

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
@@ -23,9 +23,7 @@ const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > 
 
 registerPlugin( 'a8c-editor-site-launch', {
 	render: function LaunchSidebar() {
-		const { isSidebarOpen, isAnchorFm } = useSelect( ( select ) =>
-			select( LAUNCH_STORE ).getState()
-		);
+		const { isSidebarOpen } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 		const { closeSidebar, setSidebarFullscreen, unsetSidebarFullscreen } = useDispatch(
 			LAUNCH_STORE
 		);
@@ -58,7 +56,7 @@ registerPlugin( 'a8c-editor-site-launch', {
 						isInIframe: inIframe(),
 					} }
 				>
-					<LaunchModal onClose={ closeSidebar } isLaunchImmediately={ isAnchorFm } />
+					<LaunchModal onClose={ closeSidebar } />
 				</LaunchContext.Provider>
 			</LocaleProvider>
 		);

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
@@ -66,7 +66,7 @@ domReady( () => {
 
 			switch ( launchFlow ) {
 				case GUTENBOARDING_LAUNCH_FLOW:
-					// temporary solution, before the backend returns correct launch flow value
+					// @TODO: remove this temporary solution once backend returns correct launch flow value
 					if ( isAnchorFm ) {
 						dispatch( 'automattic/launch' ).openFocusedLaunch();
 						break;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
@@ -55,7 +55,7 @@ domReady( () => {
 				is_in_iframe: inIframe(),
 			} );
 
-			// Enable anchor-flavoured gutenboarding features (the launch button works immediately).
+			// Enable anchor-flavoured features (the launch button works immediately).
 			const isAnchorFm = !! anchorFmPodcastId;
 			if ( isAnchorFm ) {
 				dispatch( 'automattic/launch' ).enableAnchorFm();
@@ -66,6 +66,11 @@ domReady( () => {
 
 			switch ( launchFlow ) {
 				case GUTENBOARDING_LAUNCH_FLOW:
+					// temporary solution, before the backend returns correct launch flow value
+					if ( isAnchorFm ) {
+						dispatch( 'automattic/launch' ).openFocusedLaunch();
+						break;
+					}
 					// Save post in the background while step-by-step flow opens
 					dispatch( 'automattic/launch' ).openSidebar();
 					delayedSavePost();

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -35,6 +35,20 @@ const Success: React.FunctionComponent = () => {
 		[]
 	);
 
+	// Save the post before displaying the action buttons and launch succes message
+	const [ isPostSaved, setIsPostSaved ] = React.useState( false );
+	const { savePost } = useDispatch( 'core/editor' );
+
+	React.useEffect( () => {
+		const asyncSavePost = async () => {
+			if ( ! isPostSaved ) {
+				await savePost();
+				setIsPostSaved( true );
+			}
+		};
+		asyncSavePost();
+	}, [ isPostSaved, savePost ] );
+
 	const { unsetModalDismissible, hideModalTitle, closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
 
 	const { siteSubdomain, sitePrimaryDomain } = useSiteDomains();
@@ -82,14 +96,16 @@ const Success: React.FunctionComponent = () => {
 	const copyButtonLabelIdle = __( 'Copy Link', __i18n_text_domain__ );
 	const copyButtonLabelActivated = __( 'Copied!', __i18n_text_domain__ );
 
+	const isLaunchComplete = ! isSiteLaunching && isPostSaved;
+
 	return (
 		<div className="focused-launch-container focused-launch-success__wrapper">
 			<Confetti className="focused-launch-success__confetti" />
 			<Title tagName="h2">{ __( 'Hooray!', __i18n_text_domain__ ) }</Title>
 			<SubTitle tagName="h3">
-				{ isSiteLaunching ? subtitleTextLaunching : subtitleTextLaunched }
+				{ isLaunchComplete ? subtitleTextLaunched : subtitleTextLaunching }
 			</SubTitle>
-			{ ! willUserBeRedirectedAutomatically && ! isSiteLaunching && (
+			{ ! willUserBeRedirectedAutomatically && isLaunchComplete && (
 				<>
 					<div className="focused-launch-success__url-wrapper">
 						<span className="focused-launch-success__url-field">{ displayedSiteUrl }</span>


### PR DESCRIPTION
This PR is similar to https://github.com/Automattic/wp-calypso/pull/48938 so it fixes 391-gh-Automattic/dotcom-manage but this time using Focused Launch flow instead of Gutenboarding pre-launch flow.

### Changes proposed in this Pull Request

* Use Focused Launch ( pbAok1-1IU-p2 ) for AnchorFM sites.
* Display Focused Launch Success View 
  * Show "Your site will be live shortly." message
  * When launch is complete and post is saved, show "Congratulations, your website is now live. We're excited to watch you grow with WordPress." message and action buttons to "Continue editing" or return to My Home.

**Technical notes:**
- `packages/launch/src/hooks/use-on-launch.ts` hook is no longer used in Focused Launch so Free plan doesn't need to be set anymore to prevent redirect to `/checkout` when launching immediately.

### Testing instructions

* Create an AnchorFM site and sandbox it.
* Launch the site from editor.
* Navigate to My Home or continue editing after the site is launched.

### Demo
- **Launch and navigate to My Home**

https://user-images.githubusercontent.com/14192054/110836959-5c9fea00-82a9-11eb-8ab7-5d271b74aa38.mov

- **Launch and continue editing**

https://user-images.githubusercontent.com/14192054/110836953-59a4f980-82a9-11eb-9885-ba5ae2007871.mov