### PR TITLE
Add Plugin Review Prompt to Jetpack Restore Flow

### DIFF
--- a/client/my-sites/backup/rewind-flow/download.tsx
+++ b/client/my-sites/backup/rewind-flow/download.tsx
@@ -8,7 +8,7 @@ import React, { FunctionComponent, useCallback, useState } from 'react';
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { defaultRewindConfig, RewindConfig } from './types';
 import { getRewindBackupProgress, rewindBackup } from 'calypso/state/activity-log/actions';
 import CheckYourEmail from './rewind-flow-notice/check-your-email';
@@ -266,7 +266,7 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 				downloadId={ downloadProgress !== undefined ? downloadId : undefined }
 				siteId={ siteId }
 			/>
-			{ render() }
+			<Card>{ render() }</Card>
 		</>
 	);
 };

--- a/client/my-sites/backup/rewind-flow/index.tsx
+++ b/client/my-sites/backup/rewind-flow/index.tsx
@@ -61,11 +61,13 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 		requestActivity( siteId, rewindId );
 	}, [ siteId, rewindId ] );
 
+	const wrapWithCard = ( content ) => <Card>{ content }</Card>;
+
 	const render = () => {
 		if ( null === applySiteOffset || loadingActivity ) {
-			return <Loading />;
+			return wrapWithCard( <Loading /> );
 		} else if ( activityRequestError?.code === 'no_activity_for_site_and_rewind_id' ) {
-			return (
+			return wrapWithCard(
 				<Error
 					siteUrl={ siteUrl }
 					errorText={ translate( 'The activity referenced by %(rewindId)s does not exist.', {
@@ -74,7 +76,7 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 				/>
 			);
 		} else if ( activityIsRewindable === false ) {
-			return (
+			return wrapWithCard(
 				<Error
 					siteUrl={ siteUrl }
 					errorText={ translate( 'The activity referenced by %(rewindId)s is not rewindable.', {
@@ -83,7 +85,7 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 				/>
 			);
 		} else if ( DataState.Success !== activityRequestState ) {
-			return (
+			return wrapWithCard(
 				<Error
 					siteUrl={ siteUrl }
 					errorText={ translate( 'An error occurred while trying to retrieve the activity' ) }
@@ -125,9 +127,7 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 				}
 			/>
 			<SidebarNavigation />
-			<div className="rewind-flow__content">
-				<Card>{ render() }</Card>
-			</div>
+			<div className="rewind-flow__content">{ render() }</div>
 		</Main>
 	);
 };

--- a/client/my-sites/backup/rewind-flow/jetpack-review-prompt.tsx
+++ b/client/my-sites/backup/rewind-flow/jetpack-review-prompt.tsx
@@ -8,7 +8,7 @@ import React, { FunctionComponent, useCallback, useEffect } from 'react';
 /**
  * Internal dependencies
  */
-import { Button } from '@wordpress/components';
+import { Button, Card } from '@wordpress/components';
 import { dismiss } from 'calypso/state/jetpack-review-prompt/actions';
 import { getIsDismissed } from 'calypso/state/jetpack-review-prompt/selectors';
 import { hasReceivedRemotePreferences as getHasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
@@ -53,30 +53,27 @@ const JetpackReviewPrompt: FunctionComponent = () => {
 		<>
 			<QueryPreferences />
 			{ hasReceivedRemotePreferences && ! isDismissed && (
-				<>
-					<hr />
-					<div className="jetpack-review-prompt">
-						<div className="jetpack-review-prompt__header">
-							<RewindFlowNotice
-								type={ RewindFlowNoticeLevel.REMINDER }
-								title={ translate(
-									'Was it easy to restore your site? Please leave a review and help us spread the word!'
-								) }
-							/>
-							<Gridicon icon="cross" size={ 24 } onClick={ dismissPrompt } />
-						</div>
-						<div className="jetpack-review-prompt__button-row">
-							<Button
-								href="https://wordpress.org/support/plugin/jetpack/reviews/#new-post"
-								target="_blank"
-								onClick={ dismissPromptAsReviewed }
-							>
-								{ translate( 'Leave a review' ) }
-								<Gridicon icon="external" />
-							</Button>
-						</div>
+				<Card className="jetpack-review-prompt">
+					<div className="jetpack-review-prompt__header">
+						<RewindFlowNotice
+							type={ RewindFlowNoticeLevel.REMINDER }
+							title={ translate(
+								'Was it easy to restore your site? Please leave a review and help us spread the word!'
+							) }
+						/>
+						<Gridicon icon="cross" size={ 24 } onClick={ dismissPrompt } />
 					</div>
-				</>
+					<div className="jetpack-review-prompt__button-row">
+						<Button
+							href="https://wordpress.org/support/plugin/jetpack/reviews/#new-post"
+							target="_blank"
+							onClick={ dismissPromptAsReviewed }
+						>
+							{ translate( 'Leave a review' ) }
+							<Gridicon icon="external" />
+						</Button>
+					</div>
+				</Card>
 			) }
 		</>
 	);

--- a/client/my-sites/backup/rewind-flow/jetpack-review-prompt.tsx
+++ b/client/my-sites/backup/rewind-flow/jetpack-review-prompt.tsx
@@ -9,8 +9,8 @@ import React, { FunctionComponent, useCallback, useEffect } from 'react';
  * Internal dependencies
  */
 import { Button } from '@wordpress/components';
-import { dismiss, dismissAsReviewed } from 'calypso/state/jetpack-review-prompt/actions';
-import { getIsDismissed, getDismissCount } from 'calypso/state/jetpack-review-prompt/selectors';
+import { dismiss } from 'calypso/state/jetpack-review-prompt/actions';
+import { getIsDismissed } from 'calypso/state/jetpack-review-prompt/selectors';
 import { hasReceivedRemotePreferences as getHasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import Gridicon from 'calypso/components/gridicon';
@@ -25,28 +25,25 @@ const JetpackReviewPrompt: FunctionComponent = () => {
 	const hasReceivedRemotePreferences = useSelector( ( state ) =>
 		getHasReceivedRemotePreferences( state )
 	);
-	const isDismissed = useSelector( ( state ) => getIsDismissed( state ) );
-	const dismissCount = useSelector( ( state ) => getDismissCount( state ) );
+	const isDismissed = useSelector( ( state ) => getIsDismissed( state, 'restore' ) );
 
 	const dismissPrompt = useCallback( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_backup_review_prompt_dismiss', {
-				dismiss_count: dismissCount,
 				reviewed: false,
 			} )
 		);
-		dispatch( dismiss( dismissCount ) );
-	}, [ dispatch, dismissCount ] );
+		dispatch( dismiss( 'restore', Date.now() ) );
+	}, [ dispatch ] );
 
 	const dismissPromptAsReviewed = useCallback( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_backup_review_prompt_dismiss', {
-				dismiss_count: dismissCount,
 				reviewed: true,
 			} )
 		);
-		dispatch( dismissAsReviewed( dismissCount ) );
-	}, [ dispatch, dismissCount ] );
+		dispatch( dismiss( 'restore', Date.now(), true ) );
+	}, [ dispatch ] );
 
 	useEffect( () => {
 		dispatch( recordTracksEvent( 'calypso_jetpack_backup_review_prompt_view' ) );

--- a/client/my-sites/backup/rewind-flow/jetpack-review-prompt.tsx
+++ b/client/my-sites/backup/rewind-flow/jetpack-review-prompt.tsx
@@ -54,32 +54,34 @@ const JetpackReviewPrompt: FunctionComponent = () => {
 
 	return (
 		<>
-			<hr />
 			<QueryPreferences />
 			{ hasReceivedRemotePreferences && ! isDismissed && (
-				<div className="jetpack-review-prompt">
-					<div className="jetpack-review-prompt__header">
-						<RewindFlowNotice
-							gridicon="star"
-							type={ RewindFlowNoticeLevel.REMINDER }
-							title={ translate( 'Had an easy restore experience?' ) }
-						/>
+				<>
+					<hr />
+					<div className="jetpack-review-prompt">
+						<div className="jetpack-review-prompt__header">
+							<RewindFlowNotice
+								gridicon="star"
+								type={ RewindFlowNoticeLevel.REMINDER }
+								title={ translate( 'Had an easy restore experience?' ) }
+							/>
+						</div>
+						<div className="jetpack-review-prompt__button-row">
+							<Button
+								href="https://wordpress.org/support/plugin/jetpack/reviews/#new-post"
+								target="_blank"
+								onClick={ dismissPromptAsReviewed }
+							>
+								<Gridicon icon="external" />
+								{ translate( 'Leave Jetpack a review' ) }
+							</Button>
+							<Button onClick={ dismissPrompt }>
+								<Gridicon icon="cross" />
+								{ translate( 'No thanks' ) }
+							</Button>
+						</div>
 					</div>
-					<div className="jetpack-review-prompt__button-row">
-						<Button
-							href="https://wordpress.org/support/plugin/jetpack/reviews/#new-post"
-							target="_blank"
-							onClick={ dismissPromptAsReviewed }
-						>
-							<Gridicon icon="external" />
-							{ translate( 'Leave Jetpack a review' ) }
-						</Button>
-						<Button onClick={ dismissPrompt }>
-							<Gridicon icon="cross" />
-							{ translate( 'No thanks' ) }
-						</Button>
-					</div>
-				</div>
+				</>
 			) }
 		</>
 	);

--- a/client/my-sites/backup/rewind-flow/jetpack-review-prompt.tsx
+++ b/client/my-sites/backup/rewind-flow/jetpack-review-prompt.tsx
@@ -3,18 +3,19 @@
  */
 import { useSelector, useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
-import React, { FunctionComponent, useCallback } from 'react';
+import React, { FunctionComponent, useCallback, useEffect } from 'react';
 
 /**
  * Internal dependencies
  */
 import { Button } from '@wordpress/components';
+import { dismiss, dismissAsReviewed } from 'calypso/state/jetpack-review-prompt/actions';
+import { getIsDismissed, getDismissCount } from 'calypso/state/jetpack-review-prompt/selectors';
 import { hasReceivedRemotePreferences as getHasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import Gridicon from 'calypso/components/gridicon';
 import QueryPreferences from 'calypso/components/data/query-preferences';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
-import { getIsDismissed, getDismissCount } from 'calypso/state/jetpack-review-prompt/selectors';
-import { dismiss, dismissAsReviewed } from 'calypso/state/jetpack-review-prompt/actions';
 
 const JetpackReviewPrompt: FunctionComponent = () => {
 	const translate = useTranslate();
@@ -28,12 +29,28 @@ const JetpackReviewPrompt: FunctionComponent = () => {
 	const dismissCount = useSelector( ( state ) => getDismissCount( state ) );
 
 	const dismissPrompt = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_review_prompt_dismiss', {
+				dismiss_count: dismissCount,
+				reviewed: false,
+			} )
+		);
 		dispatch( dismiss( dismissCount ) );
 	}, [ dispatch, dismissCount ] );
 
 	const dismissPromptAsReviewed = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_review_prompt_dismiss', {
+				dismiss_count: dismissCount,
+				reviewed: true,
+			} )
+		);
 		dispatch( dismissAsReviewed( dismissCount ) );
 	}, [ dispatch, dismissCount ] );
+
+	useEffect( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_review_prompt_view' ) );
+	}, [ dispatch ] );
 
 	return (
 		<>

--- a/client/my-sites/backup/rewind-flow/jetpack-review-prompt.tsx
+++ b/client/my-sites/backup/rewind-flow/jetpack-review-prompt.tsx
@@ -54,6 +54,7 @@ const JetpackReviewPrompt: FunctionComponent = () => {
 
 	return (
 		<>
+			<hr />
 			<QueryPreferences />
 			{ hasReceivedRemotePreferences && ! isDismissed && (
 				<div className="jetpack-review-prompt">

--- a/client/my-sites/backup/rewind-flow/jetpack-review-prompt.tsx
+++ b/client/my-sites/backup/rewind-flow/jetpack-review-prompt.tsx
@@ -39,15 +39,15 @@ const JetpackReviewPrompt: FunctionComponent = () => {
 		<>
 			<QueryPreferences />
 			{ hasReceivedRemotePreferences && ! isDismissed && (
-				<div className="review-prompt">
-					<div className="review-prompt__header">
+				<div className="jetpack-review-prompt">
+					<div className="jetpack-review-prompt__header">
 						<RewindFlowNotice
 							gridicon="star"
 							type={ RewindFlowNoticeLevel.REMINDER }
 							title={ translate( 'Had an easy restore experience?' ) }
 						/>
 					</div>
-					<div className="review-prompt__button-row">
+					<div className="jetpack-review-prompt__button-row">
 						<Button
 							href="https://wordpress.org/support/plugin/jetpack/reviews/#new-post"
 							target="_blank"

--- a/client/my-sites/backup/rewind-flow/jetpack-review-prompt.tsx
+++ b/client/my-sites/backup/rewind-flow/jetpack-review-prompt.tsx
@@ -58,10 +58,12 @@ const JetpackReviewPrompt: FunctionComponent = () => {
 					<div className="jetpack-review-prompt">
 						<div className="jetpack-review-prompt__header">
 							<RewindFlowNotice
-								gridicon="star"
 								type={ RewindFlowNoticeLevel.REMINDER }
-								title={ translate( 'Had an easy restore experience?' ) }
+								title={ translate(
+									'Was it easy to restore your site? Please leave a review and help us spread the word!'
+								) }
 							/>
+							<Gridicon icon="cross" size={ 24 } onClick={ dismissPrompt } />
 						</div>
 						<div className="jetpack-review-prompt__button-row">
 							<Button
@@ -69,12 +71,8 @@ const JetpackReviewPrompt: FunctionComponent = () => {
 								target="_blank"
 								onClick={ dismissPromptAsReviewed }
 							>
+								{ translate( 'Leave a review' ) }
 								<Gridicon icon="external" />
-								{ translate( 'Leave Jetpack a review' ) }
-							</Button>
-							<Button onClick={ dismissPrompt }>
-								<Gridicon icon="cross" />
-								{ translate( 'No thanks' ) }
 							</Button>
 						</div>
 					</div>

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -137,7 +137,6 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					"Don't want to wait? For your convenience, we'll email you when your site has been fully restored."
 				) }
 			/>
-			<JetpackReviewPrompt />
 		</>
 	);
 
@@ -168,7 +167,6 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			<Button primary href={ siteUrl } className="rewind-flow__primary-button">
 				{ translate( 'View your website' ) }
 			</Button>
-			<JetpackReviewPrompt />
 		</>
 	);
 
@@ -193,17 +191,19 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		</Error>
 	);
 
+	const isInProgress =
+		( ! inProgressRewindStatus && userHasRequestedRestore ) ||
+		( inProgressRewindStatus && [ 'queued', 'running' ].includes( inProgressRewindStatus ) );
+	const isFinished = inProgressRewindStatus !== null && inProgressRewindStatus === 'finished';
+
 	const render = () => {
 		if ( loading ) {
 			return <Loading />;
 		} else if ( ! inProgressRewindStatus && ! userHasRequestedRestore ) {
 			return renderConfirm();
-		} else if (
-			( ! inProgressRewindStatus && userHasRequestedRestore ) ||
-			( inProgressRewindStatus && [ 'queued', 'running' ].includes( inProgressRewindStatus ) )
-		) {
+		} else if ( isInProgress ) {
 			return renderInProgress();
-		} else if ( inProgressRewindStatus !== null && inProgressRewindStatus === 'finished' ) {
+		} else if ( isFinished ) {
 			return renderFinished();
 		}
 		return renderError();
@@ -216,6 +216,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 				<QueryRewindRestoreStatus siteId={ siteId } restoreId={ restoreId } />
 			) }
 			<Card>{ render() }</Card>
+			{ ( isInProgress || isFinished ) && <JetpackReviewPrompt /> }
 		</>
 	);
 };

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -8,7 +8,7 @@ import React, { FunctionComponent, useCallback, useState } from 'react';
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { defaultRewindConfig, RewindConfig } from './types';
 import { rewindRestore } from 'calypso/state/activity-log/actions';
 import CheckYourEmail from './rewind-flow-notice/check-your-email';
@@ -215,7 +215,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			{ restoreId && 'running' === inProgressRewindStatus && (
 				<QueryRewindRestoreStatus siteId={ siteId } restoreId={ restoreId } />
 			) }
-			{ render() }
+			<Card>{ render() }</Card>
 		</>
 	);
 };

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -23,6 +23,7 @@ import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import QueryRewindRestoreStatus from 'calypso/components/data/query-rewind-restore-status';
 import RewindConfigEditor from './rewind-config-editor';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
+import JetpackReviewPrompt from './review-prompt';
 
 /**
  * Type dependencies
@@ -136,6 +137,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					"Don't want to wait? For your convenience, we'll email you when your site has been fully restored."
 				) }
 			/>
+			<JetpackReviewPrompt />
 		</>
 	);
 
@@ -166,6 +168,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			<Button primary href={ siteUrl } className="rewind-flow__primary-button">
 				{ translate( 'View your website' ) }
 			</Button>
+			<JetpackReviewPrompt />
 		</>
 	);
 

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -23,7 +23,7 @@ import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import QueryRewindRestoreStatus from 'calypso/components/data/query-rewind-restore-status';
 import RewindConfigEditor from './rewind-config-editor';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
-import JetpackReviewPrompt from './review-prompt';
+import JetpackReviewPrompt from './jetpack-review-prompt';
 
 /**
  * Type dependencies

--- a/client/my-sites/backup/rewind-flow/review-prompt.tsx
+++ b/client/my-sites/backup/rewind-flow/review-prompt.tsx
@@ -13,28 +13,27 @@ import { hasReceivedRemotePreferences as getHasReceivedRemotePreferences } from 
 import Gridicon from 'calypso/components/gridicon';
 import QueryPreferences from 'calypso/components/data/query-preferences';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
-import {
-	getIsDismissed,
-	getHasBeenDismissedOnce,
-} from 'calypso/state/jetpack-review-prompt/selectors';
-import {
-	dismissReviewPrompt,
-	dismissReviewPromptPermanently,
-} from 'calypso/state/jetpack-review-prompt/actions';
+import { getIsDismissed, getDismissCount } from 'calypso/state/jetpack-review-prompt/selectors';
+import { dismiss, dismissAsReviewed } from 'calypso/state/jetpack-review-prompt/actions';
 
 const JetpackReviewPrompt: FunctionComponent = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
+	// dismiss count is stored in a preference, make sure we have that before rendering
 	const hasReceivedRemotePreferences = useSelector( ( state ) =>
 		getHasReceivedRemotePreferences( state )
 	);
 	const isDismissed = useSelector( ( state ) => getIsDismissed( state ) );
-	const hasBeenDismissedOnce = useSelector( ( state ) => getHasBeenDismissedOnce( state ) );
+	const dismissCount = useSelector( ( state ) => getDismissCount( state ) );
 
-	const dismiss = useCallback( () => {
-		dispatch( hasBeenDismissedOnce ? dismissReviewPromptPermanently() : dismissReviewPrompt() );
-	}, [ dispatch, hasBeenDismissedOnce ] );
+	const dismissPrompt = useCallback( () => {
+		dispatch( dismiss( dismissCount ) );
+	}, [ dispatch, dismissCount ] );
+
+	const dismissPromptAsReviewed = useCallback( () => {
+		dispatch( dismissAsReviewed( dismissCount ) );
+	}, [ dispatch, dismissCount ] );
 
 	return (
 		<>
@@ -52,12 +51,12 @@ const JetpackReviewPrompt: FunctionComponent = () => {
 						<Button
 							href="https://wordpress.org/support/plugin/jetpack/reviews/#new-post"
 							target="_blank"
-							onClick={ dismiss }
+							onClick={ dismissPromptAsReviewed }
 						>
 							<Gridicon icon="external" />
 							{ translate( 'Leave Jetpack a review' ) }
 						</Button>
-						<Button onClick={ dismiss }>
+						<Button onClick={ dismissPrompt }>
 							<Gridicon icon="cross" />
 							{ translate( 'No thanks' ) }
 						</Button>

--- a/client/my-sites/backup/rewind-flow/review-prompt.tsx
+++ b/client/my-sites/backup/rewind-flow/review-prompt.tsx
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { useSelector, useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import React, { FunctionComponent, useCallback } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@wordpress/components';
+import { hasReceivedRemotePreferences as getHasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import Gridicon from 'calypso/components/gridicon';
+import QueryPreferences from 'calypso/components/data/query-preferences';
+import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
+import {
+	getIsDismissed,
+	getHasBeenDismissedOnce,
+} from 'calypso/state/jetpack-review-prompt/selectors';
+import {
+	dismissReviewPrompt,
+	dismissReviewPromptPermanently,
+} from 'calypso/state/jetpack-review-prompt/actions';
+
+const JetpackReviewPrompt: FunctionComponent = () => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const hasReceivedRemotePreferences = useSelector( ( state ) =>
+		getHasReceivedRemotePreferences( state )
+	);
+	const isDismissed = useSelector( ( state ) => getIsDismissed( state ) );
+	const hasBeenDismissedOnce = useSelector( ( state ) => getHasBeenDismissedOnce( state ) );
+
+	const dismiss = useCallback( () => {
+		dispatch( hasBeenDismissedOnce ? dismissReviewPromptPermanently() : dismissReviewPrompt() );
+	}, [ dispatch, hasBeenDismissedOnce ] );
+
+	return (
+		<>
+			<QueryPreferences />
+			{ hasReceivedRemotePreferences && ! isDismissed && (
+				<div className="review-prompt">
+					<div className="review-prompt__header">
+						<RewindFlowNotice
+							gridicon="star"
+							type={ RewindFlowNoticeLevel.REMINDER }
+							title={ translate( 'Had an easy restore experience?' ) }
+						/>
+					</div>
+					<div className="review-prompt__button-row">
+						<Button
+							href="https://wordpress.org/support/plugin/jetpack/reviews/#new-post"
+							target="_blank"
+							onClick={ dismiss }
+						>
+							<Gridicon icon="external" />
+							{ translate( 'Leave Jetpack a review' ) }
+						</Button>
+						<Button onClick={ dismiss }>
+							<Gridicon icon="cross" />
+							{ translate( 'No thanks' ) }
+						</Button>
+					</div>
+				</div>
+			) }
+		</>
+	);
+};
+
+export default JetpackReviewPrompt;

--- a/client/my-sites/backup/rewind-flow/rewind-flow-notice/index.tsx
+++ b/client/my-sites/backup/rewind-flow/rewind-flow-notice/index.tsx
@@ -15,7 +15,7 @@ enum RewindFlowNoticeLevel {
 }
 
 interface Props {
-	gridicon: string;
+	gridicon?: string;
 	link?: string;
 	message?: i18nCalypso.TranslateResult;
 	title: i18nCalypso.TranslateResult;
@@ -43,14 +43,14 @@ const RewindFlowNotice: FunctionComponent< Props > = ( {
 
 	const renderLink = () => (
 		<a className={ getTitleClassName() } href={ link } target="_blank" rel="noopener noreferrer">
-			<Gridicon icon={ gridicon } />
+			{ gridicon && <Gridicon icon={ gridicon } /> }
 			{ title }
 		</a>
 	);
 
 	const renderNonLink = () => (
 		<div className={ getTitleClassName() }>
-			<Gridicon icon={ gridicon } />
+			{ gridicon && <Gridicon icon={ gridicon } /> }
 			<h4>{ title }</h4>
 		</div>
 	);

--- a/client/my-sites/backup/rewind-flow/style.scss
+++ b/client/my-sites/backup/rewind-flow/style.scss
@@ -209,6 +209,10 @@ a.rewind-flow-notice__title-warning:visited {
 .jetpack-review-prompt__button-row {
 	display: flex;
 
+	.gridicon {
+		margin-right: 6px;
+	}
+
 	:not( :first-child ) {
 		margin-left: 12px;
 	}

--- a/client/my-sites/backup/rewind-flow/style.scss
+++ b/client/my-sites/backup/rewind-flow/style.scss
@@ -206,12 +206,10 @@ a.rewind-flow-notice__title-warning:visited {
 	}
 }
 
-.review-prompt__button-row {
+.jetpack-review-prompt__button-row {
 	display: flex;
 
-	:not(:first-child) {
+	:not( :first-child ) {
 		margin-left: 12px;
 	}
-	
 }
-

--- a/client/my-sites/backup/rewind-flow/style.scss
+++ b/client/my-sites/backup/rewind-flow/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .rewind-flow__header {
 	display: flex;
 	justify-content: center;
@@ -202,3 +205,13 @@ a.rewind-flow-notice__title-warning:visited {
 		border: initial;
 	}
 }
+
+.review-prompt__button-row {
+	display: flex;
+
+	:not(:first-child) {
+		margin-left: 12px;
+	}
+	
+}
+

--- a/client/my-sites/backup/rewind-flow/style.scss
+++ b/client/my-sites/backup/rewind-flow/style.scss
@@ -206,14 +206,19 @@ a.rewind-flow-notice__title-warning:visited {
 	}
 }
 
+.jetpack-review-prompt__header {
+	display: flex;
+	justify-content: space-between;
+}
+
 .jetpack-review-prompt__button-row {
 	display: flex;
 
 	.gridicon {
-		margin-right: 6px;
+		margin-left: 6px;
 	}
 
-	:not( :first-child ) {
-		margin-left: 12px;
+	:first-child {
+		padding-left: 0;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Dismissible Jetpack Review Prompt to the "In-Progress" and "Finished" stages of the Jetpack Restore Flow
   * New Tracks events, `calypso_jetpack_backup_review_prompt_view` and `calypso_jetpack_backup_review_prompt_dismiss` to understand how many reviews are being c created as a result of the prompt

![Untitled 11](https://user-images.githubusercontent.com/2810519/112689898-21202680-8e38-11eb-99ba-7e5cda064948.png)
![Untitled 4](https://user-images.githubusercontent.com/2810519/112689911-22e9ea00-8e38-11eb-8140-9940880629ff.png)


#### Testing instructions

1. Navigate to `/backup/:siteSlug`.
   * open dev tools and start analytics logging by running `localStorage.setItem('debug', 'calypso:analytics');` via the console.
2. Find a valid backup and initiate a restore.
3. Verify that the review prompt appears while the restore is in progress and after it has finished ( see screenshots above for how it should look ).
4. Verify that viewing the prompt has logged a `calypso_jetpack_backup_review_prompt_view ` event. ( This should log twice, since two separate components will render ).
5. Dismiss via the "X" button in the corner.
6. Verify the prompt is no longer rendered
7. Check that the `calypso_jetpack_backup_review_prompt_dismiss` event logs with `reviewed` set to false.
8. Unset the `jetpack-review-prompt` preference
   * <img width="1007" alt="Screen Shot 2021-03-24 at 12 22 33 PM" src="https://user-images.githubusercontent.com/2810519/112371507-e8e3e100-8c9b-11eb-8725-f3dbd49cb139.png">
 9. Click the "Leave Jetpack a Review" button
 10. Check that the `calypso_jetpack_backup_review_prompt_dismiss` event logs with `reviewed` set to true.
 11. Verify the prompt is no longer rendered
 12. ( Requires #51432 ) Reset preference, dismiss via "No thanks" button
 13. Modify the `jetpack-review-prompt` property `dismissedAt` by subtracting `1814400000` from it ( 3 weeks in ms )
 14. Verify that the prompt redisplays 
