### PR TITLE
Stats: Include Number of Comments in Insights

### DIFF
--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -80,6 +80,13 @@ class StatsAllTime extends Component {
 							compact
 						/>
 						<StatsTab
+							gridicon="comment"
+							label={ translate( 'Comments' ) }
+							loading={ isLoading }
+							value={ comments }
+							compact
+						/>
+						<StatsTab
 							gridicon="visible"
 							label={ translate( 'Views' ) }
 							loading={ isLoading }
@@ -91,13 +98,6 @@ class StatsAllTime extends Component {
 							label={ translate( 'Visitors' ) }
 							loading={ isLoading }
 							value={ visitors }
-							compact
-						/>
-						<StatsTab
-							gridicon="comment"
-							label={ translate( 'Comments' ) }
-							loading={ isLoading }
-							value={ comments }
 							compact
 						/>
 						<StatsTab

--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -34,6 +34,7 @@ class StatsAllTime extends Component {
 		siteId: PropTypes.number,
 		requesting: PropTypes.bool,
 		query: PropTypes.object,
+		comments: PropTypes.number,
 		posts: PropTypes.number,
 		views: PropTypes.number,
 		viewsBestDay: PropTypes.string,
@@ -45,6 +46,7 @@ class StatsAllTime extends Component {
 			translate,
 			siteId,
 			requesting,
+			comments,
 			posts,
 			views,
 			visitors,
@@ -67,7 +69,7 @@ class StatsAllTime extends Component {
 		return (
 			<div>
 				{ siteId && <QuerySiteStats siteId={ siteId } statType="stats" query={ query } /> }
-				<SectionHeader label={ translate( 'All-time posts, views, and visitors' ) } />
+				<SectionHeader label={ translate( 'All-time posts, comments, views, and visitors' ) } />
 				<Card className={ classNames( 'stats-module', 'all-time', classes ) }>
 					<StatsTabs borderless>
 						<StatsTab
@@ -92,6 +94,13 @@ class StatsAllTime extends Component {
 							compact
 						/>
 						<StatsTab
+							gridicon="comment"
+							label={ translate( 'Comments' ) }
+							loading={ isLoading }
+							value={ comments }
+							compact
+						/>
+						<StatsTab
 							className="all-time__is-best"
 							gridicon="trophy"
 							label={ translate( 'Best views ever' ) }
@@ -113,6 +122,7 @@ export default connect( ( state ) => {
 	const query = {};
 	const allTimeData = getSiteStatsNormalizedData( state, siteId, 'stats', query ) || {};
 	const allTimeStats = pick( allTimeData, [
+		'comments',
 		'posts',
 		'views',
 		'visitors',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Includes the number of comments on the Insights page. In theory, this number can still be found under the "Comments" section, but it feels like it'd make sense to include it here in order to bring parity to the WP-Admin section, since that's not going to be available anymore.

#### Testing instructions

Visit `/stats/insights` and confirm that the number of Comments is now shown.

<img width="367" alt="Screenshot 2021-03-16 at 20 24 19" src="https://user-images.githubusercontent.com/43215253/111374944-9c921300-8695-11eb-902a-d7276871bb1d.png">

cc @sixhours

Related to #51095
