### PR TITLE
E2E: Fix flaky trashComment helper

### DIFF
--- a/test/e2e/lib/components/nav-bar-component.js
+++ b/test/e2e/lib/components/nav-bar-component.js
@@ -65,6 +65,7 @@ export default class NavBarComponent extends AsyncBaseContainer {
 		if ( classNames.includes( 'is-active' ) === false ) {
 			return driverHelper.clickWhenClickable( driver, notificationsSelector );
 		}
+		await driver.sleep( 400 ); // Wait for menu animation to complete
 	}
 	async openNotificationsShortcut() {
 		await driverHelper.waitTillPresentAndDisplayed(

--- a/test/e2e/lib/components/notifications-component.js
+++ b/test/e2e/lib/components/notifications-component.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { By as by, until } from 'selenium-webdriver';
+import { By as by } from 'selenium-webdriver';
 
 /**
  * Internal dependencies
@@ -38,28 +38,10 @@ export default class NotificationsComponent extends AsyncBaseContainer {
 	}
 
 	async trashComment() {
-		const self = this;
-		const trashPostSelector = by.css( 'button[title="Trash comment"]' );
-		await this.driver.wait(
-			until.elementLocated( trashPostSelector ),
-			self.explicitWaitMS,
-			'Could not locate the trash comment button'
-		);
-		const trashPostElement = await self.driver.findElement( trashPostSelector );
-		await this.driver.wait(
-			until.elementIsVisible( trashPostElement ),
-			self.explicitWaitMS,
-			'The trash post comment is not visible'
-		);
-		await driverHelper.clickWhenClickable( self.driver, trashPostSelector );
-		return self.driver
-			.wait( until.elementLocated( by.css( '.wpnc__undo-item' ) ), this.explicitWaitMS )
-			.then(
-				() => {},
-				() => {
-					driverHelper.clickWhenClickable( self.driver, trashPostSelector );
-				}
-			);
+		const trashPostLocator = by.css( 'button[title="Trash comment"]' );
+
+		await this.driver.sleep( 400 ); // Wait for menu animation to complete
+		await driverHelper.clickWhenClickable( this.driver, trashPostLocator );
 	}
 
 	async waitForUndoMessage() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix flaky `trashComment()` helper.

#### Why is it flaky?
The comment menu element is animated, so we need to wait for it before attempting to click anything inside. When an element is clicked inside a moving (animated) container, an `ElementClickInterceptedError` can be thrown because the element we wanted to click is no longer in the same spot. In this particular case, the [animation duration is 200ms](https://github.com/Automattic/wp-calypso/blob/cac4908e98be27b53e506f255f69b4302e70801e/apps/notifications/src/panel/boot/stylesheets/main.scss#L876), but we want to be safe so we're going to wait double that time.

Failure example: https://teamcity.a8c.com/viewLog.html?buildId=6040586&buildTypeId=calypso_RunCalypsoE2eDesktopTests

#### Testing instructions

All specs should pass.