### PR TITLE
Welcome guide: Correct a couple of untranslated strings in the welcome guide

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -69,7 +69,7 @@ function WelcomeTourCard( {
 							isTertiary
 							onClick={ () => setCurrentCardIndex( 0 ) }
 						>
-							Restart tour
+							{ __( 'Restart tour', 'full-site-editing' ) }
 						</Button>
 					) : null }
 				</p>
@@ -179,7 +179,9 @@ function TourRating() {
 
 	return (
 		<>
-			<p className="welcome-tour__end-text">Did you find this guide helpful?</p>
+			<p className="welcome-tour__end-text">
+				{ __( 'Did you find this guide helpful?', 'full-site-editing' ) }
+			</p>
 			<div>
 				<Button
 					aria-label={ __( 'Rate thumbs up', 'full-site-editing' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Translate a couple strings that were missing a call to `__()`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `install-plugin.sh etk add/untranslated-welcome-guide-strings`
* Open the welcome guide from the editor menu on a desktop
* "Restart tour" and "Did you find this guide helpful?" text should appear just as they currently do

Text won't be translated yet in non-en locales because it hasn't been sent for translation yet.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


#### Screenshots

The strings that were missing from translations:
![Screen Shot on 2021-03-30 at 11:34:34](https://user-images.githubusercontent.com/1500769/112908439-060d2980-914c-11eb-8263-1a50adbd0987.png)
![Screen Shot on 2021-03-30 at 11:35:02](https://user-images.githubusercontent.com/1500769/112908457-0c9ba100-914c-11eb-8c49-2e34a88c2dd9.png)

