### PR TITLE
Checkout: Update redirect processor to use explicit error handling

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-line no-restricted-imports
-import { defaultRegistry, makeRedirectResponse } from '@automattic/composite-checkout';
+import {
+	defaultRegistry,
+	makeRedirectResponse,
+	makeErrorResponse,
+} from '@automattic/composite-checkout';
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 
 /**
@@ -95,14 +99,14 @@ export default async function genericRedirectProcessor(
 		transactionOptions
 	);
 
-	return submitWpcomTransaction( formattedTransactionData, transactionOptions ).then(
-		( response?: WPCOMTransactionEndpointResponse ) => {
+	return submitWpcomTransaction( formattedTransactionData, transactionOptions )
+		.then( ( response?: WPCOMTransactionEndpointResponse ) => {
 			if ( ! response?.redirect_url ) {
 				throw new Error( 'Error during transaction' );
 			}
 			return makeRedirectResponse( response?.redirect_url );
-		}
-	);
+		} )
+		.catch( ( error ) => makeErrorResponse( error.message ) );
 }
 
 function isValidTransactionData( submitData: unknown ): submitData is RedirectTransactionRequest {

--- a/client/my-sites/checkout/composite-checkout/lib/prepare-redirect-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/prepare-redirect-transaction.ts
@@ -24,7 +24,7 @@ type SubmitRedirectTransactionData = Omit<
 	'paymentMethodType' | 'paymentPartnerProcessorId' | 'cart'
 >;
 
-export default async function prepareRedirectTransaction(
+export default function prepareRedirectTransaction(
 	paymentMethodId: string,
 	transactionData: SubmitRedirectTransactionData,
 	transactionOptions: PaymentProcessorOptions

--- a/client/my-sites/checkout/composite-checkout/lib/prepare-redirect-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/prepare-redirect-transaction.ts
@@ -6,7 +6,6 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import submitWpcomTransaction from './submit-wpcom-transaction';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from './translate-payment-method-names';
 import {
 	createTransactionEndpointRequestPayload,
@@ -15,7 +14,7 @@ import {
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type {
 	TransactionRequest,
-	WPCOMTransactionEndpointResponse,
+	WPCOMTransactionEndpointRequestPayload,
 } from '../types/transaction-endpoint';
 
 const debug = debugFactory( 'calypso:composite-checkout:submit-redirect-transaction' );
@@ -25,11 +24,11 @@ type SubmitRedirectTransactionData = Omit<
 	'paymentMethodType' | 'paymentPartnerProcessorId' | 'cart'
 >;
 
-export default async function submitRedirectTransaction(
+export default async function prepareRedirectTransaction(
 	paymentMethodId: string,
 	transactionData: SubmitRedirectTransactionData,
 	transactionOptions: PaymentProcessorOptions
-): Promise< WPCOMTransactionEndpointResponse > {
+): WPCOMTransactionEndpointRequestPayload {
 	const paymentMethodType = translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId );
 	if ( ! paymentMethodType ) {
 		throw new Error( `No payment method found for type: ${ paymentMethodId }` );
@@ -45,5 +44,5 @@ export default async function submitRedirectTransaction(
 		paymentPartnerProcessorId: transactionOptions.stripeConfiguration?.processor_id,
 	} );
 	debug( `sending redirect transaction for type: ${ paymentMethodId }`, formattedTransactionData );
-	return submitWpcomTransaction( formattedTransactionData, transactionOptions );
+	return formattedTransactionData;
 }

--- a/client/my-sites/checkout/composite-checkout/lib/we-chat-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/we-chat-processor.ts
@@ -5,6 +5,7 @@ import {
 	defaultRegistry,
 	makeRedirectResponse,
 	makeManualResponse,
+	makeErrorResponse,
 } from '@automattic/composite-checkout';
 import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-line no-restricted-imports
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
@@ -98,16 +99,16 @@ export default async function weChatProcessor(
 		options
 	);
 
-	return submitWpcomTransaction( formattedTransactionData, options ).then(
-		( response?: WPCOMTransactionEndpointResponse ) => {
+	return submitWpcomTransaction( formattedTransactionData, options )
+		.then( ( response?: WPCOMTransactionEndpointResponse ) => {
 			// The WeChat payment type should only redirect when on mobile as redirect urls
 			// are mobile app urls: e.g. weixin://wxpay/bizpayurl?pr=RaXzhu4
 			if ( userAgent.isMobile && response?.redirect_url ) {
 				return makeRedirectResponse( response?.redirect_url );
 			}
 			return makeManualResponse( response );
-		}
-	);
+		} )
+		.catch( ( error ) => makeErrorResponse( error.message ) );
 }
 
 function isValidTransactionData( submitData: unknown ): submitData is WeChatTransactionRequest {

--- a/client/my-sites/checkout/composite-checkout/lib/we-chat-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/we-chat-processor.ts
@@ -16,7 +16,8 @@ import userAgent from 'calypso/lib/user-agent';
 import getPostalCode from '../lib/get-postal-code';
 import getDomainDetails from '../lib/get-domain-details';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
-import submitRedirectTransaction from '../lib/submit-redirect-transaction';
+import prepareRedirectTransaction from '../lib/prepare-redirect-transaction';
+import submitWpcomTransaction from './submit-wpcom-transaction';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type { ManagedContactDetails } from '../types/wpcom-store-state';
 import type { WPCOMTransactionEndpointResponse } from '../types/transaction-endpoint';
@@ -80,7 +81,7 @@ export default async function weChatProcessor(
 		'wpcom'
 	)?.getContactInfo();
 
-	return submitRedirectTransaction(
+	const formattedTransactionData = prepareRedirectTransaction(
 		paymentMethodId,
 		{
 			...submitData,
@@ -95,14 +96,18 @@ export default async function weChatProcessor(
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 		},
 		options
-	).then( ( response?: WPCOMTransactionEndpointResponse ) => {
-		// The WeChat payment type should only redirect when on mobile as redirect urls
-		// are mobile app urls: e.g. weixin://wxpay/bizpayurl?pr=RaXzhu4
-		if ( userAgent.isMobile && response?.redirect_url ) {
-			return makeRedirectResponse( response?.redirect_url );
+	);
+
+	return submitWpcomTransaction( formattedTransactionData, options ).then(
+		( response?: WPCOMTransactionEndpointResponse ) => {
+			// The WeChat payment type should only redirect when on mobile as redirect urls
+			// are mobile app urls: e.g. weixin://wxpay/bizpayurl?pr=RaXzhu4
+			if ( userAgent.isMobile && response?.redirect_url ) {
+				return makeRedirectResponse( response?.redirect_url );
+			}
+			return makeManualResponse( response );
 		}
-		return makeManualResponse( response );
-	} );
+	);
 }
 
 function isValidTransactionData( submitData: unknown ): submitData is WeChatTransactionRequest {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently payment processor functions have implicit error handling; if they throw an Error during their run, it's assumed that the error is a response from the payment processing service. The error is displayed to the user and that's it. If the error is a bug in the code, however, then the error needs to be reported to our dev teams, which will only happen if a React error boundary is hit. In order for this to work, we need to differentiate between "expected" errors (errors from the payment service) and "unexpected" errors (errors in the code that prepares the transaction data). To that end I've added a new explicit "error" response type for payment processors that can be used for expected errors. Once this has been added to all processors we can make the remaining errors trigger the error boundaries, which is prepared in https://github.com/Automattic/wp-calypso/pull/51427

This PR adds the explicit error response type to the redirect processors: Stripe redirect and WeChat Pay.

#### Testing instructions

There are two things to test: the regular Stripe redirects, and the WeChat Pay mobile redirects.

- Apply D45443-code to your sandbox to force Bancontact to be available.
- Set your user currency to EUR.
- Make a new purchase in checkout and select Bancontact as the payment method, entering any string in the "name" field.
- Verify that you are redirected to the Stripe test page, that it reads "Bancontact", and that the total is correct. (No need to complete the payment.)
- Set your user currency to USD.
- Apply D45650-code to your sandbox to force WeChat to be available.
- Apply https://gist.github.com/sirbrillig/17fc953647b2df974e8d975a5d4e160a to calypso to force the mobile-only redirect to run.
- Make a new purchase in checkout and select WeChat as the payment method, entering any string in the "name" field.
- Verify that you are redirected to the Stripe test page, that it reads "WeChat Pay", and that the total is correct. (No need to complete the payment.)