### PR TITLE
P2 Signup: fix the 'A' error

### DIFF
--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -37,6 +37,7 @@ const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500;
 const ERROR_CODE_MISSING_SITE_TITLE = 123; // Random number, we don't need it.
 const ERROR_CODE_MISSING_SITE = 321; // Random number, we don't need it.
 const ERROR_CODE_TAKEN_SITE = 1337; // Random number, we don't need it.
+const ERROR_CODE_FROM_LOCAL_STORAGE = 7331; // Random number, we don't need it.
 
 const SITE_TAKEN_ERROR_CODES = [
 	'blog_name_exists',
@@ -65,10 +66,16 @@ class P2Site extends React.Component {
 			initialState = props.step.form;
 
 			if ( ! isEmpty( props.step.errors ) ) {
+				const errorMessage = props.step.errors[ 0 ].message;
+
+				this.logValidationErrorToLogstash( ERROR_CODE_FROM_LOCAL_STORAGE, errorMessage );
+
 				initialState = formState.setFieldErrors(
 					formState.setFieldsValidating( initialState ),
 					{
-						site: props.step.errors[ 0 ].message,
+						site: {
+							[ ERROR_CODE_FROM_LOCAL_STORAGE ]: errorMessage,
+						},
 					},
 					true
 				);


### PR DESCRIPTION
In this PR, we fix the rare, but persistent 'A' error in the P2 signup (https://wordpress.com/start/p2). There's been a lot of digging and discussions from @unDemian, @lezama, @akirk and me but it boils down to assigning an inconsistent `errors` object to the Form Controller. Normally, we assign an object like the following (ie when getting validation error from the API):

```
messages.site = {
    [ error.error ]: error.message,
};
```
where `error.error` is an int or string (error code) and `error.message` the error in a string. However, in the constructor of the `P2Site` component, if there's a stored error message (e.g. when a user tried the signup flow before but didn't finish and then tried again) we assign the error object like this:
```
{
    site: props.step.errors[ 0 ].message,
}
```

As you can see, `site` is now just a string, not an object comprised of the error code and the error message.

When that variable is ran through the error displaying functions, it gets mapped (for potentially multiple errors) which produces the strange 'A' error (or 'S') as it's the first letter of the error message string.

## Testing instructions

Make sure the P2 signup flow still works. It's hard to reproduce the error state otherwise.

/cc @amamujee 