### PR TITLE
Fix the "Add a domain" button to work with domain only purchase

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -32,7 +32,7 @@ function getCheckoutUrl( dependencies, localeSlug, flowName ) {
 					redirect_to: `/home/${ dependencies.siteSlug }`,
 				} ),
 			...( dependencies.isGutenboardingCreate && { isGutenboardingCreate: 1 } ),
-			...( 'domain' === flowName && { isDomainOnly: 1 } ),
+			...( [ 'domain', 'add-domain' ].includes( flowName ) && { isDomainOnly: 1 } ),
 		},
 		checkoutURL
 	);


### PR DESCRIPTION
This fixes a bug where the "Add a domain" button from the all domains list doesn't work if you try to purchase only domain.

#### Changes proposed in this Pull Request

* fix the signup getCheckoutUrl to pass `isDomainOnly` param for both `domain` and `add-domain` flows
#### Testing instructions

* Open My Sites > Upgrades > Domains and click on Manage All Your Domains
* Click on "Add domain" button at the top
* enter some string and select a domain
* choose "Just buy a domain" option
* you should end up in the checkout page (/checkout/no-site) with the selected domain in the cart

Fixes #51447 
