### PR TITLE
Make logo partner strings evergreen

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -144,7 +144,7 @@ export const QuickLinks = ( {
 				href="https://wp.me/logo-maker"
 				onClick={ trackDesignLogoAction }
 				target="_blank"
-				label={ translate( 'Create a logo with BuildMyLogo' ) }
+				label={ translate( 'Create a logo' ) }
 				external
 				iconSrc={ logotronIcon }
 			/>

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -144,7 +144,7 @@ export const QuickLinks = ( {
 				href="https://wp.me/logo-maker"
 				onClick={ trackDesignLogoAction }
 				target="_blank"
-				label={ translate( 'Create a logo with Logotron' ) }
+				label={ translate( 'Create a logo with BuildMyLogo' ) }
 				external
 				iconSrc={ logotronIcon }
 			/>

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -119,7 +119,7 @@ export const MarketingTools: FunctionComponent = () => {
 				<MarketingToolsFeature
 					title={ translate( 'Want to build a great brand? Start with a great logo' ) }
 					description={ translate(
-						'A custom logo helps your brand pop and makes your site memorable. Make a professional logo in a few clicks with our partner BuildMyLogo.'
+						'A custom logo helps your brand pop and makes your site memorable. Make a professional logo in a few clicks with our partner today.'
 					) }
 					imagePath={ logotronLogo }
 				>

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -119,7 +119,7 @@ export const MarketingTools: FunctionComponent = () => {
 				<MarketingToolsFeature
 					title={ translate( 'Want to build a great brand? Start with a great logo' ) }
 					description={ translate(
-						'A custom logo helps your brand pop and makes your site memorable. Make a professional logo in a few clicks with our partner Logotron.'
+						'A custom logo helps your brand pop and makes your site memorable. Make a professional logo in a few clicks with our partner BuildMyLogo.'
 					) }
 					imagePath={ logotronLogo }
 				>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removing partner name from the strings to prevent breaking translations when we test different partners.

#### Testing instructions

* Check out this PR and start Calypso
* Navigate to Customer Home and confirm that the Logo link in the Quick Links section is updated and works properly.
* Navigate to `marketing/tools/SITESLUG` and confirm that the Logo partner card is updated and that the link works properly.

Related to #51049 
