### PR TITLE
i18n: Update change handler in CalypsoI18nProvider when `wpI18n` updates

### DIFF
--- a/client/components/calypso-i18n-provider/index.tsx
+++ b/client/components/calypso-i18n-provider/index.tsx
@@ -27,7 +27,7 @@ const CalypsoI18nProvider: React.FunctionComponent = ( { children } ) => {
 		return () => {
 			i18n.off( 'change', onChange );
 		};
-	}, [] );
+	}, [ wpI18n ] );
 
 	return (
 		<LocaleProvider localeSlug={ localeSlug || i18nDefaultLocaleSlug }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds the `wpI18n` instance to the `useEffect` hook's dependencies, so that it removes the old `onChange` handler and adds a new one that's using the correct `wpI18n` instance.

**Before:**
![image](https://user-images.githubusercontent.com/2722412/113556397-166a4c00-9605-11eb-847d-7bb385ce6e08.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/113556422-1e29f080-9605-11eb-9a4c-de02a8a79427.png)


#### Testing instructions

* Open `calypso.live/checkout/{site}#step2` in non-English Mag-16 language.
* Confirm `Pick a payment method` is displayed translated.
