### PR TITLE
Update email comparison page layout

### DIFF
--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import config from '@automattic/calypso-config';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -10,7 +11,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from '@automattic/calypso-config';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import Main from 'calypso/components/main';
 import Header from 'calypso/my-sites/domains/domain-management/components/header';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
@@ -47,6 +48,7 @@ import { localizeUrl } from 'calypso/lib/i18n-utils';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import EmailProvidersComparison from '../email-providers-comparison';
+import EmailProvidersStackedComparison from 'calypso/my-sites/email/email-providers-stacked-comparison';
 import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import { type as domainTypes } from 'calypso/lib/domains/constants';
 
@@ -148,11 +150,20 @@ class EmailManagement extends React.Component {
 		}
 
 		const selectedDomain = validDomains[ 0 ];
+		const isGSuiteSupported = hasGSuiteSupportedDomain( [ selectedDomain ] );
+		if ( config.isEnabled( 'titan/provision-mailboxes' ) ) {
+			return (
+				<CalypsoShoppingCartProvider>
+					<EmailProvidersStackedComparison
+						domain={ selectedDomain }
+						isGSuiteSupported={ isGSuiteSupported }
+					/>
+				</CalypsoShoppingCartProvider>
+			);
+		}
+
 		return (
-			<EmailProvidersComparison
-				domain={ selectedDomain }
-				isGSuiteSupported={ hasGSuiteSupportedDomain( [ selectedDomain ] ) }
-			/>
+			<EmailProvidersComparison domain={ selectedDomain } isGSuiteSupported={ isGSuiteSupported } />
 		);
 	}
 

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-card.jsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-card.jsx
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+import PromoCard from 'calypso/components/promo-section/promo-card';
+import PromoCardPrice from 'calypso/components/promo-section/promo-card/price';
+import EmailProviderFeature from 'calypso/my-sites/email/email-providers-comparison/email-provider-details/email-provider-feature';
+
+const noop = () => {};
+
+function EmailProviderCard( {
+	children,
+	providerKey,
+	logo,
+	title,
+	badge,
+	description,
+	formattedPrice,
+	discount,
+	additionalPriceInformation,
+	detailsExpanded = false,
+	onExpandedChange = noop,
+	formFields,
+	buttonLabel,
+	onButtonClick,
+	expandButtonLabel,
+	features,
+} ) {
+	const renderFeatures = ( providerSlug, featureList ) => {
+		return featureList.map( ( feature, index ) => (
+			<EmailProviderFeature key={ `feature-${ providerSlug }-${ index }` } title={ feature } />
+		) );
+	};
+
+	const toggleVisibility = ( event ) => {
+		event.preventDefault();
+		onExpandedChange( providerKey, ! detailsExpanded );
+	};
+	const labelForExpandButton = expandButtonLabel ? expandButtonLabel : buttonLabel;
+
+	return (
+		<PromoCard
+			className={ classnames( 'email-providers-stacked-comparison__provider-card', {
+				'is-expanded': detailsExpanded,
+			} ) }
+			image={ logo }
+			title={ title }
+			badge={ badge }
+		>
+			<div className="email-providers-stacked-comparison__provider-card-main-details">
+				<p>{ description }</p>
+				<Button
+					primary={ false }
+					onClick={ toggleVisibility }
+					className="email-providers-stacked-comparison__provider-expand-cta"
+				>
+					{ labelForExpandButton }
+				</Button>
+			</div>
+			<PromoCardPrice formattedPrice={ formattedPrice } discount={ discount } />
+			{ additionalPriceInformation && (
+				<span className="email-providers-stacked-comparison__provider-additional-price-information">
+					{ additionalPriceInformation }
+				</span>
+			) }
+			<div className="email-providers-stacked-comparison__provider-form-and-features">
+				<div className="email-providers-stacked-comparison__provider-form">
+					{ formFields }
+					{ buttonLabel && (
+						<Button primary onClick={ onButtonClick }>
+							{ buttonLabel }
+						</Button>
+					) }
+				</div>
+				<div className="email-providers-stacked-comparison__provider-features">
+					{ features && renderFeatures( providerKey, features ) }
+				</div>
+			</div>
+			{ children }
+		</PromoCard>
+	);
+}
+
+EmailProviderCard.propTypes = {
+	providerKey: PropTypes.string.isRequired,
+	logo: PropTypes.object.isRequired,
+	title: PropTypes.string.isRequired,
+	badge: PropTypes.object,
+	description: PropTypes.string,
+	formattedPrice: PropTypes.node,
+	discount: PropTypes.string,
+	additionalPriceInformation: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
+	formFields: PropTypes.node,
+	buttonLabel: PropTypes.string,
+	onButtonClick: PropTypes.func,
+	expandButtonLabel: PropTypes.string,
+	features: PropTypes.arrayOf( PropTypes.string ),
+	onExpandedChange: PropTypes.func,
+};
+
+export default EmailProviderCard;

--- a/client/my-sites/email/email-providers-stacked-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.jsx
@@ -127,7 +127,7 @@ class EmailProvidersStackedComparison extends React.Component {
 	onTitanConfirmNewMailboxes = () => {
 		const { titanMailboxes } = this.state;
 
-		const mailboxesAreValid = areAllMailboxesValid( titanMailboxes );
+		const mailboxesAreValid = areAllMailboxesValid( titanMailboxes, [ 'alternativeEmail' ] );
 
 		recordTracksEvent( 'calypso_email_providers_add_click', {
 			mailbox_count: titanMailboxes.length,

--- a/client/my-sites/email/email-providers-stacked-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.jsx
@@ -1,0 +1,470 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import config from '@automattic/calypso-config';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import {
+	areAllMailboxesValid,
+	buildNewTitanMailbox,
+	transformMailboxForCart,
+} from 'calypso/lib/titan/new-mailbox';
+import { areAllUsersValid, getItemsForCart, newUsers } from 'calypso/lib/gsuite/new-users';
+import { Button } from '@automattic/components';
+import PromoCard from 'calypso/components/promo-section/promo-card';
+import EmailProviderCard from './email-provider-card';
+import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
+import {
+	getEmailForwardingFeatures,
+	getGoogleFeatures,
+	getTitanFeatures,
+} from 'calypso/my-sites/email/email-providers-comparison/email-provider-features';
+import { getProductBySlug, getProductsList } from 'calypso/state/products-list/selectors';
+import {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+	GSUITE_BASIC_SLUG,
+} from 'calypso/lib/gsuite/constants';
+import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
+import { getAnnualPrice, getGoogleMailServiceFamily, getMonthlyPrice } from 'calypso/lib/gsuite';
+import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
+import { emailManagementForwarding } from 'calypso/my-sites/email/paths';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import Gridicon from 'calypso/components/gridicon';
+import formatCurrency from '@automattic/format-currency';
+import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
+import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan.svg';
+import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
+import gSuiteLogo from 'calypso/assets/images/email-providers/gsuite.svg';
+import forwardingIcon from 'calypso/assets/images/email-providers/forwarding.svg';
+import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
+import TitanNewMailboxList from 'calypso/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox-list';
+import { withShoppingCart } from '@automattic/shopping-cart';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const identityMap = ( item ) => item;
+
+class EmailProvidersStackedComparison extends React.Component {
+	static propTypes = {
+		domain: PropTypes.object.isRequired,
+		isGSuiteSupported: PropTypes.bool.isRequired,
+	};
+
+	state = {
+		googleUsers: [],
+		titanMailboxes: [ buildNewTitanMailbox( this.props.domain.name, false ) ],
+		expanded: {
+			forwarding: false,
+			google: false,
+			titan: true,
+		},
+		addingToCart: false,
+	};
+
+	isMounted = false;
+
+	componentDidMount() {
+		this.isMounted = true;
+	}
+
+	componentWillUnmount() {
+		this.isMounted = false;
+	}
+
+	onExpandedStateChange = ( providerKey, isExpanded ) => {
+		const expandedEntries = Object.entries( this.state.expanded ).map( ( entry ) => {
+			const [ key, currentExpanded ] = entry;
+			if ( isExpanded ) {
+				return [ key, key === providerKey ];
+			}
+			return [ key, key === providerKey ? isExpanded : currentExpanded ];
+		} );
+
+		if ( isExpanded ) {
+			recordTracksEvent( 'calypso_email_providers_expand_section_click', {
+				provider: providerKey,
+			} );
+		}
+
+		this.setState( { expanded: Object.fromEntries( expandedEntries ) } );
+	};
+
+	goToEmailForwarding = () => {
+		const { domain, currentRoute, selectedSiteSlug } = this.props;
+
+		recordTracksEvent( 'calypso_email_providers_add_click', { provider: 'email-forwarding' } );
+
+		page( emailManagementForwarding( selectedSiteSlug, domain.name, currentRoute ) );
+	};
+
+	onTitanMailboxesChange = ( updatedMailboxes ) =>
+		this.setState( { titanMailboxes: updatedMailboxes } );
+
+	onTitanFormReturnKeyPress = ( event ) => {
+		// Simulate form submission
+		if ( event.key === 'Enter' ) {
+			this.onTitanConfirmNewMailboxes();
+		}
+	};
+
+	onTitanConfirmNewMailboxes = () => {
+		const { titanMailboxes } = this.state;
+
+		const mailboxesAreValid = areAllMailboxesValid( titanMailboxes );
+
+		recordTracksEvent( 'calypso_email_providers_add_click', {
+			mailbox_count: titanMailboxes.length,
+			mailboxes_valid: mailboxesAreValid ? 1 : 0,
+			provider: 'titan',
+		} );
+
+		if ( ! mailboxesAreValid ) {
+			return;
+		}
+
+		const { domain, productsList, selectedSiteSlug, shoppingCartManager } = this.props;
+
+		const cartItem = titanMailMonthly( {
+			domain: domain.name,
+			quantity: titanMailboxes.length,
+			extra: {
+				email_users: titanMailboxes.map( transformMailboxForCart ),
+			},
+		} );
+
+		this.setState( { addingToCart: true } );
+		shoppingCartManager
+			.addProductsToCart( fillInSingleCartItemAttributes( cartItem, productsList ) )
+			.then( () => {
+				if ( this.isMounted ) {
+					this.setState( { addingToCart: false } );
+				}
+				const { errors } = this.props?.cart?.messages;
+				if ( errors && errors.length ) {
+					// Stay on the page to show the relevant error(s)
+					return;
+				}
+				this.isMounted && page( '/checkout/' + selectedSiteSlug );
+			} );
+	};
+
+	onGoogleUsersChange = ( changedUsers ) => {
+		this.setState( { googleUsers: changedUsers } );
+	};
+
+	onGoogleFormReturnKeyPress = ( event ) => {
+		// Simulate form submission
+		if ( event.key === 'Enter' ) {
+			this.onGoogleConfirmNewUsers();
+		}
+	};
+
+	onGoogleConfirmNewUsers = () => {
+		const { googleUsers } = this.state;
+
+		const usersAreValid = areAllUsersValid( googleUsers );
+
+		recordTracksEvent( 'calypso_email_providers_add_click', {
+			mailbox_count: googleUsers.length,
+			mailboxes_valid: usersAreValid ? 1 : 0,
+			provider: 'google',
+		} );
+
+		if ( ! usersAreValid ) {
+			return;
+		}
+
+		const { domain, productsList, selectedSiteSlug, shoppingCartManager } = this.props;
+		const domains = [ domain ];
+		const googleProductSlug = config.isEnabled( 'google-workspace-migration' )
+			? GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
+			: GSUITE_BASIC_SLUG;
+
+		this.setState( { addingToCart: true } );
+		shoppingCartManager
+			.addProductsToCart(
+				getItemsForCart( domains, googleProductSlug, googleUsers ).map( ( item ) =>
+					fillInSingleCartItemAttributes( item, productsList )
+				)
+			)
+			.then( () => {
+				if ( this.isMounted ) {
+					this.setState( { addingToCart: false } );
+				}
+				const { errors } = this.props?.cart?.messages;
+				if ( errors && errors.length ) {
+					// Stay on the page to show the relevant error(s)
+					return;
+				}
+				this.isMounted && page( '/checkout/' + selectedSiteSlug );
+			} );
+	};
+
+	renderEmailForwardingCard() {
+		const { domain, translate } = this.props;
+
+		const buttonLabel =
+			domain.emailForwardsCount > 0
+				? translate( 'Manage email forwarding' )
+				: translate( 'Add email forwarding' );
+
+		return (
+			<EmailProviderCard
+				providerKey="forwarding"
+				logo={ { path: forwardingIcon } }
+				title={ translate( 'Email Forwarding' ) }
+				description={ translate(
+					'Use your custom domain in your email address and forward all your mail to another address.'
+				) }
+				detailsExpanded={ this.state.expanded.forwarding }
+				onExpandedChange={ this.onExpandedStateChange }
+				buttonLabel={ buttonLabel }
+				expandButtonLabel={ translate( 'Add email forwarding' ) }
+				onButtonClick={ this.goToEmailForwarding }
+				features={ getEmailForwardingFeatures() }
+			/>
+		);
+	}
+
+	renderGoogleCard() {
+		const { currencyCode, domain, gSuiteProduct, isGSuiteSupported, translate } = this.props;
+
+		// TODO: Improve handling of
+		if ( ! isGSuiteSupported ) {
+			return null;
+		}
+
+		const logoPath = config.isEnabled( 'google-workspace-migration' )
+			? googleWorkspaceIcon
+			: gSuiteLogo;
+
+		const formattedPrice = translate( '{{price/}} /user /month billed annually', {
+			components: {
+				price: <span>{ getMonthlyPrice( gSuiteProduct?.cost ?? null, currencyCode ) }</span>,
+			},
+			comment: '{{price/}} is the formatted price, e.g. $20',
+		} );
+		const discount = hasDiscount( gSuiteProduct )
+			? translate( 'First year %(discountedPrice)s', {
+					args: {
+						discountedPrice: getAnnualPrice( gSuiteProduct.sale_cost, currencyCode ),
+					},
+					comment: '%(discountedPrice)s is a formatted price, e.g. $75',
+			  } )
+			: null;
+		const additionalPriceInformation = translate( '%(price)s billed annually', {
+			args: {
+				price: getAnnualPrice( gSuiteProduct?.cost ?? null, currencyCode ),
+			},
+			comment: "Annual price formatted with the currency (e.g. '$99.99')",
+		} );
+
+		// If we don't have any users, initialize the list to have 1 empty user
+		const googleUsers =
+			( this.state.googleUsers ?? [] ).length === 0
+				? newUsers( domain.name )
+				: this.state.googleUsers;
+
+		const formFields = (
+			<FormFieldset>
+				<GSuiteNewUserList
+					extraValidation={ identityMap }
+					domains={ [ domain ] }
+					onUsersChange={ this.onGoogleUsersChange }
+					selectedDomainName={ domain.name }
+					users={ googleUsers }
+					onReturnKeyPress={ this.onGoogleFormReturnKeyPress }
+				>
+					<Button
+						className="email-providers-stacked-comparison__gsuite-user-list-action-continue"
+						primary
+						busy={ this.state.addingToCart }
+						onClick={ this.onGoogleConfirmNewUsers }
+					>
+						{ translate( 'Add %(googleMailService)s', {
+							args: {
+								googleMailService: getGoogleMailServiceFamily(),
+							},
+							comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+						} ) }
+					</Button>
+				</GSuiteNewUserList>
+			</FormFieldset>
+		);
+
+		return (
+			<EmailProviderCard
+				providerKey="google"
+				logo={ { path: logoPath } }
+				title={ getGoogleMailServiceFamily() }
+				description={ translate(
+					'Professional email integrated with Google Meet and other collaboration tools from Google.'
+				) }
+				formattedPrice={ formattedPrice }
+				discount={ discount }
+				additionalPriceInformation={ additionalPriceInformation }
+				formFields={ formFields }
+				detailsExpanded={ this.state.expanded.google }
+				onExpandedChange={ this.onExpandedStateChange }
+				onButtonClick={ this.onGoogleConfirmNewUsers }
+				expandButtonLabel={ translate( 'Add %(googleMailService)s', {
+					args: {
+						googleMailService: getGoogleMailServiceFamily(),
+					},
+					comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+				} ) }
+				features={ getGoogleFeatures() }
+			/>
+		);
+	}
+
+	renderTitanCard() {
+		const { currencyCode, domain, titanMailProduct, translate } = this.props;
+
+		const formattedPrice = translate( '{{price/}} /user /month billed monthly', {
+			components: {
+				price: <span>{ formatCurrency( titanMailProduct?.cost ?? 0, currencyCode ) }</span>,
+			},
+			comment: '{{price/}} is the formatted price, e.g. $20',
+		} );
+		// TODO: calculate whether a discount/trial applies for the current domain
+		const discount = null; //translate( '3 months free' );
+		const logo = (
+			<Gridicon
+				className="email-providers-stacked-comparison__providers-wordpress-com-email"
+				icon="my-sites"
+			/>
+		);
+		const poweredByTitan = (
+			<img src={ poweredByTitanLogo } alt={ translate( 'Powered by Titan' ) } />
+		);
+
+		const formFields = (
+			<TitanNewMailboxList
+				onMailboxesChange={ this.onTitanMailboxesChange }
+				mailboxes={ this.state.titanMailboxes }
+				domain={ domain.name }
+				onReturnKeyPress={ this.onTitanFormReturnKeyPress }
+			>
+				<Button
+					className="email-providers-stacked-comparison__titan-mailbox-action-continue"
+					primary
+					busy={ this.state.addingToCart }
+					onClick={ this.onTitanConfirmNewMailboxes }
+				>
+					{ translate( 'Add Email' ) }
+				</Button>
+			</TitanNewMailboxList>
+		);
+
+		return (
+			<EmailProviderCard
+				providerKey="titan"
+				logo={ logo }
+				title={ translate( 'Email' ) }
+				badge={ poweredByTitan }
+				description={ translate(
+					'Easy-to-use email with incredibly powerful features. Manage your email and more on any device.'
+				) }
+				detailsExpanded={ this.state.expanded.titan }
+				onExpandedChange={ this.onExpandedStateChange }
+				formattedPrice={ formattedPrice }
+				discount={ discount }
+				formFields={ formFields }
+				expandButtonLabel={ translate( 'Add Email' ) }
+				features={ getTitanFeatures() }
+			/>
+		);
+	}
+
+	renderHeaderSection() {
+		const { domain, translate } = this.props;
+		const image = {
+			path: emailIllustration,
+			align: 'right',
+		};
+
+		const translateArgs = {
+			args: {
+				domainName: domain.name,
+			},
+			comment: '%(domainName)s is the domain name, e.g example.com',
+		};
+
+		return (
+			<PromoCard
+				isPrimary
+				title={ translate( 'Get your own @%(domainName)s email address', translateArgs ) }
+				image={ image }
+				className="email-providers-stacked-comparison__action-panel"
+			>
+				<p>
+					{ translate(
+						'Pick one of our flexible options to connect your domain with email ' +
+							'and start getting emails @%(domainName)s today.',
+						translateArgs
+					) }
+				</p>
+			</PromoCard>
+		);
+	}
+
+	render() {
+		const { isGSuiteSupported } = this.props;
+
+		return (
+			<>
+				{ this.renderHeaderSection() }
+				{ this.renderTitanCard() }
+				{ this.renderGoogleCard() }
+				{ this.renderEmailForwardingCard() }
+				<TrackComponentView
+					eventName="calypso_email_providers_comparison_page_view"
+					eventProperties={ {
+						is_gsuite_supported: isGSuiteSupported,
+						layout: 'stacked',
+					} }
+				/>
+			</>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		const productSlug = config.isEnabled( 'google-workspace-migration' )
+			? GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
+			: GSUITE_BASIC_SLUG;
+
+		return {
+			currencyCode: getCurrentUserCurrencyCode( state ),
+			gSuiteProduct: getProductBySlug( state, productSlug ),
+			titanMailProduct: getProductBySlug( state, TITAN_MAIL_MONTHLY_SLUG ),
+			currentRoute: getCurrentRoute( state ),
+			productsList: getProductsList( state ),
+			selectedSiteSlug: getSelectedSiteSlug( state ),
+		};
+	},
+	( dispatch ) => {
+		return {
+			errorNotice: ( text, options ) => dispatch( errorNotice( text, options ) ),
+		};
+	}
+)( withShoppingCart( localize( EmailProvidersStackedComparison ) ) );

--- a/client/my-sites/email/email-providers-stacked-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.jsx
@@ -151,7 +151,7 @@ class EmailProvidersStackedComparison extends React.Component {
 
 		this.setState( { addingToCart: true } );
 		shoppingCartManager
-			.addProductsToCart( fillInSingleCartItemAttributes( cartItem, productsList ) )
+			.addProductsToCart( [ fillInSingleCartItemAttributes( cartItem, productsList ) ] )
 			.then( () => {
 				if ( this.isMounted ) {
 					this.setState( { addingToCart: false } );

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -1,0 +1,176 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
+.email-providers-stacked-comparison__providers {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	justify-content: space-between;
+
+	.promo-card {
+		width: calc( 33% - 0.5em );
+		margin: 8px 0;
+
+		&.no-gsuite {
+			width: calc( 50% - 0.5em );
+		}
+
+		&.no-titan {
+			width: calc( 50% - 0.5em );
+		}
+
+		&.gsuite .action-panel__figure img {
+			max-width: 24px;
+		}
+
+			&.titan {
+			.promo-card__title-badge {
+				background: none;
+				padding: 0;
+
+				img {
+					max-height: 14px;
+				}
+			}
+		}
+
+		@include breakpoint-deprecated( '<1040px' ) {
+			&,
+			&.no-gsuite {
+				width: 100%;
+			}
+		}
+	}
+}
+
+.email-providers-stacked-comparison__providers-wordpress-com-email {
+	color: var( --color-wordpress-com );
+}
+
+.email-providers-stacked-comparison__action-panel {
+	@include breakpoint-deprecated( '>1040px' ) {
+		&.is-primary {
+			padding-left: 73px;
+		}
+	}
+
+	&.is-primary .action-panel__figure {
+		max-width: 170px;
+	}
+}
+
+.email-providers-stacked-comparison__provider-card.promo-card {
+
+	.action-panel__figure {
+		margin-bottom: 0.5em;
+		margin-top: 0;
+
+		img {
+			max-width: 24px;
+		}
+	}
+
+	@include break-mobile {
+		.action-panel__title {
+			margin-bottom: 0;
+		}
+	}
+
+	.promo-card__title-badge {
+		background: none;
+		padding: 0;
+
+		img {
+			max-height: 18px;
+		}
+	}
+
+	.email-providers-stacked-comparison__provider-card-main-details {
+		display: flex;
+		flex-direction: column;
+		margin-bottom: 1em;
+
+		@include break-mobile {
+			flex-direction: row;
+			margin-bottom: 0;
+		}
+
+		p {
+			margin-bottom: 1em;
+
+			@include break-mobile {
+				flex-grow: 7;
+				line-height: 40px;
+				margin-bottom: 0;
+			}
+		}
+		.email-providers-stacked-comparison__provider-expand-cta {
+			flex-grow: 1;
+		}
+	}
+
+	.promo-card__price {
+		.price__cost {
+			font-size: $font-body-small;
+
+			span {
+				font-size: $font-title-medium;
+			}
+
+			.price__discounted {
+				text-decoration: line-through;
+			}
+		}
+
+		.price__discount {
+			display: block;
+			margin-left: 0;
+		}
+	}
+
+	.email-providers-stacked-comparison__provider-additional-price-information {
+		color: var( --color-text-subtle );
+		display: inline-block;
+		font-size: $font-body-extra-small;
+		font-style: normal;
+		margin-top: 3px;
+	}
+
+	.email-providers-stacked-comparison__provider-form-and-features {
+		justify-content: space-between;
+		margin-top: 1em;
+
+		.email-providers-stacked-comparison__provider-form {
+			.titan-new-mailbox-list__actions {
+				justify-content: space-between;
+			}
+		}
+
+		.email-providers-stacked-comparison__provider-features {
+			padding-left: 3.5em;
+
+			.email-provider-details__feature:first-child {
+				margin-top: 0;
+			}
+			.email-provider-details__feature:first-child::before {
+				border-bottom: none;
+				margin-bottom: 0;
+			}
+		}
+	}
+
+	/* Handle expanded vs contracted state */
+	.email-providers-stacked-comparison__provider-form-and-features {
+		display: none;
+	}
+
+	&.is-expanded {
+		.email-providers-stacked-comparison__provider-expand-cta {
+			display: none;
+		}
+
+		.email-providers-stacked-comparison__provider-form-and-features {
+			display: flex;
+		}
+	}
+}

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -98,7 +98,7 @@
 		p {
 			margin-bottom: 1em;
 
-			@include break-mobile {
+			@include break-xlarge {
 				flex-grow: 7;
 				line-height: 40px;
 				margin-bottom: 0;
@@ -144,10 +144,21 @@
 			.titan-new-mailbox-list__actions {
 				justify-content: space-between;
 			}
+
+			.email-providers-stacked-comparison__gsuite-user-list-action-continue {
+				margin-top: 1em;
+				@include break-mobile {
+					margin-top: 0;
+				}
+			}
 		}
 
 		.email-providers-stacked-comparison__provider-features {
-			padding-left: 3.5em;
+			margin-bottom: 1em;
+			@include break-mobile {
+				margin-bottom: 0;
+				padding-left: 3.5em;
+			}
 
 			.email-provider-details__feature:first-child {
 				margin-top: 0;
@@ -171,6 +182,11 @@
 
 		.email-providers-stacked-comparison__provider-form-and-features {
 			display: flex;
+			flex-direction: column-reverse;
+
+			@include break-mobile {
+				flex-direction: row;
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR replaces #51062 with an implementation that uses a new `EmailProvidersStackedComparison` component to render the new email comparison page layout and embed the relevant creation forms for Email and Google Workspace.
* The design is in pcDL0W-79-p2, and this hews fairly closely to those designs.
* Note that this PR is based on #51298, which extracts the feature lists for the various email providers.
* The feature is protected by the `titan/provision-mailboxes` feature flag.

#### Screenshots

_Email expanded (the default)_
<img width="1073" alt="Email expanded" src="https://user-images.githubusercontent.com/3376401/112213480-cbc0fb00-8c26-11eb-81d4-7a38de9f3077.png">

_Google Workspace/G Suite expanded_
<img width="1073" alt="Google expanded" src="https://user-images.githubusercontent.com/3376401/112213778-1cd0ef00-8c27-11eb-9fe6-fe81f0d57a7b.png">

_Email Forwarding expanded_
<img width="1073" alt="Email Forwarding expanded" src="https://user-images.githubusercontent.com/3376401/112213518-d54a6300-8c26-11eb-9eca-6b44589b8e3d.png">


#### Testing instructions

Navigate to the [live branch](https://calypso.live/?branch=update/email-comparison-page-layout), and then add `?flags=titan/provision-mailboxes` to the URL.

* Try to add each of Email, Google Workspace, and Email Forwarding to your account.
* For each provider, check that the error handling is working, and that we track clicks on the expand buttons as well as the "Add <product>" buttons.
* You should verify that the shopping cart entry created for Titan and Google Workspace includes the correct user/mailbox data. (We are addressing some back end bugs for Titan, so full testing here may trip over those issues.)

Related to #51062
Related to #51298