### PR TITLE
Address some UX issues in the email comparison page

### DIFF
--- a/client/my-sites/email/email-providers-stacked-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.jsx
@@ -362,6 +362,7 @@ class EmailProvidersStackedComparison extends React.Component {
 				mailboxes={ this.state.titanMailboxes }
 				domain={ domain.name }
 				onReturnKeyPress={ this.onTitanFormReturnKeyPress }
+				showLabels={ false }
 			>
 				<Button
 					className="email-providers-stacked-comparison__titan-mailbox-action-continue"

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -146,6 +146,8 @@
 		margin-top: 1em;
 
 		.email-providers-stacked-comparison__provider-form {
+			flex-grow: 1;
+
 			.titan-new-mailbox-list__actions {
 				justify-content: space-between;
 			}

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -23,7 +23,7 @@
 			max-width: 24px;
 		}
 
-			&.titan {
+		&.titan {
 			.promo-card__title-badge {
 				background: none;
 				padding: 0;
@@ -77,7 +77,12 @@
 	}
 
 	.promo-card__title-badge {
+		display: none;
+	}
+
+	&.is-expanded .promo-card__title-badge {
 		background: none;
+		display: inline-block;
 		padding: 0;
 
 		img {

--- a/client/my-sites/email/titan-mail-add-mailboxes/style.scss
+++ b/client/my-sites/email/titan-mail-add-mailboxes/style.scss
@@ -44,7 +44,6 @@
 
 		@include break-mobile {
 			margin-left: 1em;
-			margin-top: 20px;
 		}
 	}
 }

--- a/client/my-sites/email/titan-mail-add-mailboxes/style.scss
+++ b/client/my-sites/email/titan-mail-add-mailboxes/style.scss
@@ -17,6 +17,19 @@
 		.form-fieldset:first-child {
 			flex-grow: 2;
 		}
+
+		.titan-mail-add-mailboxes__new-mailbox-remove-mailbox-button {
+			height: 40px;
+			width: 50px;
+
+			.gridicon {
+				margin-right: 0;
+			}
+
+			span {
+				display: none;
+			}
+		}
 	}
 
 	.titan-mail-add-mailboxes__new-mailbox-remove-mailbox-button,
@@ -31,7 +44,7 @@
 
 		@include break-mobile {
 			margin-left: 1em;
-			margin-top: 1.5em;
+			margin-top: 20px;
 		}
 	}
 }

--- a/client/my-sites/email/titan-mail-add-mailboxes/style.scss
+++ b/client/my-sites/email/titan-mail-add-mailboxes/style.scss
@@ -4,10 +4,10 @@
 .titan-mail-add-mailboxes__new-mailbox .form-label .form-text-input-with-affixes__suffix {
 	font-weight: normal;
 }
-.titan-mail-add-mailboxes__new-mailbox-password-and-is-admin,
-.titan-mail-add-mailboxes__new-mailbox-name-and-remove {
+.titan-mail-add-mailboxes__new-mailbox-email-and-password,
+.titan-mail-add-mailboxes__new-mailbox-password-and-is-admin {
 	display: flex;
-	flex-direction: column-reverse;
+	flex-direction: column;
 
 	@include break-mobile {
 		align-items: flex-start;
@@ -16,6 +16,21 @@
 
 		.form-fieldset:first-child {
 			flex-grow: 2;
+			margin-right: 1em;
+		}
+	}
+}
+
+.titan-mail-add-mailboxes__new-mailbox-name-and-remove {
+	display: flex;
+	flex-direction: column-reverse;
+
+	@include break-mobile {
+		flex-direction: row;
+
+		.form-fieldset:first-child {
+			flex-grow: 2;
+			margin-right: 1em;
 		}
 
 		.titan-mail-add-mailboxes__new-mailbox-remove-mailbox-button {
@@ -40,10 +55,6 @@
 
 		.components-toggle-control p {
 			margin-bottom: 0;
-		}
-
-		@include break-mobile {
-			margin-left: 1em;
 		}
 	}
 }

--- a/client/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox-list.jsx
+++ b/client/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox-list.jsx
@@ -26,6 +26,7 @@ const TitanNewMailboxList = ( {
 	mailboxes,
 	onMailboxesChange,
 	onReturnKeyPress = noop,
+	showLabels = true,
 } ) => {
 	const translate = useTranslate();
 
@@ -74,6 +75,7 @@ const TitanNewMailboxList = ( {
 					onMailboxValueChange={ onMailboxValueChange( mailbox.uuid ) }
 					mailbox={ mailbox }
 					onReturnKeyPress={ onReturnKeyPress }
+					showLabels={ showLabels }
 				/>
 			) ) }
 
@@ -95,6 +97,7 @@ TitanNewMailboxList.propTypes = {
 	mailboxes: PropTypes.arrayOf( getMailboxPropTypeShape() ).isRequired,
 	onMailboxesChange: PropTypes.func.isRequired,
 	onReturnKeyPress: PropTypes.func,
+	showLabels: PropTypes.bool,
 };
 
 export default TitanNewMailboxList;

--- a/client/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox.jsx
+++ b/client/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox.jsx
@@ -33,6 +33,7 @@ const TitanNewMailbox = ( {
 		name: { value: name, error: nameError },
 		password: { value: password, error: passwordError },
 	},
+	showLabels = true,
 } ) => {
 	const translate = useTranslate();
 
@@ -65,7 +66,7 @@ const TitanNewMailbox = ( {
 				<div className="titan-mail-add-mailboxes__new-mailbox-name-and-remove">
 					<FormFieldset>
 						<FormLabel>
-							{ translate( 'Full name' ) }
+							{ showLabels && translate( 'Full name' ) }
 							<FormTextInput
 								placeholder={ translate( 'Full name' ) }
 								value={ name }
@@ -95,7 +96,7 @@ const TitanNewMailbox = ( {
 
 				<FormFieldset>
 					<FormLabel>
-						{ translate( 'Email address' ) }
+						{ showLabels && translate( 'Email address' ) }
 						<FormTextInputWithAffixes
 							placeholder={ translate( 'Email' ) }
 							value={ mailbox }
@@ -116,7 +117,7 @@ const TitanNewMailbox = ( {
 				<div className="titan-mail-add-mailboxes__new-mailbox-password-and-is-admin">
 					<FormFieldset>
 						<FormLabel>
-							{ translate( 'Password' ) }
+							{ showLabels && translate( 'Password' ) }
 							<FormPasswordInput
 								autoCapitalize="off"
 								autoCorrect="off"
@@ -153,11 +154,18 @@ const TitanNewMailbox = ( {
 
 				<FormFieldset>
 					<FormLabel>
-						{ translate( 'Password reset email address', {
-							comment: 'This is the email address we will send password reset emails to',
-						} ) }
+						{ showLabels &&
+							translate( 'Password reset email address', {
+								comment: 'This is the email address we will send password reset emails to',
+							} ) }
 						<FormTextInput
-							placeholder={ translate( 'Email address' ) }
+							placeholder={
+								showLabels
+									? translate( 'Email address' )
+									: translate( 'Password reset email address', {
+											comment: 'This is the email address we will send password reset emails to',
+									  } )
+							}
 							value={ alternativeEmail }
 							isError={ hasAlternativeEmailError }
 							onChange={ ( event ) => {
@@ -184,6 +192,7 @@ TitanNewMailbox.propTypes = {
 	onMailboxValueChange: PropTypes.func.isRequired,
 	onReturnKeyPress: PropTypes.func.isRequired,
 	mailbox: getMailboxPropTypeShape(),
+	showLabels: PropTypes.bool.isRequired,
 };
 
 export default TitanNewMailbox;

--- a/client/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox.jsx
+++ b/client/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox.jsx
@@ -94,27 +94,26 @@ const TitanNewMailbox = ( {
 					</Button>
 				</div>
 
-				<FormFieldset>
-					<FormLabel>
-						{ showLabels && translate( 'Email address' ) }
-						<FormTextInputWithAffixes
-							placeholder={ translate( 'Email' ) }
-							value={ mailbox }
-							isError={ hasMailboxError }
-							onChange={ ( event ) => {
-								onMailboxValueChange( 'mailbox', event.target.value.toLowerCase() );
-							} }
-							onBlur={ () => {
-								setMailboxFieldTouched( hasBeenValidated );
-							} }
-							onKeyUp={ onReturnKeyPress }
-							suffix={ `@${ domain }` }
-						/>
-					</FormLabel>
-					{ hasMailboxError && <FormInputValidation text={ mailboxError } isError /> }
-				</FormFieldset>
-
-				<div className="titan-mail-add-mailboxes__new-mailbox-password-and-is-admin">
+				<div className="titan-mail-add-mailboxes__new-mailbox-email-and-password">
+					<FormFieldset>
+						<FormLabel>
+							{ showLabels && translate( 'Email address' ) }
+							<FormTextInputWithAffixes
+								placeholder={ translate( 'Email' ) }
+								value={ mailbox }
+								isError={ hasMailboxError }
+								onChange={ ( event ) => {
+									onMailboxValueChange( 'mailbox', event.target.value.toLowerCase() );
+								} }
+								onBlur={ () => {
+									setMailboxFieldTouched( hasBeenValidated );
+								} }
+								onKeyUp={ onReturnKeyPress }
+								suffix={ `@${ domain }` }
+							/>
+						</FormLabel>
+						{ hasMailboxError && <FormInputValidation text={ mailboxError } isError /> }
+					</FormFieldset>
 					<FormFieldset>
 						<FormLabel>
 							{ showLabels && translate( 'Password' ) }
@@ -136,7 +135,9 @@ const TitanNewMailbox = ( {
 						</FormLabel>
 						{ hasPasswordError && <FormInputValidation text={ passwordError } isError /> }
 					</FormFieldset>
+				</div>
 
+				<div className="titan-mail-add-mailboxes__new-mailbox-password-and-is-admin">
 					{ showIsAdminToggle && (
 						<FormFieldset>
 							<FormToggle


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR addresses some UX issues in the email comparison page that were flagged in this internal comment: p7DVsv-aXu-p2#comment-35350

The specific changes are:
* Remove labels from the Email component
* Move some Email fields onto the same line in wider layouts
* Make the Email form be full-width
* Hide the Powered by Titan image when the Email card is contracted
* Use only an icon for the Email remove mailbox button

#### Screenshots

_Default state with Email expanded_
<img width="1073" alt="Email expanded" src="https://user-images.githubusercontent.com/3376401/112463632-28c5c980-8d6b-11eb-9d62-d1d24b28b036.png">

_State with Google Workspace expanded_
<img width="1073" alt="Google Workspace expanded" src="https://user-images.githubusercontent.com/3376401/112463670-354a2200-8d6b-11eb-8b64-641de842b90c.png">

#### Testing instructions

* Navigate to the live branch and add `?flags=titan/provision-mailboxes` to the URL.
* Try to add an email service to a domain and verify that you see the stated UI improvements

Related to #51307