### PR TITLE
Improve Jetpack cloud buttons and links contrast ratio

### DIFF
--- a/client/components/activity-card/style.scss
+++ b/client/components/activity-card/style.scss
@@ -124,11 +124,6 @@
 	float: right;
 }
 
-.button.activity-card__see-content-link {
-	margin-left: 0;
-	color: var( --studio-jetpack-green-40 );
-}
-
 .button.is-borderless.is-primary:focus {
 	box-shadow: none;
 }

--- a/client/components/jetpack-logo/index.jsx
+++ b/client/components/jetpack-logo/index.jsx
@@ -15,7 +15,7 @@ import useAriaProps from 'calypso/lib/a11y/use-aria-props';
  * Module constants
  */
 const PALETTE = colorStudio.colors;
-const COLOR_JETPACK = PALETTE[ 'Jetpack Green' ];
+const COLOR_JETPACK = PALETTE[ 'Jetpack Green 50' ];
 const COLOR_WHITE = PALETTE[ 'White' ]; // eslint-disable-line dot-notation
 
 const LogoPathSize32 = ( { monochrome = false } ) => {

--- a/client/components/jetpack/backup-card/style.scss
+++ b/client/components/jetpack/backup-card/style.scss
@@ -31,7 +31,7 @@ $cloud-icon-height: 24px;
 
 	margin-bottom: 36px;
 
-	color: var( --studio-jetpack-green-50 );
+	color: var( --color-primary-50 );
 
 	font-weight: 700;
 	line-height: $cloud-icon-height;
@@ -84,7 +84,7 @@ $cloud-icon-height: 24px;
 	margin-left: 1rem;
 
 	&.badge {
-		background-color: var( --studio-jetpack-green-5 );
+		background-color: var( --color-primary-5 );
 		color: var( --color-text );
 
 		font-size: 0.75rem;

--- a/client/components/jetpack/daily-backup-status/style.scss
+++ b/client/components/jetpack/daily-backup-status/style.scss
@@ -15,7 +15,7 @@
 
 .daily-backup-status__download-button {
 	margin: 24px 0 1rem;
-	color: var( --studio-jetpack-green-60 );
+	color: var( --color-accent );
 }
 
 .daily-backup-status__credentials-warning {
@@ -46,19 +46,6 @@
 
 	@include breakpoint-deprecated( '>660px' ) {
 		display: inline;
-	}
-}
-
-.button.daily-backup-status__activate-restores-button,
-.button.daily-backup-status__activate-restores-button:visited {
-	float: none;
-	width: 100%;
-	margin: 1rem 0 3rem;
-	text-align: center;
-	color: var( --studio-jetpack-green-60 );
-
-	@include breakpoint-deprecated( '>660px' ) {
-		width: 330px;
 	}
 }
 

--- a/client/components/jetpack/threat-item-subheader/style.scss
+++ b/client/components/jetpack/threat-item-subheader/style.scss
@@ -17,7 +17,7 @@
 		white-space: nowrap;
 
 		&.is-fixed {
-			color: var( --studio-jetpack-green-40 );
+			color: var( --color-success-50 );
 		}
 	}
 
@@ -46,7 +46,7 @@
 		color: #fff;
 
 		&.is-fixed {
-			background-color: var( --studio-jetpack-green-40 );
+			background-color: var( --color-success-50 );
 		}
 
 		&.is-ignored {
@@ -56,8 +56,8 @@
 		&.is-auto-fix {
 			margin-top: 0px;
 			margin-left: 4px;
-			color: var( --studio-jetpack-green-40 );
-			background-color: var( --studio-jetpack-green-0 );
+			color: var( --color-success-50 );
+			background-color: var( --color-success-0 );
 			position: relative;
 			top: -1px;
 		}

--- a/client/components/jetpack/threat-item/style.scss
+++ b/client/components/jetpack/threat-item/style.scss
@@ -33,7 +33,7 @@
 	}
 
 	&.is-fixed {
-		border-left: 3px solid var( --studio-jetpack-green-40 );
+		border-left: 3px solid var( --color-success-50 );
 	}
 
 	&.is-ignored {
@@ -43,7 +43,6 @@
 	&__buttons {
 		display: flex;
 		justify-content: flex-end;
-
 	}
 
 	.foldable-card__action.foldable-card__expand {

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -195,6 +195,10 @@
 
 	.site-selector__manage-hidden-sites {
 		text-decoration: underline;
+
+		&:hover {
+			text-decoration: none;
+		}
 	}
 }
 

--- a/client/jetpack-cloud/sections/settings/style.scss
+++ b/client/jetpack-cloud/sections/settings/style.scss
@@ -11,13 +11,6 @@
 	margin-bottom: 32px;
 }
 
-.settings__connected .gridicon {
-	display: inline-block;
-	fill: var( --studio-jetpack-green-40 );
-	width: 4rem;
-	height: 4rem;
-}
-
 .settings__status-uninitialized {
 	height: 90px;
 	margin-bottom: 8px;

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -45,19 +45,19 @@
 }
 
 .button {
-	color: var( --color-primary-60 );
+	color: var( --color-accent );
 	background: var( --studio-white );
-	border: 1px solid var( --color-primary-40 );
+	border: 1px solid var( --color-accent );
 	border-radius: var( --jetpack-corners-soft );
 
 	&:hover,
 	&:focus {
-		background-color: var( --color-primary-0 );
+		background-color: var( --color-accent-0 );
 	}
 
 	&:active {
-		background: var( --color-primary-5 );
-		border-color: var( --color-primary-40 );
+		background: var( --color-accent-5 );
+		border-color: var( --color-accent-40 );
 		border-width: 1px;
 	}
 
@@ -164,15 +164,15 @@
 }
 
 .button.is-borderless.is-primary {
-	color: var( --color-primary-40 );
+	color: var( --color-accent );
 
 	&:hover,
 	&:focus {
-		color: var( --color-primary-30 );
+		color: var( --color-accent-30 );
 	}
 
 	&:active {
-		color: var( --color-primary-50 );
+		color: var( --color-accent-50 );
 	}
 
 	&[disabled],

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -74,19 +74,15 @@
 }
 
 .button.is-primary {
-	color: var( --studio-white );
-	background: var( --color-primary-40 );
-	border-color: var( --color-primary-40 );
-
 	&:hover,
 	&:focus {
-		background-color: var( --color-primary-60 );
-		border-color: var( --color-primary-60 );
+		background-color: var( --color-accent-light );
+		border-color: var( --color-accent-light );
 	}
 
 	&:active {
-		background: var( --color-primary-40 );
-		border-color: var( --color-primary-40 );
+		background: var( --color-accent-dark );
+		border-color: var( --color-accent-dark );
 	}
 
 	&[disabled],

--- a/client/my-sites/backup/backup-date-picker/style.scss
+++ b/client/my-sites/backup/backup-date-picker/style.scss
@@ -8,7 +8,6 @@
 	@include breakpoint-deprecated( '>660px' ) {
 		background: transparent;
 	}
-
 }
 
 .backup-date-picker__select-date {
@@ -120,7 +119,7 @@
 }
 
 .backup-date-picker__search-icon.gridicon {
-	fill: var( --studio-jetpack-green-40 );
+	fill: currentColor;
 }
 
 /* WordPress.com-only styles */

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -155,7 +155,7 @@
 .is_jetpackcom {
 	.backup__restore-banner {
 		&.banner.card {
-			@include banner-color( var( --color-primary-40 ) );
+			@include banner-color( var( --color-accent ) );
 		}
 	}
 }

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
@@ -33,8 +33,8 @@
 	--color-primary-100-rgb: var( --studio-jetpack-green-100-rgb );
 
 	/* Theme Properties */
-	--color-accent: var( --studio-jetpack-green );
-	--color-accent-rgb: var( --studio-jetpack-green-rgb );
+	--color-accent: var( --studio-jetpack-green-50 );
+	--color-accent-rgb: var( --studio-jetpack-green-50-rgb );
 	--color-accent-dark: var( --studio-jetpack-green-70 );
 	--color-accent-dark-rgb: var( --studio-jetpack-green-70-rgb );
 	--color-accent-light: var( --studio-jetpack-green-30 );
@@ -65,8 +65,8 @@
 	--color-accent-100-rgb: var( --studio-jetpack-green-100-rgb );
 
 	/* Theme Properties */
-	--color-link: var( --studio-jetpack-green-40 );
-	--color-link-rgb: var( --studio-jetpack-green-40-rgb );
+	--color-link: var( --studio-jetpack-green-50 );
+	--color-link-rgb: var( --studio-jetpack-green-50-rgb );
 	--color-link-dark: var( --studio-jetpack-green-60 );
 	--color-link-dark-rgb: var( --studio-jetpack-green-60-rgb );
 	--color-link-light: var( --studio-jetpack-green-20 );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
@@ -1,7 +1,7 @@
 .theme-jetpack-cloud,
 .color-scheme.is-jetpack-cloud {
 	/* Theme Properties */
-	--color-primary: var( --studio-jetpack-green );
+	--color-primary: var( --studio-jetpack-green-50 );
 	--color-primary-rgb: var( --studio-jetpack-green-rgb );
 	--color-primary-dark: var( --studio-jetpack-green-70 );
 	--color-primary-dark-rgb: var( --studio-jetpack-green-70-rgb );
@@ -67,10 +67,10 @@
 	/* Theme Properties */
 	--color-link: var( --studio-jetpack-green-50 );
 	--color-link-rgb: var( --studio-jetpack-green-50-rgb );
-	--color-link-dark: var( --studio-jetpack-green-60 );
-	--color-link-dark-rgb: var( --studio-jetpack-green-60-rgb );
-	--color-link-light: var( --studio-jetpack-green-20 );
-	--color-link-light-rgb: var( --studio-jetpack-green-20-rgb );
+	--color-link-dark: var( --studio-jetpack-green-70 );
+	--color-link-dark-rgb: var( --studio-jetpack-green-70-rgb );
+	--color-link-light: var( --studio-jetpack-green-30 );
+	--color-link-light-rgb: var( --studio-jetpack-green-30-rgb );
 	--color-link-0: var( --studio-jetpack-green-0 );
 	--color-link-0-rgb: var( --studio-jetpack-green-0-rgb );
 	--color-link-5: var( --studio-jetpack-green-5 );


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR improves the contrast ratio of links and buttons in Jetpack cloud, so that it meets the [WCAG 2.0 guidelines](https://www.w3.org/TR/WCAG21/#contrast-minimum), i.e. a 4.5:1 value for body text.

Fixes 1164141197617539-as-1200075497729135

### Implementation notes

I've updated colour properties so that all colours can eventually be updated in `packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss`.

### Testing instructions

- Download this PR and run Jetpack cloud
- Make sure standard links (see _Change_ link in video below) have a `color` property of which the value is `#008710` (Jetpack Green 50)
- Make sure standard buttons (see _Create Site_ button in video below) have a `background-color` property of which the value is `#008710`
- Browse Jetpack cloud, and check that all greens (except for images) are similar. To make this easier to see, update colours locally in `packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss` to something else than green. This PR focuses on Jetpack cloud, so the pricing page (which is similar to jetpack.com in design), the login and the connect page haven't been changed.

_Notice in the contrast checker tool below that the new colour passes the AA Normal level._

### Screenshots

_Ratio (before/after)_
<img width="1552" alt="Screen Shot 2021-03-16 at 3 30 58 PM" src="https://user-images.githubusercontent.com/1620183/111371712-28914400-8670-11eb-91d4-0bd24273328f.png">
<img width="1552" alt="Screen Shot 2021-03-16 at 3 31 14 PM" src="https://user-images.githubusercontent.com/1620183/111371721-2cbd6180-8670-11eb-8f42-4f3c30938d2e.png">


_Button interaction (normal, hover, and active state)_

https://user-images.githubusercontent.com/1620183/111491865-968e4780-8712-11eb-96dc-d5cadc032839.mov




_Link interaction (normal and hover state)_


https://user-images.githubusercontent.com/1620183/111491599-5fb83180-8712-11eb-9867-0fcf5f045af5.mov