### PR TITLE
i18n: Fix quick language switcher for unified nav

### DIFF
--- a/client/layout/masterbar/quick-language-switcher.jsx
+++ b/client/layout/masterbar/quick-language-switcher.jsx
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import React, { Fragment, useReducer } from 'react';
+import React, { Fragment, useEffect, useReducer } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import config from '@automattic/calypso-config';
 import MasterbarItem from './item';
 import LanguagePickerModal from 'calypso/components/language-picker/modal';
@@ -26,6 +29,11 @@ function QuickLanguageSwitcher( props ) {
 		);
 		toggleLanguageEmpathyMode( empathyMode );
 	};
+
+	// After changing the language, the menu should be requested again so that items are fetched with the current locale.
+	useEffect( () => {
+		props.requestAdminMenu( props.selectedSiteId );
+	}, [ props.locale ] );
 
 	return (
 		<Fragment>
@@ -53,6 +61,7 @@ function QuickLanguageSwitcher( props ) {
 export default connect(
 	( state ) => ( {
 		selectedLanguageSlug: getCurrentLocaleSlug( state ),
+		selectedSiteId: getSelectedSiteId( state ),
 	} ),
-	{ setLocale }
-)( QuickLanguageSwitcher );
+	{ setLocale, requestAdminMenu }
+)( localize( QuickLanguageSwitcher ) );

--- a/client/layout/masterbar/quick-language-switcher.jsx
+++ b/client/layout/masterbar/quick-language-switcher.jsx
@@ -1,15 +1,12 @@
 /**
  * External dependencies
  */
-import React, { Fragment, useEffect, useReducer } from 'react';
+import React, { Fragment, useReducer } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import config from '@automattic/calypso-config';
 import MasterbarItem from './item';
 import LanguagePickerModal from 'calypso/components/language-picker/modal';
@@ -29,11 +26,6 @@ function QuickLanguageSwitcher( props ) {
 		);
 		toggleLanguageEmpathyMode( empathyMode );
 	};
-
-	// After changing the language, the menu should be requested again so that items are fetched with the current locale.
-	useEffect( () => {
-		props.requestAdminMenu( props.selectedSiteId );
-	}, [ props.locale ] );
 
 	return (
 		<Fragment>
@@ -61,7 +53,6 @@ function QuickLanguageSwitcher( props ) {
 export default connect(
 	( state ) => ( {
 		selectedLanguageSlug: getCurrentLocaleSlug( state ),
-		selectedSiteId: getSelectedSiteId( state ),
 	} ),
-	{ setLocale, requestAdminMenu }
-)( localize( QuickLanguageSwitcher ) );
+	{ setLocale }
+)( QuickLanguageSwitcher );

--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -3,6 +3,7 @@
  */
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { useLocale } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -27,6 +28,7 @@ const useSiteMenuItems = () => {
 	const menuItems = useSelector( ( state ) => getAdminMenu( state, selectedSiteId ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSiteId ) );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, selectedSiteId ) );
+	const locale = useLocale();
 
 	useEffect( () => {
 		if ( selectedSiteId && siteDomain ) {
@@ -35,7 +37,7 @@ const useSiteMenuItems = () => {
 				dispatch( fetchPlugins( [ selectedSiteId ] ) );
 			}
 		}
-	}, [ dispatch, isJetpack, selectedSiteId, siteDomain ] );
+	}, [ dispatch, isJetpack, selectedSiteId, siteDomain, locale ] );
 
 	/**
 	 * As a general rule we allow fallback data to remain as static as possible.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `locale` to the dependency list of the `useSiteMenuItems`'s menu items fetching effect.

#### Testing instructions

* Boot Calypso locally or use calypso.live build in this PR.
* Go to `/home/{SITE}?flags=quick-language-switcher` (note the `flags` parameter).
* Change the language using the quick language switcher in the top navigation bar.
* Confirm the main navigation on the left sidebar (or right if you're using RTL language) gets updated for the selected language. 

Related to #51064 
