### PR TITLE
Help: Fix youtube video embeds

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -1099,7 +1099,7 @@ const getVideosForSection = () => ( {
 	sharing: [
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/YVelWG3hf3o',
+			link: 'https://www.youtube.com/watch?v=YVelWG3hf3o',
 			title: translate( 'Add Social Sharing Buttons to Your Website' ),
 			description: translate(
 				'Find out how to add social sharing buttons to your WordPress.com site, which you can also ' +
@@ -1108,7 +1108,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/NcCe0ozmqFM',
+			link: 'https://www.youtube.com/watch?v=NcCe0ozmqFM',
 			title: translate( 'Connect Your Blog to Facebook Using Publicize' ),
 			description: translate(
 				'Find out how to share blog posts directly on Facebook from your WordPress.com site, ' +
@@ -1117,7 +1117,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/f44-4TgnWTs',
+			link: 'https://www.youtube.com/watch?v=f44-4TgnWTs',
 			title: translate( 'Display Your Instagram Feed on Your Website' ),
 			description: translate(
 				'Find out how to display your latest Instagram photos right on your WordPress.com site.'
@@ -1125,7 +1125,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/3rTooGV_mlg',
+			link: 'https://www.youtube.com/watch?v=3rTooGV_mlg',
 			title: translate( 'Set Up the Social Links Menu' ),
 			description: translate(
 				'Find out how to set up a social links menu on your WordPress.com or Jetpack-enabled WordPress site.'
@@ -1133,7 +1133,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/gmrOkkqMNlc',
+			link: 'https://www.youtube.com/watch?v=gmrOkkqMNlc',
 			title: translate( 'Embed a Twitter Timeline in your Sidebar' ),
 			description: translate(
 				'Find out how to display your Twitter timeline on your WordPress.com or Jetpack-enabled WordPress site.'
@@ -1141,7 +1141,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/vy-U5saqG9A',
+			link: 'https://www.youtube.com/watch?v=vy-U5saqG9A',
 			title: translate( 'Set Up a Social Media Icons Widget' ),
 			description: translate(
 				'Find out how to set up the social media icons widget on your WordPress.com or Jetpack-enabled WordPress site.'
@@ -1149,7 +1149,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/N0GRBFRkzzs',
+			link: 'https://www.youtube.com/watch?v=N0GRBFRkzzs',
 			title: translate( 'Embed a Tweet from Twitter in Your Website' ),
 			description: translate(
 				'Find out how to embed a Tweet in your content (including posts and pages) on your WordPress.com ' +
@@ -1158,7 +1158,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/uVRji6bKJUE',
+			link: 'https://www.youtube.com/watch?v=uVRji6bKJUE',
 			title: translate( 'Embed an Instagram Photo in Your Website' ),
 			description: translate(
 				'Find out how to embed an Instagram photo in your content (including posts and pages) on your WordPress.com ' +
@@ -1167,7 +1167,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/sKm3Q83JxM0',
+			link: 'https://www.youtube.com/watch?v=sKm3Q83JxM0',
 			title: translate( 'Embed a Facebook Update in Your Website' ),
 			description: translate(
 				'Find out how to embed a Facebook update in your content (including posts, pages, and even comments) on your ' +
@@ -1176,7 +1176,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/SBgNkre_b14',
+			link: 'https://www.youtube.com/watch?v=SBgNkre_b14',
 			title: translate( 'Share Blog Posts Directly on Twitter' ),
 			description: translate(
 				'Find out how to share blog posts directly on Twitter from your WordPress.com or Jetpack-enabled WordPress site.'
@@ -1186,13 +1186,13 @@ const getVideosForSection = () => ( {
 	settings: [
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/0YCZ22k4SfQ',
+			link: 'https://www.youtube.com/watch?v=0YCZ22k4SfQ',
 			title: translate( 'Add a Site Logo' ),
 			description: translate( 'Find out how to add a custom logo to your WordPress.com site.' ),
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/vucZ1uZ2NPo',
+			link: 'https://www.youtube.com/watch?v=vucZ1uZ2NPo',
 			title: translate( 'Update Your Website Title and Tagline' ),
 			description: translate(
 				'Find out how to update the Title and Tagline of your WordPress.com site, which you can also ' +
@@ -1201,7 +1201,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/Y6iPsPwYD7g',
+			link: 'https://www.youtube.com/watch?v=Y6iPsPwYD7g',
 			title: translate( 'Change Your Privacy Settings' ),
 			description: translate(
 				'Find out how to change your website privacy settings on WordPress.com.'
@@ -1209,19 +1209,19 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/bjxKGxW0MRA',
+			link: 'https://www.youtube.com/watch?v=bjxKGxW0MRA',
 			title: translate( 'Add a Site Icon' ),
 			description: translate( 'Find out how to add a site icon on WordPress.com.' ),
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/z6fCtvLB0wM',
+			link: 'https://www.youtube.com/watch?v=z6fCtvLB0wM',
 			title: translate( 'Create a Multilingual Site' ),
 			description: translate( 'Find out how to create a multilingual site on WordPress.com.' ),
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/D142Edhcpaw',
+			link: 'https://www.youtube.com/watch?v=D142Edhcpaw',
 			title: translate( 'Customize Your Content Options' ),
 			description: translate(
 				'Find out how to customize your content options on select WordPress.com themes.'
@@ -1229,7 +1229,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/Vyr-g5SEuIA',
+			link: 'https://www.youtube.com/watch?v=Vyr-g5SEuIA',
 			title: translate( 'Change Your Language Settings' ),
 			description: translate(
 				'Find out how to change your blog or website language and your interface language settings on WordPress.com.'
@@ -1237,7 +1237,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/EUuEuW_LCrc',
+			link: 'https://www.youtube.com/watch?v=EUuEuW_LCrc',
 			title: translate( 'Activate Free Email Forwarding' ),
 			description: translate(
 				'Find out how to activate free email forwarding from an address using a custom domain registered through WordPress.com.'
@@ -1247,7 +1247,7 @@ const getVideosForSection = () => ( {
 	'post-editor': [
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/hNg1rrkiAjg',
+			link: 'https://www.youtube.com/watch?v=hNg1rrkiAjg',
 			title: translate( 'Set a Featured Image for a Post or Page' ),
 			description: translate(
 				'Find out how to add a featured image where available on your WordPress.com or Jetpack-enabled WordPress site.'
@@ -1255,13 +1255,13 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/dAcEBKXPlyA',
+			link: 'https://www.youtube.com/watch?v=dAcEBKXPlyA',
 			title: translate( 'Add a Contact Form to Your Website' ),
 			description: translate( 'Find out how to add a contact form to your WordPress.com site.' ),
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/ssfHW5lwFZg',
+			link: 'https://www.youtube.com/watch?v=ssfHW5lwFZg',
 			title: translate( 'Embed a YouTube Video in Your Website' ),
 			description: translate(
 				'Find out how to embed a YouTube video in your content (including posts, pages, and even comments) ' +
@@ -1270,7 +1270,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/_tpcHN6ZtKM',
+			link: 'https://www.youtube.com/watch?v=_tpcHN6ZtKM',
 			title: translate( 'Schedule a Post' ),
 			description: translate(
 				'Find out how to schedule a post on your WordPress.com website or blog.'
@@ -1278,7 +1278,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/V8UToJoSf4Q',
+			link: 'https://www.youtube.com/watch?v=V8UToJoSf4Q',
 			title: translate( 'Add a Pay with PayPal button' ),
 			description: translate(
 				'Find out how to add a payment button to your WordPress.com website.'
@@ -1288,25 +1288,25 @@ const getVideosForSection = () => ( {
 	account: [
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/aO-6yu3_xWQ',
+			link: 'https://www.youtube.com/watch?v=aO-6yu3_xWQ',
 			title: translate( 'Change Your Password' ),
 			description: translate( 'Find out how to change your account password on WordPress.com.' ),
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/qhsjkqFdDZo',
+			link: 'https://www.youtube.com/watch?v=qhsjkqFdDZo',
 			title: translate( 'Change Your WordPress.com Username' ),
 			description: translate( 'Find out how to change your username on WordPress.com.' ),
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/Tyxu_xT6q1k',
+			link: 'https://www.youtube.com/watch?v=Tyxu_xT6q1k',
 			title: translate( 'Change Your WordPress.com Display Name' ),
 			description: translate( 'Find out how to change your display name on WordPress.com.' ),
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/07Nf8FkjO4o',
+			link: 'https://www.youtube.com/watch?v=07Nf8FkjO4o',
 			title: translate( 'Change Your Account Email Address' ),
 			description: translate(
 				'Find out how to change your account email address on WordPress.com.'
@@ -1316,7 +1316,7 @@ const getVideosForSection = () => ( {
 	customizer: [
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/pf_ST7gvY8c',
+			link: 'https://www.youtube.com/watch?v=pf_ST7gvY8c',
 			title: translate( 'Add a Custom Header Image' ),
 			description: translate(
 				'Find out how to add a custom header image to your WordPress.com website or blog.'
@@ -1324,7 +1324,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/CY20IAtl2Ac',
+			link: 'https://www.youtube.com/watch?v=CY20IAtl2Ac',
 			title: translate( 'Create a Custom Website Menu' ),
 			description: translate(
 				'Find out how to create a custom menu on your WordPress.com or Jetpack-enabled WordPress site.'
@@ -1332,13 +1332,13 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/2H_Jsgh2Z3Y',
+			link: 'https://www.youtube.com/watch?v=2H_Jsgh2Z3Y',
 			title: translate( 'Add a Widget' ),
 			description: translate( 'Find out how to add a widget to your WordPress.com website.' ),
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/ypFF4ONBfSQ',
+			link: 'https://www.youtube.com/watch?v=ypFF4ONBfSQ',
 			title: translate( 'Add a Custom Background' ),
 			description: translate(
 				'Find out how to add a custom background to your WordPress.com site.'
@@ -1346,7 +1346,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/b8EuJDrNeOA',
+			link: 'https://www.youtube.com/watch?v=b8EuJDrNeOA',
 			title: translate( 'Change Your Site Fonts' ),
 			description: translate(
 				'Find out how to change the fonts on your WordPress.com website or blog.'
@@ -1354,7 +1354,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/7VPgvxV78Kc',
+			link: 'https://www.youtube.com/watch?v=7VPgvxV78Kc',
 			title: translate( 'Add a Gallery Widget' ),
 			description: translate(
 				'Find out how to add an image gallery widget to your WordPress.com website or blog.'
@@ -1362,7 +1362,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/oDBuaBLrwF8',
+			link: 'https://www.youtube.com/watch?v=oDBuaBLrwF8',
 			title: translate( 'Use Featured Content' ),
 			description: translate(
 				'Find out how to use the Featured Content option on your WordPress.com website or blog.'
@@ -1370,7 +1370,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/3TqRr21zyiA',
+			link: 'https://www.youtube.com/watch?v=3TqRr21zyiA',
 			title: translate( 'Add an Image Widget' ),
 			description: translate(
 				'Find out how to add an image widget to your WordPress.com website or blog.'
@@ -1380,7 +1380,7 @@ const getVideosForSection = () => ( {
 	'posts-pages': [
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/3RPidSCQ0LI',
+			link: 'https://www.youtube.com/watch?v=3RPidSCQ0LI',
 			title: translate( 'Create a Landing Page' ),
 			description: translate(
 				'Find out how to create a one-page website or landing page on your WordPress.com site.'
@@ -1388,31 +1388,31 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/4IkFQzl5nXc',
+			link: 'https://www.youtube.com/watch?v=4IkFQzl5nXc',
 			title: translate( 'Set Up a Website in 5 Steps' ),
 			description: translate( 'Find out how to create a website on WordPress.com in five steps.' ),
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/mta6Y0o7yJk',
+			link: 'https://www.youtube.com/watch?v=mta6Y0o7yJk',
 			title: translate( 'Set Up a Blog in 5 Steps' ),
 			description: translate( 'Find out how to create a blog on WordPress.com in five steps.' ),
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/Gx7YNX1Wk5U',
+			link: 'https://www.youtube.com/watch?v=Gx7YNX1Wk5U',
 			title: translate( 'Create a Page' ),
 			description: translate( 'Find out how to create a page on your WordPress.com site.' ),
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/mCfuh5bCOwM',
+			link: 'https://www.youtube.com/watch?v=mCfuh5bCOwM',
 			title: translate( 'Create a Post' ),
 			description: translate( 'Find out how to create a post on WordPress.com.' ),
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/bEVHg6nopcs',
+			link: 'https://www.youtube.com/watch?v=bEVHg6nopcs',
 			title: translate( 'Use a Custom Menu in a Widget' ),
 			description: translate(
 				'Find out how to use a custom menu in a widget on your WordPress.com or Jetpack-enabled WordPress site.'
@@ -1420,7 +1420,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/nAzdUOlFoBI',
+			link: 'https://www.youtube.com/watch?v=nAzdUOlFoBI',
 			title: translate( 'Configure a Static Homepage' ),
 			description: translate(
 				'By default, your new WordPress.com website displays your latest posts. Find out how to create a static homepage instead.'
@@ -1428,7 +1428,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/MPpVeMmDOhk',
+			link: 'https://www.youtube.com/watch?v=MPpVeMmDOhk',
 			title: translate( 'Show Related Posts on Your WordPress Blog' ),
 			description: translate(
 				'Find out how to show related posts on your WordPress.com site, which you can also do on a Jetpack-enabled WordPress blog.'
@@ -1436,7 +1436,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/JVnltCZUKC4',
+			link: 'https://www.youtube.com/watch?v=JVnltCZUKC4',
 			title: translate( 'Add Testimonials' ),
 			description: translate(
 				'Find out how to add testimonials to your WordPress.com website or blog.'
@@ -1444,7 +1444,7 @@ const getVideosForSection = () => ( {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/yH_gapAUGAA',
+			link: 'https://www.youtube.com/watch?v=yH_gapAUGAA',
 			title: translate( 'Change Your Post or Page Visibility Settings' ),
 			description: translate(
 				'Find out how to change your page or post visibility settings WordPress.com.'
@@ -1454,7 +1454,7 @@ const getVideosForSection = () => ( {
 	media: [
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/VjGnEHyqVqQ',
+			link: 'https://www.youtube.com/watch?v=VjGnEHyqVqQ',
 			title: translate( 'Add a Photo Gallery' ),
 			description: translate(
 				'Find out how to add a photo gallery on your WordPress.com and Jetpack-enabled website.'
@@ -1464,7 +1464,7 @@ const getVideosForSection = () => ( {
 	themes: [
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/yOfAuOb68Hc',
+			link: 'https://www.youtube.com/watch?v=yOfAuOb68Hc',
 			title: translate( 'Change Your Website Theme on WordPress.com' ),
 			description: translate( 'Find out how to change your WordPress.com theme.' ),
 		},

--- a/client/blocks/inline-help/dialog.jsx
+++ b/client/blocks/inline-help/dialog.jsx
@@ -28,6 +28,9 @@ function InlineHelpDialog( { dialogType, videoLink, onClose, translate } ) {
 			? [ <Button onClick={ onClose }>{ translate( 'Close', { textOnly: true } ) }</Button> ]
 			: [];
 
+	// Replace youtube.com links with the embeddable version that can be iframed.
+	const videoEmbedLink = videoLink.replace( 'youtube.com/watch?v=', 'youtube.com/embed/' );
+
 	return (
 		<Dialog
 			additionalClassNames={ dialogClasses }
@@ -39,7 +42,7 @@ function InlineHelpDialog( { dialogType, videoLink, onClose, translate } ) {
 			{ dialogType === 'video' && (
 				<div className={ iframeClasses }>
 					<ResizableIframe
-						src={ videoLink + '?rel=0&amp;showinfo=0&amp;autoplay=1' }
+						src={ videoEmbedLink + '?rel=0&amp;showinfo=0&amp;autoplay=1' }
 						frameBorder="0"
 						seamless
 						allowFullScreen

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -82,8 +82,7 @@ class InlineHelpRichResult extends Component {
 			this.props.setDialogState( {
 				showDialog: true,
 				dialogType: 'video',
-				// Replace youtube.com links with the embeddable version that can be iframed.
-				videoLink: link.replace( 'youtube.com/watch?v=', 'youtube.com/embed/' ),
+				videoLink: link,
 			} );
 		} else if ( type === RESULT_ARTICLE && postId && isLocaleEnglish ) {
 			// Until we can deliver localized inline support article content, we send the

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -28,9 +28,6 @@ import getSearchQuery from 'calypso/state/inline-help/selectors/get-search-query
 import { requestGuidedTour } from 'calypso/state/guided-tours/actions';
 import { openSupportArticleDialog } from 'calypso/state/inline-support-article/actions';
 
-const amendYouTubeLink = ( link = '' ) =>
-	link.replace( 'youtube.com/embed/', 'youtube.com/watch?v=' );
-
 class InlineHelpRichResult extends Component {
 	static propTypes = {
 		setDialogState: PropTypes.func.isRequired,
@@ -121,7 +118,7 @@ const mapStateToProps = ( state, { result } ) => ( {
 	searchQuery: getSearchQuery( state ),
 	type: get( result, RESULT_TYPE, RESULT_ARTICLE ),
 	title: get( result, RESULT_TITLE ),
-	link: amendYouTubeLink( get( result, RESULT_LINK ) ),
+	link: get( result, RESULT_LINK ),
 	description: get( result, RESULT_DESCRIPTION ),
 	tour: get( result, RESULT_TOUR ),
 	postId: get( result, 'post_id' ),

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -82,7 +82,8 @@ class InlineHelpRichResult extends Component {
 			this.props.setDialogState( {
 				showDialog: true,
 				dialogType: 'video',
-				videoLink: link,
+				// Replace youtube.com links with the embeddable version that can be iframed.
+				videoLink: link.replace( 'youtube.com/watch?v=', 'youtube.com/embed/' ),
 			} );
 		} else if ( type === RESULT_ARTICLE && postId && isLocaleEnglish ) {
 			// Until we can deliver localized inline support article content, we send the


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates Youtube video urls for contextual help to use direct links (rather than embeds), for when opened in a new tab/window
* Ensures embedded help videos use the `youtube.com/embed/` url, to avoid errors related to `X-Frame-Option: sameorigin`

Fixes #50102

Note that the new tab/window behavior was introduced in https://github.com/Automattic/wp-calypso/pull/25363, but this link replacement is currently causing Youtube help video embeds to error.

#### Testing instructions

1. Visit a section in Calypso that has inline help videos (settings, themes, media, etc)
2. Click on the "?" in the lower right hand corner.
3. The first link should be to a Youtube video. Right click and open in a new tab/window... the link should go to the normal Youtube page.
4. Click through the video link normally... you should see the video play in a modal.

| Contextual help list | Watch a video | Video embed |
| - | - | - |
| <img width="825" alt="Screen Shot 2021-03-22 at 17 17 46" src="https://user-images.githubusercontent.com/1699996/112065506-b9659500-8b32-11eb-8e0d-ce9b5b3b2d91.png"> | <img width="329" alt="Screen Shot 2021-03-22 at 17 18 27" src="https://user-images.githubusercontent.com/1699996/112065510-b9fe2b80-8b32-11eb-8c51-d1a11ea57d8a.png"> | <img width="689" alt="Screen Shot 2021-03-22 at 17 18 04" src="https://user-images.githubusercontent.com/1699996/112065509-b9659500-8b32-11eb-9893-6b1e3fd129d9.png"> |



