### PR TITLE
Plans Monthly toggle: use context in translations to force adverb form

### DIFF
--- a/packages/plans-grid/src/plans-interval-toggle/index.tsx
+++ b/packages/plans-grid/src/plans-interval-toggle/index.tsx
@@ -57,20 +57,24 @@ const PlansIntervalToggle: React.FunctionComponent< PlansIntervalToggleProps > =
 	maxMonthlyDiscountPercentage,
 	className = '',
 } ) => {
-	const { __, hasTranslation } = useI18n();
+	const { __, _x, hasTranslation } = useI18n();
 	const locale = useLocale();
 
 	const fallbackMonthlyLabel = __( 'Pay monthly', __i18n_text_domain__ );
 	// Translators: intended as "pay monthly", as opposed to "pay annually"
-	const newMonthlyLabel = __( 'Monthly', __i18n_text_domain__ );
+	const newMonthlyLabel = _x( 'Monthly', 'Adverb (as in "Pay monthly")', __i18n_text_domain__ );
 	const monthlyLabel =
-		locale === 'en' || hasTranslation?.( 'Monthly' ) ? newMonthlyLabel : fallbackMonthlyLabel;
+		locale === 'en' || hasTranslation?.( 'Monthly', 'Adverb (as in "Pay monthly")' )
+			? newMonthlyLabel
+			: fallbackMonthlyLabel;
 
 	const fallbackAnnuallyLabel = __( 'Pay annually', __i18n_text_domain__ );
 	// Translators: intended as "pay annually", as opposed to "pay monthly"
-	const newAnnuallyLabel = __( 'Annually', __i18n_text_domain__ );
+	const newAnnuallyLabel = _x( 'Annually', 'Adverb (as in "Pay annually")', __i18n_text_domain__ );
 	const annuallyLabel =
-		locale === 'en' || hasTranslation?.( 'Annually' ) ? newAnnuallyLabel : fallbackAnnuallyLabel;
+		locale === 'en' || hasTranslation?.( 'Annually', 'Adverb (as in "Pay annually")' )
+			? newAnnuallyLabel
+			: fallbackAnnuallyLabel;
 
 	return (
 		<div

--- a/packages/plans-grid/src/plans-interval-toggle/index.tsx
+++ b/packages/plans-grid/src/plans-interval-toggle/index.tsx
@@ -64,7 +64,7 @@ const PlansIntervalToggle: React.FunctionComponent< PlansIntervalToggleProps > =
 	// Translators: intended as "pay monthly", as opposed to "pay annually"
 	const newMonthlyLabel = _x( 'Monthly', 'Adverb (as in "Pay monthly")', __i18n_text_domain__ );
 	const monthlyLabel =
-		locale === 'en' || hasTranslation?.( 'Monthly', 'Adverb (as in "Pay monthly")' )
+		locale === 'en' || hasTranslation( 'Monthly', 'Adverb (as in "Pay monthly")' )
 			? newMonthlyLabel
 			: fallbackMonthlyLabel;
 
@@ -72,7 +72,7 @@ const PlansIntervalToggle: React.FunctionComponent< PlansIntervalToggleProps > =
 	// Translators: intended as "pay annually", as opposed to "pay monthly"
 	const newAnnuallyLabel = _x( 'Annually', 'Adverb (as in "Pay annually")', __i18n_text_domain__ );
 	const annuallyLabel =
-		locale === 'en' || hasTranslation?.( 'Annually', 'Adverb (as in "Pay annually")' )
+		locale === 'en' || hasTranslation( 'Annually', 'Adverb (as in "Pay annually")' )
 			? newAnnuallyLabel
 			: fallbackAnnuallyLabel;
 

--- a/packages/plans-grid/src/plans-interval-toggle/index.tsx
+++ b/packages/plans-grid/src/plans-interval-toggle/index.tsx
@@ -2,9 +2,8 @@
  * External dependencies
  */
 import * as React from 'react';
-import { useI18n } from '@wordpress/react-i18n';
 import { useLocale } from '@automattic/i18n-utils';
-import { sprintf } from '@wordpress/i18n';
+import { __, _x, hasTranslation, sprintf } from '@wordpress/i18n';
 import { Popover } from '@wordpress/components';
 import classNames from 'classnames';
 import type { Plans } from '@automattic/data-stores';
@@ -57,7 +56,6 @@ const PlansIntervalToggle: React.FunctionComponent< PlansIntervalToggleProps > =
 	maxMonthlyDiscountPercentage,
 	className = '',
 } ) => {
-	const { __, _x, hasTranslation } = useI18n();
 	const locale = useLocale();
 
 	const fallbackMonthlyLabel = __( 'Pay monthly', __i18n_text_domain__ );

--- a/packages/plans-grid/src/plans-interval-toggle/index.tsx
+++ b/packages/plans-grid/src/plans-interval-toggle/index.tsx
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import * as React from 'react';
+import { useI18n } from '@wordpress/react-i18n';
 import { useLocale } from '@automattic/i18n-utils';
-import { __, _x, hasTranslation, sprintf } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
 import { Popover } from '@wordpress/components';
 import classNames from 'classnames';
 import type { Plans } from '@automattic/data-stores';
@@ -56,6 +57,7 @@ const PlansIntervalToggle: React.FunctionComponent< PlansIntervalToggleProps > =
 	maxMonthlyDiscountPercentage,
 	className = '',
 } ) => {
+	const { __, _x, hasTranslation } = useI18n();
 	const locale = useLocale();
 
 	const fallbackMonthlyLabel = __( 'Pay monthly', __i18n_text_domain__ );


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Add context information when marking the `Monthly` and `Annually` strings for translation in the plans monthly toggle
* This is to make sure that both strings are translated with the adverb form (as in "Pay monthly"), as opposed to the adjective form (as in "Monthly plan")

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Test in Gutenboarding:

- Pull this PR's branch on your local machine and run the project locally (run `yarn && yarn start` in the root folder), or visit the `calypso.live` link
- Go to `/new`
- Set the language to English (by accessing the language picker in the top right of the screen)
- Proceed through the flow until you reach the plans step
  - [x] Check that the monthly toggle labels are "Monthly" and "Annually"
- Switch to a language for which translations have completed (you can check the translations progress [here](https://translate.wordpress.com/localci/status/automattic/wp-calypso/fix/plans-monthly-toggle-translations-context))
  - [x] Check that the monthly toggle labels are displaying the latest translations for "Monthly" and "Annually" (in adverb form)
- Switch to a language for which translations have _not_ completed (you can check the translations progress [here](https://translate.wordpress.com/localci/status/automattic/wp-calypso/fix/plans-monthly-toggle-translations-context))
    - [x] Check that the monthly toggle labels are displaying the fallback translations for "Pay monthly" and "Pay annually" (in adverb form)

### Test in Focused Launch

- Prepare your sandbox:
  - Make sure you have an active ssh connection to your sandbox
  - Clear your sandbox and pull the latest version from trunk
  - Add an unlaunched site to your sandbox
- Assign yourself to the "treatment" group in the `focused_launch_flow_v2` A/B test
- Pull this PR's branch on your local machine and run the project locally:
  - Run `yarn && yarn start` in the root folder
  - After the command above has finished compiling, in a separate terminal window run `cd apps/editing-toolkit && yarn dev --sync`
- Open the block editor (e.g. by visiting `calyspo.localhost:3000/page/UNLAUNCHED_SITE_ID.wordpress.com/home`)
- Click on the "Launch" button to open Focused Launch flow
- Click on the "View all plans" link
  - [x] Check that the monthly toggle labels are "Monthly" and "Annually"
- Switch to a language for which translations have completed (you can check the translations progress [here](https://translate.wordpress.com/localci/status/automattic/wp-calypso/fix/plans-monthly-toggle-translations-context)) (the language can be changed in the WordPress.com account settings)
  - [x] Check that the monthly toggle labels are displaying the latest translations for "Monthly" and "Annually" (in adverb form)
- Switch to a language for which translations have _not_ completed (you can check the translations progress [here](https://translate.wordpress.com/localci/status/automattic/wp-calypso/fix/plans-monthly-toggle-translations-context)) (the language can be changed in the WordPress.com account settings)
    - [x] Check that the monthly toggle labels are displaying the fallback translations for "Pay monthly" and "Pay annually" (in adverb form)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Context / Screenshots

![image](https://user-images.githubusercontent.com/1083581/113129689-7c2c9180-921b-11eb-853b-e9add6de8397.png)


Fixes #50787
