### PR TITLE
Adding upsell link to Facebook card on Marketing Tools

### DIFF
--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -11,9 +11,10 @@ import config from '@automattic/calypso-config';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
 import { hasTrafficGuidePurchase } from 'calypso/my-sites/marketing/ultimate-traffic-guide';
 import MarketingToolsFeature from './feature';
 import MarketingToolsHeader from './header';
@@ -24,6 +25,7 @@ import {
 } from 'calypso/my-sites/marketing/paths';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 
 /**
@@ -57,6 +59,11 @@ export const MarketingTools: FunctionComponent = () => {
 		getSelectedSiteSlug( state )
 	);
 	const purchases = useSelector( ( state ) => getUserPurchases( state, userId ) );
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) || 0;
+	const sitePlan = useSelector( ( state ) => getSitePlanSlug( state, siteId ) ) || '';
+	const showFacebookUpsell = [ 'value_bundle', 'personal-bundle', 'free_plan' ].includes(
+		sitePlan
+	);
 
 	const handleBusinessToolsClick = () => {
 		recordTracksEvent( 'calypso_marketing_tools_business_tools_button_click' );
@@ -111,6 +118,7 @@ export const MarketingTools: FunctionComponent = () => {
 	return (
 		<Fragment>
 			{ ! purchases && <QueryUserPurchases userId={ userId } /> }
+			{ ! sitePlan && <QuerySitePlans siteId={ siteId } /> }
 			<PageViewTracker path="/marketing/tools/:site" title="Marketing > Tools" />
 
 			<MarketingToolsHeader handleButtonClick={ handleBusinessToolsClick } />
@@ -157,13 +165,23 @@ export const MarketingTools: FunctionComponent = () => {
 						) }
 						imagePath={ facebookLogo }
 					>
-						<Button
-							onClick={ handleFacebookClick }
-							href="https://wordpress.com/plugins/official-facebook-pixel"
-							target="_blank"
-						>
-							{ translate( 'Add Facebook for WordPress.com' ) }
-						</Button>
+						{ ! showFacebookUpsell && (
+							<Button
+								onClick={ handleFacebookClick }
+								href="https://wordpress.com/plugins/official-facebook-pixel"
+								target="_blank"
+							>
+								{ translate( 'Add Facebook for WordPress.com' ) }
+							</Button>
+						) }
+						{ showFacebookUpsell && (
+							<Button
+								onClick={ handleFacebookClick }
+								href={ `/plans/${ selectedSiteSlug }?customerType=business` }
+							>
+								{ translate( 'Unlock this feature' ) }
+							</Button>
+						) }
 					</MarketingToolsFeature>
 				) }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* This PR updates the Facebook card on Marketing Tools to show an plan upgrade upsell CTA for users on the Free, Personal, or Premium plans.
* A user with one of those plans who clicks the card will go to the Plans page.
* A user with the Business or Ecommerce plan will go to a plugin information page.

#### Testing instructions
* Checkout this PR and start Calypso.
* Navigate to Marketing / Tools with plans on Free, Personal, and Premium plans and confirm that each test case sees the upgrade CTA ("Unlock this feature").
* Switch to a Business or Ecommerce plan site and confirm that you see that install CTA ("Add Facebook for WordPress.com").

Related to #51038 
