### PR TITLE
Add query value to identify post sharing context

### DIFF
--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -71,6 +71,7 @@ function buildQuerystringForPost( post ) {
 	args.title = `${ post.title } — ${ post.site_name }`;
 	args.text = post.excerpt;
 	args.url = post.URL;
+	args.is_post_share = true;
 
 	const params = new URLSearchParams( args );
 	return params.toString();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This update adds a query parameter to the URL used to create a post when sharing from the Reader, specifically identifying the post creation as coming from a post sharing context.
* This is an update to support an addition to wpcomsh being added to resolve https://github.com/Automattic/wp-calypso/issues/45607, which can be found at 652-gh-Automattic/wpcomsh.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR to your local Calypso environment and follow the instructions in 652-gh-Automattic/wpcomsh

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #45607