### PR TITLE
Checklist: start site setup task does not make checklist incomplete on its own

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -142,7 +142,6 @@ const SiteSetupList = ( {
 		if ( currentTask?.completeOnView && ! currentTask?.isCompleted ) {
 			dispatch( requestSiteChecklistTaskUpdate( siteId, currentTask.id ) );
 			setTaskIsManuallySelected( true ); // force selected even though complete
-			setCurrentTaskId( null ); // The current task may no longer be available after being updated on the server
 		}
 	}, [ currentTask, dispatch, siteId ] );
 

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -213,7 +213,9 @@ const SiteSetupList = ( {
 	}
 
 	const advanceToNextIncompleteTask = () => {
-		setCurrentTaskId( firstIncompleteTask.id );
+		if ( firstIncompleteTask ) {
+			setCurrentTaskId( firstIncompleteTask.id );
+		}
 	};
 
 	return (

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -142,6 +142,7 @@ const SiteSetupList = ( {
 		if ( currentTask?.completeOnView && ! currentTask?.isCompleted ) {
 			dispatch( requestSiteChecklistTaskUpdate( siteId, currentTask.id ) );
 			setTaskIsManuallySelected( true ); // force selected even though complete
+			setCurrentTaskId( null ); // The current task may no longer be available after being updated on the server
 		}
 	}, [ currentTask, dispatch, siteId ] );
 

--- a/client/state/selectors/is-site-checklist-complete.js
+++ b/client/state/selectors/is-site-checklist-complete.js
@@ -52,7 +52,7 @@ export default function isSiteChecklistComplete( state, siteId ) {
 			return true;
 		}
 
-		// Starting site setup autocompletes, so it shouldn't cause an incomplete status.
+		// Starting site setup autocompletes, so it shouldn't cause an incomplete checklist.
 		if ( CHECKLIST_KNOWN_TASKS.START_SITE_SETUP === task.id ) {
 			return true;
 		}

--- a/client/state/selectors/is-site-checklist-complete.js
+++ b/client/state/selectors/is-site-checklist-complete.js
@@ -52,6 +52,11 @@ export default function isSiteChecklistComplete( state, siteId ) {
 			return true;
 		}
 
+		// Starting site setup autocompletes, so it shouldn't cause an incomplete status.
+		if ( CHECKLIST_KNOWN_TASKS.START_SITE_SETUP === task.id ) {
+			return true;
+		}
+
 		return false;
 	};
 

--- a/client/state/selectors/is-site-checklist-complete.js
+++ b/client/state/selectors/is-site-checklist-complete.js
@@ -34,6 +34,8 @@ export default function isSiteChecklistComplete( state, siteId ) {
 	 *	B) the task front_page_updated is pending but the site doesn't have a page set as front page.
 	 *	This is because updating the front page doesn't apply when the site doesn't have a page set as the front page.
 	 *	Any other case leads to a pending task.
+	 *	C) the mobile_app_installed task, because it shouldn't affect the site setup status.
+	 *	D) the start_site_setup task, because it autocompletes on view as a way of starting the checklist.
 	 *
 	 *		@param   {object}  task The task that we'll check to see if it's completed.
 	 *		@returns {boolean}      Whether the task is considered to be completed or not.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Two small optimizations to the site checklist

- Prevent a js error after completing the last task (and there's not a next incomplete task to move to)
- Prevent the site setup started task from flagging a checklist as incomplete. This task is autocompleted when viewed, so there's no reason to see the entire checklist if this is the only task that's incomplete.

This companion diff is not required to test this change, but is directly related: D59219-code

Related to #51311

#### Testing instructions

This is a bit difficult to test, but one practical result you can see is that after following the flow to reproduce #51311, and launching a site, you will see a slightly different launched celebration card on My Home. The secondary action will display "Dismiss," rather than "Skip site setup".

<img width="695" alt="Screen Shot 2021-03-24 at 14 09 36" src="https://user-images.githubusercontent.com/1699996/112371556-b8587300-8cac-11eb-82cc-8c5bd4352ac8.png">
