### PR TITLE
ci: Use node:14.16.0-buster as the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG use_cache=false
 ARG node_version=14.16.0
 
 ###################
-FROM node:${node_version} as builder-cache-false
+FROM node:${node_version}-buster as builder-cache-false
 
 
 ###################

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,7 +1,7 @@
 #### cache image
 #### This image is not pushed to any repository and it shouldn't be used as base image for any other docker build.
 #### Its main goal is to create a `/calypso/.cache` that can be copied over other images that can benefit from a warm cache.
-FROM node:14.16.0 as cache
+FROM node:14.16.0-buster as cache
 
 ARG node_memory=8192
 WORKDIR /calypso
@@ -34,7 +34,7 @@ ENTRYPOINT [ "/bin/bash" ]
 
 #### base image
 #### This image can be used as a base image for other builds, or to uni test and build calypso.
-FROM node:14.16.0 as base
+FROM node:14.16.0-buster as base
 
 ARG node_memory=8192
 ARG UID=1003


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Uses `node:14.16.0-buster` (based on Debian 10 aka `buster`) as the base image instead of plain `node:14.16.0` (based on Debian 9 aka `stretch`). This should give us more modern packages.
