### PR TITLE
Checkout: Convert stripe redirect processor to use cart for transactions

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -51,8 +51,8 @@ import {
 	freePurchaseProcessor,
 	multiPartnerCardProcessor,
 	fullCreditsProcessor,
-	weChatProcessor,
 } from './payment-method-processors';
+import weChatProcessor from './lib/we-chat-processor';
 import genericRedirectProcessor from './lib/generic-redirect-processor';
 import existingCardProcessor from './lib/existing-card-processor';
 import payPalProcessor from './lib/paypal-express-processor';

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -51,9 +51,9 @@ import {
 	freePurchaseProcessor,
 	multiPartnerCardProcessor,
 	fullCreditsProcessor,
-	genericRedirectProcessor,
 	weChatProcessor,
 } from './payment-method-processors';
+import genericRedirectProcessor from './lib/generic-redirect-processor';
 import existingCardProcessor from './lib/existing-card-processor';
 import payPalProcessor from './lib/paypal-express-processor';
 import useGetThankYouUrl from './hooks/use-get-thank-you-url';

--- a/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-line no-restricted-imports
+import { defaultRegistry, makeRedirectResponse } from '@automattic/composite-checkout';
+import type { LineItem, PaymentProcessorResponse } from '@automattic/composite-checkout';
+
+/**
+ * Internal dependencies
+ */
+import getPostalCode from './get-postal-code';
+import getDomainDetails from './get-domain-details';
+import { recordTransactionBeginAnalytics } from './analytics';
+import submitRedirectTransaction from './submit-redirect-transaction';
+import type { PaymentProcessorOptions } from '../types/payment-processors';
+import type { WPCOMTransactionEndpointResponse } from '../types/transaction-endpoint';
+import type { CheckoutPaymentMethodSlug } from '../types/checkout-payment-method-slug';
+import type { WPCOMCartItem } from '../types/checkout-cart';
+import type { ManagedContactDetails } from '../types/wpcom-store-state';
+
+const { select } = defaultRegistry;
+
+type RedirectTransactionRequest = {
+	name: string | undefined;
+	email: string | undefined;
+	items: WPCOMCartItem[];
+	total: LineItem;
+};
+
+export default async function genericRedirectProcessor(
+	paymentMethodId: CheckoutPaymentMethodSlug,
+	submitData: unknown,
+	transactionOptions: PaymentProcessorOptions
+): Promise< PaymentProcessorResponse > {
+	const {
+		getThankYouUrl,
+		siteSlug,
+		includeDomainDetails,
+		includeGSuiteDetails,
+		reduxDispatch,
+		responseCart,
+	} = transactionOptions;
+	if ( ! isValidTransactionData( submitData ) ) {
+		throw new Error( 'Required purchase data is missing' );
+	}
+
+	const { protocol, hostname, port, pathname } = parseUrl(
+		typeof window !== 'undefined' ? window.location.href : 'https://wordpress.com',
+		true
+	);
+	const cancelUrlQuery = {};
+	const redirectToSuccessUrl = formatUrl( {
+		protocol,
+		hostname,
+		port,
+		pathname: getThankYouUrl(),
+	} );
+	const successUrl = formatUrl( {
+		protocol,
+		hostname,
+		port,
+		pathname: `/checkout/thank-you/${ siteSlug || 'no-site' }/pending`,
+		query: { redirectTo: redirectToSuccessUrl },
+	} );
+	const cancelUrl = formatUrl( {
+		protocol,
+		hostname,
+		port,
+		pathname,
+		query: cancelUrlQuery,
+	} );
+
+	recordTransactionBeginAnalytics( {
+		paymentMethodId,
+		reduxDispatch,
+	} );
+
+	const managedContactDetails: ManagedContactDetails | undefined = select(
+		'wpcom'
+	)?.getContactInfo();
+
+	return submitRedirectTransaction(
+		paymentMethodId,
+		{
+			...submitData,
+			name: submitData.name ?? '',
+			successUrl,
+			cancelUrl,
+			couponId: responseCart.coupon,
+			country: managedContactDetails?.countryCode?.value ?? '',
+			postalCode: getPostalCode(),
+			subdivisionCode: managedContactDetails?.state?.value,
+			siteId: select( 'wpcom' )?.getSiteId?.(),
+			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+		},
+		transactionOptions
+	).then( ( response?: WPCOMTransactionEndpointResponse ) => {
+		if ( ! response?.redirect_url ) {
+			throw new Error( 'Error during transaction' );
+		}
+		return makeRedirectResponse( response?.redirect_url );
+	} );
+}
+
+function isValidTransactionData( submitData: unknown ): submitData is RedirectTransactionRequest {
+	const data = submitData as RedirectTransactionRequest;
+	if ( ! ( data?.items?.length > 0 ) ) {
+		throw new Error( 'Transaction requires items and none were provided' );
+	}
+	// Validate data required for this payment method type. Some other data may
+	// be required by the server but not required here since the server will give
+	// a better localized error message than we can provide.
+	if ( ! data.total ) {
+		throw new Error( 'Transaction requires total and none was provided' );
+	}
+	return true;
+}

--- a/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
@@ -35,6 +35,7 @@ export default async function genericRedirectProcessor(
 	const {
 		getThankYouUrl,
 		siteSlug,
+		siteId,
 		includeDomainDetails,
 		includeGSuiteDetails,
 		reduxDispatch,
@@ -90,7 +91,7 @@ export default async function genericRedirectProcessor(
 			country: managedContactDetails?.countryCode?.value ?? '',
 			postalCode: getPostalCode(),
 			subdivisionCode: managedContactDetails?.state?.value,
-			siteId: select( 'wpcom' )?.getSiteId?.(),
+			siteId: siteId ? String( siteId ) : '',
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 		},
 		transactionOptions

--- a/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
@@ -3,7 +3,7 @@
  */
 import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-line no-restricted-imports
 import { defaultRegistry, makeRedirectResponse } from '@automattic/composite-checkout';
-import type { LineItem, PaymentProcessorResponse } from '@automattic/composite-checkout';
+import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
@@ -15,7 +15,6 @@ import submitRedirectTransaction from './submit-redirect-transaction';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type { WPCOMTransactionEndpointResponse } from '../types/transaction-endpoint';
 import type { CheckoutPaymentMethodSlug } from '../types/checkout-payment-method-slug';
-import type { WPCOMCartItem } from '../types/checkout-cart';
 import type { ManagedContactDetails } from '../types/wpcom-store-state';
 
 const { select } = defaultRegistry;
@@ -23,8 +22,6 @@ const { select } = defaultRegistry;
 type RedirectTransactionRequest = {
 	name: string | undefined;
 	email: string | undefined;
-	items: WPCOMCartItem[];
-	total: LineItem;
 };
 
 export default async function genericRedirectProcessor(
@@ -105,14 +102,8 @@ export default async function genericRedirectProcessor(
 
 function isValidTransactionData( submitData: unknown ): submitData is RedirectTransactionRequest {
 	const data = submitData as RedirectTransactionRequest;
-	if ( ! ( data?.items?.length > 0 ) ) {
-		throw new Error( 'Transaction requires items and none were provided' );
-	}
-	// Validate data required for this payment method type. Some other data may
-	// be required by the server but not required here since the server will give
-	// a better localized error message than we can provide.
-	if ( ! data.total ) {
-		throw new Error( 'Transaction requires total and none was provided' );
+	if ( ! data ) {
+		throw new Error( 'Transaction requires data and none was provided' );
 	}
 	return true;
 }

--- a/client/my-sites/checkout/composite-checkout/lib/submit-redirect-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/submit-redirect-transaction.ts
@@ -17,9 +17,14 @@ import type {
 
 const debug = debugFactory( 'calypso:composite-checkout:submit-redirect-transaction' );
 
+type SubmitRedirectTransactionData = Omit<
+	TransactionRequestWithLineItems,
+	'paymentMethodType' | 'paymentPartnerProcessorId'
+>;
+
 export default async function submitRedirectTransaction(
 	paymentMethodId: string,
-	transactionData: TransactionRequestWithLineItems,
+	transactionData: SubmitRedirectTransactionData,
 	transactionOptions: PaymentProcessorOptions
 ): Promise< WPCOMTransactionEndpointResponse > {
 	const paymentMethodType = translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId );

--- a/client/my-sites/checkout/composite-checkout/lib/submit-redirect-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/submit-redirect-transaction.ts
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import submitWpcomTransaction from './submit-wpcom-transaction';
+import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from './translate-payment-method-names';
+import { createTransactionEndpointRequestPayloadFromLineItems } from './translate-cart';
+import type { PaymentProcessorOptions } from '../types/payment-processors';
+import type {
+	TransactionRequestWithLineItems,
+	WPCOMTransactionEndpointResponse,
+} from '../types/transaction-endpoint';
+
+const debug = debugFactory( 'calypso:composite-checkout:submit-redirect-transaction' );
+
+export default async function submitRedirectTransaction(
+	paymentMethodId: string,
+	transactionData: TransactionRequestWithLineItems,
+	transactionOptions: PaymentProcessorOptions
+): Promise< WPCOMTransactionEndpointResponse > {
+	const paymentMethodType = translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId );
+	if ( ! paymentMethodType ) {
+		throw new Error( `No payment method found for type: ${ paymentMethodId }` );
+	}
+	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
+		...transactionData,
+		paymentMethodType,
+		paymentPartnerProcessorId: transactionOptions.stripeConfiguration?.processor_id,
+	} );
+	debug( `sending redirect transaction for type: ${ paymentMethodId }`, formattedTransactionData );
+	return submitWpcomTransaction( formattedTransactionData, transactionOptions );
+}

--- a/client/my-sites/checkout/composite-checkout/lib/submit-redirect-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/submit-redirect-transaction.ts
@@ -8,7 +8,10 @@ import debugFactory from 'debug';
  */
 import submitWpcomTransaction from './submit-wpcom-transaction';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from './translate-payment-method-names';
-import { createTransactionEndpointRequestPayloadFromLineItems } from './translate-cart';
+import {
+	createTransactionEndpointRequestPayload,
+	createTransactionEndpointCartFromResponseCart,
+} from './translate-cart';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type {
 	TransactionRequestWithLineItems,
@@ -31,8 +34,13 @@ export default async function submitRedirectTransaction(
 	if ( ! paymentMethodType ) {
 		throw new Error( `No payment method found for type: ${ paymentMethodId }` );
 	}
-	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
+	const formattedTransactionData = createTransactionEndpointRequestPayload( {
 		...transactionData,
+		cart: createTransactionEndpointCartFromResponseCart( {
+			siteId: transactionOptions.siteId ? String( transactionOptions.siteId ) : undefined,
+			contactDetails: transactionData.domainDetails ?? null,
+			responseCart: transactionOptions.responseCart,
+		} ),
 		paymentMethodType,
 		paymentPartnerProcessorId: transactionOptions.stripeConfiguration?.processor_id,
 	} );

--- a/client/my-sites/checkout/composite-checkout/lib/submit-redirect-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/submit-redirect-transaction.ts
@@ -14,15 +14,15 @@ import {
 } from './translate-cart';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type {
-	TransactionRequestWithLineItems,
+	TransactionRequest,
 	WPCOMTransactionEndpointResponse,
 } from '../types/transaction-endpoint';
 
 const debug = debugFactory( 'calypso:composite-checkout:submit-redirect-transaction' );
 
 type SubmitRedirectTransactionData = Omit<
-	TransactionRequestWithLineItems,
-	'paymentMethodType' | 'paymentPartnerProcessorId'
+	TransactionRequest,
+	'paymentMethodType' | 'paymentPartnerProcessorId' | 'cart'
 >;
 
 export default async function submitRedirectTransaction(

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -34,6 +34,7 @@ import type {
 	WPCOMTransactionEndpointCart,
 	WPCOMTransactionEndpointRequestPayload,
 	TransactionRequestWithLineItems,
+	TransactionRequest,
 } from '../types/transaction-endpoint';
 import { isGSuiteOrGoogleWorkspaceProductSlug } from 'calypso/lib/gsuite';
 
@@ -264,13 +265,11 @@ function addRegistrationDataToGSuiteCartProduct(
 	};
 }
 
-export function createTransactionEndpointRequestPayloadFromLineItems( {
-	siteId,
-	couponId,
+export function createTransactionEndpointRequestPayload( {
+	cart,
 	country,
 	state,
 	postalCode,
-	subdivisionCode,
 	city,
 	address,
 	streetNumber,
@@ -278,7 +277,6 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 	document,
 	deviceId,
 	domainDetails,
-	items,
 	paymentMethodType,
 	paymentMethodToken,
 	paymentPartnerProcessorId,
@@ -292,17 +290,9 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 	pan,
 	gstin,
 	nik,
-}: TransactionRequestWithLineItems ): WPCOMTransactionEndpointRequestPayload {
+}: TransactionRequest ): WPCOMTransactionEndpointRequestPayload {
 	return {
-		cart: createTransactionEndpointCartFromLineItems( {
-			siteId,
-			couponId,
-			country,
-			postalCode,
-			subdivisionCode,
-			items: items.filter( ( item ) => item.type !== 'tax' ),
-			contactDetails: domainDetails || {},
-		} ),
+		cart,
 		domainDetails,
 		payment: {
 			paymentMethod: paymentMethodType,
@@ -331,6 +321,23 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 			nik,
 		},
 	};
+}
+
+export function createTransactionEndpointRequestPayloadFromLineItems(
+	args: TransactionRequestWithLineItems
+): WPCOMTransactionEndpointRequestPayload {
+	return createTransactionEndpointRequestPayload( {
+		...args,
+		cart: createTransactionEndpointCartFromLineItems( {
+			siteId: args.siteId,
+			couponId: args.couponId,
+			country: args.country,
+			postalCode: args.postalCode,
+			subdivisionCode: args.subdivisionCode,
+			items: args.items,
+			contactDetails: args.domainDetails || {},
+		} ),
+	} );
 }
 
 export function getSublabel( serverCartItem: ResponseCartProduct ): i18nCalypso.TranslateResult {

--- a/client/my-sites/checkout/composite-checkout/lib/we-chat-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/we-chat-processor.ts
@@ -1,0 +1,122 @@
+/**
+ * External dependencies
+ */
+import {
+	defaultRegistry,
+	makeRedirectResponse,
+	makeManualResponse,
+} from '@automattic/composite-checkout';
+import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-line no-restricted-imports
+import type { LineItem, PaymentProcessorResponse } from '@automattic/composite-checkout';
+
+/**
+ * Internal dependencies
+ */
+import userAgent from 'calypso/lib/user-agent';
+import getPostalCode from '../lib/get-postal-code';
+import getDomainDetails from '../lib/get-domain-details';
+import { recordTransactionBeginAnalytics } from '../lib/analytics';
+import submitRedirectTransaction from '../lib/submit-redirect-transaction';
+import type { PaymentProcessorOptions } from '../types/payment-processors';
+import type { WPCOMCartItem } from '../types/checkout-cart';
+import type { ManagedContactDetails } from '../types/wpcom-store-state';
+import type { WPCOMTransactionEndpointResponse } from '../types/transaction-endpoint';
+
+const { select } = defaultRegistry;
+
+type WeChatTransactionRequest = {
+	name: string | undefined;
+	email: string | undefined;
+	items: WPCOMCartItem[];
+	total: LineItem;
+};
+
+export default async function weChatProcessor(
+	submitData: unknown,
+	options: PaymentProcessorOptions
+): Promise< PaymentProcessorResponse > {
+	if ( ! isValidTransactionData( submitData ) ) {
+		throw new Error( 'Required purchase data is missing' );
+	}
+
+	const {
+		getThankYouUrl,
+		siteSlug,
+		includeDomainDetails,
+		includeGSuiteDetails,
+		reduxDispatch,
+		responseCart,
+	} = options;
+	const paymentMethodId = 'wechat';
+	recordTransactionBeginAnalytics( {
+		reduxDispatch,
+		paymentMethodId,
+	} );
+	const { protocol, hostname, port, pathname } = parseUrl(
+		typeof window !== 'undefined' ? window.location.href : 'https://wordpress.com',
+		true
+	);
+	const cancelUrlQuery = {};
+	const redirectToSuccessUrl = formatUrl( {
+		protocol,
+		hostname,
+		port,
+		pathname: getThankYouUrl(),
+	} );
+	const successUrl = formatUrl( {
+		protocol,
+		hostname,
+		port,
+		pathname: `/checkout/thank-you/${ siteSlug || 'no-site' }/pending`,
+		query: { redirectTo: redirectToSuccessUrl },
+	} );
+	const cancelUrl = formatUrl( {
+		protocol,
+		hostname,
+		port,
+		pathname,
+		query: cancelUrlQuery,
+	} );
+
+	const managedContactDetails: ManagedContactDetails | undefined = select(
+		'wpcom'
+	)?.getContactInfo();
+
+	return submitRedirectTransaction(
+		paymentMethodId,
+		{
+			...submitData,
+			name: submitData.name ?? '',
+			successUrl,
+			cancelUrl,
+			couponId: responseCart.coupon,
+			country: managedContactDetails?.countryCode?.value ?? '',
+			postalCode: getPostalCode(),
+			subdivisionCode: managedContactDetails?.state?.value,
+			siteId: select( 'wpcom' )?.getSiteId?.(),
+			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+		},
+		options
+	).then( ( response?: WPCOMTransactionEndpointResponse ) => {
+		// The WeChat payment type should only redirect when on mobile as redirect urls
+		// are mobile app urls: e.g. weixin://wxpay/bizpayurl?pr=RaXzhu4
+		if ( userAgent.isMobile && response?.redirect_url ) {
+			return makeRedirectResponse( response?.redirect_url );
+		}
+		return makeManualResponse( response );
+	} );
+}
+
+function isValidTransactionData( submitData: unknown ): submitData is WeChatTransactionRequest {
+	const data = submitData as WeChatTransactionRequest;
+	if ( ! ( data?.items?.length > 0 ) ) {
+		throw new Error( 'Transaction requires items and none were provided' );
+	}
+	// Validate data required for this payment method type. Some other data may
+	// be required by the server but not required here since the server will give
+	// a better localized error message than we can provide.
+	if ( ! data.total ) {
+		throw new Error( 'Transaction requires total and none was provided' );
+	}
+	return true;
+}

--- a/client/my-sites/checkout/composite-checkout/lib/we-chat-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/we-chat-processor.ts
@@ -42,6 +42,7 @@ export default async function weChatProcessor(
 	const {
 		getThankYouUrl,
 		siteSlug,
+		siteId,
 		includeDomainDetails,
 		includeGSuiteDetails,
 		reduxDispatch,
@@ -93,7 +94,7 @@ export default async function weChatProcessor(
 			country: managedContactDetails?.countryCode?.value ?? '',
 			postalCode: getPostalCode(),
 			subdivisionCode: managedContactDetails?.state?.value,
-			siteId: select( 'wpcom' )?.getSiteId?.(),
+			siteId: siteId ? String( siteId ) : '',
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 		},
 		options

--- a/client/my-sites/checkout/composite-checkout/lib/we-chat-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/we-chat-processor.ts
@@ -7,7 +7,7 @@ import {
 	makeManualResponse,
 } from '@automattic/composite-checkout';
 import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-line no-restricted-imports
-import type { LineItem, PaymentProcessorResponse } from '@automattic/composite-checkout';
+import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
@@ -18,7 +18,6 @@ import getDomainDetails from '../lib/get-domain-details';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import submitRedirectTransaction from '../lib/submit-redirect-transaction';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
-import type { WPCOMCartItem } from '../types/checkout-cart';
 import type { ManagedContactDetails } from '../types/wpcom-store-state';
 import type { WPCOMTransactionEndpointResponse } from '../types/transaction-endpoint';
 
@@ -27,8 +26,6 @@ const { select } = defaultRegistry;
 type WeChatTransactionRequest = {
 	name: string | undefined;
 	email: string | undefined;
-	items: WPCOMCartItem[];
-	total: LineItem;
 };
 
 export default async function weChatProcessor(
@@ -110,14 +107,8 @@ export default async function weChatProcessor(
 
 function isValidTransactionData( submitData: unknown ): submitData is WeChatTransactionRequest {
 	const data = submitData as WeChatTransactionRequest;
-	if ( ! ( data?.items?.length > 0 ) ) {
-		throw new Error( 'Transaction requires items and none were provided' );
-	}
-	// Validate data required for this payment method type. Some other data may
-	// be required by the server but not required here since the server will give
-	// a better localized error message than we can provide.
-	if ( ! data.total ) {
-		throw new Error( 'Transaction requires total and none was provided' );
+	if ( ! data ) {
+		throw new Error( 'Transaction requires data and none was provided' );
 	}
 	return true;
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -10,7 +10,6 @@ import { createStripePaymentMethod } from '@automattic/calypso-stripe';
  * Internal dependencies
  */
 import wp from 'calypso/lib/wp';
-import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from './lib/translate-payment-method-names';
 import { getSavedVariations } from 'calypso/lib/abtest';
 import { stringifyBody } from 'calypso/state/login/utils';
 import { recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
@@ -52,20 +51,6 @@ export async function submitEbanxCardTransaction( transactionData, submit ) {
 		paymentMethodType: 'WPCOM_Billing_Ebanx',
 	} );
 	debug( 'sending ebanx transaction', formattedTransactionData );
-	return submit( formattedTransactionData );
-}
-
-export async function submitRedirectTransaction( paymentMethodId, transactionData, submit ) {
-	const paymentMethodType = translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId );
-	if ( ! paymentMethodType ) {
-		throw new Error( `No payment method found for type: ${ paymentMethodId }` );
-	}
-	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
-		...transactionData,
-		paymentMethodType,
-		paymentPartnerProcessorId: transactionData.stripeConfiguration?.processor_id,
-	} );
-	debug( `sending redirect transaction for type: ${ paymentMethodId }`, formattedTransactionData );
 	return submit( formattedTransactionData );
 }
 

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -5,9 +5,7 @@ import {
 	defaultRegistry,
 	makeSuccessResponse,
 	makeRedirectResponse,
-	makeManualResponse,
 } from '@automattic/composite-checkout';
-import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-line no-restricted-imports
 import { confirmStripePaymentIntent } from '@automattic/calypso-stripe';
 
 /**
@@ -24,75 +22,9 @@ import {
 import getPostalCode from './lib/get-postal-code';
 import getDomainDetails from './lib/get-domain-details';
 import { createEbanxToken } from 'calypso/lib/store-transactions';
-import userAgent from 'calypso/lib/user-agent';
-import { recordTransactionBeginAnalytics } from './lib/analytics';
 import submitWpcomTransaction from './lib/submit-wpcom-transaction';
-import submitRedirectTransaction from './lib/submit-redirect-transaction';
 
 const { select } = defaultRegistry;
-
-export async function weChatProcessor( submitData, options ) {
-	const {
-		getThankYouUrl,
-		siteSlug,
-		includeDomainDetails,
-		includeGSuiteDetails,
-		reduxDispatch,
-		responseCart,
-	} = options;
-	const paymentMethodId = 'wechat';
-	recordTransactionBeginAnalytics( {
-		reduxDispatch,
-		paymentMethodId,
-	} );
-	const { protocol, hostname, port, pathname } = parseUrl(
-		typeof window !== 'undefined' ? window.location.href : 'https://wordpress.com',
-		true
-	);
-	const cancelUrlQuery = {};
-	const redirectToSuccessUrl = formatUrl( {
-		protocol,
-		hostname,
-		port,
-		pathname: getThankYouUrl(),
-	} );
-	const successUrl = formatUrl( {
-		protocol,
-		hostname,
-		port,
-		pathname: `/checkout/thank-you/${ siteSlug || 'no-site' }/pending`,
-		query: { redirectTo: redirectToSuccessUrl },
-	} );
-	const cancelUrl = formatUrl( {
-		protocol,
-		hostname,
-		port,
-		pathname,
-		query: cancelUrlQuery,
-	} );
-	return submitRedirectTransaction(
-		paymentMethodId,
-		{
-			...submitData,
-			successUrl,
-			cancelUrl,
-			couponId: responseCart.coupon,
-			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-			postalCode: submitData.postalCode || getPostalCode(),
-			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
-			siteId: select( 'wpcom' )?.getSiteId?.(),
-			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
-		},
-		options
-	).then( ( response ) => {
-		// The WeChat payment type should only redirect when on mobile as redirect urls
-		// are mobile app urls: e.g. weixin://wxpay/bizpayurl?pr=RaXzhu4
-		if ( userAgent.isMobile ) {
-			return makeRedirectResponse( response?.redirect_url );
-		}
-		return makeManualResponse( response );
-	} );
-}
 
 export async function applePayProcessor(
 	submitData,

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -31,65 +31,6 @@ import submitRedirectTransaction from './lib/submit-redirect-transaction';
 
 const { select } = defaultRegistry;
 
-export async function genericRedirectProcessor( paymentMethodId, submitData, options ) {
-	const {
-		getThankYouUrl,
-		siteSlug,
-		includeDomainDetails,
-		includeGSuiteDetails,
-		reduxDispatch,
-		responseCart,
-	} = options;
-	const { protocol, hostname, port, pathname } = parseUrl(
-		typeof window !== 'undefined' ? window.location.href : 'https://wordpress.com',
-		true
-	);
-	const cancelUrlQuery = {};
-	const redirectToSuccessUrl = formatUrl( {
-		protocol,
-		hostname,
-		port,
-		pathname: getThankYouUrl(),
-	} );
-	const successUrl = formatUrl( {
-		protocol,
-		hostname,
-		port,
-		pathname: `/checkout/thank-you/${ siteSlug || 'no-site' }/pending`,
-		query: { redirectTo: redirectToSuccessUrl },
-	} );
-	const cancelUrl = formatUrl( {
-		protocol,
-		hostname,
-		port,
-		pathname,
-		query: cancelUrlQuery,
-	} );
-
-	recordTransactionBeginAnalytics( {
-		paymentMethodId,
-		reduxDispatch,
-	} );
-
-	return submitRedirectTransaction(
-		paymentMethodId,
-		{
-			...submitData,
-			successUrl,
-			cancelUrl,
-			couponId: responseCart.coupon,
-			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-			postalCode: submitData.postalCode || getPostalCode(),
-			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
-			siteId: select( 'wpcom' )?.getSiteId?.(),
-			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
-		},
-		options
-	).then( ( response ) => {
-		return makeRedirectResponse( response?.redirect_url );
-	} );
-}
-
 export async function weChatProcessor( submitData, options ) {
 	const {
 		getThankYouUrl,

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -18,7 +18,6 @@ import {
 	submitApplePayPayment,
 	submitStripeCardTransaction,
 	submitEbanxCardTransaction,
-	submitRedirectTransaction,
 	submitFreePurchaseTransaction,
 	submitCreditsTransaction,
 } from './payment-method-helpers';
@@ -28,21 +27,19 @@ import { createEbanxToken } from 'calypso/lib/store-transactions';
 import userAgent from 'calypso/lib/user-agent';
 import { recordTransactionBeginAnalytics } from './lib/analytics';
 import submitWpcomTransaction from './lib/submit-wpcom-transaction';
+import submitRedirectTransaction from './lib/submit-redirect-transaction';
 
 const { select } = defaultRegistry;
 
-export async function genericRedirectProcessor(
-	paymentMethodId,
-	submitData,
-	{
+export async function genericRedirectProcessor( paymentMethodId, submitData, options ) {
+	const {
 		getThankYouUrl,
 		siteSlug,
 		includeDomainDetails,
 		includeGSuiteDetails,
 		reduxDispatch,
 		responseCart,
-	}
-) {
+	} = options;
 	const { protocol, hostname, port, pathname } = parseUrl(
 		typeof window !== 'undefined' ? window.location.href : 'https://wordpress.com',
 		true
@@ -87,23 +84,21 @@ export async function genericRedirectProcessor(
 			siteId: select( 'wpcom' )?.getSiteId?.(),
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 		},
-		submitWpcomTransaction
+		options
 	).then( ( response ) => {
 		return makeRedirectResponse( response?.redirect_url );
 	} );
 }
 
-export async function weChatProcessor(
-	submitData,
-	{
+export async function weChatProcessor( submitData, options ) {
+	const {
 		getThankYouUrl,
 		siteSlug,
 		includeDomainDetails,
 		includeGSuiteDetails,
 		reduxDispatch,
 		responseCart,
-	}
-) {
+	} = options;
 	const paymentMethodId = 'wechat';
 	recordTransactionBeginAnalytics( {
 		reduxDispatch,
@@ -147,7 +142,7 @@ export async function weChatProcessor(
 			siteId: select( 'wpcom' )?.getSiteId?.(),
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 		},
-		submitWpcomTransaction
+		options
 	).then( ( response ) => {
 		// The WeChat payment type should only redirect when on mobile as redirect urls
 		// are mobile app urls: e.g. weixin://wxpay/bizpayurl?pr=RaXzhu4

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -10,6 +10,36 @@ import type { WPCOMCartItem } from './checkout-cart';
 import type { Purchase } from './wpcom-store-state';
 import type { DomainContactDetails } from './backend/domain-contact-details-components';
 
+export interface TransactionRequest {
+	country: string;
+	postalCode: string;
+	cart: WPCOMTransactionEndpointCart;
+	paymentMethodType: string;
+	name: string;
+	siteId?: string | undefined;
+	couponId?: string | undefined;
+	state?: string | undefined;
+	subdivisionCode?: string | undefined;
+	city?: string | undefined;
+	address?: string | undefined;
+	streetNumber?: string | undefined;
+	phoneNumber?: string | undefined;
+	document?: string | undefined;
+	deviceId?: string | undefined;
+	domainDetails?: DomainContactDetails | undefined;
+	paymentMethodToken?: string | undefined;
+	paymentPartnerProcessorId?: string | undefined;
+	storedDetailsId?: string | undefined;
+	email?: string | undefined;
+	successUrl?: string | undefined;
+	cancelUrl?: string | undefined;
+	idealBank?: string | undefined;
+	tefBank?: string | undefined;
+	pan?: string | undefined;
+	gstin?: string | undefined;
+	nik?: string | undefined;
+}
+
 // The data required by createTransactionEndpointRequestPayloadFromLineItems
 export interface TransactionRequestWithLineItems {
 	country: string;

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -41,34 +41,8 @@ export interface TransactionRequest {
 }
 
 // The data required by createTransactionEndpointRequestPayloadFromLineItems
-export interface TransactionRequestWithLineItems {
-	country: string;
-	postalCode: string;
+export interface TransactionRequestWithLineItems extends TransactionRequest {
 	items: WPCOMCartItem[];
-	paymentMethodType: string;
-	name: string;
-	siteId?: string | undefined;
-	couponId?: string | undefined;
-	state?: string | undefined;
-	subdivisionCode?: string | undefined;
-	city?: string | undefined;
-	address?: string | undefined;
-	streetNumber?: string | undefined;
-	phoneNumber?: string | undefined;
-	document?: string | undefined;
-	deviceId?: string | undefined;
-	domainDetails?: DomainContactDetails | undefined;
-	paymentMethodToken?: string | undefined;
-	paymentPartnerProcessorId?: string | undefined;
-	storedDetailsId?: string | undefined;
-	email?: string | undefined;
-	successUrl?: string | undefined;
-	cancelUrl?: string | undefined;
-	idealBank?: string | undefined;
-	tefBank?: string | undefined;
-	pan?: string | undefined;
-	gstin?: string | undefined;
-	nik?: string | undefined;
 }
 
 export type ExistingCardTransactionRequestWithLineItems = Partial< TransactionRequestWithLineItems > &


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR converts the Stripe redirect payment processor to TypeScript and modifies it to use the shopping cart to create the transaction request instead of the line items (since those line items were already converted from the shopping cart). Because the WeChat payment processor also sometimes uses a redirect, this also converts that processor to TypeScript. As a result, there's really three changes here that could each be their own separate PR, but since testing them involves testing the same things, it seemed easier to put them all in one PR. See the individual commits for more details.

1. Convert the redirect submission processor function to TypeScript and to use the cart to generate the transaction request.
2. Convert the "generic" Stripe redirect processor function to TypeScript and to use the cart to generate the transaction request.
3. Convert the WeChat Pay processor to TypeScript and to use the cart to generate the transaction request.

Includes https://github.com/Automattic/wp-calypso/pull/51208 and will require a rebase when that is merged

#### Testing instructions

There are two things to test: the regular Stripe redirects, and the WeChat Pay mobile redirects.

- Apply D45443-code to your sandbox to force Bancontact to be available.
- Set your user currency to EUR.
- Make a new purchase in checkout and select Bancontact as the payment method, entering any string in the "name" field.
- Verify that you are redirected to the Stripe test page, that it reads "Bancontact", and that the total is correct. (No need to complete the payment.)
- Apply D45650-code to your sandbox to force WeChat to be available.
- Apply https://gist.github.com/sirbrillig/17fc953647b2df974e8d975a5d4e160a to calypso to force the mobile-only redirect to run.
- Make a new purchase in checkout and select WeChat as the payment method, entering any string in the "name" field.
- Verify that you are redirected to the Stripe test page, that it reads "WeChat Pay", and that the total is correct. (No need to complete the payment.)