### PR TITLE
Social Previews: Twitter Preview - Wrap Long Text

### DIFF
--- a/packages/social-previews/CHANGELOG.md
+++ b/packages/social-previews/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.1 (2021-04-05)
+
+- Ensure that lengthy text doesn't overflow in the Twitter preview.
+
 ## v1.1.0 (2020-09-10)
 
 - Twitter: Add previewing for attached images, videos, or quoted tweets.

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "A suite of components to generate previews for a post for both social and search engines",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/social-previews/src/twitter-preview/style.scss
+++ b/packages/social-previews/src/twitter-preview/style.scss
@@ -135,6 +135,8 @@
 			border-radius: 12px;
 
 			.twitter-preview__card-summary {
+				display: grid;
+
 				&.twitter-preview__card-has-image {
 					height: 125px;
 					display: grid;

--- a/packages/social-previews/src/twitter-preview/style.scss
+++ b/packages/social-previews/src/twitter-preview/style.scss
@@ -67,6 +67,7 @@
 			letter-spacing: -0.3px;
 			color: #787c82;
 			white-space: pre-wrap;
+			word-break: break-word;
 		}
 
 		.twitter-preview__media {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensures that the "Social Previews" feature wraps text properly for Twitter (I verified that it did with Facebook and Google already)

#### Testing instructions

Verify that the Twitter preview under the SEO tab wraps with a long string, and there is no impact to regular sorts of phrases.

**Before:**
<img width="691" alt="Screenshot 2021-04-02 at 21 32 03" src="https://user-images.githubusercontent.com/43215253/113452082-362e2400-93fb-11eb-9692-3388ab010cef.png">

**After:**
<img width="650" alt="Screenshot 2021-04-02 at 21 31 58" src="https://user-images.githubusercontent.com/43215253/113452091-39c1ab00-93fb-11eb-8c4a-c942101668f2.png">

cc @cpapazoglou
 
Fixes Automattic/jetpack#19396