### PR TITLE
Add Jetpack Search team to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -100,3 +100,6 @@
 
 # Framework
 /packages/js-utils @Automattic/team-calypso-frameworks
+
+# Jetpack Search
+/client/my-sites/jetpack-search @Automattic/jetpack-search


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add Jetpack Search team to codeowners file for the `/client/my-sites/jetpack-search` directory.

#### Testing instructions

Check the file syntax looks correct.

https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners