### PR TITLE
Gutenberg: Fix E2E suite against v10.3.0

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -241,8 +241,10 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 			this.driver,
 			By.css( '.edit-post-post-schedule__toggle' )
 		);
+		await this.driver.sleep( 400 ); // Wait for the calendar popup animation
 		// schedulePost post for the first day of the next month
 		await driverHelper.clickWhenClickable( this.driver, nextMonthSelector );
+		await this.driver.sleep( 400 ); // Wait for the month slide animation
 		await driverHelper.selectElementByText( this.driver, firstDay, '1' );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, publishDateSelector );
 		const publishDate = await this.driver.findElement( publishDateSelector ).getText();

--- a/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -246,6 +246,11 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 		await driverHelper.clickWhenClickable( this.driver, nextMonthSelector );
 		await this.driver.sleep( 400 ); // Wait for the month slide animation
 		await driverHelper.selectElementByText( this.driver, firstDay, '1' );
+		// Add another click so the calendar modal disappears and makes space for
+		// the follow-up clicks. This is because of a bug reported in
+		// https://github.com/WordPress/gutenberg/issues/30415 and can be reverted
+		// once an upstream fix is in.
+		await driverHelper.selectElementByText( this.driver, firstDay, '1' );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, publishDateSelector );
 		const publishDate = await this.driver.findElement( publishDateSelector ).getText();
 


### PR DESCRIPTION
Tracking issue: https://github.com/Automattic/wp-calypso/issues/51161.

#### Changes proposed in this pull request

- Make post schedule calendar interaction not flaky
- Add an extra click so that the calendar closes on blur (This can be reverted once WordPress/gutenberg#30415 is fixed)