### PR TITLE
Remove task definitions from CircleCI configuration.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1087,22 +1087,6 @@ workflows:
                 - trunk
                 # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
                 - /pull\/[0-9]+/
-      #      - test-e2e-canary:
-      #          requires:
-      #            - wait-calypso-live
-      #          test-flags: '-C -S $CIRCLE_SHA1'
-      # - test-e2e-canary:
-      #     name: test-e2e-canary-ie
-      #     requires:
-      #       - wait-calypso-live
-      #     test-flags: '-z -S $CIRCLE_SHA1'
-      #     test-target: 'IE11'
-      #     slack-webhook: '$SLACK_IE'
-      - test-e2e-canary:
-          name: test-e2e-canary-safari
-          requires:
-            - wait-calypso-live
-          test-flags: '-y -S $CIRCLE_SHA1'
   wp-desktop:
     jobs:
       - wp-desktop-source:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -544,31 +544,6 @@ jobs:
               curl --silent "https://hash-$CIRCLE_SHA1.calypso.live"
             fi
 
-  # Wait for calypso.live to be ready
-  #
-  # Expected usage:
-  #   - After main tests have passed (test-client, test-server)
-  #   - Before e2e tests run
-  #
-  wait-calypso-live:
-    docker:
-      - image: buildpack-deps
-    working_directory: ~/wp-calypso
-    steps:
-      - run:
-          name: Check external author
-          command: |
-            if [[ ! -z $CIRCLE_PR_USERNAME ]]; then
-              echo 'PRs from external authors cannot run on calypso.live'
-              exit 1
-            fi
-      - restore_cache: *restore-git-cache
-      - checkout
-      # Don't bother updating the git cache here, it would be the second time in the workflow
-      - run:
-          name: Wait for calypso.live build
-          command: ./test/e2e/scripts/wait-for-running-branch.sh
-
   test-e2e:
     <<: *defaults
     working_directory: ~/wp-calypso/test/e2e
@@ -1076,16 +1051,6 @@ workflows:
             branches:
               only:
                 # Only run for fork pull requets.
-                - /pull\/[0-9]+/
-      - wait-calypso-live:
-          requires:
-            - setup
-          filters:
-            branches:
-              ignore:
-                # Do not spin up calypso.live for `trunk`
-                - trunk
-                # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
                 - /pull\/[0-9]+/
   wp-desktop:
     jobs:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- remove IE11 task (disabled in #50960).
- remove Safari canary task.

#### Testing instructions

Checked validity of configuration locally:
```
➜  ~/workspace/wp-calypso-second git:(update/circleci-config-cleanup) circleci config validate
Config file at .circleci/config.yml is valid.
```

