### PR TITLE
Simplify the MediaModalSecondaryActions component

### DIFF
--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -134,7 +134,6 @@ class MediaLibraryHeader extends React.Component {
 					onViewDetails={ this.props.onViewDetails }
 					onDelete={ this.props.onDeleteItem }
 					site={ this.props.site }
-					view={ 'LIST' }
 				/>
 				<MediaLibraryScale onChange={ this.props.onMediaScaleChange } />
 			</Card>

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -89,7 +89,7 @@ class MediaModalSecondaryActions extends Component {
 	}
 }
 
-export default connect( ( state, ownProps ) => ( {
+export default connect( ( state, { site } ) => ( {
 	user: getCurrentUser( state ),
-	hideButton: ! canCurrentUser( state, ownProps.site.ID, 'publish_posts' ),
+	hideButton: ! canCurrentUser( state, site.ID, 'publish_posts' ),
 } ) )( localize( MediaModalSecondaryActions ) );

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { values, some, every, flow, partial, pick } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 
@@ -15,11 +14,6 @@ import { localize } from 'i18n-calypso';
 import { canUserDeleteItem } from 'calypso/lib/media/utils';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { getMediaModalView } from 'calypso/state/ui/media-modal/selectors';
-import { setEditorMediaModalView } from 'calypso/state/editor/actions';
-import { ModalViews } from 'calypso/state/ui/media-modal/constants';
-import { withAnalytics, bumpStat, recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { Button } from '@automattic/components';
 
 const noop = () => {};
@@ -29,37 +23,23 @@ class MediaModalSecondaryActions extends Component {
 		user: PropTypes.object,
 		site: PropTypes.object,
 		selectedItems: PropTypes.array,
-		view: PropTypes.oneOf( values( ModalViews ) ),
-		disabled: PropTypes.bool,
 		onDelete: PropTypes.func,
 		onViewDetails: PropTypes.func,
 	};
 
 	static defaultProps = {
-		disabled: false,
 		onDelete: noop,
 	};
 
 	getButtons() {
-		const {
-			disabled,
-			selectedItems,
-			site,
-			translate,
-			user,
-			view,
-
-			onDelete,
-			onViewDetails,
-		} = this.props;
+		const { selectedItems, site, translate, user, onDelete, onViewDetails } = this.props;
 
 		const buttons = [];
 
-		if ( ModalViews.LIST === view && selectedItems.length ) {
+		if ( selectedItems.length ) {
 			buttons.push( {
 				key: 'edit',
 				text: translate( 'Edit' ),
-				disabled: disabled,
 				primary: true,
 				onClick: onViewDetails,
 			} );
@@ -67,12 +47,10 @@ class MediaModalSecondaryActions extends Component {
 
 		const canDeleteItems =
 			selectedItems.length &&
-			every( selectedItems, ( item ) => {
-				return canUserDeleteItem( item, user, site );
-			} );
+			selectedItems.every( ( item ) => canUserDeleteItem( item, user, site ) );
 
-		if ( ModalViews.GALLERY !== view && canDeleteItems ) {
-			const isButtonDisabled = disabled || some( selectedItems, 'transient' );
+		if ( canDeleteItems ) {
+			const isButtonDisabled = selectedItems.some( ( item ) => item.transient );
 			buttons.push( {
 				key: 'delete',
 				icon: 'trash',
@@ -94,13 +72,16 @@ class MediaModalSecondaryActions extends Component {
 			<div>
 				{ this.getButtons().map( ( button ) => (
 					<Button
+						key={ button.key }
 						className={ classNames( 'editor-media-modal__secondary-action', button.className ) }
 						data-e2e-button={ button.key }
 						compact
-						{ ...pick( button, [ 'key', 'disabled', 'onClick', 'primary' ] ) }
+						disabled={ button.disabled }
+						onClick={ button.onClick }
+						primary={ button.primary }
 					>
 						{ button.icon && <Gridicon icon={ button.icon } /> }
-						{ button.text && button.text }
+						{ button.text }
 					</Button>
 				) ) }
 			</div>
@@ -108,28 +89,7 @@ class MediaModalSecondaryActions extends Component {
 	}
 }
 
-export default connect(
-	( state, ownProps ) => ( {
-		view: getMediaModalView( state ),
-		user: getCurrentUser( state ),
-		siteSlug: ownProps.site ? getSiteSlug( state, ownProps.site.ID ) : '',
-		hideButton: ! canCurrentUser( state, ownProps.site.ID, 'publish_posts' ),
-	} ),
-	{
-		onViewDetails: flow(
-			withAnalytics( bumpStat( 'editor_media_actions', 'edit_button_dialog' ) ),
-			withAnalytics( recordGoogleEvent( 'Media', 'Clicked Dialog Edit Button' ) ),
-			partial( setEditorMediaModalView, ModalViews.DETAIL )
-		),
-	},
-	function mergeProps( stateProps, dispatchProps, ownProps ) {
-		//We want to overwrite connected props if 'onViewDetails', 'view' were provided
-		return Object.assign(
-			{},
-			ownProps,
-			stateProps,
-			dispatchProps,
-			pick( ownProps, [ 'onViewDetails', 'view' ] )
-		);
-	}
-)( localize( MediaModalSecondaryActions ) );
+export default connect( ( state, ownProps ) => ( {
+	user: getCurrentUser( state ),
+	hideButton: ! canCurrentUser( state, ownProps.site.ID, 'publish_posts' ),
+} ) )( localize( MediaModalSecondaryActions ) );


### PR DESCRIPTION
The `MediaModalSecondaryActions` component can be significantly simplified:
- it doesn't need the `view` prop. It was always `'LIST'`
- it doesn't need a default value for the `onViewDetails` prop. It's always passed from above (two possible values, one in `/media` section, one in Media Modal)
- the `disabled` and `siteSlug` props were not used, can be both removed
- all usages of Lodash functions can be removed

Many years ago, before #11589, `MediaModalSecondaryActions` were rendered in the Dialog footer, alongside with other buttons, and rendered in all views (LIST, IMAGE_EDITOR, ...).

Then it was moved to the header toolbar in #11589 and since then this simplification opportunity was there.

**How to test:**
Verify that the secondary actions (Edit and Delete) are displayed in the Media list toolbar after an image is selected, and that they work correctly. There are two scenarios where the Media Header with Secondary Actions is used, with distinct `onViewDetails` callbacks:
- `/media` section where the Media Header is displayed in a (non-modal) content view and `onViewDetails` opens the Media Modal
- Media Modal where the Media Header is displayed in a `LIST` view and `onViewDetails` switches the modal view to another one
