### PR TITLE
ExPlat: Have dangerouslyGetExperimentAssignment log rather than throw

### DIFF
--- a/packages/explat-client/CHANGELOG.md
+++ b/packages/explat-client/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.0.2 (Unreleased)
+
+- Change dangerouslyGetExperimentAssignment to log rather than throw
+
+## 0.0.1
+
+Initial release.
+See pbmo2S-HC-p2

--- a/packages/explat-client/README.md
+++ b/packages/explat-client/README.md
@@ -1,4 +1,3 @@
-
 ⚠️ **You probably shouldn't be using this package directly.**
 
 Search for `createExPlatClient` within your codebase to find your platform's implementation.
@@ -57,24 +56,18 @@ const experimentAssignment = await loadExperimentAssignment('experiment_name')
 loadExperimentAssignment( 'experiment_name' );
 
 // Then, significantly enough in the future for the loading to have occurred:
-try {
-	const experimentAssignment = dangerouslyGetExperimentAssignment( 'experiment_name' );
-} catch ( e ) {
-	// You need to ensure that this will happen very rarely, we use throwing and a try catch block
-	// to indicate that this is the exception rather than the norm.
-	// You MAY want to provide the default experience here.
-}
+const experimentAssignment = dangerouslyGetExperimentAssignment( 'experiment_name' );
 ```
 
 This is an "asyncronous escape hatch", allowing you to use ExPlat in more synchronous code such as within `/lib`.
 
 - Gets but won't load/assign an experiment assignment.
-- MUST be wrapped in a try-catch block.
+- ~~MUST be wrapped in a try-catch block.~~ It now logs and won't throw.
 - Named so it is easy to spot in a code review.
 
 Checklist for use:
 
 - [ ] Does `loadExperiment` get called before `dangerouslyGetExperimentAssignment` gets called.
 - [ ] Does `loadExperiment` get called significantly before it (minimum 2 seconds looking at perf data, 5-10 seconds is best).
-- [ ] Is `dangerouslyGetExperimentAssignment` wrapped in a try-catch block
-- [ ] Does the catch block gracefully handle missing ExperimentAssignments.
+- [ ] ~~Is `dangerouslyGetExperimentAssignment` wrapped in a try-catch block~~
+- [ ] Are there no `console.log` errors being emitted?

--- a/packages/explat-client/src/create-explat-client.ts
+++ b/packages/explat-client/src/create-explat-client.ts
@@ -164,22 +164,14 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 		dangerouslyGetExperimentAssignment: ( experimentName: string ): ExperimentAssignment => {
 			try {
 				if ( ! Validation.isName( experimentName ) ) {
-					safeLogError( {
-						message: `Invalid experimentName: ${ experimentName }`,
-						experimentName,
-						source: 'dangerouslyGetExperimentAssignment',
-					} );
-					return createFallbackExperimentAssignment( experimentName );
+					throw new Error( `Invalid experimentName: ${ experimentName }` );
 				}
 
 				const storedExperimentAssignment = experimentAssignmentStore.retrieve( experimentName );
 				if ( ! storedExperimentAssignment ) {
-					safeLogError( {
-						message: `Trying to dangerously get an ExperimentAssignment that hasn't loaded.`,
-						experimentName,
-						source: 'dangerouslyGetExperimentAssignment',
-					} );
-					return createFallbackExperimentAssignment( experimentName );
+					throw new Error(
+						`Trying to dangerously get an ExperimentAssignment that hasn't loaded.`
+					);
 				}
 
 				// We want to be loud in development mode to help pick up any issues:

--- a/packages/explat-client/src/create-explat-client.ts
+++ b/packages/explat-client/src/create-explat-client.ts
@@ -162,31 +162,50 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 			}
 		},
 		dangerouslyGetExperimentAssignment: ( experimentName: string ): ExperimentAssignment => {
-			if ( ! Validation.isName( experimentName ) ) {
-				throw new Error( `Invalid experimentName: ${ experimentName }` );
-			}
-
-			const storedExperimentAssignment = experimentAssignmentStore.retrieve( experimentName );
-			if ( ! storedExperimentAssignment ) {
-				throw new MissingExperimentAssignmentError(
-					`Trying to dangerously get an ExperimentAssignment that hasn't loaded.`
-				);
-			}
-
-			// We want to be loud in development mode to help pick up any issues:
-			if ( config.isDevelopmentMode ) {
-				// Highlight when we dangerously get an experiment too soon to when we load one:
-				if (
-					storedExperimentAssignment &&
-					Timing.monotonicNow() - storedExperimentAssignment.retrievedTimestamp < 1000
-				) {
-					throw new Error(
-						`Warning: Trying to dangerously get an ExperimentAssignment too soon after loading it.`
-					);
+			try {
+				if ( ! Validation.isName( experimentName ) ) {
+					safeLogError( {
+						message: `Invalid experimentName: ${ experimentName }`,
+						experimentName,
+						source: 'dangerouslyGetExperimentAssignment',
+					} );
+					return createFallbackExperimentAssignment( experimentName );
 				}
-			}
 
-			return storedExperimentAssignment;
+				const storedExperimentAssignment = experimentAssignmentStore.retrieve( experimentName );
+				if ( ! storedExperimentAssignment ) {
+					safeLogError( {
+						message: `Trying to dangerously get an ExperimentAssignment that hasn't loaded.`,
+						experimentName,
+						source: 'dangerouslyGetExperimentAssignment',
+					} );
+					return createFallbackExperimentAssignment( experimentName );
+				}
+
+				// We want to be loud in development mode to help pick up any issues:
+				if ( config.isDevelopmentMode ) {
+					// Highlight when we dangerously get an experiment too soon to when we load one:
+					if (
+						storedExperimentAssignment &&
+						Timing.monotonicNow() - storedExperimentAssignment.retrievedTimestamp < 1000
+					) {
+						safeLogError( {
+							message: `Warning: Trying to dangerously get an ExperimentAssignment too soon after loading it.`,
+							experimentName,
+							source: 'dangerouslyGetExperimentAssignment',
+						} );
+					}
+				}
+
+				return storedExperimentAssignment;
+			} catch ( error ) {
+				safeLogError( {
+					message: error.message,
+					experimentName,
+					source: 'dangerouslyGetExperimentAssignment-error',
+				} );
+				return createFallbackExperimentAssignment( experimentName );
+			}
 		},
 		config,
 	};

--- a/packages/explat-client/src/test/create-explat-client.ts
+++ b/packages/explat-client/src/test/create-explat-client.ts
@@ -495,7 +495,7 @@ describe( 'ExPlatClient.dangerouslyGetExperimentAssignment', () => {
 		    Object {
 		      "experimentName": "",
 		      "message": "Invalid experimentName: ",
-		      "source": "dangerouslyGetExperimentAssignment",
+		      "source": "dangerouslyGetExperimentAssignment-error",
 		    },
 		  ],
 		]
@@ -520,7 +520,7 @@ describe( 'ExPlatClient.dangerouslyGetExperimentAssignment', () => {
 		    Object {
 		      "experimentName": "experiment_name_a",
 		      "message": "Trying to dangerously get an ExperimentAssignment that hasn't loaded.",
-		      "source": "dangerouslyGetExperimentAssignment",
+		      "source": "dangerouslyGetExperimentAssignment-error",
 		    },
 		  ],
 		]
@@ -549,7 +549,7 @@ describe( 'ExPlatClient.dangerouslyGetExperimentAssignment', () => {
 		    Object {
 		      "experimentName": "experiment_name_a",
 		      "message": "Trying to dangerously get an ExperimentAssignment that hasn't loaded.",
-		      "source": "dangerouslyGetExperimentAssignment",
+		      "source": "dangerouslyGetExperimentAssignment-error",
 		    },
 		  ],
 		]

--- a/packages/explat-client/src/test/create-explat-client.ts
+++ b/packages/explat-client/src/test/create-explat-client.ts
@@ -477,38 +477,86 @@ describe( 'ExPlatClient.loadExperimentAssignment multiple-use', () => {
 } );
 
 describe( 'ExPlatClient.dangerouslyGetExperimentAssignment', () => {
-	it( 'should throw when given an invalid name', () => {
+	it( 'should log and return fallback when given an invalid name', () => {
 		const mockedConfig = createMockedConfig();
 		const client = createExPlatClient( mockedConfig );
-		expect( () =>
-			client.dangerouslyGetExperimentAssignment( 'the-invalid-name' )
-		).toThrowErrorMatchingInlineSnapshot(
-			`"Trying to dangerously get an ExperimentAssignment that hasn't loaded."`
-		);
+		const firstNow = Date.now();
+		spiedMonotonicNow.mockImplementationOnce( () => firstNow );
+		expect( client.dangerouslyGetExperimentAssignment( '' ) ).toEqual( {
+			experimentName: '',
+			retrievedTimestamp: firstNow,
+			ttl: 60,
+			variationName: null,
+			isFallbackExperimentAssignment: true,
+		} );
+		expect( ( mockedConfig.logError as MockedFunction ).mock.calls ).toMatchInlineSnapshot( `
+		Array [
+		  Array [
+		    Object {
+		      "experimentName": "",
+		      "message": "Invalid experimentName: ",
+		      "source": "dangerouslyGetExperimentAssignment",
+		    },
+		  ],
+		]
+	` );
 	} );
 
-	it( `should throw when the matching experiment hasn't loaded yet`, () => {
+	it( `should log and return fallback when the matching experiment hasn't loaded yet`, () => {
 		const mockedConfig = createMockedConfig();
 		const client = createExPlatClient( mockedConfig );
-		expect( () =>
-			client.dangerouslyGetExperimentAssignment( 'experiment_name_a' )
-		).toThrowErrorMatchingInlineSnapshot(
-			`"Trying to dangerously get an ExperimentAssignment that hasn't loaded."`
-		);
+		const firstNow = Date.now();
+		spiedMonotonicNow.mockImplementationOnce( () => firstNow );
+		expect( client.dangerouslyGetExperimentAssignment( 'experiment_name_a' ) ).toEqual( {
+			experimentName: 'experiment_name_a',
+			retrievedTimestamp: firstNow,
+			ttl: 60,
+			variationName: null,
+			isFallbackExperimentAssignment: true,
+		} );
+		expect( ( mockedConfig.logError as MockedFunction ).mock.calls ).toMatchInlineSnapshot( `
+		Array [
+		  Array [
+		    Object {
+		      "experimentName": "experiment_name_a",
+		      "message": "Trying to dangerously get an ExperimentAssignment that hasn't loaded.",
+		      "source": "dangerouslyGetExperimentAssignment",
+		    },
+		  ],
+		]
+	` );
 	} );
 
-	it( `should throw when the matching experiment hasn't loaded yet but is currently loading`, () => {
+	it( `should log and return fallback when the matching experiment hasn't loaded yet but is currently loading`, async () => {
+		jest.useFakeTimers();
 		const mockedConfig = createMockedConfig();
 		const client = createExPlatClient( mockedConfig );
-		mockFetchExperimentAssignmentToMatchExperimentAssignment(
-			mockedConfig,
-			validExperimentAssignment
-		);
-		expect( () =>
-			client.dangerouslyGetExperimentAssignment( 'experiment_name_a' )
-		).toThrowErrorMatchingInlineSnapshot(
-			`"Trying to dangerously get an ExperimentAssignment that hasn't loaded."`
-		);
+		const firstNow = Date.now();
+		spiedMonotonicNow.mockImplementationOnce( () => firstNow );
+		const secondNow = Date.now();
+		spiedMonotonicNow.mockImplementationOnce( () => secondNow );
+		const promise = client.loadExperimentAssignment( 'experiment_name_a' );
+		expect( client.dangerouslyGetExperimentAssignment( 'experiment_name_a' ) ).toEqual( {
+			experimentName: 'experiment_name_a',
+			retrievedTimestamp: secondNow,
+			ttl: 60,
+			variationName: null,
+			isFallbackExperimentAssignment: true,
+		} );
+		expect( ( mockedConfig.logError as MockedFunction ).mock.calls ).toMatchInlineSnapshot( `
+		Array [
+		  Array [
+		    Object {
+		      "experimentName": "experiment_name_a",
+		      "message": "Trying to dangerously get an ExperimentAssignment that hasn't loaded.",
+		      "source": "dangerouslyGetExperimentAssignment",
+		    },
+		  ],
+		]
+	` );
+		jest.runAllTimers();
+		await promise;
+		jest.useRealTimers();
 	} );
 
 	it( `should return a loaded ExperimentAssignment`, async () => {
@@ -527,7 +575,7 @@ describe( 'ExPlatClient.dangerouslyGetExperimentAssignment', () => {
 		).toEqual( validExperimentAssignment );
 	} );
 
-	it( `[developerMode] should throw when run too soon after loading an ExperimentAssignment`, async () => {
+	it( `[developerMode] should log error when run too soon after loading an ExperimentAssignment`, async () => {
 		const mockedConfig = createMockedConfig( { isDevelopmentMode: true } );
 		const client = createExPlatClient( mockedConfig );
 		mockFetchExperimentAssignmentToMatchExperimentAssignment(
@@ -541,29 +589,17 @@ describe( 'ExPlatClient.dangerouslyGetExperimentAssignment', () => {
 			() => validExperimentAssignment.retrievedTimestamp + 1
 		);
 		await client.loadExperimentAssignment( validExperimentAssignment.experimentName );
-		expect( () =>
-			client.dangerouslyGetExperimentAssignment( validExperimentAssignment.experimentName )
-		).toThrowErrorMatchingInlineSnapshot(
-			`"Warning: Trying to dangerously get an ExperimentAssignment too soon after loading it."`
-		);
-	} );
-
-	it( `[developmentMode] should return a loaded ExperimentAssignment when not run too soon after`, async () => {
-		const mockedConfig = createMockedConfig( { isDevelopmentMode: true } );
-		const client = createExPlatClient( mockedConfig );
-		mockFetchExperimentAssignmentToMatchExperimentAssignment(
-			mockedConfig,
-			validExperimentAssignment
-		);
-		spiedMonotonicNow.mockImplementationOnce(
-			() => validExperimentAssignment.retrievedTimestamp + 1
-		);
-		spiedMonotonicNow.mockImplementationOnce(
-			() => validExperimentAssignment.retrievedTimestamp + 1000
-		);
-		await client.loadExperimentAssignment( validExperimentAssignment.experimentName );
-		expect(
-			client.dangerouslyGetExperimentAssignment( validExperimentAssignment.experimentName )
-		).toEqual( validExperimentAssignment );
+		client.dangerouslyGetExperimentAssignment( validExperimentAssignment.experimentName );
+		expect( ( mockedConfig.logError as MockedFunction ).mock.calls ).toMatchInlineSnapshot( `
+		Array [
+		  Array [
+		    Object {
+		      "experimentName": "experiment_name_a",
+		      "message": "Warning: Trying to dangerously get an ExperimentAssignment too soon after loading it.",
+		      "source": "dangerouslyGetExperimentAssignment",
+		    },
+		  ],
+		]
+	` );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Have dangerouslyGetExperimentAssignment log rather than throw

Looking at it now I think throwing was a bad idea and complicates things, logging is the way to go.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Added unit tests

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/50512#issuecomment-810709801
