### PR TITLE
Partner Portal: Update wpcomJetpackLicensing handler to use wpcomXhrRequest

### DIFF
--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -14,6 +14,7 @@ import { injectGuestSandboxTicketHandler } from './handlers/guest-sandbox-ticket
 import * as oauthToken from 'calypso/lib/oauth-token';
 import wpcomXhrWrapper from 'calypso/lib/wpcom-xhr-wrapper';
 import wpcomProxyRequest from 'wpcom-proxy-request';
+import wpcomXhrRequest from 'wpcom-xhr-request';
 import { inJetpackCloudOAuthOverride } from 'calypso/lib/jetpack/oauth-override';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
@@ -66,4 +67,4 @@ export default wpcom;
 /**
  * Expose `wpcomJetpackLicensing` which uses a different auth token than wpcom.
  */
-export const wpcomJetpackLicensing = wpcomUndocumented( wpcomProxyRequest );
+export const wpcomJetpackLicensing = wpcomUndocumented( wpcomXhrRequest );

--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -14,7 +14,6 @@ import { injectGuestSandboxTicketHandler } from './handlers/guest-sandbox-ticket
 import * as oauthToken from 'calypso/lib/oauth-token';
 import wpcomXhrWrapper from 'calypso/lib/wpcom-xhr-wrapper';
 import wpcomProxyRequest from 'wpcom-proxy-request';
-import wpcomXhrRequest from 'wpcom-xhr-request';
 import { inJetpackCloudOAuthOverride } from 'calypso/lib/jetpack/oauth-override';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
@@ -67,4 +66,4 @@ export default wpcom;
 /**
  * Expose `wpcomJetpackLicensing` which uses a different auth token than wpcom.
  */
-export const wpcomJetpackLicensing = wpcomUndocumented( wpcomXhrRequest );
+export const wpcomJetpackLicensing = wpcomUndocumented( wpcomXhrWrapper );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: p1617089336069400-slack-CQN0YDYM7

* This PR changes the `wpcomJetpackLicensing` handler in `/lib/wp/browser.js` to use `wpcomXhrWrapper` instead of `wpcomProxyRequest`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* If you do not have a partner key, please contact Infinity for one or you will be unable to view test this PR.
* Check out this PR locally, then run* `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal
* Click around and make sure the requests work correctly

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->