### PR TITLE
people/team/edit: improve `EditUserForm` state handling

### DIFF
--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -50,14 +50,10 @@ class EditUserForm extends Component {
 		}
 	}
 
-	getRole( roles ) {
-		return roles && roles[ 0 ] ? roles[ 0 ] : null;
-	}
-
 	getStateObject( props ) {
 		return {
 			...props.user,
-			roles: this.getRole( props.user?.roles ),
+			roles: props.user?.roles[ 0 ],
 			isExternalContributor: props.isExternalContributor,
 		};
 	}

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -44,6 +44,12 @@ class EditUserForm extends Component {
 		this.setState( this.getStateObject( nextProps ) );
 	}
 
+	componentDidUpdate() {
+		if ( ! this.hasUnsavedSettings() ) {
+			this.props.markSaved();
+		}
+	}
+
 	getRole( roles ) {
 		return roles && roles[ 0 ] ? roles[ 0 ] : null;
 	}

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -40,10 +40,6 @@ const debug = debugModule( 'calypso:my-sites:people:edit-team-member-form' );
 class EditUserForm extends Component {
 	state = this.getStateObject( this.props );
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		this.setState( this.getStateObject( nextProps ) );
-	}
-
 	componentDidUpdate() {
 		if ( ! this.hasUnsavedSettings() ) {
 			this.props.markSaved();
@@ -51,21 +47,25 @@ class EditUserForm extends Component {
 	}
 
 	getStateObject( props ) {
+		const { first_name, last_name, name, roles } = props.user;
+
 		return {
-			...props.user,
-			roles: props.user?.roles[ 0 ],
+			first_name,
+			last_name,
+			name,
+			roles: roles?.[ 0 ],
 			isExternalContributor: props.isExternalContributor,
 		};
 	}
 
 	getChangedSettings() {
-		const originalUser = this.getStateObject( this.props );
+		const originalSettings = this.getStateObject( this.props );
 		const allowedSettings = this.getAllowedSettingsToChange();
 		const changedKeys = allowedSettings.filter( ( setting ) => {
 			return (
-				'undefined' !== typeof originalUser[ setting ] &&
+				'undefined' !== typeof originalSettings[ setting ] &&
 				'undefined' !== typeof this.state[ setting ] &&
-				originalUser[ setting ] !== this.state[ setting ]
+				originalSettings[ setting ] !== this.state[ setting ]
 			);
 		} );
 		const changedSettings = changedKeys.reduce( ( acc, key ) => {

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -46,15 +46,15 @@ class EditUserForm extends Component {
 		}
 	}
 
-	getStateObject( props ) {
-		const { first_name, last_name, name, roles } = props.user;
+	getStateObject( { user, isExternalContributor } ) {
+		const { first_name, last_name, name, roles } = user;
 
 		return {
 			first_name,
 			last_name,
 			name,
 			roles: roles?.[ 0 ],
-			isExternalContributor: props.isExternalContributor,
+			isExternalContributor,
 		};
 	}
 

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -158,14 +158,16 @@ export class EditTeamMemberForm extends Component {
 				{ this.renderNotices() }
 				<Card className="edit-team-member-form__user-profile">
 					<PeopleProfile siteId={ this.props.siteId } user={ this.state.user } />
-					<EditUserForm
-						user={ this.state.user }
-						disabled={ this.state.removingUser }
-						siteId={ this.props.siteId }
-						isJetpack={ this.props.isJetpack }
-						markChanged={ this.props.markChanged }
-						markSaved={ this.props.markSaved }
-					/>
+					{ this.state.user && (
+						<EditUserForm
+							user={ this.state.user }
+							disabled={ this.state.removingUser }
+							siteId={ this.props.siteId }
+							isJetpack={ this.props.isJetpack }
+							markChanged={ this.props.markChanged }
+							markSaved={ this.props.markSaved }
+						/>
+					) }
 				</Card>
 				{ this.state.user && (
 					<DeleteUser


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a another spin off from #50992 (after https://github.com/Automattic/wp-calypso/pull/51267) and extracts a few changes which are not exactly the focus of that PR and should make it easier to review.

* Only store relevant user settings in local state
* Where applicable use props over state
* Remove the need for `UNSAFE_componentWillReceiveProps` (only render `EditUserForm` if `user` is there)
* Fix a bug where navigating away after changing settings back to their original values wouldn't work

#### Testing instructions

* Follow the testing instruction over in https://github.com/Automattic/wp-calypso/pull/51267, they should still work as described

Also:
1. Change a setting and try to navigate away, that should be prevented
2. Change that setting back to its original value, navigating away should be possible¹

¹ This is currently broken in prod
