### PR TITLE
Tests: Set default timezone for Moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
 		"start-build-web-if-fallback": "node -e \"process.env.DEV_TARGET === 'fallback' && process.exit(1)\" || yarn run start-build-fallback",
 		"start-build-web-if-evergreen": "node -e \"(! process.env.DEV_TARGET || process.env.DEV_TARGET === 'evergreen') && process.exit(1)\" || yarn run start-build-evergreen",
 		"test": "run-s -s test-client test-packages test-server test-build-tools",
-		"test-client": "jest -c=test/client/jest.config.js",
+		"test-client": "TZ=UTC jest -c=test/client/jest.config.js",
 		"test-client:watch": "yarn run -s test-client --watch",
 		"test-e2e": "cd test/e2e && yarn install --frozen-lockfile --ignore-scripts && yarn run test",
 		"encrypt-e2e-config": "openssl enc -md sha1 -aes-256-cbc -pass env:CONFIG_KEY -out ./test/e2e/config/encrypted.enc -in ./test/e2e/config/local-$NODE_ENV.json",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, we don't set a default timezone for Moment, and because of that, tests that rely on time precision can be flaky.

To reproduce such a flaky test, set your system timezone to UTC+3, UTC+4 or even further in the future. Then run `yarn run test-client lib/purchases/test/index.js` and you'll see a purchases test fail. 

This PR sets a default timezone for Moment for client tests, so this flakiness will no longer occur and Moment will work consistently.

#### Testing instructions

* Set your system timezone to UTC+3
* Run `yarn run test-client lib/purchases/test/index.js`
* Verify tests pass.

cc @yuliyan for review since he's already in my timezone 😉 

#### Context

Discovered while working on #51545.