### PR TITLE
Domain picker: stop click event propagation on the "Use a domain I own" button

### DIFF
--- a/packages/domain-picker/src/domain-picker/use-your-domain-item.tsx
+++ b/packages/domain-picker/src/domain-picker/use-your-domain-item.tsx
@@ -17,6 +17,16 @@ interface Props {
 const UseYourDomainItem: React.FunctionComponent< Props > = ( { onClick } ) => {
 	const { __, _x } = useI18n();
 
+	// Stopping propagation to prevent the `click` event from firing twice when
+	// clicking the button (once on the button, once on the wrapping component)
+	const onClickWithNoPropagation = React.useCallback(
+		( e: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
+			onClick();
+			e.stopPropagation();
+		},
+		[ onClick ]
+	);
+
 	return (
 		<WrappingComponent
 			type="button"
@@ -37,7 +47,7 @@ const UseYourDomainItem: React.FunctionComponent< Props > = ( { onClick } ) => {
 					</span>
 				</div>
 			</div>
-			<ArrowButton arrow="right" onClick={ onClick }>
+			<ArrowButton arrow="right" onClick={ onClickWithNoPropagation }>
 				{ _x(
 					'Use a domain I own',
 					'Domain transfer or mapping suggestion button',

--- a/packages/domain-picker/src/domain-picker/use-your-domain-item.tsx
+++ b/packages/domain-picker/src/domain-picker/use-your-domain-item.tsx
@@ -17,16 +17,6 @@ interface Props {
 const UseYourDomainItem: React.FunctionComponent< Props > = ( { onClick } ) => {
 	const { __, _x } = useI18n();
 
-	// Stopping propagation to prevent the `click` event from firing twice when
-	// clicking the button (once on the button, once on the wrapping component)
-	const onClickWithNoPropagation = React.useCallback(
-		( e: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
-			onClick();
-			e.stopPropagation();
-		},
-		[ onClick ]
-	);
-
 	return (
 		<WrappingComponent
 			type="button"
@@ -47,7 +37,7 @@ const UseYourDomainItem: React.FunctionComponent< Props > = ( { onClick } ) => {
 					</span>
 				</div>
 			</div>
-			<ArrowButton arrow="right" onClick={ onClickWithNoPropagation }>
+			<ArrowButton arrow="right">
 				{ _x(
 					'Use a domain I own',
 					'Domain transfer or mapping suggestion button',


### PR DESCRIPTION
## Changes proposed in this Pull Request

* For the "Use I domain I own" button, wrap the `onClick` callback and stop the event's propagation. This prevents the event from firing also on the button's parents, which would case the `onClick` callback to fire twice when clicking the button.

## Testing instructions

This PR doesn't necessarily fix a production bug, but it prevents future bugs from happening:

#### Click on button:

1. In Gutenboarding, navigate to the domain step
2. Click on the "Use a domain I own" button
3. Browser is redirected to the correct flow, as currently in production
4. Repeat while using they keyboard to focus and click the button
5. Repeat test in Focused Launch flow

#### Click on full row:

1. In Gutenboarding, navigate to the domain step
2. Click anywhere on the "Use a domain I own" row
3. Browser is redirected to the correct flow, as currently in production
4. Repeat while using they keyboard to focus and click the button
5. Repeat test in Focused Launch flow


(TODO: write more detailed tests)

Related to #50889 (this behaviour was found while working on Domain Picker integration tests) and therefore to #50888
