### PR TITLE
Anchor: Show 3 grid columns for onboarding designs at xlarge screen sizes

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -83,6 +83,7 @@
 			}
 
 			@include break-xlarge {
+				grid-template-columns: 1fr 1fr 1fr;
 				column-gap: 32px;
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the Anchor onboarding design grid to display three grid columns at xlarge screen sizes (1080px and wider)
* This is a change to the shared `DesignPicker` component but currently the `isGridMinimal` prop that triggers these styles is only used by Anchor.

Before | After
------- | -----
<img width="1477" alt="Screen Shot 2021-04-07 at 11 30 57 AM" src="https://user-images.githubusercontent.com/1689238/113893187-c8844e00-9794-11eb-8098-03b020615b9f.png"> | <img width="1516" alt="Screen Shot 2021-03-26 at 5 37 50 PM" src="https://user-images.githubusercontent.com/1689238/112695169-ff379b80-8e59-11eb-8d87-8bda199d066c.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start the Anchor onboarding flow (/new?anchor_podcast=40a166a8)
* View the columns on the design select step

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
