### PR TITLE
ETK: Change displayname to be more consistent

### DIFF
--- a/.teamcity/_self/builds/WPComPlugins_EditorToolkit.kt
+++ b/.teamcity/_self/builds/WPComPlugins_EditorToolkit.kt
@@ -10,7 +10,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 object WPComPlugins_EditorToolKit : BuildType({
-	name = "Editor ToolKit"
+	name = "Editing ToolKit"
 
 	artifactRules = "editing-toolkit.zip"
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Elsewhere in our documentation, we refer to ETK as "Editing" toolkit rather than "Editor" toolkit. I think it would be high-impact to change the ID of the build, so this just updates the display name. I'm hoping this causes the UI to show this text.

#### Testing instructions
* ETK builds should complete
* Build names should match this. (might not work till after merging)