### PR TITLE
Revert "New Page Layout Picker: refresh page pattern cache when site lang changes"

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -145,11 +145,7 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_timeline_block' );
 function load_common_module() {
 	require_once __DIR__ . '/common/index.php';
 }
-// Use a custom priority so that the common code is loaded before any of
-// the other modules. This way it can be called very early in the other
-// modules (e.g. during `__construct`). The default priority is 10, so
-// using 9 to load just before.
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_common_module', 9 );
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_common_module' );
 
 /**
  * Load Editor Site Launch.

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -36,7 +36,7 @@ class Starter_Page_Templates {
 				'starter_page_templates',
 				A8C_ETK_PLUGIN_VERSION,
 				get_option( 'site_vertical', 'default' ),
-				$this->get_verticals_locale(),
+				get_locale(),
 			)
 		);
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#51087

This ETK change was reverted in the backend