### PR TITLE
Add insert_method prop to block insertion track events

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -24,10 +24,9 @@ const noop = () => {};
  * to get specific data and populate the record.
  *
  * @param {object} block - Block object data.
- * @param {object} parentBlock - Block object data.
  * @returns {object} Record properties object.
  */
-function globalEventPropsHandler( block, parentBlock ) {
+function globalEventPropsHandler( block ) {
 	if ( ! block?.name ) {
 		return {};
 	}
@@ -155,7 +154,7 @@ function trackBlocksHandler( blocks, eventName, propertiesHandler = noop, parent
 		block = ensureBlockObject( block );
 
 		const eventProperties = {
-			...globalEventPropsHandler( block, parentBlock ),
+			...globalEventPropsHandler( block ),
 			...propertiesHandler( block, parentBlock ),
 			inner_block: !! parentBlock,
 		};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Takes a guess at which block insertion/replacement method was used by
inspecting the current state of Redux and the DOM when the
`insertBlock(s)` and `replaceBlock(s)` actions are fired on
`core/block-editor`.

Adds the `insert_method` prop to two existing tracks events:
- `wpcom_block_inserted`, when a block is inserted
- `wpcom_block_picker_block_inserted`, when a block is replaced

The prop can take the following values:
- `header-inserter`
- `slash-inserter`
- `quick-inserter`
- `block-switcher`
- or undefined

Undefined is used when we don't know what method was used. It could have
been the page layout picker, or it could have been pressing "return" at
the end of a paragraph block.

The method used here to guess which inserter was used is a bit flacky and will need e2e tests to make sure we catch when this breaks in future versions of gutenberg. But we can't merge those tests until this has been deployed (e2e tests always run against the production version of `wpcom-block-editor`

(also removing unused `parentBlock` variable because linter check was failing)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `widgets.wp.com` in your host file
* Run `install-plugin.sh wpcom-block-editor add/track-block-insertion-method` in your sandbox
* Open the block editor in a browser, filter the network tool by `wpcom_block_inserted`
* Add blocks using various methods and check that the tracks events look correct (have the correct `insert_method` prop)
* Filter the network tool by `wpcom_block_picker_block_inserted` and test the same thing

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #50426
