### PR TITLE
Jetpack Cloud: Fix busy button animation being overridden by :hover in Chrome

### DIFF
--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -52,7 +52,7 @@
 
 	&:hover,
 	&:focus {
-		background: var( --color-primary-0 );
+		background-color: var( --color-primary-0 );
 	}
 
 	&:active {
@@ -80,7 +80,7 @@
 
 	&:hover,
 	&:focus {
-		background: var( --color-primary-60 );
+		background-color: var( --color-primary-60 );
 		border-color: var( --color-primary-60 );
 	}
 
@@ -103,7 +103,7 @@
 
 	&:hover,
 	&:focus {
-		background: var( --color-scary-0 );
+		background-color: var( --color-scary-0 );
 	}
 
 	&:active {
@@ -126,7 +126,7 @@
 
 	&:hover,
 	&:focus {
-		background: var( --color-scary-40 );
+		background-color: var( --color-scary-40 );
 		border-color: var( --color-scary-40 );
 	}
 


### PR DESCRIPTION
Chrome still considers a button :hover-ed even if `pointer-events: none` is applied after the button has been hovered and because :hover styles in Jetpack cloud take over the background completely they override the animated background.

Demo:

https://user-images.githubusercontent.com/22746396/112664665-e089d280-8e62-11eb-853b-a4a558b9ed03.mov

CodeSandBox repro which confirms the Behavior in Chrome but not in Firefox:
https://codesandbox.io/s/hopeful-cloud-1s68m?file=/src/styles.css

#### Changes proposed in this Pull Request

* Fix busy button animation being overridden by :hover/:active in Chrome in Jetpack Cloud.

#### Testing instructions

* Do not checkout this PR quite yet.
* Apply this diff which reproduces the problem:
```diff
diff --git a/client/my-sites/sites/index.jsx b/client/my-sites/sites/index.jsx
index 9f8185db1f..33845d2cb3 100644
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -20,6 +20,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
  * Style dependencies
  */
 import './style.scss';
+import DemoBusyButtonBug from 'calypso/my-sites/stats/demo-busy-button-bug';

 class Sites extends Component {
 	static propTypes = {
@@ -145,6 +146,7 @@ class Sites extends Component {

 		return (
 			<>
+				<DemoBusyButtonBug />
 				{ clearPageTitle && <DocumentHead title="" /> }
 				<Main className="sites">
 					<div className="sites__select-header">
diff --git a/client/my-sites/stats/demo-busy-button-bug.tsx b/client/my-sites/stats/demo-busy-button-bug.tsx
new file mode 100644
index 0000000000..b5648c6608
--- /dev/null
+++ b/client/my-sites/stats/demo-busy-button-bug.tsx
@@ -0,0 +1,25 @@
+import React, { useState } from 'react';
+import { Button } from '@automattic/components';
+
+export default function DemoBusyButtonBug() {
+	const [ busy, setBusy ] = useState( false );
+
+	const demoProps = { busy, onClick: () => setBusy( true ) };
+
+	return (
+		<div style={ { padding: '20px', textAlign: 'center' } }>
+			<Button { ...demoProps }>Button is: { busy ? 'Busy' : 'Idle' }</Button>
+			<Button primary { ...demoProps }>
+				Button is: { busy ? 'Busy' : 'Idle' }
+			</Button>
+			<Button scary { ...demoProps }>
+				Button is: { busy ? 'Busy' : 'Idle' }
+			</Button>
+			<Button primary scary { ...demoProps }>
+				Button is: { busy ? 'Busy' : 'Idle' }
+			</Button>
+			&nbsp; &nbsp; &nbsp;
+			{ busy && <Button onClick={ () => setBusy( false ) }>Reset</Button> }
+		</div>
+	);
+}
```
* Run `yarn start-jetpack-cloud`
* Open up http://jetpack.cloud.localhost:3000/landing
* You should see 4 "Button is: Idle" buttons at the top.
* Click on one of the 4 buttons - all will become busy but the one you clicked will be lacking the background animation.
* Checkout this PR and confirm the animated background is now visible on all 4 buttons when you click.