### PR TITLE
Partner Portal: Add persistence to Partner and Partner Keys

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -10,8 +10,8 @@ import type PageJS from 'page';
  */
 import { addQueryArgs } from 'calypso/lib/route';
 import {
-	getActivePartnerKey,
 	getCurrentPartner,
+	getActivePartnerKeyId,
 } from 'calypso/state/partner-portal/partner/selectors';
 import {
 	publicToInternalLicenseFilter,
@@ -160,7 +160,7 @@ export function requireSelectedPartnerKeyContext(
 	next: () => void
 ): void {
 	const state = context.store.getState();
-	const hasKey = getActivePartnerKey( state );
+	const hasKey = getActivePartnerKeyId( state );
 	const { pathname, search } = window.location;
 
 	if ( hasKey ) {

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -11,7 +11,7 @@ import type PageJS from 'page';
 import { addQueryArgs } from 'calypso/lib/route';
 import {
 	getCurrentPartner,
-	getActivePartnerKeyId,
+	hasActivePartnerKey,
 } from 'calypso/state/partner-portal/partner/selectors';
 import {
 	publicToInternalLicenseFilter,
@@ -160,7 +160,7 @@ export function requireSelectedPartnerKeyContext(
 	next: () => void
 ): void {
 	const state = context.store.getState();
-	const hasKey = getActivePartnerKeyId( state );
+	const hasKey = hasActivePartnerKey( state );
 	const { pathname, search } = window.location;
 
 	if ( hasKey ) {

--- a/client/state/partner-portal/partner/actions.ts
+++ b/client/state/partner-portal/partner/actions.ts
@@ -58,7 +58,6 @@ export function receivePartner( partner: Partner ): PartnerPortalThunkAction {
 			partner,
 		} );
 
-		// We check the active key otherwise.
 		const activePartnerKeyId = getActivePartnerKeyId( getState() );
 		const keys = partner.keys.map( ( key ) => key.id );
 		let newKeyId = 0;

--- a/client/state/partner-portal/partner/actions.ts
+++ b/client/state/partner-portal/partner/actions.ts
@@ -61,11 +61,19 @@ export function receivePartner( partner: Partner ): PartnerPortalThunkAction {
 		// If we only get a single key, auto-select it for the user for simplicity.
 		// We check the active key otherwise.
 		const keys = partner.keys.map( ( key ) => key.id );
+		const numberOfKeys = keys.length;
+		const currentPartnerKeyId = getActivePartnerKeyId( getState() );
+		// If the current stored partner key id is disabled
+		const isPartnerKeyAvailable = keys.includes( currentPartnerKeyId );
 
-		if ( keys.length === 1 ) {
+		if ( ! isPartnerKeyAvailable ) {
+			// do something else
+			return;
+		}
+
+		if ( numberOfKeys === 1 ) {
 			dispatch( setActivePartnerKey( keys[ 0 ] ) );
-		} else if ( keys.length > 1 ) {
-			const currentPartnerKeyId = getActivePartnerKeyId( getState() );
+		} else if ( numberOfKeys > 1 ) {
 			dispatch( setActivePartnerKey( currentPartnerKeyId ) );
 		}
 	};

--- a/client/state/partner-portal/partner/actions.ts
+++ b/client/state/partner-portal/partner/actions.ts
@@ -58,23 +58,23 @@ export function receivePartner( partner: Partner ): PartnerPortalThunkAction {
 			partner,
 		} );
 
-		// If we only get a single key, auto-select it for the user for simplicity.
 		// We check the active key otherwise.
+		const activePartnerKeyId = getActivePartnerKeyId( getState() );
 		const keys = partner.keys.map( ( key ) => key.id );
-		const numberOfKeys = keys.length;
-		const currentPartnerKeyId = getActivePartnerKeyId( getState() );
-		// If the current stored partner key id is disabled
-		const isPartnerKeyAvailable = keys.includes( currentPartnerKeyId );
+		let newKeyId = 0;
 
-		if ( ! isPartnerKeyAvailable ) {
-			// do something else
-			return;
+		if ( keys.length === 1 ) {
+			// If we only get a single key, auto-select it for the user for simplicity.
+			newKeyId = keys[ 0 ];
 		}
 
-		if ( numberOfKeys === 1 ) {
-			dispatch( setActivePartnerKey( keys[ 0 ] ) );
-		} else if ( numberOfKeys > 1 ) {
-			dispatch( setActivePartnerKey( currentPartnerKeyId ) );
+		if ( keys.includes( activePartnerKeyId ) ) {
+			// If the active key id is for a valid key, select it.
+			newKeyId = activePartnerKeyId;
+		}
+
+		if ( newKeyId ) {
+			dispatch( setActivePartnerKey( newKeyId ) );
 		}
 	};
 }

--- a/client/state/partner-portal/partner/reducer.ts
+++ b/client/state/partner-portal/partner/reducer.ts
@@ -12,7 +12,13 @@ import {
 	JETPACK_PARTNER_PORTAL_PARTNER_RECEIVE,
 	JETPACK_PARTNER_PORTAL_PARTNER_RECEIVE_ERROR,
 } from 'calypso/state/action-types';
-import { combineReducers, withoutPersistence } from 'calypso/state/utils';
+import {
+	combineReducers,
+	withoutPersistence,
+	withSchemaValidation,
+	withPersistence,
+} from 'calypso/state/utils';
+import { activePartnerKeySchema, currentPartnerSchema } from './schema';
 
 export const initialState = {
 	hasFetched: false,
@@ -49,18 +55,21 @@ export const isFetching = withoutPersistence(
 	}
 );
 
-export const activePartnerKey = withoutPersistence(
-	( state = initialState.activePartnerKey, action: AnyAction ) => {
-		switch ( action.type ) {
-			case JETPACK_PARTNER_PORTAL_PARTNER_ACTIVE_PARTNER_KEY_UPDATE:
-				return action.partnerKeyId;
-		}
-
-		return state;
+const activePartnerKeyReducer = ( state = initialState.activePartnerKey, action: AnyAction ) => {
+	switch ( action.type ) {
+		case JETPACK_PARTNER_PORTAL_PARTNER_ACTIVE_PARTNER_KEY_UPDATE:
+			return action.partnerKeyId;
 	}
+
+	return state;
+};
+
+export const activePartnerKey = withSchemaValidation(
+	activePartnerKeySchema,
+	withPersistence( activePartnerKeyReducer )
 );
 
-export const current = withoutPersistence( ( state = initialState.current, action: AnyAction ) => {
+const currentPartnerReducer = ( state = initialState.current, action: AnyAction ) => {
 	switch ( action.type ) {
 		case JETPACK_PARTNER_PORTAL_PARTNER_RECEIVE:
 			if ( action.partner.keys.length === 0 ) {
@@ -72,7 +81,12 @@ export const current = withoutPersistence( ( state = initialState.current, actio
 	}
 
 	return state;
-} );
+};
+
+export const current = withSchemaValidation(
+	currentPartnerSchema,
+	withPersistence( currentPartnerReducer )
+);
 
 export const error = withoutPersistence( ( state = initialState.error, action: AnyAction ) => {
 	switch ( action.type ) {

--- a/client/state/partner-portal/partner/reducer.ts
+++ b/client/state/partner-portal/partner/reducer.ts
@@ -18,7 +18,7 @@ import {
 	withSchemaValidation,
 	withPersistence,
 } from 'calypso/state/utils';
-import { activePartnerKeySchema, currentPartnerSchema } from './schema';
+import { activePartnerKeySchema } from './schema';
 
 export const initialState = {
 	hasFetched: false,
@@ -69,7 +69,7 @@ export const activePartnerKey = withSchemaValidation(
 	withPersistence( activePartnerKeyReducer )
 );
 
-const currentPartnerReducer = ( state = initialState.current, action: AnyAction ) => {
+const current = withoutPersistence( ( state = initialState.current, action: AnyAction ) => {
 	switch ( action.type ) {
 		case JETPACK_PARTNER_PORTAL_PARTNER_RECEIVE:
 			if ( action.partner.keys.length === 0 ) {
@@ -81,12 +81,7 @@ const currentPartnerReducer = ( state = initialState.current, action: AnyAction 
 	}
 
 	return state;
-};
-
-export const current = withSchemaValidation(
-	currentPartnerSchema,
-	withPersistence( currentPartnerReducer )
-);
+} );
 
 export const error = withoutPersistence( ( state = initialState.error, action: AnyAction ) => {
 	switch ( action.type ) {

--- a/client/state/partner-portal/partner/schema.ts
+++ b/client/state/partner-portal/partner/schema.ts
@@ -1,0 +1,29 @@
+export const activePartnerKeySchema = {
+	type: 'number',
+};
+
+export const currentPartnerSchema = {
+	type: 'object',
+	additionalProperties: true,
+	required: [ 'id', 'slug' ],
+	patternProperties: {
+		'^\\d+$': {
+			id: { type: 'number' },
+			name: { type: 'string' },
+			slug: { type: 'string' },
+			keys: {
+				type: [ 'array', 'null' ],
+				items: {
+					type: 'object',
+					required: [ 'id', 'oAuthToken' ],
+					properties: {
+						id: { type: 'number' },
+						disabledOn: { type: [ 'null', 'string' ] },
+						name: { type: 'string' },
+						oAuthToken: { type: 'string' },
+					},
+				},
+			},
+		},
+	},
+};

--- a/client/state/partner-portal/partner/schema.ts
+++ b/client/state/partner-portal/partner/schema.ts
@@ -1,29 +1,4 @@
 export const activePartnerKeySchema = {
 	type: 'number',
-};
-
-export const currentPartnerSchema = {
-	type: 'object',
-	additionalProperties: true,
-	required: [ 'id', 'slug' ],
-	patternProperties: {
-		'^\\d+$': {
-			id: { type: 'number' },
-			name: { type: 'string' },
-			slug: { type: 'string' },
-			keys: {
-				type: [ 'array', 'null' ],
-				items: {
-					type: 'object',
-					required: [ 'id', 'oAuthToken' ],
-					properties: {
-						id: { type: 'number' },
-						disabledOn: { type: [ 'null', 'string' ] },
-						name: { type: 'string' },
-						oAuthToken: { type: 'string' },
-					},
-				},
-			},
-		},
-	},
+	minimum: 0,
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: 1187494150150258-as-1200070129781595/f

* This PR adds `withSchemaValidation` e `withPersistence` to the `activePartnerKeyReducer` and `currentPartnerReducer` to prevent the Partner Key selection screen when refreshing or changing the page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* If you do not have a partner key, please contact Infinity for one or you will be unable to test this PR.
* Check out this PR locally, then run* `yarn && ENABLE_FEATURES=no-force-sympathy && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal
* Select a Partner Key
* Refresh the page
* Make sure it doesn't redirect you to the "Select a Partner Key" screen

Note: Calypso is likely to skip the initial state rehydration as mentioned [here](https://github.com/Automattic/wp-calypso/pull/51317#issuecomment-805036236), and this PR might not work correctly. To avoid that, we have to enable the  `no-force-sympathy` by passing `ENABLE_FEATURES=no-force-sympathy` before running `yarn start-jetpack-cloud`.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->