### PR TITLE
Shopping Cart: Fix module importing

### DIFF
--- a/packages/launch/tsconfig.json
+++ b/packages/launch/tsconfig.json
@@ -34,6 +34,7 @@
 	"exclude": [ "**/test/*" ],
 	"references": [
 		{ "path": "../react-i18n" },
+		{ "path": "../shopping-cart" },
 		{ "path": "../data-stores" },
 		{ "path": "../components" },
 		{ "path": "../onboarding" },

--- a/packages/shopping-cart/index.ts
+++ b/packages/shopping-cart/index.ts
@@ -1,6 +1,0 @@
-export { default as useShoppingCart } from './src/use-shopping-cart';
-export { default as withShoppingCart } from './src/with-shopping-cart';
-export { default as ShoppingCartProvider } from './src/shopping-cart-provider';
-export { default as createRequestCartProduct } from './src/create-request-cart-product';
-export { getEmptyResponseCart } from './src/empty-carts';
-export * from './src/types';

--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -5,7 +5,7 @@
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
 	"types": "dist/types/index.d.ts",
-	"calypso:src": "index.ts",
+	"calypso:src": "src/index.ts",
 	"sideEffects": false,
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",

--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/shopping-cart",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "A library to use the WordPress.com shopping cart",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/shopping-cart/src/index.ts
+++ b/packages/shopping-cart/src/index.ts
@@ -1,0 +1,6 @@
+export { default as useShoppingCart } from './use-shopping-cart';
+export { default as withShoppingCart } from './with-shopping-cart';
+export { default as ShoppingCartProvider } from './shopping-cart-provider';
+export { default as createRequestCartProduct } from './create-request-cart-product';
+export { getEmptyResponseCart } from './empty-carts';
+export * from './types';

--- a/packages/shopping-cart/test/cart-actions.tsx
+++ b/packages/shopping-cart/test/cart-actions.tsx
@@ -11,7 +11,7 @@ import { screen, act, render, waitFor, fireEvent } from '@testing-library/react'
 /**
  * Internal dependencies
  */
-import { useShoppingCart, ShoppingCartProvider } from '../index';
+import { useShoppingCart, ShoppingCartProvider } from '../src/index';
 import { getEmptyResponseCart } from '../src/empty-carts';
 import type {
 	RequestCartProduct,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Even though using the `@automattic/shopping-cart` package works in calypso within the monorepo, installing the package outside the monorepo in another TypeScript app gives this error when trying to compile:

```
Module not found: Error: Can't resolve '@automattic/shopping-cart'
```

After looking at the module resolution being used by the TypeScript compiler, I believe this is because of an error in the package.json inside the `shopping-cart` package. The resolver is looking for an `index.ts` (and `index.d.ts`) within the `dist/esm` directory, but that directory has no `index` files because the `index.ts` file in the package is outside of the `src` directory that's being compiled.

In this PR I move the `index.ts` file into the `src` directory, which I hope will resolve the issue.

#### Testing instructions

Load checkout and be sure that you see a product in the cart. If anything having to do with the shopping-cart works, this change should be safe.