### PR TITLE
Add Email free trial pricing to email comparison page

### DIFF
--- a/client/my-sites/email/email-providers-stacked-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.jsx
@@ -346,9 +346,7 @@ class EmailProvidersStackedComparison extends React.Component {
 			comment: '{{price/}} is the formatted price, e.g. $20',
 		} );
 
-		const isEligibleForFreeTrial =
-			config.isEnabled( 'titan/free-trial' ) &&
-			domain?.titanMailSubscription?.isEligibleForIntroductoryOffer;
+		const isEligibleForFreeTrial = domain?.titanMailSubscription?.isEligibleForIntroductoryOffer;
 		const discount = isEligibleForFreeTrial ? translate( '3 months free' ) : null;
 
 		const logo = (

--- a/client/my-sites/email/email-providers-stacked-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.jsx
@@ -247,7 +247,7 @@ class EmailProvidersStackedComparison extends React.Component {
 	renderGoogleCard() {
 		const { currencyCode, domain, gSuiteProduct, isGSuiteSupported, translate } = this.props;
 
-		// TODO: Improve handling of
+		// TODO: Improve handling of this case
 		if ( ! isGSuiteSupported ) {
 			return null;
 		}
@@ -345,8 +345,12 @@ class EmailProvidersStackedComparison extends React.Component {
 			},
 			comment: '{{price/}} is the formatted price, e.g. $20',
 		} );
-		// TODO: calculate whether a discount/trial applies for the current domain
-		const discount = null; //translate( '3 months free' );
+
+		const isEligibleForFreeTrial =
+			config.isEnabled( 'titan/free-trial' ) &&
+			domain?.titanMailSubscription?.isEligibleForIntroductoryOffer;
+		const discount = isEligibleForFreeTrial ? translate( '3 months free' ) : null;
+
 		const logo = (
 			<Gridicon
 				className="email-providers-stacked-comparison__providers-wordpress-com-email"

--- a/config/development.json
+++ b/config/development.json
@@ -179,6 +179,7 @@
 		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,
+		"titan/free-trial": true,
 		"titan/iframe-control-panel": true,
 		"titan/phase-2": true,
 		"titan/provision-mailboxes": true,

--- a/config/development.json
+++ b/config/development.json
@@ -179,7 +179,6 @@
 		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,
-		"titan/free-trial": true,
 		"titan/iframe-control-panel": true,
 		"titan/phase-2": true,
 		"titan/provision-mailboxes": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a new `titan/free-trial` feature flag and adds logic to the email comparison page to show the correct pricing for each domain based on the eligibility data we get from the server.

#### Screenshot

<img width="1061" alt="Three month trial" src="https://user-images.githubusercontent.com/3376401/112553621-825ee000-8dcd-11eb-8af7-1926042f40a3.png">

#### Testing instructions

This is going to need coordination with the back end to work, and requires that you can enable store sandbox. (See PCYsg-IA-p2 for options, depending on whether you have a developer back end.)

The next steps depend on whether D59149-code has been merged or not.

##### The change above has _not_ been merged

* Enable store sandbox, and ensure that your currency is not set to USD, DKK, or EUR.
  - If you have a developer back end, you can take a look at the diff above to support any of these currencies
* Navigate to the [live branch](https://calypso.live/?branch=add/titan-free-trial-pricing), and once it has rendered, add `?flags=titan/free-trial` to the URL.
* Try to purchase Email for a domain where you haven't purchased Email before (this can be a new domain)
* Verify that the email comparison page shows you a three month discount for Email
* Add a mailbox, and verify that checkout also shows you a free purchase of a three month trial

##### The change above _has_ been merged

This will require a development back end, as the current rules require the domain to be purchased on or after 2021-03-29. (We may shift this date for store sandbox mode.)

* Enable store sandbox
* Navigate to the [live branch](https://calypso.live/?branch=add/titan-free-trial-pricing), and once it has rendered, add `?flags=titan/free-trial` to the URL.
* Try to purchase Email for a domain where you haven't purchased Email before (this can be a new domain)
* Verify that the email comparison page shows you a three month discount for Email
* Add a mailbox, and verify that checkout also shows you a free purchase of a three month trial