### PR TITLE
Domains: Add a link back to WordPress.com on the verification screen

### DIFF
--- a/client/landing/domains/registrant-verification/index.jsx
+++ b/client/landing/domains/registrant-verification/index.jsx
@@ -218,6 +218,7 @@ class RegistrantVerificationPage extends Component {
 				break;
 
 			case 'KS_RAM_error':
+			case 'KS_RSP_error':
 				errorState = this.getKeySystemsErrorState( error.message );
 				break;
 

--- a/client/landing/domains/registrant-verification/index.jsx
+++ b/client/landing/domains/registrant-verification/index.jsx
@@ -14,6 +14,7 @@ import DomainsLandingContentCard from '../content-card';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import wp from 'calypso/lib/wp';
 import { getMaintenanceMessageFromError } from '../utils';
+import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
 
 const wpcom = wp.undocumented();
 
@@ -80,7 +81,14 @@ class RegistrantVerificationPage extends Component {
 			),
 			actionTitle: null,
 			actionCallback: null,
-			footer: translate( 'All done. You can close this window now.' ),
+			footer: translate(
+				'All done. You can close this window now or {{domainsManagementLink}}manage your domains{{/domainsManagementLink}}.',
+				{
+					components: {
+						domainsManagementLink: <a href={ domainManagementRoot() } />,
+					},
+				}
+			),
 			isLoading: false,
 		};
 	};
@@ -143,7 +151,14 @@ class RegistrantVerificationPage extends Component {
 						},
 					}
 				),
-				footer: translate( 'All done. You can close this window now.' ),
+				footer: translate(
+					'All done. You can close this window now or {{domainsManagementLink}}manage your domains{{/domainsManagementLink}}.',
+					{
+						components: {
+							domainsManagementLink: <a href={ domainManagementRoot() } />,
+						},
+					}
+				),
 			};
 		}
 	};


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/37277

#### Changes proposed in this Pull Request

Before:

<img width="752" alt="Screenshot 2021-03-31 at 18 03 35" src="https://user-images.githubusercontent.com/3392497/113190047-6e8f0000-924b-11eb-8fad-36775aef76a6.png">

It's a dead end - which was intentional, since we cannot be sure if the user is logged in, etc. But now we have the `/domains/manage` landing page which should be a safe spot to direct them to.

After:

<img width="753" alt="Screenshot 2021-03-31 at 17 54 40" src="https://user-images.githubusercontent.com/3392497/113190179-8bc3ce80-924b-11eb-8788-511b67d9e45c.png">

#### Testing instructions

Update the WHOIS details on an ICANN-regulated TLD (gTLDs like com, blog, etc.) and set a new first, last, org or email fields. This should trigger the verification email. The link in the email goes through `public-api` first so you might need to edit it to get to the real link which looks like `https://wordpress.com/domain-services/registrant-verification?domain=example.com&email=foo@example.com&token=c18664a6282ea1231234123123`. Change the `https://wordpress.com` part to `calypso.localhost:3000` or the name of the calypso.live link.

You should get the "After" screen, with a link to `/domains/manage`. Try refreshing the verification landing page - this will trigger the "already verified" screen which also contains the new link:

<img width="753" alt="Screenshot 2021-03-31 at 17 59 53" src="https://user-images.githubusercontent.com/3392497/113327484-8bd6d380-930a-11eb-8264-fce7b3dc1681.png">

