### PR TITLE
Hide Gutenframe while it's loading

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -728,6 +728,11 @@ class CalypsoifyIframe extends Component<
 							onLoad={ () => {
 								this.onIframeLoaded( iframeUrl );
 							} }
+							// when 3rd party cookies are disabled
+							// the iframe shows an error page that flashes for a moment
+							// before the user is the redirected to wp-admin.
+							// This styling hides the iframe until it loads or the redirect is executed
+							style={ ( ! isIframeLoaded && { clip: 'rect(0, 0, 0, 0)' } ) || {} }
 						/>
 					) }
 				</div>

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -732,7 +732,6 @@ class CalypsoifyIframe extends Component<
 							// the iframe shows an error page that flashes for a moment
 							// before the user is the redirected to wp-admin.
 							// This styling hides the iframe until it loads or the redirect is executed
-							style={ ( ! isIframeLoaded && { clip: 'rect(0, 0, 0, 0)' } ) || {} }
 						/>
 					) }
 				</div>

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -732,6 +732,7 @@ class CalypsoifyIframe extends Component<
 							// the iframe shows an error page that flashes for a moment
 							// before the user is the redirected to wp-admin.
 							// This styling hides the iframe until it loads or the redirect is executed
+							style={ isIframeLoaded ? undefined : { clipPath: 'inset(50%)' } }
 						/>
 					) }
 				</div>

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -732,7 +732,7 @@ class CalypsoifyIframe extends Component<
 							// the iframe shows an error page that flashes for a moment
 							// before the user is the redirected to wp-admin.
 							// This styling hides the iframe until it loads or the redirect is executed
-							style={ isIframeLoaded ? undefined : { clipPath: 'inset(50%)' } }
+							style={ isIframeLoaded ? undefined : { opacity: 0 } }
 						/>
 					) }
 				</div>

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -46,7 +46,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			return;
 		}
 		await this.driver.switchTo().defaultContent();
-		//await driverHelper.waitTillPresentAndDisplayed( this.driver, this.editoriFrameSelector );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.editoriFrameSelector );
 		await this.driver.wait(
 			until.ableToSwitchToFrame( this.editoriFrameSelector ),
 			this.explicitWaitMS,

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -46,7 +46,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			return;
 		}
 		await this.driver.switchTo().defaultContent();
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.editoriFrameSelector );
+		//await driverHelper.waitTillPresentAndDisplayed( this.driver, this.editoriFrameSelector );
 		await this.driver.wait(
 			until.ableToSwitchToFrame( this.editoriFrameSelector ),
 			this.explicitWaitMS,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR implements the change proposed by @jsnajdr [here](https://github.com/Automattic/wp-calypso/issues/49374#issuecomment-802584542). It does the trick perfectly.

#### Testing instructions

I don't really know how to test this PR. This change needs to be under wordpress.com to be tested. 

Fixes #49374
