### PR TITLE
Framework: Refactor away from _.negate()

### DIFF
--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -8,7 +8,6 @@ import {
 	pick,
 	pickBy,
 	without,
-	negate,
 	isEmpty,
 	take,
 	filter,
@@ -154,7 +153,7 @@ class KeyedSuggestions extends React.Component {
 	};
 
 	removeEmptySuggestions = ( suggestions ) => {
-		return pickBy( suggestions, negate( isEmpty ) );
+		return pickBy( suggestions, ( suggestion ) => ! isEmpty( suggestion ) );
 	};
 
 	/**

--- a/client/layout/guided-tours/utils.js
+++ b/client/layout/guided-tours/utils.js
@@ -1,10 +1,9 @@
-/**
- * External dependencies
- */
-import { negate as not } from 'lodash';
-
 const noop = () => {};
 
 const and = ( ...conditions ) => () => conditions.every( ( cond ) => cond() );
+
+const not = function ( func ) {
+	return ! func.apply( null, arguments );
+};
 
 export { and, not, noop };

--- a/client/layout/guided-tours/utils.js
+++ b/client/layout/guided-tours/utils.js
@@ -2,8 +2,6 @@ const noop = () => {};
 
 const and = ( ...conditions ) => () => conditions.every( ( cond ) => cond() );
 
-const not = function ( func ) {
-	return ! func.apply( null, arguments );
-};
+const not = ( fn ) => ( ...args ) => ! fn( ...args );
 
 export { and, not, noop };

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { dropRightWhile, negate, identity } from 'lodash';
+import { dropRightWhile } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -58,7 +58,7 @@ class CustomNameserversForm extends React.PureComponent {
 	rows() {
 		// Remove the empty values from the end, and add one empty one
 		const { translate } = this.props;
-		const nameservers = dropRightWhile( this.props.nameservers, negate( identity ) );
+		const nameservers = dropRightWhile( this.props.nameservers, ( nameserver ) => ! nameserver );
 
 		if ( nameservers.length < MAX_NAMESERVER_LENGTH ) {
 			nameservers.push( '' );

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { find, get, includes, isEmpty, isEqual, negate, range, reduce, sortBy } from 'lodash';
+import { find, get, includes, isEmpty, isEqual, range, reduce, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -237,7 +237,7 @@ export class PluginsList extends React.Component {
 		this.removePluginStatuses();
 		this.props.plugins
 			.filter( this.isSelected ) // only use selected sites
-			.filter( negate( isDeactivatingAndJetpackSelected ) ) // ignore sites that are deactiving or activating jetpack
+			.filter( ( plugin ) => ! isDeactivatingAndJetpackSelected( plugin ) ) // ignore sites that are deactiving or activating jetpack
 			.map( ( p ) => {
 				return Object.keys( p.sites ).map( ( siteId ) => {
 					const site = this.props.allSites.find( ( s ) => s.ID === parseInt( siteId ) );

--- a/client/state/domains/dns/reducer.js
+++ b/client/state/domains/dns/reducer.js
@@ -1,18 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	filter,
-	find,
-	findIndex,
-	matches,
-	negate,
-	pick,
-	reject,
-	some,
-	startsWith,
-	without,
-} from 'lodash';
+import { filter, find, findIndex, matches, pick, reject, some, startsWith, without } from 'lodash';
 import update from 'immutability-helper';
 
 /**
@@ -46,7 +35,7 @@ function isNsRecord( domain ) {
 function removeDuplicateWpcomRecords( domain, records ) {
 	const rootARecords = filter( records, isRootARecord( domain ) );
 	const wpcomARecord = find( rootARecords, isWpcomRecord );
-	const customARecord = find( rootARecords, negate( isWpcomRecord ) );
+	const customARecord = find( rootARecords, ( record ) => ! isWpcomRecord( record ) );
 
 	if ( wpcomARecord && customARecord ) {
 		return without( records, wpcomARecord );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `negate` is essentially a helper that creates a function, returns a negated version of the predicate, passed as an argument. Simple enough to not require a helper function. This PR replaces all the `_.negate()` usage with native implementations instead.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all usages are sane and preserve the original logic.
* Verify all tests pass.