### PR TITLE
Remove code that makes the alternative email optional for Titan/Email

### DIFF
--- a/client/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox-list.jsx
+++ b/client/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox-list.jsx
@@ -26,11 +26,8 @@ const TitanNewMailboxList = ( {
 	mailboxes,
 	onMailboxesChange,
 	onReturnKeyPress = noop,
-	showAlternativeEmail = false,
 } ) => {
 	const translate = useTranslate();
-
-	const optionalMailboxFields = showAlternativeEmail ? [] : [ 'alternativeEmail' ];
 
 	const onMailboxValueChange = ( uuid ) => ( fieldName, fieldValue, mailboxFieldTouched ) => {
 		const updatedMailboxes = mailboxes.map( ( mailbox ) => {
@@ -50,7 +47,7 @@ const TitanNewMailboxList = ( {
 			return updatedMailbox;
 		} );
 
-		onMailboxesChange( validateMailboxes( updatedMailboxes, optionalMailboxFields ) );
+		onMailboxesChange( validateMailboxes( updatedMailboxes ) );
 	};
 
 	const onMailboxAdd = () => {
@@ -77,7 +74,6 @@ const TitanNewMailboxList = ( {
 					onMailboxValueChange={ onMailboxValueChange( mailbox.uuid ) }
 					mailbox={ mailbox }
 					onReturnKeyPress={ onReturnKeyPress }
-					showAlternativeEmail={ showAlternativeEmail }
 				/>
 			) ) }
 
@@ -99,7 +95,6 @@ TitanNewMailboxList.propTypes = {
 	mailboxes: PropTypes.arrayOf( getMailboxPropTypeShape() ).isRequired,
 	onMailboxesChange: PropTypes.func.isRequired,
 	onReturnKeyPress: PropTypes.func,
-	showAlternativeEmail: PropTypes.bool,
 };
 
 export default TitanNewMailboxList;

--- a/client/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox.jsx
+++ b/client/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox.jsx
@@ -33,7 +33,6 @@ const TitanNewMailbox = ( {
 		name: { value: name, error: nameError },
 		password: { value: password, error: passwordError },
 	},
-	showAlternativeEmail = false,
 } ) => {
 	const translate = useTranslate();
 
@@ -152,30 +151,28 @@ const TitanNewMailbox = ( {
 					) }
 				</div>
 
-				{ showAlternativeEmail && (
-					<FormFieldset>
-						<FormLabel>
-							{ translate( 'Password reset email address', {
-								comment: 'This is the email address we will send password reset emails to',
-							} ) }
-							<FormTextInput
-								placeholder={ translate( 'Email address' ) }
-								value={ alternativeEmail }
-								isError={ hasAlternativeEmailError }
-								onChange={ ( event ) => {
-									onMailboxValueChange( 'alternativeEmail', event.target.value );
-								} }
-								onBlur={ () => {
-									setAlternativeEmailFieldTouched( hasBeenValidated );
-								} }
-								onKeyUp={ onReturnKeyPress }
-							/>
-						</FormLabel>
-						{ hasAlternativeEmailError && (
-							<FormInputValidation text={ alternativeEmailError } isError />
-						) }
-					</FormFieldset>
-				) }
+				<FormFieldset>
+					<FormLabel>
+						{ translate( 'Password reset email address', {
+							comment: 'This is the email address we will send password reset emails to',
+						} ) }
+						<FormTextInput
+							placeholder={ translate( 'Email address' ) }
+							value={ alternativeEmail }
+							isError={ hasAlternativeEmailError }
+							onChange={ ( event ) => {
+								onMailboxValueChange( 'alternativeEmail', event.target.value );
+							} }
+							onBlur={ () => {
+								setAlternativeEmailFieldTouched( hasBeenValidated );
+							} }
+							onKeyUp={ onReturnKeyPress }
+						/>
+					</FormLabel>
+					{ hasAlternativeEmailError && (
+						<FormInputValidation text={ alternativeEmailError } isError />
+					) }
+				</FormFieldset>
 			</div>
 			<hr className="titan-mail-add-mailboxes__new-mailbox-separator" />
 		</>
@@ -187,7 +184,6 @@ TitanNewMailbox.propTypes = {
 	onMailboxValueChange: PropTypes.func.isRequired,
 	onReturnKeyPress: PropTypes.func.isRequired,
 	mailbox: getMailboxPropTypeShape(),
-	showAlternativeEmail: PropTypes.bool,
 };
 
 export default TitanNewMailbox;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes the code and flags that hid the alternative email field for Email and made the field optional in #51217
* This change was made possible by D59043-code getting deployed earlier today

#### Screenshot

<img width="777" alt="Mailbox creation form with password reset email" src="https://user-images.githubusercontent.com/3376401/112210504-70d9d480-8c23-11eb-9f2a-2f0b0b3c6144.png">

#### Testing instructions

* Navigate to the [live branch](https://calypso.live/?branch=fix/display-alternative-email-for-titan).
* For a domain you own (or purchase new), try to add Email to the domain if you don't have it already.
* When you see the page to specify the number of mailboxes, add the following to the end of the URL and hit Enter: `?flags=titan/provision-mailboxes`.
* Verify that the page renders a form with mailbox-related fields including the "Password reset email address" field.
* Ensure that the validation logic requires this field and checks that it's a valid email address.
* Open your browser console, go to the Network tab, and ensure that "Preserve log" (or its equivalent) is enabled.
* Click on the Continue button, and verify that the `alternative_email` is included in the `extra` data in the shopping cart.
* If you _really_ want to test the downstream flow, finish checkout and confirm that the email account is fully provisioned with Titan. (You should be able to check that from the Titan Control Panel for that domain.)

Related to #51217 