### PR TITLE
Fixes height restriction for languages with more content.

### DIFF
--- a/client/blocks/nav-unification-modal/style.scss
+++ b/client/blocks/nav-unification-modal/style.scss
@@ -114,7 +114,6 @@ $modal-footer-height: 30px + ( $modal-footer-padding-v * 2 );
 	justify-content: flex-end;
 	background: white;
 	width: 100%;
-	height: 100%;
 	overflow: hidden;
 
 	@media ( min-width: $modal-breakpoint ) {
@@ -202,7 +201,7 @@ $modal-footer-height: 30px + ( $modal-footer-padding-v * 2 );
 	/* Gray / Gray 90 */
 	color: #1d2327;
 	font-size: 24px;
-	
+
 	h2 {
 		line-height: 1.19;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* doesn't restrict modal to 100% so that languages with more content have a chance to be shown

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to WordPress.com
* Change your user language to one of the following languages: Russian, German, Dutch, or French.
* Activate the Nav Unification Customer Modal


Before | After
-------|------
![](https://cln.sh/Zsia1i+) | ![](https://cln.sh/pH102P+)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #51561
