### PR TITLE
Change the whats-new API locale parameter to _locale

### DIFF
--- a/packages/whats-new/src/index.js
+++ b/packages/whats-new/src/index.js
@@ -24,7 +24,7 @@ const WhatsNewGuide = ( { onClose } ) => {
 		const proxiedWpcom = wpcom();
 		proxiedWpcom.request = proxyRequest;
 		proxiedWpcom.req
-			.get( { path: `/whats-new/list?locale=${ locale }`, apiNamespace: 'wpcom/v2' } )
+			.get( { path: `/whats-new/list?_locale=${ locale }`, apiNamespace: 'wpcom/v2' } )
 			.then( ( returnedList ) => {
 				setWhatsNewData( returnedList );
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `locale` parameters in `whats-new/list` API call should be changed to `_locale` so that it'd actually be used for retrieving the translations.

#### Testing instructions

Code review