### PR TITLE
Framework: Refactor away from _.unset()

### DIFF
--- a/client/state/posts/utils/normalize-post-for-state.js
+++ b/client/state/posts/utils/normalize-post-for-state.js
@@ -1,7 +1,26 @@
 /**
  * External dependencies
  */
-import { cloneDeep, map, reduce, unset } from 'lodash';
+import { cloneDeep, map, reduce } from 'lodash';
+
+/**
+ * Recursively unset a value in an object by its path, represented by an array.
+ * Intentionally mutates `object` to mirror native `delete` operator's behavior.
+ *
+ * @param {object} object Object to remove a property from
+ * @param {Array}  path   Path to the property to remove
+ */
+const recursiveUnset = ( object, path ) => {
+	if ( path.length > 1 ) {
+		const [ , ...remainingPath ] = path;
+		recursiveUnset( object[ path[ 0 ] ], remainingPath );
+		return;
+	}
+
+	if ( object && object.hasOwnProperty( path[ 0 ] ) ) {
+		delete object[ path[ 0 ] ];
+	}
+};
 
 /**
  * Given a post object, returns a normalized post object prepared for storing
@@ -26,7 +45,7 @@ export function normalizePostForState( post ) {
 			...map( post.attachments, ( attachment, id ) => [ 'attachments', id ] ),
 		],
 		( memo, path ) => {
-			unset( memo, path.concat( 'meta', 'links' ) );
+			recursiveUnset( memo, path.concat( 'meta', 'links' ) );
 			return memo;
 		},
 		normalizedPost


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `unset()` is used just once in our codebase. While generally code that's pure and immutable is recommended, this PR doesn't aim to remove the mutation from the code but to just decouple from Lodash. So this PR replaces the usage by introducing our own inline helper function for recursive unsetting, which is as simple as possible.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all tests still pass.
