### PR TITLE
Framework: Refactor away from `_.isString()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -426,6 +426,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/is-nan': 'error',
 		'you-dont-need-lodash-underscore/is-nil': 'error',
 		'you-dont-need-lodash-underscore/is-null': 'error',
+		'you-dont-need-lodash-underscore/is-string': 'error',
 		'you-dont-need-lodash-underscore/join': 'error',
 		'you-dont-need-lodash-underscore/last-index-of': 'error',
 		'you-dont-need-lodash-underscore/pad-end': 'error',

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
-import { defaults, get, identity, isEmpty, isString, map, set, uniq } from 'lodash';
+import { defaults, get, identity, isEmpty, map, set, uniq } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,7 +31,7 @@ let defaultRegistrantType;
  * Sanitize a string by removing everything except digits
  */
 function onlyNumericCharacters( string ) {
-	return isString( string ) ? string.replace( /[^0-9]/g, '' ) : '';
+	return typeof string === 'string' ? string.replace( /[^0-9]/g, '' ) : '';
 }
 
 /*
@@ -39,7 +39,7 @@ function onlyNumericCharacters( string ) {
  * letters, plus or star symbols.
  */
 export function sanitizeVat( string ) {
-	return isString( string ) ? string.toUpperCase().replace( /[^0-9A-Z+*]/g, '' ) : '';
+	return typeof string === 'string' ? string.toUpperCase().replace( /[^0-9A-Z+*]/g, '' ) : '';
 }
 
 // If we set a field to null, react decides it's uncontrolled and complains

--- a/client/components/domains/registrant-extra-info/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/fr-validate-contact-details.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { isEmpty, isString, reduce, update } from 'lodash';
+import { isEmpty, reduce, update } from 'lodash';
 import validatorFactory from 'is-my-json-valid';
 import debugFactory from 'debug';
 
@@ -51,7 +51,7 @@ const reverseMessageMap = {
 function ruleNameFromMessage( message ) {
 	return (
 		reverseMessageMap[ message ] ||
-		( isString( message ) && message.match( /^must be (.*) format$/ ) && 'format' ) ||
+		( typeof message === 'string' && message.match( /^must be (.*) format$/ ) && 'format' ) ||
 		message
 	);
 }

--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Fragment, PureComponent } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { find, isString } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -84,7 +84,7 @@ export class LanguagePicker extends PureComponent {
 			return lang[ valueKey ] == value; // eslint-disable-line eqeqeq
 		} );
 		//if an unsupported language is provided return it without a display name
-		if ( isString( value ) && ! language ) {
+		if ( typeof value === 'string' && ! language ) {
 			return {
 				langSlug: value,
 				name: translate( 'Unsupported language' ),

--- a/client/extensions/woocommerce/state/ui/product-categories/test/actions.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/test/actions.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { isObject, isString } from 'lodash';
+import { isObject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,7 +31,7 @@ describe( 'actions', () => {
 
 			expect( action.category ).to.exist;
 			expect( isObject( action.category.id ) ).to.be.true;
-			expect( isString( action.category.id.placeholder ) ).to.be.true;
+			expect( typeof action.category.id.placeholder === 'string' ).to.be.true;
 		} );
 
 		test( 'should not create a placeholder if category is passed in', () => {

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import creditcards from 'creditcards';
-import { capitalize, compact, isEmpty, mergeWith, union, isString } from 'lodash';
+import { capitalize, compact, isEmpty, mergeWith, union } from 'lodash';
 import i18n from 'i18n-calypso';
 import { isValidPostalCode } from 'calypso/lib/postal-code';
 
@@ -295,7 +295,7 @@ validators.validIndiaPan = {
 
 validators.validIndonesiaNik = {
 	isValid( value ) {
-		const digitsOnly = isString( value ) ? value.replace( /[^0-9]/g, '' ) : '';
+		const digitsOnly = typeof value === 'string' ? value.replace( /[^0-9]/g, '' ) : '';
 		return digitsOnly.length === 16;
 	},
 	error: function ( description ) {

--- a/client/lib/gsuite/get-annual-price.js
+++ b/client/lib/gsuite/get-annual-price.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isNumber, isString } from 'lodash';
+import { isNumber } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,7 +17,7 @@ import { formatPrice } from 'calypso/lib/gsuite/utils/format-price';
  * @returns {string} - the yearly price formatted (e.g. '$99.99'), otherwise the default value
  */
 export function getAnnualPrice( cost, currencyCode, defaultValue = '-' ) {
-	if ( ! isNumber( cost ) && ! isString( currencyCode ) ) {
+	if ( ! isNumber( cost ) && typeof currencyCode !== 'string' ) {
 		return defaultValue;
 	}
 

--- a/client/lib/gsuite/get-monthly-price.js
+++ b/client/lib/gsuite/get-monthly-price.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isNumber, isString } from 'lodash';
+import { isNumber } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,7 +17,7 @@ import { formatPrice } from 'calypso/lib/gsuite/utils/format-price';
  * @returns {string} - the monthly price rounded to the nearest tenth (e.g. '$8.40'), otherwise the default value
  */
 export function getMonthlyPrice( cost, currencyCode, defaultValue = '-' ) {
-	if ( ! isNumber( cost ) && ! isString( currencyCode ) ) {
+	if ( ! isNumber( cost ) && typeof currencyCode !== 'string' ) {
 		return defaultValue;
 	}
 

--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import IO from 'socket.io-client';
-import { isString } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -26,7 +25,7 @@ import {
 const debug = debugFactory( 'calypso:happychat:connection' );
 
 const buildConnection = ( socket ) =>
-	isString( socket )
+	typeof socket === 'string'
 		? new IO( socket ) // If socket is an URL, connect to server.
 		: socket; // If socket is not an url, use it directly. Useful for testing.
 

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, isString, map, pickBy, includes } from 'lodash';
+import { find, map, pickBy, includes } from 'lodash';
 import i18n, { getLocaleSlug } from 'i18n-calypso';
 import { localizeUrl as _localizeUrl } from '@automattic/i18n-utils';
 
@@ -44,15 +44,15 @@ export function isDefaultLocale( locale ) {
  * @returns {boolean} true when the locale has a parentLangSlug
  */
 export function isLocaleVariant( locale ) {
-	if ( ! isString( locale ) ) {
+	if ( typeof locale !== 'string' ) {
 		return false;
 	}
 	const language = getLanguage( locale );
-	return !! language && isString( language.parentLangSlug );
+	return !! language && typeof language.parentLangSlug === 'string';
 }
 
 export function isLocaleRtl( locale ) {
-	if ( ! isString( locale ) ) {
+	if ( typeof locale !== 'string' ) {
 		return null;
 	}
 	const language = getLanguage( locale );

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { get, includes, isString, omit, partial, pickBy } from 'lodash';
+import { get, includes, omit, partial, pickBy } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -224,7 +224,7 @@ class SiteVerification extends Component {
 			yandex: this.state.yandexCode,
 		};
 
-		const filteredCodes = pickBy( verificationCodes, isString );
+		const filteredCodes = pickBy( verificationCodes, ( code ) => typeof code === 'string' );
 		const invalidCodes = Object.keys(
 			pickBy( filteredCodes, ( name, content ) => ! this.isValidCode( content, name ) )
 		);

--- a/client/state/posts/utils/append-to-post-edits-log.js
+++ b/client/state/posts/utils/append-to-post-edits-log.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, isString, last } from 'lodash';
+import { isEmpty, last } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,7 +25,7 @@ export function appendToPostEditsLog( postEditsLog, newPostEdits ) {
 
 	const lastEdits = last( postEditsLog );
 
-	if ( isString( lastEdits ) ) {
+	if ( typeof lastEdits === 'string' ) {
 		return [ ...postEditsLog, newPostEdits ];
 	}
 

--- a/client/state/posts/utils/merge-post-edits.js
+++ b/client/state/posts/utils/merge-post-edits.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { cloneDeep, concat, find, isString, mergeWith, reduce, reject } from 'lodash';
+import { cloneDeep, concat, find, mergeWith, reduce, reject } from 'lodash';
 
 function mergeMetadataEdits( edits, nextEdits ) {
 	// remove existing edits that get updated in `nextEdits`
@@ -25,7 +25,7 @@ export const mergePostEdits = ( ...postEditsLog ) =>
 		postEditsLog,
 		( mergedEdits, nextEdits ) => {
 			// filter out save markers
-			if ( isString( nextEdits ) ) {
+			if ( typeof nextEdits === 'string' ) {
 				return mergedEdits;
 			}
 

--- a/client/state/posts/utils/normalize-terms-for-api.js
+++ b/client/state/posts/utils/normalize-terms-for-api.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, isString, pickBy } from 'lodash';
+import { every, pickBy } from 'lodash';
 
 /**
  * Returns a normalized post terms object for sending to the API
@@ -17,7 +17,7 @@ export function normalizeTermsForApi( post ) {
 	return {
 		...post,
 		terms: pickBy( post.terms, ( terms ) => {
-			return terms.length && every( terms, isString );
+			return terms.length && every( terms, ( term ) => typeof term === 'string' );
 		} ),
 	};
 }

--- a/client/state/selectors/get-next-page-query.js
+++ b/client/state/selectors/get-next-page-query.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isString, isNumber } from 'lodash';
+import { isNumber } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,6 +12,7 @@ import getCurrentMediaQuery from 'calypso/state/selectors/get-current-media-quer
 import 'calypso/state/media/init';
 
 const DEFAULT_QUERY = Object.freeze( { number: 20 } );
+const isString = ( arg ) => typeof arg === 'string';
 
 /**
  * Returns a new query object to use to fetch the next page of media for a site

--- a/client/state/selectors/get-next-page-query.js
+++ b/client/state/selectors/get-next-page-query.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isNumber } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import getNextPageHandle from 'calypso/state/selectors/get-next-page-handle';
@@ -12,7 +7,6 @@ import getCurrentMediaQuery from 'calypso/state/selectors/get-current-media-quer
 import 'calypso/state/media/init';
 
 const DEFAULT_QUERY = Object.freeze( { number: 20 } );
-const isString = ( arg ) => typeof arg === 'string';
 
 /**
  * Returns a new query object to use to fetch the next page of media for a site
@@ -29,7 +23,7 @@ export default function getNextPageQuery( state, siteId ) {
 
 	const pageHandle = getNextPageHandle( state, siteId );
 
-	if ( [ isString, isNumber ].some( ( pred ) => pred( pageHandle ) ) ) {
+	if ( [ 'string', 'number' ].includes( typeof pageHandle ) ) {
 		return {
 			...DEFAULT_QUERY,
 			...currentQuery,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `isString` is essentially fully natively supported by the native `typeof x === 'string'`. An exception to this rule is when a string is initialized with `new String()`, but this is discouraged practice and doesn't occur anywhere in Calypso. This PR replaces the usage and adds an ESLint rule to warn against using `isString` from lodash.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all usages are sane and preserve the original logic (be it negative or not).
* Try to `import { isString } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass.