### PR TITLE
ExPlat: Change platform to Calypso

### DIFF
--- a/client/lib/explat/internals/fetch-experiment-assignment.ts
+++ b/client/lib/explat/internals/fetch-experiment-assignment.ts
@@ -16,7 +16,7 @@ export default function fetchExperimentAssignment( {
 } ): Promise< unknown > {
 	return wpcom.req.get(
 		{
-			path: '/experiments/0.1.0/assignments/wpcom',
+			path: '/experiments/0.1.0/assignments/calypso',
 			apiNamespace: 'wpcom/v2',
 		},
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the platform from `wpcom` to `calypso`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves 579-gh-Automattic/experimentation-platform