### PR TITLE
Jetpack Search: hide Jetpack footer for non-WordPress.com sites

### DIFF
--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -44,7 +44,7 @@ export default function JetpackSearchMain(): ReactElement {
 	const checkForSearchProduct = ( purchase ) => purchase.active && isJetpackSearch( purchase );
 	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
 	const hasSearchProduct =
-		sitePurchases.find( checkForSearchProduct ) || planHasJetpackSearch( site.plan?.product_slug );
+		sitePurchases.find( checkForSearchProduct ) || planHasJetpackSearch( site?.plan?.product_slug );
 	const hasLoadedSitePurchases = useSelector( hasLoadedSitePurchasesFromServer );
 	const onSettingsClick = useTrackCallback( undefined, 'calypso_jetpack_search_settings' );
 	const isWPCOM = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );

--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -30,6 +30,7 @@ import {
 	getSitePurchases,
 	hasLoadedSitePurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 
 /**
  * Asset dependencies
@@ -46,6 +47,7 @@ export default function JetpackSearchMain(): ReactElement {
 		sitePurchases.find( checkForSearchProduct ) || planHasJetpackSearch( site.plan?.product_slug );
 	const hasLoadedSitePurchases = useSelector( hasLoadedSitePurchasesFromServer );
 	const onSettingsClick = useTrackCallback( undefined, 'calypso_jetpack_search_settings' );
+	const isWPCOM = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
 
 	if ( ! hasLoadedSitePurchases ) {
 		return <JetpackSearchPlaceholder siteId={ siteId } />;
@@ -87,7 +89,7 @@ export default function JetpackSearchMain(): ReactElement {
 				/>
 			</PromoCard>
 
-			<WhatIsJetpack />
+			{ isWPCOM && <WhatIsJetpack /> }
 		</Main>
 	);
 }

--- a/client/my-sites/jetpack-search/placeholder.tsx
+++ b/client/my-sites/jetpack-search/placeholder.tsx
@@ -12,7 +12,6 @@ import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import FormattedHeader from 'calypso/components/formatted-header';
 import PromoCard from 'calypso/components/promo-section/promo-card';
-import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 
 /**
@@ -47,8 +46,6 @@ export default function JetpackSearchPlaceholder( { siteId }: Props ): ReactElem
 				<p className="jetpack-search__placeholder-description">Placeholder</p>
 				<button className="jetpack-search__placeholder-button">Placeholder</button>
 			</PromoCard>
-
-			<WhatIsJetpack />
 		</Main>
 	);
 }


### PR DESCRIPTION
Fix #48649 

#### Changes proposed in this Pull Request
In the Jetpack section, hide the Jetpack footer for non WordPress.com sites.

#### Testing instructions
- Go to http://calypso.localhost:3000/jetpack-search
- Select a **non** WordPress.com site, ensure the Jetpack footer is hidden
<img width="794" alt="Screen Shot 2021-03-25 at 11 37 59" src="https://user-images.githubusercontent.com/1425433/112392703-bb13a080-8d5e-11eb-830e-d9a9c554d2b9.png">

- Select a WordPress.com site, the Jetpack footer is shown
<img width="799" alt="Screen Shot 2021-03-25 at 11 38 10" src="https://user-images.githubusercontent.com/1425433/112392731-c5359f00-8d5e-11eb-93c8-7da37aaa5021.png">

