### PR TITLE
ci(teamcity): Allow magellan to exit with non-zero for e2e builds

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -163,6 +163,22 @@ object RunCalypsoE2eDesktopTests : BuildType({
 		// TeamCity will mute a test if it fails and then succeeds within the same build. Otherwise TeamCity UI will not
 		// display a difference between real errors and retries, making it hard to understand what is actually failing.
 		supportTestRetry = true
+
+		// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have
+		// been muted previously.
+		nonZeroExitCode = false
+
+		// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner
+		// crashes and no tests are run.
+		failOnMetricChange {
+			metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
+			threshold = 50
+			units = BuildFailureOnMetric.MetricUnit.PERCENTS
+			comparison = BuildFailureOnMetric.MetricComparison.LESS
+			compareTo = build {
+				buildRule = lastSuccessful()
+			}
+		}
 	}
 
 	dependencies {
@@ -313,6 +329,22 @@ object RunCalypsoE2eMobileTests : BuildType({
 		// TeamCity will mute a test if it fails and then succeeds within the same build. Otherwise TeamCity UI will not
 		// display a difference between real errors and retries, making it hard to understand what is actually failing.
 		supportTestRetry = true
+
+		// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have
+		// been muted previously.
+		nonZeroExitCode = false
+
+		// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner
+		// crashes and no tests are run.
+		failOnMetricChange {
+			metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
+			threshold = 50
+			units = BuildFailureOnMetric.MetricUnit.PERCENTS
+			comparison = BuildFailureOnMetric.MetricComparison.LESS
+			compareTo = build {
+				buildRule = lastSuccessful()
+			}
+		}
 	}
 
 	dependencies {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -6,6 +6,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 object WebApp : Project({


### PR DESCRIPTION
### Background

TeamCity has the capacity of [mute tests](https://www.jetbrains.com/help/teamcity/investigating-and-muting-build-failures.html) so they don't affect the result of a build. This is really useful to temporarily disable flaky tests.

However, Magellan (the test runner we use) will exit with a non-zero value if there are failing tests (muted or not). This is detected by TeamCity as a failed build, effectively negating the muted tests feature.

### Changes proposed in this Pull Request

* A non-zero exit code won't be used to determine the status of a build. This should cover us when the only failed tests have been previously muted.
* If the number of passing tests is <50% than the previous build, the build will fail. This should cover us when Magellan crashes and no tests are run.

The DSL for those changes have been generated by making the change in TeamCity UI and exporting it to DSL.

### Testing instructions

Can't be tested until merged.