### PR TITLE
Framework: Refactor away from `_.isUndefined()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -411,6 +411,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/is-nil': 'error',
 		'you-dont-need-lodash-underscore/is-null': 'error',
 		'you-dont-need-lodash-underscore/is-string': 'error',
+		'you-dont-need-lodash-underscore/is-undefined': 'error',
 		'you-dont-need-lodash-underscore/join': 'error',
 		'you-dont-need-lodash-underscore/last-index-of': 'error',
 		'you-dont-need-lodash-underscore/pad-end': 'error',

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isObjectLike, isUndefined, omit } from 'lodash';
+import { isObjectLike, omit } from 'lodash';
 import debug from 'debug';
 
 /**
@@ -67,7 +67,7 @@ export default ( eventName, eventProperties ) => {
 
 	// Remove properties that have an undefined value
 	// This allows a caller to easily remove properties from the recorded set by setting them to undefined
-	eventProperties = omit( eventProperties, isUndefined );
+	eventProperties = omit( eventProperties, ( prop ) => typeof prop === 'undefined' );
 
 	// Populate custom properties.
 	eventProperties = { ...eventProperties, ...customProperties };

--- a/bin/build-metadata.js
+++ b/bin/build-metadata.js
@@ -180,7 +180,7 @@ function processNumberFormat( format ) {
 function deepRemoveUndefinedKeysFromObject( obj ) {
 	for ( const key in obj ) {
 		if ( obj.hasOwnProperty( key ) ) {
-			if ( _.isUndefined( obj[ key ] ) ) {
+			if ( typeof obj[ key ] === 'undefined' ) {
 				delete obj[ key ];
 			} else if ( _.isObject( obj[ key ] ) ) {
 				deepRemoveUndefinedKeysFromObject( obj[ key ] );
@@ -196,7 +196,7 @@ function generateDeepRemoveEmptyArraysFromObject( allowedKeys ) {
 			if ( obj.hasOwnProperty( key ) ) {
 				if (
 					_.includes( allowedKeys, key ) &&
-					_.isArray( obj[ key ] ) &&
+					Array.isArray( obj[ key ] ) &&
 					obj[ key ].length === 0
 				) {
 					delete obj[ key ];

--- a/client/blocks/follow-button/index.jsx
+++ b/client/blocks/follow-button/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { omitBy, isUndefined } from 'lodash';
+import { omitBy } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -37,7 +37,7 @@ class FollowButtonContainer extends Component {
 					feed_ID: this.props.feedId,
 					blog_ID: this.props.siteId,
 				},
-				isUndefined
+				( data ) => typeof data === 'undefined'
 			);
 
 			this.props.follow( this.props.siteUrl, followData );

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import classNames from 'classnames';
-import { get, isUndefined, omitBy } from 'lodash';
+import { get, omitBy } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -68,7 +68,7 @@ class InlineHelpRichResult extends Component {
 				result_url: link,
 				location: 'inline-help-popover',
 			},
-			isUndefined
+			( data ) => typeof data === 'undefined'
 		);
 
 		this.props.recordTracksEvent( `calypso_inlinehelp_${ type }_open`, tracksData );

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -8,7 +8,7 @@ import page from 'page';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { get, isUndefined } from 'lodash';
+import { get } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -164,7 +164,7 @@ class TaxonomyManagerListItem extends Component {
 						<PodcastIndicator className="taxonomy-manager__podcast-indicator" />
 					) }
 				</span>
-				{ ! isUndefined( term.post_count ) && (
+				{ typeof term.post_count !== 'undefined' && (
 					<Count
 						ref="count"
 						count={ term.post_count }

--- a/client/components/data/query-post-stats/index.jsx
+++ b/client/components/data/query-post-stats/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { isEqual, isUndefined } from 'lodash';
+import { isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,7 +30,7 @@ class QueryPostStats extends Component {
 
 	UNSAFE_componentWillMount() {
 		const { requestingPostStats, siteId, postId } = this.props;
-		if ( ! requestingPostStats && siteId && ! isUndefined( postId ) ) {
+		if ( ! requestingPostStats && siteId && typeof postId !== 'undefined' ) {
 			this.requestPostStats( this.props );
 		}
 	}
@@ -42,7 +42,7 @@ class QueryPostStats extends Component {
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		const { siteId, postId, fields, heartbeat } = this.props;
 		if (
-			! ( siteId && ! isUndefined( postId ) ) ||
+			! ( siteId && typeof postId !== 'undefined' ) ||
 			( siteId === nextProps.siteId &&
 				postId === nextProps.postId &&
 				isEqual( fields, nextProps.fields ) &&

--- a/client/lib/checkout/processor-specific.js
+++ b/client/lib/checkout/processor-specific.js
@@ -3,7 +3,7 @@
  *
  */
 import i18n from 'i18n-calypso';
-import { isUndefined, pick } from 'lodash';
+import { pick } from 'lodash';
 import { CPF, CNPJ } from 'cpf_cnpj';
 
 /**
@@ -22,7 +22,7 @@ import { translateWpcomPaymentMethodToCheckoutPaymentMethod } from 'calypso/my-s
  */
 export function isEbanxCreditCardProcessingEnabledForCountry( countryCode, cart ) {
 	return (
-		! isUndefined( PAYMENT_PROCESSOR_COUNTRIES_FIELDS[ countryCode ] ) &&
+		typeof PAYMENT_PROCESSOR_COUNTRIES_FIELDS[ countryCode ] !== 'undefined' &&
 		isPaymentMethodEnabled(
 			'ebanx',
 			cart.allowed_payment_methods?.map( translateWpcomPaymentMethodToCheckoutPaymentMethod )

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -10,7 +10,6 @@ import {
 	filter,
 	flatten,
 	isEmpty,
-	isUndefined,
 	map,
 	mapValues,
 	pickBy,
@@ -45,13 +44,14 @@ function Controller( options ) {
 	this._pendingValidation = null;
 	this._onValidationComplete = null;
 
-	const debounceWait = isUndefined( options.debounceWait ) ? 1000 : options.debounceWait;
+	const debounceWait = typeof options.debounceWait === 'undefined' ? 1000 : options.debounceWait;
 	this._debouncedSanitize = debounce( this.sanitize, debounceWait );
 	this._debouncedValidate = debounce( this.validate, debounceWait );
 
-	this._hideFieldErrorsOnChange = isUndefined( options.hideFieldErrorsOnChange )
-		? false
-		: options.hideFieldErrorsOnChange;
+	this._hideFieldErrorsOnChange =
+		typeof options.hideFieldErrorsOnChange === 'undefined'
+			? false
+			: options.hideFieldErrorsOnChange;
 
 	if ( this._loadFunction ) {
 		this._loadFieldValues();

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -5,7 +5,7 @@ import { isMobile } from '@automattic/viewport';
 import debugModule from 'debug';
 import React from 'react';
 import i18n from 'i18n-calypso';
-import { find, isUndefined } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -152,7 +152,7 @@ const communityTranslatorJumpstart = {
 			return;
 		}
 
-		if ( ! isUndefined( isUserSettingsReady ) ) {
+		if ( typeof isUserSettingsReady !== 'undefined' ) {
 			_isUserSettingsReady = isUserSettingsReady;
 		}
 		if ( ! _isUserSettingsReady ) {

--- a/client/lib/users/test/store.js
+++ b/client/lib/users/test/store.js
@@ -6,7 +6,7 @@
  * External dependencies
  */
 import { assert } from 'chai';
-import { findIndex, isUndefined, some } from 'lodash';
+import { findIndex, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -202,7 +202,7 @@ describe( 'Users Store', () => {
 		test( 'There should be no undefined objects in user array after deleting a user', () => {
 			Dispatcher.handleServerAction( actions.deleteUser );
 			const users = UsersStore.getUsers( options );
-			const someUndefined = some( users, isUndefined );
+			const someUndefined = some( users, ( user ) => typeof user === 'undefined' );
 			assert.isFalse( someUndefined );
 		} );
 	} );

--- a/client/my-sites/activity/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/error-banner.jsx
@@ -5,7 +5,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { isUndefined } from 'lodash';
 
 /**
  * Internal dependencies
@@ -58,7 +57,7 @@ class ErrorBanner extends PureComponent {
 	};
 
 	handleDismiss = () =>
-		isUndefined( this.props.downloadId )
+		typeof this.props.downloadId === 'undefined'
 			? this.props.closeDialog( 'restore' )
 			: this.props.dismissDownloadError( this.props.siteId, this.props.downloadId );
 
@@ -72,15 +71,16 @@ class ErrorBanner extends PureComponent {
 			trackHappyChatBackup,
 			trackHappyChatRestore,
 		} = this.props;
-		const strings = isUndefined( downloadId )
-			? {
-					title: translate( 'Problem restoring your site' ),
-					details: translate( 'We came across a problem while trying to restore your site.' ),
-			  }
-			: {
-					title: translate( 'Problem preparing your file' ),
-					details: translate( 'There was a problem preparing your backup for downloading.' ),
-			  };
+		const strings =
+			typeof downloadId === 'undefined'
+				? {
+						title: translate( 'Problem restoring your site' ),
+						details: translate( 'We came across a problem while trying to restore your site.' ),
+				  }
+				: {
+						title: translate( 'Problem preparing your file' ),
+						details: translate( 'There was a problem preparing your backup for downloading.' ),
+				  };
 
 		return (
 			<ActivityLogBanner
@@ -92,7 +92,7 @@ class ErrorBanner extends PureComponent {
 				<TrackComponentView
 					eventName="calypso_activitylog_errorbanner_impression"
 					eventProperties={
-						isUndefined( downloadId )
+						typeof downloadId === 'undefined'
 							? {
 									error_code: errorCode,
 									failure_reason: failureReason,
@@ -111,7 +111,9 @@ class ErrorBanner extends PureComponent {
 				</Button>
 				<HappychatButton
 					className="activity-log-banner__happychat-button"
-					onClick={ isUndefined( downloadId ) ? trackHappyChatRestore : trackHappyChatBackup }
+					onClick={
+						typeof downloadId === 'undefined' ? trackHappyChatRestore : trackHappyChatBackup
+					}
 				>
 					<Gridicon icon="chat" />
 					<span>{ translate( 'Get help' ) }</span>

--- a/client/my-sites/comment/comment-delete-warning.jsx
+++ b/client/my-sites/comment/comment-delete-warning.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { isUndefined } from 'lodash';
 
 /**
  * Internal dependencies
@@ -47,7 +46,7 @@ const mapStateToProps = ( state, { siteId, commentId } ) => {
 	const comment = getSiteComment( state, siteId, commentId );
 
 	return {
-		isLoading: isUndefined( comment ),
+		isLoading: typeof comment === 'undefined',
 	};
 };
 

--- a/client/my-sites/comment/comment-permalink.jsx
+++ b/client/my-sites/comment/comment-permalink.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, isUndefined } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,7 +37,7 @@ const mapStateToProps = ( state, { siteId, commentId } ) => {
 	const comment = getSiteComment( state, siteId, commentId );
 
 	return {
-		isLoading: isUndefined( comment ),
+		isLoading: typeof comment === 'undefined',
 		permaLink: get( comment, 'URL', '' ),
 	};
 };

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, get, isEqual, isUndefined, map } from 'lodash';
+import { find, get, isEqual, map } from 'lodash';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
 import CSSTransition from 'react-transition-group/CSSTransition';
 
@@ -238,7 +238,7 @@ const mapStateToProps = ( state, { order, page, postId, siteId, status } ) => {
 	const comments = getCommentsPage( state, siteId, { order, page, postId, status } );
 	const counts = getSiteCommentCounts( state, siteId, postId );
 	const commentsCount = get( counts, 'unapproved' === status ? 'pending' : status );
-	const isLoading = isUndefined( comments );
+	const isLoading = typeof comments === 'undefined';
 	const isPostView = !! postId;
 
 	return {

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
-import { each, get, includes, isEqual, isUndefined, map } from 'lodash';
+import { each, get, includes, isEqual, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -66,7 +66,7 @@ export class CommentNavigation extends Component {
 	bulkDeletePermanently = () => {
 		const { translate } = this.props;
 		if (
-			isUndefined( window ) ||
+			typeof window === 'undefined' ||
 			window.confirm( translate( 'Delete these comments permanently?' ) )
 		) {
 			this.setBulkStatus( 'delete' )();

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import classNames from 'classnames';
-import { get, includes, isEqual, isUndefined } from 'lodash';
+import { get, includes, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -60,7 +60,7 @@ export class CommentActions extends Component {
 
 	delete = () => {
 		if (
-			isUndefined( window ) ||
+			typeof window === 'undefined' ||
 			window.confirm( this.props.translate( 'Delete this comment permanently?' ) )
 		) {
 			this.props.deletePermanently();

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import ReactDom from 'react-dom';
-import { debounce, get, isEqual, isUndefined } from 'lodash';
+import { debounce, get, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -229,7 +229,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 		siteId,
 		postId: get( comment, 'post.ID' ),
 		commentIsPending: 'unapproved' === commentStatus,
-		isLoading: isUndefined( comment ),
+		isLoading: typeof comment === 'undefined',
 		minimumComment: getMinimumComment( comment ),
 	};
 };

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -5,7 +5,7 @@ import { Card } from '@automattic/components';
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { get, isUndefined, omitBy } from 'lodash';
+import { get, omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -54,7 +54,7 @@ const HelpSearch = ( { searchQuery, openDialog, track } ) => {
 				result_url: resultLink,
 				location: HELP_COMPONENT_LOCATION,
 			},
-			isUndefined
+			( prop ) => typeof prop === 'undefined'
 		);
 		track( `calypso_inlinehelp_${ type }_open`, tracksData );
 	};

--- a/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
+++ b/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { get, isUndefined } from 'lodash';
+import { get } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
@@ -33,7 +33,7 @@ const TaxonomyCard = ( {
 	bumpStat: recordMCStat,
 } ) => {
 	const settingsLink = site ? `/settings/taxonomies/${ taxonomy }/${ site.slug }` : null;
-	const isLoading = ! labels.name || isUndefined( count );
+	const isLoading = ! labels.name || typeof count === 'undefined';
 	const classes = classNames( 'taxonomies__card-title', {
 		'is-loading': isLoading,
 	} );

--- a/client/server/lib/analytics/index.js
+++ b/client/server/lib/analytics/index.js
@@ -4,7 +4,7 @@
 
 import superagent from 'superagent';
 import { v4 as uuid } from 'uuid';
-import { isUndefined, omit, assign, get, has } from 'lodash';
+import { omit, assign, get, has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -90,7 +90,7 @@ const analytics = {
 
 			// Remove properties that have an undefined value
 			// This allows a caller to easily remove properties from the recorded set by setting them to undefined
-			eventProperties = omit( eventProperties, isUndefined );
+			eventProperties = omit( eventProperties, ( prop ) => typeof prop === 'undefined' );
 
 			const date = new Date();
 			const acceptLanguageHeader = req.get( 'Accept-Language' ) || '';

--- a/client/state/activity-log/utils.js
+++ b/client/state/activity-log/utils.js
@@ -1,11 +1,6 @@
-/**
- * External Dependencies
- */
-import { isUndefined } from 'lodash';
-
 export const filterStateToApiQuery = ( filter ) => {
 	// by default, we'll tell the api to create aggregate events
-	const aggregate = isUndefined( filter.aggregate ) ? true : filter.aggregate;
+	const aggregate = typeof filter.aggregate === 'undefined' ? true : filter.aggregate;
 
 	return Object.assign(
 		{},
@@ -28,7 +23,7 @@ export const filterStateToQuery = ( filter ) =>
 	Object.assign(
 		{},
 		filter.action && { action: filter.action.join( ',' ) },
-		! isUndefined( filter.aggregate ) && { aggregate: filter.aggregate },
+		typeof filter.aggregate !== 'undefined' && { aggregate: filter.aggregate },
 		filter.backButton && { back_button: true },
 		filter.on && { on: filter.on },
 		filter.after && { after: filter.after },
@@ -45,7 +40,7 @@ export const queryToFilterState = ( query ) =>
 	Object.assign(
 		{},
 		query.action && { action: decodeURI( query.action ).split( ',' ) },
-		! isUndefined( query.aggregate ) && { aggregate: query.aggregate },
+		typeof query.aggregate !== 'undefined' && { aggregate: query.aggregate },
 		query.on && { on: query.on },
 		query.after && { after: query.after },
 		query.before && { before: query.before },

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -3,7 +3,6 @@
  */
 import {
 	filter,
-	isUndefined,
 	orderBy,
 	has,
 	map,
@@ -59,7 +58,8 @@ const updateComment = ( commentId, newProperties ) => ( comment ) => {
 	if ( comment.ID !== commentId ) {
 		return comment;
 	}
-	const updateLikeCount = has( newProperties, 'i_like' ) && isUndefined( newProperties.like_count );
+	const updateLikeCount =
+		has( newProperties, 'i_like' ) && typeof newProperties.like_count === 'undefined';
 
 	// Comment Management allows for modifying nested fields, such as `author.name` and `author.url`.
 	// Though, there is no direct match between the GET response (which feeds the state) and the POST request.

--- a/client/state/comments/ui/reducer.js
+++ b/client/state/comments/ui/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, includes, isUndefined, map, without, has } from 'lodash';
+import { get, includes, map, without, has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -93,7 +93,7 @@ export const queries = ( state = {}, action ) => {
 			return deepUpdateComments( state, without( comments, action.commentId ), query );
 		}
 		case COMMENTS_QUERY_UPDATE:
-			return isUndefined( get( action, 'query.page' ) )
+			return typeof get( action, 'query.page' ) === 'undefined'
 				? state
 				: deepUpdateComments( state, map( action.comments, 'ID' ), action.query );
 		default:

--- a/client/state/data-getters/get-request-activity-logs-id.js
+++ b/client/state/data-getters/get-request-activity-logs-id.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isUndefined, sortBy } from 'lodash';
+import { sortBy } from 'lodash';
 
 const getRequestActivityLogsId = ( siteId, filter ) => {
 	const knownFilterOptions = [
@@ -21,7 +21,7 @@ const getRequestActivityLogsId = ( siteId, filter ) => {
 	const filterCacheKey = knownFilterOptions
 		.map( ( opt ) => {
 			const optionValue = filter[ opt ];
-			if ( isUndefined( optionValue ) ) {
+			if ( typeof optionValue === 'undefined' ) {
 				return undefined;
 			}
 

--- a/client/state/data-layer/wpcom/read/following/mine/utils.js
+++ b/client/state/data-layer/wpcom/read/following/mine/utils.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { isUndefined, map, omitBy } from 'lodash';
+import { map, omitBy } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -31,7 +31,7 @@ export const subscriptionFromApi = ( subscription ) =>
 			unseen_count: subscription.unseen_count,
 			site_icon: subscription.site_icon,
 		},
-		isUndefined
+		( prop ) => typeof prop === 'undefined'
 	);
 
 export const subscriptionsFromApi = ( apiResponse ) => {

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, isUndefined } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -76,7 +76,7 @@ export function processItem( item ) {
 		item.stream_count && { streamCount: item.stream_count },
 		item.first_published && { firstPublishedDate: item.first_published },
 		item.last_published && { lastPublishedDate: item.last_published },
-		! isUndefined( item.streams_have_same_actor ) && {
+		typeof item.streams_have_same_actor !== 'undefined' && {
 			multipleActors: ! item.streams_have_same_actor,
 		}
 	);

--- a/client/state/data-layer/wpcom/sites/users/index.js
+++ b/client/state/data-layer/wpcom/sites/users/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { get, isUndefined, map, omit, omitBy } from 'lodash';
+import { get, map, omit, omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,7 +32,7 @@ export const normalizeUser = ( user ) =>
 			display_name: user.name,
 			username: user.slug,
 		},
-		isUndefined
+		( prop ) => typeof prop === 'undefined'
 	);
 
 /**

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { assign, includes, isObjectLike, isUndefined, omitBy, times } from 'lodash';
+import { assign, includes, isObjectLike, omitBy, times } from 'lodash';
 import cookie from 'cookie';
 import { EventEmitter } from 'events';
 import { loadScript } from '@automattic/load-script';
@@ -236,7 +236,7 @@ export function recordTracksEvent( eventName: string, eventProperties?: any ) {
 
 	// Remove properties that have an undefined value
 	// This allows a caller to easily remove properties from the recorded set by setting them to undefined
-	eventProperties = omitBy( eventProperties, isUndefined );
+	eventProperties = omitBy( eventProperties, ( prop ) => typeof prop === 'undefined' );
 
 	debug( 'Recording event "%s" with actual props %o', eventName, eventProperties );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `isUndefined` is essentially fully natively supported by the native `typeof x === 'undefined'`. This PR replaces the usage and adds an ESLint rule to warn against using `isUndefined` from lodash.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all usages are sane and preserve the original logic (be it negative or not).
* Try to `import { isUndefined } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass.

#### Notes

It's expected that code style check will fail because there are pre-existing ESLint errors that we're not addressing in this PR.