### PR TITLE
Plugins Browser: show the Manage Plugins button on only Jetpack and business Atomic sites

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -355,7 +355,7 @@ export class PluginsBrowser extends Component {
 	}
 
 	shouldShowManageButton() {
-		if ( this.props.isJetpackSite ) {
+		if ( this.props.jetpackNonAtomic || this.props.hasBusinessPlan ) {
 			return true;
 		}
 		return ! this.props.selectedSiteId && this.props.hasJetpackSites;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The Manage Plugins button should be displayed only when the site is a Jetpack site or an Atomic site with a business plan.

#### Testing instructions
* Navigate to the `plugins/{your test site}` url on the this branch's Calypso live site. Test with various types of test sites, and verify that the "Manage plugins' button is displayed when expected:
    * A simple site - the button should not be displayed.
    * A Free Atomic site - the button should not be displayed.
    * A Business Atomic site - the button should be displayed.
    * A Jetpack site - the button should be displayed.
