### PR TITLE
people/team/edit: improve `EditUserForm` and fix controlled input fields bug

### DIFF
--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -4,7 +4,6 @@
 import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import debugModule from 'debug';
-import { assign, filter, includes, omit, pick } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -50,24 +49,30 @@ class EditUserForm extends Component {
 	}
 
 	getStateObject( props ) {
-		const role = this.getRole( props.roles );
-		return assign( omit( props, 'site' ), {
-			roles: role,
+		const { site, ...rest } = props;
+		return {
+			...rest,
+			roles: this.getRole( props.roles ),
 			isExternalContributor: props.isExternalContributor,
-		} );
+		};
 	}
 
 	getChangedSettings() {
 		const originalUser = this.getStateObject( this.props );
-
-		const changedKeys = filter( this.getAllowedSettingsToChange(), ( setting ) => {
+		const allowedSettings = this.getAllowedSettingsToChange();
+		const changedKeys = allowedSettings.filter( ( setting ) => {
 			return (
 				'undefined' !== typeof originalUser[ setting ] &&
 				'undefined' !== typeof this.state[ setting ] &&
 				originalUser[ setting ] !== this.state[ setting ]
 			);
 		} );
-		return pick( this.state, changedKeys );
+		const changedSettings = changedKeys.reduce( ( acc, key ) => {
+			acc[ key ] = this.state[ key ];
+			return acc;
+		}, {} );
+
+		return changedSettings;
 	}
 
 	getAllowedSettingsToChange() {
@@ -141,10 +146,8 @@ class EditUserForm extends Component {
 	handleExternalChange = ( event ) =>
 		this.setState( { isExternalContributor: event.target.checked } );
 
-	isExternalRole = ( role ) => {
-		const roles = [ 'administrator', 'editor', 'author', 'contributor' ];
-		return includes( roles, role );
-	};
+	isExternalRole = ( role ) =>
+		[ 'administrator', 'editor', 'author', 'contributor' ].includes( role );
 
 	renderField( fieldId ) {
 		let returnField = null;

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -49,10 +49,9 @@ class EditUserForm extends Component {
 	}
 
 	getStateObject( props ) {
-		const { site, ...rest } = props;
 		return {
-			...rest,
-			roles: this.getRole( props.roles ),
+			...props.user,
+			roles: this.getRole( props.user?.roles ),
 			isExternalContributor: props.isExternalContributor,
 		};
 	}
@@ -271,13 +270,11 @@ class EditUserForm extends Component {
 
 export default localize(
 	connect(
-		( state, { siteId, ID: userId, linked_user_ID: linkedUserId } ) => {
+		( state, { siteId, user } ) => {
 			const externalContributors = ( siteId && requestExternalContributors( siteId ).data ) || [];
 			return {
 				currentUser: getCurrentUser( state ),
-				isExternalContributor: externalContributors.includes(
-					undefined !== linkedUserId ? linkedUserId : userId
-				),
+				isExternalContributor: externalContributors.includes( user?.linked_user_ID ?? user?.ID ),
 				isVip: isVipSite( state, siteId ),
 				isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
 			};

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -184,7 +184,7 @@ class EditUserForm extends Component {
 						<FormTextInput
 							id="first_name"
 							name="first_name"
-							defaultValue={ this.state.first_name }
+							value={ this.state.first_name }
 							onChange={ this.handleChange }
 							onFocus={ this.recordFieldFocus( 'first_name' ) }
 						/>
@@ -202,7 +202,7 @@ class EditUserForm extends Component {
 						<FormTextInput
 							id="last_name"
 							name="last_name"
-							defaultValue={ this.state.last_name }
+							value={ this.state.last_name }
 							onChange={ this.handleChange }
 							onFocus={ this.recordFieldFocus( 'last_name' ) }
 						/>
@@ -220,7 +220,7 @@ class EditUserForm extends Component {
 						<FormTextInput
 							id="name"
 							name="name"
-							defaultValue={ this.state.name }
+							value={ this.state.name }
 							onChange={ this.handleChange }
 							onFocus={ this.recordFieldFocus( 'name' ) }
 						/>

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -159,7 +159,7 @@ export class EditTeamMemberForm extends Component {
 				<Card className="edit-team-member-form__user-profile">
 					<PeopleProfile siteId={ this.props.siteId } user={ this.state.user } />
 					<EditUserForm
-						{ ...this.state.user }
+						user={ this.state.user }
 						disabled={ this.state.removingUser }
 						siteId={ this.props.siteId }
 						isJetpack={ this.props.isJetpack }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a spin off from #50992 and extracts a few changes which are not exactly the focus of that PR and should make it easier to review.

* Remove usage of lodash methods from `<EditUserForm />`
* Explicitly pass on `user` prop to `<EditUserForm />`
* Fix controlled input fields

#### Testing instructions

Test the following steps for a simple site, an AT site and a Jetpack-connected site:

* Go to `/people/team` and click on a user which isn't you
* On a Jetpack-connected site, verify that existing values for name fields are shown¹
* Attempt to change the role, external contributor status and (if it's a Jetpack-connected site) name fields
* Everything should work exactly as on prod

¹ This is currently broken in prod

Note: There is currently a bug with the external contributor status where you can't change it more than twice without reloading the browser tab. I'll address this as a follow up to #50992.

Note: There's more potential to refactor this component, especially the way we handle the changed settings. I'll follow up here as well.

