### PR TITLE
Plans: Remove '(Entrepreneur bundle)' from CRM Free pricing

### DIFF
--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -256,7 +256,7 @@ export const EXTERNAL_PRODUCT_CRM_FREE: ( variation: Iterations ) => SelectorPro
 	isFree: true,
 	costProductSlug: PRODUCT_JETPACK_CRM_FREE,
 	monthlyProductSlug: PRODUCT_JETPACK_CRM_FREE_MONTHLY,
-	belowPriceText: translate( 'from %(minPrice)s - %(maxPrice)s (Entrepreneur bundle)', {
+	belowPriceText: translate( 'from %(minPrice)s - %(maxPrice)s', {
 		args: { minPrice: '$0', maxPrice: '$17' },
 	} ),
 	iconSlug: 'jetpack_crm',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove "(Entrepreneur bundle)" from the CRM Free card pricing copy.

#### Testing instructions

* In any of the available interfaces (Calypso Blue/Green, Jetpack Connect), load the Pricing/Plans page.
* Examine the CRM Free product card and verify that below the "Free" price, the copy says "from $0 - $17" (in your selected currency). Importantly, the parenthetical "(Entrepreneur bundle)" should no longer be displayed. See screenshots for more detail.

#### Reference screenshots (before / after)

<img width="345" alt="image" src="https://user-images.githubusercontent.com/670067/111803672-4099db00-889d-11eb-84c1-eb16f1c562c7.png"> <img width="354" alt="Screen Shot 2021-03-19 at 10 20 19" src="https://user-images.githubusercontent.com/670067/111803595-2d870b00-889d-11eb-8307-671be494ce4c.png">