### PR TITLE
Checkout: Modify PayPal payment processor to use explicit error handling

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { makeRedirectResponse } from '@automattic/composite-checkout';
+import { makeRedirectResponse, makeErrorResponse } from '@automattic/composite-checkout';
 import { format as formatUrl, parse as parseUrl, resolve as resolveUrl } from 'url'; // eslint-disable-line no-restricted-imports
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import type { ResponseCart } from '@automattic/shopping-cart';
@@ -58,9 +58,9 @@ export default async function payPalProcessor(
 		domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ) || null,
 	} );
 	debug( 'sending paypal transaction', formattedTransactionData );
-	return wpcomPayPalExpress( formattedTransactionData, transactionOptions ).then(
-		makeRedirectResponse
-	);
+	return wpcomPayPalExpress( formattedTransactionData, transactionOptions )
+		.then( makeRedirectResponse )
+		.catch( ( error ) => makeErrorResponse( error.message ) );
 }
 
 async function wpcomPayPalExpress(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently payment processor functions have implicit error handling; if they throw an Error during their run, it's assumed that the error is a response from the payment processing service. The error is displayed to the user and that's it. If the error is a bug in the code, however, then the error needs to be reported to our dev teams, which will only happen if a React error boundary is hit. In order for this to work, we need to differentiate between "expected" errors (errors from the payment service) and "unexpected" errors (errors in the code that prepares the transaction data). To that end I've added a new explicit "error" response type for payment processors that can be used for expected errors. Once this has been added to all processors we can make the remaining errors trigger the error boundaries, which is prepared in #51427

This PR adds the explicit error response type to the PayPal Express processor.
#### Testing instructions

Complete a purchase using PayPal and verify that it works as expected.