### PR TITLE
Jetpack Cloud: update all border-radii from 3px to 4px

### DIFF
--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -1,8 +1,8 @@
 // custom properties for Jetpack
 :root {
 	// border-radius
-	--jetpack-corners-sharp: 0px;
-	--jetpack-corners-soft: 3px;
+	--jetpack-corners-sharp: 0;
+	--jetpack-corners-soft: 4px;
 }
 
 .theme-jetpack-cloud,
@@ -233,11 +233,10 @@ html {
 .theme-jetpack-cloud .ReactModalPortal {
 	.dialog.card {
 		box-shadow: 0 0 0 1px var( --color-border-subtle ), 0 4px 12px var( --color-neutral-10 );
-		border-radius: 2px;
 	}
 
 	.dialog__action-buttons {
-		border-radius: 0 0 3px 3px;
+		border-radius: 0 0 var( --jetpack-corners-soft ) var( --jetpack-corners-soft );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update all border-radii from 3px to 4px on Jetpack Cloud.

See: p1HpG7-bA6-p2#comment-45648

#### Testing instructions

* Fire up this PR.
* Head to http://jetpack.cloud.localhost:3000/
* Ensure all buttons and modals have a 4px border-radius.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/113147206-725d5b00-9228-11eb-850b-20b5d7575f4e.png) | ![image](https://user-images.githubusercontent.com/390760/113147210-74271e80-9228-11eb-81bc-25d7c5789597.png)

