### PR TITLE
desktop: Bump version to 6.13.0-beta1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "6.12.0",
+	"version": "6.13.0-beta1",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/"


### PR DESCRIPTION
This is the first step of the release cycle.