### PR TITLE
Show Welcome Tour to all new users on Desktop, NUX to users on Mobile

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -57,7 +57,7 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 	 * @return boolean
 	 */
 	public function is_nux_enabled( $nux_status ) {
-		if ( defined( 'SHOW_WELCOME_TOUR' ) && SHOW_WELCOME_TOUR ) {
+		if ( defined( 'is_mobile_device' ) && is_mobile_device ) {
 			return true;
 		}
 		return 'enabled' === $nux_status;
@@ -69,6 +69,9 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 	 * @return WP_REST_Response
 	 */
 	public function get_nux_status() {
+		// Designs for WelcomeTour ong mobile are in progress, until then do not show on mobile.g
+		$is_mobile_device = wp_is_mobile();
+
 		if ( has_filter( 'wpcom_block_editor_nux_get_status' ) ) {
 			$nux_status = apply_filters( 'wpcom_block_editor_nux_get_status', false );
 		} elseif ( ! metadata_exists( 'user', get_current_user_id(), 'wpcom_block_editor_nux_status' ) ) {
@@ -78,7 +81,8 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 		}
 		return rest_ensure_response(
 			array(
-				'is_nux_enabled' => $this->is_nux_enabled( $nux_status ),
+				'is_mobile_device' => $is_mobile_device,
+				'is_nux_enabled'   => $this->is_nux_enabled( $nux_status ),
 			)
 		);
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -69,7 +69,7 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 	 * @return WP_REST_Response
 	 */
 	public function get_nux_status() {
-		// Designs for WelcomeTour ong mobile are in progress, until then do not show on mobile.g
+		// Designs for WelcomeTour ong mobile are in progress, until then do not show on mobile.
 		$is_mobile_device = wp_is_mobile();
 
 		if ( has_filter( 'wpcom_block_editor_nux_get_status' ) ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -69,10 +69,6 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 	 * @return WP_REST_Response
 	 */
 	public function get_nux_status() {
-		// Check if we want to show the Welcome Tour variant pbxNRc-Cb-p2
-		// Performing the check here means that we'll only assign a user to an experiment when this API is first called.
-		$welcome_tour_show_variant = ( defined( 'SHOW_WELCOME_TOUR' ) && SHOW_WELCOME_TOUR ) || apply_filters( 'a8c_enable_wpcom_welcome_tour', false );
-
 		if ( has_filter( 'wpcom_block_editor_nux_get_status' ) ) {
 			$nux_status = apply_filters( 'wpcom_block_editor_nux_get_status', false );
 		} elseif ( ! metadata_exists( 'user', get_current_user_id(), 'wpcom_block_editor_nux_status' ) ) {
@@ -82,8 +78,7 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 		}
 		return rest_ensure_response(
 			array(
-				'is_nux_enabled'            => $this->is_nux_enabled( $nux_status ),
-				'welcome_tour_show_variant' => $welcome_tour_show_variant,
+				'is_nux_enabled' => $this->is_nux_enabled( $nux_status ),
 			)
 		);
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -8,7 +8,7 @@ import './public-path';
 import { Guide, GuidePage } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -19,39 +19,46 @@ import WpcomNux from './welcome-modal/wpcom-nux';
 
 registerPlugin( 'wpcom-block-editor-nux', {
 	render: function WpcomBlockEditorNux() {
-		const [ isMobileDevice, setIsMobileDevice ] = useState();
-		const { isWpcomNuxEnabled, isSPTOpen } = useSelect( ( select ) => ( {
-			isWpcomNuxEnabled: select( 'automattic/nux' ).isWpcomNuxEnabled(),
-			isSPTOpen:
-				select( 'automattic/starter-page-layouts' ) && // Handle the case where SPT is not initalized.
-				select( 'automattic/starter-page-layouts' ).isOpen(),
-		} ) );
+		const { showOnboarding, isNewPageLayoutModalOpen, isLoaded, variant } = useSelect(
+			( select ) => ( {
+				showOnboarding: select( 'automattic/nux' ).isWpcomNuxEnabled(),
+				isLoaded: select( 'automattic/nux' ).isWpcomNuxStatusLoaded(),
+				variant: select( 'automattic/nux' ).wpcomNuxVariant(),
+				isNewPageLayoutModalOpen:
+					select( 'automattic/starter-page-layouts' ) && // Handle the case where SPT is not initalized.
+					select( 'automattic/starter-page-layouts' ).isOpen(),
+			} )
+		);
 
-		const { setWpcomNuxStatus } = useDispatch( 'automattic/nux' );
+		const { setWpcomNuxStatus, setWpcomNuxVariant } = useDispatch( 'automattic/nux' );
 
 		// On mount check if the WPCOM NUX status exists in state, otherwise fetch it from the API.
 		useEffect( () => {
-			if ( typeof isWpcomNuxEnabled !== 'undefined' && typeof isMobileDevice !== 'undefined' ) {
+			if ( isLoaded ) {
 				return;
 			}
 
 			const fetchWpcomNuxStatus = async () => {
 				const response = await apiFetch( { path: '/wpcom/v2/block-editor/nux' } );
-				setWpcomNuxStatus( { isNuxEnabled: response.is_nux_enabled, bypassApi: true } );
-				setIsMobileDevice( response.is_mobile_device );
+				setWpcomNuxStatus( { isNuxEnabled: response.show_editor_onboarding, bypassApi: true } );
+				setWpcomNuxVariant( response.editor_onboarding_variant );
 			};
 
 			fetchWpcomNuxStatus();
-		}, [ isWpcomNuxEnabled, setWpcomNuxStatus, isMobileDevice ] );
+		}, [ isLoaded, setWpcomNuxStatus, setWpcomNuxVariant ] );
 
-		if ( ! isWpcomNuxEnabled || isSPTOpen || typeof isMobileDevice === 'undefined' ) {
+		if ( ! showOnboarding || isNewPageLayoutModalOpen ) {
 			return null;
 		}
 
-		if ( isMobileDevice && Guide && GuidePage ) {
+		if ( variant === 'tour' ) {
+			return <LaunchWpcomWelcomeTour />;
+		}
+
+		if ( variant === 'modal' && Guide && GuidePage ) {
 			return <WpcomNux />;
 		}
 
-		return <LaunchWpcomWelcomeTour />;
+		return null;
 	},
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -7,7 +7,7 @@ import './public-path';
  */
 import { registerPlugin } from '@wordpress/plugins';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -17,6 +17,7 @@ import LaunchWpcomWelcomeTour from './welcome-tour/tour-launch';
 
 registerPlugin( 'wpcom-block-editor-nux', {
 	render: function WpcomBlockEditorNux() {
+		const [ isMobileDevice, setIsMobileDevice ] = useState();
 		const { isWpcomNuxEnabled, isSPTOpen } = useSelect( ( select ) => ( {
 			isWpcomNuxEnabled: select( 'automattic/nux' ).isWpcomNuxEnabled(),
 			isSPTOpen:
@@ -28,19 +29,25 @@ registerPlugin( 'wpcom-block-editor-nux', {
 
 		// On mount check if the WPCOM NUX status exists in state, otherwise fetch it from the API.
 		useEffect( () => {
-			if ( typeof isWpcomNuxEnabled !== 'undefined' ) {
+			if ( typeof isWpcomNuxEnabled !== 'undefined' && typeof isMobileDevice !== 'undefined' ) {
 				return;
 			}
 
 			const fetchWpcomNuxStatus = async () => {
 				const response = await apiFetch( { path: '/wpcom/v2/block-editor/nux' } );
 				setWpcomNuxStatus( { isNuxEnabled: response.is_nux_enabled, bypassApi: true } );
+				setIsMobileDevice( response.is_mobile_device );
 			};
 
 			fetchWpcomNuxStatus();
-		}, [ isWpcomNuxEnabled, setWpcomNuxStatus ] );
+		}, [ isWpcomNuxEnabled, setWpcomNuxStatus, isMobileDevice ] );
 
-		if ( ! isWpcomNuxEnabled || isSPTOpen ) {
+		if (
+			! isWpcomNuxEnabled ||
+			isSPTOpen ||
+			isMobileDevice ||
+			typeof isMobileDevice === 'undefined'
+		) {
 			return null;
 		}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -5,6 +5,7 @@ import './public-path';
 /**
  * External dependencies
  */
+import { Guide, GuidePage } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
@@ -14,6 +15,7 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import LaunchWpcomWelcomeTour from './welcome-tour/tour-launch';
+import WpcomNux from './welcome-modal/wpcom-nux';
 
 registerPlugin( 'wpcom-block-editor-nux', {
 	render: function WpcomBlockEditorNux() {
@@ -42,13 +44,12 @@ registerPlugin( 'wpcom-block-editor-nux', {
 			fetchWpcomNuxStatus();
 		}, [ isWpcomNuxEnabled, setWpcomNuxStatus, isMobileDevice ] );
 
-		if (
-			! isWpcomNuxEnabled ||
-			isSPTOpen ||
-			isMobileDevice ||
-			typeof isMobileDevice === 'undefined'
-		) {
+		if ( ! isWpcomNuxEnabled || isSPTOpen || typeof isMobileDevice === 'undefined' ) {
 			return null;
+		}
+
+		if ( isMobileDevice && Guide && GuidePage ) {
+			return <WpcomNux />;
 		}
 
 		return <LaunchWpcomWelcomeTour />;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -19,16 +19,15 @@ import LaunchWpcomWelcomeTour from './welcome-tour/tour-launch';
 
 registerPlugin( 'wpcom-block-editor-nux', {
 	render: function WpcomBlockEditorNux() {
-		const { site, isWpcomNuxEnabled, showWpcomNuxVariant, isSPTOpen } = useSelect( ( select ) => ( {
+		const { site, isWpcomNuxEnabled, isSPTOpen } = useSelect( ( select ) => ( {
 			site: select( 'automattic/site' ).getSite( window._currentSiteId ),
 			isWpcomNuxEnabled: select( 'automattic/nux' ).isWpcomNuxEnabled(),
-			showWpcomNuxVariant: select( 'automattic/nux' ).shouldShowWpcomNuxVariant(),
 			isSPTOpen:
 				select( 'automattic/starter-page-layouts' ) && // Handle the case where SPT is not initalized.
 				select( 'automattic/starter-page-layouts' ).isOpen(),
 		} ) );
 
-		const { setWpcomNuxStatus, setShowWpcomNuxVariant } = useDispatch( 'automattic/nux' );
+		const { setWpcomNuxStatus } = useDispatch( 'automattic/nux' );
 
 		// On mount check if the WPCOM NUX status exists in state, otherwise fetch it from the API.
 		useEffect( () => {
@@ -39,19 +38,18 @@ registerPlugin( 'wpcom-block-editor-nux', {
 			const fetchWpcomNuxStatus = async () => {
 				const response = await apiFetch( { path: '/wpcom/v2/block-editor/nux' } );
 				setWpcomNuxStatus( { isNuxEnabled: response.is_nux_enabled, bypassApi: true } );
-				setShowWpcomNuxVariant( { showVariant: response.welcome_tour_show_variant } );
 			};
 
 			fetchWpcomNuxStatus();
-		}, [ isWpcomNuxEnabled, setWpcomNuxStatus, setShowWpcomNuxVariant ] );
+		}, [ isWpcomNuxEnabled, setWpcomNuxStatus ] );
 
 		if ( ! isWpcomNuxEnabled || isSPTOpen ) {
 			return null;
 		}
 
 		const isPodcastingSite = !! site?.options?.anchor_podcast;
-
-		if ( showWpcomNuxVariant && ! isPodcastingSite ) {
+		// podcasting sites need to update their onboarding content to Tour format, then NUX Modal code can be removed
+		if ( ! isPodcastingSite ) {
 			return <LaunchWpcomWelcomeTour />;
 		}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -5,7 +5,6 @@ import './public-path';
 /**
  * External dependencies
  */
-import { Guide, GuidePage } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -14,13 +13,11 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import WpcomNux from './welcome-modal/wpcom-nux';
 import LaunchWpcomWelcomeTour from './welcome-tour/tour-launch';
 
 registerPlugin( 'wpcom-block-editor-nux', {
 	render: function WpcomBlockEditorNux() {
-		const { site, isWpcomNuxEnabled, isSPTOpen } = useSelect( ( select ) => ( {
-			site: select( 'automattic/site' ).getSite( window._currentSiteId ),
+		const { isWpcomNuxEnabled, isSPTOpen } = useSelect( ( select ) => ( {
 			isWpcomNuxEnabled: select( 'automattic/nux' ).isWpcomNuxEnabled(),
 			isSPTOpen:
 				select( 'automattic/starter-page-layouts' ) && // Handle the case where SPT is not initalized.
@@ -47,16 +44,6 @@ registerPlugin( 'wpcom-block-editor-nux', {
 			return null;
 		}
 
-		const isPodcastingSite = !! site?.options?.anchor_podcast;
-		// podcasting sites need to update their onboarding content to Tour format, then NUX Modal code can be removed
-		if ( ! isPodcastingSite ) {
-			return <LaunchWpcomWelcomeTour />;
-		}
-
-		if ( Guide && GuidePage ) {
-			return <WpcomNux />;
-		}
-
-		return null;
+		return <LaunchWpcomWelcomeTour />;
 	},
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
@@ -13,16 +13,17 @@ const unsubscribe = subscribe( () => {
 	unsubscribe();
 } );
 
-// Listen for these features being triggered to call dotcom nux instead.
+// Listen for these features being triggered to call dotcom welcome guide instead.
 // Note migration of areTipsEnabled: https://github.com/WordPress/gutenberg/blob/5c3a32dabe4393c45f7fe6ac5e4d78aebd5ee274/packages/data/src/plugins/persistence/index.js#L269
 subscribe( () => {
 	if ( select( 'core/nux' ).areTipsEnabled() ) {
 		dispatch( 'core/nux' ).disableTips();
-		dispatch( 'automattic/nux' ).setWpcomNuxStatus( { isNuxEnabled: true } );
+		dispatch( 'automattic/wpcom-welcome-guide' ).setShowWelcomeGuide( true );
 	}
 	if ( select( 'core/edit-post' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
-		dispatch( 'automattic/nux' ).setWpcomNuxStatus( { isNuxEnabled: true } );
-		dispatch( 'automattic/nux' ).setTourOpenStatus( { isTourManuallyOpened: true } );
+		dispatch( 'automattic/wpcom-welcome-guide' ).setShowWelcomeGuide( true, {
+			openedManually: true,
+		} );
 	}
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
@@ -32,10 +32,20 @@ const tourRatingReducer = ( state = undefined, action ) => {
 	}
 };
 
+const showWpcomNuxVariantReducer = ( state = 'tour', action ) => {
+	switch ( action.type ) {
+		case 'WPCOM_BLOCK_EDITOR_SET_NUX_VARIANT':
+			return action.variant;
+		default:
+			return state;
+	}
+};
+
 const reducer = combineReducers( {
 	isNuxEnabled: isNuxEnabledReducer,
 	isTourManuallyOpened: isTourManuallyOpenedReducer,
 	tourRating: tourRatingReducer,
+	showWpcomNuxVariant: showWpcomNuxVariantReducer,
 } );
 
 const actions = {
@@ -57,6 +67,12 @@ const actions = {
 	setTourRating: ( tourRating ) => {
 		return { type: 'WPCOM_BLOCK_EDITOR_SET_TOUR_RATING', tourRating };
 	},
+	setWpcomNuxVariant: ( variant ) => {
+		return {
+			type: 'WPCOM_BLOCK_EDITOR_SET_NUX_VARIANT',
+			variant,
+		};
+	},
 	setTourOpenStatus: ( { isTourManuallyOpened } ) => {
 		return {
 			type: 'WPCOM_BLOCK_EDITOR_SET_TOUR_OPEN',
@@ -68,7 +84,9 @@ const actions = {
 const selectors = {
 	isTourManuallyOpened: ( state ) => state.isTourManuallyOpened,
 	isWpcomNuxEnabled: ( state ) => state.isNuxEnabled,
+	isWpcomNuxStatusLoaded: ( state ) => typeof state.isNuxEnabled !== 'undefined',
 	tourRating: ( state ) => state.tourRating,
+	wpcomNuxVariant: ( state ) => state.showWpcomNuxVariant,
 };
 
 registerStore( 'automattic/nux', {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
@@ -32,20 +32,10 @@ const tourRatingReducer = ( state = undefined, action ) => {
 	}
 };
 
-const showWpcomNuxVariantReducer = ( state = false, action ) => {
-	switch ( action.type ) {
-		case 'WPCOM_BLOCK_EDITOR_SET_NUX_VARIANT':
-			return action.showVariant;
-		default:
-			return state;
-	}
-};
-
 const reducer = combineReducers( {
 	isNuxEnabled: isNuxEnabledReducer,
 	isTourManuallyOpened: isTourManuallyOpenedReducer,
 	tourRating: tourRatingReducer,
-	showWpcomNuxVariant: showWpcomNuxVariantReducer,
 } );
 
 const actions = {
@@ -67,12 +57,6 @@ const actions = {
 	setTourRating: ( tourRating ) => {
 		return { type: 'WPCOM_BLOCK_EDITOR_SET_TOUR_RATING', tourRating };
 	},
-	setShowWpcomNuxVariant: ( { showVariant } ) => {
-		return {
-			type: 'WPCOM_BLOCK_EDITOR_SET_NUX_VARIANT',
-			showVariant,
-		};
-	},
 	setTourOpenStatus: ( { isTourManuallyOpened } ) => {
 		return {
 			type: 'WPCOM_BLOCK_EDITOR_SET_TOUR_OPEN',
@@ -85,7 +69,6 @@ const selectors = {
 	isTourManuallyOpened: ( state ) => state.isTourManuallyOpened,
 	isWpcomNuxEnabled: ( state ) => state.isNuxEnabled,
 	tourRating: ( state ) => state.tourRating,
-	shouldShowWpcomNuxVariant: ( state ) => state.showWpcomNuxVariant,
 };
 
 registerStore( 'automattic/nux', {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-modal/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-modal/wpcom-nux.js
@@ -18,33 +18,33 @@ import previewImage from './images/preview.svg';
 import privateImage from './images/private.svg';
 
 function WpcomNux() {
-	const { isWpcomNuxEnabled, isSPTOpen, isTourManuallyOpened } = useSelect( ( select ) => ( {
-		isWpcomNuxEnabled: select( 'automattic/nux' ).isWpcomNuxEnabled(),
-		isSPTOpen:
+	const { show, isNewPageLayoutModalOpen, isManuallyOpened } = useSelect( ( select ) => ( {
+		show: select( 'automattic/wpcom-welcome-guide' ).isWelcomeGuideShown(),
+		isNewPageLayoutModalOpen:
 			select( 'automattic/starter-page-layouts' ) && // Handle the case where SPT is not initalized.
 			select( 'automattic/starter-page-layouts' ).isOpen(),
-		isTourManuallyOpened: select( 'automattic/nux' ).isTourManuallyOpened(),
+		isManuallyOpened: select( 'automattic/wpcom-welcome-guide' ).isWelcomeGuideManuallyOpened(),
 	} ) );
 
 	const { closeGeneralSidebar } = useDispatch( 'core/edit-post' );
-	const { setWpcomNuxStatus, setTourOpenStatus } = useDispatch( 'automattic/nux' );
+	const { setShowWelcomeGuide } = useDispatch( 'automattic/wpcom-welcome-guide' );
 
 	// Hide editor sidebar first time users sees the editor
 	useEffect( () => {
-		isWpcomNuxEnabled && closeGeneralSidebar();
-	}, [ closeGeneralSidebar, isWpcomNuxEnabled ] );
+		show && closeGeneralSidebar();
+	}, [ closeGeneralSidebar, show ] );
 
-	// Track opening of the NUX Guide
+	// Track opening of the welcome guide
 	useEffect( () => {
-		if ( isWpcomNuxEnabled && ! isSPTOpen ) {
+		if ( show && ! isNewPageLayoutModalOpen ) {
 			recordTracksEvent( 'calypso_editor_wpcom_nux_open', {
 				is_gutenboarding: window.calypsoifyGutenberg?.isGutenboarding,
-				is_manually_opened: isTourManuallyOpened,
+				is_manually_opened: isManuallyOpened,
 			} );
 		}
-	}, [ isWpcomNuxEnabled, isSPTOpen, isTourManuallyOpened ] );
+	}, [ isManuallyOpened, isNewPageLayoutModalOpen, show ] );
 
-	if ( ! isWpcomNuxEnabled || isSPTOpen ) {
+	if ( ! show || isNewPageLayoutModalOpen ) {
 		return null;
 	}
 
@@ -52,8 +52,7 @@ function WpcomNux() {
 		recordTracksEvent( 'calypso_editor_wpcom_nux_dismiss', {
 			is_gutenboarding: window.calypsoifyGutenberg?.isGutenboarding,
 		} );
-		setWpcomNuxStatus( { isNuxEnabled: false } );
-		setTourOpenStatus( { isTourManuallyOpened: false } );
+		setShowWelcomeGuide( false, { openedManually: false } );
 	};
 
 	const nuxPages = getWpcomNuxPages();

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/disable-core-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/disable-core-nux.js
@@ -13,18 +13,17 @@ const unsubscribe = subscribe( () => {
 	unsubscribe();
 } );
 
-// Listen for these features being triggered to call dotcom nux instead.
+// Listen for these features being triggered to call dotcom welcome guide instead.
 // Note migration of areTipsEnabled: https://github.com/WordPress/gutenberg/blob/5c3a32dabe4393c45f7fe6ac5e4d78aebd5ee274/packages/data/src/plugins/persistence/index.js#L269
 subscribe( () => {
 	if ( select( 'core/nux' ).areTipsEnabled() ) {
 		dispatch( 'core/nux' ).disableTips();
-		dispatch( 'automattic/nux' ).setWpcomNuxStatus( { isNuxEnabled: true } );
+		dispatch( 'automattic/wpcom-welcome-guide' ).setShowWelcomeGuide( true );
 	}
 	if ( select( 'core/edit-post' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
-		dispatch( 'automattic/nux' ).setWpcomNuxStatus( {
-			isNuxEnabled: true,
+		dispatch( 'automattic/wpcom-welcome-guide' ).setShowWelcomeGuide( true, {
+			openedManually: true,
 		} );
-		dispatch( 'automattic/nux' ).setTourOpenStatus( { isTourManuallyOpened: true } );
 	}
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -157,8 +157,10 @@ function CardOverlayControls( { onMinimize, onDismiss, slideNumber } ) {
 
 function TourRating() {
 	let isDisabled = false;
-	const tourRating = useSelect( ( select ) => select( 'automattic/nux' ).tourRating() );
-	const { setTourRating } = useDispatch( 'automattic/nux' );
+	const tourRating = useSelect( ( select ) =>
+		select( 'automattic/wpcom-welcome-guide' ).getTourRating()
+	);
+	const { setTourRating } = useDispatch( 'automattic/wpcom-welcome-guide' );
 
 	if ( ! isDisabled && tourRating ) {
 		isDisabled = true;


### PR DESCRIPTION
## Changes proposed in this Pull Request

- [x] Remove `apply_filter` code that hooked to experiment
- [x] Remove client code that handled the variant variable and determined which editor welcome to show to user
- [x] Remove  check fo Anchor.fm usage since  @allilevine has [REMOVED anchor NUX content](https://github.com/Automattic/wp-calypso/commit/1c2161f5e768d87353d42f9e4ad2ad3d36a06b36)
- [x] Show NUX modal to mobile users

A subsequent diff will remove the experiment code D53894-code

## Testing instructions

* pull down this branch
* `yarn dev --sync` to your sandbox
 OR
* from your sandbox: 
  * `cd /home/wpcom/public_html`  
  *  `install-plugin.sh etk update/show-welcome-tour-to-new-users-cept-anchorfm`  (nifty!)
* On a simple site that is sandboxed test the following:

* Clear application data:  In dev tools Application tab you must clear the site's local storage to ensure the @automattic/nux store is reset. Must be done in order to show the Welcome Guide on first load.

**Scenario #1 Desktop**
* Welcome Tour should show when opening editor
  * go through all slides, minimize, maximize, etc to make sure Tour works 
* Open Tour from Options Menu (aka More Menu) -> "Welcome Guide"
* Close, then re-open editor and make sure the Welcome Tour does not automatically show

**Scenario #2 Mobile**
* Clear application data agin
* Use Chrome dev tools to mimic mobile
 OR
* BETTER if you are using https://github.com/Automattic/a8c-wp-env you can easily test on your mobile device via the Jurassic Tube integration (or ngrok)
* The NUX Modal should show


Related to # https://github.com/Automattic/wp-calypso/issues/50877