### PR TITLE
Design Picker: Cleanup after extraction to package

### DIFF
--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -134,7 +134,7 @@ function waitForSelectedSite(): Promise< Site | undefined > {
 	} ).finally( unsubscribe );
 }
 /**
- * If the list of available designs (stored in the `@automattic/domain-picker` package)
+ * If the list of available designs (stored in the `@automattic/design-picker` package)
  * has been updated, replace the cached list of designs with the updated designs.
  */
 function ensureRandomizedDesignsAreUpToDate() {
@@ -148,10 +148,10 @@ function ensureRandomizedDesignsAreUpToDate() {
 /**
  *
  * Compare cached designs in the ONBOARD_STORE to the source of designs defined
- * in the `@automattic/domain-picker` package
+ * in the `@automattic/design-picker` package
  *
  * @param stored randomizedDesigns cached in WP_ONBOARD
- * @param available designs sourced from the `@automattic/domain-picker` package
+ * @param available designs sourced from the `@automattic/design-picker` package
  */
 function isDeepEqual( stored: Design[], available: Design[] ): boolean {
 	return isEmpty( xorWith( stored, available, isEqual ) );

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -4,14 +4,14 @@
 import '@automattic/calypso-polyfills';
 import * as React from 'react';
 import ReactDom from 'react-dom';
-import { xorWith, isEqual, isEmpty, shuffle } from 'lodash';
+import { xorWith, isEqual, isEmpty } from 'lodash';
 import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 import config from '@automattic/calypso-config';
 import { subscribe, select, dispatch } from '@wordpress/data';
 import { initializeAnalytics } from '@automattic/calypso-analytics';
 import type { Site as SiteStore } from '@automattic/data-stores';
 import accessibleFocus from '@automattic/accessible-focus';
-import { availableDesigns } from '@automattic/design-picker';
+import { getAvailableDesigns } from '@automattic/design-picker';
 import type { Design } from '@automattic/design-picker';
 
 /**
@@ -139,11 +139,9 @@ function waitForSelectedSite(): Promise< Site | undefined > {
  */
 function ensureRandomizedDesignsAreUpToDate() {
 	const designsInStore = select( ONBOARD_STORE ).getRandomizedDesigns();
+	const availableDesigns = getAvailableDesigns();
 	if ( ! isDeepEqual( designsInStore.featured, availableDesigns.featured ) ) {
-		dispatch( ONBOARD_STORE ).setRandomizedDesigns( {
-			...availableDesigns,
-			featured: shuffle( availableDesigns.featured ),
-		} );
+		dispatch( ONBOARD_STORE ).setRandomizedDesigns( getAvailableDesigns( { randomize: true } ) );
 	}
 }
 

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -134,8 +134,8 @@ function waitForSelectedSite(): Promise< Site | undefined > {
 	} ).finally( unsubscribe );
 }
 /**
- * If available-designs-config.json has been updated, replace the cached list
- * of designs with the updated designs
+ * If the list of available designs (stored in the `@automattic/domain-picker` package)
+ * has been updated, replace the cached list of designs with the updated designs.
  */
 function ensureRandomizedDesignsAreUpToDate() {
 	const designsInStore = select( ONBOARD_STORE ).getRandomizedDesigns();
@@ -147,11 +147,11 @@ function ensureRandomizedDesignsAreUpToDate() {
 
 /**
  *
- * Compare cached designs in the ONBOARD_STORE to the source of designs in
- * available-designs-config.json
+ * Compare cached designs in the ONBOARD_STORE to the source of designs defined
+ * in the `@automattic/domain-picker` package
  *
  * @param stored randomizedDesigns cached in WP_ONBOARD
- * @param available designs sourced from available-designs-config.json
+ * @param available designs sourced from the `@automattic/domain-picker` package
  */
 function isDeepEqual( stored: Design[], available: Design[] ): boolean {
 	return isEmpty( xorWith( stored, available, isEqual ) );

--- a/client/landing/gutenboarding/onboarding-block/colors.scss
+++ b/client/landing/gutenboarding/onboarding-block/colors.scss
@@ -4,7 +4,7 @@
 	--mainColor: var( --studio-blue-40 );
 	--highlightColor: var( --studio-blue-20 );
 
-	.design-selector,
+	.designs,
 	.style-preview,
 	.plans,
 	.domains,

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -60,8 +60,9 @@ const Designs: React.FunctionComponent = () => {
 			<DesignPicker
 				designs={ getRandomizedDesigns().featured.filter(
 					( design ) =>
-						// TODO Add finalized design templates to available-designs-config.json
-						// along with is_anchorfm prop
+						// TODO Add finalized design templates to available designs config
+						// along with `is_anchorfm` prop (config is stored in the
+						// `@automattic/design-picker` package)
 						isAnchorFmSignup === design.features.includes( 'anchorfm' )
 				) }
 				isGridMinimal={ isAnchorFmSignup }

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -24,7 +24,7 @@ import { useIsAnchorFm } from '../../path';
  */
 import './style.scss';
 
-const DesignSelector: React.FunctionComponent = () => {
+const Designs: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const locale = useLocale();
 	const { goBack, goNext } = useStepNavigation();
@@ -41,9 +41,9 @@ const DesignSelector: React.FunctionComponent = () => {
 	} ) );
 
 	return (
-		<div className="gutenboarding-page design-selector">
-			<div className="design-selector__header">
-				<div className="design-selector__heading">
+		<div className="gutenboarding-page designs">
+			<div className="designs__header">
+				<div className="designs__heading">
 					<Title>{ __( 'Choose a design' ) }</Title>
 					<SubTitle>
 						{ isAnchorFmSignup
@@ -75,9 +75,9 @@ const DesignSelector: React.FunctionComponent = () => {
 					goNext();
 				} }
 				premiumBadge={
-					<Badge className="design-selector__premium-badge">
-						<JetpackLogo className="design-selector__premium-badge-logo" size={ 20 } />
-						<span className="design-selector__premium-badge-text">{ __( 'Premium' ) }</span>
+					<Badge className="designs__premium-badge">
+						<JetpackLogo className="designs__premium-badge-logo" size={ 20 } />
+						<span className="designs__premium-badge-text">{ __( 'Premium' ) }</span>
 					</Badge>
 				}
 			/>
@@ -85,4 +85,4 @@ const DesignSelector: React.FunctionComponent = () => {
 	);
 };
 
-export default DesignSelector;
+export default Designs;

--- a/client/landing/gutenboarding/onboarding-block/designs/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/designs/style.scss
@@ -3,12 +3,12 @@
 @import '../../mixins';
 @import '../../variables.scss';
 
-.design-selector {
+.designs {
 	background-color: var( --contrastColor );
 	color: var( --mainColor );
 	padding-bottom: $onboarding-footer-height;
 
-	.design-selector__header {
+	.designs__header {
 		@include onboarding-heading-padding;
 
 		display: flex;
@@ -16,11 +16,11 @@
 		align-items: center;
 	}
 
-	.design-selector__heading {
+	.designs__heading {
 		flex-grow: 1;
 	}
 
-	.design-selector__premium-badge {
+	.designs__premium-badge {
 		background-color: var( --studio-gray-80 );
 		/* stylelint-disable-next-line */
 		border-radius: 1em;
@@ -30,7 +30,7 @@
 		white-space: nowrap;
 	}
 
-	.design-selector__premium-badge-logo {
+	.designs__premium-badge-logo {
 		height: auto;
 		margin-left: -4px;
 		width: 14px;
@@ -44,7 +44,7 @@
 		}
 	}
 
-	.design-selector__premium-badge-text {
+	.designs__premium-badge-text {
 		display: inline-block;
 		margin-top: -0.05em;
 		text-transform: uppercase;

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -24,7 +24,7 @@ import {
 	useStepRouteParam,
 } from '../path';
 import { usePrevious } from '../hooks/use-previous';
-import DesignSelector from './design-selector';
+import Designs from './designs';
 import CreateSite from './create-site';
 import CreateSiteError from './create-site-error';
 import AcquireIntent from './acquire-intent';
@@ -156,7 +156,7 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 				</Route>
 
 				<Route path={ makePath( Step.DesignSelection ) }>
-					<DesignSelector />
+					<Designs />
 				</Route>
 
 				<Route path={ makePath( Step.Style ) }>

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -13,7 +13,7 @@ import { isEnabled } from '@automattic/calypso-config';
  * Internal dependencies
  */
 import MShotsImage from './mshots-image';
-import { availableDesigns, getDesignImageUrl, getDesignUrl, mShotOptions } from '../utils';
+import { getAvailableDesigns, getDesignImageUrl, getDesignUrl, mShotOptions } from '../utils';
 import type { Design } from '../types';
 
 /**
@@ -34,7 +34,7 @@ interface Props {
 const DesignPicker: React.FC< Props > = ( {
 	locale,
 	onSelect,
-	designs = availableDesigns.featured,
+	designs = getAvailableDesigns().featured,
 	premiumBadge,
 	isGridMinimal,
 } ) => {

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -3,6 +3,6 @@
  */
 export { default } from './components';
 
-export { availableDesigns, availableDesignsConfig, getFontTitle } from './utils';
+export { getAvailableDesigns, availableDesignsConfig, getFontTitle } from './utils';
 export { FONT_PAIRINGS, ANCHORFM_FONT_PAIRINGS, DESIGN_IMAGE_FOLDER } from './constants';
 export type { FontPair, Design } from './types';

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -32,7 +32,8 @@ export interface Design {
 
 	/**
 	 * Quickly hide a design from the picker without having to remove
-	 * it from the available-designs-config.json file.
+	 * it from the list of available design configs (stored in the
+	 * `@automattic/design-picker` package)
 	 */
 	hide?: boolean;
 }

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -91,7 +91,7 @@ export function getAvailableDesigns( {
 	};
 
 	if ( randomize ) {
-		// Fisher-Yates algorithm https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
+		// Durstenfeld algorithm https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
 		for ( let i = designs.featured.length - 1; i > 0; i-- ) {
 			const j = Math.floor( Math.random() * ( i + 1 ) );
 			[ designs.featured[ i ], designs.featured[ j ] ] = [

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -41,9 +41,9 @@ export const getDesignUrl = ( design: Design, locale: string ): string => {
 	);
 };
 
-// Used for prefetching design screenshots and the real loading in the design-selector
+// Used for both prefetching and loading design screenshots
 export const mShotOptions = (): MShotsOptions => {
-	// Take care changing these values as animation css in design-selector expect these height values
+	// Take care changing these values, as the design-picker CSS animations are written for these values (see the *__landscape and *__portrait classes)
 	if ( isEnabled( 'gutenboarding/landscape-preview' ) ) {
 		return { vpw: 1600, vph: 1600, w: 600, h: 600 };
 	}

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -59,11 +59,17 @@ export const getDesignImageUrl = ( design: Design ): string => {
 	}.${ canUseWebP ? 'webp' : 'jpg' }?v=3`;
 };
 
-export function getAvailableDesigns(
-	includeAlphaDesigns: boolean = isEnabled( 'gutenboarding/alpha-templates' ),
-	useFseDesigns: boolean = isEnabled( 'gutenboarding/site-editor' )
-): AvailableDesigns {
-	let designs = availableDesignsConfig;
+interface AvailableDesignsOptions {
+	includeAlphaDesigns?: boolean;
+	useFseDesigns?: boolean;
+	randomize?: boolean;
+}
+export function getAvailableDesigns( {
+	includeAlphaDesigns = isEnabled( 'gutenboarding/alpha-templates' ),
+	useFseDesigns = isEnabled( 'gutenboarding/site-editor' ),
+	randomize = false,
+}: AvailableDesignsOptions = {} ): AvailableDesigns {
+	let designs = { ...availableDesignsConfig };
 
 	// We can tell different environments (via the config JSON) to show pre-prod "alpha" designs.
 	// Otherwise they'll be hidden by default.
@@ -84,7 +90,16 @@ export function getAvailableDesigns(
 		),
 	};
 
+	if ( randomize ) {
+		// Fisher-Yates algorithm https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
+		for ( let i = designs.featured.length - 1; i > 0; i-- ) {
+			const j = Math.floor( Math.random() * ( i + 1 ) );
+			[ designs.featured[ i ], designs.featured[ j ] ] = [
+				designs.featured[ j ],
+				designs.featured[ i ],
+			];
+		}
+	}
+
 	return designs;
 }
-
-export const availableDesigns = getAvailableDesigns();

--- a/test/e2e/lib/flows/gutenboarding-flow.js
+++ b/test/e2e/lib/flows/gutenboarding-flow.js
@@ -7,7 +7,7 @@ import config from 'config';
  * Internal dependencies
  */
 import AcquireIntentPage from '../pages/gutenboarding/acquire-intent-page.js';
-import DesignSelectorPage from '../pages/gutenboarding/design-selector-page.js';
+import DesignSelectorPage from '../pages/gutenboarding/designs-page.js';
 import StylePreviewPage from '../pages/gutenboarding/style-preview-page.js';
 import PlansPage from '../pages/gutenboarding/plans-page.js';
 import DomainsPage from '../pages/gutenboarding/domains-page.js';

--- a/test/e2e/lib/pages/gutenboarding/designs-page.js
+++ b/test/e2e/lib/pages/gutenboarding/designs-page.js
@@ -11,7 +11,7 @@ import * as dataHelper from '../../data-helper';
 
 export default class DesignSelectorPage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.design-selector' ) );
+		super( driver, By.css( '.designs' ) );
 		this.freeOptionSelector = By.css( 'button[data-e2e-button="freeOption"]' );
 		this.paidOptionSelector = By.css( 'button[data-e2e-button="paidOption"]' );
 	}

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -11,7 +11,7 @@ import LoginFlow from '../lib/flows/login-flow.js';
 import DeleteSiteFlow from '../lib/flows/delete-site-flow.js';
 import NewPage from '../lib/pages/gutenboarding/new-page.js';
 import AcquireIntentPage from '../lib/pages/gutenboarding/acquire-intent-page.js';
-import DesignSelectorPage from '../lib/pages/gutenboarding/design-selector-page.js';
+import DesignSelectorPage from '../lib/pages/gutenboarding/designs-page.js';
 import StylePreviewPage from '../lib/pages/gutenboarding/style-preview-page.js';
 import PlansPage from '../lib/pages/gutenboarding/plans-page.js';
 import DomainsPage from '../lib/pages/gutenboarding/domains-page.js';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rename `<DesignSelector />` step in Gutenboarding to `<Designs />` (component, folder, css classes, e2e tests and comments)
* Move design randomization logic from Gutenboarding to the `@automattic/design-picker` package (by updating the `getAvalableDesigns()` function), without interfering with how the designs are persisted in Gutenboarding (+ added unit test)
* Updated references to `available-designs-config.json` across p2s and fieldguide

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure that designs are persisted/randomized correctly:
  1. Visit `/new/design?fresh` and take note of the order of the designs
  2. Visit `/new/design`
    - [ ] Check that the designs are in the same order as in point 1
  3. Visit `/new/design?fresh` again
    - [ ] Check that the designs are in a different order than the ones in points 1/2
- Visit `/new
  - [ ] make sure that the Gutenboarding flow (and the Design step in particular) works like before
- Run `cd packages/design-picker && yarn jest` and verify that all tests are passing
- Make sure that gutenboarding e2e tests are passing (or at least, in case they are failing, that it's not because of these changes 🤷 )
- See the list of updates (onebin id: `28e5c`) that were made to p2s and FieldGuide
  - [ ] Verify that there are no references left that need updating

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #51404