### PR TITLE
Add JetpackReviewPrompt into Scan flow.

### DIFF
--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -38,6 +38,7 @@ import { triggerScanRun } from 'calypso/lib/jetpack/trigger-scan-run';
 import { withApplySiteOffset, applySiteOffsetType } from 'calypso/components/site-offset';
 import ScanNavigation from './navigation';
 import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
+import JetpackReviewPrompt from 'calypso/blocks/jetpack-review-prompt';
 
 /**
  * Type dependencies
@@ -71,6 +72,9 @@ interface Props {
 }
 
 class ScanPage extends Component< Props > {
+	state = {
+		showJetpackReviewPrompt: false,
+	};
 	renderProvisioning() {
 		return (
 			<>
@@ -268,6 +272,23 @@ class ScanPage extends Component< Props > {
 		return this.renderScanOkay();
 	}
 
+	renderJetpackReviewPrompt() {
+		const { scanState, isRequestingScan } = this.props;
+		if ( ! scanState ) {
+			return;
+		}
+		const { threats, mostRecent } = scanState;
+
+		const threatsFound = threats?.length;
+		const errorFound = !! mostRecent?.error;
+
+		// Only render JetpackReviewPrompt after this.renderScanOkay() is called.
+		if ( isRequestingScan || threatsFound || errorFound || scanState?.state !== 'idle' ) {
+			return;
+		}
+		return <JetpackReviewPrompt type="scan" align="left" />;
+	}
+
 	render() {
 		const { siteId, siteSettingsUrl } = this.props;
 		const isJetpackPlatform = isJetpackCloud();
@@ -295,6 +316,7 @@ class ScanPage extends Component< Props > {
 				<Card>
 					<div className="scan__content">{ this.renderScanState() }</div>
 				</Card>
+				{ this.renderJetpackReviewPrompt() }
 			</Main>
 		);
 	}

--- a/client/state/data-layer/wpcom/sites/alerts/fix-status.js
+++ b/client/state/data-layer/wpcom/sites/alerts/fix-status.js
@@ -14,6 +14,7 @@ import { requestScanStatus } from 'calypso/state/jetpack-scan/actions';
 import { requestJetpackScanHistory } from 'calypso/state/jetpack-scan/history/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { setValidFrom } from 'calypso/state/jetpack-review-prompt/actions.ts';
 
 const POLL_EVERY_MILLISECONDS = 1000;
 
@@ -60,6 +61,10 @@ export const success = ( action, fixer_state ) => {
 					duration: 4000,
 				}
 			),
+			// Make the 'jetpack-review-prompt' (calypso preference) valid, triggering a
+			// user prompt to submit a review of the Jetpack plugin on the /scan/:site page.
+			setValidFrom( 'scan', Date.now() ),
+
 			requestScanStatus( action.siteId ),
 			// Since we can fix threats from the History section, we need to update that
 			// information as well.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a review prompt to the main Scan page, only if the user has completed a successful threat auto-fix.

![Screenshot on 2021-03-31 at 18-58-10](https://user-images.githubusercontent.com/11078128/113221555-460b0400-9253-11eb-82d2-7ef6fbb21b5f.png)

#### Testing instructions

1. Checkout and run this PR ('yarn start`)
2. Select (or create with JN) a jetpack site with Scan enabled. 
3. Go to  'http://calypso.localhost:3000/scan/:site` 
4. Open dev tools and start analytics logging by running `localStorage.setItem('debug', 'calypso:analytics');` via the console.
5. Go to the `/wp-content/plugins/` directory and modify any main plugin file and add the line:
    - `$eicar = "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*";`
    - ( this will trigger a scan threat that Jetpack can auto-fix in the next steps)
6. Click "Scan now" button to start a scan.
7. When scan finishes (you should have 1 scan threat), click "Auto fix 1 threat", and confirm "Fix all threats" button. 
8. When auto-fix finishes, you should see the review prompt at the bottom of the Scan card like shown in the image above.
9. Verify the `calypso_jetpack_review_prompt_view' Tracks event logged in the console, with the `type` property set to 'scan'
11. Dismiss the prompt by pressing the X in the top right corner.
12. Verify that the `calypso_jetpack_review_prompt_dismiss` event is logged with `type: scan`.
13. Unset the `jetpack-review-prompt` preference
   * <img width="1007" alt="Screen Shot 2021-03-24 at 12 22 33 PM" src="https://user-images.githubusercontent.com/2810519/112371507-e8e3e100-8c9b-11eb-8725-f3dbd49cb139.png">
 14. Repeat steps 5 - 8 again.
 15. Click the "Leave a Review" button
 16. Check that the `calypso_jetpack_review_prompt_dismiss` event logged with `type: scan, reviewed: true` properties set.
 17. Verify the prompt is no longer rendered and the that it opens the Jetpack plugin review page.

Related to # 1192874419362946-as-1199999287485857