### PR TITLE
Fixes launch flow refresh bug

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -12,7 +12,6 @@ import {
 	omitBy,
 	pick,
 	startsWith,
-	has,
 } from 'lodash';
 
 /**
@@ -797,14 +796,8 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 
 export function isFreePlansDomainUpsellFulfilled( stepName, defaultDependencies, nextProps ) {
 	const { submitSignupStep, isPaidPlan } = nextProps;
-	const hasDomain = has( nextProps, 'signupDependencies.domainItem' );
-	const hasPlan = has( nextProps, 'signupDependencies.cartItem' );
 	const domainItem = get( nextProps, 'signupDependencies.domainItem', false );
 	const cartItem = get( nextProps, 'signupDependencies.cartItem', false );
-
-	if ( ! hasDomain || ! hasPlan ) {
-		return;
-	}
 
 	if ( isPaidPlan || domainItem || cartItem ) {
 		const selectedDomainUpsellItem = null;

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -10,6 +10,7 @@ import {
 	isPlanFulfilled,
 	isSiteTopicFulfilled,
 	isSiteTypeFulfilled,
+	isFreePlansDomainUpsellFulfilled,
 } from '../step-actions';
 import { useNock } from 'calypso/test-helpers/use-nock';
 import flows from 'calypso/signup/config/flows';
@@ -512,5 +513,87 @@ describe( 'isSiteTopicFulfilled()', () => {
 		isSiteTopicFulfilled( stepName, undefined, nextProps );
 
 		expect( flows.excludeStep ).toHaveBeenCalledWith( 'site-topic-with-optional-survey-question' );
+	} );
+} );
+
+describe( 'isFreePlansDomainUpsellFulfilled()', () => {
+	const submitSignupStep = jest.fn();
+
+	beforeEach( () => {
+		flows.excludeStep.mockClear();
+		submitSignupStep.mockClear();
+	} );
+
+	test( 'should not call submitSignupStep() when no domain or cart item and site is on free plan', () => {
+		const stepName = 'domain-upsell';
+		const nextProps = {
+			submitSignupStep,
+			isPaidPlan: false,
+			signupDependencies: {
+				domainItem: undefined,
+				cartItem: undefined,
+			},
+		};
+
+		isFreePlansDomainUpsellFulfilled( stepName, null, nextProps );
+
+		expect( submitSignupStep ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should call submitSignupStep() when site is on a paid plan', () => {
+		const stepName = 'domain-upsell';
+		const nextProps = {
+			submitSignupStep,
+			isPaidPlan: true,
+			signupDependencies: {
+				domainItem: undefined,
+				cartItem: undefined,
+			},
+		};
+
+		isFreePlansDomainUpsellFulfilled( stepName, null, nextProps );
+
+		expect( submitSignupStep ).toHaveBeenCalledWith(
+			{ stepName, selectedDomainUpsellItem: null, wasSkipped: true },
+			{ selectedDomainUpsellItem: null }
+		);
+	} );
+
+	test( 'should call submitSignupStep() when a cartItem is passed', () => {
+		const stepName = 'domain-upsell';
+		const nextProps = {
+			submitSignupStep,
+			isPaidPlan: false,
+			signupDependencies: {
+				domainItem: undefined,
+				cartItem: {},
+			},
+		};
+
+		isFreePlansDomainUpsellFulfilled( stepName, null, nextProps );
+
+		expect( submitSignupStep ).toHaveBeenCalledWith(
+			{ stepName, selectedDomainUpsellItem: null, wasSkipped: true },
+			{ selectedDomainUpsellItem: null }
+		);
+	} );
+
+	test( 'should call submitSignupStep() when a domainItem is passed', () => {
+		const stepName = 'domain-upsell';
+		const nextProps = {
+			submitSignupStep,
+			isPaidPlan: false,
+			signupDependencies: {
+				domainItem: {},
+				cartItem: undefined,
+			},
+		};
+
+		isFreePlansDomainUpsellFulfilled( stepName, null, nextProps );
+
+		expect( submitSignupStep ).toHaveBeenCalledWith(
+			{ stepName, selectedDomainUpsellItem: null, wasSkipped: true },
+			{ selectedDomainUpsellItem: null }
+		);
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This change removes the early return statement from the isFreePlansDomainUpsellFulfilled function. The early return prevented the step from being skipped if a paid plan is present.

### Testing instructions
This fixes #50400. I recommend following these instructions on `trunk` to reproduce the bug before testing the PR.
1. Create a new account with a free domain and a paid monthly plan.
1. Go to http://calypso.localhost:3000/start/launch-site?siteSlug={slug}
1. Click on Skip Purchase, the page should "refresh".

### Testing for regressions

Start the launch flow by going to http://calypso.localhost:3000/start/launch-site?siteSlug={slug} for the following cases:

#### Site with free plan and free domain
- [x] Select "Skip Purchase" and select free plan - domain upsell screen should be shown.
- [x] Select "Skip Purchase" and select paid plan - domain upsell screen should not be shown. 
- [x] Select a paid domain  - domain upsell screen should not be shown. 

#### Site with paid plan and free domain
- [x] Select "Skip Purchase" - domain upsell screen should not be shown.
- [x] Select a paid domain  - domain upsell screen should not be shown. 

#### Site with paid plan and paid domain
The site should be launched directly.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #50400
