### PR TITLE
E2E: Fix flaky site/post creation flows

### DIFF
--- a/test/e2e/lib/flows/create-site-flow.js
+++ b/test/e2e/lib/flows/create-site-flow.js
@@ -1,6 +1,12 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
+import * as driverHelper from '../driver-helper';
 import FindADomainComponent from '../components/find-a-domain-component';
 import PickAPlanPage from '../pages/signup/pick-a-plan-page';
 import StartPage from '../pages/signup/start-page.js';
@@ -20,6 +26,17 @@ export default class CreateSiteFlow {
 
 		const pickAPlanPage = await PickAPlanPage.Expect( this.driver );
 		await pickAPlanPage.selectFreePlan();
+
+		// Let's give the create request enough time to finish. Sometimes it takes
+		// way more than the default 20 seconds, and the cost of waiting a bit
+		// longer is definitely lower than the cost of repeating the whole spec.
+		const hoorayTitleLocator = By.css( '.signup-processing-screen__title' );
+		await driverHelper.waitUntilElementWithTextLocated(
+			this.driver,
+			hoorayTitleLocator,
+			/your site will be ready shortly/i
+		);
+		await driverHelper.waitTillNotPresent( this.driver, hoorayTitleLocator, 60000 );
 
 		const myHomePage = await MyHomePage.Expect( this.driver );
 		return await myHomePage.siteSetupListExists();

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -71,7 +71,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async publish( { visit = false, closePanel = true } = {} ) {
 		await driverHelper.clickWhenClickable( this.driver, this.prePublishButtonSelector );
 		await driverHelper.clickWhenClickable( this.driver, this.publishButtonSelector );
-		await driverHelper.waitTillNotPresent( this.driver, this.publishingSpinnerSelector );
+		// Let's give publishing request enough time to finish. Sometimes it takes
+		// way more than the default 20 seconds, and the cost of waiting a bit
+		// longer is definitely lower than the cost of repeating the whole spec.
+		await driverHelper.waitTillNotPresent( this.driver, this.publishingSpinnerSelector, 60000 );
 
 		if ( closePanel ) {
 			try {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

An attempt to fix flaky specs where publishing a post or launching a site takes more than the default 20sec timeout.  The cost of waiting a bit more and passing on the first attempt is definitely lower than repeating the whole block (often multiple times).

Example of a failure we're trying to fix here: https://app.circleci.com/pipelines/github/Automattic/wp-e2e-tests-for-branches/63809/workflows/d3424884-e97e-496d-987e-a490f54ce362/jobs/153290/tests

#### Testing instructions

Launch and domain suites should pass on the first run.