### PR TITLE
G Suite: Fix unable to add new G Suite users

### DIFF
--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -88,13 +88,19 @@ class GSuiteAddUsers extends React.Component {
 		this.recordClickEvent( 'calypso_email_management_gsuite_add_users_continue_button_click' );
 
 		if ( canContinue ) {
+			// TODO: Determine product slug when adding new users based on actual product
+			let productSlug = GSUITE_BASIC_SLUG;
+
+			// Checks plan type only when a new account is being purchased (it is not provided when new users are added)
+			if ( planType !== undefined && planType === 'starter' ) {
+				productSlug = GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY;
+			}
+
 			this.props.shoppingCartManager
 				.addProductsToCart(
-					getItemsForCart(
-						domains,
-						'basic' === planType ? GSUITE_BASIC_SLUG : GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
-						users
-					).map( ( item ) => fillInSingleCartItemAttributes( item, this.props.productsList ) )
+					getItemsForCart( domains, productSlug, users ).map( ( item ) =>
+						fillInSingleCartItemAttributes( item, this.props.productsList )
+					)
 				)
 				.then( () => {
 					this.isMounted && page( '/checkout/' + selectedSite.slug );


### PR DESCRIPTION
This pull request fixes an error displayed in the checkout when adding new users to an existing G Suite account:

> Unable to purchase Google Workspace for 'example.com' because of the following error: please specify another domain name as a Google Workspace account already exists for 'example.com'.

This error is triggered because Google Workspace users - and not G Suite users - were added to the shopping cart. Note this is a stop-gap solution that addresses a regression from https://github.com/Automattic/wp-calypso/pull/50670, I'll come up with a better solution in another pull request.