### PR TITLE
ETK: Add permission_callback for the sideload images batch endpoint

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-wp-rest-sideload-image-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-wp-rest-sideload-image-controller.php
@@ -46,10 +46,11 @@ class WP_REST_Sideload_Image_Controller extends \WP_REST_Attachments_Controller 
 			'/' . $this->rest_base . '/batch',
 			array(
 				array(
-					'methods'       => \WP_REST_Server::CREATABLE,
-					'callback'      => array( $this, 'create_items' ),
-					'show_in_index' => false,
-					'args'          => array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_items' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'show_in_index'       => false,
+					'args'                => array(
 						'resources' => array(
 							'description' => 'URL to the image to be side-loaded.',
 							'type'        => 'array',


### PR DESCRIPTION
This is a small change to fix a PHP notice for an API endpoint that used to be used in the v1 of full site editing on wpcom for the page layout picker. I believe the endpoint is no longer in use, but before we remove it (as that'd be a bigger discussion), let's fix the PHP notice.

#### Changes proposed in this Pull Request

* Add `permission_callback` for the existing (though possibly no longer used) `sideload/image/batch` API endpoint to silence the PHP notices warning that it doesn't have a permission callback.

The method ends up just batching requests to the other endpoint (`sideload/image`) so a permission callback is still ultimately run for each request, this change just ensures that it happens up-front and removes the warning

#### Screenshots

While running a local development environment with `WP_DEBUG_DISPLAY` set to `true` I see the following notices when loading the post editor:

![image](https://user-images.githubusercontent.com/14988353/112942635-27860980-917c-11eb-9aa6-cdd172ae5c6b.png)

After this change, the notice about this endpoint should be removed. I now just see one other notice (not covered in this PR):

![image](https://user-images.githubusercontent.com/14988353/112942685-3a004300-917c-11eb-9ff4-f39d9e7e912b.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

With this change applied, and running a development environment with `WP_DEBUG_DISPLAY` set to `true`, you should no longer see the PHP notice about a missing `permission_callback` when opening up the post editor.

Test for regressions:

I wasn't able to test this endpoint in wpcom (possibly it isn't working there?), so the easiest way I could find to test this (also because we don't have any code calling it) is to run the ETK plugin in a local dev environment via a8c-wp-env

* Check out this branch and run it locally in `a8c-wp-env`
* Open up the post editor and enter the following in your browser's dev console to side load a single image into your site:

```
wp.apiFetch( { path: '/fse/v1/sideload/image?url=https://s.w.org/style/images/about/WordPress-logotype-standard-white.png,', method: 'POST', data: '' } );
```

* Go check your media library, and you should see the single WordPress image in the library
* Repeat the above steps but enter the following instead, to load multiple images into the library (the `sideload/image/batch` endpoint):

```
wp.apiFetch( { path: '/fse/v1/sideload/image/batch?resources[0][url]=https://s.w.org/style/images/about/WordPress-logotype-standard-white.png&resources[1][url]=https://i1.wp.com/s1.wp.com/wp-content/themes/h4/landing/marketing/pages/hp-jan-2020-v2/media/desktop/domains-img-2x.jpg', method: 'POST', data: '' } );
```

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
