### PR TITLE
Checkout: use cart data directly for PayPal processor function

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -439,6 +439,7 @@ export default function CompositeCheckout( {
 			recordEvent,
 			reduxDispatch,
 			responseCart,
+			siteId,
 			siteSlug,
 			stripeConfiguration,
 		} ),
@@ -450,6 +451,7 @@ export default function CompositeCheckout( {
 			recordEvent,
 			reduxDispatch,
 			responseCart,
+			siteId,
 			siteSlug,
 			stripeConfiguration,
 		]

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -503,7 +503,7 @@ export default function CompositeCheckout( {
 					} ),
 					dataForProcessor
 				),
-			paypal: ( transactionData: unknown ) => payPalProcessor( transactionData, dataForProcessor ),
+			paypal: () => payPalProcessor( dataForProcessor ),
 		} ),
 		[
 			siteId,

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -5,6 +5,7 @@ import debugFactory from 'debug';
 import { defaultRegistry, makeRedirectResponse } from '@automattic/composite-checkout';
 import { format as formatUrl, parse as parseUrl, resolve as resolveUrl } from 'url'; // eslint-disable-line no-restricted-imports
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
+import type { ResponseCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -12,30 +13,20 @@ import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import getPostalCode from '../lib/get-postal-code';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
-import type { WPCOMCartItem } from '../types/checkout-cart';
 import type { ManagedContactDetails } from '../types/wpcom-store-state';
 import getDomainDetails from '../lib/get-domain-details';
 import type { PayPalExpressEndpointRequestPayload } from '../types/paypal-express';
 import { createAccount } from '../payment-method-helpers';
 import wp from 'calypso/lib/wp';
 import type { DomainContactDetails } from '../types/backend/domain-contact-details-components';
-import { createTransactionEndpointCartFromLineItems } from '../lib/translate-cart';
+import { createTransactionEndpointCartFromResponseCart } from '../lib/translate-cart';
 
 const { select } = defaultRegistry;
 const debug = debugFactory( 'calypso:composite-checkout:paypal-express-processor' );
 
-type PayPalPaymentMethodData = {
-	items: WPCOMCartItem[];
-};
-
 export default async function payPalProcessor(
-	transactionData: unknown,
 	transactionOptions: PaymentProcessorOptions
 ): Promise< PaymentProcessorResponse > {
-	if ( ! isValidTransactionData( transactionData ) ) {
-		throw new Error( 'Required purchase data is missing' );
-	}
-
 	const {
 		getThankYouUrl,
 		createUserAndSiteBeforeTransaction,
@@ -66,7 +57,7 @@ export default async function payPalProcessor(
 	)?.getContactInfo();
 
 	const formattedTransactionData = createPayPalExpressEndpointRequestPayloadFromLineItems( {
-		...transactionData,
+		responseCart,
 		successUrl,
 		cancelUrl,
 		siteId: select( 'wpcom' )?.getSiteId?.() ?? '',
@@ -80,14 +71,6 @@ export default async function payPalProcessor(
 	return wpcomPayPalExpress( formattedTransactionData, transactionOptions ).then(
 		makeRedirectResponse
 	);
-}
-
-function isValidTransactionData( submitData: unknown ): submitData is PayPalPaymentMethodData {
-	const data = submitData as PayPalPaymentMethodData;
-	if ( ! ( data?.items?.length > 0 ) ) {
-		throw new Error( 'Transaction requires items and none were provided' );
-	}
-	return true;
 }
 
 async function wpcomPayPalExpress(
@@ -128,7 +111,7 @@ function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 	postalCode,
 	subdivisionCode,
 	domainDetails,
-	items,
+	responseCart,
 }: {
 	successUrl: string;
 	cancelUrl: string;
@@ -138,19 +121,19 @@ function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 	postalCode: string;
 	subdivisionCode: string;
 	domainDetails: DomainContactDetails | null;
-	items: WPCOMCartItem[];
+	responseCart: ResponseCart;
 } ): PayPalExpressEndpointRequestPayload {
 	return {
 		successUrl,
 		cancelUrl,
-		cart: createTransactionEndpointCartFromLineItems( {
+		cart: createTransactionEndpointCartFromResponseCart( {
 			siteId,
 			couponId,
 			country,
 			postalCode,
 			subdivisionCode,
-			items,
 			contactDetails: domainDetails,
+			responseCart,
 		} ),
 		country,
 		postalCode,

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -62,7 +62,6 @@ export default async function payPalProcessor(
 		successUrl,
 		cancelUrl,
 		siteId,
-		couponId: responseCart.coupon,
 		country: managedContactDetails?.countryCode?.value ?? '',
 		postalCode: getPostalCode(),
 		subdivisionCode: managedContactDetails?.state?.value ?? '',
@@ -107,7 +106,6 @@ function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 	successUrl,
 	cancelUrl,
 	siteId,
-	couponId,
 	country,
 	postalCode,
 	subdivisionCode,
@@ -117,7 +115,6 @@ function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 	successUrl: string;
 	cancelUrl: string;
 	siteId: string | number | undefined;
-	couponId: string;
 	country: string;
 	postalCode: string;
 	subdivisionCode: string;
@@ -129,7 +126,6 @@ function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 		cancelUrl,
 		cart: createTransactionEndpointCartFromResponseCart( {
 			siteId: siteId ? String( siteId ) : undefined,
-			couponId,
 			country,
 			postalCode,
 			subdivisionCode,

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -34,6 +34,7 @@ export default async function payPalProcessor(
 		includeDomainDetails,
 		includeGSuiteDetails,
 		responseCart,
+		siteId,
 	} = transactionOptions;
 	recordTransactionBeginAnalytics( {
 		reduxDispatch,
@@ -60,7 +61,7 @@ export default async function payPalProcessor(
 		responseCart,
 		successUrl,
 		cancelUrl,
-		siteId: select( 'wpcom' )?.getSiteId?.() ?? '',
+		siteId,
 		couponId: responseCart.coupon,
 		country: managedContactDetails?.countryCode?.value ?? '',
 		postalCode: getPostalCode(),
@@ -83,7 +84,7 @@ async function wpcomPayPalExpress(
 
 			// If the account is already created(as happens when we are reprocessing after a transaction error), then
 			// the create account response will not have a site ID, so we fetch from state.
-			const siteId = siteIdFromResponse || select( 'wpcom' )?.getSiteId();
+			const siteId = siteIdFromResponse || transactionOptions.siteId;
 			const newPayload = {
 				...payload,
 				siteId,
@@ -115,7 +116,7 @@ function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 }: {
 	successUrl: string;
 	cancelUrl: string;
-	siteId: string;
+	siteId: string | number | undefined;
 	couponId: string;
 	country: string;
 	postalCode: string;
@@ -127,7 +128,7 @@ function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 		successUrl,
 		cancelUrl,
 		cart: createTransactionEndpointCartFromResponseCart( {
-			siteId,
+			siteId: siteId ? String( siteId ) : undefined,
 			couponId,
 			country,
 			postalCode,

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -144,7 +144,6 @@ function translateReponseCartProductToWPCOMCartItem(
 // '/me/transactions/': WPCOM_JSON_API_Transactions_Endpoint
 export function createTransactionEndpointCartFromResponseCart( {
 	siteId,
-	couponId,
 	country,
 	postalCode,
 	subdivisionCode,
@@ -152,7 +151,6 @@ export function createTransactionEndpointCartFromResponseCart( {
 	responseCart,
 }: {
 	siteId: string | undefined;
-	couponId?: string;
 	country: string;
 	postalCode: string;
 	subdivisionCode?: string;
@@ -163,7 +161,7 @@ export function createTransactionEndpointCartFromResponseCart( {
 		blog_id: siteId || '0',
 		cart_key: siteId || 'no-site',
 		create_new_blog: siteId ? false : true,
-		coupon: couponId || '',
+		coupon: responseCart.coupon || '',
 		currency: responseCart.currency,
 		temporary: false,
 		extra: [],

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -144,16 +144,10 @@ function translateReponseCartProductToWPCOMCartItem(
 // '/me/transactions/': WPCOM_JSON_API_Transactions_Endpoint
 export function createTransactionEndpointCartFromResponseCart( {
 	siteId,
-	country,
-	postalCode,
-	subdivisionCode,
 	contactDetails,
 	responseCart,
 }: {
 	siteId: string | undefined;
-	country: string;
-	postalCode: string;
-	subdivisionCode?: string;
 	contactDetails: DomainContactDetails | null;
 	responseCart: ResponseCart;
 } ): WPCOMTransactionEndpointCart {
@@ -168,13 +162,7 @@ export function createTransactionEndpointCartFromResponseCart( {
 		products: responseCart.products.map( ( item ) =>
 			addRegistrationDataToGSuiteCartProduct( item, contactDetails )
 		),
-		tax: {
-			location: {
-				country_code: country,
-				postal_code: postalCode,
-				subdivision_code: subdivisionCode,
-			},
-		},
+		tax: responseCart.tax,
 	};
 }
 

--- a/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
+++ b/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
@@ -21,4 +21,5 @@ export interface PaymentProcessorOptions {
 	responseCart: ResponseCart;
 	getThankYouUrl: GetThankYouUrl;
 	siteSlug: string | undefined;
+	siteId: number | undefined;
 }

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { ResponseCartProductExtra } from '@automattic/shopping-cart';
+import type { RequestCartProduct } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -103,7 +103,7 @@ export type WPCOMTransactionEndpointCart = {
 	currency: string;
 	temporary: false;
 	extra: string[];
-	products: WPCOMTransactionEndpointCartItem[];
+	products: RequestCartProduct[];
 	tax: {
 		location: {
 			country_code: string;
@@ -111,15 +111,6 @@ export type WPCOMTransactionEndpointCart = {
 			subdivision_code?: string;
 		};
 	};
-};
-
-export type WPCOMTransactionEndpointCartItem = {
-	product_id: number;
-	meta?: string;
-	currency: string;
-	volume: number;
-	extra?: ResponseCartProductExtra;
-	quantity: number | null;
 };
 
 export type WPCOMTransactionEndpointResponse = {

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { RequestCartProduct } from '@automattic/shopping-cart';
+import type { RequestCartProduct, ResponseCartTaxData } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -104,13 +104,7 @@ export type WPCOMTransactionEndpointCart = {
 	temporary: false;
 	extra: string[];
 	products: RequestCartProduct[];
-	tax: {
-		location: {
-			country_code: string;
-			postal_code?: string;
-			subdivision_code?: string;
-		};
-	};
+	tax: Omit< ResponseCartTaxData, 'display_taxes' >;
 };
 
 export type WPCOMTransactionEndpointResponse = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The PayPal payment processor function, much like our other processor functions, currently accepts `WPCOMCartItem` objects and transforms them into shopping-cart product objects so they can be submitted to the transaction endpoint. However, the `WPCOMCartItem` objects that the processor functions use are created in the first place by parsing the shopping-cart objects we get from the server. There's no reason to transform this data to `WPCOMCartItem` and back when we can instead pass it directly.

This PR modifies the PayPal processor function to accept the `ResponseCart` and uses its data to send to the transaction endpoints. (I'd like to do this for all our processor functions, but this is a start.)

#### Testing instructions

This should not have any noticable effects. It adds additional data to other payment method processors but does not change the data they are currently using.

Complete a purchase using PayPal and verify that it works as expected.
