### PR TITLE
Prevent credentials form from submitting unused parameter

### DIFF
--- a/client/jetpack-cloud/sections/settings/advanced-credentials/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/index.tsx
@@ -214,9 +214,18 @@ const AdvancedCredentials: FunctionComponent< Props > = ( { action, host, role }
 		if ( formHasErrors ) {
 			return;
 		}
+
+		const credentials = { role, ...formState };
+
+		if ( formMode === FormMode.Password ) {
+			credentials.kpri = '';
+		} else if ( formMode === FormMode.PrivateKey ) {
+			credentials.pass = '';
+		}
+
 		dispatch( recordTracksEvent( 'calypso_jetpack_advanced_credentials_flow_credentials_update' ) );
-		dispatch( updateCredentials( siteId, { role, ...formState }, true, false ) );
-	}, [ formHasErrors, dispatch, siteId, role, formState ] );
+		dispatch( updateCredentials( siteId, credentials, true, false ) );
+	}, [ formHasErrors, dispatch, siteId, role, formState, formMode ] );
 
 	const renderUnconnectedButtons = () => (
 		<>


### PR DESCRIPTION
### Changes proposed in this Pull Request

In the SSH credentials form in Jetpack cloud (see capture below), after switching mode (from password to private key or vice-versa), the request to update the credentials includes the value for the previously selected mode, which leads the update to inevitably fail. This PR fixes this.

Fixes 1164141197617539-as-1200050355441535

### Testing instructions

- Download the PR and run cloud
- Make sure you have a self-hosted Jetpack site available
- Visit `/settings/:site?host=generic`
- Select SSH as credential type, and enter the server address and username
- Select the private key mode and enter a random value
- Save. The request should fail.
- Click on _Review credentials_, and select the password mode
- Enter the proper password
- The credentials should now be updated (optionally, check that the payload of the request shows an empty value for `kpri`)
- Then, do the opposite and make sure you can update the credentials in private key mode (or at least that the payload of the request shows an empty value for `pass`)

### Screenshots

_Credentials form_
<img width="1007" alt="Screen Shot 2021-03-15 at 3 13 18 PM" src="https://user-images.githubusercontent.com/1620183/111208219-df25f380-85a0-11eb-8e2d-5ebff7069155.png">
