### PR TITLE
Add Jetpack Review Prompt Preference

### DIFF
--- a/client/state/jetpack-review-prompt/actions.ts
+++ b/client/state/jetpack-review-prompt/actions.ts
@@ -2,16 +2,24 @@
  * Internal dependencies
  */
 import { savePreference } from 'calypso/state/preferences/actions';
-import PREFERENCE_NAME from './constants';
+import { PREFERENCE_NAME, PreferenceType } from './constants';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const dismissReviewPrompt = () => {
-	return savePreference( PREFERENCE_NAME, Date.now() );
+const dismiss = ( previousCount: number ) => {
+	return savePreference( PREFERENCE_NAME, {
+		dismissedAt: Date.now(),
+		dismissCount: previousCount + 1,
+		reviewed: false,
+	} as PreferenceType );
 };
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const dismissReviewPromptPermanently = () => {
-	return savePreference( PREFERENCE_NAME, 'permanent' );
+const dismissAsReviewed = ( previousCount: number ) => {
+	return savePreference( PREFERENCE_NAME, {
+		dismissedAt: Date.now(),
+		dismissCount: previousCount,
+		reviewed: true,
+	} as PreferenceType );
 };
 
-export { dismissReviewPrompt, dismissReviewPromptPermanently };
+export { dismiss, dismissAsReviewed };

--- a/client/state/jetpack-review-prompt/actions.ts
+++ b/client/state/jetpack-review-prompt/actions.ts
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import { savePreference } from 'calypso/state/preferences/actions';
+import PREFERENCE_NAME from './constants';
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const dismissReviewPrompt = () => {
+	return savePreference( PREFERENCE_NAME, Date.now() );
+};
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const dismissReviewPromptPermanently = () => {
+	return savePreference( PREFERENCE_NAME, 'permanent' );
+};
+
+export { dismissReviewPrompt, dismissReviewPromptPermanently };

--- a/client/state/jetpack-review-prompt/constants.ts
+++ b/client/state/jetpack-review-prompt/constants.ts
@@ -1,0 +1,3 @@
+const PREFERENCE_NAME = 'jetpack-review-prompt-dismiss';
+
+export default PREFERENCE_NAME;

--- a/client/state/jetpack-review-prompt/constants.ts
+++ b/client/state/jetpack-review-prompt/constants.ts
@@ -13,5 +13,6 @@ export const emptyPreference: PreferenceType = {
 };
 
 const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
+
 export const TIME_BETWEEN_PROMPTS = 2 * WEEK_IN_MS;
 export const MAX_DISMISS_COUNT = 2;

--- a/client/state/jetpack-review-prompt/constants.ts
+++ b/client/state/jetpack-review-prompt/constants.ts
@@ -1,3 +1,17 @@
-const PREFERENCE_NAME = 'jetpack-review-prompt-dismiss';
+export const PREFERENCE_NAME = 'jetpack-review-prompt';
 
-export default PREFERENCE_NAME;
+export interface PreferenceType {
+	dismissCount: number;
+	dismissedAt: number | null;
+	reviewed: boolean;
+}
+
+export const emptyPreference: PreferenceType = {
+	dismissCount: 0,
+	dismissedAt: null,
+	reviewed: false,
+};
+
+const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
+export const TIME_BETWEEN_PROMPTS = 2 * WEEK_IN_MS;
+export const MAX_DISMISS_COUNT = 2;

--- a/client/state/jetpack-review-prompt/selectors.ts
+++ b/client/state/jetpack-review-prompt/selectors.ts
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import { getPreference } from 'calypso/state/preferences/selectors';
+import PREFERENCE_NAME from './constants';
+
+/**
+ * Type dependencies
+ */
+import type { AppState } from 'calypso/types';
+
+const TWO_WEEKS_IN_MS = 1000 * 60 * 60 * 24 * 7 * 2;
+
+const getIsDismissed = ( state: AppState ): boolean => {
+	const prefValue = getPreference( state, PREFERENCE_NAME ) as number | 'permanent' | null;
+	if ( null === prefValue ) {
+		return false;
+	}
+	return 'number' === typeof prefValue ? Date.now() - prefValue < TWO_WEEKS_IN_MS : true;
+};
+
+const getHasBeenDismissedOnce = ( state: AppState ): boolean => {
+	const prefValue = getPreference( state, PREFERENCE_NAME ) as number | 'permanent' | null;
+	return null !== prefValue;
+};
+
+export { getIsDismissed, getHasBeenDismissedOnce };

--- a/client/state/jetpack-review-prompt/selectors.ts
+++ b/client/state/jetpack-review-prompt/selectors.ts
@@ -25,11 +25,11 @@ const getIsDismissed = ( state: AppState ): boolean => {
 	const { dismissCount, dismissedAt, reviewed } =
 		( getPreference( state, PREFERENCE_NAME ) as PreferenceType ) || emptyPreference;
 
-	if ( reviewed || MAX_DISMISS_COUNT >= dismissCount ) {
+	if ( reviewed || MAX_DISMISS_COUNT <= dismissCount ) {
 		return true;
 	}
 	return dismissCount > 0 && dismissedAt !== null
-		? Date.now() - dismissedAt > TIME_BETWEEN_PROMPTS
+		? Date.now() - dismissedAt < TIME_BETWEEN_PROMPTS
 		: false;
 };
 

--- a/client/state/jetpack-review-prompt/test/selectors.ts
+++ b/client/state/jetpack-review-prompt/test/selectors.ts
@@ -6,7 +6,8 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { getDismissCount } from '../selectors';
+import { getDismissCount, getIsDismissed } from '../selectors';
+import { TIME_BETWEEN_PROMPTS } from '../constants';
 
 describe( 'selectors', () => {
 	describe( 'getDismissCount()', () => {
@@ -27,6 +28,69 @@ describe( 'selectors', () => {
 				},
 			};
 			expect( getDismissCount( state ) ).to.equal( 3 );
+		} );
+	} );
+
+	describe( 'getIsDismissed()', () => {
+		test( 'should return false if no preference saved', () => {
+			const state = { preferences: {} };
+			expect( getIsDismissed( state ) ).to.be.false;
+		} );
+		test( 'should return true if reviewed', () => {
+			const state = {
+				preferences: {
+					localValues: {
+						'jetpack-review-prompt': {
+							dismissCount: 1,
+							dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+							reviewed: true,
+						},
+					},
+				},
+			};
+			expect( getIsDismissed( state ) ).to.be.true;
+		} );
+		test( 'should return false if dismissed just now', () => {
+			const state = {
+				preferences: {
+					localValues: {
+						'jetpack-review-prompt': {
+							dismissCount: 1,
+							dismissedAt: Date.now(),
+							reviewed: false,
+						},
+					},
+				},
+			};
+			expect( getIsDismissed( state ) ).to.be.true;
+		} );
+		test( 'should return true if dismissed longer than TIME_BETWEEN_PROMPTS', () => {
+			const state = {
+				preferences: {
+					localValues: {
+						'jetpack-review-prompt': {
+							dismissCount: 1,
+							dismissedAt: Date.now() - ( TIME_BETWEEN_PROMPTS + 1 ),
+							reviewed: false,
+						},
+					},
+				},
+			};
+			expect( getIsDismissed( state ) ).to.be.false;
+		} );
+		test( 'should return true if dismissed twice', () => {
+			const state = {
+				preferences: {
+					localValues: {
+						'jetpack-review-prompt': {
+							dismissCount: 2,
+							dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+							reviewed: false,
+						},
+					},
+				},
+			};
+			expect( getIsDismissed( state ) ).to.be.true;
 		} );
 	} );
 } );

--- a/client/state/jetpack-review-prompt/test/selectors.ts
+++ b/client/state/jetpack-review-prompt/test/selectors.ts
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getDismissCount } from '../selectors';
+
+describe( 'selectors', () => {
+	describe( 'getDismissCount()', () => {
+		test( 'should return zero if no preference saved', () => {
+			const state = { preferences: {} };
+			expect( getDismissCount( state ) ).to.equal( 0 );
+		} );
+		test( 'should return count if preference is saved', () => {
+			const state = {
+				preferences: {
+					localValues: {
+						'jetpack-review-prompt': {
+							dismissCount: 3,
+							dismissedAt: null,
+							reviewed: false,
+						},
+					},
+				},
+			};
+			expect( getDismissCount( state ) ).to.equal( 3 );
+		} );
+	} );
+} );

--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -86,5 +86,14 @@ export const remoteValuesSchema = {
 				},
 			},
 		},
+		'jetpack-review-prompt': {
+			type: 'object',
+			properties: {
+				dismissedAt: { type: [ 'number', 'null' ] },
+				dismissedCount: { type: 'number', minimum: 0 },
+				reviewed: { type: 'number' },
+			},
+			required: [ 'dismissedAt', 'dismissedCount', 'reviewed' ],
+		},
 	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add selectors and actions for showing and dismissing Jetpack Review Prompts
* **Selectors** ( `client/state/jetpack-review-prompt/selectors.ts` )
   * `getDismissCount` will return the number o time the prompt has been dismissed
   * `getIsDismissed` will return if the prompt is currently dismissed, taking into account how many dismisses, the time since the last dismiss, etc.
* **Actions** ( `client/state/jetpack-review-prompt/actions.ts` )
   * `dismissAsReviewed()` will permanently dismiss the review prompt 
   * `dimiss()` will dismiss the review prompt for 2 weeks ( an arbitrary amount  of time ). It should be called with the result of the `getDismissCount()` selector to correctly update the dismiss count

#### Testing instructions

* run `yarn test-client state/jetpack-review-prompt` and verify all new tests pass

