### PR TITLE
Refactor: Load ETK common code before the `plugins_loaded` action

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -47,6 +47,9 @@ define( 'A8C_ETK_PLUGIN_VERSION', 'dev' );
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';
 
+// Enqueues the shared JS data stores and defines shared helper functions.
+require_once __DIR__ . '/common/index.php';
+
 /**
  * Load dotcom-FSE.
  */
@@ -138,14 +141,6 @@ function load_timeline_block() {
 	require_once __DIR__ . '/jetpack-timeline/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_timeline_block' );
-
-/**
- * Load common module.
- */
-function load_common_module() {
-	require_once __DIR__ . '/common/index.php';
-}
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_common_module' );
 
 /**
  * Load Editor Site Launch.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`common/index.php` contains helper functions that would be useful when other ETK modules are being setup during the `plugins_loaded` action. Unfortunately they can't be used though, because those helper functions are defined as part of `plugins_loaded` too.

There's nothing in `common/index.php` that means loading it should be delayed. So moving the `require_once` call so that it gets loaded as soon as `full-site-editing-plugin.php` is loaded.

Context: as part of #51122 I want to be able to call `get_iso_639_locale()` during `Starter_Page_Templates`'s `__construct()`, so I want to guarantee that `get_iso_639_locale()` gets defined first.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `install-plugin.php etk update/etk-load-common-code-earlier`
* Smoke test ETK, it's functions should still load (new page modal, launch flows, etc.)
* Verify that the common js/css assets are still enqueued (e.g. check for `hide-plugin-buttons-mobile.css` in the network tab)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

