### PR TITLE
Implement popular Security products experiment

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -59,4 +59,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: false,
 	},
+	pricingPagePopularProducts: {
+		datestamp: '20210324',
+		variations: {
+			withComplete_control: 50,
+			withSecurityRT_test: 50,
+		},
+		defaultVariation: 'withComplete_control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/plans/jetpack-plans/iterations.ts
+++ b/client/my-sites/plans/jetpack-plans/iterations.ts
@@ -1,13 +1,16 @@
 /**
  * Internal dependencies
  */
+import { abtest } from 'calypso/lib/abtest';
 import { getUrlParts } from 'calypso/lib/url/url-parts';
 
 /**
  * Iterations
  */
 
-export enum Iterations {}
+export enum Iterations {
+	SECURITY = 'securityPopularProducts',
+}
 
 const iterationNames: string[] = Object.values( Iterations );
 
@@ -38,7 +41,9 @@ const getCurrentCROIterationName = (): Iterations | null => {
 		}
 	}
 
-	return null;
+	return abtest( 'pricingPagePopularProducts' ) === 'withSecurityRT_test'
+		? Iterations.SECURITY
+		: null;
 };
 
 type IterationValueFunction< T > = ( key: Iterations | null ) => T | undefined;

--- a/client/my-sites/plans/jetpack-plans/product-grid/products-order.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/products-order.ts
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { getForCurrentCROIteration, Iterations } from '../iterations';
 import {
 	PLAN_JETPACK_SECURITY_DAILY,
 	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
@@ -44,5 +45,27 @@ const PRODUCT_POSITION_IN_GRID: Record< string, number > = {
 	...setProductsInPosition( JETPACK_CRM_FREE_PRODUCTS, 80 ),
 };
 
-export const getProductPosition = ( slug: JetpackPlanSlugs | JetpackProductSlug ): number =>
-	PRODUCT_POSITION_IN_GRID[ slug ] ?? 100;
+const PRODUCT_POSITION_IN_GRID_SECURITY: Record< string, number > = {
+	[ PRODUCT_JETPACK_BACKUP_DAILY ]: 1,
+	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: 1,
+	[ PLAN_JETPACK_SECURITY_DAILY ]: 10,
+	[ PLAN_JETPACK_SECURITY_DAILY_MONTHLY ]: 10,
+	[ PLAN_JETPACK_SECURITY_REALTIME ]: 20,
+	[ PLAN_JETPACK_SECURITY_REALTIME_MONTHLY ]: 20,
+	...setProductsInPosition( JETPACK_COMPLETE_PLANS, 30 ),
+	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: 40,
+	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: 40,
+	...setProductsInPosition( JETPACK_SCAN_PRODUCTS, 50 ),
+	...setProductsInPosition( JETPACK_ANTI_SPAM_PRODUCTS, 60 ),
+	...setProductsInPosition( JETPACK_SEARCH_PRODUCTS, 70 ),
+	...setProductsInPosition( JETPACK_CRM_FREE_PRODUCTS, 80 ),
+};
+
+export const getProductPosition = ( slug: JetpackPlanSlugs | JetpackProductSlug ): number => {
+	const positions =
+		getForCurrentCROIteration( {
+			[ Iterations.SECURITY ]: PRODUCT_POSITION_IN_GRID_SECURITY,
+		} ) || PRODUCT_POSITION_IN_GRID;
+
+	return positions[ slug ] ?? 100;
+};


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR implements a new A/B test for the pricing page. It puts Security products in the popular products section.

Fixes 1196108640073826-as-1199946500089743

### Testing instructions

- Download the PR and run both Calypso and cloud concurrently
- Notice the new experiment `pricingPagePopularProducts` in the A/B test menu
- Select the `withComplete_control` variation
- Check that the page behaves as in production (especially the order of products)
- Select the `withSecurityRT_test` variation
- Check that the order of products in the popular section is now Backup Daily, Security Daily, and Security Real-time

### Screenshots

#### Calypso

_Before_
<img width="1552" alt="Screen Shot 2021-03-17 at 2 14 18 PM" src="https://user-images.githubusercontent.com/1620183/111521754-e0d1f180-872f-11eb-8cf5-f21a48e97f89.png">

_After_
<img width="1552" alt="Screen Shot 2021-03-17 at 2 22 48 PM" src="https://user-images.githubusercontent.com/1620183/111521778-e8919600-872f-11eb-85f8-59ebfa49192c.png">
 
<img width="1552" alt="Screen Shot 2021-03-17 at 2 22 53 PM" src="https://user-images.githubusercontent.com/1620183/111521795-ef200d80-872f-11eb-9c9d-96729ed340e7.png">


#### Cloud

_Before_
<img width="1552" alt="Screen Shot 2021-03-17 at 2 22 26 PM" src="https://user-images.githubusercontent.com/1620183/111521820-f3e4c180-872f-11eb-96c3-040cc2b73e81.png">

_After_
<img width="1552" alt="Screen Shot 2021-03-17 at 2 23 09 PM" src="https://user-images.githubusercontent.com/1620183/111521845-fb0bcf80-872f-11eb-8596-f4f7d0fa2785.png">
<img width="1552" alt="Screen Shot 2021-03-17 at 2 23 12 PM" src="https://user-images.githubusercontent.com/1620183/111521863-00691a00-8730-11eb-9849-199084ed2259.png">