### PR TITLE
Fixed margin right to arrow icon when then heading is collapsed

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -266,7 +266,7 @@ $font-size: rem( 14px );
 			}
 		}
 
-		.sidebar__menu.is-togglable.is-toggle-open .sidebar__expandable-arrow {
+		.sidebar__menu.is-togglable .sidebar__expandable-arrow {
 			margin-right: 10px;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix the arrow margin for collapsed reader sections that can be expanded (e.g. "Followed sites", "Lists", "Tags".

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit Reader page
* Expand and collapse a selected section like "Followed sites"
* Expand and collapse a non-selected section.
* The arrow icon should remain in the same location.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #51191
