### PR TITLE
Jetpack Cloud: Clear form data when credentials are deleted

### DIFF
--- a/client/jetpack-cloud/sections/settings/advanced-credentials/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/index.tsx
@@ -206,8 +206,11 @@ const AdvancedCredentials: FunctionComponent< Props > = ( { action, host, role }
 
 	const handleDeleteCredentials = () => {
 		dispatch( recordTracksEvent( 'calypso_jetpack_advanced_credentials_flow_credentials_delete' ) );
-
 		dispatch( deleteCredentials( siteId, role ) );
+
+		setFormState( INITIAL_FORM_STATE );
+		setFormMode( FormMode.Password );
+		setFormErrors( INITIAL_FORM_ERRORS );
 	};
 
 	const handleUpdateCredentials = useCallback( () => {

--- a/client/state/jetpack/credentials/actions.js
+++ b/client/state/jetpack/credentials/actions.js
@@ -9,7 +9,7 @@ import {
 } from 'calypso/state/action-types';
 
 import 'calypso/state/data-layer/wpcom/activity-log/get-credentials';
-import 'calypso/state/data-layer/wpcom/activity-log/delete-credentials';
+import { success as removeCredentialsFromState } from 'calypso/state/data-layer/wpcom/activity-log/delete-credentials';
 import 'calypso/state/data-layer/wpcom/activity-log/update-credentials';
 import 'calypso/state/data-layer/wpcom/activity-log/rewind/activate';
 import 'calypso/state/jetpack/init';
@@ -37,8 +37,18 @@ export const autoConfigCredentials = ( siteId ) => ( {
 	siteId,
 } );
 
-export const deleteCredentials = ( siteId, role ) => ( {
-	type: JETPACK_CREDENTIALS_DELETE,
-	siteId,
-	role,
-} );
+export const deleteCredentials = ( siteId, role ) => ( dispatch ) => {
+	// Optimistically store an empty credentials object,
+	// assuming the API delete request will succeed.
+	//
+	// NOTE: This is a little sub-optimal and ignores the rewind_state parameter,
+	// but we're also not currently handling the error case anyway; see:
+	// client/state/data-layer/wpcom/activity-log/delete-credentials/index.js
+	dispatch( removeCredentialsFromState( { siteId }, {} ) );
+
+	dispatch( {
+		type: JETPACK_CREDENTIALS_DELETE,
+		siteId,
+		role,
+	} );
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes `1164141197617539-as-1199981808818553`.

* In the credentials wizard, immediately reset the form state when the **Delete credentials** button is clicked.
* When the `deleteCredentials` action is triggered, optimistically clear the selected site's credentials from the app state by dispatching the `JETPACK_CREDENTIALS_STORE` action, to stimulate a redirect to the first step of the credentials wizard.

#### Testing instructions

* Open Calypso Green, select a site, and visit the **Settings** page.
* If valid credentials haven't already been saved for the site you selected, save the site's credentials.
* Click the **Delete credentials** button. You should be immediately redirected to the first step of the credentials wizard.
* Select a host to get to the second step of the credentials wizard.
* Verify that the form has been reset and that no credentials data from before is visible on the page.

#### Reference videos

##### Before

https://user-images.githubusercontent.com/670067/110949724-8dfbd280-8308-11eb-9c49-e26af4bad73f.mp4

##### After

https://user-images.githubusercontent.com/670067/110949739-93f1b380-8308-11eb-87c6-436094e211eb.mp4