### PR TITLE
Add new_quantity field to extra in new purchase flow

### DIFF
--- a/client/my-sites/email/email-providers-stacked-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.jsx
@@ -146,6 +146,7 @@ class EmailProvidersStackedComparison extends React.Component {
 			quantity: titanMailboxes.length,
 			extra: {
 				email_users: titanMailboxes.map( transformMailboxForCart ),
+				new_quantity: titanMailboxes.length,
 			},
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This fixes a bug in the updated email comparison page from #51307 (which was rolled out in #51392)
* The core issue was that we weren't sending in the `new_quantity` field in the `extra` data, so the back end was trying to kick off the provisioning with 0 accounts.

#### Testing instructions

* Navigate to the live branch and open your browser console.
* Try to add Email to a domain, and verify that the shopping cart data sent to the server (and received from the server!) has `extra.new_quantity` specified as the number of new accounts.

Related to #51307 
Related to #51392
