### PR TITLE
Gutenberg: Revert E2E hotfix after production rollback

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -246,11 +246,6 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 		await driverHelper.clickWhenClickable( this.driver, nextMonthSelector );
 		await this.driver.sleep( 400 ); // Wait for the month slide animation
 		await driverHelper.selectElementByText( this.driver, firstDay, '1' );
-		// Add another click so the calendar modal disappears and makes space for
-		// the follow-up clicks. This is because of a bug reported in
-		// https://github.com/WordPress/gutenberg/issues/30415 and can be reverted
-		// once an upstream fix is in.
-		await driverHelper.selectElementByText( this.driver, firstDay, '1' );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, publishDateSelector );
 		const publishDate = await this.driver.findElement( publishDateSelector ).getText();
 


### PR DESCRIPTION
This reverts commit add448fb5ebaecb13508f778f3ee17c2473df8ca.

#### Changes proposed in this Pull Request

* Revert hotfix for v10.3 included in https://github.com/Automattic/wp-calypso/pull/51525

#### Testing instructions

`wp-calypso-gutenberg-post-editor-spec.js` suite should pass.