### PR TITLE
Framework: Refactor away from _.constant()

### DIFF
--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -28,7 +28,7 @@ import playIconImage from 'calypso/assets/images/reader/play-icon.png';
 import './style.scss';
 
 const noop = () => {};
-const defaultSizingFunction = () => {};
+const defaultSizingFunction = () => ( {} );
 
 class ReaderFeaturedVideo extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { throttle, constant } from 'lodash';
+import { throttle } from 'lodash';
 import ReactDom from 'react-dom';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
@@ -28,6 +28,7 @@ import playIconImage from 'calypso/assets/images/reader/play-icon.png';
 import './style.scss';
 
 const noop = () => {};
+const defaultSizingFunction = () => {};
 
 class ReaderFeaturedVideo extends React.Component {
 	static propTypes = {
@@ -50,7 +51,7 @@ class ReaderFeaturedVideo extends React.Component {
 	};
 
 	setVideoSizingStrategy = ( videoEmbed ) => {
-		let sizingFunction = constant( {} );
+		let sizingFunction = defaultSizingFunction;
 		if ( videoEmbed ) {
 			const maxWidth = ReactDom.findDOMNode( this ).parentNode.offsetWidth;
 			const embedSize = EmbedHelper.getEmbedSizingFunction( videoEmbed );

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -4,7 +4,6 @@
 import {
 	assign,
 	camelCase,
-	constant,
 	debounce,
 	every,
 	filter,
@@ -242,12 +241,16 @@ function setFieldErrors( formState, fieldErrors, hideFieldErrorsOnChange ) {
 	);
 }
 
+function getDefaultFieldState() {
+	return {
+		isShowingErrors: true,
+	};
+}
+
 function showAllErrors( formState ) {
 	return updateFields(
 		initializeFields( formState, getAllFieldValues( formState ) ),
-		constant( {
-			isShowingErrors: true,
-		} )
+		getDefaultFieldState
 	);
 }
 

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -241,17 +241,10 @@ function setFieldErrors( formState, fieldErrors, hideFieldErrorsOnChange ) {
 	);
 }
 
-function getDefaultFieldState() {
-	return {
-		isShowingErrors: true,
-	};
-}
-
 function showAllErrors( formState ) {
-	return updateFields(
-		initializeFields( formState, getAllFieldValues( formState ) ),
-		getDefaultFieldState
-	);
+	return updateFields( initializeFields( formState, getAllFieldValues( formState ) ), () => ( {
+		isShowingErrors: true,
+	} ) );
 }
 
 function hasErrors( formState ) {

--- a/client/lib/form-state/test/index.js
+++ b/client/lib/form-state/test/index.js
@@ -1,13 +1,15 @@
 /**
  * External dependencies
  */
-import { assign, constant, mapValues, zipObject } from 'lodash';
+import { assign, mapValues, zipObject } from 'lodash';
 import assert from 'assert';
 
 /**
  * Internal dependencies
  */
 import formState from '../';
+
+const getDefaultErrors = () => [];
 
 function checkNthState( n, callback ) {
 	let count = 0;
@@ -26,12 +28,15 @@ function testController( options ) {
 
 	const defaults = {
 		loadFunction: function ( onComplete ) {
-			const fieldValues = zipObject( fieldNames, fieldNames.map( constant( 'loaded' ) ) );
+			const fieldValues = zipObject(
+				fieldNames,
+				fieldNames.map( () => 'loaded' )
+			);
 			onComplete( null, fieldValues );
 		},
 
 		validatorFunction: function ( fieldValues, onComplete ) {
-			const fieldErrors = mapValues( fieldValues, constant( [] ) );
+			const fieldErrors = mapValues( fieldValues, getDefaultErrors );
 			onComplete( null, fieldErrors );
 		},
 

--- a/client/lib/form-state/test/index.js
+++ b/client/lib/form-state/test/index.js
@@ -9,8 +9,6 @@ import assert from 'assert';
  */
 import formState from '../';
 
-const getDefaultErrors = () => [];
-
 function checkNthState( n, callback ) {
 	let count = 0;
 
@@ -36,7 +34,7 @@ function testController( options ) {
 		},
 
 		validatorFunction: function ( fieldValues, onComplete ) {
-			const fieldErrors = mapValues( fieldValues, getDefaultErrors );
+			const fieldErrors = mapValues( fieldValues, () => [] );
 			onComplete( null, fieldErrors );
 		},
 

--- a/client/state/guided-tours/selectors/index.js
+++ b/client/state/guided-tours/selectors/index.js
@@ -1,18 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	constant,
-	difference,
-	find,
-	findLast,
-	flatMap,
-	get,
-	includes,
-	map,
-	startsWith,
-	pick,
-} from 'lodash';
+import { difference, find, findLast, flatMap, get, includes, map, startsWith, pick } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -149,7 +138,7 @@ const findTriggeredTour = ( state ) => {
 
 	const newTours = difference( toursFromTriggers, toursToDismiss );
 	return find( newTours, ( tour ) => {
-		const { when = constant( true ) } = find( relevantFeatures, { tour } );
+		const { when = () => true } = find( relevantFeatures, { tour } );
 		return when( state );
 	} );
 };

--- a/client/state/guided-tours/test/selectors.js
+++ b/client/state/guided-tours/test/selectors.js
@@ -6,7 +6,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { constant, times } from 'lodash';
+import { times } from 'lodash';
 
 /**
  * Internal dependencies
@@ -233,7 +233,7 @@ describe( 'selectors', () => {
 			 * anymore.
 			 */
 			const state = makeState( {
-				actionLog: times( 50, constant( navigateToTest ) ),
+				actionLog: times( 50, () => navigateToTest ),
 				toursHistory: [ testTourSeen, themesTourSeen ],
 				queryArguments: { tour: 'themes', _timestamp: 0 },
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `constant` is essentially fully natively supported by defining a function that returns the value. This PR replaces the usage.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all usages are sane and preserve the original logic.
* Verify all tests pass.