### PR TITLE
ETK Nav Sidebar: Use site icon for menu toggle when available

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -11,7 +11,7 @@ import {
 	IsolatedEventContainer,
 	withConstrainedTabbing,
 } from '@wordpress/components';
-import { chevronLeft, wordpress } from '@wordpress/icons';
+import { Icon, chevronLeft, wordpress } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { applyFilters, doAction, hasAction } from '@wordpress/hooks';
 import { get, isEmpty, partition } from 'lodash';
@@ -62,6 +62,33 @@ function WpcomBlockEditorNavSidebar() {
 			getSite()?.title,
 		];
 	} );
+
+	const { isRequestingSiteIcon, siteIconUrl } = useSelect( ( select ) => {
+		const { isResolving } = select( 'core/data' );
+		const { getEntityRecord } = select( 'core' );
+		const siteData = getEntityRecord( 'root', '__unstableBase', undefined ) || {};
+
+		return {
+			isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
+				'root',
+				'__unstableBase',
+				undefined,
+			] ),
+			siteIconUrl: siteData.site_icon_url,
+		};
+	}, [] );
+
+	let closeIcon = <Icon size={ 36 } icon={ wordpress } />;
+
+	if ( siteIconUrl ) {
+		closeIcon = (
+			<img
+				className="wpcom-block-editor-nav-sidebar-nav-sidebar__close-icon"
+				alt={ __( 'Site Icon', 'full-site-editing' ) }
+				src={ siteIconUrl }
+			/>
+		);
+	}
 
 	const { current: currentPost, drafts: draftPosts, recent: recentPosts } = useNavItems();
 	const statusLabels = usePostStatusLabels();
@@ -206,10 +233,10 @@ function WpcomBlockEditorNavSidebar() {
 							'edit-post-fullscreen-mode-close',
 							'wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button'
 						) }
-						icon={ wordpress }
-						iconSize={ 36 }
 						onClick={ dismissSidebar }
-					/>
+					>
+						{ closeIcon }
+					</Button>
 					<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__site-title">
 						<h2>{ siteTitle ? decodeEntities( siteTitle ) : '' }</h2>
 					</div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -11,7 +11,7 @@ import {
 	IsolatedEventContainer,
 	withConstrainedTabbing,
 } from '@wordpress/components';
-import { Icon, chevronLeft, wordpress } from '@wordpress/icons';
+import { chevronLeft } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { applyFilters, doAction, hasAction } from '@wordpress/hooks';
 import { get, isEmpty, partition } from 'lodash';
@@ -26,6 +26,7 @@ import { compose } from '@wordpress/compose';
 import { STORE_KEY, POST_IDS_TO_EXCLUDE } from '../../constants';
 import CreatePage from '../create-page';
 import NavItem from '../nav-item';
+import SiteIcon from '../site-icon';
 import { Post } from '../../types';
 import './style.scss';
 
@@ -62,33 +63,6 @@ function WpcomBlockEditorNavSidebar() {
 			getSite()?.title,
 		];
 	} );
-
-	const { isRequestingSiteIcon, siteIconUrl } = useSelect( ( select ) => {
-		const { isResolving } = select( 'core/data' );
-		const { getEntityRecord } = select( 'core' );
-		const siteData = getEntityRecord( 'root', '__unstableBase', undefined ) || {};
-
-		return {
-			isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
-				'root',
-				'__unstableBase',
-				undefined,
-			] ),
-			siteIconUrl: siteData.site_icon_url,
-		};
-	}, [] );
-
-	let closeIcon = <Icon size={ 36 } icon={ wordpress } />;
-
-	if ( siteIconUrl ) {
-		closeIcon = (
-			<img
-				className="wpcom-block-editor-nav-sidebar-nav-sidebar__close-icon"
-				alt={ __( 'Site Icon', 'full-site-editing' ) }
-				src={ siteIconUrl }
-			/>
-		);
-	}
 
 	const { current: currentPost, drafts: draftPosts, recent: recentPosts } = useNavItems();
 	const statusLabels = usePostStatusLabels();
@@ -231,11 +205,12 @@ function WpcomBlockEditorNavSidebar() {
 						ref={ dismissButtonMount }
 						className={ classNames(
 							'edit-post-fullscreen-mode-close',
-							'wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button'
+							'wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button',
+							'has-icon'
 						) }
 						onClick={ dismissSidebar }
 					>
-						{ closeIcon }
+						<SiteIcon />
 					</Button>
 					<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__site-title">
 						<h2>{ siteTitle ? decodeEntities( siteTitle ) : '' }</h2>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -104,16 +104,8 @@ $sidebar-button-text-color: #a2aab2; // former $light-gray-900
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button {
-	position: fixed;
-	top: 0;
-	left: 0;
 	height: $header-height !important;
 	background-color: $sidebar-nav-header-background-color !important;
-	color: $white;
-
-	&:hover {
-		color: $white;
-	}
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__home-button {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -70,10 +70,11 @@ $sidebar-button-text-color: #a2aab2; // former $light-gray-900
 .wpcom-block-editor-nav-sidebar-nav-sidebar__header {
 	box-sizing: content-box;
 	background-color: $sidebar-nav-header-background-color;
+	display: flex;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__site-title {
-	margin: 0 0 0 74px;
+	margin-left: $grid-unit-10;
 	align-items: center;
 	display: flex;
 	min-height: 60px;
@@ -113,10 +114,6 @@ $sidebar-button-text-color: #a2aab2; // former $light-gray-900
 	&:hover {
 		color: $white;
 	}
-}
-
-.wpcom-block-editor-nav-sidebar-nav-sidebar__close-icon {
-	width: 36px;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__home-button {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -106,6 +106,8 @@ $sidebar-button-text-color: #a2aab2; // former $light-gray-900
 .wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button {
 	height: $header-height !important;
 	background-color: $sidebar-nav-header-background-color !important;
+	// Prevents the icon button from shrinking when the site title goes on 2+ lines
+	flex-shrink: 0;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__home-button {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -135,7 +135,7 @@ $sidebar-button-text-color: #a2aab2; // former $light-gray-900
 .wpcom-block-editor-nav-sidebar-nav-sidebar__list-heading,
 .wpcom-block-editor-nav-sidebar-nav-sidebar__list-subheading {
 	padding: $grid-unit-05 $grid-unit-20;
-	/* stylelint-disable-next-line scales/font-size */
+	/* stylelint-disable-next-line scales/font-size, declaration-property-unit-allowed-list */
 	font-size: 18px;
 	color: $white;
 	margin: 0 0 8px;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -108,6 +108,15 @@ $sidebar-button-text-color: #a2aab2; // former $light-gray-900
 	left: 0;
 	height: $header-height !important;
 	background-color: $sidebar-nav-header-background-color !important;
+	color: $white;
+
+	&:hover {
+		color: $white;
+	}
+}
+
+.wpcom-block-editor-nav-sidebar-nav-sidebar__close-icon {
+	width: 36px;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__home-button {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/site-icon/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/site-icon/index.tsx
@@ -7,19 +7,17 @@ import { Icon, wordpress } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 export default function SiteIcon(): JSX.Element {
-	const currentSiteId: number = window._currentSiteId;
-
 	// The site icon url should be available from /wp/v2/settings or similar in the future,
 	// but for now it's accessible at the index endpoint.
 	// https://github.com/WordPress/gutenberg/blob/68c3978be352c6d3982f73bcf8c80744608c53c8/lib/init.php#L160
-	const siteIconUrl = useSelect(
-		( select ) => {
-			const { getEntityRecord } = select( 'core' );
-			const siteData = getEntityRecord( 'root', '__unstableBase', undefined ) || {};
-			return siteData.site_icon_url;
-		},
-		[ currentSiteId ]
-	);
+	const siteIconUrl: string | undefined = useSelect( ( select ) => {
+		const { getEntityRecord } = select( 'core' );
+		// getEntityRecord usually takes a key to get a specific entity, but here we pass undefined to get the "root" entity.
+		// While this works, the function isn't typed this way, so casting undefined as number to prevent compiler errors.
+		const siteData =
+			getEntityRecord( 'root', '__unstableBase', ( undefined as unknown ) as number ) || {};
+		return siteData.site_icon_url;
+	}, [] );
 
 	if ( siteIconUrl ) {
 		return (

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/site-icon/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/site-icon/index.tsx
@@ -9,13 +9,13 @@ import { __ } from '@wordpress/i18n';
 export default function SiteIcon(): JSX.Element {
 	const currentSiteId: number = window._currentSiteId;
 
-	// The site icon url should probably be available from /wp/v2/settings or similar in the future,
+	// The site icon url should be available from /wp/v2/settings or similar in the future,
 	// but for now it's accessible at the index endpoint.
 	// https://github.com/WordPress/gutenberg/blob/68c3978be352c6d3982f73bcf8c80744608c53c8/lib/init.php#L160
 	const siteIconUrl = useSelect(
 		( select ) => {
 			const { getEntityRecord } = select( 'core' );
-			const siteData = getEntityRecord( 'root', '__unstableBase', 0 ) || {};
+			const siteData = getEntityRecord( 'root', '__unstableBase', undefined ) || {};
 			return siteData.site_icon_url;
 		},
 		[ currentSiteId ]
@@ -23,14 +23,11 @@ export default function SiteIcon(): JSX.Element {
 
 	if ( siteIconUrl ) {
 		return (
-			<>
-				{ /* <span></span> */ }
-				<img
-					className="edit-post-fullscreen-mode-close_site-icon"
-					alt={ __( 'Site Icon', 'full-site-editing' ) }
-					src={ siteIconUrl }
-				/>
-			</>
+			<img
+				className="edit-post-fullscreen-mode-close_site-icon"
+				alt={ __( 'Site Icon', 'full-site-editing' ) }
+				src={ siteIconUrl }
+			/>
 		);
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/site-icon/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/site-icon/index.tsx
@@ -6,26 +6,17 @@ import { useSelect } from '@wordpress/data';
 import { Icon, wordpress } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
-import 'a8c-fse-common-data-stores';
-
-const SITE_STORE = 'automattic/site';
-
 export default function SiteIcon(): JSX.Element {
 	const currentSiteId: number = window._currentSiteId;
 
-	/**
-	 * The site icon should be available from the `core` data store in the future,
-	 * via the /wp/v2/settings endpoint, so we can avoid the additional wpcom API call.
-	 *
-	 * @see https://github.com/WordPress/gutenberg/pull/19967
-	 */
+	// The site icon url should probably be available from /wp/v2/settings or similar in the future,
+	// but for now it's accessible at the index endpoint.
+	// https://github.com/WordPress/gutenberg/blob/68c3978be352c6d3982f73bcf8c80744608c53c8/lib/init.php#L160
 	const siteIconUrl = useSelect(
 		( select ) => {
-			const siteDetails = select( SITE_STORE ).getSite( currentSiteId );
-			return siteDetails?.icon?.img;
+			const { getEntityRecord } = select( 'core' );
+			const siteData = getEntityRecord( 'root', '__unstableBase', 0 ) || {};
+			return siteData.site_icon_url;
 		},
 		[ currentSiteId ]
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/site-icon/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/site-icon/index.tsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelect } from '@wordpress/data';
+import { Icon, wordpress } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import 'a8c-fse-common-data-stores';
+
+const SITE_STORE = 'automattic/site';
+
+export default function SiteIcon(): JSX.Element {
+	const currentSiteId: number = window._currentSiteId;
+
+	/**
+	 * The site icon should be available from the `core` data store in the future,
+	 * via the /wp/v2/settings endpoint, so we can avoid the additional wpcom API call.
+	 *
+	 * @see https://github.com/WordPress/gutenberg/pull/19967
+	 */
+	const siteIconUrl = useSelect(
+		( select ) => {
+			const siteDetails = select( SITE_STORE ).getSite( currentSiteId );
+			return siteDetails?.icon?.img;
+		},
+		[ currentSiteId ]
+	);
+
+	if ( siteIconUrl ) {
+		return (
+			<>
+				{ /* <span></span> */ }
+				<img
+					className="edit-post-fullscreen-mode-close_site-icon"
+					alt={ __( 'Site Icon', 'full-site-editing' ) }
+					src={ siteIconUrl }
+				/>
+			</>
+		);
+	}
+
+	return <Icon size={ 36 } icon={ wordpress } />;
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -25,7 +25,6 @@ const Button = ( {
 export default function ToggleSidebarButton(): JSX.Element {
 	const { toggleSidebar } = useDispatch( STORE_KEY );
 	const isSidebarOpen = useSelect( ( select ) => select( STORE_KEY ).isSidebarOpened() );
-	const isSidebarClosing = useSelect( ( select ) => select( STORE_KEY ).isSidebarClosing() );
 
 	const handleClick = () => {
 		recordTracksEvent( `calypso_editor_sidebar_open` );
@@ -41,7 +40,7 @@ export default function ToggleSidebarButton(): JSX.Element {
 				'wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button',
 				'has-icon',
 				{
-					'is-hidden': isSidebarOpen || isSidebarClosing,
+					'is-hidden': isSidebarOpen,
 				}
 			) }
 			onClick={ handleClick }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { Button as OriginalButton } from '@wordpress/components';
-import { wordpress } from '@wordpress/icons';
+import { Icon, wordpress } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { __ } from '@wordpress/i18n';
@@ -26,6 +26,32 @@ export default function ToggleSidebarButton(): JSX.Element {
 	const { toggleSidebar } = useDispatch( STORE_KEY );
 	const isSidebarOpen = useSelect( ( select ) => select( STORE_KEY ).isSidebarOpened() );
 	const isSidebarClosing = useSelect( ( select ) => select( STORE_KEY ).isSidebarClosing() );
+	const { isRequestingSiteIcon, siteIconUrl } = useSelect( ( select ) => {
+		const { isResolving } = select( 'core/data' );
+		const { getEntityRecord } = select( 'core' );
+		const siteData = getEntityRecord( 'root', '__unstableBase', undefined ) || {};
+
+		return {
+			isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
+				'root',
+				'__unstableBase',
+				undefined,
+			] ),
+			siteIconUrl: siteData.site_icon_url,
+		};
+	}, [] );
+
+	let closeIcon = <Icon size={ 36 } icon={ wordpress } />;
+
+	if ( siteIconUrl ) {
+		closeIcon = (
+			<img
+				className="wpcom-block-editor-nav-sidebar-nav-sidebar__close-icon"
+				alt={ __( 'Site Icon', 'full-site-editing' ) }
+				src={ siteIconUrl }
+			/>
+		);
+	}
 
 	const handleClick = () => {
 		recordTracksEvent( `calypso_editor_sidebar_open` );
@@ -41,13 +67,14 @@ export default function ToggleSidebarButton(): JSX.Element {
 				'wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button',
 				{
 					'is-hidden': isSidebarOpen || isSidebarClosing,
+					'has-icon': siteIconUrl,
 				}
 			) }
-			icon={ wordpress }
-			iconSize={ 36 }
 			onClick={ handleClick }
 			aria-haspopup="dialog"
 			aria-expanded={ isSidebarOpen }
-		/>
+		>
+			{ closeIcon }
+		</Button>
 	);
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { Button as OriginalButton } from '@wordpress/components';
-import { Icon, wordpress } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { __ } from '@wordpress/i18n';
@@ -13,6 +12,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import { STORE_KEY } from '../../constants';
+import SiteIcon from '../site-icon';
 import './style.scss';
 
 const Button = ( {
@@ -26,32 +26,6 @@ export default function ToggleSidebarButton(): JSX.Element {
 	const { toggleSidebar } = useDispatch( STORE_KEY );
 	const isSidebarOpen = useSelect( ( select ) => select( STORE_KEY ).isSidebarOpened() );
 	const isSidebarClosing = useSelect( ( select ) => select( STORE_KEY ).isSidebarClosing() );
-	const { isRequestingSiteIcon, siteIconUrl } = useSelect( ( select ) => {
-		const { isResolving } = select( 'core/data' );
-		const { getEntityRecord } = select( 'core' );
-		const siteData = getEntityRecord( 'root', '__unstableBase', undefined ) || {};
-
-		return {
-			isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
-				'root',
-				'__unstableBase',
-				undefined,
-			] ),
-			siteIconUrl: siteData.site_icon_url,
-		};
-	}, [] );
-
-	let closeIcon = <Icon size={ 36 } icon={ wordpress } />;
-
-	if ( siteIconUrl ) {
-		closeIcon = (
-			<img
-				className="wpcom-block-editor-nav-sidebar-nav-sidebar__close-icon"
-				alt={ __( 'Site Icon', 'full-site-editing' ) }
-				src={ siteIconUrl }
-			/>
-		);
-	}
 
 	const handleClick = () => {
 		recordTracksEvent( `calypso_editor_sidebar_open` );
@@ -65,16 +39,16 @@ export default function ToggleSidebarButton(): JSX.Element {
 			className={ classnames(
 				'edit-post-fullscreen-mode-close',
 				'wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button',
+				'has-icon',
 				{
 					'is-hidden': isSidebarOpen || isSidebarClosing,
-					'has-icon': siteIconUrl,
 				}
 			) }
 			onClick={ handleClick }
 			aria-haspopup="dialog"
 			aria-expanded={ isSidebarOpen }
 		>
-			{ closeIcon }
+			<SiteIcon />
 		</Button>
 	);
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
@@ -1,9 +1,13 @@
 @import '~@wordpress/base-styles/variables';
+@import '~@wordpress/base-styles/mixins';
+@import '../nav-sidebar/style.scss';
 
 .wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button {
 	height: $header-height !important;
 
 	&.is-hidden {
 		visibility: hidden;
+		animation: visibility $sidebar-transition-period linear;
+		@include reduce-motion( 'animation' );
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
@@ -6,7 +6,7 @@
 	height: $header-height !important;
 
 	// Match this animation with the nav-sidebar, so that the button is not hidden
-	// before the sidebar menu finished sliding out.
+	// before the sidebar menu finishes sliding out.
 	&.is-hidden {
 		visibility: hidden;
 		animation: visibility $sidebar-transition-period linear;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
@@ -7,9 +7,11 @@
 
 	// Match this animation with the nav-sidebar, so that the button is not hidden
 	// before the sidebar menu finishes sliding out.
+	transition: visibility $sidebar-transition-period linear;
+	@include reduce-motion( 'transition' );
+
 	&.is-hidden {
 		visibility: hidden;
-		animation: visibility $sidebar-transition-period linear;
-		@include reduce-motion( 'animation' );
+
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
@@ -5,6 +5,8 @@
 .wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button {
 	height: $header-height !important;
 
+	// Match this animation with the nav-sidebar, so that the button is not hidden
+	// before the sidebar menu finished sliding out.
 	&.is-hidden {
 		visibility: hidden;
 		animation: visibility $sidebar-transition-period linear;

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -79,12 +79,6 @@ export interface SiteDetailsPlan {
 	is_free: boolean;
 }
 
-export interface SiteIcon {
-	img: string;
-	ico: string;
-	media_id: number;
-}
-
 export interface SiteDetails {
 	ID: number;
 	name: string | undefined;
@@ -96,7 +90,6 @@ export interface SiteDetails {
 		selected_features?: FeatureId[];
 	};
 	plan?: SiteDetailsPlan;
-	icon?: SiteIcon;
 }
 
 export interface SiteError {

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -79,6 +79,12 @@ export interface SiteDetailsPlan {
 	is_free: boolean;
 }
 
+export interface SiteIcon {
+	img: string;
+	ico: string;
+	media_id: number;
+}
+
 export interface SiteDetails {
 	ID: number;
 	name: string | undefined;
@@ -90,6 +96,7 @@ export interface SiteDetails {
 		selected_features?: FeatureId[];
 	};
 	plan?: SiteDetailsPlan;
+	icon?: SiteIcon;
 }
 
 export interface SiteError {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use the site icon for toggling the editor sidebar menu (when in full screen mode), rather then the default "W" icon.

Related to #51396
Related to #51482
Resolves #51740

| Closed | Open |
| - | - |
| <img width="500" alt="Screen Shot 2021-04-05 at 22 49 17" src="https://user-images.githubusercontent.com/1699996/113657012-abe7f900-9662-11eb-9028-a523681054ed.png"> | <img width="508" alt="Screen Shot 2021-04-05 at 22 49 31" src="https://user-images.githubusercontent.com/1699996/113657008-ab4f6280-9662-11eb-828f-49014944e4b2.png"> |


#### Testing instructions

Testing this requires install the Editing Toolkit plugin, v10.3.0 or higher of the Gutenberg plugin, and wpcomsh (for dot org sites). I recommend a8c-wp-env (for installing all dependencies), or installing the plugin zip to an Atomic site (PCYsg-ly5-p2#etk-and-atomic-sites).

Note that the [sidebar menu styles were changed](https://github.com/WordPress/gutenberg/pull/29888) in v10.3 of Gutenberg (the current release). If you wanted to be thorough, you could test with a previous version of the plugin as well (I did while I was developing and it looked okay).

1. Set a site icon, using either the Customizer or Settings (Calpyso version)
1. Open a page or post in the editor
1. You should see the site icon used to toggle the sidebar.
1. Ensure focus and hover styles, as well as keyboard navigation, work as expected

Note that this requires D59822-code to work for Simple sites.