### PR TITLE
Export ReturnOrGeneratorYieldUnion type from @automattic/data-stores

### DIFF
--- a/packages/data-stores/CHANGELOG.md
+++ b/packages/data-stores/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.1
+- Export the `ReturnOrGeneratorYieldUnion` type.
+
 ## 2.0.0
 
 - Initial release with stores:

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/data-stores",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "Calypso Data Stores",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -31,3 +31,4 @@ export {
  * Helper types
  */
 export * from './mapped-types';
+export { ReturnOrGeneratorYieldUnion } from './launch/actions';

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -31,4 +31,4 @@ export {
  * Helper types
  */
 export * from './mapped-types';
-export { ReturnOrGeneratorYieldUnion } from './launch/actions';
+export type { ReturnOrGeneratorYieldUnion } from './launch/actions';

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -31,4 +31,3 @@ export {
  * Helper types
  */
 export * from './mapped-types';
-export type { ReturnOrGeneratorYieldUnion } from './launch/actions';

--- a/packages/data-stores/src/launch/actions.ts
+++ b/packages/data-stores/src/launch/actions.ts
@@ -160,7 +160,7 @@ export const disablePersistentSuccessView = () =>
  * This works until one of the action creators is a generator and doesn't actually "Return" an action.
  * This type helper allows for actions to be both functions and generators
  */
-type ReturnOrGeneratorYieldUnion< T extends ( ...args: any ) => any > = T extends (
+export type ReturnOrGeneratorYieldUnion< T extends ( ...args: any ) => any > = T extends (
 	...args: any
 ) => infer Return
 	? Return extends Generator< infer T, infer U, any >

--- a/packages/data-stores/src/launch/actions.ts
+++ b/packages/data-stores/src/launch/actions.ts
@@ -8,6 +8,7 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import type { LaunchStepType } from './types';
+import type { ReturnOrGeneratorYieldUnion } from '../mapped-types';
 import { PLANS_STORE } from './constants';
 import type { Plans } from '..';
 
@@ -154,19 +155,6 @@ export const disablePersistentSuccessView = () =>
 	( {
 		type: 'DISABLE_SUCCESS_VIEW',
 	} as const );
-
-/**
- * Usually we use ReturnType of all the action creators to deduce all the actions.
- * This works until one of the action creators is a generator and doesn't actually "Return" an action.
- * This type helper allows for actions to be both functions and generators
- */
-export type ReturnOrGeneratorYieldUnion< T extends ( ...args: any ) => any > = T extends (
-	...args: any
-) => infer Return
-	? Return extends Generator< infer T, infer U, any >
-		? T | U
-		: Return
-	: never;
 
 export type LaunchAction = ReturnOrGeneratorYieldUnion<
 	| typeof setSiteTitle

--- a/packages/data-stores/src/mapped-types.ts
+++ b/packages/data-stores/src/mapped-types.ts
@@ -22,6 +22,7 @@ import type { FunctionKeys } from 'utility-types';
  *
  * @template S Selector map, usually from `import * as selectors from './my-store/selectors';`
  */
+// eslint-disable-next-line @typescript-eslint/ban-types
 export type SelectFromMap< S extends object > = {
 	[ selector in FunctionKeys< S > ]: (
 		...args: TailParameters< S[ selector ] >
@@ -47,6 +48,7 @@ export type DispatchFromMap< A extends Record< string, ( ...args: any[] ) => any
  * This is useful for typing some @wordpres/data functions that make a leading
  * `state` argument implicit.
  */
+// eslint-disable-next-line @typescript-eslint/ban-types
 export type TailParameters< F extends Function > = F extends ( head: any, ...tail: infer T ) => any
 	? T
 	: never;

--- a/packages/data-stores/src/mapped-types.ts
+++ b/packages/data-stores/src/mapped-types.ts
@@ -59,3 +59,16 @@ export type GeneratorReturnType< T extends ( ...args: any[] ) => Generator > = T
 ) => Generator< any, infer R, any >
 	? R
 	: never;
+
+/**
+ * Usually we use ReturnType of all the action creators to deduce all the actions.
+ * This works until one of the action creators is a generator and doesn't actually "Return" an action.
+ * This type helper allows for actions to be both functions and generators
+ */
+export type ReturnOrGeneratorYieldUnion< T extends ( ...args: any ) => any > = T extends (
+	...args: any
+) => infer Return
+	? Return extends Generator< infer T, infer U, any >
+		? T | U
+		: Return
+	: never;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Export `ReturnOrGeneratorYieldUnion` type from the `@automattic/data-stores` package
* This would be a good change because we would like to use it in https://github.com/woocommerce/woocommerce-gutenberg-products-block. Having this type exported would mean less code duplication.

#### Testing instructions
You should be able to `import type { ReturnOrGeneratorYieldUnion } from '@automattic/data-stores';` with this change applied.