### PR TITLE
Make wpcom-proxy-request not private

### DIFF
--- a/packages/wpcom-proxy-request/package.json
+++ b/packages/wpcom-proxy-request/package.json
@@ -22,7 +22,6 @@
 		"url": "git+https://github.com/Automattic/wp-calypso.git",
 		"directory": "packages/wpcom-proxy-request"
 	},
-	"private": true,
 	"publishConfig": {
 		"access": "public"
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `private: true` from the `wpcom-proxy-request` package so it can be published on npm by lerna

#### Testing instructions
1. Log out of npm `npm logout`
2. Run `git tag wpcom-proxy-request@6.0.0`
3. Run `npx lerna publish from-git`. Ensure the option to publish `wpcom-proxy-request` is given.