### PR TITLE
G Suite: Enable Google Workspace on all environments

### DIFF
--- a/client/components/gsuite/gsuite-learn-more/test/__snapshots__/index.js.snap
+++ b/client/components/gsuite/gsuite-learn-more/test/__snapshots__/index.js.snap
@@ -16,7 +16,7 @@ exports[`GSuiteLearnMore it renders GSuiteLearnMore with no props 1`] = `
       rel="noopener noreferrer"
       target="_blank"
     >
-      Learn more about integrating G Suite with your site.
+      Learn more about integrating Google Workspace with your site.
     </a>
   </p>
 </div>

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -41,6 +41,7 @@
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,
+		"google-workspace-migration": true,
 		"gdpr-banner": false,
 		"help": true,
 		"inline-help": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -36,6 +36,7 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": true,
 		"google-my-business": false,
+		"google-workspace-migration": true,
 		"help": true,
 		"inline-help": true,
 		"ive/use-external-assignment": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -42,6 +42,7 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": true,
 		"google-my-business": false,
+		"google-workspace-migration": true,
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,

--- a/config/production.json
+++ b/config/production.json
@@ -41,6 +41,7 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": true,
 		"google-my-business": true,
+		"google-workspace-migration": true,
 		"gutenboarding/new-launch-mobile": true,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -44,6 +44,7 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": false,
 		"google-my-business": true,
+		"google-workspace-migration": true,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
 		"happychat": true,

--- a/config/test.json
+++ b/config/test.json
@@ -40,6 +40,7 @@
 		"devdocs/redirect-loggedout-homepage": true,
 		"gdpr-banner": false,
 		"google-my-business": false,
+		"google-workspace-migration": true,
 		"gutenboarding/new-launch-mobile": true,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,


### PR DESCRIPTION
This pull request enables Google Workspace on all environments (except Jetpack) where it wasn't enabled yet. This will allow WordPress.com users to purchase Google Workspace instead of G Suite.