### PR TITLE
Partner Portal: Add ability to revoke licenses

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement, useCallback, useState } from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/revoke-license-dialog';
+
+interface Props {
+	licenseKey: string;
+	product: string;
+	domain: string;
+	attachedAt: string | null;
+	revokedAt: string | null;
+}
+
+export default function LicenseDetailsActions( {
+	licenseKey,
+	product,
+	domain,
+	attachedAt,
+	revokedAt,
+}: Props ): ReactElement {
+	const translate = useTranslate();
+	const licenseState = getLicenseState( attachedAt, revokedAt );
+	const [ revokeDialog, setRevokeDialog ] = useState( false );
+
+	const openRevokeDialog = useCallback( () => {
+		setRevokeDialog( true );
+	}, [ setRevokeDialog ] );
+
+	const closeRevokeDialog = useCallback( () => {
+		setRevokeDialog( false );
+	}, [ setRevokeDialog ] );
+
+	return (
+		<div className="license-details__actions">
+			{ licenseState !== LicenseState.Revoked && (
+				<Button onClick={ openRevokeDialog } scary>
+					{ translate( 'Revoke License' ) }
+				</Button>
+			) }
+
+			{ revokeDialog && (
+				<RevokeLicenseDialog
+					licenseKey={ licenseKey }
+					product={ product }
+					domain={ domain }
+					onClose={ closeRevokeDialog }
+				/>
+			) }
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -13,6 +13,7 @@ import { Card } from '@automattic/components';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import Gridicon from 'calypso/components/gridicon';
 import FormattedDate from 'calypso/components/formatted-date';
+import LicenseDetailsActions from 'calypso/jetpack-cloud/sections/partner-portal/license-details/actions';
 
 /**
  * Style dependencies
@@ -21,6 +22,8 @@ import './style.scss';
 
 interface Props {
 	licenseKey: string;
+	product: string;
+	domain: string;
 	username: string | null;
 	blogId: number | null;
 	issuedAt: string;
@@ -31,6 +34,8 @@ interface Props {
 
 export default function LicenseDetails( {
 	licenseKey,
+	product,
+	domain,
 	username,
 	blogId,
 	issuedAt,
@@ -98,6 +103,14 @@ export default function LicenseDetails( {
 					{ blogId ? <span>{ blogId }</span> : <Gridicon icon="minus" /> }
 				</li>
 			</ul>
+
+			<LicenseDetailsActions
+				licenseKey={ licenseKey }
+				product={ product }
+				domain={ domain }
+				attachedAt={ attachedAt }
+				revokedAt={ revokedAt }
+			/>
 		</Card>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -179,6 +179,8 @@ export default function LicensePreview( {
 			{ isOpen && (
 				<LicenseDetails
 					licenseKey={ licenseKey }
+					product={ product }
+					domain={ domain }
 					username={ username }
 					blogId={ blogId }
 					issuedAt={ issuedAt }

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -1,0 +1,122 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement, useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Button, Dialog } from '@automattic/components';
+import Gridicon from 'calypso/components/gridicon';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { noop } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
+import useRefreshLicenseList from 'calypso/state/partner-portal/licenses/hooks/use-refresh-license-list';
+import useRevokeLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-revoke-license-mutation';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	licenseKey: string;
+	product: string;
+	domain: string;
+	onClose: ( action?: string ) => void;
+}
+
+export default function RevokeLicenseDialog( {
+	licenseKey,
+	product,
+	domain,
+	onClose,
+	...rest
+}: Props ): ReactElement {
+	let close = noop;
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const refreshLicenceList = useRefreshLicenseList( LicenseListContext );
+	const mutation = useRevokeLicenseMutation( {
+		onSuccess: () => {
+			close();
+			dispatch( refreshLicenceList() );
+		},
+		onError: ( error: Error ) => {
+			dispatch( errorNotice( error.message ) );
+		},
+	} );
+	const helpUrl = '';
+
+	close = useCallback( () => {
+		if ( ! mutation.isLoading ) {
+			onClose();
+		}
+	}, [ onClose, mutation.isLoading ] );
+
+	const revoke = useCallback( () => {
+		mutation.mutate( { licenseKey } );
+	}, [ licenseKey, mutation.mutate ] );
+
+	const buttons = [
+		<Button disabled={ false } onClick={ close }>
+			{ translate( 'Go back' ) }
+		</Button>,
+
+		<Button primary scary busy={ mutation.isLoading } onClick={ revoke }>
+			{ translate( 'Revoke License' ) }
+		</Button>,
+	];
+
+	if ( helpUrl ) {
+		buttons.unshift(
+			<a href={ helpUrl } target="_blank" rel="noreferrer noopener">
+				{ translate( 'Learn more about revoking licenses' ) }
+				&nbsp;
+				<Gridicon icon="external" size={ 18 } />
+			</a>
+		);
+	}
+
+	return (
+		<Dialog
+			isVisible={ true }
+			buttons={ buttons }
+			additionalClassNames="revoke-license-dialog"
+			onClose={ close }
+			{ ...rest }
+		>
+			<h2 className="revoke-license-dialog__heading">
+				{ translate( 'Are you sure you want to revoke this license?' ) }
+			</h2>
+
+			<p>
+				{ translate(
+					'A revoked license cannot be reused and the associated site will no longer have access to the provisioned product. You will stop being billing for this license immediately.'
+				) }
+			</p>
+
+			<ul>
+				{ domain && (
+					<li>
+						<strong>{ translate( 'Site:' ) }</strong> { domain }
+					</li>
+				) }
+				<li>
+					<strong>{ translate( 'Product:' ) }</strong> { product }
+				</li>
+				<li>
+					<strong>{ translate( 'License:' ) }</strong> <code>{ licenseKey }</code>
+				</li>
+			</ul>
+
+			<p className="revoke-license-dialog__warning">
+				<Gridicon icon="info-outline" size={ 18 } />
+
+				{ translate( 'Please note this action cannot be undone.' ) }
+			</p>
+		</Dialog>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/style.scss
@@ -1,0 +1,63 @@
+@import '~@wordpress/base-styles/_breakpoints.scss';
+@import '~@wordpress/base-styles/_mixins.scss';
+
+.revoke-license-dialog {
+	.dialog__content {
+		max-width: 628px;
+
+		&, & p {
+			font-size: 1rem;
+		}
+	}
+
+	.dialog__action-buttons {
+		display: flex;
+		justify-content: flex-end;
+		align-items: center;
+		background: var( --studio-gray-0 );
+		border: 0;
+
+		a {
+			margin-right: auto;
+			font-weight: 600;
+			text-decoration: underline;
+		}
+	}
+
+	&__heading {
+		margin: -16px -16px 16px;
+		padding: 9px 16px;
+		font-size: 1.25rem;
+		font-weight: 600;
+		line-height: 20px;
+		color: var( --studio-red-60 );
+		border-bottom: 1px solid var( --studio-gray-5 );
+
+		@include break-mobile() {
+			margin: -24px -24px 24px;
+			padding: 9px 24px;
+			line-height: 36px;
+		}
+	}
+
+	&__warning {
+		font-weight: 600;
+		color: var( --studio-red-60 );
+
+		.gridicon {
+			position: relative;
+			top: 2px;
+			margin-right: 7px;
+		}
+	}
+
+	ul {
+		margin-left: 39px;
+		font-weight: 600;
+		line-height: 30px;
+
+		code {
+			font-size: 0.875rem;
+		}
+	}
+}

--- a/client/state/partner-portal/licenses/hooks/use-refresh-license-list.ts
+++ b/client/state/partner-portal/licenses/hooks/use-refresh-license-list.ts
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { Context, useContext } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { LicenseListContext, PartnerPortalThunkAction } from 'calypso/state/partner-portal/types';
+import { fetchLicenses } from 'calypso/state/partner-portal/licenses/actions';
+
+export default function useRefreshLicenseList(
+	context: Context< LicenseListContext >
+): () => PartnerPortalThunkAction {
+	const { filter, search, sortField, sortDirection, currentPage } = useContext( context );
+
+	return () => fetchLicenses( filter, search, sortField, sortDirection, currentPage );
+}

--- a/client/state/partner-portal/licenses/hooks/use-revoke-license-mutation.ts
+++ b/client/state/partner-portal/licenses/hooks/use-revoke-license-mutation.ts
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { useMutation, UseMutationOptions, UseMutationResult } from 'react-query';
+
+/**
+ * Internal dependencies
+ */
+import { APILicense } from 'calypso/state/partner-portal/types';
+import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+
+interface MutationRevokeLicenseVariables {
+	licenseKey: string;
+}
+
+function mutationRevokeLicense( {
+	licenseKey,
+}: MutationRevokeLicenseVariables ): Promise< APILicense > {
+	return wpcomJpl.req.post( {
+		method: 'DELETE',
+		apiNamespace: 'wpcom/v2',
+		path: '/jetpack-licensing/license',
+		body: { license_key: licenseKey },
+	} );
+}
+
+export default function useRevokeLicenseMutation< TContext = unknown >(
+	options?: UseMutationOptions< APILicense, Error, MutationRevokeLicenseVariables, TContext >
+): UseMutationResult< APILicense, Error, MutationRevokeLicenseVariables, TContext > {
+	return useMutation< APILicense, Error, MutationRevokeLicenseVariables, TContext >(
+		mutationRevokeLicense,
+		options
+	);
+}

--- a/client/state/partner-portal/licenses/test/hooks.js
+++ b/client/state/partner-portal/licenses/test/hooks.js
@@ -12,8 +12,60 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 /**
  * Internal dependencies
  */
+import { LICENSES_PER_PAGE } from 'calypso/state/partner-portal/licenses/constants';
+import {
+	LicenseSortDirection,
+	LicenseSortField,
+	LicenseState,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import useRefreshLicenseList from 'calypso/state/partner-portal/licenses/hooks/use-refresh-license-list';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import useIssueLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-issue-license-mutation';
+import useRevokeLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-revoke-license-mutation';
+import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
+import {
+	JETPACK_PARTNER_PORTAL_LICENSE_COUNTS_REQUEST,
+	JETPACK_PARTNER_PORTAL_LICENSES_REQUEST,
+} from 'calypso/state/action-types';
+
+describe( 'useRefreshLicenseList', () => {
+	it( 'returns a thunk action creator which refreshes the license list', () => {
+		const stub = {
+			filter: LicenseState.Revoked,
+			search: 'foo',
+			sortField: LicenseSortField.RevokedAt,
+			sortDirection: LicenseSortDirection.Ascending,
+			currentPage: 2,
+		};
+		const dispatch = jest.fn();
+		const wrapper = ( { children } ) => (
+			<LicenseListContext.Provider value={ stub }>{ children }</LicenseListContext.Provider>
+		);
+		const { result } = renderHook( () => useRefreshLicenseList( LicenseListContext ), {
+			wrapper,
+		} );
+
+		const thunk = result.current();
+
+		thunk( dispatch );
+
+		expect( dispatch.mock.calls[ 0 ][ 0 ] ).toEqual( {
+			type: JETPACK_PARTNER_PORTAL_LICENSES_REQUEST,
+			filter: stub.filter,
+			search: stub.search,
+			sortField: stub.sortField,
+			sortDirection: stub.sortDirection,
+			page: stub.currentPage,
+			perPage: LICENSES_PER_PAGE,
+			fetcher: 'wpcomJetpackLicensing',
+		} );
+
+		expect( dispatch.mock.calls[ 1 ][ 0 ] ).toEqual( {
+			type: JETPACK_PARTNER_PORTAL_LICENSE_COUNTS_REQUEST,
+			fetcher: 'wpcomJetpackLicensing',
+		} );
+	} );
+} );
 
 describe( 'useProductsQuery', () => {
 	it( 'returns successful request data', async () => {
@@ -87,6 +139,33 @@ describe( 'useIssueLicenseMutation', () => {
 		} );
 
 		await act( async () => result.current.mutateAsync( { product: 'jetpack-scan' } ) );
+
+		expect( result.current.data ).toEqual( stub );
+	} );
+} );
+
+describe( 'useRevokeLicenseMutation', () => {
+	it( 'returns successful request data', async () => {
+		const queryClient = new QueryClient();
+		const wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+		const stub = {
+			issued_at: '2021-03-30 15:17:42',
+			license_id: 12345,
+			license_key: 'jetpack-scan_foobarbaz',
+			revoked_at: null,
+		};
+
+		nock( 'https://public-api.wordpress.com' )
+			.delete( '/wpcom/v2/jetpack-licensing/license', '{"license_key":"jetpack-scan_foobarbaz"}' )
+			.reply( 200, stub );
+
+		const { result } = renderHook( () => useRevokeLicenseMutation(), {
+			wrapper,
+		} );
+
+		await act( async () => result.current.mutateAsync( { licenseKey: 'jetpack-scan_foobarbaz' } ) );
 
 		expect( result.current.data ).toEqual( stub );
 	} );


### PR DESCRIPTION
- Context: pbtFPC-Um-p2
- Design: pbtFPC-103-p2 Note that the "Learn more" link is missing as the URL is not finalized. The PR includes everything necessary but the URL itself which can be added later as a one-line patch.

#### Changes proposed in this Pull Request

* Partner Portal Add ability to revoke individual licenses.

#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key, if prompted.
* Expand any license or issue a new one via the "Issue New License" button at the top.
* Click on the "Revoke License" button in the expanded license view.
* Play around with the dialog, cancel, click outside, revoke the license etc. and confirm everything matches designs.
* Upon revoking, the dialog should close and the list of licenses should update, including the filter bar numbers above the license list.

![Screenshot 2021-03-30 at 21 04 42](https://user-images.githubusercontent.com/22746396/113035119-8e66eb00-919b-11eb-9a25-af03b1004242.png)
_Note: The visible license code is already revoked._
