### PR TITLE
Upload Plugins: Show plugin eligibility notice on Free Atomic sites 

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -177,6 +177,9 @@ export const HardBlockingNotice = ( {
 export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) => {
 	const holdMessages = getHoldMessages( context, translate );
 	const blockingMessages = getBlockingMessages( translate );
+	// eslint-disable-next-line
+	console.log( holds );
+	// console.log( blockingMessages, holdMessages );
 
 	const blockingHold = holds.find( ( h ) => isHardBlockingHoldType( h, blockingMessages ) );
 

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -37,6 +37,7 @@ import {
 	isEligibleForAutomatedTransfer,
 	getAutomatedTransferStatus,
 } from 'calypso/state/automated-transfer/selectors';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { successNotice } from 'calypso/state/notices/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 
@@ -170,6 +171,7 @@ const mapStateToProps = ( state ) => {
 	const hasEligibilityMessages = ! (
 		isEmpty( eligibilityHolds ) && isEmpty( eligibilityWarnings )
 	);
+	const isJetpackNonAtomic = isJetpack && ! isAtomicSite( state, siteId );
 
 	return {
 		siteId,
@@ -184,7 +186,7 @@ const mapStateToProps = ( state ) => {
 		installing: progress === 100,
 		isJetpackMultisite,
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
-		showEligibility: ! isJetpack && ( hasEligibilityMessages || ! isEligible ),
+		showEligibility: ! isJetpackNonAtomic && ( hasEligibilityMessages || ! isEligible ),
 		automatedTransferStatus: getAutomatedTransferStatus( state, siteId ),
 	};
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the logic to show Eligibility notice for Free Atomic sites on wordpress.com/plugins/upload page. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
