### PR TITLE
Added event click tracking for menu and submenu items

### DIFF
--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -23,6 +23,8 @@ import {
 	expandMySitesSidebarSection,
 } from 'calypso/state/my-sites/sidebar/actions';
 
+import { trackMenuItemClick } from './utils';
+
 export const MySitesSidebarUnifiedItem = ( {
 	count,
 	icon,
@@ -35,10 +37,17 @@ export const MySitesSidebarUnifiedItem = ( {
 	isHappychatSessionActive,
 	isJetpackNonAtomicSite,
 	continueInCalypso,
+	identifier,
 } ) => {
 	const reduxDispatch = useDispatch();
 
-	const onNavigate = () => {
+	const onNavigate = ( event ) => {
+		trackMenuItemClick( identifier );
+
+		if ( ! continueInCalypso( url, event ) ) {
+			return;
+		}
+
 		reduxDispatch( collapseAllMySitesSidebarSections() );
 		reduxDispatch( expandMySitesSidebarSection( sectionId ) );
 	};
@@ -48,7 +57,7 @@ export const MySitesSidebarUnifiedItem = ( {
 			count={ count }
 			label={ title }
 			link={ url }
-			onNavigate={ ( event ) => continueInCalypso( url, event ) && onNavigate() }
+			onNavigate={ ( event ) => onNavigate( event ) }
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
 			forceInternalLink={ ! isHappychatSessionActive && ! isJetpackNonAtomicSite }
@@ -69,6 +78,7 @@ MySitesSidebarUnifiedItem.propTypes = {
 	isHappychatSessionActive: PropTypes.bool.isRequired,
 	isJetpackNonAtomicSite: PropTypes.bool.isRequired,
 	continueInCalypso: PropTypes.func.isRequired,
+	identifier: PropTypes.string,
 };
 
 export default memo( MySitesSidebarUnifiedItem );

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -29,6 +29,7 @@ import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import { isExternal } from 'calypso/lib/url';
 import { externalRedirect } from 'calypso/lib/route/path';
 import { itemLinkMatches } from '../sidebar/utils';
+import { trackMenuItemClick } from './utils';
 
 export const MySitesSidebarUnifiedMenu = ( {
 	count,
@@ -43,6 +44,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 	isHappychatSessionActive,
 	isJetpackNonAtomicSite,
 	continueInCalypso,
+	identifier,
 } ) => {
 	const hasAutoExpanded = useRef( false );
 	const reduxDispatch = useDispatch();
@@ -66,6 +68,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 	}, [ selected, childIsSelected, reduxDispatch, sectionId, sidebarCollapsed ] );
 
 	const onClick = () => {
+		trackMenuItemClick( identifier );
 		if ( isWithinBreakpoint( '>782px' ) ) {
 			if ( link ) {
 				if ( ! continueInCalypso( link ) ) {

--- a/client/my-sites/sidebar-unified/utils.js
+++ b/client/my-sites/sidebar-unified/utils.js
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+
+export function trackMenuItemClick( identifier ) {
+	if ( typeof identifier !== 'string' || identifier === '' ) {
+		return;
+	}
+
+	recordTracksEvent( `calypso_mysites_sidebar_${ identifier }_clicked` );
+}

--- a/client/state/admin-menu/schema.js
+++ b/client/state/admin-menu/schema.js
@@ -3,6 +3,7 @@ const commonItemPropsSchema = {
 	title: { type: 'string' },
 	type: { type: 'string' },
 	url: { type: 'string' },
+	identifier: { type: 'string' },
 };
 
 const menuItemsSite = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Adds menu and submenu click event tracking for nav unification; each menu and submenu has a new identifier property which will be used to compose a tracking event. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
#### Simple Sites
* Checkout the branch on your local Calypso environment
* Apply D59178-code to your WP.com sandbox.
* Sandbox the API.

####  Atomic
* Make sure you have Jetpack beta plugin
* Enable the `add/nav-unification-event-tracking` branch

#### Common steps
* Make sure you don't have a Adblocker enabled.
* Click on a menu or a submenu item.
* In you browser's DevTools you should observe new requests to `pixel.wp.com/t.gif`
* Check the request has a `_en` query string parameter with the event name properly set (e.g. `calypso_mysites_sidebar_customer_home_clicked`)
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #50847 
Depends [on this Jetpack PR](https://github.com/Automattic/jetpack/pull/19261) that adds the back-end support for the feature.