### PR TITLE
Checkout: Convert PayPal payment processor to TypeScript

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -88,6 +88,7 @@ import mergeIfObjects from './lib/merge-if-objects';
 import type { ReactStandardAction } from './types/analytics';
 import useCreatePaymentCompleteCallback from './hooks/use-create-payment-complete-callback';
 import useMaybeJetpackIntroCouponCode from './hooks/use-maybe-jetpack-intro-coupon-code';
+import type { PaymentProcessorOptions } from './types/payment-processors';
 
 const { colors } = colorStudio;
 const debug = debugFactory( 'calypso:composite-checkout:composite-checkout' );
@@ -429,33 +430,29 @@ export default function CompositeCheckout( {
 	const includeDomainDetails = contactDetailsType === 'domain';
 	const includeGSuiteDetails = contactDetailsType === 'gsuite';
 	const transactionOptions = { createUserAndSiteBeforeTransaction };
-	const dataForProcessor = useMemo(
+	const dataForProcessor: PaymentProcessorOptions = useMemo(
 		() => ( {
+			createUserAndSiteBeforeTransaction,
+			getThankYouUrl,
 			includeDomainDetails,
 			includeGSuiteDetails,
 			recordEvent,
-			createUserAndSiteBeforeTransaction,
-			stripeConfiguration,
 			reduxDispatch,
 			responseCart,
+			siteSlug,
+			stripeConfiguration,
 		} ),
 		[
+			createUserAndSiteBeforeTransaction,
+			getThankYouUrl,
 			includeDomainDetails,
 			includeGSuiteDetails,
 			recordEvent,
-			createUserAndSiteBeforeTransaction,
-			stripeConfiguration,
 			reduxDispatch,
 			responseCart,
-		]
-	);
-	const dataForRedirectProcessor = useMemo(
-		() => ( {
-			...dataForProcessor,
-			getThankYouUrl,
 			siteSlug,
-		} ),
-		[ dataForProcessor, getThankYouUrl, siteSlug ]
+			stripeConfiguration,
+		]
 	);
 
 	const domainDetails = getDomainDetails( {
@@ -473,27 +470,26 @@ export default function CompositeCheckout( {
 			card: ( transactionData: unknown ) =>
 				multiPartnerCardProcessor( transactionData, dataForProcessor, transactionOptions ),
 			alipay: ( transactionData: unknown ) =>
-				genericRedirectProcessor( 'alipay', transactionData, dataForRedirectProcessor ),
+				genericRedirectProcessor( 'alipay', transactionData, dataForProcessor ),
 			p24: ( transactionData: unknown ) =>
-				genericRedirectProcessor( 'p24', transactionData, dataForRedirectProcessor ),
+				genericRedirectProcessor( 'p24', transactionData, dataForProcessor ),
 			bancontact: ( transactionData: unknown ) =>
-				genericRedirectProcessor( 'bancontact', transactionData, dataForRedirectProcessor ),
+				genericRedirectProcessor( 'bancontact', transactionData, dataForProcessor ),
 			giropay: ( transactionData: unknown ) =>
-				genericRedirectProcessor( 'giropay', transactionData, dataForRedirectProcessor ),
-			wechat: ( transactionData: unknown ) =>
-				weChatProcessor( transactionData, dataForRedirectProcessor ),
+				genericRedirectProcessor( 'giropay', transactionData, dataForProcessor ),
+			wechat: ( transactionData: unknown ) => weChatProcessor( transactionData, dataForProcessor ),
 			netbanking: ( transactionData: unknown ) =>
-				genericRedirectProcessor( 'netbanking', transactionData, dataForRedirectProcessor ),
+				genericRedirectProcessor( 'netbanking', transactionData, dataForProcessor ),
 			id_wallet: ( transactionData: unknown ) =>
-				genericRedirectProcessor( 'id_wallet', transactionData, dataForRedirectProcessor ),
+				genericRedirectProcessor( 'id_wallet', transactionData, dataForProcessor ),
 			ideal: ( transactionData: unknown ) =>
-				genericRedirectProcessor( 'ideal', transactionData, dataForRedirectProcessor ),
+				genericRedirectProcessor( 'ideal', transactionData, dataForProcessor ),
 			sofort: ( transactionData: unknown ) =>
-				genericRedirectProcessor( 'sofort', transactionData, dataForRedirectProcessor ),
+				genericRedirectProcessor( 'sofort', transactionData, dataForProcessor ),
 			eps: ( transactionData: unknown ) =>
-				genericRedirectProcessor( 'eps', transactionData, dataForRedirectProcessor ),
+				genericRedirectProcessor( 'eps', transactionData, dataForProcessor ),
 			'ebanx-tef': ( transactionData: unknown ) =>
-				genericRedirectProcessor( 'brazil-tef', transactionData, dataForRedirectProcessor ),
+				genericRedirectProcessor( 'brazil-tef', transactionData, dataForProcessor ),
 			'full-credits': ( transactionData: unknown ) =>
 				fullCreditsProcessor( transactionData, dataForProcessor, transactionOptions ),
 			'existing-card': ( transactionData: unknown ) =>
@@ -507,13 +503,11 @@ export default function CompositeCheckout( {
 					} ),
 					dataForProcessor
 				),
-			paypal: ( transactionData: unknown ) =>
-				payPalProcessor( transactionData, dataForRedirectProcessor ),
+			paypal: ( transactionData: unknown ) => payPalProcessor( transactionData, dataForProcessor ),
 		} ),
 		[
 			siteId,
 			dataForProcessor,
-			dataForRedirectProcessor,
 			transactionOptions,
 			countryCode,
 			subdivisionCode,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -51,11 +51,11 @@ import {
 	freePurchaseProcessor,
 	multiPartnerCardProcessor,
 	fullCreditsProcessor,
-	payPalProcessor,
 	genericRedirectProcessor,
 	weChatProcessor,
 } from './payment-method-processors';
 import existingCardProcessor from './lib/existing-card-processor';
+import payPalProcessor from './lib/paypal-express-processor';
 import useGetThankYouUrl from './hooks/use-get-thank-you-url';
 import createAnalyticsEventHandler from './record-analytics';
 import { useProductVariants } from './hooks/product-variants';

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import debugFactory from 'debug';
 import { defaultRegistry, makeRedirectResponse } from '@automattic/composite-checkout';
 import { format as formatUrl, parse as parseUrl, resolve as resolveUrl } from 'url'; // eslint-disable-line no-restricted-imports
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
@@ -8,17 +9,21 @@ import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 /**
  * Internal dependencies
  */
-import { wpcomPayPalExpress, submitPayPalExpressRequest } from '../payment-method-helpers';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import getPostalCode from '../lib/get-postal-code';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type { WPCOMCartItem } from '../types/checkout-cart';
 import type { ManagedContactDetails } from '../types/wpcom-store-state';
 import getDomainDetails from '../lib/get-domain-details';
+import { createPayPalExpressEndpointRequestPayloadFromLineItems } from '../types/paypal-express'; // FIXME: move from types
+import type { PayPalExpressEndpointRequestPayload } from '../types/paypal-express';
+import { createAccount } from '../payment-method-helpers';
+import wp from 'calypso/lib/wp';
 
 const { select } = defaultRegistry;
+const debug = debugFactory( 'calypso:composite-checkout:paypal-express-processor' );
 
-type PayPalTransactionRequest = {
+type PayPalPaymentMethodData = {
 	items: WPCOMCartItem[];
 };
 
@@ -59,27 +64,56 @@ export default async function payPalProcessor(
 		'wpcom'
 	)?.getContactInfo();
 
-	return submitPayPalExpressRequest(
-		{
-			...transactionData,
-			successUrl,
-			cancelUrl,
-			siteId: select( 'wpcom' )?.getSiteId?.() ?? '',
-			couponId: responseCart.coupon,
-			country: managedContactDetails?.countryCode?.value ?? '',
-			postalCode: getPostalCode(),
-			subdivisionCode: managedContactDetails?.state?.value ?? '',
-			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
-		},
-		wpcomPayPalExpress,
-		transactionOptions
-	).then( makeRedirectResponse );
+	const formattedTransactionData = createPayPalExpressEndpointRequestPayloadFromLineItems( {
+		...transactionData,
+		successUrl,
+		cancelUrl,
+		siteId: select( 'wpcom' )?.getSiteId?.() ?? '',
+		couponId: responseCart.coupon,
+		country: managedContactDetails?.countryCode?.value ?? '',
+		postalCode: getPostalCode(),
+		subdivisionCode: managedContactDetails?.state?.value ?? '',
+		domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ) || null,
+	} );
+	debug( 'sending paypal transaction', formattedTransactionData );
+	return wpcomPayPalExpress( formattedTransactionData, transactionOptions ).then(
+		makeRedirectResponse
+	);
 }
 
-function isValidTransactionData( submitData: unknown ): submitData is PayPalTransactionRequest {
-	const data = submitData as PayPalTransactionRequest;
+function isValidTransactionData( submitData: unknown ): submitData is PayPalPaymentMethodData {
+	const data = submitData as PayPalPaymentMethodData;
 	if ( ! ( data?.items?.length > 0 ) ) {
 		throw new Error( 'Transaction requires items and none were provided' );
 	}
 	return true;
+}
+
+async function wpcomPayPalExpress(
+	payload: PayPalExpressEndpointRequestPayload,
+	transactionOptions: PaymentProcessorOptions
+) {
+	if ( transactionOptions && transactionOptions.createUserAndSiteBeforeTransaction ) {
+		return createAccount().then( ( response ) => {
+			const siteIdFromResponse = response?.blog_details?.blogid;
+
+			// If the account is already created(as happens when we are reprocessing after a transaction error), then
+			// the create account response will not have a site ID, so we fetch from state.
+			const siteId = siteIdFromResponse || select( 'wpcom' )?.getSiteId();
+			const newPayload = {
+				...payload,
+				siteId,
+				cart: {
+					...payload.cart,
+					blog_id: siteId || '0',
+					cart_key: siteId || 'no-site',
+					create_new_blog: false,
+				},
+			};
+
+			return wp.undocumented().paypalExpressUrl( newPayload );
+		} );
+	}
+
+	return wp.undocumented().paypalExpressUrl( payload );
 }

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -15,10 +15,11 @@ import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type { WPCOMCartItem } from '../types/checkout-cart';
 import type { ManagedContactDetails } from '../types/wpcom-store-state';
 import getDomainDetails from '../lib/get-domain-details';
-import { createPayPalExpressEndpointRequestPayloadFromLineItems } from '../types/paypal-express'; // FIXME: move from types
 import type { PayPalExpressEndpointRequestPayload } from '../types/paypal-express';
 import { createAccount } from '../payment-method-helpers';
 import wp from 'calypso/lib/wp';
+import type { DomainContactDetails } from '../types/backend/domain-contact-details-components';
+import { createTransactionEndpointCartFromLineItems } from '../lib/translate-cart';
 
 const { select } = defaultRegistry;
 const debug = debugFactory( 'calypso:composite-checkout:paypal-express-processor' );
@@ -116,4 +117,43 @@ async function wpcomPayPalExpress(
 	}
 
 	return wp.undocumented().paypalExpressUrl( payload );
+}
+
+function createPayPalExpressEndpointRequestPayloadFromLineItems( {
+	successUrl,
+	cancelUrl,
+	siteId,
+	couponId,
+	country,
+	postalCode,
+	subdivisionCode,
+	domainDetails,
+	items,
+}: {
+	successUrl: string;
+	cancelUrl: string;
+	siteId: string;
+	couponId: string;
+	country: string;
+	postalCode: string;
+	subdivisionCode: string;
+	domainDetails: DomainContactDetails | null;
+	items: WPCOMCartItem[];
+} ): PayPalExpressEndpointRequestPayload {
+	return {
+		successUrl,
+		cancelUrl,
+		cart: createTransactionEndpointCartFromLineItems( {
+			siteId,
+			couponId,
+			country,
+			postalCode,
+			subdivisionCode,
+			items,
+			contactDetails: domainDetails,
+		} ),
+		country,
+		postalCode,
+		domainDetails,
+	};
 }

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import { defaultRegistry, makeRedirectResponse } from '@automattic/composite-checkout';
+import { format as formatUrl, parse as parseUrl, resolve as resolveUrl } from 'url'; // eslint-disable-line no-restricted-imports
+import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
+
+/**
+ * Internal dependencies
+ */
+import { wpcomPayPalExpress, submitPayPalExpressRequest } from '../payment-method-helpers';
+import { recordTransactionBeginAnalytics } from '../lib/analytics';
+import getPostalCode from '../lib/get-postal-code';
+import type { PaymentProcessorOptions } from '../types/payment-processors';
+import type { WPCOMCartItem } from '../types/checkout-cart';
+import type { ManagedContactDetails } from '../types/wpcom-store-state';
+import getDomainDetails from '../lib/get-domain-details';
+
+const { select } = defaultRegistry;
+
+type PayPalTransactionRequest = {
+	items: WPCOMCartItem[];
+};
+
+export default async function payPalProcessor(
+	transactionData: unknown,
+	transactionOptions: PaymentProcessorOptions
+): Promise< PaymentProcessorResponse > {
+	if ( ! isValidTransactionData( transactionData ) ) {
+		throw new Error( 'Required purchase data is missing' );
+	}
+
+	const {
+		getThankYouUrl,
+		createUserAndSiteBeforeTransaction,
+		reduxDispatch,
+		includeDomainDetails,
+		includeGSuiteDetails,
+		responseCart,
+	} = transactionOptions;
+	recordTransactionBeginAnalytics( {
+		reduxDispatch,
+		paymentMethodId: 'paypal',
+	} );
+
+	const { protocol, hostname, port, pathname } = parseUrl( window.location.href, true );
+
+	const successUrl = resolveUrl( window.location.href, getThankYouUrl() );
+
+	const cancelUrl = formatUrl( {
+		protocol,
+		hostname,
+		port,
+		pathname,
+		query: createUserAndSiteBeforeTransaction ? { cart: 'no-user' } : {},
+	} );
+
+	const managedContactDetails: ManagedContactDetails | undefined = select(
+		'wpcom'
+	)?.getContactInfo();
+
+	return submitPayPalExpressRequest(
+		{
+			...transactionData,
+			successUrl,
+			cancelUrl,
+			siteId: select( 'wpcom' )?.getSiteId?.() ?? '',
+			couponId: responseCart.coupon,
+			country: managedContactDetails?.countryCode?.value ?? '',
+			postalCode: getPostalCode(),
+			subdivisionCode: managedContactDetails?.state?.value ?? '',
+			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+		},
+		wpcomPayPalExpress,
+		transactionOptions
+	).then( makeRedirectResponse );
+}
+
+function isValidTransactionData( submitData: unknown ): submitData is PayPalTransactionRequest {
+	const data = submitData as PayPalTransactionRequest;
+	if ( ! ( data?.items?.length > 0 ) ) {
+		throw new Error( 'Transaction requires items and none were provided' );
+	}
+	return true;
+}

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -10,7 +10,6 @@ import { createStripePaymentMethod } from '@automattic/calypso-stripe';
  * Internal dependencies
  */
 import wp from 'calypso/lib/wp';
-import { createPayPalExpressEndpointRequestPayloadFromLineItems } from './types/paypal-express';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from './lib/translate-payment-method-names';
 import { getSavedVariations } from 'calypso/lib/abtest';
 import { stringifyBody } from 'calypso/state/login/utils';
@@ -28,14 +27,6 @@ export async function submitApplePayPayment( transactionData, submit, transactio
 		paymentPartnerProcessorId: transactionData.stripeConfiguration.processor_id,
 	} );
 	debug( 'submitting apple-pay transaction', formattedTransactionData );
-	return submit( formattedTransactionData, transactionOptions );
-}
-
-export async function submitPayPalExpressRequest( transactionData, submit, transactionOptions ) {
-	const formattedTransactionData = createPayPalExpressEndpointRequestPayloadFromLineItems( {
-		...transactionData,
-	} );
-	debug( 'sending paypal transaction', formattedTransactionData );
 	return submit( formattedTransactionData, transactionOptions );
 }
 
@@ -218,32 +209,6 @@ export async function wpcomTransaction( payload, transactionOptions ) {
 	}
 
 	return wp.undocumented().transactions( payload );
-}
-
-export async function wpcomPayPalExpress( payload, transactionOptions ) {
-	if ( transactionOptions && transactionOptions.createUserAndSiteBeforeTransaction ) {
-		return createAccount().then( ( response ) => {
-			const siteIdFromResponse = response?.blog_details?.blogid;
-
-			// If the account is already created(as happens when we are reprocessing after a transaction error), then
-			// the create account response will not have a site ID, so we fetch from state.
-			const siteId = siteIdFromResponse || select( 'wpcom' )?.getSiteId();
-			const newPayload = {
-				...payload,
-				siteId,
-				cart: {
-					...payload.cart,
-					blog_id: siteId || '0',
-					cart_key: siteId || 'no-site',
-					create_new_blog: false,
-				},
-			};
-
-			return wp.undocumented().paypalExpressUrl( newPayload );
-		} );
-	}
-
-	return wp.undocumented().paypalExpressUrl( payload );
 }
 
 export function createStripePaymentMethodToken( { stripe, name, country, postalCode } ) {

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -118,7 +118,7 @@ async function createAccountCallback( response ) {
 	} );
 }
 
-async function createAccount() {
+export async function createAccount() {
 	let newSiteParams = null;
 	try {
 		newSiteParams = JSON.parse( window.localStorage.getItem( 'siteParams' ) || '{}' );

--- a/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
+++ b/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
@@ -3,11 +3,13 @@
  */
 import { useDispatch } from 'react-redux';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
+import type { ResponseCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
  */
 import type { ReactStandardAction } from '../types/analytics';
+import type { GetThankYouUrl } from '../hooks/use-get-thank-you-url';
 
 export interface PaymentProcessorOptions {
 	includeDomainDetails: boolean;
@@ -16,4 +18,7 @@ export interface PaymentProcessorOptions {
 	stripeConfiguration: StripeConfiguration | null;
 	recordEvent: ( action: ReactStandardAction ) => void;
 	reduxDispatch: ReturnType< typeof useDispatch >;
+	responseCart: ResponseCart;
+	getThankYouUrl: GetThankYouUrl;
+	siteSlug: string | undefined;
 }

--- a/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
+++ b/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
@@ -1,8 +1,6 @@
 /**
  * Internal dependencies
  */
-import { createTransactionEndpointCartFromLineItems } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-cart';
-import type { WPCOMCartItem } from 'calypso/my-sites/checkout/composite-checkout/types/checkout-cart';
 import type { DomainContactDetails } from 'calypso/my-sites/checkout/composite-checkout/types/backend/domain-contact-details-components';
 import { WPCOMTransactionEndpointCart } from './transaction-endpoint';
 
@@ -18,44 +16,5 @@ export type PayPalExpressEndpointRequestPayload = {
 	country: string;
 	postalCode: string;
 };
-
-export function createPayPalExpressEndpointRequestPayloadFromLineItems( {
-	successUrl,
-	cancelUrl,
-	siteId,
-	couponId,
-	country,
-	postalCode,
-	subdivisionCode,
-	domainDetails,
-	items,
-}: {
-	successUrl: string;
-	cancelUrl: string;
-	siteId: string;
-	couponId: string;
-	country: string;
-	postalCode: string;
-	subdivisionCode: string;
-	domainDetails: DomainContactDetails | null;
-	items: WPCOMCartItem[];
-} ): PayPalExpressEndpointRequestPayload {
-	return {
-		successUrl,
-		cancelUrl,
-		cart: createTransactionEndpointCartFromLineItems( {
-			siteId,
-			couponId,
-			country,
-			postalCode,
-			subdivisionCode,
-			items,
-			contactDetails: domainDetails,
-		} ),
-		country,
-		postalCode,
-		domainDetails,
-	};
-}
 
 export type PayPalExpressEndpointResponse = unknown;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As the data requirements for submitting a payment transaction are rather complex, it helps to have strong types supporting them. This PR converts the PayPal Express payment processor function and all its dependencies into TypeScript.

#### Testing instructions

This should not have any noticable effects. It adds additional data to other payment method processors but does not change the data they are currently using.

Complete a purchase using PayPal and verify that it works as expected.