### PR TITLE
Plans: Ensure Advertising Features is Compatible with PlanTypeSelector

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -127,7 +127,8 @@ export class PlansFeaturesMain extends Component {
 			isValidFeatureKey( selectedFeature ) &&
 			getPlan( selectedPlan ) &&
 			! isPersonalPlan( selectedPlan ) &&
-			! previousRoute.startsWith( '/plans/' )
+			( this.getKindOfPlanTypeSelector( this.props ) === 'interval' ||
+				! previousRoute.startsWith( '/plans/' ) )
 		) {
 			return true;
 		}
@@ -515,6 +516,12 @@ export class PlansFeaturesMain extends Component {
 		const { siteId, customHeader, shouldShowPlansRedesign } = this.props;
 		const plans = this.getPlansForPlanFeatures();
 		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
+		const kindOfPlanTypeSelector = this.getKindOfPlanTypeSelector( this.props );
+
+		// If advertising plans for a certain feature, ensure user has pressed "View all plans" before they can see others
+		const hidePlanSelector =
+			this.getKindOfPlanTypeSelector( this.props ) === 'customer' &&
+			this.isDisplayingPlansNeededForFeature();
 
 		return (
 			<div className="plans-features-main">
@@ -525,11 +532,13 @@ export class PlansFeaturesMain extends Component {
 				<div className="plans-features-main__notice" />
 
 				{ customHeader }
-				<PlanTypeSelector
-					{ ...this.props }
-					kind={ this.getKindOfPlanTypeSelector( this.props ) }
-					plans={ visiblePlans }
-				/>
+				{ ! hidePlanSelector && (
+					<PlanTypeSelector
+						{ ...this.props }
+						kind={ kindOfPlanTypeSelector }
+						plans={ visiblePlans }
+					/>
+				) }
 				{ shouldShowPlansRedesign ? this.showFeatureComparison() : this.getPlanFeatures() }
 				{ this.renderProductsSelector() }
 				{ this.mayRenderFAQ() }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -520,8 +520,7 @@ export class PlansFeaturesMain extends Component {
 
 		// If advertising plans for a certain feature, ensure user has pressed "View all plans" before they can see others
 		const hidePlanSelector =
-			this.getKindOfPlanTypeSelector( this.props ) === 'customer' &&
-			this.isDisplayingPlansNeededForFeature();
+			kindOfPlanTypeSelector === 'customer' && this.isDisplayingPlansNeededForFeature();
 
 		return (
 			<div className="plans-features-main">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #41044, a change was introduced that allowed specific plans to be advertised if an upsell nudge for a certain feature had been clicked. Since then, the `PlanTypeSelector` component (the little toggle at the top of the page) was introduced, and this meant that users could see all plans (even ones that don't offer the feature they've clicked for) without clicking "View all plans". This creates a rather misleading experience, which this PR aims to rectify. 

#### Testing instructions

(The videos are probably better for demonstrating this, so you might want to check those, but here's a step-by-step guide)

1. Find a nudge that, once clicked, offers the "Upgrade your plan to access this feature and more" screen (an easy one is clicking the button for "Collect PayPal payments" under `/earn`)
2. Set this to `return 'interval';`

https://github.com/Automattic/wp-calypso/blob/b1424df3a9d3e9ad1dbca7726eb1fc753f78348d/client/my-sites/plans-features-main/index.jsx#L503-L513

3. Click that nudge in step one
4. Verify that the `PlanTypeSelector` component still appears, and click "Pay monthly"
5. Confirm that the same plans appear, except showing their monthly prices
6. Press "View all plans" and verify that all plans appear.


https://user-images.githubusercontent.com/43215253/112748553-33bf6a80-8fb4-11eb-90ed-57c057c20500.mov

7. Set the function in step 2 to `return 'customer';`
8. Click the nudge in step one again
9. Verify that the `PlanTypeSelector` component appears only after "View all plans" has been clicked


https://user-images.githubusercontent.com/43215253/112748633-e7285f00-8fb4-11eb-8335-fc85b7ec25fc.mov

cc @mmtr, @gwwar, @kwight 
