### PR TITLE
Framework: Refactor away from `_.isInteger()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -407,6 +407,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/is-array': 'error',
 		'you-dont-need-lodash-underscore/is-finite': 'error',
 		'you-dont-need-lodash-underscore/is-function': 'error',
+		'you-dont-need-lodash-underscore/is-integer': 'error',
 		'you-dont-need-lodash-underscore/is-nan': 'error',
 		'you-dont-need-lodash-underscore/is-nil': 'error',
 		'you-dont-need-lodash-underscore/is-null': 'error',

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { get, has, isInteger } from 'lodash';
+import { get, has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -213,7 +213,7 @@ export const post = ( context, next ) => {
 	const jetpackCopy = parseInt( get( context, 'query.jetpack-copy', null ) );
 
 	// Check if this value is an integer.
-	const duplicatePostId = isInteger( jetpackCopy ) ? jetpackCopy : null;
+	const duplicatePostId = Number.isInteger( jetpackCopy ) ? jetpackCopy : null;
 
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -15,7 +15,6 @@ import {
 	values,
 	omit,
 	startsWith,
-	isInteger,
 } from 'lodash';
 
 /**
@@ -428,7 +427,7 @@ export const activeReplies = withoutPersistence( ( state = {}, action ) => {
 
 function updateCount( counts, rawStatus, value = 1 ) {
 	const status = rawStatus === 'unapproved' ? 'pending' : rawStatus;
-	if ( ! counts || ! isInteger( counts[ status ] ) ) {
+	if ( ! counts || ! Number.isInteger( counts[ status ] ) ) {
 		return undefined;
 	}
 	const newCounts = {

--- a/client/state/posts/revisions/reducer.js
+++ b/client/state/posts/revisions/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { filter, get, isEmpty, isInteger, keyBy, omit } from 'lodash';
+import { filter, get, isEmpty, keyBy, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,7 +24,7 @@ export function diffs( state = {}, { diffs: diffsFromServer, postId, revisions, 
 	if ( type !== POST_REVISIONS_RECEIVE ) {
 		return state;
 	}
-	if ( ! isInteger( siteId ) || siteId <= 0 ) {
+	if ( ! Number.isInteger( siteId ) || siteId <= 0 ) {
 		return state;
 	}
 
@@ -35,11 +35,11 @@ export function diffs( state = {}, { diffs: diffsFromServer, postId, revisions, 
 	};
 
 	const filteredDiffs = filter( diffsFromServer, ( { diff, from, to } ) => {
-		if ( ! isInteger( from ) || from < 0 ) {
+		if ( ! Number.isInteger( from ) || from < 0 ) {
 			// `from` can be zero
 			return false;
 		}
-		if ( ! isInteger( to ) || to < 1 ) {
+		if ( ! Number.isInteger( to ) || to < 1 ) {
 			// `to` cannot be zero
 			return false;
 		}

--- a/client/state/selectors/get-image-editor-is-greater-than-minimum-dimensions.js
+++ b/client/state/selectors/get-image-editor-is-greater-than-minimum-dimensions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isInteger } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { MinimumImageDimensions } from 'calypso/state/editor/image-editor/constants';
@@ -13,8 +8,8 @@ import getImageEditorOriginalAspectRatio from 'calypso/state/selectors/get-image
  * Returns whether the original image size is greater than minimumImageDimensions values.
  *
  * @param  {object}  state Global state tree
- * @param   {Integer} minimumWidth the minimum width of the image
- * @param   {Integer} minimumHeight the minimum height of the image
+ * @param   {number} minimumWidth the minimum width of the image
+ * @param   {number} minimumHeight the minimum height of the image
  * @returns {boolean} whether dimensions of the image meet the minimum dimension requirements
  */
 export default function getImageEditorIsGreaterThanMinimumDimensions(
@@ -28,8 +23,8 @@ export default function getImageEditorIsGreaterThanMinimumDimensions(
 		const { width, height } = originalAspectRatio;
 
 		if (
-			isInteger( width ) &&
-			isInteger( height ) &&
+			Number.isInteger( width ) &&
+			Number.isInteger( height ) &&
 			width > minimumWidth &&
 			height > minimumHeight
 		) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `isInteger()` is essentially fully natively supported by the native `Number.isInteger()`. This PR replaces the usage and adds an ESLint rule to warn against using `isInteger()` from lodash.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all usages are sane and preserve the original logic.
* Try to `import { isInteger } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass.