### PR TITLE
Enable one-click OAuth support in Calypso

### DIFF
--- a/client/auth/connect.jsx
+++ b/client/auth/connect.jsx
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -15,55 +15,46 @@ import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import WordPressLogo from 'calypso/components/wordpress-logo';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 
-class Connect extends React.Component {
-	getCreateAccountUrl = () => {
-		return config.isEnabled( 'devdocs' )
-			? 'https://wordpress.com/start/developer'
-			: 'https://wordpress.com/start';
-	};
+export default function Connect( { authUrl } ) {
+	const translate = useTranslate();
 
-	render() {
-		return (
-			<Main className="auth auth__connect">
-				<WordPressLogo size={ 72 } />
-				{ ! config( 'oauth_client_id' ) ? (
-					<Notice
-						status="is-warning"
-						text={ this.props.translate(
-							'You need to set `oauth_client_id` in your config file.'
-						) }
-						showDismiss={ false }
-					>
-						<NoticeAction href="https://developer.wordpress.com/apps/">
-							{ this.props.translate( 'Go to Developer Resources' ) }
-						</NoticeAction>
-					</Notice>
-				) : (
-					<div className="auth__connect-intro">
-						<p className="auth__welcome">
-							{ this.props.translate(
-								'Welcome to Calypso. Authorize the application with your WordPress.com credentials to get started.'
-							) }
-						</p>
-						<Button href={ this.props.authUrl }>{ this.props.translate( 'Authorize App' ) }</Button>
-					</div>
-				) }
-				<a
-					className="auth__help"
-					target="_blank"
-					rel="noopener noreferrer"
-					title={ this.props.translate( 'Visit the Calypso GitHub repository for help' ) }
-					href="https://github.com/Automattic/wp-calypso"
+	return (
+		<Main className="auth auth__connect">
+			<WordPressLogo size={ 72 } />
+			{ ! config( 'oauth_client_id' ) ? (
+				<Notice
+					status="is-warning"
+					text={ translate( 'You need to set `oauth_client_id` in your config file.' ) }
+					showDismiss={ false }
 				>
-					<Gridicon icon="help" />
-				</a>
-				<div className="auth__links">
-					<a href={ this.getCreateAccountUrl() }>{ this.props.translate( 'Create account' ) }</a>
+					<NoticeAction href="https://developer.wordpress.com/apps/">
+						{ translate( 'Go to Developer Resources' ) }
+					</NoticeAction>
+				</Notice>
+			) : (
+				<div className="auth__connect-intro">
+					<p className="auth__welcome">
+						{ translate(
+							'Welcome to Calypso. Authorize the application with your WordPress.com credentials to get started.'
+						) }
+					</p>
+					<Button href={ authUrl }>{ translate( 'Authorize App' ) }</Button>
 				</div>
-			</Main>
-		);
-	}
+			) }
+			<a
+				className="auth__help"
+				target="_blank"
+				rel="noopener noreferrer"
+				title={ translate( 'Visit the WordPress.com support site for help' ) }
+				href={ localizeUrl( 'https://wordpress.com/support/' ) }
+			>
+				<Gridicon icon="help" />
+			</a>
+			<div className="auth__links">
+				<a href="/start">{ translate( 'Create account' ) }</a>
+			</div>
+		</Main>
+	);
 }
-
-export default localize( Connect );

--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -35,7 +35,7 @@ export default {
 		let authUrl;
 
 		if ( config( 'oauth_client_id' ) ) {
-			// TODO: flags=oauth should be present only is dev-like environments
+			// TODO: flags=oauth should be present only in dev-like environments
 			// where we need to preserve the flag on full reloads and redirects
 			const redirectUri = `${ window.location.origin }/api/oauth/token?flags=oauth`;
 
@@ -64,7 +64,7 @@ export default {
 			store.set( 'wpcom_token_expires_in', context.hash.expires_in );
 		}
 
-		// TODO: flags=oauth should be present only is dev-like environments
+		// TODO: flags=oauth should be present only in dev-like environments
 		// where we need to preserve the flag on full reloads and redirects
 		document.location.replace( '/?flags=oauth' );
 	},

--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -35,7 +35,9 @@ export default {
 		let authUrl;
 
 		if ( config( 'oauth_client_id' ) ) {
-			const redirectUri = `${ window.location.origin }/api/oauth/token`;
+			// TODO: flags=oauth should be present only is dev-like environments
+			// where we need to preserve the flag on full reloads and redirects
+			const redirectUri = `${ window.location.origin }/api/oauth/token?flags=oauth`;
 
 			const params = new URLSearchParams( {
 				response_type: 'token',
@@ -62,6 +64,8 @@ export default {
 			store.set( 'wpcom_token_expires_in', context.hash.expires_in );
 		}
 
-		document.location.replace( '/' );
+		// TODO: flags=oauth should be present only is dev-like environments
+		// where we need to preserve the flag on full reloads and redirects
+		document.location.replace( '/?flags=oauth' );
 	},
 };

--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -18,8 +18,6 @@ import store from 'store';
  */
 import './style.scss';
 
-const WP_AUTHORIZE_ENDPOINT = 'https://public-api.wordpress.com/oauth2/authorize';
-
 export default {
 	oauthLogin: function ( context, next ) {
 		if ( ! config.isEnabled( 'oauth' ) || getToken() ) {
@@ -37,10 +35,7 @@ export default {
 		let authUrl;
 
 		if ( config( 'oauth_client_id' ) ) {
-			const protocol = config( 'protocol' );
-			const host = config( 'hostname' );
-			const port = config( 'port' );
-			const redirectUri = `${ protocol }://${ host }:${ port }/api/oauth/token`;
+			const redirectUri = `${ window.location.origin }/api/oauth/token`;
 
 			const params = new URLSearchParams( {
 				response_type: 'token',
@@ -50,7 +45,7 @@ export default {
 				blog_id: 0,
 			} );
 
-			authUrl = `${ WP_AUTHORIZE_ENDPOINT }?${ params.toString() }`;
+			authUrl = `https://public-api.wordpress.com/oauth2/authorize?${ params.toString() }`;
 		}
 
 		context.primary = <ConnectComponent authUrl={ authUrl } />;

--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -18,7 +18,7 @@ const debug = debugModule( 'calypso:user:utilities' );
 const userUtils = {
 	getLogoutUrl( redirect ) {
 		const userData = user().get();
-		let url = '/logout';
+		let url;
 		let subdomain = '';
 
 		// If logout_URL isn't set, then go ahead and return the logout URL

--- a/client/server/api/index.js
+++ b/client/server/api/index.js
@@ -20,7 +20,7 @@ export default function api() {
 		response.json( { version } );
 	} );
 
-	if ( config.isEnabled( 'oauth' ) && ! config.isEnabled( 'jetpack-cloud' ) ) {
+	if ( config.isEnabled( 'desktop' ) ) {
 		oauth( app );
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -10,6 +10,7 @@
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
 	"siftscience_key": "e00e878351",
+	"oauth_client_id": "39911",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -145,6 +145,7 @@
 		"wordpress-action-search": false
 	},
 	"siftscience_key": "a4f69f6759",
+	"oauth_client_id": "39911",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": true,

--- a/config/production.json
+++ b/config/production.json
@@ -178,6 +178,7 @@
 	},
 	"rtl": false,
 	"siftscience_key": "a4f69f6759",
+	"oauth_client_id": "39911",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -182,6 +182,7 @@
 		"wordpress-action-search": false
 	},
 	"siftscience_key": "e00e878351",
+	"oauth_client_id": "39911",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": false,

--- a/config/test.json
+++ b/config/test.json
@@ -8,6 +8,7 @@
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
 	"siftscience_key": "e00e878351",
+	"oauth_client_id": "39911",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -188,6 +188,7 @@
 		"wordpress-action-search": false
 	},
 	"siftscience_key": "e00e878351",
+	"oauth_client_id": "39911",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": false,


### PR DESCRIPTION
Add ability to run OAuth-enabled Calypso on `calypso.live` or `calypso.localhost`. REST API requests don't use auth cookies at all, only OAuth tokens in `Authorization` headers.

- add the Calypso OAuth client ID to all relevant config environment. No need to specify your own local client ID
- enables the OAuth server endpoints (`/sms`, `/oauth`, `/logout`) only for Desktop app, the only one that should really use it. This removes the only usage of `config.isEnabled( 'oauth' )` from server, one that was not even necessary.
- don't use `config( 'hostname' )` etc to construct the redirect URI. Using `window.location.origin` is better.
- preserve the `flags=oauth` query arg in URL when redirecting to wordpress.com OAuth authorization URL and back.

**How to test:**
- apply D59479-code on your sandbox and point `public-api.wordpress.com` to that sandbox. That diff implements special origin check for `calypso.live` subdomains
- load the calypso.live link from the PR and add `?flags=oauth` query arg to the URL
- go through the OAuth auth loop and authorize Calypso to use your account
- enjoy Calypso without 3rd party cookies on `calypso.live`

For the best experience, load the calypso.live link in Safari with ITP enabled. Without OAuth, it wouldn't work at all.
