### PR TITLE
Restarts the test to emphasize the free domain option in the launch flow

### DIFF
--- a/client/signup/steps/domain-upsell/index.jsx
+++ b/client/signup/steps/domain-upsell/index.jsx
@@ -51,8 +51,7 @@ export default function DomainUpsellStep( props ) {
 		'domain_upsell_emphasize_free_v3'
 	);
 
-	const isInDomainUpsellEmphasizeFreeTest =
-		experimentAssignment && 'treatment' === experimentAssignment.variationName;
+	const isInDomainUpsellEmphasizeFreeTest = 'treatment' === experimentAssignment?.variationName;
 
 	return (
 		<div

--- a/client/signup/steps/domain-upsell/index.jsx
+++ b/client/signup/steps/domain-upsell/index.jsx
@@ -18,14 +18,10 @@ import formatCurrency from '@automattic/format-currency';
 import QuerySecureYourBrand from 'calypso/components/data/query-secure-your-brand';
 import Badge from 'calypso/components/badge';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
-import {
-	getVariationForUser,
-	isLoading as isExperimentLoadingSelector,
-} from 'calypso/state/experiments/selectors';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormLabel from 'calypso/components/forms/form-label';
-import Experiment from 'calypso/components/experiment';
+import { useExperiment } from 'calypso/lib/explat';
 
 /**
  * Style dependencies
@@ -51,9 +47,12 @@ export default function DomainUpsellStep( props ) {
 		}
 	);
 
+	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
+		'domain_upsell_emphasize_free_v3'
+	);
+
 	const isInDomainUpsellEmphasizeFreeTest =
-		'treatment' ===
-		useSelector( ( state ) => getVariationForUser( state, 'domain_upsell_emphasize_free_v2' ) );
+		experimentAssignment && 'treatment' === experimentAssignment.variationName;
 
 	return (
 		<div
@@ -61,7 +60,6 @@ export default function DomainUpsellStep( props ) {
 				is_in_domain_upsell_emphasize_free_test: isInDomainUpsellEmphasizeFreeTest,
 			} ) }
 		>
-			<Experiment name="domain_upsell_emphasize_free_v2" />
 			<StepWrapper
 				flowName={ flowName }
 				stepName={ stepName }
@@ -71,7 +69,11 @@ export default function DomainUpsellStep( props ) {
 				subHeaderText={ subHeaderText }
 				fallbackSubHeaderText={ subHeaderText }
 				isWideLayout={ false }
-				stepContent={ RecommendedDomains( { ...props, isInDomainUpsellEmphasizeFreeTest } ) }
+				stepContent={ RecommendedDomains( {
+					...props,
+					isInDomainUpsellEmphasizeFreeTest,
+					isLoadingExperimentAssignment,
+				} ) }
 			/>
 		</div>
 	);
@@ -113,20 +115,20 @@ function RecommendedDomains( props ) {
 		submitSignupStep,
 		goToNextStep,
 		isInDomainUpsellEmphasizeFreeTest,
+		isLoadingExperimentAssignment,
 	} = props;
 	const translate = useTranslate();
 	const [ selectedDomain, setSelectedDomain ] = useState( null );
 	const selectDomain = ( event ) => setSelectedDomain( event.target.value );
 	const secureYourBrand = useSelector( ( state ) => getSecureYourBrand( state ) );
 	const isSecureYourBrandLoading = useSelector( ( state ) => isRequestingSecureYourBrand( state ) );
-	const isExperimentLoading = useSelector( ( state ) => isExperimentLoadingSelector( state ) );
 	const hasError = useSelector( ( state ) => hasSecureYourBrandError( state ) );
 	const productData = secureYourBrand.product_data;
 	const selectedProduct = productData?.filter(
 		( product ) => product.domain === selectedDomain
 	)[ 0 ];
 
-	const isLoading = isSecureYourBrandLoading || isExperimentLoading;
+	const isLoading = isSecureYourBrandLoading || isLoadingExperimentAssignment;
 
 	const upgradeCtaText = isInDomainUpsellEmphasizeFreeTest
 		? translate( 'Use %(selectedDomain)s (%(originalCost)s)', {
@@ -216,7 +218,7 @@ function RecommendedDomains( props ) {
 					) }
 				</div>
 			</Card>
-			{ ! isInDomainUpsellEmphasizeFreeTest && (
+			{ ! isInDomainUpsellEmphasizeFreeTest && ! isLoading && (
 				<div className="domain-upsell__continue-link">
 					<Button compact borderless plain onClick={ handleSkipButtonClick }>
 						{ translate( `No thanks, I'll stick with %s`, {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: pbxNRc-HM-p2#comment-1830

This change restarts the test which was first introduced in #50324, using the new ExPlat client.

![image](https://user-images.githubusercontent.com/5436027/113284936-f9cdcb80-9307-11eb-9827-0dd9a2ff585d.png)

#### Testing instructions

1. Make sure you are using an English locale
2. Sign up for a free user and site
3. Assign yourself to the treatment group
4. Launch the site from the /home menu
5. Select a free domain and plan
6. The domain upsell test should look like the screenshot above (The free domain option has been converted to a button).
7. Confirm that there is no change when assigned to control.

A way to skip this is to directly start the launch flow by removing the cart items and going to http://calypso.localhost:3000/start/launch-site/domains-launch?siteSlug=YOURSITE.wordpress.com