### PR TITLE
Admin Menu: Use masks where possible to theme SVG icons

### DIFF
--- a/client/layout/sidebar/custom-icon.jsx
+++ b/client/layout/sidebar/custom-icon.jsx
@@ -13,20 +13,21 @@
  */
 import React from 'react';
 
-const SidebarCustomIcon = ( { alt, className, icon, ...rest } ) => {
+const SidebarCustomIcon = ( { icon, ...rest } ) => {
 	if ( ! icon ) {
 		return null;
 	}
 
 	if ( icon.indexOf( 'data:image' ) === 0 || icon.indexOf( 'http' ) === 0 ) {
+		const imgStyle = `url("${ icon }")`;
+		const imgStyles = { backgroundImage: imgStyle, maskImage: imgStyle };
+
 		return (
-			<img
-				alt={ alt || '' }
-				className={ 'sidebar__menu-icon ' + ( className || '' ) }
-				src={ icon }
-				width="20"
+			<span
+				className={ 'sidebar__menu-icon dashicons sidebar__menu-icon-img' }
+				style={ imgStyles }
 				{ ...rest }
-			/>
+			></span>
 		);
 	}
 

--- a/client/layout/sidebar/custom-icon.jsx
+++ b/client/layout/sidebar/custom-icon.jsx
@@ -20,7 +20,7 @@ const SidebarCustomIcon = ( { icon, ...rest } ) => {
 
 	if ( icon.indexOf( 'data:image' ) === 0 || icon.indexOf( 'http' ) === 0 ) {
 		const imgStyle = `url("${ icon }")`;
-		const imgStyles = { backgroundImage: imgStyle, maskImage: imgStyle };
+		const imgStyles = { backgroundImage: imgStyle, maskImage: imgStyle, WebkitMaskImage: imgStyle };
 
 		return (
 			<span

--- a/client/layout/sidebar/custom-icon.jsx
+++ b/client/layout/sidebar/custom-icon.jsx
@@ -19,18 +19,22 @@ const SidebarCustomIcon = ( { icon, ...rest } ) => {
 	}
 
 	if ( icon.indexOf( 'data:image' ) === 0 || icon.indexOf( 'http' ) === 0 ) {
+		const isSVG = icon.indexOf( 'data:image/svg+xml' ) === 0;
 		const imgStyle = `url("${ icon }")`;
-		const imgStyles = { backgroundImage: imgStyle, maskImage: imgStyle, WebkitMaskImage: imgStyle };
+		const imgStyles = {
+			backgroundImage: imgStyle,
+			...( isSVG ? { maskImage: imgStyle, WebkitMaskImage: imgStyle } : {} ),
+		};
 
 		return (
 			<span
-				className={ 'sidebar__menu-icon dashicons sidebar__menu-icon-img' }
+				className={ 'sidebar__menu-icon dashicons' + ( isSVG ? ' sidebar__menu-icon-img' : '' ) }
 				style={ imgStyles }
 				{ ...rest }
-			></span>
+			/>
 		);
 	}
 
-	return <span className={ 'sidebar__menu-icon dashicons-before ' + icon } { ...rest }></span>;
+	return <span className={ 'sidebar__menu-icon dashicons-before ' + icon } { ...rest } />;
 };
 export default SidebarCustomIcon;

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -698,3 +698,10 @@ $font-size: rem( 14px );
 		}
 	}
 }
+
+@supports ( mask-image: none ) or ( -webkit-mask-image: none ) {
+	.sidebar__menu-icon-img {
+		background-image: none !important;
+		background-color: currentColor;
+	}
+}

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -703,5 +703,11 @@ $font-size: rem( 14px );
 	.sidebar__menu-icon-img {
 		background-image: none !important;
 		background-color: currentColor;
+		mask-size: contain;
+		mask-repeat: no-repeat;
+		mask-position: center center;
+		-webkit-mask-size: contain;
+		-webkit-mask-repeat: no-repeat;
+		-webkit-mask-position: center center;
 	}
 }

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -157,6 +157,7 @@ $font-size: rem( 14px );
 		}
 
 		.sidebar__menu-icon {
+			background-size: contain;
 			color: var( --color-sidebar-gridicon-fill );
 			margin-right: 8px;
 		}


### PR DESCRIPTION
The SVG icon used for Jetpack was not getting styled in the same way as
the other icons that used the Dashicons font. This change attempts to
allow SVG to inherit the same styling as other icons. Currently it is
only Jetpack that this will affect, but it's needed for Woocommerce, and
probably other plugins in the future.

#### Changes proposed in this Pull Request

The PR changes the `SidebarCustomIcon` component to use background images and masks rather than embedding an image tag. I searched for uses of the component through the code, and it seems that it's only used in this context, so this should be a safe change.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This needs to be tested in conjunction with Automattic/jetpack#19364
* Apply the associated diff (D59576-code) to the above PR and sandbox the API
* With this branch, the Jetpack icon should follow the styling of the other icons in the menu

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #49145

