### PR TITLE
Nav unification: remove reduced opacity for image icons

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -203,7 +203,7 @@ $font-size: rem( 14px );
 					color: var( --color-sidebar-menu-hover-text );
 				}
 				img.sidebar__menu-icon {
-					filter: grayscale(60%);
+					filter: grayscale( 60% );
 				}
 			}
 		}

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -163,10 +163,6 @@ $font-size: rem( 14px );
 			margin-right: 8px;
 		}
 
-		img.sidebar__menu-icon {
-			opacity: 0.6;
-		}
-
 		.selected .sidebar__menu-link {
 			background: var( --color-sidebar-menu-selected-background );
 			color: var( --color-sidebar-menu-selected-text );
@@ -207,7 +203,7 @@ $font-size: rem( 14px );
 					color: var( --color-sidebar-menu-hover-text );
 				}
 				img.sidebar__menu-icon {
-					opacity: 1;
+					filter: grayscale(60%);
 				}
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes style rule reducing opacity for image icons in the sidebar nav
* Changes the hover style to grayscale instead of opacity

To do:
- [ ] Find a hover style that works for all themes that need it
- [ ] Make sure the hover style is compatible with all supported browsers

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch: D59395-code
* Go to Calypso /home and check that the image icons (like Jetpack) are displayed at 100% opacity
* Hover over the image icons to check the hover style

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #49145