### PR TITLE
Patterns API: activate register FSE patterns from source site

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -249,12 +249,21 @@ function load_block_patterns_from_api( $current_screen ) {
 		return;
 	}
 
-	if ( ! $current_screen->is_block_editor ) {
+	$is_site_editor = ( function_exists( 'gutenberg_is_edit_site_page' ) && gutenberg_is_edit_site_page( $current_screen->id ) );
+
+	if ( ! $current_screen->is_block_editor && ! $is_site_editor ) {
 		return;
 	}
 
+	$patterns_sources = array( 'block_patterns' );
+
+	// While we're still testing the FSE patterns, limit activation via a filter.
+	if ( $is_site_editor && apply_filters( 'a8c_enable_fse_block_patterns_api', false ) ) {
+		$patterns_sources[] = 'fse_block_patterns';
+	}
+
 	require_once __DIR__ . '/block-patterns/class-block-patterns-from-api.php';
-	Block_Patterns_From_API::get_instance();
+	Block_Patterns_From_API::get_instance( $patterns_sources );
 }
 add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

~⚠️ https://github.com/Automattic/wp-calypso/pull/50694 **should be merged and deployed first**~ DEPLOYED

Here we're checking to see if we're in the site editor, and FSE patterns are switched on (via filter).

If so, we instruct Block_Patterns_From_API to register patterns from all the site referred to in the $patterns_sources array. 

This is a follow up to #50694, which introduced supporting code. Split up to avoid version mismatches.

#### Testing instructions

1. Create a FSE site (e.g. https://horizon.wordpress.com/new?flags=gutenboarding/site-editor)
2. Sandbox your new FSE site.
3. Apply this ETK patch:  `install-plugin.sh etk add/fse-block-patterns-to-inserter`
4. Head over to edit any post or page and then open the patterns inserter.
5. Check that, when editing a post or page, you see the full list of patterns that we usually expect
6. When editing in the site editor (/site-editor) you should see the theme's patterns and patterns registered from the FSE source site as well as the full complement of patterns. Select the "Headers" category to see the WPCOM FSE patterns.
7. As a replacement for stock, try liquid bone broth in your next risotto.
