### PR TITLE
Framework: Refactor away from _.castArray()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -406,6 +406,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/all': 'error',
 		'you-dont-need-lodash-underscore/any': 'error',
 		'you-dont-need-lodash-underscore/bind': 'error',
+		'you-dont-need-lodash-underscore/cast-array': 'error',
 		'you-dont-need-lodash-underscore/collect': 'error',
 		'you-dont-need-lodash-underscore/contains': 'error',
 		'you-dont-need-lodash-underscore/detect': 'error',

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -4,7 +4,7 @@
 import { use, select } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
 import { applyFilters } from '@wordpress/hooks';
-import { castArray, find } from 'lodash';
+import { find } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -89,7 +89,7 @@ const ensureBlockObject = ( block ) => {
  * @returns {void}
  */
 function trackBlocksHandler( blocks, eventName, propertiesHandler = noop, parentBlock ) {
-	const castBlocks = castArray( blocks );
+	const castBlocks = Array.isArray( blocks ) ? blocks : [ blocks ];
 	if ( ! castBlocks || ! castBlocks.length ) {
 		return;
 	}
@@ -131,8 +131,10 @@ function trackBlocksHandler( blocks, eventName, propertiesHandler = noop, parent
  * @returns {Function} track handler
  */
 const getBlocksTracker = ( eventName ) => ( blockIds ) => {
+	const blockIdArray = Array.isArray( blockIds ) ? blockIds : [ blockIds ];
+
 	// track separately for each block
-	castArray( blockIds ).forEach( ( blockId ) => {
+	blockIdArray.forEach( ( blockId ) => {
 		tracksRecordEvent( eventName, { block_name: getTypeForBlockId( blockId ) } );
 	} );
 };

--- a/build-tools/webpack/assets-writer-plugin.js
+++ b/build-tools/webpack/assets-writer-plugin.js
@@ -78,9 +78,10 @@ Object.assign( AssetsWriter.prototype, {
 				).map( ( asset ) => fixupPath( asset.name ) ),
 			} ) );
 
-			statsToOutput.assetsByChunkName = _.mapValues( stats.assetsByChunkName, ( asset ) =>
-				_.castArray( asset ).map( fixupPath )
-			);
+			statsToOutput.assetsByChunkName = _.mapValues( stats.assetsByChunkName, ( asset ) => {
+				const assets = Array.isArray( asset ) ? asset : [ asset ];
+				return assets.map( fixupPath );
+			} );
 
 			statsToOutput.chunks = stats.chunks.map( ( chunk ) =>
 				Object.assign( {}, chunk, {

--- a/client/components/domains/registrant-extra-info/with-contact-details-validation.jsx
+++ b/client/components/domains/registrant-extra-info/with-contact-details-validation.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import validatorFactory from 'is-my-json-valid';
-import { castArray, get, isEmpty, map, once, reduce, replace, update } from 'lodash';
+import { get, isEmpty, map, once, reduce, replace, update } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:domains:with-contact-details-validation' );
 
@@ -26,7 +26,7 @@ export function disableSubmitButton( children ) {
 		return children;
 	}
 
-	return map( castArray( children ), ( child, index ) =>
+	return map( Array.isArray( children ) ? children : [ children ], ( child, index ) =>
 		React.cloneElement( child, {
 			disabled: !! child.props.className.match( /submit-button/ ) || child.props.disabled,
 			key: index,
@@ -50,7 +50,7 @@ export function interpretIMJVError( error, schema ) {
 
 	if ( schema ) {
 		// Search up the schema for an explicit errorField & message
-		const path = [ ...castArray( error.schemaPath ) ];
+		const path = Array.isArray( error.schemaPath ) ? [ ...error.schemaPath ] : [ error.schemaPath ];
 
 		// The errorCode is primary because messages are localized, so without
 		// the code consumers couldn't do anything other than display errors.

--- a/client/state/domains/management/validation-schemas/actions.js
+++ b/client/state/domains/management/validation-schemas/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import {
@@ -32,5 +27,5 @@ export const addValidationSchemas = ( schemas ) => ( {
  */
 export const requestValidationSchemas = ( tlds ) => ( {
 	type: DOMAIN_MANAGEMENT_VALIDATION_SCHEMAS_REQUEST,
-	tlds: castArray( tlds ),
+	tlds: Array.isArray( tlds ) ? tlds : [ tlds ],
 } );

--- a/client/state/media/actions.js
+++ b/client/state/media/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import {
@@ -49,7 +44,7 @@ export function receiveMedia( siteId, media, found, query ) {
 	return {
 		type: MEDIA_RECEIVE,
 		siteId,
-		media: castArray( media ),
+		media: Array.isArray( media ) ? media : [ media ],
 		found,
 		query,
 	};
@@ -218,7 +213,7 @@ export const updateMediaItem = ( siteId, item, originalMediaItem ) => ( {
 export function deleteMedia( siteId, mediaIds ) {
 	return {
 		type: MEDIA_DELETE,
-		mediaIds: castArray( mediaIds ),
+		mediaIds: Array.isArray( mediaIds ) ? mediaIds : [ mediaIds ],
 		siteId,
 	};
 }

--- a/client/state/media/thunks/delete-media.js
+++ b/client/state/media/thunks/delete-media.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { castArray } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -24,9 +23,11 @@ export const deleteMedia = ( siteId, item ) => ( dispatch ) => {
 	debug( 'Deleting media from %d by ID %d', siteId, item.ID );
 
 	// don't attempt to delete transient items
-	const items = castArray( item ).filter( ( i ) => typeof i.ID === 'number' );
+	const items = Array.isArray( item ) ? item : [ item ];
 
-	items.forEach( ( mediaItem ) => {
-		dispatch( deleteMediaItem( siteId, mediaItem.ID ) );
-	} );
+	items
+		.filter( ( i ) => typeof i.ID === 'number' )
+		.forEach( ( mediaItem ) => {
+			dispatch( deleteMediaItem( siteId, mediaItem.ID ) );
+		} );
 };

--- a/client/state/media/thunks/upload-media.js
+++ b/client/state/media/thunks/upload-media.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, zip } from 'lodash';
+import { zip } from 'lodash';
 
 /**
  * Internal dependencies
@@ -46,7 +46,11 @@ export const uploadMedia = (
 	onItemFailure = noop
 ) => async ( dispatch ) => {
 	// https://stackoverflow.com/questions/25333488/why-isnt-the-filelist-object-an-array
-	files = isFileList( files ) ? Array.from( files ) : castArray( files );
+	if ( isFileList( files ) ) {
+		files = Array.from( files );
+	} else if ( ! Array.isArray( files ) ) {
+		files = [ files ];
+	}
 	const uploadedItems = [];
 
 	const transientItems = dispatch( createTransientMediaItems( files, site ) );

--- a/packages/page-template-modal/src/components/block-iframe-preview.js
+++ b/packages/page-template-modal/src/components/block-iframe-preview.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { each, filter, get, castArray, debounce } from 'lodash';
+import { each, filter, get, debounce } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -105,7 +105,9 @@ const BlockFramePreview = ( {
 	} );
 
 	// Rendering blocks list.
-	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );
+	const renderedBlocks = useMemo( () => ( Array.isArray( blocks ) ? blocks : [ blocks ] ), [
+		blocks,
+	] );
 	const [ recomputeBlockListKey, triggerRecomputeBlockList ] = useReducer(
 		( state ) => state + 1,
 		0


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `castArray` is essentially fully natively supported by the simple syntax `Array.isArray( a ) ? a : [ a ]`. This PR replaces the usage and adds an ESLint rule to warn against using `castArray` from lodash.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Try to `import { castArray } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass.

#### Notes

An ESLint error is expected and is not being introduced in this PR.