### PR TITLE
E2E: Fix iframe driver switch intermittent failure

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -720,6 +720,7 @@ class CalypsoifyIframe extends Component<
 					{ ! isIframeLoaded && <Placeholder /> }
 					{ ( shouldLoadIframe || isIframeLoaded ) && (
 						<Iframe
+							className={ isIframeLoaded ? 'is-loaded' : '' }
 							ref={ this.iframeRef }
 							src={ isIframeLoaded ? currentIFrameUrl : iframeUrl }
 							// Iframe url needs to be kept in state to prevent editor reloading if frame_nonce changes

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -22,7 +22,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		super( driver, By.css( '.edit-post-header' ), url );
 		this.editorType = editorType;
 
-		this.editoriFrameSelector = By.css( '.calypsoify.is-iframe iframe' );
+		this.editoriFrameSelector = By.css( '.calypsoify.is-iframe iframe.is-loaded' );
 		this.publishHeaderSelector = By.css( '.editor-post-publish-panel__header' );
 		this.prePublishButtonSelector = By.css(
 			'.editor-post-publish-panel__toggle[aria-disabled="false"]'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `.is-loaded` classname to the iframe editor when it is loaded.
* Update driver to look for `iframe.is-loaded` instead.

This is based on the suspicion that iframe might be rerendered twice or multiple times and the driver was switched to the iframe element that was rendered earlier.

This is branched off the PR https://github.com/Automattic/wp-calypso/pull/51573 so we can run the tests multiple times to see which one fails often and which one doesn't.

#### Testing instructions

* Re-run build in TC multiple times and see if it still fails with the error `.edit-post-header` not found.

Related to https://github.com/Automattic/wp-calypso/pull/51573
