### PR TITLE
Site selector: consolidate styles with nav unification

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -183,7 +183,14 @@
 	color: var( --color-sidebar-menu-hover-text );
 }
 
-.layout__secondary .site__home {
-	background: var( --color-sidebar-menu-selected-background );
-	color: var( --color-sidebar-menu-selected-text );
+.layout__secondary {
+	.site__home {
+		background: var( --color-sidebar-menu-selected-background );
+		color: var( --color-sidebar-menu-selected-text );
+	}
+
+	.site__badge {
+		background: var(--color-sidebar-menu-hover-background);
+    	color: var(--color-sidebar-menu-hover-text);
+	}
 }

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -177,30 +177,13 @@
 	padding: 1px 10px;
 }
 
-.notouch .site-selector.is-hover-enabled .site:hover .site__badge {
-	background: var( --color-sidebar-background );
-	color: var( --color-sidebar-text );
-}
-
 .current-site .site:hover .site__badge,
 .purchases-site .site:hover .site__badge {
 	background: var( --color-sidebar-menu-hover-background );
 	color: var( --color-sidebar-menu-hover-text );
 }
 
-// Secondary Layout: sites selector, sidebar, etc.
-.layout__secondary {
-	.site__home {
-		background: var( --color-sidebar-menu-selected-background );
-		color: var( --color-sidebar-menu-selected-text );
-	}
-}
-
-// Secondary Layout. Site selector.
-.layout__secondary,
-.site-selector {
-	.site__badge {
-		background: var( --color-sidebar-menu-hover-background );
-		color: var( --color-sidebar-menu-hover-text );
-	}
+.layout__secondary .site__home {
+	background: var( --color-sidebar-menu-selected-background );
+	color: var( --color-sidebar-menu-selected-text );
 }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -53,15 +53,35 @@
 	}
 }
 
-// Highlight & hover effects
-.site-selector .site.is-highlighted,
-.site-selector .all-sites.is-highlighted,
+
 .notouch .site-selector.is-hover-enabled .site:hover,
-.notouch .site-selector.is-hover-enabled .all-sites:hover {
-	background: var( --color-sidebar-menu-hover-background );
+.notouch .site-selector.is-hover-enabled .all-sites:hover
+.site-selector .site.is-highlighted,
+.site-selector .all-sites.is-highlighted {
+	background-color: var( --color-neutral-5 );
 	cursor: pointer;
 
 	.site__badge {
+		background-color: var( --color-surface );
+	}
+
+	.site__title,
+	.site__domain {
+		&::after {
+			@include long-content-fade( $color: var( --color-neutral-5-rgb ) );
+		}
+	}
+}
+
+// Highlight & hover effects
+.notouch .layout__secondary .site-selector.is-hover-enabled .site:hover,
+.notouch .layout__secondary .site-selector.is-hover-enabled .all-sites:hover
+.layout__secondary .site-selector .site.is-highlighted,
+.layout__secondary .site-selector .all-sites.is-highlighted {
+	background: var( --color-sidebar-menu-hover-background );
+
+	.site__badge {
+		background: var( --color-sidebar-background );
 		color: var( --color-sidebar-text );
 	}
 
@@ -81,6 +101,12 @@
 		border-color: var( --color-sidebar-menu-hover-text );
 		color: var( --color-sidebar-menu-hover-text );
 	}
+}
+
+// Tweaking secondary Layout styles.
+.layout__secondary .site-selector .site__badge {
+	background: var( --color-sidebar-menu-hover-background );
+	color: var( --color-sidebar-menu-hover-text );
 }
 
 .site-selector .search {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There are a few visual issues that impact the site selector component when it's rendered into the sidebar or in any other location. This PR addresses them in order to provide a consistent visualization.

It continues the https://github.com/Automattic/wp-calypso/pull/51509 PR and fixes the issue mentioned [here](https://github.com/Automattic/wp-calypso/issues/49180#issuecomment-811434519).

#### Testing instructions

Apply these changes. Confirm the following:

before | after 
-----|-------
![image](https://user-images.githubusercontent.com/77539/113312416-a5632580-92e0-11eb-885a-9616714bb09a.png) | ![image](https://user-images.githubusercontent.com/77539/113312463-b2801480-92e0-11eb-9dff-81e8fcc9d33c.png)

Also, confirm the styles look good when the site selector is rendered in the sidebar:

<img src="https://user-images.githubusercontent.com/77539/113312582-d4799700-92e0-11eb-9c85-81aea3225c61.png" width="300px" />
