### PR TITLE
Notice: set gridicon color same to main container

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -22,6 +22,10 @@
 		margin-bottom: 24px;
 	}
 
+	.gridicon {
+		fill: var( --color-neutral-80 );
+	}
+
 	// Success!
 	&.is-success {
 		.notice__icon-wrapper {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR sets the background color of gridicon elements with the color of the main wrapper element of the `<Notice />` component.

Fixes https://github.com/Automattic/wp-calypso/issues/49148

#### Testing instructions

Check the white background color is removed from the gridicon notice icon.

Before | After
-------|--------
![image](https://user-images.githubusercontent.com/77539/112675885-7c591580-8e46-11eb-91d3-6a1ba56bd107.png) | ![image](https://user-images.githubusercontent.com/77539/112673680-c5f43100-8e43-11eb-816a-3920fa234aa8.png)
![image](https://user-images.githubusercontent.com/77539/112675964-972b8a00-8e46-11eb-846d-b074f1dd60bc.png) | ![image](https://user-images.githubusercontent.com/77539/112673783-e45a2c80-8e43-11eb-8ed4-c59ab966f73a.png)
![image](https://user-images.githubusercontent.com/77539/112676005-ac081d80-8e46-11eb-8302-540d20ca8902.png) | ![image](https://user-images.githubusercontent.com/77539/112673856-fd62dd80-8e43-11eb-954a-42dcae6aaa8c.png)
![image](https://user-images.githubusercontent.com/77539/112676058-bd512a00-8e46-11eb-839d-dfcf3e9bcd06.png) | ![image](https://user-images.githubusercontent.com/77539/112673959-1c616f80-8e44-11eb-94a3-9b322ddc7021.png)

Related to https://github.com/Automattic/wp-calypso/issues/49148
