### PR TITLE
Export: Place the loading indicator better in non-EN

### DIFF
--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -70,3 +70,7 @@
 		width: 100%;
 	}
 }
+
+div.export-card .foldable-card__summary div {
+	display: flex;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the bad placement of the loading indicator in non-English UI.

#### Testing instructions

* Change the WordPress.com interface language to non-English (e.g. Italian or German).
* Go to a WordPress.com site in Calypso.
* Visit the export section via Tools > Export Data.
* Click on export button available on the top (see screenshot).
* Observe the loading indicator not placed below the button.

#### Screenshots

Before:

![exporting-old](https://user-images.githubusercontent.com/203408/112824275-a26ef780-908a-11eb-9b93-71552c160968.gif)

After:
![exporting-new](https://user-images.githubusercontent.com/203408/112824283-a569e800-908a-11eb-964b-008cd59eb47a.gif)


Fixes #32111
