### PR TITLE
Checkout: Modify multiCardProcessor to use cart for creating transaction

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -46,7 +46,8 @@ import filterAppropriatePaymentMethods from './lib/filter-appropriate-payment-me
 import useStoredCards from './hooks/use-stored-cards';
 import usePrepareProductsForCart from './hooks/use-prepare-products-for-cart';
 import useCreatePaymentMethods from './hooks/use-create-payment-methods';
-import { applePayProcessor, multiPartnerCardProcessor } from './payment-method-processors';
+import { applePayProcessor } from './payment-method-processors';
+import multiPartnerCardProcessor from './lib/multi-partner-card-processor';
 import freePurchaseProcessor from './lib/free-purchase-processor';
 import fullCreditsProcessor from './lib/full-credits-processor';
 import weChatProcessor from './lib/we-chat-processor';
@@ -466,7 +467,7 @@ export default function CompositeCheckout( {
 				applePayProcessor( transactionData, dataForProcessor, transactionOptions ),
 			'free-purchase': () => freePurchaseProcessor( dataForProcessor ),
 			card: ( transactionData: unknown ) =>
-				multiPartnerCardProcessor( transactionData, dataForProcessor, transactionOptions ),
+				multiPartnerCardProcessor( transactionData, dataForProcessor ),
 			alipay: ( transactionData: unknown ) =>
 				genericRedirectProcessor( 'alipay', transactionData, dataForProcessor ),
 			p24: ( transactionData: unknown ) =>

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -1,0 +1,265 @@
+/**
+ * External dependencies
+ */
+import {
+	defaultRegistry,
+	makeSuccessResponse,
+	makeRedirectResponse,
+} from '@automattic/composite-checkout';
+import debugFactory from 'debug';
+import { confirmStripePaymentIntent, createStripePaymentMethod } from '@automattic/calypso-stripe';
+import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
+import type { Stripe, StripeConfiguration } from '@automattic/calypso-stripe';
+
+/**
+ * Internal dependencies
+ */
+import getPostalCode from './get-postal-code';
+import getDomainDetails from './get-domain-details';
+import { createEbanxToken } from 'calypso/lib/store-transactions';
+import submitWpcomTransaction from './submit-wpcom-transaction';
+import {
+	createTransactionEndpointRequestPayload,
+	createTransactionEndpointCartFromResponseCart,
+} from './translate-cart';
+import type { PaymentProcessorOptions } from '../types/payment-processors';
+import type { ManagedContactDetails } from '../types/wpcom-store-state';
+import type {
+	TransactionRequest,
+	WPCOMTransactionEndpointResponse,
+} from '../types/transaction-endpoint';
+
+const { select } = defaultRegistry;
+const debug = debugFactory( 'calypso:composite-checkout:multi-partner-card-processor' );
+
+type CardTransactionRequest = {
+	paymentPartner: string;
+};
+
+type StripeCardTransactionRequest = {
+	stripe: Stripe;
+	stripeConfiguration: StripeConfiguration;
+	name: string;
+	countryCode: string | undefined;
+	postalCode: string | undefined;
+};
+
+type EbanxCardTransactionRequest = {
+	name: string;
+	countryCode: string;
+	number: string;
+	cvv: string;
+	'expiration-date': string;
+	state: string;
+	city: string;
+	postalCode: string;
+	address: string;
+	streetNumber: string;
+	phoneNumber: string;
+	document: string;
+};
+
+type SubmitCardTransactionData = Omit<
+	TransactionRequest,
+	'paymentMethodType' | 'paymentPartnerProcessorId' | 'cart'
+>;
+
+type EbanxToken = {
+	deviceId: string;
+	token: string;
+};
+
+async function stripeCardProcessor(
+	submitData: unknown,
+	transactionOptions: PaymentProcessorOptions
+): Promise< PaymentProcessorResponse > {
+	if ( ! isValidStripeCardTransactionData( submitData ) ) {
+		throw new Error( 'Required purchase data is missing' );
+	}
+
+	const {
+		includeDomainDetails,
+		includeGSuiteDetails,
+		recordEvent: onEvent,
+		responseCart,
+	} = transactionOptions;
+
+	const managedContactDetails: ManagedContactDetails | undefined = select(
+		'wpcom'
+	)?.getContactInfo();
+
+	const { id: paymentMethodToken } = await createStripePaymentMethodToken( {
+		...submitData,
+		country: managedContactDetails?.countryCode?.value,
+		postalCode: getPostalCode(),
+	} );
+
+	return submitStripeCardTransaction(
+		{
+			...submitData,
+			couponId: responseCart.coupon,
+			country: managedContactDetails?.countryCode?.value ?? '',
+			postalCode: getPostalCode(),
+			subdivisionCode: managedContactDetails?.state?.value,
+			siteId: transactionOptions.siteId ? String( transactionOptions.siteId ) : undefined,
+			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+			paymentMethodToken,
+		},
+		transactionOptions
+	)
+		.then( ( stripeResponse ) => {
+			if ( stripeResponse?.message?.payment_intent_client_secret ) {
+				// 3DS authentication required
+				onEvent( { type: 'SHOW_MODAL_AUTHORIZATION' } );
+				return confirmStripePaymentIntent(
+					submitData.stripeConfiguration,
+					stripeResponse?.message?.payment_intent_client_secret
+				);
+			}
+			return stripeResponse;
+		} )
+		.then( ( stripeResponse ) => {
+			if ( stripeResponse?.redirect_url ) {
+				return makeRedirectResponse( stripeResponse.redirect_url );
+			}
+			return makeSuccessResponse( stripeResponse );
+		} );
+}
+
+async function ebanxCardProcessor(
+	submitData: unknown,
+	transactionOptions: PaymentProcessorOptions
+): Promise< PaymentProcessorResponse > {
+	if ( ! isValidEbanxCardTransactionData( submitData ) ) {
+		throw new Error( 'Required purchase data is missing' );
+	}
+	const { includeDomainDetails, includeGSuiteDetails, responseCart, siteId } = transactionOptions;
+
+	const paymentMethodToken: EbanxToken = await createEbanxToken( 'new_purchase', {
+		country: submitData.countryCode,
+		name: submitData.name,
+		number: submitData.number,
+		cvv: submitData.cvv,
+		'expiration-date': submitData[ 'expiration-date' ],
+	} );
+
+	return submitEbanxCardTransaction(
+		{
+			...submitData,
+			couponId: responseCart.coupon,
+			country: submitData.countryCode,
+			siteId: siteId ? String( siteId ) : undefined,
+			deviceId: paymentMethodToken?.deviceId,
+			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+			paymentMethodToken: paymentMethodToken.token,
+		},
+		transactionOptions
+	).then( makeSuccessResponse );
+}
+
+export default async function multiPartnerCardProcessor(
+	submitData: unknown,
+	dataForProcessor: PaymentProcessorOptions
+): Promise< PaymentProcessorResponse > {
+	if ( ! isValidMultiPartnerTransactionData( submitData ) ) {
+		throw new Error( 'Required purchase data is missing' );
+	}
+	const paymentPartner = submitData.paymentPartner;
+	if ( paymentPartner === 'stripe' ) {
+		return stripeCardProcessor( submitData, dataForProcessor );
+	}
+	if ( paymentPartner === 'ebanx' ) {
+		return ebanxCardProcessor( submitData, dataForProcessor );
+	}
+	throw new RangeError( 'Unrecognized card payment partner: "' + paymentPartner + '"' );
+}
+
+function isValidMultiPartnerTransactionData(
+	submitData: unknown
+): submitData is CardTransactionRequest {
+	const data = submitData as CardTransactionRequest;
+	if ( ! data?.paymentPartner ) {
+		throw new Error( 'Transaction requires paymentPartner and none was provided' );
+	}
+	return true;
+}
+
+function isValidStripeCardTransactionData(
+	submitData: unknown
+): submitData is StripeCardTransactionRequest {
+	const data = submitData as StripeCardTransactionRequest;
+	if ( ! data?.stripe ) {
+		throw new Error( 'Transaction requires stripe and none was provided' );
+	}
+	if ( ! data?.stripeConfiguration ) {
+		throw new Error( 'Transaction requires stripeConfiguration and none was provided' );
+	}
+	return true;
+}
+
+function isValidEbanxCardTransactionData(
+	submitData: unknown
+): submitData is EbanxCardTransactionRequest {
+	const data = submitData as EbanxCardTransactionRequest;
+	if ( ! data ) {
+		throw new Error( 'Transaction requires data and none was provided' );
+	}
+	return true;
+}
+
+async function submitStripeCardTransaction(
+	transactionData: SubmitCardTransactionData,
+	transactionOptions: PaymentProcessorOptions
+): Promise< WPCOMTransactionEndpointResponse > {
+	const formattedTransactionData = createTransactionEndpointRequestPayload( {
+		...transactionData,
+		cart: createTransactionEndpointCartFromResponseCart( {
+			siteId: transactionOptions.siteId ? String( transactionOptions.siteId ) : undefined,
+			contactDetails: transactionData.domainDetails ?? null,
+			responseCart: transactionOptions.responseCart,
+		} ),
+		paymentMethodToken: transactionData.paymentMethodToken,
+		paymentMethodType: 'WPCOM_Billing_Stripe_Payment_Method',
+		paymentPartnerProcessorId: transactionOptions.stripeConfiguration?.processor_id,
+	} );
+	debug( 'sending stripe transaction', formattedTransactionData );
+	return submitWpcomTransaction( formattedTransactionData, transactionOptions );
+}
+
+function createStripePaymentMethodToken( {
+	stripe,
+	name,
+	country,
+	postalCode,
+}: {
+	stripe: Stripe;
+	name: string | undefined;
+	country: string | undefined;
+	postalCode: string | undefined;
+} ) {
+	return createStripePaymentMethod( stripe, {
+		name,
+		address: {
+			country,
+			postal_code: postalCode,
+		},
+	} );
+}
+
+async function submitEbanxCardTransaction(
+	transactionData: SubmitCardTransactionData,
+	transactionOptions: PaymentProcessorOptions
+): Promise< WPCOMTransactionEndpointResponse > {
+	const formattedTransactionData = createTransactionEndpointRequestPayload( {
+		...transactionData,
+		cart: createTransactionEndpointCartFromResponseCart( {
+			siteId: transactionOptions.siteId ? String( transactionOptions.siteId ) : undefined,
+			contactDetails: transactionData.domainDetails ?? null,
+			responseCart: transactionOptions.responseCart,
+		} ),
+		paymentMethodToken: transactionData.paymentMethodToken,
+		paymentMethodType: 'WPCOM_Billing_Ebanx',
+	} );
+	debug( 'sending ebanx transaction', formattedTransactionData );
+	return submitWpcomTransaction( formattedTransactionData, transactionOptions );
+}

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -74,6 +74,7 @@ async function stripeCardProcessor(
 		includeGSuiteDetails,
 		recordEvent: onEvent,
 		responseCart,
+		siteId,
 	} = transactionOptions;
 
 	const managedContactDetails: ManagedContactDetails | undefined = select(
@@ -88,16 +89,15 @@ async function stripeCardProcessor(
 
 	const formattedTransactionData = createTransactionEndpointRequestPayload( {
 		...submitData,
-		couponId: responseCart.coupon,
 		country: managedContactDetails?.countryCode?.value ?? '',
 		postalCode: getPostalCode(),
 		subdivisionCode: managedContactDetails?.state?.value,
 		siteId: transactionOptions.siteId ? String( transactionOptions.siteId ) : undefined,
 		paymentMethodToken,
 		cart: createTransactionEndpointCartFromResponseCart( {
-			siteId: transactionOptions.siteId ? String( transactionOptions.siteId ) : undefined,
+			siteId: siteId ? String( siteId ) : undefined,
 			contactDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ) ?? null,
-			responseCart: transactionOptions.responseCart,
+			responseCart: responseCart,
 		} ),
 		paymentMethodType: 'WPCOM_Billing_Stripe_Payment_Method',
 		paymentPartnerProcessorId: transactionOptions.stripeConfiguration?.processor_id,

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -4,7 +4,6 @@
 import debugFactory from 'debug';
 import i18n from 'i18n-calypso';
 import { defaultRegistry } from '@automattic/composite-checkout';
-import { createStripePaymentMethod } from '@automattic/calypso-stripe';
 
 /**
  * Internal dependencies
@@ -31,27 +30,6 @@ export async function submitApplePayPayment( transactionData, submit, transactio
 
 export async function fetchStripeConfiguration( requestArgs, wpcom ) {
 	return wpcom.stripeConfiguration( requestArgs );
-}
-
-export async function submitStripeCardTransaction( transactionData, submit, transactionOptions ) {
-	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
-		...transactionData,
-		paymentMethodToken: transactionData.paymentMethodToken.id,
-		paymentMethodType: 'WPCOM_Billing_Stripe_Payment_Method',
-		paymentPartnerProcessorId: transactionData.stripeConfiguration.processor_id,
-	} );
-	debug( 'sending stripe transaction', formattedTransactionData );
-	return submit( formattedTransactionData, transactionOptions );
-}
-
-export async function submitEbanxCardTransaction( transactionData, submit ) {
-	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
-		...transactionData,
-		paymentMethodToken: transactionData.paymentMethodToken.token,
-		paymentMethodType: 'WPCOM_Billing_Ebanx',
-	} );
-	debug( 'sending ebanx transaction', formattedTransactionData );
-	return submit( formattedTransactionData );
 }
 
 async function createAccountCallback( response ) {
@@ -149,14 +127,4 @@ function getErrorMessage( { error, message } ) {
 		default:
 			return message;
 	}
-}
-
-export function createStripePaymentMethodToken( { stripe, name, country, postalCode } ) {
-	return createStripePaymentMethod( stripe, {
-		name,
-		address: {
-			country,
-			postal_code: postalCode,
-		},
-	} );
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -1,25 +1,14 @@
 /**
  * External dependencies
  */
-import {
-	defaultRegistry,
-	makeSuccessResponse,
-	makeRedirectResponse,
-} from '@automattic/composite-checkout';
-import { confirmStripePaymentIntent } from '@automattic/calypso-stripe';
+import { defaultRegistry, makeSuccessResponse } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
  */
-import {
-	createStripePaymentMethodToken,
-	submitApplePayPayment,
-	submitStripeCardTransaction,
-	submitEbanxCardTransaction,
-} from './payment-method-helpers';
+import { submitApplePayPayment } from './payment-method-helpers';
 import getPostalCode from './lib/get-postal-code';
 import getDomainDetails from './lib/get-domain-details';
-import { createEbanxToken } from 'calypso/lib/store-transactions';
 import submitWpcomTransaction from './lib/submit-wpcom-transaction';
 
 const { select } = defaultRegistry;
@@ -41,86 +30,4 @@ export async function applePayProcessor(
 		submitWpcomTransaction,
 		transactionOptions
 	).then( makeSuccessResponse );
-}
-
-export async function stripeCardProcessor(
-	submitData,
-	{ includeDomainDetails, includeGSuiteDetails, recordEvent: onEvent, responseCart },
-	transactionOptions
-) {
-	const paymentMethodToken = await createStripePaymentMethodToken( {
-		...submitData,
-		country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-		postalCode: getPostalCode(),
-	} );
-	return submitStripeCardTransaction(
-		{
-			...submitData,
-			couponId: responseCart.coupon,
-			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-			postalCode: getPostalCode(),
-			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
-			siteId: select( 'wpcom' )?.getSiteId?.(),
-			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
-			paymentMethodToken,
-		},
-		submitWpcomTransaction,
-		transactionOptions
-	)
-		.then( ( stripeResponse ) => {
-			if ( stripeResponse?.message?.payment_intent_client_secret ) {
-				// 3DS authentication required
-				onEvent( { type: 'SHOW_MODAL_AUTHORIZATION' } );
-				return confirmStripePaymentIntent(
-					submitData.stripeConfiguration,
-					stripeResponse?.message?.payment_intent_client_secret
-				);
-			}
-			return stripeResponse;
-		} )
-		.then( ( stripeResponse ) => {
-			if ( stripeResponse?.redirect_url ) {
-				return makeRedirectResponse( stripeResponse.redirect_url );
-			}
-			return makeSuccessResponse( stripeResponse );
-		} );
-}
-
-export async function ebanxCardProcessor(
-	submitData,
-	{ includeDomainDetails, includeGSuiteDetails, responseCart }
-) {
-	const paymentMethodToken = await createEbanxToken( 'new_purchase', {
-		country: submitData.countryCode,
-		name: submitData.name,
-		number: submitData.number,
-		cvv: submitData.cvv,
-		'expiration-date': submitData[ 'expiration-date' ],
-	} );
-	return submitEbanxCardTransaction(
-		{
-			...submitData,
-			couponId: responseCart.coupon,
-			siteId: select( 'wpcom' )?.getSiteId?.(),
-			deviceId: paymentMethodToken?.deviceId,
-			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
-			paymentMethodToken,
-		},
-		submitWpcomTransaction
-	).then( makeSuccessResponse );
-}
-
-export async function multiPartnerCardProcessor(
-	submitData,
-	dataForProcessor,
-	transactionOptions
-) {
-	const paymentPartner = submitData.paymentPartner;
-	if ( paymentPartner === 'stripe' ) {
-		return stripeCardProcessor( submitData, dataForProcessor, transactionOptions );
-	}
-	if ( paymentPartner === 'ebanx' ) {
-		return ebanxCardProcessor( submitData, dataForProcessor );
-	}
-	throw new RangeError( 'Unrecognized card payment partner: "' + paymentPartner + '"' );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR modifies the new credit card payment processor (which is actually two processors: Stripe cards and Ebanx cards) to use the shopping cart for creating the transaction request cart, rather than converting the line items, since the line items themselves have been converted from the shopping cart. This is the same refactoring that was done for other processors in #51336, #51240, https://github.com/Automattic/wp-calypso/pull/51460, and #51156. As part of this work, this also converts the processor to TypeScript.

This also adds explicit error handling during the transaction so that #51427 will be able to trigger error boundaries for explicit errors.

#### Testing instructions

We must test both the Stripe processor and the Ebanx processor.

For Stripe:

- Add a product to your cart and visit checkout. 
- Select any country _except_ for Brazil in the contact form.
- Select "Credit or debit card" as your payment method, enter your credit card information, and submit the purchase.
- Verify that the transaction is successful.

For Ebanx:

- Make sure your account currency is set to BRL.
- Add a product to your cart and visit checkout. 
- Select Brazil in the contact form.
- Verify that the form asks for all the Ebanx fields in addition to the credit card fields (Taxpayer Identification Number, Phone, etc.)
- Use an [ebanx test card](https://developer.ebanx.com/docs/resources/testCreditCards/) and [test customer info](https://developer.ebanx.com/docs/resources/testCustomerData/).
- Submit the purchase and verify that the payment succeeds.