### PR TITLE
Add Jetpack Plugin Review Prompt to Scan Flow

### DIFF
--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -38,6 +38,7 @@ import { triggerScanRun } from 'calypso/lib/jetpack/trigger-scan-run';
 import { withApplySiteOffset, applySiteOffsetType } from 'calypso/components/site-offset';
 import ScanNavigation from './navigation';
 import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
+import ThreatFixedReviewPrompt from 'calypso/my-sites/scan/threat-fixed-review-prompt';
 
 /**
  * Type dependencies
@@ -158,6 +159,7 @@ class ScanPage extends Component< Props > {
 						{ translate( 'Scan now' ) }
 					</Button>
 				) }
+				<ThreatFixedReviewPrompt />
 			</>
 		);
 	}

--- a/client/my-sites/scan/threat-fixed-review-prompt/index.tsx
+++ b/client/my-sites/scan/threat-fixed-review-prompt/index.tsx
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import React, { useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@wordpress/components';
+import Gridicon from 'calypso/components/gridicon';
+import QueryPreferences from 'calypso/components/data/query-preferences';
+import { dismiss } from 'calypso/state/jetpack-review-prompt/actions';
+import {
+	getIsValid,
+	getIsDismissed,
+	getExistingPreference,
+} from 'calypso/state/jetpack-review-prompt/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const ThreatFixedReviewPrompt: React.FC = () => {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+	const dispatch = useDispatch();
+	const isReviewPromptValid = useSelector( ( state ) => getIsValid( state, 'scan' ) );
+	const isReviewPromptDismissed = useSelector( ( state ) => getIsDismissed( state, 'scan' ) );
+	const lastThreatFixedDate = useSelector(
+		( state ) => getExistingPreference( state, 'scan' )?.validFrom
+	);
+
+	const dismissPrompt = useCallback(
+		( type = 'scan', dismissedAt = Date.now(), reviewed = false ) => {
+			dispatch( dismiss( type, dismissedAt, reviewed ) );
+		},
+		[ dispatch ]
+	);
+
+	return isReviewPromptValid && ! isReviewPromptDismissed ? (
+		<>
+			<QueryPreferences />
+			<div className="threat-fixed-review-prompt">
+				<div className="threat-fixed-review-prompt__header">
+					<p>
+						{ translate( 'Scan fixed all threats {{strong}}%s{{/strong}}. Your site looks great!', {
+							args: [ moment.utc( lastThreatFixedDate ).fromNow() ],
+							components: {
+								strong: <strong />,
+							},
+						} ) }
+					</p>
+					<p>
+						{ translate(
+							'Are you happy with Jetpack Scan? Please leave a review and help us spread the word!'
+						) }
+					</p>
+				</div>
+				<div className="threat-fixed-review-prompt__buttons">
+					<Button
+						href="https://wordpress.org/support/plugin/jetpack/reviews/#new-post"
+						target="_blank"
+						onClick={ dismissPrompt }
+						isSecondary
+					>
+						{ translate( 'Leave a review' ) } <Gridicon icon="external" />
+					</Button>
+					<Button onClick={ dismissPrompt } isSecondary>
+						{ translate( 'No thanks' ) }
+						<Gridicon icon="cross" />
+					</Button>
+				</div>
+			</div>
+		</>
+	) : null;
+};
+
+export default ThreatFixedReviewPrompt;

--- a/client/my-sites/scan/threat-fixed-review-prompt/index.tsx
+++ b/client/my-sites/scan/threat-fixed-review-prompt/index.tsx
@@ -53,25 +53,22 @@ const ThreatFixedReviewPrompt: React.FC = () => {
 								strong: <strong />,
 							},
 						} ) }
-					</p>
-					<p>
+						<br />
 						{ translate(
 							'Are you happy with Jetpack Scan? Please leave a review and help us spread the word!'
 						) }
 					</p>
+					<Button onClick={ dismissPrompt }>
+						<Gridicon icon="cross" />
+					</Button>
 				</div>
 				<div className="threat-fixed-review-prompt__buttons">
 					<Button
 						href="https://wordpress.org/support/plugin/jetpack/reviews/#new-post"
 						target="_blank"
 						onClick={ dismissPrompt }
-						isSecondary
 					>
 						{ translate( 'Leave a review' ) } <Gridicon icon="external" />
-					</Button>
-					<Button onClick={ dismissPrompt } isSecondary>
-						{ translate( 'No thanks' ) }
-						<Gridicon icon="cross" />
 					</Button>
 				</div>
 			</div>

--- a/client/my-sites/scan/threat-fixed-review-prompt/style.scss
+++ b/client/my-sites/scan/threat-fixed-review-prompt/style.scss
@@ -5,7 +5,14 @@
 }
 
 .threat-fixed-review-prompt__header {
-	padding-top: 1.2rem;
+	display: flex;
+	p {
+		padding-top: 1.2rem;
+		line-height: 24px;
+	}
+	button {
+		margin-right: -10px;
+	}
 }
 
 .threat-fixed-review-prompt__buttons {
@@ -14,8 +21,10 @@
 	:not( :first-child ) {
 		margin-left: 12px;
 	}
-}
-
-.threat-fixed-review-prompt__buttons a.components-button.is-secondary {
-	color: var( --color-primary );
+	.components-button {
+		box-shadow: inset 0 0 0 1px var( --color-neutral-10 );
+		svg {
+			padding-left: 5px;
+		}
+	}
 }

--- a/client/my-sites/scan/threat-fixed-review-prompt/style.scss
+++ b/client/my-sites/scan/threat-fixed-review-prompt/style.scss
@@ -10,8 +10,8 @@
 		padding-top: 1.2rem;
 		line-height: 24px;
 	}
-	button {
-		margin-right: -10px;
+	button.components-button {
+		transform: translateX( 15px );
 	}
 }
 

--- a/client/my-sites/scan/threat-fixed-review-prompt/style.scss
+++ b/client/my-sites/scan/threat-fixed-review-prompt/style.scss
@@ -1,0 +1,21 @@
+.threat-fixed-review-prompt {
+	margin: 1rem -1.5rem 0;
+	padding: 0 1.5rem;
+	border-top: 1px solid #ccc;
+}
+
+.threat-fixed-review-prompt__header {
+	padding-top: 1.2rem;
+}
+
+.threat-fixed-review-prompt__buttons {
+	display: flex;
+
+	:not( :first-child ) {
+		margin-left: 12px;
+	}
+}
+
+.threat-fixed-review-prompt__buttons a.components-button.is-secondary {
+	color: var( --color-primary );
+}

--- a/client/state/data-layer/wpcom/sites/alerts/fix-status.js
+++ b/client/state/data-layer/wpcom/sites/alerts/fix-status.js
@@ -14,6 +14,7 @@ import { requestScanStatus } from 'calypso/state/jetpack-scan/actions';
 import { requestJetpackScanHistory } from 'calypso/state/jetpack-scan/history/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { setValidFrom } from 'calypso/state/jetpack-review-prompt/actions.ts';
 
 const POLL_EVERY_MILLISECONDS = 1000;
 
@@ -60,6 +61,10 @@ export const success = ( action, fixer_state ) => {
 					duration: 4000,
 				}
 			),
+			// Make the 'jetpack-review-prompt' (calypso preference) valid, triggering a
+			// user prompt to submit a review of the Jetpack plugin on the /scan/:site page.
+			setValidFrom( 'scan', Date.now() ),
+
 			requestScanStatus( action.siteId ),
 			// Since we can fix threats from the History section, we need to update that
 			// information as well.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a review prompt to the main Scan page, only if the user has completed a successful threat auto-fix.

<img width="736" alt="Screenshot on 2021-03-25 at 17-47-56" src="https://user-images.githubusercontent.com/11078128/112548470-acdf7780-8d92-11eb-895d-524a67741dd8.png">



#### Testing instructions

1. Checkout and run this PR ('yarn start`)
2. Select (or create with JN) a jetpack site with Scan enabled. 
3. Go to  'http://calypso.localhost:3000/scan/:site` 
4. Open dev tools and start analytics logging by running `localStorage.setItem('debug', 'calypso:analytics');` via the console.
5. Go to the `/wp-content/plugins/` directory and modify any main plugin file and add the line:
    - `$eicar = "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*";`
    - ( this will trigger a scan threat that Jetpack can auto-fix in the next steps)
6. Click "Scan now" button to start a scan.
7. When scan finishes (you should have 1 scan threat), click "Auto fix 1 threat", and confirm "Fix all threats" button. 
8. When auto-fix finishes, you should see the review prompt at the bottom of the Scan card like shown in the image above.
9. Verify the `calypso_jetpack_scan_review_prompt_view' Tracks event logged in the console.
10. Refresh the page and verify that the review prompt is persistent.
11. Dismiss the prompt by pressing the X in the top right corner.
12. Verify that the `calypso_jetpack_scan_review_prompt_dismiss` event is logged.
13. Unset the `jetpack-review-prompt` preference
   * <img width="1007" alt="Screen Shot 2021-03-24 at 12 22 33 PM" src="https://user-images.githubusercontent.com/2810519/112371507-e8e3e100-8c9b-11eb-8725-f3dbd49cb139.png">
 14. Repeat steps 5 - 8 again.
 15. Click the "Leave a Review" button
 16. Check that the `calypso_jetpack_scan_review_prompt_dismiss` event logged with `reviewed: true`.
 17. Verify the prompt is no longer rendered and the that it opens the Jetpack plugin review page.

Related to # 1192874419362946-as-1199999287485857