### PR TITLE
Fix translation of welcome tour button labels

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -91,6 +91,10 @@ function WelcomeTourCard( {
 }
 
 function CardNavigation( { cardIndex, lastCardIndex, onDismiss, setCurrentCardIndex } ) {
+	// These are defined on their own lines because of a minification issue.
+	// __('translations') do not always work correctly when used inside of ternary statements.
+	const startTourLabel = __( 'Start Tour', 'full-site-editing' );
+	const nextLabel = __( 'Next', 'full-site-editing' );
 	return (
 		<>
 			<PaginationControl
@@ -114,9 +118,7 @@ function CardNavigation( { cardIndex, lastCardIndex, onDismiss, setCurrentCardIn
 					isPrimary={ true }
 					onClick={ () => setCurrentCardIndex( cardIndex + 1 ) }
 				>
-					{ cardIndex === 0
-						? __( 'Start Tour', 'full-site-editing' )
-						: __( 'Next', 'full-site-editing' ) }
+					{ cardIndex === 0 ? startTourLabel : nextLabel }
 				</Button>
 			</div>
 		</>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
It appears that the minifier is interfering with our `make-pot` translation tool and preventing strings from being translated properly

Reported here p1616762612066500-slack-C013QHLF28Y
Another instance of this issue https://github.com/Automattic/wp-calypso/pull/49812

#### Testing instructions

##### Test string extraction locally
```
cd apps/editing-toolkit
yarn build
cd editing-toolkit-plugin/wpcom-block-editor-nux/dist
wp i18n make-pot . test.pot --domain=full-site-editing
```
then open `test.pot` and search for "`Start Tour`", without this PR `Start Tour` is not found, with this PR applied, `Start Tour` should be found

##### Test locally
Interestingly, I cannot see this translating the button label locally
* syncing to my sandbox with `yarn dev --sync` 
* setting the interface language to `ES`, 
* Navigating to the editor and opening the welcome tour
* I still see the english (❓) I would expect to see the translated string locally because `Start Tour` is already translated on translate.wordpress.com but perhaps there's a gap in my understanding of what needs to happen to see the translated string?