### PR TITLE
Update Jetpack Review Prompt Preference

### DIFF
--- a/client/state/jetpack-review-prompt/actions.ts
+++ b/client/state/jetpack-review-prompt/actions.ts
@@ -3,46 +3,64 @@
  */
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { getExistingPreference } from './selectors';
-import { PREFERENCE_NAME } from './constants';
+import { PREFERENCE_NAME, PreferenceType } from './constants';
 import { savePreference } from 'calypso/state/preferences/actions';
+import { AppState } from 'calypso/types';
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const dismiss = ( type: 'restore' | 'scan', reviewed = false ) => ( dispatch, getState ) => {
-	const state = getState();
+const combineDismissPreference = (
+	state: AppState,
+	type: 'restore' | 'scan',
+	dismissedAt: number,
+	reviewed: boolean
+): PreferenceType => {
 	const fullPref = getPreference( state, PREFERENCE_NAME ) ?? {};
 	const previousPref = getExistingPreference( state, type );
 
-	return dispatch(
-		savePreference( PREFERENCE_NAME, {
-			...fullPref,
-			[ type ]: {
-				...previousPref,
-				dismissCount: previousPref.dismissCount + ( reviewed ? 0 : 1 ),
-				dismissedAt: Date.now(),
-				reviewed,
-			},
-		} )
-	);
+	return {
+		...fullPref,
+		[ type ]: {
+			...previousPref,
+			dismissCount: previousPref.dismissCount + ( reviewed ? 0 : 1 ),
+			dismissedAt,
+			reviewed,
+		},
+	};
 };
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const dismiss = (
+	type: 'restore' | 'scan',
+	dismissedAt: number = Date.now(),
+	reviewed = false
+) => ( dispatch, getState ) =>
+	dispatch(
+		savePreference(
+			PREFERENCE_NAME,
+			combineDismissPreference( getState(), type, dismissedAt, reviewed )
+		)
+	);
+
+const combineValidPreference = (
+	state: AppState,
+	type: 'restore' | 'scan',
+	validFrom: number | null
+): PreferenceType => {
+	const fullPref = getPreference( state, PREFERENCE_NAME ) ?? {};
+	const previousPref = getExistingPreference( state, type );
+
+	return {
+		...fullPref,
+		[ type ]: {
+			...previousPref,
+			validFrom: validFrom ?? Date.now(),
+		},
+	};
+};
+
 const setValidFrom = ( type: 'restore' | 'scan', validFrom: number | null = null ) => (
 	dispatch,
 	getState
-) => {
-	const state = getState();
-	const fullPref = getPreference( state, PREFERENCE_NAME ) ?? {};
-	const previousPref = getExistingPreference( state, type );
-
-	return dispatch(
-		savePreference( PREFERENCE_NAME, {
-			...fullPref,
-			[ type ]: {
-				...previousPref,
-				validFrom: validFrom ?? Date.now(),
-			},
-		} )
+) =>
+	dispatch(
+		savePreference( PREFERENCE_NAME, combineValidPreference( getState(), type, validFrom ) )
 	);
-};
-
-export { dismiss, setValidFrom };
+export { dismiss, setValidFrom, combineDismissPreference, combineValidPreference };

--- a/client/state/jetpack-review-prompt/actions.ts
+++ b/client/state/jetpack-review-prompt/actions.ts
@@ -7,7 +7,7 @@ import { PREFERENCE_NAME } from './constants';
 import { savePreference } from 'calypso/state/preferences/actions';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const dismiss = ( type: 'restore' | 'scan' ) => ( dispatch, getState ) => {
+const dismiss = ( type: 'restore' | 'scan', reviewed = false ) => ( dispatch, getState ) => {
 	const state = getState();
 	const fullPref = getPreference( state, PREFERENCE_NAME ) ?? {};
 	const previousPref = getExistingPreference( state, type );
@@ -17,26 +17,9 @@ const dismiss = ( type: 'restore' | 'scan' ) => ( dispatch, getState ) => {
 			...fullPref,
 			[ type ]: {
 				...previousPref,
-				dismissCount: previousPref.dismissCount + 1,
+				dismissCount: previousPref.dismissCount + ( reviewed ? 0 : 1 ),
 				dismissedAt: Date.now(),
-			},
-		} )
-	);
-};
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const dismissAsReviewed = ( type: 'restore' | 'scan' ) => ( dispatch, getState ) => {
-	const state = getState();
-	const fullPref = getPreference( state, PREFERENCE_NAME ) ?? {};
-	const previousPref = getExistingPreference( state, type );
-
-	return dispatch(
-		savePreference( PREFERENCE_NAME, {
-			...fullPref,
-			[ type ]: {
-				...previousPref,
-				dismissedAt: Date.now(),
-				reviewed: true,
+				reviewed,
 			},
 		} )
 	);
@@ -62,4 +45,4 @@ const setValidFrom = ( type: 'restore' | 'scan', validFrom: number | null = null
 	);
 };
 
-export { dismiss, dismissAsReviewed, setValidFrom };
+export { dismiss, setValidFrom };

--- a/client/state/jetpack-review-prompt/actions.ts
+++ b/client/state/jetpack-review-prompt/actions.ts
@@ -5,21 +5,33 @@ import { savePreference } from 'calypso/state/preferences/actions';
 import { PREFERENCE_NAME, PreferenceType } from './constants';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const dismiss = ( previousCount: number ) => {
+const dismiss = ( previousCount: number, validFrom: number | null = null ) => {
 	return savePreference( PREFERENCE_NAME, {
 		dismissedAt: Date.now(),
 		dismissCount: previousCount + 1,
 		reviewed: false,
+		validFrom,
 	} as PreferenceType );
 };
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const dismissAsReviewed = ( previousCount: number ) => {
+const dismissAsReviewed = ( previousCount: number, validFrom: number | null = null ) => {
 	return savePreference( PREFERENCE_NAME, {
 		dismissedAt: Date.now(),
 		dismissCount: previousCount,
 		reviewed: true,
+		validFrom,
 	} as PreferenceType );
 };
 
-export { dismiss, dismissAsReviewed };
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const setValidFrom = ( validFrom: number | null = null ) => {
+	return savePreference( PREFERENCE_NAME, {
+		dismissedAt: null,
+		dismissCount: 0,
+		reviewed: true,
+		validFrom: validFrom ?? Date.now(),
+	} as PreferenceType );
+};
+
+export { dismiss, dismissAsReviewed, setValidFrom };

--- a/client/state/jetpack-review-prompt/actions.ts
+++ b/client/state/jetpack-review-prompt/actions.ts
@@ -1,37 +1,65 @@
 /**
  * Internal dependencies
  */
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { getExistingPreference } from './selectors';
+import { PREFERENCE_NAME } from './constants';
 import { savePreference } from 'calypso/state/preferences/actions';
-import { PREFERENCE_NAME, PreferenceType } from './constants';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const dismiss = ( previousCount: number, validFrom: number | null = null ) => {
-	return savePreference( PREFERENCE_NAME, {
-		dismissedAt: Date.now(),
-		dismissCount: previousCount + 1,
-		reviewed: false,
-		validFrom,
-	} as PreferenceType );
+const dismiss = ( type: 'restore' | 'scan' ) => ( dispatch, getState ) => {
+	const state = getState();
+	const fullPref = getPreference( state, PREFERENCE_NAME ) ?? {};
+	const previousPref = getExistingPreference( state, type );
+
+	return dispatch(
+		savePreference( PREFERENCE_NAME, {
+			...fullPref,
+			[ type ]: {
+				...previousPref,
+				dismissCount: previousPref.dismissCount + 1,
+				dismissedAt: Date.now(),
+			},
+		} )
+	);
 };
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const dismissAsReviewed = ( previousCount: number, validFrom: number | null = null ) => {
-	return savePreference( PREFERENCE_NAME, {
-		dismissedAt: Date.now(),
-		dismissCount: previousCount,
-		reviewed: true,
-		validFrom,
-	} as PreferenceType );
+const dismissAsReviewed = ( type: 'restore' | 'scan' ) => ( dispatch, getState ) => {
+	const state = getState();
+	const fullPref = getPreference( state, PREFERENCE_NAME ) ?? {};
+	const previousPref = getExistingPreference( state, type );
+
+	return dispatch(
+		savePreference( PREFERENCE_NAME, {
+			...fullPref,
+			[ type ]: {
+				...previousPref,
+				dismissedAt: Date.now(),
+				reviewed: true,
+			},
+		} )
+	);
 };
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const setValidFrom = ( validFrom: number | null = null ) => {
-	return savePreference( PREFERENCE_NAME, {
-		dismissedAt: null,
-		dismissCount: 0,
-		reviewed: true,
-		validFrom: validFrom ?? Date.now(),
-	} as PreferenceType );
+const setValidFrom = ( type: 'restore' | 'scan', validFrom: number | null = null ) => (
+	dispatch,
+	getState
+) => {
+	const state = getState();
+	const fullPref = getPreference( state, PREFERENCE_NAME ) ?? {};
+	const previousPref = getExistingPreference( state, type );
+
+	return dispatch(
+		savePreference( PREFERENCE_NAME, {
+			...fullPref,
+			[ type ]: {
+				...previousPref,
+				validFrom: validFrom ?? Date.now(),
+			},
+		} )
+	);
 };
 
 export { dismiss, dismissAsReviewed, setValidFrom };

--- a/client/state/jetpack-review-prompt/constants.ts
+++ b/client/state/jetpack-review-prompt/constants.ts
@@ -4,12 +4,14 @@ export interface PreferenceType {
 	dismissCount: number;
 	dismissedAt: number | null;
 	reviewed: boolean;
+	validFrom: number | null;
 }
 
 export const emptyPreference: PreferenceType = {
 	dismissCount: 0,
 	dismissedAt: null,
 	reviewed: false,
+	validFrom: null,
 };
 
 const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;

--- a/client/state/jetpack-review-prompt/constants.ts
+++ b/client/state/jetpack-review-prompt/constants.ts
@@ -1,13 +1,18 @@
 export const PREFERENCE_NAME = 'jetpack-review-prompt';
 
-export interface PreferenceType {
+export interface SinglePreferenceType {
 	dismissCount: number;
 	dismissedAt: number | null;
 	reviewed: boolean;
 	validFrom: number | null;
 }
 
-export const emptyPreference: PreferenceType = {
+export interface PreferenceType {
+	scan?: SinglePreferenceType;
+	restore?: SinglePreferenceType;
+}
+
+export const emptyPreference: SinglePreferenceType = {
 	dismissCount: 0,
 	dismissedAt: null,
 	reviewed: false,

--- a/client/state/jetpack-review-prompt/selectors.ts
+++ b/client/state/jetpack-review-prompt/selectors.ts
@@ -8,6 +8,7 @@ import {
 	PREFERENCE_NAME,
 	PreferenceType,
 	TIME_BETWEEN_PROMPTS,
+	SinglePreferenceType,
 } from './constants';
 
 /**
@@ -15,15 +16,16 @@ import {
  */
 import type { AppState } from 'calypso/types';
 
-const getDismissCount = ( state: AppState ): number => {
-	const preference =
-		( getPreference( state, PREFERENCE_NAME ) as PreferenceType ) || emptyPreference;
-	return preference.dismissCount;
+const getExistingPreference = (
+	state: AppState,
+	type: 'scan' | 'restore'
+): SinglePreferenceType => {
+	const pref = ( getPreference( state, PREFERENCE_NAME ) as PreferenceType ) || {};
+	return pref[ type ] ?? emptyPreference;
 };
 
-const getIsDismissed = ( state: AppState ): boolean => {
-	const { dismissCount, dismissedAt, reviewed } =
-		( getPreference( state, PREFERENCE_NAME ) as PreferenceType ) || emptyPreference;
+const getIsDismissed = ( state: AppState, type: 'scan' | 'restore' ): boolean => {
+	const { dismissCount, dismissedAt, reviewed } = getExistingPreference( state, type );
 
 	if ( reviewed || MAX_DISMISS_COUNT <= dismissCount ) {
 		return true;
@@ -33,10 +35,9 @@ const getIsDismissed = ( state: AppState ): boolean => {
 		: false;
 };
 
-const getValidFrom = ( state: AppState ): number | null => {
-	const preference =
-		( getPreference( state, PREFERENCE_NAME ) as PreferenceType ) || emptyPreference;
-	return preference.validFrom;
+const getIsValid = ( state: AppState, type: 'scan' | 'restore' ): boolean => {
+	const { validFrom } = getExistingPreference( state, type );
+	return null !== validFrom ? validFrom < Date.now() : false;
 };
 
-export { getDismissCount, getIsDismissed, getValidFrom };
+export { getIsDismissed, getIsValid, getExistingPreference };

--- a/client/state/jetpack-review-prompt/selectors.ts
+++ b/client/state/jetpack-review-prompt/selectors.ts
@@ -33,4 +33,10 @@ const getIsDismissed = ( state: AppState ): boolean => {
 		: false;
 };
 
-export { getDismissCount, getIsDismissed };
+const getValidFrom = ( state: AppState ): number | null => {
+	const preference =
+		( getPreference( state, PREFERENCE_NAME ) as PreferenceType ) || emptyPreference;
+	return preference.validFrom;
+};
+
+export { getDismissCount, getIsDismissed, getValidFrom };

--- a/client/state/jetpack-review-prompt/test/actions.ts
+++ b/client/state/jetpack-review-prompt/test/actions.ts
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+
+// import { getIsDismissed, getIsValid } from '../selectors';
+// import { TIME_BETWEEN_PROMPTS } from '../constants';
+import { combineDismissPreference, combineValidPreference } from '../actions';
+
+describe( 'actions', () => {
+	describe( 'combineDismissPreference()', () => {
+		test( 'should set dismissedAt', () => {
+			const dismissDate = Date.now();
+
+			expect(
+				combineDismissPreference( { preferences: {} }, 'scan', dismissDate, false ).scan
+			).to.have.property( 'dismissedAt', dismissDate );
+		} );
+
+		test( 'should set dismissCount to 1 on initial dismiss', () => {
+			expect(
+				combineDismissPreference( { preferences: {} }, 'scan', Date.now(), false ).scan
+			).to.have.property( 'dismissCount', 1 );
+		} );
+
+		test( 'should increment dismissCount', () => {
+			expect(
+				combineDismissPreference(
+					{
+						preferences: {
+							localValues: {
+								'jetpack-review-prompt': {
+									scan: {
+										dismissCount: 1,
+										dismissedAt: Date.now(),
+										validFrom: null,
+										reviewed: false,
+									},
+								},
+							},
+						},
+					},
+					'scan',
+					Date.now(),
+					false
+				).scan
+			).to.have.property( 'dismissCount', 2 );
+		} );
+
+		test( 'should set reviewed', () => {
+			expect(
+				combineDismissPreference(
+					{
+						preferences: {},
+					},
+					'scan',
+					Date.now(),
+					true
+				).scan
+			).to.have.property( 'reviewed', true );
+		} );
+
+		describe( 'combineDismissPreference()', () => {
+			test( 'should set validFrom', () => {
+				const validFrom = Date.now();
+
+				expect(
+					combineValidPreference( { preferences: {} }, 'scan', validFrom ).scan
+				).to.have.property( 'validFrom', validFrom );
+			} );
+		} );
+	} );
+} );

--- a/client/state/jetpack-review-prompt/test/selectors.ts
+++ b/client/state/jetpack-review-prompt/test/selectors.ts
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { getIsDismissed } from '../selectors';
+import { getIsDismissed, getIsValid } from '../selectors';
 import { TIME_BETWEEN_PROMPTS } from '../constants';
 
 describe( 'selectors', () => {
@@ -82,6 +82,73 @@ describe( 'selectors', () => {
 				},
 			};
 			expect( getIsDismissed( state, 'scan' ) ).to.be.true;
+		} );
+	} );
+
+	describe( 'getIsValid()', () => {
+		test( 'should return false if preference is empty', () => {
+			const state = {
+				preferences: {},
+			};
+			expect( getIsValid( state, 'scan' ) ).to.be.false;
+		} );
+		test( 'should return false if isValid has not been set', () => {
+			const state = {
+				preferences: {
+					localValues: {
+						'jetpack-review-prompt': {
+							scan: {
+								dismissCount: 0,
+								dismissedAt: null,
+								reviewed: false,
+								validFrom: null,
+							},
+						},
+					},
+				},
+			};
+			expect( getIsValid( state, 'scan' ) ).to.be.false;
+		} );
+		test( 'should return true if isValid has been set', () => {
+			const state = {
+				preferences: {
+					localValues: {
+						'jetpack-review-prompt': {
+							scan: {
+								dismissCount: 0,
+								dismissedAt: null,
+								reviewed: false,
+								validFrom: Date.now() - 1,
+							},
+						},
+					},
+				},
+			};
+			expect( getIsValid( state, 'scan' ) ).to.be.true;
+		} );
+		test( 'should return true if isValid has been set on correct sub-property', () => {
+			const state = {
+				preferences: {
+					localValues: {
+						'jetpack-review-prompt': {
+							scan: {
+								dismissCount: 0,
+								dismissedAt: null,
+								reviewed: false,
+								validFrom: Date.now() + 100000,
+							},
+							restore: {
+								dismissCount: 0,
+								dismissedAt: null,
+								reviewed: false,
+								validFrom: Date.now() - 1,
+							},
+						},
+					},
+				},
+			};
+			expect( getIsValid( state, 'restore' ) ).to.be.true;
+			expect( getIsValid( state, 'scan' ) ).to.be.false;
 		} );
 	} );
 } );

--- a/client/state/jetpack-review-prompt/test/selectors.ts
+++ b/client/state/jetpack-review-prompt/test/selectors.ts
@@ -6,91 +6,82 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { getDismissCount, getIsDismissed } from '../selectors';
+import { getIsDismissed } from '../selectors';
 import { TIME_BETWEEN_PROMPTS } from '../constants';
 
 describe( 'selectors', () => {
-	describe( 'getDismissCount()', () => {
-		test( 'should return zero if no preference saved', () => {
-			const state = { preferences: {} };
-			expect( getDismissCount( state ) ).to.equal( 0 );
-		} );
-		test( 'should return count if preference is saved', () => {
-			const state = {
-				preferences: {
-					localValues: {
-						'jetpack-review-prompt': {
-							dismissCount: 3,
-							dismissedAt: null,
-							reviewed: false,
-						},
-					},
-				},
-			};
-			expect( getDismissCount( state ) ).to.equal( 3 );
-		} );
-	} );
-
 	describe( 'getIsDismissed()', () => {
 		test( 'should return false if no preference saved', () => {
 			const state = { preferences: {} };
-			expect( getIsDismissed( state ) ).to.be.false;
+			expect( getIsDismissed( state, 'scan' ) ).to.be.false;
 		} );
 		test( 'should return true if reviewed', () => {
 			const state = {
 				preferences: {
 					localValues: {
 						'jetpack-review-prompt': {
-							dismissCount: 1,
-							dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
-							reviewed: true,
+							scan: {
+								dismissCount: 1,
+								dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+								reviewed: true,
+								validFrom: null,
+							},
 						},
 					},
 				},
 			};
-			expect( getIsDismissed( state ) ).to.be.true;
+			expect( getIsDismissed( state, 'scan' ) ).to.be.true;
 		} );
 		test( 'should return false if dismissed just now', () => {
 			const state = {
 				preferences: {
 					localValues: {
 						'jetpack-review-prompt': {
-							dismissCount: 1,
-							dismissedAt: Date.now(),
-							reviewed: false,
+							scan: {
+								dismissCount: 1,
+								dismissedAt: Date.now(),
+								reviewed: false,
+								validFrom: null,
+							},
 						},
 					},
 				},
 			};
-			expect( getIsDismissed( state ) ).to.be.true;
+			expect( getIsDismissed( state, 'scan' ) ).to.be.true;
 		} );
 		test( 'should return true if dismissed longer than TIME_BETWEEN_PROMPTS', () => {
 			const state = {
 				preferences: {
 					localValues: {
 						'jetpack-review-prompt': {
-							dismissCount: 1,
-							dismissedAt: Date.now() - ( TIME_BETWEEN_PROMPTS + 1 ),
-							reviewed: false,
+							scan: {
+								dismissCount: 1,
+								dismissedAt: Date.now() - ( TIME_BETWEEN_PROMPTS + 1 ),
+								reviewed: false,
+								validFrom: null,
+							},
 						},
 					},
 				},
 			};
-			expect( getIsDismissed( state ) ).to.be.false;
+			expect( getIsDismissed( state, 'scan' ) ).to.be.false;
 		} );
 		test( 'should return true if dismissed twice', () => {
 			const state = {
 				preferences: {
 					localValues: {
 						'jetpack-review-prompt': {
-							dismissCount: 2,
-							dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
-							reviewed: false,
+							scan: {
+								dismissCount: 2,
+								dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+								reviewed: false,
+								validFrom: null,
+							},
 						},
 					},
 				},
 			};
-			expect( getIsDismissed( state ) ).to.be.true;
+			expect( getIsDismissed( state, 'scan' ) ).to.be.true;
 		} );
 	} );
 } );

--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -92,6 +92,7 @@ export const remoteValuesSchema = {
 				dismissedAt: { type: [ 'number', 'null' ] },
 				dismissedCount: { type: 'number', minimum: 0 },
 				reviewed: { type: 'number' },
+				validFrom: { type: [ 'number', 'null' ] },
 			},
 			required: [ 'dismissedAt', 'dismissedCount', 'reviewed' ],
 		},

--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -89,12 +89,21 @@ export const remoteValuesSchema = {
 		'jetpack-review-prompt': {
 			type: 'object',
 			properties: {
+				scan: { $ref: '#/definitions/dismissiblePrompt' },
+				restore: { $ref: '#/definitions/dismissiblePrompt' },
+			},
+		},
+	},
+	definitions: {
+		dismissiblePrompt: {
+			type: 'object',
+			properties: {
 				dismissedAt: { type: [ 'number', 'null' ] },
 				dismissedCount: { type: 'number', minimum: 0 },
 				reviewed: { type: 'number' },
 				validFrom: { type: [ 'number', 'null' ] },
 			},
-			required: [ 'dismissedAt', 'dismissedCount', 'reviewed' ],
+			required: [ 'dismissedAt', 'dismissedCount', 'reviewed', 'validFrom' ],
 		},
 	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Nest preference within object so it can be addressed separately for different sections ( currently scan and restore )
* Add validFrom to hide prompt until certain date or criteria is met

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* verify `yarn test-client state/jetpack-review-prompt` passes

Follow up from #51356