### PR TITLE
Adding atomic site logs feature to Hosting Configuration

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2681,4 +2681,20 @@ Undocumented.prototype.saveDifmInterestForUser = function () {
 	} );
 };
 
+Undocumented.prototype.getAtomicSiteLogs = function ( siteIdOrSlug, start, end, scrollId ) {
+	return this.wpcom.req.post(
+		{
+			path: `/sites/${ siteIdOrSlug }/hosting/logs`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{},
+		{
+			start,
+			end,
+			page_size: 10000,
+			scroll_id: scrollId,
+		}
+	);
+};
+
 export default Undocumented;

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -26,6 +26,7 @@ import SupportCard from './support-card';
 import PhpVersionCard from './php-version-card';
 import SiteBackupCard from './site-backup-card';
 import MiscellaneousCard from './miscellaneous-card';
+import WebServerLogsCard from './web-server-logs-card';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import Notice from 'calypso/components/notice';
@@ -167,6 +168,7 @@ class Hosting extends Component {
 							<PhpMyAdminCard disabled={ isDisabled } />
 							<PhpVersionCard disabled={ isDisabled } />
 							<MiscellaneousCard disabled={ isDisabled } />
+							<WebServerLogsCard disabled={ isDisabled } />
 						</Column>
 						<Column type="sidebar">
 							<SiteBackupCard disabled={ isDisabled } />

--- a/client/my-sites/hosting/web-server-logs-card/index.js
+++ b/client/my-sites/hosting/web-server-logs-card/index.js
@@ -1,0 +1,259 @@
+/**
+ * External dependencies
+ */
+import React, { useState, useEffect } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import moment from 'moment';
+import { get, isEmpty, map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { Button, Card, ProgressBar } from '@automattic/components';
+import CardHeading from 'calypso/components/card-heading';
+import FormLabel from 'calypso/components/forms/form-label';
+import MaterialIcon from 'calypso/components/material-icon';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import wpcom from 'calypso/lib/wp';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { isAtomicSiteLogAccessEnabled } from 'calypso/state/selectors/is-atomic-site-log-access-enabled';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const WebServerLogsCard = ( props ) => {
+	const {
+		successNotice: downloadSuccessNotice,
+		errorNotice: downloadErrorNotice,
+		siteId,
+		siteSlug,
+		translate,
+		isAtomicSiteLogAccessEnabled: siteLogsEnabled,
+	} = props;
+	const now = moment.utc();
+	const oneHourAgo = now.clone().subtract( 1, 'hour' );
+	const dateTimeFormat = 'YYYY-MM-DD HH:mm:ss';
+	const [ startDateTime, setStartDateTime ] = useState( oneHourAgo.format( dateTimeFormat ) );
+	const [ endDateTime, setEndDateTime ] = useState( now.format( dateTimeFormat ) );
+	const [ downloading, setDownloading ] = useState( false );
+	const [ progress, setProgress ] = useState( null );
+	const [ showProgress, setShowProgress ] = useState( false );
+	const [ startDateValidation, setStartDateValidation ] = useState( {
+		isValid: true,
+		validationInfo: '',
+	} );
+	const [ endDateValidation, setEndDateValidation ] = useState( {
+		isValid: true,
+		validationInfo: '',
+	} );
+
+	useEffect( () => {
+		const startMoment = moment.utc( startDateTime );
+		const endMoment = moment.utc( endDateTime );
+
+		const startDateIsValid =
+			startMoment.isValid() && startDateTime === startMoment.format( dateTimeFormat );
+		const endDateIsValid =
+			endMoment.isValid() && endDateTime === endMoment.format( dateTimeFormat );
+
+		setStartDateValidation( {
+			isValid: startDateIsValid,
+			validationInfo: startDateIsValid
+				? translate( 'Date is valid' )
+				: translate( 'Start date format is not valid.' ),
+		} );
+
+		setEndDateValidation( {
+			isValid: endDateIsValid,
+			validationInfo: endDateIsValid
+				? translate( 'Date is valid' )
+				: translate( 'End date format is not valid.' ),
+		} );
+
+		if ( ! startDateIsValid || ! endDateIsValid ) {
+			return;
+		}
+
+		if ( ! startMoment.isBefore( endMoment ) ) {
+			setStartDateValidation( {
+				isValid: false,
+				validationInfo: translate( 'Start date must be earlier than end date.' ),
+			} );
+		}
+
+		if ( startMoment.isBefore( moment.utc().subtract( 30, 'days' ) ) ) {
+			setStartDateValidation( {
+				isValid: false,
+				validationInfo: translate( 'Start date must be less than 30 days ago.' ),
+			} );
+		}
+	}, [ startDateTime, endDateTime ] );
+
+	const updateStartDateTime = ( event ) => {
+		setStartDateTime( event.target.value );
+	};
+
+	const updateEndDateTime = ( event ) => {
+		setEndDateTime( event.target.value );
+	};
+
+	const downloadLogs = async () => {
+		setShowProgress( true );
+		setProgress( 0 );
+		setDownloading( true );
+
+		const startMoment = moment.utc( startDateTime );
+		const endMoment = moment.utc( endDateTime );
+
+		const dateFormat = 'YYYYMMDDHHmmss';
+		const startString = startMoment.format( dateFormat );
+		const endString = endMoment.format( dateFormat );
+
+		const startTime = startMoment.unix();
+		const endTime = endMoment.unix();
+
+		let scrollId = null;
+		let logs = [];
+		let logFile = new Blob();
+		let totalLogs = 0;
+		let isError = false;
+
+		do {
+			await wpcom
+				.undocumented()
+				.getAtomicSiteLogs( siteId, startTime, endTime, scrollId )
+				.then( ( response ) => {
+					const newLogData = get( response, 'data.logs', [] );
+					scrollId = get( response, 'data.scroll_id', null );
+
+					if ( isEmpty( logs ) ) {
+						logs = [ Object.keys( newLogData[ 0 ] ).join( ',' ) + '\n' ];
+						totalLogs = get( response, 'data.total_results', 1 );
+					}
+
+					logs = [
+						...logs,
+						...map( newLogData, ( entry ) => {
+							return Object.values( entry ).join( ',' ) + '\n';
+						} ),
+					];
+
+					setProgress( Math.floor( 100 * ( ( logs.length - 1 ) / totalLogs ) ) );
+				} )
+				.catch( ( error ) => {
+					isError = true;
+
+					downloadErrorNotice( get( error, 'message', 'Could not retrieve logs.' ) );
+				} );
+		} while ( null !== scrollId );
+
+		setDownloading( false );
+
+		if ( isError ) {
+			return;
+		}
+
+		logFile = new Blob( logs );
+
+		const url = window.URL.createObjectURL( logFile );
+		const link = document.createElement( 'a' );
+		link.href = url;
+		link.setAttribute( 'download', siteSlug + '-' + startString + '-' + endString + '.csv' );
+		link.click();
+		window.URL.revokeObjectURL( url );
+
+		downloadSuccessNotice( 'Logs downloaded successfully.' );
+	};
+
+	const getContent = () => {
+		return (
+			<>
+				<p className="web-server-logs-card__info">
+					{ translate(
+						'To help troubleshoot or debug problems with your site, you may download web server logs between the following dates.'
+					) }
+				</p>
+				<div className="web-server-logs-card__dates">
+					<div className="web-server-logs-card__start">
+						<FormFieldset>
+							<FormLabel>{ translate( 'Log Start:' ) }</FormLabel>
+							<FormTextInput
+								value={ startDateTime }
+								onChange={ updateStartDateTime }
+								isValid={ startDateValidation.isValid }
+								isError={ ! startDateValidation.isValid }
+							/>
+							<FormInputValidation
+								isError={ ! startDateValidation.isValid }
+								text={ startDateValidation.validationInfo }
+							/>
+						</FormFieldset>
+					</div>
+					<div className="web-server-logs-card__end">
+						<FormFieldset>
+							<FormLabel>{ translate( 'Log End:' ) }</FormLabel>
+							<FormTextInput
+								value={ endDateTime }
+								onChange={ updateEndDateTime }
+								isValid={ endDateValidation.isValid }
+								isError={ ! endDateValidation.isValid }
+							/>
+							<FormInputValidation
+								isError={ ! endDateValidation.isValid }
+								text={ endDateValidation.validationInfo }
+							/>
+						</FormFieldset>
+					</div>
+				</div>
+				<p className="web-server-logs-card__info">
+					{ translate( 'Note: Please specify times as YYYY-MM-DD HH:MM:SS in UTC.' ) }
+				</p>
+				<div className="web-server-logs-card__download">
+					{ showProgress && (
+						<div>
+							{ downloading && <span>Downloading logs: { progress }%</span> }
+							{ ! downloading && <span>Done</span> }
+							<ProgressBar value={ progress } isPulsing={ downloading } />
+						</div>
+					) }
+					<Button
+						primary
+						disabled={ downloading || ! startDateValidation.isValid || ! endDateValidation.isValid }
+						onClick={ downloadLogs }
+					>
+						Download Logs
+					</Button>
+				</div>
+			</>
+		);
+	};
+
+	if ( ! siteLogsEnabled ) {
+		return null;
+	}
+
+	return (
+		<Card className="web-server-logs-card">
+			<MaterialIcon icon="settings" size={ 32 } />
+			<CardHeading>{ translate( 'Download Web Server Logs' ) }</CardHeading>
+			{ getContent() }
+		</Card>
+	);
+};
+
+export default connect(
+	( state ) => {
+		return {
+			siteId: getSelectedSiteId( state ),
+			siteSlug: getSelectedSiteSlug( state ),
+			isAtomicSiteLogAccessEnabled: isAtomicSiteLogAccessEnabled( state ),
+		};
+	},
+	{ successNotice, errorNotice }
+)( localize( WebServerLogsCard ) );

--- a/client/my-sites/hosting/web-server-logs-card/index.js
+++ b/client/my-sites/hosting/web-server-logs-card/index.js
@@ -46,7 +46,7 @@ const WebServerLogsCard = ( props ) => {
 	const [ startDateTime, setStartDateTime ] = useState( oneHourAgo.format( dateTimeFormat ) );
 	const [ endDateTime, setEndDateTime ] = useState( now.format( dateTimeFormat ) );
 	const [ downloading, setDownloading ] = useState( false );
-	const [ progress, setProgress ] = useState( null );
+	const [ progress, setProgress ] = useState( { recordsDownloaded: 0, totalRecordsAvailable: 0 } );
 	const [ showProgress, setShowProgress ] = useState( false );
 	const [ startDateValidation, setStartDateValidation ] = useState( {
 		isValid: true,
@@ -109,8 +109,8 @@ const WebServerLogsCard = ( props ) => {
 
 	const downloadLogs = async () => {
 		setShowProgress( true );
-		setProgress( 0 );
 		setDownloading( true );
+		setProgress( { recordsDownloaded: 0, totalRecordsAvailable: 0 } );
 
 		const startMoment = moment.utc( startDateTime );
 		const endMoment = moment.utc( endDateTime );
@@ -157,7 +157,7 @@ const WebServerLogsCard = ( props ) => {
 						} ),
 					];
 
-					setProgress( Math.floor( 100 * ( ( logs.length - 1 ) / totalLogs ) ) );
+					setProgress( { recordsDownloaded: logs.length - 1, totalRecordsAvailable: totalLogs } );
 				} )
 				.catch( ( error ) => {
 					isError = true;
@@ -240,9 +240,23 @@ const WebServerLogsCard = ( props ) => {
 				<div className="web-server-logs-card__download">
 					{ showProgress && (
 						<div>
-							{ downloading && <span>Downloading logs: { progress }%</span> }
-							{ ! downloading && <span>Done</span> }
-							<ProgressBar value={ progress } isPulsing={ downloading } />
+							<span>
+								{ translate(
+									'Download progress: %(logRecordsDownloaded)d of %(totalLogRecordsAvailable)d records',
+									{
+										args: {
+											logRecordsDownloaded: progress.recordsDownloaded,
+											totalLogRecordsAvailable: progress.totalRecordsAvailable,
+										},
+									}
+								) }
+							</span>
+							<ProgressBar
+								value={ progress.recordsDownloaded }
+								total={ progress.totalRecordsAvailable }
+								isPulsing={ downloading }
+								canGoBackwards={ true }
+							/>
 						</div>
 					) }
 					<Button

--- a/client/my-sites/hosting/web-server-logs-card/style.scss
+++ b/client/my-sites/hosting/web-server-logs-card/style.scss
@@ -1,0 +1,22 @@
+.web-server-logs-card__info {
+	color: var( --color-text-subtle );
+}
+
+.web-server-logs-card__dates {
+	display: flex;
+	flex-direction: row;
+	align-items: stretch;
+}
+
+.web-server-logs-card__start {
+	flex: 1;
+}
+
+.web-server-logs-card__end {
+	flex: 1;
+	margin-left: 1em;
+}
+
+.web-server-logs-card__download {
+	margin-top: 1em;
+}

--- a/client/state/selectors/is-atomic-site-log-access-enabled.js
+++ b/client/state/selectors/is-atomic-site-log-access-enabled.js
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { isSupportSession } from 'calypso/state/support/selectors';
+import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
+
+export function isAtomicSiteLogAccessEnabled( state ) {
+	return currentUserHasFlag( state, 'calypso_atomic_site_logs' ) || isSupportSession( state );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the ability to download web server logs from an Atomic site once the feature is enabled on the back end.

Depends on D58569-code and D58566-code

#### Testing instructions

1. Enable the feature on the back end for a test user.
2. View the Hosting Configuration page for an Atomic site for the test user.
3. Make sure you see the "Download Web Server Logs" section.
4. Select some start and end time within the last 30 days.
5. Click the download button.
6. Make sure that the downloaded data looks correct.

Also:

1. Make sure you can't set a start date more than 30 days ago.
2. Make sure that you can't set an end date before the start date.
3. Make sure that you can't set an invalid date string.
4. Make sure that if the option isn't enabled for the user on the back end, that the Server Logs section isn't shown.

Adding some images to aid translations:

Screenshot with valid start and end dates prior to download:
<img width="737" alt="Screen Shot 2021-03-16 at 1 41 59 PM" src="https://user-images.githubusercontent.com/1379730/111356728-06db9100-865f-11eb-8e07-465eacf3ca24.png">

Error message indicating an invalid start date/time format (missing seconds):
<img width="320" alt="Screen Shot 2021-03-16 at 1 55 53 PM" src="https://user-images.githubusercontent.com/1379730/111357086-5c17a280-865f-11eb-82d4-485e86633ed6.png">

Error message indicating an invalid end date/time format:
<img width="320" alt="Screen Shot 2021-03-16 at 2 05 16 PM" src="https://user-images.githubusercontent.com/1379730/111358480-c1b85e80-8660-11eb-80dc-43ba0e803d70.png">

Error message showing when the start date/time is later than the end date/time:
<img width="652" alt="Screen Shot 2021-03-16 at 1 42 41 PM" src="https://user-images.githubusercontent.com/1379730/111357146-69cd2800-865f-11eb-9cce-5cc85ade075a.png">

Screenshot showing download about to start:
<img width="736" alt="Screen Shot 2021-03-16 at 2 01 32 PM" src="https://user-images.githubusercontent.com/1379730/111357933-27f0b180-8660-11eb-84cb-5b57e087db79.png">

Screenshot showing a successful download indicating the number of records:
<img width="737" alt="Screen Shot 2021-03-16 at 1 43 38 PM" src="https://user-images.githubusercontent.com/1379730/111357265-8a957d80-865f-11eb-9844-5bfd203e099b.png">

Screenshot showing that a download failed due to an error:
<img width="731" alt="Screen Shot 2021-03-16 at 1 52 30 PM" src="https://user-images.githubusercontent.com/1379730/111358035-4656ad00-8660-11eb-881c-209df492ee6d.png">

Success message after successful logs download:
<img width="333" alt="Screen Shot 2021-03-16 at 1 44 16 PM" src="https://user-images.githubusercontent.com/1379730/111357380-a1d46b00-865f-11eb-84d6-3dd1d04c0706.png">


