### PR TITLE
Checkout: Replace url module in payPalProcessor with native JS

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -45,7 +45,7 @@ export default async function payPalProcessor(
 	} catch ( error ) {
 		currentUrl = `https://wordpress.com/checkout/${ siteSlug }`;
 	}
-	const currentUrlWithoutQuery = currentUrl.split( '?' )[ 0 ];
+	const currentUrlWithoutQuery = currentUrl.split( /\?|#/ )[ 0 ];
 	const successUrl = thankYouUrl.startsWith( 'http' )
 		? thankYouUrl
 		: currentUrlWithoutQuery + thankYouUrl;

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -45,11 +45,13 @@ export default async function payPalProcessor(
 	} catch ( error ) {
 		currentUrl = `https://wordpress.com/checkout/${ siteSlug }`;
 	}
-	const successUrl = thankYouUrl.startsWith( 'http' ) ? thankYouUrl : currentUrl + thankYouUrl;
-	const normalizedUrlWithoutQueryString = currentUrl.split( '?' )[ 0 ];
+	const currentUrlWithoutQuery = currentUrl.split( '?' )[ 0 ];
+	const successUrl = thankYouUrl.startsWith( 'http' )
+		? thankYouUrl
+		: currentUrlWithoutQuery + thankYouUrl;
 	const cancelUrl = createUserAndSiteBeforeTransaction
-		? normalizedUrlWithoutQueryString + '?cart=no-user'
-		: normalizedUrlWithoutQueryString;
+		? currentUrlWithoutQuery + '?cart=no-user'
+		: currentUrlWithoutQuery;
 
 	const formattedTransactionData = createPayPalExpressEndpointRequestPayloadFromLineItems( {
 		responseCart,

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -40,15 +40,16 @@ export default async function payPalProcessor(
 
 	const thankYouUrl = getThankYouUrl();
 	let currentUrl;
+	let currentBaseUrl;
 	try {
 		currentUrl = window.location.href;
+		currentBaseUrl = window.location.origin;
 	} catch ( error ) {
 		currentUrl = `https://wordpress.com/checkout/${ siteSlug }`;
+		currentBaseUrl = 'https://wordpress.com';
 	}
 	const currentUrlWithoutQuery = currentUrl.split( /\?|#/ )[ 0 ];
-	const successUrl = thankYouUrl.startsWith( 'http' )
-		? thankYouUrl
-		: currentUrlWithoutQuery + thankYouUrl;
+	const successUrl = thankYouUrl.startsWith( 'http' ) ? thankYouUrl : currentBaseUrl + thankYouUrl;
 	const cancelUrl = createUserAndSiteBeforeTransaction
 		? currentUrlWithoutQuery + '?cart=no-user'
 		: currentUrlWithoutQuery;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The PayPal express payment processor uses the deprecated `url` module. This PR replaces it with native JS.

#### Testing instructions

- Make a purchase with PayPal through checkout but cancel the purchase after being redirected to PayPal.
- Verify that you are returned to checkout correctly.
- Resubmit the purchase and complete it.
- Verify that you are sent to a valid thank-you page.