### PR TITLE
chore(renovate): Deduplicate packages after an update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -59,6 +59,7 @@
 		"enabled": true,
 		"schedule": "every weekday"
 	},
+	"postUpdateOptions": "yarnDedupeHighest",
 	"prConcurrentLimit": 10,
 	"prHourlyLimit": 6,
 	"semanticCommits": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Configure renovate to deduplicate packages (https://docs.renovatebot.com/configuration-options/#postupdateoptions)
