### PR TITLE
Partner Portal: Refactor license issuing data layer

### DIFF
--- a/client/components/data/query-jetpack-partner-portal-licenses/index.ts
+++ b/client/components/data/query-jetpack-partner-portal-licenses/index.ts
@@ -34,7 +34,7 @@ export default function QueryJetpackPartnerPortalLicenses( {
 	const activeKeyId = useSelector( getActivePartnerKeyId );
 
 	useEffect( () => {
-		// Key switching for requests is already done for us - we use keyId just to re-trigger the request.
+		// Key switching for requests is already done for us - we use activeKeyId just to re-trigger the request.
 		dispatch( fetchLicenses( filter, search, sortField, sortDirection, page ) );
 	}, [ dispatch, activeKeyId, filter, search, sortField, sortDirection, page ] );
 

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/style.scss
@@ -24,21 +24,4 @@
 			margin: 0 10px;
 		}
 	}
-
-	&__issue-button {
-		&--is-loading {
-			position: relative;
-
-			span {
-				opacity: 0;
-			}
-
-			.spinner {
-				position: absolute;
-				left: 50%;
-				top: 50%;
-				transform: translate( -50%, -50% );
-			}
-		}
-	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -7,7 +7,7 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import { getLicenseState, noop } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { Card } from '@automattic/components';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
@@ -28,9 +28,6 @@ interface Props {
 	revokedAt: string | null;
 	onCopyLicense?: () => void;
 }
-
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
 
 export default function LicenseDetails( {
 	licenseKey,

--- a/client/jetpack-cloud/sections/partner-portal/license-list-context/index.ts
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-context/index.ts
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { LicenseListContext as LicenseListContextInterface } from 'calypso/state/partner-portal/types';
+
+const LicenseListContext = React.createContext< LicenseListContextInterface >( {
+	currentPage: 1,
+	search: '',
+	filter: LicenseFilter.NotRevoked,
+	sortField: LicenseSortField.IssuedAt,
+	sortDirection: LicenseSortDirection.Descending,
+} );
+
+export default LicenseListContext;

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropsWithChildren, ReactElement, useCallback } from 'react';
+import React, { PropsWithChildren, ReactElement, useCallback, useContext } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -34,6 +34,7 @@ import Gridicon from 'calypso/components/gridicon';
 import Pagination from 'calypso/components/pagination';
 import { addQueryArgs } from 'calypso/lib/route';
 import { internalToPublicLicenseSortField } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
 
 /**
  * Style dependencies
@@ -107,22 +108,11 @@ function SortButton( {
 	);
 }
 
-interface Props {
-	filter: LicenseFilter;
-	search: string;
-	currentPage: number;
-	sortField: LicenseSortField;
-	sortDirection: LicenseSortDirection;
-}
-
-export default function LicenseList( {
-	filter,
-	search,
-	currentPage,
-	sortField,
-	sortDirection,
-}: Props ): ReactElement {
+export default function LicenseList(): ReactElement {
 	const translate = useTranslate();
+	const { filter, search, sortField, sortDirection, currentPage } = useContext(
+		LicenseListContext
+	);
 	const hasFetched = useSelector( hasFetchedLicenses );
 	const isFetching = useSelector( isFetchingLicenses );
 	const licenses = useSelector( getPaginatedLicenses ) as PaginatedItems< License >;
@@ -207,6 +197,7 @@ export default function LicenseList( {
 						</Card>
 					</LicenseTransition>
 				) }
+
 				{ showPagination && (
 					<LicenseTransition>
 						<Pagination

--- a/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 
@@ -16,9 +16,9 @@ import NavItem from 'calypso/components/section-nav/item';
 import Count from 'calypso/components/count';
 import Search from 'calypso/components/search';
 import UrlSearch from 'calypso/lib/url-search';
-import QueryJetpackPartnerPortalLicenseCounts from 'calypso/components/data/query-jetpack-partner-portal-license-counts';
 import { getLicenseCounts } from 'calypso/state/partner-portal/licenses/selectors';
 import { internalToPublicLicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
 
 /**
  * Style dependencies
@@ -26,14 +26,13 @@ import { internalToPublicLicenseFilter } from 'calypso/jetpack-cloud/sections/pa
 import './style.scss';
 
 interface Props {
-	filter: LicenseFilter;
-	search: string;
 	doSearch: ( query: string ) => void;
 	getSearchOpen: () => boolean;
 }
 
-function LicenseStateFilter( { filter, search, doSearch }: Props ): ReactElement {
+function LicenseStateFilter( { doSearch }: Props ): ReactElement {
 	const translate = useTranslate();
+	const { filter, search } = useContext( LicenseListContext );
 	const counts = useSelector( getLicenseCounts );
 	const basePath = '/partner-portal/';
 
@@ -75,8 +74,6 @@ function LicenseStateFilter( { filter, search, doSearch }: Props ): ReactElement
 			selectedCount={ selectedItem.count }
 			className="license-state-filter"
 		>
-			<QueryJetpackPartnerPortalLicenseCounts />
-
 			<NavTabs
 				label={ translate( 'State' ) }
 				selectedText={ selectedItem.label }

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -25,6 +25,7 @@ import {
 	getCurrentPartner,
 } from 'calypso/state/partner-portal/partner/selectors';
 import { setActivePartnerKey } from 'calypso/state/partner-portal/partner/actions';
+import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
 
 /**
  * Style dependencies
@@ -50,9 +51,12 @@ export default function Licenses( {
 	const dispatch = useDispatch();
 	const partner = useSelector( getCurrentPartner );
 	const activeKeyId = useSelector( getActivePartnerKeyId );
-	const onKeySelect = useCallback( ( option ) => {
-		dispatch( setActivePartnerKey( parseInt( option.value ) ) );
-	}, [] );
+	const onKeySelect = useCallback(
+		( option ) => {
+			dispatch( setActivePartnerKey( parseInt( option.value ) ) );
+		},
+		[ dispatch ]
+	);
 
 	const options =
 		partner &&
@@ -62,6 +66,14 @@ export default function Licenses( {
 		} ) );
 
 	options?.unshift( { label: translate( 'Partner Key' ) as string, value: '', isLabel: true } );
+
+	const context = {
+		filter,
+		search,
+		currentPage,
+		sortDirection,
+		sortField,
+	};
 
 	return (
 		<Main wideLayout={ true } className="licenses">
@@ -82,15 +94,11 @@ export default function Licenses( {
 				</Button>
 			</div>
 
-			<LicenseStateFilter filter={ filter } search={ search } />
+			<LicenseListContext.Provider value={ context }>
+				<LicenseStateFilter />
 
-			<LicenseList
-				filter={ filter }
-				search={ search }
-				currentPage={ currentPage }
-				sortDirection={ sortDirection }
-				sortField={ sortField }
-			/>
+				<LicenseList />
+			</LicenseListContext.Provider>
 		</Main>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -8,6 +8,14 @@ import {
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 
 /**
+ * Noop which can be reused (e.g. in equality checks).
+ *
+ * @returns {void}
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+export function noop() {}
+
+/**
  * Get the state of a license based on its properties.
  * For example, if a license is neither attached to a site and revoked then it is both detached and revoked but
  * the dominant state would be considered to be revoked as it is of higher importance.

--- a/client/state/partner-portal/licenses/actions.ts
+++ b/client/state/partner-portal/licenses/actions.ts
@@ -12,11 +12,13 @@ import {
 	JETPACK_PARTNER_PORTAL_LICENSE_COUNTS_RECEIVE,
 	JETPACK_PARTNER_PORTAL_LICENSE_COUNTS_REQUEST,
 } from 'calypso/state/action-types';
+import { ReduxDispatch } from 'calypso/state/redux-store';
 import {
 	HttpAction,
 	License,
 	LicenseCounts,
 	PaginatedItems,
+	PartnerPortalThunkAction,
 } from 'calypso/state/partner-portal/types';
 import { LICENSES_PER_PAGE } from 'calypso/state/partner-portal/licenses/constants';
 import {
@@ -41,16 +43,22 @@ export function fetchLicenses(
 	sortField: LicenseSortField,
 	sortDirection: LicenseSortDirection,
 	page: number
-): HttpAction {
-	return createHttpAction( {
-		type: JETPACK_PARTNER_PORTAL_LICENSES_REQUEST,
-		filter,
-		search,
-		sortField,
-		sortDirection,
-		page: page,
-		perPage: LICENSES_PER_PAGE,
-	} );
+): PartnerPortalThunkAction {
+	return ( dispatch: ReduxDispatch ): void => {
+		dispatch(
+			createHttpAction( {
+				type: JETPACK_PARTNER_PORTAL_LICENSES_REQUEST,
+				filter,
+				search,
+				sortField,
+				sortDirection,
+				page: page,
+				perPage: LICENSES_PER_PAGE,
+			} )
+		);
+
+		dispatch( fetchLicenseCounts() );
+	};
 }
 
 export function receiveLicenses( paginatedLicenses: PaginatedItems< License > ): AnyAction {

--- a/client/state/partner-portal/licenses/hooks/use-issue-license-mutation.ts
+++ b/client/state/partner-portal/licenses/hooks/use-issue-license-mutation.ts
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { useMutation, UseMutationOptions, UseMutationResult } from 'react-query';
+
+/**
+ * Internal dependencies
+ */
+import { APILicense } from 'calypso/state/partner-portal/types';
+import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+
+interface MutationIssueLicenseVariables {
+	product: string;
+}
+
+function mutationIssueLicense( { product }: MutationIssueLicenseVariables ): Promise< APILicense > {
+	return wpcomJpl.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: '/jetpack-licensing/license',
+		body: { product },
+	} );
+}
+
+export default function useIssueLicenseMutation< TContext = unknown >(
+	options?: UseMutationOptions< APILicense, Error, MutationIssueLicenseVariables, TContext >
+): UseMutationResult< APILicense, Error, MutationIssueLicenseVariables, TContext > {
+	return useMutation< APILicense, Error, MutationIssueLicenseVariables, TContext >(
+		mutationIssueLicense,
+		options
+	);
+}

--- a/client/state/partner-portal/licenses/hooks/use-products-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-products-query.ts
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+
+/**
+ * Internal dependencies
+ */
+import { APIProductFamily } from 'calypso/state/partner-portal/types';
+import wpcom from 'calypso/lib/wp';
+
+function queryProducts(): Promise< APIProductFamily[] > {
+	return wpcom.req.get( {
+		apiNamespace: 'wpcom/v2',
+		path: '/jetpack-licensing/product-families',
+	} );
+}
+
+export default function useProductsQuery< TError = unknown, TData = unknown >(
+	options?: UseQueryOptions< APIProductFamily[], TError, TData >
+): UseQueryResult< TData, TError > {
+	return useQuery< APIProductFamily[], TError, TData >(
+		[ 'partner-portal', 'licenses', 'products' ],
+		queryProducts,
+		options
+	);
+}

--- a/client/state/partner-portal/licenses/test/actions.js
+++ b/client/state/partner-portal/licenses/test/actions.js
@@ -24,26 +24,34 @@ jest.mock( 'calypso/state/partner-portal/partner/selectors', () => ( {
 
 describe( 'actions', () => {
 	describe( '#fetchLicenses()', () => {
-		test( 'should dispatch a request action when called', () => {
+		test( 'should return a thunk which dispatches 2 actions when called', () => {
 			const { fetchLicenses } = actions;
+			const dispatch = jest.fn();
 
-			expect(
-				fetchLicenses(
-					LicenseState.Detached,
-					'bar',
-					LicenseSortField.IssuedAt,
-					LicenseSortDirection.Descending,
-					2
-				)
-			).toEqual( {
+			const thunk = fetchLicenses(
+				LicenseState.Detached,
+				'bar',
+				LicenseSortField.IssuedAt,
+				LicenseSortDirection.Descending,
+				2
+			);
+
+			thunk( dispatch );
+
+			expect( dispatch.mock.calls[ 0 ][ 0 ] ).toEqual( {
 				type: JETPACK_PARTNER_PORTAL_LICENSES_REQUEST,
 				filter: LicenseState.Detached,
 				search: 'bar',
-				fetcher: 'wpcomJetpackLicensing',
 				sortField: LicenseSortField.IssuedAt,
 				sortDirection: LicenseSortDirection.Descending,
 				page: 2,
 				perPage: LICENSES_PER_PAGE,
+				fetcher: 'wpcomJetpackLicensing',
+			} );
+
+			expect( dispatch.mock.calls[ 1 ][ 0 ] ).toEqual( {
+				type: JETPACK_PARTNER_PORTAL_LICENSE_COUNTS_REQUEST,
+				fetcher: 'wpcomJetpackLicensing',
 			} );
 		} );
 	} );

--- a/client/state/partner-portal/licenses/test/hooks.js
+++ b/client/state/partner-portal/licenses/test/hooks.js
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+import nock from 'nock';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+/**
+ * Internal dependencies
+ */
+import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
+import useIssueLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-issue-license-mutation';
+
+describe( 'useProductsQuery', () => {
+	it( 'returns successful request data', async () => {
+		const queryClient = new QueryClient();
+		const wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+		const stub = [
+			{
+				name: 'Jetpack Scan',
+				slug: 'jetpack-scan',
+				products: [
+					{
+						name: 'Jetpack Scan Daily',
+						product_id: 2106,
+						slug: 'jetpack-scan',
+					},
+				],
+			},
+			{
+				name: 'Jetpack Backup',
+				slug: 'jetpack-backup',
+				products: [
+					{
+						name: 'Jetpack Backup (Daily)',
+						product_id: 2100,
+						slug: 'jetpack-backup-daily',
+					},
+					{
+						name: 'Jetpack Backup (Real-time)',
+						product_id: 2102,
+						slug: 'jetpack-backup-realtime',
+					},
+				],
+			},
+		];
+
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/jetpack-licensing/product-families' )
+			.reply( 200, stub );
+
+		const { result, waitFor } = renderHook( () => useProductsQuery(), {
+			wrapper,
+		} );
+
+		await waitFor( () => result.current.isSuccess );
+
+		expect( result.current.data ).toEqual( stub );
+	} );
+} );
+
+describe( 'useIssueLicenseMutation', () => {
+	it( 'returns successful request data', async () => {
+		const queryClient = new QueryClient();
+		const wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+		const stub = {
+			issued_at: '2021-03-30 15:17:42',
+			license_id: 12345,
+			license_key: 'jetpack-scan_foobarbaz',
+			revoked_at: null,
+		};
+
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/jetpack-licensing/license', '{"product":"jetpack-scan"}' )
+			.reply( 200, stub );
+
+		const { result } = renderHook( () => useIssueLicenseMutation(), {
+			wrapper,
+		} );
+
+		await act( async () => result.current.mutateAsync( { product: 'jetpack-scan' } ) );
+
+		expect( result.current.data ).toEqual( stub );
+	} );
+} );

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -3,6 +3,11 @@
  */
 import { Action, AnyAction } from 'redux';
 import { ThunkAction } from 'redux-thunk';
+import {
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 
 /**
  * Utility.
@@ -31,10 +36,37 @@ export interface PaginatedItems< T > {
 	totalPages: number;
 }
 
+export interface LicenseListContext {
+	currentPage: number;
+	search: string;
+	filter: LicenseFilter;
+	sortField: LicenseSortField;
+	sortDirection: LicenseSortDirection;
+}
+
 export interface APIError {
 	status: number;
 	code: string | null;
 	message: string;
+}
+
+// The API-returned license object is not quite consistent right now so we only define the properties we actively rely on.
+export interface APILicense {
+	license_key: string;
+	issued_at: string;
+	revoked_at: string | null;
+}
+
+export interface APIProductFamilyProduct {
+	name: string;
+	slug: string;
+	product_id: number;
+}
+
+export interface APIProductFamily {
+	name: string;
+	slug: string;
+	products: APIProductFamilyProduct[];
 }
 
 /**


### PR DESCRIPTION
This PR consists of extracted refactors and improvements from #51245. Patch seems larger than it is due to code moving around a bit.

#### Changes proposed in this Pull Request

* Refactor the data layer and react-query usage when issuing licenses in the Partner Portal to improve data flow, extract concerns and add tests.

The nitty-gritty:
* Extract react-query usage into custom hooks and add tests for those hooks.
* Reduce data being passed down multiple levels with Context for the list of licenses.
* Adjust license fetching to also automatically fetch license counts as well.
* Extract common types into `types.ts`.
* Replace the custom submit button loading animation with the built-in `busy` prop for `Button`.

#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key, if prompted.
* Click on the "Issue New License" button at the top.
* Play around with the form, issue a couple licenses, make sure you are redirected back to the list of licenses and the just issued license shows up expanded, with the "Just issued" label as per designs.

![Screenshot 2021-03-18 at 18 14 59](https://user-images.githubusercontent.com/22746396/111660167-7cd62880-8816-11eb-85f8-fb0f7ddf4d66.png)
![Screenshot 2021-03-18 at 18 15 10](https://user-images.githubusercontent.com/22746396/111660186-7fd11900-8816-11eb-9352-869eb2fb40f5.png)
