### PR TITLE
TC: Load existing node_modules from docker image

### DIFF
--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -70,7 +70,7 @@ open class PluginBaseBuild : Template({
 					echo "No existing node_modules were found."
 				fi
 
-				# Install modules
+				# Install modules.
 				yarn install
 			"""
 		}

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -62,16 +62,7 @@ open class PluginBaseBuild : Template({
 				# Update composer
 				composer install
 
-				# Load existing node_modules to reduce install time.
-				if [ -d /calypso/node_modules ] ; then
-					echo "Loading existing found node_modules..."
-					mv /calypso/node_modules ./node_modules
-				else
-					echo "No existing node_modules were found."
-				fi
-
-				# Install modules.
-				yarn install
+				$yarn_install_cmd
 			"""
 		}
 		bashNodeScript {
@@ -111,7 +102,7 @@ open class PluginBaseBuild : Template({
 			scriptContent = """
 				# 1. Download and unzip current release build.
 				cd $workingDir
-				
+
 				mkdir ./release-archive
 				wget "%teamcity.serverUrl%/repository/download/%system.teamcity.buildType.id%/$releaseTag.tcbuildtag/$pluginSlug.zip?guest=1&branch=trunk" -O ./tmp-release-archive-download.zip
 				unzip ./tmp-release-archive-download.zip -d ./release-archive

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -62,6 +62,11 @@ open class PluginBaseBuild : Template({
 				# Update composer
 				composer install
 
+				# Load existing node_modules to reduce install time.
+				if [ -d /calypso/node_modules ] ; then
+					mv /calypso/node_modules ./node_modules
+				fi
+
 				# Install modules
 				yarn install
 			"""

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -64,7 +64,10 @@ open class PluginBaseBuild : Template({
 
 				# Load existing node_modules to reduce install time.
 				if [ -d /calypso/node_modules ] ; then
+					echo "Loading existing found node_modules..."
 					mv /calypso/node_modules ./node_modules
+				else
+					echo "No existing node_modules were found."
 				fi
 
 				# Install modules

--- a/.teamcity/_self/projects/DesktopApp.kt
+++ b/.teamcity/_self/projects/DesktopApp.kt
@@ -48,7 +48,7 @@ object E2ETests : BuildType({
 				openssl aes-256-cbc -md md5 -d -in desktop/resource/calypso/secrets.json.enc -out config/secrets.json -k "%CALYPSO_SECRETS_ENCRYPTION_KEY%"
 
 				# Install modules
-				yarn install
+				${_self.yarn_install_cmd}
 				yarn run build-desktop:install-app-deps
 			"""
 			dockerImage = "%docker_image_desktop%"

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -44,7 +44,7 @@ object RunCalypsoE2eDesktopTests : BuildType({
 				export NODE_ENV="test"
 
 				# Install modules
-				yarn install
+				${_self.yarn_install_cmd}
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}
@@ -210,7 +210,7 @@ object RunCalypsoE2eMobileTests : BuildType({
 				export NODE_ENV="test"
 
 				# Install modules
-				yarn install
+				${_self.yarn_install_cmd}
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}
@@ -438,7 +438,7 @@ object RunAllUnitTests : BuildType({
 				export NODE_ENV="test"
 
 				# Install modules
-				yarn install
+				${_self.yarn_install_cmd}
 			"""
 		}
 		bashNodeScript {
@@ -651,7 +651,7 @@ object CheckCodeStyleBranch : BuildType({
 				export NODE_ENV="test"
 
 				# Install modules
-				yarn install
+				${_self.yarn_install_cmd}
 			"""
 		}
 		bashNodeScript {
@@ -744,7 +744,7 @@ object RunCalypsoPlaywrightE2eTests : BuildType({
 				export PLAYWRIGHT_BROWSERS_PATH=0
 
 				# Install modules
-				yarn install
+				${_self.yarn_install_cmd}
 
 				# Build package
 				yarn workspace @automattic/calypso-e2e build

--- a/.teamcity/_self/yarnInstall.kt
+++ b/.teamcity/_self/yarnInstall.kt
@@ -1,0 +1,17 @@
+package _self
+
+/**
+ * Use variable in scripts to take advantage of node_module caching.
+ */
+val yarn_install_cmd = """
+	# Load existing node_modules to reduce install time.
+	if [ -d /calypso/node_modules ] ; then
+		echo "Loading existing found node_modules..."
+		mv /calypso/node_modules ./node_modules
+	else
+		echo "No existing node_modules were found."
+	fi
+
+	# Install modules.
+	yarn install
+""".trimIndent()

--- a/.teamcity/_self/yarnInstall.kt
+++ b/.teamcity/_self/yarnInstall.kt
@@ -5,7 +5,7 @@ package _self
  */
 val yarn_install_cmd = """
 	# Load existing node_modules to reduce install time.
-	if [ -d /calypso/node_modules ] ; then
+	if [ -d /calypso/node_modules ] && [ "%use_cached_node_modules%" == "true" ] ; then
 		echo "Loading existing found node_modules..."
 		mv /calypso/node_modules ./node_modules
 	else

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -210,7 +210,7 @@ object CheckCodeStyle : BuildType({
 				export NODE_ENV="test"
 
 				# Install modules
-				yarn install
+				${_self.yarn_install_cmd}
 			"""
 		}
 		bashNodeScript {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -45,6 +45,7 @@ project {
 
 	params {
 		param("env.NODE_OPTIONS", "--max-old-space-size=32000")
+		param("use_cached_node_modules", "true")
 		text("E2E_WORKERS", "16", label = "Magellan parallel workers", description = "Number of parallel workers in Magellan (e2e tests)", allowEmpty = true)
 		text("env.JEST_MAX_WORKERS", "16", label = "Jest max workers", description = "How many tests run in parallel", allowEmpty = true)
 		password("matticbot_oauth_token", "credentialsJSON:34cb38a5-9124-41c4-8497-74ed6289d751", display = ParameterDisplay.HIDDEN)


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Attempts loading the existing node_modules from the Docker image. (Added in #51421, [docker images rebuilt here](https://teamcity.a8c.com/buildConfiguration/calypso_BuildBaseImages/6038457?branch=%3Cdefault%3E&buildTypeTab=overview&mode=builds&buildTab=overview))

This should theoretically reduce `yarn install` time.

Initial results for ETK build:

| Action | Before | After |
| ------------- | ------------- | ------------- |
| Yarn install time: | 53s | 23.34s  |
| Prepare environment time: | 1:06 | 47s  |
| Total completion time: | 2:10 | 1:53 |

I believe this is reducing yarn install time by more than half, or about 30s. However, the typical `prepare environment` for all wpcom plugins is just above one minute. This only reduces it to <50s. In other words, I think the benefit could be bigger.

#### Testing instructions
1. ETK and other wpcom plugin builds should successfully complete
2. The prepare environment step should be faster than before. (Less than one minute, ideally)
