### PR TITLE
Jetpack Checkout: Change Jetpack post checkout URL from my-plan to recommendations

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card/test/button.jsx
+++ b/client/components/jetpack/card/jetpack-free-card/test/button.jsx
@@ -26,7 +26,7 @@ const siteId = 1;
 const siteFragment = 'bored-sheep.jurassic.ninja';
 const siteUrl = `https://${ siteFragment }`;
 const adminUrl = `${ siteUrl }/wp-admin/`;
-const jetpackAdminUrl = `${ adminUrl }admin.php?page=jetpack#/my-plan`;
+const jetpackAdminUrl = `${ adminUrl }admin.php?page=jetpack#/recommendations`;
 
 const getLink = () => screen.getByRole( 'link' );
 const getHref = () => getLink().getAttribute( 'href' );

--- a/client/components/jetpack/card/jetpack-free-card/use-jetpack-free-button-props.ts
+++ b/client/components/jetpack/card/jetpack-free-card/use-jetpack-free-button-props.ts
@@ -14,7 +14,7 @@ import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { PLAN_JETPACK_FREE } from 'calypso/lib/plans/constants';
 import { addQueryArgs } from 'calypso/lib/route';
 import { getUrlParts, getUrlFromParts } from 'calypso/lib/url';
-import getJetpackWpAdminUrl from 'calypso/state/selectors/get-jetpack-wp-admin-url';
+import getJetpackRecommendationsUrl from 'calypso/state/selectors/get-jetpack-recommendations-url';
 
 /**
  * Type dependencies
@@ -52,7 +52,7 @@ const buildHref = (
 			jetpackAdminUrlFromQuery = getUrlFromParts( {
 				...getUrlParts( wpAdminUrlFromQuery.href ),
 				search: '?page=jetpack',
-				hash: '/my-plan',
+				hash: '/recommendations',
 			} ).href;
 		}
 	}
@@ -76,7 +76,7 @@ export default function useJetpackFreeButtonProps(
 	siteId: SiteId,
 	urlQueryArgs: QueryArgs = {}
 ): Props {
-	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
+	const recommendationsUrl = useSelector( getJetpackRecommendationsUrl );
 	const trackCallback = useTrackCallback( undefined, 'calypso_product_jpfree_click', {
 		site_id: siteId || undefined,
 	} );
@@ -84,8 +84,8 @@ export default function useJetpackFreeButtonProps(
 		storePlan( PLAN_JETPACK_FREE );
 		trackCallback();
 	}, [ trackCallback ] );
-	const href = useMemo( () => buildHref( wpAdminUrl, siteId, urlQueryArgs ), [
-		wpAdminUrl,
+	const href = useMemo( () => buildHref( recommendationsUrl, siteId, urlQueryArgs ), [
+		recommendationsUrl,
 		siteId,
 		urlQueryArgs,
 	] );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -281,7 +281,7 @@ function getFallbackDestination( {
 			if ( isJetpackCloud() ) {
 				if ( redirectCloudCheckoutToWpAdmin() && adminUrl ) {
 					debug( 'checkout is Jetpack Cloud, returning wp-admin url' );
-					return `${ adminUrl }admin.php?page=jetpack#/my-plan`;
+					return `${ adminUrl }admin.php?page=jetpack#/recommendations`;
 				}
 				debug( 'checkout is Jetpack Cloud, returning Jetpack Redirect API url' );
 				return `${ JETPACK_REDIRECT_URL }&site=${ siteSlug }&query=${ encodeURIComponent(

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -327,7 +327,7 @@ describe( 'getThankYouPageUrl', () => {
 			},
 			adminUrl,
 		} );
-		expect( url ).toBe( `https://my.site/wp-admin/admin.php?page=jetpack#/my-plan` );
+		expect( url ).toBe( `https://my.site/wp-admin/admin.php?page=jetpack#/recommendations` );
 	} );
 
 	it( 'redirects to the plans page with thank-you query string if there is a non-atomic jetpack product', () => {

--- a/client/state/selectors/get-jetpack-recommendations-url.js
+++ b/client/state/selectors/get-jetpack-recommendations-url.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -12,7 +7,7 @@ import { getUrlParts, getUrlFromParts } from 'calypso/lib/url';
 export default function getJetpackRecommendationsUrl( state ) {
 	const site = getSelectedSite( state );
 
-	const adminUrl = get( site, 'options.admin_url' );
+	const adminUrl = site?.options?.admin_url;
 	return adminUrl
 		? getUrlFromParts( {
 				...getUrlParts( adminUrl + 'admin.php' ),

--- a/client/state/selectors/get-jetpack-recommendations-url.js
+++ b/client/state/selectors/get-jetpack-recommendations-url.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getUrlParts, getUrlFromParts } from 'calypso/lib/url';
+
+export default function getJetpackRecommendationsUrl( state ) {
+	const site = getSelectedSite( state );
+
+	const adminUrl = get( site, 'options.admin_url' );
+	return adminUrl
+		? getUrlFromParts( {
+				...getUrlParts( adminUrl + 'admin.php' ),
+				search: '?page=jetpack',
+				hash: '/recommendations',
+		  } ).href
+		: undefined;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the post checkout URL so that users are directed to the recommendations page instead of the my-plan page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Connect a new Jurassic Ninja site and go through the connect flow. When you reach the plans page, replace `https://cloud.jetpack.com/` in the URL with `http://jetpack.cloud.localhost:3001/`, or the equivalent for your dev environment.
2. Verify that the "Start for free" button leads to `/wp-admin/admin.php?page=jetpack#/recommendations`.
3. Purchase a plan and verify that you are taken to `/wp-admin/admin.php?page=jetpack#/recommendations`.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
