### PR TITLE
Refining logic for displaying error banner on nameserver settings

### DIFF
--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -75,7 +75,7 @@ class NameServers extends React.Component {
 		}
 
 		return this.state.nameservers.every( ( nameserver ) => {
-			return WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
+			return ! nameserver || WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
 		} );
 	};
 
@@ -85,7 +85,7 @@ class NameServers extends React.Component {
 		}
 
 		return this.state.nameservers.every( ( nameserver ) => {
-			return CLOUDFLARE_NAMESERVERS_REGEX.test( nameserver );
+			return ! nameserver || CLOUDFLARE_NAMESERVERS_REGEX.test( nameserver );
 		} );
 	};
 
@@ -114,13 +114,13 @@ class NameServers extends React.Component {
 
 	warning() {
 		const { translate } = this.props;
-
 		if (
 			this.hasWpcomNameservers() ||
 			this.hasCloudflareNameservers() ||
 			this.isPendingTransfer() ||
 			this.needsVerification() ||
-			! this.state.nameservers
+			! this.state.nameservers ||
+			! this.state.nameservers.length
 		) {
 			return null;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a follow-up to https://github.com/Automattic/wp-calypso/pull/50862, further refining the logic which determines when we display a notification banner to users on the domain management page indicating that they should be using WP.COM nameservers.

Per discussion at p1615754456004400-slack-C01D0SM3Q0P, we want to hide the notification banner when no nameserver values have been entered, or when any entered values match Cloudflare nameservers, so the user only gets the notification banner if they have actively entered servers that match neither WP.COM nor Cloudflare.

![image](https://user-images.githubusercontent.com/13437011/111375706-950a4400-866c-11eb-9ce2-ac14b755ac10.png)
![image](https://user-images.githubusercontent.com/13437011/111375758-a5222380-866c-11eb-9800-7339c5ad0700.png)
![image](https://user-images.githubusercontent.com/13437011/111375813-b2d7a900-866c-11eb-9d9b-fc06807c38ae.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site (in production) with a Premium account and redeem a free domain onto it. (Alternatively, use an existing site where this has already been done.)
* Check out this PR to your local dev environment.
* Navigate to http://calypso.localhost:3000/domains/manage/{MAPPED-DOMAIN}/name-servers/{MAPPED-DOMAIN}.
    * Via menuing, this is Upgrades -> Domains -> (Select Mapped Domain) -> Change Your Name Server and DNS Records.
* Disable the "Use Wordpress.com Name Servers" toggle.
* Verify that the notification banner does not display if all text boxes are empty.
* Verify that the banner also does not appear if the only values entered in the boxes match the pattern *.ns.cloudflare.com.
* Verify the banner does appear with any other (non-WPCOM-nameserver) value.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 520-gh-Automattic/dotcom-manage