### PR TITLE
Fix disappearing sidebar when switching to Jetpack site or Mobile view

### DIFF
--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -22,47 +22,41 @@ let pinnedSidebarBottom = false;
 let ticking = false; // Used for Scroll event throttling.
 
 export const handleScroll = ( event: React.UIEvent< HTMLElement > ): void => {
-	// Run only in browser context and for desktop viewports.
-	if ( typeof window === undefined || window.innerWidth <= 660 ) {
-		return;
-	}
-
 	// Do not run until next requestAnimationFrame or if running out of browser context.
 	if ( ticking ) {
 		return;
 	}
 
 	const windowHeight = window.innerHeight;
-	const content = document.getElementById( 'content' );
-	const contentHeight = document.getElementById( 'content' )?.scrollHeight;
+	const contentEl = document.getElementById( 'content' );
+	const contentHeight = contentEl?.scrollHeight;
 	const secondaryEl = document.getElementById( 'secondary' ); // Or referred as sidebar.
 	const secondaryElHeight = secondaryEl?.scrollHeight;
 	const masterbarHeight = document.getElementById( 'header' )?.getBoundingClientRect().height;
 
 	// Check whether we need to adjust content height so that scroll events are triggered.
 	// Sidebar has overflow: initial and position:fixed, so content is our only chance for scroll events.
-	if ( content && contentHeight && masterbarHeight && secondaryElHeight ) {
+	if ( contentEl && contentHeight && masterbarHeight && secondaryElHeight ) {
 		if ( contentHeight < secondaryElHeight ) {
 			// Adjust the content height so that it matches the sidebar + masterbar vertical scroll estate.
-			content.style.minHeight = secondaryElHeight + masterbarHeight + 'px';
+			contentEl.style.minHeight = secondaryElHeight + masterbarHeight + 'px';
 		}
 
 		if (
 			windowHeight >= secondaryElHeight + masterbarHeight &&
-			content !== null &&
-			secondaryEl !== null &&
-			( content.style.minHeight !== 'initial' || secondaryEl.style.position )
+			contentEl &&
+			secondaryEl &&
+			( contentEl.style.minHeight !== 'initial' || secondaryEl.style.position )
 		) {
 			// In case that window is taller than the sidebar we reinstate the content min-height. CSS code: client/layout/style.scss:30.
-			content.style.minHeight = 'initial';
+			contentEl.style.minHeight = 'initial';
 			// In case that window is taller than the sidebar after resize we need to clean up any previously set inline styles
 			secondaryEl.removeAttribute( 'style' );
 		}
 	}
 
 	if (
-		secondaryEl !== undefined &&
-		secondaryEl !== null &&
+		secondaryEl &&
 		secondaryElHeight !== undefined &&
 		masterbarHeight !== undefined &&
 		( secondaryElHeight + masterbarHeight > windowHeight || 'resize' === event.type ) // Only run when sidebar & masterbar are taller than window height OR we have a resize event


### PR DESCRIPTION
Fixes the following unified sidebar bug that's been bugging me lately: 🙂 

1. Open a Simple site in Calypso (has a unified sidebar)
2. Make the window height small enough so that the sidebar doesn't fit and needs to be scrolled along with the page
3. Scroll or resize the window to make `handleScroll` add custom styles to the `secondary` element
4. Now either switch to a Jetpack site (with non-unified sidebar) or resize to a mobile view (`handleScroll` returns early there)
5. Watch the sidebar disappear completely.

The problem is that we switched to a situation where the scroll synchronizing is not active, but the custom styles were left behind.

My patch extracts the handler adding and removing logic to a helper `SidebarScrollSynchronizer` component that adds and removes the scroll handlers when they are enabled or disabled. And removes the leftover styles when being disabled.