### PR TITLE
Update e2e test selectors used to dismiss page layout picker

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -664,11 +664,11 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 				);
 				await driverHelper.clickWhenClickable(
 					this.driver,
-					By.css( 'button.template-selector-item__label[value="blank"]' )
+					By.css( 'button.page-template-modal__blank-button' )
 				);
 			} else {
 				const useBlankButton = await this.driver.findElement(
-					By.css( '.page-template-modal__buttons .components-button.is-primary' )
+					By.css( 'button.page-template-modal__blank-button' )
 				);
 				await this.driver.executeScript( 'arguments[0].click()', useBlankButton );
 			}


### PR DESCRIPTION

#### Changes proposed in this Pull Request

The changes in #49860 changed how the "blank page" button works in the new page layout modal. Unfortunately the e2e tests were not updated at the same time.

This change updates the selectors to use the new "Blank page" button.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tests pass
* Profit?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
