### PR TITLE
Help: Fix site selector

### DIFF
--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -111,6 +111,6 @@
 	margin: 0;
 }
 
-.help-contact-form .gridicon {
+.help-contact-form .help-result__icon {
 	margin-right: 16px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I introduced a visual bug in #50671 that added an unnecessary margin to the site picker dropdown icon (thanks @obenland for catching it!) This makes the CSS selector more specific so it only targets help results. 

**Before**

<img width="335" alt="Screen Shot 2021-03-18 at 10 52 09 AM" src="https://user-images.githubusercontent.com/2124984/111646405-fef32c80-87d7-11eb-83f3-a1c68c35a348.png">

**After**

<img width="346" alt="Screen Shot 2021-03-18 at 10 42 49 AM" src="https://user-images.githubusercontent.com/2124984/111645997-a328a380-87d7-11eb-95e6-cb2bbacbc83a.png">


#### Testing instructions

* Switch to this PR, navigate to `/help/contact`
* The site picker in the contact form should look like the "After" example above
* Make sure other help results still show the icon with a right margin; type something like "site map" into the subject field and wait for the results to populate below the form