### PR TITLE
SiteSelector: Fix space between top and search bar

### DIFF
--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -68,22 +68,11 @@
 	padding: 0;
 	position: static;
 	overflow-y: auto;
-
-	&.is-large {
-		margin-top: 50px;
-	}
 }
 
 .sites-dropdown .site-selector__sites {
 	max-height: 30vh;
 	border-radius: 0 0 2px 2px;
-}
-
-.sites-dropdown .site-selector .search {
-	position: absolute;
-	top: 67px;
-	left: 0;
-	right: 0;
 }
 
 .sites-dropdown .site-selector .search input {

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -24,10 +24,6 @@
 	width: 100%;
 }
 
-.account__settings-form .sites-dropdown .site-selector .search {
-	top: 57px;
-}
-
 .account__link-destination {
 	.components-base-control__field {
 		align-items: flex-start;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use static positioning for the search element in the `SitesDropdown`; absolute positioning seems unnecessarily complicated and was positioning the search bar over the site content:

<img width="400" alt="Screen Shot 2021-03-30 at 12 37 37 PM" src="https://user-images.githubusercontent.com/2124984/113024420-b8e18580-9154-11eb-941d-1ac61dd5581c.png">

I notice it doesn't fully expand in the `/devdocs` example with this change; we may need to set a minimum height.

We use this component in the following places when you have multiple sites:

**Me -> Account settings**

<img width="357" alt="Screen Shot 2021-03-30 at 12 26 01 PM" src="https://user-images.githubusercontent.com/2124984/113023821-10332600-9154-11eb-973a-1d0c608afbc3.png">

**Theme Showcase**

Click Activate on a theme in the showcase to see a modal with the selector:

<img width="402" alt="Screen Shot 2021-03-30 at 12 04 09 PM" src="https://user-images.githubusercontent.com/2124984/113023983-3a84e380-9154-11eb-9d4f-ba37bda0a2fc.png">

**ProductSelector block**

Not sure where this is in the wild, but it's demo'ed in `/devdocs`:

<img width="1356" alt="Screen Shot 2021-03-30 at 12 21 34 PM" src="https://user-images.githubusercontent.com/2124984/113024060-4f617700-9154-11eb-9fa4-1ae550581a6d.png">

**Help/Contact us form**

<img width="343" alt="Screen Shot 2021-03-30 at 12 04 18 PM" src="https://user-images.githubusercontent.com/2124984/113024146-699b5500-9154-11eb-9f70-3c573b42a52f.png">

#### Testing instructions

* Switch to this PR and check the above locations on a multisite account
* Make sure the spacing looks correct and you can access the sites and search bar

Fixes #40195
