### PR TITLE
Checkout: Add wpcom-checkout to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,6 +67,7 @@
 /packages/composite-checkout/ @Automattic/shilling
 /packages/calypso-stripe/ @Automattic/shilling
 /packages/shopping-cart/ @Automattic/shilling
+/packages/wpcom-checkout/ @Automattic/shilling
 
 # Reader
 /client/reader @Automattic/reader


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the new `@automattic/wpcom-checkout` package to the CODEOWNERS file, owned by the Shilling team.

#### Testing instructions

None.