### PR TITLE
Help: Remove references to deprecated mobile-themes support page

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -684,15 +684,6 @@ const getContextLinksForSection = () => ( {
 			),
 		},
 		{
-			link: localizeUrl( 'https://wordpress.com/support/themes/mobile-themes/' ),
-			post_id: 4925,
-			title: translate( 'Mobile Themes' ),
-			description: translate(
-				'When a visitor browses to a WordPress.com site on a mobile device, we show ' +
-					'special themes designed to work on small screens focusing on fast load times.'
-			),
-		},
-		{
 			link: localizeUrl( 'https://wordpress.com/support/premium-themes/' ),
 			post_id: 12112,
 			title: translate( 'Premium Themes' ),
@@ -721,15 +712,6 @@ const getContextLinksForSection = () => ( {
 			description: translate(
 				'A theme controls the general look and feel of your site including things like ' +
 					'page layout, widget locations, and default font.'
-			),
-		},
-		{
-			link: localizeUrl( 'https://wordpress.com/support/themes/mobile-themes/' ),
-			post_id: 4925,
-			title: translate( 'Mobile Themes' ),
-			description: translate(
-				'When a visitor browses to a WordPress.com site on a mobile device, we show ' +
-					'special themes designed to work on small screens focusing on fast load times.'
 			),
 		},
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove references in inline help to the [mobile-themes support page](https://wordpress.com/support/themes/mobile-themes/). The feature and related support page have been deprecated since last year.

Internal reference: p1HpG7-84F-p2

#### Testing instructions

* Visit /themes/{site}
* Click the "?" to open contextual help
* You should not see a link to the "Mobile Themes" support page

<img width="339" alt="Screen Shot 2021-03-22 at 17 46 20" src="https://user-images.githubusercontent.com/1699996/112067832-bbc9ee00-8b36-11eb-952a-d6321cb03772.png">
