### PR TITLE
Add billing interval to purchase list status

### DIFF
--- a/client/lib/products-values/get-product-billing-term-label.ts
+++ b/client/lib/products-values/get-product-billing-term-label.ts
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { TERM_MONTHLY, TERM_ANNUALLY, TERM_BIENNIALLY } from 'calypso/lib/plans/constants';
+import { PRODUCTS_LIST } from 'calypso/lib/products-values/products-list';
+
+/**
+ * Type dependencies
+ */
+import type { ProductSlug } from 'calypso/lib/products-values/types';
+import type { Product } from 'calypso/lib/products-values/products-list';
+
+/**
+ * Returns the billing term label for a product (i.e. "every month", "every year", "every two years").
+ *
+ * @param {ProductSlug} productSlug Product slug
+ * @returns {string} Translated billing term label
+ */
+export function getProductBillingTermLabel( productSlug: ProductSlug ): string | undefined {
+	const product: Product = PRODUCTS_LIST[ productSlug ];
+
+	if ( product && product.term ) {
+		switch ( product.term ) {
+			case TERM_MONTHLY:
+				return String( translate( 'monthly' ) );
+			case TERM_ANNUALLY:
+				return String( translate( 'yearly' ) );
+			case TERM_BIENNIALLY:
+				return String( translate( 'every two years' ) );
+		}
+	}
+
+	return undefined;
+}

--- a/client/lib/products-values/get-product-billing-term-label.ts
+++ b/client/lib/products-values/get-product-billing-term-label.ts
@@ -19,7 +19,7 @@ import type { Product } from 'calypso/lib/products-values/products-list';
  * Returns the billing term label for a product (i.e. "every month", "every year", "every two years").
  *
  * @param {ProductSlug} productSlug Product slug
- * @returns {string} Translated billing term label
+ * @returns {string|undefined} Translated billing term label
  */
 export function getProductBillingTermLabel( productSlug: ProductSlug ): string | undefined {
 	const product: Product = PRODUCTS_LIST[ productSlug ];

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -133,7 +133,7 @@ function getSubscriptionEndDate( purchase ) {
  * Returns a purchase term label (i.e. "every month", "every year", "every two years").
  *
  * @param {object} purchase The purchase
- * @returns {string} The purchase's term label
+ * @returns {string|undefined} The purchase's term label
  */
 function getPurchaseBillingTermLabel( purchase ) {
 	if ( isPlan( purchase ) ) {

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -1,12 +1,14 @@
+
 import {
 	getPlan,
-	isMonthly as isMonthlyPlan,
+	getProductBillingTermLabel,
 	getProductFromSlug,
 	isDomainMapping,
 	isDomainRegistration,
 	isDomainTransfer,
 	isGSuiteOrGoogleWorkspace,
 	isJetpackPlan,
+	isMonthly as isMonthlyPlan,
 	isMonthlyProduct,
 	isPlan,
 	isTheme,
@@ -16,18 +18,19 @@ import {
 	isWpComPlan,
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
+	getPlanBillingTermLabel,
 } from '@automattic/calypso-products';
 import { encodeProductForUrl } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
-import i18n from 'i18n-calypso';
+import i18n, { translate } from 'i18n-calypso';
 import { find } from 'lodash';
 import moment from 'moment';
 import page from 'page';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getRenewalItemFromProduct } from 'calypso/lib/cart-values/cart-items';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { reduxDispatch } from 'calypso/lib/redux-bridge';
 import { errorNotice } from 'calypso/state/notices/actions';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 const debug = debugFactory( 'calypso:purchases' );
 
@@ -124,6 +127,20 @@ function getPartnerName( purchase ) {
 function getSubscriptionEndDate( purchase ) {
 	const localeSlug = i18n.getLocaleSlug();
 	return moment( purchase.expiryDate ).locale( localeSlug ).format( 'LL' );
+}
+
+/**
+ * Returns a purchase term label (i.e. "every month", "every year", "every two years").
+ *
+ * @param {object} purchase The purchase
+ * @returns {string} The purchase's term label
+ */
+function getPurchaseBillingTermLabel( purchase ) {
+	if ( isPlan( purchase ) ) {
+		return getPlanBillingTermLabel( purchase.productSlug, translate );
+	}
+
+	return getProductBillingTermLabel( purchase.productSlug, translate );
 }
 
 /**
@@ -754,6 +771,7 @@ export {
 	getDisplayName,
 	getPartnerName,
 	getPurchasesBySite,
+	getPurchaseBillingTermLabel,
 	getRenewalPrice,
 	getSubscriptionEndDate,
 	getSubscriptionsBySite,

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -197,9 +197,21 @@ class PurchaseItem extends Component {
 				);
 			}
 
-			return translate( 'Renews %(interval)s at %(amount)s on {{span}}%(date)s{{/span}}', {
+			if ( getPurchaseBillingTermLabel( purchase ) ) {
+				return translate( 'Renews %(interval)s at %(amount)s on {{span}}%(date)s{{/span}}', {
+					args: {
+						interval: getPurchaseBillingTermLabel( purchase ),
+						amount: purchase.priceText,
+						date: renewDate.format( 'LL' ),
+					},
+					components: {
+						span: <span className="purchase-item__date" />,
+					},
+				} );
+			}
+
+			return translate( 'Renews at %(amount)s on {{span}}%(date)s{{/span}}', {
 				args: {
-					interval: getPurchaseBillingTermLabel( purchase ),
 					amount: purchase.priceText,
 					date: renewDate.format( 'LL' ),
 				},

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -12,20 +12,21 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { getPaymentMethodImageURL } from 'calypso/lib/checkout/payment-methods';
 import {
+	creditCardExpiresBeforeSubscription,
+	creditCardHasAlreadyExpired,
 	getDisplayName,
+	getPartnerName,
+	getPurchaseBillingTermLabel,
 	isExpired,
 	isExpiring,
 	isIncludedWithPlan,
+	isIntroductoryOfferFreeTrial,
 	isOneTimePurchase,
 	isPartnerPurchase,
 	isRecentMonthlyPurchase,
+	isWithinIntroductoryOfferPeriod,
 	isRenewing,
 	purchaseType,
-	creditCardExpiresBeforeSubscription,
-	creditCardHasAlreadyExpired,
-	getPartnerName,
-	isWithinIntroductoryOfferPeriod,
-	isIntroductoryOfferFreeTrial,
 } from 'calypso/lib/purchases';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import { getPurchaseListUrlFor } from 'calypso/my-sites/purchases/paths';
@@ -196,8 +197,9 @@ class PurchaseItem extends Component {
 				);
 			}
 
-			return translate( 'Renews at %(amount)s on {{span}}%(date)s{{/span}}', {
+			return translate( 'Renews %(interval)s at %(amount)s on {{span}}%(date)s{{/span}}', {
 				args: {
+					interval: getPurchaseBillingTermLabel( purchase ),
 					amount: purchase.priceText,
 					date: renewDate.format( 'LL' ),
 				},

--- a/client/my-sites/plans/jetpack-plans/types.ts
+++ b/client/my-sites/plans/jetpack-plans/types.ts
@@ -2,6 +2,7 @@ import type { ITEM_TYPE_PLAN, ITEM_TYPE_PRODUCT } from './constants';
 import type { PlanRecommendation } from './plan-upgrade/types';
 import type {
 	TERM_ANNUALLY,
+	TERM_BIENNIALLY,
 	TERM_MONTHLY,
 	JetpackProductCategory,
 } from '@automattic/calypso-products';
@@ -9,7 +10,7 @@ import type { Purchase } from 'calypso/lib/purchases/types';
 import type { TranslateResult } from 'i18n-calypso';
 import type { ReactNode, ReactElement } from 'react';
 
-export type Duration = typeof TERM_ANNUALLY | typeof TERM_MONTHLY;
+export type Duration = typeof TERM_ANNUALLY | typeof TERM_MONTHLY | typeof TERM_BIENNIALLY;;
 export type DurationString = 'annual' | 'monthly';
 export type ItemType = typeof ITEM_TYPE_PLAN | typeof ITEM_TYPE_PRODUCT;
 

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -39,8 +39,10 @@ import type {
 	PlanSlug,
 	WithCamelCaseSlug,
 	WithSnakeCaseSlug,
+	ProductSlug,
 } from './types';
 import type { TranslateResult } from 'i18n-calypso';
+import { PRODUCTS_LIST } from './products-list';
 
 export function getPlans(): Record< string, Plan > {
 	return PLANS_LIST;
@@ -565,6 +567,45 @@ export function getPlanTermLabel(
 		case TERM_BIENNIALLY:
 			return translate( 'Two year subscription' );
 	}
+}
+
+export function getPlanBillingTermLabel( 
+	planName: string,
+	translate: ( text: string ) => string
+): string | undefined {
+	const plan = getPlan( planName );
+	if ( ! plan || ! plan.term ) {
+		return;
+	}
+
+	switch ( plan.term ) {
+		case TERM_MONTHLY:
+			return translate( 'monthly' );
+		case TERM_ANNUALLY:
+			return translate( 'yearly' );
+		case TERM_BIENNIALLY:
+			return translate( 'every two years' );
+	}
+}
+
+export function getProductBillingTermLabel( 
+	productSlug: ProductSlug,
+	translate: ( text: string ) => string
+): string | undefined {
+	const product: Product = PRODUCTS_LIST[ productSlug ];
+
+	if ( product && product.term ) {
+		switch ( product.term ) {
+			case TERM_MONTHLY:
+				return String( translate( 'monthly' ) );
+			case TERM_ANNUALLY:
+				return String( translate( 'yearly' ) );
+			case TERM_BIENNIALLY:
+				return String( translate( 'every two years' ) );
+		}
+	}
+
+	return undefined;
 }
 
 export const getPopularPlanSpec = ( {


### PR DESCRIPTION
As a follow-up (or alternative) to #51099, this adds the billing interval to "Renews on…" statuses in the purchases list. I used the terms "monthly", "yearly", and "every two years" to reduce confusion around "biennially" and "annually".

Fixes: #47877

**Before** | **After**
------------ | -------------
<img width="1058" alt="Screen Shot 2021-03-18 at 2 29 22 PM" src="https://user-images.githubusercontent.com/942359/111678247-7637b900-87f6-11eb-9efb-dba75d48850f.png"> | <img width="1065" alt="Screen Shot 2021-03-18 at 2 26 44 PM" src="https://user-images.githubusercontent.com/942359/111678268-7b950380-87f6-11eb-8c5b-f2a892541d78.png">

**To test:**
- on an account with purchases (with payment methods assigned and auto-renew on)
- visit Me > Purchases
- verify that the purchase status includes a billing interval
- visit My Site > Upgrades > Purchases
- verify that the purchase status includes a billing interval
