### PR TITLE
Framework: Refactor away from _.slice()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -433,6 +433,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/repeat': 'error',
 		'you-dont-need-lodash-underscore/reverse': 'error',
 		'you-dont-need-lodash-underscore/select': 'error',
+		'you-dont-need-lodash-underscore/slice': 'error',
 		'you-dont-need-lodash-underscore/split': 'error',
 		'you-dont-need-lodash-underscore/take-right': 'error',
 		'you-dont-need-lodash-underscore/to-lower': 'error',

--- a/client/components/sorted-grid/index.jsx
+++ b/client/components/sorted-grid/index.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { get, keys, last, map, omit, reduce, slice } from 'lodash';
+import { get, keys, last, map, omit, reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,7 +28,7 @@ class SortedGrid extends PureComponent {
 		const items = [];
 
 		for ( let i = 0; i < this.props.items.length; i += this.props.itemsPerRow ) {
-			const row = slice( this.props.items, i, i + this.props.itemsPerRow );
+			const row = this.props.items.slice( i, i + this.props.itemsPerRow );
 			const groups = reduce(
 				map( row, this.props.getItemGroup ),
 				( results, group ) => {

--- a/client/my-sites/comments/comment-tree/index.jsx
+++ b/client/my-sites/comments/comment-tree/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { filter, find, get, isEqual, map, orderBy, slice } from 'lodash';
+import { filter, find, get, isEqual, map, orderBy } from 'lodash';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
 import CSSTransition from 'react-transition-group/CSSTransition';
 
@@ -81,7 +81,7 @@ export class CommentTree extends Component {
 
 	getCommentsPage = ( comments, page ) => {
 		const startingIndex = ( page - 1 ) * COMMENTS_PER_PAGE;
-		return slice( comments, startingIndex, startingIndex + COMMENTS_PER_PAGE );
+		return comments.slice( startingIndex, startingIndex + COMMENTS_PER_PAGE );
 	};
 
 	getEmptyMessage = () => {

--- a/client/state/selectors/get-filtered-billing-transactions.js
+++ b/client/state/selectors/get-filtered-billing-transactions.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { getLocaleSlug } from 'i18n-calypso';
-import { compact, flatMap, omit, slice, some, values } from 'lodash';
+import { compact, flatMap, omit, some, values } from 'lodash';
 import moment from 'moment';
 
 /**
@@ -108,7 +108,7 @@ export default createSelector(
 		const total = results.length;
 
 		const pageIndex = page - 1;
-		results = slice( results, pageIndex * PAGE_SIZE, pageIndex * PAGE_SIZE + PAGE_SIZE );
+		results = results.slice( pageIndex * PAGE_SIZE, pageIndex * PAGE_SIZE + PAGE_SIZE );
 
 		return {
 			transactions: results,

--- a/client/state/selectors/test/get-filtered-billing-transactions.js
+++ b/client/state/selectors/test/get-filtered-billing-transactions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { cloneDeep, slice } from 'lodash';
+import { cloneDeep } from 'lodash';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -177,7 +177,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 			expect( result ).toEqual( {
 				pageSize: PAGE_SIZE,
 				total: 10,
-				transactions: slice( state.billingTransactions.items.past, 0, PAGE_SIZE ),
+				transactions: state.billingTransactions.items.past.slice( 0, PAGE_SIZE ),
 			} );
 		} );
 
@@ -213,7 +213,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 			expect( result ).toEqual( {
 				pageSize: PAGE_SIZE,
 				total: 10,
-				transactions: slice( state.billingTransactions.items.past, 0, PAGE_SIZE ),
+				transactions: state.billingTransactions.items.past.slice( 0, PAGE_SIZE ),
 			} );
 		} );
 
@@ -237,7 +237,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 			expect( result ).toEqual( {
 				pageSize: PAGE_SIZE,
 				total: 10,
-				transactions: slice( state.billingTransactions.items.past, 0, PAGE_SIZE ),
+				transactions: state.billingTransactions.items.past.slice( 0, PAGE_SIZE ),
 			} );
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `slice` is essentially fully natively supported by the native `Array.prototype.slice()`. This PR replaces the usage and adds an ESLint rule to warn against using `slice` from lodash.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all 4 usages are sane and we'll never end up triggering `.slice()` on an `undefined` or `null`.
* Try to `import { slice } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass.