### PR TITLE
Themes showcase: Display banners to all Free tiers

### DIFF
--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -23,6 +23,7 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
+import isWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 
 const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 	const {
@@ -32,11 +33,11 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 		isVip,
 		siteSlug,
 		translate,
-		isJetpack,
+		isJetpackNotAtomic,
 	} = props;
 
 	const displayUpsellBanner = ! requestingSitePlans && ! hasUnlimitedPremiumThemes && ! isVip;
-	const bannerLocationBelowSearch = ! isJetpack;
+	const bannerLocationBelowSearch = ! isJetpackNotAtomic;
 
 	const upsellUrl = `/plans/${ siteSlug }`;
 	let upsellBanner = null;
@@ -98,7 +99,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 } );
 
 export default connect( ( state, { siteId } ) => ( {
-	isJetpack: isJetpackSite( state, siteId ),
+	isJetpackNotAtomic: isJetpackSite( state, siteId ) && ! isWpcomAtomic( state, siteId ),
 	isVip: isVipSite( state, siteId ),
 	siteSlug: getSiteSlug( state, siteId ),
 	hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the banner logic in the Theme Showcase so that it still treats a Free tier of Atomic as a Free wpcom site. 
Before, it seems as though we were relying on is_jetpack as a way to signify to not show it on "Atomic Plans", but Atomic Plans aren't a thing, so we want to show this to sites on the Free tier. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a Business Atomic site
2. If an a11n, remove the business plan but don't revert it to wpcom. 
3. Or you can ping me in Slack for instructions on how to provision a Free Atomic site. 
4. Navigate to https://wordpress.com/themes/ 
5. Scroll down and click "Show all themes"
6. You should see upsell banners.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #51351
