### PR TITLE
Themes: Fix deletion of recommended theme for Jetpack sites

### DIFF
--- a/client/state/themes/actions/confirm-delete.js
+++ b/client/state/themes/actions/confirm-delete.js
@@ -9,7 +9,8 @@ import i18n from 'i18n-calypso';
 import accept from 'calypso/lib/accept';
 import { getSiteTitle } from 'calypso/state/sites/selectors';
 import { deleteTheme } from 'calypso/state/themes/actions/delete-theme';
-import { getTheme } from 'calypso/state/themes/selectors';
+import { getRecommendedThemes, getTheme } from 'calypso/state/themes/selectors';
+import { errorNotice } from 'calypso/state/notices/actions';
 
 import 'calypso/state/themes/init';
 
@@ -24,7 +25,22 @@ import 'calypso/state/themes/init';
  */
 export function confirmDelete( themeId, siteId ) {
 	return ( dispatch, getState ) => {
-		const { name: themeName } = getTheme( getState(), siteId, themeId );
+		let theme = getTheme( getState(), siteId, themeId );
+		if ( ! theme ) {
+			const recommendedThemes = getRecommendedThemes( getState() );
+			theme = recommendedThemes.find( ( recTheme ) => recTheme.id === themeId );
+		}
+
+		if ( ! theme ) {
+			dispatch(
+				errorNotice(
+					i18n.translate( 'An error has occurred while deleting your theme. Please, try again.' )
+				)
+			);
+			return;
+		}
+
+		const themeName = theme.name;
 		const siteTitle = getSiteTitle( getState(), siteId );
 		accept(
 			i18n.translate( 'Are you sure you want to delete %(themeName)s from %(siteTitle)s?', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes deletion of recommended themes. Currently, when attempting to delete a theme for Jetpack sites, we don't account for recommended themes. This PR updates that behavior, so we either peek into the currently loaded themes, or in the recommended themes when attempting to delete a theme.

#### Testing instructions

* Go to `/themes/:site` where `:site` is a Jetpack site.
* Activate Twenty Twenty.
* Activate Twenty Twenty One.
* Click on the dots of Twenty Twenty.
* Click on "Delete".
* Verify the theme gets deleted successfully.

Related to #51220
