### PR TITLE
Account: save color scheme in app preference when saving user settings

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -73,6 +73,7 @@ import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-chang
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { savePreference } from 'calypso/state/preferences/actions';
 
 export const noticeId = 'me-settings-notice';
 const noticeOptions = {
@@ -712,6 +713,14 @@ class Account extends React.Component {
 			this.props.markSaved();
 		}
 
+		// In order to keep the app preference in-sync,
+		// we'd like to save the color scheme property
+		// once the user settings was successfuly saved.
+		// https://github.com/Automattic/wp-calypso/issues/48220
+		if ( this.shouldUpdateColorSchemePreference ) {
+			this.props.saveColorSchemePreference( this.shouldUpdateColorSchemePreference );
+		}
+
 		if ( this.state.redirect ) {
 			user()
 				.clear()
@@ -754,6 +763,10 @@ class Account extends React.Component {
 		} );
 
 		try {
+			// Store in a class property if the color scheme should be saved
+			// once the user settings save successfully.
+			this.shouldUpdateColorSchemePreference = this.props.unsavedUserSettings.calypso_preferences?.colorScheme;
+
 			const response = await this.props.saveUnsavedUserSettings( fields );
 			this.handleSubmitSuccess( response, formName );
 		} catch ( error ) {
@@ -1146,6 +1159,8 @@ export default compose(
 			saveUnsavedUserSettings,
 			setUserSetting,
 			successNotice,
+			saveColorSchemePreference: ( newColorScheme ) =>
+				savePreference( 'colorScheme', newColorScheme ),
 		}
 	),
 	localize,

--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -54,6 +54,7 @@ export const remoteValuesSchema = {
 				'blue',
 				'classic-blue',
 				'classic-bright',
+				'classic-dark',
 				'coffee',
 				'contrast',
 				'ectoplasm',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR saves the color scheme in the app preference when it changes. Right now, the color scheme is only saved in the user settings that keep the data out-of-sync temporarily, producing a flash of the previous color.
Also, [it adds](https://github.com/Automattic/wp-calypso/pull/51448/commits/bdc95c778bf2d68beac0738855c213de04fd7258) the missing `classic-dark` color to the reducer scheme.

Fixes https://github.com/Automattic/wp-calypso/issues/48220

#### Testing instructions

You can confirm the issue by taking a look at its instructions.
Then, you can confirm that the color is properly applied from the initial moment of the rendering process with no color flash issue.

You can use the [live testing branch](https://hash-bdc95c778bf2d68beac0738855c213de04fd7258.calypso.live/home/damian.blog).

Related to https://github.com/Automattic/wp-calypso/issues/48220
