### PR TITLE
Set default progress to 0 for unhandled transfer states

### DIFF
--- a/client/my-sites/woocommerce/dashboard/required-plugins-install-view.jsx
+++ b/client/my-sites/woocommerce/dashboard/required-plugins-install-view.jsx
@@ -94,7 +94,9 @@ class RequiredPluginsInstallView extends Component {
 			toInstall: [],
 			workingOn: '',
 			progress:
-				automatedTransferStatus && ! ( transferStates.COMPLETE === automatedTransferStatus ) // Complete status means we're skipping it altogether.
+				automatedTransferStatus &&
+				transferStatusesToTimes[ automatedTransferStatus ] &&
+				! ( transferStates.COMPLETE === automatedTransferStatus ) // Don't need to wait transfer, proceed with everything else.
 					? transferStatusesToTimes[ automatedTransferStatus ]
 					: 0,
 			totalSeconds: this.getTotalSeconds(),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR sets WooCommerce setup default progress to 0 when it's the `automatedTransferStatus` state is not defined in `transferStatusesToTimes`. This caused the progress to be `undefined` and eventually `NaN` when actual progress is calculated.

#### Testing instructions

1. Run calypso in your development environment.
4. Create a new business site.
5. Install `Hello Dolly` plugin to turn it into Atomic site.
6. Navigate to `/woocommerce-installation/{your new site}`.
7. Click on `Set up my store!`.
8. Observe that the progress bar progresses incrementally until 100%.

