### PR TITLE
Notifications: remove usages of createReactClass

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -27,7 +27,6 @@
 		"@automattic/calypso-polyfills": "^1.0.0",
 		"calypso": "^0.17.0",
 		"classnames": "^2.2.6",
-		"create-react-class": "^15.6.3",
 		"debug": "^4.1.1",
 		"i18n-calypso": "^5.0.0",
 		"lodash": "^4.17.21",

--- a/apps/notifications/src/panel/comment-replies-cache/index.js
+++ b/apps/notifications/src/panel/comment-replies-cache/index.js
@@ -11,7 +11,7 @@ const debug = require( 'debug' )( 'notifications:note' );
 function getItem( key ) {
 	let item;
 	try {
-		item = localStorage.getItem( key );
+		item = window.localStorage.getItem( key );
 		return JSON.parse( item );
 	} catch ( e ) {
 		if ( e instanceof SyntaxError ) {
@@ -26,7 +26,7 @@ function getItem( key ) {
 
 function setItem( key, value ) {
 	try {
-		localStorage.setItem( key, JSON.stringify( value ) );
+		window.localStorage.setItem( key, JSON.stringify( value ) );
 	} catch ( e ) {
 		debug( 'couldnt set localStorage item for: %s', key );
 	}
@@ -34,7 +34,7 @@ function setItem( key, value ) {
 
 function removeItem( key ) {
 	try {
-		localStorage.removeItem( key );
+		window.localStorage.removeItem( key );
 	} catch ( e ) {
 		debug( 'couldnt remove item from localStorage for: %s', key );
 	}
@@ -43,8 +43,6 @@ function removeItem( key ) {
 /**
  * Clears out state persisted reply cache
  *
- * @alias cleanup
- *
  * When filling out a reply to a comment,
  * the text is saved in `localStorage` to
  * prevent it from disappearing on accidental
@@ -52,18 +50,16 @@ function removeItem( key ) {
  * However, we don't want to pre-fill a comment
  * reply if the saved version is older than a
  * certain period of time: in this case, one day.
- *
- * @returns {undefined}
  */
-function cleanupRepliesCache() {
+function cleanup() {
 	const keysToRemove = [];
 
 	try {
-		for ( let i = 0; i < localStorage.length; i++ ) {
-			const storedReplyKey = localStorage.key( i );
+		for ( let i = 0; i < window.localStorage.length; i++ ) {
+			const storedReplyKey = window.localStorage.key( i );
 
 			// cleanup caches replies older than a day
-			if ( 'reply_' == localStorage.key( i ).substring( 0, 6 ) ) {
+			if ( 'reply_' === window.localStorage.key( i ).substring( 0, 6 ) ) {
 				const storedReply = getItem( storedReplyKey );
 
 				if ( storedReply && Date.now() - storedReply[ 1 ] >= 24 * 60 * 60 * 1000 ) {
@@ -75,21 +71,12 @@ function cleanupRepliesCache() {
 		debug( 'couldnt cleanup cache' );
 	}
 
-	keysToRemove.forEach( function ( key ) {
-		removeItem( key );
-	} );
+	keysToRemove.forEach( removeItem );
 }
-
-export const LocalStorageMixin = {
-	localStorage: {
-		getItem: getItem,
-		setItem: setItem,
-		removeItem: removeItem,
-	},
-};
-export const cleanup = cleanupRepliesCache;
 
 export default {
 	cleanup,
-	LocalStorageMixin,
+	getItem,
+	setItem,
+	removeItem,
 };

--- a/apps/notifications/src/panel/templates/comment-reply-input.jsx
+++ b/apps/notifications/src/panel/templates/comment-reply-input.jsx
@@ -1,10 +1,11 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 import actions from '../state/actions';
-import getSiteSuggestions from '../state/selectors/get-site-suggestions';
 
 /**
  * Internal dependencies
@@ -21,51 +22,44 @@ import { modifierKeyIsActive } from '../helpers/input';
 const debug = require( 'debug' )( 'notifications:reply' );
 const { recordTracksEvent } = require( '../helpers/stats' );
 
-const hasTouch = () =>
-	'ontouchstart' in window || ( window.DocumentTouch && document instanceof DocumentTouch );
+function stopEvent( event ) {
+	event.stopPropagation();
+	event.preventDefault();
+}
 
-const CommentReplyInput = createReactClass( {
-	displayName: 'CommentReplyInput',
-	mixins: [ repliesCache.LocalStorageMixin, Suggestions ],
+class CommentReplyInput extends React.Component {
+	replyInput = React.createRef();
 
-	statics: {
-		stopEvent: function ( event ) {
-			event.stopPropagation();
-			event.preventDefault();
-		},
-	},
-
-	getInitialState: function () {
-		const getSavedReply = function () {
-			const savedReply = this.localStorage.getItem( this.savedReplyKey );
-
-			return savedReply ? savedReply[ 0 ] : '';
-		};
+	constructor( props ) {
+		super( props );
 
 		this.savedReplyKey = 'reply_' + this.props.note.id;
 
-		return {
-			value: getSavedReply.apply( this ),
+		const savedReply = repliesCache.getItem( this.savedReplyKey );
+		const savedReplyValue = savedReply ? savedReply[ 0 ] : '';
+
+		this.state = {
+			value: savedReplyValue,
 			hasClicked: false,
 			isSubmitting: false,
 			rowCount: 1,
 			retryCount: 0,
 		};
-	},
+	}
 
-	componentDidMount: function () {
+	componentDidMount() {
 		window.addEventListener( 'keydown', this.handleKeyDown, false );
 		window.addEventListener( 'keydown', this.handleCtrlEnter, false );
-	},
+	}
 
-	componentWillUnmount: function () {
+	componentWillUnmount() {
 		window.removeEventListener( 'keydown', this.handleKeyDown, false );
 		window.removeEventListener( 'keydown', this.handleCtrlEnter, false );
 
 		this.props.enableKeyboardShortcuts();
-	},
+	}
 
-	handleKeyDown: function ( event ) {
+	handleKeyDown = ( event ) => {
 		if ( ! this.props.keyboardShortcutsAreEnabled ) {
 			return;
 		}
@@ -74,37 +68,37 @@ const CommentReplyInput = createReactClass( {
 			return;
 		}
 
-		if ( 82 == event.keyCode ) {
+		if ( 82 === event.keyCode ) {
 			/* 'r' key */
-			this.replyInput.focus();
-			CommentReplyInput.stopEvent( event );
+			this.replyInput.current.focus();
+			stopEvent( event );
 		}
-	},
+	};
 
-	handleCtrlEnter: function ( event ) {
+	handleCtrlEnter = ( event ) => {
 		if ( this.state.isSubmitting ) {
 			return;
 		}
 
-		if ( ( event.ctrlKey || event.metaKey ) && ( 10 == event.keyCode || 13 == event.keyCode ) ) {
-			CommentReplyInput.stopEvent( event );
+		if ( ( event.ctrlKey || event.metaKey ) && ( 10 === event.keyCode || 13 === event.keyCode ) ) {
+			stopEvent( event );
 			this.handleSubmit();
 		}
-	},
+	};
 
-	handleSendEnter: function ( event ) {
+	handleSendEnter = ( event ) => {
 		if ( this.state.isSubmitting ) {
 			return;
 		}
 
-		if ( 13 == event.keyCode ) {
-			CommentReplyInput.stopEvent( event );
+		if ( 13 === event.keyCode ) {
+			stopEvent( event );
 			this.handleSubmit();
 		}
-	},
+	};
 
-	handleChange: function ( event ) {
-		const textarea = this.replyInput;
+	handleChange = ( event ) => {
+		const textarea = this.replyInput.current;
 
 		this.props.disableKeyboardShortcuts();
 
@@ -118,11 +112,11 @@ const CommentReplyInput = createReactClass( {
 
 		// persist the comment reply on local storage
 		if ( this.savedReplyKey ) {
-			this.localStorage.setItem( this.savedReplyKey, [ event.target.value, Date.now() ] );
+			repliesCache.setItem( this.savedReplyKey, [ event.target.value, Date.now() ] );
 		}
-	},
+	};
 
-	handleClick: function ( event ) {
+	handleClick = () => {
 		this.props.disableKeyboardShortcuts();
 
 		if ( ! this.state.hasClicked ) {
@@ -130,30 +124,29 @@ const CommentReplyInput = createReactClass( {
 				hasClicked: true,
 			} );
 		}
-	},
+	};
 
-	handleFocus: function () {
+	handleFocus = () => {
 		this.props.disableKeyboardShortcuts();
-	},
+	};
 
-	handleBlur: function () {
+	handleBlur = () => {
 		this.props.enableKeyboardShortcuts();
 
 		// Reset the field if there's no valid user input
 		// The regex strips whitespace
-		if ( '' == this.state.value.replace( /^\s+|\s+$/g, '' ) ) {
+		if ( '' === this.state.value.replace( /^\s+|\s+$/g, '' ) ) {
 			this.setState( {
 				value: '',
 				hasClicked: false,
 				rowCount: 1,
 			} );
 		}
-	},
+	};
 
-	handleSubmit( event ) {
+	handleSubmit = ( event ) => {
 		let wpObject;
 		let submitComment;
-		const component = this;
 		let statusMessage;
 		const successMessage = this.props.translate( 'Reply posted!' );
 		const linkMessage = this.props.translate( 'View your comment.' );
@@ -162,7 +155,7 @@ const CommentReplyInput = createReactClass( {
 			event.preventDefault();
 		}
 
-		if ( '' == this.state.value ) return;
+		if ( '' === this.state.value ) return;
 
 		this.props.global.toggleNavigation( false );
 
@@ -170,7 +163,7 @@ const CommentReplyInput = createReactClass( {
 			isSubmitting: true,
 		} );
 
-		if ( this.state.retryCount == 0 ) {
+		if ( this.state.retryCount === 0 ) {
 			bumpStat( 'notes-click-action', 'replyto-comment' );
 			recordTracksEvent( 'calypso_notification_note_reply', {
 				note_type: this.props.note.type,
@@ -204,29 +197,27 @@ const CommentReplyInput = createReactClass( {
 						isSubmitting: false,
 						retryCount: 0,
 					} );
-					this.replyInput.focus();
+					this.replyInput.current.focus();
 
 					this.props.global.updateStatusBar( errorMessageDuplicateComment, [ 'fail' ], 6000 );
 					this.props.unselectNote();
-				} else if ( component.state.retryCount < 3 ) {
-					component.setState( {
-						retryCount: component.state.retryCount + 1,
+				} else if ( this.state.retryCount < 3 ) {
+					this.setState( {
+						retryCount: this.state.retryCount + 1,
 					} );
 
-					window.setTimeout( function () {
-						component.handleSubmit();
-					}, 2000 * component.state.retryCount );
+					window.setTimeout( () => this.handleSubmit(), 2000 * this.state.retryCount );
 				} else {
-					component.setState( {
+					this.setState( {
 						isSubmitting: false,
 						retryCount: 0,
 					} );
 
 					/* Flag submission failure */
-					component.props.global.updateStatusBar( errorMessage, [ 'fail' ], 6000 );
+					this.props.global.updateStatusBar( errorMessage, [ 'fail' ], 6000 );
 
-					component.props.enableKeyboardShortcuts();
-					component.props.global.toggleNavigation( true );
+					this.props.enableKeyboardShortcuts();
+					this.props.global.toggleNavigation( true );
 
 					debug( 'Failed to submit comment reply: %s', error.message );
 				}
@@ -234,15 +225,15 @@ const CommentReplyInput = createReactClass( {
 				return;
 			}
 
-			if ( component.props.note.meta.ids.comment ) {
+			if ( this.props.note.meta.ids.comment ) {
 				// pre-emptively approve the comment if it wasn't already
-				component.props.approveNote( component.props.note.id, true );
-				component.props.global.client.getNote( component.props.note.id );
+				this.props.approveNote( this.props.note.id, true );
+				this.props.global.client.getNote( this.props.note.id );
 			}
 
 			// remove focus from textarea so we can resume using keyboard
 			// shortcuts without typing in the field
-			component.replyInput.blur();
+			this.replyInput.current.blur();
 
 			if ( data.URL && validURL.test( data.URL ) ) {
 				statusMessage = formatString(
@@ -255,12 +246,12 @@ const CommentReplyInput = createReactClass( {
 				statusMessage = successMessage;
 			}
 
-			component.props.global.updateStatusBar( statusMessage, [ 'success' ], 12000 );
+			this.props.global.updateStatusBar( statusMessage, [ 'success' ], 12000 );
 
-			component.props.enableKeyboardShortcuts();
-			component.props.global.toggleNavigation( true );
+			this.props.enableKeyboardShortcuts();
+			this.props.global.toggleNavigation( true );
 
-			component.setState( {
+			this.setState( {
 				value: '',
 				isSubmitting: false,
 				hasClicked: false,
@@ -269,18 +260,38 @@ const CommentReplyInput = createReactClass( {
 			} );
 
 			// remove the comment reply from local storage
-			component.localStorage.removeItem( component.savedReplyKey );
+			repliesCache.removeItem( this.savedReplyKey );
 
 			// route back to list after successful comment post
-			component.props.selectNote( component.props.note.id );
+			this.props.selectNote( this.props.note.id );
 		} );
-	},
+	};
 
-	storeReplyInput( ref ) {
-		this.replyInput = ref;
-	},
+	insertSuggestion = ( suggestion, suggestionsQuery ) => {
+		if ( ! suggestion ) {
+			return;
+		}
 
-	render: function () {
+		const element = this.replyInput.current;
+		const caretPosition = element.selectionStart;
+		const startString = this.state.value.slice(
+			0,
+			Math.max( caretPosition - suggestionsQuery.length, 0 )
+		);
+		const endString = this.state.value.slice( caretPosition );
+
+		this.setState( {
+			value: startString + suggestion.user_login + ' ' + endString,
+		} );
+
+		element.focus();
+
+		// move the caret after the inserted suggestion
+		const insertPosition = startString.length + suggestion.user_login.length + 1;
+		setTimeout( () => element.setSelectionRange( insertPosition, insertPosition ), 0 );
+	};
+
+	render() {
 		const value = this.state.value;
 		let submitLink = '';
 		const sendText = this.props.translate( 'Send', { context: 'verb: imperative' } );
@@ -314,7 +325,7 @@ const CommentReplyInput = createReactClass( {
 			<div className="wpnc__reply-box">
 				<textarea
 					className="form-textarea"
-					ref={ this.storeReplyInput }
+					ref={ this.replyInput }
 					rows={ this.state.rowCount }
 					value={ value }
 					placeholder={ this.props.defaultValue }
@@ -324,26 +335,26 @@ const CommentReplyInput = createReactClass( {
 					onChange={ this.handleChange }
 				/>
 				{ submitLink }
-				{ this.renderSuggestions() }
+				<Suggestions
+					site={ this.props.note.meta.ids.site }
+					onInsertSuggestion={ this.insertSuggestion }
+					getContextEl={ () => this.replyInput.current }
+				/>
 			</div>
 		);
-	},
-} );
+	}
+}
 
-const mapStateToProps = ( state, { note } ) => ( {
-	suggestions: getSiteSuggestions( state, note.meta.ids.site ),
+const mapStateToProps = ( state ) => ( {
 	keyboardShortcutsAreEnabled: getKeyboardShortcutsEnabled( state ),
 } );
 
 const mapDispatchToProps = {
 	approveNote: actions.notes.approveNote,
-	fetchSuggestions: actions.suggestions.fetchSuggestions,
 	selectNote: actions.ui.selectNote,
 	unselectNote: actions.ui.unselectNote,
 	enableKeyboardShortcuts: actions.ui.enableKeyboardShortcuts,
 	disableKeyboardShortcuts: actions.ui.disableKeyboardShortcuts,
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, null, { pure: false } )(
-	localize( CommentReplyInput )
-);
+export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentReplyInput ) );


### PR DESCRIPTION
Removes usages of `create-react-class` from Notifications and converts old-fashioned classes and mixins to a more modern React code.

The interaction between `CommentReplyInput` and `Suggestions` was quite messy a required a lot of cleanup. `Suggestions` was a mixin that was "blended" into `CommentReplyInput`, sharing the same `this` and `this.state`. Separating `Suggestions` into a proper component took some work.

**How to test:**
The most affected part is composing replies. Verify that you can type into the notification's inline comment box, and that mentions work there perfectly.
