### PR TITLE
Signup Flow: Fix paid items not being added to cart bug

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -128,6 +128,13 @@ export default class SignupFlowController {
 			this._assertFlowProvidedDependenciesFromConfig( options.providedDependencies );
 			this._reduxStore.dispatch( updateDependencies( options.providedDependencies ) );
 		} else {
+			// If the launch flow was open in one tab, a new tab opened with the onboarding flow
+			// would have stored dependencies referencing the incorrect (launch flow) site slug.
+			// As a result, any plans selected during onboarding would be added to the launch flow
+			// site's cart, and not the onboarding site's cart. To prevent this, we reset stored
+			// dependencies before initializing the flow controller.
+			this.reset();
+
 			// TODO: synces deps from progress to dep store: are they ever out of sync?
 			const storedDependencies = this._getStoredDependencies();
 			if ( ! isEmpty( storedDependencies ) ) {


### PR DESCRIPTION
## Description
Potentially fixes #50430

If we open a browser tab, navigate to one site's launch flow, and then open the onboarding flow for an entirely different site in another tab, we cannot add paid plans to the onboarding flow's cart.

This happens because the launch flow persists its site slug in redux state which is subsequently cached in indexedDB. This launch flow site slug is then referenced in the onboarding site flow. As a result, any paid items selected in onboarding are inadvertently added to the launch site's cart.

See https://cloudup.com/cHMd7LKm1IF or 

https://user-images.githubusercontent.com/1083581/109791959-4d6acd80-7c13-11eb-9746-b431818a5405.mp4

## Stack Trace
- Visiting the launch site signup flow persists the site slug in the signup dependency store.

<img width="1344" alt="Screen Shot 2021-03-12 at 12 39 53 AM" src="https://user-images.githubusercontent.com/5414230/110914855-c8934a00-82cb-11eb-9834-8343e3bc6483.png">

- Visiting the onboarding flow in a separate tab shows us that the persisted site slug from the launch signup flow is being used.

<img width="1344" alt="Screen Shot 2021-03-12 at 12 43 18 AM" src="https://user-images.githubusercontent.com/5414230/110915211-30499500-82cc-11eb-8ea9-6d751ea78aac.png">

- Selecting a paid plan then invokes the `onSelectPlan` method ([Link](https://github.com/Automattic/wp-calypso/blob/c964cba6d450fd7c9fc230a751f5b46ecef7693e/client/signup/steps/plans/index.jsx#L65))
- `onSelectPlan` calls the `submitSignupStep` redux action ([Link](https://github.com/Automattic/wp-calypso/blob/c964cba6d450fd7c9fc230a751f5b46ecef7693e/client/signup/steps/plans/index.jsx#L99))
- The action is handled by the progress reducer and updates Progress state. Progress state is keeping track of which steps have been completed by the user. ([Link](https://github.com/Automattic/wp-calypso/blob/c964cba6d450fd7c9fc230a751f5b46ecef7693e/client/state/signup/progress/reducer.js#L105-L112))
- The flow controller is listening to Progress store state ([Link](https://github.com/Automattic/wp-calypso/blob/c964cba6d450fd7c9fc230a751f5b46ecef7693e/client/lib/signup/flow-controller.ts#L120-L122))
- When the plans step is complete in the onboarding flow, the flow-controller begins processing steps ([Link](https://github.com/Automattic/wp-calypso/blob/c964cba6d450fd7c9fc230a751f5b46ecef7693e/client/lib/signup/flow-controller.ts#L258-L260))
- When a step is processed, a relevant api request is made ([Link](https://github.com/Automattic/wp-calypso/blob/c964cba6d450fd7c9fc230a751f5b46ecef7693e/client/lib/signup/flow-controller.ts#L316-L321))
- Information about the outdated site slug from the dependency store is passed into the api request here ([Link](https://github.com/Automattic/wp-calypso/blob/c964cba6d450fd7c9fc230a751f5b46ecef7693e/client/lib/signup/flow-controller.ts#L307))
- Step processing references a dictionary to find the correct api function to invoke for the paid plans step ([Link](https://github.com/Automattic/wp-calypso/blob/c964cba6d450fd7c9fc230a751f5b46ecef7693e/client/signup/config/steps-pure.js#L211))
- The `addPlanToCart` api function references the outdated slug ([Link](https://github.com/Automattic/wp-calypso/blob/c964cba6d450fd7c9fc230a751f5b46ecef7693e/client/lib/signup/step-actions/index.js#L347-L348))
- The plan is processed and added to the incorrect site's cart ([Link](https://github.com/Automattic/wp-calypso/blob/c964cba6d450fd7c9fc230a751f5b46ecef7693e/client/lib/signup/step-actions/index.js#L360))

## Things to Consider
- With these changes, we would reset stored dependencies before loading any flow. After [reading more about dependencies](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/signup/README.md) in the signup flow, this seems like it _should_ be fine. With that being said, Calypso flows are unfamiliar to me, and I'm definitely going to be leaning on others for  more information and advice.
- An alternative to this approach would be to prevent the dependency store from being persisted in indexedDB. It seems like it would be a more intuitive long term solution, but I'm not entirely certain what implications this approach would have. I'm open to the idea though!

## Testing instructions
1. Select an un-launched site start the launch flow from My home; it doesn't matter if you land on /start/launch-site or /start/new-launch.
2. Open a new tab and go to /start directly (or try creating a new site from wordpress.com/pricing)
3. Select a free domain.
4. Select a paid plan.
5. Verify that, although the site is created, we are brought to a screen with an empty cart
6. Apply this PR
7. Follow instructions 1-3 again. Now verify that there is a paid plan in the cart. 