### PR TITLE
Install docker compose on wpcom docker image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -136,7 +136,7 @@ RUN apt update &&\
 	wget https://packages.sury.org/php/apt.gpg -O /etc/apt/trusted.gpg.d/php-sury.gpg &&\
 	echo "deb https://packages.sury.org/php/ stretch main" > /etc/apt/sources.list.d/php-sury.list &&\
 	apt update &&\
-	apt-get install -y php7.4-cli php7.4-xml php7.4-mbstring &&\
+	apt-get install -y php7.4-cli php7.4-xml php7.4-mbstring docker-compose &&\
 	composer install
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -134,7 +134,7 @@ COPY --from=cache --chown=$UID /calypso/composer.* /calypso/
 RUN apt update &&\
 	apt-get install -y apt-transport-https zip &&\
 	wget https://packages.sury.org/php/apt.gpg -O /etc/apt/trusted.gpg.d/php-sury.gpg &&\
-	echo "deb https://packages.sury.org/php/ stretch main" > /etc/apt/sources.list.d/php-sury.list &&\
+	echo "deb https://packages.sury.org/php/ buster main" > /etc/apt/sources.list.d/php-sury.list &&\
 	apt update &&\
 	apt-get install -y php7.4-cli php7.4-xml php7.4-mbstring docker-compose &&\
 	composer install


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Adds docker-compose to wpcom docker image. This would allow us to run wp-env in this image, which unblocks #51073.

#### Testing instructions
- [x] Building the docker image should complete successfully.

