### PR TITLE
Welcome guide: add integration tests for the welcome guide data store

### DIFF
--- a/apps/editing-toolkit/bin/js-unit-setup.js
+++ b/apps/editing-toolkit/bin/js-unit-setup.js
@@ -22,3 +22,5 @@ beforeAll( () => {
 afterAll( () => {
 	global.console.error.mockRestore();
 } );
+
+jest.mock( 'a8c-fse-common-data-stores', () => {}, { virtual: true } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/index.js
@@ -1,6 +1,8 @@
 /**
  * Internal dependencies
  */
-import './src/store';
+import { register } from './src/store';
 import './src/disable-core-nux';
 import './src/block-editor-nux';
+
+register();

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
@@ -12,6 +12,8 @@ const showWelcomeGuideReducer = ( state = undefined, action ) => {
 			return action.response.show_welcome_guide;
 		case 'WPCOM_WELCOME_GUIDE_SHOW_SET':
 			return action.show;
+		case 'WPCOM_WELCOME_GUIDE_RESET_STORE':
+			return undefined;
 		default:
 			return state;
 	}
@@ -25,6 +27,9 @@ const welcomeGuideManuallyOpenedReducer = ( state = false, action ) => {
 			}
 			return state;
 
+		case 'WPCOM_WELCOME_GUIDE_RESET_STORE':
+			return false;
+
 		default:
 			return state;
 	}
@@ -35,6 +40,8 @@ const tourRatingReducer = ( state = undefined, action ) => {
 	switch ( action.type ) {
 		case 'WPCOM_WELCOME_GUIDE_TOUR_RATING_SET':
 			return action.tourRating;
+		case 'WPCOM_WELCOME_GUIDE_RESET_STORE':
+			return undefined;
 		default:
 			return state;
 	}
@@ -44,6 +51,8 @@ const welcomeGuideVariantReducer = ( state = 'tour', action ) => {
 	switch ( action.type ) {
 		case 'WPCOM_WELCOME_GUIDE_FETCH_STATUS_SUCCESS':
 			return action.response.variant;
+		case 'WPCOM_WELCOME_GUIDE_RESET_STORE':
+			return 'tour';
 		default:
 			return state;
 	}
@@ -81,6 +90,11 @@ const actions = {
 	setTourRating: ( tourRating ) => {
 		return { type: 'WPCOM_WELCOME_GUIDE_TOUR_RATING_SET', tourRating };
 	},
+	// The `resetStore` action is only used for testing to reset the
+	// store inbetween tests.
+	resetStore: () => ( {
+		type: 'WPCOM_WELCOME_GUIDE_RESET_STORE',
+	} ),
 };
 
 const selectors = {
@@ -91,10 +105,12 @@ const selectors = {
 	getWelcomeGuideVariant: ( state ) => state.welcomeGuideVariant,
 };
 
-registerStore( 'automattic/wpcom-welcome-guide', {
-	reducer,
-	actions,
-	selectors,
-	controls,
-	persist: true,
-} );
+export function register() {
+	return registerStore( 'automattic/wpcom-welcome-guide', {
+		reducer,
+		actions,
+		selectors,
+		controls,
+		persist: true,
+	} );
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
@@ -98,7 +98,7 @@ const actions = {
 };
 
 const selectors = {
-	isWelcomeGuideManuallyOpened: ( state ) => state.isTourManuallyOpened,
+	isWelcomeGuideManuallyOpened: ( state ) => state.welcomeGuideManuallyOpened,
 	isWelcomeGuideShown: ( state ) => !! state.showWelcomeGuide,
 	isWelcomeGuideStatusLoaded: ( state ) => typeof state.showWelcomeGuide !== 'undefined',
 	getTourRating: ( state ) => state.tourRating,

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/test/store.test.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/test/store.test.js
@@ -1,0 +1,133 @@
+/**
+ * External dependencies
+ */
+import waitForExpect from 'wait-for-expect';
+
+/**
+ * Internal dependencies
+ */
+import { dispatch, select } from '@wordpress/data';
+import { register } from '../store';
+
+const STORE_KEY = 'automattic/wpcom-welcome-guide';
+
+beforeAll( () => {
+	register();
+} );
+
+let originalFetch;
+beforeEach( () => {
+	dispatch( STORE_KEY ).resetStore();
+	originalFetch = window.fetch;
+	window.fetch = jest.fn();
+} );
+
+afterEach( () => {
+	window.fetch = originalFetch;
+} );
+
+test( 'resetting the store', async () => {
+	window.fetch.mockResolvedValue( {
+		status: 200,
+		json: () => Promise.resolve( { show_welcome_guide: true, variant: 'modal' } ),
+	} );
+
+	dispatch( STORE_KEY ).fetchWelcomeGuideStatus();
+	await waitForExpect( () =>
+		expect( select( STORE_KEY ).isWelcomeGuideStatusLoaded() ).toBe( true )
+	);
+	dispatch( STORE_KEY ).setShowWelcomeGuide( true, { openedManually: true } );
+	dispatch( STORE_KEY ).setTourRating( 'thumbs-up' );
+
+	dispatch( STORE_KEY ).resetStore();
+
+	expect( select( STORE_KEY ).isWelcomeGuideManuallyOpened() ).toBe( false );
+	expect( select( STORE_KEY ).isWelcomeGuideShown() ).toBe( false );
+	expect( select( STORE_KEY ).isWelcomeGuideStatusLoaded() ).toBe( false );
+	expect( select( STORE_KEY ).getTourRating() ).toBeUndefined();
+	expect( select( STORE_KEY ).getWelcomeGuideVariant() ).toBe( 'tour' );
+} );
+
+test( "by default the store isn't loaded", () => {
+	const isLoaded = select( STORE_KEY ).isWelcomeGuideStatusLoaded();
+	expect( isLoaded ).toBe( false );
+} );
+
+test( 'after fetching the guide status the store is loaded', async () => {
+	window.fetch.mockResolvedValue( {
+		status: 200,
+		json: () => Promise.resolve( { show_welcome_guide: true, variant: 'tour' } ),
+	} );
+
+	dispatch( STORE_KEY ).fetchWelcomeGuideStatus();
+
+	await waitForExpect( () => {
+		const isLoaded = select( STORE_KEY ).isWelcomeGuideStatusLoaded();
+		expect( isLoaded ).toBe( true );
+	} );
+
+	expect( window.fetch ).toHaveBeenCalledWith(
+		'/wpcom/v2/block-editor/nux?_locale=user',
+		expect.anything()
+	);
+
+	// Check the store is loaded with the state that came from the server
+	const isWelcomeGuideShown = select( STORE_KEY ).isWelcomeGuideShown();
+	expect( isWelcomeGuideShown ).toBe( true );
+	const welcomeGuideVariant = select( STORE_KEY ).getWelcomeGuideVariant();
+	expect( welcomeGuideVariant ).toBe( 'tour' );
+} );
+
+test( 'toggle welcome guide visibility', () => {
+	// setShowWelcomeGuide kicks off a save. This mock fixes unresolved promise
+	// rejection errors that appear in CLI output
+	window.fetch.mockResolvedValue( { status: 200, json: () => Promise.resolve( {} ) } );
+
+	dispatch( STORE_KEY ).setShowWelcomeGuide( true );
+	expect( select( STORE_KEY ).isWelcomeGuideShown() ).toBe( true );
+
+	dispatch( STORE_KEY ).setShowWelcomeGuide( false );
+	expect( select( STORE_KEY ).isWelcomeGuideShown() ).toBe( false );
+} );
+
+test( 'guide manually opened flag is false by default', () => {
+	expect( select( STORE_KEY ).isWelcomeGuideManuallyOpened() ).toBe( false );
+} );
+
+test( '"manually opened" flag can be set when opening welcome guide', () => {
+	// setShowWelcomeGuide kicks off a save. This mock fixes unresolved promise
+	// rejection errors that appear in CLI output
+	window.fetch.mockResolvedValue( { status: 200, json: () => Promise.resolve( {} ) } );
+
+	dispatch( STORE_KEY ).setShowWelcomeGuide( true, { openedManually: true } );
+	expect( select( STORE_KEY ).isWelcomeGuideManuallyOpened() ).toBe( true );
+
+	dispatch( STORE_KEY ).setShowWelcomeGuide( true, { openedManually: false } );
+	expect( select( STORE_KEY ).isWelcomeGuideManuallyOpened() ).toBe( false );
+} );
+
+test( 'leaving `openedManually` unspecified leaves the flag unchanged', () => {
+	// setShowWelcomeGuide kicks off a save. This mock fixes unresolved promise
+	// rejection errors that appear in CLI output
+	window.fetch.mockResolvedValue( { status: 200, json: () => Promise.resolve( {} ) } );
+
+	expect( select( STORE_KEY ).isWelcomeGuideManuallyOpened() ).toBe( false );
+
+	dispatch( STORE_KEY ).setShowWelcomeGuide( true, { openedManually: true } );
+	expect( select( STORE_KEY ).isWelcomeGuideManuallyOpened() ).toBe( true );
+
+	dispatch( STORE_KEY ).setShowWelcomeGuide( false );
+	expect( select( STORE_KEY ).isWelcomeGuideManuallyOpened() ).toBe( true );
+} );
+
+test( 'tour rating is "undefined" by default', () => {
+	expect( select( STORE_KEY ).getTourRating() ).toBeUndefined();
+} );
+
+test( 'tour rating can be set to "thumbs-up" or "thumbs-down"', () => {
+	dispatch( STORE_KEY ).setTourRating( 'thumbs-up' );
+	expect( select( STORE_KEY ).getTourRating() ).toBe( 'thumbs-up' );
+
+	dispatch( STORE_KEY ).setTourRating( 'thumbs-down' );
+	expect( select( STORE_KEY ).getTourRating() ).toBe( 'thumbs-down' );
+} );

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -155,6 +155,7 @@
 		"@types/wordpress__plugins": "^2.3.7",
 		"@wordpress/eslint-plugin": "^8.0.2",
 		"babel-jest": "^26.3.0",
+		"wait-for-expect": "^3.0.2",
 		"webpack": "^5.24.4"
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add tests for the store that controls the wpcom welcome guide. Rather than testing actions/selectors in isolation, I'm testing the store in an integrated way so:
   * added a `resetStore()` action to help write isolated tests
   * changed `store.js` so it exports a `register()` function rather than registering the store on import. This allows the tests to control when the store (which is a global) is registered.
* Fix the `isWelcomeGuideManuallyOpened()` selector, which was broken and only discovered as part of writing these tests

The fact `isWelcomeGuideManuallyOpened()` was broken means that the `isManuallyOpened` prop of the `calypso_editor_wpcom_nux_open` tracks event has been broken for about a week.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To run tests
* `cd apps/editing-toolkit && yarn test:js`

To smoke test welcome guide
* `install-plugin.sh etk add/tests-for-welcome-guide-store`
* Sandbox test site
* Open welcome guide from the editor menu and check it's still working

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

