### PR TITLE
Framework: Refactor away from `_.every()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -398,6 +398,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/drop-right': 'error',
 		'you-dont-need-lodash-underscore/ends-with': 'error',
 		'you-dont-need-lodash-underscore/entries': 'error',
+		'you-dont-need-lodash-underscore/every': 'error',
 		'you-dont-need-lodash-underscore/extend-own': 'error',
 		'you-dont-need-lodash-underscore/fill': 'error',
 		'you-dont-need-lodash-underscore/foldl': 'error',

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -7,7 +7,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { every, includes, keys, reduce, some } from 'lodash';
+import { includes, keys, reduce, some } from 'lodash';
 import store from 'store';
 import { getLocaleSlug } from 'i18n-calypso';
 
@@ -134,7 +134,7 @@ ABTest.prototype.init = function ( name, geoLocation ) {
 			this.localeTargets = false;
 		} else if (
 			Array.isArray( testConfig.localeTargets ) &&
-			every( testConfig.localeTargets, langSlugIsValid )
+			testConfig.localeTargets.every( langSlugIsValid )
 		) {
 			// Allow specific locales.
 			this.localeTargets = testConfig.localeTargets;
@@ -149,7 +149,7 @@ ABTest.prototype.init = function ( name, geoLocation ) {
 	if (
 		testConfig.localeExceptions &&
 		Array.isArray( testConfig.localeExceptions ) &&
-		every( testConfig.localeExceptions, langSlugIsValid )
+		testConfig.localeExceptions.every( langSlugIsValid )
 	) {
 		this.localeExceptions = testConfig.localeExceptions;
 	}

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -5,7 +5,6 @@ import {
 	assign,
 	camelCase,
 	debounce,
-	every,
 	filter,
 	flatten,
 	isEmpty,
@@ -304,7 +303,7 @@ function isInitialized( field ) {
 }
 
 function isEveryFieldInitialized( formState ) {
-	return every( formState, isInitialized );
+	return Object.values( formState ).every( isInitialized );
 }
 
 function isFieldInvalid( formState, fieldName ) {
@@ -337,7 +336,7 @@ function getErrorMessages( formState ) {
 }
 
 function isSubmitButtonDisabled( formState ) {
-	return ! every( formState, isInitialized );
+	return ! Object.values( formState ).every( isInitialized );
 }
 
 function isFieldDisabled( formState, fieldName ) {

--- a/client/lib/query-manager/media/index.js
+++ b/client/lib/query-manager/media/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import moment from 'moment';
-import { every, includes } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,7 +27,7 @@ export default class MediaQueryManager extends PaginatedQueryManager {
 	 * @returns {boolean}       Whether media item matches query
 	 */
 	static matches( query, media ) {
-		return every( { ...this.DefaultQuery, ...query }, ( value, key ) => {
+		return Object.entries( { ...this.DefaultQuery, ...query } ).every( ( [ key, value ] ) => {
 			switch ( key ) {
 				case 'search':
 					if ( ! value ) {
@@ -67,10 +67,11 @@ export default class MediaQueryManager extends PaginatedQueryManager {
 					return value === media.post_ID;
 
 				case 'after':
-				case 'before':
+				case 'before': {
 					const queryDate = moment( value, moment.ISO_8601 );
 					const comparison = /after$/.test( key ) ? 'isAfter' : 'isBefore';
 					return queryDate.isValid() && moment( media.date )[ comparison ]( queryDate );
+				}
 			}
 
 			return true;

--- a/client/lib/query-manager/post/index.js
+++ b/client/lib/query-manager/post/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import moment from 'moment';
-import { every, some, includes, get } from 'lodash';
+import { some, includes, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,9 +27,9 @@ export default class PostQueryManager extends PaginatedQueryManager {
 	 */
 	static matches( query, post ) {
 		const queryWithDefaults = Object.assign( {}, this.DefaultQuery, query );
-		return every( queryWithDefaults, ( value, key ) => {
+		return Object.entries( queryWithDefaults ).every( ( [ key, value ] ) => {
 			switch ( key ) {
-				case 'search':
+				case 'search': {
 					if ( ! value ) {
 						return true;
 					}
@@ -39,6 +39,7 @@ export default class PostQueryManager extends PaginatedQueryManager {
 						( post.title && includes( post.title.toLowerCase(), search ) ) ||
 						( post.content && includes( post.content.toLowerCase(), search ) )
 					);
+				}
 
 				case 'after':
 				case 'before':
@@ -51,7 +52,7 @@ export default class PostQueryManager extends PaginatedQueryManager {
 				}
 
 				case 'term':
-					return every( value, ( slugs, taxonomy ) => {
+					return Object.entries( value ).every( ( [ taxonomy, slugs ] ) => {
 						slugs = slugs.split( ',' );
 						return some( post.terms[ taxonomy ], ( { slug } ) => includes( slugs, slug ) );
 					} );

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import _debug from 'debug';
-import { intersection, map, every, find, get } from 'lodash';
+import { intersection, map, find, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -207,7 +207,7 @@ export class DomainWarnings extends React.PureComponent {
 					) ) }
 				</ul>
 			);
-			if ( every( map( wrongMappedDomains, 'name' ), isSubdomain ) ) {
+			if ( map( wrongMappedDomains, 'name' ).every( isSubdomain ) ) {
 				text = translate( "Some of your domains' DNS records need to be configured.", {
 					context: 'Notice for mapped subdomain that has DNS records need to set up',
 				} );

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -48,7 +48,6 @@ class MediaModalSecondaryActions extends Component {
 		const canDeleteItems =
 			selectedItems.length &&
 			selectedItems.every( ( item ) => canUserDeleteItem( item, user, site ) );
-
 		if ( canDeleteItems ) {
 			const isButtonDisabled = selectedItems.some( ( item ) => item.transient );
 			buttons.push( {

--- a/client/state/domains/dns/test/utils.js
+++ b/client/state/domains/dns/test/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, isEmpty, values } from 'lodash';
+import { isEmpty, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ describe( 'utils', () => {
 
 			const errors = validateAllFields( initialData );
 
-			expect( every( values( errors ), isEmpty ) ).toBe( true );
+			expect( values( errors ).every( isEmpty ) ).toBe( true );
 		} );
 	} );
 } );

--- a/client/state/imports/site-importer/actions.js
+++ b/client/state/imports/site-importer/actions.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { stringify } from 'qs';
-import { every, get } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -93,9 +93,8 @@ export const startMappingSiteImporterAuthors = ( { importerStatus, site, targetS
 
 		// Check if all authors are mapped before starting the import.
 		const newState = getImporterStatus( getState(), importerId );
-		const areAllAuthorsMapped = every(
-			get( newState, 'customData.sourceAuthors', [] ),
-			'mappedTo'
+		const areAllAuthorsMapped = get( newState, 'customData.sourceAuthors', [] ).every(
+			( { mappedTo } ) => mappedTo
 		);
 
 		if ( areAllAuthorsMapped ) {

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, filter, find, get, pick, reduce, some, sortBy, values } from 'lodash';
+import { filter, find, get, pick, reduce, some, sortBy, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -148,7 +148,7 @@ export function getSitesWithoutPlugin( state, siteIds, pluginSlug ) {
 			return false;
 		}
 
-		return every( installedOnSiteIds, function ( installedOnSiteId ) {
+		return installedOnSiteIds.every( function ( installedOnSiteId ) {
 			return installedOnSiteId !== siteId;
 		} );
 	} );

--- a/client/state/plugins/premium/selectors.js
+++ b/client/state/plugins/premium/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, filter, find, get, includes, some } from 'lodash';
+import { filter, find, get, includes, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -57,7 +57,7 @@ export const getPluginsForSite = function ( state, siteId, forPlugin = false ) {
 
 export const isStarted = function ( state, siteId, forPlugin = false ) {
 	const pluginList = getPluginsForSite( state, siteId, forPlugin );
-	return ! every( pluginList, ( item ) => {
+	return ! pluginList.every( ( item ) => {
 		return 'wait' === item.status;
 	} );
 };

--- a/client/state/posts/utils/index.js
+++ b/client/state/posts/utils/index.js
@@ -14,10 +14,7 @@ export { isDiscussionEqual } from 'calypso/state/posts/utils/is-discussion-equal
 export { isStatusEqual } from 'calypso/state/posts/utils/is-state-equal';
 export { isTermsEqual } from 'calypso/state/posts/utils/is-terms-equal';
 export { mergePostEdits } from 'calypso/state/posts/utils/merge-post-edits';
-export {
-	areAllMetadataEditsApplied,
-	getUnappliedMetadataEdits,
-} from 'calypso/state/posts/utils/metadata-edits';
+export { getUnappliedMetadataEdits } from 'calypso/state/posts/utils/metadata-edits';
 export { normalizePostForApi } from 'calypso/state/posts/utils/normalize-post-for-api';
 export { normalizePostForDisplay } from 'calypso/state/posts/utils/normalize-post-for-display';
 export { normalizePostForEditing } from 'calypso/state/posts/utils/normalize-post-for-editing';

--- a/client/state/posts/utils/is-discussion-equal.js
+++ b/client/state/posts/utils/is-discussion-equal.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, every } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Returns true if the modified properties in the local edit of the `discussion` object (the edited
@@ -12,5 +12,7 @@ import { get, every } from 'lodash';
  * @returns {boolean}                      are there differences in local edits vs saved values?
  */
 export function isDiscussionEqual( localDiscussionEdits, savedDiscussion ) {
-	return every( localDiscussionEdits, ( value, key ) => get( savedDiscussion, [ key ] ) === value );
+	return Object.entries( localDiscussionEdits ).every(
+		( [ key, value ] ) => get( savedDiscussion, [ key ] ) === value
+	);
 }

--- a/client/state/posts/utils/is-terms-equal.js
+++ b/client/state/posts/utils/is-terms-equal.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, isPlainObject, map, toArray, xor } from 'lodash';
+import { isPlainObject, map, toArray, xor } from 'lodash';
 
 /**
  * Returns truthy if local terms object is the same as the API response
@@ -11,7 +11,7 @@ import { every, isPlainObject, map, toArray, xor } from 'lodash';
  * @returns {boolean}                are there differences in local edits vs saved terms
  */
 export function isTermsEqual( localTermEdits, savedTerms ) {
-	return every( localTermEdits, ( terms, taxonomy ) => {
+	return Object.entries( localTermEdits ).every( ( [ taxonomy, terms ] ) => {
 		const termsArray = toArray( terms );
 		const isHierarchical = isPlainObject( termsArray[ 0 ] );
 		const normalizedEditedTerms = isHierarchical ? map( termsArray, 'ID' ) : termsArray;

--- a/client/state/posts/utils/metadata-edits.js
+++ b/client/state/posts/utils/metadata-edits.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, filter, find } from 'lodash';
+import { filter, find } from 'lodash';
 
 function isUnappliedMetadataEdit( edit, savedMetadata ) {
 	const savedRecord = find( savedMetadata, { key: edit.key } );
@@ -26,8 +26,4 @@ function isUnappliedMetadataEdit( edit, savedMetadata ) {
  */
 export function getUnappliedMetadataEdits( edits, savedMetadata ) {
 	return filter( edits, ( edit ) => isUnappliedMetadataEdit( edit, savedMetadata ) );
-}
-
-export function areAllMetadataEditsApplied( edits, savedMetadata ) {
-	return every( edits, ( edit ) => ! isUnappliedMetadataEdit( edit, savedMetadata ) );
 }

--- a/client/state/posts/utils/normalize-terms-for-api.js
+++ b/client/state/posts/utils/normalize-terms-for-api.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, pickBy } from 'lodash';
+import { pickBy } from 'lodash';
 
 /**
  * Returns a normalized post terms object for sending to the API
@@ -17,7 +17,7 @@ export function normalizeTermsForApi( post ) {
 	return {
 		...post,
 		terms: pickBy( post.terms, ( terms ) => {
-			return terms.length && every( terms, ( term ) => typeof term === 'string' );
+			return terms.length && terms.every( ( term ) => typeof term === 'string' );
 		} ),
 	};
 }

--- a/client/state/sites/selectors/verify-jetpack-modules-active.js
+++ b/client/state/sites/selectors/verify-jetpack-modules-active.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { every } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import isJetpackModuleActive from './is-jetpack-module-active';
@@ -27,5 +22,5 @@ export default function verifyJetpackModulesActive( state, siteId, moduleIds ) {
 		moduleIds = [ moduleIds ];
 	}
 
-	return every( moduleIds, ( moduleId ) => isJetpackModuleActive( state, siteId, moduleId ) );
+	return moduleIds.every( ( moduleId ) => isJetpackModuleActive( state, siteId, moduleId ) );
 }

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-
-import { every, get, includes, map, mapKeys, omit, omitBy, some, startsWith } from 'lodash';
+import { get, includes, map, mapKeys, omit, omitBy, some, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -196,7 +195,7 @@ export function getSerializedThemesQueryWithoutPage( query, siteId ) {
  */
 export function isThemeMatchingQuery( query, theme ) {
 	const queryWithDefaults = { ...DEFAULT_THEME_QUERY, ...query };
-	return every( queryWithDefaults, ( value, key ) => {
+	return Object.entries( queryWithDefaults ).every( ( [ key, value ] ) => {
 		switch ( key ) {
 			case 'search': {
 				if ( ! value ) {
@@ -231,7 +230,7 @@ export function isThemeMatchingQuery( query, theme ) {
 				// TODO: Change filters object shape to be more like post's terms, i.e.
 				// { color: 'blue,red', feature: 'post-slider' }
 				const filters = value.split( ',' );
-				return every( filters, ( f ) =>
+				return filters.every( ( f ) =>
 					some( theme.taxonomies, ( terms ) => some( terms, { slug: f } ) )
 				);
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `every` is essentially fully natively supported by the native `Array.prototype.every()`. An exception to that rule is that Lodash's `every` supports objects, too - for those instances, we convert to an array first using `Object.entries()`. This PR replaces all the `_.every()` usage and adds an ESLint rule to warn against using it from Lodash.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all usages are sane and preserve the original logic.
* Try to `import { every } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass - most of the code is covered by tests.