### PR TITLE
Stats: Display Number of "Best Views Ever"

### DIFF
--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -32,10 +32,7 @@ class StatsTabsTab extends React.Component {
 	};
 
 	ensureValue = ( value ) => {
-		const { loading, children, numberFormat, format } = this.props;
-		if ( children ) {
-			return null;
-		}
+		const { loading, numberFormat, format } = this.props;
 
 		if ( ! loading && ( value || value === 0 ) ) {
 			return format ? format( value ) : numberFormat( value );

--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -63,8 +63,8 @@ class StatsTabsTab extends React.Component {
 		} );
 
 		const tabIcon = gridicon ? <Gridicon icon={ gridicon } size={ 18 } /> : null;
-		const tabLabel = <span className="stats-tab__label label">{ label }</span>;
-		const tabValue = <span className="stats-tab__value value">{ this.ensureValue( value ) }</span>;
+		const tabLabel = <span className="stats-tabs__label label">{ label }</span>;
+		const tabValue = <span className="stats-tabs__value value">{ this.ensureValue( value ) }</span>;
 		const hasClickAction = href || tabClick;
 
 		return (
@@ -78,7 +78,7 @@ class StatsTabsTab extends React.Component {
 						{ children }
 					</a>
 				) : (
-					<span className="stats-tab__span no-link">
+					<span className="stats-tabs__span no-link">
 						{ tabIcon }
 						{ tabLabel }
 						{ tabValue }

--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -63,11 +63,12 @@ class StatsTabsTab extends React.Component {
 		} );
 
 		const tabIcon = gridicon ? <Gridicon icon={ gridicon } size={ 18 } /> : null;
-		const tabLabel = <span className="label">{ label }</span>;
-		const tabValue = <span className="value">{ this.ensureValue( value ) }</span>;
+		const tabLabel = <span className="stats-tab__label label">{ label }</span>;
+		const tabValue = <span className="stats-tab__value value">{ this.ensureValue( value ) }</span>;
 		const hasClickAction = href || tabClick;
 
 		return (
+			// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions
 			<li className={ tabClass } onClick={ this.clickHandler }>
 				{ hasClickAction ? (
 					<a href={ href }>
@@ -77,7 +78,7 @@ class StatsTabsTab extends React.Component {
 						{ children }
 					</a>
 				) : (
-					<span className="no-link">
+					<span className="stats-tab__span no-link">
 						{ tabIcon }
 						{ tabLabel }
 						{ tabValue }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I'm not actually sure why the line of code causing the issue was introduced to begin with since it hasn't been touched for several years, but I've hunted around and it doesn't seem to affect anything else, so this should be fine. The value is already here, so I think this definitely was intended to be displayed at some point.

https://github.com/Automattic/wp-calypso/blob/edad5f7ffaba7fbbf84b665ce826850dd5a2b960/client/my-sites/stats/all-time/index.jsx#L108

#### Testing instructions

* Verify that a number appears next to "Best views ever" on the Insights page

<img width="364" alt="Screenshot 2021-03-19 at 15 06 15" src="https://user-images.githubusercontent.com/43215253/111801347-c5e4b600-88c4-11eb-915f-77e01aca1a58.png">

cc @cpapazoglou - sorry for missing this initially!

Related to #51116
