### PR TITLE
E2E: Refactor out followLinkWhenFollowable helper

### DIFF
--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -112,32 +112,6 @@ export function waitTillFocused( driver, selector, pollingOverride, waitOverride
 	);
 }
 
-export function followLinkWhenFollowable( driver, selector, waitOverride ) {
-	const timeoutWait = waitOverride ? waitOverride : explicitWaitMS;
-	return driver.wait(
-		function () {
-			return driver.findElement( selector ).then(
-				function ( element ) {
-					return element.getAttribute( 'href' ).then(
-						function ( href ) {
-							driver.get( href );
-							return true;
-						},
-						function () {
-							return false;
-						}
-					);
-				},
-				function () {
-					return false;
-				}
-			);
-		},
-		timeoutWait,
-		`Timed out waiting for link with ${ selector.using } of '${ selector.value }' to be followable`
-	);
-}
-
 export function waitTillPresentAndDisplayed( driver, selector, waitOverride ) {
 	const timeoutWait = waitOverride ? waitOverride : explicitWaitMS;
 

--- a/test/e2e/lib/pages/pressable/pressable-site-settings-page.js
+++ b/test/e2e/lib/pages/pressable/pressable-site-settings-page.js
@@ -22,11 +22,6 @@ export default class PressableSiteSettingsPage extends AsyncBaseContainer {
 		return driverHelper.waitTillNotPresent( this.driver, loadingSelector, explicitWaitMS * 4 );
 	}
 
-	gotoWPAdmin() {
-		const buttonSelector = By.css( '.site-show-bar-wp-btn' );
-		return driverHelper.followLinkWhenFollowable( this.driver, buttonSelector );
-	}
-
 	async activateJetpackPremium() {
 		const activationLink = By.css( '.jetpack-activation-notice a[href*="/jetpack_partnership"]' );
 		await this.driver.sleep( 1000 ); // Button isn't clickable right away

--- a/test/e2e/lib/pages/pressable/pressable-sites-page.js
+++ b/test/e2e/lib/pages/pressable/pressable-sites-page.js
@@ -50,13 +50,6 @@ export default class PressableSitesPage extends AsyncBaseContainer {
 		);
 	}
 
-	async gotoWPAdmin( siteName ) {
-		const siteSettingsButton = By.xpath(
-			`//div[@class='site-bottom-wrapper'][descendant::a[contains(.,'${ siteName }')]]//div[contains(@class, 'manage-settings')]`
-		);
-		return await driverHelper.clickWhenClickable( this.driver, siteSettingsButton );
-	}
-
 	async deleteFirstSite() {
 		const siteSettingsButton = By.xpath(
 			"//div[@class='site-bottom-wrapper'][descendant::a[contains(.,'e2eflowtesting')]]//div[contains(@class, 'manage-settings')]"

--- a/test/e2e/lib/pages/wp-admin/wp-admin-sidebar.js
+++ b/test/e2e/lib/pages/wp-admin/wp-admin-sidebar.js
@@ -99,7 +99,7 @@ export default class WPAdminSidebar extends AsyncBaseContainer {
 			await driverHelper.clickWhenClickable( this.driver, menuSelector );
 		}
 		if ( driverManager.currentScreenSize() === 'mobile' ) {
-			return await driverHelper.followLinkWhenFollowable( this.driver, menuItemSelector );
+			return await driverHelper.clickWhenClickable( this.driver, menuItemSelector );
 		}
 		return await driverHelper.clickWhenClickable( this.driver, menuItemSelector );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Refactor out `followLinkWhenFollowable` helper. This helper followed a link's URL programmatically, which doesn't seem to be a good practice in E2E testing. By replacing it with `clickWhenClickable` we're ensuring the actual user action is performed. 
- Bonus removal of an unused `gotoWPAdmin` helper :)

#### Testing instructions

All specs should pass.