### PR TITLE
Framework: Refactor away from _.takeRight()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -433,6 +433,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/reverse': 'error',
 		'you-dont-need-lodash-underscore/select': 'error',
 		'you-dont-need-lodash-underscore/split': 'error',
+		'you-dont-need-lodash-underscore/take-right': 'error',
 		'you-dont-need-lodash-underscore/to-lower': 'error',
 		'you-dont-need-lodash-underscore/to-upper': 'error',
 	},

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
-import { get, size, takeRight, delay } from 'lodash';
+import { get, size, delay } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -343,7 +343,7 @@ class PostCommentList extends React.Component {
 			return null;
 		}
 
-		const displayedComments = takeRight( commentIds, numberToTake );
+		const displayedComments = numberToTake ? commentIds.slice( numberToTake * -1 ) : [];
 
 		return {
 			displayedComments,

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { map, get, last, uniqBy, size, filter, takeRight, compact } from 'lodash';
+import { map, get, last, uniqBy, size, filter, compact } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -52,7 +52,7 @@ class ConversationCaterpillarComponent extends React.Component {
 
 	handleTickle = () => {
 		const { blogId, postId } = this.props;
-		const commentsToExpand = takeRight( this.getExpandableComments(), NUMBER_TO_EXPAND );
+		const commentsToExpand = this.getExpandableComments().slice( -1 * NUMBER_TO_EXPAND );
 
 		// expand all N comments to excerpt
 		this.props.expandComments( {
@@ -79,7 +79,7 @@ class ConversationCaterpillarComponent extends React.Component {
 	render() {
 		const { translate, parentCommentId, comments } = this.props;
 		const allExpandableComments = this.getExpandableComments();
-		const expandableComments = takeRight( allExpandableComments, NUMBER_TO_EXPAND );
+		const expandableComments = allExpandableComments.slice( -1 * NUMBER_TO_EXPAND );
 		const isRoot = ! parentCommentId;
 		const numberUnfetchedComments = this.props.commentCount - size( comments );
 		const commentCount = isRoot

--- a/client/components/gravatar-caterpillar/index.jsx
+++ b/client/components/gravatar-caterpillar/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { map, size, takeRight, filter, uniqBy } from 'lodash';
+import { map, size, filter, uniqBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,9 +32,8 @@ class GravatarCaterpillar extends React.Component {
 		const gravatarSmallScreenThreshold = maxGravatarsToDisplay / 2;
 
 		// Only display authors with a gravatar, and only display each author once
-		const displayedUsers = takeRight(
-			filter( uniqBy( users, 'avatar_URL' ), 'avatar_URL' ),
-			maxGravatarsToDisplay
+		const displayedUsers = filter( uniqBy( users, 'avatar_URL' ), 'avatar_URL' ).slice(
+			-1 * maxGravatarsToDisplay
 		);
 		const displayedUsersCount = size( displayedUsers );
 

--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { concat, filter, find, map, get, sortBy, takeRight } from 'lodash';
+import { concat, filter, find, map, get, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -152,7 +152,7 @@ const timelineReducer = ( state = [], action ) => {
 export const timeline = withSchemaValidation(
 	timelineSchema,
 	withPersistence( timelineReducer, {
-		serialize: ( state ) => takeRight( state, HAPPYCHAT_MAX_STORED_MESSAGES ),
+		serialize: ( state ) => state.slice( -1 * HAPPYCHAT_MAX_STORED_MESSAGES ),
 	} )
 );
 

--- a/client/state/ui/action-log/reducer.js
+++ b/client/state/ui/action-log/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { get, has, includes, isFunction, overSome, takeRight } from 'lodash';
+import { get, has, includes, isFunction, overSome } from 'lodash';
 
 /**
  * Internal dependencies
@@ -49,7 +49,7 @@ const newAction = ( action ) => ( {
 	timestamp: Date.now(),
 } );
 
-const maybeAdd = ( state, action ) => ( action ? takeRight( [ ...state, action ], 50 ) : state );
+const maybeAdd = ( state, action ) => ( action ? [ ...state, action ].slice( -50 ) : state );
 
 export default ( state = [], action ) =>
 	isRelevantAction( action ) ? maybeAdd( state, newAction( action ) ) : state;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `takeRight` is essentially fully natively supported by the `Array.prototype.slice()` method with a negative number argument pased. This PR replaces the usage and adds an ESLint rule to warn against using `takeRight` from lodash.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Try to `import { takeRight } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass.