### PR TITLE
Checkout: Fix incorrect import

### DIFF
--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { Theme } from 'src/lib/theme';
+import { Theme } from '../lib/theme';
 import styled from '../lib/styled';
 
 const RadioButtonWrapper = styled.div<


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes an import in the `@automattic/composite-checkout` package which was not correctly using a relative path (it may have been an import automatically added by an IDE).

Part of https://github.com/Automattic/wp-calypso/issues/50647

#### Testing instructions

Verify that there are no build errors.