### PR TITLE
Emails: Update routes not to rely on any specific order

### DIFF
--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -50,23 +50,6 @@ export default function () {
 
 	registerMultiPage( {
 		paths: [
-			paths.emailManagementNewTitanAccount(
-				':site',
-				':domain',
-				paths.emailManagementAllSitesPrefix
-			),
-			paths.emailManagementNewTitanAccount( ':site', ':domain' ),
-		],
-		handlers: [
-			...commonHandlers,
-			controller.emailManagementNewTitanAccount,
-			makeLayout,
-			clientRender,
-		],
-	} );
-
-	registerMultiPage( {
-		paths: [
 			paths.emailManagementNewGSuiteAccount(
 				':site',
 				':domain',
@@ -95,6 +78,23 @@ export default function () {
 		handlers: [
 			...commonHandlers,
 			controller.emailManagementManageTitanAccount,
+			makeLayout,
+			clientRender,
+		],
+	} );
+
+	registerMultiPage( {
+		paths: [
+			paths.emailManagementNewTitanAccount(
+				':site',
+				':domain',
+				paths.emailManagementAllSitesPrefix
+			),
+			paths.emailManagementNewTitanAccount( ':site', ':domain' ),
+		],
+		handlers: [
+			...commonHandlers,
+			controller.emailManagementNewTitanAccount,
 			makeLayout,
 			clientRender,
 		],

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -6,6 +6,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import { GOOGLE_WORKSPACE_PRODUCT_TYPE, GSUITE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import controller from './controller';
 import * as paths from './paths';
@@ -29,16 +30,17 @@ export default function () {
 		handlers: [ ...commonHandlers, controller.emailManagement, makeLayout, clientRender ],
 	} );
 
+	const productType = `:productType(${ GOOGLE_WORKSPACE_PRODUCT_TYPE }|${ GSUITE_PRODUCT_TYPE })`;
+
 	registerMultiPage( {
 		paths: [
 			paths.emailManagementAddGSuiteUsers(
 				':site',
 				':domain',
-				':productType',
+				productType,
 				paths.emailManagementAllSitesPrefix
 			),
-			paths.emailManagementAddGSuiteUsers( ':site', ':domain', ':productType' ),
-			paths.emailManagementAddGSuiteUsers( ':site' ),
+			paths.emailManagementAddGSuiteUsers( ':site', ':domain', productType ),
 		],
 		handlers: [
 			...commonHandlers,
@@ -53,10 +55,10 @@ export default function () {
 			paths.emailManagementNewGSuiteAccount(
 				':site',
 				':domain',
-				':productType',
+				productType,
 				paths.emailManagementAllSitesPrefix
 			),
-			paths.emailManagementNewGSuiteAccount( ':site', ':domain', ':productType' ),
+			paths.emailManagementNewGSuiteAccount( ':site', ':domain', productType ),
 		],
 		handlers: [
 			...commonHandlers,


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/51400 which attempts to address the same issue in a much more robust way.

The first thing it does is that it reverts to the original ordering of the routes, as ultimately the order shouldn't matter (and there is no guarantee that another developer may not change this order inadvertently in the future). It then defines specific values for the product type in the route of the `Add New Users` page (G Suite), so this route doesn't collide with the one of the `Add New Mailboxes` page (Titan). Each of the following urls should show a different page (although the ones for G Suite and Google Workspace only differs by their heading):

* https://wordpress.com/email/:domain/google-workspace/add-users/:site
* https://wordpress.com/email/:domain/gsuite/add-users/:site
* https://wordpress.com/email/:domain/titan/new/:site

#### Testing instructions

1. Run `git checkout update/email-routes` and start your server, or open a [live branch](https://calypso.live/?branch=update/email-routes)
2. Log into a WordPress.com account with emails accounts of each type
3. Open the [`Email` page](http://calypso.localhost:3000/email)
4. Click the `Add New Users` button for a Google Workspace account
5. Assert that the `Add New Users` page for Google Workspace is displayed
6. Go back, and click the `Add New Users` button for a G Suite account
7. Assert that the `Add New Users` page for G Suite is displayed
8. Go back, and click the `Add New Mailboxes` button for a Titan account
9. Assert that the `Add New Mailboxes` page is displayed