### PR TITLE
Partner Portal: Add a way for users to issue licenses

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -20,6 +20,7 @@ import JetpackComFooter from 'calypso/jetpack-cloud/sections/pricing/jpcom-foote
 import PartnerPortalSidebar from 'calypso/jetpack-cloud/sections/partner-portal/sidebar';
 import SelectPartnerKey from 'calypso/jetpack-cloud/sections/partner-portal/select-partner-key';
 import Licenses from 'calypso/jetpack-cloud/sections/partner-portal/primary/licenses';
+import IssueLicense from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license';
 import {
 	LicenseFilter,
 	LicenseSortDirection,
@@ -56,6 +57,14 @@ export function partnerPortalContext( context: PageJS.Context, next: () => void 
 			sortField={ sortField }
 		/>
 	);
+	context.footer = <JetpackComFooter />;
+	next();
+}
+
+export function issueLicenseContext( context: PageJS.Context, next: () => void ): void {
+	context.header = <Header />;
+	context.secondary = <PartnerPortalSidebar path={ context.path } />;
+	context.primary = <IssueLicense />;
 	context.footer = <JetpackComFooter />;
 	next();
 }

--- a/client/jetpack-cloud/sections/partner-portal/index.ts
+++ b/client/jetpack-cloud/sections/partner-portal/index.ts
@@ -25,5 +25,13 @@ export default function () {
 		clientRender
 	);
 
+	page(
+		`/partner-portal/issue-license`,
+		controller.requirePartnerKeyContext,
+		controller.issueLicenseContext,
+		makeLayout,
+		clientRender
+	);
+
 	page( `/partner-portal/*`, '/partner-portal' );
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement, useCallback, useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { useMutation, useQuery } from 'react-query';
+import { useTranslate } from 'i18n-calypso';
+import classnames from 'classnames';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { Button, Card } from '@automattic/components';
+import wpcom, { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import { addQueryArgs } from 'calypso/lib/url';
+import { errorNotice } from 'calypso/state/notices/actions';
+import SelectDropdown from 'calypso/components/select-dropdown';
+import Spinner from 'calypso/components/spinner';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface ProductOption {
+	value: string;
+	label: string;
+}
+
+interface APILicense {
+	license_key: string;
+}
+
+export interface APIProductFamilyProduct {
+	name: string;
+	slug: string;
+	product_id: number;
+}
+
+export interface APIProductFamily {
+	name: string;
+	slug: string;
+	products: APIProductFamilyProduct[];
+}
+
+function queryProducts(): Promise< ProductOption[] > {
+	return wpcom.req
+		.get( {
+			apiNamespace: 'wpcom/v2',
+			path: '/jetpack-licensing/product-families',
+		} )
+		.then( ( families: APIProductFamily[] ) =>
+			families.flatMap( ( family ) =>
+				family.products.map( ( product ) => ( {
+					value: product.slug,
+					label: product.name,
+				} ) )
+			)
+		);
+}
+
+function mutationIssueLicense( product: string ): Promise< APILicense > {
+	return wpcomJpl.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: '/jetpack-licensing/license',
+		body: { product },
+	} );
+}
+
+export default function IssueLicenseForm(): ReactElement {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const query = useQuery( [ 'partner-portal', 'products' ], queryProducts );
+	const mutation = useMutation( mutationIssueLicense, {
+		onError: ( error: Error ) => {
+			dispatch( errorNotice( error.message ) );
+		},
+		onSuccess: ( license ) => {
+			page.redirect( addQueryArgs( { highlight: license.license_key }, '/partner-portal' ) );
+		},
+	} );
+	const [ product, setProduct ] = useState( '' );
+
+	const onSelectProduct = useCallback( ( option ) => setProduct( option.value ), [ setProduct ] );
+
+	const onIssueLicense = useCallback( () => {
+		mutation.mutate( product );
+	}, [ product, mutation.mutate ] );
+
+	useEffect( () => {
+		// Make sure we keep product in sync with the query results.
+		if ( ! query.data || query.data.length === 0 ) {
+			return;
+		}
+
+		const found = query.data.find( ( option ) => option.value === product );
+
+		if ( ! found ) {
+			setProduct( query.data[ 0 ].value );
+		}
+	}, [ product, query.data, setProduct ] );
+
+	return (
+		<Card className="issue-license-form">
+			<p>{ translate( 'Select a product you want to issue a license for' ) }</p>
+
+			{ query.isLoading && <div className="issue-license-form__placeholder" /> }
+
+			{ ! query.isLoading && (
+				<SelectDropdown
+					initialSelected={ product }
+					options={ query.data }
+					onSelect={ onSelectProduct }
+				/>
+			) }
+
+			<div className="issue-license-form__actions">
+				<Button href="/partner-portal">{ translate( 'Go back' ) }</Button>
+
+				<Button
+					className={ classnames( 'issue-license-form__issue-button', {
+						'issue-license-form__issue-button--is-loading': mutation.isLoading,
+					} ) }
+					primary
+					disabled={ query.isLoading || mutation.isLoading }
+					onClick={ onIssueLicense }
+				>
+					<span>{ translate( 'Issue License' ) }</span>
+
+					{ mutation.isLoading && <Spinner /> }
+				</Button>
+			</div>
+		</Card>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/style.scss
@@ -1,0 +1,44 @@
+@import '~@wordpress/base-styles/_mixins.scss';
+
+.issue-license-form {
+	p {
+		font-size: 1rem;
+	}
+
+	&__placeholder {
+		@include placeholder( --color-neutral-10 );
+
+		height: 43px;
+	}
+
+	.select-dropdown__container {
+		width: 100%;
+	}
+
+	&__actions {
+		display: flex;
+		justify-content: flex-end;
+		margin: 42px -10px 0;
+
+		> * {
+			margin: 0 10px;
+		}
+	}
+
+	&__issue-button {
+		&--is-loading {
+			position: relative;
+
+			span {
+				opacity: 0;
+			}
+
+			.spinner {
+				position: absolute;
+				left: 50%;
+				top: 50%;
+				transform: translate( -50%, -50% );
+			}
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import React, { useState, useCallback, ReactElement } from 'react';
+import React, { ReactElement, useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { getQueryArg } from '@wordpress/url';
+import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import classnames from 'classnames';
 import moment from 'moment';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -52,9 +53,8 @@ export default function LicensePreview( {
 }: Props ): ReactElement {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const [ isOpen, setOpen ] = useState(
-		getQueryArg( window.location.href, 'highlight' ) === licenseKey
-	);
+	const isHighlighted = getQueryArg( window.location.href, 'highlight' ) === licenseKey;
+	const [ isOpen, setOpen ] = useState( isHighlighted );
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const domain = siteUrl ? getUrlParts( siteUrl ).hostname : '';
 	const showDomain =
@@ -69,6 +69,14 @@ export default function LicensePreview( {
 	const onCopyLicense = useCallback( () => {
 		dispatch( infoNotice( translate( 'License copied!' ), { duration: 2000 } ) );
 	}, [ dispatch, translate ] );
+
+	useEffect( () => {
+		if ( isHighlighted ) {
+			page.redirect(
+				removeQueryArgs( window.location.pathname + window.location.search, 'highlight' )
+			);
+		}
+	}, [] );
 
 	return (
 		<div

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -3,14 +3,15 @@
  */
 import React, { useState, useCallback, ReactElement } from 'react';
 import { useDispatch } from 'react-redux';
+import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { getUrlParts } from 'calypso/lib/url';
 import classnames from 'classnames';
+import moment from 'moment';
 
 /**
  * Internal dependencies
  */
-
+import { getUrlParts } from 'calypso/lib/url';
 import { infoNotice } from 'calypso/state/notices/actions';
 import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { LicenseState, LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
@@ -51,11 +52,15 @@ export default function LicensePreview( {
 }: Props ): ReactElement {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const [ isOpen, setOpen ] = useState( false );
+	const [ isOpen, setOpen ] = useState(
+		getQueryArg( window.location.href, 'highlight' ) === licenseKey
+	);
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const domain = siteUrl ? getUrlParts( siteUrl ).hostname : '';
 	const showDomain =
 		domain && [ LicenseState.Attached, LicenseState.Revoked ].indexOf( licenseState ) !== -1;
+	const justIssued =
+		moment.utc( issuedAt, 'YYYY-MM-DD HH:mm:ss' ) > moment.utc().subtract( 1, 'minute' );
 
 	const open = useCallback( () => {
 		setOpen( ! isOpen );
@@ -94,6 +99,13 @@ export default function LicensePreview( {
 							<span className="license-preview__tag license-preview__tag--is-revoked">
 								<Gridicon icon="block" size={ 18 } />
 								{ translate( 'Revoked' ) }
+							</span>
+						) }
+
+						{ justIssued && (
+							<span className="license-preview__tag license-preview__tag--is-just-issued">
+								<Gridicon icon="checkmark-circle" size={ 18 } />
+								{ translate( 'Just issued' ) }
 							</span>
 						) }
 					</h3>

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -1,5 +1,6 @@
 @import '~@wordpress/base-styles/_breakpoints.scss';
 @import '~@wordpress/base-styles/_mixins.scss';
+@import '~@wordpress/base-styles/_mixins.scss';
 
 .license-preview {
 	margin: 0;
@@ -75,6 +76,12 @@
 		font-size: 0.875rem;
 		line-height: 1rem;
 
+		&--is-just-issued {
+			color: var( --studio-green-50 );
+			opacity: 0;
+			animation: hide-just-issued-tag 5s linear;
+		}
+
 		&--is-detached {
 			color: var( --studio-orange-40 );
 		}
@@ -126,5 +133,18 @@
 	&--placeholder &__label + div,
 	&--placeholder &__copy-license-key {
 		@include placeholder( --color-neutral-10 );
+	}
+}
+
+@keyframes hide-just-issued-tag {
+	0% {
+		display: inline;
+		opacity: 1;
+	}
+	50% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement, useEffect } from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'calypso/components/main';
+import CardHeading from 'calypso/components/card-heading';
+import IssueLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/issue-license-form';
+
+export default function IssueLicense(): ReactElement {
+	const translate = useTranslate();
+
+	useEffect( () => {
+		const layoutClass = 'layout__content--partner-portal-issue-license';
+		const content = document.getElementById( 'content' );
+
+		if ( content ) {
+			content.classList.add( layoutClass );
+
+			return () => content.classList.remove( layoutClass );
+		}
+	}, [] );
+
+	return (
+		<Main className="issue-license">
+			<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
+
+			<IssueLicenseForm />
+		</Main>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -8,6 +8,7 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import Main from 'calypso/components/main';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -76,6 +77,9 @@ export default function Licenses( {
 						compact
 					/>
 				) }
+				<Button href="/partner-portal/issue-license" primary style={ { marginLeft: 'auto' } }>
+					{ translate( 'Issue New License' ) }
+				</Button>
 			</div>
 
 			<LicenseStateFilter filter={ filter } search={ search } />

--- a/client/jetpack-cloud/sections/partner-portal/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/style.scss
@@ -1,3 +1,9 @@
 @import '~@wordpress/base-styles/breakpoints';
 @import '~@wordpress/base-styles/mixins';
 @import '~@automattic/typography/styles/fonts';
+
+.layout__content--partner-portal-issue-license {
+	// Make sure the layout container is high enough so select dropdowns do not get cut off.
+	// Important since there's some imperative code that applies an inline min-height style to do some scroll hacks.
+	min-height: 100vh !important;
+}


### PR DESCRIPTION
- Context: pbtFPC-Um-p2
- Design: pbtFPC-103-p2

#### Changes proposed in this Pull Request

* Add a new "Issue a new License" page where users can issue licenses directly from the portal.

#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key, if prompted.
* Click on the "Issue New License" button at the top.
* Play around with the form, issue a couple licenses, make sure you are redirected back to the list of licenses and the just issued license shows up expanded, with the "Just issued" label as per designs.

![Screenshot 2021-03-18 at 18 14 59](https://user-images.githubusercontent.com/22746396/111660167-7cd62880-8816-11eb-85f8-fb0f7ddf4d66.png)
![Screenshot 2021-03-18 at 18 15 10](https://user-images.githubusercontent.com/22746396/111660186-7fd11900-8816-11eb-9352-869eb2fb40f5.png)
