### PR TITLE
ci(e2e): save e2e videos as a subdirectory of screenshots

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -116,7 +116,7 @@ object RunCalypsoE2eDesktopTests : BuildType({
 				set -x
 
 				mkdir -p screenshots
-				find test/e2e/temp -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
+				find test/e2e -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
 
 				mkdir -p logs
 				find test/e2e -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
@@ -266,7 +266,7 @@ object RunCalypsoE2eMobileTests : BuildType({
 				set -x
 
 				mkdir -p screenshots
-				find test/e2e/temp -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
+				find test/e2e -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
 
 				mkdir -p logs
 				find test/e2e -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
@@ -784,7 +784,7 @@ object RunCalypsoPlaywrightE2eTests : BuildType({
 				set -x
 
 				mkdir -p screenshots-playwright
-				find test/e2e -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
+				find test/e2e/temp -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
 		}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -784,7 +784,7 @@ object RunCalypsoPlaywrightE2eTests : BuildType({
 				set -x
 
 				mkdir -p screenshots-playwright
-				find test/e2e/temp -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
+				find test/e2e -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
 		}


### PR DESCRIPTION
### Background

Magellan (the test runner we use for e2e) uses multiple `mocha` processes to run the tests. Each process is assigned a temporary directory inside `test/e2e/temp` where they can dump screenshots, logs, etc. Later, a [bash script](https://github.com/Automattic/wp-calypso/blob/176874641177235feaaff7c5e09807bc6c63d92f/.teamcity/_self/projects/WebApp.kt#L118) collects all those screenshots and makes them available as artifacts.

Video recordings are saved in a hardcoded path `test/e2e/screenshots/videos`, while screenshots were saved in `test/e2e/temp/*/screenshots`

### Changes proposed in this Pull Request

Change the bash script used to gather the artifacts to include `test/e2e/screenshots` as well.

### Testing instructions

Check the "E2E Mobile" build (it is failing at the moment with an unrelated problem) and verify it has videos stored as Build Artifacts.