### PR TITLE
Checkout: Fix transaction endpoint types

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -334,7 +334,7 @@ function createTransactionEndpointCartItemFromLineItem(
 		volume: item.wpcom_meta?.volume ?? 1,
 		quantity: item.wpcom_meta?.quantity ?? null,
 		extra: item.wpcom_meta?.extra,
-	} as WPCOMTransactionEndpointCartItem;
+	};
 }
 
 function addRegistrationDataToGSuiteItem(
@@ -348,9 +348,12 @@ function addRegistrationDataToGSuiteItem(
 		...item,
 		wpcom_meta: {
 			...item.wpcom_meta,
-			extra: { ...item.wpcom_meta.extra, google_apps_registration_data: contactDetails },
+			extra: {
+				...item.wpcom_meta.extra,
+				google_apps_registration_data: contactDetails || undefined,
+			},
 		},
-	} as WPCOMCartItem;
+	};
 }
 
 export function createTransactionEndpointRequestPayloadFromLineItems( {

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -119,6 +119,7 @@ export type WPCOMTransactionEndpointCartItem = {
 	currency: string;
 	volume: number;
 	extra?: ResponseCartProductExtra;
+	quantity: number | null;
 };
 
 export type WPCOMTransactionEndpointResponse = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A few functions that format cart data for the transaction endpoints use type casting to allow invalid properties. This should never have been done as it defeats the purpose of type safety. This PR fixes the issue by removing the type casting and fixing the types to include the missing properties.

#### Testing instructions

None. This should not have any functional change except for replacing some G Suite data with `undefined` instead of `null`. I don't think there's any testing needed.