### PR TITLE
Wpcom block editor: try install-plugin integration

### DIFF
--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -1,0 +1,152 @@
+package _self
+
+import jetbrains.buildServer.configs.kotlin.v2019_2.Template
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.placeholder
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+
+open class PluginBaseBuild : Template({
+	name = "Plugin Base Build"
+
+	// For easier access and syntax highlighting in strings:
+	val pluginSlug = "%plugin_slug%"
+	val workingDir = "apps/$pluginSlug"
+	val archiveDir = "%archive_dir%"
+	val buildEnv = "%build_env%"
+	val releaseTag = "%release_tag%"
+
+	artifactRules = "$pluginSlug.zip"
+	buildNumberPattern = "%build.prefix%.%build.counter%"
+
+	vcs {
+		root(Settings.WpCalypso)
+		cleanCheckout = true
+	}
+
+	triggers {
+		vcs {
+			branchFilter = """
+				+:*
+				-:pull*
+			""".trimIndent()
+		}
+	}
+
+	features {
+		pullRequests {
+			vcsRootExtId = "${Settings.WpCalypso.id}"
+			provider = github {
+				authType = token {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
+			}
+		}
+
+		commitStatusPublisher {
+			vcsRootExtId = "${Settings.WpCalypso.id}"
+			publisher = github {
+				githubUrl = "https://api.github.com"
+				authType = personalToken {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+			}
+		}
+	}
+
+	steps {
+		bashNodeScript {
+			name = "Prepare environment"
+			scriptContent = """
+				# Update composer
+				composer install
+
+				# Install modules
+				yarn install
+			"""
+		}
+		bashNodeScript {
+			name = "Build artifacts"
+			scriptContent = """
+				export NODE_ENV="$buildEnv"
+				echo "changing to... $workingDir"
+				cd $workingDir
+				ls
+				yarn build
+			"""
+		}
+
+		// Build-specified steps will run here.
+		placeholder {  }
+
+		/**
+		 * We download the archive directly in this step rather than relying on
+		 * an artifact dependency. We do this because if two commits on trunk
+		 * build at the same time, then they will both point to the same artifact
+		 * dependency. In this scenario, we actually want the current build to
+		 * diff against the artifact from that other commit build.
+		 *
+		 * Using the artifact dependency feature, we can only rely on already-finished
+		 * builds at the time the current build *starts*. This means every build
+		 * would have to run in serial, which is not possible in TeamCity without
+		 * a plugin. As a result, commits have to happen several minutes apart
+		 * in order for the diff tagging feature to work correctly in this scenario.
+		 *
+		 * Downloading from the API directly means that the previous build only
+		 * has to finish by the time this *step* begins. As a result, as long as
+		 * the two builds start further apart than the time this step takes,
+		 * then we can diff against the correct artifact. This means two builds
+		 * can be started within a few seconds of each other on trunk, and the
+		 * most recent build of the two can still rely on the other's artifact.
+		 */
+		bashNodeScript {
+			name = "Process Artifact"
+			scriptContent = """
+				# 1. Download and unzip current ETK release build.
+				cd $workingDir
+				wget "%teamcity.serverUrl%/repository/download/%system.teamcity.buildType.id%/$releaseTag.tcbuildtag/$pluginSlug.zip?guest=1&branch=trunk" -O ./tmp-release-archive-download.zip
+
+				mkdir ./release-archive
+				unzip ./tmp-release-archive-download.zip -d ./release-archive
+				echo "Diffing against current trunk release build (`grep build_number ./release-archive/build_meta.txt | sed s/build_number=//`).";
+
+				# 2. Change anything from the ETK release build which is "unstable", like the version number and build metadata.
+				# These operations restore idempotence between the two builds.
+				rm -f ./release-archive/build_meta.txt
+
+				cd ./release-archive
+				%normalize_files%
+				cd ..
+
+				# 3. Check if the current build has changed, and if so, tag it for release.
+				# Note: we exclude asset changes because we only really care if the build files (JS/CSS) change. That file is basically just metadata.
+				if ! diff -rq --exclude="*.asset.php" $archiveDir ./release-archive/ ; then
+					echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
+					tag_response=`curl -s -X POST -H "Content-Type: text/plain" --data "$releaseTag" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`
+					echo -e "Build tagging status: ${'$'}tag_response\n"
+
+					# Ping commit merger in Slack if we're on the main branch and the build has changed.
+					if [ "%teamcity.build.branch.is_default%" == "true" ] ; then
+						echo "Posting slack reminder."
+						ping_response=`curl -s -d "commit=%build.vcs.number%&plugin=$pluginSlug" -X POST %mc-post-root%?plugin-deploy-reminder`
+						echo -e "Slack ping status: ${'$'}ping_response\n"
+					fi
+				fi
+
+				# 4. Create metadata file with info for the download script.
+				cd $archiveDir
+				tee build_meta.txt <<-EOM
+					commit_hash=%build.vcs.number%
+					commit_url=https://github.com/Automattic/wp-calypso/commit/%build.vcs.number%
+					build_number=%build.number%
+					EOM
+
+				# 5. Create artifact of cwd.
+				echo
+				zip -r ../../../$pluginSlug.zip .
+			"""
+		}
+	}
+})

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -128,7 +128,7 @@ open class PluginBaseBuild : Template({
 					echo -e "Build tagging status: ${'$'}tag_response\n"
 
 					# Ping commit merger in Slack if we're on the main branch and the build has changed.
-					if [ "%teamcity.build.branch.is_default%" == "true" ] ; then
+					if [ "%teamcity.build.branch.is_default%" == "true" ] && [ "%with_slack_notify%" == "true" ] ; then
 						echo "Posting slack reminder."
 						ping_response=`curl -s -d "commit=%build.vcs.number%&plugin=$pluginSlug" -X POST %mc-post-root%?plugin-deploy-reminder`
 						echo -e "Slack ping status: ${'$'}ping_response\n"

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -14,8 +14,7 @@ open class PluginBaseBuild : Template({
 	val pluginSlug = "%plugin_slug%"
 	val workingDir = "apps/$pluginSlug"
 	val archiveDir = "%archive_dir%"
-	val releaseTag = if ("%release_tag%".length > 0) "%release_tag%" else "$pluginSlug-release-build"
-	val buildEnv = if ("%build_env%".length > 0) "%build_env%" else "production"
+	val releaseTag = "%release_tag%"
 
 	artifactRules = "$pluginSlug.zip"
 	buildNumberPattern = "%build.prefix%.%build.counter%"
@@ -70,7 +69,7 @@ open class PluginBaseBuild : Template({
 		bashNodeScript {
 			name = "Build artifacts"
 			scriptContent = """
-				export NODE_ENV="$buildEnv"
+				export NODE_ENV="%build_env%"
 				cd $workingDir
 				yarn build
 			"""

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -36,7 +36,7 @@ open class PluginBaseBuild : Template({
 
 	features {
 		pullRequests {
-			vcsRootExtId = Settings.WpCalypso.id
+			vcsRootExtId = "${Settings.WpCalypso.id}"
 			provider = github {
 				authType = token {
 					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
@@ -46,7 +46,7 @@ open class PluginBaseBuild : Template({
 		}
 
 		commitStatusPublisher {
-			vcsRootExtId = Settings.WpCalypso.id
+			vcsRootExtId = "${Settings.WpCalypso.id}"
 			publisher = github {
 				githubUrl = "https://api.github.com"
 				authType = personalToken {

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -14,7 +14,8 @@ open class PluginBaseBuild : Template({
 	val pluginSlug = "%plugin_slug%"
 	val workingDir = "apps/$pluginSlug"
 	val archiveDir = "%archive_dir%"
-	val releaseTag = "%release_tag%"
+	val releaseTag = if ("%release_tag%".length > 0) "%release_tag%" else "$pluginSlug-release-build"
+	val buildEnv = if ("%build_env%".length > 0) "%build_env%" else "production"
 
 	artifactRules = "$pluginSlug.zip"
 	buildNumberPattern = "%build.prefix%.%build.counter%"
@@ -35,7 +36,7 @@ open class PluginBaseBuild : Template({
 
 	features {
 		pullRequests {
-			vcsRootExtId = "${Settings.WpCalypso.id}"
+			vcsRootExtId = Settings.WpCalypso.id
 			provider = github {
 				authType = token {
 					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
@@ -45,7 +46,7 @@ open class PluginBaseBuild : Template({
 		}
 
 		commitStatusPublisher {
-			vcsRootExtId = "${Settings.WpCalypso.id}"
+			vcsRootExtId = Settings.WpCalypso.id
 			publisher = github {
 				githubUrl = "https://api.github.com"
 				authType = personalToken {
@@ -69,7 +70,7 @@ open class PluginBaseBuild : Template({
 		bashNodeScript {
 			name = "Build artifacts"
 			scriptContent = """
-				export NODE_ENV="%build_env%"
+				export NODE_ENV="$buildEnv"
 				cd $workingDir
 				yarn build
 			"""

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -14,7 +14,6 @@ open class PluginBaseBuild : Template({
 	val pluginSlug = "%plugin_slug%"
 	val workingDir = "apps/$pluginSlug"
 	val archiveDir = "%archive_dir%"
-	val buildEnv = "%build_env%"
 	val releaseTag = "%release_tag%"
 
 	artifactRules = "$pluginSlug.zip"
@@ -70,15 +69,13 @@ open class PluginBaseBuild : Template({
 		bashNodeScript {
 			name = "Build artifacts"
 			scriptContent = """
-				export NODE_ENV="$buildEnv"
-				echo "changing to... $workingDir"
+				export NODE_ENV="%build_env%"
 				cd $workingDir
-				ls
 				yarn build
 			"""
 		}
 
-		// Build-specified steps will run here.
+		// Steps specified in builds which extend the Template will run here.
 		placeholder {  }
 
 		/**
@@ -104,7 +101,7 @@ open class PluginBaseBuild : Template({
 		bashNodeScript {
 			name = "Process Artifact"
 			scriptContent = """
-				# 1. Download and unzip current ETK release build.
+				# 1. Download and unzip current release build.
 				cd $workingDir
 				wget "%teamcity.serverUrl%/repository/download/%system.teamcity.buildType.id%/$releaseTag.tcbuildtag/$pluginSlug.zip?guest=1&branch=trunk" -O ./tmp-release-archive-download.zip
 
@@ -112,7 +109,7 @@ open class PluginBaseBuild : Template({
 				unzip ./tmp-release-archive-download.zip -d ./release-archive
 				echo "Diffing against current trunk release build (`grep build_number ./release-archive/build_meta.txt | sed s/build_number=//`).";
 
-				# 2. Change anything from the ETK release build which is "unstable", like the version number and build metadata.
+				# 2. Change anything from the release build which is "unstable", like the version number and build metadata.
 				# These operations restore idempotence between the two builds.
 				rm -f ./release-archive/build_meta.txt
 

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -1,80 +1,52 @@
 package _self.projects
 
+import _self.PluginBaseBuild
 import _self.bashNodeScript
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 object WPComPlugins : Project({
 	id("WPComPlugins")
 	name = "WPCom Plugins"
-	buildType(EditingToolKit)
+
+	// Override the Docker image for plugin builds.
 	params {
-		text("docker_image_wpcom", "registry.a8c.com/calypso/ci-wpcom:latest", label = "Docker image", description = "Docker image to use for the run", allowEmpty = true)
+		param("docker_image", "registry.a8c.com/calypso/ci-wpcom:latest")
+
 	}
+	buildType(EditingToolkit)
+	buildType(WpcomBlockEditor)
+	buildType(Notifications)
+	buildType(O2Blocks)
+
+	// For some reason, TeamCity needs this to reference the Template.
+	template(PluginBaseBuild())
 })
 
-private object EditingToolKit : BuildType({
+private object EditingToolkit : BuildType({
 	id("WPComPlugins_EditorToolKit")
 	name = "Editing ToolKit"
 
-	artifactRules = "editing-toolkit.zip"
+	templates(PluginBaseBuild())
 
-	buildNumberPattern = "%build.prefix%.%build.counter%"
 	params {
 		param("build.prefix", "3")
-	}
-
-	vcs {
-		root(Settings.WpCalypso)
-		cleanCheckout = true
-	}
-
-	triggers {
-		vcs {
-			branchFilter = """
-				+:*
-				-:pull*
-			""".trimIndent()
-		}
-	}
-
-	features {
-		pullRequests {
-			vcsRootExtId = "${Settings.WpCalypso.id}"
-			provider = github {
-				authType = token {
-					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
-				}
-				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
-			}
-		}
-
-		commitStatusPublisher {
-			vcsRootExtId = "${Settings.WpCalypso.id}"
-			publisher = github {
-				githubUrl = "https://api.github.com"
-				authType = personalToken {
-					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
-				}
-			}
-		}
+		param("plugin_slug", "editing-toolkit")
+		param("archive_dir", "./editing-toolkit-plugin/")
+		param("build_env", "production")
+		param("release_tag", "etk-release-build")
+		param("normalize_files", "sed -i -e \"/^\\s\\* Version:/c\\ * Version: %build.number%\" -e \"/^define( 'A8C_ETK_PLUGIN_VERSION'/c\\define( 'A8C_ETK_PLUGIN_VERSION', '%build.number%' );\" full-site-editing-plugin.php && sed -i -e \"/^Stable tag:\\s/c\\Stable tag: %build.number%\" readme.txt\n")
 	}
 
 	steps {
 		bashNodeScript {
-			name = "Prepare environment"
+			name = "Update version"
 			scriptContent = """
-				# Update composer
-				composer install
-
-				# Install modules
-				yarn install
+				cd apps/editing-toolkit
+				# Update plugin version in the plugin file and readme.txt.
+				sed -i -e "/^\s\* Version:/c\ * Version: %build.number%" -e "/^define( 'A8C_ETK_PLUGIN_VERSION'/c\define( 'A8C_ETK_PLUGIN_VERSION', '%build.number%' );" ./editing-toolkit-plugin/full-site-editing-plugin.php
+				sed -i -e "/^Stable tag:\s/c\Stable tag: %build.number%" ./editing-toolkit-plugin/readme.txt
 			"""
-			dockerImage = "%docker_image_wpcom%"
 		}
 		bashNodeScript {
 			name = "Run JS tests"
@@ -85,21 +57,6 @@ private object EditingToolKit : BuildType({
 				cd apps/editing-toolkit
 				yarn test:js --reporters=default --reporters=jest-junit --maxWorkers=${'$'}JEST_MAX_WORKERS
 			"""
-			dockerImage = "%docker_image_wpcom%"
-		}
-		bashNodeScript {
-			name = "Build artifacts"
-			scriptContent = """
-				export NODE_ENV="production"
-
-				cd apps/editing-toolkit
-				yarn build
-
-				# Update plugin version in the plugin file and readme.txt.
-				sed -i -e "/^\s\* Version:/c\ * Version: %build.number%" -e "/^define( 'A8C_ETK_PLUGIN_VERSION'/c\define( 'A8C_ETK_PLUGIN_VERSION', '%build.number%' );" ./editing-toolkit-plugin/full-site-editing-plugin.php
-				sed -i -e "/^Stable tag:\s/c\Stable tag: %build.number%" ./editing-toolkit-plugin/readme.txt
-			"""
-			dockerImage = "%docker_image_wpcom%"
 		}
 		// Note: We run the PHP lint after the build to verify that the newspack-blocks
 		// code is also formatted correctly.
@@ -113,73 +70,53 @@ private object EditingToolKit : BuildType({
 				fi
 				yarn lint:php
 			"""
-			dockerImage = "%docker_image_wpcom%"
 		}
-		/**
-		 * We download the archive directly in this step rather than relying on
-		 * an artifact dependency. We do this because if two commits on trunk
-		 * build at the same time, then they will both point to the same artifact
-		 * dependency. In this scenario, we actually want the current build to
-		 * diff against the artifact from that other commit build.
-		 *
-		 * Using the artifact dependency feature, we can only rely on already-finished
-		 * builds at the time the current build *starts*. This means every build
-		 * would have to run in serial, which is not possible in TeamCity without
-		 * a plugin. As a result, commits have to happen several minutes apart
-		 * in order for the diff tagging feature to work correctly in this scenario.
-		 *
-		 * Downloading from the API directly means that the previous build only
-		 * has to finish by the time this *step* begins. As a result, as long as
-		 * the two builds start further apart than the time this step takes,
-		 * then we can diff against the correct artifact. This means two builds
-		 * can be started within a few seconds of each other on trunk, and the
-		 * most recent build of the two can still rely on the other's artifact.
-		 */
-		bashNodeScript {
-			name = "Process artifact"
-			scriptContent = """
-				cd apps/editing-toolkit
+	}
+})
 
-				# 1. Downlaod and unzip current ETK release build.
-				wget "%teamcity.serverUrl%/repository/download/calypso_WPComPlugins_EditorToolKit/etk-release-build.tcbuildtag/editing-toolkit.zip?guest=1&branch=trunk" -O ./tmp-etk-download.zip
-				mkdir ./current-etk-release
-				unzip ./tmp-etk-download.zip -d ./current-etk-release
-				echo "Diffing against current trunk release build (`grep build_number ./current-etk-release/build_meta.txt | sed s/build_number=//`).";
+private object WpcomBlockEditor : BuildType({
+	templates(PluginBaseBuild())
+	id("WPComPlugins_WpcomBlockEditor")
+	name = "Wpcom Block Editor"
 
-				# 2. Change anything from the ETK release build which is "unstable", like the version number and build metadata.
-				# These operations restore idempotence between the two builds.
-				rm -f ./current-etk-release/build_meta.txt
-				sed -i -e "/^\s\* Version:/c\ * Version: %build.number%" -e "/^define( 'A8C_ETK_PLUGIN_VERSION'/c\define( 'A8C_ETK_PLUGIN_VERSION', '%build.number%' );" ./current-etk-release/full-site-editing-plugin.php
-				sed -i -e "/^Stable tag:\s/c\Stable tag: %build.number%" ./current-etk-release/readme.txt
+	artifactRules = "wpcom-block-editor.zip"
+	params {
+		param("build.prefix", "1")
+		param("plugin_slug", "wpcom-block-editor")
+		param("archive_dir", "./dist/")
+		param("build_env", "development")
+		param("release_tag", "wpcom-block-editor-release-build")
+	}
+})
 
-				# 3. Check if the current build has changed, and if so, tag it for release.
-				# Note: we exclude asset changes because we only really care if the build files (JS/CSS) change. That file is basically just metadata.
-				if ! diff -rq --exclude="*.asset.php" ./editing-toolkit-plugin/ ./current-etk-release/ ; then
-					echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
-					tag_response=`curl -s -X POST -H "Content-Type: text/plain" --data "etk-release-build" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`
-					echo -e "Build tagging status: ${'$'}tag_response\n"
+private object Notifications : BuildType({
+	val slug = "notifications"
+	templates(PluginBaseBuild())
+	id("WPComPlugins_Notifications")
+	name = "Notifications"
 
-					# Ping commit merger in Slack if we're on the main branch and the build has changed.
-					if [ "%teamcity.build.branch.is_default%" == "true" ] ; then
-						echo "Posting slack reminder."
-						ping_response=`curl -s -d "commit=%build.vcs.number%&plugin=editing-toolkit" -X POST %mc-post-root%?plugin-deploy-reminder`
-						echo -e "Slack ping status: ${'$'}ping_response\n"
-					fi
-				fi
+	artifactRules = "$slug.zip"
+	params {
+		param("build.prefix", "1")
+		param("plugin_slug", slug)
+		param("archive_dir", "./dist/")
+		param("build_env", "production")
+		param("release_tag", "$slug-release-build")
+	}
+})
 
-				# 4. Create metadata file with info for the download script.
-				cd editing-toolkit-plugin
-				tee build_meta.txt <<-EOM
-					commit_hash=%build.vcs.number%
-					commit_url=https://github.com/Automattic/wp-calypso/commit/%build.vcs.number%
-					build_number=%build.number%
-					EOM
+private object O2Blocks : BuildType({
+	val slug = "o2-blocks"
+	templates(PluginBaseBuild())
+	id("WPComPlugins_O2Blocks")
+	name = "O2 Blocks"
 
-				# 5. Create artifact of cwd.
-				echo
-				zip -r ../../../editing-toolkit.zip .
-			"""
-			dockerImage = "%docker_image_wpcom%"
-		}
+	artifactRules = "wpcom-block-editor.zip"
+	params {
+		param("build.prefix", "1")
+		param("plugin_slug", slug)
+		param("archive_dir", "./dist/")
+		param("build_env", "development")
+		param("release_tag", "$slug-release-build")
 	}
 })

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -35,6 +35,7 @@ private object EditingToolkit : BuildType({
 		param("archive_dir", "./editing-toolkit-plugin/")
 		param("build_env", "production")
 		param("release_tag", "etk-release-build")
+		param("with_slack_notify", "true" )
 		param("normalize_files", "sed -i -e \"/^\\s\\* Version:/c\\ * Version: %build.number%\" -e \"/^define( 'A8C_ETK_PLUGIN_VERSION'/c\\define( 'A8C_ETK_PLUGIN_VERSION', '%build.number%' );\" full-site-editing-plugin.php && sed -i -e \"/^Stable tag:\\s/c\\Stable tag: %build.number%\" readme.txt\n")
 	}
 

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -33,7 +33,6 @@ private object EditingToolkit : BuildType({
 		param("build.prefix", "3")
 		param("plugin_slug", "editing-toolkit")
 		param("archive_dir", "./editing-toolkit-plugin/")
-		param("build_env", "production")
 		param("release_tag", "etk-release-build")
 		param("with_slack_notify", "true" )
 		param("normalize_files", "sed -i -e \"/^\\s\\* Version:/c\\ * Version: %build.number%\" -e \"/^define( 'A8C_ETK_PLUGIN_VERSION'/c\\define( 'A8C_ETK_PLUGIN_VERSION', '%build.number%' );\" full-site-editing-plugin.php && sed -i -e \"/^Stable tag:\\s/c\\Stable tag: %build.number%\" readme.txt\n")
@@ -80,44 +79,34 @@ private object WpcomBlockEditor : BuildType({
 	id("WPComPlugins_WpcomBlockEditor")
 	name = "Wpcom Block Editor"
 
-	artifactRules = "wpcom-block-editor.zip"
 	params {
 		param("build.prefix", "1")
 		param("plugin_slug", "wpcom-block-editor")
 		param("archive_dir", "./dist/")
 		param("build_env", "development")
-		param("release_tag", "wpcom-block-editor-release-build")
 	}
 })
 
 private object Notifications : BuildType({
-	val slug = "notifications"
 	templates(PluginBaseBuild())
 	id("WPComPlugins_Notifications")
 	name = "Notifications"
 
-	artifactRules = "$slug.zip"
 	params {
 		param("build.prefix", "1")
-		param("plugin_slug", slug)
+		param("plugin_slug", "notifications")
 		param("archive_dir", "./dist/")
-		param("build_env", "production")
-		param("release_tag", "$slug-release-build")
 	}
 })
 
 private object O2Blocks : BuildType({
-	val slug = "o2-blocks"
 	templates(PluginBaseBuild())
 	id("WPComPlugins_O2Blocks")
 	name = "O2 Blocks"
 
-	artifactRules = "wpcom-block-editor.zip"
 	params {
 		param("build.prefix", "1")
-		param("plugin_slug", slug)
+		param("plugin_slug", "o2-blocks")
 		param("archive_dir", "./dist/")
-		param("build_env", "development")
-		param("release_tag", "$slug-release-build")
 	}
 })

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -4,15 +4,21 @@ import _self.PluginBaseBuild
 import _self.bashNodeScript
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
+import jetbrains.buildServer.configs.kotlin.v2019_2.Parametrized
+import jetbrains.buildServer.configs.kotlin.v2019_2.ParametrizedWithType
 
 object WPComPlugins : Project({
 	id("WPComPlugins")
 	name = "WPCom Plugins"
 
-	// Override the Docker image for plugin builds.
+	// Default params for WPcom Plugins.
 	params {
 		param("docker_image", "registry.a8c.com/calypso/ci-wpcom:latest")
-
+		param("release_tag", "%plugin_slug%-release-build")
+		param("with_slack_notify", "false")
+		param("build.prefix", "1")
+		param("normalize_files", "")
+		param("build_env", "production")
 	}
 	buildType(EditingToolkit)
 	buildType(WpcomBlockEditor)
@@ -23,19 +29,19 @@ object WPComPlugins : Project({
 	template(PluginBaseBuild())
 })
 
+
 private object EditingToolkit : BuildType({
 	id("WPComPlugins_EditorToolKit")
 	name = "Editing ToolKit"
 
 	templates(PluginBaseBuild())
-
 	params {
-		param("build.prefix", "3")
 		param("plugin_slug", "editing-toolkit")
 		param("archive_dir", "./editing-toolkit-plugin/")
 		param("release_tag", "etk-release-build")
-		param("with_slack_notify", "true" )
+		param("build.prefix", "3")
 		param("normalize_files", "sed -i -e \"/^\\s\\* Version:/c\\ * Version: %build.number%\" -e \"/^define( 'A8C_ETK_PLUGIN_VERSION'/c\\define( 'A8C_ETK_PLUGIN_VERSION', '%build.number%' );\" full-site-editing-plugin.php && sed -i -e \"/^Stable tag:\\s/c\\Stable tag: %build.number%\" readme.txt\n")
+
 	}
 
 	steps {
@@ -80,7 +86,6 @@ private object WpcomBlockEditor : BuildType({
 	name = "Wpcom Block Editor"
 
 	params {
-		param("build.prefix", "1")
 		param("plugin_slug", "wpcom-block-editor")
 		param("archive_dir", "./dist/")
 		param("build_env", "development")
@@ -93,7 +98,6 @@ private object Notifications : BuildType({
 	name = "Notifications"
 
 	params {
-		param("build.prefix", "1")
 		param("plugin_slug", "notifications")
 		param("archive_dir", "./dist/")
 	}
@@ -105,7 +109,6 @@ private object O2Blocks : BuildType({
 	name = "O2 Blocks"
 
 	params {
-		param("build.prefix", "1")
 		param("plugin_slug", "o2-blocks")
 		param("archive_dir", "./dist/")
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -259,7 +259,7 @@ function load_block_patterns_from_api( $current_screen ) {
 add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );
 
 /**
- * Load WPCOM Block Patterns Modifications
+ * Load WPCOM Block Patterns Modifications.
  *
  * This is responsible for modifying how block patterns behave in the editor,
  * including adding support for premium block patterns. The patterns themselves


### PR DESCRIPTION
## Changes proposed in this Pull Request
In this PR, I refactor the ETK build into a "build template". This allows us to utilize the exact same build structure for every wpcom plugin. For this change, verifying that the ETK build works as expected is enough.
 
Secondly, I've added builds for each of the "apps" to use this setup. I'm not sure how to get them to show up in TeamCity -- perhaps after merging? This will make it much easier to incorporate those plugins into the build script.

**Note: these builds are mostly placeholders for the time being, will flesh out the details for each in separate PRs.**

Bringing consistency to app workflows would be awesome. These are only some of the benefits over the previous approach:
- No need to set the team city API token
- No need to manually create a diff
- No more merge conflicts, assuming that the same workflow is followed as is for ETK.
- Easy testing of branch builds.
- No need to visit TeamCity to install the plugin.

With further tweaks, we can also add:
- Correct meta information in diffs.
- Slack notifications on changed trunk builds.

 
## Testing instructions
1. Make sure that the ETK build works exactly the same way as before.
2. TBD