### PR TITLE
Playwright: change browser management in BrowserManager.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -797,7 +797,7 @@ object RunCalypsoPlaywrightE2eTests : BuildType({
 				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 				export TEST_FILES=${'$'}(join ',' ${'$'}(ls -1 specs-playwright/**/*spec.js))
 
-				xvfb-run yarn magellan --config=magellan-playwright.json --max_workers=%E2E_WORKERS% --suiteTag=parallel --local_browser=chrome --mocha_args="--config .mocharc_playwright.yml --reporter mocha-teamcity-reporter" --test=${'$'}{TEST_FILES}
+				xvfb-run yarn magellan --config=magellan-playwright.json --max_workers=%E2E_WORKERS% --suiteTag=parallel --local_browser=chrome --test=${'$'}{TEST_FILES}
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
 			dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -733,7 +733,7 @@ object RunCalypsoPlaywrightE2eTests : BuildType({
 				export PLAYWRIGHT_BROWSERS_PATH=0
 
 				# Install modules
-				${_self.yarn_install_cmd}
+				yarn install
 
 				# Build package
 				yarn workspace @automattic/calypso-e2e build

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -797,7 +797,7 @@ object RunCalypsoPlaywrightE2eTests : BuildType({
 				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 				export TEST_FILES=${'$'}(join ',' ${'$'}(ls -1 specs-playwright/**/*spec.js))
 
-				xvfb-run yarn magellan --config=magellan-playwright.json --max_workers=%E2E_WORKERS% --suiteTag=parallel --local_browser=chrome --mocha_args="--reporter mocha-teamcity-reporter" --test=${'$'}{TEST_FILES}
+				xvfb-run yarn magellan --config=magellan-playwright.json --max_workers=%E2E_WORKERS% --suiteTag=parallel --local_browser=chrome --mocha_args="--config .mocharc_playwright.yml --reporter mocha-teamcity-reporter" --test=${'$'}{TEST_FILES}
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
 			dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -714,7 +714,7 @@ object RunCalypsoPlaywrightE2eTests : BuildType({
 	name = "Playwright E2E tests"
 	description = "Runs Calypso e2e tests using Playwright"
 	params {
-		param("use_cached_node_modules", "true")
+		param("use_cached_node_modules", "false")
 	}
 
 	artifactRules = """

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -733,7 +733,12 @@ object RunCalypsoPlaywrightE2eTests : BuildType({
 				export PLAYWRIGHT_BROWSERS_PATH=0
 
 				# Install modules
-				yarn install
+				# Normally, we would use the following
+				# ${_self.yarn_install_cmd}
+				# However, due to the prepopulated node_modules
+				# folder not containing the Playwright binaries,
+				# for the time being the raw command is used.
+				yarn install --frozen-lockfile --production --ignore-optional
 
 				# Build package
 				yarn workspace @automattic/calypso-e2e build

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -797,7 +797,7 @@ object RunCalypsoPlaywrightE2eTests : BuildType({
 				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 				export TEST_FILES=${'$'}(join ',' ${'$'}(ls -1 specs-playwright/**/*spec.js))
 
-				xvfb-run yarn magellan --config=magellan-playwright.json --max_workers=%E2E_WORKERS% --suiteTag=parallel --local_browser=chrome --test=${'$'}{TEST_FILES}
+				xvfb-run yarn magellan --config=magellan-playwright.json --max_workers=%E2E_WORKERS% --suiteTag=parallel --local_browser=chrome --mocha_args="-R mocha-teamcity-reporter" --test=${'$'}{TEST_FILES}
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
 			dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -713,6 +713,9 @@ object CheckCodeStyleBranch : BuildType({
 object RunCalypsoPlaywrightE2eTests : BuildType({
 	name = "Playwright E2E tests"
 	description = "Runs Calypso e2e tests using Playwright"
+	params {
+		param("use_cached_node_modules", "true")
+	}
 
 	artifactRules = """
 		reports => reports
@@ -733,12 +736,7 @@ object RunCalypsoPlaywrightE2eTests : BuildType({
 				export PLAYWRIGHT_BROWSERS_PATH=0
 
 				# Install modules
-				# Normally, we would use the following
-				# ${_self.yarn_install_cmd}
-				# However, due to the prepopulated node_modules
-				# folder not containing the Playwright binaries,
-				# for the time being the raw command is used.
-				yarn install --frozen-lockfile --production --ignore-optional
+				${_self.yarn_install_cmd}
 
 				# Build package
 				yarn workspace @automattic/calypso-e2e build

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -15,7 +15,7 @@
 	],
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
-		"@types/config": "0.0.38",
+		"@types/config": "^0.0.38",
 		"config": "^1.28.0",
 		"playwright": "^1.9.1"
 	},

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -15,12 +15,11 @@
 	],
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
+		"@types/config": "0.0.38",
 		"config": "^1.28.0",
 		"playwright": "^1.9.1"
 	},
-	"devDependencies": {
-		"@types/config": "^0.0.38"
-	},
+	"devDependencies": {},
 	"scripts": {
 		"clean": "yarn build --clean && npx rimraf dist",
 		"build": "tsc --build ./tsconfig.json"

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -15,11 +15,12 @@
 	],
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
-		"@types/config": "^0.0.38",
 		"config": "^1.28.0",
 		"playwright": "^1.9.1"
 	},
-	"devDependencies": {},
+	"devDependencies": {
+		"@types/config": "^0.0.38"
+	},
 	"scripts": {
 		"clean": "yarn build --clean && npx rimraf dist",
 		"build": "tsc --build ./tsconfig.json"

--- a/packages/calypso-e2e/src/browser-manager.ts
+++ b/packages/calypso-e2e/src/browser-manager.ts
@@ -8,7 +8,7 @@
  */
 import { chromium } from 'playwright';
 import config from 'config';
-import type { Browser, BrowserContext } from 'playwright';
+import type { Browser, BrowserContext, Page } from 'playwright';
 
 /**
  * Internal dependencies
@@ -68,6 +68,30 @@ export function getScreenDimension(): { width: number; height: number } {
 		default:
 			throw new Error( 'Unsupported screen size specified.' );
 	}
+}
+
+/**
+ * Familiar entrypoint to initialize the browser from a test writer's perspective.
+ *
+ * @returns {Promise<Page>} New Page instance.
+ */
+export async function start(): Promise< Page > {
+	return await newPage();
+}
+
+/**
+ * Returns a new instance of a Page.
+ *
+ * This function wraps and sets additional parameters before returning a new instance
+ * of a Page.
+ * Page represents a tab in a browser where the actual test are run.
+ *
+ * @returns {Promise<Page>} New Page instance.
+ */
+export async function newPage(): Promise< Page > {
+	const browserContext = await newBrowserContext();
+	browserContext.setDefaultTimeout( 5000 );
+	return await browserContext.newPage();
 }
 
 /**

--- a/packages/calypso-e2e/src/browser-manager.ts
+++ b/packages/calypso-e2e/src/browser-manager.ts
@@ -15,7 +15,7 @@ import type { Browser, BrowserContext } from 'playwright';
  */
 import type { screenSize, localeCode } from './types';
 
-const browserStartTimeoutMS = 3000;
+const playwrightTimeoutMS: number = config.get( 'playwrightTimeoutMS' );
 
 export let browser: Browser;
 
@@ -107,6 +107,6 @@ export async function launchBrowser(): Promise< Browser > {
 	return await chromium.launch( {
 		headless: isHeadless,
 		args: [ '--window-position=0,0', `--window-size=${ dimension.width },${ dimension.height }` ],
-		timeout: browserStartTimeoutMS,
+		timeout: playwrightTimeoutMS,
 	} );
 }

--- a/packages/calypso-e2e/src/browser-manager.ts
+++ b/packages/calypso-e2e/src/browser-manager.ts
@@ -15,7 +15,7 @@ import type { Browser, BrowserContext } from 'playwright';
  */
 import type { screenSize, localeCode } from './types';
 
-const browserStartTimeoutMS = 2000;
+const browserStartTimeoutMS = 3000;
 
 export let browser: Browser;
 
@@ -109,17 +109,4 @@ export async function launchBrowser(): Promise< Browser > {
 		args: [ '--window-position=0,0', `--window-size=${ dimension.width },${ dimension.height }` ],
 		timeout: browserStartTimeoutMS,
 	} );
-}
-
-/**
- * Terminates an instance of the Browser.
- *
- * When called, this function will unset the reference to the browser instance,
- * then call on the browser to terminate all instances of existing BrowserContexts.
- * Any open pages are also destroyed in this process.
- *
- * @returns {void} No return value.
- */
-export function quitBrowser(): void {
-	browser.close();
 }

--- a/test/e2e/.mocharc_playwright.yml
+++ b/test/e2e/.mocharc_playwright.yml
@@ -5,3 +5,5 @@ require:
 file:
   - 'lib/before.js'
   - 'lib/hooks-playwright/hooks.ts'
+reporter:
+  - 'spec-junit-reporter'

--- a/test/e2e/.mocharc_playwright.yml
+++ b/test/e2e/.mocharc_playwright.yml
@@ -1,9 +1,10 @@
 require:
   - 'esm'
-  - 'test/mocha.env.js'
   - 'mocha-steps'
 file:
   - 'lib/before.js'
   - 'lib/hooks-playwright/hooks.ts'
 reporter:
   - 'spec-junit-reporter'
+# Timeout for mocha when starting up only.
+timeout: 5000

--- a/test/e2e/.mocharc_playwright.yml
+++ b/test/e2e/.mocharc_playwright.yml
@@ -5,3 +5,5 @@ require:
 file:
   - 'lib/before.js'
   - 'lib/hooks-playwright/hooks.ts'
+reporter:
+  - 'mocha-teamcity-reporter'

--- a/test/e2e/.mocharc_playwright.yml
+++ b/test/e2e/.mocharc_playwright.yml
@@ -1,0 +1,7 @@
+require:
+  - 'esm'
+  - 'test/mocha.env.js'
+  - 'mocha-steps'
+file:
+  - 'lib/before.js'
+  - 'lib/hooks-playwright/hooks.ts'

--- a/test/e2e/.mocharc_playwright.yml
+++ b/test/e2e/.mocharc_playwright.yml
@@ -5,5 +5,3 @@ require:
 file:
   - 'lib/before.js'
   - 'lib/hooks-playwright/hooks.ts'
-reporter:
-  - 'mocha-teamcity-reporter'

--- a/test/e2e/config/default.json
+++ b/test/e2e/config/default.json
@@ -7,6 +7,7 @@
 	"startBrowserTimeoutMS": 60000,
 	"startAppTimeoutMS": 240000,
 	"afterHookTimeoutMS": 60000,
+	"playwrightTimeoutMS": 9000,
 	"browser": "chrome",
 	"proxy": "direct",
 	"saveAllScreenshots": false,

--- a/test/e2e/lib/hooks-playwright/hooks.ts
+++ b/test/e2e/lib/hooks-playwright/hooks.ts
@@ -25,6 +25,6 @@ before( 'Launch browser instance', async function () {
  *
  * @returns {Promise<void>} Void promise.
  */
-after( 'Close browser', function () {
-	return BrowserManager.browser.close();
+after( 'Close browser', async function () {
+	return await BrowserManager.browser.close();
 } );

--- a/test/e2e/lib/hooks-playwright/hooks.ts
+++ b/test/e2e/lib/hooks-playwright/hooks.ts
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { after } from 'mocha';
 import { BrowserManager } from '@automattic/calypso-e2e';
 
 /**
@@ -13,8 +12,8 @@ import { BrowserManager } from '@automattic/calypso-e2e';
  * then call on the browser to terminate all instances of existing BrowserContexts.
  * Any open pages are also destroyed in this process.
  *
- * @returns {void} No return value.
+ * @returns {Promise<void>} Void promise.
  */
-after( function () {
-	BrowserManager.browser.close();
+after( 'Close browser', function () {
+	return BrowserManager.browser.close();
 } );

--- a/test/e2e/lib/hooks-playwright/hooks.ts
+++ b/test/e2e/lib/hooks-playwright/hooks.ts
@@ -3,15 +3,21 @@
 /**
  * External dependencies
  */
+import config from 'config';
 import { BrowserManager } from '@automattic/calypso-e2e';
 
+const playwrightTimeoutMS = config.get( 'playwrightTimeoutMS' );
+
 /**
- * Hook to launch a Browser and obtain the BrowserContext.
+ * Hook to launch a new instance of BrowserContext then a new
+ * Page for testing.
  *
  * @returns {void} No return value.
  */
 before( 'Launch browser instance', async function () {
 	this.browserContext = await BrowserManager.newBrowserContext();
+	await this.browserContext.setDefaultTimeout( playwrightTimeoutMS );
+	this.page = await this.browserContext.newPage();
 } );
 
 /**

--- a/test/e2e/lib/hooks-playwright/hooks.ts
+++ b/test/e2e/lib/hooks-playwright/hooks.ts
@@ -3,22 +3,7 @@
 /**
  * External dependencies
  */
-import config from 'config';
 import { BrowserManager } from '@automattic/calypso-e2e';
-
-const playwrightTimeoutMS = config.get( 'playwrightTimeoutMS' );
-
-/**
- * Hook to launch a new instance of BrowserContext then a new
- * Page for testing.
- *
- * @returns {void} No return value.
- */
-before( 'Launch browser instance', async function () {
-	this.browserContext = await BrowserManager.newBrowserContext();
-	await this.browserContext.setDefaultTimeout( playwrightTimeoutMS );
-	this.page = await this.browserContext.newPage();
-} );
 
 /**
  * Hook to terminate a Browser instance.

--- a/test/e2e/lib/hooks-playwright/hooks.ts
+++ b/test/e2e/lib/hooks-playwright/hooks.ts
@@ -1,0 +1,20 @@
+/* eslint-disable mocha/no-top-level-hooks */
+
+/**
+ * External dependencies
+ */
+import { after } from 'mocha';
+import { BrowserManager } from '@automattic/calypso-e2e';
+
+/**
+ * Terminates an instance of the Browser.
+ *
+ * When called, this function will unset the reference to the browser instance,
+ * then call on the browser to terminate all instances of existing BrowserContexts.
+ * Any open pages are also destroyed in this process.
+ *
+ * @returns {void} No return value.
+ */
+after( function () {
+	BrowserManager.browser.close();
+} );

--- a/test/e2e/lib/hooks-playwright/hooks.ts
+++ b/test/e2e/lib/hooks-playwright/hooks.ts
@@ -6,11 +6,16 @@
 import { BrowserManager } from '@automattic/calypso-e2e';
 
 /**
- * Terminates an instance of the Browser.
+ * Hook to launch a new BrowserContext.
  *
- * When called, this function will unset the reference to the browser instance,
- * then call on the browser to terminate all instances of existing BrowserContexts.
- * Any open pages are also destroyed in this process.
+ * @returns {void} No return value.
+ */
+before( 'Launch browser instance', async function () {
+	this.browserContext = await BrowserManager.newBrowserContext();
+} );
+
+/**
+ * Hook to terminate a Browser instance.
  *
  * @returns {Promise<void>} Void promise.
  */

--- a/test/e2e/lib/hooks-playwright/hooks.ts
+++ b/test/e2e/lib/hooks-playwright/hooks.ts
@@ -23,8 +23,8 @@ before( 'Launch browser instance', async function () {
 /**
  * Hook to terminate a Browser instance.
  *
- * @returns {Promise<void>} Void promise.
+ * @returns {void} No return value.
  */
 after( 'Close browser', async function () {
-	return await BrowserManager.browser.close();
+	await BrowserManager.browser.close();
 } );

--- a/test/e2e/lib/hooks-playwright/hooks.ts
+++ b/test/e2e/lib/hooks-playwright/hooks.ts
@@ -6,7 +6,7 @@
 import { BrowserManager } from '@automattic/calypso-e2e';
 
 /**
- * Hook to launch a new BrowserContext.
+ * Hook to launch a Browser and obtain the BrowserContext.
  *
  * @returns {void} No return value.
  */

--- a/test/e2e/magellan-playwright.json
+++ b/test/e2e/magellan-playwright.json
@@ -1,6 +1,6 @@
 {
 	"mocha_tests": [ "specs-playwright" ],
-	"mocha_args": "-R spec-junit-reporter",
+	"mocha_config": "./.mocharc_playwright.yml",
 	"max_test_attempts": 3,
 	"max_workers": 1,
 	"sauce": false,

--- a/test/e2e/specs-playwright/wp-log-in-out-spec.js
+++ b/test/e2e/specs-playwright/wp-log-in-out-spec.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import config from 'config';
+import { BrowserManager } from '@automattic/calypso-e2e';
 
 /**
  * Internal dependencies
@@ -15,42 +16,31 @@ const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 
 describe( `Main Suite 1 @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let page;
 
-	describe( 'Subsuite 1', function () {
+	describe( 'Subsuite 1-1', function () {
 		step( 'Can see the log in page', async function () {
-			page = this.page;
 			const url = LoginPage.getLoginURL();
-			/*
-			Waits for network activity to cease.
-			Only as a proof of concept. In a production test, should check
-			for the presence of desired elements using a selector.
-			*/
-			return await page.goto( url, { waitUntill: 'networkidle' } );
+			return await this.page.goto( url, { waitUntill: 'networkidle' } );
 		} );
 	} );
 
-	describe( 'Subsuite 2', function () {
-		step( 'Can alsosee the log in page', async function () {
-			const url = LoginPage.getLoginURL();
-			/*
-			Waits for network activity to cease.
-			Only as a proof of concept. In a production test, should check
-			for the presence of desired elements using a selector.
-			*/
-			return await page.goto( url, { waitUntill: 'networkidle' } );
+	describe( 'Subsuite 1-2', function () {
+		step( 'Should also pass', async function () {
+			return await this.page.goto( 'https://google.com', { waitUntill: 'networkidle' } );
 		} );
 	} );
 } );
 
 describe( `Main Suite 2 @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let page;
 
-	describe( 'Subsuite 1', function () {
+	describe( 'Subsuite 2-1', function () {
+		before( 'start browser', async function () {
+			this.page = await BrowserManager.start();
+		} );
+
 		step( 'Should fail', async function () {
-			page = this.page;
-			await page.click( 'non-existing-selector' );
+			await this.page.click( 'non-existing-selector' );
 		} );
 
 		step( 'Should be aborted', async function () {
@@ -60,7 +50,25 @@ describe( `Main Suite 2 @parallel`, function () {
 			Only as a proof of concept. In a production test, should check
 			for the presence of desired elements using a selector.
 			*/
-			return await page.goto( url, { waitUntill: 'networkidle' } );
+			return await this.page.goto( url, { waitUntill: 'networkidle' } );
+		} );
+	} );
+
+	describe( 'Subsuite 2-2', function () {
+		before( 'start browser', async function () {
+			this.page = await BrowserManager.start();
+		} );
+
+		step( 'Should pass', async function () {
+			return await this.page.goto( 'https://wordpress.com/support/', {
+				waitUntill: 'networkidle',
+			} );
+		} );
+
+		step( 'Also should pass', async function () {
+			return await this.page.goto( 'https://wordpress.com/support/start', {
+				waitUntill: 'networkidle',
+			} );
 		} );
 	} );
 } );

--- a/test/e2e/specs-playwright/wp-log-in-out-spec.js
+++ b/test/e2e/specs-playwright/wp-log-in-out-spec.js
@@ -13,7 +13,7 @@ import LoginPage from '../lib/pages/login-page';
  */
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 
-describe( `Main Suite 1`, function () {
+describe( `Main Suite 1 @parallel`, function () {
 	this.timeout( mochaTimeOut );
 	let page;
 
@@ -43,7 +43,7 @@ describe( `Main Suite 1`, function () {
 	} );
 } );
 
-describe( `Main Suite 2`, function () {
+describe( `Main Suite 2 @parallel`, function () {
 	this.timeout( mochaTimeOut );
 	let page;
 

--- a/test/e2e/specs-playwright/wp-log-in-out-spec.js
+++ b/test/e2e/specs-playwright/wp-log-in-out-spec.js
@@ -13,22 +13,47 @@ import LoginPage from '../lib/pages/login-page';
  */
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 
-describe( `Auth Screen @canary @parallel`, function () {
+describe( `Main Suite 1`, function () {
 	this.timeout( mochaTimeOut );
-
-	// Page represents a tab in a browser.
-	// Test steps interact with the page to execute its instructions.
 	let page;
 
-	// Open a new page (tab) within the BrowserContext.
-	// This is akin to the following call in the Selenium test:
-	// driver = await driverManager.startBrowser();
-	before( 'Open new test tab', async function () {
-		page = await this.browserContext.newPage();
+	describe( 'Subsuite 1', function () {
+		step( 'Can see the log in page', async function () {
+			page = this.page;
+			const url = LoginPage.getLoginURL();
+			/*
+			Waits for network activity to cease.
+			Only as a proof of concept. In a production test, should check
+			for the presence of desired elements using a selector.
+			*/
+			return await page.goto( url, { waitUntill: 'networkidle' } );
+		} );
 	} );
 
-	describe( 'Loading the log-in page', function () {
-		step( 'Can see the log in page', async function () {
+	describe( 'Subsuite 2', function () {
+		step( 'Can alsosee the log in page', async function () {
+			const url = LoginPage.getLoginURL();
+			/*
+			Waits for network activity to cease.
+			Only as a proof of concept. In a production test, should check
+			for the presence of desired elements using a selector.
+			*/
+			return await page.goto( url, { waitUntill: 'networkidle' } );
+		} );
+	} );
+} );
+
+describe( `Main Suite 2`, function () {
+	this.timeout( mochaTimeOut );
+	let page;
+
+	describe( 'Subsuite 1', function () {
+		step( 'Should fail', async function () {
+			page = this.page;
+			await page.click( 'non-existing-selector' );
+		} );
+
+		step( 'Should be aborted', async function () {
 			const url = LoginPage.getLoginURL();
 			/*
 			Waits for network activity to cease.

--- a/test/e2e/specs-playwright/wp-log-in-out-spec.js
+++ b/test/e2e/specs-playwright/wp-log-in-out-spec.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import config from 'config';
-import { BrowserManager } from '@automattic/calypso-e2e';
 
 /**
  * Internal dependencies
@@ -17,18 +16,12 @@ const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 describe( `Auth Screen @canary @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
-	// BrowserContext is equivalent to the `driver` used in Selenium.
-	let browserContext;
 	// Page represents a tab in a browser.
 	// Test steps interact with the page to execute its instructions.
 	let page;
 
-	before( 'Start browser', async function () {
-		browserContext = await BrowserManager.newBrowserContext();
-	} );
-
 	beforeEach( 'Open new test tab', async function () {
-		page = await browserContext.newPage();
+		page = await this.browserContext.newPage();
 		// Set the page using mocha's metadata. Upon test failure,
 		// mocha hooks can access the page to perform actions.
 		this.currentTest.page = page;

--- a/test/e2e/specs-playwright/wp-log-in-out-spec.js
+++ b/test/e2e/specs-playwright/wp-log-in-out-spec.js
@@ -45,8 +45,4 @@ describe( `Auth Screen @canary @parallel`, function () {
 			return await page.goto( url, { waitUntill: 'networkidle' } );
 		} );
 	} );
-
-	after( 'close browser', function () {
-		BrowserManager.quitBrowser();
-	} );
 } );

--- a/test/e2e/specs-playwright/wp-log-in-out-spec.js
+++ b/test/e2e/specs-playwright/wp-log-in-out-spec.js
@@ -20,11 +20,11 @@ describe( `Auth Screen @canary @parallel`, function () {
 	// Test steps interact with the page to execute its instructions.
 	let page;
 
-	beforeEach( 'Open new test tab', async function () {
+	// Open a new page (tab) within the BrowserContext.
+	// This is akin to the following call in the Selenium test:
+	// driver = await driverManager.startBrowser();
+	before( 'Open new test tab', async function () {
 		page = await this.browserContext.newPage();
-		// Set the page using mocha's metadata. Upon test failure,
-		// mocha hooks can access the page to perform actions.
-		this.currentTest.page = page;
 	} );
 
 	describe( 'Loading the log-in page', function () {

--- a/test/e2e/specs-playwright/wp-log-in-out-spec.js
+++ b/test/e2e/specs-playwright/wp-log-in-out-spec.js
@@ -17,6 +17,10 @@ const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 describe( `Main Suite 1 @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
+	before( 'start browser', async function () {
+		this.page = await BrowserManager.start();
+	} );
+
 	describe( 'Subsuite 1-1', function () {
 		step( 'Can see the log in page', async function () {
 			const url = LoginPage.getLoginURL();
@@ -34,11 +38,11 @@ describe( `Main Suite 1 @parallel`, function () {
 describe( `Main Suite 2 @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
-	describe( 'Subsuite 2-1', function () {
-		before( 'start browser', async function () {
-			this.page = await BrowserManager.start();
-		} );
+	before( 'start browser', async function () {
+		this.page = await BrowserManager.start();
+	} );
 
+	describe( 'Subsuite 2-1', function () {
 		step( 'Should fail', async function () {
 			await this.page.click( 'non-existing-selector' );
 		} );
@@ -55,10 +59,6 @@ describe( `Main Suite 2 @parallel`, function () {
 	} );
 
 	describe( 'Subsuite 2-2', function () {
-		before( 'start browser', async function () {
-			this.page = await BrowserManager.start();
-		} );
-
 		step( 'Should pass', async function () {
 			return await this.page.goto( 'https://wordpress.com/support/', {
 				waitUntill: 'networkidle',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This patch changes browser instance management occurs which impacts how tests are written.

#### New Files

**Hook file**
This file will contain hooks specifically for the Playwright tests.

**Mocha Configuration**
Mocha configuration file for Playwright test suite is added.

#### Changes to existing files

**TeamCity configuration**
- do not use cached `node_modules` folder when installing dependencies.

**Spec file**
- add multiple steps and subsuites to exercise browser behavior.

**Browser Manager**
- add new functions to manage the three layers of Playwright browser behavior (browser, browser context, page)
- add entrypoint function `start` to be called by test writer.

**Configuration**
- Playwright-specific timeout added.

#### Changes in behavior

BrowserManager is responsible for handling the browser instance, context and pages.
Test writer is expected to call the entrypoint `start` function inside the top-level describe block.

#### Testing

To test, verify the following:
- existing Calypso E2E tests are not affected (i.e. passes).
- Playwright E2E tests should fail with an error in `page.click` as expected.

Partially implements #51082.
Parent: #51419
Child: #51209