### PR TITLE
E2E: Rename & move clearTextArea to correct spot

### DIFF
--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -563,16 +563,6 @@ export function getElementByText( driver, selector, text ) {
 	};
 }
 
-export async function clearTextArea( driver, selector ) {
-	const textArea = await driver.findElement( selector );
-	const textValue = await textArea.getText();
-	let i = textValue.length;
-	while ( i > 0 ) {
-		await textArea.sendKeys( webdriver.Key.BACK_SPACE );
-		i--;
-	}
-}
-
 export async function dismissAlertIfPresent( driver ) {
 	try {
 		await driver.switchTo().alert().dismiss();

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -113,8 +113,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async enterTitle( title ) {
-		const titleFieldSelector = By.css( '.editor-post-title__input' );
-		return await driverHelper.setWhenSettable( this.driver, titleFieldSelector, title );
+		const titleElement = await this.driver.findElement( By.css( '.editor-post-title__input' ) );
+		await titleElement.clear();
+		return titleElement.sendKeys( title );
 	}
 
 	async getTitle() {
@@ -127,7 +128,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		const appenderSelector = By.css( '.block-editor-default-block-appender' );
 		const paragraphSelector = By.css( 'p.block-editor-rich-text__editable:first-of-type' );
 		await driverHelper.clickWhenClickable( this.driver, appenderSelector );
-		return await driverHelper.setWhenSettable( this.driver, paragraphSelector, text );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, paragraphSelector );
+		const paragraphElement = this.driver.findElement( paragraphSelector );
+		await paragraphElement.clear();
+		return paragraphElement.sendKeys( text );
 	}
 
 	async getContent() {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -114,8 +114,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async enterTitle( title ) {
 		const titleFieldSelector = By.css( '.editor-post-title__input' );
-		await driverHelper.clearTextArea( this.driver, titleFieldSelector );
-		return await this.driver.findElement( titleFieldSelector ).sendKeys( title );
+		return await driverHelper.setWhenSettable( this.driver, titleFieldSelector, title );
 	}
 
 	async getTitle() {
@@ -128,8 +127,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		const appenderSelector = By.css( '.block-editor-default-block-appender' );
 		const paragraphSelector = By.css( 'p.block-editor-rich-text__editable:first-of-type' );
 		await driverHelper.clickWhenClickable( this.driver, appenderSelector );
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, paragraphSelector );
-		return await this.driver.findElement( paragraphSelector ).sendKeys( text );
+		return await driverHelper.setWhenSettable( this.driver, paragraphSelector, text );
 	}
 
 	async getContent() {
@@ -138,8 +136,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async replaceTextOnLastParagraph( text ) {
 		const paragraphSelector = By.css( 'p.block-editor-rich-text__editable:first-of-type' );
-		await driverHelper.clearTextArea( this.driver, paragraphSelector );
-		return await this.driver.findElement( paragraphSelector ).sendKeys( text );
+		return await driverHelper.setWhenSettable( this.driver, paragraphSelector, text );
 	}
 
 	async insertShortcode( shortcode ) {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -113,9 +113,8 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async enterTitle( title ) {
-		const titleElement = await this.driver.findElement( By.css( '.editor-post-title__input' ) );
-		await titleElement.clear();
-		return titleElement.sendKeys( title );
+		const titleSelector = By.css( '.editor-post-title__input' );
+		return driverHelper.setWhenSettable( this.driver, titleSelector, title );
 	}
 
 	async getTitle() {
@@ -129,9 +128,21 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		const paragraphSelector = By.css( 'p.block-editor-rich-text__editable:first-of-type' );
 		await driverHelper.clickWhenClickable( this.driver, appenderSelector );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, paragraphSelector );
-		const paragraphElement = this.driver.findElement( paragraphSelector );
-		await paragraphElement.clear();
-		return paragraphElement.sendKeys( text );
+		const paragraphElement = await this.clearText( paragraphSelector );
+		await paragraphElement.sendKeys( text );
+
+		return paragraphElement;
+	}
+
+	async clearText( selector ) {
+		const paragraphElement = await this.driver.findElement( selector );
+		const text = await paragraphElement.getText();
+		let i = text.length;
+		while ( i > 0 ) {
+			await paragraphElement.sendKeys( webdriver.Key.BACK_SPACE );
+			i--;
+		}
+		return paragraphElement;
 	}
 
 	async getContent() {
@@ -140,7 +151,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async replaceTextOnLastParagraph( text ) {
 		const paragraphSelector = By.css( 'p.block-editor-rich-text__editable:first-of-type' );
-		return await driverHelper.setWhenSettable( this.driver, paragraphSelector, text );
+		const paragraphElement = await this.clearText( paragraphSelector );
+		await paragraphElement.sendKeys( text );
+
+		return paragraphElement;
 	}
 
 	async insertShortcode( shortcode ) {

--- a/test/e2e/lib/pages/themes-page.js
+++ b/test/e2e/lib/pages/themes-page.js
@@ -78,7 +78,6 @@ export default class ThemesPage extends AsyncBaseContainer {
 		const searchToggleSelector = by.css( '.themes-magic-search-card div.search' );
 		const searchFieldSelector = by.css( '.themes-magic-search-card input.search__input' );
 		await driverHelper.clickWhenClickable( this.driver, searchToggleSelector, this.explicitWaitMS );
-		await driverHelper.clearTextArea( this.driver, searchFieldSelector );
 		await driverHelper.setWhenSettable( this.driver, searchFieldSelector, phrase );
 		await this.driver.findElement( searchFieldSelector ).sendKeys( ' ' );
 		return await this.waitUntilThemesLoaded();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `clearTextArea` helper isn't actually for clearing `textarea` elements, as it checks for `innerText` of an element. We're using it only for clearing out paragraph block content in the GutenbergEditorComponent, so I moved it there and renamed to `clearText`.

#### Testing instructions

All tests should pass.