### PR TITLE
Notifications: prep build for new process

### DIFF
--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -116,7 +116,7 @@ open class PluginBaseBuild : Template({
 
 				# 3. Check if the current build has changed, and if so, tag it for release.
 				# Note: we exclude asset changes because we only really care if the build files (JS/CSS) change. That file is basically just metadata.
-				if ! diff -rq --exclude="*.asset.php" --exclude="cache-buster.txt" $archiveDir ./release-archive/ ; then
+				if ! diff -ru --exclude="*.asset.php" --exclude="cache-buster.txt" $archiveDir ./release-archive/ ; then
 					echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
 					tag_response=`curl -s -X POST -H "Content-Type: text/plain" --data "$releaseTag" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`
 					echo -e "Build tagging status: ${'$'}tag_response\n"

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -116,7 +116,7 @@ open class PluginBaseBuild : Template({
 
 				# 3. Check if the current build has changed, and if so, tag it for release.
 				# Note: we exclude asset changes because we only really care if the build files (JS/CSS) change. That file is basically just metadata.
-				if ! diff -ru --exclude="*.asset.php" --exclude="cache-buster.txt" $archiveDir ./release-archive/ ; then
+				if ! diff -rq --exclude="*.asset.php" --exclude="cache-buster.txt" $archiveDir ./release-archive/ ; then
 					echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
 					tag_response=`curl -s -X POST -H "Content-Type: text/plain" --data "$releaseTag" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`
 					echo -e "Build tagging status: ${'$'}tag_response\n"

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -116,7 +116,7 @@ open class PluginBaseBuild : Template({
 
 				# 3. Check if the current build has changed, and if so, tag it for release.
 				# Note: we exclude asset changes because we only really care if the build files (JS/CSS) change. That file is basically just metadata.
-				if ! diff -rq --exclude="*.asset.php" $archiveDir ./release-archive/ ; then
+				if ! diff -rq --exclude="*.asset.php" --exclude="cache-buster.txt" $archiveDir ./release-archive/ ; then
 					echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
 					tag_response=`curl -s -X POST -H "Content-Type: text/plain" --data "$releaseTag" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`
 					echo -e "Build tagging status: ${'$'}tag_response\n"

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -102,6 +102,14 @@ private object Notifications : BuildType({
 		param("plugin_slug", "notifications")
 		param("archive_dir", "./dist/")
 		param("build_env", "development")
+		param("normalize_files", """
+			style_ref=$(grep '<link rel="stylesheet" href="build.min.css' ./dist/index.html) &&\
+			sed -i "" "s~.*<link rel=\"stylesheet\" href=\"build.min.*~$style_ref~" ./dist_2/index.html &&\
+			script_ref=$(grep '<script charset="UTF-8" src="build.min.js' ./dist/index.html) &&\
+			sed -i "" "s~.*<script charset=\"UTF-8\" src=\"build.min.*~$script_ref~" ./dist_2/index.html ./dist_2/rtl.html &&\
+			style_ref=$(grep '<link rel="stylesheet" href="build.min.rtl.css' ./dist/rtl.html) &&\
+			sed -i "" "s~.*<link rel=\"stylesheet\" href=\"build.min.rtl.css.*~$style_ref~" ./dist_2/rtl.html
+		""".trimIndent())
 	}
 })
 

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -107,7 +107,7 @@ private object Notifications : BuildType({
 			}
 			new_hash=`get_hash dist/index.html`
 			old_hash=`get_hash release-archive/index.html`
-			
+			echo "The old hash was ${'$'}old_hash"
 			sed -i "s/${'$'}old_hash/${'$'}new_hash/g" release-archive/index.html release-archive/rtl.html
 		""".trimIndent())
 	}

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -104,7 +104,7 @@ private object Notifications : BuildType({
 		param("build_env", "development")
 		param("normalize_files", """
 			style_ref=$(grep '<link rel="stylesheet" href="build.min.css' ./dist/index.html) &&\
-			sed -i "" "s~.*<link rel=\"stylesheet\" href=\"build.min.*~${'$'}style_ref~" ./release-archive//index.html &&\
+			sed -i "" "s~.*<link rel=\"stylesheet\" href=\"build.min.*~${'$'}style_ref~" ./release-archive/index.html &&\
 			script_ref=$(grep '<script charset="UTF-8" src="build.min.js' ./dist/index.html) &&\
 			sed -i "" "s~.*<script charset=\"UTF-8\" src=\"build.min.*~${'$'}script_ref~" ./release-archive/index.html ./release-archive/rtl.html &&\
 			style_ref_rtl=$(grep '<link rel="stylesheet" href="build.min.rtl.css' ./dist/rtl.html) &&\

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -101,6 +101,7 @@ private object Notifications : BuildType({
 	params {
 		param("plugin_slug", "notifications")
 		param("archive_dir", "./dist/")
+		param("build_env", "development")
 	}
 })
 

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -102,11 +102,11 @@ private object Notifications : BuildType({
 		param("plugin_slug", "notifications")
 		param("archive_dir", "./dist/")
 		param("normalize_files", """
-			style_ref=$(grep '<link rel="stylesheet" href="build.min.css' ./dist/index.html) &&\
+			style_ref=`grep '<link rel="stylesheet" href="build.min.css' ./dist/index.html` &&\
 			sed -i "s~.*<link rel=\"stylesheet\" href=\"build.min.*~${'$'}style_ref~" ./release-archive/index.html &&\
-			script_ref=$(grep '<script charset="UTF-8" src="build.min.js' ./dist/index.html) &&\
+			script_ref=`grep '<script charset="UTF-8" src="build.min.js' ./dist/index.html` &&\
 			sed -i "s~.*<script charset=\"UTF-8\" src=\"build.min.*~${'$'}script_ref~" ./release-archive/index.html ./release-archive/rtl.html &&\
-			style_ref_rtl=$(grep '<link rel="stylesheet" href="build.min.rtl.css' ./dist/rtl.html) &&\
+			style_ref_rtl=`grep '<link rel="stylesheet" href="build.min.rtl.css' ./dist/rtl.html` &&\
 			sed -i "s~.*<link rel=\"stylesheet\" href=\"build.min.rtl.css.*~${'$'}style_ref_rtl~" ./release-archive/rtl.html
 		""".trimIndent())
 	}

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -101,14 +101,13 @@ private object Notifications : BuildType({
 	params {
 		param("plugin_slug", "notifications")
 		param("archive_dir", "./dist/")
-		param("build_env", "development")
 		param("normalize_files", """
 			style_ref=$(grep '<link rel="stylesheet" href="build.min.css' ./dist/index.html) &&\
-			sed -i "" "s~.*<link rel=\"stylesheet\" href=\"build.min.*~${'$'}style_ref~" ./release-archive/index.html &&\
+			sed -i s~.*<link rel=\"stylesheet\" href=\"build.min.*~${'$'}style_ref~" ./release-archive/index.html &&\
 			script_ref=$(grep '<script charset="UTF-8" src="build.min.js' ./dist/index.html) &&\
-			sed -i "" "s~.*<script charset=\"UTF-8\" src=\"build.min.*~${'$'}script_ref~" ./release-archive/index.html ./release-archive/rtl.html &&\
+			sed -i s~.*<script charset=\"UTF-8\" src=\"build.min.*~${'$'}script_ref~" ./release-archive/index.html ./release-archive/rtl.html &&\
 			style_ref_rtl=$(grep '<link rel="stylesheet" href="build.min.rtl.css' ./dist/rtl.html) &&\
-			sed -i "" "s~.*<link rel=\"stylesheet\" href=\"build.min.rtl.css.*~${'$'}style_ref_rtl~" ./release-archive/rtl.html
+			sed -i s~.*<link rel=\"stylesheet\" href=\"build.min.rtl.css.*~${'$'}style_ref_rtl~" ./release-archive/rtl.html
 		""".trimIndent())
 	}
 })

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -108,7 +108,11 @@ private object Notifications : BuildType({
 			new_hash=`get_hash dist/index.html`
 			old_hash=`get_hash release-archive/index.html`
 			echo "The old hash was ${'$'}old_hash"
+			echo "The new hash is ${'$'}new_hash"
 			sed -i "s/${'$'}old_hash/${'$'}new_hash/g" release-archive/index.html release-archive/rtl.html
+			cat release-archive/index.html
+			cat release-archive/rtl.html
+			cat dist/index.html
 		""".trimIndent())
 	}
 })

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -118,12 +118,12 @@ private object Notifications : BuildType({
 
 			# All scripts and styles use the same "hash" version, so replace any
 			# instances of the hash in the *old* files with the newest version.
-			sed -i "s/${'$'}old_hash/${'$'}new_hash/g" release-archive/index.html release-archive/rtl.html
+			sed -i "s~${'$'}old_hash~${'$'}new_hash~g" release-archive/index.html release-archive/rtl.html
 
 			# Replace the old cache buster with the new one in the previous release html files.
 			new_cache_buster=`cat dist/cache-buster.txt`
 			old_cache_buster=`cat release-archive/cache-buster.txt`
-			sed -i "s/${'$'}old_cache_buster/${'$'}new_cache_buster/g" release-archive/index.html release-archive/rtl.html
+			sed -i "s~${'$'}old_cache_buster~${'$'}new_cache_buster~g" release-archive/index.html release-archive/rtl.html
 		""".trimIndent())
 	}
 })

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -104,11 +104,11 @@ private object Notifications : BuildType({
 		param("build_env", "development")
 		param("normalize_files", """
 			style_ref=$(grep '<link rel="stylesheet" href="build.min.css' ./dist/index.html) &&\
-			sed -i "" "s~.*<link rel=\"stylesheet\" href=\"build.min.*~${'$'}style_ref~" ./dist_2/index.html &&\
+			sed -i "" "s~.*<link rel=\"stylesheet\" href=\"build.min.*~${'$'}style_ref~" ./release-archive//index.html &&\
 			script_ref=$(grep '<script charset="UTF-8" src="build.min.js' ./dist/index.html) &&\
-			sed -i "" "s~.*<script charset=\"UTF-8\" src=\"build.min.*~${'$'}script_ref~" ./dist_2/index.html ./dist_2/rtl.html &&\
+			sed -i "" "s~.*<script charset=\"UTF-8\" src=\"build.min.*~${'$'}script_ref~" ./release-archive/index.html ./release-archive/rtl.html &&\
 			style_ref_rtl=$(grep '<link rel="stylesheet" href="build.min.rtl.css' ./dist/rtl.html) &&\
-			sed -i "" "s~.*<link rel=\"stylesheet\" href=\"build.min.rtl.css.*~${'$'}style_ref_rtl~" ./dist_2/rtl.html
+			sed -i "" "s~.*<link rel=\"stylesheet\" href=\"build.min.rtl.css.*~${'$'}style_ref_rtl~" ./release-archive/rtl.html
 		""".trimIndent())
 	}
 })

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -102,12 +102,13 @@ private object Notifications : BuildType({
 		param("plugin_slug", "notifications")
 		param("archive_dir", "./dist/")
 		param("normalize_files", """
-			style_ref=`grep '<link rel="stylesheet" href="build.min.css' ./dist/index.html` &&\
-			sed -i "s~.*<link rel=\"stylesheet\" href=\"build.min.*~${'$'}style_ref~" ./release-archive/index.html &&\
-			script_ref=`grep '<script charset="UTF-8" src="build.min.js' ./dist/index.html` &&\
-			sed -i "s~.*<script charset=\"UTF-8\" src=\"build.min.*~${'$'}script_ref~" ./release-archive/index.html ./release-archive/rtl.html &&\
-			style_ref_rtl=`grep '<link rel="stylesheet" href="build.min.rtl.css' ./dist/rtl.html` &&\
-			sed -i "s~.*<link rel=\"stylesheet\" href=\"build.min.rtl.css.*~${'$'}style_ref_rtl~" ./release-archive/rtl.html
+			function get_hash {
+				echo `sed -nE 's~.*<link rel="stylesheet" href="build.min.css\?([a-zA-Z0-9]+)">.*~\1~p' ${'$'}1`
+			}
+			new_hash=`get_hash dist/index.html`
+			old_hash=`get_hash release-archive/index.html`
+			
+			sed -i "s/${'$'}old_hash/${'$'}new_hash/g" release-archive/index.html release-archive/rtl.html
 		""".trimIndent())
 	}
 })

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -104,11 +104,11 @@ private object Notifications : BuildType({
 		param("build_env", "development")
 		param("normalize_files", """
 			style_ref=$(grep '<link rel="stylesheet" href="build.min.css' ./dist/index.html) &&\
-			sed -i "" "s~.*<link rel=\"stylesheet\" href=\"build.min.*~$style_ref~" ./dist_2/index.html &&\
+			sed -i "" "s~.*<link rel=\"stylesheet\" href=\"build.min.*~${'$'}style_ref~" ./dist_2/index.html &&\
 			script_ref=$(grep '<script charset="UTF-8" src="build.min.js' ./dist/index.html) &&\
-			sed -i "" "s~.*<script charset=\"UTF-8\" src=\"build.min.*~$script_ref~" ./dist_2/index.html ./dist_2/rtl.html &&\
-			style_ref=$(grep '<link rel="stylesheet" href="build.min.rtl.css' ./dist/rtl.html) &&\
-			sed -i "" "s~.*<link rel=\"stylesheet\" href=\"build.min.rtl.css.*~$style_ref~" ./dist_2/rtl.html
+			sed -i "" "s~.*<script charset=\"UTF-8\" src=\"build.min.*~${'$'}script_ref~" ./dist_2/index.html ./dist_2/rtl.html &&\
+			style_ref_rtl=$(grep '<link rel="stylesheet" href="build.min.rtl.css' ./dist/rtl.html) &&\
+			sed -i "" "s~.*<link rel=\"stylesheet\" href=\"build.min.rtl.css.*~${'$'}style_ref_rtl~" ./dist_2/rtl.html
 		""".trimIndent())
 	}
 })

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -101,18 +101,29 @@ private object Notifications : BuildType({
 	params {
 		param("plugin_slug", "notifications")
 		param("archive_dir", "./dist/")
+		// This param is executed in bash right before the build script compares
+		// the build with the previous release version. The purpose of this code
+		// is to remove sources of randomness so that the diff operation only
+		// compares legitimate changes.
 		param("normalize_files", """
 			function get_hash {
+				# If the stylesheet in the HTML file is pointing at "build.min.css?foobar123",
+				# this will just return the "foobar123" portion of the file. This
+				# is a source of randomness which needs to be eliminated.
 				echo `sed -nE 's~.*<link rel="stylesheet" href="build.min.css\?([a-zA-Z0-9]+)">.*~\1~p' ${'$'}1`
 			}
 			new_hash=`get_hash dist/index.html`
 			old_hash=`get_hash release-archive/index.html`
-			echo "The old hash was ${'$'}old_hash"
-			echo "The new hash is ${'$'}new_hash"
+
+
+			# All scripts and styles use the same "hash" version, so replace any
+			# instances of the hash in the *old* files with the newest version.
 			sed -i "s/${'$'}old_hash/${'$'}new_hash/g" release-archive/index.html release-archive/rtl.html
-			cat release-archive/index.html
-			cat release-archive/rtl.html
-			cat dist/index.html
+
+			# Replace the old cache buster with the new one in the previous release html files.
+			new_cache_buster=`cat dist/cache-buster.txt`
+			old_cache_buster=`cat release-archive/cache-buster.txt`
+			sed -i "s/${'$'}old_cache_buster/${'$'}new_cache_buster/g" release-archive/index.html release-archive/rtl.html
 		""".trimIndent())
 	}
 })

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -103,11 +103,11 @@ private object Notifications : BuildType({
 		param("archive_dir", "./dist/")
 		param("normalize_files", """
 			style_ref=$(grep '<link rel="stylesheet" href="build.min.css' ./dist/index.html) &&\
-			sed -i s~.*<link rel=\"stylesheet\" href=\"build.min.*~${'$'}style_ref~" ./release-archive/index.html &&\
+			sed -i "s~.*<link rel=\"stylesheet\" href=\"build.min.*~${'$'}style_ref~" ./release-archive/index.html &&\
 			script_ref=$(grep '<script charset="UTF-8" src="build.min.js' ./dist/index.html) &&\
-			sed -i s~.*<script charset=\"UTF-8\" src=\"build.min.*~${'$'}script_ref~" ./release-archive/index.html ./release-archive/rtl.html &&\
+			sed -i "s~.*<script charset=\"UTF-8\" src=\"build.min.*~${'$'}script_ref~" ./release-archive/index.html ./release-archive/rtl.html &&\
 			style_ref_rtl=$(grep '<link rel="stylesheet" href="build.min.rtl.css' ./dist/rtl.html) &&\
-			sed -i s~.*<link rel=\"stylesheet\" href=\"build.min.rtl.css.*~${'$'}style_ref_rtl~" ./release-archive/rtl.html
+			sed -i "s~.*<link rel=\"stylesheet\" href=\"build.min.rtl.css.*~${'$'}style_ref_rtl~" ./release-archive/rtl.html
 		""".trimIndent())
 	}
 })

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -115,7 +115,6 @@ private object Notifications : BuildType({
 			new_hash=`get_hash dist/index.html`
 			old_hash=`get_hash release-archive/index.html`
 
-
 			# All scripts and styles use the same "hash" version, so replace any
 			# instances of the hash in the *old* files with the newest version.
 			sed -i "s~${'$'}old_hash~${'$'}new_hash~g" release-archive/index.html release-archive/rtl.html


### PR DESCRIPTION
#### Changes proposed in this Pull Request
1. Change build mode to development so that non-minified files are also available in the artifact. (Currently, only minified files exist, so the non-minified ones are not being updated on wpcom.)
2. Normalize notifications files before comparing versions. Currently, every build is marked as a "changed" build because there are a few files which differ on each build (namely, index.html, rtl.html, and cache-buster.txt). I've added sed and exclusions to cover the cases. In other words, it will now catch if something meaningful changes in the build.

#### Testing instructions

With D59598-code applied, do the following on your sandbox:

1. execute `install-plugin.sh notes add/notifiactions-improvements --phab`
2. Verify that the phabricator output looks good on the created diff
3. Test notifications panel by sandboxing widgets.wp.com

