### PR TITLE
Change the editor links when Dashboard Appearance toggle is enabled

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -7,7 +7,7 @@ import { get, has } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isEligibleForGutenframe } from 'calypso/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe';
+import shouldLoadGutenframe from 'calypso/state/selectors/should-load-gutenframe';
 import { EDITOR_START, POST_EDIT } from 'calypso/state/action-types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CalypsoifyIframe from './calypsoify-iframe';
@@ -180,7 +180,7 @@ export const redirect = async ( context, next ) => {
 	const state = getState();
 	const siteId = getSelectedSiteId( state );
 
-	if ( ! isEligibleForGutenframe( state, siteId ) ) {
+	if ( ! shouldLoadGutenframe( state, siteId ) ) {
 		const postType = determinePostType( context );
 		const postId = getPostID( context );
 

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -8,6 +8,8 @@ import { get, has } from 'lodash';
  * Internal dependencies
  */
 import shouldLoadGutenframe from 'calypso/state/selectors/should-load-gutenframe';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import { hasUserSettingsRequestFailed } from 'calypso/state/user-settings/selectors';
 import { EDITOR_START, POST_EDIT } from 'calypso/state/action-types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CalypsoifyIframe from './calypsoify-iframe';
@@ -15,6 +17,7 @@ import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import { addQueryArgs } from 'calypso/lib/route';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import { requestSelectedEditor } from 'calypso/state/selected-editor/actions';
+import { fetchUserSettings } from 'calypso/state/user-settings/actions';
 import {
 	getSiteUrl,
 	getSiteOption,
@@ -82,6 +85,24 @@ function waitForSiteIdAndSelectedEditor( context ) {
 		context.store.dispatch(
 			requestSelectedEditor( getSelectedSiteId( context.store.getState() ) )
 		);
+	} );
+}
+
+function areCalypsoPreferencesAvailable( state ) {
+	return 'undefined' !== typeof getUserSettings( state )?.calypso_preferences;
+}
+
+function waitForCalypsoPreferences( context ) {
+	return new Promise( ( resolve ) => {
+		const unsubscribe = context.store.subscribe( () => {
+			const state = context.store.getState();
+			if ( ! areCalypsoPreferencesAvailable( state ) && ! hasUserSettingsRequestFailed( state ) ) {
+				return;
+			}
+			unsubscribe();
+			resolve();
+		} );
+		context.store.dispatch( fetchUserSettings() );
 	} );
 }
 
@@ -171,11 +192,16 @@ export const redirect = async ( context, next ) => {
 	const {
 		store: { getState },
 	} = context;
-	const tmpState = getState();
+	const tmpState = await getState();
 	const selectedEditor = getSelectedEditor( tmpState, getSelectedSiteId( tmpState ) );
+	const checkPromises = [];
 	if ( ! selectedEditor ) {
-		await waitForSiteIdAndSelectedEditor( context );
+		checkPromises.push( waitForSiteIdAndSelectedEditor( context ) );
 	}
+	if ( ! areCalypsoPreferencesAvailable( tmpState ) ) {
+		checkPromises.push( waitForCalypsoPreferences( context ) );
+	}
+	await Promise.all( checkPromises );
 
 	const state = getState();
 	const siteId = getSelectedSiteId( state );

--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -25,6 +25,10 @@ jest.mock( 'calypso/my-sites/themes/theme-preview', () =>
 jest.mock( 'calypso/my-sites/themes/themes-site-selector-modal', () =>
 	require( 'calypso/components/empty-component' )
 );
+jest.mock( 'calypso/state/selectors/is-nav-unification-enabled', () => ( {
+	__esModule: true,
+	default: () => true,
+} ) );
 
 describe( 'main', () => {
 	describe( 'Calling renderToString() on Theme Info sheet', () => {

--- a/client/state/selectors/get-editor-url.js
+++ b/client/state/selectors/get-editor-url.js
@@ -1,15 +1,15 @@
 /**
  * Internal dependencies
  */
-import { isEligibleForGutenframe } from 'calypso/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe';
 import { shouldCalypsoifyJetpack } from 'calypso/state/selectors/should-calypsoify-jetpack';
+import shouldLoadGutenframe from 'calypso/state/selectors/should-load-gutenframe';
 import { getSiteAdminUrl, getSiteSlug } from 'calypso/state/sites/selectors';
 import { getEditorPath } from 'calypso/state/editor/selectors';
 import { addQueryArgs } from 'calypso/lib/route';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 
 export const getEditorUrl = ( state, siteId, postId = null, postType = 'post' ) => {
-	if ( ! isEligibleForGutenframe( state, siteId ) ) {
+	if ( ! shouldLoadGutenframe( state, siteId ) ) {
 		const siteAdminUrl = getSiteAdminUrl( state, siteId );
 		let url = `${ siteAdminUrl }post-new.php?post_type=${ postType }`;
 

--- a/client/state/selectors/is-nav-unification-enabled.js
+++ b/client/state/selectors/is-nav-unification-enabled.js
@@ -19,8 +19,10 @@ import { isE2ETest } from 'calypso/lib/e2e';
 const CURRENT_ROLLOUT_SEGMENT_PERCENTAGE = 75;
 
 export default ( state ) => {
+	const hasDocument = 'undefined' !== typeof document;
+
 	// Disable if explicitly requested by the `?disable-nav-unification` query param.
-	if ( new URL( document.location ).searchParams.has( 'disable-nav-unification' ) ) {
+	if ( hasDocument && new URL( document.location ).searchParams.has( 'disable-nav-unification' ) ) {
 		return false;
 	}
 
@@ -45,6 +47,11 @@ export default ( state ) => {
 	// Enable nav-unification for all a12s.
 	if ( isAutomatticTeamMember( getReaderTeams( state ) ) ) {
 		return true;
+	}
+
+	// By this point we're checking the cookies which can't be done on the server.
+	if ( ! hasDocument ) {
+		return false;
 	}
 
 	// Enable for E2E tests checking Nav Unification.

--- a/client/state/selectors/should-load-gutenframe.js
+++ b/client/state/selectors/should-load-gutenframe.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { isEligibleForGutenframe } from 'calypso/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe';
+import { shouldCalypsoifyJetpack } from 'calypso/state/selectors/should-calypsoify-jetpack';
+import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
+
+export const shouldLoadGutenframe = ( state, siteId ) =>
+	isEligibleForGutenframe( state, siteId ) &&
+	shouldCalypsoifyJetpack( state, siteId ) &&
+	( ! isNavUnificationEnabled( state ) ||
+		! getUserSettings( state )?.calypso_preferences?.linkDestination );
+
+export default shouldLoadGutenframe;

--- a/client/state/selectors/should-load-gutenframe.js
+++ b/client/state/selectors/should-load-gutenframe.js
@@ -2,14 +2,12 @@
  * Internal dependencies
  */
 import { isEligibleForGutenframe } from 'calypso/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe';
-import { shouldCalypsoifyJetpack } from 'calypso/state/selectors/should-calypsoify-jetpack';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 
 export const shouldLoadGutenframe = ( state, siteId ) => {
 	return (
 		isEligibleForGutenframe( state, siteId ) &&
-		shouldCalypsoifyJetpack( state, siteId ) &&
 		( ! isNavUnificationEnabled( state ) ||
 			! getUserSettings( state )?.calypso_preferences?.linkDestination )
 	);

--- a/client/state/selectors/should-load-gutenframe.js
+++ b/client/state/selectors/should-load-gutenframe.js
@@ -6,10 +6,12 @@ import { shouldCalypsoifyJetpack } from 'calypso/state/selectors/should-calypsoi
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 
-export const shouldLoadGutenframe = ( state, siteId ) =>
-	isEligibleForGutenframe( state, siteId ) &&
-	shouldCalypsoifyJetpack( state, siteId ) &&
-	( ! isNavUnificationEnabled( state ) ||
-		! getUserSettings( state )?.calypso_preferences?.linkDestination );
-
+export const shouldLoadGutenframe = ( state, siteId ) => {
+	return (
+		isEligibleForGutenframe( state, siteId ) &&
+		shouldCalypsoifyJetpack( state, siteId ) &&
+		( ! isNavUnificationEnabled( state ) ||
+			! getUserSettings( state )?.calypso_preferences?.linkDestination )
+	);
+};
 export default shouldLoadGutenframe;

--- a/client/state/selectors/test/get-editor-close-config.js
+++ b/client/state/selectors/test/get-editor-close-config.js
@@ -1,4 +1,8 @@
 /**
+ * @jest-environment jsdom
+ */
+
+/**
  * Internal dependencies
  */
 import getEditorCloseConfig from 'calypso/state/selectors/get-editor-close-config';

--- a/client/state/user-settings/reducer.js
+++ b/client/state/user-settings/reducer.js
@@ -98,10 +98,25 @@ export const updating = ( state = false, action ) => {
 	return state;
 };
 
+export const failed = ( state = false, action ) => {
+	switch ( action.type ) {
+		case USER_SETTINGS_SAVE:
+		case USER_SETTINGS_REQUEST:
+		case USER_SETTINGS_SAVE_SUCCESS:
+		case USER_SETTINGS_REQUEST_SUCCESS:
+			return false;
+		case USER_SETTINGS_REQUEST_FAILURE:
+		case USER_SETTINGS_SAVE_FAILURE:
+			return true;
+	}
+	return state;
+};
+
 export default combineReducers( {
 	settings,
 	unsavedSettings,
 	fetching,
 	updatingPassword,
 	updating,
+	failed,
 } );

--- a/client/state/user-settings/selectors.js
+++ b/client/state/user-settings/selectors.js
@@ -17,3 +17,10 @@ export const isPendingPasswordChange = ( state ) => state.userSettings.updatingP
  * @param {state} state State object
  */
 export const isUpdatingUserSettings = ( state ) => state.userSettings.updating;
+
+/*
+ * Returns whether the previous request to save or retrieve the settings, failed.
+ *
+ * @param {state} state State object
+ */
+export const hasUserSettingsRequestFailed = ( state ) => state.userSettings.failed;

--- a/client/state/user-settings/test/reducer.js
+++ b/client/state/user-settings/test/reducer.js
@@ -22,7 +22,7 @@ import {
 describe( 'reducer', () => {
 	test( 'should export expected reducer keys', () => {
 		expect( Object.keys( reducer( undefined, {} ) ).sort() ).toEqual(
-			[ 'fetching', 'settings', 'unsavedSettings', 'updatingPassword', 'updating' ].sort()
+			[ 'failed', 'fetching', 'settings', 'unsavedSettings', 'updatingPassword', 'updating' ].sort()
 		);
 	} );
 


### PR DESCRIPTION
The links to the editor still default to the iframe'd `/posts` URLs and
that means that people can find themselves back in Calypso even though
they have enabled the 'Dashboard Appearance' option, which should
default to `wp-admin`.



#### Changes proposed in this Pull Request

This change, updates the logic in the selector for these links, as well
as the redirect logic as the iframe loads, to take the 'Dashboard
Appearance' setting in to account.

Fixes https://github.com/Automattic/wp-calypso/issues/51058

#### Testing instructions

As outlined in #51058.

* Change your 'Dashboard Appearance' setting in `/me/account` so that it is enabled.
* Click on the 'Write' button in the top bar. This should now take you to the `wp-admin` version of the editor.
* Clicking on the 'All Posts' link in the left side nav, should take you back to `wp-admin`
* Also check that heading to /post/<YOUR SITE> redirects you to `wp-admin`


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Notes

It's worth noting that this is relying on something that could be considered a bug. When the editor is loaded outside of the iframe, the code to override the editor `closeUrl` isn't loaded, so it is left as the default, which is `wp-admin`. By making sure that we load the editor in `wp-admin`, outside of the iframe, then the link works as expected. 

We should change this so the code takes the 'Dashboard Appearance' setting into account and loads the code when appropriate. This is a much larger change though.

Also, I think there will need to be a separate change to update the link in the top navigation bar in `wp-admin`, as well as possibly the WordPress.com navigation module in Jetpack.

Related to #51058
