### PR TITLE
Jetpack Cloud: Don't render the sidebar in /settings with no site selected

### DIFF
--- a/client/jetpack-cloud/sections/settings/index.js
+++ b/client/jetpack-cloud/sections/settings/index.js
@@ -19,7 +19,7 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
 export default function () {
 	if ( isJetpackCloud() ) {
-		page( settingsPath(), siteSelection, sites, navigation, makeLayout, clientRender );
+		page( settingsPath(), siteSelection, sites, makeLayout, clientRender );
 		page(
 			settingsPath( ':site' ),
 			siteSelection,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `navigation` middleware from the site-agnostic route for the Settings page, because it renders the sidebar before we need it and requires a site to be selected to work correctly.

#### Testing instructions

**NOTE:** To observe the bug fixed by this PR, run the same test steps on `cloud.jetpack.com/settings`.

* Open Calypso Green and visit `/settings` without having selected a site.
* Verify that:
  * the page loads correctly with no console errors;
  * you see the site selector; and
  * you're able to select a site and navigate to its Settings page.