### PR TITLE
New Page Layout Picker: refresh page pattern cache when site lang changes (round 2)

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -36,7 +36,7 @@ class Starter_Page_Templates {
 				'starter_page_templates',
 				A8C_ETK_PLUGIN_VERSION,
 				get_option( 'site_vertical', 'default' ),
-				get_locale(),
+				$this->get_verticals_locale(),
 			)
 		);
 


### PR DESCRIPTION
**This is round to after having to revert #51087 which caused fatals during deploy.**

#### Changes proposed in this Pull Request

* Change pattern cache key to use site locale instead of account/user locale
* ~Update execution order to ensure the `get_iso_639_locale()` function is available when `__construct()` is called~
* ~Protect against fatals during deploy by not calling `get_iso_639_locale()` if the host still has the old version of `full-site-editing-plugin.php` that hasn't updated the execution order~ #51158 has taken care of these items

After changing the site language the layout names and categories in the page layout picker still show in the previous language. And when the pattern is inserted it inserts the pervious language. You'd have to wait a day after updating the site language before the picker would fix itself.

The problem is the pattern data is cached using a key that includes the _account_ language, not the _site_ language. This change makes sure the cache key is using the exact same locale slug that's being used in the query to get pattern data.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `install-plugin.sh etk update/refresh-page-pattern-cache-on-site-lang-change` on sandbox
* On sandbox site create a new page (layout picker will open)
* In another tab update the site language
* Refresh the editor tab, the modal updates to show pattern thumbnails, names and categories using the new language
* Insert a layout, and the content added to the page should be in the new site language.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
