### PR TITLE
Limit log request window to 14 days

### DIFF
--- a/client/my-sites/hosting/web-server-logs-card/index.js
+++ b/client/my-sites/hosting/web-server-logs-card/index.js
@@ -98,6 +98,13 @@ const WebServerLogsCard = ( props ) => {
 				validationInfo: translate( 'Start date must be less than 30 days ago.' ),
 			} );
 		}
+
+		if ( startMoment.isBefore( moment.utc().subtract( 14, 'days' ) ) ) {
+			setStartDateValidation( {
+				isValid: false,
+				validationInfo: translate( 'Please select a time range of less than 14 days.' ),
+			} );
+		}
 	}, [ startDateTime, endDateTime ] );
 
 	const updateStartDateTime = ( event ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In many cases, requesting more than two weeks of logs at a time will fail immediately, so this PR will limit the maximum request window to 14 days.

<img width="731" alt="Screen Shot 2021-03-16 at 9 37 09 PM" src="https://user-images.githubusercontent.com/1379730/111401529-d536ea00-869f-11eb-879e-6d11b53766ef.png">


#### Testing instructions

Try to request more than 14 days of logs at a time.
Make sure you get an error message and that the download button is disabled.
Make sure that you can still download less than 14 days of logs within the last 30 days.