### PR TITLE
Jetpack Cloud: disable feature flag that enables Jetpack Connect and Checkout

### DIFF
--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -36,7 +36,7 @@
 		"dev/preferences-helper": true,
 		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,
-		"jetpack-cloud/connect": true,
+		"jetpack-cloud/connect": false,
 		"jetpack/backups-date-picker": true,
 		"jetpack/backups-restore": true,
 		"jetpack/scan-product": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -32,7 +32,7 @@
 		"current-site/stale-cart-notice": false,
 		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,
-		"jetpack-cloud/connect": true,
+		"jetpack-cloud/connect": false,
 		"jetpack/backups-date-picker": true,
 		"jetpack/backups-restore": true,
 		"jetpack/scan-product": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -33,7 +33,7 @@
 		"current-site/stale-cart-notice": false,
 		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,
-		"jetpack-cloud/connect": true,
+		"jetpack-cloud/connect": false,
 		"jetpack/backups-date-picker": true,
 		"jetpack/backups-restore": true,
 		"jetpack/scan-product": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable the `jetpack-cloud/connect` feature flag to hide/disable Jetpack Connect and Checkout on Jetpack Cloud. To understand the reasons, please go read 1164141197617539-as-1200142258036347. For context, this flag was introduced in https://github.com/Automattic/wp-calypso/pull/47596.

#### Testing instructions

* Download this PR.
* Run `yarn start-jetpack-cloud` to start Jetpack Green.
* Visit the pricing page located at `http://jetpack.cloud.localhost:3000/pricing`.
* Click on any Jetpack product.
* Make sure that you are redirected to `wordpress.com/jetpack/connect`.
* Visit `http://jetpack.cloud.localhost:3000/pricing/[site]?site=[site]&source=jetpack-plans` replacing `[site]` with a real Jetpack site slug that you own.
* Click on any Jetpack product.
* Make sure that you are redirected to `wordpress.com/checkout`.

Related to 1164141197617539-as-1200142258036347
