### PR TITLE
Checkout: Allow cart products to include a redirect URL

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -113,6 +113,13 @@ export default function getThankYouPageUrl( {
 		debug( 'ignorning redirectTo', redirectTo );
 	}
 
+	// If there's a redirect URL set on a product in the cart, use the first one we find.
+	const urlFromCart = cart ? getRedirectUrlFromCart( cart ) : null;
+	if ( urlFromCart ) {
+		debug( 'returning url from cart', urlFromCart );
+		return urlFromCart;
+	}
+
 	// Note: this function is called early on for redirect-type payment methods, when the receipt isn't set yet.
 	// The `:receiptId` string is filled in by our pending page after the PayPal checkout
 	const pendingOrReceiptId = getPendingOrReceiptId( receiptId, orderId, purchaseId );
@@ -520,4 +527,18 @@ function getThankYouPageUrlForTrafficGuide( {
 	if ( hasTrafficGuide( cart ) ) {
 		return `/checkout/thank-you/${ siteSlug }/${ pendingOrReceiptId }`;
 	}
+}
+
+function getRedirectUrlFromCart( cart: ResponseCart ): string | null {
+	const firstProductWithUrl = cart.products.find( ( product ) => {
+		if ( product.extra?.afterPurchaseUrl ) {
+			return true;
+		}
+		return false;
+	} );
+	debug(
+		'looking for redirect url in cart products found',
+		firstProductWithUrl?.extra.afterPurchaseUrl
+	);
+	return firstProductWithUrl?.extra.afterPurchaseUrl ?? null;
 }

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -427,9 +427,34 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/plans/my-plan/foo.bar?thank-you=true&install=all' );
 	} );
 
+	it( 'redirects to the afterPurchaseUrl from the first cart item if set', () => {
+		const cart = {
+			products: [ { extra: { afterPurchaseUrl: '/after/purchase/url' } } ],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			cart,
+			siteSlug: 'foo.bar',
+		} );
+		expect( url ).toBe( '/after/purchase/url' );
+	} );
+
 	it( 'redirects to internal redirectTo url if set', () => {
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
+			siteSlug: 'foo.bar',
+			redirectTo: '/foo/bar',
+		} );
+		expect( url ).toBe( '/foo/bar' );
+	} );
+
+	it( 'redirects to internal redirectTo url if set even if afterPurchaseUrl exists on a cart item', () => {
+		const cart = {
+			products: [ { extra: { afterPurchaseUrl: '/after/purchase/url' } } ],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			cart,
 			siteSlug: 'foo.bar',
 			redirectTo: '/foo/bar',
 		} );
@@ -487,6 +512,21 @@ describe( 'getThankYouPageUrl', () => {
 			isEligibleForSignupDestinationResult: false,
 		} );
 		expect( url ).toBe( '/' );
+	} );
+
+	it( 'redirects to afterPurchaseUrl if set even if there is a url from a cookie', () => {
+		const getUrlFromCookie = jest.fn( () => '/cookie' );
+		const cart = {
+			products: [ { product_slug: 'foo', extra: { afterPurchaseUrl: '/after/purchase/url' } } ],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+			getUrlFromCookie,
+			isEligibleForSignupDestinationResult: true,
+		} );
+		expect( url ).toBe( '/after/purchase/url' );
 	} );
 
 	it( 'redirects to url from cookie with notice type set to "purchase-success" if isEligibleForSignupDestination is set', () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -427,7 +427,7 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/plans/my-plan/foo.bar?thank-you=true&install=all' );
 	} );
 
-	it( 'redirects to the afterPurchaseUrl from the first cart item if set', () => {
+	it( 'redirects to the afterPurchaseUrl from a cart item if set', () => {
 		const cart = {
 			products: [ { extra: { afterPurchaseUrl: '/after/purchase/url' } } ],
 		};
@@ -437,6 +437,29 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 		} );
 		expect( url ).toBe( '/after/purchase/url' );
+	} );
+
+	it( 'redirects to the afterPurchaseUrl from the most recent cart item if multiple are set', () => {
+		const cart = {
+			products: [
+				{
+					product_slug: 'older_product',
+					time_added_to_cart: 1617228489,
+					extra: { afterPurchaseUrl: '/older/purchase/url' },
+				},
+				{
+					product_slug: 'newer_product',
+					time_added_to_cart: 1617228689,
+					extra: { afterPurchaseUrl: '/newer/purchase/url' },
+				},
+			],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			cart,
+			siteSlug: 'foo.bar',
+		} );
+		expect( url ).toBe( '/newer/purchase/url' );
 	} );
 
 	it( 'redirects to internal redirectTo url if set', () => {

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -141,6 +141,7 @@ export interface ResponseCartProduct {
 	is_bundled: boolean;
 	is_sale_coupon_applied: boolean;
 	meta: string;
+	time_added_to_cart: number;
 	months_per_bill_period: number | null;
 	volume: number;
 	quantity: number | null;

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -186,6 +186,7 @@ export interface ResponseCartProductExtra {
 	google_apps_registration_data?: DomainContactDetails;
 	purchaseType?: string;
 	privacy?: boolean;
+	afterPurchaseUrl?: string;
 }
 
 export interface RequestCartProductExtra extends ResponseCartProductExtra {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a new optional property to each cart item, `extra.afterPurchaseUrl`. If set on a product in the cart, this will be used as the redirect URL after checkout unless there's also a `redirectTo` argument passed in (typically from the `redirect_to` query string argument). If there are multiple products in the cart with an `afterPurchaseUrl`, the most recently added one will be used (this is deterministic because the cart items are sorted before being returned from the cart but could still cause unexpected behavior in some cases if used a lot).

This property can be used in place of the `redirect_to` query string or the `wpcom_signup_complete_destination` cookie when a particular flow desires to hard-code a post-checkout URL. The advantage of using this property over the cookie is that since it is tied to a product in the cart, if that product is removed, the URL will no longer be used. The advantage of using this property over the query string is that it can be set at any time (whenever the cart item is created) and will persist with the cart until checkout without needing to explicitly persist it between pages.

Note to self:

- [x] Verify that this property is preserved if the variant selector within checkout is used to change a plan.
- [x] Verify that this property is preserved if the upsells within checkout are used to change a plan.

#### Testing instructions

The automated tests should be enough for now. This just adds the property; it is not used yet.