### PR TITLE
New Onboarding: Capture site creation error to E2E and re-enable onboarding E2E.

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { Redirect, Switch, Route, useLocation } from 'react-router-dom';
 import { useSelect, useDispatch } from '@wordpress/data';
 import type { BlockEditProps } from '@wordpress/blocks';
+import { isE2ETest } from 'calypso/lib/e2e';
 
 /**
  * Internal dependencies
@@ -109,6 +110,11 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 
 	function createSiteOrError() {
 		if ( newSiteError ) {
+			// Temporarily capture error related to new site creation to E2E
+			if ( isE2ETest() ) {
+				throw new Error( `onboarding-debug ${ JSON.stringify( newSiteError ) }` );
+			}
+
 			return <CreateSiteError linkTo={ getLatestStepPath() } />;
 		} else if ( canUseCreateSiteStep() ) {
 			return <CreateSite />;

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -36,7 +36,7 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 		driver = await driverManager.startBrowser();
 	} );
 
-	describe.skip( 'Create new site as existing user @parallel @canary', function () {
+	describe( 'Create new site as existing user @parallel @canary', function () {
 		const siteTitle = dataHelper.randomPhrase();
 		const domainQuery = dataHelper.randomPhrase();
 		let newSiteDomain = '';
@@ -118,6 +118,19 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 				);
 				await plansPage.expandAllPlans();
 				await plansPage.selectFreePlan();
+
+				// Redirect console messages that starts with "onboarding-debug" to E2E log.
+				driver
+					.manage()
+					.logs()
+					.get( 'browser' )
+					.then( function ( logs ) {
+						logs.forEach( ( log ) => {
+							if ( log.message.indexOf( 'onboarding-debug' ) > -1 ) {
+								console.log( log.message );
+							}
+						} );
+					} );
 			}
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is just to help us gain insight into why onboarding E2E tests fail intermittently during site creation.

* On Onboarding side, output site creation error to the console log.
* On E2E side, extract the error from the console log and output the error to the E2E log.
* Re-enable E2E test.

#### Testing instructions

* Because sandboxing `public-api.wordpress.com` would cause local e2e test to not run properly, we have to simulate an error this way:
  * Add ``throw new Error(`onboarding-error ${ JSON.stringify( { foo: 'bar' } ) }`);``  in `onboarding-block/edit.tsx` after line 119.
  * Modify `test/e2e/config/default.json`, change `calypsoBaseUrl` to `http://calypso.localhost:3000`.
  * Comment out `line 148` in `use-on-site-creation.ts` which is this line `window.location.href = destination;` 
* Run `yarn start` in one terminal.
* Run `cd test/e2e` and `./node_modules/.bin/mocha specs/wp-gutenboarding-spec.js` on the another terminal.
* You should see the error captured similar to the screenshot below.

![image](https://user-images.githubusercontent.com/1287077/111595373-be45e400-87d4-11eb-85fd-28ec82880d3e.png)

Related to #49466
