### PR TITLE
Nav Unification: Update color of dismissible upsell nudge in sidebar for contrast

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -134,7 +134,7 @@ $font-size: rem( 14px );
 
 			.sidebar__menu-link {
 				padding: 5px 12px;
-				/* stylelint-disable-next-line scales/font-size */
+				/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 				font-size: rem( 13px );
 				line-height: 1.4;
 				font-weight: 400;
@@ -271,7 +271,7 @@ $font-size: rem( 14px );
 		}
 
 		.notice {
-			/* stylelint-disable-next-line scales/font-weight */
+			/* stylelint-disable-next-line scales/font-weights */
 			font-weight: 300;
 
 			&.is-compact {
@@ -289,6 +289,7 @@ $font-size: rem( 14px );
 					left: calc( 50% - 9px );
 					width: 18px;
 					height: 18px;
+					/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 					border-radius: 50%;
 				}
 			}
@@ -332,6 +333,10 @@ $font-size: rem( 14px );
 	.upsell-nudge.banner.card.is-compact .banner__action {
 		top: 0;
 		margin-left: 0;
+	}
+
+	.upsell-nudge.banner.card.is-compact .dismissible-card__close-icon {
+		fill: var( --color-text );
 	}
 
 	// client/my-sites/current-site/style.scss
@@ -400,11 +405,12 @@ $font-size: rem( 14px );
 		.current-site__notices > a::before {
 			content: '\f534';
 			font-family: 'dashicons';
-			/* stylelint-disable-next-line scales/font-size */
+			/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 			font-size: 20px;
 			line-height: 20px;
 			background-color: #a7aaad;
 			color: white;
+			/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 			border-radius: 50%;
 			margin: 3px 0 3px 1px;
 		}
@@ -457,7 +463,7 @@ $font-size: rem( 14px );
 		.sidebar__menu-link {
 			cursor: pointer;
 			color: var( --color-sidebar-text-alternative );
-			/* stylelint-disable-next-line scales/font-size */
+			/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 			font-size: rem( 13px );
 
 			&:hover,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix a contrast issue with dismissible nudges in the unified nav sidebar

**Before**

<img width="288" alt="Screen Shot 2021-03-19 at 12 20 35 PM" src="https://user-images.githubusercontent.com/2124984/111811537-83fc4580-88ad-11eb-8346-03e5d8f24dee.png">

**After**

<img width="301" alt="Screen Shot 2021-03-19 at 12 15 00 PM" src="https://user-images.githubusercontent.com/2124984/111811545-86f73600-88ad-11eb-8f7e-bb57f82b45fe.png">

#### Testing instructions

* Switch to this PR
* Find a site that has a domain sale upsell; I think this happens on sites that already have a mapped domain.
* Make sure the dismiss icon is visible on the upsell
* Make sure you can dismiss the nudge

Fixes #51118