### PR TITLE
Playwright: implement a basic browser manager.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -799,6 +799,9 @@ object RunCalypsoPlaywrightE2eTests : BuildType({
 				# Decrypt config
 				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
 
+				# Compile TypeScript
+				yarn build
+
 				# Run the test
 				export BROWSERSIZE="mobile"
 				export BROWSERLOCALE="en"

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -745,6 +745,10 @@ object RunCalypsoPlaywrightE2eTests : BuildType({
 
 				# Install modules
 				yarn install
+
+				# Compile TypeScript
+				yarn build
+
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}
@@ -798,9 +802,6 @@ object RunCalypsoPlaywrightE2eTests : BuildType({
 
 				# Decrypt config
 				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
-
-				# Compile TypeScript
-				yarn build
 
 				# Run the test
 				export BROWSERSIZE="mobile"

--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -12,3 +12,6 @@
 
 # chromedriver logs
 chrome*.log
+
+# typescript output
+dist/

--- a/test/e2e/lib/browser-manager.js
+++ b/test/e2e/lib/browser-manager.js
@@ -1,0 +1,116 @@
+/**
+ * @file Manages instance of Playwright Browser and BrowserContext.
+ * @author Edwin Takahashi
+ */
+
+/**
+ * External dependencies
+ */
+import config from 'config';
+import playwright from 'playwright';
+
+const browserStartTimeoutMS = 2000;
+
+export let browser;
+
+/**
+ * Returns the target screen size for tests to run against.
+ *
+ * By default, this function will return 'desktop' as the target.
+ * To specify another screen size, set the BROWSERSIZE environment variable.
+ *
+ * @returns {string} String representation of the target screen size.
+ */
+export function targetScreenSize() {
+	return ! process.env.BROWSERSIZE ? 'desktop' : process.env.BROWSERSIZE.toLowerCase();
+}
+
+/**
+ * Returns the locale under test.
+ *
+ * By default, this function will return 'en' as the locale.
+ * To set the locale, set the BROWSERLOCALE environment variable.
+ *
+ * @returns {string} String representation of the locale.
+ */
+export function targetLocale() {
+	return ! process.env.BROWSERLOCALE ? 'en' : process.env.BROWSERLOCALE.toLowerCase();
+}
+
+/**
+ * Returns a set of screen dimensions in numbers.
+ *
+ * This function takes the string output of `targetScreenSize` and returns an object
+ * key/value mapping of the screen diemensions represented by the string.
+ *
+ * @returns {Number, Number} Object with key/value mapping of screen dimensions.
+ */
+export function getScreenDimension() {
+	switch ( targetScreenSize() ) {
+		case 'mobile':
+			return { width: 400, height: 1000 };
+		case 'tablet':
+			return { width: 1024, height: 1000 };
+		case 'desktop':
+			return { width: 1440, height: 1000 };
+		case 'laptop':
+			return { width: 1400, height: 790 };
+		default:
+			throw new Error( 'Unsupported screen size specified.' );
+	}
+}
+
+/**
+ * Returns a new instance of a BrowserContext.
+ *
+ * A BrowserContext represents an isolated environment, akin to incognito mode
+ * inside which a single test suite is run.
+ * BrowserContexts are cheap to create and incur low overhead costs while allowing
+ * for parallelization of test suites.
+ *
+ * @returns {Promise<playwright.BrowserContext>} New BrowserContext instance.
+ */
+export async function newBrowserContext() {
+	// If no existing instance of a Browser, then launch a new instance.
+	if ( ! browser ) {
+		browser = await launchBrowser();
+	}
+
+	// Generate a new BrowserContext.
+	return await browser.newContext( {
+		viewport: null, // Do not override window size set in the browser launch parameters.
+	} );
+}
+
+/**
+ * Returns a new instance of a Browser.
+ *
+ * A Browser instance can be any one of the browser types supported by Playwright.
+ * Considerable overhead and costs are incurred when launching a new Browser instance.
+ *
+ * @returns {Promise<playwright.Browser>} New Browser instance.
+ */
+export async function launchBrowser() {
+	const isHeadless =
+		process.env.HEADLESS === 'true' || config.has( 'headless' ) === 'true' ? true : false;
+
+	const dimension = getScreenDimension();
+	return await playwright.chromium.launch( {
+		headless: isHeadless,
+		args: [ '--window-position=0,0', `--window-size=${ dimension.width },${ dimension.height }` ],
+		timeout: browserStartTimeoutMS,
+	} );
+}
+
+/**
+ * Terminates an instance of the Browser.
+ *
+ * When called, this function will unset the reference to the browser instance,
+ * then call on the browser to terminate all instances of existing BrowserContexts.
+ * Any open pages are also destroyed in this process.
+ *
+ */
+export function quitBrowser() {
+	browser.close();
+	browser = undefined;
+}

--- a/test/e2e/lib/browser-manager.ts
+++ b/test/e2e/lib/browser-manager.ts
@@ -6,12 +6,12 @@
 /**
  * External dependencies
  */
+import { Browser, BrowserContext, chromium } from 'playwright';
 import config from 'config';
-import playwright from 'playwright';
 
 const browserStartTimeoutMS = 2000;
 
-export let browser;
+export let browser: Browser;
 
 /**
  * Returns the target screen size for tests to run against.
@@ -21,7 +21,7 @@ export let browser;
  *
  * @returns {string} String representation of the target screen size.
  */
-export function targetScreenSize() {
+export function targetScreenSize(): string {
 	return ! process.env.BROWSERSIZE ? 'desktop' : process.env.BROWSERSIZE.toLowerCase();
 }
 
@@ -33,7 +33,7 @@ export function targetScreenSize() {
  *
  * @returns {string} String representation of the locale.
  */
-export function targetLocale() {
+export function targetLocale(): string {
 	return ! process.env.BROWSERLOCALE ? 'en' : process.env.BROWSERLOCALE.toLowerCase();
 }
 
@@ -43,9 +43,10 @@ export function targetLocale() {
  * This function takes the string output of `targetScreenSize` and returns an object
  * key/value mapping of the screen diemensions represented by the string.
  *
- * @returns {Number, Number} Object with key/value mapping of screen dimensions.
+ * @returns {number, number} Object with key/value mapping of screen dimensions.
+ * @throws {Error} If target screen size was not set.
  */
-export function getScreenDimension() {
+export function getScreenDimension(): { width: number; height: number } {
 	switch ( targetScreenSize() ) {
 		case 'mobile':
 			return { width: 400, height: 1000 };
@@ -68,9 +69,9 @@ export function getScreenDimension() {
  * BrowserContexts are cheap to create and incur low overhead costs while allowing
  * for parallelization of test suites.
  *
- * @returns {Promise<playwright.BrowserContext>} New BrowserContext instance.
+ * @returns {Promise<BrowserContext>} New BrowserContext instance.
  */
-export async function newBrowserContext() {
+export async function newBrowserContext(): Promise< BrowserContext > {
 	// If no existing instance of a Browser, then launch a new instance.
 	if ( ! browser ) {
 		browser = await launchBrowser();
@@ -88,14 +89,13 @@ export async function newBrowserContext() {
  * A Browser instance can be any one of the browser types supported by Playwright.
  * Considerable overhead and costs are incurred when launching a new Browser instance.
  *
- * @returns {Promise<playwright.Browser>} New Browser instance.
+ * @returns {Promise<Browser>} New Browser instance.
  */
-export async function launchBrowser() {
-	const isHeadless =
-		process.env.HEADLESS === 'true' || config.has( 'headless' ) === 'true' ? true : false;
+export async function launchBrowser(): Promise< Browser > {
+	const isHeadless = process.env.HEADLESS === 'true' || config.has( 'headless' );
 
 	const dimension = getScreenDimension();
-	return await playwright.chromium.launch( {
+	return await chromium.launch( {
 		headless: isHeadless,
 		args: [ '--window-position=0,0', `--window-size=${ dimension.width },${ dimension.height }` ],
 		timeout: browserStartTimeoutMS,
@@ -109,8 +109,8 @@ export async function launchBrowser() {
  * then call on the browser to terminate all instances of existing BrowserContexts.
  * Any open pages are also destroyed in this process.
  *
+ * @returns {void} No return value.
  */
-export function quitBrowser() {
+export function quitBrowser(): void {
 	browser.close();
-	browser = undefined;
 }

--- a/test/e2e/lib/browser-manager.ts
+++ b/test/e2e/lib/browser-manager.ts
@@ -9,6 +9,11 @@
 import { Browser, BrowserContext, chromium } from 'playwright';
 import config from 'config';
 
+/**
+ * Internal dependencies
+ */
+import type { screenSize, localeCode } from './types';
+
 const browserStartTimeoutMS = 2000;
 
 export let browser: Browser;
@@ -19,10 +24,12 @@ export let browser: Browser;
  * By default, this function will return 'desktop' as the target.
  * To specify another screen size, set the BROWSERSIZE environment variable.
  *
- * @returns {string} String representation of the target screen size.
+ * @returns {screenSize} Target screen size.
  */
-export function targetScreenSize(): string {
-	return ! process.env.BROWSERSIZE ? 'desktop' : process.env.BROWSERSIZE.toLowerCase();
+export function getTargetScreenSize(): screenSize {
+	return ! process.env.BROWSERSIZE
+		? 'desktop'
+		: ( process.env.BROWSERSIZE.toLowerCase() as screenSize );
 }
 
 /**
@@ -31,23 +38,24 @@ export function targetScreenSize(): string {
  * By default, this function will return 'en' as the locale.
  * To set the locale, set the BROWSERLOCALE environment variable.
  *
- * @returns {string} String representation of the locale.
+ * @returns {localeCode} Target locale code.
  */
-export function targetLocale(): string {
+export function getTargetLocale(): localeCode {
 	return ! process.env.BROWSERLOCALE ? 'en' : process.env.BROWSERLOCALE.toLowerCase();
 }
 
 /**
  * Returns a set of screen dimensions in numbers.
  *
- * This function takes the string output of `targetScreenSize` and returns an object
- * key/value mapping of the screen diemensions represented by the string.
+ * This function takes the output of `getTargetScreenSize` and returns an
+ * object key/value mapping of the screen diemensions represented by
+ * the output.
  *
  * @returns {number, number} Object with key/value mapping of screen dimensions.
  * @throws {Error} If target screen size was not set.
  */
 export function getScreenDimension(): { width: number; height: number } {
-	switch ( targetScreenSize() ) {
+	switch ( getTargetScreenSize() ) {
 		case 'mobile':
 			return { width: 400, height: 1000 };
 		case 'tablet':

--- a/test/e2e/lib/types.ts
+++ b/test/e2e/lib/types.ts
@@ -1,0 +1,3 @@
+// Browser Manager
+export type screenSize = 'desktop' | 'mobile' | 'laptop' | 'tablet';
+export type localeCode = string;

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -11,6 +11,7 @@
 	"defaultTestArgs": "-g -s $BROWSERSIZE",
 	"scripts": {
 		"build": "tsc --build ./tsconfig.json",
+		"clean": "tsc --build ./tsconfig.json --clean && npx rimraf dist",
 		"lint": "eslint . --max-warnings=0",
 		"precommitlint": "LIST=`git diff-index --name-only HEAD | grep js$`; if [ \"$LIST\" ]; then eslint $LIST --max-warnings=0; fi",
 		"precommit": "node scripts/pre-commit-hook.js",
@@ -69,7 +70,6 @@
 		"testarmada-magellan": "11.0.10",
 		"testarmada-magellan-local-executor": "^2.0.3",
 		"testarmada-magellan-mocha-plugin": "github:Automattic/magellan-mocha-plugin#b731cdf6f27a6fa6e45ddcba0b8741370b2df523",
-		"typescript": "^4.1.3",
 		"xml2json-command": "^0.0.3",
 		"xmpp.js": "^0.3.0",
 		"xunit-viewer": "^5.1.8"

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -10,6 +10,7 @@
 	"main": "greetings.js",
 	"defaultTestArgs": "-g -s $BROWSERSIZE",
 	"scripts": {
+		"build": "tsc --build ./tsconfig.json",
 		"lint": "eslint . --max-warnings=0",
 		"precommitlint": "LIST=`git diff-index --name-only HEAD | grep js$`; if [ \"$LIST\" ]; then eslint $LIST --max-warnings=0; fi",
 		"precommit": "node scripts/pre-commit-hook.js",
@@ -23,6 +24,7 @@
 		"@babel/preset-env": "^7.3.1",
 		"@babel/register": "^7.0.0",
 		"@babel/runtime": "^7.3.1",
+		"@types/config": "0.0.38",
 		"@xmpp/plugins": "^0.3.0",
 		"asana-phrase": "^0.0.8",
 		"cached-path-relative": ">=1.0.2",
@@ -67,6 +69,7 @@
 		"testarmada-magellan": "11.0.10",
 		"testarmada-magellan-local-executor": "^2.0.3",
 		"testarmada-magellan-mocha-plugin": "github:Automattic/magellan-mocha-plugin#b731cdf6f27a6fa6e45ddcba0b8741370b2df523",
+		"typescript": "^4.1.3",
 		"xml2json-command": "^0.0.3",
 		"xmpp.js": "^0.3.0",
 		"xunit-viewer": "^5.1.8"

--- a/test/e2e/specs-playwright/wp-log-in-out-spec.js
+++ b/test/e2e/specs-playwright/wp-log-in-out-spec.js
@@ -6,7 +6,7 @@ import config from 'config';
 /**
  * Internal dependencies
  */
-import * as browserManager from '../lib/browser-manager';
+import * as browserManager from '../dist/lib/browser-manager';
 
 import LoginPage from '../lib/pages/login-page';
 

--- a/test/e2e/specs-playwright/wp-log-in-out-spec.js
+++ b/test/e2e/specs-playwright/wp-log-in-out-spec.js
@@ -43,4 +43,8 @@ describe( `Auth Screen @canary @parallel`, function () {
 			return await page.goto( url, { waitUntill: 'networkidle' } );
 		} );
 	} );
+
+	after( 'close browser', function () {
+		browserManager.quitBrowser();
+	} );
 } );

--- a/test/e2e/specs-playwright/wp-log-in-out-spec.js
+++ b/test/e2e/specs-playwright/wp-log-in-out-spec.js
@@ -1,32 +1,46 @@
 /**
  * External dependencies
  */
+import config from 'config';
 
-import playwright from 'playwright';
+/**
+ * Internal dependencies
+ */
+import * as browserManager from '../lib/browser-manager';
 
 import LoginPage from '../lib/pages/login-page';
 
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+
 describe( `Auth Screen @canary @parallel`, function () {
-	this.timeout( 30000 );
+	this.timeout( mochaTimeOut );
+
+	// BrowserContext is equivalent to the `driver` used in Selenium.
+	let browserContext;
+	// Page represents a tab in a browser.
+	// Test steps interact with the page to execute its instructions.
 	let page;
-	let browser;
 
 	before( 'Start browser', async function () {
-		browser = await playwright.chromium.launch( {
-			headless: false,
-		} );
-		const browserContext = await browser.newContext();
+		browserContext = await browserManager.newBrowserContext();
+	} );
+
+	beforeEach( 'Open new test tab', async function () {
 		page = await browserContext.newPage();
+		// Set the page using mocha's metadata. Upon test failure,
+		// mocha hooks can access the page to perform actions.
+		this.currentTest.page = page;
 	} );
 
-	describe( 'Loading the log-in screen using Playwright', function () {
-		step( 'Can see the log in screen', async function () {
+	describe( 'Loading the log-in page', function () {
+		step( 'Can see the log in page', async function () {
 			const url = LoginPage.getLoginURL();
-			await page.goto( url, { waitUntill: 'networkidle' } );
+			/* 
+			Waits for network activity to cease.
+			Only as a proof of concept. In a production test, should check
+			for the presence of desired elements using a selector.
+			*/
+			return await page.goto( url, { waitUntill: 'networkidle' } );
 		} );
-	} );
-
-	after( 'close browser', function () {
-		browser.close();
 	} );
 } );

--- a/test/e2e/tsconfig.json
+++ b/test/e2e/tsconfig.json
@@ -1,22 +1,26 @@
 {
-	"extends": "@automattic/calypso-build/tsconfig",
 	"compilerOptions": {
-		"allowSyntheticDefaultImports": true,
-		// Target latest version of ECMAScript.
-		"target": "ESNext",
-		// Search under node_modules for non-relative imports.
-		"moduleResolution": "node",
-		// Process & infer types from .js files.
+		"target": "es2020",
+		"lib": [ "DOM", "es2020" ],
+		"baseUrl": ".",
+		"module": "commonjs",
 		"allowJs": false,
-		// Don't emit; allow Babel to transform files.
-		"noEmit": false,
-		// Enable strictest settings like strictNullChecks & noImplicitAny.
+		"declaration": true,
+		"declarationDir": "types",
+		"outDir": "dist",
+		"rootDir": ".",
 		"strict": true,
-		// Import non-ES modules as default imports.
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"moduleResolution": "node",
 		"esModuleInterop": true,
-		"skipLibCheck": true,
-		"module": "CommonJS"
+		"forceConsistentCasingInFileNames": true,
+		"types": [ "node" ],
+		"noEmitHelpers": true,
+		"importHelpers": true,
+		"composite": true
 	},
-	"include": [ "lib" ],
-	"exclude": [ "node_modules", "specs**/" ]
+	"include": [ "lib" ]
 }

--- a/test/e2e/tsconfig.json
+++ b/test/e2e/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		// Target latest version of ECMAScript.
+		"target": "ESNext",
+		// Search under node_modules for non-relative imports.
+		"moduleResolution": "node",
+		// Process & infer types from .js files.
+		"allowJs": false,
+		// Don't emit; allow Babel to transform files.
+		"noEmit": false,
+		// Enable strictest settings like strictNullChecks & noImplicitAny.
+		"strict": true,
+		// Import non-ES modules as default imports.
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"module": "CommonJS"
+	},
+	"include": [ "lib" ],
+	"exclude": [ "node_modules", "specs**/" ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3549,6 +3549,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/config@0.0.38":
+  version "0.0.38"
+  resolved "https://registry.yarnpkg.com/@types/config/-/config-0.0.38.tgz#ca30679b21b5b297299467e3a3f1c8e2e64b9170"
+  integrity sha512-z2WizAfIFgSv8SQfQ8c0LlbDAcK47D/o93XW6bxZ9t3bs4fmmfAPjk1nhAIBTG84PBBCHfSPM+8g7vhLdbFokg==
+
 "@types/cookie@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.0.tgz#14f854c0f93d326e39da6e3b6f34f7d37513d108"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Implement a basic `browser-manager.js` that provides convenient utilities to manage the Playwright browser instance. Its functions are modelled after the Selenium-based `driver-helper.js` file.

##### Functions implemented

- screen size
- locale
- generate new context
- launch new browser
- quit browser

Note that:
- BrowserManager uses BrowserContexts instead of starting a new Browser instance for [performance reasons](https://playwright.dev/docs/core-concepts#browser-contexts). 
- Only one browser is ever launched.

The demonstration script `Auth screen canary` has been updated to use abilities offered by browser-manager.

#### Testing instructions

Ensure that tests can run on TeamCity using the new browser manager. Example TeamCity run is shown [here](https://teamcity.a8c.com/buildConfiguration/calypso_RunCalypsoPlaywrightE2eTests/6019216).

Partially implements #51082.
