### PR TITLE
Help: Remove experiment, add "Contact support" button to header for all users

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -29,7 +29,6 @@ import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { getUserPurchases, isFetchingUserPurchases } from 'calypso/state/purchases/selectors';
 import { planHasFeature } from 'calypso/lib/plans';
 import { FEATURE_BUSINESS_ONBOARDING } from 'calypso/lib/plans/constants';
-import Experiment, { DefaultVariation, Variation } from 'calypso/components/experiment';
 
 /**
  * Style dependencies
@@ -336,16 +335,11 @@ class Help extends React.PureComponent {
 						subHeaderText={ translate( 'Get help with your WordPress.com site' ) }
 						align="left"
 					/>
-					<Experiment name="calypso_help_contact_button">
-						<Variation name="treatment">
-							<div className="help__contact-us-header-button">
-								<Button onClick={ this.trackContactUsClick } href="/help/contact/">
-									{ translate( 'Contact support' ) }
-								</Button>
-							</div>
-						</Variation>
-						<DefaultVariation name="control" />
-					</Experiment>
+					<div className="help__contact-us-header-button">
+						<Button onClick={ this.trackContactUsClick } href="/help/contact/">
+							{ translate( 'Contact support' ) }
+						</Button>
+					</div>
 				</div>
 				<HelpSearch onSearch={ this.setIsSearching } />
 				{ ! this.state.isSearching && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Following up on experiment in #50595, remove the experiment and add a Contact support button to the header area of the help screen (pending final approval from Happiness).

**Visual**

<img width="1134" alt="Screen Shot 2021-03-12 at 11 21 03 AM" src="https://user-images.githubusercontent.com/2124984/110968036-0a041380-8325-11eb-9183-7797412eed62.png">

#### Testing instructions

* Switch to this PR and navigate to `/help`
* You should see the "Contact support" button in the upper right.
* Clicking on the button should take you to `/help/contact` and fire a Tracks event, `calypso_help_header_button_click`