### PR TITLE
Cleanup old Focused Launch feature flag code

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
@@ -88,10 +88,6 @@ function enqueue_launch_flow_script_and_style( $site_launch_options ) {
 		case 'focused-launch':
 			$script_name = 'focused-launch';
 			break;
-		case 'launch-site':
-			// @TODO: this is just temporary for testing via feature flag. Remove it once focused-launch is live
-			$script_name = 'focused-launch';
-			break;
 		default:
 			// For redirect or invalid flows, skip & exit early.
 			return;


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Cleanup some old, unnecessary code which caused the focused launch flow script to load even not necessary (i.e when the launch flow was set to `launch-site`)

The code was added in #49004, but it's not necessary since the switch to Experiment Platform in #49067

## Testing instructions

This PR shouldn't cause any changes/regressions. Expected behaviour is same as production.

#### Setup

- Prepare your sandbox:
  - Make sure you have an active ssh connection to your sandbox
  - Clear your sandbox and pull the latest version from trunk
- Pull this PR's branch on your local machine and run the project locally:
  - Run `yarn && yarn start` in the root folder
  - After the command above has finished compiling, in a separate terminal window run `cd apps/editing-toolkit && yarn dev --sync`

#### Redirect flow for sites created with `/start`

* Create a site with `/start` and add it to the sandbox (do not launch it)
* Disable Focused Launch flow A/B testing experiment (select `control` on the `focused_launch_flow_v2` experiment)
* Navigate to `/page/SITE_ID.wordpress.com/home`
* Click "Launch" button in the header bar
  * [x] Browser should be redirected to `/start/launch-site` flow

#### Focused Launch flow for sites created with `/start`

* Create a site with `/start` and add it to the sandbox (do not launch it)
* Enable Focused Launch flow A/B testing experiment (select `treatment` on the `focused_launch_flow_v2` experiment)
* Navigate to `/page/SITE_ID.wordpress.com/home`
* Click "Launch" button in the header bar
  * [x] Focused Launch modal should be displayed

#### Focused Launch flow for sites created with `/new`

* Create a site with `/new` and add it to the sandbox (do not launch it)
* Navigate to `/page/SITE_ID.wordpress.com/home`
* Click "Launch" button in the header bar
  * [x] Focused Launch modal should be displayed


Related to #49004
Related to #49067