### PR TITLE
Restrict log access to the past 14 days due to ES limitations

### DIFF
--- a/client/my-sites/hosting/web-server-logs-card/index.js
+++ b/client/my-sites/hosting/web-server-logs-card/index.js
@@ -92,17 +92,10 @@ const WebServerLogsCard = ( props ) => {
 			} );
 		}
 
-		if ( startMoment.isBefore( moment.utc().subtract( 30, 'days' ) ) ) {
-			setStartDateValidation( {
-				isValid: false,
-				validationInfo: translate( 'Start date must be less than 30 days ago.' ),
-			} );
-		}
-
 		if ( startMoment.isBefore( moment.utc().subtract( 14, 'days' ) ) ) {
 			setStartDateValidation( {
 				isValid: false,
-				validationInfo: translate( 'Please select a time range of less than 14 days.' ),
+				validationInfo: translate( 'Start date must be less than 14 days ago.' ),
 			} );
 		}
 	}, [ startDateTime, endDateTime ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Because indexes older than 14 days are currently significantly slower, we are going to restrict log requests to the last 14 days for now.

#### Testing instructions

Attempt to request logs with a start date of more than 14 days in the past. Make sure that an error is displayed.

Make sure that a start date within 14 days still works properly.