### PR TITLE
Hide Cloudflare CDN upsell for non-WPCOM users

### DIFF
--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -44,6 +44,7 @@ class SiteSettingsPerformance extends Component {
 			site,
 			siteId,
 			siteIsJetpack,
+			siteIsAtomic,
 			siteIsAtomicPrivate,
 			siteIsUnlaunched,
 			siteSlug,
@@ -53,6 +54,7 @@ class SiteSettingsPerformance extends Component {
 			trackEvent,
 			updateFields,
 		} = this.props;
+		const siteIsJetpackNonAtomic = siteIsJetpack && ! siteIsAtomic;
 
 		return (
 			<Main className="settings-performance site-settings site-settings__performance-settings">
@@ -68,7 +70,7 @@ class SiteSettingsPerformance extends Component {
 				/>
 				<SiteSettingsNavigation site={ site } section="performance" />
 
-				{ showCloudflare && <Cloudflare /> }
+				{ showCloudflare && ! siteIsJetpackNonAtomic && <Cloudflare /> }
 
 				<Search
 					handleAutosavingToggle={ handleAutosavingToggle }
@@ -136,13 +138,14 @@ const connectComponent = connect( ( state ) => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
 	const siteIsJetpack = isJetpackSite( state, siteId );
-	const siteIsAtomicPrivate =
-		isSiteAutomatedTransfer( state, siteId ) && isPrivateSite( state, siteId );
+	const siteIsAtomic = isSiteAutomatedTransfer( state, siteId );
+	const siteIsAtomicPrivate = siteIsAtomic && isPrivateSite( state, siteId );
 	const showCloudflare = config.isEnabled( 'cloudflare' );
 
 	return {
 		site,
 		siteIsJetpack,
+		siteIsAtomic,
 		siteIsAtomicPrivate,
 		siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -49,6 +49,7 @@ import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import Banner from 'calypso/components/banner';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 
 function updateQueryString( query = {} ) {
 	return {
@@ -158,6 +159,7 @@ class StatsSite extends Component {
 			slug,
 			isAdmin,
 			isJetpack,
+			isAtomic,
 			isVip,
 		} = this.props;
 
@@ -165,6 +167,7 @@ class StatsSite extends Component {
 		const { period, endOf } = this.props.period;
 		const moduleStrings = statsStrings();
 		let fileDownloadList;
+		const isJetpackNonAtomic = isJetpack && ! isAtomic;
 
 		const query = memoizedQuery( period, endOf );
 
@@ -204,7 +207,7 @@ class StatsSite extends Component {
 					slug={ slug }
 				/>
 
-				{ ! isVip && isAdmin && ! hasWordAds && <Cloudflare /> }
+				{ ! isVip && isAdmin && ! hasWordAds && ! isJetpackNonAtomic && <Cloudflare /> }
 
 				<div id="my-stats-content">
 					<ChartTabs
@@ -378,11 +381,13 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
 		const isVip = isVipSite( state, siteId );
+		const isAtomic = isSiteAutomatedTransfer( state, siteId );
 		const showEnableStatsModule =
 			siteId && isJetpack && isJetpackModuleActive( state, siteId, 'stats' ) === false;
 		return {
 			isAdmin: canCurrentUser( state, siteId, 'manage_options' ),
 			isJetpack,
+			isAtomic,
 			hasWordAds: getSiteOption( state, siteId, 'wordads' ),
 			siteId,
 			isVip,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Per discussion at p1616181112013900-slack-C0299DMPG, we need to not display Cloudflare CDN ad banners for users who are not WPCOM customers (i.e. standalone Jetpack). This PR adds an extra check in both places we are displaying this banner and avoids rendering if the site is a non-Atomic Jetpack site.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the following on a simple, Atomic, and standalone Jetpack site and verify that the simple and Atomic sites show a Cloudflare banner, but the Jetpack one does not.
    * `/stats/day/{siteUrl}`
    * `/settings/performance/{siteUrl}`


Simple/Atomic:
![image](https://user-images.githubusercontent.com/13437011/111835768-5d490980-88c3-11eb-9b8b-3b28d4c1ac06.png)
![image](https://user-images.githubusercontent.com/13437011/111835802-6d60e900-88c3-11eb-94aa-474db4218745.png)

Jetpack standalone:
![image](https://user-images.githubusercontent.com/13437011/111836998-38ee2c80-88c5-11eb-9a88-8ee7cdc44126.png)
![image](https://user-images.githubusercontent.com/13437011/111836486-5ff82e80-88c4-11eb-9cf2-7099c6be65d8.png)

