### PR TITLE
E2E: Experimental editor init switch speed up.

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -52,11 +52,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			this.explicitWaitMS,
 			'Could not locate the editor iFrame.'
 		);
-		await this.driver.sleep( 2000 );
-	}
-
-	async _postInit() {
-		await this.driver.sleep( 2000 );
 	}
 
 	async initEditor( { dismissPageTemplateSelector = false } = {} ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Now that we've addressed the actual problem of why iframe context switch is flakey (https://github.com/Automattic/wp-calypso/pull/51580), let's see if we can remove the original `sleep()` workaround without repercussions. This would ideally shave off 4 seconds.

#### Testing instructions

* Re-run the test in TC and collect results.

Related to https://github.com/Automattic/wp-calypso/pull/51580
