### PR TITLE
QueryManager state updates: add withQueryManager wrapper

### DIFF
--- a/client/lib/query-manager/with-query-manager.js
+++ b/client/lib/query-manager/with-query-manager.js
@@ -1,0 +1,35 @@
+/**
+ * Apply a `callback` transformation to a `QueryManager` instance in `state[ siteId ]` and
+ * return a state object updated with its result.
+ * If the `state[ siteId ]` object doesn't exist, it's created with the `create` function.
+ * If `create` is `false`, the `callback` will not be applied (there is no `QueryManager` to
+ * apply it to after all) and unchanged state will be returned.
+ *
+ * @param {object} state State object
+ * @param {string} siteId State key
+ * @param {Function | boolean} create Optional create callback
+ * @param {Function} callback Transformation callback
+ * @returns {object} Updated state object
+ */
+export default function withQueryManager( state, siteId, create, callback ) {
+	if ( ! siteId ) {
+		return state;
+	}
+
+	const prevManager = state[ siteId ] || ( create && create() );
+
+	if ( ! prevManager ) {
+		return state;
+	}
+
+	const nextManager = callback( prevManager );
+
+	if ( nextManager === prevManager ) {
+		return state;
+	}
+
+	return {
+		...state,
+		[ siteId ]: nextManager,
+	};
+}

--- a/client/lib/query-manager/with-query-manager.js
+++ b/client/lib/query-manager/with-query-manager.js
@@ -7,11 +7,11 @@
  *
  * @param {object} state State object
  * @param {string} siteId State key
- * @param {Function | boolean} create Optional create callback
  * @param {Function} callback Transformation callback
+ * @param {Function} [create] Optional create callback
  * @returns {object} Updated state object
  */
-export default function withQueryManager( state, siteId, create, callback ) {
+export default function withQueryManager( state, siteId, callback, create ) {
 	if ( ! siteId ) {
 		return state;
 	}

--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -28,6 +28,7 @@ import {
 } from 'calypso/state/action-types';
 import { combineReducers } from 'calypso/state/utils';
 import isTransientMediaId from 'calypso/lib/media/utils/is-transient-media-id';
+import withQueryManager from 'calypso/lib/query-manager/with-query-manager';
 import MediaQueryManager from 'calypso/lib/query-manager/media';
 import { ValidationErrors as MediaValidationErrors } from 'calypso/lib/media/constants';
 import { transformSite as transformSiteTransientItems } from 'calypso/state/media/utils/transientItems';
@@ -144,43 +145,28 @@ export const errors = ( state = {}, action ) => {
 	return state;
 };
 
-function applyToManager( state, siteId, method, createDefault, ...args ) {
-	if ( ! state[ siteId ] ) {
-		if ( ! createDefault ) {
-			return state;
-		}
-
-		return {
-			...state,
-			[ siteId ]: new MediaQueryManager()[ method ]( ...args ),
-		};
-	}
-
-	const nextManager = state[ siteId ][ method ]( ...args );
-
-	if ( nextManager === state[ siteId ] ) {
-		return state;
-	}
-
-	return {
-		...state,
-		[ siteId ]: nextManager,
-	};
-}
-
 export const queries = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case MEDIA_RECEIVE: {
 			const { siteId, media, found, query } = action;
-			return applyToManager( state, siteId, 'receive', true, media, { found, query } );
+			return withQueryManager(
+				state,
+				siteId,
+				() => new MediaQueryManager(),
+				( manager ) => manager.receive( media, { found, query } )
+			);
 		}
 		case MEDIA_DELETE: {
 			const { siteId, mediaIds } = action;
-			return applyToManager( state, siteId, 'removeItems', true, mediaIds );
+			return withQueryManager( state, siteId, false, ( manager ) =>
+				manager.removeItems( mediaIds )
+			);
 		}
 		case MEDIA_ITEM_EDIT: {
 			const { siteId, mediaItem } = action;
-			return applyToManager( state, siteId, 'receive', true, mediaItem, { patch: true } );
+			return withQueryManager( state, siteId, false, ( manager ) =>
+				manager.receive( mediaItem, { patch: true } )
+			);
 		}
 		case MEDIA_SOURCE_CHANGE:
 		case MEDIA_CLEAR_SITE: {

--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -152,21 +152,17 @@ export const queries = ( state = {}, action ) => {
 			return withQueryManager(
 				state,
 				siteId,
-				() => new MediaQueryManager(),
-				( manager ) => manager.receive( media, { found, query } )
+				( m ) => m.receive( media, { found, query } ),
+				() => new MediaQueryManager()
 			);
 		}
 		case MEDIA_DELETE: {
 			const { siteId, mediaIds } = action;
-			return withQueryManager( state, siteId, false, ( manager ) =>
-				manager.removeItems( mediaIds )
-			);
+			return withQueryManager( state, siteId, ( m ) => m.removeItems( mediaIds ) );
 		}
 		case MEDIA_ITEM_EDIT: {
 			const { siteId, mediaItem } = action;
-			return withQueryManager( state, siteId, false, ( manager ) =>
-				manager.receive( mediaItem, { patch: true } )
-			);
+			return withQueryManager( state, siteId, ( m ) => m.receive( mediaItem, { patch: true } ) );
 		}
 		case MEDIA_SOURCE_CHANGE:
 		case MEDIA_CLEAR_SITE: {

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -173,8 +173,8 @@ const queriesReducer = ( state = {}, action ) => {
 			return withQueryManager(
 				state,
 				siteId,
-				() => new PostQueryManager(),
-				( manager ) => manager.receive( normalizedPosts, { query, found } )
+				( m ) => m.receive( normalizedPosts, { query, found } ),
+				() => new PostQueryManager()
 			);
 		}
 		case POSTS_RECEIVE: {
@@ -191,50 +191,49 @@ const queriesReducer = ( state = {}, action ) => {
 
 			return reduce(
 				postsBySiteId,
-				( memo, sitePosts, siteId ) => {
-					return withQueryManager(
+				( memo, sitePosts, siteId ) =>
+					withQueryManager(
 						memo,
 						siteId,
-						() => new PostQueryManager(),
-						( manager ) => manager.receive( sitePosts )
-					);
-				},
+						( m ) => m.receive( sitePosts ),
+						() => new PostQueryManager()
+					),
 				state
 			);
 		}
 		case POST_RESTORE: {
 			const { siteId, postId } = action;
-			return withQueryManager( state, siteId, false, ( manager ) =>
-				manager.receive( { ID: postId, status: '__RESTORE_PENDING' }, { patch: true } )
+			return withQueryManager( state, siteId, ( m ) =>
+				m.receive( { ID: postId, status: '__RESTORE_PENDING' }, { patch: true } )
 			);
 		}
 		case POST_RESTORE_FAILURE: {
 			const { siteId, postId } = action;
-			return withQueryManager( state, siteId, false, ( manager ) =>
-				manager.receive( { ID: postId, status: 'trash' }, { patch: true } )
+			return withQueryManager( state, siteId, ( m ) =>
+				m.receive( { ID: postId, status: 'trash' }, { patch: true } )
 			);
 		}
 		case POST_SAVE: {
 			const { siteId, postId, post } = action;
-			return withQueryManager( state, siteId, false, ( manager ) =>
-				manager.receive( { ID: postId, ...post }, { patch: true } )
+			return withQueryManager( state, siteId, ( m ) =>
+				m.receive( { ID: postId, ...post }, { patch: true } )
 			);
 		}
 		case POST_DELETE: {
 			const { siteId, postId } = action;
-			return withQueryManager( state, siteId, false, ( manager ) =>
-				manager.receive( { ID: postId, status: '__DELETE_PENDING' }, { patch: true } )
+			return withQueryManager( state, siteId, ( m ) =>
+				m.receive( { ID: postId, status: '__DELETE_PENDING' }, { patch: true } )
 			);
 		}
 		case POST_DELETE_FAILURE: {
 			const { siteId, postId } = action;
-			return withQueryManager( state, siteId, false, ( manager ) =>
-				manager.receive( { ID: postId, status: 'trash' }, { patch: true } )
+			return withQueryManager( state, siteId, ( m ) =>
+				m.receive( { ID: postId, status: 'trash' }, { patch: true } )
 			);
 		}
 		case POST_DELETE_SUCCESS: {
 			const { siteId, postId } = action;
-			return withQueryManager( state, siteId, false, ( manager ) => manager.removeItem( postId ) );
+			return withQueryManager( state, siteId, ( m ) => m.removeItem( postId ) );
 		}
 	}
 

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -19,6 +19,7 @@ import {
 /**
  * Internal dependencies
  */
+import withQueryManager from 'calypso/lib/query-manager/with-query-manager';
 import PostQueryManager from 'calypso/lib/query-manager/post';
 import { combineReducers, withSchemaValidation, withPersistence } from 'calypso/state/utils';
 import {
@@ -151,33 +152,6 @@ export function queryRequests( state = {}, action ) {
 	return state;
 }
 
-function applyToManager( state, siteId, method, createDefault, ...args ) {
-	if ( ! siteId ) {
-		return state;
-	}
-
-	if ( ! state[ siteId ] ) {
-		if ( ! createDefault ) {
-			return state;
-		}
-
-		return {
-			...state,
-			[ siteId ]: new PostQueryManager()[ method ]( ...args ),
-		};
-	}
-
-	const nextManager = state[ siteId ][ method ]( ...args );
-	if ( nextManager === state[ siteId ] ) {
-		return state;
-	}
-
-	return {
-		...state,
-		[ siteId ]: nextManager,
-	};
-}
-
 /**
  * Returns the updated post query state after an action has been dispatched.
  * The state reflects a mapping by site ID of serialized query key to an array
@@ -196,7 +170,12 @@ const queriesReducer = ( state = {}, action ) => {
 				return state;
 			}
 			const normalizedPosts = posts.map( normalizePostForState );
-			return applyToManager( state, siteId, 'receive', true, normalizedPosts, { query, found } );
+			return withQueryManager(
+				state,
+				siteId,
+				() => new PostQueryManager(),
+				( manager ) => manager.receive( normalizedPosts, { query, found } )
+			);
 		}
 		case POSTS_RECEIVE: {
 			const { posts } = action;
@@ -213,84 +192,49 @@ const queriesReducer = ( state = {}, action ) => {
 			return reduce(
 				postsBySiteId,
 				( memo, sitePosts, siteId ) => {
-					return applyToManager( memo, siteId, 'receive', true, sitePosts );
+					return withQueryManager(
+						memo,
+						siteId,
+						() => new PostQueryManager(),
+						( manager ) => manager.receive( sitePosts )
+					);
 				},
 				state
 			);
 		}
 		case POST_RESTORE: {
 			const { siteId, postId } = action;
-			return applyToManager(
-				state,
-				siteId,
-				'receive',
-				false,
-				{
-					ID: postId,
-					status: '__RESTORE_PENDING',
-				},
-				{ patch: true }
+			return withQueryManager( state, siteId, false, ( manager ) =>
+				manager.receive( { ID: postId, status: '__RESTORE_PENDING' }, { patch: true } )
 			);
 		}
 		case POST_RESTORE_FAILURE: {
 			const { siteId, postId } = action;
-			return applyToManager(
-				state,
-				siteId,
-				'receive',
-				false,
-				{
-					ID: postId,
-					status: 'trash',
-				},
-				{ patch: true }
+			return withQueryManager( state, siteId, false, ( manager ) =>
+				manager.receive( { ID: postId, status: 'trash' }, { patch: true } )
 			);
 		}
 		case POST_SAVE: {
 			const { siteId, postId, post } = action;
-			return applyToManager(
-				state,
-				siteId,
-				'receive',
-				false,
-				{
-					ID: postId,
-					...post,
-				},
-				{ patch: true }
+			return withQueryManager( state, siteId, false, ( manager ) =>
+				manager.receive( { ID: postId, ...post }, { patch: true } )
 			);
 		}
 		case POST_DELETE: {
 			const { siteId, postId } = action;
-			return applyToManager(
-				state,
-				siteId,
-				'receive',
-				false,
-				{
-					ID: postId,
-					status: '__DELETE_PENDING',
-				},
-				{ patch: true }
+			return withQueryManager( state, siteId, false, ( manager ) =>
+				manager.receive( { ID: postId, status: '__DELETE_PENDING' }, { patch: true } )
 			);
 		}
 		case POST_DELETE_FAILURE: {
 			const { siteId, postId } = action;
-			return applyToManager(
-				state,
-				siteId,
-				'receive',
-				false,
-				{
-					ID: postId,
-					status: 'trash',
-				},
-				{ patch: true }
+			return withQueryManager( state, siteId, false, ( manager ) =>
+				manager.receive( { ID: postId, status: 'trash' }, { patch: true } )
 			);
 		}
 		case POST_DELETE_SUCCESS: {
 			const { siteId, postId } = action;
-			return applyToManager( state, siteId, 'removeItem', false, postId );
+			return withQueryManager( state, siteId, false, ( manager ) => manager.removeItem( postId ) );
 		}
 	}
 

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -333,15 +333,15 @@ const queriesReducer = ( state = {}, action ) => {
 			return withQueryManager(
 				state,
 				siteId,
-				() => new ThemeQueryManager( null, { itemKey: 'id' } ),
 				// Always 'patch' to avoid overwriting existing fields when receiving
 				// from a less rich endpoint such as /mine
-				( manager ) => manager.receive( map( themes, fromApi ), { query, found, patch: true } )
+				( m ) => m.receive( map( themes, fromApi ), { query, found, patch: true } ),
+				() => new ThemeQueryManager( null, { itemKey: 'id' } )
 			);
 		}
 		case THEME_DELETE_SUCCESS: {
 			const { siteId, themeId } = action;
-			return withQueryManager( state, siteId, false, ( manager ) => manager.removeItem( themeId ) );
+			return withQueryManager( state, siteId, ( m ) => m.removeItem( themeId ) );
 		}
 	}
 

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -7,6 +7,7 @@ import { mapValues, omit, map } from 'lodash';
  * Internal dependencies
  */
 import { withStorageKey } from '@automattic/state-utils';
+import withQueryManager from 'calypso/lib/query-manager/with-query-manager';
 import ThemeQueryManager from 'calypso/lib/query-manager/theme';
 import { combineReducers, withSchemaValidation, withPersistence } from 'calypso/state/utils';
 import {
@@ -304,29 +305,6 @@ export const queryRequestErrors = ( state = {}, action ) => {
 	return state;
 };
 
-function applyToManager( state, siteId, method, createDefault, ...args ) {
-	if ( ! state[ siteId ] ) {
-		if ( ! createDefault ) {
-			return state;
-		}
-
-		return {
-			...state,
-			[ siteId ]: new ThemeQueryManager( null, { itemKey: 'id' } )[ method ]( ...args ),
-		};
-	}
-
-	const nextManager = state[ siteId ][ method ]( ...args );
-	if ( nextManager === state[ siteId ] ) {
-		return state;
-	}
-
-	return {
-		...state,
-		[ siteId ]: nextManager,
-	};
-}
-
 function fromApi( theme ) {
 	if ( ! theme || ! theme.description ) {
 		return theme;
@@ -352,20 +330,18 @@ const queriesReducer = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case THEMES_REQUEST_SUCCESS: {
 			const { siteId, query, themes, found } = action;
-			return applyToManager(
-				// Always 'patch' to avoid overwriting existing fields when receiving
-				// from a less rich endpoint such as /mine
+			return withQueryManager(
 				state,
 				siteId,
-				'receive',
-				true,
-				map( themes, fromApi ),
-				{ query, found, patch: true }
+				() => new ThemeQueryManager( null, { itemKey: 'id' } ),
+				// Always 'patch' to avoid overwriting existing fields when receiving
+				// from a less rich endpoint such as /mine
+				( manager ) => manager.receive( map( themes, fromApi ), { query, found, patch: true } )
 			);
 		}
 		case THEME_DELETE_SUCCESS: {
 			const { siteId, themeId } = action;
-			return applyToManager( state, siteId, 'removeItem', false, themeId );
+			return withQueryManager( state, siteId, false, ( manager ) => manager.removeItem( themeId ) );
 		}
 	}
 


### PR DESCRIPTION
When refactoring reducers that use a `QueryManager` in #50222, I came up with this improved helper to apply transformations to `QueryManager` instances:
```js
const newState = withQueryManager(
  state,
  siteId,
  () => new PostsQueryManager(),
  manager => manager.receive( items, { patch: true } )
);
```
as a replacement to:
```js
const newState = applyToManager( state, siteId, 'receive', true, items, { patch: true } );
```

What I like about it is that it's much more obvious which method we are calling (`receive`) and what are the arguments. Typechecking that call should be much easier with this syntax.

The callback is needed because we don't always call the method -- only when the `QueryManager` exists. This convention is similar to a "monadic" callbacks e.g. in promises:
```js
withPromise( x ).then( manager => manager.receive() )
```
also calls the callback only if the promise is resolved.

**How to test:**
- verify that unit tests pass
- verify that Posts list loads and can be manipulated (delete, change post status, ...)
- verify that Pages list loads and can be manipulated (beware that the implementation is quite different from Posts, although it also a list of posts just with different type)
- verify that Media list loads and image editing works
- verify that Themes list loads and themes on Jetpack sites can be deleted (beware that Themes are a bit messy and have pre-existing bugs)