### PR TITLE
Add New site button in the unified sidebar

### DIFF
--- a/client/my-sites/sidebar-unified/add-new-site.jsx
+++ b/client/my-sites/sidebar-unified/add-new-site.jsx
@@ -1,9 +1,4 @@
 /**
- * Collapse Sidebar Menu Item
- *
- **/
-
-/**
  * External dependencies
  */
 import React, { Fragment } from 'react';

--- a/client/my-sites/sidebar-unified/add-new-site.jsx
+++ b/client/my-sites/sidebar-unified/add-new-site.jsx
@@ -1,0 +1,48 @@
+/**
+ * Collapse Sidebar Menu Item
+ *
+ **/
+
+/**
+ * External dependencies
+ */
+import React, { Fragment } from 'react';
+import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
+import SidebarItem from 'calypso/layout/sidebar/item';
+import SidebarSeparator from 'calypso/layout/sidebar/separator';
+import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
+import TranslatableString from 'calypso/components/translatable/proptype';
+
+export const AddNewSite = ( { title, icon } ) => {
+	const visibleSiteCount = useSelector( getCurrentUser ).visible_site_count;
+	const onboardingUrl = useSelector( getOnboardingUrl );
+
+	if ( visibleSiteCount > 1 ) {
+		return null;
+	}
+
+	return (
+		<Fragment>
+			<SidebarSeparator key={ 'add-new-site-separator' } />
+			<SidebarItem
+				label={ title }
+				link={ `${ onboardingUrl }?ref=calypso-sidebar` }
+				customIcon={ <SidebarCustomIcon icon={ icon } /> }
+			/>
+		</Fragment>
+	);
+};
+
+AddNewSite.propTypes = {
+	title: TranslatableString.isRequired,
+	icon: PropTypes.string.isRequired,
+};
+
+export default AddNewSite;

--- a/client/my-sites/sidebar-unified/add-new-site.jsx
+++ b/client/my-sites/sidebar-unified/add-new-site.jsx
@@ -7,7 +7,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 
 /**
@@ -19,14 +19,22 @@ import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarSeparator from 'calypso/layout/sidebar/separator';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import TranslatableString from 'calypso/components/translatable/proptype';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 
 export const AddNewSite = ( { title, icon } ) => {
+	const reduxDispatch = useDispatch();
 	const visibleSiteCount = useSelector( getCurrentUser ).visible_site_count;
 	const onboardingUrl = useSelector( getOnboardingUrl );
 
 	if ( visibleSiteCount > 1 ) {
 		return null;
 	}
+
+	const onNavigate = () => {
+		reduxDispatch( recordTracksEvent( 'calypso_add_new_wordpress_click' ) );
+		reduxDispatch( setLayoutFocus( 'content' ) );
+	};
 
 	return (
 		<Fragment>
@@ -35,6 +43,7 @@ export const AddNewSite = ( { title, icon } ) => {
 				label={ title }
 				link={ `${ onboardingUrl }?ref=calypso-sidebar` }
 				customIcon={ <SidebarCustomIcon icon={ icon } /> }
+				onNavigate={ onNavigate }
 			/>
 		</Fragment>
 	);

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -22,6 +22,7 @@ import CurrentSite from 'calypso/my-sites/current-site';
 import MySitesSidebarUnifiedItem from './item';
 import MySitesSidebarUnifiedMenu from './menu';
 import CollapseSidebar from './collapse-sidebar';
+import AddNewSite from './add-new-site';
 import useSiteMenuItems from './use-site-menu-items';
 import useDomainsViewStatus from './use-domains-view-status';
 import { getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
@@ -141,6 +142,11 @@ export const MySitesSidebarUnified = ( { path } ) => {
 						/>
 					);
 				} ) }
+				<AddNewSite
+					key="add-new-site"
+					title={ translate( 'Add new site' ) }
+					icon="dashicons-plus-alt"
+				/>
 				<CollapseSidebar
 					key="collapse"
 					title={ translate( 'Collapse menu' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds new site button in the unified sidebar
* Followed the styling of the WP Admin already existing counterpart
![](https://cln.sh/iznMdf+)
* Followed the link pattern used here https://github.com/Automattic/wp-calypso/blob/1385df60ff25b349594d98bab8cfbe1f9e1cb551/client/my-sites/sidebar/index.jsx#L1005

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. running the following in the Dispatcher of Redux extension
```
{
    type: 'CURRENT_USER_RECEIVE',
    user: {
        "ID": 1,
        "visible_site_count": 1,
    }
}
```
"Add new site" button should be added just before the Collapse button

2. running the following in the Dispatcher of Redux extension
```
{
    type: 'CURRENT_USER_RECEIVE',
    user: {
        "ID": 1,
        "visible_site_count": 2,
    }
}
```
"Add new site" button should be removed

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/50988
