### PR TITLE
Fix README explaining where notes code lives

### DIFF
--- a/apps/notifications/README.md
+++ b/apps/notifications/README.md
@@ -2,7 +2,7 @@
 
 The _**notifications panel**_ (also known as "masterbar notifications" and "the bell notifications") is a cross-environment app that runs directly inside of Calypso and in an `iframe` on WordPress.com sites which aren't Calypso.
 
-This module is where the code for the notifications panel lives. Calypso views are imported as normal `node` imports while the `iframe` version is served from `https://widgets.wp.com/notes`.
+This module is where the code for the notifications panel lives. Calypso views are imported as normal `node` imports while the `iframe` version is served from `https://widgets.wp.com/notes` or `https://widgets.wp.com/notifications`.
 
 ## Building and developing
 


### PR DESCRIPTION
I just noticed that this comment wasn't exactly correct, so I added the other serving location.