### PR TITLE
Add upgrade nudge to non-business Atomic sites.

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -28,6 +28,7 @@ import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-selected-or-all-sites-jetpack-can-manage';
 import getRecommendedPlugins from 'calypso/state/selectors/get-recommended-plugins';
 import hasJetpackSites from 'calypso/state/selectors/has-jetpack-sites';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -422,7 +423,7 @@ export class PluginsBrowser extends Component {
 			! this.props.selectedSiteId ||
 			! this.props.sitePlan ||
 			this.props.isVipSite ||
-			this.props.isJetpackSite ||
+			this.props.jetpackNonAtomic ||
 			this.props.hasBusinessPlan
 		) {
 			return null;
@@ -534,6 +535,8 @@ export default flow(
 				hasPremiumPlan,
 				hasBusinessPlan,
 				isJetpackSite: isJetpackSite( state, selectedSiteId ),
+				jetpackNonAtomic:
+					isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId ),
 				isVipSite: isVipSite( state, selectedSiteId ),
 				hasJetpackSites: hasJetpackSites( state ),
 				isRequestingSites: isRequestingSites( state ),

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -95,13 +95,13 @@ describe( 'PluginsBrowser basic tests', () => {
 			0
 		);
 	} );
-	test( 'should not show upsell nudge if jetpack site', () => {
+	test( 'should not show upsell nudge if non-atomic jetpack site', () => {
 		const comp = shallow(
 			<PluginsBrowser
 				{ ...props }
 				selectedSiteId={ 10 }
 				sitePlan={ { product_slug: PLAN_PREMIUM } }
-				isJetpackSite={ true }
+				jetpackNonAtomic={ true }
 				hasBusinessPlan={ false }
 			/>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The upgrade nudge banner should be displayed on all non-business Atomic sites. Change the banner display logic to check for sites that are Jetpack and not Atomic.

#### Testing instructions

* Navigate to the `plugins/{your test site}` url on the this branch's Calypso live branch for various types of test sites, and verify that the upgrade banner is displayed when expected:
   * A simple site - the banner should be displayed.
   * A Free Atomic site - the banner should be displayed (The Jetpack logo is currently displayed, which should be fixed by #51351.)
   * A Business Atomic site - the banner should not be displayed.
   * A Jetpack site - the banner should not be displayed.

