### PR TITLE
build/simplified-rtl-2

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -90,7 +90,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
-		"@automattic/calypso-build": "^7.0.0",
+		"@automattic/calypso-build": "^8.0.0",
 		"@automattic/composite-checkout": "^1.0.0",
 		"@automattic/data-stores": "^2.0.0",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -42,7 +42,7 @@
 		"wpcom-proxy-request": "^6.0.0"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^7.0.0",
+		"@automattic/calypso-build": "^8.0.0",
 		"enzyme": "^3.11.0",
 		"html-webpack-plugin": "^5.0.0-beta.4",
 		"webpack": "^5.24.4"

--- a/apps/o2-blocks/package.json
+++ b/apps/o2-blocks/package.json
@@ -22,7 +22,7 @@
 		"build": "BROWSERSLIST_ENV=wpcom calypso-build"
 	},
 	"dependencies": {
-		"@automattic/calypso-build": "^7.0.0",
+		"@automattic/calypso-build": "^8.0.0",
 		"@wordpress/api-fetch": "^3.21.5",
 		"@wordpress/base-styles": "^3.3.3",
 		"@wordpress/block-editor": "^5.2.10",

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -50,7 +50,7 @@
 		"tinymce": "^4.9.6"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^7.0.0",
+		"@automattic/calypso-build": "^8.0.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^3.0.1",
 		"enzyme": "^3.11.0",
 		"npm-run-all": "^4.1.5"

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
 		"@automattic/accessible-focus": "^1.0.0-alpha.0",
 		"@automattic/browser-data-collector": "^0.0.1",
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
-		"@automattic/calypso-build": "^7.0.0",
+		"@automattic/calypso-build": "^8.0.0",
 		"@automattic/calypso-color-schemes": "^2.1.1",
 		"@automattic/calypso-config": "^1.0.0-alpha.0",
 		"@automattic/calypso-polyfills": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
 	"dependencies": {
 		"@automattic/babel-plugin-i18n-calypso": "^1.2.0",
 		"@automattic/babel-plugin-transform-wpcalypso-async": "^1.0.1",
-		"@automattic/calypso-build": "^7.0.0",
+		"@automattic/calypso-build": "^8.0.0",
 		"@automattic/calypso-color-schemes": "^2.1.1",
 		"@automattic/calypso-doctor": "^0.1.0",
 		"@automattic/calypso-polyfills": "^1.0.0",

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -2,14 +2,21 @@
 
 ## trunk
 
+## 8.0.0
+
 - Breaking: Drop option `postCssConfig` for Sass loader. The property `postCssOptions` will be passed as is
   to `postcss-loader`. See the doc in <https://github.com/webpack-contrib/postcss-loader#postcssoptions>
 - Breaking: `calypso-build`, `transpile` and `webpack/minify` won't set `defaults` as browserslist environment anymore.
   Instead they will fallback to the [default resolution methods from browserslist](https://github.com/browserslist/browserslist#queries)
-- Added: peer dependency postcss ^8.2.6
+- Breaking: `webpack/minify` API has changed. Now it only accepts 4 options: `terserOptions`, `cssMinimizerOptions`, `parallel` and `extractComments`.
+- Added: `webpack/minify` will use CssMinimizerWebpackPlugin to minimize CSS files.
+- Added dependencies:
+  - css-minimizer-webpack-plugin ^1.3.0
+  - postcss ^8.2.6 (peer dependency)
 - Updated dependencies:
   - postcss-custom-properties to ^11.0.0
   - postcss-loader to ^5.0.0
+  - @automattic/webpack-rtl-plugin to ^5.0.0
 
 ## 7.0.0
 

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "7.0.0",
+	"version": "8.0.0",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"babel",
@@ -34,7 +34,7 @@
 		"extends @wordpress/browserslist-config"
 	],
 	"dependencies": {
-		"@automattic/webpack-rtl-plugin": "^4.0.0",
+		"@automattic/webpack-rtl-plugin": "^5.0.0",
 		"@babel/cli": "^7.13.10",
 		"@babel/compat-data": "^7.13.11",
 		"@babel/core": "^7.13.10",
@@ -55,6 +55,7 @@
 		"browserslist": "^4.8.2",
 		"cache-loader": "^4.1.0",
 		"css-loader": "^3.4.2",
+		"css-minimizer-webpack-plugin": "^1.3.0",
 		"duplicate-package-checker-webpack-plugin": "^3.0.0",
 		"enzyme-adapter-react-16": "^1.15.1",
 		"enzyme-to-json": "^3.4.3",

--- a/packages/calypso-build/webpack/minify.js
+++ b/packages/calypso-build/webpack/minify.js
@@ -5,6 +5,7 @@ const TerserPlugin = require( 'terser-webpack-plugin' );
 const browserslist = require( 'browserslist' );
 const babelPlugins = require( '@babel/compat-data/plugins' );
 const semver = require( 'semver' );
+const CssMinimizerPlugin = require( 'css-minimizer-webpack-plugin' );
 
 const supportedBrowsers = browserslist();
 
@@ -103,12 +104,19 @@ function chooseTerserEcmaVersion( browsers ) {
  * Returns an array containing a Terser plugin object to be used in Webpack minification.
  *
  * @see https://github.com/webpack-contrib/terser-webpack-plugin for complete descriptions of options.
- *
- * @param {object} options Options passed to the terser plugin
+ * @param {object} options Options
+ * @param options.terserOptions Options for Terser plugin
+ * @param options.cssMinimizerOptions Options for CSS Minimizer plugin
+ * @param options.extractComments Whether to extract comments into a separate LICENSE file (defaults to true)
+ * @param options.parallel Whether to run minifiers in parallel (defaults to true)
  * @returns {object[]}     Terser plugin object to be used in Webpack minification.
  */
-module.exports = ( options ) => {
-	let terserOptions = options.terserOptions || {};
+module.exports = ( {
+	terserOptions = {},
+	cssMinimizerOptions = {},
+	parallel = true,
+	extractComments = true,
+} = {} ) => {
 	terserOptions = {
 		ecma: chooseTerserEcmaVersion( supportedBrowsers ),
 		ie8: false,
@@ -117,6 +125,13 @@ module.exports = ( options ) => {
 		),
 		...terserOptions,
 	};
+	cssMinimizerOptions = {
+		preset: 'default',
+		...cssMinimizerOptions,
+	};
 
-	return [ new TerserPlugin( { ...options, terserOptions } ) ];
+	return [
+		new TerserPlugin( { parallel, extractComments, terserOptions } ),
+		new CssMinimizerPlugin( { parallel, minimizerOptions: cssMinimizerOptions } ),
+	];
 };

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -48,7 +48,7 @@
 		"react-stripe-elements": "^4.0.2"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^7.0.0",
+		"@automattic/calypso-build": "^8.0.0",
 		"@automattic/calypso-polyfills": "^1.0.0",
 		"@testing-library/jest-dom": "^5.9.0",
 		"@testing-library/react": "^10.0.5",

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -48,7 +48,7 @@
 		"prop-types": "^15.7.2"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^7.0.0",
+		"@automattic/calypso-build": "^8.0.0",
 		"enzyme": "^3.11.0",
 		"jest": "^26.4.0",
 		"react": "^16.12.0",

--- a/packages/webpack-rtl-plugin/CHANGELOG.md
+++ b/packages/webpack-rtl-plugin/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 5.0.0 - 2021-03-26
+
+### Breaking
+
+- Drop support to minimze generated CSS code. Users that still need CSS minification can use [CssMinimizerWebpackPlugin](https://webpack.js.org/plugins/css-minimizer-webpack-plugin)
+- Drop support to customize the filename used to generate RTL files. It will always be `<original-css-filename>.rtl.css`
+
 ## 4.0.0 - 2020-12-11
 
 ### Added

--- a/packages/webpack-rtl-plugin/package.json
+++ b/packages/webpack-rtl-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/webpack-rtl-plugin",
-	"version": "4.0.0",
+	"version": "5.0.0",
 	"description": "Webpack plugin to produce a rtl css bundle.",
 	"main": "src/index.js",
 	"author": "Automattic Inc.",

--- a/packages/webpack-rtl-plugin/src/index.js
+++ b/packages/webpack-rtl-plugin/src/index.js
@@ -1,9 +1,6 @@
 const path = require( 'path' );
-const { createHash } = require( 'crypto' );
 const rtlcss = require( 'rtlcss' );
 const cssDiff = require( '@romainberger/css-diff' );
-const { forEachOfLimit } = require( 'async' );
-const cssnano = require( 'cssnano' );
 const { ConcatSource } = require( 'webpack' ).sources;
 
 const pluginName = 'WebpackRTLPlugin';
@@ -11,7 +8,6 @@ const pluginName = 'WebpackRTLPlugin';
 class WebpackRTLPlugin {
 	constructor( options ) {
 		this.options = {
-			filename: false,
 			options: {},
 			plugins: [],
 			...options,
@@ -20,117 +16,39 @@ class WebpackRTLPlugin {
 
 	apply( compiler ) {
 		compiler.hooks.thisCompilation.tap( pluginName, ( compilation ) => {
-			compilation.hooks.processAssets.tapAsync(
+			compilation.hooks.processAssets.tapPromise(
 				{ name: pluginName, stage: compilation.PROCESS_ASSETS_STAGE_DERIVED },
-				( assets, callback ) => {
-					forEachOfLimit(
-						Array.from( compilation.chunks ),
-						5,
-						( chunk, key, cb ) => {
-							const rtlFiles = [];
-							let cssnanoPromise = Promise.resolve();
-
-							Array.from( chunk.files ).forEach( ( asset ) => {
-								const match = this.options.test
-									? new RegExp( this.options.test ).test( asset )
-									: true;
-
-								if ( path.extname( asset ) !== '.css' ) {
-									return;
+				async ( assets ) =>
+					Promise.all(
+						Object.keys( assets )
+							.filter( ( asset ) => path.extname( asset ) === '.css' )
+							.map( async ( asset ) => {
+								if ( this.options.test ) {
+									const re = new RegExp( this.options.test );
+									if ( ! re.test( asset ) ) {
+										return;
+									}
 								}
 
+								// Extract RTL
 								const baseSource = assets[ asset ].source();
-								let filename;
-								let rtlSource;
-
-								if ( match ) {
-									rtlSource = rtlcss.process(
-										baseSource,
-										this.options.options,
-										this.options.plugins
-									);
-
-									if (
-										this.options.filename instanceof Array &&
-										this.options.filename.length === 2
-									) {
-										filename = asset.replace(
-											this.options.filename[ 0 ],
-											this.options.filename[ 1 ]
-										);
-									} else if ( this.options.filename ) {
-										filename = this.options.filename;
-
-										if ( /\[contenthash]/.test( this.options.filename ) ) {
-											const hash = createHash( 'md5' )
-												.update( rtlSource )
-												.digest( 'hex' )
-												.substr( 0, 10 );
-											filename = filename.replace( '[contenthash]', hash );
-										}
-										if ( /\[id]/.test( this.options.filename ) ) {
-											filename = filename.replace( '[id]', chunk.id );
-										}
-										if ( /\[name]/.test( this.options.filename ) ) {
-											filename = filename.replace( '[name]', chunk.name );
-										}
-										if ( /\[file]/.test( this.options.filename ) ) {
-											filename = filename.replace( '[file]', asset );
-										}
-										if ( /\[filebase]/.test( this.options.filename ) ) {
-											filename = filename.replace( '[filebase]', path.basename( asset ) );
-										}
-										if ( /\[ext]/.test( this.options.filename ) ) {
-											filename = filename.replace( '.[ext]', path.extname( asset ) );
-										}
-									} else {
-										const newFilename = `${ path.basename( asset, '.css' ) }.rtl`;
-										filename = asset.replace( path.basename( asset, '.css' ), newFilename );
-									}
-
-									if ( this.options.diffOnly ) {
-										rtlSource = cssDiff( baseSource, rtlSource );
-									}
+								let rtlSource = rtlcss.process(
+									baseSource,
+									this.options.options,
+									this.options.plugins
+								);
+								if ( this.options.diffOnly ) {
+									rtlSource = cssDiff( baseSource, rtlSource );
 								}
 
-								if ( this.options.minify !== false ) {
-									let nanoOptions = { from: undefined };
-									if ( typeof this.options.minify === 'object' ) {
-										nanoOptions = this.options.minify;
-									}
+								// Compute the filename
+								const baseName = path.basename( asset, '.css' );
+								const filename = asset.replace( baseName, `${ baseName }.rtl` );
 
-									cssnanoPromise = cssnanoPromise.then( () => {
-										let minify = cssnano.process( baseSource, nanoOptions ).then( ( output ) => {
-											assets[ asset ] = new ConcatSource( output.css );
-										} );
-
-										if ( match ) {
-											const rtlMinify = cssnano
-												.process( rtlSource, nanoOptions )
-												.then( ( output ) => {
-													assets[ filename ] = new ConcatSource( output.css );
-													rtlFiles.push( filename );
-												} );
-
-											minify = Promise.all( [ minify, rtlMinify ] );
-										}
-
-										return minify;
-									} );
-								} else if ( match ) {
-									assets[ filename ] = new ConcatSource( rtlSource );
-									rtlFiles.push( filename );
-								}
-							} );
-
-							cssnanoPromise.then( () => {
-								rtlFiles.forEach( ( file ) => chunk.files.add( file ) );
-								cb();
-							} );
-						},
-						callback
-					);
-				}
+								// Save the asset
+								assets[ filename ] = new ConcatSource( rtlSource );
+							} )
+					)
 			);
 		} );
 	}

--- a/packages/webpack-rtl-plugin/test/index.js
+++ b/packages/webpack-rtl-plugin/test/index.js
@@ -35,9 +35,7 @@ const baseConfig = {
 		new MiniCssExtractPlugin( {
 			filename: 'style.css',
 		} ),
-		new WebpackRTLPlugin( {
-			minify: false,
-		} ),
+		new WebpackRTLPlugin(),
 	],
 };
 
@@ -101,7 +99,6 @@ describe( 'Webpack RTL Plugin', () => {
 					} ),
 					new WebpackRTLPlugin( {
 						test: /css\//i,
-						minify: false,
 					} ),
 				],
 			};
@@ -125,185 +122,6 @@ describe( 'Webpack RTL Plugin', () => {
 
 		it( 'should create a two css bundles', () => {
 			expect( fs.existsSync( bundlePath ) ).toBe( true );
-			expect( fs.existsSync( cssBundlePath ) ).toBe( true );
-			expect( fs.existsSync( rtlCssBundlePath ) ).toBe( true );
-		} );
-	} );
-
-	describe( 'Filename options', () => {
-		let cssBundleName;
-		let rtlCssBundleName;
-		let cssBundlePath;
-		let rtlCssBundlePath;
-
-		beforeAll( ( done ) => {
-			const config = {
-				...baseConfig,
-				output: {
-					path: path.resolve( __dirname, 'dist-hash' ),
-					filename: 'bundle.js',
-				},
-				plugins: [
-					new MiniCssExtractPlugin( {
-						filename: 'style.[contenthash].css',
-					} ),
-					new WebpackRTLPlugin( {
-						filename: 'style.[contenthash].rtl.css',
-						minify: false,
-					} ),
-				],
-			};
-
-			webpack( config, ( err, stats ) => {
-				if ( err ) {
-					return done( err );
-				}
-
-				if ( stats.hasErrors() ) {
-					return done( new Error( stats.toString() ) );
-				}
-
-				Object.keys( stats.compilation.assets ).forEach( ( asset ) => {
-					const chunk = asset.split( '.' );
-
-					if ( path.extname( asset ) === '.css' ) {
-						if ( chunk[ chunk.length - 2 ] === 'rtl' ) {
-							rtlCssBundleName = asset;
-							rtlCssBundlePath = path.join( __dirname, 'dist-hash', asset );
-						} else {
-							cssBundleName = asset;
-							cssBundlePath = path.join( __dirname, 'dist-hash', asset );
-						}
-					}
-				} );
-
-				done();
-			} );
-		} );
-
-		it( 'should create a two css bundles', () => {
-			expect( fs.existsSync( cssBundlePath ) ).toBe( true );
-			expect( fs.existsSync( rtlCssBundlePath ) ).toBe( true );
-		} );
-
-		it( 'should create a second bundle with a different hash', () => {
-			const cssChunk = cssBundleName.split( '.' );
-			const rtlCssChunk = rtlCssBundleName.split( '.' );
-
-			expect( cssChunk[ 1 ] ).not.toBe( rtlCssChunk[ 1 ] );
-		} );
-	} );
-
-	describe( 'Filename options with patterns', () => {
-		let cssBundleName;
-		let rtlCssBundleName;
-		let cssBundlePath;
-		let rtlCssBundlePath;
-
-		beforeAll( ( done ) => {
-			const config = {
-				...baseConfig,
-				output: {
-					path: path.resolve( __dirname, 'dist-patterns' ),
-					filename: 'bundle.js',
-				},
-				plugins: [
-					new MiniCssExtractPlugin( {
-						filename: 'style.[contenthash].css',
-					} ),
-					new WebpackRTLPlugin( {
-						filename: '[id]-[file]-[contenthash]-[name]-[filebase].rtl.[ext]',
-						minify: false,
-					} ),
-				],
-			};
-
-			webpack( config, ( err, stats ) => {
-				if ( err ) {
-					return done( err );
-				}
-
-				if ( stats.hasErrors() ) {
-					return done( new Error( stats.toString() ) );
-				}
-
-				Object.keys( stats.compilation.assets ).forEach( ( asset ) => {
-					const chunk = asset.split( '.' );
-
-					if ( path.extname( asset ) === '.css' ) {
-						if ( chunk[ chunk.length - 2 ] === 'rtl' ) {
-							rtlCssBundleName = asset;
-							rtlCssBundlePath = path.join( __dirname, 'dist-patterns', asset );
-						} else {
-							cssBundleName = asset;
-							cssBundlePath = path.join( __dirname, 'dist-patterns', asset );
-						}
-					}
-				} );
-
-				done();
-			} );
-		} );
-
-		it( 'should create a two css bundles', () => {
-			expect( fs.existsSync( cssBundlePath ) ).toBe( true );
-			expect( fs.existsSync( rtlCssBundlePath ) ).toBe( true );
-		} );
-
-		it( 'should create a second bundle with a different hash', () => {
-			const cssChunk = cssBundleName.split( '.' )[ 1 ];
-			const rtlCssChunk = rtlCssBundleName.split( '-' )[ 2 ];
-
-			expect( cssChunk ).not.toBe( rtlCssChunk );
-		} );
-	} );
-
-	describe( 'Filename options with replace array', () => {
-		let cssBundlePath;
-		let rtlCssBundlePath;
-
-		beforeAll( ( done ) => {
-			const config = {
-				...baseConfig,
-				output: {
-					path: path.resolve( __dirname, 'dist-replace' ),
-					filename: 'bundle.js',
-				},
-				plugins: [
-					new MiniCssExtractPlugin( {
-						filename: 'style.[contenthash].css',
-					} ),
-					new WebpackRTLPlugin( {
-						filename: [ /(\.css)/, '-rtl$1' ],
-						minify: false,
-					} ),
-				],
-			};
-
-			webpack( config, ( err, stats ) => {
-				if ( err ) {
-					return done( err );
-				}
-
-				if ( stats.hasErrors() ) {
-					return done( new Error( stats.toString() ) );
-				}
-
-				Object.keys( stats.compilation.assets ).forEach( ( asset ) => {
-					if ( path.extname( asset ) === '.css' ) {
-						if ( asset.substr( -7, 3 ) === 'rtl' ) {
-							rtlCssBundlePath = path.join( __dirname, 'dist-replace', asset );
-						} else {
-							cssBundlePath = path.join( __dirname, 'dist-replace', asset );
-						}
-					}
-				} );
-
-				done();
-			} );
-		} );
-
-		it( 'should create a two css bundles', () => {
 			expect( fs.existsSync( cssBundlePath ) ).toBe( true );
 			expect( fs.existsSync( rtlCssBundlePath ) ).toBe( true );
 		} );
@@ -378,7 +196,6 @@ describe( 'Webpack RTL Plugin', () => {
 								},
 							],
 						},
-						minify: false,
 					} ),
 				],
 			};
@@ -432,7 +249,6 @@ describe( 'Webpack RTL Plugin', () => {
 								],
 							},
 						],
-						minify: false,
 					} ),
 				],
 			};
@@ -472,7 +288,6 @@ describe( 'Webpack RTL Plugin', () => {
 					} ),
 					new WebpackRTLPlugin( {
 						diffOnly: true,
-						minify: false,
 					} ),
 				],
 			};
@@ -496,45 +311,6 @@ describe( 'Webpack RTL Plugin', () => {
 				.readFileSync( path.join( __dirname, 'rtl-diff-result.css' ), 'utf-8' )
 				.replace( /\r/g, '' );
 			expect( contentRrlCss ).toBe( expected );
-		} );
-	} );
-
-	describe( 'Minify', () => {
-		const rtlCssBundlePath = path.join( __dirname, 'dist-min/style.rtl.css' );
-
-		beforeAll( ( done ) => {
-			const config = {
-				...baseConfig,
-				output: {
-					path: path.resolve( __dirname, 'dist-min' ),
-					filename: 'bundle.js',
-				},
-				plugins: [
-					new MiniCssExtractPlugin( {
-						filename: 'style.css',
-					} ),
-					new WebpackRTLPlugin(),
-				],
-			};
-
-			webpack( config, ( err, stats ) => {
-				if ( err ) {
-					return done( err );
-				}
-
-				if ( stats.hasErrors() ) {
-					return done( new Error( stats.toString() ) );
-				}
-
-				done();
-			} );
-		} );
-
-		it( 'should minify the css', () => {
-			const contentRrlCss = fs.readFileSync( rtlCssBundlePath, 'utf-8' );
-			const expected =
-				'.foo{padding-right:10px}.bar{position:absolute;left:100px}.prev{width:10px}.foo .bar{height:10px}';
-			expect( contentRrlCss ).toContain( expected );
 		} );
 	} );
 } );

--- a/packages/whats-new/package.json
+++ b/packages/whats-new/package.json
@@ -44,7 +44,7 @@
 		"wpcom": "^6.0.0"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^7.0.0",
+		"@automattic/calypso-build": "^8.0.0",
 		"react": "^16.12.0"
 	},
 	"peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9418,6 +9418,21 @@ css-mediaquery@^0.1.2:
   resolved "https://registry.yarnpkg.com/css-mediaquery/-/css-mediaquery-0.1.2.tgz#6a2c37344928618631c54bd33cedd301da18bea0"
   integrity sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA=
 
+css-minimizer-webpack-plugin@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-1.3.0.tgz#d867b4a54ca9920125b30263505e8cca72bc8cf1"
+  integrity sha512-jFa0Siplmfef4ndKglpVaduY47oHQwioAOEGK0f0vAX0s+vc+SmP6cCMoc+8Adau5600RnOEld5VVdC8CQau7w==
+  dependencies:
+    cacache "^15.0.5"
+    cssnano "^4.1.10"
+    find-cache-dir "^3.3.1"
+    jest-worker "^26.3.0"
+    p-limit "^3.0.2"
+    schema-utils "^3.0.0"
+    serialize-javascript "^5.0.1"
+    source-map "^0.6.1"
+    webpack-sources "^1.4.3"
+
 css-node-extract@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-node-extract/-/css-node-extract-2.1.3.tgz#ec388a857b8fdf13fefd94b3da733257162405da"
@@ -15873,7 +15888,7 @@ jest-worker@^24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
-jest-worker@^26.2.1, jest-worker@^26.6.2:
+jest-worker@^26.2.1, jest-worker@^26.3.0, jest-worker@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
   integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==


### PR DESCRIPTION
### Background

In #51295 we refactored how RTL files are generated. However we had to revert it in #51449 because RTL support was broken.

I found the problem: the original code crated RTL files in the `assets` collection inside Webpack, but didn't associate the newly created RTL files with the original `chunk`. Other plugins, like `assets-writer`, traverses the `chunk` structure to find all the files, therefore it was missing the RTL files.

This PR brings back the original PR, plus refactors `webpack-rtl-plugin` to link the RTL file back to the original `chunk`.

### Changes proposed in this Pull Request

* Bring back #51295 (was reverted in #51449)
* `[@automattic/webpack-rtl-plugin]`: associate the new RTL files with the corresponding chunk.

#### Testing instructions


* Load the live branch, switch to a RTL language and verify styles are correct.
* Compare files:
  * Build this branch with `rm -fr public/evergreen && CALYPSO_ENV=production NODE_ENV=production yarn build-client-evergreen`.
  * Do the same with `trunk` in a separate directory.
  * Verify `public/evergreen/*.css` files are the same in both cases (`diff -qr wp-calypso/public/evergreen wp-calypso2/public/evergreen | grep css`)
  * Verify `build/assets-evergreen.json` is the same in both cases.
 