### PR TITLE
Add e2e test coverage for post and comment likes.

### DIFF
--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -571,3 +571,16 @@ export async function waitTillTextPresent( driver, selector, text, waitOverride 
 		`Timed out waiting for element with ${ selector.using } of '${ selector.value }' to be present and displayed with text '${ text }'`
 	);
 }
+
+/**
+ * Waits until the input driver is able to switch to the designated frame.
+ * Upon successful resolution, the driver will be left focused on the new frame.
+ *
+ * @param {WebDriver} driver The parent WebDriver instance
+ * @param {By} locator The element's locator
+ * @param {number} [timeout=explicitWaitMS] The timeout in milliseconds
+ * @returns {Promise<boolean>} A promise that will resolve with true if the switch was succesfull
+ */
+export function waitUntilAbleToSwitchToFrame( driver, locator, timeout = explicitWaitMS ) {
+	return driver.wait( until.ableToSwitchToFrame( locator ), timeout );
+}

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -293,6 +293,22 @@ export async function ensureNotLoggedIn( driver ) {
 	return driver.sleep( 500 );
 }
 
+/**
+ * Ensure a user isn't logged into wordpress.com, remote-login, or the given test site url.
+ *
+ * Clearing cookies on each site ensures a login step is required for popup based logins.
+ *
+ * @param driver Webdriver
+ * @param siteUrl to clear cookies from
+ */
+export async function ensureNotLoggedIntoSite( driver, siteUrl = false ) {
+	await ensureNotLoggedIn( driver ); // Clear wpcom/calypso cookies
+	await clearCookiesAndDeleteLocalStorage( driver, 'https://r-login.wordpress.com/' ); // Clear cookies on remote login
+	if ( siteUrl ) {
+		await clearCookiesAndDeleteLocalStorage( driver, siteUrl ); // Clear cookies on url
+	}
+}
+
 export async function dismissAllAlerts( driver ) {
 	await times( 3, async () => {
 		try {

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -264,14 +264,21 @@ export default class LoginFlow {
 
 		const loginPage = await LoginPage.Expect( this.driver );
 
-		await loginPage.login(
-			this.account.email || this.account.username,
-			this.account.password,
-			false,
-			{ retry: false }
-		);
+		try {
+			await loginPage.login(
+				this.account.email || this.account.username,
+				this.account.password,
+				false,
+				{ retry: false }
+			);
+		} catch ( error ) {
+			// Popup login window closes itself so let's handle WebDriver complaints
+			if ( 'NoSuchWindowError' !== error.name ) {
+				throw error;
+			}
+		}
 
-		// Switch back to post window
+		// Make sure we've switched back to the post window
 		await driverHelper.switchToWindowByIndex( this.driver, 0 );
 	}
 

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -16,6 +16,7 @@ import GuideComponent from '../components/guide-component.js';
 
 import * as dataHelper from '../data-helper';
 import * as driverManager from '../driver-manager';
+import * as driverHelper from '../driver-helper';
 import * as loginCookieHelper from '../login-cookie-helper';
 import PagesPage from '../pages/pages-page';
 
@@ -255,6 +256,23 @@ export default class LoginFlow {
 			this.account.email || this.account.username,
 			this.account.password
 		);
+	}
+
+	async loginUsingPopup() {
+		await driverHelper.waitForNumberOfWindows( this.driver, 2 );
+		await driverHelper.switchToWindowByIndex( this.driver, 1 );
+
+		const loginPage = await LoginPage.Expect( this.driver );
+
+		await loginPage.login(
+			this.account.email || this.account.username,
+			this.account.password,
+			false,
+			{ retry: false }
+		);
+
+		// Switch back to post window
+		await driverHelper.switchToWindowByIndex( this.driver, 0 );
 	}
 
 	async loginAndOpenWooStore() {

--- a/test/e2e/lib/pages/frontend/comment-likes-component.js
+++ b/test/e2e/lib/pages/frontend/comment-likes-component.js
@@ -38,7 +38,11 @@ export default class CommentLikesComponent extends AsyncBaseContainer {
 		const commentLikeLink = By.xpath(
 			`//div[@class='comment-content']/p[.='${ this.comment }']/../p/a[@class='comment-like-link']`
 		);
+
+		// Scrolling 100px prevents the action bar from covering the like button on mobile
+		// causing test failures
 		await driverHelper.scrollIntoView( this.driver, commentLikeLink, 'end' );
+		await this.driver.executeScript( 'window.scrollBy(0, 100)' );
 		await driverHelper.clickWhenClickable( this.driver, commentLikeLink );
 	}
 	async expectLiked() {
@@ -51,6 +55,11 @@ export default class CommentLikesComponent extends AsyncBaseContainer {
 		const commentUnLikeLink = By.xpath(
 			`//div[@class='comment-content']/p[.='${ this.comment }']/../p[@class='comment-likes comment-liked']/a[@class='comment-like-link']`
 		);
+
+		// Scrolling 100px prevents the action bar from covering the like button on mobile
+		// causing test failures
+		await driverHelper.scrollIntoView( this.driver, commentUnLikeLink, 'end' );
+		await this.driver.executeScript( 'window.scrollBy(0, 100)' );
 		await driverHelper.clickWhenClickable( this.driver, commentUnLikeLink );
 	}
 	async expectNotLiked() {

--- a/test/e2e/lib/pages/frontend/comment-likes-component.js
+++ b/test/e2e/lib/pages/frontend/comment-likes-component.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import AsyncBaseContainer from '../../async-base-container';
+import * as driverHelper from '../../driver-helper';
+
+export default class CommentLikesComponent extends AsyncBaseContainer {
+	/**
+	 * Encapsulates post comment like clicks and assertions
+	 *
+	 * @param driver WebDriver driver
+	 * @param comment Text used to locate the comment under test
+	 * @param url Url of the post where the comment can be found
+	 */
+	constructor( driver, comment, url ) {
+		super( driver, By.xpath( `//div[@class='comment-content']/p[.='${ comment }']` ), url );
+		this.comment = comment;
+	}
+
+	static async Expect( driver, comment ) {
+		const page = new this( driver, comment );
+		await page._expectInit();
+		return page;
+	}
+
+	static async Visit( driver, comment, url ) {
+		const page = new this( driver, comment, url );
+		await page._visitInit();
+		return page;
+	}
+
+	async likeComment() {
+		const commentLikeLink = By.xpath(
+			`//div[@class='comment-content']/p[.='${ this.comment }']/../p/a[@class='comment-like-link']`
+		);
+		await driverHelper.scrollIntoView( this.driver, commentLikeLink, 'end' );
+		await driverHelper.clickWhenClickable( this.driver, commentLikeLink );
+	}
+	async expectLiked() {
+		const commentLikedText = By.xpath(
+			`//div[@class='comment-content']/p[.='${ this.comment }']/../p/span[starts-with(text(),'Liked by')]`
+		);
+		await driverHelper.waitUntilLocatedAndVisible( this.driver, commentLikedText );
+	}
+	async unlikeComment() {
+		const commentUnLikeLink = By.xpath(
+			`//div[@class='comment-content']/p[.='${ this.comment }']/../p[@class='comment-likes comment-liked']/a[@class='comment-like-link']`
+		);
+		await driverHelper.clickWhenClickable( this.driver, commentUnLikeLink );
+	}
+	async expectNotLiked() {
+		const commentUnLikedText = By.xpath(
+			`//div[@class='comment-content']/p[.='${ this.comment }']/../p/span[starts-with(text(),'Like')]`
+		);
+		await driverHelper.waitUntilLocatedAndVisible( this.driver, commentUnLikedText );
+	}
+}

--- a/test/e2e/lib/pages/frontend/post-likes-component.js
+++ b/test/e2e/lib/pages/frontend/post-likes-component.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import * as driverHelper from '../../driver-helper';
+import AsyncBaseContainer from '../../async-base-container';
+export default class PostLikesComponent extends AsyncBaseContainer {
+	/**
+	 * Encapsulates the iframe switching required to click on
+	 * post like buttons and assert their "Liked" state
+	 *
+	 * @param driver WebDriver driver
+	 * @param url Url of the post where the likes widget can be found
+	 */
+	constructor( driver, url ) {
+		super( driver, By.css( 'iframe.post-likes-widget' ), url );
+	}
+
+	async _preInit() {
+		// Ensure we're starting from the top frame before expecting on this.expectedElementSelector
+		await this.driver.switchTo().defaultContent();
+	}
+
+	async clickLike() {
+		await driverHelper.waitUntilAbleToSwitchToFrame( this.driver, this.expectedElementSelector );
+		const likeButton = By.css( '.like.sd-button' );
+		await driverHelper.scrollIntoView( this.driver, likeButton );
+		await driverHelper.clickWhenClickable( this.driver, likeButton );
+		await this.driver.switchTo().defaultContent();
+	}
+
+	async expectLiked() {
+		await driverHelper.waitUntilAbleToSwitchToFrame( this.driver, this.expectedElementSelector );
+		await driverHelper.waitUntilLocatedAndVisible(
+			this.driver,
+			By.xpath( `//span[@class='wpl-count-text'][.='You like this.']` )
+		);
+		await this.driver.switchTo().defaultContent();
+	}
+
+	async clickUnlike() {
+		await driverHelper.waitUntilAbleToSwitchToFrame( this.driver, this.expectedElementSelector );
+		const likedButton = By.css( '.liked.sd-button' );
+		await driverHelper.scrollIntoView( this.driver, likedButton );
+		await driverHelper.clickWhenClickable( this.driver, likedButton );
+		await this.driver.switchTo().defaultContent();
+	}
+
+	async expectNotLiked() {
+		await driverHelper.waitUntilAbleToSwitchToFrame( this.driver, this.expectedElementSelector );
+		await driverHelper.waitUntilLocatedAndVisible(
+			this.driver,
+			By.xpath( `//span[@class='wpl-count-text'][.='Be the first to like this.']` )
+		);
+		await this.driver.switchTo().defaultContent();
+	}
+}

--- a/test/e2e/specs/wp-likes-spec.js
+++ b/test/e2e/specs/wp-likes-spec.js
@@ -95,6 +95,10 @@ describe( `[${ host }] Likes: (${ screenSize })`, function () {
 			await loginFlow.loginUsingPopup();
 
 			await postLikes.expectLiked();
+
+			// And Unlike it
+			await postLikes.clickUnlike();
+			await postLikes.expectNotLiked();
 		} );
 	} );
 } );

--- a/test/e2e/specs/wp-likes-spec.js
+++ b/test/e2e/specs/wp-likes-spec.js
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import * as driverManager from '../lib/driver-manager';
+import * as dataHelper from '../lib/data-helper';
+import LoginFlow from '../lib/flows/login-flow';
+import CommentsAreaComponent from '../lib/pages/frontend/comments-area-component';
+import PostLikesComponent from '../lib/pages/frontend/post-likes-component';
+import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
+import CommentLikesComponent from '../lib/pages/frontend/comment-likes-component';
+
+const host = dataHelper.getJetpackHost();
+const screenSize = driverManager.currentScreenSize();
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const mochaTimeoutMS = config.get( 'mochaTimeoutMS' );
+const blogPostTitle = dataHelper.randomPhrase();
+const blogPostQuote =
+	'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
+
+/**
+ * This spec ensures likes on wordpress.com posts and comments work as expected
+ * for both loggedin and logged out users.
+ */
+describe( `[${ host }] Likes: (${ screenSize })`, function () {
+	let driver;
+	let postUrl;
+	this.timeout( mochaTimeoutMS );
+	const comment = dataHelper.randomPhrase();
+	const accountKey = 'gutenbergSimpleSiteUser';
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
+
+	describe( 'Like posts and comments @parallel', function () {
+		step( 'Login, create a new post and view it', async function () {
+			const loginFlow = new LoginFlow( driver, accountKey );
+			await loginFlow.loginAndStartNewPost( null, true );
+
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.enterTitle( blogPostTitle );
+			await gEditorComponent.enterText( blogPostQuote );
+			postUrl = await gEditorComponent.publish( { visit: true } );
+		} );
+
+		step( 'Like post', async function () {
+			const postLikes = await PostLikesComponent.Expect( driver );
+			await postLikes.clickLike();
+			await postLikes.expectLiked();
+		} );
+
+		step( 'Unlike post', async function () {
+			const postLikes = await PostLikesComponent.Expect( driver );
+			await postLikes.clickUnlike();
+			await postLikes.expectNotLiked();
+		} );
+
+		step( 'Post comment', async function () {
+			const commentArea = await CommentsAreaComponent.Expect( driver );
+
+			// commentArea.reply fails to find .comment-reply-link at times,
+			// as we're not concerned with the assertion just call postComment directly
+			await commentArea._postComment( {
+				comment: comment,
+				name: 'e2eTestName',
+				email: 'e2eTestName@test.com',
+			} );
+		} );
+
+		step( 'Like comment', async function () {
+			const commentLikes = await CommentLikesComponent.Expect( driver, comment );
+			await commentLikes.likeComment();
+			await commentLikes.expectLiked();
+		} );
+
+		step( 'Unlike comment', async function () {
+			const commentLikes = await CommentLikesComponent.Expect( driver, comment );
+			await commentLikes.unlikeComment();
+			await commentLikes.expectNotLiked();
+		} );
+
+		step( 'Like post as logged out user', async function () {
+			await driverManager.ensureNotLoggedIntoSite( driver, postUrl );
+
+			const postLikes = await PostLikesComponent.Visit( driver, postUrl );
+			await postLikes.clickLike();
+
+			const loginFlow = new LoginFlow( driver, accountKey );
+			await loginFlow.loginUsingPopup();
+
+			await postLikes.expectLiked();
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds e2e test coverage for post and comment likes.

Follow up from D59475-code, pcNnmV-2K-p2 

#### Testing instructions
```
NODE_CONFIG_ENV=decrypted BROWSERSIZE=desktop ./node_modules/.bin/mocha specs/wp-likes-spec.js 
```