### PR TITLE
Checkout: Move react to devDependencies of composite-checkout and shopping-cart

### DIFF
--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -45,11 +45,11 @@
 		"debug": "^4.1.1",
 		"emotion-theming": "^10.0.27",
 		"prop-types": "^15.7.2",
-		"react-dom": "^16.12.0",
-		"react-stripe-elements": "^4.0.2",
-		"react": "^16.12.0"
+		"react-stripe-elements": "^4.0.2"
 	},
 	"devDependencies": {
+		"react": "^16.12.0",
+		"react-dom": "^16.12.0",
 		"@automattic/calypso-build": "^7.0.0",
 		"@automattic/calypso-polyfills": "^1.0.0",
 		"@testing-library/jest-dom": "^5.9.0",

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -210,7 +210,7 @@ export function Checkout( {
 	children,
 	className,
 }: {
-	children: React.ReactChildren;
+	children: React.ReactNode;
 	className?: string;
 } ): JSX.Element {
 	const { isRTL } = useI18n();

--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -37,13 +37,13 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/shopping-cart#readme",
 	"dependencies": {
-		"debug": "^4.1.1",
-		"react": "^16.12.0"
+		"debug": "^4.1.1"
 	},
 	"devDependencies": {
 		"@automattic/calypso-polyfills": "^1.0.0",
 		"@testing-library/jest-dom": "^5.9.0",
 		"@testing-library/react": "^10.0.5",
+		"react": "^16.12.0",
 		"react-dom": "^16.12.0"
 	},
 	"private": true


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the `react` and `react-dom` dependencies to the `devDependencies` section of their respective `package.json` files. This should allow consumers of these components to specify their own React versions without risking installing React more than once.

I discovered this issue while trying to use these packages outside of calypso where they were failing due to multiple versions of React.

#### Testing instructions

This should not cause any problems but if it does, they will be obvious. Add a product to your cart and load checkout to verify there are no errors.