### PR TITLE
update(media): rename `setMediaLibrarySelectedItems` with `selectMediaItems`

### DIFF
--- a/client/blocks/image-selector/index.jsx
+++ b/client/blocks/image-selector/index.jsx
@@ -15,7 +15,7 @@ import isDropZoneVisible from 'calypso/state/selectors/is-drop-zone-visible';
 import MediaModal from 'calypso/post-editor/media-modal';
 import { localize } from 'i18n-calypso';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { setMediaLibrarySelectedItems } from 'calypso/state/media/actions';
+import { selectMediaItems } from 'calypso/state/media/actions';
 
 /**
  * Style dependencies
@@ -40,7 +40,7 @@ export class ImageSelector extends Component {
 		showEditIcon: PropTypes.bool,
 		siteId: PropTypes.number,
 		translate: PropTypes.func,
-		setMediaLibrarySelectedItems: PropTypes.func,
+		selectMediaItems: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -58,7 +58,7 @@ export class ImageSelector extends Component {
 		const { siteId, imageIds } = this.props;
 
 		if ( imageIds ) {
-			this.props.setMediaLibrarySelectedItems(
+			this.props.selectMediaItems(
 				siteId,
 				imageIds.map( ( ID ) => ( { ID } ) )
 			);
@@ -174,5 +174,5 @@ export default connect(
 		}
 		return props;
 	},
-	{ setMediaLibrarySelectedItems }
+	{ selectMediaItems }
 )( localize( ImageSelector ) );

--- a/client/blocks/image-selector/test/index.jsx
+++ b/client/blocks/image-selector/test/index.jsx
@@ -43,7 +43,7 @@ describe( 'ImageSelector', () => {
 		onImageSelected: noop,
 		onRemoveImage: noop,
 		imageIds: [],
-		setMediaLibrarySelectedItems: noop,
+		selectMediaItems: noop,
 	};
 	const store = {
 		getState: () => ( {

--- a/client/blocks/image-selector/test/preview.jsx
+++ b/client/blocks/image-selector/test/preview.jsx
@@ -21,7 +21,7 @@ describe( 'ImageSelectorPreview', () => {
 		onImageSelected: noop,
 		onRemoveImage: noop,
 		imageIds: [],
-		setMediaLibrarySelectedItems: noop,
+		selectMediaItems: noop,
 		translate: () => {},
 		getMediaItem: ( siteId, itemId ) => require( './fixtures' ).DUMMY_MEDIA[ itemId ],
 	};

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -57,7 +57,7 @@ import {
 	PerformanceTrackProps,
 } from 'calypso/lib/performance-tracking';
 import { REASON_BLOCK_EDITOR_UNKOWN_IFRAME_LOAD_FAILURE } from 'calypso/state/desktop/window-events';
-import { setMediaLibrarySelectedItems } from 'calypso/state/media/actions';
+import { selectMediaItems } from 'calypso/state/media/actions';
 import { fetchMediaItem, getMediaItem } from 'calypso/state/media/thunks';
 import Iframe from './iframe';
 
@@ -243,7 +243,7 @@ class CalypsoifyIframe extends Component<
 		if ( WindowActions.ClassicBlockOpenMediaModel === action ) {
 			if ( data.imageId ) {
 				const { siteId } = this.props;
-				this.props.setMediaLibrarySelectedItems( siteId, [ { ID: data.imageId } ] );
+				this.props.selectMediaItems( siteId, [ { ID: data.imageId } ] );
 			}
 
 			this.setState( {
@@ -292,9 +292,9 @@ class CalypsoifyIframe extends Component<
 					};
 				} );
 
-				this.props.setMediaLibrarySelectedItems( siteId, selectedItems );
+				this.props.selectMediaItems( siteId, selectedItems );
 			} else {
-				this.props.setMediaLibrarySelectedItems( siteId, [] );
+				this.props.selectMediaItems( siteId, [] );
 			}
 
 			this.setState( { isMediaModalVisible: true, allowedTypes, gallery, multiple } );
@@ -910,7 +910,7 @@ const mapDispatchToProps = {
 	trashPost,
 	updateSiteFrontPage,
 	notifyDesktopCannotOpenEditor,
-	setMediaLibrarySelectedItems,
+	selectMediaItems,
 	fetchMediaItem,
 	getMediaItem,
 	clearLastNonEditorRoute,

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -25,7 +25,7 @@ import {
 	getKeyringConnections,
 } from 'calypso/state/sharing/keyring/selectors';
 import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions';
-import { setMediaLibrarySelectedItems } from 'calypso/state/media/actions';
+import { selectMediaItems } from 'calypso/state/media/actions';
 
 /**
  * Style dependencies
@@ -120,7 +120,7 @@ class MediaLibrary extends Component {
 		}
 
 		if ( ! isEqual( selectedItems, filteredItems ) ) {
-			this.props.setMediaLibrarySelectedItems( this.props.site.ID, filteredItems );
+			this.props.selectMediaItems( this.props.site.ID, filteredItems );
 		}
 
 		this.props.onAddMedia();
@@ -217,6 +217,6 @@ export default connect(
 	} ),
 	{
 		requestKeyringConnections,
-		setMediaLibrarySelectedItems,
+		selectMediaItems,
 	}
 )( MediaLibrary );

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -20,7 +20,7 @@ import ListPlanUpgradeNudge from './list-plan-upgrade-nudge';
 import SortedGrid from 'calypso/components/sorted-grid';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { getPreference } from 'calypso/state/preferences/selectors';
-import { setMediaLibrarySelectedItems } from 'calypso/state/media/actions';
+import { selectMediaItems } from 'calypso/state/media/actions';
 import isFetchingNextPage from 'calypso/state/selectors/is-fetching-next-page';
 
 const noop = () => {};
@@ -139,7 +139,7 @@ export class MediaLibraryList extends React.Component {
 		} );
 
 		if ( this.props.site ) {
-			this.props.setMediaLibrarySelectedItems( this.props.site.ID, selectedItems );
+			this.props.selectMediaItems( this.props.site.ID, selectedItems );
 		}
 	};
 
@@ -260,5 +260,5 @@ export default connect(
 		selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
 		isFetchingNextPage: isFetchingNextPage( state, site?.ID ),
 	} ),
-	{ setMediaLibrarySelectedItems }
+	{ selectMediaItems }
 )( withRtl( withLocalizedMoment( MediaLibraryList ) ) );

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -40,7 +40,7 @@ describe( 'MediaLibraryList item selection', () => {
 	let wrapper;
 	let mediaList;
 
-	const setMediaLibrarySelectedItems = jest.fn();
+	const selectMediaItems = jest.fn();
 
 	function toggleItem( itemIndex, shiftClick ) {
 		mediaList.toggleItem( fixtures.media[ itemIndex ], shiftClick );
@@ -70,7 +70,7 @@ describe( 'MediaLibraryList item selection', () => {
 					mediaScale={ 0.24 }
 					moment={ moment }
 					selectedItems={ [] }
-					setMediaLibrarySelectedItems={ setMediaLibrarySelectedItems }
+					selectMediaItems={ selectMediaItems }
 				/>
 			);
 			mediaList = wrapper.find( MediaList ).instance();
@@ -159,7 +159,7 @@ describe( 'MediaLibraryList item selection', () => {
 					moment={ moment }
 					single
 					selectedItems={ [] }
-					setMediaLibrarySelectedItems={ setMediaLibrarySelectedItems }
+					selectMediaItems={ selectMediaItems }
 				/>
 			);
 			mediaList = wrapper.find( MediaList ).instance();
@@ -202,7 +202,7 @@ describe( 'MediaLibraryList item selection', () => {
 					source={ source }
 					single
 					selectedItems={ [] }
-					setMediaLibrarySelectedItems={ setMediaLibrarySelectedItems }
+					selectMediaItems={ selectMediaItems }
 				/>
 			)
 				.find( MediaList )

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -30,11 +30,7 @@ import accept from 'calypso/lib/accept';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import searchUrl from 'calypso/lib/search-url';
 import { editMedia, deleteMedia } from 'calypso/state/media/thunks';
-import {
-	setMediaLibrarySelectedItems,
-	changeMediaSource,
-	clearSite,
-} from 'calypso/state/media/actions';
+import { selectMediaItems, changeMediaSource, clearSite } from 'calypso/state/media/actions';
 
 /**
  * Style dependencies
@@ -81,7 +77,7 @@ class Media extends Component {
 		}
 
 		if ( this.props.selectedSite ) {
-			this.props.setMediaLibrarySelectedItems( this.props.selectedSite.ID, [] );
+			this.props.selectMediaItems( this.props.selectedSite.ID, [] );
 		}
 
 		if ( this.props.currentRoute !== redirect ) {
@@ -437,7 +433,7 @@ const mapStateToProps = ( state, { mediaId } ) => {
 export default connect( mapStateToProps, {
 	editMedia,
 	deleteMedia,
-	setMediaLibrarySelectedItems,
+	selectMediaItems,
 	changeMediaSource,
 	clearSite,
 } )( localize( Media ) );

--- a/client/post-editor/media-modal/gallery/drop-zone.jsx
+++ b/client/post-editor/media-modal/gallery/drop-zone.jsx
@@ -13,7 +13,7 @@ import { isEqual } from 'lodash';
 import getMediaLibrarySelectedItems from 'calypso/state/selectors/get-media-library-selected-items';
 import MediaLibraryDropZone from 'calypso/my-sites/media-library/drop-zone';
 import { filterItemsByMimePrefix } from 'calypso/lib/media/utils';
-import { setMediaLibrarySelectedItems } from 'calypso/state/media/actions';
+import { selectMediaItems } from 'calypso/state/media/actions';
 
 class EditorMediaModalGalleryDropZone extends React.Component {
 	static propTypes = {
@@ -34,7 +34,7 @@ class EditorMediaModalGalleryDropZone extends React.Component {
 		const filteredItems = filterItemsByMimePrefix( selectedItems, 'image' );
 
 		if ( ! isEqual( selectedItems, filteredItems ) ) {
-			this.props.setMediaLibrarySelectedItems( site.ID, filteredItems );
+			this.props.selectMediaItems( site.ID, filteredItems );
 			this.props.onInvalidItemAdded();
 		}
 	};
@@ -54,5 +54,5 @@ export default connect(
 	( state, { site } ) => ( {
 		selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
 	} ),
-	{ setMediaLibrarySelectedItems }
+	{ selectMediaItems }
 )( EditorMediaModalGalleryDropZone );

--- a/client/post-editor/media-modal/gallery/remove-button.jsx
+++ b/client/post-editor/media-modal/gallery/remove-button.jsx
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
  */
 import { ScreenReaderText } from '@automattic/components';
 import getMediaLibrarySelectedItems from 'calypso/state/selectors/get-media-library-selected-items';
-import { setMediaLibrarySelectedItems } from 'calypso/state/media/actions';
+import { selectMediaItems } from 'calypso/state/media/actions';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -31,7 +31,7 @@ class RemoveButton extends PureComponent {
 
 		const items = reject( selectedItems, ( item ) => item.ID === itemId );
 
-		this.props.setMediaLibrarySelectedItems( siteId, items );
+		this.props.selectMediaItems( siteId, items );
 	};
 
 	render() {
@@ -56,5 +56,5 @@ export default connect(
 	( state, { siteId } ) => ( {
 		selectedItems: getMediaLibrarySelectedItems( state, siteId ),
 	} ),
-	{ setMediaLibrarySelectedItems }
+	{ selectMediaItems }
 )( localize( RemoveButton ) );

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -25,11 +25,7 @@ import { resetMediaModalView } from 'calypso/state/ui/media-modal/actions';
 import { setEditorMediaModalView } from 'calypso/state/editor/actions';
 import { ModalViews } from 'calypso/state/ui/media-modal/constants';
 import { editMedia, deleteMedia, addExternalMedia } from 'calypso/state/media/thunks';
-import {
-	changeMediaSource,
-	setMediaLibrarySelectedItems,
-	setQuery,
-} from 'calypso/state/media/actions';
+import { changeMediaSource, selectMediaItems, setQuery } from 'calypso/state/media/actions';
 import ImageEditor from 'calypso/blocks/image-editor';
 import VideoEditor from 'calypso/blocks/video-editor';
 import MediaModalDialog from './dialog';
@@ -109,7 +105,7 @@ export class EditorMediaModal extends Component {
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( nextProps.site && this.props.visible && ! nextProps.visible ) {
-			this.props.setMediaLibrarySelectedItems( nextProps.site.ID, [] );
+			this.props.selectMediaItems( nextProps.site.ID, [] );
 		}
 
 		if ( this.props.visible === nextProps.visible ) {
@@ -135,13 +131,13 @@ export class EditorMediaModal extends Component {
 	UNSAFE_componentWillMount() {
 		const { view, selectedItems, site, single } = this.props;
 		if ( ! isEmpty( selectedItems ) && ( view === ModalViews.LIST || single ) ) {
-			this.props.setMediaLibrarySelectedItems( site.ID, [] );
+			this.props.selectMediaItems( site.ID, [] );
 		}
 	}
 
 	componentWillUnmount() {
 		this.props.resetView();
-		this.props.setMediaLibrarySelectedItems( this.props.site.ID, [] );
+		this.props.selectMediaItems( this.props.site.ID, [] );
 	}
 
 	getDefaultState( props ) {
@@ -266,7 +262,7 @@ export class EditorMediaModal extends Component {
 	};
 
 	onAddAndEditImage = () => {
-		this.props.setMediaLibrarySelectedItems( this.props.site.ID, [] );
+		this.props.selectMediaItems( this.props.site.ID, [] );
 
 		this.props.setView( ModalViews.IMAGE_EDITOR );
 	};
@@ -581,7 +577,7 @@ export default connect(
 		recordEditorEvent,
 		recordEditorStat,
 		editMedia,
-		setMediaLibrarySelectedItems,
+		selectMediaItems,
 		setQuery,
 		addExternalMedia,
 		changeMediaSource,

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -60,7 +60,7 @@ describe( 'EditorMediaModal', () => {
 	let spy;
 	let deleteMedia;
 	let onClose;
-	let setMediaLibrarySelectedItems;
+	let selectMediaItems;
 	let changeMediaSource;
 	let baseProps;
 
@@ -68,10 +68,10 @@ describe( 'EditorMediaModal', () => {
 		spy = sandbox.spy();
 		deleteMedia = sandbox.stub();
 		onClose = sandbox.stub();
-		setMediaLibrarySelectedItems = sandbox.stub();
+		selectMediaItems = sandbox.stub();
 		changeMediaSource = sandbox.stub();
 		baseProps = {
-			setMediaLibrarySelectedItems,
+			selectMediaItems,
 			site: DUMMY_SITE,
 			selectedItems: DUMMY_MEDIA,
 			translate,
@@ -87,7 +87,7 @@ describe( 'EditorMediaModal', () => {
 
 	test( 'When `single` selection screen chosen should initialise with no items selected', () => {
 		shallow( <EditorMediaModal { ...baseProps } single={ true } view={ null } /> ).instance();
-		expect( setMediaLibrarySelectedItems ).to.have.been.calledWith( DUMMY_SITE.ID, [] );
+		expect( selectMediaItems ).to.have.been.calledWith( DUMMY_SITE.ID, [] );
 	} );
 
 	test( 'should prompt to delete a single item from the list view', () => {

--- a/client/state/media/actions.js
+++ b/client/state/media/actions.js
@@ -291,7 +291,7 @@ export function setMediaItemErrors( siteId, mediaId, errors ) {
  * @param  {Array}   media  Array of media objects
  * @returns {object}        Action object
  */
-export function setMediaLibrarySelectedItems( siteId, media ) {
+export function selectMediaItems( siteId, media ) {
 	return {
 		type: MEDIA_LIBRARY_SELECTED_ITEMS_UPDATE,
 		media,

--- a/client/state/media/test/reducer.js
+++ b/client/state/media/test/reducer.js
@@ -27,7 +27,7 @@ import {
 	receiveMedia,
 	setMediaItemErrors,
 	setNextPageHandle,
-	setMediaLibrarySelectedItems,
+	selectMediaItems,
 	successMediaItemRequest,
 } from '../actions';
 import { ValidationErrors as MediaValidationErrors } from 'calypso/lib/media/constants';
@@ -468,7 +468,7 @@ describe( 'reducer', () => {
 			};
 			const result = selectedItems(
 				deepFreeze( state ),
-				setMediaLibrarySelectedItems( siteId, [ mediaItem ] )
+				selectMediaItems( siteId, [ mediaItem ] )
 			);
 
 			expect( result ).to.deep.eql( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rename `setMediaLibrarySelectedItems` to `selectMediaItems` throughout Calypso

#### Testing instructions

* Open the media library both from your sidebar navigation as well as the block editor
* The following actions should still work as expected:
  * Select and deselect items
  * Select an item and delete it
  * An item uploaded via drag & drop should appear selected
* Verify you see a `MEDIA_LIBRARY_SELECTED_ITEMS_UPDATE` redux action being dispatched after you select or deselect items (can be seen using the Redux devtools)

Fixes #43867 
