### PR TITLE
Server: use de/serialize helpers when caching server state

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -38,7 +38,7 @@ import { createReduxStore } from 'calypso/state';
 import { setDocumentHeadLink } from 'calypso/state/document-head/actions';
 import { setStore } from 'calypso/state/redux-store';
 import initialReducer from 'calypso/state/reducer';
-import { DESERIALIZE, LOCALE_SET } from 'calypso/state/action-types';
+import { LOCALE_SET } from 'calypso/state/action-types';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
 import { login } from 'calypso/lib/paths';
 import { logSectionResponse } from './analytics';
@@ -47,7 +47,7 @@ import { getLanguage, filterLanguageRevisions } from 'calypso/lib/i18n-utils';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { GUTENBOARDING_SECTION_DEFINITION } from 'calypso/landing/gutenboarding/section';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
-
+import { deserialize } from 'calypso/state/utils';
 import middlewareBuildTarget from '../middleware/build-target.js';
 import middlewareAssets from '../middleware/assets.js';
 import middlewareCache from '../middleware/cache.js';
@@ -59,7 +59,7 @@ const calypsoEnv = config( 'env_id' );
 // TODO: Re-use (a modified version of) client/state/initial-state#getInitialServerState here
 function getInitialServerState( serializedServerState ) {
 	// Bootstrapped state from a server-render
-	const serverState = initialReducer( serializedServerState, { type: DESERIALIZE } );
+	const serverState = deserialize( initialReducer, serializedServerState );
 	return pick( serverState, Object.keys( serializedServerState ) );
 }
 

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -74,11 +74,6 @@ jest.mock( 'calypso/state/redux-store', () => ( {
 
 jest.mock( 'calypso/state/reducer', () => jest.fn() );
 
-jest.mock( 'calypso/state/action-types', () => ( {
-	DESERIALIZE: 'DESERIALIZE',
-	LOCALE_SET: 'LOCALE_SET',
-} ) );
-
 jest.mock( 'calypso/state/current-user/actions', () => ( {
 	setCurrentUser: jest.fn(),
 } ) );

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -28,7 +28,7 @@ import {
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getCurrentLocaleVariant from 'calypso/state/selectors/get-current-locale-variant';
 import initialReducer from 'calypso/state/reducer';
-import { SERIALIZE } from 'calypso/state/action-types';
+import { serialize } from 'calypso/state/utils';
 import { logToLogstash } from 'calypso/state/logstash/actions';
 import stateCache from 'calypso/server/state-cache';
 import { getNormalizedPath } from 'calypso/server/isomorphic-routing';
@@ -257,7 +257,7 @@ export function serverRender( req, res ) {
 		// And cache on the server, too.
 		if ( cacheKey ) {
 			const cacheableInitialState = pick( context.store.getState(), cacheableReduxSubtrees );
-			const serverState = initialReducer( cacheableInitialState, { type: SERIALIZE } );
+			const serverState = serialize( initialReducer, cacheableInitialState );
 			stateCache.set( cacheKey, serverState );
 		}
 	}


### PR DESCRIPTION
Spinoff from #50222 that uses the `serialize` and `deserialize` helpers when saving/restoring server state. Currently the helpers just "dispatch" the `SERIALIZE` and `DESERIALIZE` actions to the reducer, as they did before, but soon they internal implementation will change.

I'm not sure whether the helpers and the `action-types` need mocking in the `server/pages/test` test. They are either simple side-effect-free functions with no dependencies, or constants. They should never be harmful to any unit test.