### PR TITLE
People: Change the subHeaderText for different filters

### DIFF
--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -55,6 +55,21 @@ class People extends React.Component {
 		}
 	}
 
+	renderSubheaderText() {
+		const { translate, filter } = this.props;
+
+		switch ( filter ) {
+			case 'followers':
+				return translate(
+					'People who have subscribed to your site using their WordPress.com account.'
+				);
+			case 'email-followers':
+				return translate( 'People who have subscribed to your site using their email address.' );
+			default:
+				return translate( 'Invite contributors to your site and manage their access settings.' );
+		}
+	}
+
 	render() {
 		const {
 			isComingSoon,
@@ -94,9 +109,7 @@ class People extends React.Component {
 					brandFont
 					className="people__page-heading"
 					headerText={ translate( 'People' ) }
-					subHeaderText={ translate(
-						'Invite contributors to your site and manage their access settings.'
-					) }
+					subHeaderText={ this.renderSubheaderText() }
 					align="left"
 				/>
 				<div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Part of the Wayfinder initiative and related to #50721 
* Change the `subHeaderText` depending on the active filter on the People section for Followers and Email Followers

**Before**

<img width="777" alt="Screen Shot 2021-03-12 at 3 58 18 PM" src="https://user-images.githubusercontent.com/2124984/110997713-cc66b100-834b-11eb-80ed-6deb3ade5345.png">
<img width="789" alt="Screen Shot 2021-03-12 at 3 58 23 PM" src="https://user-images.githubusercontent.com/2124984/110997714-ccff4780-834b-11eb-8ff8-05defc1a2fe1.png">


**After**

<img width="766" alt="Screen Shot 2021-03-12 at 3 55 36 PM" src="https://user-images.githubusercontent.com/2124984/110997572-9b867c00-834b-11eb-91ee-a375f3eedb8b.png">
<img width="798" alt="Screen Shot 2021-03-12 at 3 55 43 PM" src="https://user-images.githubusercontent.com/2124984/110997574-9c1f1280-834b-11eb-9491-80018527e27b.png">


#### Testing instructions

* Switch to this PR and navigate to `/people/SITE`
* Click on Followers filter; you should see the subheading under the page title change
* Repeat for Email Followers; this heading should change, too
* Make sure nothing breaks and that strings are properly prepped for translation