### PR TITLE
Update nav unification rollout percentage to 20%.

### DIFF
--- a/client/state/selectors/is-nav-unification-enabled.js
+++ b/client/state/selectors/is-nav-unification-enabled.js
@@ -16,7 +16,7 @@ import isNavUnificationNewUser from 'calypso/state/selectors/is-nav-unification-
 import { isE2ETest } from 'calypso/lib/e2e';
 
 // Gradual rollout (segment of existing users + all new users registered after March 5, 2021).
-const CURRENT_ROLLOUT_SEGMENT_PERCENTAGE = 5;
+const CURRENT_ROLLOUT_SEGMENT_PERCENTAGE = 20;
 
 export default ( state ) => {
 	// Disable if explicitly requested by the `?disable-nav-unification` query param.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update nav unification rollout percentage to 20%.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Log in with a non a11n account:

1. running the following in the Dispatcher of Redux extension
```
{
    type: 'CURRENT_USER_RECEIVE',
    user: {
        "ID": 1221,
    }
}
```
Feature should disable

2. running the following in the Dispatcher of Redux extension
```
{
    type: 'CURRENT_USER_RECEIVE',
    user: {
        "ID": 1219,
    }
}
```
Feature should enable & Welcome Modal be shown

Please review the WPCOM part too: D58883-code

**Deploy sequence**
1. Merge https://github.com/Automattic/wp-calypso/pull/51131
2. When it hits staging, deploy D58883-code and do a sanity check
3. Deploy Calypso