### PR TITLE
Apply Jetpack cloud base styles to landing page

### DIFF
--- a/client/components/empty-content/no-sites-message/index.jsx
+++ b/client/components/empty-content/no-sites-message/index.jsx
@@ -16,6 +16,7 @@ const NoSitesMessage = ( { translate } ) => {
 	const onboardingUrl = useSelector( ( state ) => getOnboardingUrl( state ) );
 	return (
 		<EmptyContent
+			className="no-sites-message"
 			title={ translate( "You don't have any WordPress sites yet." ) }
 			line={ translate( 'Would you like to start one?' ) }
 			action={ translate( 'Create Site' ) }

--- a/client/components/jetpack/masterbar/index.tsx
+++ b/client/components/jetpack/masterbar/index.tsx
@@ -20,6 +20,10 @@ import AsyncLoad from 'calypso/components/async-load';
  * Style dependencies
  */
 import './style.scss';
+// We import these styles from here because this is the only section that gets always
+// loaded when a user visits Jetpack Cloud. We might have to find a better place for
+// this in the future.
+import 'calypso/jetpack-cloud/style.scss';
 
 const JetpackCloudMasterBar: React.FC = () => {
 	const translate = useTranslate();

--- a/client/components/jetpack/sidebar/index.jsx
+++ b/client/components/jetpack/sidebar/index.jsx
@@ -25,10 +25,6 @@ import SidebarRegion from 'calypso/layout/sidebar/region';
  * Style dependencies
  */
 import './style.scss';
-// We import these styles from here because this is the only section that gets always
-// loaded when a user visits Jetpack Cloud. We might have to find a better place for
-// this in the future.
-import 'calypso/jetpack-cloud/style.scss';
 
 class JetpackCloudSidebar extends Component {
 	static propTypes = {

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -80,13 +80,13 @@
 
 	&:hover,
 	&:focus {
-		background: var( --color-primary-30 );
-		border-color: var( --color-primary-30 );
+		background: var( --color-primary-60 );
+		border-color: var( --color-primary-60 );
 	}
 
 	&:active {
-		background: var( --color-primary-50 );
-		border-color: var( --color-primary-50 );
+		background: var( --color-primary-40 );
+		border-color: var( --color-primary-40 );
 	}
 
 	&[disabled],
@@ -201,13 +201,12 @@
 // Universal Text Styles
 
 html {
-
 	h2 {
 		font-size: $font-title-small;
 		font-weight: 600;
 		line-height: 32px;
 
-		@include breakpoint-deprecated('>660px') {
+		@include breakpoint-deprecated( '>660px' ) {
 			font-size: $font-headline-small;
 			line-height: 40px;
 		}
@@ -228,7 +227,7 @@ html {
 		font-size: $font-body;
 		line-height: 24px;
 
-		@include breakpoint-deprecated('>660px') {
+		@include breakpoint-deprecated( '>660px' ) {
 			font-size: $font-title-small;
 			line-height: 24px;
 		}
@@ -248,4 +247,17 @@ html {
 
 .empty-content__illustration {
 	filter: hue-rotate( -80deg ) saturate( 1.5 );
+}
+
+.no-sites-message,
+.no-visible-sites-message {
+	.empty-content__illustration {
+		filter: none;
+	}
+
+	.empty-content__title,
+	.empty-content__line {
+		font-weight: 400;
+		line-height: inherit;
+	}
 }

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -152,6 +152,7 @@ export function renderNoVisibleSites( context ) {
 		actionURL: '//dashboard.wordpress.com/wp-admin/index.php?page=my-blogs',
 		secondaryAction: i18n.translate( 'Create New Site' ),
 		secondaryActionURL: `${ onboardingUrl }?ref=calypso-nosites`,
+		className: 'no-visible-sites-message',
 	} );
 
 	makeLayout( context, noop );

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -12,6 +12,8 @@
 
 .sites__select-heading {
 	font-size: $font-title-small;
+	font-weight: 400;
+	line-height: inherit;
 	margin-top: 16px;
 	margin-bottom: 24px;
 
@@ -25,5 +27,16 @@
 
 	.site-selector {
 		overflow: auto;
+	}
+}
+
+/**
+ * Jetpack cloud specific styles
+ */
+
+.is-section-jetpack-cloud {
+	.sites {
+		padding-left: 0;
+		padding-right: 0;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

Jetpack cloud has some base styles that are imported in the sidebar component. The landing page doesn't have a sidebar and therefore these styles aren't applied there. This PR fixes this by importing these styles in the masterbar instead.

This update makes base components have the same styles across the platform, which will make fixing contrast issues easier in a next PR.

### Implementation notes

A further improvement might be to import cloud base styles directly via a webpack config.

### Testing instructions

- Download the PR and run Jetpack cloud
- Visit the landing page
- Check that the 3 states mentioned below match production (to easily simulate these states, edit the `noSite` middleware locally at `client/jetpack-cloud/controller.ts`). Note that the input placeholder and secondary button match the rest of the site rather than the landing page in production.

### Screenshots

_No site_
<img width="817" alt="Screen Shot 2021-03-17 at 10 13 15 AM" src="https://user-images.githubusercontent.com/1620183/111485540-131e2780-870d-11eb-8081-cbc35b75c28e.png">


_No visible site_
![screenshot (1)](https://user-images.githubusercontent.com/1620183/111487332-a572fb00-870e-11eb-834b-b89171389a45.png)



_1+ site_
![screenshot](https://user-images.githubusercontent.com/1620183/111487302-9e4bed00-870e-11eb-805b-6e8930c662a4.png)

