### PR TITLE
Notice: Do not set gridicon background color

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -22,10 +22,6 @@
 		margin-bottom: 24px;
 	}
 
-	.gridicon {
-		fill: var( --color-neutral-80 );
-	}
-
 	// Success!
 	&.is-success {
 		.notice__icon-wrapper {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reverts a style change introduced here https://github.com/Automattic/wp-calypso/pull/51455 (to fix this issue https://github.com/Automattic/wp-calypso/issues/49148) since this PR affects the `<Notice />` component in other contexts.

#### Testing instructions

* Che the following issues have been fixed on this branch

before | after
-----|-------
![image](https://user-images.githubusercontent.com/77539/112975397-f41a8f00-9129-11eb-918a-eb7135579bb7.png) | ![image](https://user-images.githubusercontent.com/77539/112975405-f8df4300-9129-11eb-9fab-a2d6fb5d986b.png)
![image](https://user-images.githubusercontent.com/77539/112975459-0f859a00-912a-11eb-8099-07e9f052d9d2.png) | ![image](https://user-images.githubusercontent.com/77539/112975489-1a402f00-912a-11eb-9df6-6da6ea334eea.png)

