### PR TITLE
Checkout: Modify existingCardProcessor to use cart for creating transaction

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -23,22 +23,19 @@ import type { TransactionRequest } from '../types/transaction-endpoint';
 
 const debug = debugFactory( 'calypso:composite-checkout:existing-card-processor' );
 
-type ExistingCardTransactionRequest = Omit<
-	Partial< TransactionRequest > &
-		Required<
-			Pick<
-				TransactionRequest,
-				| 'country'
-				| 'postalCode'
-				| 'name'
-				| 'storedDetailsId'
-				| 'siteId'
-				| 'paymentMethodToken'
-				| 'paymentPartnerProcessorId'
-			>
-		>,
-	'paymentMethodType'
->;
+type ExistingCardTransactionRequest = Partial< Omit< TransactionRequest, 'paymentMethodType' > > &
+	Required<
+		Pick<
+			TransactionRequest,
+			| 'country'
+			| 'postalCode'
+			| 'name'
+			| 'storedDetailsId'
+			| 'siteId'
+			| 'paymentMethodToken'
+			| 'paymentPartnerProcessorId'
+		>
+	>;
 
 export default async function existingCardProcessor(
 	transactionData: unknown,

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -45,21 +45,6 @@ export interface TransactionRequestWithLineItems extends TransactionRequest {
 	items: WPCOMCartItem[];
 }
 
-export type ExistingCardTransactionRequestWithLineItems = Partial< TransactionRequestWithLineItems > &
-	Required<
-		Pick<
-			TransactionRequestWithLineItems,
-			| 'country'
-			| 'postalCode'
-			| 'items'
-			| 'name'
-			| 'storedDetailsId'
-			| 'siteId'
-			| 'paymentMethodToken'
-			| 'paymentPartnerProcessorId'
-		>
-	>;
-
 export type WPCOMTransactionEndpoint = (
 	_: WPCOMTransactionEndpointRequestPayload
 ) => Promise< WPCOMTransactionEndpointResponse >;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR modifies the saved credit card payment processor to use the shopping cart for creating the transaction request cart, rather than converting the line items, since the line items themselves have been converted from the shopping cart. This is the same refactoring that was done for other processors in https://github.com/Automattic/wp-calypso/pull/51336, https://github.com/Automattic/wp-calypso/pull/51240, and https://github.com/Automattic/wp-calypso/pull/51156.

This also adds explicit error handling during the transaction so that https://github.com/Automattic/wp-calypso/pull/51427 will be able to trigger error boundaries for unexpected errors.

#### Testing instructions

- Make a purchase through checkout using a previously saved credit card. Verify that the transaction is successful.