### PR TITLE
DevDocs: Import JetpackReviewPromptExample

### DIFF
--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -80,7 +80,7 @@ import UserMentions from 'calypso/blocks/user-mentions/docs/example';
 import SupportArticleDialog from 'calypso/blocks/support-article-dialog/docs/example';
 import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning/docs/example';
 import UpsellNudge from 'calypso/blocks/upsell-nudge/docs/example';
-import JetpackReviewPrompt from 'calypso/blocks/jetpack-review-prompt/docs/example'
+import JetpackReviewPrompt from 'calypso/blocks/jetpack-review-prompt/docs/example';
 
 export default class AppComponents extends React.Component {
 	static displayName = 'AppComponents';

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -75,6 +75,7 @@ import JetpackColophonExample from 'calypso/components/jetpack-colophon/docs/exa
 import JetpackHeaderExample from 'calypso/components/jetpack-header/docs/example';
 import JetpackLogoExample from 'calypso/components/jetpack-logo/docs/example';
 import LanguagePicker from 'calypso/components/language-picker/docs/example';
+import JetpackReviewPromptExample from 'calypso/blocks/jetpack-review-prompt/docs/example';
 import LayoutExample from 'calypso/components/layout/docs/example';
 import LineChart from 'calypso/components/line-chart/docs/example';
 import ListEnd from 'calypso/components/list-end/docs/example';


### PR DESCRIPTION
#51560 seems to have broken the design view of DevDocs by not importing the example component.

**To test:**
- visit /devdocs/design
- verify that there are no errors in the browser console and that the page renders correctly