### PR TITLE
composite-checkout: Add makeErrorResponse payment processor response type

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -101,14 +101,14 @@ When a payment method is ready to submit its data, it can use an appropriate "pa
 
 Payment method components (probably the `submitButton`) can access these functions using the [usePaymentProcessor](#usePaymentProcessor) hook, passing the key used for that function in `paymentProcessors` as an argument. However, for convenience, the `submitButton` will be provided with an `onClick` handler that can do this automatically. The `onClick` function takes two arguments, a string which is the key of the payment processor to be used, and an object that contains the data needed by the payment processor.
 
-If you use the `onClick` function, the payment processor function's response will control what happens next. Each payment processor function must return a Promise that either resolves to one of three results on success (see [makeManualResponse](#makeManualResponse), [makeRedirectResponse](#makeRedirectResponse), or [makeSuccessResponse](#makeSuccessResponse)), or rejects on failure.
+If you use the `onClick` function, the payment processor function's response will control what happens next. Each payment processor function must return a Promise that either resolves to one of four results on success (see [makeManualResponse](#makeManualResponse), [makeRedirectResponse](#makeRedirectResponse), [makeSuccessResponse](#makeSuccessResponse)), or [makeErrorResponse](#makeErrorResponse) on failure.
 
 If not using the `onClick` function, when the `submitButton` component has been clicked, it should do the following (these are normally handled by `onClick`):
 
 1. Call `setTransactionPending()` from [useTransactionStatus](#useTransactionStatus). This will change the [form status](#useFormStatus) to [`.SUBMITTING`](#FormStatus) and disable the form.
 2. Call the payment processor function returned from [usePaymentProcessor](#usePaymentProcessor]), passing whatever data that function requires. Each payment processor will be different, so you'll need to know the API of that function explicitly.
 3. Payment processor functions return a `Promise`. When the `Promise` resolves, check its value (it will be one of [makeManualResponse](#makeManualResponse), [makeRedirectResponse](#makeRedirectResponse), or [makeSuccessResponse](#makeSuccessResponse)). Then call `setTransactionComplete(responseData: unknown)` from [useTransactionStatus](#useTransactionStatus) if the transaction was a success. If the transaction requires a redirect, call `setTransactionRedirecting(url: string)` instead.
-4. If the `Promise` rejects, call `setTransactionError(message: string)`.
+4. If the `Promise` resolves to [makeErrorResponse](#makeErrorResponse), call `setTransactionError(message: string)`.
 5. At this point the [CheckoutProvider](#CheckoutProvider) will automatically take action if the transaction status is [`.COMPLETE`](#TransactionStatus) (call [onPaymentComplete](#CheckoutProvider)), [`.ERROR`](#TransactionStatus) (display the error and re-enable the form), or [`.REDIRECTING`](#TransactionStatus) (redirect to the url). If for some reason the transaction should be cancelled, call `resetTransaction()`.
 
 ## Line Items
@@ -346,6 +346,7 @@ An enum that holds the values of the [payment processor function return value's 
 - `.SUCCESS` (the payload will be an `unknown` object that is the server response).
 - `.REDIRECT` (the payload will be a `string` that is the redirect URL).
 - `.MANUAL` (the payload will be an `unknown` object that is determined by the payment processor function).
+- `.ERROR` (the payload will be a `string` that is the error message).
 
 ### SubmitButtonWrapper
 
@@ -413,6 +414,10 @@ Returns a step object whose properties can be added to a [CheckoutStep](Checkout
 ### getDefaultPaymentMethodStep
 
 Returns a step object whose properties can be added to a [CheckoutStep](CheckoutStep) (and customized) to display a way to select a payment method. The payment methods displayed are those provided to the [CheckoutProvider](#checkoutprovider).
+
+### makeErrorResponse
+
+An action creator function to be used by a [payment processor function](#payment-methods) for a [ERROR](#PaymentProcessorResponseType) response. It takes one string argument and will record the string as the error.
 
 ### makeManualResponse
 

--- a/packages/composite-checkout/src/lib/invalid-payment-processor-response-error.ts
+++ b/packages/composite-checkout/src/lib/invalid-payment-processor-response-error.ts
@@ -1,6 +1,6 @@
 export default class InvalidPaymentProcessorResponseError extends Error {
 	constructor( paymentProcessorId: string ) {
-		const message = `Unknown payment processor response for processor "${ paymentProcessorId }". Payment processor functions should return one of makeManualResponse, makeSuccessResponse, or makeRedirectResponse.`;
+		const message = `Unknown payment processor response for processor "${ paymentProcessorId }". Payment processor functions should return one of makeManualResponse, makeSuccessResponse, makeRedirectResponse, or makeErrorResponse.`;
 		super( message );
 		this.name = 'InvalidPaymentProcessorResponseError';
 	}

--- a/packages/composite-checkout/src/lib/payment-processors.ts
+++ b/packages/composite-checkout/src/lib/payment-processors.ts
@@ -13,6 +13,7 @@ import {
 	PaymentProcessorSuccess,
 	PaymentProcessorRedirect,
 	PaymentProcessorManual,
+	PaymentProcessorError,
 	PaymentProcessorResponseType,
 } from '../types';
 
@@ -27,6 +28,10 @@ export function usePaymentProcessor( key: string ): PaymentProcessorFunction {
 export function usePaymentProcessors(): Record< string, PaymentProcessorFunction > {
 	const { paymentProcessors } = useContext( CheckoutContext );
 	return paymentProcessors;
+}
+
+export function makeErrorResponse( url: string ): PaymentProcessorError {
+	return { type: PaymentProcessorResponseType.ERROR, payload: url };
 }
 
 export function makeSuccessResponse(

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -80,6 +80,7 @@ import {
 	makeManualResponse,
 	makeSuccessResponse,
 	makeRedirectResponse,
+	makeErrorResponse,
 } from './lib/payment-processors';
 import useProcessPayment from './components/use-process-payment';
 import RadioButton from './components/radio-button';
@@ -143,6 +144,7 @@ export {
 	getDefaultOrderSummary,
 	getDefaultOrderSummaryStep,
 	getDefaultPaymentMethodStep,
+	makeErrorResponse,
 	makeManualResponse,
 	makeRedirectResponse,
 	makeSuccessResponse,

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -135,6 +135,10 @@ export type PaymentCompleteCallbackArguments = {
 
 export type PaymentProcessorResponseData = unknown;
 
+export type PaymentProcessorError = {
+	type: PaymentProcessorResponseType.ERROR;
+	payload: string;
+};
 export type PaymentProcessorSuccess = {
 	type: PaymentProcessorResponseType.SUCCESS;
 	payload: PaymentProcessorResponseData;
@@ -149,6 +153,7 @@ export type PaymentProcessorManual = {
 };
 
 export type PaymentProcessorResponse =
+	| PaymentProcessorError
 	| PaymentProcessorSuccess
 	| PaymentProcessorRedirect
 	| PaymentProcessorManual;
@@ -163,6 +168,7 @@ export enum PaymentProcessorResponseType {
 	SUCCESS = 'SUCCESS',
 	REDIRECT = 'REDIRECT',
 	MANUAL = 'MANUAL',
+	ERROR = 'ERROR',
 }
 
 export enum TransactionStatus {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When an error is thrown by a composite-checkout payment processor, it is displayed to the user as a notice, but this error does not trigger React error boundaries and does not get reported as a fatal error (so we rarely discover these except by user reports). Partly this is because we can't differentiate between "expected" errors during a transaction (eg: Stripe saying "invalid card") and "unexpected" errors (eg: `Cannot access 'coupon' property of undefined`) because the way that payment processors currently have to report a failure is to throw an error (aka reject the Promise that they return). In this PR we add a new payment processor response type of `ERROR` and a corresponding function `makeErrorResponse`.

In later PRs we'll need to add this response to every payment processor, then finally we can make it so that any remaining Promise rejection triggers an error boundary (see https://github.com/Automattic/wp-calypso/pull/51427).

#### Testing instructions

This shouldn't have any specific effect, it merely makes it possible for payment processors to return this result and for the result to operate as an error. To test this properly we need a processor to be updated, which will come later (but take a look at https://github.com/Automattic/wp-calypso/pull/51427 if you want to see it all operating together).