### PR TITLE
E2E: Do not set value with setWhenSettable if that value is already set

### DIFF
--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -265,7 +265,13 @@ export function setWhenSettable(
 			}
 			await highlightElement( driver, element );
 			const currentValue = await element.getAttribute( 'value' );
+			if ( currentValue === value ) {
+				// Do nothing if given value is already set
+				return element;
+			}
+
 			if ( currentValue ) {
+				// Clear the input if it has some value
 				await element.sendKeys( Key.END );
 				for ( let i = 0; i < currentValue.length; i++ ) {
 					await element.sendKeys( Key.BACK_SPACE );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* (A follow-up to https://github.com/Automattic/wp-calypso/pull/51451) Improve the setWhenSettable helper to not set value if that value is already set

#### Testing instructions

All tests should pass.