### PR TITLE
Themes: Disable deletion of recommended themes

### DIFF
--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -20,6 +20,7 @@ import {
 } from 'calypso/state/themes/actions';
 import {
 	getJetpackUpgradeUrlIfPremiumTheme,
+	getRecommendedThemes,
 	getThemeDetailsUrl,
 	getThemeHelpUrl,
 	getThemePurchaseUrl,
@@ -97,10 +98,17 @@ function getAllThemeOptions() {
 	const deleteTheme = {
 		label: translate( 'Delete' ),
 		action: confirmDelete,
-		hideForTheme: ( state, themeId, siteId, origin ) =>
-			! isJetpackSite( state, siteId ) ||
-			origin === 'wpcom' ||
-			isThemeActive( state, themeId, siteId ),
+		hideForTheme: ( state, themeId, siteId, origin ) => {
+			const recommendedThemes = getRecommendedThemes( state );
+			const isThemeRecommended = recommendedThemes.some( ( recTheme ) => recTheme.id === themeId );
+
+			return (
+				! isJetpackSite( state, siteId ) ||
+				origin === 'wpcom' ||
+				isThemeActive( state, themeId, siteId ) ||
+				isThemeRecommended
+			);
+		},
 	};
 
 	const customize = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR disables the deletion of recommended themes. This is necessary because we don't actually delete those themes, we just deactivate them. Also, currently deleting such a theme triggers an error. 

An alternative to #51277.

#### Testing instructions

* Go to `/themes/:site` where `:site` is a Jetpack site.
* Click on the dots of a theme you previously activated and then activated another one.
* Verify the "Delete" button isn't there.
