### PR TITLE
Domains: Remove addPersonalPlan from DomainSearch page

### DIFF
--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -27,7 +27,6 @@ import {
 	domainMapping,
 	domainTransfer,
 	domainRegistration,
-	planItem,
 	updatePrivacyForDomain,
 } from 'calypso/lib/cart-values/cart-items';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
@@ -54,7 +53,6 @@ import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import NewDomainsRedirectionNoticeUpsell from 'calypso/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
 import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
-import { PLAN_PERSONAL } from 'calypso/lib/plans/constants';
 
 /**
  * Style dependencies
@@ -132,23 +130,12 @@ class DomainSearch extends Component {
 
 	componentDidMount() {
 		this.isMounted = true;
-
-		if ( 'upgrade' === this.props.context.query.ref ) {
-			this.addPersonalPlan();
-		}
 	}
 
 	checkSiteIsUpgradeable( props ) {
 		if ( props.selectedSite && ! props.isSiteUpgradeable ) {
 			page.redirect( '/domains/add' );
 		}
-	}
-
-	addPersonalPlan() {
-		this.props.shoppingCartManager.addProductsToCart( [
-			fillInSingleCartItemAttributes( planItem( PLAN_PERSONAL, {} ), this.props.productsList ),
-		] );
-		page.replace( this.props.context.pathname );
 	}
 
 	addDomain( suggestion ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There is a sidebar upsell that is displayed for sites with no plan that reads "Free domain with an annual plan" with button that reads "Upgrade". The intent of this button is to start a flow where the customer purchases a plan and a domain.

https://github.com/Automattic/wp-calypso/pull/51609 changes how the upsell works so that it first visits the plans page. Once the backend change is made to support this in D59605-code, this logic in the domains page that automatically adds a plan will no longer be used and can be removed.

NOTE: this will not be safe to merge until D59605-code is merged!

<img width="275" alt="Screen Shot 2021-04-01 at 6 02 43 PM" src="https://user-images.githubusercontent.com/2036909/113360097-1cb3ac00-9317-11eb-8df2-5b098501972e.png">


#### Testing instructions

- Start with a site that has no paid plan.
- Visit the customer home page for the site, eg: http://calypso.localhost:3000/home/example.com
- Click the "Upgrade" button in the sidebar notification that reads "Free domain with an annual plan" (see first screenshot above).
- Verify that you are redirected to the plans page for your site.