### PR TITLE
Author Selector: Auto-focus using prop rather than ref

### DIFF
--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -98,7 +98,7 @@ class AuthorSwitcherShell extends React.Component {
 							placeholder={ this.props.translate( 'Find Author…', { context: 'search label' } ) }
 							delaySearch={ true }
 							// eslint-disable-next-line jsx-a11y/no-autofocus
-							autoFocus={ this.props.users.length > 10 && ! hasTouch() }
+							autoFocus={ ! hasTouch() }
 						/>
 					) }
 					{ this.props.fetchInitialized &&

--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -60,16 +60,6 @@ class AuthorSwitcherShell extends React.Component {
 		}
 	}
 
-	componentDidUpdate( prevProps, prevState ) {
-		if ( ! this.state.showAuthorMenu ) {
-			return;
-		}
-
-		if ( ! prevState.showAuthorMenu && this.props.users.length > 10 && ! hasTouch() ) {
-			setTimeout( () => this.authorSelectorSearchRef.current?.focus(), 0 );
-		}
-	}
-
 	render() {
 		const { users, fetchNameSpace } = this.props;
 		const infiniteListKey = fetchNameSpace + this.instance;
@@ -107,7 +97,8 @@ class AuthorSwitcherShell extends React.Component {
 							onSearch={ this.onSearch }
 							placeholder={ this.props.translate( 'Find Author…', { context: 'search label' } ) }
 							delaySearch={ true }
-							ref={ this.authorSelectorSearchRef }
+							// eslint-disable-next-line jsx-a11y/no-autofocus
+							autoFocus={ this.props.users.length > 10 && ! hasTouch() }
 						/>
 					) }
 					{ this.props.fetchInitialized &&


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switches the auto-focusing logic to use the auto-focus prop rather than manually auto-focusing.

Fixes #49200

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1. Get a site with multiple authors (at least 10)
2. Go to people/edit/:site/:user
3. Scroll to the bottom and select the option to attribute posts by the author to another.
4. Click the "Choose an author" button
5. Ensure that the search is auto-focused

Search doesn't appear for sites with less than 10 users, so no need to test that.

You can test on a mobile device if possible and ensure that search is not auto-focused on it.
