### PR TITLE
Remove support for deprecated /block-editor/nux API params

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -89,13 +89,8 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 
 		return rest_ensure_response(
 			array(
-				'show_welcome_guide'        => $show_welcome_guide,
-				'variant'                   => $variant,
-
-				// These are legacy rest params that can be removed after
-				// we know the new JS files have been deployed.
-				'is_nux_enabled'            => $show_welcome_guide,
-				'welcome_tour_show_variant' => 'tour' === $variant,
+				'show_welcome_guide' => $show_welcome_guide,
+				'variant'            => $variant,
 			)
 		);
 	}
@@ -107,14 +102,8 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 	 * @return WP_REST_Response
 	 */
 	public function update_nux_status( $request ) {
-		$params = $request->get_json_params();
-		if ( isset( $params['show_welcome_guide'] ) ) {
-			$nux_status = $params['show_welcome_guide'] ? 'enabled' : 'dismissed';
-		} else {
-			// This legacy rest param can be removed after we know the new
-			// JS files have been deployed.
-			$nux_status = $params['isNuxEnabled'] ? 'enabled' : 'dismissed';
-		}
+		$params     = $request->get_json_params();
+		$nux_status = $params['show_welcome_guide'] ? 'enabled' : 'dismissed';
 		if ( has_action( 'wpcom_block_editor_nux_update_status' ) ) {
 			do_action( 'wpcom_block_editor_nux_update_status', $nux_status );
 		}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
@@ -9,14 +9,7 @@ import { combineReducers, registerStore } from '@wordpress/data';
 const showWelcomeGuideReducer = ( state = undefined, action ) => {
 	switch ( action.type ) {
 		case 'WPCOM_WELCOME_GUIDE_FETCH_STATUS_SUCCESS':
-			if ( typeof action.response.show_welcome_guide !== 'undefined' ) {
-				return action.response.show_welcome_guide;
-			}
-
-			// This legacy rest param can be removed after we know the new
-			// PHP files have been deployed.
-			return action.response.is_nux_enabled;
-
+			return action.response.show_welcome_guide;
 		case 'WPCOM_WELCOME_GUIDE_SHOW_SET':
 			return action.show;
 		default:
@@ -50,14 +43,7 @@ const tourRatingReducer = ( state = undefined, action ) => {
 const welcomeGuideVariantReducer = ( state = 'tour', action ) => {
 	switch ( action.type ) {
 		case 'WPCOM_WELCOME_GUIDE_FETCH_STATUS_SUCCESS':
-			if ( typeof action.response.variant !== 'undefined' ) {
-				return action.response.variant;
-			}
-
-			// This legacy rest param can be removed after we know the new
-			// PHP files have been deployed.
-			return action.response.welcome_tour_show_variant ? 'tour' : 'modal';
-
+			return action.response.variant;
 		default:
 			return state;
 	}
@@ -83,13 +69,7 @@ const actions = {
 		apiFetch( {
 			path: '/wpcom/v2/block-editor/nux',
 			method: 'POST',
-			data: {
-				show_welcome_guide: show,
-
-				// This legacy rest param can be removed after we know the new
-				// PHP files have been deployed.
-				isNuxEnabled: show,
-			},
+			data: { show_welcome_guide: show },
 		} );
 
 		return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The API params for the /block-editor/nux API were renamed in #51055.
Support for the old param names was kept to make sure the deployment ran
smoothly (the old JS needed to work with the new PHP vice versa).

Now that the deployment is done we can remove support for the old param
names.

* Remove `is_nux_enabled` from GET response
* Remove `welcome_tour_show_variant` from GET response
* Remove `isNuxEnabled` support from POST request handler
* Update JS store so it no longer handles these properties

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `install-plugin.sh etk [[this-branch-name]]`
* Open editor of the sandboxed site and clean `localStorage` of the sandboxed site
* Refresh the page
* See in network tools that the old params are no longer part of the `/block-editor/nux` request
* Open the welcome guide from the menu and confirm the POST data no longer includes `isNuxEnabled`
* You might want to use the FORCE_SHOW_WPCOM_WELCOME_GUIDE flag on your sandbox to force the guide to show (although you can do the same thing by opening the guide from the menu and refreshing the page while it's still open.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

