### PR TITLE
New Page Layout Picker: refresh page pattern cache when site lang changes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -145,7 +145,11 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_timeline_block' );
 function load_common_module() {
 	require_once __DIR__ . '/common/index.php';
 }
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_common_module' );
+// Use a custom priority so that the common code is loaded before any of
+// the other modules. This way it can be called very early in the other
+// modules (e.g. during `__construct`). The default priority is 10, so
+// using 9 to load just before.
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_common_module', 9 );
 
 /**
  * Load Editor Site Launch.

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -36,7 +36,7 @@ class Starter_Page_Templates {
 				'starter_page_templates',
 				A8C_ETK_PLUGIN_VERSION,
 				get_option( 'site_vertical', 'default' ),
-				get_locale(),
+				$this->get_verticals_locale(),
 			)
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change pattern cache key to use site locale instead of account/user locale
* Update execution order to ensure the `get_iso_639_locale()` function is available when `__construct()` is called

After changing the site language the layout names and categories in the page layout picker still show in the previous language. And when the pattern is inserted it inserts the pervious language. You'd have to wait a day after updating the site language before the picker would fix itself.

The problem is the pattern data is cached using a key that includes the _account_ language, not the _site_ language. This change makes sure the cache key is using the exact same locale slug that's being used in the query to get pattern data.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `install-plugin.sh etk update/refresh-page-pattern-cache-on-site-lang-change` on sandbox
* On sandbox site create a new page (layout picker will open)
* In another tab update the site language
* Refresh the editor tab, the modal updates to show pattern thumbnails, names and categories using the new language
* Insert a layout, and the content added to the page should be in the new site language.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

