### PR TITLE
Allow Titan/Email management paths to be accessed in domain-only sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -63,6 +63,9 @@ import {
 	emailManagementForwarding,
 	emailManagementAddGSuiteUsers,
 	emailManagementNewGSuiteAccount,
+	emailManagementManageTitanAccount,
+	emailManagementNewTitanAccount,
+	emailManagementTitanControlPanelRedirect,
 } from 'calypso/my-sites/email/paths';
 import SitesComponent from 'calypso/my-sites/sites';
 import { successNotice, warningNotice } from 'calypso/state/notices/actions';
@@ -180,6 +183,9 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 		emailManagementAddGSuiteUsers,
 		emailManagementNewGSuiteAccount,
 		emailManagementForwarding,
+		emailManagementManageTitanAccount,
+		emailManagementNewTitanAccount,
+		emailManagementTitanControlPanelRedirect,
 	];
 
 	let domainManagementPaths = allPaths.map( ( pathFactory ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change adds Titan/Email-related paths to the set of paths that can be accessed for domain-only sites

#### Testing instructions

* For a domain-only site, verify that you can start the process to purchase and set up Email.

Fixes #51025
