### PR TITLE
ci: Adds missing libgbm-dev dependency (#50694)

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -86,6 +86,7 @@ RUN apt update \
 		libatk-bridge2.0-0 \
 		libatspi2.0-0 \
 		libgtk-3-0 \
+		libgbm-dev \
 		libnspr4 \
 		libnss3 \
 		libnss3 \


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds missing `libgbm-dev ` dependency, required to run electron (Desktop e2e tests).

Should fix

```
./electron: error while loading shared libraries: libgbm.so.1: cannot open shared object file: No such file or directory
```
