### PR TITLE
Show an error notice when a user can't add email for a domain

### DIFF
--- a/client/lib/domains/can-current-user-add-email.js
+++ b/client/lib/domains/can-current-user-add-email.js
@@ -1,3 +1,3 @@
 export function canCurrentUserAddEmail( domain ) {
-	return !! domain?.canCurrentUserAddEmail;
+	return !! domain?.currentUserCanAddEmail;
 }

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-card.jsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-card.jsx
@@ -29,8 +29,8 @@ function EmailProviderCard( {
 	onExpandedChange = noop,
 	formFields,
 	buttonLabel,
-	buttonDisabled = false,
 	onButtonClick,
+	showExpandButton = true,
 	expandButtonLabel,
 	features,
 } ) {
@@ -57,13 +57,15 @@ function EmailProviderCard( {
 		>
 			<div className="email-providers-stacked-comparison__provider-card-main-details">
 				<p>{ description }</p>
-				<Button
-					primary={ false }
-					onClick={ toggleVisibility }
-					className="email-providers-stacked-comparison__provider-expand-cta"
-				>
-					{ labelForExpandButton }
-				</Button>
+				{ showExpandButton && (
+					<Button
+						primary={ false }
+						onClick={ toggleVisibility }
+						className="email-providers-stacked-comparison__provider-expand-cta"
+					>
+						{ labelForExpandButton }
+					</Button>
+				) }
 			</div>
 			<PromoCardPrice formattedPrice={ formattedPrice } discount={ discount } />
 			{ additionalPriceInformation && (
@@ -75,7 +77,7 @@ function EmailProviderCard( {
 				<div className="email-providers-stacked-comparison__provider-form">
 					{ formFields }
 					{ buttonLabel && (
-						<Button primary disabled={ buttonDisabled } onClick={ onButtonClick }>
+						<Button primary onClick={ onButtonClick }>
 							{ buttonLabel }
 						</Button>
 					) }
@@ -100,8 +102,8 @@ EmailProviderCard.propTypes = {
 	additionalPriceInformation: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
 	formFields: PropTypes.node,
 	buttonLabel: PropTypes.string,
-	buttonDisabled: PropTypes.bool,
 	onButtonClick: PropTypes.func,
+	showExpandButton: PropTypes.bool,
 	expandButtonLabel: PropTypes.string,
 	features: PropTypes.arrayOf( PropTypes.string ),
 	onExpandedChange: PropTypes.func,

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-card.jsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-card.jsx
@@ -29,6 +29,7 @@ function EmailProviderCard( {
 	onExpandedChange = noop,
 	formFields,
 	buttonLabel,
+	buttonDisabled = false,
 	onButtonClick,
 	expandButtonLabel,
 	features,
@@ -74,7 +75,7 @@ function EmailProviderCard( {
 				<div className="email-providers-stacked-comparison__provider-form">
 					{ formFields }
 					{ buttonLabel && (
-						<Button primary onClick={ onButtonClick }>
+						<Button primary disabled={ buttonDisabled } onClick={ onButtonClick }>
 							{ buttonLabel }
 						</Button>
 					) }
@@ -99,6 +100,7 @@ EmailProviderCard.propTypes = {
 	additionalPriceInformation: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
 	formFields: PropTypes.node,
 	buttonLabel: PropTypes.string,
+	buttonDisabled: PropTypes.bool,
 	onButtonClick: PropTypes.func,
 	expandButtonLabel: PropTypes.string,
 	features: PropTypes.arrayOf( PropTypes.string ),

--- a/client/my-sites/email/email-providers-stacked-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.jsx
@@ -42,7 +42,7 @@ import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
 import { emailManagementForwarding } from 'calypso/my-sites/email/paths';
 import { errorNotice } from 'calypso/state/notices/actions';
-import { Notice } from 'calypso/components/notice';
+import Notice from 'calypso/components/notice';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import Gridicon from 'calypso/components/gridicon';
@@ -131,7 +131,6 @@ class EmailProvidersStackedComparison extends React.Component {
 		const { titanMailboxes } = this.state;
 
 		const mailboxesAreValid = areAllMailboxesValid( titanMailboxes, [ 'alternativeEmail' ] );
-		const mailboxesAreValid = areAllMailboxesValid( titanMailboxes );
 		const userCanAddEmail = canCurrentUserAddEmail( domain );
 
 		recordTracksEvent( 'calypso_email_providers_add_click', {
@@ -466,8 +465,8 @@ class EmailProvidersStackedComparison extends React.Component {
 
 		return (
 			<>
-				{ this.renderDomainEligibilityNotice() }
 				{ this.renderHeaderSection() }
+				{ this.renderDomainEligibilityNotice() }
 				{ this.renderTitanCard() }
 				{ this.renderGoogleCard() }
 				{ this.renderEmailForwardingCard() }

--- a/client/my-sites/email/email-providers-stacked-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.jsx
@@ -18,6 +18,7 @@ import {
 } from 'calypso/lib/titan/new-mailbox';
 import { areAllUsersValid, getItemsForCart, newUsers } from 'calypso/lib/gsuite/new-users';
 import { Button } from '@automattic/components';
+import { canCurrentUserAddEmail, getCurrentUserCannotAddEmailReason } from 'calypso/lib/domains';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import EmailProviderCard from './email-provider-card';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
@@ -41,6 +42,7 @@ import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
 import { emailManagementForwarding } from 'calypso/my-sites/email/paths';
 import { errorNotice } from 'calypso/state/notices/actions';
+import { Notice } from 'calypso/components/notice';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import Gridicon from 'calypso/components/gridicon';
@@ -431,11 +433,32 @@ class EmailProvidersStackedComparison extends React.Component {
 		);
 	}
 
+	renderDomainEligibilityNotice() {
+		const { domain } = this.props;
+
+		const canUserAddEmail = canCurrentUserAddEmail( domain );
+		if ( canUserAddEmail ) {
+			return null;
+		}
+
+		const cannotAddEmailReason = getCurrentUserCannotAddEmailReason( domain );
+		if ( ! cannotAddEmailReason || ! cannotAddEmailReason.message ) {
+			return null;
+		}
+
+		return (
+			<Notice showDismiss={ false } status="is-error">
+				{ cannotAddEmailReason.message }
+			</Notice>
+		);
+	}
+
 	render() {
 		const { isGSuiteSupported } = this.props;
 
 		return (
 			<>
+				{ this.renderDomainEligibilityNotice() }
 				{ this.renderHeaderSection() }
 				{ this.renderTitanCard() }
 				{ this.renderGoogleCard() }

--- a/client/my-sites/email/email-providers-stacked-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.jsx
@@ -245,6 +245,7 @@ class EmailProvidersStackedComparison extends React.Component {
 				detailsExpanded={ this.state.expanded.forwarding }
 				onExpandedChange={ this.onExpandedStateChange }
 				buttonLabel={ buttonLabel }
+				buttonDisabled={ ! canCurrentUserAddEmail( domain ) }
 				expandButtonLabel={ translate( 'Add email forwarding' ) }
 				onButtonClick={ this.goToEmailForwarding }
 				features={ getEmailForwardingFeatures() }

--- a/client/my-sites/email/email-providers-stacked-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.jsx
@@ -128,6 +128,7 @@ class EmailProvidersStackedComparison extends React.Component {
 		const { titanMailboxes } = this.state;
 
 		const mailboxesAreValid = areAllMailboxesValid( titanMailboxes, [ 'alternativeEmail' ] );
+		const mailboxesAreValid = areAllMailboxesValid( titanMailboxes );
 
 		recordTracksEvent( 'calypso_email_providers_add_click', {
 			mailbox_count: titanMailboxes.length,

--- a/client/my-sites/email/email-providers-stacked-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.jsx
@@ -300,6 +300,7 @@ class EmailProvidersStackedComparison extends React.Component {
 						className="email-providers-stacked-comparison__gsuite-user-list-action-continue"
 						primary
 						busy={ this.state.addingToCart }
+						disabled={ ! canCurrentUserAddEmail( domain ) }
 						onClick={ this.onGoogleConfirmNewUsers }
 					>
 						{ translate( 'Add %(googleMailService)s', {
@@ -374,6 +375,7 @@ class EmailProvidersStackedComparison extends React.Component {
 					className="email-providers-stacked-comparison__titan-mailbox-action-continue"
 					primary
 					busy={ this.state.addingToCart }
+					disabled={ ! canCurrentUserAddEmail( domain ) }
 					onClick={ this.onTitanConfirmNewMailboxes }
 				>
 					{ translate( 'Add Email' ) }

--- a/client/my-sites/email/email-providers-stacked-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.jsx
@@ -127,22 +127,25 @@ class EmailProvidersStackedComparison extends React.Component {
 	};
 
 	onTitanConfirmNewMailboxes = () => {
+		const { domain } = this.props;
 		const { titanMailboxes } = this.state;
 
 		const mailboxesAreValid = areAllMailboxesValid( titanMailboxes, [ 'alternativeEmail' ] );
 		const mailboxesAreValid = areAllMailboxesValid( titanMailboxes );
+		const userCanAddEmail = canCurrentUserAddEmail( domain );
 
 		recordTracksEvent( 'calypso_email_providers_add_click', {
 			mailbox_count: titanMailboxes.length,
 			mailboxes_valid: mailboxesAreValid ? 1 : 0,
 			provider: 'titan',
+			user_can_add_email: userCanAddEmail,
 		} );
 
-		if ( ! mailboxesAreValid ) {
+		if ( ! mailboxesAreValid || ! userCanAddEmail ) {
 			return;
 		}
 
-		const { domain, productsList, selectedSiteSlug, shoppingCartManager } = this.props;
+		const { productsList, selectedSiteSlug, shoppingCartManager } = this.props;
 
 		const cartItem = titanMailMonthly( {
 			domain: domain.name,
@@ -181,21 +184,24 @@ class EmailProvidersStackedComparison extends React.Component {
 	};
 
 	onGoogleConfirmNewUsers = () => {
+		const { domain } = this.props;
 		const { googleUsers } = this.state;
 
 		const usersAreValid = areAllUsersValid( googleUsers );
+		const userCanAddEmail = canCurrentUserAddEmail( domain );
 
 		recordTracksEvent( 'calypso_email_providers_add_click', {
 			mailbox_count: googleUsers.length,
 			mailboxes_valid: usersAreValid ? 1 : 0,
 			provider: 'google',
+			user_can_add_email: userCanAddEmail ? 1 : 0,
 		} );
 
-		if ( ! usersAreValid ) {
+		if ( ! usersAreValid || ! userCanAddEmail ) {
 			return;
 		}
 
-		const { domain, productsList, selectedSiteSlug, shoppingCartManager } = this.props;
+		const { productsList, selectedSiteSlug, shoppingCartManager } = this.props;
 		const domains = [ domain ];
 		const googleProductSlug = config.isEnabled( 'google-workspace-migration' )
 			? GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -166,6 +166,10 @@
 				margin-bottom: 0;
 				padding-left: 3.5em;
 			}
+		}
+
+		.email-providers-stacked-comparison__provider-features {
+			padding-left: 3.5em;
 
 			.email-provider-details__feature:first-child {
 				margin-top: 0;

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -166,10 +166,6 @@
 				margin-bottom: 0;
 				padding-left: 3.5em;
 			}
-		}
-
-		.email-providers-stacked-comparison__provider-features {
-			padding-left: 3.5em;
 
 			.email-provider-details__feature:first-child {
 				margin-top: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds some new pieces of logic when a user isn't allowed to add email for a domain:
 * We show an error notice at the top of the email comparison page that includes the error message returned from the server
 * We contract all visible email provider cards and remove the buttons that allow users to expand those cards
 * In the case the user already has email forwarding set up and is the domain is not eligible, we automatically expand that card to show a "Manage email forwarding" button
 * We track an impression for the notice and track both the domain name and the code of the error

This PR doesn't add any specific actions or links for the returned error.

#### Screenshot

_Error notice for an expired domain_
<img width="1114" alt="Screenshot 2021-03-29 at 22 51 30" src="https://user-images.githubusercontent.com/3376401/112899821-edb4f480-90e2-11eb-8884-f5d1aad1768d.png">


#### Testing instructions

* Navigate to the [live branch](https://calypso.live/?branch=add/notices-for-domain-email-ineligibility).
* Try to add email to a domain in any of the following states: _(you don't need to test all options here, just some to make sure we're showing the error message)_
   - The domain has expired (which includes domains in redemption)
   - The domain is owned by another user
   - The domain has been cancelled (which includes parked domains, and domains cancelled within the refund period/AGP)
   - The domain has been suspended because you didn't verify your contact email address
   - The domain has a dispute flag set _(this may be the easiest one to test with, as you should be able to set a dispute flag via the domains report card)_
 * Verify that the notice is displayed in the email comparison page and that the card are correctly contracted without an expand button.
 
_It may be much simpler to mimic some of these states by using a development back end._

Related to #51307
Related to #51299