### PR TITLE
Checkout: Add check for Google Workspace extra license when submitting transaction with cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -253,7 +253,10 @@ function addRegistrationDataToGSuiteCartProduct(
 	item: ResponseCartProduct,
 	contactDetails: DomainContactDetails | null
 ): ResponseCartProduct {
-	if ( ! isGSuiteOrGoogleWorkspaceProductSlug( item.product_slug ) ) {
+	if (
+		! isGSuiteOrGoogleWorkspaceProductSlug( item.product_slug ) ||
+		isGoogleWorkspaceExtraLicence( item )
+	) {
 		return item;
 	}
 	return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/50670 the code [that adds registration data to G Suite cart products](https://github.com/Automattic/wp-calypso/blob/a13e6ddacdf59ce5f2d6b26c22900c0f4afd1adb/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts#L233-L235) was modified so that it does not add that data for Google Workspace extra licenses. However, at the same time that was being developed, https://github.com/Automattic/wp-calypso/pull/51156 was created to transition how transactions are built, duplicating the modified function for use by updated processors. As a result, the updated version of the function does not include the change for extra licenses.

This PR adds the new condition to the updated function.

Note that the old version of the function will be removed in https://github.com/Automattic/wp-calypso/pull/51466

#### Testing instructions

A visual comparison between the old function `addRegistrationDataToGSuiteItem` and the new function `addRegistrationDataToGSuiteCartProduct` should be sufficient.