### PR TITLE
E2E: Fix and refactor verifyTextPresent helper

### DIFF
--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -551,12 +551,41 @@ export async function selectElementByText( driver, selector, text ) {
 	return await this.clickWhenClickable( driver, element );
 }
 
-export async function verifyTextPresent( driver, selector, text ) {
-	const element = async () => {
-		const allElements = await driver.findElements( selector );
-		return await webdriver.promise.filter( allElements, getInnerTextMatcherFunction( text ) );
-	};
-	return await this.isElementPresent( driver, element );
+/**
+ * Waits until an element with given locator and inner text is located.
+ *
+ * @param {WebDriver} driver The parent WebDriver instance
+ * @param {By} locator The element's locator
+ * @param {string|RegExp} text The text the element should contain
+ * @param {number} [timeout=explicitWaitMS] The timeout in milliseconds
+ * @returns {Promise<WebElement>} A promise that will resolve with the located element
+ */
+export async function waitUntilElementWithTextLocated(
+	driver,
+	locator,
+	text,
+	timeout = explicitWaitMS
+) {
+	const locatorStr = typeof locator === 'function' ? 'by function()' : locator + '';
+
+	return driver.wait(
+		new WebElementCondition(
+			`for element to be located ${ locatorStr } and contain text "${ text }"`,
+			async function () {
+				const locatedElements = await driver.findElements( locator );
+				if ( locatedElements.length === 0 ) {
+					return null;
+				}
+				const elementsWithText = await webdriver.promise.filter(
+					locatedElements,
+					getInnerTextMatcherFunction( text )
+				);
+
+				return elementsWithText[ 0 ];
+			}
+		),
+		timeout
+	);
 }
 
 export function getElementByText( driver, selector, text ) {

--- a/test/e2e/lib/flows/delete-account-flow.js
+++ b/test/e2e/lib/flows/delete-account-flow.js
@@ -19,7 +19,7 @@ export default class DeleteAccountFlow {
 			const closeAccountPage = await CloseAccountPage.Expect( this.driver );
 			await closeAccountPage.chooseCloseAccount();
 			await closeAccountPage.enterAccountNameAndClose( name );
-			await closeAccountPage.ConfirmAccountHasBeenClosed();
+			await closeAccountPage.confirmAccountHasBeenClosed();
 			return await LoggedOutMasterbarComponent.Expect( this.driver );
 		} )().catch( ( err ) => {
 			SlackNotifier.warn(

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -600,18 +600,14 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async schedulePost( publishDate ) {
 		await driverHelper.clickWhenClickable( this.driver, this.prePublishButtonSelector );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishHeaderSelector );
-		await driverHelper.verifyTextPresent(
+		await driverHelper.waitUntilElementWithTextLocated(
 			this.driver,
 			By.css( '.editor-post-publish-panel__link' ),
 			publishDate
 		);
 		await driverHelper.clickWhenClickable( this.driver, this.publishButtonSelector );
 		await driverHelper.waitTillNotPresent( this.driver, this.publishingSpinnerSelector );
-		await driverHelper.waitTillPresentAndDisplayed(
-			this.driver,
-			By.css( '.post-publish-panel__postpublish-header' )
-		);
-		return await driverHelper.verifyTextPresent(
+		await driverHelper.waitUntilElementWithTextLocated(
 			this.driver,
 			By.css( '.post-publish-panel__postpublish-header' ),
 			'Scheduled'

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -610,7 +610,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.waitUntilElementWithTextLocated(
 			this.driver,
 			By.css( '.post-publish-panel__postpublish-header' ),
-			'Scheduled'
+			/scheduled/i
 		);
 	}
 

--- a/test/e2e/lib/pages/account/close-account-page.js
+++ b/test/e2e/lib/pages/account/close-account-page.js
@@ -55,8 +55,8 @@ export default class CloseAccountPage extends AsyncBaseContainer {
 		);
 	}
 
-	async ConfirmAccountHasBeenClosed() {
-		await driverHelper.verifyTextPresent(
+	async confirmAccountHasBeenClosed() {
+		await driverHelper.waitUntilElementWithTextLocated(
 			this.driver,
 			by.css( '.empty-content__title' ),
 			'Your account has been closed'

--- a/test/e2e/lib/pages/reader-page.js
+++ b/test/e2e/lib/pages/reader-page.js
@@ -78,7 +78,11 @@ export default class ReaderPage extends AsyncBaseContainer {
 
 	async waitForCommentToAppear( comment ) {
 		const commentSelector = by.css( '.comments__comment-content' );
-		return await driverHelper.verifyTextPresent( this.driver, commentSelector, comment );
+		return await driverHelper.waitUntilElementWithTextLocated(
+			this.driver,
+			commentSelector,
+			comment
+		);
 	}
 
 	static getReaderURL() {

--- a/test/e2e/lib/pages/reader-page.js
+++ b/test/e2e/lib/pages/reader-page.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { By as by } from 'selenium-webdriver';
+// eslint-disable-next-line no-restricted-imports
 import URL from 'url';
 
 /**

--- a/test/e2e/lib/pages/woocommerce/store-products-page.js
+++ b/test/e2e/lib/pages/woocommerce/store-products-page.js
@@ -24,7 +24,7 @@ export default class StoreProductsPage extends AsyncBaseContainer {
 	}
 
 	async productDisplayed( productTitle ) {
-		return await driverHelper.verifyTextPresent(
+		return await driverHelper.waitUntilElementWithTextLocated(
 			this.driver,
 			by.css( '.products__list-name' ),
 			productTitle


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix & refactor the `verifyTextPresent` helper to actually verify the element with given text is present. Up to this point we weren't really verifying anything wherever this helper was used. This was happening because the function is just returning a bool instead of throwing an error if the element w/ text is not found. 

#### Testing instructions

All specs should pass.