### PR TITLE
Moving state and toggle function to parent component.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
@@ -4,181 +4,33 @@ import './public-path';
 /**
  * External dependencies
  */
+import { useState } from 'react';
 import { registerPlugin } from '@wordpress/plugins';
-import { Fill, Guide, GuidePage, MenuItem } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { Fill, MenuItem } from '@wordpress/components';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useEffect, createInterpolateElement } from '@wordpress/element';
+import WhatsNewGuide from '@automattic/whats-new';
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
-import './style.scss';
-const universalNavImage = 'https://s0.wp.com/i/whats-new/universal-nav.png';
-const dragDropImage = 'https://s0.wp.com/i/whats-new/drag-drop.png';
-const singlePageSiteImage = 'https://s0.wp.com/i/whats-new/single-page-website.png';
-const anchorFmImage = 'https://s0.wp.com/i/whats-new/convert-to-audio.jpg';
-
 function WhatsNewMenuItem() {
-	const { toggleWhatsNew } = useDispatch( 'automattic/whats-new' );
-	const isActive = useSelect( ( select ) => select( 'automattic/whats-new' ).isWhatsNewActive() );
-	const whatsNewPages = getWhatsNewPages();
+	const [ showGuide, setShowGuide ] = useState( false );
+	const openWhatsNew = () => setShowGuide( true );
+	const closeWhatsNew = () => setShowGuide( false );
 
 	// Record Tracks event if user opens What's New
 	useEffect( () => {
-		if ( isActive ) {
+		if ( showGuide ) {
 			recordTracksEvent( 'calypso_block_editor_whats_new_open' );
 		}
-	}, [ isActive ] );
+	}, [ showGuide ] );
 
 	return (
 		<>
 			<Fill name="ToolsMoreMenuGroup">
-				<MenuItem onClick={ toggleWhatsNew }>{ __( "What's new", 'full-site-editing' ) }</MenuItem>
+				<MenuItem onClick={ openWhatsNew }>{ __( "What's new", 'full-site-editing' ) }</MenuItem>
 			</Fill>
-			{ isActive && (
-				<Guide
-					className="whats-new"
-					contentLabel={ __( "What's New at WordPress.com", 'full-site-editing' ) }
-					finishButtonText={ __( 'Close', 'full-site-editing' ) }
-					onFinish={ toggleWhatsNew }
-				>
-					{ whatsNewPages.map( ( page, index ) => (
-						<WhatsNewPage
-							key={ page.heading }
-							pageNumber={ index + 1 }
-							isLastPage={ index === whatsNewPages.length - 1 }
-							{ ...page }
-						/>
-					) ) }
-				</Guide>
-			) }
+			{ showGuide && <WhatsNewGuide onClose={ closeWhatsNew } /> }
 		</>
-	);
-}
-
-function getWhatsNewPages() {
-	return [
-		{
-			imgSrc: universalNavImage,
-			heading: __( 'Easier navigation', 'full-site-editing' ),
-			description: createInterpolateElement(
-				/* translators: the embed is a link */
-				__(
-					'<p>This month all WordPress.com accounts will receive sidebar and menu updates, making it easier to manage your site from the left sidebar.</p><p><Link>Learn more</Link></p>',
-					'full-site-editing'
-				),
-				{
-					Link: (
-						<a
-							href="https://wordpress.com/support/account-settings/#dashboard-appearance"
-							target="_blank"
-							rel="noreferrer"
-						/>
-					),
-					p: <p />,
-				}
-			),
-		},
-		{
-			imgSrc: dragDropImage,
-			heading: __( 'Drag and drop blocks and patterns in the editor', 'full-site-editing' ),
-			description: createInterpolateElement(
-				/* translators: the embed is a link */
-				__(
-					'<p>You can now drag and drop Blocks, and even Block Patterns, into your content directly from the Block Inserter.</p><p><Link>Learn more</Link></p>',
-					'full-site-editing'
-				),
-				{
-					Link: (
-						<a
-							href="https://make.wordpress.org/core/2021/01/08/core-editor-improvement-drag-drop-blocks-and-patterns-from-the-inserter/"
-							target="_blank"
-							rel="noreferrer"
-						/>
-					),
-					p: <p />,
-				}
-			),
-		},
-		{
-			imgSrc: singlePageSiteImage,
-			heading: __( 'Quickly build single-page websites', 'full-site-editing' ),
-			description: createInterpolateElement(
-				/* translators: the embed is a link */
-				__(
-					'<p>Introducing our freshly-launched Blank Canvas theme, which is optimized for single-page websites.</p><p><Link>Learn more</Link></p>',
-					'full-site-editing'
-				),
-				{
-					Link: (
-						<a
-							href="https://wordpress.com/blog/2021/01/25/building-single-page-websites-on-wordpress-com/"
-							target="_blank"
-							rel="noreferrer"
-						/>
-					),
-					p: <p />,
-				}
-			),
-		},
-		{
-			imgSrc: anchorFmImage,
-			heading: __( 'Create podcast episodes automatically', 'full-site-editing' ),
-			description: createInterpolateElement(
-				/* translators: the embed is a link */
-				__(
-					'<p>Instantly convert any page or post’s text into an Anchor podcast. This new text-to-speech feature automatically transforms your written words into speech – no voice recording required.</p><p><Link>Learn more</Link></p>',
-					'full-site-editing'
-				),
-				{
-					Link: (
-						<a
-							href="https://wordpress.com/support/create-anchor-podcast/"
-							target="_blank"
-							rel="noreferrer"
-						/>
-					),
-					p: <p />,
-				}
-			),
-		},
-	];
-}
-
-function WhatsNewPage( {
-	pageNumber,
-	isLastPage,
-	alignBottom = false,
-	heading,
-	description,
-	imgSrc,
-} ) {
-	useEffect( () => {
-		recordTracksEvent( 'calypso_block_editor_whats_new_slide_view', {
-			slide_number: pageNumber,
-			is_last_slide: isLastPage,
-		} );
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
-	return (
-		<GuidePage className="whats-new__page">
-			<div className="whats-new__text">
-				<h1 className="whats-new__heading">{ heading }</h1>
-				<div className="whats-new__description">{ description }</div>
-			</div>
-			<div className="whats-new__visual">
-				<img
-					// Force remount so the stale image doesn't remain while new image is fetched
-					key={ imgSrc }
-					src={ imgSrc }
-					alt=""
-					aria-hidden="true"
-					className={ 'whats-new__image' + ( alignBottom ? ' align-bottom' : '' ) }
-				/>
-			</div>
-		</GuidePage>
 	);
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
@@ -4,13 +4,13 @@ import './public-path';
 /**
  * External dependencies
  */
-import { useState } from 'react';
-import { registerPlugin } from '@wordpress/plugins';
+import { __ } from '@wordpress/i18n';
 import { Fill, MenuItem } from '@wordpress/components';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import WhatsNewGuide from '@automattic/whats-new';
+import { registerPlugin } from '@wordpress/plugins';
 import { useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import WhatsNewGuide from '@automattic/whats-new';
 
 function WhatsNewMenuItem() {
 	const [ showGuide, setShowGuide ] = useState( false );

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -3,10 +3,9 @@
  */
 import { useDispatch, useSelector } from 'react-redux';
 import page from 'page';
-import React, { Fragment, FunctionComponent, useState } from 'react';
+import React, { Fragment, FunctionComponent } from 'react';
 import { useTranslate, getLocaleSlug } from 'i18n-calypso';
 import config from '@automattic/calypso-config';
-import WhatsNewGuide from '@automattic/whats-new';
 
 /**
  * Internal dependencies
@@ -55,9 +54,6 @@ export const MarketingTools: FunctionComponent = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const recordTracksEvent = ( event: string ) => dispatch( recordTracksEventAction( event ) );
-	const [ showGuide, setShowGuide ] = useState( false );
-	const openWhatsNew = () => setShowGuide( true );
-	const closeWhatsNew = () => setShowGuide( false );
 
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) ) || 0;
 	const selectedSiteSlug: T.SiteSlug | null = useSelector( ( state ) =>
@@ -125,9 +121,6 @@ export const MarketingTools: FunctionComponent = () => {
 			{ ! purchases && <QueryUserPurchases userId={ userId } /> }
 			{ ! sitePlan && <QuerySitePlans siteId={ siteId } /> }
 			<PageViewTracker path="/marketing/tools/:site" title="Marketing > Tools" />
-			<Button onClick={ openWhatsNew }> Click Me!</Button>
-
-			{ showGuide && <WhatsNewGuide onClose={ closeWhatsNew } /> }
 
 			<MarketingToolsHeader handleButtonClick={ handleBusinessToolsClick } />
 

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -56,7 +56,8 @@ export const MarketingTools: FunctionComponent = () => {
 	const dispatch = useDispatch();
 	const recordTracksEvent = ( event: string ) => dispatch( recordTracksEventAction( event ) );
 	const [ showGuide, setShowGuide ] = useState( false );
-	const toggleWhatsNew = () => setShowGuide( ! showGuide );
+	const openWhatsNew = () => setShowGuide( true );
+	const closeWhatsNew = () => setShowGuide( false );
 
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) ) || 0;
 	const selectedSiteSlug: T.SiteSlug | null = useSelector( ( state ) =>
@@ -124,9 +125,9 @@ export const MarketingTools: FunctionComponent = () => {
 			{ ! purchases && <QueryUserPurchases userId={ userId } /> }
 			{ ! sitePlan && <QuerySitePlans siteId={ siteId } /> }
 			<PageViewTracker path="/marketing/tools/:site" title="Marketing > Tools" />
-			<Button onClick={ toggleWhatsNew }> Click Me!</Button>
+			<Button onClick={ openWhatsNew }> Click Me!</Button>
 
-			{ showGuide && <WhatsNewGuide toggleWhatsNew={ toggleWhatsNew } /> }
+			{ showGuide && <WhatsNewGuide onClose={ closeWhatsNew } /> }
 
 			<MarketingToolsHeader handleButtonClick={ handleBusinessToolsClick } />
 

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -3,9 +3,10 @@
  */
 import { useDispatch, useSelector } from 'react-redux';
 import page from 'page';
-import React, { Fragment, FunctionComponent } from 'react';
+import React, { Fragment, FunctionComponent, useState } from 'react';
 import { useTranslate, getLocaleSlug } from 'i18n-calypso';
 import config from '@automattic/calypso-config';
+import WhatsNewGuide from '@automattic/whats-new';
 
 /**
  * Internal dependencies
@@ -54,6 +55,9 @@ export const MarketingTools: FunctionComponent = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const recordTracksEvent = ( event: string ) => dispatch( recordTracksEventAction( event ) );
+	const [ showGuide, setShowGuide ] = useState( false );
+	const toggleWhatsNew = () => setShowGuide( ! showGuide );
+
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) ) || 0;
 	const selectedSiteSlug: T.SiteSlug | null = useSelector( ( state ) =>
 		getSelectedSiteSlug( state )
@@ -120,6 +124,9 @@ export const MarketingTools: FunctionComponent = () => {
 			{ ! purchases && <QueryUserPurchases userId={ userId } /> }
 			{ ! sitePlan && <QuerySitePlans siteId={ siteId } /> }
 			<PageViewTracker path="/marketing/tools/:site" title="Marketing > Tools" />
+			<Button onClick={ toggleWhatsNew }> Click Me!</Button>
+
+			{ showGuide && <WhatsNewGuide toggleWhatsNew={ toggleWhatsNew } /> }
 
 			<MarketingToolsHeader handleButtonClick={ handleBusinessToolsClick } />
 

--- a/packages/whats-new/src/index.js
+++ b/packages/whats-new/src/index.js
@@ -14,7 +14,7 @@ import proxyRequest from 'wpcom-proxy-request';
 import './style.scss';
 import WhatsNewPage from './whats-new-page';
 
-const WhatsNewGuide = ( { toggleWhatsNew } ) => {
+const WhatsNewGuide = ( { onClose } ) => {
 	const [ whatsNewData, setWhatsNewData ] = useState( null );
 	const __ = useI18n().__;
 	const locale = useLocale();
@@ -38,7 +38,7 @@ const WhatsNewGuide = ( { toggleWhatsNew } ) => {
 			className="whats-new-guide__main"
 			contentLabel={ __( "What's New at WordPress.com", __i18n_text_domain__ ) }
 			finishButtonText={ __( 'Close', __i18n_text_domain__ ) }
-			onFinish={ toggleWhatsNew }
+			onFinish={ onClose }
 		>
 			{ whatsNewData.map( ( page, index ) => (
 				<WhatsNewPage

--- a/packages/whats-new/src/index.js
+++ b/packages/whats-new/src/index.js
@@ -14,8 +14,7 @@ import proxyRequest from 'wpcom-proxy-request';
 import './style.scss';
 import WhatsNewPage from './whats-new-page';
 
-const WhatsNewGuide = () => {
-	const [ showGuide, setShowGuide ] = useState( true );
+const WhatsNewGuide = ( { toggleWhatsNew } ) => {
 	const [ whatsNewData, setWhatsNewData ] = useState( null );
 	const __ = useI18n().__;
 	const locale = useLocale();
@@ -31,9 +30,7 @@ const WhatsNewGuide = () => {
 			} );
 	}, [ locale ] );
 
-	const toggleWhatsNew = () => setShowGuide( false );
-
-	if ( ! ( whatsNewData && showGuide ) ) return null;
+	if ( ! whatsNewData ) return null;
 
 	return (
 		<Guide

--- a/packages/whats-new/src/index.js
+++ b/packages/whats-new/src/index.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useState } from 'react';
 import { Guide } from '@wordpress/components';
+import proxyRequest from 'wpcom-proxy-request';
+import React, { useEffect, useState } from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import { useLocale } from '@automattic/i18n-utils';
 import wpcom from 'wpcom';
-import proxyRequest from 'wpcom-proxy-request';
 
 /**
  * Internal dependencies
@@ -30,7 +30,9 @@ const WhatsNewGuide = ( { onClose } ) => {
 			} );
 	}, [ locale ] );
 
-	if ( ! whatsNewData ) return null;
+	if ( ! whatsNewData ) {
+		return null;
+	}
 
 	return (
 		<Guide

--- a/packages/whats-new/src/whats-new-page.js
+++ b/packages/whats-new/src/whats-new-page.js
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
+import { Button, GuidePage } from '@wordpress/components';
 import React, { useEffect } from 'react';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Button, GuidePage } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
 
 function WhatsNewPage( { description, heading, imageSrc, isLastPage, link, pageNumber } ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Moves the showGuide state and the toggle function to the parent component.
* The implementation in Marketing Tools in this PR is for testing purposes only. The final implementation will be different. 

This removes the `wp/data` approach used in #50926.

#### Testing instructions

* Checkout this PR and start Calypso
* Navigate to `marketing/tools/SITESLUG`
* Click the `Click me!` button and confirm that the What's New guide loads as expected.
* Click through the slides and confirm that the guide closes.
* Click the `Click me!` button again and confirm that the guide loads again.

Related to #50926 
