### PR TITLE
Prevent deleting or removing a user when they have active subscriptions

### DIFF
--- a/client/my-sites/people/people-notices/index.jsx
+++ b/client/my-sites/people/people-notices/index.jsx
@@ -128,7 +128,7 @@ class PeopleNotices extends React.Component {
 						{
 							count: productNames.length,
 							args: {
-								domains: productNames.join( ', ' ),
+								productNames: productNames.join( ', ' ),
 								...translateArg( log ),
 							},
 							components: {

--- a/client/my-sites/people/people-notices/index.jsx
+++ b/client/my-sites/people/people-notices/index.jsx
@@ -105,14 +105,30 @@ class PeopleNotices extends React.Component {
 				} );
 			case 'RECEIVE_DELETE_SITE_USER_FAILURE':
 				if ( 'user_owns_domain_subscription' === log.error.error ) {
-					const numDomains = log.error.message.split( ',' ).length;
+					const domains = log.error.data ?? log.error.message.split( ',' );
 					return i18n.translate(
 						'@%(user)s owns following domain used on this site: {{strong}}%(domains)s{{/strong}}. This domain will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
 						'@%(user)s owns following domains used on this site: {{strong}}%(domains)s{{/strong}}. These domains will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
 						{
-							count: numDomains,
+							count: domains.length,
 							args: {
-								domains: log.error.message,
+								domains: domains.join( ', ' ),
+								...translateArg( log ),
+							},
+							components: {
+								strong: <strong />,
+							},
+						}
+					);
+				} else if ( 'user_has_active_subscriptions' === log.error.error ) {
+					const productNames = log.error.data ?? [];
+					return i18n.translate(
+						'@%(user)s owns following product used on this site: {{strong}}%(productNames)s{{/strong}}. This product will have to be transferred to a different site, user, or canceled before removing or deleting @%(user)s.',
+						'@%(user)s owns following products used on this site: {{strong}}%(productNames)s{{/strong}}. These products will have to be transferred to a different site, user, or canceled before removing or deleting @%(user)s.',
+						{
+							count: productNames.length,
+							args: {
+								domains: productNames.join( ', ' ),
 								...translateArg( log ),
 							},
 							components: {
@@ -121,6 +137,7 @@ class PeopleNotices extends React.Component {
 						}
 					);
 				}
+
 				if ( isMultisite( this.props.site ) ) {
 					return i18n.translate( 'There was an error removing @%(user)s', {
 						args: translateArg( log ),


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/27481

#### Changes proposed in this Pull Request

It is not possible to remove a user with active domain subscriptions:
<img width="748" alt="Screenshot 2021-03-03 at 11 44 01" src="https://user-images.githubusercontent.com/3392497/109801116-f1ee0f00-7c15-11eb-8c2f-496906de4ee8.png">

However, other active upgrades are not a blocker - which is an issue, because the user then cannot manage those purchases.

This PR adds handling for a new backend check (see D59343-code) that should prevent this situation and show an appropriate error message:

<img width="759" alt="Screenshot 2021-03-25 at 22 58 50" src="https://user-images.githubusercontent.com/3392497/112554154-afa39200-8dbd-11eb-93e2-417c925811c4.png">

#### Testing instructions

Best tested with D59343-code, though it should work without it (just won't show any new error messages and a user with active upgrades _will_ be possible to remove - but we need to preserve backwards compatibility).

Go to Users -> All users and try to remove a user that owns upgrades on the site. Try one with only domain subscriptions, only non-domain ones (usually a paid plan) or a mix of both.