### PR TITLE
Copy node_modules from cache image to base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -58,6 +58,9 @@ COPY --from=cache --chown=$UID /calypso/.nvm /calypso/.nvm
 COPY --from=cache --chown=$UID /calypso/.cache /calypso/.cache
 COPY --from=cache --chown=$UID /calypso/.bashrc /calypso/.bashrc
 
+# Copy node_modules to reduce install time of future builds.
+COPY --from=cache --chown=$UID /calypso/node_modules /calypso/node_modules
+
 ENTRYPOINT [ "/bin/bash" ]
 
 #### ci-desktop image


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Attempt copying node_modules to the base docker image. The goal is to significantly reduce the `yarn install` time which currently must run for every individual build. For example, in each WPcom plugin build, `yarn install` takes more than half the time.

Locally, a fresh `yarn install` takes about a minute. Immediately after, it takes 5 seconds. Hopefully we can realize similar gains in CI.

Related to #
