### PR TITLE
Framework: Refactor away from stubTrue and stubFalse

### DIFF
--- a/client/state/domains/management/reducer.js
+++ b/client/state/domains/management/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, merge, omit, stubFalse, stubTrue } from 'lodash';
+import { get, merge, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -42,11 +42,10 @@ import { whoisType } from '../../../lib/domains/whois/constants';
 export const isRequestingContactDetailsCache = withoutPersistence( ( state = false, action ) => {
 	switch ( action.type ) {
 		case DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_REQUEST:
-			return stubTrue( state, action );
+			return true;
 		case DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_REQUEST_SUCCESS:
-			return stubFalse( state, action );
 		case DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_REQUEST_FAILURE:
-			return stubFalse( state, action );
+			return false;
 	}
 
 	return state;
@@ -57,11 +56,10 @@ export const isRequestingWhois = keyedReducer(
 	withoutPersistence( ( state = false, action ) => {
 		switch ( action.type ) {
 			case DOMAIN_MANAGEMENT_WHOIS_REQUEST:
-				return stubTrue( state, action );
+				return true;
 			case DOMAIN_MANAGEMENT_WHOIS_REQUEST_SUCCESS:
-				return stubFalse( state, action );
 			case DOMAIN_MANAGEMENT_WHOIS_REQUEST_FAILURE:
-				return stubFalse( state, action );
+				return false;
 		}
 
 		return state;

--- a/client/state/guided-tours/test/fixtures/config.js
+++ b/client/state/guided-tours/test/fixtures/config.js
@@ -1,12 +1,9 @@
 /**
- * External dependencies
- */
-import { stubTrue } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { isNewUser } from 'calypso/state/guided-tours/contexts';
+
+const stubTrue = () => true;
 
 export const MainTourMeta = {
 	name: 'main',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `stubTrue` and `stubFalse` are essentially functions that return `true` or `false`. This PR replaces the usage.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all tests pass.