### PR TITLE
Search: remove default props

### DIFF
--- a/packages/search/src/search.stories.jsx
+++ b/packages/search/src/search.stories.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 
-import { Search } from './search';
+import Search from './search';
 
 export default { title: 'Search', component: Search };
 

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -184,7 +184,7 @@ const InnerSearch = (
 
 	useEffect( () => {
 		if ( keyword ) {
-			onSearchProp( keyword );
+			onSearchProp?.( keyword );
 		}
 		// Disable reason: This effect covers the case where a keyword was passed in as the default value and we only want to run it on first search; the useUpdateEffect below will handle the rest of the time that keyword updates
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -116,7 +116,7 @@ const InnerSearch = (
 		pinned = false,
 		onSearchClose,
 		onSearchChange,
-		onSearch: onSearchProp,
+		onSearch,
 		onBlur: onBlurProp,
 		onKeyDown: onKeyDownProp,
 		onClick,
@@ -171,20 +171,20 @@ const InnerSearch = (
 	);
 
 	const doSearch: ( ( search: string ) => void ) & { cancel?: () => void } = React.useMemo( () => {
-		if ( ! onSearchProp ) {
+		if ( ! onSearch ) {
 			return () => {}; // eslint-disable-line @typescript-eslint/no-empty-function
 		}
 
 		if ( ! delaySearch ) {
-			return onSearchProp;
+			return onSearch;
 		}
 
-		return debounce( onSearchProp, delayTimeout );
-	}, [ onSearchProp, delayTimeout, delaySearch ] );
+		return debounce( onSearch, delayTimeout );
+	}, [ onSearch, delayTimeout, delaySearch ] );
 
 	useEffect( () => {
 		if ( keyword ) {
-			onSearchProp?.( keyword );
+			onSearch?.( keyword );
 		}
 		// Disable reason: This effect covers the case where a keyword was passed in as the default value and we only want to run it on first search; the useUpdateEffect below will handle the rest of the time that keyword updates
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -30,9 +30,6 @@ import './style.scss';
  * Internal variables
  */
 const SEARCH_DEBOUNCE_MS = 300;
-const noop = () => {
-	/* Default noop callback for some props */
-};
 
 type KeyboardOrMouseEvent =
 	| MouseEvent< HTMLButtonElement | HTMLInputElement >
@@ -114,19 +111,17 @@ type ImperativeHandle = {
 
 const InnerSearch = (
 	{
-		delaySearch,
-		disabled,
-		pinned,
+		delaySearch = false,
+		disabled = false,
+		pinned = false,
 		onSearchClose,
 		onSearchChange,
-		onSearch: onSearchProp = () => {
-			/* noop default */
-		},
+		onSearch: onSearchProp,
 		onBlur: onBlurProp,
 		onKeyDown: onKeyDownProp,
 		onClick,
 		describedBy,
-		delayTimeout,
+		delayTimeout = SEARCH_DEBOUNCE_MS,
 		defaultValue = '',
 		defaultIsOpen = false,
 		autoFocus = false,
@@ -135,17 +130,17 @@ const InnerSearch = (
 		overlayStyling,
 		placeholder: placeholderProp,
 		inputLabel,
-		disableAutocorrect,
+		disableAutocorrect = false,
 		className,
 		dir,
-		fitsContainer,
-		searching,
-		compact,
-		hideOpenIcon,
-		openIconSide,
+		fitsContainer = false,
+		searching = false,
+		compact = false,
+		hideOpenIcon = false,
+		openIconSide = 'left',
 		minLength,
 		maxLength,
-		hideClose,
+		hideClose = false,
 	}: Props,
 	forwardedRef: Ref< ImperativeHandle >
 ) => {
@@ -175,10 +170,17 @@ const InnerSearch = (
 		[]
 	);
 
-	const doSearch: ( ( search: string ) => void ) & { cancel?: () => void } = React.useMemo(
-		() => ( delaySearch ? debounce( onSearchProp, delayTimeout ) : onSearchProp ),
-		[ onSearchProp, delayTimeout, delaySearch ]
-	);
+	const doSearch: ( ( search: string ) => void ) & { cancel?: () => void } = React.useMemo( () => {
+		if ( ! onSearchProp ) {
+			return () => {}; // eslint-disable-line @typescript-eslint/no-empty-function
+		}
+
+		if ( ! delaySearch ) {
+			return onSearchProp;
+		}
+
+		return debounce( onSearchProp, delayTimeout );
+	}, [ onSearchProp, delayTimeout, delaySearch ] );
 
 	useEffect( () => {
 		if ( keyword ) {
@@ -259,10 +261,7 @@ const InnerSearch = (
 	}, [ keyword, isOpen, hasFocus ] );
 
 	const onBlur = ( event: FocusEvent< HTMLInputElement > ) => {
-		if ( onBlurProp ) {
-			onBlurProp( event );
-		}
-
+		onBlurProp?.( event );
 		setHasFocus( false );
 	};
 
@@ -432,32 +431,7 @@ const InnerSearch = (
 	);
 };
 
-export const Search = React.forwardRef( InnerSearch );
-Search.defaultProps = {
-	autoFocus: false,
-	compact: false,
-	delaySearch: false,
-	delayTimeout: SEARCH_DEBOUNCE_MS,
-	describedBy: undefined,
-	dir: undefined,
-	disableAutocorrect: false,
-	disabled: false,
-	fitsContainer: false,
-	hideClose: false,
-	hideOpenIcon: false,
-	defaultIsOpen: false,
-	onClick: noop,
-	onKeyDown: noop,
-	onSearchChange: noop,
-	onSearchOpen: noop,
-	onSearchClose: noop,
-	openIconSide: 'left' as const,
-	//undefined value for overlayStyling is an optimization that will
-	//disable overlay scrolling calculation when no overlay is provided.
-	overlayStyling: undefined,
-	pinned: false,
-	recordEvent: noop,
-	searching: false,
-};
+const Search = React.forwardRef( InnerSearch );
+Search.displayName = 'Search';
 
 export default Search;


### PR DESCRIPTION
Removes the `Search.defaultProps` object, because `defaultProps` is a class component thing and should not be used on function components, they say:

https://twitter.com/dan_abramov/status/1133878326358171650

We're setting default values when destructuring the props instead.

I removed all callback props defaulting to `noop` after checking that they are all called with the `onSomething?.()` operator.

The only exception is the `onSearch` prop that required a little bit more complex patch of the `doSearch` callback, to account for the `undefined` value.

Two little drive-by changes:
- remove the named export of `Search`. It's used only by the Storybook module, which can use the default export
- assign a `displayName` to the result of `forwardRef`
