### PR TITLE
Checkout: Update dataForProcessor in PurchaseModal to include missing data

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
@@ -2,11 +2,12 @@
  * External dependencies
  */
 import React, { useState, useMemo } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { CheckoutProvider } from '@automattic/composite-checkout';
 import { useStripe } from '@automattic/calypso-stripe';
+import { useShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -18,6 +19,7 @@ import Placeholder from './placeholder';
 import useCreatePaymentCompleteCallback from 'calypso/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback';
 import existingCardProcessor from 'calypso/my-sites/checkout/composite-checkout/lib/existing-card-processor';
 import getContactDetailsType from 'calypso/my-sites/checkout/composite-checkout/lib/get-contact-details-type';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 /**
  * Style dependencies
@@ -59,20 +61,34 @@ export default function PurchaseModalWrapper( props ) {
 	} );
 	const { stripeConfiguration } = useStripe();
 	const reduxDispatch = useDispatch();
+	const { responseCart } = useShoppingCart();
+	const selectedSite = useSelector( getSelectedSite );
 
 	const contactDetailsType = getContactDetailsType( props.cart );
 	const includeDomainDetails = contactDetailsType === 'domain';
 	const includeGSuiteDetails = contactDetailsType === 'gsuite';
+	// NOTE: dataForProcessor must satisfy the PaymentProcessorOptions type
 	const dataForProcessor = useMemo(
 		() => ( {
+			createUserAndSiteBeforeTransaction: false,
+			getThankYouUrl: () => '/plans',
 			includeDomainDetails,
 			includeGSuiteDetails,
 			recordEvent: noop,
-			stripeConfiguration,
-			createUserAndSiteBeforeTransaction: false,
 			reduxDispatch,
+			responseCart,
+			siteSlug: selectedSite?.slug ?? '',
+			siteId: selectedSite?.ID ?? '',
+			stripeConfiguration,
 		} ),
-		[ includeDomainDetails, includeGSuiteDetails, stripeConfiguration, reduxDispatch ]
+		[
+			includeDomainDetails,
+			includeGSuiteDetails,
+			stripeConfiguration,
+			reduxDispatch,
+			selectedSite,
+			responseCart,
+		]
 	);
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Over time, more required options are being added to the `PaymentProcessorOptions` type that is used by checkout's payment processor functions. However, as these have been added, I have failed to update the creation of that object in the one-click upsell modal. This PR brings it up-to-date and adds a comment that will help find it in the future since that file is not TypeScript.

(This also adds `siteId` even though it's not going to be required until https://github.com/Automattic/wp-calypso/pull/51156)

Before:

<img width="429" alt="Screen Shot 2021-03-23 at 2 39 11 PM" src="https://user-images.githubusercontent.com/2036909/112200393-90520c80-8be5-11eb-984e-5df5d22d859a.png">

After:

<img width="398" alt="Screen Shot 2021-03-23 at 2 39 56 PM" src="https://user-images.githubusercontent.com/2036909/112200487-a9f35400-8be5-11eb-822b-a564f6b17ea9.png">


#### Testing instructions

Complete a one-click upsell purchase and verify that it works and that no errors occur. 

To do this you'll need a Personal or Premium plan already purchased, and you'll need to have at least one stored card, then visit `/checkout/offer-quickstart-session/1234/example.com` where `example.com` is your site (the number is a receipt ID but doesn't really matter).

Click "Yes, I want a WordPress Expert by my side!" then click the "Pay" button in the modal.