### PR TITLE
WooCommerce: Make sure plugin state is loaded before showing setup page

### DIFF
--- a/client/my-sites/woocommerce/main.jsx
+++ b/client/my-sites/woocommerce/main.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -9,12 +10,25 @@ import React from 'react';
 import RequiredPluginsInstallView from './dashboard/required-plugins-install-view';
 import WooCommerceColophon from './woocommerce-colophon';
 import Main from 'calypso/components/main';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { isLoaded as arePluginsLoaded } from 'calypso/state/plugins/installed/selectors';
+import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 
 function WooCommerce() {
+	const siteId = useSelector( getSelectedSiteId );
+	const areInstalledPluginsLoadedIntoState = useSelector( ( state ) =>
+		arePluginsLoaded( state, siteId )
+	);
+
+	if ( ! siteId ) {
+		return null;
+	}
+
 	return (
 		<div className="woocommerce">
 			<Main class="main" wideLayout>
-				<RequiredPluginsInstallView />
+				<QueryJetpackPlugins siteIds={ [ siteId ] } />
+				{ areInstalledPluginsLoadedIntoState && <RequiredPluginsInstallView /> }
 			</Main>
 			<WooCommerceColophon />
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make sure plugin state is loaded before showing the setup page

_Note: I'm not confident that this totally addresses #50833. However, if testing shows that this improves matters or at the very least doesn't make matters worse, I think it is worth deploying this fix, as I believe that it will help in some scenarios._

_Followup PRs will be opened to make further improvements to the robustness of the WooCommerce installation in Calypso._

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start with a Business site without WooCommerce installed
2. Install the Hello Dolly plugin, to convert the site to Atomic
3. Click on "WooCommerce" in the admin sidebar
4. Click "Set up my store!"
5. Verify that the page auto-redirects to the WooCommerce setup wizard after installing the WooCommerce plugin. You should arrive on this page...

<img width="1275" alt="Screen Shot 2021-03-01 at 16 30 20" src="https://user-images.githubusercontent.com/2098816/109562595-96544200-7aac-11eb-809c-f6c6698034bf.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Partially addresses #50833 
