### PR TITLE
Jetpack Pricing Page: Add A/A test to test ExPlat usage

### DIFF
--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -9,7 +9,6 @@ import React from 'react';
  */
 import JetpackComMasterbar from '../jpcom-masterbar';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { useExperiment } from 'calypso/lib/explat';
 import { preventWidows } from 'calypso/lib/formatting';
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
 
@@ -20,18 +19,6 @@ import './style.scss';
 
 const Header: React.FC< Props > = () => {
 	const translate = useTranslate();
-	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'jetpack_explat_testing'
-	);
-
-	let headerText;
-	if ( isLoadingExperimentAssignment ) {
-		headerText = translate( 'Security, performance, and marketing tools made for WordPress' );
-	} else if ( 'treatment' === experimentAssignment?.variationName ) {
-		headerText = translate( 'Security, performance, and marketing tools made for WordPress' );
-	} else {
-		headerText = translate( 'Security, performance, and marketing tools made for WordPress' );
-	}
 
 	return (
 		<>
@@ -40,7 +27,9 @@ const Header: React.FC< Props > = () => {
 			<div className="header">
 				<FormattedHeader
 					className="header__main-title"
-					headerText={ preventWidows( headerText ) }
+					headerText={ preventWidows(
+						translate( 'Security, performance, and marketing tools made for WordPress' )
+					) }
 					align="center"
 				/>
 			</div>

--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -9,6 +9,7 @@ import React from 'react';
  */
 import JetpackComMasterbar from '../jpcom-masterbar';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useExperiment } from 'calypso/lib/explat';
 import { preventWidows } from 'calypso/lib/formatting';
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
 
@@ -19,6 +20,18 @@ import './style.scss';
 
 const Header: React.FC< Props > = () => {
 	const translate = useTranslate();
+	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
+		'jetpack_explat_testing'
+	);
+
+	let headerText;
+	if ( isLoadingExperimentAssignment ) {
+		headerText = translate( 'Security, performance, and marketing tools made for WordPress' );
+	} else if ( 'treatment' === experimentAssignment?.variationName ) {
+		headerText = translate( 'Security, performance, and marketing tools made for WordPress' );
+	} else {
+		headerText = translate( 'Security, performance, and marketing tools made for WordPress' );
+	}
 
 	return (
 		<>
@@ -27,9 +40,7 @@ const Header: React.FC< Props > = () => {
 			<div className="header">
 				<FormattedHeader
 					className="header__main-title"
-					headerText={ preventWidows(
-						translate( 'Security, performance, and marketing tools made for WordPress' )
-					) }
+					headerText={ preventWidows( headerText ) }
 					align="center"
 				/>
 			</div>

--- a/client/my-sites/plans/jetpack-plans/plans-header.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-header.tsx
@@ -22,7 +22,6 @@ import Notice from 'calypso/components/notice';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
-import { useExperiment } from 'calypso/lib/explat';
 
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
 
@@ -36,36 +35,23 @@ type StandardHeaderProps = {
 	siteId: number | null;
 };
 
-const StandardPlansHeader = ( { shouldShowPlanRecommendation, siteId }: StandardHeaderProps ) => {
-	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'jetpack_explat_testing'
-	);
-
-	let headerText;
-	if ( isLoadingExperimentAssignment ) {
-		headerText = translate( 'Security, performance, and marketing tools made for WordPress' );
-	} else if ( 'treatment' === experimentAssignment?.variationName ) {
-		headerText = translate( 'Security, performance, and marketing tools made for WordPress' );
-	} else {
-		headerText = translate( 'Security, performance, and marketing tools made for WordPress' );
-	}
-
-	return (
-		<>
-			<FormattedHeader headerText={ translate( 'Plans' ) } align="left" brandFont />
-			<PlansNavigation path={ '/plans' } />
-			{ shouldShowPlanRecommendation && siteId && (
-				<JetpackPluginUpdateWarning
-					siteId={ siteId }
-					minJetpackVersion={ JETPACK_LEGACY_PLANS_MAX_PLUGIN_VERSION }
-				/>
-			) }
-			{ ! shouldShowPlanRecommendation && (
-				<h2 className="jetpack-plans__pricing-header">{ preventWidows( headerText ) }</h2>
-			) }
-		</>
-	);
-};
+const StandardPlansHeader = ( { shouldShowPlanRecommendation, siteId }: StandardHeaderProps ) => (
+	<>
+		<FormattedHeader headerText={ translate( 'Plans' ) } align="left" brandFont />
+		<PlansNavigation path={ '/plans' } />
+		{ shouldShowPlanRecommendation && siteId && (
+			<JetpackPluginUpdateWarning
+				siteId={ siteId }
+				minJetpackVersion={ JETPACK_LEGACY_PLANS_MAX_PLUGIN_VERSION }
+			/>
+		) }
+		{ ! shouldShowPlanRecommendation && (
+			<h2 className="jetpack-plans__pricing-header">
+				{ preventWidows( 'Security, performance, and marketing tools made for WordPress' ) }
+			</h2>
+		) }
+	</>
+);
 
 const ConnectFlowPlansHeader = () => (
 	<>

--- a/client/my-sites/plans/jetpack-plans/plans-header.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-header.tsx
@@ -47,7 +47,9 @@ const StandardPlansHeader = ( { shouldShowPlanRecommendation, siteId }: Standard
 		) }
 		{ ! shouldShowPlanRecommendation && (
 			<h2 className="jetpack-plans__pricing-header">
-				{ preventWidows( 'Security, performance, and marketing tools made for WordPress' ) }
+				{ preventWidows(
+					translate( 'Security, performance, and marketing tools made for WordPress' )
+				) }
 			</h2>
 		) }
 	</>

--- a/client/my-sites/plans/jetpack-plans/plans-header.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-header.tsx
@@ -9,7 +9,11 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { getPlanRecommendationFromContext } from './plan-upgrade/utils';
-import { JETPACK_LEGACY_PLANS_MAX_PLUGIN_VERSION } from '@automattic/calypso-products';
+import {
+	JETPACK_LEGACY_PLANS_MAX_PLUGIN_VERSION,
+	PLAN_JETPACK_FREE,
+	JETPACK_PRODUCTS_LIST,
+} from '@automattic/calypso-products';
 import JetpackPluginUpdateWarning from 'calypso/blocks/jetpack-plugin-update-warning';
 import { preventWidows } from 'calypso/lib/formatting';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
@@ -18,7 +22,8 @@ import Notice from 'calypso/components/notice';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
-import { PLAN_JETPACK_FREE, JETPACK_PRODUCTS_LIST } from '@automattic/calypso-products';
+import { useExperiment } from 'calypso/lib/explat';
+
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
 
 type HeaderProps = {
@@ -31,25 +36,36 @@ type StandardHeaderProps = {
 	siteId: number | null;
 };
 
-const StandardPlansHeader = ( { shouldShowPlanRecommendation, siteId }: StandardHeaderProps ) => (
-	<>
-		<FormattedHeader headerText={ translate( 'Plans' ) } align="left" brandFont />
-		<PlansNavigation path={ '/plans' } />
-		{ shouldShowPlanRecommendation && siteId && (
-			<JetpackPluginUpdateWarning
-				siteId={ siteId }
-				minJetpackVersion={ JETPACK_LEGACY_PLANS_MAX_PLUGIN_VERSION }
-			/>
-		) }
-		{ ! shouldShowPlanRecommendation && (
-			<h2 className="jetpack-plans__pricing-header">
-				{ preventWidows(
-					translate( 'Security, performance, and marketing tools made for WordPress' )
-				) }
-			</h2>
-		) }
-	</>
-);
+const StandardPlansHeader = ( { shouldShowPlanRecommendation, siteId }: StandardHeaderProps ) => {
+	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
+		'jetpack_explat_testing'
+	);
+
+	let headerText;
+	if ( isLoadingExperimentAssignment ) {
+		headerText = translate( 'Security, performance, and marketing tools made for WordPress' );
+	} else if ( 'treatment' === experimentAssignment?.variationName ) {
+		headerText = translate( 'Security, performance, and marketing tools made for WordPress' );
+	} else {
+		headerText = translate( 'Security, performance, and marketing tools made for WordPress' );
+	}
+
+	return (
+		<>
+			<FormattedHeader headerText={ translate( 'Plans' ) } align="left" brandFont />
+			<PlansNavigation path={ '/plans' } />
+			{ shouldShowPlanRecommendation && siteId && (
+				<JetpackPluginUpdateWarning
+					siteId={ siteId }
+					minJetpackVersion={ JETPACK_LEGACY_PLANS_MAX_PLUGIN_VERSION }
+				/>
+			) }
+			{ ! shouldShowPlanRecommendation && (
+				<h2 className="jetpack-plans__pricing-header">{ preventWidows( headerText ) }</h2>
+			) }
+		</>
+	);
+};
 
 const ConnectFlowPlansHeader = () => (
 	<>

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { useExperiment } from 'calypso/lib/explat';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { EXTERNAL_PRODUCTS_LIST } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import {
@@ -37,6 +38,9 @@ import type {
 
 import './style.scss';
 
+import debugFactory from 'debug';
+const debug = debugFactory( 'calypso:plans:abtesting' );
+
 const SelectorPage: React.FC< SelectorPageProps > = ( {
 	defaultDuration = TERM_ANNUALLY,
 	siteSlug: siteSlugProp,
@@ -48,6 +52,23 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	highlightedProducts = [],
 }: SelectorPageProps ) => {
 	const dispatch = useDispatch();
+
+	const [ loadingExperiment, experiment ] = useExperiment( 'jetpack_explat_testing_20210510' );
+	useEffect( () => {
+		if ( loadingExperiment ) {
+			debug( 'Loading experiment ...' );
+			return;
+		}
+
+		if ( ! experiment ) {
+			debug( 'ERROR CONDITION: Experiment not loading, but no information found.' );
+			return;
+		}
+
+		debug( 'Experiment loaded!' );
+		debug( 'Experiment name:', experiment.experimentName );
+		debug( 'Assigned variation:', experiment.variationName );
+	}, [ loadingExperiment, experiment ] );
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlugState = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a simple A/A test to the Jetpack pricing page to test usage of the new ExPlat system.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. In Calypso select a Jetpack site and visit `/plans/quaint-lemming.jurassic.ninja` while assigned to both treatment and control, and verify that you see the same header for both.
2. In Jetpack Cloud visit `/pricing` while assigned to both treatment and control and verify that you see the same header for both.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
