### PR TITLE
Partner Portal: Fix redirecting to pages outside the portal

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -14,6 +14,7 @@ import {
 	publicToInternalLicenseFilter,
 	publicToInternalLicenseSortField,
 	valueToEnum,
+	ensurePartnerPortalReturnUrl,
 } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import Header from './header';
 import JetpackComFooter from 'calypso/jetpack-cloud/sections/pricing/jpcom-footer';
@@ -79,9 +80,7 @@ export function requirePartnerKeyContext( context: PageJS.Context, next: () => v
 		return;
 	}
 
-	const returnUrl = pathname.startsWith( '/partner-portal' )
-		? pathname + search
-		: '/partner-portal';
+	const returnUrl = ensurePartnerPortalReturnUrl( pathname + search );
 
 	page.redirect(
 		addQueryArgs(

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -79,7 +79,7 @@ export function requirePartnerKeyContext( context: PageJS.Context, next: () => v
 		return;
 	}
 
-	const returnUrl = ! pathname.startsWith( '/partner-portal' )
+	const returnUrl = pathname.startsWith( '/partner-portal' )
 		? pathname + search
 		: '/partner-portal';
 

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -72,16 +72,19 @@ export function issueLicenseContext( context: PageJS.Context, next: () => void )
 export function requirePartnerKeyContext( context: PageJS.Context, next: () => void ): void {
 	const state = context.store.getState();
 	const hasKey = getActivePartnerKey( state );
+	const { pathname, search } = window.location;
 
 	if ( hasKey ) {
 		next();
 		return;
 	}
 
+	const returnUrl = '/partner-portal' === pathname ? pathname + search : '/partner-portal';
+
 	page.redirect(
 		addQueryArgs(
 			{
-				return: window.location.pathname + window.location.search,
+				return: returnUrl,
 			},
 			'/partner-portal/partner-key'
 		)

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -79,7 +79,9 @@ export function requirePartnerKeyContext( context: PageJS.Context, next: () => v
 		return;
 	}
 
-	const returnUrl = '/partner-portal' === pathname ? pathname + search : '/partner-portal';
+	const returnUrl = ! pathname.startsWith( '/partner-portal' )
+		? pathname + search
+		: '/partner-portal';
 
 	page.redirect(
 		addQueryArgs(

--- a/client/jetpack-cloud/sections/partner-portal/select-partner-key/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/select-partner-key/index.tsx
@@ -19,6 +19,7 @@ import {
 	hasActivePartnerKey,
 	hasFetchedPartner,
 } from 'calypso/state/partner-portal/partner/selectors';
+import { ensurePartnerPortalReturnUrl } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
 import Main from 'calypso/components/main';
 import CardHeading from 'calypso/components/card-heading';
@@ -43,10 +44,7 @@ export default function SelectPartnerKey(): ReactElement | null {
 	useEffect( () => {
 		if ( hasKey ) {
 			const returnQuery = getQueryArg( window.location.href, 'return' ) as string;
-			const returnUrl =
-				returnQuery && returnQuery.startsWith( '/partner-portal' )
-					? returnQuery
-					: '/partner-portal';
+			const returnUrl = ensurePartnerPortalReturnUrl( returnQuery );
 
 			page.redirect( returnUrl );
 		}

--- a/client/jetpack-cloud/sections/partner-portal/select-partner-key/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/select-partner-key/index.tsx
@@ -42,8 +42,12 @@ export default function SelectPartnerKey(): ReactElement | null {
 
 	useEffect( () => {
 		if ( hasKey ) {
-			const returnUrl = getQueryArg( window.location.href, 'return' ) as string;
-			page.redirect( returnUrl || '/partner-portal' );
+			const returnQuery = getQueryArg( window.location.href, 'return' ) as string;
+			const returnUrl =
+				returnQuery && returnQuery.startsWith( '/partner-portal' )
+					? returnQuery
+					: '/partner-portal';
+			page.redirect( returnUrl );
 		}
 	}, [ hasKey ] );
 

--- a/client/jetpack-cloud/sections/partner-portal/select-partner-key/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/select-partner-key/index.tsx
@@ -47,6 +47,7 @@ export default function SelectPartnerKey(): ReactElement | null {
 				returnQuery && returnQuery.startsWith( '/partner-portal' )
 					? returnQuery
 					: '/partner-portal';
+
 			page.redirect( returnUrl );
 		}
 	}, [ hasKey ] );

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -129,3 +129,16 @@ export function publicToInternalLicenseSortField(
 export function internalToPublicLicenseSortField( internalSortField: LicenseSortField ): string {
 	return internalSortFieldMap[ internalSortField ] || internalSortField;
 }
+
+/**
+ * Check if the given URL belongs to the Partner Portal. If true, returns the URL, otherwise it returns the
+ *  Partner Portal base URL: '/partner-portal'
+ *
+ * @param {string} returnToUrl The URL that
+ * @returns {string} The right URL to return to
+ */
+export function ensurePartnerPortalReturnUrl( returnToUrl: string ): string {
+	return returnToUrl && returnToUrl.startsWith( '/partner-portal' )
+		? returnToUrl
+		: '/partner-portal';
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: 1187494150150258-as-1200043581561248/f

* This PR fixes the issue where the Select Partner Key component was redirecting to pages outside of the Partner Portal. It fixes both the controller (when we come from another page and click to open the Partner Portal) and the redirection within the component (when we already have a URL with redirection).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* If you do not have a partner key with licenses, please contact Infinity for one or you will be unable to view test this PR.
* Before checking out this PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal
* Click on "Manage Sites" and then click back on the "Partner Portal" menu item.
* The URL now should look like http://jetpack.cloud.localhost:3000/partner-portal/partner-key?return=%2Flanding (and if you select a key, you will be redirect to /landing)
* Checkout this PR, and go through the step 3 and 4 again.
* The URL now should look like http://jetpack.cloud.localhost:3000/partner-portal/partner-key?return=%2Fpartner-portal and if you select a key, you will be redirected to the portal.
* Also try changing the `?return` value to something else manually. The component will handle the redirection and it will redirect it to the correct page

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->