### PR TITLE
o2-blocks: Make calypso the source of truth

### DIFF
--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -112,9 +112,7 @@ open class PluginBaseBuild : Template({
 				# These operations restore idempotence between the two builds.
 				rm -f ./release-archive/build_meta.txt
 
-				cd ./release-archive
 				%normalize_files%
-				cd ..
 
 				# 3. Check if the current build has changed, and if so, tag it for release.
 				# Note: we exclude asset changes because we only really care if the build files (JS/CSS) change. That file is basically just metadata.

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -41,7 +41,7 @@ private object EditingToolkit : BuildType({
 		param("archive_dir", "./editing-toolkit-plugin/")
 		param("release_tag", "etk-release-build")
 		param("build.prefix", "3")
-		param("normalize_files", "sed -i -e \"/^\\s\\* Version:/c\\ * Version: %build.number%\" -e \"/^define( 'A8C_ETK_PLUGIN_VERSION'/c\\define( 'A8C_ETK_PLUGIN_VERSION', '%build.number%' );\" full-site-editing-plugin.php && sed -i -e \"/^Stable tag:\\s/c\\Stable tag: %build.number%\" readme.txt\n")
+		param("normalize_files", "sed -i -e \"/^\\s\\* Version:/c\\ * Version: %build.number%\" -e \"/^define( 'A8C_ETK_PLUGIN_VERSION'/c\\define( 'A8C_ETK_PLUGIN_VERSION', '%build.number%' );\" ./release-archive/full-site-editing-plugin.php && sed -i -e \"/^Stable tag:\\s/c\\Stable tag: %build.number%\" ./release-archive/readme.txt\n")
 
 	}
 

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -122,10 +122,10 @@ private object O2Blocks : BuildType({
 
 				# Copy existing dist files to release directory
 				mkdir release-files
-				cp -r dist release-files/dist
+				cp -r dist release-files/dist/
 
 				# Add index.php file
-				cp index.php release-files
+				cp index.php release-files/
 			"""
 		}
 	}

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -111,6 +111,22 @@ private object O2Blocks : BuildType({
 
 	params {
 		param("plugin_slug", "o2-blocks")
-		param("archive_dir", "./dist/")
+		param("archive_dir", "./release-files/")
+	}
+
+	steps {
+		bashNodeScript {
+			name = "Create release directory"
+			scriptContent = """
+				cd apps/o2-blocks
+
+				# Copy existing dist files to release directory
+				mkdir release-files
+				cp -r dist release-files/dist
+
+				# Add index.php file
+				cp index.php release-files
+			"""
+		}
 	}
 })

--- a/apps/o2-blocks/index.php
+++ b/apps/o2-blocks/index.php
@@ -1,40 +1,80 @@
 <?php
-/*
+/**
  * Plugin Name: A8C Blocks
  * Description: A8C Specific Blocks
  * Author: A8C
+ * Text Domain: full-site-editing
+ *
+ * @package o2-blocks
  *
  * Instructions:
- * 1. Build `o2-blocks`: `yarn build`
- * 2. Start a test WP instance at the root of the `o2-blocks` repo: `wp-env start`
- * 3. When you access your test WP instance, you should then see the `A8C Blocks` plugin installed and activated.
+ *   1. The block code is found in Calypso in `apps/o2-blocks` - see the README there for
+ *      information on how to edit and maintain them.
+ *      https://github.com/Automattic/wp-calypso/tree/trunk/apps/o2-blocks
+ *
+ *   2. The block code is built from a TeamCity job in Calypso
+ *      https://github.com/Automattic/wp-calypso/blob/a13e6ddacdf59ce5f2d6b26c22900c0f4afd1adb/.teamcity/_self/projects/WPComPlugins.kt#L107
+ *
+ *      It's built on every Calypso deploy. Why not just the ones where we modify o2-blocks?
+ *      Changes to Calypso's components, build system, and framework may indirectly change
+ *      the build of these blocks. We expect to update code here on every change to the
+ *      o2-blocks code but it's safe and normal from time to time to go ahead and rebuild the
+ *      blocks to capture ancillary work going on in general.
+ *
+ *   3. Login to your sandbox and fetch the updated block code with the install-plugins.sh script
+ *
+ *      ```
+ *      # Prep the latest trunk build for release
+ *      wpdev~/public_html# install-plugin.sh o2-blocks --release
+ *
+ *      # Alternatively, load changes from a branch (e.g. to test a PR.)
+ *      ```
+ *      wpdev~/public_html# install-plugin.sh o2-blocks $brach_name
+ *      ```
  */
 
+/**
+ * Load editor assets.
+ */
 function a8c_editor_assets() {
-	$assets = require( plugin_dir_path( __FILE__ ) . 'dist/editor.asset.php' );
+	$assets = require plugin_dir_path( __FILE__ ) . 'dist/editor.asset.php';
 
 	wp_enqueue_script(
 		'a8c-blocks-js',
 		plugins_url( 'dist/editor.js', __FILE__ ),
 		$assets['dependencies'],
-		$assets['version']
+		$assets['version'],
+		true
 	);
 
+	$style_file = 'dist/editor' . is_rtl() ? '.rtl.css' : '.css';
 	wp_enqueue_style(
 		'a8c-blocks-block-editor-css',
-		plugins_url( 'dist/editor.css', __FILE__ ),
+		plugins_url( $style_file, __FILE__ ),
 		array( 'wp-edit-blocks' ),
 		$assets['version']
 	);
+
+	wp_enqueue_script(
+		'idioticon',
+		plugins_url( 'dist/idioticon.build.js', __FILE__ ),
+		array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-components' ),
+		filemtime( plugin_dir_path( __FILE__ ) . 'dist/idioticon.build.js' ),
+		true
+	);
 }
 
+/**
+ * Load front-end view assets.
+ */
 function a8c_view_assets() {
-	if ( !is_admin() ) {
-		$assets = require( plugin_dir_path( __FILE__ ) . 'dist/view.asset.php' );
+	if ( ! is_admin() ) {
+		$assets = require plugin_dir_path( __FILE__ ) . 'dist/view.asset.php';
 
+		$style_file = 'dist/view' . is_rtl() ? '.rtl.css' : '.css';
 		wp_enqueue_style(
 			'a8c-blocks-block-view-css',
-			plugins_url( 'dist/view.css', __FILE__ ),
+			plugins_url( $style_file, __FILE__ ),
 			array(),
 			$assets['version']
 		);

--- a/apps/o2-blocks/index.php
+++ b/apps/o2-blocks/index.php
@@ -3,6 +3,7 @@
  * Plugin Name: A8C Blocks
  * Description: A8C Specific Blocks
  * Author: A8C
+ * Text Domain: full-site-editing
  *
  * @package o2-blocks
  *
@@ -52,14 +53,6 @@ function a8c_editor_assets() {
 		plugins_url( $style_file, __FILE__ ),
 		array( 'wp-edit-blocks' ),
 		$assets['version']
-	);
-
-	wp_enqueue_script(
-		'idioticon',
-		plugins_url( 'dist/idioticon.build.js', __FILE__ ),
-		array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-components' ),
-		filemtime( plugin_dir_path( __FILE__ ) . 'dist/idioticon.build.js' ),
-		true
 	);
 }
 

--- a/apps/o2-blocks/index.php
+++ b/apps/o2-blocks/index.php
@@ -3,7 +3,6 @@
  * Plugin Name: A8C Blocks
  * Description: A8C Specific Blocks
  * Author: A8C
- * Text Domain: full-site-editing
  *
  * @package o2-blocks
  *

--- a/apps/o2-blocks/index.php
+++ b/apps/o2-blocks/index.php
@@ -63,7 +63,7 @@ function a8c_view_assets() {
 	if ( ! is_admin() ) {
 		$assets = require plugin_dir_path( __FILE__ ) . 'dist/view.asset.php';
 
-		$style_file = 'dist/view' . is_rtl() ? '.rtl.css' : '.css';
+		$style_file = 'dist/view' . ( is_rtl() ? '.rtl.css' : '.css' );
 		wp_enqueue_style(
 			'a8c-blocks-block-view-css',
 			plugins_url( $style_file, __FILE__ ),

--- a/apps/o2-blocks/index.php
+++ b/apps/o2-blocks/index.php
@@ -47,7 +47,7 @@ function a8c_editor_assets() {
 		true
 	);
 
-	$style_file = 'dist/editor' . is_rtl() ? '.rtl.css' : '.css';
+	$style_file = 'dist/editor' . ( is_rtl() ? '.rtl.css' : '.css' );
 	wp_enqueue_style(
 		'a8c-blocks-block-editor-css',
 		plugins_url( $style_file, __FILE__ ),


### PR DESCRIPTION
The goal here is to make calypso the source of truth for o2-blocks. The idea is to reduce the amount of context switching needed to develop changes, and to simplify the deploy process. Currently, the two `index.php` files are not kept in sync between wpcom and calypso. This resolves that. I also noticed that the `/dist` directory on wpcom was not exactly the same as the one here in calypso, so this will also resolve that.

### Changes proposed in this Pull Request
1. Copy changes to index.php from wpcom to calypso.
2. Fix phpcs issues
3. Use `is_rtl()` for RTL style loading. (This allows us to keep the same directory structure in /dist on both wpcom and calypso)
4. Include index.php in build artifact (so that calypso is the source of truth)

Note: this will remove `idioticon`, which @dmsnell says is ok to do because it's not currently working with p2 anyways.

### Testing instructions:
1. Run `install-plugin.sh o2b add/consistent-o2-blocks-structure --phab`
2. Verify that the phabricator files look as expected
3. Verify that o2 blocks works on a sandboxed p2 site.