### PR TITLE
Enable image editing on private Atomic sites

### DIFF
--- a/client/my-sites/media-library/proxied-image.tsx
+++ b/client/my-sites/media-library/proxied-image.tsx
@@ -57,30 +57,29 @@ const ProxiedImage: React.FC< ProxiedImageProps > = function ProxiedImage( {
 	...rest
 } ) {
 	const [ imageObjectUrl, setImageObjectUrl ] = useState< string >( '' );
-	const requestId = `media-library-proxied-image-${ siteSlug }${ filePath }${ query }`;
 
 	useEffect( () => {
-		if ( ! imageObjectUrl ) {
-			if ( cache[ requestId ] ) {
-				const url = URL.createObjectURL( cache[ requestId ] );
-				setImageObjectUrl( url );
-				debug( 'set image from cache', { url } );
-			} else {
-				debug( 'requesting image from API', { requestId, imageObjectUrl } );
-				const options = { query };
-				if ( maxSize !== null ) {
-					options.maxSize = maxSize;
-				}
-				wpcom
-					.undocumented()
-					.getAtomicSiteMediaViaProxyRetry( siteSlug, filePath, options )
-					.then( ( data: Blob ) => {
-						cacheResponse( requestId, data );
-						setImageObjectUrl( URL.createObjectURL( data ) );
-						debug( 'got image from API', { requestId, imageObjectUrl, data } );
-					} )
-					.catch( onError );
+		const requestId = `media-library-proxied-image-${ siteSlug }${ filePath }${ query }`;
+
+		if ( cache[ requestId ] ) {
+			const url = URL.createObjectURL( cache[ requestId ] );
+			setImageObjectUrl( url );
+			debug( 'set image from cache', { url } );
+		} else {
+			debug( 'requesting image from API', { requestId, imageObjectUrl } );
+			const options = { query };
+			if ( maxSize !== null ) {
+				options.maxSize = maxSize;
 			}
+			wpcom
+				.undocumented()
+				.getAtomicSiteMediaViaProxyRetry( siteSlug, filePath, options )
+				.then( ( data: Blob ) => {
+					cacheResponse( requestId, data );
+					setImageObjectUrl( URL.createObjectURL( data ) );
+					debug( 'got image from API', { requestId, imageObjectUrl, data } );
+				} )
+				.catch( onError );
 		}
 
 		return () => {
@@ -89,7 +88,7 @@ const ProxiedImage: React.FC< ProxiedImageProps > = function ProxiedImage( {
 				URL.revokeObjectURL( imageObjectUrl );
 			}
 		};
-	}, [ filePath, requestId, siteSlug ] );
+	}, [ siteSlug, filePath, query ] );
 
 	if ( ! imageObjectUrl ) {
 		return placeholder as React.ReactElement;

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -25,7 +25,6 @@ import { Button, ScreenReaderText } from '@automattic/components';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import versionCompare from 'calypso/lib/version-compare';
 import { getMimePrefix, isItemBeingUploaded, isVideoPressItem } from 'calypso/lib/media/utils';
-import config from '@automattic/calypso-config';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSiteOption, isJetpackModuleActive, isJetpackSite } from 'calypso/state/sites/selectors';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
@@ -94,11 +93,6 @@ export class EditorMediaModalDetailItem extends Component {
 
 		// do not allow if, for some reason, there isn't a valid item yet
 		if ( ! item ) {
-			return false;
-		}
-
-		// do not show if the feature flag isn't set
-		if ( ! config.isEnabled( 'post-editor/image-editor' ) ) {
 			return false;
 		}
 

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -28,6 +28,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSiteOption, isJetpackModuleActive, isJetpackSite } from 'calypso/state/sites/selectors';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 
 const noop = () => {};
 
@@ -87,15 +88,15 @@ export class EditorMediaModalDetailItem extends Component {
 	 * @returns {boolean} `true` if the image-editor can be enabled.
 	 */
 	shouldShowImageEditingButtons( item ) {
-		const { isSitePrivate } = this.props;
+		const { isSitePrivate, isSiteAtomic } = this.props;
 
 		// do not allow if, for some reason, there isn't a valid item yet
 		if ( ! item ) {
 			return false;
 		}
 
-		// do not allow for private sites
-		if ( isSitePrivate ) {
+		// do not allow for non-atomic private sites
+		if ( isSitePrivate && ! isSiteAtomic ) {
 			return false;
 		}
 
@@ -311,6 +312,7 @@ const connectComponent = connect( ( state ) => {
 		isVideoPressEnabled: getSiteOption( state, siteId, 'videopress_enabled' ),
 		isVideoPressModuleActive: isJetpackModuleActive( state, siteId, 'videopress' ),
 		isSitePrivate: isPrivateSite( state, siteId ),
+		isSiteAtomic: isSiteAutomatedTransfer( state, siteId ),
 		siteId,
 		canUserUploadFiles,
 	};

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { flowRight, get, includes } from 'lodash';
+import { flowRight, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 import url from 'url';
 import Gridicon from 'calypso/components/gridicon';
@@ -23,7 +23,6 @@ import EditorMediaModalDetailPreviewAudio from './detail-preview-audio';
 import EditorMediaModalDetailPreviewDocument from './detail-preview-document';
 import { Button, ScreenReaderText } from '@automattic/components';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
-import versionCompare from 'calypso/lib/version-compare';
 import { getMimePrefix, isItemBeingUploaded, isVideoPressItem } from 'calypso/lib/media/utils';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSiteOption, isJetpackModuleActive, isJetpackSite } from 'calypso/state/sites/selectors';
@@ -85,10 +84,9 @@ export class EditorMediaModalDetailItem extends Component {
 	 * enabled/shown
 	 *
 	 * @param  {object} item - media item
-	 * @param  {object} site - current site
 	 * @returns {boolean} `true` if the image-editor can be enabled.
 	 */
-	shouldShowImageEditingButtons( item, site ) {
+	shouldShowImageEditingButtons( item ) {
 		const { isSitePrivate } = this.props;
 
 		// do not allow if, for some reason, there isn't a valid item yet
@@ -98,14 +96,6 @@ export class EditorMediaModalDetailItem extends Component {
 
 		// do not allow for private sites
 		if ( isSitePrivate ) {
-			return false;
-		}
-
-		// do not allow for Jetpack site with a non-valid version
-		if (
-			get( site, 'jetpack', false ) &&
-			versionCompare( get( site, 'options.jetpack_version', '0.0' ), '4.7-alpha', '<' )
-		) {
 			return false;
 		}
 
@@ -180,9 +170,9 @@ export class EditorMediaModalDetailItem extends Component {
 	}
 
 	renderImageEditorButtons( classname ) {
-		const { item, site } = this.props;
+		const { item } = this.props;
 
-		if ( ! this.shouldShowImageEditingButtons( item, site ) ) {
+		if ( ! this.shouldShowImageEditingButtons( item ) ) {
 			return null;
 		}
 

--- a/client/post-editor/media-modal/detail/detail-preview-image.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-image.jsx
@@ -26,25 +26,18 @@ export default class EditorMediaModalDetailPreviewImage extends Component {
 		onLoad: noop,
 	};
 
-	constructor( props ) {
-		super( props );
-
-		this.onImagePreloaderLoad = this.onImagePreloaderLoad.bind( this );
-		this.state = { loading: false };
-	}
+	state = { loading: true };
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.item.URL === nextProps.item.URL ) {
-			return null;
+		if ( this.props.item.URL !== nextProps.item.URL ) {
+			this.setState( { loading: true } );
 		}
-
-		this.setState( { loading: true } );
 	}
 
-	onImagePreloaderLoad() {
+	onImagePreloaderLoad = () => {
 		this.setState( { loading: false } );
 		this.props.onLoad();
-	}
+	};
 
 	render() {
 		const src = url( this.props.item, {

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -108,7 +108,6 @@
 		"perfmon": false,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
-		"post-editor/image-editor": true,
 		"post-editor/revisions": true,
 		"press-this": true,
 		"privacy-policy": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -83,7 +83,6 @@
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,
-		"post-editor/image-editor": true,
 		"press-this": false,
 		"purchases/new-payment-methods": true,
 		"reader": true,

--- a/config/development.json
+++ b/config/development.json
@@ -145,7 +145,6 @@
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,
 		"post-editor/html-toolbar": true,
-		"post-editor/image-editor": true,
 		"press-this": true,
 		"privacy-policy": true,
 		"publicize-preview": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -102,7 +102,6 @@
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,
 		"post-editor/html-toolbar": true,
-		"post-editor/image-editor": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"press-this": true,

--- a/config/production.json
+++ b/config/production.json
@@ -109,7 +109,6 @@
 		"post-editor/checkout-overlay": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,
-		"post-editor/image-editor": true,
 		"press-this": true,
 		"privacy-policy": true,
 		"publicize-preview": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -111,7 +111,6 @@
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,
 		"post-editor/html-toolbar": true,
-		"post-editor/image-editor": true,
 		"press-this": true,
 		"privacy-policy": true,
 		"publicize-preview": true,

--- a/config/test.json
+++ b/config/test.json
@@ -85,7 +85,6 @@
 		"network-connection": true,
 		"perfmon": false,
 		"plans/personal-plan": true,
-		"post-editor/image-editor": true,
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,7 +119,6 @@
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,
 		"post-editor/html-toolbar": true,
-		"post-editor/image-editor": true,
 		"post-editor/preview-scroll-to-content": true,
 		"press-this": true,
 		"privacy-policy": true,


### PR DESCRIPTION
Since the "private by default" project for Atomic sites, we have an `atomic-proxy` REST endpoint to download media files that are protected by authentication. It's used to display media file thumbnails in the Media Gallery.

This PR uses the same `atomic-proxy` REST endpoint for editing images. As the `atomic-proxy` requests are regular requests to `public-api.wordpress.com`, they don't need any CORS headers and can be easily loaded into canvas.

Image editing on private Simple sites remains disabled because there we need to download the media files directly, and we'll need to add the right `Access-Control-Allow-Origin` and `Access-Control-Allow-Credentials` headers to server responses to make them work with a canvas.

Besides the core work enabling `atomic-proxy`, there are a few independent related commits:
- remove the `post-editor/image-editor` feature flag that's always `true`
- remove legacy Jetpack version check (`> 4.7-alpha`). @tyxla enjoys removing these 🙂 
- in the original non-`atomic-proxy` case, use Fetch API instead of XHR to fetch the image


**How to test:**
- go to an Atomic site that is Private
- open its Media section in Calypso
- edit an image, make sure that the detail modal has an "Edit Image" button
- verify that after clicking that button, you can rotate/crop the image and save it back
