### PR TITLE
Plans: Make Jetpack Free card style match other product cards

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card/style.scss
@@ -30,6 +30,7 @@
 	font-weight: 700;
 
 	@include breakpoint-deprecated( '>660px' ) {
+		margin-top: initial;
 		margin-bottom: initial;
 	}
 }
@@ -77,6 +78,7 @@
 	}
 
 	@include breakpoint-deprecated( '>660px' ) {
+		margin-top: 16px;
 		margin-bottom: 16px;
 	}
 
@@ -87,6 +89,9 @@
 		align-items: center;
 		flex-wrap: wrap;
 		flex: 2 1;
+
+		margin-top: initial;
+		margin-bottom: -14px;
 
 		> li {
 			width: calc( 50% - 8px );

--- a/client/components/jetpack/card/jetpack-free-card/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card/style.scss
@@ -33,7 +33,6 @@
 	display: block;
 
 	width: 100%;
-	max-width: 210px;
 	margin: 24px 0;
 
 	color: var( --studio-jetpack-green-40 );
@@ -41,6 +40,10 @@
 	border-radius: 4px;
 
 	font-size: 1rem;
+
+	@include break-small {
+		max-width: 210px;
+	}
 
 	@include break-large {
 		margin-bottom: 0;

--- a/client/components/jetpack/card/jetpack-free-card/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card/style.scss
@@ -18,6 +18,7 @@
 
 .jetpack-free-card__title {
 	color: var( --studio-gray-100 );
+	margin: 12px 0 20px;
 
 	font-family: 'Noto Sans SemiCondensed Bold', 'Noto Sans', $sans;
 	font-size: 1.875rem;

--- a/client/components/jetpack/card/jetpack-free-card/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card/style.scss
@@ -28,6 +28,10 @@
 	font-family: 'Noto Sans SemiCondensed Bold', 'Noto Sans', $sans;
 	font-size: 1.875rem;
 	font-weight: 700;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-bottom: initial;
+	}
 }
 
 .jetpack-free-card__subheadline {

--- a/client/components/jetpack/card/jetpack-free-card/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card/style.scss
@@ -6,11 +6,16 @@
 
 	@include break-small {
 		display: flex;
+		flex-direction: column;
+	}
+
+	@include breakpoint-deprecated( '>660px' ) {
+		flex-direction: row;
 	}
 }
 
 .jetpack-free-card__header {
-	@include break-small {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex: 1;
 		margin-inline-end: 32px;
 	}
@@ -41,7 +46,7 @@
 
 	font-size: 1rem;
 
-	@include break-small {
+	@include breakpoint-deprecated( '>660px' ) {
 		max-width: 210px;
 	}
 
@@ -55,34 +60,39 @@
 
 	color: var( --studio-gray-60 );
 
-	@include break-small {
-		flex: 1;
+	flex: 1;
+	margin: 0 16px 32px;
 
-		margin: 12px 0;
-		padding-left: 28px;
+	> li {
+		margin-bottom: 16px;
+		padding-inline-start: 8px;
+	}
 
-		> li {
-			margin-bottom: 16px;
-		}
+	> li:last-child {
+		margin-bottom: initial;
+	}
 
-		> li:last-child {
-			margin-bottom: initial;
-		}
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-bottom: 16px;
 	}
 
 	@include break-large {
+		align-self: center;
+
 		display: flex;
 		align-items: center;
 		flex-wrap: wrap;
 		flex: 2 1;
 
-		padding-left: 0;
-
 		> li {
 			width: calc( 50% - 8px );
 			padding-inline-start: 8px;
 
-			margin-bottom: initial;
+			margin-bottom: 14px;
+		}
+
+		> li:last-child {
+			margin-bottom: 14px;
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The over-arching goal of this PR is to bring the `JetpackFreeCard` component's styles more into alignment with all the other product cards in the grid.

* Make the "Start for free" button full-width on narrow screens.
* Add vertical space between the feature list items, and left-align their bullet points with the card header/sub-header.
* Adjust margin and padding for the product name and the card itself.

#### Testing instructions

* **In all experiences**, open the Pricing/Plans page.
* Resizing the viewport to cover **all screen widths**, verify that the Jetpack Free card looks/feels/behaves as much like the other product cards as possible (with the exception that it's full-width on wider screens; we still want that). See reference screenshots below for comparison.

#### Reference screenshots

##### Mobile (1 grid column; <660px) (before / after)

<img width="300" src="https://user-images.githubusercontent.com/670067/111806581-201f5000-88a0-11eb-914a-c7672a5fb82f.png"> <img width="300" src="https://user-images.githubusercontent.com/670067/111820293-50bab600-88af-11eb-9ad3-2e9d8fa10ff8.png">

##### Tablet (2 grid columns; ~660px - ~960px) (before / after)

<img width="300" src="https://user-images.githubusercontent.com/670067/111820058-0a655700-88af-11eb-81f8-37fce56558d0.png"> <img width="300" src="https://user-images.githubusercontent.com/670067/111819772-be1a1700-88ae-11eb-984a-a40e911daa2d.png">

##### Desktop (3 grid columns, >960px) (before / after)

<img width="300" src="https://user-images.githubusercontent.com/670067/111807948-7fca2b00-88a1-11eb-91c9-b7739ac720c8.png"> <img width="300" src="https://user-images.githubusercontent.com/670067/111819568-7d220280-88ae-11eb-94d5-af7eb6c7363e.png">
