### PR TITLE
Checkout: Convert transaction endpoint submission function to TypeScript

### DIFF
--- a/client/lib/domains/cart-utils.js
+++ b/client/lib/domains/cart-utils.js
@@ -13,7 +13,7 @@ import { isDomainRegistration } from 'calypso/lib/products-values/is-domain-regi
  * Depending on the current step in checkout, the user's domain can be found in
  * either the cart or the receipt.
  *
- * @param {import('calypso/my-sites/checkout/composite-checkout/types/wpcom-store-state').TransactionResponse} [receipt] - The receipt for the transaction
+ * @param {import('calypso/my-sites/checkout/composite-checkout/types/transaction-endpoint').WPCOMTransactionEndpointResponse} [receipt] - The receipt for the transaction
  * @param {import('@automattic/shopping-cart').ResponseCart} cart - The cart for the transaction
  *
  * @returns {string|null} the name of the first domain for the transaction.

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -36,7 +36,8 @@ import {
 	retrieveSignupDestination,
 	clearSignupDestinationCookie,
 } from 'calypso/signup/storageUtils';
-import type { TransactionResponse, Purchase } from '../types/wpcom-store-state';
+import type { Purchase } from '../types/wpcom-store-state';
+import type { WPCOMTransactionEndpointResponse } from '../types/transaction-endpoint';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { recordPurchase } from 'calypso/lib/analytics/record-purchase';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from '../lib/translate-payment-method-names';
@@ -330,7 +331,7 @@ function recordPaymentCompleteAnalytics( {
 	reduxDispatch,
 }: {
 	paymentMethodId: string | null;
-	transactionResult: TransactionResponse | undefined;
+	transactionResult: WPCOMTransactionEndpointResponse | undefined;
 	redirectUrl: string;
 	responseCart: ResponseCart;
 	reduxDispatch: ReturnType< typeof useDispatch >;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
@@ -12,7 +12,7 @@ import type { ResponseCart } from '@automattic/shopping-cart';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import isEligibleForSignupDestination from 'calypso/state/selectors/is-eligible-for-signup-destination';
 import getThankYouPageUrl from './get-thank-you-page-url';
-import type { TransactionResponse } from '../../types/wpcom-store-state';
+import type { WPCOMTransactionEndpointResponse } from '../../types/transaction-endpoint';
 import {
 	isTreatmentOneClickTest,
 	isTreatmentDifmUpsellTest,
@@ -92,7 +92,7 @@ export default function useGetThankYouUrl( {
 
 export interface GetThankYouUrlProps {
 	siteSlug: string | undefined;
-	transactionResult?: TransactionResponse | undefined;
+	transactionResult?: WPCOMTransactionEndpointResponse | undefined;
 	redirectTo?: string | undefined;
 	purchaseId?: number | undefined;
 	feature?: string | undefined;

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -10,7 +10,7 @@ import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
  * Internal dependencies
  */
 import { createTransactionEndpointRequestPayloadFromLineItems } from './translate-cart';
-import { wpcomTransaction } from '../payment-method-helpers';
+import submitWpcomTransaction from './submit-wpcom-transaction';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type { ExistingCardTransactionRequestWithLineItems } from '../types/transaction-endpoint';
 
@@ -59,7 +59,7 @@ async function submitExistingCardPayment(
 	} );
 	debug( 'submitting existing card transaction', formattedTransactionData );
 
-	return wpcomTransaction( formattedTransactionData, transactionOptions );
+	return submitWpcomTransaction( formattedTransactionData, transactionOptions );
 }
 
 type ExistingCardTransactionRequest = Omit<

--- a/client/my-sites/checkout/composite-checkout/lib/normalize-transaction-response.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/normalize-transaction-response.ts
@@ -1,13 +1,21 @@
 /**
  * Internal dependencies
  */
-import { TransactionResponse } from 'calypso/my-sites/checkout/composite-checkout/types/wpcom-store-state';
+import { WPCOMTransactionEndpointResponse } from '../types/transaction-endpoint';
 
-export default function normalizeTransactionResponse( response: unknown ): TransactionResponse {
+const emptyResponse: WPCOMTransactionEndpointResponse = {
+	success: false,
+	error_code: '',
+	error_message: '',
+};
+
+export default function normalizeTransactionResponse(
+	response: unknown
+): WPCOMTransactionEndpointResponse {
 	if ( ! response ) {
-		return {};
+		return emptyResponse;
 	}
-	const transactionResponse = response as TransactionResponse;
+	const transactionResponse = response as WPCOMTransactionEndpointResponse;
 	if (
 		transactionResponse.message ||
 		transactionResponse.order_id ||
@@ -18,5 +26,5 @@ export default function normalizeTransactionResponse( response: unknown ): Trans
 	) {
 		return transactionResponse;
 	}
-	return {};
+	return emptyResponse;
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -186,31 +186,6 @@ function getErrorMessage( { error, message } ) {
 	}
 }
 
-export async function wpcomTransaction( payload, transactionOptions ) {
-	if ( transactionOptions && transactionOptions.createUserAndSiteBeforeTransaction ) {
-		return createAccount().then( ( response ) => {
-			const siteIdFromResponse = response?.blog_details?.blogid;
-
-			// If the account is already created(as happens when we are reprocessing after a transaction error), then
-			// the create account response will not have a site ID, so we fetch from state.
-			const siteId = siteIdFromResponse || select( 'wpcom' )?.getSiteId();
-			const newPayload = {
-				...payload,
-				cart: {
-					...payload.cart,
-					blog_id: siteId || '0',
-					cart_key: siteId || 'no-site',
-					create_new_blog: false,
-				},
-			};
-
-			return wp.undocumented().transactions( newPayload );
-		} );
-	}
-
-	return wp.undocumented().transactions( payload );
-}
-
 export function createStripePaymentMethodToken( { stripe, name, country, postalCode } ) {
 	return createStripePaymentMethod( stripe, {
 		name,

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -15,7 +15,6 @@ import { confirmStripePaymentIntent } from '@automattic/calypso-stripe';
  */
 import {
 	createStripePaymentMethodToken,
-	wpcomTransaction,
 	submitApplePayPayment,
 	submitStripeCardTransaction,
 	submitEbanxCardTransaction,
@@ -28,6 +27,7 @@ import getDomainDetails from './lib/get-domain-details';
 import { createEbanxToken } from 'calypso/lib/store-transactions';
 import userAgent from 'calypso/lib/user-agent';
 import { recordTransactionBeginAnalytics } from './lib/analytics';
+import submitWpcomTransaction from './lib/submit-wpcom-transaction';
 
 const { select } = defaultRegistry;
 
@@ -87,7 +87,7 @@ export async function genericRedirectProcessor(
 			siteId: select( 'wpcom' )?.getSiteId?.(),
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 		},
-		wpcomTransaction
+		submitWpcomTransaction
 	).then( ( response ) => {
 		return makeRedirectResponse( response?.redirect_url );
 	} );
@@ -147,7 +147,7 @@ export async function weChatProcessor(
 			siteId: select( 'wpcom' )?.getSiteId?.(),
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 		},
-		wpcomTransaction
+		submitWpcomTransaction
 	).then( ( response ) => {
 		// The WeChat payment type should only redirect when on mobile as redirect urls
 		// are mobile app urls: e.g. weixin://wxpay/bizpayurl?pr=RaXzhu4
@@ -172,7 +172,7 @@ export async function applePayProcessor(
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 			postalCode: getPostalCode(),
 		},
-		wpcomTransaction,
+		submitWpcomTransaction,
 		transactionOptions
 	).then( makeSuccessResponse );
 }
@@ -198,7 +198,7 @@ export async function stripeCardProcessor(
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 			paymentMethodToken,
 		},
-		wpcomTransaction,
+		submitWpcomTransaction,
 		transactionOptions
 	)
 		.then( ( stripeResponse ) => {
@@ -240,7 +240,7 @@ export async function ebanxCardProcessor(
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 			paymentMethodToken,
 		},
-		wpcomTransaction
+		submitWpcomTransaction
 	).then( makeSuccessResponse );
 }
 
@@ -273,7 +273,7 @@ export async function freePurchaseProcessor(
 			country: null,
 			postalCode: null,
 		},
-		wpcomTransaction
+		submitWpcomTransaction
 	).then( makeSuccessResponse );
 }
 
@@ -292,7 +292,7 @@ export async function fullCreditsProcessor(
 			postalCode: submitData.postalCode || getPostalCode(),
 			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
 		},
-		wpcomTransaction,
+		submitWpcomTransaction,
 		transactionOptions
 	).then( makeSuccessResponse );
 }

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -107,10 +107,16 @@ export type WPCOMTransactionEndpointCart = {
 	tax: Omit< ResponseCartTaxData, 'display_taxes' >;
 };
 
+type PurchaseSiteId = number;
+
 export type WPCOMTransactionEndpointResponse = {
 	success: boolean;
 	error_code: string;
 	error_message: string;
-	receipt_id: number;
-	purchases: Record< number, Purchase >;
+	failed_purchases?: Record< PurchaseSiteId, Purchase[] >;
+	purchases?: Record< PurchaseSiteId, Purchase[] >;
+	receipt_id?: number;
+	order_id?: number;
+	redirect_url?: string;
+	message?: { payment_intent_client_secret: string };
 };

--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -893,20 +893,9 @@ export type WpcomStoreState = {
 	siteId: string;
 	siteSlug: string;
 	recaptchaClientId: number;
-	transactionResult: TransactionResponse;
+	transactionResult?: WPCOMTransactionEndpointResponse | undefined;
 	contactDetails: ManagedContactDetails;
 };
-
-type PurchaseSiteId = number;
-
-export interface TransactionResponse {
-	failed_purchases?: Record< PurchaseSiteId, Purchase[] >;
-	purchases?: Record< PurchaseSiteId, Purchase[] >;
-	receipt_id?: number;
-	order_id?: number;
-	redirect_url?: string;
-	message?: { payment_intent_client_secret: string };
-}
 
 export interface FailedPurchase {
 	product_meta: string;
@@ -1011,7 +1000,7 @@ export function getInitialWpcomStoreState(
 		siteId: '',
 		siteSlug: '',
 		recaptchaClientId: -1,
-		transactionResult: {},
+		transactionResult: undefined,
 		contactDetails,
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -20,6 +20,7 @@ import {
 } from './backend/domain-contact-validation-endpoint';
 import { tryToGuessPostalCodeFormat } from 'calypso/lib/postal-code';
 import { SignupValidationResponse } from './backend/signup-validation-endpoint';
+import type { WPCOMTransactionEndpointResponse } from './transaction-endpoint';
 
 export type ManagedContactDetailsShape< T > = {
 	firstName?: T;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Each payment processor except for PayPal Express uses the "regular" transactions endpoint and passes through the function `wpcomTransaction` to do that. This PR converts that function to TypeScript (renaming it `submitWpcomTransaction`).

In the process, this cleans up the transaction response type, for which there were two types already defined, but the correct type was a combination of the two.

Includes https://github.com/Automattic/wp-calypso/pull/51156 and will require a rebase when that is merged.

#### Testing instructions

First, test making a purchase in checkout using a non-PayPal payment method. Even though this touches nearly all payment methods, just testing one of them should be sufficient because they all use the modified function.

Second, it would be a good idea to visually compare `wpcomTransaction` and `submitWpcomTransaction` and make sure that they are the same.