### PR TITLE
Gutenframe: dont poll the iframe loading state for 5000ms

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -660,7 +660,7 @@ class CalypsoifyIframe extends Component<
 			: `Block Editor > ${ postTypeText } > New`;
 	};
 
-	onIframeLoaded = async ( iframeUrl: string ) => {
+	onIframeLoaded = ( iframeUrl: string ) => {
 		clearTimeout( this.waitForIframeToLoad );
 		if ( ! this.successfulIframeLoad ) {
 			window.location.replace( iframeUrl );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -664,25 +664,12 @@ class CalypsoifyIframe extends Component<
 		clearTimeout( this.waitForIframeToLoad );
 		if ( ! this.successfulIframeLoad ) {
 			// Sometimes (like in IE) the WindowActions.Loaded message arrives after
-			// the onLoad event is fired. To deal with this case we'll poll
-			// `this.successfulIframeLoad` for a while before redirecting.
-
-			// Checks to see if the iFrame has loaded every 200ms. If it has
-			// loaded, then resolve the promise.
-			let pendingIsLoadedInterval;
-			const pollForLoadedFlag = new Promise( ( resolve ) => {
-				pendingIsLoadedInterval = setInterval(
-					() => this.successfulIframeLoad && resolve( 'iframe-loaded' ),
-					200
-				);
-			} );
-
-			const fiveSeconds = new Promise( ( resolve ) => setTimeout( resolve, 5000, 'timeout' ) );
-
-			const finishCondition = await Promise.race( [ pollForLoadedFlag, fiveSeconds ] );
-			clearInterval( pendingIsLoadedInterval );
-
-			if ( finishCondition === 'timeout' ) {
+			// the onLoad event is fired. To deal with this case we'll wait for a tick
+			// and check `this.successfulIframeLoad` value again
+			const successfulIframeLoadFromNextTick = new Promise( ( resolve ) =>
+				setTimeout( () => resolve( this.successfulIframeLoad ), 0 )
+			);
+			if ( ! ( await successfulIframeLoadFromNextTick ) ) {
 				window.location.replace( iframeUrl );
 				return;
 			}

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -663,16 +663,8 @@ class CalypsoifyIframe extends Component<
 	onIframeLoaded = async ( iframeUrl: string ) => {
 		clearTimeout( this.waitForIframeToLoad );
 		if ( ! this.successfulIframeLoad ) {
-			// Sometimes (like in IE) the WindowActions.Loaded message arrives after
-			// the onLoad event is fired. To deal with this case we'll wait for a tick
-			// and check `this.successfulIframeLoad` value again
-			const successfulIframeLoadFromNextTick = new Promise( ( resolve ) =>
-				setTimeout( () => resolve( this.successfulIframeLoad ), 0 )
-			);
-			if ( ! ( await successfulIframeLoadFromNextTick ) ) {
-				window.location.replace( iframeUrl );
-				return;
-			}
+			window.location.replace( iframeUrl );
+			return;
 		}
 		window.performance?.mark( 'iframe_loaded' );
 		this.setState( { isIframeLoaded: true, currentIFrameUrl: iframeUrl } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Since we're phasing out IE support, this PR drops the polling logic that was added to try a bit harder keeping IE users iframed. Because this 5 seconds polling [brings other problems](https://github.com/Automattic/wp-calypso/issues/49374).

#### Testing instructions

1. Go to https://calypso.live/?branch=fix/dont-poll-for-5000ms
2. Go to Posts > Add new post
3. The editor should be iframed (your browser's URL should remain a calypso live URL). 

 
Related to #41006
