### PR TITLE
Checkout: Explicitly pass coupon from cart to payment processor functions

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -54,6 +54,7 @@ async function submitExistingCardPayment(
 	debug( 'formatting existing card transaction', transactionData );
 	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
 		...transactionData,
+		couponId: transactionOptions.responseCart.coupon,
 		paymentMethodType: 'WPCOM_Billing_MoneyPress_Stored',
 	} );
 	debug( 'submitting existing card transaction', formattedTransactionData );

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -248,7 +248,7 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 	return {
 		cart: createTransactionEndpointCartFromLineItems( {
 			siteId,
-			couponId: couponId || getCouponIdFromProducts( items ),
+			couponId,
 			country,
 			postalCode,
 			subdivisionCode,
@@ -283,11 +283,6 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 			nik,
 		},
 	};
-}
-
-function getCouponIdFromProducts( items: WPCOMCartItem[] ): string | undefined {
-	const couponItem = items.find( ( item ) => item.type === 'coupon' );
-	return couponItem?.wpcom_meta?.couponCode;
 }
 
 export function getSublabel( serverCartItem: ResponseCartProduct ): i18nCalypso.TranslateResult {

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -246,23 +246,15 @@ export async function ebanxCardProcessor(
 
 export async function multiPartnerCardProcessor(
 	submitData,
-	{ includeDomainDetails, includeGSuiteDetails, recordEvent },
+	dataForProcessor,
 	transactionOptions
 ) {
 	const paymentPartner = submitData.paymentPartner;
 	if ( paymentPartner === 'stripe' ) {
-		return stripeCardProcessor(
-			submitData,
-			{ includeDomainDetails, includeGSuiteDetails, recordEvent },
-			transactionOptions
-		);
+		return stripeCardProcessor( submitData, dataForProcessor, transactionOptions );
 	}
 	if ( paymentPartner === 'ebanx' ) {
-		return ebanxCardProcessor( submitData, {
-			includeDomainDetails,
-			includeGSuiteDetails,
-			recordEvent,
-		} );
+		return ebanxCardProcessor( submitData, dataForProcessor );
 	}
 	throw new RangeError( 'Unrecognized card payment partner: "' + paymentPartner + '"' );
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -34,7 +34,14 @@ const { select } = defaultRegistry;
 export async function genericRedirectProcessor(
 	paymentMethodId,
 	submitData,
-	{ getThankYouUrl, siteSlug, includeDomainDetails, includeGSuiteDetails, reduxDispatch }
+	{
+		getThankYouUrl,
+		siteSlug,
+		includeDomainDetails,
+		includeGSuiteDetails,
+		reduxDispatch,
+		responseCart,
+	}
 ) {
 	const { protocol, hostname, port, pathname } = parseUrl(
 		typeof window !== 'undefined' ? window.location.href : 'https://wordpress.com',
@@ -73,6 +80,7 @@ export async function genericRedirectProcessor(
 			...submitData,
 			successUrl,
 			cancelUrl,
+			couponId: responseCart.coupon,
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
 			postalCode: submitData.postalCode || getPostalCode(),
 			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
@@ -87,7 +95,14 @@ export async function genericRedirectProcessor(
 
 export async function weChatProcessor(
 	submitData,
-	{ getThankYouUrl, siteSlug, includeDomainDetails, includeGSuiteDetails, reduxDispatch }
+	{
+		getThankYouUrl,
+		siteSlug,
+		includeDomainDetails,
+		includeGSuiteDetails,
+		reduxDispatch,
+		responseCart,
+	}
 ) {
 	const paymentMethodId = 'wechat';
 	recordTransactionBeginAnalytics( {
@@ -125,6 +140,7 @@ export async function weChatProcessor(
 			...submitData,
 			successUrl,
 			cancelUrl,
+			couponId: responseCart.coupon,
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
 			postalCode: submitData.postalCode || getPostalCode(),
 			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
@@ -144,12 +160,13 @@ export async function weChatProcessor(
 
 export async function applePayProcessor(
 	submitData,
-	{ includeDomainDetails, includeGSuiteDetails },
+	{ includeDomainDetails, includeGSuiteDetails, responseCart },
 	transactionOptions
 ) {
 	return submitApplePayPayment(
 		{
 			...submitData,
+			couponId: responseCart.coupon,
 			siteId: select( 'wpcom' )?.getSiteId?.(),
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
@@ -162,7 +179,7 @@ export async function applePayProcessor(
 
 export async function stripeCardProcessor(
 	submitData,
-	{ includeDomainDetails, includeGSuiteDetails, recordEvent: onEvent },
+	{ includeDomainDetails, includeGSuiteDetails, recordEvent: onEvent, responseCart },
 	transactionOptions
 ) {
 	const paymentMethodToken = await createStripePaymentMethodToken( {
@@ -173,6 +190,7 @@ export async function stripeCardProcessor(
 	return submitStripeCardTransaction(
 		{
 			...submitData,
+			couponId: responseCart.coupon,
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
 			postalCode: getPostalCode(),
 			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
@@ -204,7 +222,7 @@ export async function stripeCardProcessor(
 
 export async function ebanxCardProcessor(
 	submitData,
-	{ includeDomainDetails, includeGSuiteDetails }
+	{ includeDomainDetails, includeGSuiteDetails, responseCart }
 ) {
 	const paymentMethodToken = await createEbanxToken( 'new_purchase', {
 		country: submitData.countryCode,
@@ -216,6 +234,7 @@ export async function ebanxCardProcessor(
 	return submitEbanxCardTransaction(
 		{
 			...submitData,
+			couponId: responseCart.coupon,
 			siteId: select( 'wpcom' )?.getSiteId?.(),
 			deviceId: paymentMethodToken?.deviceId,
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
@@ -250,11 +269,12 @@ export async function multiPartnerCardProcessor(
 
 export async function freePurchaseProcessor(
 	submitData,
-	{ includeDomainDetails, includeGSuiteDetails }
+	{ includeDomainDetails, includeGSuiteDetails, responseCart }
 ) {
 	return submitFreePurchaseTransaction(
 		{
 			...submitData,
+			couponId: responseCart.coupon,
 			siteId: select( 'wpcom' )?.getSiteId?.(),
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 			// this data is intentionally empty so we do not charge taxes
@@ -267,12 +287,13 @@ export async function freePurchaseProcessor(
 
 export async function fullCreditsProcessor(
 	submitData,
-	{ includeDomainDetails, includeGSuiteDetails },
+	{ includeDomainDetails, includeGSuiteDetails, responseCart },
 	transactionOptions
 ) {
 	return submitCreditsTransaction(
 		{
 			...submitData,
+			couponId: responseCart.coupon,
 			siteId: select( 'wpcom' )?.getSiteId?.(),
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

https://github.com/Automattic/wp-calypso/pull/51084 caused a regression by removing all the non-product line items (including coupons) from the data provided to the payment processors. It turns out that all payment processors except for PayPal Express collected their coupon data from the line items if it wasn't provided explicitly. As a result, coupons were no longer being submitted as part of the transaction for all payment methods except for PayPal.

This PR explicitly passes the coupon through the payment processor functions.

#### Testing instructions

- Apply a coupon to checkout.
- Submit checkout using a payment method other than PayPal.
- Verify that the coupon was applied to final receipt.