### PR TITLE
App builds: Include the README file in the final artifact

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
 							// Disabled because they don't make a lot of sense or they are buggy
 							[ 'lint-maximum-heading-length', false ],
 							[ 'lint-no-duplicate-headings', false ],
+							[ 'no-literal-urls', false ],
 
 							// Rules we would like to enable eventually. Violations needs to be fixed manually before enabling the rule.
 							[ 'lint-fenced-code-flag', false ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,6 @@ module.exports = {
 							// Disabled because they don't make a lot of sense or they are buggy
 							[ 'lint-maximum-heading-length', false ],
 							[ 'lint-no-duplicate-headings', false ],
-							[ 'no-literal-urls', false ],
 
 							// Rules we would like to enable eventually. Violations needs to be fixed manually before enabling the rule.
 							[ 'lint-fenced-code-flag', false ],

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -117,7 +117,7 @@ open class PluginBaseBuild : Template({
 
 				# 3. Check if the current build has changed, and if so, tag it for release.
 				# Note: we exclude asset changes because we only really care if the build files (JS/CSS) change. That file is basically just metadata.
-				if ! diff -rq --exclude="*.asset.php" --exclude="cache-buster.txt" $archiveDir ./release-archive/ ; then
+				if ! diff -rq --exclude="*.asset.php" --exclude="cache-buster.txt" --exclude="README.md" $archiveDir ./release-archive/ ; then
 					echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
 					tag_response=`curl -s -X POST -H "Content-Type: text/plain" --data "$releaseTag" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`
 					echo -e "Build tagging status: ${'$'}tag_response\n"

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -100,9 +100,10 @@ open class PluginBaseBuild : Template({
 		bashNodeScript {
 			name = "Process Artifact"
 			scriptContent = """
-				# 1. Download and unzip current release build.
 				cd $workingDir
+				cp README.md $archiveDir
 
+				# 1. Download and unzip current release build.
 				mkdir ./release-archive
 				wget "%teamcity.serverUrl%/repository/download/%system.teamcity.buildType.id%/$releaseTag.tcbuildtag/$pluginSlug.zip?guest=1&branch=trunk" -O ./tmp-release-archive-download.zip
 				unzip ./tmp-release-archive-download.zip -d ./release-archive

--- a/apps/editing-toolkit/README.md
+++ b/apps/editing-toolkit/README.md
@@ -2,7 +2,7 @@
 
 This plugin includes many sub-features which add blocks and new functionality to the Gutenberg editor. The plugin provides a single codebase which can be installed on any platform which requires these features, such as the WordPress.com multisite or other standalone WordPress instances.
 
-This code is developed in the calypso monorepo at https://github.com/Automattic/wp-calypso/tree/trunk/apps/editing-toolkit.
+This code is developed in the calypso monorepo at <https://github.com/Automattic/wp-calypso/tree/trunk/apps/editing-toolkit>.
 
 ## Rename Info
 

--- a/apps/editing-toolkit/README.md
+++ b/apps/editing-toolkit/README.md
@@ -2,6 +2,8 @@
 
 This plugin includes many sub-features which add blocks and new functionality to the Gutenberg editor. The plugin provides a single codebase which can be installed on any platform which requires these features, such as the WordPress.com multisite or other standalone WordPress instances.
 
+This code is developed in the calypso monorepo at https://github.com/Automattic/wp-calypso/tree/trunk/apps/editing-toolkit.
+
 ## Rename Info
 
 This plugin has been renamed from Full Site Editing Plugin to WordPress.com Editing Toolkit Plugin.

--- a/apps/notifications/README.md
+++ b/apps/notifications/README.md
@@ -4,6 +4,8 @@ The _**notifications panel**_ (also known as "masterbar notifications" and "the 
 
 This module is where the code for the notifications panel lives. Calypso views are imported as normal `node` imports while the `iframe` version is served from `https://widgets.wp.com/notes` or `https://widgets.wp.com/notifications`.
 
+This code is developed in the calypso monorepo at https://github.com/Automattic/wp-calypso/tree/trunk/apps/notifications.
+
 ## Building and developing
 
 Most work on the notifications panel should happen in Calypso the same way other Calypso changes are developed.

--- a/apps/notifications/README.md
+++ b/apps/notifications/README.md
@@ -4,7 +4,7 @@ The _**notifications panel**_ (also known as "masterbar notifications" and "the 
 
 This module is where the code for the notifications panel lives. Calypso views are imported as normal `node` imports while the `iframe` version is served from `https://widgets.wp.com/notes` or `https://widgets.wp.com/notifications`.
 
-This code is developed in the calypso monorepo at https://github.com/Automattic/wp-calypso/tree/trunk/apps/notifications.
+This code is developed in the calypso monorepo at <https://github.com/Automattic/wp-calypso/tree/trunk/apps/notifications>.
 
 ## Building and developing
 

--- a/apps/o2-blocks/README.md
+++ b/apps/o2-blocks/README.md
@@ -1,6 +1,6 @@
 # Gutenberg extensions for o2 theme
 
-This code is developed in the calypso monorepo at https://github.com/Automattic/wp-calypso/tree/trunk/apps/o2-blocks.
+This code is developed in the calypso monorepo at <https://github.com/Automattic/wp-calypso/tree/trunk/apps/o2-blocks>.
 
 Your extension should follow this structure:
 

--- a/apps/o2-blocks/README.md
+++ b/apps/o2-blocks/README.md
@@ -1,5 +1,7 @@
 # Gutenberg extensions for o2 theme
 
+This code is developed in the calypso monorepo at https://github.com/Automattic/wp-calypso/tree/trunk/apps/o2-blocks.
+
 Your extension should follow this structure:
 
 ```

--- a/apps/wpcom-block-editor/README.md
+++ b/apps/wpcom-block-editor/README.md
@@ -4,6 +4,8 @@ This package provides utilities for the WordPress.com block editor integration.
 
 These utilities are intended to be built and then served from `widgets.wp.com`, so they can be loaded by a WordPress.com or a Jetpack connected site.
 
+This code is developed in the calypso monorepo at https://github.com/Automattic/wp-calypso/tree/trunk/apps/wpcom-block-editor.
+
 ## Editors
 
 There are two editors supported:

--- a/apps/wpcom-block-editor/README.md
+++ b/apps/wpcom-block-editor/README.md
@@ -4,7 +4,7 @@ This package provides utilities for the WordPress.com block editor integration.
 
 These utilities are intended to be built and then served from `widgets.wp.com`, so they can be loaded by a WordPress.com or a Jetpack connected site.
 
-This code is developed in the calypso monorepo at https://github.com/Automattic/wp-calypso/tree/trunk/apps/wpcom-block-editor.
+This code is developed in the calypso monorepo at <https://github.com/Automattic/wp-calypso/tree/trunk/apps/wpcom-block-editor>.
 
 ## Editors
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Add a blurb to each wpcom app readme about where the code is developed.
* Include the readme in the build artifact

The purpose of this PR is to provide a way for folks browsing the internal wpcom source to know where the code for each plugin is developed. For example, when visiting `trunk/widgets.wp.com/notifications` in opengrok, the readme from this repository would display there so that folks don't get confused about where the code should be developed.

An alternative would be maintaining a separate readme on WordPress.com. But in the spirit of keeping the source code exactly in sync, I thought it would be nice to include the readme which already exists. What do you think?

#### Testing instructions
- [ ] Wpcom app builds should pass.
- [ ] `install-plugin.sh` for any of the plugins should add the readme to the wpcom repository
