### PR TITLE
Add unit tests to Jetpack Free card button

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card/button.tsx
+++ b/client/components/jetpack/card/jetpack-free-card/button.tsx
@@ -1,29 +1,21 @@
 /**
  * External dependencies
  */
-import React, { FC } from 'react';
-import { useSelector } from 'react-redux';
+import React from 'react';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { Button } from '@automattic/components';
 
 /**
  * Internal dependencies
  */
-import { storePlan } from 'calypso/jetpack-connect/persistence-utils';
-import { PLAN_JETPACK_FREE } from 'calypso/lib/plans/constants';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
-import { addQueryArgs } from 'calypso/lib/route';
-import { getUrlParts, getUrlFromParts } from 'calypso/lib/url';
-import { JPC_PATH_BASE } from 'calypso/jetpack-connect/constants';
-import getJetpackWpAdminUrl from 'calypso/state/selectors/get-jetpack-wp-admin-url';
+import useJetpackFreeButtonProps from './use-jetpack-free-button-props';
 
 /**
  * Type dependencies
  */
 import type { QueryArgs } from 'calypso/my-sites/plans/jetpack-plans/types';
 
-interface JetpackFreeCardButtonProps {
+interface Props {
 	className?: string;
 	label?: TranslateResult;
 	primary?: boolean;
@@ -31,7 +23,7 @@ interface JetpackFreeCardButtonProps {
 	urlQueryArgs: QueryArgs;
 }
 
-const JetpackFreeCardButton: FC< JetpackFreeCardButtonProps > = ( {
+const JetpackFreeCardButton: React.FC< Props > = ( {
 	className,
 	label,
 	primary = false,
@@ -39,57 +31,10 @@ const JetpackFreeCardButton: FC< JetpackFreeCardButtonProps > = ( {
 	urlQueryArgs,
 } ) => {
 	const translate = useTranslate();
-	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
-	const trackCallback = useTrackCallback( undefined, 'calypso_product_jpfree_click', {
-		site_id: siteId || undefined,
-	} );
-	const { site } = urlQueryArgs;
-
-	// If the user is not logged in and there is a site in the URL, we need to construct
-	// the URL to wp-admin from the `site` query parameter
-	let jetpackAdminUrlFromQuery;
-
-	if ( site ) {
-		let wpAdminUrlFromQuery;
-
-		// Ensure that URL is valid
-		try {
-			// Slugs of secondary sites of a multisites network follow this syntax: example.net::second-site
-			wpAdminUrlFromQuery = new URL(
-				`https://${ site.replaceAll( '::', '/' ) }/wp-admin/admin.php`
-			);
-		} catch ( e ) {}
-
-		if ( wpAdminUrlFromQuery ) {
-			jetpackAdminUrlFromQuery = getUrlFromParts( {
-				...getUrlParts( wpAdminUrlFromQuery.href ),
-				search: '?page=jetpack',
-				hash: '/my-plan',
-			} ).href;
-		}
-	}
-
-	const onClickTrack = () => {
-		storePlan( PLAN_JETPACK_FREE );
-		trackCallback();
-	};
-
-	// `siteId` is going to be null if the user is not logged in, so we need to check
-	// if there is a site in the URL also
-	const isSiteinContext = siteId || site;
-
-	// Jetpack Connect flow uses `url` instead of `site` as the query parameter for a site URL
-	const { site: url, ...restQueryArgs } = urlQueryArgs;
-	const startHref =
-		isJetpackCloud() && ! isSiteinContext
-			? addQueryArgs(
-					{ url, ...restQueryArgs, plan: PLAN_JETPACK_FREE },
-					`https://wordpress.com${ JPC_PATH_BASE }`
-			  )
-			: wpAdminUrl || jetpackAdminUrlFromQuery || JPC_PATH_BASE;
+	const props = useJetpackFreeButtonProps( siteId, urlQueryArgs );
 
 	return (
-		<Button primary={ primary } className={ className } href={ startHref } onClick={ onClickTrack }>
+		<Button primary={ primary } className={ className } { ...props }>
 			{ label || translate( 'Start for free' ) }
 		</Button>
 	);

--- a/client/components/jetpack/card/jetpack-free-card/test/button.jsx
+++ b/client/components/jetpack/card/jetpack-free-card/test/button.jsx
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencides
+ */
+import { render as rtlRender, screen, fireEvent } from 'config/testing-library';
+import JetpackFreeCardButton from '../button';
+import { JPC_PATH_BASE } from 'calypso/jetpack-connect/constants';
+import { PLAN_JETPACK_FREE } from 'calypso/lib/plans/constants';
+import { SESSION_STORAGE_SELECTED_PLAN } from 'calypso/jetpack-connect/persistence-utils';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import * as analytics from 'calypso/state/analytics/actions/record';
+import { reducer as ui } from 'calypso/state/ui/reducer';
+
+jest.mock( 'calypso/lib/jetpack/is-jetpack-cloud' );
+
+const siteId = 1;
+const siteFragment = 'bored-sheep.jurassic.ninja';
+const siteUrl = `https://${ siteFragment }`;
+const adminUrl = `${ siteUrl }/wp-admin/`;
+const jetpackAdminUrl = `${ adminUrl }admin.php?page=jetpack#/my-plan`;
+
+const getLink = () => screen.getByRole( 'link' );
+const getHref = () => getLink().getAttribute( 'href' );
+const render = ( el, options ) => rtlRender( el, { ...options, reducers: { ui } } );
+
+describe( 'JetpackFreeCardButton', () => {
+	it( 'should link to the connect path in WordPress.com, for Jetpack cloud with no site in context', () => {
+		const param = 'a';
+		const value = 1;
+
+		isJetpackCloud.mockReturnValue( true );
+		render( <JetpackFreeCardButton urlQueryArgs={ { [ param ]: value } } /> );
+
+		expect( getHref() ).toEqual(
+			`https://wordpress.com${ JPC_PATH_BASE }?${ param }=${ value }&plan=${ PLAN_JETPACK_FREE }`
+		);
+
+		isJetpackCloud.mockRestore();
+	} );
+
+	it( 'should link to the Jetpack section in the site admin, when site in state', () => {
+		const initialState = {
+			ui: { selectedSiteId: siteId },
+			sites: {
+				items: {
+					[ siteId ]: { options: { admin_url: adminUrl } },
+				},
+			},
+		};
+
+		render( <JetpackFreeCardButton />, { initialState } );
+
+		expect( getHref() ).toEqual( jetpackAdminUrl );
+	} );
+
+	it( 'should link to the Jetpack section in the site admin, when site in context', () => {
+		render( <JetpackFreeCardButton urlQueryArgs={ { site: siteFragment } } /> );
+
+		expect( getHref() ).toEqual( jetpackAdminUrl );
+	} );
+
+	it( 'should link to the Jetpack section in the site admin, when subsite in context', () => {
+		const subSiteFragment = `${ siteFragment }::second::third`;
+		const subSiteUrl = `${ siteUrl }/second/third`;
+
+		render( <JetpackFreeCardButton urlQueryArgs={ { site: subSiteFragment } } /> );
+
+		expect( getHref() ).toEqual( jetpackAdminUrl.replace( siteUrl, subSiteUrl ) );
+	} );
+
+	it( 'should link to the connect page, if site in context is invalid', () => {
+		render( <JetpackFreeCardButton urlQueryArgs={ { site: '%' } } /> );
+
+		expect( getHref() ).toEqual( JPC_PATH_BASE );
+	} );
+
+	it( 'should link to the connect page, by default', () => {
+		render( <JetpackFreeCardButton /> );
+
+		expect( getHref() ).toEqual( JPC_PATH_BASE );
+	} );
+
+	it( 'should track clicks', () => {
+		const spy = jest.spyOn( analytics, 'recordTracksEvent' );
+
+		render( <JetpackFreeCardButton siteId={ siteId } /> );
+		fireEvent.click( getLink() );
+
+		expect( spy ).toHaveBeenCalledWith( 'calypso_product_jpfree_click', { site_id: siteId } );
+
+		spy.mockRestore();
+	} );
+
+	it( 'should store Jetpack Free in session storage when clicked', () => {
+		render( <JetpackFreeCardButton siteId={ siteId } /> );
+
+		fireEvent.click( getLink() );
+
+		expect( window.sessionStorage.getItem( SESSION_STORAGE_SELECTED_PLAN ) ).toEqual(
+			PLAN_JETPACK_FREE
+		);
+	} );
+} );

--- a/client/components/jetpack/card/jetpack-free-card/use-jetpack-free-button-props.ts
+++ b/client/components/jetpack/card/jetpack-free-card/use-jetpack-free-button-props.ts
@@ -45,9 +45,7 @@ const buildHref = (
 		// Ensure that URL is valid
 		try {
 			// Slugs of secondary sites of a multisites network follow this syntax: example.net::second-site
-			wpAdminUrlFromQuery = new URL(
-				`https://${ site.replaceAll( '::', '/' ) }/wp-admin/admin.php`
-			);
+			wpAdminUrlFromQuery = new URL( `https://${ site.replace( /::/g, '/' ) }/wp-admin/admin.php` );
 		} catch ( e ) {}
 
 		if ( wpAdminUrlFromQuery ) {

--- a/client/components/jetpack/card/jetpack-free-card/use-jetpack-free-button-props.ts
+++ b/client/components/jetpack/card/jetpack-free-card/use-jetpack-free-button-props.ts
@@ -67,7 +67,10 @@ const buildHref = (
 	const { site: url, ...restQueryArgs } = urlQueryArgs;
 
 	return isJetpackCloud() && ! isSiteinContext
-		? addQueryArgs( { url, ...restQueryArgs }, `https://wordpress.com${ JPC_PATH_BASE }` )
+		? addQueryArgs(
+				{ url, ...restQueryArgs, plan: PLAN_JETPACK_FREE },
+				`https://wordpress.com${ JPC_PATH_BASE }`
+		  )
 		: wpAdminUrl || jetpackAdminUrlFromQuery || JPC_PATH_BASE;
 };
 

--- a/client/components/jetpack/card/jetpack-free-card/use-jetpack-free-button-props.ts
+++ b/client/components/jetpack/card/jetpack-free-card/use-jetpack-free-button-props.ts
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { JPC_PATH_BASE } from 'calypso/jetpack-connect/constants';
+import { storePlan } from 'calypso/jetpack-connect/persistence-utils';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import { PLAN_JETPACK_FREE } from 'calypso/lib/plans/constants';
+import { addQueryArgs } from 'calypso/lib/route';
+import { getUrlParts, getUrlFromParts } from 'calypso/lib/url';
+import getJetpackWpAdminUrl from 'calypso/state/selectors/get-jetpack-wp-admin-url';
+
+/**
+ * Type dependencies
+ */
+import type { QueryArgs } from 'calypso/my-sites/plans/jetpack-plans/types';
+
+type SiteId = number | null;
+
+interface Props {
+	href: string;
+	onClick: React.MouseEventHandler;
+}
+
+const buildHref = (
+	wpAdminUrl: string | undefined,
+	siteId: SiteId,
+	urlQueryArgs: QueryArgs
+): string => {
+	const { site } = urlQueryArgs;
+
+	// If the user is not logged in and there is a site in the URL, we need to construct
+	// the URL to wp-admin from the `site` query parameter
+	let jetpackAdminUrlFromQuery;
+
+	if ( site ) {
+		let wpAdminUrlFromQuery;
+
+		// Ensure that URL is valid
+		try {
+			// Slugs of secondary sites of a multisites network follow this syntax: example.net::second-site
+			wpAdminUrlFromQuery = new URL(
+				`https://${ site.replaceAll( '::', '/' ) }/wp-admin/admin.php`
+			);
+		} catch ( e ) {}
+
+		if ( wpAdminUrlFromQuery ) {
+			jetpackAdminUrlFromQuery = getUrlFromParts( {
+				...getUrlParts( wpAdminUrlFromQuery.href ),
+				search: '?page=jetpack',
+				hash: '/my-plan',
+			} ).href;
+		}
+	}
+
+	// `siteId` is going to be null if the user is not logged in, so we need to check
+	// if there is a site in the URL also
+	const isSiteinContext = siteId || site;
+
+	// Jetpack Connect flow uses `url` instead of `site` as the query parameter for a site URL
+	const { site: url, ...restQueryArgs } = urlQueryArgs;
+
+	return isJetpackCloud() && ! isSiteinContext
+		? addQueryArgs( { url, ...restQueryArgs }, `https://wordpress.com${ JPC_PATH_BASE }` )
+		: wpAdminUrl || jetpackAdminUrlFromQuery || JPC_PATH_BASE;
+};
+
+export default function useJetpackFreeButtonProps(
+	siteId: SiteId,
+	urlQueryArgs: QueryArgs = {}
+): Props {
+	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
+	const trackCallback = useTrackCallback( undefined, 'calypso_product_jpfree_click', {
+		site_id: siteId || undefined,
+	} );
+	const onClick = useCallback( () => {
+		storePlan( PLAN_JETPACK_FREE );
+		trackCallback();
+	}, [ trackCallback ] );
+	const href = useMemo( () => buildHref( wpAdminUrl, siteId, urlQueryArgs ), [
+		wpAdminUrl,
+		siteId,
+		urlQueryArgs,
+	] );
+
+	return {
+		href,
+		onClick,
+	};
+}

--- a/client/jetpack-connect/persistence-utils.js
+++ b/client/jetpack-connect/persistence-utils.js
@@ -9,7 +9,7 @@ import cookie from 'cookie';
 import { JETPACK_CONNECT_TTL_SECONDS } from 'calypso/state/jetpack-connect/constants';
 import { urlToSlug } from 'calypso/lib/url';
 
-const SESSION_STORAGE_SELECTED_PLAN = 'jetpack_connect_selected_plan';
+export const SESSION_STORAGE_SELECTED_PLAN = 'jetpack_connect_selected_plan';
 
 /**
  * Utilities for storing jetpack connect state that needs to persist across

--- a/client/package.json
+++ b/client/package.json
@@ -233,6 +233,7 @@
 		"yamlparser": "^0.0.2"
 	},
 	"devDependencies": {
+		"@testing-library/react": "^11.2.5",
 		"autoprefixer": "^9.7.3",
 		"component-event": "^0.1.4",
 		"component-query": "^0.0.3",

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -112,4 +112,6 @@ const reducer = combineReducers( {
 	siteSelectionInitialized,
 } );
 
+export { reducer };
+
 export default withStorageKey( 'ui', reducer );

--- a/client/test-helpers/config/testing-library.jsx
+++ b/client/test-helpers/config/testing-library.jsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import { render as rtlRender } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import initialReducer from 'calypso/state/reducer';
+
+const render = ( ui, { initialState, store, reducers, ...renderOptions } = {} ) => {
+	if ( ! store ) {
+		let reducer = initialReducer;
+
+		if ( typeof reducers === 'object' ) {
+			for ( const key in reducers ) {
+				reducer = reducer.addReducer( [ key ], reducers[ key ] );
+			}
+		}
+
+		store = createStore( reducer, initialState );
+	}
+
+	const Wrapper = ( { children } ) => <Provider store={ store }>{ children }</Provider>;
+
+	return rtlRender( ui, { wrapper: Wrapper, ...renderOptions } );
+};
+
+export * from '@testing-library/react';
+
+export { render };

--- a/test/client/jest.config.js
+++ b/test/client/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
 		),
 	},
 	modulePaths: [ '<rootDir>/extensions' ],
+	moduleDirectories: [ 'node_modules', '<rootDir>/test-helpers/' ],
 	rootDir: '../../client',
 	resolver: '<rootDir>../test/module-resolver.js',
 	testEnvironment: 'node',


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR extracts the logic that builds the Jetpack Free button props in its own hook. It was introduced in #50735, but since that PR was reverted, here it is again.

This PR also contains unit tests to check the hook logic.

### Implementation notes

The initial intent was to test `useJetpackFreeButtonProps`, of which the logic was extracted in #50735 for reuse. Given how React hooks work, it was easier to test a component consuming this hook than to directly test the hook (which seems to be the recommended practice).

Because `JetpackFreeCardButton` might disappear depending on the outcome of the experiment introduced by #50735, I've just tested its `href` and `onClick` provided by the hook. The hook will remain no matter what.

I've chosen to use the `react-testing-library` instead of `enzyme`, that's already included in the repo. I won't develop the full rationale, but the main reason is that I find it easier to write concise tests, and to test user interactions with the former. Ease of use is important to make the practice of unit testing sticky.

### Testing instructions


#### Hook

- Download the PR, and run Calypso and cloud concurrently
- In Calypso, visit `/jetpack/connect/store?source=jetpack-connect-plans` and check that the Jetpack Free card behaves as in production
- In cloud, visit `/pricing` and check that the Jetpack Free card behaves as in production


#### Tests

- Make sure all tests pass
- Review code
