### PR TITLE
Update Color Studio version to 2.5.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,7 @@
 		"@automattic/calypso-config": "^1.0.0-alpha.0",
 		"@automattic/calypso-polyfills": "^1.0.0",
 		"@automattic/calypso-stripe": "^1.0.0",
-		"@automattic/color-studio": "^2.3.0",
+		"@automattic/color-studio": "2.5.0",
 		"@automattic/components": "^1.0.0-alpha.1",
 		"@automattic/composite-checkout": "^1.0.0",
 		"@automattic/create-calypso-config": "^1.0.0-alpha.0",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
 		"@automattic/calypso-color-schemes": "^2.1.1",
 		"@automattic/calypso-doctor": "^0.1.0",
 		"@automattic/calypso-polyfills": "^1.0.0",
-		"@automattic/color-studio": "2.4.0",
+		"@automattic/color-studio": "2.5.0",
 		"@automattic/components": "^1.0.0-alpha.1",
 		"@automattic/data-stores": "^1.0.0-alpha.1",
 		"@automattic/i18n-utils": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,10 +11,10 @@
     lodash "^4.17.4"
     recast "^0.12.1"
 
-"@automattic/color-studio@2.4.0", "@automattic/color-studio@^2.3.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@automattic/color-studio/-/color-studio-2.4.0.tgz#d21406b30eca90077f7ca9bf3ca884d79ce8dda6"
-  integrity sha512-xdiW5uBONTi3+R6Eee1PpsPxWQH9DGPpEu5NN0/uHd5DjL6EfBNAOI7qujz4eqz76bWoz2R/zRNNjCn91caWjw==
+"@automattic/color-studio@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@automattic/color-studio/-/color-studio-2.5.0.tgz#27f69e2569062258f24ca50f0a4b8a572a00e287"
+  integrity sha512-gZWaJbx3p1oennAIoJtMGluTmoM95Efk4rc44TSBxWSZZ8gH3Am2eh1o3i1NhrZmg2Zt3AiVFeZZ4AJccIpBKQ==
 
 "@automattic/lasagna@^0.6.1":
   version "0.6.1"


### PR DESCRIPTION
In https://github.com/Automattic/color-studio/pull/39 we updated the default Jetpack color to Green 40, and Color Studio's version was [bumped to 2.5.0](https://github.com/Automattic/color-studio/commit/5623403c5350d02ee453c31c9ddec2dd3907a8db) shortly afterwards. This updates the Color Studio dep in Calypso.

#### Changes proposed in this Pull Request

* Updates Color Studio version to 2.5.0.

#### Testing instructions

No code changes.