### PR TITLE
Framework: Refactor away from `_.toPairs()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -425,6 +425,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/split': 'error',
 		'you-dont-need-lodash-underscore/take-right': 'error',
 		'you-dont-need-lodash-underscore/to-lower': 'error',
+		'you-dont-need-lodash-underscore/to-pairs': 'error',
 		'you-dont-need-lodash-underscore/to-upper': 'error',
 		'you-dont-need-lodash-underscore/uniq': 'error',
 	},

--- a/client/lib/products-values/sort.js
+++ b/client/lib/products-values/sort.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { difference, flatten, groupBy, sortBy, toPairs } from 'lodash';
+import { difference, flatten, groupBy, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,7 +40,7 @@ function sortProducts( products ) {
 
 	domainItems = difference( products, includedItems );
 	domainItems = domainItems.filter( isDomainProduct );
-	domainItems = toPairs( groupBy( domainItems, 'meta' ) );
+	domainItems = Object.entries( groupBy( domainItems, 'meta' ) );
 	domainItems = sortBy( domainItems, function ( pair ) {
 		if ( pair[ 1 ][ 0 ] && pair[ 1 ][ 0 ].cost === 0 ) {
 			return -1;

--- a/client/lib/query-manager/key.js
+++ b/client/lib/query-manager/key.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { sortBy, toPairs, omitBy } from 'lodash';
+import { sortBy, omitBy } from 'lodash';
 
 /**
  * QueryKey manages the serialization and deserialization of a query key for
@@ -65,7 +65,7 @@ export default class QueryKey {
 		// key ordering in the original object, to ensure that:
 		//
 		// QueryKey.stringify( { a: 1, b: 2 } ) === QueryKey.stringify( { b: 2, a: 1 } )
-		const stableQuery = sortBy( toPairs( prunedQuery ), ( pair ) => pair[ 0 ] );
+		const stableQuery = sortBy( Object.entries( prunedQuery ), ( pair ) => pair[ 0 ] );
 
 		return JSON.stringify( stableQuery );
 	}

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { map, toPairs, pick, flowRight } from 'lodash';
+import { map, pick, flowRight } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -154,7 +154,7 @@ class PodcastingDetails extends Component {
 				disabled={ isRequestingSettings || ! isPodcastingEnabled }
 			>
 				<option value="0">None</option>
-				{ map( toPairs( podcastingTopics ), ( [ topic, subtopics ] ) => {
+				{ map( Object.entries( podcastingTopics ), ( [ topic, subtopics ] ) => {
 					// The keys for podcasting in Apple Podcasts use &amp;
 					const topicKey = topic.replace( '&', '&amp;' );
 					return [

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { compact, get, head, isEqual, sortBy, toPairs, unionWith } from 'lodash';
+import { compact, get, head, isEqual, sortBy, unionWith } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:data-layer:remove-duplicate-gets' );
 
@@ -44,14 +44,15 @@ const isGetRequest = ( request ) => 'GET' === get( request, 'method', '' ).toUpp
 /**
  * Generate a deterministic key for comparing request descriptions
  *
- * @param {string} path API endpoint path
- * @param {string} apiNamespace used for endpoint versioning
- * @param {string} apiVersion used for endpoint versioning
- * @param {object<string, *>} query GET query string
+ * @param {object}            requestOptions              Request options
+ * @param {string}            requestOptions.path         API endpoint path
+ * @param {string}            requestOptions.apiNamespace used for endpoint versioning
+ * @param {string}            requestOptions.apiVersion   used for endpoint versioning
+ * @param {object<string, *>} requestOptions.query        GET query string
  * @returns {string} unique key up to duplicate request descriptions
  */
-export const buildKey = ( { path, apiNamespace, apiVersion, query } ) =>
-	JSON.stringify( [ path, apiNamespace, apiVersion, sortBy( toPairs( query ), head ) ] );
+export const buildKey = ( { path, apiNamespace, apiVersion, query = {} } ) =>
+	JSON.stringify( [ path, apiNamespace, apiVersion, sortBy( Object.entries( query ), head ) ] );
 
 /**
  * Joins a responder action into a unique list of responder actions
@@ -71,8 +72,8 @@ export const addResponder = ( list, item ) => ( {
  *
  * @see applyDuplicateHandlers
  *
- * @param {OutboundData} outboundData request info
- * @returns {OutboundData} filtered request info
+ * @param {object} outboundData request info
+ * @returns {object} filtered request info
  */
 export const removeDuplicateGets = ( outboundData ) => {
 	const { nextRequest } = outboundData;
@@ -102,8 +103,8 @@ export const removeDuplicateGets = ( outboundData ) => {
  *
  * @see removeDuplicateGets
  *
- * @param {InboundData} inboundData request info
- * @returns {InboundData} processed request info
+ * @param {object} inboundData request info
+ * @returns {object} processed request info
  */
 export const applyDuplicatesHandlers = ( inboundData ) => {
 	const { originalRequest } = inboundData;

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { toPairs, isEqual, omit } from 'lodash';
+import { isEqual, omit } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -79,7 +79,7 @@ export const editMedia = ( action ) => {
 				method: 'POST',
 				path: `/sites/${ siteId }/media/${ mediaId }/edit`,
 				apiVersion: '1.1',
-				formData: toPairs( rest ),
+				formData: Object.entries( rest ),
 			},
 			action
 		),

--- a/client/state/http/index.js
+++ b/client/state/http/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { identity, toPairs } from 'lodash';
+import { identity } from 'lodash';
 import { extendAction } from '@automattic/state-utils';
 
 /**
@@ -68,7 +68,7 @@ export const httpHandler = async ( { dispatch }, action ) => {
 	let serialize;
 
 	if ( contentType === 'application/x-www-form-urlencoded' ) {
-		serialize = ( data ) => encodeQueryParameters( toPairs( data ) );
+		serialize = ( data ) => encodeQueryParameters( Object.entries( data ) );
 	} else if ( typeof body !== 'string' ) {
 		serialize = JSON.stringify.bind( JSON );
 	} else {

--- a/client/state/selectors/get-timezones.js
+++ b/client/state/selectors/get-timezones.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, map, toPairs } from 'lodash';
+import { get, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,13 +26,13 @@ import 'calypso/state/timezones/init';
  * @returns {Array} Timezones arrays
  */
 export default function getTimezones( state ) {
-	const continents = toPairs( get( state, 'timezones.byContinents', null ) );
+	const continents = get( state, 'timezones.byContinents', null );
 
 	if ( ! continents ) {
 		return null;
 	}
 
-	return map( continents, ( zones ) => [
+	return map( Object.entries( continents ), ( zones ) => [
 		zones[ 0 ],
 		map( zones[ 1 ], ( value ) => [ value, getTimezonesLabel( state, value ) ] ),
 	] );

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes, isEmpty, reduce, snakeCase, toPairs } from 'lodash';
+import { includes, isEmpty, reduce, snakeCase } from 'lodash';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 
 /**
@@ -59,7 +59,7 @@ function recordSubmitStep( stepName, providedDependencies ) {
 				[ 'cart_item', 'domain_item', 'selected_domain_upsell_item' ].includes( propName ) &&
 				typeof propValue !== 'string'
 			) {
-				propValue = toPairs( propValue )
+				propValue = Object.entries( propValue )
 					.map( ( pair ) => pair.join( ':' ) )
 					.join( ',' );
 			}

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -1,18 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	sortBy,
-	toPairs,
-	camelCase,
-	mapKeys,
-	isNumber,
-	get,
-	filter,
-	map,
-	concat,
-	flatten,
-} from 'lodash';
+import { sortBy, camelCase, mapKeys, isNumber, get, filter, map, concat, flatten } from 'lodash';
 import { translate, getLocaleSlug } from 'i18n-calypso';
 import moment from 'moment';
 
@@ -138,7 +127,7 @@ export function buildExportArray( data, parent = null ) {
  * @returns {string}          Serialized stats query
  */
 export function getSerializedStatsQuery( query = {} ) {
-	return JSON.stringify( sortBy( toPairs( query ), ( pair ) => pair[ 0 ] ) );
+	return JSON.stringify( sortBy( Object.entries( query ), ( pair ) => pair[ 0 ] ) );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `toPairs` is essentially fully natively supported by the native `Object.entries()`. An exception to that rule is that Lodash's `toPairs` supports bullish values, too - for those instances, we ensure we already have an object to work with (even if it's an empty one). This PR replaces all the `_.toPairs()` usage and adds an ESLint rule to warn against using it from Lodash.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all usages are sane and preserve the original logic.
* Try to `import { toPairs } from 'lodash'` in your code, and verify you're getting an ESLint error.
* Verify all tests pass - much of the code is covered by tests.