### PR TITLE
Cloudflare - Release features by updating feature flags

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -21,7 +21,7 @@
 		"async-payments": false,
 		"automated-transfer": true,
 		"blogger-plan": false,
-		"cloudflare": false,
+		"cloudflare": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management/threaded-view": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -17,7 +17,7 @@
 		"async-payments": false,
 		"blogger-plan": false,
 		"catch-js-errors": false,
-		"cloudflare": false,
+		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -21,7 +21,7 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"cloudflare": false,
+		"cloudflare": true,
 		"composite-checkout-testing": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/production.json
+++ b/config/production.json
@@ -21,7 +21,7 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"cloudflare": false,
+		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -22,7 +22,7 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"cloudflare": false,
+		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": true,

--- a/config/test.json
+++ b/config/test.json
@@ -31,7 +31,7 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
-		"cloudflare": false,
+		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,7 +24,7 @@
 		"comments/management/threaded-view": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"cloudflare": false,
+		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates feature flags to publicly release the CDN marketing cards and analytics tool for our Cloudflare partnership.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify code update - all environments should have the feature flag `cloudflare` set to `true`.
* Check out this branch locally, or test on calypso.live.
* To verify behavior, navigate to Tools -> Marketing -> Traffic, verify that "Cloudflare Web Analytics" card appears without a flag specified in the URL.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

