### PR TITLE
Titan: Fix unable to add new mailboxes

### DIFF
--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -50,6 +50,23 @@ export default function () {
 
 	registerMultiPage( {
 		paths: [
+			paths.emailManagementNewTitanAccount(
+				':site',
+				':domain',
+				paths.emailManagementAllSitesPrefix
+			),
+			paths.emailManagementNewTitanAccount( ':site', ':domain' ),
+		],
+		handlers: [
+			...commonHandlers,
+			controller.emailManagementNewTitanAccount,
+			makeLayout,
+			clientRender,
+		],
+	} );
+
+	registerMultiPage( {
+		paths: [
 			paths.emailManagementNewGSuiteAccount(
 				':site',
 				':domain',
@@ -78,23 +95,6 @@ export default function () {
 		handlers: [
 			...commonHandlers,
 			controller.emailManagementManageTitanAccount,
-			makeLayout,
-			clientRender,
-		],
-	} );
-
-	registerMultiPage( {
-		paths: [
-			paths.emailManagementNewTitanAccount(
-				':site',
-				':domain',
-				paths.emailManagementAllSitesPrefix
-			),
-			paths.emailManagementNewTitanAccount( ':site', ':domain' ),
-		],
-		handlers: [
-			...commonHandlers,
-			controller.emailManagementNewTitanAccount,
 			makeLayout,
 			clientRender,
 		],


### PR DESCRIPTION
This pull requests fixes an issue where the `Add New Users` page for G Suite would be displayed instead of the `Add New Mailboxes` page for Titan when adding new mailboxes for a Titan account. This is a regression introduced in https://github.com/Automattic/wp-calypso/pull/51330, and that was caused by a change in routing which made routes more consistent but at the same time didn't take into account route precedence. The solution here is simply to declare the route of the `Add New Mailboxes` page before the one for the `Add New Users` page (apart from this nothing changed):

* https://wordpress.com/email/:domain/titan/new/:site
* https://wordpress.com/email/:domain/google-workspace/add-users/:site
* https://wordpress.com/email/:domain/gsuite/add-users/:site