### PR TITLE
Shopping Cart: Remove purchaseDomain from ResponseCartProduct

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1044,7 +1044,6 @@ export function getRenewalItemFromCartItem( cartItem, properties ) {
 		extra: {
 			purchaseId: properties.id,
 			purchaseType: 'renewal',
-			includedDomain: properties.includedDomain,
 		},
 	} );
 }
@@ -1179,16 +1178,6 @@ export function isRenewal( cartItem ) {
  */
 export function privacyAvailable( cartItem ) {
 	return get( cartItem, 'extra.privacy_available', true );
-}
-
-/**
- * Get the included domain for a cart item
- *
- * @param {CartItemValue} cartItem - `CartItemValue` object
- * @returns {string} the included domain
- */
-export function getIncludedDomain( cartItem ) {
-	return cartItem.extra && cartItem.extra.includedDomain;
 }
 
 /**

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1043,7 +1043,6 @@ export function getRenewalItemFromCartItem( cartItem, properties ) {
 	return merge( {}, cartItem, {
 		extra: {
 			purchaseId: properties.id,
-			purchaseDomain: properties.domain,
 			purchaseType: 'renewal',
 			includedDomain: properties.includedDomain,
 		},

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -738,7 +738,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 			).toEqual( {
 				extra: {
 					includedDomain: 'included.com',
-					purchaseDomain: 'purchased.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 					source: 'source',
@@ -755,7 +754,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 			).toEqual( {
 				extra: {
 					includedDomain: 'included.com',
-					purchaseDomain: 'purchased.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},
@@ -775,7 +773,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 				extra: {
 					google_apps_users: 123,
 					includedDomain: 'included.com',
-					purchaseDomain: 'purchased.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},
@@ -794,7 +791,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 			).toEqual( {
 				extra: {
 					includedDomain: 'included.com',
-					purchaseDomain: 'purchased.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 					source: 'source',
@@ -814,7 +810,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 			).toEqual( {
 				extra: {
 					includedDomain: 'included.com',
-					purchaseDomain: 'purchased.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},
@@ -829,7 +824,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 			).toEqual( {
 				extra: {
 					includedDomain: 'included.com',
-					purchaseDomain: 'purchased.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},
@@ -844,7 +838,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 			).toEqual( {
 				extra: {
 					includedDomain: 'included.com',
-					purchaseDomain: 'purchased.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},
@@ -862,7 +855,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 			).toEqual( {
 				extra: {
 					includedDomain: 'included.com',
-					purchaseDomain: 'purchased.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},
@@ -880,7 +872,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 			).toEqual( {
 				extra: {
 					includedDomain: 'included.com',
-					purchaseDomain: 'purchased.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},
@@ -898,7 +889,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 			).toEqual( {
 				extra: {
 					includedDomain: 'included.com',
-					purchaseDomain: 'purchased.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},
@@ -916,7 +906,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 			).toEqual( {
 				extra: {
 					includedDomain: 'included.com',
-					purchaseDomain: 'purchased.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -723,7 +723,6 @@ describe( 'hasToUpgradeToPayForADomain()', () => {
 describe( 'getRenewalItemFromProduct()', () => {
 	const buildPurchase = ( overrides ) => ( {
 		id: 123,
-		includedDomain: 'included.com',
 		domain: 'purchased.com',
 		...overrides,
 	} );
@@ -737,7 +736,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 				getRenewalItemFromProduct( buildPurchase( { product_slug: 'domain_map' } ), properties )
 			).toEqual( {
 				extra: {
-					includedDomain: 'included.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 					source: 'source',
@@ -753,7 +751,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 				getRenewalItemFromProduct( buildPurchase( { product_slug: PLAN_PERSONAL } ), properties )
 			).toEqual( {
 				extra: {
-					includedDomain: 'included.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},
@@ -772,7 +769,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 			).toEqual( {
 				extra: {
 					google_apps_users: 123,
-					includedDomain: 'included.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},
@@ -790,7 +786,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 				)
 			).toEqual( {
 				extra: {
-					includedDomain: 'included.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 					source: 'source',
@@ -809,7 +804,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 				)
 			).toEqual( {
 				extra: {
-					includedDomain: 'included.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},
@@ -823,7 +817,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 				getRenewalItemFromProduct( buildPurchase( { product_slug: 'custom-design' } ), properties )
 			).toEqual( {
 				extra: {
-					includedDomain: 'included.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},
@@ -837,7 +830,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 				getRenewalItemFromProduct( buildPurchase( { product_slug: 'videopress' } ), properties )
 			).toEqual( {
 				extra: {
-					includedDomain: 'included.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},
@@ -854,7 +846,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 				)
 			).toEqual( {
 				extra: {
-					includedDomain: 'included.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},
@@ -871,7 +862,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 				)
 			).toEqual( {
 				extra: {
-					includedDomain: 'included.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},
@@ -888,7 +878,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 				)
 			).toEqual( {
 				extra: {
-					includedDomain: 'included.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},
@@ -905,7 +894,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 				)
 			).toEqual( {
 				extra: {
-					includedDomain: 'included.com',
 					purchaseId: 123,
 					purchaseType: 'renewal',
 				},

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -161,7 +161,7 @@ function handleRenewNowClick( purchase, siteSlug, options = {} ) {
 	const { productSlugs, purchaseIds } = getProductSlugsAndPurchaseIds( [ renewItem ] );
 
 	let renewalUrl = `/checkout/${ productSlugs[ 0 ] }/renew/${ purchaseIds[ 0 ] }/${
-		siteSlug || renewItem.extra.purchaseDomain || ''
+		siteSlug || ''
 	}`;
 	if ( options.redirectTo ) {
 		renewalUrl += '?redirect_to=' + encodeURIComponent( options.redirectTo );
@@ -202,7 +202,7 @@ function handleRenewMultiplePurchasesClick( purchases, siteSlug, options = {} ) 
 	}
 
 	let renewalUrl = `/checkout/${ productSlugs.join( ',' ) }/renew/${ purchaseIds.join( ',' ) }/${
-		siteSlug || renewItems[ 0 ].extra.purchaseDomain || ''
+		siteSlug || ''
 	}`;
 	if ( options.redirectTo ) {
 		renewalUrl += '?redirect_to=' + encodeURIComponent( options.redirectTo );

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -14,7 +14,6 @@ import Gridicon from 'calypso/components/gridicon';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { canRemoveFromCart } from 'calypso/lib/cart-values';
-import { getIncludedDomain } from 'calypso/lib/cart-values/cart-items';
 import {
 	isCredits,
 	isGSuiteOrExtraLicenseOrGoogleWorkspace,
@@ -192,8 +191,6 @@ export class CartItem extends React.Component {
 			) );
 		} else if ( isCredits( cartItem ) ) {
 			info = null;
-		} else if ( getIncludedDomain( cartItem ) ) {
-			info = getIncludedDomain( cartItem );
 		} else if ( isTheme( cartItem ) ) {
 			info = selectedSite && selectedSite.domain;
 		} else {

--- a/client/my-sites/checkout/composite-checkout/components/test/lib/fixtures.ts
+++ b/client/my-sites/checkout/composite-checkout/components/test/lib/fixtures.ts
@@ -17,7 +17,6 @@ export const responseCartWithRenewal = {
 			volume: 1,
 			extra: {
 				purchaseId: '1234',
-				purchaseDomain: 'userpersonalsitetest1234.wordpress.com',
 				purchaseType: 'renewal',
 				context: 'calypstore',
 				registrar: 'OpenSRS',

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -3,7 +3,7 @@
  */
 import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-line no-restricted-imports
 import debugFactory from 'debug';
-import type { ResponseCart } from '@automattic/shopping-cart';
+import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 
 const debug = debugFactory( 'calypso:composite-checkout:get-thank-you-page-url' );
 
@@ -152,11 +152,8 @@ export default function getThankYouPageUrl( {
 	debug( 'cookie url is', urlFromCookie );
 
 	if ( cart && hasRenewalItem( cart ) ) {
-		const renewalItem = getRenewalItems( cart )[ 0 ];
-		const managePurchaseUrl = managePurchase(
-			renewalItem.extra.purchaseDomain,
-			renewalItem.extra.purchaseId
-		);
+		const renewalItem: ResponseCartProduct = getRenewalItems( cart )[ 0 ];
+		const managePurchaseUrl = managePurchase( siteSlug, renewalItem.subscription_id );
 		debug(
 			'renewal item in cart',
 			renewalItem,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -151,16 +151,18 @@ export default function getThankYouPageUrl( {
 	const urlFromCookie = getUrlFromCookie();
 	debug( 'cookie url is', urlFromCookie );
 
-	if ( cart && hasRenewalItem( cart ) ) {
+	if ( cart && hasRenewalItem( cart ) && siteSlug ) {
 		const renewalItem: ResponseCartProduct = getRenewalItems( cart )[ 0 ];
-		const managePurchaseUrl = managePurchase( siteSlug, renewalItem.subscription_id );
-		debug(
-			'renewal item in cart',
-			renewalItem,
-			'so returning managePurchaseUrl',
-			managePurchaseUrl
-		);
-		return managePurchaseUrl;
+		if ( renewalItem && renewalItem.subscription_id ) {
+			const managePurchaseUrl = managePurchase( siteSlug, renewalItem.subscription_id );
+			debug(
+				'renewal item in cart',
+				renewalItem,
+				'so returning managePurchaseUrl',
+				managePurchaseUrl
+			);
+			return managePurchaseUrl;
+		}
 	}
 
 	// Domain only flow

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
@@ -71,6 +71,7 @@ export default function useGetThankYouUrl( {
 		debug( 'getThankYouUrl returned', url );
 		return url;
 	}, [
+		previousRoute,
 		isInEditor,
 		transactionResult,
 		isEligibleForSignupDestinationResult,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -212,12 +212,7 @@ function useAddRenewalItems( {
 					} );
 					return null;
 				}
-				return createRenewalItemToAddToCart(
-					productSlug,
-					product.product_id,
-					subscriptionId,
-					selectedSiteSlug
-				);
+				return createRenewalItemToAddToCart( productSlug, product.product_id, subscriptionId );
 			} )
 			.filter( doesValueExist );
 
@@ -373,8 +368,7 @@ function getProductSlugFromAlias( productAlias: string ): string {
 function createRenewalItemToAddToCart(
 	productAlias: string,
 	productId: string | number,
-	purchaseId: string | number | undefined | null,
-	selectedSiteSlug: string | null
+	purchaseId: string | number | undefined | null
 ): RequestCartProduct | null {
 	const [ slug, meta ] = productAlias.split( ':' );
 	// See https://github.com/Automattic/wp-calypso/pull/15043 for explanation of
@@ -388,7 +382,6 @@ function createRenewalItemToAddToCart(
 
 	const renewalItemExtra = {
 		purchaseId: String( purchaseId ),
-		purchaseDomain: selectedSiteSlug ? String( selectedSiteSlug ) : undefined,
 		purchaseType: 'renewal',
 	};
 	return {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -452,9 +452,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to manage purchase page if there is a renewal', () => {
 		const cart = {
-			products: [
-				{ extra: { purchaseType: 'renewal', purchaseDomain: 'foo.bar', purchaseId: '123abc' } },
-			],
+			products: [ { extra: { purchaseType: 'renewal', purchaseId: '123abc' } } ],
 		};
 		const url = getThankYouPageUrl( { ...defaultArgs, siteSlug: 'foo.bar', cart } );
 		expect( url ).toBe( '/me/purchases/foo.bar/123abc' );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -452,7 +452,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to manage purchase page if there is a renewal', () => {
 		const cart = {
-			products: [ { extra: { purchaseType: 'renewal', purchaseId: '123abc' } } ],
+			products: [ { subscription_id: '123abc', extra: { purchaseType: 'renewal' } } ],
 		};
 		const url = getThankYouPageUrl( { ...defaultArgs, siteSlug: 'foo.bar', cart } );
 		expect( url ).toBe( '/me/purchases/foo.bar/123abc' );

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -46,7 +46,7 @@ export interface RequestCartProduct {
 	meta: string;
 	volume: number;
 	quantity: number | null;
-	extra: ResponseCartProductExtra;
+	extra: RequestCartProductExtra;
 }
 
 /**
@@ -166,7 +166,7 @@ export interface CartLocation {
 	subdivisionCode: string | null;
 }
 
-export type ResponseCartProductExtra = {
+export interface ResponseCartProductExtra {
 	context?: string;
 	source?: string;
 	premium?: boolean;
@@ -176,7 +176,11 @@ export type ResponseCartProductExtra = {
 	google_apps_registration_data?: DomainContactDetails;
 	purchaseType?: string;
 	privacy?: boolean;
-};
+}
+
+export interface RequestCartProductExtra extends ResponseCartProductExtra {
+	purchaseId?: string;
+}
 
 export interface GSuiteProductUser {
 	firstname: string;

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -174,10 +174,7 @@ export type ResponseCartProductExtra = {
 	domain_to_bundle?: string;
 	google_apps_users?: GSuiteProductUser[];
 	google_apps_registration_data?: DomainContactDetails;
-	purchaseId?: string;
-	purchaseDomain?: string;
 	purchaseType?: string;
-	includedDomain?: string;
 	privacy?: boolean;
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Because we didn't fully grok the `extra` property of shopping cart products when we created TypeScript types for them, we added some properties to the `ResponseCartProduct` that aren't actually returned by the server. Specifically `purchaseDomain`, `includedDomain`, and `purchaseId`. I'm fairly certain that none of those are ever returned by the shopping-cart endpoint. They _are_ created inside calypso by `getRenewalItemFromCartItem()` which is used in a few places explicitly, but it seems to effectively create its own type. `purchaseId` _might_ be used by the shopping-cart endpoint when creating renewals, but the renewals I tested seemed to work fine without it. Still, it is included in tests on the shopping-cart endpoint itself so I'm going to keep that in, but only for the `RequestCartProduct` type.

This PR removes `purchaseDomain`, `includedDomain`, and `purchaseId` from `ResponseCartProductExtra` and adds `purchaseId` to `RequestCartProductExtra`. It then removes all uses of `purchaseDomain` and `includedDomain` for cart products in calypso.

Note that `includedDomain` _does_ exist on purchase objects, but they are quite different than cart products.

#### Testing instructions

This was detected because the lack of these properties was throwing a fatal error in `getThankYouPageUrl` after checkout if the cart contained a renewal [here](https://github.com/Automattic/wp-calypso/blob/af98a76be99dbf475eb12b77a7d956e0ec8ba95d/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts#L156). I'm not sure why this sometimes did not cause a fatal error, but it may be partially because [the fatal error is only thrown in development mode](https://github.com/Automattic/wp-calypso/blob/af98a76be99dbf475eb12b77a7d956e0ec8ba95d/client/me/purchases/paths.js#L23).

In any case, we can test this by adding renewal items to the shopping cart and completing checkout. Verify there are no fatal errors and that you are redirected to the manage purchase page for the renewed product.