### PR TITLE
Jetpack Plans: Use product tier prices from product catalog

### DIFF
--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -104,14 +104,6 @@ export const JETPACK_PRODUCTS_LIST = [
 	...JETPACK_SEARCH_PRODUCTS,
 ];
 
-// Jetpack Search tiers
-export const JETPACK_SEARCH_TIER_UP_TO_100_RECORDS = 'up_to_100_records';
-export const JETPACK_SEARCH_TIER_UP_TO_1K_RECORDS = 'up_to_1k_records';
-export const JETPACK_SEARCH_TIER_UP_TO_10K_RECORDS = 'up_to_10k_records';
-export const JETPACK_SEARCH_TIER_UP_TO_100K_RECORDS = 'up_to_100k_records';
-export const JETPACK_SEARCH_TIER_UP_TO_1M_RECORDS = 'up_to_1m_records';
-export const JETPACK_SEARCH_TIER_MORE_THAN_1M_RECORDS = 'more_than_1m_records';
-
 export const JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/backup/';
 export const JETPACK_SEARCH_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/search/';
 export const JETPACK_SCAN_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/scan/';

--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -317,37 +317,38 @@ export const getJetpackProducts = () => {
 			monthly: [ CONSTANTS.PRODUCT_JETPACK_SEARCH_MONTHLY ],
 		},
 		optionShortNamesCallback: ( productObject ) => {
-			const numberOfDefinedTiers = 5;
-			switch ( productObject.price_tier_slug ) {
-				case CONSTANTS.JETPACK_SEARCH_TIER_UP_TO_100_RECORDS:
-					return translate( 'Pricing Tier 1: Up to 100 records' );
-				case CONSTANTS.JETPACK_SEARCH_TIER_UP_TO_1K_RECORDS:
-					return translate( 'Pricing Tier 2: Up to 1,000 records' );
-				case CONSTANTS.JETPACK_SEARCH_TIER_UP_TO_10K_RECORDS:
-					return translate( 'Pricing Tier 3: Up to 10,000 records' );
-				case CONSTANTS.JETPACK_SEARCH_TIER_UP_TO_100K_RECORDS:
-					return translate( 'Pricing Tier 4: Up to 100,000 records' );
-				case CONSTANTS.JETPACK_SEARCH_TIER_UP_TO_1M_RECORDS:
-					return translate( 'Pricing Tier 5: Up to 1,000,000 records' );
-				case CONSTANTS.JETPACK_SEARCH_TIER_MORE_THAN_1M_RECORDS: {
-					// This is a catch-all tier with prices increasing
-					// proportionally per million records, so define fake
-					// tiers here to show the user what they will actually
-					// pay and why.
-					const tierNumber =
-						numberOfDefinedTiers + Math.floor( productObject.price_tier_usage_quantity / 1000000 );
-					const tierMaximumRecords =
-						1000000 * Math.ceil( productObject.price_tier_usage_quantity / 1000000 );
-					return translate( 'Pricing Tier %(tierNumber)d: Up to %(tierMaximumRecords)s records', {
-						args: {
-							tierNumber,
-							tierMaximumRecords: numberFormat( tierMaximumRecords ),
-						},
-					} );
-				}
-				default:
-					return null;
+			const quantity = productObject.price_tier_usage_quantity;
+			if ( quantity <= 100 ) {
+				return translate( 'Pricing Tier 1: Up to 100 records' );
 			}
+			if ( quantity <= 1000 ) {
+				return translate( 'Pricing Tier 2: Up to 1,000 records' );
+			}
+			if ( quantity <= 10000 ) {
+				return translate( 'Pricing Tier 3: Up to 10,000 records' );
+			}
+			if ( quantity <= 100000 ) {
+				return translate( 'Pricing Tier 4: Up to 100,000 records' );
+			}
+			if ( quantity <= 100000 ) {
+				return translate( 'Pricing Tier 5: Up to 1,000,000 records' );
+			}
+			if ( quantity > 100000 ) {
+				// This is a catch-all tier with prices increasing
+				// proportionally per million records, so define fake
+				// tiers here to show the user what they will actually
+				// pay and why.
+				const numberOfDefinedTiers = 5;
+				const tierNumber = numberOfDefinedTiers + Math.floor( quantity / 1000000 );
+				const tierMaximumRecords = 1000000 * Math.ceil( quantity / 1000000 );
+				return translate( 'Pricing Tier %(tierNumber)d: Up to %(tierMaximumRecords)s records', {
+					args: {
+						tierNumber,
+						tierMaximumRecords: numberFormat( tierMaximumRecords ),
+					},
+				} );
+			}
+			return null;
 		},
 		optionActionButtonNames: getJetpackProductsShortNames(),
 		optionDisplayNames: getJetpackProductsDisplayNames(),

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -77,7 +77,7 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 		return false;
 	}, [ item.productSlug, sitePlan, siteProducts ] );
 	// Calculate the product price.
-	const { originalPrice, discountedPrice, priceTiers } = useItemPrice(
+	const { originalPrice, discountedPrice, priceTierList } = useItemPrice(
 		siteId,
 		item,
 		item?.monthlyProductSlug || ''
@@ -147,9 +147,9 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 			isDeprecated={ item.legacy }
 			isAligned={ isAligned }
 			features={ item.features }
-			displayFrom={ ! siteId && priceTiers !== null }
+			displayFrom={ ! siteId && priceTierList.length > 0 }
 			belowPriceText={ item.belowPriceText }
-			tooltipText={ priceTiers && productTooltip( item, priceTiers ) }
+			tooltipText={ priceTierList.length > 0 && productTooltip( item, priceTierList ) }
 			aboveButtonText={ productAboveButtonText( item, siteProduct, isOwned, isItemPlanFeature ) }
 			isDisabled={ isDisabled }
 			disabledMessage={ disabledMessage }

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -3,21 +3,14 @@
  */
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { clone } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { isProductsListFetching } from 'calypso/state/products-list/selectors/is-products-list-fetching';
 import { getProductCost } from 'calypso/state/products-list/selectors/get-product-cost';
-import {
-	getProductPriceTiers,
-	getProductPriceTierList,
-} from 'calypso/state/products-list/selectors/get-product-price-tiers';
-import type {
-	PriceTiers,
-	PriceTierEntry,
-} from 'calypso/state/products-list/selectors/get-product-price-tiers';
+import { getProductPriceTierList } from 'calypso/state/products-list/selectors/get-product-price-tiers';
+import type { PriceTierEntry } from 'calypso/state/products-list/selectors/get-product-price-tiers';
 import { TERM_MONTHLY } from 'calypso/lib/plans/constants';
 import {
 	getSiteAvailableProductCost,
@@ -37,10 +30,6 @@ interface ItemPrices {
 	isFetching: boolean | null;
 	originalPrice: number;
 	discountedPrice?: number;
-	/**
-	 * @deprecated use priceTierList
-	 **/
-	priceTiers: PriceTiers | null;
 	priceTierList: PriceTierEntry[];
 }
 
@@ -48,10 +37,6 @@ interface ItemRawPrices {
 	isFetching: boolean | null;
 	itemCost: number | null;
 	monthlyItemCost: number | null;
-	/**
-	 * @deprecated use priceTierList
-	 **/
-	priceTiers: PriceTiers | null;
 	priceTierList: PriceTierEntry[];
 }
 
@@ -65,7 +50,6 @@ const useProductListItemPrices = (
 		useSelector( ( state ) => productSlug && getProductCost( state, productSlug ) ) || null;
 	const monthlyItemCost =
 		useSelector( ( state ) => getProductCost( state, monthlyItemSlug ) ) || null;
-	const priceTiers = useSelector( ( state ) => getProductPriceTiers( state, productSlug ) );
 	const priceTierList = useSelector( ( state ) =>
 		productSlug ? getProductPriceTierList( state, productSlug ) : []
 	);
@@ -74,7 +58,6 @@ const useProductListItemPrices = (
 		isFetching,
 		itemCost,
 		monthlyItemCost,
-		priceTiers,
 		priceTierList,
 	};
 };
@@ -96,7 +79,6 @@ const useSiteAvailableProductPrices = (
 		useSelector(
 			( state ) => siteId && getSiteAvailableProductCost( state, siteId, monthlyItemSlug )
 		) || null;
-	const priceTiers = useSelector( ( state ) => getProductPriceTiers( state, productSlug ) );
 	const priceTierList = useSelector( ( state ) =>
 		productSlug ? getProductPriceTierList( state, productSlug ) : []
 	);
@@ -105,7 +87,6 @@ const useSiteAvailableProductPrices = (
 		isFetching,
 		itemCost,
 		monthlyItemCost,
-		priceTiers,
 		priceTierList,
 	};
 };
@@ -121,7 +102,6 @@ const useItemPrice = (
 	const isFetching = siteId ? sitePrices.isFetching : listPrices.isFetching;
 	const itemCost = siteId ? sitePrices.itemCost : listPrices.itemCost;
 	const monthlyItemCost = siteId ? sitePrices.monthlyItemCost : listPrices.monthlyItemCost;
-	const rawPriceTiers = siteId ? sitePrices.priceTiers : listPrices.priceTiers;
 
 	const priceTierList = useMemo(
 		() => ( siteId ? sitePrices.priceTierList : listPrices.priceTierList ),
@@ -132,32 +112,17 @@ const useItemPrice = (
 		return {
 			isFetching,
 			originalPrice: 0,
-			priceTiers: null,
 			priceTierList: [],
 		};
 	}
 
 	let originalPrice = 0;
 	let discountedPrice = undefined;
-	let priceTiers: PriceTiers | null = rawPriceTiers;
 	if ( item && itemCost ) {
 		originalPrice = itemCost;
 		if ( monthlyItemCost && item.term !== TERM_MONTHLY ) {
 			originalPrice = monthlyItemCost;
 			discountedPrice = itemCost / 12;
-
-			if ( rawPriceTiers ) {
-				priceTiers = {};
-				for ( const tierKey in rawPriceTiers ) {
-					const tier = clone( rawPriceTiers[ tierKey ] );
-					if ( 'flat_price' in tier ) {
-						tier.flat_price = tier.flat_price / 12;
-					} else if ( 'variable_price_per_unit' in tier ) {
-						tier.variable_price_per_unit = tier.variable_price_per_unit / 12;
-					}
-					priceTiers[ tierKey ] = tier;
-				}
-			}
 		}
 	}
 
@@ -171,7 +136,6 @@ const useItemPrice = (
 		isFetching,
 		originalPrice,
 		discountedPrice,
-		priceTiers,
 		priceTierList,
 	};
 };

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -296,8 +296,8 @@ export function productTooltip(
 			'{{Info}}More info{{/Info}}',
 		{
 			args: {
-				price100: priceTier100.flat_fee_monthly_display,
-				price1000: priceTier1000.flat_fee_monthly_display,
+				price100: priceTier100.minimum_price_monthly_display,
+				price1000: priceTier1000.minimum_price_monthly_display,
 			},
 			comment:
 				'price100 = formatted price per 100 records, price1000 = formatted price per 1000 records. See https://jetpack.com/upgrade/search/.',

--- a/client/state/products-list/selectors/get-product-price-tiers.ts
+++ b/client/state/products-list/selectors/get-product-price-tiers.ts
@@ -13,15 +13,10 @@ type Product = {
 export interface PriceTierEntry {
 	minimum_units: number;
 	maximum_units?: undefined | null | number;
-	per_unit_fee: number;
-	per_unit_fee_display: string;
-	per_unit_fee_monthly_display: string;
-	flat_fee: number;
-	flat_fee_display: string;
-	flat_fee_monthly_display: string;
-	undiscounted_per_unit_fee?: undefined | null | number;
-	transform_quantity_divide_by?: undefined | null | number;
-	transform_quantity_round?: undefined | null | 'up' | 'down';
+	minimum_price_display: string;
+	minimum_price_monthly_display: string;
+	maximum_price_display?: string | null | undefined;
+	maximum_price_monthly_display?: string | null | undefined;
 }
 
 /**

--- a/client/state/products-list/selectors/get-product-price-tiers.ts
+++ b/client/state/products-list/selectors/get-product-price-tiers.ts
@@ -7,10 +7,6 @@ import 'calypso/state/products-list/init';
 import type { AppState } from 'calypso/types';
 
 type Product = {
-	/**
-	 * @deprecated use price_tier_list
-	 */
-	price_tiers: PriceTiers;
 	price_tier_list: PriceTierEntry[];
 };
 
@@ -27,11 +23,6 @@ export interface PriceTierEntry {
 /**
  * @deprecated use PriceTierEntry
  */
-export type PriceTiers = Record< string, PriceTier >;
-
-/**
- * @deprecated use PriceTierEntry
- */
 export type PriceTier =
 	| {
 			flat_price: number;
@@ -40,30 +31,6 @@ export type PriceTier =
 			variable_price_per_unit: number;
 			unit: number;
 	  };
-
-/**
- * Returns the price tiers of the specified product.
- *
- * @deprecated Use getProductPriceTierList
- *
- * @param {object} state - global state tree
- * @param {string} productSlug - internal product slug, eg 'jetpack_premium'
- * @returns {PriceTiers|null} The price tiers or null. See PriceTiers for format.
- */
-export function getProductPriceTiers( state: AppState, productSlug?: string ): PriceTiers | null {
-	if ( ! productSlug ) {
-		return null;
-	}
-	const product = getProductBySlug( state, productSlug ) as Product;
-
-	if ( ! product || ! product.price_tiers || ! Object.keys( product.price_tiers ).length ) {
-		return null;
-	}
-
-	return product.price_tiers;
-}
-
-export default getProductPriceTiers;
 
 /**
  * Returns the price tiers of the specified product.

--- a/client/state/products-list/selectors/get-product-price-tiers.ts
+++ b/client/state/products-list/selectors/get-product-price-tiers.ts
@@ -7,11 +7,31 @@ import 'calypso/state/products-list/init';
 import type { AppState } from 'calypso/types';
 
 type Product = {
+	/**
+	 * @deprecated use price_tier_list
+	 */
 	price_tiers: PriceTiers;
+	price_tier_list: PriceTierEntry[];
 };
 
+export interface PriceTierEntry {
+	minimum_units: number;
+	maximum_units?: undefined | null | number;
+	per_unit_fee: number;
+	flat_fee: number;
+	undiscounted_per_unit_fee?: undefined | null | number;
+	transform_quantity_divide_by?: undefined | null | number;
+	transform_quantity_round?: undefined | null | 'up' | 'down';
+}
+
+/**
+ * @deprecated use PriceTierEntry
+ */
 export type PriceTiers = Record< string, PriceTier >;
 
+/**
+ * @deprecated use PriceTierEntry
+ */
 export type PriceTier =
 	| {
 			flat_price: number;
@@ -23,6 +43,8 @@ export type PriceTier =
 
 /**
  * Returns the price tiers of the specified product.
+ *
+ * @deprecated Use getProductPriceTierList
  *
  * @param {object} state - global state tree
  * @param {string} productSlug - internal product slug, eg 'jetpack_premium'
@@ -42,3 +64,20 @@ export function getProductPriceTiers( state: AppState, productSlug?: string ): P
 }
 
 export default getProductPriceTiers;
+
+/**
+ * Returns the price tiers of the specified product.
+ *
+ * @param {object} state - global state tree
+ * @param {string} productSlug - internal product slug, eg 'jetpack_premium'
+ * @returns {PriceTierEntry[]} The price tiers.
+ */
+export function getProductPriceTierList( state: AppState, productSlug: string ): PriceTierEntry[] {
+	const product = getProductBySlug( state, productSlug ) as Product;
+
+	if ( ! product || ! product.price_tier_list ) {
+		return [];
+	}
+
+	return product.price_tier_list;
+}

--- a/client/state/products-list/selectors/get-product-price-tiers.ts
+++ b/client/state/products-list/selectors/get-product-price-tiers.ts
@@ -14,7 +14,11 @@ export interface PriceTierEntry {
 	minimum_units: number;
 	maximum_units?: undefined | null | number;
 	per_unit_fee: number;
+	per_unit_fee_display: string;
+	per_unit_fee_monthly_display: string;
 	flat_fee: number;
+	flat_fee_display: string;
+	flat_fee_monthly_display: string;
 	undiscounted_per_unit_fee?: undefined | null | number;
 	transform_quantity_divide_by?: undefined | null | number;
 	transform_quantity_round?: undefined | null | 'up' | 'down';

--- a/client/state/products-list/selectors/get-product-price-tiers.ts
+++ b/client/state/products-list/selectors/get-product-price-tiers.ts
@@ -25,18 +25,6 @@ export interface PriceTierEntry {
 }
 
 /**
- * @deprecated use PriceTierEntry
- */
-export type PriceTier =
-	| {
-			flat_price: number;
-	  }
-	| {
-			variable_price_per_unit: number;
-			unit: number;
-	  };
-
-/**
  * Returns the price tiers of the specified product.
  *
  * @param {object} state - global state tree

--- a/client/state/products-list/selectors/index.js
+++ b/client/state/products-list/selectors/index.js
@@ -5,7 +5,7 @@ export { getPlanPrice } from './get-plan-price';
 export { getProductBySlug } from './get-product-by-slug';
 export { getProductCost } from './get-product-cost';
 export { getProductDisplayCost } from './get-product-display-cost';
-export { getProductPriceTiers } from './get-product-price-tiers';
+export { getProductPriceTierList } from './get-product-price-tiers';
 export { getProductsList } from './get-products-list';
 export { isProductsListFetching } from './is-products-list-fetching';
 export { planSlugToPlanProduct } from './plan-slug-to-plan-product';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For each product returned by the `/products` and `/sites/%s/products` endpoints, we include two pieces of data which are deprecated now that our pricing data is driven by the Product Catalog: `price_tiers` and `price_tier_slug`. These have been replaced by `price_tier_list` and `price_tier_usage_quantity`, respectively. However, the data in these properties differs in its format. This PR replaces all uses of the deprecated properties in calypso with the new properties.

Requires D59709-code 

Part of 137-gh-Automattic/payments-shilling

#### Screenshots

<img width="345" alt="before" src="https://user-images.githubusercontent.com/2036909/113627209-2bf56b00-9631-11eb-9c09-6bfcada43b3b.png">

<img width="354" alt="before-monthly" src="https://user-images.githubusercontent.com/2036909/113627218-2f88f200-9631-11eb-99ce-ae6ec54cc221.png">

<img width="343" alt="records-details" src="https://user-images.githubusercontent.com/2036909/113630544-0ae34900-9636-11eb-9ffc-0db6e58e2613.png">


#### Testing instructions

- Apply D59709-code and sandbox the API.
- Visit `/plans/example.com` for a Jetpack site with no plan.
- Scroll down to the `Site Search` card, and click on the small "i" icon.
- Verify that the prices displayed in the card are the same before and after this change.
- Switch the toggle at the top of the page to "Monthly".
- Click on the "i" icon again.
- Verify that the prices displayed in the card are the same before and after this change.

To test the changes to `RecordsDetails`, we need to be able to see that component and I haven't yet figured out a way to render it naturally. However, you can apply the following patch, and then you'll be able to see it jammed into the space for the `Site Search` card:

```diff
--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -198,6 +198,7 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
                                <ul className="product-grid__product-grid">
                                        { otherProducts.map( ( product ) => (
                                                <li key={ product.iconSlug }>
+                                                       { product.children }
                                                        <ProductCard
                                                                item={ product }
                                                                onClick={ onSelectProduct }
```
