### PR TITLE
Fix ETK slack notifications, other plugin builds

### DIFF
--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -103,19 +103,19 @@ open class PluginBaseBuild : Template({
 			scriptContent = """
 				# 1. Download and unzip current release build.
 				cd $workingDir
-				# wget "%teamcity.serverUrl%/repository/download/%system.teamcity.buildType.id%/$releaseTag.tcbuildtag/$pluginSlug.zip?guest=1&branch=trunk" -O ./tmp-release-archive-download.zip
-
 				mkdir ./release-archive
-				unzip ./tmp-release-archive-download.zip -d ./release-archive
-				echo "Diffing against current trunk release build (`grep build_number ./release-archive/build_meta.txt | sed s/build_number=//`).";
+
+				# wget "%teamcity.serverUrl%/repository/download/%system.teamcity.buildType.id%/$releaseTag.tcbuildtag/$pluginSlug.zip?guest=1&branch=trunk" -O ./tmp-release-archive-download.zip
+				#unzip ./tmp-release-archive-download.zip -d ./release-archive
+				#echo "Diffing against current trunk release build (`grep build_number ./release-archive/build_meta.txt | sed s/build_number=//`).";
 
 				# 2. Change anything from the release build which is "unstable", like the version number and build metadata.
 				# These operations restore idempotence between the two builds.
-				rm -f ./release-archive/build_meta.txt
+				#rm -f ./release-archive/build_meta.txt
 
-				cd ./release-archive
-				%normalize_files%
-				cd ..
+				#cd ./release-archive
+				#%normalize_files%
+				#cd ..
 
 				# 3. Check if the current build has changed, and if so, tag it for release.
 				# Note: we exclude asset changes because we only really care if the build files (JS/CSS) change. That file is basically just metadata.

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -103,7 +103,7 @@ open class PluginBaseBuild : Template({
 			scriptContent = """
 				# 1. Download and unzip current release build.
 				cd $workingDir
-				wget "%teamcity.serverUrl%/repository/download/%system.teamcity.buildType.id%/$releaseTag.tcbuildtag/$pluginSlug.zip?guest=1&branch=trunk" -O ./tmp-release-archive-download.zip
+				# wget "%teamcity.serverUrl%/repository/download/%system.teamcity.buildType.id%/$releaseTag.tcbuildtag/$pluginSlug.zip?guest=1&branch=trunk" -O ./tmp-release-archive-download.zip
 
 				mkdir ./release-archive
 				unzip ./tmp-release-archive-download.zip -d ./release-archive

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -36,6 +36,7 @@ private object EditingToolkit : BuildType({
 
 	templates(PluginBaseBuild())
 	params {
+		param("with_slack_notify", "true")
 		param("plugin_slug", "editing-toolkit")
 		param("archive_dir", "./editing-toolkit-plugin/")
 		param("release_tag", "etk-release-build")

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -276,7 +276,7 @@ function load_wpcom_block_patterns_modifications() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_patterns_modifications' );
 
 /**
- * Load Block Inserter Modifications module
+ * Load Block Inserter Modifications module.
  */
 function load_block_inserter_modifications() {
 	require_once __DIR__ . '/block-inserter-modifications/index.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request
When I merged #51159, I forgot to enable slack notifications for ETK. This adds that back. Additionally, we need to temporarily remove the code which downloads old plugins for comparison. We'll add it back as soon as the build can generate fresh archives on trunk

#### Testing instructions
- [ ] Merge and will get a notification 
- [ ] etk build passes

