### PR TITLE
Checkout: render additional terms of service if included in the cart response

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { TermsOfServiceRecord, useShoppingCart } from '@automattic/shopping-cart';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'calypso/components/gridicon';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+const debug = debugFactory( 'calypso:composite-checkout:additional-terms-of-service' );
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+export default function AdditionalTermsOfServiceInCart(): JSX.Element | null {
+	const translate = useTranslate();
+	const { responseCart } = useShoppingCart();
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	if ( responseCart.terms_of_service.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<>
+			{ responseCart.terms_of_service.map( ( termsOfServiceRecord ) => {
+				const message = getMessageForTermsOfServiceRecord(
+					termsOfServiceRecord,
+					translate,
+					siteSlug
+				);
+
+				if ( ! message ) {
+					return null;
+				}
+
+				return (
+					<div className="checkout__titan-terms-of-service">
+						<Gridicon icon="info-outline" size={ 18 } />
+						<p>{ message }</p>
+					</div>
+				);
+			} ) }
+		</>
+	);
+}
+
+function getMessageForTermsOfServiceRecord(
+	termsOfServiceRecord: TermsOfServiceRecord,
+	translate: ReturnType< typeof useTranslate >,
+	siteSlug: string | null
+): TranslateResult {
+	switch ( termsOfServiceRecord.code ) {
+		case 'terms_for_bundled_trial_auto_renewal_paypal':
+			return translate(
+				'At the end of the promotional period we will begin charging your PayPal account (%(email)s) the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}',
+				{
+					args: {
+						email: termsOfServiceRecord.args?.email,
+						productName: termsOfServiceRecord.args?.product_name,
+						renewalPrice: termsOfServiceRecord.args?.renewal_price,
+					},
+					components: {
+						link: (
+							<a
+								href={ `/purchases/subscriptions/${ siteSlug }` }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+				}
+			);
+		case 'terms_for_bundled_trial_auto_renewal_credit_card':
+			return translate(
+				'At the end of the promotional period we will begin charging your %(cardType)s card ending in %(cardLast4)s the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}',
+				{
+					args: {
+						cardType: termsOfServiceRecord.args?.card_type,
+						cardLast4: termsOfServiceRecord.args?.card_last_4,
+						productName: termsOfServiceRecord.args?.product_name,
+						renewalPrice: termsOfServiceRecord.args?.renewal_price,
+					},
+					components: {
+						link: (
+							<a
+								href={ `/purchases/subscriptions/${ siteSlug }` }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+				}
+			);
+		default:
+			debug(
+				`Unknown terms of service code: ${ termsOfServiceRecord.code }`,
+				termsOfServiceRecord
+			);
+			return '';
+	}
+}

--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -59,8 +59,16 @@ function getMessageForTermsOfServiceRecord(
 	locale: string,
 	siteSlug: string | null
 ): TranslateResult {
+	const { args = {} } = termsOfServiceRecord;
 	switch ( termsOfServiceRecord.code ) {
 		case 'terms_for_bundled_trial_auto_renewal_paypal':
+			if ( ! args.email || ! args.product_name || ! args.renewal_price ) {
+				debug(
+					`Malformed terms of service args with code: ${ termsOfServiceRecord.code }`,
+					termsOfServiceRecord
+				);
+				return '';
+			}
 			if (
 				locale !== 'en' &&
 				! i18nCalypso.hasTranslation(
@@ -73,9 +81,9 @@ function getMessageForTermsOfServiceRecord(
 				'At the end of the promotional period we will begin charging your PayPal account (%(email)s) the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}',
 				{
 					args: {
-						email: termsOfServiceRecord.args?.email,
-						productName: termsOfServiceRecord.args?.product_name,
-						renewalPrice: termsOfServiceRecord.args?.renewal_price,
+						email: args.email,
+						productName: args.product_name,
+						renewalPrice: args.renewal_price,
 					},
 					components: {
 						link: (
@@ -89,6 +97,13 @@ function getMessageForTermsOfServiceRecord(
 				}
 			);
 		case 'terms_for_bundled_trial_auto_renewal_credit_card':
+			if ( ! args.card_type || ! args.card_last_4 || ! args.product_name || ! args.renewal_price ) {
+				debug(
+					`Malformed terms of service args with code: ${ termsOfServiceRecord.code }`,
+					termsOfServiceRecord
+				);
+				return '';
+			}
 			if (
 				locale !== 'en' &&
 				! i18nCalypso.hasTranslation(
@@ -101,10 +116,10 @@ function getMessageForTermsOfServiceRecord(
 				'At the end of the promotional period we will begin charging your %(cardType)s card ending in %(cardLast4)s the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}',
 				{
 					args: {
-						cardType: termsOfServiceRecord.args?.card_type,
-						cardLast4: termsOfServiceRecord.args?.card_last_4,
-						productName: termsOfServiceRecord.args?.product_name,
-						renewalPrice: termsOfServiceRecord.args?.renewal_price,
+						cardType: args.card_type,
+						cardLast4: args.card_last_4,
+						productName: args.product_name,
+						renewalPrice: args.renewal_price,
 					},
 					components: {
 						link: (

--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -22,7 +22,7 @@ export default function AdditionalTermsOfServiceInCart(): JSX.Element | null {
 	const { responseCart } = useShoppingCart();
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
-	if ( responseCart.terms_of_service.length === 0 ) {
+	if ( ! responseCart.terms_of_service || responseCart.terms_of_service.length === 0 ) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -3,7 +3,8 @@
  */
 import React from 'react';
 import { TermsOfServiceRecord, useShoppingCart } from '@automattic/shopping-cart';
-import { useTranslate, TranslateResult } from 'i18n-calypso';
+import i18nCalypso, { useTranslate, TranslateResult } from 'i18n-calypso';
+import { useLocale } from '@automattic/i18n-utils';
 import { useSelector } from 'react-redux';
 import debugFactory from 'debug';
 
@@ -19,6 +20,7 @@ const debug = debugFactory( 'calypso:composite-checkout:additional-terms-of-serv
 
 export default function AdditionalTermsOfServiceInCart(): JSX.Element | null {
 	const translate = useTranslate();
+	const locale = useLocale();
 	const { responseCart } = useShoppingCart();
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
@@ -28,10 +30,11 @@ export default function AdditionalTermsOfServiceInCart(): JSX.Element | null {
 
 	return (
 		<>
-			{ responseCart.terms_of_service.map( ( termsOfServiceRecord ) => {
+			{ responseCart.terms_of_service.map( ( termsOfServiceRecord, index ) => {
 				const message = getMessageForTermsOfServiceRecord(
 					termsOfServiceRecord,
 					translate,
+					locale,
 					siteSlug
 				);
 
@@ -40,7 +43,7 @@ export default function AdditionalTermsOfServiceInCart(): JSX.Element | null {
 				}
 
 				return (
-					<div className="checkout__titan-terms-of-service">
+					<div className="checkout__titan-terms-of-service" key={ index }>
 						<Gridicon icon="info-outline" size={ 18 } />
 						<p>{ message }</p>
 					</div>
@@ -53,10 +56,19 @@ export default function AdditionalTermsOfServiceInCart(): JSX.Element | null {
 function getMessageForTermsOfServiceRecord(
 	termsOfServiceRecord: TermsOfServiceRecord,
 	translate: ReturnType< typeof useTranslate >,
+	locale: string,
 	siteSlug: string | null
 ): TranslateResult {
 	switch ( termsOfServiceRecord.code ) {
 		case 'terms_for_bundled_trial_auto_renewal_paypal':
+			if (
+				locale !== 'en' &&
+				! i18nCalypso.hasTranslation(
+					'At the end of the promotional period we will begin charging your PayPal account (%(email)s) the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}'
+				)
+			) {
+				return '';
+			}
 			return translate(
 				'At the end of the promotional period we will begin charging your PayPal account (%(email)s) the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}',
 				{
@@ -77,6 +89,14 @@ function getMessageForTermsOfServiceRecord(
 				}
 			);
 		case 'terms_for_bundled_trial_auto_renewal_credit_card':
+			if (
+				locale !== 'en' &&
+				! i18nCalypso.hasTranslation(
+					'At the end of the promotional period we will begin charging your %(cardType)s card ending in %(cardLast4)s the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}'
+				)
+			) {
+				return '';
+			}
 			return translate(
 				'At the end of the promotional period we will begin charging your %(cardType)s card ending in %(cardLast4)s the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}',
 				{

--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -30,7 +30,7 @@ export default function AdditionalTermsOfServiceInCart(): JSX.Element | null {
 
 	return (
 		<>
-			{ responseCart.terms_of_service.map( ( termsOfServiceRecord, index ) => {
+			{ responseCart.terms_of_service.map( ( termsOfServiceRecord ) => {
 				const message = getMessageForTermsOfServiceRecord(
 					termsOfServiceRecord,
 					translate,
@@ -43,7 +43,7 @@ export default function AdditionalTermsOfServiceInCart(): JSX.Element | null {
 				}
 
 				return (
-					<div className="checkout__titan-terms-of-service" key={ index }>
+					<div className="checkout__titan-terms-of-service" key={ termsOfServiceRecord.key }>
 						<Gridicon icon="info-outline" size={ 18 } />
 						<p>{ message }</p>
 					</div>

--- a/client/my-sites/checkout/composite-checkout/components/checkout-terms.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-terms.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { hasRenewableSubscription } from 'calypso/lib/cart-values/cart-items';
+import AdditionalTermsOfServiceInCart from './additional-terms-of-service-in-cart';
 import TermsOfService from './terms-of-service';
 import DomainRefundPolicy from './domain-refund-policy';
 import DomainRegistrationAgreement from './domain-registration-agreement';
@@ -38,6 +39,7 @@ class CheckoutTerms extends React.Component {
 				<ConciergeRefundPolicy cart={ cart } />
 				<BundledDomainNotice cart={ cart } />
 				<TitanTermsOfService cart={ cart } />
+				<AdditionalTermsOfServiceInCart />
 			</Fragment>
 		);
 	}

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -90,7 +90,7 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	cart_generated_at_timestamp: number;
 	tax: ResponseCartTaxData;
 	next_domain_is_free: boolean;
-	terms_of_service: TermsOfServiceRecord[];
+	terms_of_service?: TermsOfServiceRecord[];
 }
 
 export interface ResponseCartTaxData {

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -243,6 +243,7 @@ export type FrDomainContactExtraDetails = {
 };
 
 export interface TermsOfServiceRecord {
+	key: string;
 	code: string;
 	args?: Record< string, string >;
 }

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -90,6 +90,7 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	cart_generated_at_timestamp: number;
 	tax: ResponseCartTaxData;
 	next_domain_is_free: boolean;
+	terms_of_service: TermsOfServiceRecord[];
 }
 
 export interface ResponseCartTaxData {
@@ -240,3 +241,8 @@ export type FrDomainContactExtraDetails = {
 	trademarkNumber?: string;
 	sirenSiret?: string;
 };
+
+export interface TermsOfServiceRecord {
+	code: string;
+	args?: Record< string, string >;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Requires D59082-code
* If the shopping cart response includes elements in the `terms_of_service` array, then they will be rendered in the ToS section of checkout.
* In this PR, a message including the renewal cost and payment method that will be used for auto renewing is included.

PayPal
![image](https://user-images.githubusercontent.com/15204776/112233307-d3b97480-8bff-11eb-8f16-fbfeaf05b6d3.png)

Credit Card
![image](https://user-images.githubusercontent.com/15204776/112233498-2b57e000-8c00-11eb-95af-1d7f66e76e70.png)

#### Testing instructions

* Follow the instructions from D59082-code to setup the backend response
* Verify that the UI renders as displayed in the images
* Verify that you can continue and complete the purchase