### PR TITLE
Checkout: Remove unused line item conversion functions

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -3,12 +3,13 @@
  */
 import { translate } from 'i18n-calypso';
 import { getTotalLineItemFromCart } from '@automattic/wpcom-checkout';
+import type { LineItem } from '@automattic/composite-checkout';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
  */
-import { WPCOMCart, WPCOMCartItem } from '../types/checkout-cart';
+import { WPCOMCart } from '../types/checkout-cart';
 import {
 	readWPCOMPaymentMethodClass,
 	translateWpcomPaymentMethodToCheckoutPaymentMethod,
@@ -52,51 +53,25 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 		.map( translateWpcomPaymentMethodToCheckoutPaymentMethod );
 
 	return {
-		items: products.map( translateReponseCartProductToWPCOMCartItem ),
+		items: products.map( translateReponseCartProductToLineItem ),
 		total: totalItem,
 		allowedPaymentMethods,
 	};
 }
 
 // Convert a backend cart item to a checkout cart item
-function translateReponseCartProductToWPCOMCartItem(
-	serverCartItem: ResponseCartProduct
-): WPCOMCartItem {
+function translateReponseCartProductToLineItem( serverCartItem: ResponseCartProduct ): LineItem {
 	const {
-		product_id,
 		product_slug,
 		currency,
-		item_original_cost_display,
-		item_original_cost_integer,
-		item_subtotal_monthly_cost_display,
-		item_subtotal_monthly_cost_integer,
-		item_original_subtotal_display,
-		item_original_subtotal_integer,
-		related_monthly_plan_cost_display,
-		related_monthly_plan_cost_integer,
-		is_sale_coupon_applied,
-		months_per_bill_period,
 		item_subtotal_display,
 		item_subtotal_integer,
-		is_domain_registration,
-		is_bundled,
-		meta,
-		extra,
-		volume,
-		quantity,
 		uuid,
-		product_cost_integer,
-		product_cost_display,
 	} = serverCartItem;
 
 	const label = getLabel( serverCartItem );
 
 	const type = isPlan( serverCartItem ) ? 'plan' : product_slug;
-
-	// for displaying crossed-out original price
-	const itemOriginalCostDisplay = item_original_cost_display || '';
-	const itemOriginalSubtotalDisplay = item_original_subtotal_display || '';
-	const itemSubtotalMonthlyCostDisplay = item_subtotal_monthly_cost_display || '';
 
 	return {
 		id: uuid,
@@ -106,30 +81,6 @@ function translateReponseCartProductToWPCOMCartItem(
 			currency: currency || '',
 			value: item_subtotal_integer || 0,
 			displayValue: item_subtotal_display || '',
-		},
-		wpcom_response_cart_product: serverCartItem,
-		wpcom_meta: {
-			uuid: uuid,
-			meta,
-			product_id,
-			product_slug,
-			extra,
-			volume,
-			quantity,
-			is_domain_registration: is_domain_registration || false,
-			is_bundled: is_bundled || false,
-			item_original_cost_display: itemOriginalCostDisplay,
-			item_original_cost_integer: item_original_cost_integer || 0,
-			item_subtotal_monthly_cost_display: itemSubtotalMonthlyCostDisplay,
-			item_subtotal_monthly_cost_integer: item_subtotal_monthly_cost_integer || 0,
-			item_original_subtotal_display: itemOriginalSubtotalDisplay,
-			item_original_subtotal_integer: item_original_subtotal_integer || 0,
-			is_sale_coupon_applied: is_sale_coupon_applied || false,
-			months_per_bill_period,
-			product_cost_integer: product_cost_integer || 0,
-			product_cost_display: product_cost_display || '',
-			related_monthly_plan_cost_integer: related_monthly_plan_cost_integer || 0,
-			related_monthly_plan_cost_display: related_monthly_plan_cost_display || '',
 		},
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/test/translate-cart.js
+++ b/client/my-sites/checkout/composite-checkout/test/translate-cart.js
@@ -291,9 +291,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 			it( 'has the expected label (the domain name)', function () {
 				expect( clientCart.items[ 1 ].label ).toBe( 'foo.cash' );
 			} );
-			it( 'has the expected meta (the domain name)', function () {
-				expect( clientCart.items[ 1 ].wpcom_meta?.meta ).toBe( 'foo.cash' );
-			} );
 			it( 'has the expected type', function () {
 				expect( clientCart.items[ 1 ].type ).toBe( 'dotcash_domain' );
 			} );
@@ -305,9 +302,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 			} );
 			it( 'has the expected display value', function () {
 				expect( clientCart.items[ 1 ].amount.displayValue ).toBe( 'R$0' );
-			} );
-			it( 'has the expected volume', function () {
-				expect( clientCart.items[ 1 ].wpcom_meta?.volume ).toBe( 1 );
 			} );
 		} );
 
@@ -503,24 +497,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 			it( 'has the expected label', function () {
 				expect( clientCart.items[ 2 ].label ).toBe( 'G Suite' );
 			} );
-			it( 'has the expected product_id', function () {
-				expect( clientCart.items[ 2 ].wpcom_meta?.product_id ).toBe( 69 );
-			} );
-			it( 'has the expected google_apps_users', function () {
-				expect( clientCart.items[ 2 ].wpcom_meta?.extra?.google_apps_users?.[ 0 ] ).toEqual( {
-					email: 'foo@foo.cash',
-					firstname: 'First',
-					lastname: 'User',
-				} );
-				expect( clientCart.items[ 2 ].wpcom_meta?.extra?.google_apps_users?.[ 1 ] ).toEqual( {
-					email: 'bar@foo.cash',
-					firstname: 'Second',
-					lastname: 'User',
-				} );
-			} );
-			it( 'has the expected volume', function () {
-				expect( clientCart.items[ 2 ].wpcom_meta?.volume ).toBe( 2 );
-			} );
 			it( 'has the expected type', function () {
 				expect( clientCart.items[ 2 ].type ).toBe( 'gapps' );
 			} );
@@ -532,9 +508,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 			} );
 			it( 'has the expected display value', function () {
 				expect( clientCart.items[ 2 ].amount.displayValue ).toBe( '$72' );
-			} );
-			it( 'has the expected meta (the domain name)', function () {
-				expect( clientCart.items[ 2 ].wpcom_meta?.meta ).toBe( 'foo.cash' );
 			} );
 		} );
 
@@ -660,21 +633,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 			} );
 			it( 'has the expected currency', function () {
 				expect( clientCart.items[ 0 ].amount.currency ).toBe( 'USD' );
-			} );
-			it( 'has the expected original cost value', function () {
-				expect( clientCart.items[ 0 ].wpcom_meta.item_original_cost_integer ).toBe( 14400 );
-			} );
-			it( 'has the expected original cost display value', function () {
-				expect( clientCart.items[ 0 ].wpcom_meta.item_original_cost_display ).toBe( '$144' );
-			} );
-			it( 'has the expected original monthly cost value', function () {
-				expect( clientCart.items[ 0 ].wpcom_meta.item_subtotal_monthly_cost_integer ).toBe( 1200 );
-			} );
-			it( 'has the expected original monthly cost display value', function () {
-				expect( clientCart.items[ 0 ].wpcom_meta.item_subtotal_monthly_cost_display ).toBe( '$12' );
-			} );
-			it( 'has the expected months per bill period', function () {
-				expect( clientCart.items[ 0 ].wpcom_meta.months_per_bill_period ).toBe( 12 );
 			} );
 			it( 'has the expected value', function () {
 				expect( clientCart.items[ 0 ].amount.value ).toBe( 12700 );

--- a/client/my-sites/checkout/composite-checkout/types/checkout-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/types/checkout-cart.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import type { ResponseCartProductExtra, ResponseCartProduct } from '@automattic/shopping-cart';
 import type { LineItem } from '@automattic/composite-checkout';
 
 /**
@@ -9,42 +8,8 @@ import type { LineItem } from '@automattic/composite-checkout';
  */
 import type { CheckoutPaymentMethodSlug } from './checkout-payment-method-slug';
 
-/**
- * Cart item with WPCOM specific info added.
- */
-export type WPCOMCartItem = LineItem & {
-	wpcom_response_cart_product: ResponseCartProduct;
-	wpcom_meta: {
-		uuid: string;
-		meta?: string;
-		plan_length?: string;
-		product_id: number;
-		product_slug: string;
-		extra: ResponseCartProductExtra;
-		volume?: number;
-		quantity?: number | null;
-		item_original_cost_display: string;
-		item_original_cost_integer: number;
-		item_subtotal_monthly_cost_display: string;
-		item_subtotal_monthly_cost_integer: number;
-		item_original_subtotal_display: string;
-		item_original_subtotal_integer: number;
-		months_per_bill_period: null | number;
-		is_bundled?: boolean;
-		is_domain_registration?: boolean;
-		is_sale_coupon_applied?: boolean;
-		couponCode?: string;
-		product_cost_integer?: number;
-		product_cost_display?: string;
-
-		// Temporary optional properties for the monthly pricing test
-		related_monthly_plan_cost_display?: string;
-		related_monthly_plan_cost_integer?: number;
-	};
-};
-
 export interface WPCOMCart {
-	items: WPCOMCartItem[];
+	items: LineItem[];
 	total: LineItem;
 	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
 }

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -6,7 +6,6 @@ import type { RequestCartProduct, ResponseCartTaxData } from '@automattic/shoppi
 /**
  * Internal dependencies
  */
-import type { WPCOMCartItem } from './checkout-cart';
 import type { Purchase } from './wpcom-store-state';
 import type { DomainContactDetails } from './backend/domain-contact-details-components';
 
@@ -38,11 +37,6 @@ export interface TransactionRequest {
 	pan?: string | undefined;
 	gstin?: string | undefined;
 	nik?: string | undefined;
-}
-
-// The data required by createTransactionEndpointRequestPayloadFromLineItems
-export interface TransactionRequestWithLineItems extends TransactionRequest {
-	items: WPCOMCartItem[];
 }
 
 export type WPCOMTransactionEndpoint = (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes unused functions from checkout that have to do with converting line items (as defined by `@automattic/composite-checkout`) to cart items required by the transactions endpoints. It also removes the `WPCOMCartItem` type, which was a hack added so that shopping cart product data could be passed through the `CheckoutProvider`. Since we now go directly to the shopping cart for everything, we no longer need this hack.

(Some of the PRs which removed using line items to generate the transaction cart: https://github.com/Automattic/wp-calypso/pull/51467, https://github.com/Automattic/wp-calypso/pull/51463, https://github.com/Automattic/wp-calypso/pull/51460, and https://github.com/Automattic/wp-calypso/pull/51465)

#### Testing instructions

The only functional effect of this change is that the line items returned by `translateResponseCartToWPCOMCart()` no longer include `wpcom_meta` or `wpcom_response_cart_product` properties.

Therefore no testing should be required; just verify that neither of those properties are used anywhere.