### PR TITLE
Components: Fix Card children key warning

### DIFF
--- a/packages/components/src/card/index.tsx
+++ b/packages/components/src/card/index.tsx
@@ -65,15 +65,10 @@ const Card = < T extends TagName = 'div' >(
 		React.createElement(
 			tagName,
 			{ ...props, className: elementClass, ref: forwardedRef },
-			<>
-				{ displayAsLink && (
-					<Gridicon
-						className="card__link-indicator"
-						icon={ target ? 'external' : 'chevron-right' }
-					/>
-				) }
-				{ children }
-			</>
+			displayAsLink && (
+				<Gridicon className="card__link-indicator" icon={ target ? 'external' : 'chevron-right' } />
+			),
+			children
 		)
 	);
 };

--- a/packages/components/src/card/index.tsx
+++ b/packages/components/src/card/index.tsx
@@ -62,12 +62,19 @@ const Card = < T extends TagName = 'div' >(
 			{ children }
 		</a>
 	) : (
-		React.createElement( tagName, { ...props, className: elementClass, ref: forwardedRef }, [
-			displayAsLink && (
-				<Gridicon className="card__link-indicator" icon={ target ? 'external' : 'chevron-right' } />
-			),
-			children,
-		] )
+		React.createElement(
+			tagName,
+			{ ...props, className: elementClass, ref: forwardedRef },
+			<>
+				{ displayAsLink && (
+					<Gridicon
+						className="card__link-indicator"
+						icon={ target ? 'external' : 'chevron-right' }
+					/>
+				) }
+				{ children }
+			</>
+		)
 	);
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the annoying warning that appears when `Card` is used without a `href` with 1 or more children and a `displayAsLink` prop:

![](https://cldup.com/8gFDv-f7DX.png)

#### Testing instructions

* Checkout this branch and run Calypso locally.
* Go to `/home/:site`
* Verify you don't see the warning in the console anymore.