### PR TITLE
Search: fix bugs with onSearch infinite loop and debounced call on empty keyword

### DIFF
--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -200,11 +200,12 @@ const InnerSearch = (
 				doSearch.cancel?.();
 			}
 
-			doSearch( keyword );
+			// call the callback directly without debouncing
+			onSearch?.( keyword );
 		}
 
 		onSearchChange?.( keyword );
-	}, [ doSearch, keyword, onSearchChange ] );
+	}, [ keyword ] );
 
 	const openSearch = ( event: KeyboardOrMouseEvent ) => {
 		event.preventDefault();


### PR DESCRIPTION
Fixes two bugs in the `Search` component.

The first one is about calling the `onSearch` prop not only when the `keyword` changes, but also when the `onSearch` prop value itself changes. That can easily lead to infinite loops if `onSearch` is different on each render. As shown by the unit test.

The second one is about calling `onSearch` without debouncing when the keyword becomes empty. We correctly cancel the scheduled debounced callback, but then proceed to call the debounced `doSearch` function instead of calling `onSearch` directly. Again covered by a unit test.
