### PR TITLE
Site Badge: apply colors by context

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -138,8 +138,6 @@
 }
 
 .site__home {
-	background: var( --color-sidebar-menu-selected-background );
-	color: var( --color-sidebar-menu-selected-text );
 	display: block;
 	width: 32px;
 	height: 32px;
@@ -168,8 +166,8 @@
 }
 
 .site__badge {
-	background: var( --color-sidebar-menu-hover-background );
-	color: var( --color-sidebar-menu-hover-text );
+	color: var( --color-neutral-60 );
+	background-color: var( --color-neutral-5 );
 	font-size: $font-body-extra-small;
 	border-radius: 12px;
 	clear: both;
@@ -179,13 +177,27 @@
 	padding: 1px 10px;
 }
 
-.notouch .site-selector.is-hover-enabled .site:hover .site__badge {
-	background: var( --color-sidebar-background );
-	color: var( --color-sidebar-text );
-}
+// Secondary Layout: sites selector, sidebar, etc.
+.layout__secondary {
+	.site__home {
+		background: var( --color-sidebar-menu-selected-background );
+		color: var( --color-sidebar-menu-selected-text );
+	}
 
-.current-site .site:hover .site__badge,
-.purchases-site .site:hover .site__badge {
-	background: var( --color-sidebar-menu-hover-background );
-	color: var( --color-sidebar-menu-hover-text );
+	.site__badge {
+		background: var( --color-sidebar-menu-hover-background );
+		color: var( --color-sidebar-menu-hover-text );
+	}
+
+
+	.notouch .site-selector.is-hover-enabled .site:hover .site__badge {
+		background: var( --color-sidebar-background );
+		color: var( --color-sidebar-text );
+	}
+
+	.current-site .site:hover .site__badge,
+	.purchases-site .site:hover .site__badge {
+		background: var( --color-sidebar-menu-hover-background );
+		color: var( --color-sidebar-menu-hover-text );
+	}
 }

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -177,26 +177,29 @@
 	padding: 1px 10px;
 }
 
+.notouch .site-selector.is-hover-enabled .site:hover .site__badge {
+	background: var( --color-sidebar-background );
+	color: var( --color-sidebar-text );
+}
+
+.current-site .site:hover .site__badge,
+.purchases-site .site:hover .site__badge {
+	background: var( --color-sidebar-menu-hover-background );
+	color: var( --color-sidebar-menu-hover-text );
+}
+
 // Secondary Layout: sites selector, sidebar, etc.
 .layout__secondary {
 	.site__home {
 		background: var( --color-sidebar-menu-selected-background );
 		color: var( --color-sidebar-menu-selected-text );
 	}
+}
 
+// Secondary Layout. Site selector.
+.layout__secondary,
+.site-selector {
 	.site__badge {
-		background: var( --color-sidebar-menu-hover-background );
-		color: var( --color-sidebar-menu-hover-text );
-	}
-
-
-	.notouch .site-selector.is-hover-enabled .site:hover .site__badge {
-		background: var( --color-sidebar-background );
-		color: var( --color-sidebar-text );
-	}
-
-	.current-site .site:hover .site__badge,
-	.purchases-site .site:hover .site__badge {
 		background: var( --color-sidebar-menu-hover-background );
 		color: var( --color-sidebar-menu-hover-text );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR applies the site badge colors by context, meaning that sometimes it will apply the colors defined by the nav unification (when the badge is rendered in the secondary layout / sidebar), of applying neutral colors in other contexts, for instance, in the primary layout.

Fixes https://github.com/Automattic/wp-calypso/issues/49180

#### Testing instructions

* Confirm the visual issue described here https://github.com/Automattic/wp-calypso/issues/49180
Basically, you should see the colors defined by the nav unification.

* applying the changes on this branch, you should see the badge with neutral colors when it's rendered in a different context than the secondary layout, for instance, testing in the notifications page:

<img width="600" alt="Screen Shot 2021-03-29 at 12 45 55 PM" src="https://user-images.githubusercontent.com/77539/112863007-c4697980-908c-11eb-89f9-90f666bb231b.png">

* In the secondary layout, the colors should be defined by the nav unification.

<img width="582" alt="Screen Shot 2021-03-29 at 12 48 02 PM" src="https://user-images.githubusercontent.com/77539/112863261-0c889c00-908d-11eb-8f82-619260335b5a.png">

Related to https://github.com/Automattic/wp-calypso/issues/49180
