### PR TITLE
Notices: move to an external package.

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -7,6 +7,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { isEnabled } from '@automattic/calypso-config';
 import { Button, Card } from '@automattic/components';
+import SiteNotice from '@automattic/notices';
 
 /**
  * Internal dependencies
@@ -123,11 +124,7 @@ class CurrentSite extends Component {
 						</CalypsoShoppingCartProvider>
 					) }
 					{ selectedSite && isEnabled( 'current-site/notice' ) && (
-						<AsyncLoad
-							require="calypso/my-sites/current-site/notice"
-							placeholder={ null }
-							site={ selectedSite }
-						/>
+						<SiteNotice site={ selectedSite } />
 					) }
 				</div>
 			</Card>

--- a/client/package.json
+++ b/client/package.json
@@ -38,6 +38,7 @@
 		"@automattic/launch": "^1.0.0",
 		"@automattic/load-script": "^1.0.0",
 		"@automattic/material-design-icons": "^1.0.0",
+		"@automattic/notices": "^1.0.0",
 		"@automattic/notifications": "^1.0.0",
 		"@automattic/onboarding": "^1.0.0",
 		"@automattic/plans-grid": "^1.0.0-alpha.0",

--- a/packages/notices/.gitignore
+++ b/packages/notices/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/notices/README.md
+++ b/packages/notices/README.md
@@ -1,0 +1,1 @@
+# Calypso Notices

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "@automattic/notices",
+	"version": "1.0.0",
+	"description": "A notices/nudges compontent for WPCOM sites",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.ts",
+	"sideEffects": false,
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch"
+	},
+	"files": [
+		"dist",
+		"src"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/notices"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"keywords": [
+		"notices"
+	],
+	"author": "Automattic Inc.",
+	"license": "GPL-2.0-or-later",
+	"bugs": {
+		"url": "https://github.com/Automattic/wp-calypso/issues"
+	},
+	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/notices#readme",
+	"dependencies": {
+		"@automattic/react-i18n": "^1.0.0-alpha.0",
+		"prop-types": "^15.7.2"
+	},
+	"devDependencies": {
+		"react": "^16.12.0",
+		"react-dom": "^16.12.0",
+		"@automattic/calypso-build": "^7.0.0",
+		"@automattic/calypso-polyfills": "^1.0.0",
+		"@testing-library/jest-dom": "^5.9.0",
+		"@testing-library/react": "^10.0.5",
+		"webpack": "^5.24.4"
+	}
+}

--- a/packages/notices/src/index.ts
+++ b/packages/notices/src/index.ts
@@ -1,0 +1,1 @@
+export const HelloWorld = ( name: string ): string => `Hello ${ name }`;

--- a/packages/notices/src/index.ts
+++ b/packages/notices/src/index.ts
@@ -1,1 +1,0 @@
-export const HelloWorld = ( name: string ): string => `Hello ${ name }`;

--- a/packages/notices/src/index.tsx
+++ b/packages/notices/src/index.tsx
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+export { default } from './site';

--- a/packages/notices/src/site/index.tsx
+++ b/packages/notices/src/site/index.tsx
@@ -1,0 +1,268 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import moment from 'moment';
+import { select, dispatch } from 'react-redux';
+import { translate } from 'i18n-calypso';
+import config, { isEnabled } from '@automattic/calypso-config';
+import { Plans, User, Site } from '@automattic/data-stores';
+import { get, reject } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getUrlParts } from 'calypso/lib/url/url-parts';
+import { SiteData } from '../types';
+//  import Notice from 'calypso/components/notice';
+//  import NoticeAction from 'calypso/components/notice/notice-action';
+//  import getActiveDiscount from 'calypso/state/selectors/get-active-discount';
+//  import { domainManagementList } from 'calypso/my-sites/domains/paths';
+//  import {
+// 	 hasDomainCredit,
+// 	 isCurrentUserCurrentPlanOwner,
+//  } from 'calypso/state/sites/plans/selectors';
+//  import canCurrentUser from 'calypso/state/selectors/can-current-user';
+//  import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
+//  import isEligibleForFreeToPaidUpsell from 'calypso/state/selectors/is-eligible-for-free-to-paid-upsell';
+//  import { recordTracksEvent } from 'calypso/state/analytics/actions';
+//  import QuerySitePlans from 'calypso/components/data/query-site-plans';
+//  import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
+//  import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+//  import { getProductsList } from 'calypso/state/products-list/selectors';
+//  import QueryProductsList from 'calypso/components/data/query-products-list';
+//  import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
+//  import { getUnformattedDomainPrice, getUnformattedDomainSalePrice } from 'calypso/lib/domains';
+//  import formatCurrency from '@automattic/format-currency/src';
+//  import { getPreference } from 'calypso/state/preferences/selectors';
+//  import { isJetpackSite } from 'calypso/state/sites/selectors';
+//  import { savePreference } from 'calypso/state/preferences/actions';
+//  import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
+//  import isSiteMigrationActiveRoute from 'calypso/state/selectors/is-site-migration-active-route';
+//  import { getSectionName } from 'calypso/state/ui/selectors';
+//  import { getTopJITM } from 'calypso/state/jitm/selectors';
+//  import AsyncLoad from 'calypso/components/async-load';
+//  import UpsellNudge from 'calypso/blocks/upsell-nudge';
+//  import { preventWidows } from 'calypso/lib/formatting';
+//  import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+
+//  const DOMAIN_UPSELL_NUDGE_DISMISS_KEY = 'domain_upsell_nudge_dismiss'
+
+interface Props {
+	site: SiteData | null;
+}
+
+const getSiteRedirectNotice: FunctionComponent< Props > = ( { site } ) => {
+	// 	 if ( ! site || this.props.isDomainOnly ) {
+	// 		 return null;
+	// 	 }
+
+	if ( ! ( site?.options && site.options.is_redirect ) ) {
+		return null;
+	}
+	const { hostname } = getUrlParts( site.URL );
+
+	return <div>{ hostname }</div>;
+
+	// 	 return (
+	// 		 <Notice
+	// 			 icon="info-outline"
+	// 			 isCompact
+	// 			 showDismiss={ false }
+	// 			 text={ translate( 'Redirects to {{a}}%(url)s{{/a}}', {
+	// 				 args: { url: hostname },
+	// 				 components: { a: <a href={ site.URL } /> },
+	// 			 } ) }
+	// 		 >
+	// 			 <NoticeAction href={ domainManagementList( site.domain ) }>
+	// 				 { translate( 'Edit' ) }
+	// 			 </NoticeAction>
+	// 		 </Notice>
+	// 	 );
+};
+
+const domainCreditNotice = () => {
+	// 	 if ( ! this.props.hasDomainCredit || ! this.props.canManageOptions ) {
+	// 		 return null;
+	// 	 }
+	// 	 if ( isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams ) {
+	// 		 return null;
+	// 	 }
+	// 	 const eventName = 'calypso_domain_credit_reminder_impression';
+	// 	 const eventProperties = { cta_name: 'current_site_domain_notice' };
+	// 	 const { translate } = this.props;
+	// 	 const noticeText = preventWidows( translate( 'Free domain available' ) );
+	// 	 const ctaText = translate( 'Claim' );
+	// 	 return (
+	// 		 <UpsellNudge
+	// 			 callToAction={ ctaText }
+	// 			 compact
+	// 			 event={ eventName }
+	// 			 forceHref={ true }
+	// 			 forceDisplay={ true }
+	// 			 href={ `/domains/add/${ this.props.site.slug }` }
+	// 			 title={ noticeText }
+	// 			 tracksClickName="calypso_domain_credit_reminder_click"
+	// 			 tracksClickProperties={ eventProperties }
+	// 			 tracksImpressionName={ eventName }
+	// 			 tracksImpressionProperties={ eventProperties }
+	// 		 />
+	// 	 );
+};
+
+const domainUpsellNudge = () => {
+	// 	 if ( ! this.props.isPlanOwner || this.props.domainUpsellNudgeDismissedDate ) {
+	// 		 return null;
+	// 	 }
+	// 	 if ( this.props.isJetpack ) {
+	// 		 return null;
+	// 	 }
+	// 	 if ( isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams ) {
+	// 		 return null;
+	// 	 }
+	// 	 const eligibleDomains = reject(
+	// 		 this.props.domains,
+	// 		 ( domain ) =>
+	// 			 domain.isWPCOMDomain ||
+	// 			 domain.name.endsWith( '.wpcomstaging.com' ) ||
+	// 			 ( domain.registrationDate && moment( domain.registrationDate ).add( 7, 'days' ).isAfter() )
+	// 	 );
+	// 	 if ( eligibleDomains.length !== 1 ) {
+	// 		 return null;
+	// 	 }
+	// 	 const { site, currencyCode, productsList, translate } = this.props;
+	// 	 const priceAndSaleInfo = Object.entries( productsList ).reduce(
+	// 		 function ( result, [ key, value ] ) {
+	// 			 if ( value.is_domain_registration && value.available ) {
+	// 				 const regularPrice = getUnformattedDomainPrice( key, productsList );
+	// 				 const minRegularPrice = get( result, 'minRegularPrice', regularPrice );
+	// 				 result.minRegularPrice = Math.min( minRegularPrice, regularPrice );
+	// 				 const salePrice = getUnformattedDomainSalePrice( key, productsList );
+	// 				 if ( salePrice ) {
+	// 					 const minSalePrice = get( result, 'minSalePrice', salePrice );
+	// 					 result.minSalePrice = Math.min( minSalePrice, salePrice );
+	// 					 result.saleTlds.push( value.tld );
+	// 				 }
+	// 			 }
+	// 			 return result;
+	// 		 },
+	// 		 { saleTlds: [] }
+	// 	 );
+	// 	 if ( ! priceAndSaleInfo.minSalePrice && ! priceAndSaleInfo.minRegularPrice ) {
+	// 		 return null;
+	// 	 }
+	// 	 let noticeText;
+	// 	 if ( priceAndSaleInfo.minSalePrice ) {
+	// 		 if ( get( priceAndSaleInfo, 'saleTlds.length', 0 ) === 1 ) {
+	// 			 noticeText = translate( 'Get a %(tld)s domain for just %(salePrice)s for a limited time', {
+	// 				 args: {
+	// 					 tld: priceAndSaleInfo.saleTlds[ 0 ],
+	// 					 salePrice: formatCurrency( priceAndSaleInfo.minSalePrice, currencyCode ),
+	// 				 },
+	// 			 } );
+	// 		 } else {
+	// 			 noticeText = translate( 'Domains on sale starting at %(minSalePrice)s', {
+	// 				 args: {
+	// 					 minSalePrice: formatCurrency( priceAndSaleInfo.minSalePrice, currencyCode ),
+	// 				 },
+	// 			 } );
+	// 		 }
+	// 	 } else {
+	// 		 noticeText = translate( 'Add another domain from %(minDomainPrice)s', {
+	// 			 args: {
+	// 				 minDomainPrice: formatCurrency( priceAndSaleInfo.minRegularPrice, currencyCode ),
+	// 			 },
+	// 		 } );
+	// 	 }
+	// 	 return (
+	// 		 <UpsellNudge
+	// 			 callToAction={ translate( 'Add' ) }
+	// 			 compact
+	// 			 href={ `/domains/add/${ site.slug }` }
+	// 			 onDismissClick={ this.props.clickDomainUpsellDismiss }
+	// 			 dismissPreferenceName="calypso_upgrade_nudge_cta_click"
+	// 			 event="calypso_upgrade_nudge_impression"
+	// 			 forceDisplay={ true }
+	// 			 horizontal={ true }
+	// 			 title={ preventWidows( noticeText ) }
+	// 			 tracksClickName="calypso_upgrade_nudge_cta_click"
+	// 			 tracksClickProperties={ { cta_name: 'domain-upsell-nudge' } }
+	// 			 tracksImpressionName="calypso_upgrade_nudge_impression"
+	// 			 tracksImpressionProperties={ { cta_name: 'domain-upsell-nudge' } }
+	// 			 tracksDismissName="calypso_upgrade_nudge_cta_click"
+	// 			 tracksDismissProperties={ { cta_name: 'domain-upsell-nudge-dismiss' } }
+	// 		 />
+	// 	 );
+};
+
+const promotionEndsToday = ( { endsAt }: { endsAt: Date } ) => {
+	const now = new Date();
+	const format = 'YYYYMMDD';
+	return moment( now ).format( format ) === moment( endsAt ).format( format );
+};
+
+const activeDiscountNotice = () => {
+	// 	 if ( ! this.props.activeDiscount ) {
+	// 		 return null;
+	// 	 }
+	// 	 if ( isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams ) {
+	// 		 return null;
+	// 	 }
+	// 	 const { site, activeDiscount } = this.props;
+	// 	 const { nudgeText, nudgeEndsTodayText, ctaText, name } = activeDiscount;
+	// 	 const bannerText =
+	// 		 nudgeEndsTodayText && this.promotionEndsToday( activeDiscount )
+	// 			 ? nudgeEndsTodayText
+	// 			 : nudgeText;
+	// 	 if ( ! bannerText ) {
+	// 		 return null;
+	// 	 }
+	// 	 const eventProperties = { cta_name: 'active-discount-sidebar' };
+	// 	 return (
+	// 		 <UpsellNudge
+	// 			 event="calypso_upgrade_nudge_impression"
+	// 			 forceDisplay={ true }
+	// 			 tracksClickName="calypso_upgrade_nudge_cta_click"
+	// 			 tracksClickProperties={ eventProperties }
+	// 			 tracksImpressionName="calypso_upgrade_nudge_impression"
+	// 			 tracksImpressionProperties={ eventProperties }
+	// 			 callToAction={ ctaText || 'Upgrade' }
+	// 			 href={ `/plans/${ site.slug }?discount=${ name }` }
+	// 			 title={ bannerText }
+	// 		 />
+	// 	 );
+};
+
+const SiteNotice: FunctionComponent< Props > = ( { site } ) => {
+	// const { site, isMigrationInProgress, hasJITM } = this.props;
+	// if ( ! site || isMigrationInProgress ) {
+	// 	return <div className="current-site__notices" />;
+	// }
+
+	const discountOrFreeToPaid = activeDiscountNotice();
+
+	// const showJitms =
+	// 	! ( isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams ) &&
+	// 	( discountOrFreeToPaid || config.isEnabled( 'jitms' ) );
+
+	return (
+		<div className="site__notices">
+			{ /* <QueryProductsList /> */ }
+			{ /* <QueryActivePromotions /> */ }
+			{ getSiteRedirectNotice( site ) }
+			{ /* { showJitms && (
+				<AsyncLoad
+					require="calypso/blocks/jitm"
+					placeholder={ null }
+					messagePath="calypso:sites:sidebar_notice"
+					template="sidebar-banner"
+				/>
+			) } */ }
+			{ /* <QuerySitePlans siteId={ site.ID } /> */ }
+			{ /* { ! hasJITM && domainCreditNotice }
+			{ ! ( hasJITM || discountOrFreeToPaid || domainCreditNotice ) && domainUpsellNudge() } */ }
+		</div>
+	);
+};
+
+export default SiteNotice;

--- a/packages/notices/src/types.ts
+++ b/packages/notices/src/types.ts
@@ -1,0 +1,16 @@
+export interface SiteData {
+	ID: number;
+	name: string;
+	URL: string;
+	slug: string;
+	domain: string;
+	locale: string;
+	options?: SiteDataOptions;
+	// TODO: fill out the rest of this
+}
+
+export interface SiteDataOptions {
+	admin_url: string | undefined;
+	is_redirect: boolean;
+	// TODO: fill out the rest of this
+}

--- a/packages/notices/tsconfig-cjs.json
+++ b/packages/notices/tsconfig-cjs.json
@@ -1,0 +1,13 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"declaration": false,
+		"declarationMap": false,
+		"declarationDir": null,
+		"outDir": "dist/cjs",
+		"composite": false,
+		"incremental": true,
+		"tsBuildInfoFile": "../../.tsc-cache/packages__notices--cjs"
+	}
+}

--- a/packages/notices/tsconfig.json
+++ b/packages/notices/tsconfig.json
@@ -1,0 +1,37 @@
+{
+	"compilerOptions": {
+		"target": "ES5",
+		"lib": [ "DOM", "ES2015", "ES2017" ],
+
+		"baseUrl": ".",
+		"module": "esnext",
+		"allowJs": true,
+		"jsx": "react",
+		"declaration": true,
+		"declarationMap": true,
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src",
+
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+
+		"moduleResolution": "node",
+		"esModuleInterop": true,
+
+		"forceConsistentCasingInFileNames": true,
+
+		"typeRoots": [ "../../node_modules/@types" ],
+		"types": [],
+
+		"importHelpers": true,
+		"composite": true,
+		"tsBuildInfoFile": "../../.tsc-cache/packages__notices"
+	},
+	"include": [ "src" ],
+	"exclude": [ "**/docs/*", "**/test/*" ],
+	"references": [ { "path": "../react-i18n" } ]
+}


### PR DESCRIPTION
This PR aims to decouple the notices component from Calypso so that it can be reused from another client (eg WP Admin).

<details>
  <summary>Below you can explore an interesting dependency graph 😜!</summary>
![dependencygraph](https://user-images.githubusercontent.com/12430020/112004270-4e17c500-8b2a-11eb-989f-87ab388cbadc.png)
</details>

### Steps

- [x] Init package
- [ ] #51686 Rewrite `Notice` 
- [ ] Rewrite `SiteNotice` https://github.com/Automattic/wp-calypso/blob/ed3e91545e431da92beeffcbe80289eadde067c0/client/my-sites/current-site/notice.jsx#L51 in Typescript
- [ ] Create stores needed be `SiteNotice` inside https://github.com/Automattic/wp-calypso/blob/c998d4cb825c72b00e37cbbadc8fd8445b92acea/packages/data-stores/src/index.ts#L1-L33
- [ ] Replace redux state from `SiteNotice` with the above data stores.

#### Changes proposed in this Pull Request

*

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
