### PR TITLE
Change shopping-cart package to be public

### DIFF
--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -45,6 +45,5 @@
 		"@testing-library/react": "^10.0.5",
 		"react": "^16.12.0",
 		"react-dom": "^16.12.0"
-	},
-	"private": true
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies the `@automattic/shopping-cart` package to remove the `private` key so that the package can be published.

#### Testing instructions

None