### PR TITLE
Sidebar: remove outline border from menu-link

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -148,6 +148,10 @@
 		}
 	}
 
+	&:focus {
+		outline: none;
+	}
+
 	.badge {
 		margin: -7px 0 -8px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the outline border from menu-link elements, fixing https://github.com/Automattic/wp-calypso/issues/50000

Fixes https://github.com/Automattic/wp-calypso/issues/50000

#### Testing instructions

* Select `Stats` section. Compare and confirm you don't see the dotted border around the link.

before | after
-----|-----
![image](https://user-images.githubusercontent.com/77539/113000303-11f5ed00-9146-11eb-959f-299c62c37528.png) | ![image](https://user-images.githubusercontent.com/77539/113000277-0b677580-9146-11eb-91e3-eafca90091f6.png)



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
