### PR TITLE
Update the publish date of wpcom-proxy-request

### DIFF
--- a/packages/wpcom-proxy-request/History.md
+++ b/packages/wpcom-proxy-request/History.md
@@ -1,6 +1,8 @@
 # History
 
-## 6.0.0 / TBD
+## Next / TBD
+
+## 6.0.0 / 2021-03-19
 
 - Add "support" for streamed responses and `onStreamRecord`. Doesn't implement, just tolerates the callback.
 - Breaking: Return Promise (rather than `XMLHttpRequest` instance) if no callback argument is provided.


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Update Documentation: According to https://www.npmjs.com/package/wpcom-proxy-request, the 6.0 version was released on 2021-03-19. Note, I wasn't involved in this, I am a mere bystander, someone actively working on this may know more than I do.

![2021-03-25_16-29](https://user-images.githubusercontent.com/937354/112546880-0aba9200-8d88-11eb-9ccf-cf66d9fdd109.png)


#### Testing instructions

* No functional changes

Related to https://github.com/Automattic/jetpack/issues/19308

