### PR TITLE
i18n: Fix holidays names localization for chat closure notices

### DIFF
--- a/client/me/help/contact-form-notice/chat-holiday-closure.jsx
+++ b/client/me/help/contact-form-notice/chat-holiday-closure.jsx
@@ -14,14 +14,6 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 const DATE_FORMAT = 'LLL';
 
-export const easterHolidayName = translate( 'Easter', {
-	context: 'Holiday name',
-} );
-
-export const xmasHolidayName = translate( 'Christmas', {
-	context: 'Holiday name',
-} );
-
 const ChatHolidayClosureNotice = ( { closesAt, compact, displayAt, holidayName, reopensAt } ) => {
 	const moment = useLocalizedMoment();
 

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -609,21 +609,27 @@ class HelpContact extends React.Component {
 				{ isUserAffectedByLiveChatClosure && (
 					<>
 						<ChatHolidayClosureNotice
-							holidayName="Easter"
+							holidayName={ translate( 'Easter', {
+								context: 'Holiday name',
+							} ) }
 							compact={ compact }
 							displayAt="2021-03-28 00:00Z"
 							closesAt="2021-04-04 00:00Z"
 							reopensAt="2021-04-05 06:00Z"
 						/>
 						<ChatHolidayClosureNotice
-							holidayName="Christmas"
+							holidayName={ translate( 'Christmas', {
+								context: 'Holiday name',
+							} ) }
 							compact={ compact }
 							displayAt="2021-12-17 00:00Z"
 							closesAt="2021-12-24 00:00Z"
 							reopensAt="2021-12-26 07:00Z"
 						/>
 						<ChatHolidayClosureNotice
-							holidayName="New Year's Day"
+							holidayName={ translate( "New Year's Day", {
+								context: 'Holiday name',
+							} ) }
 							compact={ compact }
 							displayAt="2021-12-26 07:00Z"
 							closesAt="2021-12-31 00:00Z"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix holidays names localization for chat closure notices

**Before:**
![image](https://user-images.githubusercontent.com/2722412/113215032-f17f7d00-9282-11eb-8851-2396e6f1acf5.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/113215023-efb5b980-9282-11eb-9189-aad6964b4a42.png)

#### Testing instructions

* Go to `calypso.live/help/contact` and confirm holiday name gets localized

Related to 230-gh-Automattic/i18n-issues
