### PR TITLE
`useLocale()` hook falls back to using `@wordpress/i18n` locale data

### DIFF
--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -24,6 +24,7 @@
 	},
 	"dependencies": {
 		"@wordpress/compose": "^3.24.5",
+		"@wordpress/i18n": "^3.19.0",
 		"react": "^16.12.0"
 	},
 	"devDependencies": {

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import * as i18n from '@wordpress/i18n';
 
-export const localeContext = createContext< string >( 'en' );
+export const localeContext = createContext< string | null >( null );
 
 interface Props {
 	localeSlug: string;
@@ -15,7 +16,16 @@ export const LocaleProvider: React.FC< Props > = ( { children, localeSlug } ) =>
 );
 
 /**
- * React hook providing the current locale slug supplied to `<LocaleProvider>`.
+ * Get the current locale slug from the @wordpress/i18n locale data
+ */
+function getWpI18nLocaleSlug(): string | undefined {
+	return i18n.getLocaleData()?.[ '' ]?.language;
+}
+
+/**
+ * React hook providing the current locale slug. If `<LocaleProvider>` hasn't
+ * been defined in the component tree then it will fall back to using the
+ * data from `@wordpress/i18n` to determine the current locale slug.
  *
  * @example
  *
@@ -26,7 +36,26 @@ export const LocaleProvider: React.FC< Props > = ( { children, localeSlug } ) =>
  * }
  */
 export function useLocale(): string {
-	return useContext( localeContext );
+	const fromProvider = useContext( localeContext );
+	const providerHasLocale = !! fromProvider;
+
+	const [ fromWpI18n, setWpLocale ] = useState( getWpI18nLocaleSlug() );
+
+	useEffect( () => {
+		// If the <LocaleProvider> has been used further up the component tree
+		// then we don't want to subscribe to any defaultI18n changes.
+		if ( providerHasLocale ) {
+			return;
+		}
+
+		setWpLocale( getWpI18nLocaleSlug() );
+
+		return i18n.subscribe( () => {
+			setWpLocale( getWpI18nLocaleSlug() );
+		} );
+	}, [ providerHasLocale ] );
+
+	return fromProvider || fromWpI18n || 'en';
 }
 
 /**

--- a/packages/i18n-utils/src/test/locale-context.tsx
+++ b/packages/i18n-utils/src/test/locale-context.tsx
@@ -5,8 +5,9 @@
  * External dependencies
  */
 import React from 'react';
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import { render } from '@testing-library/react';
+import { getLocaleData, subscribe } from '@wordpress/i18n';
 import '@testing-library/jest-dom/extend-expect';
 
 /**
@@ -14,8 +15,18 @@ import '@testing-library/jest-dom/extend-expect';
  */
 import { LocaleProvider, useLocale, withLocale } from '../locale-context';
 
+jest.mock( '@wordpress/i18n', () => ( {
+	getLocaleData: jest.fn( () => ( {} ) ),
+	subscribe: jest.fn( () => () => undefined ),
+} ) );
+
+beforeEach( () => {
+	( getLocaleData as jest.Mock ).mockReset();
+	( subscribe as jest.Mock ).mockReset();
+} );
+
 describe( 'useLocale', () => {
-	it( 'returns "en" if there is no LocaleProvider', () => {
+	it( 'returns "en" if there is no LocaleProvider or @wordpress/i18n data', () => {
 		const { result } = renderHook( () => useLocale() );
 
 		expect( result.current ).toBe( 'en' );
@@ -38,6 +49,73 @@ describe( 'useLocale', () => {
 
 		rerender( { localeSlug: 'ar' } );
 
+		expect( result.current ).toBe( 'ar' );
+	} );
+
+	it( "uses locale data from @wordpress/i18n if <LocaleProvider> isn't present", () => {
+		( getLocaleData as jest.Mock ).mockImplementation( () => ( {
+			'': { language: 'ar' },
+		} ) );
+
+		const { result } = renderHook( () => useLocale() );
+
+		expect( result.current ).toBe( 'ar' );
+	} );
+
+	it( 'prefers <LocaleProvider> if both are present', () => {
+		( getLocaleData as jest.Mock ).mockImplementation( () => ( {
+			'': { language: 'he' },
+		} ) );
+
+		const { result } = renderHook( () => useLocale(), {
+			wrapper: LocaleProvider,
+			initialProps: { localeSlug: 'es' },
+		} );
+
+		expect( result.current ).toBe( 'es' );
+	} );
+
+	it( 'subscribes to changes to @wordpress/i18n data', () => {
+		( getLocaleData as jest.Mock ).mockImplementation( () => ( {
+			'': { language: 'es' },
+		} ) );
+
+		let subscribeCallback;
+		( subscribe as jest.Mock ).mockImplementation( ( callback ) => {
+			subscribeCallback = callback;
+		} );
+
+		const { result } = renderHook( () => useLocale() );
+
+		expect( subscribe ).toHaveBeenCalledWith( expect.any( Function ) );
+		expect( result.current ).toBe( 'es' );
+
+		( getLocaleData as jest.Mock ).mockImplementation( () => ( {
+			'': { language: 'ja' },
+		} ) );
+		act( () => subscribeCallback() );
+
+		expect( result.current ).toBe( 'ja' );
+	} );
+
+	it( 'unsubscribes from @wordpress/i18n when <LocaleProvider> starts to provide a value', () => {
+		( getLocaleData as jest.Mock ).mockImplementation( () => ( {
+			'': { language: 'es' },
+		} ) );
+
+		const unsubscribe = jest.fn();
+		( subscribe as jest.Mock ).mockImplementation( () => unsubscribe );
+
+		const { result, rerender } = renderHook( () => useLocale(), {
+			wrapper: LocaleProvider,
+			initialProps: { localeSlug: undefined },
+		} );
+
+		expect( result.current ).toBe( 'es' );
+
+		rerender( { localeSlug: 'ar' } );
+
+		expect( unsubscribe ).toHaveBeenCalled();
 		expect( result.current ).toBe( 'ar' );
 	} );
 } );


### PR DESCRIPTION
`useLocale()` was originally written to only work with the `<LocaleProvider>`. Back then there was no way to access the locale data from `@wordpress/i18n` so we were getting the locale slug using a homegrown method for each application. Calypso set it up in `<CalypsoI18nProvider>`. Some features in the ETK manually send the locale slug to the client using `wp_localize_script()` if it's needed.

Now that there's a standard way to access the underlying locale data we can transition away from using `<LocaleProvider>` and `useLocale()` can get the slug directly from `@wordpress/i18n`.

It would be nice for something like `useLocale()` to be available in `@wordpress/react-i18n`, but I'm not sure that's possible. Making language metadata available on the data object using the special empty string key might be a wpcom specific thing.

I originally made this change to get the What's New modal's text translated correctly. It currently always requests data with `locale=en` because it uses `useLocale()` without providing a `<LocaleProvider>`. I thought rather than add the provider we should just fix the hook to work with the new version of `@wordpress/i18n` so the homegrown provider isn't necessary. ~~Unfortunately there appears to be a bug in the What's New modal endpoint where now that the correct locale slug is being sent the endpoint returns no description text @donlair~~ Use D59565-code to test this fix with the What's New modal.

#### Changes proposed in this Pull Request

* If data from `<LocaleProvider>` isn't available, `useLocale()` will fallback to `@wordpress/i18n` and subscribe to changes
* Unit tests
* Type annotation changes in `@automattic/react-i18n` to deal with the `@wp/i18n` upgrade

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test Gutenboarding and confirm translations are loaded and displayed as expected.
* Test ETK (Editor Site Launch/Welcome Guide) and confirm translations are loaded and displayed as expected.
* Test What's New modal
   * Apply D59565-code to sandbox
   * Open editor and choose "What's New" from the editor menu
   * Watch the network tab and see the `/whats-new/list?locale=es` request now uses the correct locale slug

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
