### PR TITLE
Checkout: Fix renewal check in WPLineItem

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -735,7 +735,7 @@ function WPLineItem( {
 	const onEvent = useEvents();
 	const isDisabled = formStatus !== FormStatus.READY;
 
-	const isRenewal = !! product?.extra?.purchaseId;
+	const isRenewal = product?.extra?.purchaseType === 'renewal';
 	// Show the variation picker when this is not a renewal
 	const shouldShowVariantSelector = getItemVariants && product && ! isRenewal;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There's code in the checkout order review step that takes certain actions for products which are renewals. Up until now, the code testing for a renewal was basing it on the (sometimes) invalid `purchaseId` property of a product. Since https://github.com/Automattic/wp-calypso/pull/51015, that property has been explicitly removed from the response cart product type. This can cause problems. (That PR didn't cause those problems, however, it just made them easier to spot.)

This PR updates the component so that it instead uses the `purchaseType` property to determine renewals.

Note that the bug this triggers will only occur under specific circumstances, where the `productId` has not been sent to the server as part of the cart. Apparently the cart will happily save that property as part of the cart product even though it doesn't seem to be actively _used_ anywhere.

Before:

<img width="500" alt="Screen Shot 2021-03-15 at 9 01 30 PM" src="https://user-images.githubusercontent.com/2036909/111240515-c3871100-85d1-11eb-9289-28fcc69fa4f9.png">

After:

<img width="496" alt="Screen Shot 2021-03-15 at 9 02 20 PM" src="https://user-images.githubusercontent.com/2036909/111240526-c8e45b80-85d1-11eb-8b1b-fdb80e8d50ce.png">

#### Testing instructions

- Use a site with an active plan subscription. Let's say it's a Personal plan.
- Visit checkout for your site directly, adding the already-owned plan as part alias of the URL. This might look like `/checkout/example.com/personal`.
- Click "Edit" on the first step and verify that the plan variant picker (with monthly, yearly, and two-year variants) does not appear.