### PR TITLE
Plans: Add plan to cart and redirect to "add domain" for special query string

### DIFF
--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -67,7 +67,6 @@ class DomainSearch extends Component {
 		basePath: PropTypes.string.isRequired,
 		context: PropTypes.object.isRequired,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
-		hasPlanInCart: PropTypes.bool,
 		isSiteUpgradeable: PropTypes.bool,
 		productsList: PropTypes.object.isRequired,
 		selectedSite: PropTypes.object,
@@ -222,7 +221,7 @@ class DomainSearch extends Component {
 	}
 
 	render() {
-		const { selectedSite, selectedSiteSlug, translate, isManagingAllDomains } = this.props;
+		const { selectedSite, selectedSiteSlug, translate, isManagingAllDomains, cart } = this.props;
 
 		if ( ! selectedSite ) {
 			return null;
@@ -232,6 +231,8 @@ class DomainSearch extends Component {
 			'domain-search-page-wrapper': this.state.domainRegistrationAvailable,
 		} );
 		const { domainRegistrationMaintenanceEndTime } = this.state;
+
+		const hasPlanInCart = hasPlan( cart );
 
 		let content;
 
@@ -283,7 +284,7 @@ class DomainSearch extends Component {
 							noticeText={ translate( 'You must verify your email to register new domains.' ) }
 							noticeStatus="is-info"
 						>
-							{ ! this.props.hasPlanInCart && <NewDomainsRedirectionNoticeUpsell /> }
+							{ ! hasPlanInCart && <NewDomainsRedirectionNoticeUpsell /> }
 							<RegisterDomainStep
 								suggestion={ this.getInitialSuggestion() }
 								domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
@@ -316,7 +317,7 @@ class DomainSearch extends Component {
 }
 
 export default connect(
-	( state, ownProps ) => {
+	( state ) => {
 		const siteId = getSelectedSiteId( state );
 
 		return {
@@ -327,7 +328,6 @@ export default connect(
 			domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 			isSiteUpgradeable: isSiteUpgradeable( state, siteId ),
 			productsList: getProductsList( state ),
-			hasPlanInCart: hasPlan( ownProps.cart ),
 		};
 	},
 	{

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -146,12 +146,18 @@ const PlanFeaturesActionsButton = ( {
 		);
 	}
 
+	let buttonText = freePlan
+		? translate( 'Select Free', { context: 'button' } )
+		: translate( 'Upgrade', { context: 'verb' } );
+
+	if ( props.buttonText ) {
+		buttonText = props.buttonText;
+	}
+
 	if ( availableForPurchase || isPlaceholder ) {
 		return (
 			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
-				{ props.buttonText || freePlan
-					? translate( 'Select Free', { context: 'button' } )
-					: translate( 'Upgrade', { context: 'verb' } ) }
+				{ buttonText }
 			</Button>
 		);
 	}

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -291,6 +291,7 @@ export class PlanFeatures extends Component {
 
 	renderMobileView() {
 		const {
+			redirectToAddDomainFlow,
 			basePlansPath,
 			canPurchase,
 			isInSignup,
@@ -316,6 +317,12 @@ export class PlanFeatures extends Component {
 
 		if ( freePlanProperties ) {
 			reorderedPlans.push( freePlanProperties );
+		}
+
+		let buttonText = null;
+
+		if ( redirectToAddDomainFlow ) {
+			buttonText = translate( 'Add to Cart' );
 		}
 
 		return map( reorderedPlans, ( properties ) => {
@@ -368,6 +375,7 @@ export class PlanFeatures extends Component {
 					<p className="plan-features__description">{ planDescription }</p>
 					<PlanFeaturesActions
 						availableForPurchase={ availableForPurchase }
+						buttonText={ buttonText }
 						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }
 						current={ current }
@@ -634,6 +642,10 @@ export class PlanFeatures extends Component {
 			let forceDisplayButton = false;
 			let buttonText = null;
 
+			if ( this.props.redirectToAddDomainFlow ) {
+				buttonText = translate( 'Add to Cart' );
+			}
+
 			if ( disableBloggerPlanWithNonBlogDomain || this.props.nonDotBlogDomains.length > 0 ) {
 				if ( planMatches( planName, { type: TYPE_BLOGGER } ) ) {
 					availableForPurchase = false;
@@ -798,10 +810,17 @@ export class PlanFeatures extends Component {
 				}
 			}
 
+			let buttonText;
+
+			if ( this.props.redirectToAddDomainFlow ) {
+				buttonText = this.props.translate( 'Add to Cart' );
+			}
+
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesActions
 						availableForPurchase={ availableForPurchase }
+						buttonText={ buttonText }
 						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }
 						current={ current }

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -320,9 +320,11 @@ export class PlanFeatures extends Component {
 		}
 
 		let buttonText = null;
+		let forceDisplayButton = false;
 
 		if ( redirectToAddDomainFlow ) {
 			buttonText = translate( 'Add to Cart' );
+			forceDisplayButton = true;
 		}
 
 		return map( reorderedPlans, ( properties ) => {
@@ -375,6 +377,7 @@ export class PlanFeatures extends Component {
 					<p className="plan-features__description">{ planDescription }</p>
 					<PlanFeaturesActions
 						availableForPurchase={ availableForPurchase }
+						forceDisplayButton={ forceDisplayButton }
 						buttonText={ buttonText }
 						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }
@@ -644,6 +647,7 @@ export class PlanFeatures extends Component {
 
 			if ( this.props.redirectToAddDomainFlow ) {
 				buttonText = translate( 'Add to Cart' );
+				forceDisplayButton = true;
 			}
 
 			if ( disableBloggerPlanWithNonBlogDomain || this.props.nonDotBlogDomains.length > 0 ) {
@@ -811,15 +815,18 @@ export class PlanFeatures extends Component {
 			}
 
 			let buttonText;
+			let forceDisplayButton = false;
 
 			if ( this.props.redirectToAddDomainFlow ) {
 				buttonText = this.props.translate( 'Add to Cart' );
+				forceDisplayButton = true;
 			}
 
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesActions
 						availableForPurchase={ availableForPurchase }
+						forceDisplayButton={ forceDisplayButton }
 						buttonText={ buttonText }
 						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -83,6 +83,7 @@ import PlanFeaturesScroller from './scroller';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 /**
  * Style dependencies
@@ -923,7 +924,7 @@ const hasPlaceholders = ( planProperties ) =>
 	planProperties.filter( ( planProps ) => planProps.isPlaceholder ).length > 0;
 
 /* eslint-disable wpcalypso/redux-no-bound-selectors */
-export default connect(
+const ConnectedPlanFeatures = connect(
 	( state, ownProps ) => {
 		const {
 			isInSignup,
@@ -1115,4 +1116,12 @@ export default connect(
 	}
 )( withShoppingCart( localize( PlanFeatures ) ) );
 
-/* eslint-enable wpcalypso/redux-no-bound-selectors */
+/* eslint-enable */
+
+export default function PlanFeaturesWrapper( props ) {
+	return (
+		<CalypsoShoppingCartProvider>
+			<ConnectedPlanFeatures { ...props } />
+		</CalypsoShoppingCartProvider>
+	);
+}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -222,6 +222,7 @@ export class PlansFeaturesMain extends Component {
 			plansWithScroll,
 			isReskinned,
 			isInVerticalScrollingPlansExperiment,
+			redirectToAddDomainFlow,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -241,6 +242,7 @@ export class PlansFeaturesMain extends Component {
 			>
 				{ this.renderSecondaryFormattedHeader() }
 				<PlanFeatures
+					redirectToAddDomainFlow={ redirectToAddDomainFlow }
 					basePlansPath={ basePlansPath }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
 					displayJetpackPlans={ displayJetpackPlans }
@@ -559,6 +561,7 @@ export class PlansFeaturesMain extends Component {
 }
 
 PlansFeaturesMain.propTypes = {
+	redirectToAddDomainFlow: PropTypes.bool,
 	basePlansPath: PropTypes.string,
 	displayJetpackPlans: PropTypes.bool.isRequired,
 	hideFreePlan: PropTypes.bool,

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -608,8 +608,11 @@ export default connect(
 		const siteId = get( props.site, [ 'ID' ] );
 		const currentPlan = getSitePlan( state, siteId );
 		const sitePlanSlug = currentPlan?.product_slug;
-		const eligibleForWpcomMonthlyPlans =
-			isWpComFreePlan( sitePlanSlug ) || isWpComMonthlyPlan( sitePlanSlug );
+		// In the "purchase a plan and free domain" flow we do not want to show
+		// monthly plans because monthly plans do not come with a free domain.
+		const eligibleForWpcomMonthlyPlans = props.redirectToAddDomainFlow
+			? false
+			: isWpComFreePlan( sitePlanSlug ) || isWpComMonthlyPlan( sitePlanSlug );
 
 		const customerType = chooseDefaultCustomerType( {
 			currentCustomerType: props.customerType,

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -503,7 +503,12 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	getKindOfPlanTypeSelector( props ) {
-		if ( props.displayJetpackPlans || props.isInSignup || props.eligibleForWpcomMonthlyPlans ) {
+		if (
+			props.displayJetpackPlans ||
+			props.isInSignup ||
+			props.eligibleForWpcomMonthlyPlans ||
+			props.redirectToAddDomainFlow
+		) {
 			return 'interval';
 		}
 
@@ -515,14 +520,20 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	render() {
-		const { siteId, customHeader, shouldShowPlansRedesign } = this.props;
+		const { siteId, customHeader, shouldShowPlansRedesign, redirectToAddDomainFlow } = this.props;
 		const plans = this.getPlansForPlanFeatures();
 		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
 		const kindOfPlanTypeSelector = this.getKindOfPlanTypeSelector( this.props );
 
 		// If advertising plans for a certain feature, ensure user has pressed "View all plans" before they can see others
-		const hidePlanSelector =
+		let hidePlanSelector =
 			kindOfPlanTypeSelector === 'customer' && this.isDisplayingPlansNeededForFeature();
+
+		// In the "purchase a plan and free domain" flow we do not want to show
+		// monthly plans because monthly plans do not come with a free domain.
+		if ( redirectToAddDomainFlow ) {
+			hidePlanSelector = true;
+		}
 
 		return (
 			<div className="plans-features-main">
@@ -608,11 +619,8 @@ export default connect(
 		const siteId = get( props.site, [ 'ID' ] );
 		const currentPlan = getSitePlan( state, siteId );
 		const sitePlanSlug = currentPlan?.product_slug;
-		// In the "purchase a plan and free domain" flow we do not want to show
-		// monthly plans because monthly plans do not come with a free domain.
-		const eligibleForWpcomMonthlyPlans = props.redirectToAddDomainFlow
-			? false
-			: isWpComFreePlan( sitePlanSlug ) || isWpComMonthlyPlan( sitePlanSlug );
+		const eligibleForWpcomMonthlyPlans =
+			isWpComFreePlan( sitePlanSlug ) || isWpComMonthlyPlan( sitePlanSlug );
 
 		const customerType = chooseDefaultCustomerType( {
 			currentCustomerType: props.customerType,

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -14,6 +14,7 @@ import isSiteWpcom from 'calypso/state/selectors/is-site-wpcom';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import { productSelect } from 'calypso/my-sites/plans/jetpack-plans/controller';
 import setJetpackPlansHeader from 'calypso/my-sites/plans/jetpack-plans/plans-header';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 function showJetpackPlans( context ) {
 	const getState = context.store.getState();
@@ -32,16 +33,18 @@ export function plans( context, next ) {
 	}
 
 	context.primary = (
-		<Plans
-			context={ context }
-			intervalType={ context.params.intervalType }
-			customerType={ context.query.customerType }
-			selectedFeature={ context.query.feature }
-			selectedPlan={ context.query.plan }
-			withDiscount={ context.query.discount }
-			discountEndDate={ context.query.ts }
-			redirectTo={ context.query.redirect_to }
-		/>
+		<CalypsoShoppingCartProvider>
+			<Plans
+				context={ context }
+				intervalType={ context.params.intervalType }
+				customerType={ context.query.customerType }
+				selectedFeature={ context.query.feature }
+				selectedPlan={ context.query.plan }
+				withDiscount={ context.query.discount }
+				discountEndDate={ context.query.ts }
+				redirectTo={ context.query.redirect_to }
+			/>
+		</CalypsoShoppingCartProvider>
 	);
 	next();
 }

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -43,6 +43,7 @@ export function plans( context, next ) {
 				withDiscount={ context.query.discount }
 				discountEndDate={ context.query.ts }
 				redirectTo={ context.query.redirect_to }
+				redirectToAddDomainFlow={ context.query.domainAddFlow }
 			/>
 		</CalypsoShoppingCartProvider>
 	);

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -14,7 +14,6 @@ import isSiteWpcom from 'calypso/state/selectors/is-site-wpcom';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import { productSelect } from 'calypso/my-sites/plans/jetpack-plans/controller';
 import setJetpackPlansHeader from 'calypso/my-sites/plans/jetpack-plans/plans-header';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 function showJetpackPlans( context ) {
 	const getState = context.store.getState();
@@ -33,19 +32,17 @@ export function plans( context, next ) {
 	}
 
 	context.primary = (
-		<CalypsoShoppingCartProvider>
-			<Plans
-				context={ context }
-				intervalType={ context.params.intervalType }
-				customerType={ context.query.customerType }
-				selectedFeature={ context.query.feature }
-				selectedPlan={ context.query.plan }
-				withDiscount={ context.query.discount }
-				discountEndDate={ context.query.ts }
-				redirectTo={ context.query.redirect_to }
-				redirectToAddDomainFlow={ context.query.addDomainFlow }
-			/>
-		</CalypsoShoppingCartProvider>
+		<Plans
+			context={ context }
+			intervalType={ context.params.intervalType }
+			customerType={ context.query.customerType }
+			selectedFeature={ context.query.feature }
+			selectedPlan={ context.query.plan }
+			withDiscount={ context.query.discount }
+			discountEndDate={ context.query.ts }
+			redirectTo={ context.query.redirect_to }
+			redirectToAddDomainFlow={ context.query.addDomainFlow }
+		/>
 	);
 	next();
 }

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -43,7 +43,7 @@ export function plans( context, next ) {
 				withDiscount={ context.query.discount }
 				discountEndDate={ context.query.ts }
 				redirectTo={ context.query.redirect_to }
-				redirectToAddDomainFlow={ context.query.domainAddFlow }
+				redirectToAddDomainFlow={ context.query.addDomainFlow }
 			/>
 		</CalypsoShoppingCartProvider>
 	);

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -39,6 +39,7 @@ import { isTreatmentPlansReorderTest } from 'calypso/state/marketing/selectors';
 class Plans extends React.Component {
 	static propTypes = {
 		context: PropTypes.object.isRequired,
+		redirectToAddDomainFlow: PropTypes.bool,
 		displayJetpackPlans: PropTypes.bool,
 		intervalType: PropTypes.string,
 		customerType: PropTypes.string,
@@ -153,6 +154,7 @@ class Plans extends React.Component {
 									/>
 								) : (
 									<PlansFeaturesMain
+										redirectToAddDomainFlow={ this.props.redirectToAddDomainFlow }
 										displayJetpackPlans={ displayJetpackPlans }
 										hideFreePlan={ true }
 										customerType={ customerType }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There is a sidebar upsell that is displayed for sites with no plan that reads "Free domain with an annual plan" with button that reads "Upgrade". The intent of this button is to start a flow where the customer purchases a plan and a domain.

The way in which this currently works is that the upsell redirects you to the "add domain" page with a flag that silently adds a Personal plan to your cart as soon as the page loads. This can cause a lot of confusion if the customer then does not select a domain and navigates away because the plan has already been added to the cart which will trigger cart abandonment notices and emails even though the customer didn't intend to add that plan.

The PR adds a flag to the plans page which will cause the plan purchase buttons to add the selected plan to your cart and then redirect to the "add domain" page. This way adding the plan becomes explicit and also provides the customer the opportunity to choose which plan they would prefer.

This does not remove the flag on the domains page yet, although it can be removed as soon as D59605-code is merged.

Fixes https://github.com/Automattic/wp-calypso/issues/51212

Includes https://github.com/Automattic/wp-calypso/pull/51605 and will require a rebase when that is merged.

This requires D59605-code to modify where the upsell button goes, but can be safely merged before that.

<img width="275" alt="Screen Shot 2021-04-01 at 6 02 43 PM" src="https://user-images.githubusercontent.com/2036909/113358817-7ebee200-9314-11eb-925f-c470ba52598f.png">

<img width="1064" alt="Screen Shot 2021-04-03 at 5 30 55 PM" src="https://user-images.githubusercontent.com/2036909/113491942-64b30a00-94a2-11eb-82bd-1434133b4e7c.png">

<img width="910" alt="Screen Shot 2021-04-01 at 6 02 27 PM" src="https://user-images.githubusercontent.com/2036909/113358849-88484a00-9314-11eb-8fc5-722234ddd535.png">


To do:

- [x] Hide the monthly plans if this flag is set because they do not come with a domain.
- [x] Verify that this works (or at least doesn't cause problems) for Jetpack sites.
- [x] Maybe hide that "If you upgrade to the Personal plan" upsell on the "add domain" page if the cart contains a plan. (Turns out that was a bug; it was already supposed to do that.)
- [x] Maybe change the "Upgrade" links on the plans page to read "Add to cart" as described in https://github.com/Automattic/wp-calypso/issues/51212#issuecomment-810939074 (this also exposed a bug which I've fixed here.)
- [x] Maybe remove the old `ref=upgrade` behavior in a later PR to make the transition easier between the backend change and the frontend. (Moved to https://github.com/Automattic/wp-calypso/pull/51642)

#### Testing instructions

- Apply D59605-code and sandbox the API.
- Start with a site that has no paid plan.
- Visit the customer home page for the site, eg: http://calypso.localhost:3000/home/example.com
- Click the "Upgrade" button in the sidebar notification that reads "Free domain with an annual plan" (see first screenshot above).
- Verify that you are redirected to the plans page for your site (see second screenshot above).
- Click the "Upgrade" button on a plan's card to select that plan.
- Verify that you are redirected to the "Site Domains" page (see third screenshot above).
- Click to select a domain.
- Click through any email upsell you may see.
- Verify that you arrive at checkout with both the plan and the domain in your cart.