### PR TITLE
Extract email features into separate file and clean up Titan feature flag code

### DIFF
--- a/client/my-sites/email/email-providers-comparison/email-provider-features.js
+++ b/client/my-sites/email/email-providers-comparison/email-provider-features.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+const getEmailForwardingFeatures = () => {
+	return [ translate( 'No billing' ), translate( 'Receive emails sent to your custom domain' ) ];
+};
+
+const getGoogleFeatures = () => {
+	return [
+		translate( 'Annual billing' ),
+		translate( 'Send and receive from your custom domain' ),
+		translate( '30GB storage' ),
+		translate( 'Email, calendars, and contacts' ),
+		translate( 'Video calls, docs, spreadsheets, and more' ),
+		translate( 'Work from anywhere on any device – even offline' ),
+	];
+};
+
+const getTitanFeatures = () => {
+	return [
+		translate( 'Monthly billing' ),
+		translate( 'Send and receive from your custom domain' ),
+		translate( '30GB storage' ),
+		translate( 'Email, calendars, and contacts' ),
+		translate( 'One-click import of existing emails and contacts' ),
+	];
+};
+
+export { getEmailForwardingFeatures, getGoogleFeatures, getTitanFeatures };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR extracts the feature lists for Titan, Google, and Email Forwarding into a separate to facilitate re-use for upcoming updates to the email comparison page.

#### Testing instructions

* Using a local build or a live branch, try to add email to a domain you already own. Verify that the features for all three options appear.