### PR TITLE
Add review prompt on Jetpack Restore

### DIFF
--- a/client/my-sites/backup/rewind-flow/download.tsx
+++ b/client/my-sites/backup/rewind-flow/download.tsx
@@ -8,7 +8,7 @@ import React, { FunctionComponent, useCallback, useState } from 'react';
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { defaultRewindConfig, RewindConfig } from './types';
 import { getRewindBackupProgress, rewindBackup } from 'calypso/state/activity-log/actions';
 import CheckYourEmail from './rewind-flow-notice/check-your-email';
@@ -266,7 +266,7 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 				downloadId={ downloadProgress !== undefined ? downloadId : undefined }
 				siteId={ siteId }
 			/>
-			{ render() }
+			<Card>{ render() }</Card>
 		</>
 	);
 };

--- a/client/my-sites/backup/rewind-flow/index.tsx
+++ b/client/my-sites/backup/rewind-flow/index.tsx
@@ -61,11 +61,13 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 		requestActivity( siteId, rewindId );
 	}, [ siteId, rewindId ] );
 
+	const wrapWithCard = ( content ) => <Card>{ content }</Card>;
+
 	const render = () => {
 		if ( null === applySiteOffset || loadingActivity ) {
-			return <Loading />;
+			return wrapWithCard( <Loading /> );
 		} else if ( activityRequestError?.code === 'no_activity_for_site_and_rewind_id' ) {
-			return (
+			return wrapWithCard(
 				<Error
 					siteUrl={ siteUrl }
 					errorText={ translate( 'The activity referenced by %(rewindId)s does not exist.', {
@@ -74,7 +76,7 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 				/>
 			);
 		} else if ( activityIsRewindable === false ) {
-			return (
+			return wrapWithCard(
 				<Error
 					siteUrl={ siteUrl }
 					errorText={ translate( 'The activity referenced by %(rewindId)s is not rewindable.', {
@@ -83,7 +85,7 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 				/>
 			);
 		} else if ( DataState.Success !== activityRequestState ) {
-			return (
+			return wrapWithCard(
 				<Error
 					siteUrl={ siteUrl }
 					errorText={ translate( 'An error occurred while trying to retrieve the activity' ) }
@@ -125,9 +127,7 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 				}
 			/>
 			<SidebarNavigation />
-			<div className="rewind-flow__content">
-				<Card>{ render() }</Card>
-			</div>
+			<div className="rewind-flow__content">{ render() }</div>
 		</Main>
 	);
 };

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -11,19 +11,20 @@ import React, { FunctionComponent, useCallback, useState } from 'react';
 import { Button, Card } from '@automattic/components';
 import { defaultRewindConfig, RewindConfig } from './types';
 import { rewindRestore } from 'calypso/state/activity-log/actions';
+import { setValidFrom } from 'calypso/state/jetpack-review-prompt/actions';
 import CheckYourEmail from './rewind-flow-notice/check-your-email';
 import Error from './error';
 import getInProgressRewindStatus from 'calypso/state/selectors/get-in-progress-rewind-status';
 import getRestoreProgress from 'calypso/state/selectors/get-restore-progress';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import Gridicon from 'calypso/components/gridicon';
+import JetpackReviewPrompt from 'calypso/blocks/jetpack-review-prompt';
 import Loading from './loading';
 import ProgressBar from './progress-bar';
-import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import QueryRewindRestoreStatus from 'calypso/components/data/query-rewind-restore-status';
+import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import RewindConfigEditor from './rewind-config-editor';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
-import JetpackReviewPrompt from './jetpack-review-prompt';
 
 /**
  * Type dependencies
@@ -63,9 +64,10 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		[ dispatch, rewindConfig, rewindId, siteId ]
 	);
 	const onConfirm = useCallback( () => {
+		dispatch( setValidFrom( 'restore', Date.now() ) );
 		setUserHasRequestedRestore( true );
 		requestRestore();
-	}, [ setUserHasRequestedRestore, requestRestore ] );
+	}, [ dispatch, setUserHasRequestedRestore, requestRestore ] );
 
 	const loading = rewindState.state === 'uninitialized';
 	const { restoreId } = rewindState.rewind || {};
@@ -216,7 +218,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 				<QueryRewindRestoreStatus siteId={ siteId } restoreId={ restoreId } />
 			) }
 			<Card>{ render() }</Card>
-			{ ( isInProgress || isFinished ) && <JetpackReviewPrompt /> }
+			{ ( isInProgress || isFinished ) && <JetpackReviewPrompt align="center" type="restore" /> }
 		</>
 	);
 };

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -8,7 +8,7 @@ import React, { FunctionComponent, useCallback, useState } from 'react';
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { defaultRewindConfig, RewindConfig } from './types';
 import { rewindRestore } from 'calypso/state/activity-log/actions';
 import CheckYourEmail from './rewind-flow-notice/check-your-email';
@@ -23,6 +23,7 @@ import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import QueryRewindRestoreStatus from 'calypso/components/data/query-rewind-restore-status';
 import RewindConfigEditor from './rewind-config-editor';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
+import JetpackReviewPrompt from './jetpack-review-prompt';
 
 /**
  * Type dependencies
@@ -190,17 +191,19 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		</Error>
 	);
 
+	const isInProgress =
+		( ! inProgressRewindStatus && userHasRequestedRestore ) ||
+		( inProgressRewindStatus && [ 'queued', 'running' ].includes( inProgressRewindStatus ) );
+	const isFinished = inProgressRewindStatus !== null && inProgressRewindStatus === 'finished';
+
 	const render = () => {
 		if ( loading ) {
 			return <Loading />;
 		} else if ( ! inProgressRewindStatus && ! userHasRequestedRestore ) {
 			return renderConfirm();
-		} else if (
-			( ! inProgressRewindStatus && userHasRequestedRestore ) ||
-			( inProgressRewindStatus && [ 'queued', 'running' ].includes( inProgressRewindStatus ) )
-		) {
+		} else if ( isInProgress ) {
 			return renderInProgress();
-		} else if ( inProgressRewindStatus !== null && inProgressRewindStatus === 'finished' ) {
+		} else if ( isFinished ) {
 			return renderFinished();
 		}
 		return renderError();
@@ -212,7 +215,8 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			{ restoreId && 'running' === inProgressRewindStatus && (
 				<QueryRewindRestoreStatus siteId={ siteId } restoreId={ restoreId } />
 			) }
-			{ render() }
+			<Card>{ render() }</Card>
+			{ ( isInProgress || isFinished ) && <JetpackReviewPrompt /> }
 		</>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Dismissible Jetpack Review Prompt to the "In-Progress" and "Finished" stages of the Jetpack Restore Flow
   * New Tracks events, `calypso_jetpack_review_prompt_view` and `calypso_jetpack_review_prompt_dismiss` to understand how many reviews are being created as a result of the prompt

![Screen Shot 2021-03-32 at 18 02 12](https://user-images.githubusercontent.com/2810519/113229312-8f575580-924b-11eb-9fd6-1026d5554e60.png)

#### Testing instructions

1. Navigate to `/backup/:siteSlug`.
   * open dev tools and start analytics logging by running `localStorage.setItem('debug', 'calypso:analytics');` via the console.
2. Find a valid backup and initiate a restore.
3. Verify that the review prompt appears while the restore is in progress and after it has finished ( see screenshots above for how it should look ).
4. Verify that viewing the prompt has logged a `calypso_jetpack_review_prompt_view ` event. ( This should log twice, since two separate components will render ).
5. Dismiss via the "X" button in the corner.
6. Verify the prompt is no longer rendered
7. Check that the `calypso_jetpack_review_prompt_dismiss` event logs with `reviewed` set to false.
8. Unset the `jetpack-review-prompt` preference
   * <img width="1007" alt="Screen Shot 2021-03-24 at 12 22 33 PM" src="https://user-images.githubusercontent.com/2810519/112371507-e8e3e100-8c9b-11eb-8725-f3dbd49cb139.png">
 9. Click the "Leave Jetpack a Review" button
 10. Check that the `calypso_jetpack_backup_review_prompt_dismiss` event logs with `reviewed` set to true.
 11. Verify the prompt is no longer rendered
 12. Reset preference, dismiss via upper left cross
 13. Modify the `jetpack-review-prompt` property `dismissedAt` by subtracting `1814400000` from it ( 3 weeks in ms )
 14. Verify that the prompt redisplays 
