### PR TITLE
Reader: Use Gutenberg for Reader Comments via IsolatedBlockEditor

### DIFF
--- a/client/blocks/comments/autoresizing-form-textarea.jsx
+++ b/client/blocks/comments/autoresizing-form-textarea.jsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import React, { forwardRef } from 'react';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import AutoDirection from 'calypso/components/auto-direction';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import withUserMentions from 'calypso/blocks/user-mentions/index';
+import withPasteToLink from 'calypso/lib/paste-to-link';
+
+import './autoresizing-form-textarea.scss';
+
+const AutoresizingFormTextarea = (
+	{
+		hasFocus,
+		value,
+		placeholder,
+		onKeyUp,
+		onKeyDown,
+		onFocus,
+		onBlur,
+		onChange,
+		siteId,
+		enableAutoFocus,
+	},
+	forwardedRef
+) => {
+	const classes = classnames( 'expanding-area', { focused: hasFocus } );
+
+	return (
+		<div className={ classes }>
+			<pre>
+				<span>{ value }</span>
+				<br />
+			</pre>
+			<AutoDirection>
+				<FormTextarea
+					value={ value }
+					placeholder={ placeholder }
+					onKeyUp={ onKeyUp }
+					onKeyDown={ onKeyDown }
+					onFocus={ onFocus }
+					onBlur={ onBlur }
+					onChange={ onChange }
+					siteId={ siteId }
+					enableAutoFocus={ enableAutoFocus }
+					forwardedRef={ forwardedRef }
+				/>
+			</AutoDirection>
+		</div>
+	);
+};
+
+export default withPasteToLink( withUserMentions( forwardRef( AutoresizingFormTextarea ) ) );

--- a/client/blocks/comments/autoresizing-form-textarea.jsx
+++ b/client/blocks/comments/autoresizing-form-textarea.jsx
@@ -47,7 +47,8 @@ const AutoresizingFormTextarea = (
 					onBlur={ onBlur }
 					onChange={ onChange }
 					siteId={ siteId }
-					enableAutoFocus={ enableAutoFocus }
+					// eslint-disable-next-line jsx-a11y/no-autofocus
+					autoFocus={ enableAutoFocus }
 					forwardedRef={ forwardedRef }
 				/>
 			</AutoDirection>

--- a/client/blocks/comments/autoresizing-form-textarea.scss
+++ b/client/blocks/comments/autoresizing-form-textarea.scss
@@ -1,0 +1,38 @@
+.expanding-area {
+	position: relative;
+	$initial-focused-height: 70px;
+
+	pre,
+	textarea {
+		max-height: 400px;
+		min-height: 33px;
+		margin: 0;
+		padding: 5px;
+		font-size: $font-body-small;
+		font-family: $serif;
+		line-height: 21px;
+
+		white-space: pre-wrap;
+		word-wrap: break-word;
+		word-break: break-word;
+	}
+
+	textarea {
+		position: absolute;
+		top: 0;
+		left: 0;
+		height: 100%;
+		resize: none;
+	}
+
+	pre {
+		border: 1px solid var( --color-neutral-light );
+		box-sizing: border-box;
+		display: block;
+		visibility: hidden;
+	}
+
+	&.focused {
+		min-height: $initial-focused-height;
+	}
+}

--- a/client/blocks/comments/block-editor/autocompleters/index.js
+++ b/client/blocks/comments/block-editor/autocompleters/index.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import makeUserCompleter from './user';
+import makeXPostCompleter from './xpost';
+
+import './style.scss';
+
+export default async function addAutocompleters( userSuggestions ) {
+	const xpostCompleter = await makeXPostCompleter();
+	return ( completers = [] ) => {
+		completers.push( xpostCompleter );
+		// Override the standard user completer with a custom one
+		const userCompleterPos = completers.findIndex( ( item ) => item.name === 'users' );
+
+		if ( userCompleterPos !== -1 ) {
+			completers[ userCompleterPos ] = makeUserCompleter( userSuggestions );
+		}
+
+		return completers;
+	};
+}

--- a/client/blocks/comments/block-editor/autocompleters/style.scss
+++ b/client/blocks/comments/block-editor/autocompleters/style.scss
@@ -1,0 +1,35 @@
+.editor-autocompleters__tags,
+.editor-autocompleters__xpost {
+	justify-content: space-between;
+}
+
+.editor-autocompleters__site-slug {
+	color: var( --color-accent );
+	padding-right: 10px;
+}
+
+.editor-autocompleters__site-name {
+	display: flex;
+	align-items: center;
+	min-width: 230px;
+	justify-content: space-between;
+}
+
+.editor-autocompleters__site-blavatar {
+	width: 24px;
+    height: 24px;
+}
+
+.editor-autocompleters__site-blavatar {
+    padding-left: 5px;
+}
+
+.editor-autocompleters__tag-slug {
+	text-align: left;
+}
+
+.editor-autocompleters__user {
+	&:hover .editor-autocompleters__user-slug {
+		color: var( --color-accent );
+	}
+}

--- a/client/blocks/comments/block-editor/autocompleters/user.jsx
+++ b/client/blocks/comments/block-editor/autocompleters/user.jsx
@@ -1,0 +1,59 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'calypso/lib/wp';
+
+export default async () => ( {
+	name: 'xpost',
+	className: 'autocompleters__xpost',
+	triggerPrefix: '+',
+	options: await new Promise( ( resolve, reject ) => {
+		wpcom.req.get(
+			{
+				path: '/internal/P2s',
+				apiVersion: '1.1',
+			},
+			( error, result ) => {
+				if ( error ) return reject( error );
+
+				return resolve(
+					Object.entries( result.list ).map( ( [ subdomain, p2 ] ) => ( {
+						...p2,
+						subdomain,
+					} ) )
+				);
+			}
+		);
+	} ),
+	getOptionKeywords( p2 ) {
+		return [ p2.title, p2.subdomain ];
+	},
+	getOptionLabel( site ) {
+		const { subdomain, title, blavatar } = site;
+		const url = blavatar.replace( /.*?src=["'](.*?)["'].*/, '$1' );
+
+		return [
+			<span key="slug" className="editor-autocompleters__site-slug">
+				+{ subdomain }
+			</span>,
+			<span key="name" className="editor-autocompleters__site-name">
+				{ title }{ ' ' }
+				<img
+					key="blavatar"
+					className="editor-autocompleters__site-blavatar"
+					alt={ title }
+					src={ url }
+				/>
+			</span>,
+		];
+	},
+	getOptionCompletion( site ) {
+		return `+${ site.subdomain }`;
+	},
+} );

--- a/client/blocks/comments/block-editor/autocompleters/user.jsx
+++ b/client/blocks/comments/block-editor/autocompleters/user.jsx
@@ -4,56 +4,37 @@
  */
 import React from 'react';
 
-/**
- * Internal dependencies
- */
-import wpcom from 'calypso/lib/wp';
-
-export default async () => ( {
-	name: 'xpost',
-	className: 'autocompleters__xpost',
-	triggerPrefix: '+',
-	options: await new Promise( ( resolve, reject ) => {
-		wpcom.req.get(
-			{
-				path: '/internal/P2s',
-				apiVersion: '1.1',
-			},
-			( error, result ) => {
-				if ( error ) return reject( error );
-
-				return resolve(
-					Object.entries( result.list ).map( ( [ subdomain, p2 ] ) => ( {
-						...p2,
-						subdomain,
-					} ) )
-				);
-			}
-		);
-	} ),
-	getOptionKeywords( p2 ) {
-		return [ p2.title, p2.subdomain ];
+export default ( suggestions ) => ( {
+	name: 'users',
+	className: 'editor-autocompleters__user',
+	triggerPrefix: '@',
+	options: suggestions,
+	getOptionKeywords( user ) {
+		return [ user.user_login, user.display_name ];
 	},
-	getOptionLabel( site ) {
-		const { subdomain, title, blavatar } = site;
-		const url = blavatar.replace( /.*?src=["'](.*?)["'].*/, '$1' );
+	getOptionLabel( user ) {
+		const avatar = user.image_URL ? (
+			<img
+				key="avatar"
+				alt=""
+				className="editor-autocompleters__user-avatar"
+				src={ user.image_URL }
+			/>
+		) : (
+			<span key="avatar" className="editor-autocompleters__no-avatar"></span>
+		);
 
 		return [
-			<span key="slug" className="editor-autocompleters__site-slug">
-				+{ subdomain }
+			avatar,
+			<span key="name" className="editor-autocompleters__user-name">
+				{ user.display_name }
 			</span>,
-			<span key="name" className="editor-autocompleters__site-name">
-				{ title }{ ' ' }
-				<img
-					key="blavatar"
-					className="editor-autocompleters__site-blavatar"
-					alt={ title }
-					src={ url }
-				/>
+			<span key="slug" className="editor-autocompleters__user-slug">
+				{ user.user_login }
 			</span>,
 		];
 	},
-	getOptionCompletion( site ) {
-		return `+${ site.subdomain }`;
+	getOptionCompletion( user ) {
+		return `@${ user.user_login }`;
 	},
 } );

--- a/client/blocks/comments/block-editor/autocompleters/xpost.jsx
+++ b/client/blocks/comments/block-editor/autocompleters/xpost.jsx
@@ -1,0 +1,59 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'calypso/lib/wp';
+
+export default async () => ( {
+	name: 'xpost',
+	className: 'autocompleters__xpost',
+	triggerPrefix: '+',
+	options: await new Promise( ( resolve, reject ) => {
+		wpcom.req.get(
+			{
+				path: '/internal/P2s',
+				apiVersion: '1.1',
+			},
+			( error, result ) => {
+				if ( error ) return reject( error );
+
+				return resolve(
+					Object.entries( result.list ).map( ( [ subdomain, p2 ] ) => ( {
+						...p2,
+						subdomain,
+					} ) )
+				);
+			}
+		);
+	} ),
+	getOptionKeywords( p2 ) {
+		return [ p2.title, p2.subdomain ];
+	},
+	getOptionLabel( site ) {
+		const { subdomain, title, blavatar } = site;
+		const url = blavatar.replace( /.*?src=["'](.*?)["'].*/, '$1' );
+
+		return [
+			<span key="slug" className="editor-autocompleters__site-slug">
+				+{ subdomain }
+			</span>,
+			<span key="name" className="editor-autocompleters__site-name">
+				{ title }{ ' ' }
+				<img
+					key="blavatar"
+					className="editor-autocompleters__site-blavatar"
+					alt={ title }
+					src={ url }
+				/>
+			</span>,
+		];
+	},
+	getOptionCompletion( site ) {
+		return `+${ site.subdomain }`;
+	},
+} );

--- a/client/blocks/comments/block-editor/autocompleters/xpost.jsx
+++ b/client/blocks/comments/block-editor/autocompleters/xpost.jsx
@@ -13,24 +13,17 @@ export default async () => ( {
 	name: 'xpost',
 	className: 'autocompleters__xpost',
 	triggerPrefix: '+',
-	options: await new Promise( ( resolve, reject ) => {
-		wpcom.req.get(
-			{
-				path: '/internal/P2s',
-				apiVersion: '1.1',
-			},
-			( error, result ) => {
-				if ( error ) return reject( error );
-
-				return resolve(
-					Object.entries( result.list ).map( ( [ subdomain, p2 ] ) => ( {
-						...p2,
-						subdomain,
-					} ) )
-				);
-			}
-		);
-	} ),
+	options: await wpcom.req
+		.get( {
+			path: '/internal/P2s',
+			apiVersion: '1.1',
+		} )
+		.then( ( result ) =>
+			Object.entries( result.list ).map( ( [ subdomain, p2 ] ) => ( {
+				...p2,
+				subdomain,
+			} ) )
+		),
 	getOptionKeywords( p2 ) {
 		return [ p2.title, p2.subdomain ];
 	},

--- a/client/blocks/comments/block-editor/index.jsx
+++ b/client/blocks/comments/block-editor/index.jsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect } from 'react';
+import IsolatedBlockEditor from 'isolated-block-editor';
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import connectUserMentions from 'calypso/blocks/user-mentions/connect';
+import getAddAutocompleters from './autocompleters';
+
+import './style.scss';
+
+const allowedBlocks = [
+	'core/paragraph',
+	'core/heading',
+	'core/list',
+	'core/code',
+	'core/table',
+	'core/quote',
+	'core/separator',
+];
+
+const BlockEditor = ( { onChange, suggestions } ) => {
+	useEffect( () => {
+		getAddAutocompleters( suggestions ).then( ( addAutoCompleters ) => {
+			addFilter(
+				'editor.Autocomplete.completers',
+				'readerComments/autocompleters',
+				addAutoCompleters
+			);
+		} );
+	}, [ suggestions ] );
+
+	return (
+		<>
+			<IsolatedBlockEditor
+				onSaveContent={ ( html ) => onChange( html ) }
+				// eslint-disable-next-line no-console
+				onError={ console.error }
+				settings={ {
+					iso: {
+						moreMenu: false,
+						blocks: {
+							allowBlocks: allowedBlocks,
+						},
+					},
+				} }
+			/>
+		</>
+	);
+};
+
+export default connectUserMentions( BlockEditor );

--- a/client/blocks/comments/block-editor/index.jsx
+++ b/client/blocks/comments/block-editor/index.jsx
@@ -39,21 +39,19 @@ const BlockEditor = ( { onChange, suggestions } ) => {
 	}, [ suggestions ] );
 
 	return (
-		<>
-			<IsolatedBlockEditor
-				onSaveContent={ ( html ) => onChange( html ) }
-				// eslint-disable-next-line no-console
-				onError={ console.error }
-				settings={ {
-					iso: {
-						moreMenu: false,
-						blocks: {
-							allowBlocks: allowedBlocks,
-						},
+		<IsolatedBlockEditor
+			onSaveContent={ ( html ) => onChange( html ) }
+			// eslint-disable-next-line no-console
+			onError={ console.error }
+			settings={ {
+				iso: {
+					moreMenu: false,
+					blocks: {
+						allowBlocks: allowedBlocks,
 					},
-				} }
-			/>
-		</>
+				},
+			} }
+		/>
 	);
 };
 

--- a/client/blocks/comments/block-editor/style.scss
+++ b/client/blocks/comments/block-editor/style.scss
@@ -1,0 +1,32 @@
+[data-type='core/heading'] {
+	@at-root {
+		h1#{&}, h2#{&}, h3#{&}, h4#{&}, h5#{&}, h6#{&} {
+			margin-bottom: 0.5rem;
+			font-family: inherit;
+			font-weight: 600;
+			line-height: 1.2;
+			color: inherit;
+		}
+
+		h1#{&} {
+			/* stylelint-disable-next-line scales/font-sizes */
+			font-size: 2.5rem;
+		}
+		h2#{&} {
+			font-size: 2rem;
+		}
+		h3#{&} {
+			/* stylelint-disable-next-line scales/font-sizes */
+			font-size: 1.75rem;
+		}
+		h4#{&} {
+			font-size: 1.5rem;
+		}
+		h5#{&} {
+			font-size: 1.25rem;
+		}
+		h6#{&} {
+			font-size: 1rem;
+		}
+	}
+}

--- a/client/blocks/comments/comment-edit-form.jsx
+++ b/client/blocks/comments/comment-edit-form.jsx
@@ -69,9 +69,7 @@ class PostCommentForm extends Component {
 
 	handleFocus = () => this.setState( { haveFocus: true } );
 
-	handleTextChange = ( event ) => {
-		const commentText = event.target.value;
-
+	handleTextChange = ( commentText ) => {
 		this.setState( { commentText } );
 	};
 
@@ -141,35 +139,17 @@ class PostCommentForm extends Component {
 			'is-visible': this.state.haveFocus || this.hasCommentText(),
 		} );
 
-		const expandingAreaClasses = classNames( {
-			focused: this.state.haveFocus,
-			'expanding-area': true,
-		} );
-
-		const isReply = !! this.props.parentCommentId;
-
 		// How auto expand works for the textarea is covered in this article:
 		// http://alistapart.com/article/expanding-text-areas-made-elegant
 		return (
 			<form className="comments__edit-form">
 				<FormFieldset>
-					<div className={ expandingAreaClasses }>
-						<pre>
-							<span>{ this.state.commentText }</span>
-							<br />
-						</pre>
-						<AutoDirection>
-							<PostCommentFormTextarea
-								value={ this.state.commentText }
-								onKeyUp={ this.handleKeyUp }
-								onKeyDown={ this.handleKeyDown }
-								onFocus={ this.handleFocus }
-								onBlur={ this.handleBlur }
-								onChange={ this.handleTextChange }
-								enableAutoFocus={ isReply }
-							/>
-						</AutoDirection>
-					</div>
+					<AutoDirection>
+						<PostCommentFormTextarea
+							onChange={ this.handleTextChange }
+							siteId={ this.props.post.site_ID }
+						/>
+					</AutoDirection>
 					<button
 						className={ buttonClasses }
 						disabled={ this.state.commentText.length === 0 }

--- a/client/blocks/comments/comment-edit-form.scss
+++ b/client/blocks/comments/comment-edit-form.scss
@@ -9,45 +9,6 @@
 		padding: 5px 10px;
 	}
 
-	// The inner working of these styles is covered here: http://alistapart.com/article/expanding-text-areas-made-elegant
-	.expanding-area {
-		position: relative;
-		$initial-focused-height: 70px;
-
-		pre,
-		textarea {
-			max-height: 400px;
-			min-height: 33px;
-			margin: 0;
-			padding: 5px 60px 5px 5px;
-			font-size: $font-body-small;
-			font-family: $serif;
-			line-height: 21px;
-
-			white-space: pre-wrap;
-			word-wrap: break-word;
-		}
-
-		textarea {
-			position: absolute;
-			top: 0;
-			left: 0;
-			height: 100%;
-			resize: none;
-		}
-
-		pre {
-			border: 1px solid var( --color-neutral-light );
-			box-sizing: border-box;
-			display: block;
-			visibility: hidden;
-		}
-
-		&.focused {
-			min-height: $initial-focused-height;
-		}
-	}
-
 	button {
 		opacity: 0;
 		position: absolute;
@@ -57,7 +18,7 @@
 		font-size: $font-body-extra-small;
 		font-weight: 600;
 		text-transform: uppercase;
-	color: var( --color-text-subtle );
+		color: var( --color-text-subtle );
 		transition: all 0.2s ease-in-out;
 
 		&.is-active {

--- a/client/blocks/comments/form-textarea.jsx
+++ b/client/blocks/comments/form-textarea.jsx
@@ -2,30 +2,8 @@
  * External dependencies
  */
 import React from 'react';
+import AsyncLoad from 'calypso/components/async-load';
 
-/**
- * Internal dependencies
- */
-import FormTextarea from 'calypso/components/forms/form-textarea';
-import withUserMentions from 'calypso/blocks/user-mentions/index';
-import withPasteToLink from 'calypso/lib/paste-to-link';
+const PostCommentFormTextarea = ( props ) => <AsyncLoad require="./block-editor" { ...props } />;
 
-/* eslint-disable jsx-a11y/no-autofocus */
-const PostCommentFormTextarea = React.forwardRef( ( props, ref ) => (
-	<FormTextarea
-		className="comments__form-textarea"
-		value={ props.value }
-		placeholder={ props.placeholder }
-		forwardedRef={ ref }
-		onKeyUp={ props.onKeyUp }
-		onKeyDown={ props.onKeyDown }
-		onFocus={ props.onFocus }
-		onBlur={ props.onBlur }
-		onChange={ props.onChange }
-		onPaste={ props.onPaste }
-		autoFocus={ props.enableAutoFocus }
-	/>
-) );
-/* eslint-enable jsx-a11y/no-autofocus */
-
-export default withUserMentions( withPasteToLink( PostCommentFormTextarea ) );
+export default PostCommentFormTextarea;

--- a/client/blocks/comments/form-textarea.jsx
+++ b/client/blocks/comments/form-textarea.jsx
@@ -1,9 +1,0 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import AsyncLoad from 'calypso/components/async-load';
-
-const PostCommentFormTextarea = ( props ) => <AsyncLoad require="./block-editor" { ...props } />;
-
-export default PostCommentFormTextarea;

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -82,9 +82,7 @@ class PostCommentForm extends React.Component {
 		this.setState( { haveFocus: true } );
 	}
 
-	handleTextChange( event ) {
-		const commentText = event.target.value;
-
+	handleTextChange( commentText ) {
 		this.setState( { commentText } );
 
 		// Update the comment text in the container's state
@@ -181,13 +179,6 @@ class PostCommentForm extends React.Component {
 			'is-visible': this.state.haveFocus || this.hasCommentText(),
 		} );
 
-		const expandingAreaClasses = classNames( {
-			focused: this.state.haveFocus,
-			'expanding-area': true,
-		} );
-
-		const isReply = !! this.props.parentCommentId;
-
 		// How auto expand works for the textarea is covered in this article:
 		// http://alistapart.com/article/expanding-text-areas-made-elegant
 		return (
@@ -195,25 +186,9 @@ class PostCommentForm extends React.Component {
 				<ProtectFormGuard isChanged={ this.hasCommentText() } />
 				<FormFieldset>
 					<Gravatar user={ this.props.currentUser } />
-					<div className={ expandingAreaClasses }>
-						<pre>
-							<span>{ this.state.commentText }</span>
-							<br />
-						</pre>
-						<AutoDirection>
-							<PostCommentFormTextarea
-								value={ this.state.commentText }
-								placeholder={ translate( 'Enter your comment here…' ) }
-								onKeyUp={ this.handleKeyUp }
-								onKeyDown={ this.handleKeyDown }
-								onFocus={ this.handleFocus }
-								onBlur={ this.handleBlur }
-								onChange={ this.handleTextChange }
-								siteId={ post.site_ID }
-								enableAutoFocus={ isReply }
-							/>
-						</AutoDirection>
-					</div>
+					<AutoDirection>
+						<PostCommentFormTextarea onChange={ this.handleTextChange } siteId={ post.site_ID } />
+					</AutoDirection>
 					<Button
 						className={ buttonClasses }
 						disabled={ this.state.commentText.length === 0 }

--- a/client/blocks/comments/form.scss
+++ b/client/blocks/comments/form.scss
@@ -8,6 +8,7 @@
 		position: absolute;
 		top: 0;
 		left: 0;
+		/* stylelint-disable-next-line scales/radii */
 		border-radius: 48px;
 	}
 
@@ -16,47 +17,7 @@
 		padding: 5px 10px;
 	}
 
-	// The inner working of these styles is covered here: http://alistapart.com/article/expanding-text-areas-made-elegant
-	.expanding-area {
-		position: relative;
-		$initial-focused-height: 70px;
-
-		pre,
-		textarea {
-			max-height: 400px;
-			min-height: 33px;
-			margin: 0;
-			padding: 5px;
-			font-size: $font-body-small;
-			font-family: $serif;
-			line-height: 21px;
-
-			white-space: pre-wrap;
-			word-wrap: break-word;
-			word-break: break-word;
-		}
-
-		textarea {
-			position: absolute;
-			top: 0;
-			left: 0;
-			height: 100%;
-			resize: none;
-		}
-
-		pre {
-			border: 1px solid var( --color-neutral-light );
-			box-sizing: border-box;
-			display: block;
-			visibility: hidden;
-		}
-
-		&.focused {
-			min-height: $initial-focused-height;
-		}
-	}
-
-	button {
+	button:not( .components-button ) {
 		opacity: 0;
 		position: absolute;
 		margin: 16px 0 -19px;

--- a/client/package.json
+++ b/client/package.json
@@ -74,6 +74,7 @@
 		"@wordpress/editor": "^9.25.10",
 		"@wordpress/element": "^2.19.1",
 		"@wordpress/format-library": "^1.26.10",
+		"@wordpress/hooks": "^2.12.1",
 		"@wordpress/i18n": "^3.19.0",
 		"@wordpress/icons": "^2.9.1",
 		"@wordpress/interface": "^1.0.6",

--- a/client/package.json
+++ b/client/package.json
@@ -147,6 +147,7 @@
 		"immutable": "^3.8.2",
 		"inherits": "^2.0.4",
 		"is-my-json-valid": "^2.20.0",
+		"isolated-block-editor": "https://github.com/Automattic/isolated-block-editor.git#alpha-0",
 		"jest-emotion": "^10.0.27",
 		"jest-fetch-mock": "^2.1.2",
 		"jest-mock-process": "^1.4.0",

--- a/config/development.json
+++ b/config/development.json
@@ -153,6 +153,7 @@
 		"reader": true,
 		"reader/comment-polling": false,
 		"reader/full-errors": true,
+		"reader/gutenberg-for-comments": false,
 		"reader/list-management": true,
 		"reader/seen-posts": true,
 		"recommend-plugins": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4592,6 +4592,20 @@
     "@wordpress/dom-ready" "^2.12.1"
     "@wordpress/i18n" "^3.18.0"
 
+"@wordpress/annotations@^1.24.8":
+  version "1.24.8"
+  resolved "https://registry.yarnpkg.com/@wordpress/annotations/-/annotations-1.24.8.tgz#184bb7716dcda62cac3c19f3349656f4cbbf2f3e"
+  integrity sha512-nzSJ+pWtddb7GUmVK8JCFBneHE7TkeucWFKPaSItvSUf/wlhDBRIvcf0RCfNc6RRWe85krdvGsRCcQAC+mp2NQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@wordpress/data" "^4.26.8"
+    "@wordpress/hooks" "^2.11.1"
+    "@wordpress/i18n" "^3.18.0"
+    "@wordpress/rich-text" "^3.24.8"
+    lodash "^4.17.19"
+    rememo "^3.0.0"
+    uuid "^8.3.0"
+
 "@wordpress/api-fetch@^3.21.5":
   version "3.21.5"
   resolved "https://registry.yarnpkg.com/@wordpress/api-fetch/-/api-fetch-3.21.5.tgz#a550e45be5c9b937a163650f894286c93fc6601d"
@@ -4733,6 +4747,14 @@
   integrity sha512-Pr0JGWAX0xS3cP7kVBZCrzfVqgeVU0Nz8+FuIXAtKEyCtgCO+bbmdfGaaRMnlSh6lO6r7MZ7wjPMqdfoVMKl6Q==
   dependencies:
     "@babel/runtime" "^7.12.5"
+
+"@wordpress/block-serialization-spec-parser@^3.7.2":
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-3.7.2.tgz#8658753f2908032fbb166ee339da4769c013416d"
+  integrity sha512-rmNuQ3GRnyb6pmQuErpgQxEVZiFFWOc/CT+jCc4nX5rnNzoTFL8WcalkPL61I4v648PLtG15sLIbf7J3mFWBuw==
+  dependencies:
+    pegjs "^0.10.0"
+    phpegjs "^1.0.0-beta7"
 
 "@wordpress/blocks@^7.0.6":
   version "7.0.6"
@@ -5140,7 +5162,7 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@wordpress/i18n@^3.18.0", "@wordpress/i18n@^3.19.0", "@wordpress/i18n@^3.7.0":
+"@wordpress/i18n@^3.17.1-next.1+c95ee08bb", "@wordpress/i18n@^3.18.0", "@wordpress/i18n@^3.19.0", "@wordpress/i18n@^3.7.0":
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-3.19.0.tgz#63e6be761598b1840a8314d9781d7ce8f543f1a8"
   integrity sha512-dACJKGzcaTS8AufH6HpHYm3v9zB6uRPK6DQg6F+oL8EhvENs1o+oSfwP3RDYmaI7BHSg/JYID+vIGm/nZDMx6A==
@@ -5226,6 +5248,19 @@
   integrity sha512-Lenyw+K2KgiqddBv5fDCh2JRfXFrONWNvPfv1DKXzHXTvBSI0JkU1RVP5WZTcVuEtctCZWL5JbhrkG2I26w68g==
   dependencies:
     "@babel/runtime" "^7.12.5"
+    "@wordpress/i18n" "^3.18.0"
+    lodash "^4.17.19"
+
+"@wordpress/list-reusable-blocks@^1.25.8":
+  version "1.25.8"
+  resolved "https://registry.yarnpkg.com/@wordpress/list-reusable-blocks/-/list-reusable-blocks-1.25.8.tgz#1e8a7e9fe5ebec9de67cdecfc60ab229ca9c5008"
+  integrity sha512-Hjra7q1TCJTuRBYA/k0h/ThIpcK+FfamXfwtwo1FoGceuNdNWrGF+vvp87dcZ1v+FYOcEh5d8Bctcj7ZhGTdGg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@wordpress/api-fetch" "^3.21.5"
+    "@wordpress/components" "^12.0.8"
+    "@wordpress/compose" "^3.24.5"
+    "@wordpress/element" "^2.19.1"
     "@wordpress/i18n" "^3.18.0"
     lodash "^4.17.19"
 
@@ -5322,7 +5357,7 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@wordpress/react-i18n@^1.0.0":
+"@wordpress/react-i18n@^1.0.0", "@wordpress/react-i18n@^1.0.0-next.2":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@wordpress/react-i18n/-/react-i18n-1.0.0.tgz#c26529ed38be5b3b17c6c38ba4874f9dfcca5495"
   integrity sha512-iRS/zLaJd0bSC+DuuL7GtO8rFKbb60bwugvKfN5xbe2+YicC8QNvwlrIwwZrJLf7bYuJ8IY53TqFHkAsJQNAFg==
@@ -15221,6 +15256,62 @@ isobject@^4.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
   integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
 
+"isolated-block-editor@https://github.com/Automattic/isolated-block-editor.git#alpha-0":
+  version "1.0.0"
+  resolved "https://github.com/Automattic/isolated-block-editor.git#5682ddeb940bfac9c3923491263aaf4ce44aaf0e"
+  dependencies:
+    "@wordpress/a11y" "^2.14.3"
+    "@wordpress/annotations" "^1.24.8"
+    "@wordpress/api-fetch" "^3.21.5"
+    "@wordpress/autop" "^2.11.1"
+    "@wordpress/blob" "^2.12.1"
+    "@wordpress/block-editor" "^5.2.10"
+    "@wordpress/block-library" "^2.28.7"
+    "@wordpress/block-serialization-default-parser" "^3.9.1"
+    "@wordpress/block-serialization-spec-parser" "^3.7.2"
+    "@wordpress/blocks" "^7.0.6"
+    "@wordpress/components" "^12.0.8"
+    "@wordpress/compose" "^3.24.5"
+    "@wordpress/core-data" "^2.25.9"
+    "@wordpress/data" "^4.26.8"
+    "@wordpress/data-controls" "^1.20.8"
+    "@wordpress/date" "^3.13.1"
+    "@wordpress/deprecated" "^2.11.1"
+    "@wordpress/dom" "^2.16.2"
+    "@wordpress/dom-ready" "^2.12.1"
+    "@wordpress/editor" "^9.25.10"
+    "@wordpress/element" "^2.19.1"
+    "@wordpress/escape-html" "^1.11.1"
+    "@wordpress/format-library" "^1.26.10"
+    "@wordpress/hooks" "^2.11.1"
+    "@wordpress/html-entities" "^2.10.1"
+    "@wordpress/i18n" "^3.18.0"
+    "@wordpress/icons" "^2.9.1"
+    "@wordpress/interface" "^1.0.6"
+    "@wordpress/is-shallow-equal" "^3.0.1"
+    "@wordpress/keyboard-shortcuts" "^1.13.8"
+    "@wordpress/keycodes" "^2.18.3"
+    "@wordpress/list-reusable-blocks" "^1.25.8"
+    "@wordpress/media-utils" "^1.19.5"
+    "@wordpress/notices" "^2.12.8"
+    "@wordpress/plugins" "^2.24.7"
+    "@wordpress/primitives" "^1.11.1"
+    "@wordpress/priority-queue" "^1.10.1"
+    "@wordpress/react-i18n" "^1.0.0-next.2"
+    "@wordpress/redux-routine" "^3.13.1"
+    "@wordpress/reusable-blocks" "^1.1.10"
+    "@wordpress/rich-text" "^3.24.8"
+    "@wordpress/server-side-render" "^1.20.8"
+    "@wordpress/shortcode" "^2.12.1"
+    "@wordpress/token-list" "^1.14.1"
+    "@wordpress/url" "^2.21.2"
+    "@wordpress/viewport" "^2.25.8"
+    "@wordpress/warning" "^1.3.1"
+    "@wordpress/wordcount" "^2.14.1"
+    classnames "^2.2.6"
+    redux-undo "^1.0.1"
+    refx "^3.1.1"
+
 isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
@@ -19651,6 +19742,11 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pegjs@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/pegjs/-/pegjs-0.10.0.tgz#cf8bafae6eddff4b5a7efb185269eaaf4610ddbd"
+  integrity sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=
+
 pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
@@ -19675,6 +19771,11 @@ phone@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/phone/-/phone-2.4.2.tgz#74d6a54288280470d0cefa31e2f0720b7e59005d"
   integrity sha512-d9oLwWCnInj5wJIZjSyAvyBd4SWM4p3C6VmZVAhAlWG8q0dLANTEfRLMn2ybL/TdXbTuOCY4GJbePf3ujPmVvQ==
+
+phpegjs@^1.0.0-beta7:
+  version "1.0.0-beta7"
+  resolved "https://registry.yarnpkg.com/phpegjs/-/phpegjs-1.0.0-beta7.tgz#b8b6ed85019807ffd0efe203e002a3e5ed8b4d94"
+  integrity sha1-uLbthQGYB//Q7+ID4AKj5e2LTZQ=
 
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
@@ -22187,6 +22288,11 @@ redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
   integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
+redux-undo@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/redux-undo/-/redux-undo-1.0.1.tgz#8d989d6c326e6718f4471042e90a5b8b6f3317eb"
+  integrity sha512-0yFPT+FUgwxCEiS0Mg5T1S4tkgjR8h6sJRY9CW4EMsbJOf1SxO289TbJmlzhRouCHacdDF+powPjrjLHoJYxWQ==
 
 redux@^4.0.0, redux@^4.0.1, redux@^4.0.4, redux@^4.0.5:
   version "4.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5148,12 +5148,12 @@
     "@wordpress/url" "^2.21.2"
     lodash "^4.17.19"
 
-"@wordpress/hooks@^2.11.1", "@wordpress/hooks@^2.12.0", "@wordpress/hooks@^2.6.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-2.12.0.tgz#d82d79f001266b5a16879998cafb8de44567e311"
-  integrity sha512-BXQw5ZKupKbwlczHFJcDPG8cNi8MmiRgLI42Dwl181+1w9UOHGAjbsRmgYreAIU8vXEx2Gr1QW0HroVpZxixoA==
+"@wordpress/hooks@^2.11.1", "@wordpress/hooks@^2.12.0", "@wordpress/hooks@^2.12.1", "@wordpress/hooks@^2.6.0":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-2.12.1.tgz#3785da02dcbf9053d1e4e8e953be97820f4a8214"
+  integrity sha512-Ubnz9V8mrlCCkZ8RwKKHIljZcuroM/uVHR9q1JIqEXs/iJtzWMutf3qla2+HsZ+3W+AaiEOEatbyVUkgsRvouA==
   dependencies:
-    "@babel/runtime" "^7.12.5"
+    "@babel/runtime" "^7.13.10"
 
 "@wordpress/html-entities@^2.10.1", "@wordpress/html-entities@^2.5.0":
   version "2.10.1"
@@ -5162,7 +5162,7 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@wordpress/i18n@^3.17.1-next.1+c95ee08bb", "@wordpress/i18n@^3.18.0", "@wordpress/i18n@^3.19.0", "@wordpress/i18n@^3.7.0":
+"@wordpress/i18n@^3.18.0", "@wordpress/i18n@^3.19.0", "@wordpress/i18n@^3.7.0":
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-3.19.0.tgz#63e6be761598b1840a8314d9781d7ce8f543f1a8"
   integrity sha512-dACJKGzcaTS8AufH6HpHYm3v9zB6uRPK6DQg6F+oL8EhvENs1o+oSfwP3RDYmaI7BHSg/JYID+vIGm/nZDMx6A==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Uses the `IsolatedBlockEditor` to enable Gutenberg for Reader comments

Caveats of the current version: Autocompleters do not work. I have no idea why but it appears the filter isn't running as the `console.log` in the `addAutocompleters` function isn't running ever (even though this worked on previous proof of concepts). Ideas I've explored:
1. Maybe it's calling a different `addFilter` than needed (as in package resolution issues) but it's not that. The packages are deduplicated and it's using the same verison of `@wordpress/hooks` package for everything.
2. Maybe the way to do this changed since I last explored it? Nope. It's the same in the private p2editor repository so I know it is the correct way to do it.
3. Maybe the promise isn't resolving for some reason? Nope, I've verified the promise is resolving as expected.

Anyone have clever ideas of how to debug this issue? It seems to be something down to the way the filter is being added because it's just not being run anymore.

I also expect this will blow up the bundle size somehow. There are some significant new dependencies, but that's why I decided to `AsyncLoad` the comments box. This should be fine as there's on most posts you would have to scroll down to see it anyway so it's okay if it pops into view later.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open up a blog post in reader, append `flags=reader/gutenberg-for-comments` and try to leave a comment (it works as expected aside from auto completers 😁)
* Also leave a comment without the flag to make sure that the old way still works (with user mentions and paste to link).

Related to #48386 
