### PR TITLE
Block patterns: add unit tests to the ETK

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -31,16 +31,29 @@ class Block_Patterns_From_API {
 	private $valid_patterns_sources = array( 'block_patterns', 'fse_block_patterns' );
 
 	/**
+	 * Patterns source sites.
+	 *
+	 * @var array
+	 */
+	private $patterns_sources;
+
+	/**
+	 * A collection of utility methods.
+	 *
+	 * @var Block_Patterns_Utils
+	 */
+	private $utils;
+
+	/**
 	 * Block_Patterns constructor.
 	 *
 	 * @param array                $patterns_sources A array of strings, each of which matches a valid source for retrieving patterns.
 	 * @param Block_Patterns_Utils $utils            A class dependency containing utils methods.
 	 */
-	public function __construct( $patterns_sources = array(), Block_Patterns_Utils $utils = null ) {
-		// Tells the backend which patterns source site to default to.
+	public function __construct( $patterns_sources, Block_Patterns_Utils $utils = null ) {
+		$patterns_sources       = empty( $patterns_sources ) ? array( 'block_patterns' ) : $patterns_sources;
 		$this->patterns_sources = empty( array_diff( $patterns_sources, $this->valid_patterns_sources ) ) ? $patterns_sources : array( 'block_patterns' );
-
-		$this->utils = empty( $utils ) ? new \A8C\FSE\Block_Patterns_Utils() : $utils;
+		$this->utils            = empty( $utils ) ? new \A8C\FSE\Block_Patterns_Utils() : $utils;
 	}
 
 	/**
@@ -159,7 +172,7 @@ class Block_Patterns_From_API {
 			return $this->utils->remote_get( $request_url );
 		}
 
-		$block_patterns = $this->utils->cache_get( $this->patterns_cache_key, 'ptk_patterns' );
+		$block_patterns = $this->utils->cache_get( $patterns_cache_key, 'ptk_patterns' );
 
 		// Load fresh data if we don't have any patterns.
 		if ( false === $block_patterns || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE ) ) {
@@ -175,7 +188,7 @@ class Block_Patterns_From_API {
 			);
 
 			$block_patterns = $this->utils->remote_get( $request_url );
-			$this->utils->cache_add( $this->patterns_cache_key, $block_patterns, 'ptk_patterns', DAY_IN_SECONDS );
+			$this->utils->cache_add( $patterns_cache_key, $block_patterns, 'ptk_patterns', DAY_IN_SECONDS );
 		}
 
 		return $block_patterns;

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -34,11 +34,9 @@ class Block_Patterns_From_API {
 	 * Block_Patterns constructor.
 	 *
 	 * @param array                $patterns_sources A array of strings, each of which matches a valid source for retrieving patterns.
-	 * @param Block_Patterns_Utils                   A class dependency containing utils methods.
+	 * @param Block_Patterns_Utils $utils            A class dependency containing utils methods.
 	 */
-	private function __construct( $patterns_sources, Block_Patterns_Utils $utils = null ) {
-		$patterns_sources = empty( $patterns_sources ) ? array( 'block_patterns' ) : $patterns_sources;
-
+	public function __construct( $patterns_sources = array(), Block_Patterns_Utils $utils = null ) {
 		// Tells the backend which patterns source site to default to.
 		$this->patterns_sources = empty( array_diff( $patterns_sources, $this->valid_patterns_sources ) ) ? $patterns_sources : array( 'block_patterns' );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
@@ -88,7 +88,7 @@ class Block_Patterns_From_Api_Test extends TestCase {
 	 */
 	public function test_patterns_request_succeeds_with_empty_cache() {
 		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ) );
-		$block_patterns_from_api = new Block_Patterns_From_API( $utils_mock );
+		$block_patterns_from_api = new Block_Patterns_From_API( array(), $utils_mock );
 
 		$utils_mock->expects( $this->once() )
 			->method( 'cache_get' )
@@ -96,7 +96,7 @@ class Block_Patterns_From_Api_Test extends TestCase {
 
 		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
-			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web' );
+			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=block_patterns' );
 
 		$utils_mock->expects( $this->once() )
 			->method( 'cache_add' )
@@ -110,7 +110,7 @@ class Block_Patterns_From_Api_Test extends TestCase {
 	 */
 	public function test_patterns_request_succeeds_with_set_cache() {
 		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ), array( $this->pattern_mock_object ) );
-		$block_patterns_from_api = new Block_Patterns_From_API( $utils_mock );
+		$block_patterns_from_api = new Block_Patterns_From_API( array(), $utils_mock );
 
 		$utils_mock->expects( $this->once() )
 			->method( 'cache_get' )
@@ -135,7 +135,7 @@ class Block_Patterns_From_Api_Test extends TestCase {
 
 		add_filter( 'a8c_override_patterns_source_site', $example_site );
 		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ) );
-		$block_patterns_from_api = new Block_Patterns_From_API( $utils_mock );
+		$block_patterns_from_api = new Block_Patterns_From_API( array(), $utils_mock );
 
 		$utils_mock->expects( $this->never() )
 			->method( 'cache_get' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
@@ -100,7 +100,7 @@ class Block_Patterns_From_Api_Test extends TestCase {
 
 		$utils_mock->expects( $this->once() )
 			->method( 'cache_add' )
-			->with( $this->stringContains( 'key-largo' ), array( $this->pattern_mock_object ), 'ptk_patterns', DAY_IN_SECONDS);
+			->with( $this->stringContains( 'key-largo' ), array( $this->pattern_mock_object ), 'ptk_patterns', DAY_IN_SECONDS );
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
@@ -65,15 +65,20 @@ class Block_Patterns_From_Api_Test extends TestCase {
 	public function createBlockPatternsUtilsMock( $pattern_mock_response, $cache_get = false, $cache_add = true, $get_patterns_cache_key = 'key-largo', $get_block_patterns_locale = 'fr' ) {
 		$mock = $this->createMock( Block_Patterns_Utils::class );
 
-		$mock->method( 'remote_get' )->willReturn( $pattern_mock_response );
+		$mock->method( 'remote_get' )
+			->willReturn( $pattern_mock_response );
 
-		$mock->method( 'cache_get' )->willReturn( $cache_get );
+		$mock->method( 'cache_get' )
+			->willReturn( $cache_get );
 
-		$mock->method( 'cache_add' )->willReturn( $cache_add );
+		$mock->method( 'cache_add' )
+			->willReturn( $cache_add );
 
-		$mock->method( 'get_patterns_cache_key' )->willReturn( $get_patterns_cache_key );
+		$mock->method( 'get_patterns_cache_key' )
+			->willReturn( $get_patterns_cache_key );
 
-		$mock->method( 'get_block_patterns_locale' )->willReturn( $get_block_patterns_locale );
+		$mock->method( 'get_block_patterns_locale' )
+			->willReturn( $get_block_patterns_locale );
 
 		return $mock;
 	}
@@ -85,15 +90,15 @@ class Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ) );
 		$block_patterns_from_api = new Block_Patterns_From_API( $utils_mock );
 
-		$utils_mock ->expects( $this->once() )
+		$utils_mock->expects( $this->once() )
 			->method( 'cache_get' )
 			->willReturn( false );
 
-		$utils_mock ->expects( $this->once() )
+		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
 			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web' );
 
-		$utils_mock ->expects( $this->once() )
+		$utils_mock->expects( $this->once() )
 			->method( 'cache_add' )
 			->with( $this->stringContains( 'key-largo' ), array( $this->pattern_mock_object ), 'ptk_patterns', DAY_IN_SECONDS);
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Coming Soon Tests File
+ * Run: yarn run test:php --testsuite block-patterns
+ *
+ * @package full-site-editing-plugin
+ */
+
+namespace A8C\FSE;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../class-block-patterns-from-api.php';
+
+/**
+ * Class Coming_Soon_Test
+ */
+class Block_Patterns_From_Api_Test extends TestCase {
+	/** @var  \PHPUnit_Framework_MockObject_MockObject */
+	protected $utils_mock;
+
+	/** @var  Representation of a Pattern as returned by the API. */
+	protected $pattern_mock_object;
+
+	public function setUp() {
+		parent::setUp();
+		$this->pattern_mock_object = [
+			'ID'            => '1',
+			'site_id'       => '2',
+			'title'         => 'test title',
+			'name'          => 'test pattern name',
+			'description'   => 'test description',
+			'html'          => '<p>test</p>',
+			'source_url'    => 'http;//test',
+			'modified_date' => 'dd:mm:YY',
+			'categories'    => [
+				[
+					'title' => 'test-category',
+				]
+			],
+		];
+	}
+
+	// Returns a mock of Block_Patterns_Utils
+	public function createBlockPatternsUtilsMock( $pattern_mock_response, $cache_get = false, $cache_add = true, $get_patterns_cache_key = 'key-largo', $get_block_patterns_locale = 'fr' ) {
+		$mock = $this->createMock( Block_Patterns_Utils::class );
+
+		$mock
+			->method( 'remote_get' )
+			->willReturn( $pattern_mock_response );
+
+		$mock
+			->method( 'cache_get' )
+			->willReturn( $cache_get );
+
+		$mock
+			->method( 'cache_add' )
+			->willReturn( $cache_add );
+
+		$mock
+			->method( 'get_patterns_cache_key' )
+			->willReturn( $get_patterns_cache_key );
+
+		$mock
+			->method( 'get_block_patterns_locale' )
+			->willReturn( $get_block_patterns_locale );
+
+		return $mock;
+	}
+
+	public function test_patterns_request_succeeds_with_empty_cache() {
+		$utils_mock              = $this->createBlockPatternsUtilsMock( [ $this->pattern_mock_object ] );
+		$block_patterns_from_api = new Block_Patterns_From_API( $utils_mock );
+
+		$utils_mock ->expects( $this->once() )
+			->method( 'cache_get' )
+			->willReturn( false );
+
+		$utils_mock ->expects( $this->once() )
+			->method( 'remote_get' )
+			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web' );
+
+		$utils_mock ->expects( $this->once() )
+			->method( 'cache_add' )
+			->with( $this->stringContains( 'key-largo' ), [ $this->pattern_mock_object ], 'ptk_patterns', DAY_IN_SECONDS);
+
+		$this->assertEquals( [ 'a8c/' . $this->pattern_mock_object['name'] => true, ], $block_patterns_from_api->register_patterns() );
+	}
+
+	public function test_patterns_request_succeeds_with_set_cache() {
+		$utils_mock              = $this->createBlockPatternsUtilsMock( [ $this->pattern_mock_object ], [ $this->pattern_mock_object ] );
+		$block_patterns_from_api = new Block_Patterns_From_API( $utils_mock );
+
+		$utils_mock->expects( $this->once() )
+			->method( 'cache_get' )
+			->with( $this->stringContains( 'key-largo' ), 'ptk_patterns' );
+
+		$utils_mock->expects( $this->never() )
+			->method( 'remote_get' );
+
+		$utils_mock->expects( $this->never() )
+			->method( 'cache_add' );
+
+		$this->assertEquals( [ 'a8c/' . $this->pattern_mock_object['name'] => true, ], $block_patterns_from_api->register_patterns() );
+	}
+
+	public function test_patterns_request_succeeds_with_override_source_site() {
+		$example_site = function() {
+			return 'dotcom';
+		};
+
+		add_filter( 'a8c_override_patterns_source_site', $example_site);
+		$utils_mock              = $this->createBlockPatternsUtilsMock( [ $this->pattern_mock_object ] );
+		$block_patterns_from_api = new Block_Patterns_From_API( $utils_mock );
+
+		$utils_mock->expects( $this->never() )
+			->method( 'cache_get' );
+
+		$utils_mock->expects( $this->never() )
+			->method( 'cache_add' );
+
+		$utils_mock ->expects( $this->once() )
+			->method( 'remote_get' )
+			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=dotcom&tags=pattern&pattern_meta=is_web' );
+
+		$this->assertEquals( [ 'a8c/' . $this->pattern_mock_object['name'] => true, ], $block_patterns_from_api->register_patterns() );
+
+		remove_filter( 'a8c_override_patterns_source_site', $example_site );
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
@@ -16,15 +16,26 @@ require_once __DIR__ . '/../class-block-patterns-from-api.php';
  * Class Coming_Soon_Test
  */
 class Block_Patterns_From_Api_Test extends TestCase {
-	/** @var  \PHPUnit_Framework_MockObject_MockObject */
+	/**
+	 * PHPUnit_Framework_MockObject_MockObject.
+	 *
+	 * @var string
+	 */
 	protected $utils_mock;
 
-	/** @var  Representation of a Pattern as returned by the API. */
+	/**
+	 * Representation of a Pattern as returned by the API.
+	 *
+	 * @var string
+	 */
 	protected $pattern_mock_object;
 
+	/**
+	 * Pre-test setup.
+	 */
 	public function setUp() {
 		parent::setUp();
-		$this->pattern_mock_object = [
+		$this->pattern_mock_object = array(
 			'ID'            => '1',
 			'site_id'       => '2',
 			'title'         => 'test title',
@@ -33,43 +44,45 @@ class Block_Patterns_From_Api_Test extends TestCase {
 			'html'          => '<p>test</p>',
 			'source_url'    => 'http;//test',
 			'modified_date' => 'dd:mm:YY',
-			'categories'    => [
-				[
+			'categories'    => array(
+				array(
 					'title' => 'test-category',
-				]
-			],
-		];
+				),
+			),
+		);
 	}
 
-	// Returns a mock of Block_Patterns_Utils
+	/**
+	 *  Returns a mock of Block_Patterns_Utils.
+	 *
+	 * @param array      $pattern_mock_response     What we want Block_Patterns_Utils->remote_get() to return.
+	 * @param bool|array $cache_get                 What we want Block_Patterns_Utils->cache_get() to return.
+	 * @param bool       $cache_add                 What we want Block_Patterns_Utils->cache_add() to return.
+	 * @param string     $get_patterns_cache_key    What we want Block_Patterns_Utils->get_patterns_cache_key() to return.
+	 * @param string     $get_block_patterns_locale What we want Block_Patterns_Utils->get_block_patterns_locale() to return.
+	 * @return obj PHP Unit mock object.
+	 */
 	public function createBlockPatternsUtilsMock( $pattern_mock_response, $cache_get = false, $cache_add = true, $get_patterns_cache_key = 'key-largo', $get_block_patterns_locale = 'fr' ) {
 		$mock = $this->createMock( Block_Patterns_Utils::class );
 
-		$mock
-			->method( 'remote_get' )
-			->willReturn( $pattern_mock_response );
+		$mock->method( 'remote_get' )->willReturn( $pattern_mock_response );
 
-		$mock
-			->method( 'cache_get' )
-			->willReturn( $cache_get );
+		$mock->method( 'cache_get' )->willReturn( $cache_get );
 
-		$mock
-			->method( 'cache_add' )
-			->willReturn( $cache_add );
+		$mock->method( 'cache_add' )->willReturn( $cache_add );
 
-		$mock
-			->method( 'get_patterns_cache_key' )
-			->willReturn( $get_patterns_cache_key );
+		$mock->method( 'get_patterns_cache_key' )->willReturn( $get_patterns_cache_key );
 
-		$mock
-			->method( 'get_block_patterns_locale' )
-			->willReturn( $get_block_patterns_locale );
+		$mock->method( 'get_block_patterns_locale' )->willReturn( $get_block_patterns_locale );
 
 		return $mock;
 	}
 
+	/**
+	 *  Tests that we're making a request where there are no cached patterns.
+	 */
 	public function test_patterns_request_succeeds_with_empty_cache() {
-		$utils_mock              = $this->createBlockPatternsUtilsMock( [ $this->pattern_mock_object ] );
+		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ) );
 		$block_patterns_from_api = new Block_Patterns_From_API( $utils_mock );
 
 		$utils_mock ->expects( $this->once() )
@@ -82,13 +95,16 @@ class Block_Patterns_From_Api_Test extends TestCase {
 
 		$utils_mock ->expects( $this->once() )
 			->method( 'cache_add' )
-			->with( $this->stringContains( 'key-largo' ), [ $this->pattern_mock_object ], 'ptk_patterns', DAY_IN_SECONDS);
+			->with( $this->stringContains( 'key-largo' ), array( $this->pattern_mock_object ), 'ptk_patterns', DAY_IN_SECONDS);
 
-		$this->assertEquals( [ 'a8c/' . $this->pattern_mock_object['name'] => true, ], $block_patterns_from_api->register_patterns() );
+		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
 	}
 
+	/**
+	 *  Tests that we're NOT making a request where there ARE cached patterns.
+	 */
 	public function test_patterns_request_succeeds_with_set_cache() {
-		$utils_mock              = $this->createBlockPatternsUtilsMock( [ $this->pattern_mock_object ], [ $this->pattern_mock_object ] );
+		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ), array( $this->pattern_mock_object ) );
 		$block_patterns_from_api = new Block_Patterns_From_API( $utils_mock );
 
 		$utils_mock->expects( $this->once() )
@@ -101,16 +117,19 @@ class Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock->expects( $this->never() )
 			->method( 'cache_add' );
 
-		$this->assertEquals( [ 'a8c/' . $this->pattern_mock_object['name'] => true, ], $block_patterns_from_api->register_patterns() );
+		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
 	}
 
+	/**
+	 *  Tests that we're making a request where we're overriding the source site.
+	 */
 	public function test_patterns_request_succeeds_with_override_source_site() {
-		$example_site = function() {
+		$example_site = function () {
 			return 'dotcom';
 		};
 
-		add_filter( 'a8c_override_patterns_source_site', $example_site);
-		$utils_mock              = $this->createBlockPatternsUtilsMock( [ $this->pattern_mock_object ] );
+		add_filter( 'a8c_override_patterns_source_site', $example_site );
+		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ) );
 		$block_patterns_from_api = new Block_Patterns_From_API( $utils_mock );
 
 		$utils_mock->expects( $this->never() )
@@ -119,11 +138,11 @@ class Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock->expects( $this->never() )
 			->method( 'cache_add' );
 
-		$utils_mock ->expects( $this->once() )
+		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
 			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=dotcom&tags=pattern&pattern_meta=is_web' );
 
-		$this->assertEquals( [ 'a8c/' . $this->pattern_mock_object['name'] => true, ], $block_patterns_from_api->register_patterns() );
+		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
 
 		remove_filter( 'a8c_override_patterns_source_site', $example_site );
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -263,8 +263,7 @@ function load_block_patterns_from_api( $current_screen ) {
 	}
 
 	require_once __DIR__ . '/block-patterns/class-block-patterns-from-api.php';
-	Block_Patterns_From_API::get_instance( $patterns_sources );
-	$block_patterns_from_api = new Block_Patterns_From_API();
+	$block_patterns_from_api = new Block_Patterns_From_API( $patterns_sources );
 	$block_patterns_from_api->register_patterns();
 }
 add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -264,6 +264,8 @@ function load_block_patterns_from_api( $current_screen ) {
 
 	require_once __DIR__ . '/block-patterns/class-block-patterns-from-api.php';
 	Block_Patterns_From_API::get_instance( $patterns_sources );
+	$block_patterns_from_api = new Block_Patterns_From_API();
+	$block_patterns_from_api->register_patterns();
 }
 add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/phpunit.xml.dist
+++ b/apps/editing-toolkit/editing-toolkit-plugin/phpunit.xml.dist
@@ -5,6 +5,7 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
+	beStrictAboutTestsThatDoNotTestAnything="false"
 	>
     <php>
         <const name="WP_TESTS_MULTISITE" value="1" />
@@ -18,6 +19,9 @@
 		</testsuite>
 		<testsuite name="coming-soon">
 			<directory suffix="-test.php">./coming-soon/test/</directory>
+		</testsuite>
+		<testsuite name="block-patterns">
+			<directory suffix="-test.php">./block-patterns/test/</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/apps/editing-toolkit/editing-toolkit-plugin/phpunit.xml.dist
+++ b/apps/editing-toolkit/editing-toolkit-plugin/phpunit.xml.dist
@@ -5,7 +5,6 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
-	beStrictAboutTestsThatDoNotTestAnything="false"
 	>
     <php>
         <const name="WP_TESTS_MULTISITE" value="1" />


### PR DESCRIPTION
#### Changes proposed in this Pull Request\

⚠️ ~https://github.com/Automattic/wp-calypso/pull/51772 needs to be merged and deployed **before** this PR as it includes the utils dependency~. ✅ 

This PR:

- extracts functions that have side-effects into a utils class for ease of testing and dependency injection
- adds test coverage for the `Block_Patterns_From_API` class

#### Testing instructions

```
cd apps/editing-toolkit
yarn run test:php --testsuite block-patterns
```
