### PR TITLE
Gutenboarding: Update mShots url for design step to include use_screenshot_overrides param

### DIFF
--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -40,6 +40,7 @@ export const getDesignUrl = ( design: Design, locale: string ): string => {
 			site_title: design.title,
 			viewport_height: 700,
 			language: locale,
+			use_screenshot_overrides: true,
 		}
 	);
 };


### PR DESCRIPTION
This change fixes rendering for the Rivington design by switching on an override in the `template/demo` endpoint introduced in D59099-code.

#### Before and after

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/112239595-de751780-8c9a-11eb-9b3b-825adbdfaf24.png) | ![image](https://user-images.githubusercontent.com/14988353/112239606-e339cb80-8c9a-11eb-9661-cddcf0b04386.png) |

#### Changes proposed in this Pull Request

* Update the `template/demo` endpoint url passed to mShots for the screenshots in the Gutenboarding design step to use the `use_screenshot_overrides` param, which fixes rendering for the Slideshow block in the Rivington design.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new` and on the design step check that the Rivington screenshot looks like the After image above
* Proceed to the font selection step — the slideshow for Rivington should still show the back / forward buttons

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #50919 
