### PR TITLE
Actions: add a new Gardening action

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -1,0 +1,35 @@
+name: Repo gardening
+
+on:
+  # We need to listen to all these events to catch all scenarios
+  pull_request:
+    types: ['opened', 'synchronize', 'edited', 'closed', 'labeled']
+
+jobs:
+  repo-gardening:
+    name: 'Assign issues, Clean up labels, and notify Design and Editorial when necessary'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+     - name: Checkout
+       uses: actions/checkout@v2
+
+     - name: Setup Node
+       uses: actions/setup-node@v2
+       with:
+         node-version: 12
+
+     - name: Wait for prior instances of the workflow to finish
+       uses: softprops/turnstyle@v1
+       env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+     - name: 'Run gardening action'
+       uses: automattic/action-repo-gardening@v1.1.0
+       with:
+         github_token: ${{ secrets.GITHUB_TOKEN }}
+         slack_token: ${{ secrets.SLACK_TOKEN }}
+         slack_design_channel: ${{ secrets.SLACK_DESIGN_CHANNEL }}
+         slack_editorial_channel: ${{ secrets.SLACK_EDITORIAL_CHANNEL }}
+         tasks: 'assignIssues,cleanLabels,notifyDesign,notifyEditorial'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

﻿This will allow us to do a few things automatically:

- Add assignee for issues which are being worked on, and adds the "In Progress" label.
- Remove Status labels once a PR has been merged.
- Send a Slack Notification to the Design team to request feedback, based on labels applied to a PR.
- Send a Slack notification to the Editorial team to request feedback, based on labels.

For more info:
- https://github.com/Automattic/jetpack/pull/19239
- https://github.com/Automattic/action-repo-gardening

Some of these things are already handled via webhooks today; this would allow us to switch from the webhooks to the action. For more info about this, see this internal reference: p3btAN-1nR-p2

#### Testing instructions

* Check actions running on this repo: https://github.com/Automattic/wp-calypso/actions?query=branch%3Aadd%2Fgardening-action+workflow%3ARepo+gardening
* See the labels and assignee added to #51636. 
* See the Design Input Requested label that was added to this PR after I added the Needs Design Review label, and see the matching message: p1617301466158000-slack-C9EJ7KSGH
* See the Editorial Input Requested label that was added to this PR after I added the Needs Copy Review label, and see the matching message: p1617300418070200-slack-C029XD8PN

Fixes #51636