### PR TITLE
E2E: Do not run domain specs in parallel

### DIFF
--- a/test/e2e/specs/wp-manage-domains-spec.js
+++ b/test/e2e/specs/wp-manage-domains-spec.js
@@ -34,7 +34,7 @@ const screenSize = driverManager.currentScreenSize();
 const domainsInboxId = config.get( 'domainsInboxId' );
 const host = dataHelper.getJetpackHost();
 
-describe( `[${ host }] Managing Domains: (${ screenSize })`, function () {
+describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
 	let driver;
 
@@ -43,7 +43,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize })`, function () {
 		driver = await driverManager.startBrowser();
 	} );
 
-	describe( 'Adding a domain to an existing site @parallel', function () {
+	describe( 'Adding a domain to an existing site', function () {
 		const blogName = dataHelper.getNewBlogName();
 		const domainEmailAddress = dataHelper.getEmailAddress( blogName, domainsInboxId );
 		const expectedDomainName = blogName + '.com';
@@ -118,7 +118,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize })`, function () {
 		} );
 	} );
 
-	describe( 'Map a domain to an existing site @parallel', function () {
+	describe( 'Map a domain to an existing site', function () {
 		const blogName = 'nature.com';
 
 		before( async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Do not run specs that empty the cart on the same site concurrently. This can create a race condition where the cart has been pre-emptied and the spec fails.

Context: p1616999958016400-slack-C01QG4Y91RR

#### Testing instructions

The `wp-manage-domains-spec.js` suite should pass on the first run.