### PR TITLE
Add "with-design-picker" onboarding flow

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -232,17 +232,12 @@ function getNewSiteParams( {
 		// If there's a selected design, use similar new site options to what used
 		// in gutenboarding (see `client/landing/gutenboarding/stores/onboard/actions.ts`)
 		// `Design` type defined in `packages/design-picker/src/types.ts`
+		// Note: the site_creation_flow is not overridden
 		newSiteParams.options.theme = `pub/${ selectedDesign.theme }`;
 		newSiteParams.options.template = selectedDesign.template;
 		newSiteParams.options.font_base = selectedDesign.fonts.base;
 		newSiteParams.options.font_headings = selectedDesign.fonts.headings;
 		newSiteParams.options.use_patterns = true;
-
-		// TODO: needs same value to be supported in the backend
-		//(see https://github.com/Automattic/wp-calypso/issues/51231)
-		// Is this override necessary? Before overriding, the site_creation_flow
-		// is "with-design-picker"
-		newSiteParams.options.site_creation_flow = 'onboarding-with-design';
 	}
 
 	return newSiteParams;

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -174,6 +174,24 @@ function getNewSiteParams( {
 	// when segment and vertical values are not sent. Check pbAok1-p2#comment-834.
 	const shouldUseDefaultAnnotationAsFallback = true;
 
+	// If there's a selected design, use similar new site options to what used
+	// in gutenboarding (see `client/landing/gutenboarding/stores/onboard/actions.ts`)
+	const selectedDesign = get( signupDependencies, 'selectedDesign', false );
+	const withDesignOptions = {
+		theme: `pub/${ selectedDesign?.theme || themeSlugWithRepo }`,
+		...( selectedDesign?.template && {
+			template: selectedDesign.template,
+		} ),
+		...( selectedDesign?.fonts && {
+			font_base: selectedDesign?.fonts.base,
+			font_headings: selectedDesign?.fonts.headings,
+		} ),
+		use_patterns: true,
+		// TODO: needs same value to be supported in the backend
+		//(see https://github.com/Automattic/wp-calypso/issues/51231)
+		site_creation_flow: 'onboarding-with-design',
+	};
+
 	const newSiteParams = {
 		blog_title: siteTitle,
 		public: Visibility.PublicNotIndexed,
@@ -193,6 +211,7 @@ function getNewSiteParams( {
 			site_creation_flow: flowToCheck,
 			timezone_string: guessTimezone(),
 			wpcom_public_coming_soon: 1,
+			...( selectedDesign && withDesignOptions ),
 		},
 		validate: false,
 	};

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -229,18 +229,12 @@ function getNewSiteParams( {
 	}
 
 	if ( selectedDesign ) {
-		// If there's a selected design, use similar new site options to what used
-		// in gutenboarding (see `client/landing/gutenboarding/stores/onboard/actions.ts`)
-		// `Design` type defined in `packages/design-picker/src/types.ts`
-		// Note: the site_creation_flow is not overridden
+		// If there's a selected design, it means we're in "with_design_picker" flow.
 		newSiteParams.options.theme = `pub/${ selectedDesign.theme }`;
 		newSiteParams.options.template = selectedDesign.template;
 		newSiteParams.options.font_base = selectedDesign.fonts.base;
 		newSiteParams.options.font_headings = selectedDesign.fonts.headings;
 		newSiteParams.options.use_patterns = true;
-		// @TODO: remove next line when working on
-		// https://github.com/Automattic/wp-calypso/issues/51231
-		newSiteParams.options.site_creation_flow = 'gutenboarding';
 	}
 
 	return newSiteParams;

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -238,6 +238,9 @@ function getNewSiteParams( {
 		newSiteParams.options.font_base = selectedDesign.fonts.base;
 		newSiteParams.options.font_headings = selectedDesign.fonts.headings;
 		newSiteParams.options.use_patterns = true;
+		// @TODO: remove next line when working on
+		// https://github.com/Automattic/wp-calypso/issues/51231
+		newSiteParams.options.site_creation_flow = 'gutenboarding';
 	}
 
 	return newSiteParams;

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -229,7 +229,7 @@ function getNewSiteParams( {
 	}
 
 	if ( selectedDesign ) {
-		// If there's a selected design, it means we're in "with_design_picker" flow.
+		// If there's a selected design, it means that the current flow contains the "design" step.
 		newSiteParams.options.theme = `pub/${ selectedDesign.theme }`;
 		newSiteParams.options.template = selectedDesign.template;
 		newSiteParams.options.font_base = selectedDesign.fonts.base;

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -437,6 +437,14 @@ export function generateFlows( {
 		showRecaptcha: true,
 	};
 
+	flows[ 'with-design-picker' ] = {
+		steps: [ 'user', 'domains', 'plans', 'design' ],
+		destination: getSignupDestination,
+		description: 'Default onboarding experience with design picker as the last step',
+		lastModified: '2021-03-19',
+		showRecaptcha: true,
+	};
+
 	return flows;
 }
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -441,7 +441,7 @@ export function generateFlows( {
 		steps: [ 'user', 'domains', 'plans', 'design' ],
 		destination: getSignupDestination,
 		description: 'Default onboarding experience with design picker as the last step',
-		lastModified: '2021-03-19',
+		lastModified: '2021-03-29',
 		showRecaptcha: true,
 	};
 

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -71,6 +71,7 @@ const stepNameToModuleName = {
 	'plans-ecommerce-monthly': 'plans',
 	'plans-personal-monthly': 'plans',
 	'plans-premium-monthly': 'plans',
+	design: 'design-picker',
 };
 
 export function getStepModuleName( stepName ) {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -721,6 +721,12 @@ export function generateSteps( {
 				cartItem: PLAN_ECOMMERCE_MONTHLY,
 			},
 		},
+
+		design: {
+			stepName: 'design-picker',
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'selectedDesign' ],
+		},
 	};
 }
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -726,6 +726,7 @@ export function generateSteps( {
 			stepName: 'design-picker',
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'selectedDesign' ],
+			optionalDependencies: [ 'selectedDesign' ],
 		},
 	};
 }

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { identity } from 'lodash';
+import DesignPicker from '@automattic/design-picker';
 
 /**
  * Internal dependencies
@@ -13,7 +14,6 @@ import { identity } from 'lodash';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-import DesignGrid from 'calypso/landing/gutenboarding/onboarding-block/design-selector/design-grid';
 
 /**
  * Style dependencies
@@ -53,7 +53,7 @@ class DesignPickerStep extends Component {
 	};
 
 	renderDesignPicker() {
-		return <DesignGrid locale="en" onSelect={ this.pickDesign } />;
+		return <DesignPicker locale="en" onSelect={ this.pickDesign } />;
 	}
 
 	headerText() {

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -43,7 +43,6 @@ class DesignPickerStep extends Component {
 		this.props.submitSignupStep(
 			{
 				stepName: this.props.stepName,
-				selectedDesign,
 			},
 			{
 				selectedDesign,

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -66,9 +66,7 @@ class DesignPickerStep extends Component {
 	subHeaderText() {
 		const { translate } = this.props;
 
-		return translate( 'Pick your favorite homepage layout. You can customize or change it later.', {
-			context: 'Design picker step subheader in Signup',
-		} );
+		return translate( 'Pick your favorite homepage layout. You can customize or change it later.' );
 	}
 
 	render() {

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+import DesignGrid from 'calypso/landing/gutenboarding/onboarding-block/design-selector/design-grid';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class DesignPickerStep extends Component {
+	static propTypes = {
+		goToNextStep: PropTypes.func.isRequired,
+		signupDependencies: PropTypes.object.isRequired,
+		stepName: PropTypes.string.isRequired,
+		translate: PropTypes.func,
+	};
+
+	static defaultProps = {
+		useHeadstart: true,
+		translate: identity,
+	};
+
+	pickDesign = ( selectedDesign ) => {
+		recordTracksEvent( 'calypso_signup_select_design', {
+			theme: `pub/${ selectedDesign?.theme }`,
+			template: selectedDesign?.template,
+		} );
+
+		this.props.submitSignupStep(
+			{
+				stepName: this.props.stepName,
+				selectedDesign,
+			},
+			{
+				selectedDesign,
+			}
+		);
+
+		this.props.goToNextStep();
+	};
+
+	renderDesignPicker() {
+		return <DesignGrid locale="en" onSelect={ this.pickDesign } />;
+	}
+
+	headerText() {
+		const { translate } = this.props;
+
+		return translate( 'Choose a design' );
+	}
+	subHeaderText() {
+		const { translate } = this.props;
+
+		return translate( 'Pick your favorite homepage layout. You can customize or change it later.', {
+			context: 'Design picker step subheader in Signup',
+		} );
+	}
+
+	render() {
+		const headerText = this.headerText();
+		const subHeaderText = this.subHeaderText();
+
+		return (
+			<StepWrapper
+				fallbackHeaderText={ headerText }
+				headerText={ headerText }
+				fallbackSubHeaderText={ subHeaderText }
+				subHeaderText={ subHeaderText }
+				stepContent={ this.renderDesignPicker() }
+				{ ...this.props }
+			/>
+		);
+	}
+}
+
+export default connect( null, { submitSignupStep } )( localize( DesignPickerStep ) );

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -25,6 +25,7 @@ class DesignPickerStep extends Component {
 		goToNextStep: PropTypes.func.isRequired,
 		signupDependencies: PropTypes.object.isRequired,
 		stepName: PropTypes.string.isRequired,
+		locale: PropTypes.string.isRequired,
 		translate: PropTypes.func,
 	};
 
@@ -53,7 +54,8 @@ class DesignPickerStep extends Component {
 	};
 
 	renderDesignPicker() {
-		return <DesignPicker locale="en" onSelect={ this.pickDesign } />;
+		// props.locale obtained via `localize` HoC
+		return <DesignPicker locale={ this.props.locale } onSelect={ this.pickDesign } />;
 	}
 
 	headerText() {

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -1,0 +1,14 @@
+@import '~@wordpress/base-styles/_breakpoints.scss';
+@import '~@wordpress/base-styles/_mixins.scss';
+
+.signup__step.is-design {
+	.step-wrapper {
+		padding-left: 24px;
+		padding-right: 24px;
+
+		@include break-xlarge {
+			padding-left: 0;
+			padding-right: 0;
+		}
+	}
+}

--- a/client/state/signup/dependency-store/schema.js
+++ b/client/state/signup/dependency-store/schema.js
@@ -29,6 +29,14 @@ export const dependencyStoreSchema = {
 				},
 			],
 		},
+		selectedDesign: {
+			fonts: {
+				headings: { type: 'string' },
+				base: { type: 'string' },
+			},
+			template: { type: 'string' },
+			theme: { type: 'string' },
+		},
 		surveyQuestion: { type: 'string' },
 		surveySiteType: { type: 'string' },
 		theme: { type: 'string' },

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -64,6 +64,10 @@ function recordSubmitStep( stepName, providedDependencies ) {
 					.join( ',' );
 			}
 
+			if ( includes( [ 'selected_design' ], propName ) ) {
+				propValue = propValue.slug;
+			}
+
 			return {
 				...props,
 				[ propName ]: propValue,

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -34,7 +34,10 @@ interface Props {
 const DesignPicker: React.FC< Props > = ( {
 	locale,
 	onSelect,
-	designs = getAvailableDesigns().featured,
+	designs = getAvailableDesigns().featured.filter(
+		// By default, exclude anchorfm-specific designs
+		( design ) => design.features.findIndex( ( f ) => f === 'anchorfm' ) < 0
+	),
 	premiumBadge,
 	isGridMinimal,
 } ) => {


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Create a new signup step (`design`) and a new signup flow (`onboarding-with-design`)
* Add a new component responsible for rendering the `design` signup step, which is basically a wrapper around the `<DesignPicker />` component from the `@automattic/design-picker` component
* Update the parameters (sent to the backend) used to create a new site for when there's a selected design

**Caveats:**

-  theming the `<DesignPicker />` component is tracked separately in #51401 and is not a goal of this PR
- the `Uncaught (in promise) TypeError: Cannot read property 'replace' of undefined at eval (controller.js:308)` console error is also reproducible in `trunk` and therefore is not introduced by this PR

## Testing instructions

### Make sure that all A/Cs are fulfilled

A/Cs are defined in #51230

### Test new flow (free plan, selecting a design)

- Visit `/start/with-design-picker`
- Pick a free domain
- Pick the free plan
- Pick a design
- Check that:
  - [ ] Site is created successfully
  - [ ] Site is assigned the design that was picked during the signup flow

### Test new flow (paid plan, selecting a design)\

- Visit `/start/with-design-picker`
- Pick a free domain
- Pick a paid plan
- Pick a design
- Check that:
  - [ ] Browser is redirected to checkout
  - [ ] Upon completion of the checkout, the site is created successfully
  - [ ] Site is assigned the design that was picked during the signup flow

### Test new flow (free plan, skipping design)

- Visit `/start/with-design-picker`
- Pick a free domain
- Pick the free plan
- Skip the design step (scroll all the way to the bottom of the screen and click on ignore link)
- Check that:
  - [ ] Site is created successfully
  - [ ] Site is assigned the default design (Herve)

### Test new flow (change locale, free plan, selecting a design)

- In the WordPress.com settings, change your language to a locale different than english
- Visit `/start/with-design-picker`
- Pick a free domain
- Pick the free plan
- When on the design step, check that:
  - [ ] All strings (title, subtitle, ignore link) are translated

### Smoke tests other flows 

- Visit `/start` or any other signup flow
- Smoke test:
  - [ ] Everything should keep working as expected




Closes #51230
