### PR TITLE
New Page Layout Picker: Remove lodash from starter-page-templates feature in ETK

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-plugin.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-plugin.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { stubTrue } from 'lodash';
 import '@wordpress/nux';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -42,7 +41,7 @@ export const PageTemplatesPlugin = compose(
 			},
 			insertTemplate: ( title, blocks ) => {
 				// Add filter to let the tracking library know we are inserting a template.
-				addFilter( INSERTING_HOOK_NAME, INSERTING_HOOK_NAMESPACE, stubTrue );
+				addFilter( INSERTING_HOOK_NAME, INSERTING_HOOK_NAMESPACE, () => true );
 
 				// Set post title.
 				if ( title ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `_.stubTrue` usage

Cleaning up lodash usage while I'm in the area. See p4TIVU-9Bf-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* in your sandbox
*  `cd /home/wpcom/public_html`
* `install-plugin.sh etk update/remove-lodash-starter-page-templates`
* Smoke test new page modal in sandboxed site
* Filter network requests by `wpcom_block_inserted` in browser, insert page layout using modal, confirm that the `from_template_selector` property on the `wpcom_block_inserted` events that are sent is `true` (that's what the hook `isInsertingPageTemplate` hook is ultimately being used for) 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
