### PR TITLE
Wayfinder: Add a subheading for portfolio projects

### DIFF
--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -35,6 +35,13 @@ function Types( {
 	showPublishedStatus,
 	translate,
 } ) {
+	let subHeaderText = '';
+	if ( 'Testimonials' === get( postType, 'label', '' ) ) {
+		subHeaderText = translate( 'Create and manage all the testimonials on your site.' );
+	} else if ( 'Projects' === get( postType, 'label', '' ) ) {
+		subHeaderText = translate( 'Create, edit, and manage the portfolio projects on your site.' );
+	}
+
 	return (
 		<Main wideLayout>
 			<DocumentHead title={ get( postType, 'label', '' ) } />
@@ -44,11 +51,7 @@ function Types( {
 				brandFont
 				className="types__page-heading"
 				headerText={ get( postType, 'label', '' ) }
-				subHeaderText={
-					get( postType, 'label', '' ) === 'Testimonials'
-						? translate( 'Create and manage all the testimonials on your site.' )
-						: ''
-				}
+				subHeaderText={ subHeaderText }
 				align="left"
 			/>
 			{ userCanEdit &&


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a subheading for portfolio projects; part of the Wayfinder initiative to add guide posts to screens across Calypso

**Before**

<img width="1109" alt="Screen Shot 2021-03-12 at 12 35 16 PM" src="https://user-images.githubusercontent.com/2124984/110976836-679d5d80-832f-11eb-8434-ccf54fad4b2f.png">

**After**

<img width="1084" alt="Screen Shot 2021-03-12 at 12 33 42 PM" src="https://user-images.githubusercontent.com/2124984/110976730-4177bd80-832f-11eb-9ad5-8e2c5d00d92a.png">


#### Testing instructions

* Switch to this PR and activate the Portfolio post type under Settings -> Writing
* Go to `/types/jetpack-portfolio` and note the subheading on the screen
* Make sure it's wrapped in a translate function and doesn't break anything else
