### PR TITLE
Framework: Remove unnecessary _.flow() usage

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { debounce, get, flow, isEmpty } from 'lodash';
+import { debounce, get, isEmpty } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 
@@ -369,28 +369,25 @@ export class SiteAddressChanger extends Component {
 	}
 }
 
-export default flow(
-	localize,
-	connect(
-		( state ) => {
-			const selectedSite = getSelectedSite( state );
-			const siteId = selectedSite.ID;
-			const selectedSiteSlug = selectedSite.slug;
+export default connect(
+	( state ) => {
+		const selectedSite = getSelectedSite( state );
+		const siteId = selectedSite.ID;
+		const selectedSiteSlug = selectedSite.slug;
 
-			return {
-				siteId,
-				selectedSiteSlug,
-				isAvailable: isSiteAddressValidationAvailable( state, siteId ),
-				isSiteAddressChangeRequesting: isRequestingSiteAddressChange( state, siteId ),
-				isAvailabilityPending: getSiteAddressAvailabilityPending( state, siteId ),
-				validationError: getSiteAddressValidationError( state, siteId ),
-			};
-		},
-		{
-			requestSiteAddressChange,
-			requestSiteAddressAvailability,
-			clearValidationError,
-			recordTracksEvent,
-		}
-	)
-)( SiteAddressChanger );
+		return {
+			siteId,
+			selectedSiteSlug,
+			isAvailable: isSiteAddressValidationAvailable( state, siteId ),
+			isSiteAddressChangeRequesting: isRequestingSiteAddressChange( state, siteId ),
+			isAvailabilityPending: getSiteAddressAvailabilityPending( state, siteId ),
+			validationError: getSiteAddressValidationError( state, siteId ),
+		};
+	},
+	{
+		requestSiteAddressChange,
+		requestSiteAddressAvailability,
+		clearValidationError,
+		recordTracksEvent,
+	}
+)( localize( SiteAddressChanger ) );

--- a/client/components/domains/register-domain-step/analytics.js
+++ b/client/components/domains/register-domain-step/analytics.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flow, mapKeys, mapValues, snakeCase, startsWith } from 'lodash';
+import { mapKeys, mapValues, snakeCase, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -134,8 +134,7 @@ function processFiltersForAnalytics( filters ) {
 		mapValues( input, ( value ) => ( Array.isArray( value ) ? value.join( ',' ) : value ) );
 	const prepareKeys = ( input ) =>
 		mapKeys( input, ( value, key ) => `filters_${ snakeCase( key ) }` );
-	const transformation = flow( prepareKeys, convertArraysToCSV );
-	return transformation( filters );
+	return convertArraysToCSV( prepareKeys( filters ) );
 }
 
 export function recordFiltersReset( filters, keysToReset, section ) {

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-
-import { filter, find, flow, forEach, map, take } from 'lodash';
+import { filter, find, forEach, map, take } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -42,8 +41,6 @@ function promiseForImage( image ) {
 		image.onerror = () => reject( image );
 	} );
 }
-
-const promiseForURL = flow( imageForURL, promiseForImage );
 
 export default function waitForImagesToLoad( post ) {
 	return new Promise( ( resolve ) => {
@@ -126,7 +123,7 @@ export default function waitForImagesToLoad( post ) {
 			if ( imageUrl in knownImages ) {
 				return Promise.resolve( knownImages[ imageUrl ] );
 			}
-			return promiseForURL( imageUrl );
+			return promiseForImage( imageForURL( imageUrl ) );
 		} );
 
 		forEach( promises, ( promise ) => {

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { flow } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -229,18 +228,13 @@ class MeSidebar extends React.Component {
 	}
 }
 
-const enhance = flow(
-	localize,
-	connect(
-		( state ) => ( {
-			currentUser: getCurrentUser( state ),
-		} ),
-		{
-			logoutUser,
-			recordGoogleEvent,
-			setNextLayoutFocus,
-		}
-	)
-);
-
-export default enhance( MeSidebar );
+export default connect(
+	( state ) => ( {
+		currentUser: getCurrentUser( state ),
+	} ),
+	{
+		logoutUser,
+		recordGoogleEvent,
+		setNextLayoutFocus,
+	}
+)( localize( MeSidebar ) );

--- a/client/my-sites/domains/domain-management/components/domain/primary-flag.jsx
+++ b/client/my-sites/domains/domain-management/components/domain/primary-flag.jsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { flow } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,9 +26,6 @@ DomainPrimaryFlag.propTypes = {
 	translate: PropTypes.func.isRequired,
 };
 
-export default flow(
-	localize,
-	connect( ( state ) => ( {
-		isDomainOnly: isDomainOnlySite( state, getSelectedSiteId( state ) ),
-	} ) )
-)( DomainPrimaryFlag );
+export default connect( ( state ) => ( {
+	isDomainOnly: isDomainOnlySite( state, getSelectedSiteId( state ) ),
+} ) )( localize( DomainPrimaryFlag ) );

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import pageRouter from 'page';
 import { connect } from 'react-redux';
-import { flow, get, includes, partial } from 'lodash';
+import { get, includes, partial } from 'lodash';
 import { saveAs } from 'browser-filesaver';
 import classNames from 'classnames';
 
@@ -797,4 +797,4 @@ const mapDispatch = {
 	updateSiteFrontPage,
 };
 
-export default flow( localize, connect( mapState, mapDispatch ) )( Page );
+export default connect( mapState, mapDispatch )( localize( Page ) );

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -6,7 +6,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { debounce, filter, first, flow, get, has, last, map, throttle } from 'lodash';
+import { debounce, filter, first, get, has, last, map, throttle } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -239,13 +239,10 @@ class EditorDiffViewer extends PureComponent {
 	}
 }
 
-export default flow(
-	localize,
-	connect(
-		( state, { siteId, postId, selectedRevisionId } ) => ( {
-			revision: getPostRevision( state, siteId, postId, selectedRevisionId, 'display' ),
-			diffView: getPostRevisionsDiffView( state ),
-		} ),
-		{ recordTracksEvent }
-	)
-)( EditorDiffViewer );
+export default connect(
+	( state, { siteId, postId, selectedRevisionId } ) => ( {
+		revision: getPostRevision( state, siteId, postId, selectedRevisionId, 'display' ),
+		diffView: getPostRevisionsDiffView( state ),
+	} ),
+	{ recordTracksEvent }
+)( localize( EditorDiffViewer ) );

--- a/client/post-editor/editor-revisions-list/item.jsx
+++ b/client/post-editor/editor-revisions-list/item.jsx
@@ -6,7 +6,7 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { flow, get } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -105,17 +105,14 @@ EditorRevisionsListItem.propTypes = {
 	translate: PropTypes.func.isRequired,
 };
 
-export default flow(
-	localize,
-	connect(
-		( state, { revision, siteId } ) => ( {
-			authorName: get(
-				getPostRevisionAuthor( state, get( revision, 'post_author' ) ),
-				'display_name',
-				''
-			),
-			isMultiUserSite: ! isSingleUserSite( state, siteId ),
-		} ),
-		{ selectPostRevision }
-	)
-)( EditorRevisionsListItem );
+export default connect(
+	( state, { revision, siteId } ) => ( {
+		authorName: get(
+			getPostRevisionAuthor( state, get( revision, 'post_author' ) ),
+			'display_name',
+			''
+		),
+		isMultiUserSite: ! isSingleUserSite( state, siteId ),
+	} ),
+	{ selectPostRevision }
+)( localize( EditorRevisionsListItem ) );

--- a/client/post-editor/editor-revisions/dialog.jsx
+++ b/client/post-editor/editor-revisions/dialog.jsx
@@ -5,7 +5,7 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { get, flow } from 'lodash';
+import { get } from 'lodash';
 import { Dialog } from '@automattic/components';
 
 /**
@@ -105,15 +105,12 @@ class PostRevisionsDialog extends PureComponent {
 	}
 }
 
-export default flow(
-	localize,
-	connect(
-		( state ) => ( {
-			isVisible: isPostRevisionsDialogVisible( state ),
-			postId: getEditorPostId( state ),
-			revision: getPostRevisionsSelectedRevision( state ),
-			siteId: getSelectedSiteId( state ),
-		} ),
-		{ recordTracksEvent, closeDialog: closePostRevisionsDialog, selectPostRevision }
-	)
-)( PostRevisionsDialog );
+export default connect(
+	( state ) => ( {
+		isVisible: isPostRevisionsDialogVisible( state ),
+		postId: getEditorPostId( state ),
+		revision: getPostRevisionsSelectedRevision( state ),
+		siteId: getSelectedSiteId( state ),
+	} ),
+	{ recordTracksEvent, closeDialog: closePostRevisionsDialog, selectPostRevision }
+)( localize( PostRevisionsDialog ) );

--- a/client/post-editor/editor-revisions/index.jsx
+++ b/client/post-editor/editor-revisions/index.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { flow, get } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -86,28 +86,25 @@ EditorRevisions.propTypes = {
 	translate: PropTypes.func.isRequired,
 };
 
-export default flow(
-	localize,
-	connect(
-		( state ) => {
-			const postId = getEditorPostId( state );
-			const siteId = getSelectedSiteId( state );
+export default connect(
+	( state ) => {
+		const postId = getEditorPostId( state );
+		const siteId = getSelectedSiteId( state );
 
-			const revisions = getPostRevisions( state, siteId, postId );
-			const selectedRevisionId = getPostRevisionsSelectedRevisionId( state );
-			const comparisons = getPostRevisionsComparisons( state, siteId, postId );
-			const selectedDiff = get( comparisons, [ selectedRevisionId, 'diff' ], {} );
+		const revisions = getPostRevisions( state, siteId, postId );
+		const selectedRevisionId = getPostRevisionsSelectedRevisionId( state );
+		const comparisons = getPostRevisionsComparisons( state, siteId, postId );
+		const selectedDiff = get( comparisons, [ selectedRevisionId, 'diff' ], {} );
 
-			return {
-				authorsIds: getPostRevisionsAuthorsId( state, siteId, postId ),
-				comparisons,
-				postId,
-				revisions,
-				selectedDiff,
-				selectedRevisionId,
-				siteId,
-			};
-		},
-		{ recordTracksEvent }
-	)
-)( EditorRevisions );
+		return {
+			authorsIds: getPostRevisionsAuthorsId( state, siteId, postId ),
+			comparisons,
+			postId,
+			revisions,
+			selectedDiff,
+			selectedRevisionId,
+			siteId,
+		};
+	},
+	{ recordTracksEvent }
+)( localize( EditorRevisions ) );

--- a/client/signup/steps/import-url-onboarding/index.jsx
+++ b/client/signup/steps/import-url-onboarding/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { flow, get, includes, invoke, isEmpty } from 'lodash';
+import { get, includes, invoke, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -373,18 +373,15 @@ class ImportURLOnboardingStepComponent extends Component {
 	}
 }
 
-export default flow(
-	connect(
-		( state ) => ( {
-			urlInputValue: getNuxUrlInputValue( state ),
-		} ),
-		{
-			recordTracksEvent,
-			saveSignupStep,
-			setImportOriginSiteDetails,
-			setNuxUrlInputValue,
-			setSiteTitle,
-		}
-	),
-	localize
-)( ImportURLOnboardingStepComponent );
+export default connect(
+	( state ) => ( {
+		urlInputValue: getNuxUrlInputValue( state ),
+	} ),
+	{
+		recordTracksEvent,
+		saveSignupStep,
+		setImportOriginSiteDetails,
+		setNuxUrlInputValue,
+		setSiteTitle,
+	}
+)( localize( ImportURLOnboardingStepComponent ) );

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { flow, get, includes, invoke } from 'lodash';
+import { get, includes, invoke } from 'lodash';
 
 /**
  * Internal dependencies
@@ -304,17 +304,14 @@ class ImportURLStepComponent extends Component {
 	}
 }
 
-export default flow(
-	connect(
-		( state ) => ( {
-			urlInputValue: getNuxUrlInputValue( state ),
-		} ),
-		{
-			recordTracksEvent,
-			saveSignupStep,
-			setImportOriginSiteDetails,
-			setNuxUrlInputValue,
-		}
-	),
-	localize
-)( ImportURLStepComponent );
+export default connect(
+	( state ) => ( {
+		urlInputValue: getNuxUrlInputValue( state ),
+	} ),
+	{
+		recordTracksEvent,
+		saveSignupStep,
+		setImportOriginSiteDetails,
+		setNuxUrlInputValue,
+	}
+)( localize( ImportURLStepComponent ) );

--- a/client/state/posts/utils/normalize-post-for-api.js
+++ b/client/state/posts/utils/normalize-post-for-api.js
@@ -1,14 +1,7 @@
 /**
- * External dependencies
- */
-import { flow } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { normalizeTermsForApi } from 'calypso/state/posts/utils/normalize-terms-for-api';
-
-const normalizeApiFlow = flow( [ normalizeTermsForApi ] );
 
 /**
  * Returns a normalized post object for sending to the API
@@ -21,5 +14,5 @@ export function normalizePostForApi( post ) {
 		return null;
 	}
 
-	return normalizeApiFlow( post );
+	return normalizeTermsForApi( post );
 }

--- a/client/state/posts/utils/normalize-post-for-editing.js
+++ b/client/state/posts/utils/normalize-post-for-editing.js
@@ -1,14 +1,7 @@
 /**
- * External dependencies
- */
-import { flow } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { getTermIdsFromEdits } from 'calypso/state/posts/utils/get-term-ids-from-edits';
-
-const normalizeEditedFlow = flow( [ getTermIdsFromEdits ] );
 
 /**
  * Given a post object, returns a normalized post object
@@ -21,5 +14,5 @@ export function normalizePostForEditing( post ) {
 		return null;
 	}
 
-	return normalizeEditedFlow( post );
+	return getTermIdsFromEdits( post );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There are plenty of instances where we use `_.flow()` without a good reason to do so. Most often, we're doing it with just one or two callbacks, in which case we can just directly nest the calls inline. This PR cleans those up to both remove the Lodash usages and simplify the code.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify Calypso still builds and tests still pass.