### PR TITLE
Framework: Refactor away from `_.uniq()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -436,5 +436,6 @@ module.exports = {
 		'you-dont-need-lodash-underscore/take-right': 'error',
 		'you-dont-need-lodash-underscore/to-lower': 'error',
 		'you-dont-need-lodash-underscore/to-upper': 'error',
+		'you-dont-need-lodash-underscore/uniq': 'error',
 	},
 };

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/contextual-tips/contextual-tip.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/contextual-tips/contextual-tip.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, filter, deburr, lowerCase, includes, uniq } from 'lodash';
+import { get, filter, deburr, lowerCase, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -30,7 +30,8 @@ function ContextualTip( { searchTerm, random = false, canUserCreate } ) {
 		tipsList,
 		( { keywords, permission } ) =>
 			canUserCreate( permission ) &&
-			filter( uniq( keywords ), ( keyword ) => includes( normalizedSearchTerm, keyword ) ).length
+			filter( [ ...new Set( keywords ) ], ( keyword ) => includes( normalizedSearchTerm, keyword ) )
+				.length
 	);
 
 	if ( ! foundTips.length ) {

--- a/client/blocks/image-selector/preview.jsx
+++ b/client/blocks/image-selector/preview.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { isEqual, uniq } from 'lodash';
+import { isEqual } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
@@ -84,11 +84,13 @@ export class ImageSelectorPreview extends Component {
 	updateImageState = ( callback ) => {
 		const { itemIds, onImageChange, siteId } = this.props;
 		this.setTransientImages();
-		const images = uniq(
-			itemIds
-				.map( ( id ) => this.props.getMediaItem( siteId, id ) )
-				.filter( ( mediaItem ) => mediaItem )
-		);
+		const images = [
+			...new Set(
+				itemIds
+					.map( ( id ) => this.props.getMediaItem( siteId, id ) )
+					.filter( ( mediaItem ) => mediaItem )
+			),
+		];
 
 		this.setState( { images }, () => {
 			if ( 'function' === typeof callback ) {

--- a/client/blocks/product-selector/utils.js
+++ b/client/blocks/product-selector/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flattenDeep, pickBy, uniq } from 'lodash';
+import { flattenDeep, pickBy } from 'lodash';
 
 /**
  * Extract the product slugs out of an array of product objects.
@@ -9,8 +9,9 @@ import { flattenDeep, pickBy, uniq } from 'lodash';
  * @param {Array} products Array of product objects.
  * @returns {Array} Array of the product slugs.
  */
-export const extractProductSlugs = ( products ) =>
-	uniq( flattenDeep( products.map( ( product ) => Object.values( product.options ) ) ) );
+export const extractProductSlugs = ( products ) => [
+	...new Set( flattenDeep( products.map( ( product ) => Object.values( product.options ) ) ) ),
+];
 
 /**
  * Filter products to the ones that are within specified slugs.

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
-import { defaults, get, identity, isEmpty, map, set, uniq } from 'lodash';
+import { defaults, get, identity, isEmpty, map, set } from 'lodash';
 
 /**
  * Internal dependencies
@@ -182,7 +182,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 				if ( registrantVatIdIsNotEmpty ) {
 					return validationErrors.registrantVatId === []
 						? null
-						: map( uniq( validationErrors.registrantVatId ), renderValidationError );
+						: map( [ ...new Set( validationErrors.registrantVatId ) ], renderValidationError );
 				}
 
 				return null;
@@ -221,7 +221,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 
 		const sirenSiretValidationMessage = () => {
 			if ( this.props.isManaged ) {
-				return map( uniq( validationErrors.sirenSiret ?? [] ), renderValidationError );
+				return map( [ ...new Set( validationErrors.sirenSiret ) ], renderValidationError );
 			}
 
 			if ( validationErrors.sirenSiret ) {
@@ -265,7 +265,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 
 		const trademarkNumberValidationMessage = () => {
 			if ( this.props.isManaged ) {
-				return map( uniq( validationErrors.trademarkNumber ?? [] ), ( error ) =>
+				return map( [ ...new Set( validationErrors.trademarkNumber ) ], ( error ) =>
 					renderValidationError( error )
 				);
 			}

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -8,7 +8,7 @@ import { line as d3Line, area as d3Area, curveMonotoneX as d3MonotoneXCurve } fr
 import { scaleLinear as d3ScaleLinear, scaleTime as d3TimeScale } from 'd3-scale';
 import { axisBottom as d3AxisBottom, axisRight as d3AxisRight } from 'd3-axis';
 import { select as d3Select, mouse as d3Mouse } from 'd3-selection';
-import { concat, first, last, throttle, uniq } from 'lodash';
+import { concat, first, last, throttle } from 'lodash';
 
 /**
  * Internal dependencies
@@ -444,7 +444,7 @@ class LineChart extends Component {
 	};
 
 	getTooltipPositionMap = ( values ) => {
-		const sortedUniqValues = uniq( values ).sort(
+		const sortedUniqValues = [ ...new Set( values ) ].sort(
 			( leftValue, rightValue ) => leftValue - rightValue
 		);
 

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { clone, difference, each, forEach, identity, last, map, some, take, uniq } from 'lodash';
+import { clone, difference, each, forEach, identity, last, map, some, take } from 'lodash';
 import classNames from 'classnames';
 import debugFactory from 'debug';
 
@@ -490,12 +490,14 @@ class TokenField extends PureComponent {
 	};
 
 	_addNewTokens = ( tokens ) => {
-		const tokensToAdd = uniq(
-			tokens
-				.map( this.props.saveTransform )
-				.filter( Boolean )
-				.filter( ( token ) => ! this._valueContainsToken( token ) )
-		);
+		const tokensToAdd = [
+			...new Set(
+				tokens
+					.map( this.props.saveTransform )
+					.filter( Boolean )
+					.filter( ( token ) => ! this._valueContainsToken( token ) )
+			),
+		];
 		debug( '_addNewTokens: tokensToAdd', tokensToAdd );
 
 		if ( tokensToAdd.length > 0 ) {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -4,7 +4,7 @@
 import page from 'page';
 import React from 'react';
 import i18n from 'i18n-calypso';
-import { get, some, startsWith, uniq } from 'lodash';
+import { get, some, startsWith } from 'lodash';
 import { removeQueryArgs } from '@wordpress/url';
 
 /**
@@ -282,7 +282,7 @@ export function updateRecentSitesPreferences( context ) {
 
 		if ( siteId && siteId !== recentSites[ 0 ] ) {
 			// Also filter recent sites if not available locally
-			const updatedRecentSites = uniq( [ siteId, ...recentSites ] )
+			const updatedRecentSites = [ ...new Set( [ siteId, ...recentSites ] ) ]
 				.slice( 0, 5 )
 				.filter( ( recentId ) => !! getSite( state, recentId ) );
 

--- a/client/my-sites/media-library/upload-button.jsx
+++ b/client/my-sites/media-library/upload-button.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { uniq } from 'lodash';
 import classNames from 'classnames';
 import page from 'page';
 
@@ -78,7 +77,7 @@ export class MediaLibraryUploadButton extends React.Component {
 		}
 		const allowedFileTypesForSite = getAllowedFileTypesForSite( this.props.site );
 
-		return uniq( allowedFileTypesForSite.concat( VideoPressFileTypes ) )
+		return [ ...new Set( allowedFileTypesForSite.concat( VideoPressFileTypes ) ) ]
 			.map( ( type ) => `.${ type }` )
 			.join();
 	};

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { includes, uniq } from 'lodash';
+import { includes } from 'lodash';
 import { isEnabled } from '@automattic/calypso-config';
 
 /**
@@ -314,7 +314,7 @@ export default connect(
 	( state, props ) => {
 		const selectedSiteId = getSelectedSiteId( state );
 		const sites = getSelectedOrAllSitesWithPlugins( state );
-		const siteIds = uniq( siteObjectsToSiteIds( sites ) );
+		const siteIds = [ ...new Set( siteObjectsToSiteIds( sites ) ) ];
 
 		return {
 			plugin: getPluginOnSites( state, siteIds, props.pluginSlug ),

--- a/client/my-sites/site-settings/date-time-format/default-formats.js
+++ b/client/my-sites/site-settings/date-time-format/default-formats.js
@@ -1,22 +1,19 @@
 /**
- * External dependencies
- */
-import { uniq } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { translate } from 'i18n-calypso';
 
 export function getDefaultDateFormats() {
-	return uniq( [
-		translate( 'F j, Y' ),
-		translate( 'Y-m-d' ),
-		translate( 'm/d/Y' ),
-		translate( 'd/m/Y' ),
-	] );
+	return [
+		...new Set( [
+			translate( 'F j, Y' ),
+			translate( 'Y-m-d' ),
+			translate( 'm/d/Y' ),
+			translate( 'd/m/Y' ),
+		] ),
+	];
 }
 
 export function getDefaultTimeFormats() {
-	return uniq( [ translate( 'g:i a' ), translate( 'g:i A' ), translate( 'H:i' ) ] );
+	return [ ...new Set( [ translate( 'g:i a' ), translate( 'g:i A' ), translate( 'H:i' ) ] ) ];
 }

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import { throttle, map, uniq } from 'lodash';
+import { throttle, map } from 'lodash';
 import { connect } from 'react-redux';
 import { loadScript } from '@automattic/load-script';
 import { localize } from 'i18n-calypso';
@@ -139,7 +139,7 @@ class StatsGeochart extends Component {
 			domain: currentUserCountryCode,
 		};
 
-		const regions = uniq( map( data, 'region' ) );
+		const regions = [ ...new Set( map( data, 'region' ) ) ];
 
 		if ( 1 === regions.length ) {
 			options.region = regions[ 0 ];

--- a/client/state/guided-tours/selectors/index.js
+++ b/client/state/guided-tours/selectors/index.js
@@ -11,7 +11,6 @@ import {
 	includes,
 	map,
 	startsWith,
-	uniq,
 	pick,
 } from 'lodash';
 import debugFactory from 'debug';
@@ -56,8 +55,8 @@ const relevantFeatures = flatMap( GuidedToursConfig, ( tourMeta, key ) =>
  * tour.
  */
 const getToursFromFeaturesReached = createSelector(
-	( state ) =>
-		uniq(
+	( state ) => [
+		...new Set(
 			getActionLog( state )
 				.filter( ( { type } ) => type === ROUTE_SET )
 				.reduceRight( ( allTours, { path: triggerPath } ) => {
@@ -68,6 +67,7 @@ const getToursFromFeaturesReached = createSelector(
 					return newTours ? [ ...allTours, ...newTours ] : allTours;
 				}, [] )
 		),
+	],
 	[ getActionLog ]
 );
 
@@ -76,7 +76,7 @@ const getToursFromFeaturesReached = createSelector(
  * recently and in the past.
  */
 const getToursSeen = createSelector(
-	( state ) => uniq( map( getToursHistory( state ), 'tourName' ) ),
+	( state ) => [ ...new Set( map( getToursHistory( state ), 'tourName' ) ) ],
 	[ getToursHistory ]
 );
 
@@ -130,18 +130,22 @@ const findTriggeredTour = ( state ) => {
 		return;
 	}
 
-	const toursFromTriggers = uniq( [
-		...getToursFromFeaturesReached( state ),
-		// Right now, only one source from which to derive tours, but we may
-		// have more later. Examples:
-		// ...getToursFromPurchases( state ),
-		// ...getToursFromFirstActions( state ),
-	] );
+	const toursFromTriggers = [
+		...new Set( [
+			...getToursFromFeaturesReached( state ),
+			// Right now, only one source from which to derive tours, but we may
+			// have more later. Examples:
+			// ...getToursFromPurchases( state ),
+			// ...getToursFromFirstActions( state ),
+		] ),
+	];
 
-	const toursToDismiss = uniq( [
-		// Same idea here.
-		...getToursSeen( state ),
-	] );
+	const toursToDismiss = [
+		...new Set( [
+			// Same idea here.
+			...getToursSeen( state ),
+		] ),
+	];
 
 	const newTours = difference( toursFromTriggers, toursToDismiss );
 	return find( newTours, ( tour ) => {

--- a/client/state/posts/selectors/get-post-revisions-authors-id.js
+++ b/client/state/posts/selectors/get-post-revisions-authors-id.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, map, uniq } from 'lodash';
+import { get, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,11 +11,12 @@ import { createSelector } from '@automattic/state-utils';
 import 'calypso/state/posts/init';
 
 export const getPostRevisionsAuthorsId = createSelector(
-	( state, siteId, postId ) =>
-		uniq(
+	( state, siteId, postId ) => [
+		...new Set(
 			map( get( state.posts.revisions.diffs, [ siteId, postId, 'revisions' ], {} ), ( r ) =>
 				parseInt( r.post_author, 10 )
 			)
 		),
+	],
 	( state ) => [ state.posts.revisions.diffs ]
 );

--- a/client/state/themes/selectors/get-themes-for-query-ignoring-page.js
+++ b/client/state/themes/selectors/get-themes-for-query-ignoring-page.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { uniq, flatMap } from 'lodash';
+import { flatMap } from 'lodash';
 import { createSelector } from '@automattic/state-utils';
 
 /**
@@ -45,7 +45,7 @@ export const getThemesForQueryIgnoringPage = createSelector(
 
 		// FIXME: The themes endpoint weirdly sometimes returns duplicates (spread
 		// over different pages) which we need to remove manually here for now.
-		return uniq( themesForQueryIgnoringPage );
+		return [ ...new Set( themesForQueryIgnoringPage ) ];
 	},
 	( state ) => state.themes.queries,
 	( state, siteId, query ) => getSerializedThemesQueryWithoutPage( query, siteId )

--- a/client/state/themes/selectors/get-themes-for-query.js
+++ b/client/state/themes/selectors/get-themes-for-query.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes, uniq } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,7 +43,7 @@ export const getThemesForQuery = createSelector(
 
 		// FIXME: The themes endpoint weirdly sometimes returns duplicates (spread
 		// over different pages) which we need to remove manually here for now.
-		return uniq( themes );
+		return [ ...new Set( themes ) ];
 	},
 	( state ) => state.themes.queries,
 	( state, siteId, query ) => getSerializedThemesQuery( query, siteId )

--- a/packages/webpack-extensive-lodash-replacement-plugin/README.md
+++ b/packages/webpack-extensive-lodash-replacement-plugin/README.md
@@ -3,7 +3,7 @@
 Replaces most usage of `lodash` with `lodash-es`:
 
 ```js
-import { uniq } from 'lodash';
+import { get } from 'lodash';
 import map from 'lodash/map';
 import camelCase from 'lodash.camelcase';
 ```
@@ -11,7 +11,7 @@ import camelCase from 'lodash.camelcase';
 Becomes:
 
 ```js
-import { uniq } from 'lodash-es';
+import { get } from 'lodash-es';
 import map from 'lodash-es/map';
 import camelCase from 'lodash-es/camelCase';
 ```


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `uniq` is essentially fully natively supported by the native `[ ...new Set( items ) ]`. This PR replaces the usage and adds an ESLint rule to warn against using `uniq` from lodash.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all usages are sane and preserve the original logic.
* Try to `import { uniq } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass.