### PR TITLE
E2E: Address Gutenboarding suite issues

### DIFF
--- a/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
+++ b/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
@@ -23,11 +23,13 @@ export default class AcquireIntentPage extends AsyncBaseContainer {
 	}
 
 	async goToNextStep() {
-		return await driverHelper.clickWhenClickable( this.driver, this.nextButtonSelector );
+		await driverHelper.clickWhenClickable( this.driver, this.nextButtonSelector );
+		await this.driver.switchTo().defaultContent();
 	}
 
 	async skipStep() {
 		const skipButtonSelector = By.css( '.action-buttons__skip' );
-		return await driverHelper.clickWhenClickable( this.driver, skipButtonSelector );
+		await driverHelper.clickWhenClickable( this.driver, skipButtonSelector );
+		await this.driver.switchTo().defaultContent();
 	}
 }

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -146,9 +146,9 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 
 	describe( 'Visit Gutenboarding page as a logged in user', function () {
 		step( 'Can log in as user', async function () {
-			this.loginFlow = new LoginFlow( driver );
-			this.loginFlow.login();
+			await new LoginFlow( driver ).login();
 		} );
+
 		step( 'Can visit Gutenboarding', async function () {
 			await NewPage.Visit( driver );
 		} );

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -120,7 +120,7 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 				await plansPage.selectFreePlan();
 
 				// Redirect console messages that starts with "onboarding-debug" to E2E log.
-				driver
+				await driver
 					.manage()
 					.logs()
 					.get( 'browser' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add some missing awaits.
  They're necessary to ensure the `step` has completed.
* Make sure the WebDriver content is ready after navigating to a new page.
  IIUC, when navigating to a new page via click, the driver’s context frame changes. Because the context switch promise is detached from the click one, the context one can resolve first and we can end up with a `stale element reference: <clicked> element is not attached to the page document` error. 

#### Testing instructions

~All specs~ Gutenboarding suite should pass 😛 