### PR TITLE
Titan: Remove usage of Lodash in TitanRedirector

### DIFF
--- a/client/my-sites/email/titan-redirector/index.jsx
+++ b/client/my-sites/email/titan-redirector/index.jsx
@@ -5,7 +5,6 @@ import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import page from 'page';
-import { map, fromPairs } from 'lodash-es';
 
 /**
  * Internal dependencies
@@ -163,13 +162,13 @@ export default connect( ( state ) => {
 	const sitesItems = getSitesItems( state );
 
 	// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
-	const siteSlugPairs = map( sitesItems, ( site ) => {
+	const siteSlugPairs = Object.values( sitesItems ).map( ( site ) => {
 		return [ site.ID, getSiteSlug( state, site.ID ) ];
 	} );
 
 	return {
 		isLoggedIn: isUserLoggedIn( state ),
-		siteSlugs: fromPairs( siteSlugPairs ),
+		siteSlugs: Object.fromEntries( siteSlugPairs ),
 		currentQuery: getCurrentQueryArguments( state ),
 		currentRoute: getCurrentRoute( state ),
 		hasAllSitesLoaded: hasAllSitesList( state ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #50760 we removed all `fromPairs`  usages of `lodash`, but we missed the ones from `lodash-es`. This PR removes the single remaining instance. It also uses the occasion to remove a stray `map()` in favor of `Array.prototype.map()`.

Ideally, the `siteSlugPairs` bit would be extracted to a separate Redux selector, but this seems like work for another PR if you're interested in it, @Automattic/cobalt folks.

If you want to find out why we're moving away from Lodash, see #50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify testing instructions of #48826 still work well.