### PR TITLE
Upsell nudge: don't show Jetpack logo for Atomic sites.

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -47,6 +47,7 @@ export const UpsellNudge = ( {
 	isJetpackDevDocs,
 	isJetpack,
 	isAtomic,
+	isStandaloneJetpack,
 	isVip,
 	siteIsWPForTeams,
 	list,
@@ -129,7 +130,7 @@ export const UpsellNudge = ( {
 			horizontal={ horizontal }
 			href={ href }
 			icon="star"
-			jetpack={ isJetpack || isJetpackDevDocs } //Force show Jetpack example in Devdocs
+			jetpack={ isStandaloneJetpack || isJetpackDevDocs } //Force show Jetpack example in Devdocs
 			isAtomic={ isAtomic }
 			list={ list }
 			onClick={ onClick }
@@ -157,12 +158,15 @@ UpsellNudge.defaultProps = {
 export default connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
 
+	const isJetpack = isJetpackSite( state, siteId );
+	const isAtomic = isSiteAutomatedTransfer( state, siteId );
 	return {
 		site: getSite( state, siteId ),
 		planHasFeature: hasFeature( state, siteId, ownProps.feature ),
 		canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
-		isJetpack: isJetpackSite( state, siteId ),
-		isAtomic: isSiteAutomatedTransfer( state, siteId ),
+		isJetpack,
+		isAtomic,
+		isStandaloneJetpack: isJetpack && ! isAtomic,
 		isVip: isVipSite( state, siteId ),
 		siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
 		canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Pairs well with #51339 

There will be Free sites on Atomic shortly, and so not all Jetpack sites deserve a Jetpack logo. 

This PR is an attempt at not showing the Jetpack logo when it's not appropriate, i.e. on a Free Atomic site. 

Honestly, considering how complicated this is: 
```
const shouldNotDisplay =
		isVip ||
		! canManageSite ||
		! site ||
		typeof site !== 'object' ||
		typeof site.jetpack !== 'boolean' ||
		( feature && planHasFeature ) ||
		( ! feature && ! isFreePlan( site.plan ) ) ||
		( feature === FEATURE_NO_ADS && site.options.wordads ) ||
		( ! jetpack && site.jetpack ) ||
		( jetpack && ! site.jetpack );
```

I'm fairly confident that this PR is missing some cases...

![image](https://user-images.githubusercontent.com/7129409/112206113-f17cde80-8beb-11eb-9747-b80c693cebae.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Get a "Free" Atomic site by removing the Business plan on an already-Atomic Business site. 
- Ensure no Jetpack logo shows when not expected. 
- Are there any places that we want to show a Jetpack logo to wpcom/Atomic sites? I'm honestly not sure.  

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #51339 and #51584
