### PR TITLE
Improve DB Scanning messages

### DIFF
--- a/client/components/jetpack/threat-description/index.tsx
+++ b/client/components/jetpack/threat-description/index.tsx
@@ -23,6 +23,8 @@ export interface Props {
 	fix?: string | ReactNode;
 	context?: object;
 	diff?: string;
+	rows?: Record< string, unknown >;
+	table?: string;
 	filename?: string;
 	isFixable: bool;
 }
@@ -72,8 +74,30 @@ class ThreatDescription extends React.PureComponent< Props > {
 		);
 	}
 
+	renderDatabaseRows(): ReactNode | null {
+		const { rows, table } = this.props;
+		if ( ! rows || ! table ) {
+			return null;
+		}
+
+		const content = Object.values( rows ).map( ( row ) => JSON.stringify( row ) + '\n' );
+
+		return (
+			<>
+				<p className="threat-description__section-text">
+					{ translate( 'Threat found in the table %(threatTable)s, in the following rows:', {
+						args: {
+							threatTable: table,
+						},
+					} ) }
+				</p>
+				<pre className="threat-description__alert-filename">{ content }</pre>
+			</>
+		);
+	}
+
 	render() {
-		const { children, status, problem, fix, diff, context, filename } = this.props;
+		const { children, status, problem, fix, diff, rows, context, filename } = this.props;
 
 		return (
 			<div className="threat-description">
@@ -81,12 +105,13 @@ class ThreatDescription extends React.PureComponent< Props > {
 					<strong>{ translate( 'What was the problem?' ) }</strong>
 				</p>
 				{ this.renderTextOrNode( <p className="threat-description__section-text">{ problem }</p> ) }
-				{ ( filename || context || diff ) && (
+				{ ( filename || context || diff || rows ) && (
 					<p className="threat-description__section-title">
 						<strong>{ translate( 'The technical details' ) }</strong>
 					</p>
 				) }
 				{ this.renderFilename() }
+				{ this.renderDatabaseRows() }
 				{ context && <MarkedLines context={ context } /> }
 				{ diff && <DiffViewer diff={ diff } /> }
 				{ fix && (

--- a/client/components/jetpack/threat-item-header/index.tsx
+++ b/client/components/jetpack/threat-item-header/index.tsx
@@ -110,12 +110,17 @@ const ThreatItemHeader: React.FC< Props > = ( { threat, isStyled = true } ) => {
 			}
 			return (
 				<>
-					{ translate( 'Database %(threatCount)d threat', 'Database %(threatCount)d threats', {
-						count: Object.keys( threat.rows ).length,
-						args: {
-							threatCount: Object.keys( threat.rows ).length,
-						},
-					} ) }
+					{ translate(
+						'Database threat on table %(threatTable)s affecting %(threatCount)d row ',
+						'Database threat on %(threatTable)s affecting %(threatCount)d rows',
+						{
+							count: Object.keys( threat.rows ).length,
+							args: {
+								threatCount: Object.keys( threat.rows ).length,
+								threatTable: threat.table,
+							},
+						}
+					) }
 				</>
 			);
 

--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -88,13 +88,24 @@ const ThreatItem: React.FC< Props > = ( {
 		if ( ! threat.fixable ) {
 			return (
 				<>
-					<p className="threat-description__section-text">
-						{ translate(
-							'Jetpack Scan cannot automatically fix this threat. We suggest that you resolve the threat manually: ' +
-								'ensure that WordPress, your theme, and all of your plugins are up to date, and remove ' +
-								'the offending code, theme, or plugin from your site.'
-						) }
-					</p>
+					{ ! threat.rows && (
+						<p className="threat-description__section-text">
+							{ translate(
+								'Jetpack Scan cannot automatically fix this threat. We suggest that you resolve the threat manually: ' +
+									'ensure that WordPress, your theme, and all of your plugins are up to date, and remove ' +
+									'the offending code, theme, or plugin from your site.'
+							) }
+						</p>
+					) }
+					{ threat.rows && (
+						<p className="threat-description__section-text">
+							{ translate(
+								'Jetpack Scan cannot automatically fix this threat. We suggest that you resolve the threat manually: ' +
+									'ensure that WordPress, your theme, and all of your plugins are up to date, and remove or edit ' +
+									'the offending post from your site.'
+							) }
+						</p>
+					) }
 					{ 'current' === threat.status && (
 						<p className="threat-description__section-text">
 							{ translate(
@@ -163,6 +174,8 @@ const ThreatItem: React.FC< Props > = ( {
 				problem={ threat.description }
 				context={ threat.context }
 				diff={ threat.diff }
+				rows={ threat.rows }
+				table={ threat.table }
 				filename={ threat.filename }
 				isFixable={ isFixable }
 			/>

--- a/client/components/jetpack/threat-item/types.tsx
+++ b/client/components/jetpack/threat-item/types.tsx
@@ -30,7 +30,8 @@ export interface BaseThreat {
 	fixerStatus?: string;
 	filename?: string;
 	extension?: Extension;
-	rows?: number;
+	rows?: Record< string, unknown >;
+	table?: string;
 	diff?: string;
 	context?: object;
 }

--- a/client/components/jetpack/threat-item/utils.ts
+++ b/client/components/jetpack/threat-item/utils.ts
@@ -55,7 +55,7 @@ export const getThreatVulnerability = ( threat: Threat ): string | i18nCalypso.T
 			return translate( 'Vulnerability found in theme' );
 
 		case 'database':
-			return '';
+			return 'Vulnerability found in database table';
 
 		case 'none':
 		default:

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -36,6 +36,7 @@ export const formatScanThreat = ( threat ) => ( {
 	extension: threat.extension,
 	rows: threat.rows,
 	diff: threat.diff,
+	table: threat.table,
 	context: threat.context,
 } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Improve the message when showing DB Scanning results in the Scan page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a Jurassic Ninja site at https://jurassic.ninja/create/?shortlived
* Use the [jetpack threat tester](https://github.com/Automattic/jetpack-threat-tester) to add a few innocuous DB threats for testing.
* Connect the site to Jetpack and purchase a plan that includes scan with credits
* Scan the site and verify that a threat was added because of the default salts.

## Testing wordpress.com

* Go to https://calypso.live/scan/{test-site}?branch=add/improve-database-scanning-messaging
* Click on the database threat to open it's details
* Verify that we're showing the rows where the threat was found alongside the other text changes

## Testing cloud.jetpack.com 

* Checkout and build this branch locally
* Go to http://jetpack.cloud.localhost:3000/scan/{test-site}
* Verify as for wordpress.com above

## Screenshots

- Before:
<img width="696" alt="Screen Shot 2021-03-25 at 15 37 21" src="https://user-images.githubusercontent.com/12788275/112525800-07230d00-8d80-11eb-9b22-35258dd70613.png">

- After:
<img width="688" alt="Screen Shot 2021-03-25 at 11 18 39" src="https://user-images.githubusercontent.com/12788275/112525827-0e4a1b00-8d80-11eb-8240-89281f3ddf8f.png">


