### PR TITLE
Replace VideoPress JS player with iFrame

### DIFF
--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -126,8 +126,6 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 		const { isPlaying, item } = this.props;
 		const { height = 480, videopress_guid, width = 854 } = item;
 
-		// todo: Build the URL based on available params
-		// EX: add autoPlay = {props.isPlaying}
 		const params = {
 			autoPlay: isPlaying,
 			height,

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -4,21 +4,12 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { get, invoke } from 'lodash';
+import { get, keys } from 'lodash';
 import classNames from 'classnames';
-import debug from 'debug';
-import wpcomProxyRequest from 'wpcom-proxy-request';
-
-/**
- * Internal dependencies
- */
-import { loadScript, removeScriptCallback } from '@automattic/load-script';
 
 /**
  * Module variables
  */
-const log = debug( 'calypso:post-editor:videopress' );
-const videoPressUrl = 'https://wordpress.com/wp-content/plugins/video/assets/js/next/videopress.js';
 const noop = () => {};
 
 class EditorMediaModalDetailPreviewVideoPress extends Component {
@@ -27,24 +18,20 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 		isPlaying: PropTypes.bool,
 		item: PropTypes.object.isRequired,
 		onPause: PropTypes.func,
-		onScriptLoadError: PropTypes.func,
 		onVideoLoaded: PropTypes.func,
 	};
 
 	static defaultProps = {
 		isPlaying: false,
 		onPause: noop,
-		onScriptLoadError: noop,
 		onVideoLoaded: noop,
 	};
 
 	componentDidMount() {
-		this.loadInitializeScript();
 		window.addEventListener( 'message', this.receiveMessage, false );
 	}
 
 	componentWillUnmount() {
-		removeScriptCallback( videoPressUrl, this.onScriptLoaded );
 		this.destroy();
 	}
 
@@ -59,7 +46,6 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	componentDidUpdate( prevProps ) {
 		if ( this.props.item.videopress_guid !== prevProps.item.videopress_guid ) {
 			this.destroy();
-			this.loadInitializeScript();
 		}
 	}
 
@@ -71,78 +57,10 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 		return false;
 	}
 
-	// Run requests through the rest proxy to support loading private videos.
-	requestProvider = ( observable ) => {
-		return () => {
-			return observable( ( set, reject, done ) => {
-				const { videopress_guid: guid } = this.props.item;
-
-				if ( ! guid ) {
-					return;
-				}
-
-				const getVideo = ( id ) => {
-					const data = { path: '/videos/' + id };
-
-					wpcomProxyRequest( data, function ( err, body, headers ) {
-						if ( err ) {
-							return;
-						}
-
-						// If an upload_date property is present, we have a valid response.
-						if ( body.upload_date != null ) {
-							done( body );
-						} else {
-							const error = new Error( body ? body.message : 'Unknown' );
-							error.code = body ? body.error : null;
-							error.errorMessage = body ? body.errorMessage : null;
-							error.status = headers.status;
-							reject( error );
-						}
-					} );
-				};
-
-				getVideo( guid );
-
-				return () => {};
-			} );
-		};
-	};
-
 	setVideoInstance = ( ref ) => ( this.video = ref );
 
-	loadInitializeScript() {
-		loadScript( videoPressUrl, this.onScriptLoaded );
-	}
-
-	onScriptLoaded = ( error ) => {
-		const { isPlaying, item, onScriptLoadError } = this.props;
-
-		if ( error ) {
-			log( `Script${ get( error, 'src', '' ) } failed to load.` );
-			onScriptLoadError();
-
-			return;
-		}
-
-		const { height = 480, videopress_guid, width = 854 } = item;
-
-		if ( ! videopress_guid ) {
-			return;
-		}
-
-		if ( typeof window !== 'undefined' && window.videopress ) {
-			this.player = window.videopress( videopress_guid, this.video, {
-				autoPlay: isPlaying,
-				height,
-				width,
-				requestProvider: this.requestProvider,
-			} );
-		}
-	};
-
 	receiveMessage = ( event ) => {
-		if ( event.origin && event.origin !== location.origin ) {
+		if ( event.origin && event.origin !== 'https://video.wordpress.com' ) {
 			return;
 		}
 
@@ -150,26 +68,30 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 
 		if (
 			! data ||
-			'videopress_loading_state' !== data.event ||
-			! ( 'state' in data ) ||
-			! ( 'converting' in data )
+			-1 ===
+				[ 'videopress_loading_state', 'videopress_action_pause_response' ].indexOf( data.event )
 		) {
 			return;
 		}
 
-		if ( 'loaded' === data.state && ! data.converting ) {
+		if (
+			'videopress_loading_state' === data.event &&
+			'loaded' === get( data, 'state' ) &&
+			! get( data, 'converting' )
+		) {
 			this.props.onVideoLoaded();
+		} else if ( 'videopress_action_pause_response' === data.event ) {
+			const currentTime = get( data, 'currentTime' );
+			this.props.onPause( currentTime );
 		}
 	};
 
 	destroy() {
 		window.removeEventListener( 'message', this.receiveMessage );
 
-		if ( ! this.player ) {
+		if ( ! this.video ) {
 			return;
 		}
-
-		invoke( this, 'player.destroy' );
 
 		// Remove DOM created outside of React.
 		while ( this.video.firstChild ) {
@@ -178,37 +100,46 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	}
 
 	play() {
-		const playerState = get( this, 'player.state' );
-
-		if ( ! playerState ) {
+		if ( ! this.video ) {
 			return;
 		}
 
-		invoke( this, 'player.state.play' );
+		this.video.contentWindow.postMessage(
+			{ event: 'videopress_action_play' },
+			'https://video.wordpress.com'
+		);
 	}
 
 	pause() {
-		const playerState = get( this, 'player.state' );
-
-		if ( ! playerState ) {
+		if ( ! this.video ) {
 			return;
 		}
 
-		invoke( this, 'player.state.pause' );
-
-		const currentTime = invoke( this, 'player.state.videoAt' );
-
-		if ( ! currentTime ) {
-			return;
-		}
-
-		this.props.onPause( currentTime );
+		this.video.contentWindow.postMessage(
+			{ event: 'videopress_action_pause' },
+			'https://video.wordpress.com'
+		);
 	}
 
 	render() {
 		const classes = classNames( this.props.className, 'is-video' );
+		const { isPlaying, item } = this.props;
+		const { height = 480, videopress_guid, width = 854 } = item;
 
-		return <div className={ classes } ref={ this.setVideoInstance } />;
+		// todo: Build the URL based on available params
+		// EX: add autoPlay = {props.isPlaying}
+		const params = {
+			autoPlay: isPlaying,
+			height,
+			width,
+			fill: true,
+		};
+		const qs = keys( params ).map( ( key ) => `${ key }=${ params[ key ] }` );
+		const videoUrl = `https://video.wordpress.com/v/${ videopress_guid }?${ qs.join( '&' ) }`;
+
+		return (
+			<iframe title="Video" src={ videoUrl } className={ classes } ref={ this.setVideoInstance } />
+		);
 	}
 }
 


### PR DESCRIPTION
The incoming HLS streaming support in VideoPress requires CORS support that we may not be able to support on arbitrary domains for displaying private video content. Switching the VideoPress player to the iframe embed will give us a consistent origin that will allow us to provide the player the access it needs to private videos.

This will also update the current player to the videojs player which no longer has a `state` object to inspect or execute actions against, so `postMessage` has been used instead in order to control the player through the iframe.


#### Changes proposed in this Pull Request

* replace the VideoPress js player with the iframe embed
* re-implement player control (play / pause) as `postMessage` calls to the iframe

#### Testing instructions

This PR depends on changes to the VideoPress player to add support for the new `postMessage` calls ( 309-gh-Automattic/videopress ), and to wordpress.com in order to support the new CORS headers ( D58751-code )

* Select a site that has VideoPress enabled
* Select a video from the media library
* The video player should work correctly in the preview window
* Press `Edit Thumbnail`
* The video player should work correctly in the preview window. The `Select Frame` button should become clickable once the video loads and clicking it should not throw any errors on screen.
* Return to the media library and the new thumbnail should be displayed (you may need to refresh).

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #