### PR TITLE
Purchase Management: Display introductory offer information when relevant

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -34,6 +34,15 @@ function createPurchaseObject( purchase ) {
 		expiryStatus: camelCase( purchase.expiry_status ),
 		includedDomain: purchase.included_domain,
 		includedDomainPurchaseAmount: purchase.included_domain_purchase_amount,
+		introductoryOffer: purchase.introductory_offer
+			? {
+					costPerInterval: Number( purchase.introductory_offer.cost_per_interval ),
+					endDate: String( purchase.introductory_offer.end_date ),
+					intervalCount: Number( purchase.introductory_offer.interval_count ),
+					intervalUnit: String( purchase.introductory_offer.interval_unit ),
+					isWithinPeriod: Boolean( purchase.introductory_offer.is_within_period ),
+			  }
+			: null,
 		isCancelable: Boolean( purchase.is_cancelable ),
 		isDomainRegistration: Boolean( purchase.is_domain_registration ),
 		isRechargeable: Boolean( purchase.is_rechargable ),

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -555,6 +555,14 @@ function isRenewing( purchase ) {
 	return includes( [ 'active', 'autoRenewing' ], purchase.expiryStatus );
 }
 
+function isWithinIntroductoryOfferPeriod( purchase ) {
+	return purchase.introductoryOffer?.isWithinPeriod;
+}
+
+function isIntroductoryOfferFreeTrial( purchase ) {
+	return purchase.introductoryOffer?.costPerInterval === 0;
+}
+
 function isSubscription( purchase ) {
 	const nonSubscriptionFunctions = [ isDomainRegistration, isOneTimePurchase ];
 
@@ -759,6 +767,8 @@ export {
 	isRenewal,
 	isRenewing,
 	isSubscription,
+	isWithinIntroductoryOfferPeriod,
+	isIntroductoryOfferFreeTrial,
 	maybeWithinRefundPeriod,
 	needsToRenewSoon,
 	paymentLogoType,

--- a/client/lib/purchases/utils.ts
+++ b/client/lib/purchases/utils.ts
@@ -5,6 +5,7 @@
 /**
  * Type dependencies
  */
+import { useTranslate } from 'i18n-calypso';
 import type { Purchase } from './types';
 
 /**
@@ -19,4 +20,69 @@ export function getPurchaseByProductSlug(
 	slug: string
 ): Purchase | undefined {
 	return purchases.find( ( purchase ) => purchase.productSlug === slug );
+}
+
+export function getIntroductoryOfferIntervalDisplay(
+	translate: ReturnType< typeof useTranslate >,
+	intervalUnit: string,
+	intervalCount: number,
+	isFreeTrial: boolean
+): string {
+	let text = String( translate( 'Discount for first period' ) );
+	if ( isFreeTrial ) {
+		if ( intervalUnit === 'month' ) {
+			if ( intervalCount === 1 ) {
+				text = String( translate( 'First month free' ) );
+			} else {
+				text = String(
+					translate( 'First %(numberOfMonths)d months free', {
+						args: {
+							numberOfMonths: intervalCount,
+						},
+					} )
+				);
+			}
+		}
+		if ( intervalUnit === 'year' ) {
+			if ( intervalCount === 1 ) {
+				text = String( translate( 'First year free' ) );
+			} else {
+				text = String(
+					translate( 'First %(numberOfYears)d years free', {
+						args: {
+							numberOfYears: intervalCount,
+						},
+					} )
+				);
+			}
+		}
+	} else {
+		if ( intervalUnit === 'month' ) {
+			if ( intervalCount === 1 ) {
+				text = String( translate( 'Discount for first month' ) );
+			} else {
+				text = String(
+					translate( 'Discount for first %(numberOfMonths)d months', {
+						args: {
+							numberOfMonths: intervalCount,
+						},
+					} )
+				);
+			}
+		}
+		if ( intervalUnit === 'year' ) {
+			if ( intervalCount === 1 ) {
+				text = String( translate( 'Discount for first year' ) );
+			} else {
+				text = String(
+					translate( 'Discount for first %(numberOfYears)d years', {
+						args: {
+							numberOfYears: intervalCount,
+						},
+					} )
+				);
+			}
+		}
+	}
+	return text;
 }

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -23,6 +23,8 @@ import {
 	isSubscription,
 	isCloseToExpiration,
 	isRenewable,
+	isWithinIntroductoryOfferPeriod,
+	isIntroductoryOfferFreeTrial,
 } from 'calypso/lib/purchases';
 import {
 	isDomainRegistration,
@@ -46,6 +48,7 @@ import { getCurrentUser, getCurrentUserId } from 'calypso/state/current-user/sel
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
 import PaymentInfoBlock from './payment-info-block';
+import { getIntroductoryOfferIntervalDisplay } from 'calypso/lib/purchases/utils';
 
 export default function PurchaseMeta( {
 	purchaseId = false,
@@ -77,6 +80,7 @@ export default function PurchaseMeta( {
 					<em className="manage-purchase__detail-label">{ translate( 'Price' ) }</em>
 					<span className="manage-purchase__detail">
 						<PurchaseMetaPrice purchase={ purchase } />
+						<PurchaseMetaIntroductoryOfferDetail purchase={ purchase } />
 					</span>
 				</li>
 				<PurchaseMetaExpiration
@@ -256,6 +260,28 @@ function PurchaseMetaPrice( { purchase } ) {
 			period: <span className="manage-purchase__time-period" />,
 		},
 	} );
+}
+
+function PurchaseMetaIntroductoryOfferDetail( { purchase } ) {
+	const translate = useTranslate();
+
+	if ( ! isWithinIntroductoryOfferPeriod( purchase ) ) {
+		return null;
+	}
+
+	const text = getIntroductoryOfferIntervalDisplay(
+		translate,
+		purchase.introductoryOffer.intervalUnit,
+		purchase.introductoryOffer.intervalCount,
+		isIntroductoryOfferFreeTrial( purchase )
+	);
+
+	return (
+		<>
+			<br />
+			<small> { text } </small>
+		</>
+	);
 }
 
 function PurchaseMetaPaymentDetails( { purchase, getChangePaymentMethodUrlFor, siteSlug, site } ) {

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -24,6 +24,8 @@ import {
 	creditCardExpiresBeforeSubscription,
 	creditCardHasAlreadyExpired,
 	getPartnerName,
+	isWithinIntroductoryOfferPeriod,
+	isIntroductoryOfferFreeTrial,
 } from 'calypso/lib/purchases';
 import { isDomainTransfer, isConciergeSession } from 'calypso/lib/products-values';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
@@ -96,6 +98,38 @@ class PurchaseItem extends Component {
 							},
 						}
 					) }
+				</span>
+			);
+		}
+
+		if ( isWithinIntroductoryOfferPeriod( purchase ) && isIntroductoryOfferFreeTrial( purchase ) ) {
+			if ( isRenewing( purchase ) ) {
+				return translate( 'Free trial ends on {{span}}%(date)s{{/span}}, renews automatically', {
+					args: {
+						timeUntilExpiry: expiry.fromNow(),
+						date: expiry.format( 'LL' ),
+					},
+					components: {
+						span: <span className="purchase-item__date" />,
+					},
+				} );
+			}
+			const expiryClass =
+				expiry < moment().add( 7, 'days' )
+					? 'purchase-item__is-error'
+					: 'purchase-item__is-warning';
+
+			return (
+				<span className={ expiryClass }>
+					{ translate( 'Free trial ends on {{span}}%(date)s{{/span}}', {
+						args: {
+							date: expiry.format( 'LL' ),
+						},
+						components: {
+							span: <span className="purchase-item__date" />,
+						},
+					} ) }
+					{ this.trackImpression( 'purchase-expiring' ) }
 				</span>
 			);
 		}

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -106,7 +106,6 @@ class PurchaseItem extends Component {
 			if ( isRenewing( purchase ) ) {
 				return translate( 'Free trial ends on {{span}}%(date)s{{/span}}, renews automatically', {
 					args: {
-						timeUntilExpiry: expiry.fromNow(),
 						date: expiry.format( 'LL' ),
 					},
 					components: {

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
+import i18nCalypso, { localize } from 'i18n-calypso';
 import page from 'page';
 import classNames from 'classnames';
 
@@ -55,7 +55,7 @@ class PurchaseItem extends Component {
 	}
 
 	getStatus() {
-		const { purchase, translate, moment, name, isJetpack, isDisconnectedSite } = this.props;
+		const { purchase, translate, locale, moment, name, isJetpack, isDisconnectedSite } = this.props;
 		const expiry = moment( purchase.expiryDate );
 
 		if ( purchase && isPartnerPurchase( purchase ) ) {
@@ -103,34 +103,50 @@ class PurchaseItem extends Component {
 		}
 
 		if ( isWithinIntroductoryOfferPeriod( purchase ) && isIntroductoryOfferFreeTrial( purchase ) ) {
-			if ( isRenewing( purchase ) ) {
-				return translate( 'Free trial ends on {{span}}%(date)s{{/span}}, renews automatically', {
-					args: {
-						date: expiry.format( 'LL' ),
-					},
-					components: {
-						span: <span className="purchase-item__date" />,
-					},
-				} );
-			}
-			const expiryClass =
-				expiry < moment().add( 7, 'days' )
-					? 'purchase-item__is-error'
-					: 'purchase-item__is-warning';
-
-			return (
-				<span className={ expiryClass }>
-					{ translate( 'Free trial ends on {{span}}%(date)s{{/span}}', {
+			if (
+				isRenewing( purchase ) &&
+				( locale === 'en' ||
+					i18nCalypso.hasTranslation(
+						'Free trial ends on {{span}}%(date)s{{/span}}, renews automatically at %(amount)s'
+					) )
+			) {
+				return translate(
+					'Free trial ends on {{span}}%(date)s{{/span}}, renews automatically at %(amount)s',
+					{
 						args: {
 							date: expiry.format( 'LL' ),
+							amount: purchase.priceText,
 						},
 						components: {
 							span: <span className="purchase-item__date" />,
 						},
-					} ) }
-					{ this.trackImpression( 'purchase-expiring' ) }
-				</span>
-			);
+					}
+				);
+			}
+
+			if (
+				locale === 'en' ||
+				i18nCalypso.hasTranslation( 'Free trial ends on {{span}}%(date)s{{/span}}' )
+			) {
+				const expiryClass =
+					expiry < moment().add( 7, 'days' )
+						? 'purchase-item__is-error'
+						: 'purchase-item__is-warning';
+
+				return (
+					<span className={ expiryClass }>
+						{ translate( 'Free trial ends on {{span}}%(date)s{{/span}}', {
+							args: {
+								date: expiry.format( 'LL' ),
+							},
+							components: {
+								span: <span className="purchase-item__date" />,
+							},
+						} ) }
+						{ this.trackImpression( 'purchase-expiring' ) }
+					</span>
+				);
+			}
 		}
 
 		if ( isRenewing( purchase ) && purchase.renewDate ) {

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -47,6 +47,7 @@ import type {
 	WPCOMProductVariant,
 	OnChangeItemVariant,
 } from './item-variation-picker';
+import { getIntroductoryOfferIntervalDisplay } from 'calypso/lib/purchases/utils';
 
 const WPOrderReviewList = styled.ul< { theme?: Theme } >`
 	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
@@ -646,67 +647,13 @@ function IntroductoryOfferCallout( {
 	if ( ! product.introductory_offer_terms?.enabled ) {
 		return null;
 	}
-
-	let text = String( translate( 'Discount for first period' ) );
-	const intervalUnit = product.introductory_offer_terms.interval_unit;
-	const intervalCount = product.introductory_offer_terms.interval_count;
-
-	if ( product.item_subtotal_integer === 0 ) {
-		if ( intervalUnit === 'month' ) {
-			if ( intervalCount === 1 ) {
-				text = String( translate( 'First month free' ) );
-			} else {
-				text = String(
-					translate( 'First %(numberOfMonths)d months free', {
-						args: {
-							numberOfMonths: intervalCount,
-						},
-					} )
-				);
-			}
-		}
-		if ( intervalUnit === 'year' ) {
-			if ( intervalCount === 1 ) {
-				text = String( translate( 'First year free' ) );
-			} else {
-				text = String(
-					translate( 'First %(numberOfYears)d years free', {
-						args: {
-							numberOfYears: intervalCount,
-						},
-					} )
-				);
-			}
-		}
-	} else {
-		if ( intervalUnit === 'month' ) {
-			if ( intervalCount === 1 ) {
-				text = String( translate( 'Discount for first month' ) );
-			} else {
-				text = String(
-					translate( 'Discount for first %(numberOfMonths)d months', {
-						args: {
-							numberOfMonths: intervalCount,
-						},
-					} )
-				);
-			}
-		}
-		if ( intervalUnit === 'year' ) {
-			if ( intervalCount === 1 ) {
-				text = String( translate( 'Discount for first year' ) );
-			} else {
-				text = String(
-					translate( 'Discount for first %(numberOfYears)d years', {
-						args: {
-							numberOfYears: intervalCount,
-						},
-					} )
-				);
-			}
-		}
-	}
-
+	const isFreeTrial = product.item_subtotal_integer === 0;
+	const text = getIntroductoryOfferIntervalDisplay(
+		translate,
+		product.introductory_offer_terms.interval_unit,
+		product.introductory_offer_terms.interval_count,
+		isFreeTrial
+	);
 	return <DiscountCallout>{ text }</DiscountCallout>;
 }
 

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -376,7 +376,7 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): i18nCalypso.
 	}
 
 	if ( ! isRenewalItem && serverCartItem.months_per_bill_period === 1 ) {
-		return translate( 'Monthly subscription' );
+		return translate( 'Billed monthly' );
 	}
 
 	if ( isRenewalItem ) {

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -90,6 +90,7 @@ describe( 'selectors', () => {
 				expiryStatus: '',
 				includedDomain: undefined,
 				includedDomainPurchaseAmount: undefined,
+				introductoryOffer: null,
 				isCancelable: false,
 				isDomainRegistration: false,
 				isRechargeable: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds new messages to the purchase list and purchase detail screens when an introductory offer is active. Feedback is welcome about what is the best way (and language) to communicate this.

In Purchase List adds changes the regular message (only for free trials):

**When auto-renew is on**
![image](https://user-images.githubusercontent.com/15204776/112678140-33966200-8e30-11eb-8fcd-cc54c10173ed.png)


**When auto-renew is off**
![image](https://user-images.githubusercontent.com/15204776/112678112-2c6f5400-8e30-11eb-96cd-405032ae9cc8.png)


In the purchase details it reuses the same message implemented for checkout in #50494
![image](https://user-images.githubusercontent.com/15204776/111554367-d6255580-874b-11eb-94f9-e4960a8fb280.png)

#### Testing instructions

Follow the steps in D59006-code to purchase a subscription with an introductory offer.
Open the purchases list and verify that the subscription is explicit about the free trial it contains.
Open the purchase detail and verify that it includes the duration of the free trial right below the price.
