### PR TITLE
Log Olark config failures to logstash

### DIFF
--- a/client/state/happychat/user/actions.js
+++ b/client/state/happychat/user/actions.js
@@ -9,6 +9,7 @@ import {
 } from 'calypso/state/action-types';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { setSupportLevel } from 'calypso/state/help/actions';
+import { logToLogstash } from 'calypso/state/logstash/actions';
 
 import 'calypso/state/happychat/init';
 
@@ -37,6 +38,20 @@ export const requestHappychatEligibility = () => ( dispatch ) => {
 			// whether the user is logged in when fetching the user profile)
 			if ( error && error.message && error.error !== 'authorization_required' ) {
 				dispatch( errorNotice( error.message ) );
+				// Log this failure to logstash. This is debug info for https://github.com/Automattic/wp-calypso/issues/51517
+				// and can probably be removed once that's closed.
+				dispatch(
+					logToLogstash( {
+						feature: 'calypso_client',
+						message: 'Olark configuration request failed',
+						severity: 'error',
+						extra: {
+							error: error.name,
+							status: error.status,
+							message: error.message,
+						},
+					} )
+				);
 			}
 		} );
 };


### PR DESCRIPTION
Addresses #51517

We've seen sustained increased response times to the /help/olark/mine endpoint over the past week. To try to debug and find a reproduction case, this PR logs failure (including 504s as originally reported) to logstash, so we have better data to dive into.