### PR TITLE
Framework: Refactor away from _.overEvery()

### DIFF
--- a/client/layout/guided-tours/docs/API.md
+++ b/client/layout/guided-tours/docs/API.md
@@ -29,7 +29,7 @@ There are three ways a tour can get triggered:
 </Tour>;
 ```
 
-Note that you can use e.g. `lodash`'s `overEvery` as an `and` function to connect different `when` conditions. When you do so, consider your conditions' order: the function stops evaluating its argument functions as soon as one condition is false. This will affect you if you're assigning users to an A/B test, for example. Also think about how computing-intensive the functions are -- ideally order them so that you can bail with the least amount of resources as possible.
+Note that you can use e.g. the `and` utility function to connect different `when` conditions. When you do so, consider your conditions' order: the function stops evaluating its argument functions as soon as one condition is false. This will affect you if you're assigning users to an A/B test, for example. Also think about how computing-intensive the functions are -- ideally order them so that you can bail with the least amount of resources as possible.
 
 For more comprehensive examples of tours, look at [TUTORIAL.md](TUTORIAL.md) or explore existing tours in `client/layout/guided-tours/tours`.
 

--- a/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
+++ b/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
@@ -4,12 +4,12 @@
  */
 import { isDesktop } from '@automattic/viewport';
 import React, { Fragment } from 'react';
-import { overEvery as and } from 'lodash';
-import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
+import Gridicon from 'calypso/components/gridicon';
+import { and } from 'calypso/layout/guided-tours/utils';
 import {
 	makeTour,
 	Continue,

--- a/client/layout/guided-tours/test/utils.js
+++ b/client/layout/guided-tours/test/utils.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import { and } from 'calypso/layout/guided-tours/utils';
+
+describe( 'Guided Tours utilities: and()', () => {
+	test( 'returns true when all passed callbacks are truthy', () => {
+		const a = () => true;
+		const b = () => 1;
+		const c = () => 'a string';
+		expect( and( a, b, c )() ).toEqual( true );
+	} );
+
+	test( 'returns false when one or more callbacks are not truthy', () => {
+		const a = () => true;
+		const b = () => 0;
+		const c = () => 'a string';
+		expect( and( a, b, c )() ).toEqual( false );
+	} );
+} );

--- a/client/layout/guided-tours/utils.js
+++ b/client/layout/guided-tours/utils.js
@@ -1,8 +1,10 @@
 /**
  * External dependencies
  */
-import { overEvery as and, negate as not } from 'lodash';
+import { negate as not } from 'lodash';
 
 const noop = () => {};
+
+const and = ( ...conditions ) => () => conditions.every( ( cond ) => cond() );
 
 export { and, not, noop };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `overEvery()` is used just once in our codebase - in Guided Tours. This PR updates the usage to a simple function that does the same job. We also update examples and documentation as needed.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Try a guided tour and verify it still works well. For example go to `/media/:site?tour=mediaBasicsTour` where `:site` is one of your sites.
* Verify all tests still pass.
