### PR TITLE
Remove home link hover state in Jetpack cloud

### DIFF
--- a/client/components/jetpack/masterbar/index.tsx
+++ b/client/components/jetpack/masterbar/index.tsx
@@ -10,7 +10,6 @@ import { useTranslate } from 'i18n-calypso';
 import { getDocumentHeadTitle } from 'calypso/state/document-head/selectors/get-document-head-title';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { useSelector } from 'react-redux';
-import Item from 'calypso/layout/masterbar/item';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import ProfileDropdown from 'calypso/components/jetpack/profile-dropdown';
@@ -33,15 +32,17 @@ const JetpackCloudMasterBar: React.FC = () => {
 		<Masterbar
 			className="is-jetpack-cloud-masterbar" // eslint-disable-line wpcalypso/jsx-classname-namespace
 		>
-			<Item
+			<a
 				className="masterbar__item-home"
-				url="/"
-				tooltip={ translate( 'Jetpack Cloud Dashboard', {
-					comment: 'Jetpack Cloud top navigation bar item',
-				} ) }
+				href="/"
+				title={
+					translate( 'Jetpack Cloud Dashboard', {
+						comment: 'Jetpack Cloud top navigation bar item',
+					} ) as string
+				}
 			>
 				<JetpackLogo size={ 28 } full={ ! isNarrow || isExteriorPage } aria={ { hidden: true } } />
-			</Item>
+			</a>
 			<AsyncLoad require="calypso/components/jetpack/portal-nav" placeholder={ null } />
 			{ headerTitle && <h1 className="masterbar__item-title">{ headerTitle }</h1> }
 			<ProfileDropdown />

--- a/client/components/jetpack/masterbar/style.scss
+++ b/client/components/jetpack/masterbar/style.scss
@@ -2,10 +2,20 @@
 	justify-content: space-between;
 
 	.masterbar__item-home {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+
 		border-right: 1px solid var( --color-masterbar-border );
-		flex: 0 0 auto;
-		padding: 0;
-		width: auto;
+
+		&:hover .jetpack-logo {
+			transform: scale( 1.1 );
+		}
+
+		&:focus {
+			box-shadow: inset 0 0 0 2px var( --color-primary-light );
+			outline-width: 0;
+		}
 
 		@include breakpoint-deprecated( '>660px' ) {
 			min-width: var( --sidebar-width-min );
@@ -14,18 +24,10 @@
 		@include breakpoint-deprecated( '>960px' ) {
 			min-width: var( --sidebar-width-max );
 		}
+	}
 
-		.masterbar__item-content {
-			color: var( --color-masterbar-text );
-			display: flex;
-			justify-content: center;
-			padding: 0 16px;
-			width: 100%;
-
-			svg {
-				fill: var( --color-black );
-			}
-		}
+	.jetpack-logo {
+		transition: transform 0.2s ease;
 	}
 
 	.masterbar__item-title {
@@ -37,22 +39,5 @@
 		color: var( --color-neutral-80 );
 
 		text-transform: none;
-	}
-
-	.masterbar__item-me {
-		min-width: 18px;
-		flex: 0 0 auto;
-
-		// Calypso's masterbar hides this item content and we need to show it
-		// so we override its display property.
-		@include breakpoint-deprecated( '<480px' ) {
-			.masterbar__item-content {
-				display: block;
-			}
-		}
-	}
-
-	.masterbar__item-me--open {
-		box-shadow: 0 -1px 0 1px var( --studio-gray-20 );
 	}
 }

--- a/client/components/jetpack/masterbar/style.scss
+++ b/client/components/jetpack/masterbar/style.scss
@@ -10,10 +10,6 @@
 
 		border-right: 1px solid var( --color-masterbar-border );
 
-		&:hover .jetpack-logo {
-			transform: scale( 1.1 );
-		}
-
 		&:focus {
 			box-shadow: inset 0 0 0 2px var( --color-primary-light );
 			outline-width: 0;
@@ -26,10 +22,6 @@
 		@include breakpoint-deprecated( '>960px' ) {
 			min-width: var( --sidebar-width-max );
 		}
-	}
-
-	.jetpack-logo {
-		transition: transform 0.2s ease;
 	}
 
 	.masterbar__item-title {

--- a/client/components/jetpack/masterbar/style.scss
+++ b/client/components/jetpack/masterbar/style.scss
@@ -6,6 +6,7 @@
 		justify-content: center;
 		align-items: center;
 
+		box-sizing: border-box;
 		padding: 0 16px;
 
 		border-right: 1px solid var( --color-masterbar-border );
@@ -16,11 +17,11 @@
 		}
 
 		@include breakpoint-deprecated( '>660px' ) {
-			min-width: var( --sidebar-width-min );
+			min-width: calc( var( --sidebar-width-min ) + 1px ); // Account right border
 		}
 
 		@include breakpoint-deprecated( '>960px' ) {
-			min-width: var( --sidebar-width-max );
+			min-width: calc( var( --sidebar-width-max ) + 1px ); // Account right border
 		}
 	}
 

--- a/client/components/jetpack/masterbar/style.scss
+++ b/client/components/jetpack/masterbar/style.scss
@@ -6,6 +6,8 @@
 		justify-content: center;
 		align-items: center;
 
+		padding: 0 16px;
+
 		border-right: 1px solid var( --color-masterbar-border );
 
 		&:hover .jetpack-logo {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR removes the subtle hover state of the home link in Jetpack cloud header. It also removes some unused CSS.

Another PR originally made the over state more obvious (#51048), but it was pointed out that the primary branding of the page should not have any hover state.

### Testing instructions

- Download the PR and run cloud
- Visit any page that contains the masterbar
- Check that the home link containing the Jetpack logo behaves as before, and that it has no hover state

### Screenshots

_Before_

https://user-images.githubusercontent.com/1620183/111163295-60669180-8573-11eb-9f31-959984bf0ab5.mov



_After_

https://user-images.githubusercontent.com/1620183/111163324-652b4580-8573-11eb-8af8-f509ddff6926.mov

