### PR TITLE
G Suite: Update urls to better support G Suite and Google Workspace

### DIFF
--- a/client/components/upgrades/gsuite/gsuite-upsell-card/product-details.jsx
+++ b/client/components/upgrades/gsuite/gsuite-upsell-card/product-details.jsx
@@ -9,13 +9,13 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from '@automattic/calypso-config';
 import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import googleWorkspaceLogo from 'calypso/assets/images/email-providers/google-workspace/logo.svg';
 import GSuitePrice from 'calypso/components/gsuite/gsuite-price';
 import GSuiteCompactFeatures from 'calypso/components/gsuite/gsuite-features/compact';
 import { GSUITE_SLUG_PROP_TYPES } from 'calypso/lib/gsuite/constants';
+import { isGoogleWorkspaceProductSlug } from 'calypso/lib/gsuite';
 
 function GSuiteUpsellProductDetails( { currencyCode, domain, product, productSlug } ) {
 	const translate = useTranslate();
@@ -24,7 +24,7 @@ function GSuiteUpsellProductDetails( { currencyCode, domain, product, productSlu
 		<div className="gsuite-upsell-card__product-details">
 			<div className="gsuite-upsell-card__product-intro">
 				<div className="gsuite-upsell-card__product-presentation">
-					{ config.isEnabled( 'google-workspace-migration' ) ? (
+					{ isGoogleWorkspaceProductSlug( productSlug ) ? (
 						<img src={ googleWorkspaceLogo } alt="Google Workspace" />
 					) : (
 						<span className="gsuite-upsell-card__product-logo">G Suite</span>

--- a/client/lib/gsuite/constants.js
+++ b/client/lib/gsuite/constants.js
@@ -23,3 +23,12 @@ export const GSUITE_SLUG_PROP_TYPES = PropTypes.oneOf( [
  */
 export const GSUITE_PRODUCT_FAMILY = 'G Suite';
 export const GOOGLE_WORKSPACE_PRODUCT_FAMILY = 'Google Workspace';
+
+/**
+ * Defines product types to use as slugs in urls.
+ *
+ * @see emailManagementAddGSuiteUsers() in client/my-sites/email/paths.js
+ * @see emailManagementNewGSuiteAccount() in client/my-sites/email/paths.js
+ */
+export const GOOGLE_WORKSPACE_PRODUCT_TYPE = 'google-workspace';
+export const GSUITE_PRODUCT_TYPE = 'gsuite';

--- a/client/lib/gsuite/gsuite-product-type.js
+++ b/client/lib/gsuite/gsuite-product-type.js
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+	GOOGLE_WORKSPACE_PRODUCT_TYPE,
+	GSUITE_BASIC_SLUG,
+	GSUITE_PRODUCT_TYPE,
+} from 'calypso/lib/gsuite/constants';
+
+/**
+ * Retrieves the product slug from the specified product type.
+ *
+ * @param {string} productType - type of the product
+ * @returns {string} the corresponding product slug
+ */
+export function getProductSlug( productType ) {
+	if ( productType === GOOGLE_WORKSPACE_PRODUCT_TYPE ) {
+		return GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY;
+	}
+
+	return GSUITE_BASIC_SLUG;
+}
+
+/**
+ * Retrieves the product type to use as slug in urls for the specified product slug.
+ *
+ * @param {string} productSlug - slug of the product
+ * @returns {string} the corresponding product type
+ * @see emailManagementAddGSuiteUsers() in client/my-sites/email/paths.js
+ * @see emailManagementNewGSuiteAccount() in client/my-sites/email/paths.js
+ */
+export function getProductType( productSlug ) {
+	if ( productSlug === GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY ) {
+		return GOOGLE_WORKSPACE_PRODUCT_TYPE;
+	}
+
+	return GSUITE_PRODUCT_TYPE;
+}

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -26,3 +26,4 @@ export { hasGSuiteWithAnotherProvider } from './has-gsuite-with-another-provider
 export { hasGSuiteWithUs } from './has-gsuite-with-us';
 export { hasPendingGSuiteUsers } from './has-pending-gsuite-users';
 export { getGoogleMailServiceFamily } from './get-google-mail-service-family';
+export { getProductSlug, getProductType } from './gsuite-product-type';

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -189,20 +189,27 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 		emailManagementTitanControlPanelRedirect,
 	];
 
+	// Builds a list of paths using a site slug plus any additional parameter that may be required
 	let domainManagementPaths = allPaths.map( ( pathFactory ) => {
-		if ( pathFactory === emailManagementNewGSuiteAccount ) {
-			// `emailManagementNewGSuiteAccount` takes `planType` from `context.params`, otherwise path comparisons won't work well.
-			return emailManagementNewGSuiteAccount( slug, slug, contextParams.planType );
+		if ( pathFactory === emailManagementAddGSuiteUsers ) {
+			return emailManagementAddGSuiteUsers( slug, slug, contextParams.productType );
 		}
+
+		if ( pathFactory === emailManagementNewGSuiteAccount ) {
+			return emailManagementNewGSuiteAccount( slug, slug, contextParams.productType );
+		}
+
 		return pathFactory( slug, slug );
 	} );
 
+	// Builds a list of paths using a site slug, and which are relative to the root of the domain management section
 	domainManagementPaths = domainManagementPaths.concat(
 		allPaths.map( ( pathFactory ) => {
 			return pathFactory( slug, slug, domainManagementRoot() );
 		} )
 	);
 
+	// Builds a list of paths using a site slug but also a primary domain - if they differ
 	if ( primaryDomain && slug !== primaryDomain.name ) {
 		domainManagementPaths = domainManagementPaths.concat(
 			allPaths.map( ( pathFactory ) => pathFactory( slug, primaryDomain.name ) )

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -215,7 +215,11 @@ export default {
 
 	domainManagementAddGSuiteUsersRedirect( pageContext ) {
 		page.redirect(
-			emailManagementAddGSuiteUsers( pageContext.params.site, pageContext.params.domain )
+			emailManagementAddGSuiteUsers(
+				pageContext.params.site,
+				pageContext.params.domain,
+				pageContext.params.productType
+			)
 		);
 	},
 

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -29,11 +29,7 @@ import {
 	domainManagementDomainConnectMapping,
 	domainManagementRoot,
 } from 'calypso/my-sites/domains/paths';
-import {
-	emailManagement,
-	emailManagementAddGSuiteUsers,
-	emailManagementForwarding,
-} from 'calypso/my-sites/email/paths';
+import { emailManagement, emailManagementForwarding } from 'calypso/my-sites/email/paths';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { decodeURIComponentIfValid } from 'calypso/lib/url';
 
@@ -211,16 +207,6 @@ export default {
 			/>
 		);
 		next();
-	},
-
-	domainManagementAddGSuiteUsersRedirect( pageContext ) {
-		page.redirect(
-			emailManagementAddGSuiteUsers(
-				pageContext.params.site,
-				pageContext.params.domain,
-				pageContext.params.productType
-			)
-		);
 	},
 
 	domainManagementSecurity( pageContext, next ) {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -13,13 +13,14 @@ import { withShoppingCart } from '@automattic/shopping-cart';
 /**
  * Internal dependencies
  */
+import config from '@automattic/calypso-config';
 import EmptyContent from 'calypso/components/empty-content';
 import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import Main from 'calypso/components/main';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { canDomainAddGSuite } from 'calypso/lib/gsuite';
+import { canDomainAddGSuite, getProductType } from 'calypso/lib/gsuite';
 import {
 	hasPlan,
 	hasDomainInCart,
@@ -37,6 +38,10 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
+import {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+	GSUITE_BASIC_SLUG,
+} from 'calypso/lib/gsuite/constants';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { getProductsList } from 'calypso/state/products-list/selectors';
@@ -173,7 +178,18 @@ class DomainSearch extends Component {
 			] )
 			.then( () => {
 				if ( canDomainAddGSuite( domain ) ) {
-					page( '/domains/add/' + domain + '/google-apps/' + this.props.selectedSiteSlug );
+					const gSuiteProductSlug = config.isEnabled( 'google-workspace-migration' )
+						? GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
+						: GSUITE_BASIC_SLUG;
+
+					page(
+						'/domains/add/' +
+							domain +
+							'/' +
+							getProductType( gSuiteProductSlug ) +
+							'/' +
+							this.props.selectedSiteSlug
+					);
 				} else {
 					page( '/checkout/' + this.props.selectedSiteSlug );
 				}

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -232,15 +232,22 @@ export default function () {
 			domainsController.redirectToDomainSearchSuggestion
 		);
 
-		page(
-			'/domains/add/:registerDomain/google-apps/:domain',
-			siteSelection,
-			navigation,
-			domainsController.redirectIfNoSite( '/domains/add' ),
-			domainsController.jetpackNoDomainsWarning,
-			domainsController.googleAppsWithRegistration,
-			makeLayout,
-			clientRender
+		[
+			'/domains/add/:registerDomain/google-workspace/:domain',
+			'/domains/add/:registerDomain/gsuite/:domain',
+		].forEach( ( path ) =>
+			page(
+				path,
+				...[
+					siteSelection,
+					navigation,
+					domainsController.redirectIfNoSite( '/domains/add' ),
+					domainsController.jetpackNoDomainsWarning,
+					domainsController.googleAppsWithRegistration,
+					makeLayout,
+					clientRender,
+				]
+			)
 		);
 
 		page(

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -69,6 +69,7 @@ export default function () {
 
 	registerMultiPage( {
 		paths: [
+			paths.domainManagementAddGSuiteUsers( ':site', ':domain', ':productType' ),
 			paths.domainManagementAddGSuiteUsers( ':site', ':domain' ),
 			paths.domainManagementAddGSuiteUsers( ':site' ),
 		],

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -67,15 +67,6 @@ export default function () {
 		handlers: [ domainManagementController.domainManagementEmailRedirect ],
 	} );
 
-	registerMultiPage( {
-		paths: [
-			paths.domainManagementAddGSuiteUsers( ':site', ':domain', ':productType' ),
-			paths.domainManagementAddGSuiteUsers( ':site', ':domain' ),
-			paths.domainManagementAddGSuiteUsers( ':site' ),
-		],
-		handlers: [ domainManagementController.domainManagementAddGSuiteUsersRedirect ],
-	} );
-
 	page(
 		paths.domainManagementEmailForwarding( ':site', ':domain' ),
 		domainManagementController.domainManagementEmailForwardingRedirect

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -79,16 +79,12 @@ export function domainManagementEdit( siteName, domainName, relativeTo ) {
 	return domainManagementEditBase( siteName, domainName, 'edit', relativeTo );
 }
 
-export function domainManagementAddGSuiteUsers( siteName, domainName ) {
-	let path;
-
+export function domainManagementAddGSuiteUsers( siteName, domainName, productType ) {
 	if ( domainName ) {
-		path = domainManagementEditBase( siteName, domainName, 'add-gsuite-users' );
-	} else {
-		path = domainManagementRoot() + '/add-gsuite-users/' + siteName;
+		return domainManagementEditBase( siteName, domainName, productType + '/add-users' );
 	}
 
-	return path;
+	return domainManagementRoot() + '/' + productType + '/add-users/' + siteName;
 }
 
 export function domainManagementContactsPrivacy( siteName, domainName, relativeTo = null ) {

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -79,14 +79,6 @@ export function domainManagementEdit( siteName, domainName, relativeTo ) {
 	return domainManagementEditBase( siteName, domainName, 'edit', relativeTo );
 }
 
-export function domainManagementAddGSuiteUsers( siteName, domainName, productType ) {
-	if ( domainName ) {
-		return domainManagementEditBase( siteName, domainName, productType + '/add-users' );
-	}
-
-	return domainManagementRoot() + '/' + productType + '/add-users/' + siteName;
-}
-
 export function domainManagementContactsPrivacy( siteName, domainName, relativeTo = null ) {
 	return domainManagementEditBase( siteName, domainName, 'contacts-privacy', relativeTo );
 }

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import page from 'page';
 import { isEnabled } from '@automattic/calypso-config';
 
 /**
@@ -10,7 +9,6 @@ import { isEnabled } from '@automattic/calypso-config';
  */
 import EmailForwarding from 'calypso/my-sites/email/email-forwarding';
 import EmailManagement from 'calypso/my-sites/email/email-management';
-import { emailManagementAddGSuiteUsers } from 'calypso/my-sites/email/paths';
 import GSuiteAddUsers from 'calypso/my-sites/email/gsuite-add-users';
 import TitanMailAddMailboxes from 'calypso/my-sites/email/titan-mail-add-mailboxes';
 import TitanMailQuantitySelection from 'calypso/my-sites/email/titan-mail-quantity-selection';
@@ -22,24 +20,22 @@ export default {
 	emailManagementAddGSuiteUsers( pageContext, next ) {
 		pageContext.primary = (
 			<CalypsoShoppingCartProvider>
-				<GSuiteAddUsers selectedDomainName={ pageContext.params.domain } />
+				<GSuiteAddUsers
+					productType={ pageContext.params.productType }
+					selectedDomainName={ pageContext.params.domain }
+				/>
 			</CalypsoShoppingCartProvider>
 		);
 
 		next();
 	},
 
-	emailManagementAddGSuiteUsersLegacyRedirect( pageContext ) {
-		page.redirect(
-			emailManagementAddGSuiteUsers( pageContext.params.site, pageContext.params.domain )
-		);
-	},
-
 	emailManagementNewGSuiteAccount( pageContext, next ) {
 		pageContext.primary = (
 			<CalypsoShoppingCartProvider>
 				<GSuiteAddUsers
-					planType={ pageContext.params.planType }
+					isNewAccount
+					productType={ pageContext.params.productType }
 					selectedDomainName={ pageContext.params.domain }
 				/>
 			</CalypsoShoppingCartProvider>

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -27,6 +27,7 @@ import {
 	getGoogleDriveUrl,
 	getGoogleSheetsUrl,
 	getGoogleSlidesUrl,
+	getProductType,
 	hasPendingGSuiteUsers,
 } from 'calypso/lib/gsuite';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -81,9 +82,8 @@ class GSuiteUsersCard extends React.Component {
 	renderDomainWithGSuite( domainName, users ) {
 		const { selectedSiteSlug, translate } = this.props;
 
-		// The product name is same for all users as product license is associated to domain
-		// Hence a snapshot of the product name from the first user is sufficient
-		const productName = users[ 0 ].product_name;
+		// Retrieves product information from the first user, which is fine as all users share exactly the same product data
+		const { product_name: productName, product_slug: productSlug } = users[ 0 ];
 
 		const header = (
 			<>
@@ -104,7 +104,11 @@ class GSuiteUsersCard extends React.Component {
 			<Button
 				primary
 				compact
-				href={ emailManagementAddGSuiteUsers( selectedSiteSlug, domainName ) }
+				href={ emailManagementAddGSuiteUsers(
+					selectedSiteSlug,
+					domainName,
+					getProductType( productSlug )
+				) }
 				onClick={ this.goToAddGoogleApps }
 			>
 				{ translate( 'Add New Users' ) }

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -30,6 +30,7 @@ import {
 	getProductType,
 	hasPendingGSuiteUsers,
 } from 'calypso/lib/gsuite';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -80,7 +81,7 @@ class GSuiteUsersCard extends React.Component {
 	};
 
 	renderDomainWithGSuite( domainName, users ) {
-		const { selectedSiteSlug, translate } = this.props;
+		const { currentRoute, selectedSiteSlug, translate } = this.props;
 
 		// Retrieves product information from the first user, which is fine as all users share exactly the same product data
 		const { product_name: productName, product_slug: productSlug } = users[ 0 ];
@@ -107,7 +108,8 @@ class GSuiteUsersCard extends React.Component {
 				href={ emailManagementAddGSuiteUsers(
 					selectedSiteSlug,
 					domainName,
-					getProductType( productSlug )
+					getProductType( productSlug ),
+					currentRoute
 				) }
 				onClick={ this.goToAddGoogleApps }
 			>
@@ -308,6 +310,7 @@ const manageClick = ( domainName, email ) =>
 	);
 
 GSuiteUsersCard.propTypes = {
+	currentRoute: PropTypes.string,
 	domains: PropTypes.array.isRequired,
 	gsuiteUsers: PropTypes.array.isRequired,
 	selectedDomainName: PropTypes.string,
@@ -321,6 +324,7 @@ export default connect(
 			? [ getSelectedDomain( ownProps ) ]
 			: ownProps.domains;
 		return {
+			currentRoute: getCurrentRoute( state ),
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 			user: getCurrentUser( state ),
 			domainsAsList: domainsList,

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -27,6 +27,7 @@ import {
 	getEligibleGSuiteDomain,
 	getGoogleMailServiceFamily,
 	getGSuiteSupportedDomains,
+	getProductSlug,
 } from 'calypso/lib/gsuite';
 import {
 	areAllUsersValid,
@@ -35,10 +36,7 @@ import {
 	validateAgainstExistingUsers,
 } from 'calypso/lib/gsuite/new-users';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import {
-	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
-	GSUITE_BASIC_SLUG,
-} from 'calypso/lib/gsuite/constants';
+import { GOOGLE_WORKSPACE_PRODUCT_TYPE, GSUITE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
@@ -81,24 +79,16 @@ class GSuiteAddUsers extends React.Component {
 	}
 
 	handleContinue = () => {
-		const { domains, planType, selectedSite } = this.props;
+		const { domains, productType, selectedSite } = this.props;
 		const { users } = this.state;
 		const canContinue = areAllUsersValid( users );
 
 		this.recordClickEvent( 'calypso_email_management_gsuite_add_users_continue_button_click' );
 
 		if ( canContinue ) {
-			// TODO: Determine product slug when adding new users based on actual product
-			let productSlug = GSUITE_BASIC_SLUG;
-
-			// Checks plan type only when a new account is being purchased (it is not provided when new users are added)
-			if ( planType !== undefined && planType === 'starter' ) {
-				productSlug = GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY;
-			}
-
 			this.props.shoppingCartManager
 				.addProductsToCart(
-					getItemsForCart( domains, productSlug, users ).map( ( item ) =>
+					getItemsForCart( domains, getProductSlug( productType ), users ).map( ( item ) =>
 						fillInSingleCartItemAttributes( item, this.props.productsList )
 					)
 				)
@@ -262,11 +252,14 @@ class GSuiteAddUsers extends React.Component {
 	}
 
 	render() {
-		const { translate, planType, selectedDomainName, selectedSite } = this.props;
+		const { isNewAccount, productType, translate, selectedDomainName, selectedSite } = this.props;
 
-		const analyticsPath = planType
-			? emailManagementNewGSuiteAccount( ':site', ':domain', ':planType' )
+		const analyticsPath = isNewAccount
+			? emailManagementNewGSuiteAccount( ':site', ':domain', ':productType' )
 			: emailManagementAddGSuiteUsers( ':site', selectedDomainName ? ':domain' : undefined );
+
+		const googleMailServiceFamily = getGoogleMailServiceFamily( getProductSlug( productType ) );
+
 		return (
 			<Fragment>
 				<PageViewTracker path={ analyticsPath } title="Domain Management > Add G Suite Users" />
@@ -279,12 +272,12 @@ class GSuiteAddUsers extends React.Component {
 						onClick={ this.goToEmail }
 						selectedDomainName={ selectedDomainName }
 					>
-						{ getGoogleMailServiceFamily() }
+						{ googleMailServiceFamily }
 					</DomainManagementHeader>
 
 					<EmailVerificationGate
 						noticeText={ translate( 'You must verify your email to purchase %(productFamily)s.', {
-							args: { productFamily: getGoogleMailServiceFamily() },
+							args: { productFamily: googleMailServiceFamily },
 							comment: '%(productFamily)s can be either "G Suite" or "Google Workspace"',
 						} ) }
 						noticeStatus="is-info"
@@ -300,8 +293,9 @@ class GSuiteAddUsers extends React.Component {
 GSuiteAddUsers.propTypes = {
 	domains: PropTypes.array.isRequired,
 	gsuiteUsers: PropTypes.array,
+	isNewAccount: PropTypes.bool,
 	isRequestingDomains: PropTypes.bool.isRequired,
-	planType: PropTypes.oneOf( [ 'basic', 'starter' ] ),
+	productType: PropTypes.oneOf( [ GOOGLE_WORKSPACE_PRODUCT_TYPE, GSUITE_PRODUCT_TYPE ] ),
 	selectedDomainName: PropTypes.string.isRequired,
 	selectedSite: PropTypes.shape( {
 		slug: PropTypes.string.isRequired,

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -291,6 +291,7 @@ class GSuiteAddUsers extends React.Component {
 }
 
 GSuiteAddUsers.propTypes = {
+	currentRoute: PropTypes.string,
 	domains: PropTypes.array.isRequired,
 	gsuiteUsers: PropTypes.array,
 	isNewAccount: PropTypes.bool,

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -34,9 +34,10 @@ export default function () {
 			paths.emailManagementAddGSuiteUsers(
 				':site',
 				':domain',
+				':productType',
 				paths.emailManagementAllSitesPrefix
 			),
-			paths.emailManagementAddGSuiteUsers( ':site', ':domain' ),
+			paths.emailManagementAddGSuiteUsers( ':site', ':domain', ':productType' ),
 			paths.emailManagementAddGSuiteUsers( ':site' ),
 		],
 		handlers: [
@@ -49,21 +50,13 @@ export default function () {
 
 	registerMultiPage( {
 		paths: [
-			paths.emailManagementAddGSuiteUsersLegacy( ':site', ':domain' ),
-			paths.emailManagementAddGSuiteUsersLegacy( ':site' ),
-		],
-		handlers: [ controller.emailManagementAddGSuiteUsersLegacyRedirect ],
-	} );
-
-	registerMultiPage( {
-		paths: [
 			paths.emailManagementNewGSuiteAccount(
 				':site',
 				':domain',
-				':planType',
+				':productType',
 				paths.emailManagementAllSitesPrefix
 			),
-			paths.emailManagementNewGSuiteAccount( ':site', ':domain', ':planType' ),
+			paths.emailManagementNewGSuiteAccount( ':site', ':domain', ':productType' ),
 		],
 		handlers: [
 			...commonHandlers,

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -15,43 +15,48 @@ function resolveRootPath( relativeTo ) {
 	if ( relativeTo === emailManagementAllSitesPrefix || relativeTo === domainManagementRoot() ) {
 		return emailManagementAllSitesPrefix;
 	}
+
 	if ( isUnderEmailManagementAll( relativeTo ) || isUnderDomainManagementAll( relativeTo ) ) {
 		return emailManagementAllSitesPrefix;
 	}
+
 	return emailManagementPrefix;
 }
 
-export function emailManagementAddGSuiteUsers( siteName, domainName, relativeTo = null ) {
-	let path;
-
+/**
+ * Retrieves the url of the Add New Users page either for G Suite or Google Workspace:
+ *
+ * https://wordpress.com/email/:domainName/google-workspace/add-users/:siteName
+ * https://wordpress.com/email/:domainName/gsuite/add-users/:siteName
+ * https://wordpress.com/email/google-workspace/add-users/:siteName
+ * https://wordpress.com/email/gsuite/add-users/:siteName
+ *
+ * @param {string} siteName - slug of the current site
+ * @param {string} domainName - domain name of the account to add users to
+ * @param {string} productType - type of account
+ * @param {string} relativeTo - optional path prefix
+ * @returns {string} the corresponding url
+ */
+export function emailManagementAddGSuiteUsers(
+	siteName,
+	domainName,
+	productType,
+	relativeTo = null
+) {
 	if ( domainName ) {
-		path = emailManagementEdit( siteName, domainName, 'gsuite/add-users', relativeTo );
-	} else {
-		path = '/email/gsuite/add-users/' + siteName;
+		return emailManagementEdit( siteName, domainName, productType + '/add-users', relativeTo );
 	}
 
-	return path;
-}
-
-export function emailManagementAddGSuiteUsersLegacy( siteName, domainName ) {
-	let path;
-
-	if ( domainName ) {
-		path = emailManagementEdit( siteName, domainName, 'add-gsuite-users' );
-	} else {
-		path = '/email/add-gsuite-users/' + siteName;
-	}
-
-	return path;
+	return '/email/' + productType + '/add-users/' + siteName;
 }
 
 export function emailManagementNewGSuiteAccount(
 	siteName,
 	domainName,
-	planType,
+	productType,
 	relativeTo = null
 ) {
-	return emailManagementEdit( siteName, domainName, 'gsuite/new/' + planType, relativeTo );
+	return emailManagementEdit( siteName, domainName, productType + '/new', relativeTo );
 }
 
 export function emailManagementManageTitanAccount(


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/51302 which updates urls from the `Add New Users` and `Upsell` pages to be able to correctly handle G Suite and Google Workspace accounts:

Add New Users | Upsell
------ | -----
![screenshot](https://user-images.githubusercontent.com/594356/112201891-06b83400-8c11-11eb-804a-43b011b2e6d2.png) | ![screenshot](https://user-images.githubusercontent.com/594356/112201989-2b141080-8c11-11eb-9270-8a8cda1b313e.png)

As a reminder, the `Add New Users` page is used when a user purchases extra licenses but also when they purchase a new account. If the user is purchasing additional licenses for an existing Google Workspace account, we shouldn't add a G Suite product to the shopping cart (and vice-versa). So the idea is to specify the type of product in the url itself to identify clearly the account. The change to the url of the `Upsell` page is just cosmetic though. Here are the former urls:

* http://calypso.localhost:3000/email/example.com/gsuite/new/basic/example.com
* http://calypso.localhost:3000/email/example.com/gsuite/new/starter/example.com
* http://calypso.localhost:3000/email/example.com/gsuite/add-users/example.com
* http://calypso.localhost:3000/domains/add/example.com/google-apps/example.com

The new urls are more descriptive and consistent:

* http://calypso.localhost:3000/email/example.com/gsuite/new/example.com
* http://calypso.localhost:3000/email/example.com/google-workspace/new/example.com
* http://calypso.localhost:3000/email/example.com/gsuite/add-users/example.com
* http://calypso.localhost:3000/email/example.com/google-workspace/add-users/example.com
* http://calypso.localhost:3000/domains/add/example.com/gsuite/example.com
* http://calypso.localhost:3000/domains/add/example.com/google-workspace/example.com

Finally, this pull request:

* Fixes a wrong title displayed when adding new users to a G Suite account
* Fixes all sites view lost when showing `Add New Users` page
* Removes unnecessary feature gates (and check the product slug instead)
* Removes legacy redirects introduced in https://github.com/Automattic/wp-calypso/pull/31703
* Removes legacy redirects introduced in https://github.com/Automattic/wp-calypso/pull/32189

Regarding the latter, my goal was to simplify our code. Moreover, those redirects have been around for at least two years now so it's probably more than time to remove them.

/cc @hacchism @sstabrizi as some Happiness Engineers may reference those urls in their predefined messages.

#### Testing instructions

You will have to add `?flags=-google-workspace-migration` to the url (and reload the page) to be able to purchase G Suite instead of Google Workspace. Here are some flows to check:

1. Purchase new domain with Google Workspace
2. Purchase new domain with G Suite
3. Add Google Workspace to an existing domain
4. Add G Suite to an existing domain
5. Add new users to an existing Google Workspace account
6. Add new users to an existing G Suite account
7. Perform steps #3 to #6 with a domain-only site

There is no need to perform the actual purchase though, just check that the right information is displayed in the checkout. You can also check with an account with more than one site that the sidebar doesn't change when accessing the `Add New Users` page (assuming the view was switched to `All My Sites`).
