### PR TITLE
Checkout: Show order review step when clicking stale cart items notice

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -286,9 +286,32 @@ export default function WPCheckout( {
 		return isCompleteAndValid( contactInfo );
 	};
 
+	// The "Summary" view is displayed in the sidebar at desktop (wide) widths
+	// and before the first step at mobile (smaller) widths. At smaller widths it
+	// starts collapsed and can be expanded; at wider widths (as a sidebar) it is
+	// always visible. It is not a step and its visibility is managed manually.
 	const [ isSummaryVisible, setIsSummaryVisible ] = useState( false );
 
-	const [ isOrderReviewActive, setIsOrderReviewActive ] = useState( false );
+	// The "Order review" step is not managed by Composite Checkout and is shown/hidden manually.
+	// If the page includes a 'order-review=true' query string, then start with
+	// the order review step visible.
+	const [ isOrderReviewActive, setIsOrderReviewActive ] = useState( () => {
+		try {
+			const shouldInitOrderReviewStepActive =
+				window?.location?.search.includes( 'order-review=true' ) ?? false;
+			if ( shouldInitOrderReviewStepActive ) {
+				return true;
+			}
+		} catch ( error ) {
+			// If there's a problem loading the query string, just default to false.
+			debug(
+				'Error loading query string to determine if we should see the order review step at load',
+				error
+			);
+		}
+		return false;
+	} );
+
 	const { formStatus } = useFormStatus();
 
 	// Copy siteId to the store so it can be more easily accessed during payment submission

--- a/client/my-sites/current-site/stale-cart-items-notice.js
+++ b/client/my-sites/current-site/stale-cart-items-notice.js
@@ -57,7 +57,7 @@ function useShowStaleCartNotice() {
 				infoNotice( translate( 'Your cart is awaiting payment.' ), {
 					id: staleCartItemNoticeId,
 					button: translate( 'View your cart' ),
-					href: '/checkout/' + selectedSiteSlug,
+					href: `/checkout/${ selectedSiteSlug }?order-review=true`, // Redirect to the order-review step
 					onClick: () => {
 						reduxDispatch( recordTracksEvent( 'calypso_cart_abandonment_notice_click' ) );
 					},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The "Order review" step of checkout is not controlled by the rest of the checkout system (it's not step one of three; checkout only is aware of two steps: contact info and payment method) and is manually made active by clicking its "Edit" button.

This PR adds an optional `order-review=true` query parameter, which, if set, will cause checkout to load with the "Order review" step active instead. The idea is that this parameter could be used by links to checkout where displaying an editable cart might be more desirable than jumping straight into contact info or payment method.

This then modifies the "Stale cart items notice" so that it uses the new query parameter when linking to checkout.

<img width="537" alt="Screen Shot 2021-03-30 at 4 26 37 PM" src="https://user-images.githubusercontent.com/2036909/113052120-c149b880-9174-11eb-93bc-e5f9d0d15acb.png">


<img width="578" alt="Screen Shot 2021-03-30 at 2 31 26 PM" src="https://user-images.githubusercontent.com/2036909/113038899-0cf46600-9165-11eb-8516-0852fd6ccb0d.png">
 
#### Testing instructions

Make sure this doesn't affect normal checkout:

- Visit checkout via any usual manner (eg: add a plan to your cart).
- Verify that the "Order review" step is collapsed and that the other steps are expanded (either the contact step will be active or, if that's already filled in, the payment method step will be active).
- Verify that clicking "Edit" on the "Order review" step makes that step active and collapses the other steps.

Now test the stale cart item notice:

- Add a product to your cart.
- Wait 10 minutes.
- Visit a calypso page other than checkout.
- When you see the "Your cart is awaiting payment" notice, click "View your cart".
- Verify that when checkout loads, the "Order review" step is active.