### PR TITLE
Framework: Refactor away from _.isFunction()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -422,6 +422,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/inject': 'error',
 		'you-dont-need-lodash-underscore/is-array': 'error',
 		'you-dont-need-lodash-underscore/is-finite': 'error',
+		'you-dont-need-lodash-underscore/is-function': 'error',
 		'you-dont-need-lodash-underscore/is-nan': 'error',
 		'you-dont-need-lodash-underscore/is-nil': 'error',
 		'you-dont-need-lodash-underscore/is-null': 'error',

--- a/client/components/checklist/checklist.js
+++ b/client/components/checklist/checklist.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import React, { Children, PureComponent, cloneElement } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { isFunction, times } from 'lodash';
+import { times } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -81,7 +81,7 @@ class Checklist extends PureComponent {
 				return { expandedTaskIndex: null }; // Collapse
 			}
 
-			if ( isFunction( this.props.onExpandTask ) ) {
+			if ( typeof this.props.onExpandTask === 'function' ) {
 				this.props.onExpandTask(
 					Children.toArray( this.props.children )[ newExpandedTaskIndex ].props
 				);

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { isFunction, map } from 'lodash';
+import { map } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -41,7 +41,7 @@ class ThemeMoreButton extends Component {
 
 	closePopover = ( action ) => {
 		this.setState( { showPopover: false } );
-		if ( isFunction( action ) ) {
+		if ( typeof action === 'function' ) {
 			action();
 		}
 	};

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import debugModule from 'debug';
-import { isFunction } from 'lodash';
 import page from 'page';
 import { v4 as uuid } from 'uuid';
 import { addQueryArgs } from 'calypso/lib/route';
@@ -149,14 +148,14 @@ export class WebPreviewContent extends Component {
 		// remove all textual selections when user gives focus to preview iframe
 		// they might be confusing
 		if ( typeof window !== 'undefined' ) {
-			if ( isFunction( window.getSelection ) ) {
+			if ( typeof window.getSelection === 'function' ) {
 				const selection = window.getSelection();
-				if ( isFunction( selection.empty ) ) {
+				if ( typeof selection.empty === 'function' ) {
 					selection.empty();
-				} else if ( isFunction( selection.removeAllRanges ) ) {
+				} else if ( typeof selection.removeAllRanges === 'function' ) {
 					selection.removeAllRanges();
 				}
-			} else if ( document.selection && isFunction( document.selection.empty ) ) {
+			} else if ( typeof document.selection && document.selection.empty === 'function' ) {
 				document.selection.empty();
 			}
 		}

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -155,7 +155,7 @@ export class WebPreviewContent extends Component {
 				} else if ( typeof selection.removeAllRanges === 'function' ) {
 					selection.removeAllRanges();
 				}
-			} else if ( typeof document.selection && document.selection.empty === 'function' ) {
+			} else if ( document.selection && typeof document.selection.empty === 'function' ) {
 				document.selection.empty();
 			}
 		}

--- a/client/devdocs/main.jsx
+++ b/client/devdocs/main.jsx
@@ -5,7 +5,6 @@
 import debug from 'debug';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { isFunction } from 'lodash';
 
 /**
  * Internal dependencies
@@ -90,7 +89,7 @@ export default class Devdocs extends React.Component {
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
-		if ( isFunction( this.props.onSearchChange ) && prevState.term !== this.state.term ) {
+		if ( typeof this.props.onSearchChange === 'function' && prevState.term !== this.state.term ) {
 			this.props.onSearchChange( this.state.term );
 		}
 	}

--- a/client/extensions/woocommerce/lib/redux-utils.js
+++ b/client/extensions/woocommerce/lib/redux-utils.js
@@ -3,7 +3,7 @@
  */
 
 import { bindActionCreators } from 'redux';
-import { isFunction, reduce } from 'lodash';
+import { reduce } from 'lodash';
 
 /**
  * Calls Redux' bindActionCreators on the passed in actionCreators
@@ -15,7 +15,7 @@ import { isFunction, reduce } from 'lodash';
  * @returns {Function|object} result of bindActionCreators
  */
 export const bindActionCreatorsWithSiteId = ( actionCreators, dispatch, siteId ) => {
-	if ( isFunction( actionCreators ) ) {
+	if ( typeof actionCreators === 'function' ) {
 		return bindActionCreators( actionCreators.bind( null, siteId ), dispatch );
 	}
 

--- a/client/extensions/woocommerce/state/data-layer/ui/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/products/index.js
@@ -3,7 +3,7 @@
  */
 
 import { translate } from 'i18n-calypso';
-import { find, isObject, isFunction, isEqual, compact } from 'lodash';
+import { find, isObject, isEqual, compact } from 'lodash';
 
 /**
  * Internal dependencies
@@ -83,13 +83,13 @@ export function handleProductActionListCreate( store, action ) {
 		const products = Object.values( updatedProductIds ).map( ( productId ) =>
 			getProduct( store.getState(), productId )
 		);
-		if ( isFunction( successAction ) ) {
+		if ( typeof successAction === 'function' ) {
 			return dispatch( successAction( products, updatedProductIds ) );
 		}
 		return dispatch( successAction );
 	};
 	const onFailure = ( dispatch, { productError } ) => {
-		if ( isFunction( failureAction ) ) {
+		if ( typeof failureAction === 'function' ) {
 			dispatch( failureAction( productError ) );
 		} else {
 			dispatch( failureAction );

--- a/client/extensions/woocommerce/state/helpers.js
+++ b/client/extensions/woocommerce/state/helpers.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-
-import { isFunction, isObject } from 'lodash';
+import { isObject } from 'lodash';
 
 /**
  * Dispatch an action or function with additional properties.
@@ -19,7 +18,7 @@ import { isFunction, isObject } from 'lodash';
  * @param {object} props The props to be sent to the function or assigned to the object.
  */
 export function dispatchWithProps( dispatch, getState, action, props ) {
-	if ( isFunction( action ) ) {
+	if ( typeof action === 'function' ) {
 		const returnValue = action( dispatch, getState, props );
 		dispatchWithProps( dispatch, getState, returnValue, props );
 	} else if ( isObject( action ) ) {

--- a/client/extensions/woocommerce/state/sites/coupons/handlers.js
+++ b/client/extensions/woocommerce/state/sites/coupons/handlers.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { trim, isFunction } from 'lodash';
+import { trim } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -107,7 +107,7 @@ function apiError( action, error ) {
 		return;
 	}
 
-	if ( isFunction( failureAction ) ) {
+	if ( typeof failureAction === 'function' ) {
 		return failureAction( error );
 	}
 

--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, CSSProperties, FunctionComponent } from 'react';
 import classNames from 'classnames';
-import { defer, isFunction } from 'lodash';
+import { defer } from 'lodash';
 import debugFactory from 'debug';
 import { translate } from 'i18n-calypso';
 
@@ -163,7 +163,7 @@ export default class Step extends Component< Props, State > {
 	}
 
 	async wait( props: Props, context ) {
-		if ( isFunction( props.wait ) ) {
+		if ( typeof props.wait === 'function' ) {
 			await context.dispatch( props.wait() );
 		}
 	}

--- a/client/layout/guided-tours/tour-branching.js
+++ b/client/layout/guided-tours/tour-branching.js
@@ -3,14 +3,14 @@
  */
 
 import { Children } from 'react';
-import { flatMap, identity, isFunction } from 'lodash';
+import { flatMap, identity } from 'lodash';
 
 /*
  * Transforms a React `Children` object into an array. The children of a `Step` are
  * a render prop and we need to call the function to get the children array.
  */
 const childrenToArray = ( children ) => {
-	if ( isFunction( children ) ) {
+	if ( typeof children === 'function' ) {
 		children = children( { translate: identity } );
 	}
 

--- a/client/layout/masterbar/item.jsx
+++ b/client/layout/masterbar/item.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import { isFunction } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import TranslatableString from 'calypso/components/translatable/proptype';
 
@@ -31,7 +30,7 @@ class MasterbarItem extends Component {
 	_preloaded = false;
 
 	preload = () => {
-		if ( ! this._preloaded && isFunction( this.props.preloadSection ) ) {
+		if ( ! this._preloaded && typeof this.props.preloadSection === 'function' ) {
 			this._preloaded = true;
 			this.props.preloadSection();
 		}

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -5,7 +5,6 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
-import { isFunction } from 'lodash';
 
 /**
  * Internal dependencies
@@ -47,7 +46,7 @@ export default function SidebarItem( props ) {
 	const expandSectionIfSelected = () => {
 		const { expandSection, selected } = props;
 
-		if ( selected && isFunction( expandSection ) ) {
+		if ( selected && typeof expandSection === 'function' ) {
 			expandSection();
 		}
 	};

--- a/client/lib/form-state/store/index.js
+++ b/client/lib/form-state/store/index.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-
-import { isFunction, reduce } from 'lodash';
+import { reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -42,7 +41,7 @@ class Store {
 	}
 
 	_dispatch( action ) {
-		if ( isFunction( action ) ) {
+		if ( typeof action === 'function' ) {
 			action( this._dispatch.bind( this ), this.get.bind( this ) );
 			return;
 		}

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { difference, get, has, includes, pick, values, isFunction } from 'lodash';
+import { difference, get, has, includes, pick, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -72,7 +72,7 @@ export function getPlanByPathSlug( pathSlug, group ) {
 	/** @type {Plan[]} */
 	let plans = Object.values( PLANS_LIST );
 	plans = plans.filter( ( p ) => ( group ? p.group === group : true ) );
-	return plans.find( ( p ) => isFunction( p.getPathSlug ) && p.getPathSlug() === pathSlug );
+	return plans.find( ( p ) => typeof p.getPathSlug === 'function' && p.getPathSlug() === pathSlug );
 }
 
 export function getPlanPath( plan ) {

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import { identity, isEqual, find, replace, some, isFunction, get } from 'lodash';
+import { identity, isEqual, find, replace, some, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -648,7 +648,7 @@ export function connectFor( sharingService, mapStateToProps, mapDispatchToProps 
 				userId,
 				isExpanded: isServiceExpanded( state, service ),
 			};
-			return isFunction( mapStateToProps ) ? mapStateToProps( state, props ) : props;
+			return typeof mapStateToProps === 'function' ? mapStateToProps( state, props ) : props;
 		},
 		{
 			createSiteConnection,

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { translate, TranslateResult, numberFormat } from 'i18n-calypso';
-import { compact, isObject, isFunction } from 'lodash';
+import { compact, isObject } from 'lodash';
 import page from 'page';
 import React, { createElement, Fragment } from 'react';
 import formatCurrency from '@automattic/format-currency';
@@ -604,7 +604,7 @@ export function buildCardFeaturesFromItem(
 		if ( features ) {
 			return buildCardFeaturesFromFeatureKeys( features, options, variation );
 		}
-	} else if ( isFunction( item.getFeatures ) ) {
+	} else if ( typeof item.getFeatures === 'function' ) {
 		const features = getForCurrentCROIteration( item.getFeatures );
 
 		if ( features ) {

--- a/client/state/analytics/actions/with-analytics.js
+++ b/client/state/analytics/actions/with-analytics.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { curry, get, isFunction, merge } from 'lodash';
+import { curry, get, merge } from 'lodash';
 
 const mergedMetaData = ( a, b ) => [
 	...get( a, 'meta.analytics', [] ),
@@ -9,7 +9,7 @@ const mergedMetaData = ( a, b ) => [
 ];
 
 const joinAnalytics = ( analytics, action ) =>
-	isFunction( action )
+	typeof action === 'function'
 		? ( dispatch ) => {
 				dispatch( analytics );
 				dispatch( action );

--- a/client/state/ui/action-log/reducer.js
+++ b/client/state/ui/action-log/reducer.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-
-import { get, has, includes, isFunction, overSome } from 'lodash';
+import { get, has, includes, overSome } from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,7 +39,7 @@ const hasRelevantAnalytics = ( action ) =>
 
 const isRelevantActionType = ( action ) =>
 	has( relevantTypes, action.type ) &&
-	( ! isFunction( relevantTypes[ action.type ] ) || relevantTypes[ action.type ]( action ) );
+	( typeof relevantTypes[ action.type ] !== 'function' || relevantTypes[ action.type ]( action ) );
 
 const isRelevantAction = overSome( [ isRelevantActionType, hasRelevantAnalytics ] );
 

--- a/client/test-helpers/use-sinon/index.js
+++ b/client/test-helpers/use-sinon/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import sinon from 'sinon';
-import { isFunction } from 'lodash';
 
 const noop = () => {};
 
@@ -23,7 +22,7 @@ const noop = () => {};
 export function useFakeTimers( now = 0, clockCallback = noop ) {
 	let clock;
 
-	if ( isFunction( now ) && clockCallback === noop ) {
+	if ( typeof now === 'function' && clockCallback === noop ) {
 		clockCallback = now;
 		now = 0;
 	}
@@ -53,7 +52,7 @@ export function useFakeTimers( now = 0, clockCallback = noop ) {
 export function useSandbox( config, sandboxCallback = noop ) {
 	let sandbox;
 
-	if ( isFunction( config ) && sandboxCallback === noop ) {
+	if ( typeof config === 'function' && sandboxCallback === noop ) {
 		sandboxCallback = config;
 		config = undefined;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `isFunction` is essentially fully natively supported by the native `typeof x === 'function'`. This PR replaces the usage and adds an ESLint rule to warn against using `isFunction` from lodash.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all usages are sane and preserve the original logic (be it negative or not).
* Try to `import { isFunction } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass.

#### Notes

There are pre-existing ESLint errors, those are expected to fail again in a couple of files.