### PR TITLE
Checkout: Convert free and full credits payment processors to use cart for transactions

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -464,8 +464,7 @@ export default function CompositeCheckout( {
 		() => ( {
 			'apple-pay': ( transactionData: unknown ) =>
 				applePayProcessor( transactionData, dataForProcessor, transactionOptions ),
-			'free-purchase': ( transactionData: unknown ) =>
-				freePurchaseProcessor( transactionData, dataForProcessor ),
+			'free-purchase': () => freePurchaseProcessor( dataForProcessor ),
 			card: ( transactionData: unknown ) =>
 				multiPartnerCardProcessor( transactionData, dataForProcessor, transactionOptions ),
 			alipay: ( transactionData: unknown ) =>
@@ -489,8 +488,7 @@ export default function CompositeCheckout( {
 				genericRedirectProcessor( 'eps', transactionData, dataForProcessor ),
 			'ebanx-tef': ( transactionData: unknown ) =>
 				genericRedirectProcessor( 'brazil-tef', transactionData, dataForProcessor ),
-			'full-credits': ( transactionData: unknown ) =>
-				fullCreditsProcessor( transactionData, dataForProcessor ),
+			'full-credits': () => fullCreditsProcessor( dataForProcessor ),
 			'existing-card': ( transactionData: unknown ) =>
 				existingCardProcessor(
 					mergeIfObjects( transactionData, {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -46,11 +46,8 @@ import filterAppropriatePaymentMethods from './lib/filter-appropriate-payment-me
 import useStoredCards from './hooks/use-stored-cards';
 import usePrepareProductsForCart from './hooks/use-prepare-products-for-cart';
 import useCreatePaymentMethods from './hooks/use-create-payment-methods';
-import {
-	applePayProcessor,
-	freePurchaseProcessor,
-	multiPartnerCardProcessor,
-} from './payment-method-processors';
+import { applePayProcessor, multiPartnerCardProcessor } from './payment-method-processors';
+import freePurchaseProcessor from './lib/free-purchase-processor';
 import fullCreditsProcessor from './lib/full-credits-processor';
 import weChatProcessor from './lib/we-chat-processor';
 import genericRedirectProcessor from './lib/generic-redirect-processor';

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -50,8 +50,8 @@ import {
 	applePayProcessor,
 	freePurchaseProcessor,
 	multiPartnerCardProcessor,
-	fullCreditsProcessor,
 } from './payment-method-processors';
+import fullCreditsProcessor from './lib/full-credits-processor';
 import weChatProcessor from './lib/we-chat-processor';
 import genericRedirectProcessor from './lib/generic-redirect-processor';
 import existingCardProcessor from './lib/existing-card-processor';
@@ -493,7 +493,7 @@ export default function CompositeCheckout( {
 			'ebanx-tef': ( transactionData: unknown ) =>
 				genericRedirectProcessor( 'brazil-tef', transactionData, dataForProcessor ),
 			'full-credits': ( transactionData: unknown ) =>
-				fullCreditsProcessor( transactionData, dataForProcessor, transactionOptions ),
+				fullCreditsProcessor( transactionData, dataForProcessor ),
 			'existing-card': ( transactionData: unknown ) =>
 				existingCardProcessor(
 					mergeIfObjects( transactionData, {

--- a/client/my-sites/checkout/composite-checkout/lib/free-purchase-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/free-purchase-processor.ts
@@ -10,38 +10,30 @@ import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
  */
 import getDomainDetails from './get-domain-details';
 import submitWpcomTransaction from './submit-wpcom-transaction';
-import { createTransactionEndpointRequestPayloadFromLineItems } from './translate-cart';
+import {
+	createTransactionEndpointRequestPayload,
+	createTransactionEndpointCartFromResponseCart,
+} from './translate-cart';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
-import type { WPCOMCartItem } from '../types/checkout-cart';
 import type {
-	TransactionRequestWithLineItems,
+	TransactionRequest,
 	WPCOMTransactionEndpointResponse,
 } from '../types/transaction-endpoint';
 
 const debug = debugFactory( 'calypso:composite-checkout:free-purchase-processor' );
 
-type FreePurchaseTransactionRequest = {
-	items: WPCOMCartItem[];
-};
-
 type SubmitFreePurchaseTransactionData = Omit<
-	TransactionRequestWithLineItems,
-	'paymentMethodType' | 'paymentPartnerProcessorId'
+	TransactionRequest,
+	'paymentMethodType' | 'paymentPartnerProcessorId' | 'cart'
 >;
 
 export default async function freePurchaseProcessor(
-	submitData: unknown,
 	transactionOptions: PaymentProcessorOptions
 ): Promise< PaymentProcessorResponse > {
-	if ( ! isValidTransactionData( submitData ) ) {
-		throw new Error( 'Required purchase data is missing' );
-	}
-
 	const { siteId, responseCart, includeDomainDetails, includeGSuiteDetails } = transactionOptions;
 
 	return submitFreePurchaseTransaction(
 		{
-			...submitData,
 			name: '',
 			couponId: responseCart.coupon,
 			siteId: siteId ? String( siteId ) : '',
@@ -59,20 +51,15 @@ async function submitFreePurchaseTransaction(
 	transactionOptions: PaymentProcessorOptions
 ): Promise< WPCOMTransactionEndpointResponse > {
 	debug( 'formatting free transaction', transactionData );
-	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
+	const formattedTransactionData = createTransactionEndpointRequestPayload( {
 		...transactionData,
+		cart: createTransactionEndpointCartFromResponseCart( {
+			siteId: transactionOptions.siteId ? String( transactionOptions.siteId ) : undefined,
+			contactDetails: transactionData.domainDetails ?? null,
+			responseCart: transactionOptions.responseCart,
+		} ),
 		paymentMethodType: 'WPCOM_Billing_WPCOM',
 	} );
 	debug( 'submitting free transaction', formattedTransactionData );
 	return submitWpcomTransaction( formattedTransactionData, transactionOptions );
-}
-
-function isValidTransactionData(
-	submitData: unknown
-): submitData is FreePurchaseTransactionRequest {
-	const data = submitData as FreePurchaseTransactionRequest;
-	if ( ! ( data?.items?.length > 0 ) ) {
-		throw new Error( 'Transaction requires items and none were provided' );
-	}
-	return true;
 }

--- a/client/my-sites/checkout/composite-checkout/lib/free-purchase-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/free-purchase-processor.ts
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+import { makeSuccessResponse } from '@automattic/composite-checkout';
+import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
+
+/**
+ * Internal dependencies
+ */
+import getDomainDetails from './get-domain-details';
+import submitWpcomTransaction from './submit-wpcom-transaction';
+import { createTransactionEndpointRequestPayloadFromLineItems } from './translate-cart';
+import type { PaymentProcessorOptions } from '../types/payment-processors';
+import type { WPCOMCartItem } from '../types/checkout-cart';
+import type {
+	TransactionRequestWithLineItems,
+	WPCOMTransactionEndpointResponse,
+} from '../types/transaction-endpoint';
+
+const debug = debugFactory( 'calypso:composite-checkout:free-purchase-processor' );
+
+type FreePurchaseTransactionRequest = {
+	items: WPCOMCartItem[];
+};
+
+type SubmitFreePurchaseTransactionData = Omit<
+	TransactionRequestWithLineItems,
+	'paymentMethodType' | 'paymentPartnerProcessorId'
+>;
+
+export default async function freePurchaseProcessor(
+	submitData: unknown,
+	transactionOptions: PaymentProcessorOptions
+): Promise< PaymentProcessorResponse > {
+	if ( ! isValidTransactionData( submitData ) ) {
+		throw new Error( 'Required purchase data is missing' );
+	}
+
+	const { siteId, responseCart, includeDomainDetails, includeGSuiteDetails } = transactionOptions;
+
+	return submitFreePurchaseTransaction(
+		{
+			...submitData,
+			name: '',
+			couponId: responseCart.coupon,
+			siteId: siteId ? String( siteId ) : '',
+			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+			// this data is intentionally empty so we do not charge taxes
+			country: '',
+			postalCode: '',
+		},
+		transactionOptions
+	).then( makeSuccessResponse );
+}
+
+async function submitFreePurchaseTransaction(
+	transactionData: SubmitFreePurchaseTransactionData,
+	transactionOptions: PaymentProcessorOptions
+): Promise< WPCOMTransactionEndpointResponse > {
+	debug( 'formatting free transaction', transactionData );
+	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
+		...transactionData,
+		paymentMethodType: 'WPCOM_Billing_WPCOM',
+	} );
+	debug( 'submitting free transaction', formattedTransactionData );
+	return submitWpcomTransaction( formattedTransactionData, transactionOptions );
+}
+
+function isValidTransactionData(
+	submitData: unknown
+): submitData is FreePurchaseTransactionRequest {
+	const data = submitData as FreePurchaseTransactionRequest;
+	if ( ! ( data?.items?.length > 0 ) ) {
+		throw new Error( 'Transaction requires items and none were provided' );
+	}
+	return true;
+}

--- a/client/my-sites/checkout/composite-checkout/lib/full-credits-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/full-credits-processor.ts
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+import { defaultRegistry, makeSuccessResponse } from '@automattic/composite-checkout';
+import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
+
+/**
+ * Internal dependencies
+ */
+import getPostalCode from './get-postal-code';
+import getDomainDetails from './get-domain-details';
+import submitWpcomTransaction from './submit-wpcom-transaction';
+import { createTransactionEndpointRequestPayloadFromLineItems } from './translate-cart';
+import type { PaymentProcessorOptions } from '../types/payment-processors';
+import type { WPCOMCartItem } from '../types/checkout-cart';
+import type { ManagedContactDetails } from '../types/wpcom-store-state';
+import type {
+	TransactionRequestWithLineItems,
+	WPCOMTransactionEndpointResponse,
+} from '../types/transaction-endpoint';
+
+const { select } = defaultRegistry;
+
+const debug = debugFactory( 'calypso:composite-checkout:full-credits-processor' );
+
+type FullCreditsTransactionRequest = {
+	items: WPCOMCartItem[];
+};
+
+type SubmitFullCreditsTransactionData = Omit<
+	TransactionRequestWithLineItems,
+	'paymentMethodType' | 'paymentPartnerProcessorId'
+>;
+
+export default async function fullCreditsProcessor(
+	submitData: unknown,
+	transactionOptions: PaymentProcessorOptions
+): Promise< PaymentProcessorResponse > {
+	if ( ! isValidTransactionData( submitData ) ) {
+		throw new Error( 'Required purchase data is missing' );
+	}
+
+	const { siteId, responseCart, includeDomainDetails, includeGSuiteDetails } = transactionOptions;
+
+	const managedContactDetails: ManagedContactDetails | undefined = select(
+		'wpcom'
+	)?.getContactInfo();
+
+	return submitCreditsTransaction(
+		{
+			...submitData,
+			name: '',
+			couponId: responseCart.coupon,
+			siteId: siteId ? String( siteId ) : '',
+			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+			country: managedContactDetails?.countryCode?.value ?? '',
+			postalCode: getPostalCode(),
+			subdivisionCode: managedContactDetails?.state?.value,
+		},
+		transactionOptions
+	).then( makeSuccessResponse );
+}
+
+async function submitCreditsTransaction(
+	transactionData: SubmitFullCreditsTransactionData,
+	transactionOptions: PaymentProcessorOptions
+): Promise< WPCOMTransactionEndpointResponse > {
+	debug( 'formatting full credits transaction', transactionData );
+	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
+		...transactionData,
+		paymentMethodType: 'WPCOM_Billing_WPCOM',
+	} );
+	debug( 'submitting full credits transaction', formattedTransactionData );
+	return submitWpcomTransaction( formattedTransactionData, transactionOptions );
+}
+
+function isValidTransactionData(
+	submitData: unknown
+): submitData is FullCreditsTransactionRequest {
+	const data = submitData as FullCreditsTransactionRequest;
+	if ( ! ( data?.items?.length > 0 ) ) {
+		throw new Error( 'Transaction requires items and none were provided' );
+	}
+	return true;
+}

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -54,16 +54,6 @@ export async function submitEbanxCardTransaction( transactionData, submit ) {
 	return submit( formattedTransactionData );
 }
 
-export function submitCreditsTransaction( transactionData, submit, transactionOptions ) {
-	debug( 'formatting full credits transaction', transactionData );
-	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
-		...transactionData,
-		paymentMethodType: 'WPCOM_Billing_WPCOM',
-	} );
-	debug( 'submitting full credits transaction', formattedTransactionData );
-	return submit( formattedTransactionData, transactionOptions );
-}
-
 export function submitFreePurchaseTransaction( transactionData, submit ) {
 	debug( 'formatting free transaction', transactionData );
 	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -54,16 +54,6 @@ export async function submitEbanxCardTransaction( transactionData, submit ) {
 	return submit( formattedTransactionData );
 }
 
-export function submitFreePurchaseTransaction( transactionData, submit ) {
-	debug( 'formatting free transaction', transactionData );
-	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
-		...transactionData,
-		paymentMethodType: 'WPCOM_Billing_WPCOM',
-	} );
-	debug( 'submitting free transaction', formattedTransactionData );
-	return submit( formattedTransactionData );
-}
-
 async function createAccountCallback( response ) {
 	// Set siteId from response
 	const siteIdFromResponse = response?.blog_details?.blogid;

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -17,7 +17,6 @@ import {
 	submitStripeCardTransaction,
 	submitEbanxCardTransaction,
 	submitFreePurchaseTransaction,
-	submitCreditsTransaction,
 } from './payment-method-helpers';
 import getPostalCode from './lib/get-postal-code';
 import getDomainDetails from './lib/get-domain-details';
@@ -142,25 +141,5 @@ export async function freePurchaseProcessor(
 			postalCode: null,
 		},
 		submitWpcomTransaction
-	).then( makeSuccessResponse );
-}
-
-export async function fullCreditsProcessor(
-	submitData,
-	{ includeDomainDetails, includeGSuiteDetails, responseCart },
-	transactionOptions
-) {
-	return submitCreditsTransaction(
-		{
-			...submitData,
-			couponId: responseCart.coupon,
-			siteId: select( 'wpcom' )?.getSiteId?.(),
-			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
-			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-			postalCode: submitData.postalCode || getPostalCode(),
-			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
-		},
-		submitWpcomTransaction,
-		transactionOptions
 	).then( makeSuccessResponse );
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -16,7 +16,6 @@ import {
 	submitApplePayPayment,
 	submitStripeCardTransaction,
 	submitEbanxCardTransaction,
-	submitFreePurchaseTransaction,
 } from './payment-method-helpers';
 import getPostalCode from './lib/get-postal-code';
 import getDomainDetails from './lib/get-domain-details';
@@ -124,22 +123,4 @@ export async function multiPartnerCardProcessor(
 		return ebanxCardProcessor( submitData, dataForProcessor );
 	}
 	throw new RangeError( 'Unrecognized card payment partner: "' + paymentPartner + '"' );
-}
-
-export async function freePurchaseProcessor(
-	submitData,
-	{ includeDomainDetails, includeGSuiteDetails, responseCart }
-) {
-	return submitFreePurchaseTransaction(
-		{
-			...submitData,
-			couponId: responseCart.coupon,
-			siteId: select( 'wpcom' )?.getSiteId?.(),
-			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
-			// this data is intentionally empty so we do not charge taxes
-			country: null,
-			postalCode: null,
-		},
-		submitWpcomTransaction
-	).then( makeSuccessResponse );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR converts the "Free" and "Full credits" payment processor functions to TypeScript and modifies them to use the shopping cart for creating the transaction request instead of the line items, since the line items were converted from the shopping cart in the first place.

Includes https://github.com/Automattic/wp-calypso/pull/51240 and will require a rebase when that is merged.

#### Testing instructions

- Add sufficient credits to your account to completely cover a purchase.
- Add a product to your cart and visit checkout.
- Choose the "credits" payment method and click to complete your purchase.
- Verify that the purchase was successful.

Then, free:

- Remove all credits from your account.
- Add a free product to your cart. The easiest way to do this is to have an unused domain credit on a plan and add a domain to your cart.
- Visit checkout, select the "free" payment method, and click to complete your purchase.
- Verify that the purchase was successful.