### PR TITLE
build(webpack): Uses minimizer from esbuild-loader

### DIFF
--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 - Breaking: Drop option `postCssConfig` for Sass loader. The property `postCssOptions` will be passed as is
   to `postcss-loader`. See the doc in <https://github.com/webpack-contrib/postcss-loader#postcssoptions>
+- Added new minimizer (`/webpack/minify-esbuild`) that uses `esbuild-loader` instead of Terser (see
+  <https://github.com/privatenumber/esbuild-loader#minification-eg-terser>)
 - Added: peer dependency postcss ^8.2.6
+- Added: dependency esbuild-loader ^2.10.0
 - Updated dependencies:
   - postcss-custom-properties to ^11.0.0
   - postcss-loader to ^5.0.0

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -58,6 +58,7 @@
 		"duplicate-package-checker-webpack-plugin": "^3.0.0",
 		"enzyme-adapter-react-16": "^1.15.1",
 		"enzyme-to-json": "^3.4.3",
+		"esbuild-loader": "^2.10.0",
 		"file-loader": "^4.3.0",
 		"jest-config": "^26.4.0",
 		"jest-emotion": "^10.0.27",

--- a/packages/calypso-build/webpack/minify-esbuild.js
+++ b/packages/calypso-build/webpack/minify-esbuild.js
@@ -1,0 +1,46 @@
+/**
+ * External Dependencies
+ */
+const { ESBuildMinifyPlugin } = require( 'esbuild-loader' );
+const browserslist = require( 'browserslist' );
+
+// The list of browsers to check supported by esbuild
+
+const getTarget = () => {
+	// esbuild only supports these targets (https://esbuild.github.io/api/#target)
+	const supportedBrowsersByEsbuild = [ 'chrome', 'firefox', 'safari', 'edge' ];
+
+	// Get the version of supported targets based on browserslist environment
+	const browsers = browserslist( null, {
+		env: process.env.BROWSERSLIST_ENV || 'defaults',
+	} ).filter( ( browser ) => supportedBrowsersByEsbuild.includes( browser.split( ' ' )[ 0 ] ) );
+
+	// Pick the lowest version for each supported browser
+	const minVersions = browsers.reduce( ( list, browser ) => {
+		const [ name, version ] = browser.split( ' ' );
+		list[ name ] = Math.min( name in list ? list[ name ] : Infinity, Number( version ) );
+		return list;
+	}, {} );
+
+	// Concatenate them in the format expected by esbuild
+	const esbuildTarget = Object.entries( minVersions )
+		.map( ( [ k, v ] ) => `${ k }${ v }` )
+		.join( ',' );
+
+	return esbuildTarget;
+};
+
+/**
+ * Returns an instance of MinifyPlugin from `esbuild-loader`
+ *
+ * @see https://github.com/privatenumber/esbuild-loader
+ *
+ * @returns {object[]}     ESBuildMinifyPlugin plugin object to be used in Webpack minification.
+ */
+module.exports = () => {
+	return [
+		new ESBuildMinifyPlugin( {
+			target: getTarget(),
+		} ),
+	];
+};

--- a/packages/calypso-build/webpack/minify-esbuild.js
+++ b/packages/calypso-build/webpack/minify-esbuild.js
@@ -6,7 +6,7 @@ const browserslist = require( 'browserslist' );
 
 // The list of browsers to check supported by esbuild
 
-const getTarget = () => {
+const getTargets = () => {
 	// esbuild only supports these targets (https://esbuild.github.io/api/#target)
 	const supportedBrowsersByEsbuild = [ 'chrome', 'firefox', 'safari', 'edge' ];
 
@@ -23,11 +23,9 @@ const getTarget = () => {
 	}, {} );
 
 	// Concatenate them in the format expected by esbuild
-	const esbuildTarget = Object.entries( minVersions )
-		.map( ( [ k, v ] ) => `${ k }${ v }` )
-		.join( ',' );
+	const esbuildTargets = Object.entries( minVersions ).map( ( [ k, v ] ) => `${ k }${ v }` );
 
-	return esbuildTarget;
+	return esbuildTargets;
 };
 
 /**
@@ -40,7 +38,7 @@ const getTarget = () => {
 module.exports = () => {
 	return [
 		new ESBuildMinifyPlugin( {
-			target: getTarget(),
+			target: getTargets(),
 		} ),
 	];
 };

--- a/packages/calypso-build/webpack/minify-esbuild.js
+++ b/packages/calypso-build/webpack/minify-esbuild.js
@@ -39,6 +39,7 @@ module.exports = () => {
 	return [
 		new ESBuildMinifyPlugin( {
 			target: getTargets(),
+			format: 'iife',
 		} ),
 	];
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -16826,14 +16826,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.0, json5@^2.1.1, json5@^2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
-  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
-  dependencies:
-    minimist "^1.2.5"
-
-json5@^2.2.0:
+json5@^2.1.0, json5@^2.1.1, json5@^2.1.2, json5@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -11253,6 +11253,23 @@ es6-weak-map@^2.0.2:
     es6-iterator "^2.0.3"
     es6-symbol "^3.1.1"
 
+esbuild-loader@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/esbuild-loader/-/esbuild-loader-2.10.0.tgz#35b570187aee0036b2f4b37db66870f7407f3d40"
+  integrity sha512-BRWmc/7gU6/FmI+MP+E+9Zb/CE0BA1XMOQkdvJ7B/T2gad1Mlim8aMhvvRdS9on5S8JzkC+uNHGQmt/WmbbXbQ==
+  dependencies:
+    esbuild "^0.9.2"
+    joycon "^2.2.5"
+    json5 "^2.2.0"
+    loader-utils "^2.0.0"
+    type-fest "^0.21.3"
+    webpack-sources "^2.2.0"
+
+esbuild@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.9.2.tgz#7e9fde247c913ed8ee059e2648b0c53f7d00abe5"
+  integrity sha512-xE3oOILjnmN8PSjkG3lT9NBbd1DbxNqolJ5qNyrLhDWsFef3yTp/KTQz1C/x7BYFKbtrr9foYtKA6KA1zuNAUQ==
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -16519,6 +16536,11 @@ jest@^26.4.0:
     import-local "^3.0.2"
     jest-cli "^26.4.0"
 
+joycon@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/joycon/-/joycon-2.2.5.tgz#8d4cf4cbb2544d7b7583c216fcdfec19f6be1615"
+  integrity sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ==
+
 jpeg-js@^0.4.2:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.3.tgz#6158e09f1983ad773813704be80680550eff977b"
@@ -16808,6 +16830,13 @@ json5@^2.1.0, json5@^2.1.1, json5@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
+  dependencies:
+    minimist "^1.2.5"
+
+json5@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
 
@@ -26957,6 +26986,11 @@ type-fest@^0.18.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
   integrity sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==
 
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
 type-fest@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
@@ -28185,7 +28219,7 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack-sources@^2.1.1:
+webpack-sources@^2.1.1, webpack-sources@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.2.0.tgz#058926f39e3d443193b6c31547229806ffd02bac"
   integrity sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Uses `esbuild` as a minimizer to replace `terser` for `evergreen` build. In my local laptop, this makes evergreen build ~40s faster:

```
With Terser
<e> [webpack.Progress]  |  | 41873 ms asset processing > TerserPlugin

With esbuild-loader
<w> [webpack.Progress]  |  | 4269 ms asset processing > esbuild-minify
```

Caveats:
* `esbuild` won't move license comments (`@license`, `@preserve` and `/*!...`) to a separate `.LICENSE.txt` file, they will stay in the minified file.
* `esbuild` assumes files will be loaded via `<script type="module">` and as such it injects some "global" vars. We need to wrap them in an IIFE to avoid polluting the global namespace.



#### Testing instructions

* Smoke-test live branch in an evergreen browser, make sure there are no JS errors.
* Smoke-test live branch in IE11, make sure there are no JS errors.
