### PR TITLE
Components: Remove lodash-es noop from TimelineExample

### DIFF
--- a/client/components/timeline/docs/example.jsx
+++ b/client/components/timeline/docs/example.jsx
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
-import { noop } from 'lodash-es';
 
 /**
  * Internal dependencies
  */
 import Timeline from 'calypso/components/timeline';
 import TimelineEvent from 'calypso/components/timeline/timeline-event.jsx';
+
+const noop = () => {};
 
 class TimelineExample extends PureComponent {
 	static displayName = 'TimelineExample';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We use `lodash-es` to transitively replace all lodash usage at build time so we use modular and not monolithic lodash. However, there are 2 instances where we directly import `lodash-es`. This PR removes one of them, and the other one is handled in #51545.

#### Testing instructions

* Verify `/devdocs/design/timeline` still works well.
