### PR TITLE
Domains: Fix cancel transfer out from domain management

### DIFF
--- a/client/my-sites/domains/domain-management/components/outbound-transfer-confirmation/index.jsx
+++ b/client/my-sites/domains/domain-management/components/outbound-transfer-confirmation/index.jsx
@@ -44,10 +44,9 @@ class OutboundTransferConfirmation extends React.PureComponent {
 
 	onCancelTransferClick = () => {
 		const { domain, siteId } = this.props;
-		this.props.cancelDomainTransferRequest( {
-			domainName: domain.name,
-			siteId: siteId,
+		this.props.cancelDomainTransferRequest( domain.name, {
 			declineTransfer: true,
+			siteId,
 		} );
 		this.props.recordTracksEvent( 'calypso_outbound_transfer_cancel_click' );
 	};


### PR DESCRIPTION
Due to a wrong invocation, the button was not working at all 😅 

#### Changes proposed in this Pull Request
Fix the arguments to the `cancelDomainTransferRequest` action.

#### Testing instructions
<img width="674" alt="Screenshot 2021-03-31 at 18 21 14" src="https://user-images.githubusercontent.com/3392497/113192116-e78f5700-924d-11eb-98e6-27b751a49368.png">

Make sure that for a domain that is pending transfer out, the `Cancel transfer` button does not throw a JS error (it might fail, of course, if you hacked a domain to be in this state).

Best to hack the `OutboundTransferConfirmation`'s `render` method to always render `this.this.renderWithAcceptButton`. And then confirm that the button works - even if it will ultimately just show an error notice. But on production it fails with `e.options is not defined` etc.
Compare also this invocation with the other one of the same action: https://github.com/Automattic/wp-calypso/blob/38c37bbfe35b8c741c4e346637987ddc0fb3ab59/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx#L48. Notice the domain name is a separate, first parameter, and the `options` are second.