### PR TITLE
Updating Cloudflare banner tracking

### DIFF
--- a/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
+++ b/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
@@ -137,6 +137,7 @@ export function CloudflareAnalyticsSettings( {
 					'Choose an additional analytics tool to connect and get unique insights about your site traffic.'
 				) }
 				event={ 'jetpack_cloudflare_analytics_settings' }
+				tracksClickProperties={ { plan: site.plan.product_slug } }
 				feature={ FEATURE_CLOUDFLARE_ANALYTICS }
 				plan={ plan }
 				href={ null }

--- a/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
+++ b/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
@@ -74,7 +74,9 @@ export function CloudflareAnalyticsSettings( {
 	};
 
 	const recordSupportLinkClick = () => {
-		trackTracksEvent( 'calypso_traffic_settings_cloudflare_support_click' );
+		trackTracksEvent( 'calypso_traffic_settings_cloudflare_support_click', {
+			plan: site.plan.product_slug,
+		} );
 	};
 
 	const handleCodeChange = ( event ) => {
@@ -109,8 +111,14 @@ export function CloudflareAnalyticsSettings( {
 			handleFieldChange( '', () => {
 				handleSubmitForm();
 			} );
+			trackTracksEvent( 'calypso_traffic_settings_cloudflare_disable_cloudflare', {
+				plan: site.plan.product_slug,
+			} );
 		} else {
 			setIsCloudflareEnabled( true );
+			trackTracksEvent( 'calypso_traffic_settings_cloudflare_enable_cloudflare', {
+				plan: site.plan.product_slug,
+			} );
 		}
 	};
 

--- a/client/my-sites/stats/cloudflare.js
+++ b/client/my-sites/stats/cloudflare.js
@@ -23,43 +23,41 @@ const Cloudflare = () => {
 	const sitePlan = useSelector( ( state ) => getSitePlanSlug( state, siteId ) );
 	const showUpsell = [ 'personal-bundle', 'free_plan' ].includes( sitePlan );
 
+	if ( ! showCloudflare ) return null;
+
 	return (
 		<>
-			{ showCloudflare && (
-				<>
-					{ ! sitePlan && <QuerySitePlans siteId={ siteId } /> }
-					{ sitePlan && ! showUpsell && (
-						<Banner
-							title={ translate( 'Discover more stats with Cloudflare Analytics' ) }
-							description={ translate(
-								'Cloudflare Analytics give you deeper insights into your site traffic and performance.'
-							) }
-							callToAction={ translate( 'Learn more' ) }
-							disableCircle={ true }
-							dismissPreferenceName="cloudflare-banner"
-							event="calypso_stats_cloudflare_analytics_learn_more_click"
-							highlight="info"
-							horizontal={ true }
-							href="https://www.cloudflare.com/pg-lp/cloudflare-for-wordpress-dot-com?utm_source=wordpress.com&utm_medium=affiliate&utm_campaign=paygo_2021-02_a8_pilot&utm_content=stats"
-							iconPath={ cloudflareIllustration }
-							showIcon={ true }
-							tracksImpressionName="calypso_stats_cloudflare_banner_view"
-						/>
+			{ ! sitePlan && <QuerySitePlans siteId={ siteId } /> }
+			{ !! sitePlan && ! showUpsell && (
+				<Banner
+					title={ translate( 'Discover more stats with Cloudflare Analytics' ) }
+					description={ translate(
+						'Cloudflare Analytics give you deeper insights into your site traffic and performance.'
 					) }
-					{ sitePlan && showUpsell && (
-						<UpsellNudge
-							title={ translate( 'Upgrade your plan for even more stats' ) }
-							description={ translate(
-								'Get deeper insights into your site traffic and performance with Cloudflare Analytics.'
-							) }
-							customerType="business"
-							tracksImpressionName="calypso_stats_cloudflare_upsell_view"
-							event="calypso_stats_cloudflare_analytics_upsell_nudge_click"
-							showIcon={ true }
-							callToAction={ translate( 'Upgrade' ) }
-						/>
+					callToAction={ translate( 'Learn more' ) }
+					disableCircle={ true }
+					dismissPreferenceName="cloudflare-banner"
+					event="calypso_stats_cloudflare_analytics_learn_more_click"
+					highlight="info"
+					horizontal={ true }
+					href="https://www.cloudflare.com/pg-lp/cloudflare-for-wordpress-dot-com?utm_source=wordpress.com&utm_medium=affiliate&utm_campaign=paygo_2021-02_a8_pilot&utm_content=stats"
+					iconPath={ cloudflareIllustration }
+					showIcon={ true }
+					tracksImpressionName="calypso_stats_cloudflare_banner_view"
+				/>
+			) }
+			{ !! sitePlan && showUpsell && (
+				<UpsellNudge
+					title={ translate( 'Upgrade your plan for even more stats' ) }
+					description={ translate(
+						'Get deeper insights into your site traffic and performance with Cloudflare Analytics.'
 					) }
-				</>
+					customerType="business"
+					tracksImpressionName="calypso_stats_cloudflare_upsell_view"
+					event="calypso_stats_cloudflare_analytics_upsell_nudge_click"
+					showIcon={ true }
+					callToAction={ translate( 'Upgrade' ) }
+				/>
 			) }
 		</>
 	);

--- a/client/my-sites/stats/cloudflare.js
+++ b/client/my-sites/stats/cloudflare.js
@@ -44,6 +44,7 @@ const Cloudflare = () => {
 					iconPath={ cloudflareIllustration }
 					showIcon={ true }
 					tracksImpressionName="calypso_stats_cloudflare_banner_view"
+					tracksClickProperties={ { plan: sitePlan } }
 				/>
 			) }
 			{ !! sitePlan && showUpsell && (
@@ -55,6 +56,7 @@ const Cloudflare = () => {
 					customerType="business"
 					tracksImpressionName="calypso_stats_cloudflare_upsell_view"
 					event="calypso_stats_cloudflare_analytics_upsell_nudge_click"
+					tracksClickProperties={ { plan: sitePlan } }
 					showIcon={ true }
 					callToAction={ translate( 'Upgrade' ) }
 				/>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -203,6 +203,7 @@ class StatsSite extends Component {
 					siteId={ siteId }
 					slug={ slug }
 				/>
+
 				{ ! isVip && isAdmin && ! hasWordAds && <Cloudflare /> }
 
 				<div id="my-stats-content">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Expanding info passed to Tracks for event tracking.

#### Testing instructions
* Checkout this branch and start Calypso
* Turn on Tracks events debugging (type `localStorage.debug = 'wpcom-block-editor:tracks’` in your dev console)
* Click the various Cloudflare upgrade banners and nudges on My Home, Stats, Settings > Performance, and Marketing > Traffic

Related to #
