### PR TITLE
Nav Unification: Decode Entities on Sidebar Title

### DIFF
--- a/client/layout/sidebar/expandable-heading.jsx
+++ b/client/layout/sidebar/expandable-heading.jsx
@@ -12,6 +12,7 @@ import Count from 'calypso/components/count';
 import MaterialIcon from 'calypso/components/material-icon';
 import SidebarHeading from 'calypso/layout/sidebar/heading';
 import TranslatableString from 'calypso/components/translatable/proptype';
+import { decodeEntities } from 'calypso/lib/formatting';
 
 const noop = () => {};
 
@@ -45,7 +46,7 @@ const ExpandableSidebarHeading = ( {
 			) }
 			{ undefined !== customIcon && customIcon }
 			<span className="sidebar__expandable-title">
-				{ title }
+				{ decodeEntities( title ) }
 				{ undefined !== count && <Count count={ count } /> }
 			</span>
 			{ ! hideExpandableIcon && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Similar to #50079, but just ensures that the title of a Sidebar section displays properly 

#### Testing instructions

Verify that the sidebar displays properly on Simple sites. I assume there's other languages where this would be beneficial, but the initial issue refers to using the Dutch language.

**Before:**
<img width="268" alt="Screenshot 2021-03-25 at 20 09 33" src="https://user-images.githubusercontent.com/43215253/112537467-a22edd80-8da6-11eb-861e-96eb78bae49e.png">

**After:**
<img width="262" alt="Screenshot 2021-03-25 at 20 11 39" src="https://user-images.githubusercontent.com/43215253/112537483-a78c2800-8da6-11eb-9ef4-dac49041d43f.png">

cc @mmtr 

Fixes #51390
Fixes #51439