### PR TITLE
Disable the hosting settings for sites not on a supported plan.

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -209,7 +209,8 @@ export default connect(
 		return {
 			transferState: getAutomatedTransferStatus( state, siteId ),
 			isTransferring: isAutomatedTransferActive( state, siteId ),
-			isDisabled: ! isSiteAutomatedTransfer( state, siteId ),
+			isDisabled:
+				! isSiteOnAtomicPlan( state, siteId ) || ! isSiteAutomatedTransfer( state, siteId ),
 			isOnAtomicPlan: isSiteOnAtomicPlan( state, siteId ),
 			canViewAtomicHosting: canSiteViewAtomicHosting( state ),
 			siteSlug: getSelectedSiteSlug( state ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the render of the Hosting Settings view to not display if the site is on an unsupported plan. 

Before this change, the isDisabled flag was incorrectly assuming that all sites that are not Automated Transfer were eligible. It should be checked against the specific plans Ecommerce and Business. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to Settings -> Hosting Configuration on a sites with each plan level. 

To test this on a "Free" Atomic site, you can upgrade to business and then remove the subscription. This should put the site into a "Free" mode until its reverted. 

Note that currently the Banner is treating this as Jetpack, and will need to be fixed on its own in a separate PR. 

![image](https://user-images.githubusercontent.com/7129409/112200347-86c8a480-8be5-11eb-9004-a290a2838930.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #51351 
