### PR TITLE
Add alternativeEmail validation and  mailbox availability checks for Titan Email

### DIFF
--- a/client/lib/titan/new-mailbox.js
+++ b/client/lib/titan/new-mailbox.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import emailValidator from 'email-validator';
 import PropTypes from 'prop-types';
 import { translate } from 'i18n-calypso';
@@ -125,6 +126,30 @@ const validateFullEmailAddress = ( { value, error }, allowEmpty = false ) => {
 	};
 };
 
+const validateAlternativeEmailAddress = ( { value, error }, domainName, allowEmpty = false ) => {
+	if ( ! error && value && domainName ) {
+		const parts = `${ value }`.split( '@' );
+		if ( parts.length > 1 && parts[ 1 ].toLowerCase() === domainName.toLowerCase() ) {
+			return {
+				value,
+				error: translate(
+					'Please supply an email address on a different domain than {{strong}}%(domain)s{{/strong}}',
+					{
+						args: {
+							domain: domainName,
+						},
+						components: {
+							strong: <strong />,
+						},
+					}
+				),
+			};
+		}
+	}
+
+	return validateFullEmailAddress( { value, error }, allowEmpty );
+};
+
 const validateMailboxName = ( { value, error }, { value: domainName, error: domainError } ) => {
 	if ( error ) {
 		return { value, error };
@@ -162,8 +187,9 @@ const validateMailbox = ( mailbox, optionalFields = [] ) => {
 
 	return {
 		uuid: mailbox.uuid,
-		alternativeEmail: validateFullEmailAddress(
+		alternativeEmail: validateAlternativeEmailAddress(
 			alternativeEmail,
+			domain.value,
 			optionalFields.includes( 'alternativeEmail' )
 		),
 		domain,

--- a/client/lib/titan/new-mailbox.js
+++ b/client/lib/titan/new-mailbox.js
@@ -261,10 +261,10 @@ const transformMailboxForCart = ( {
 
 const checkEmailAvailability = async ( emailAddress ) => {
 	try {
-		const result = await wp.undocumented().getTitanEmailAddressAvailability( emailAddress );
-		return result?.message === 'OK';
+		await wp.undocumented().getTitanEmailAddressAvailability( emailAddress );
+		return true;
 	} catch ( e ) {
-		return false;
+		return e.statusCode !== 409;
 	}
 };
 
@@ -289,11 +289,9 @@ const areAllMailboxesAvailable = async ( mailboxes, onMailboxesChange ) => {
 	);
 	const checks = await promisified_checks;
 	checks
-		.map( ( check, index ) => [ check, index ] )
-		.filter( ( check_index ) => ! check_index[ 0 ] )
-		.forEach( ( check_index ) =>
-			decorateMailboxWithExistenceError( mailboxes[ check_index[ 1 ] ] )
-		);
+		.map( ( check, index ) => ( { check, mailbox: mailboxes[ index ] } ) )
+		.filter( ( { check } ) => ! check )
+		.forEach( ( { mailbox } ) => decorateMailboxWithExistenceError( mailbox ) );
 	const result = checks.every( ( check ) => check );
 	! result && onMailboxesChange && onMailboxesChange( mailboxes );
 	return result;

--- a/client/lib/titan/new-mailbox.js
+++ b/client/lib/titan/new-mailbox.js
@@ -303,7 +303,6 @@ export {
 	areAllMailboxesAvailable,
 	areAllMailboxesValid,
 	buildNewTitanMailbox,
-	checkEmailAvailability,
 	getMailboxPropTypeShape,
 	sanitizeEmailSuggestion,
 	transformMailboxForCart,

--- a/client/lib/titan/new-mailbox.js
+++ b/client/lib/titan/new-mailbox.js
@@ -259,9 +259,9 @@ const transformMailboxForCart = ( {
 	password,
 } );
 
-const checkEmailAvailability = async ( emailAddress ) => {
+const checkMailboxAvailability = async ( domain, mailbox ) => {
 	try {
-		const response = await wp.undocumented().getTitanEmailAddressAvailability( emailAddress );
+		const response = await wp.undocumented().getTitanMailboxAvailability( domain, mailbox );
 		return { message: response.message, status: 200 };
 	} catch ( e ) {
 		return { message: e.message, status: e.statusCode };
@@ -288,10 +288,9 @@ const decorateMailboxWithExistenceError = ( mailbox, message ) => {
 
 const areAllMailboxesAvailable = async ( mailboxes, onMailboxesChange ) => {
 	const promisified_responses = Promise.all(
-		mailboxes.map( ( mailbox ) => {
-			const email = `${ mailbox.mailbox.value }@${ mailbox.domain.value }`;
-			return checkEmailAvailability( email );
-		} )
+		mailboxes.map( ( mailbox ) =>
+			checkMailboxAvailability( mailbox.domain.value, mailbox.mailbox.value )
+		)
 	);
 	const responses = await promisified_responses;
 	const checks = responses.map( ( { message, status }, index ) => {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -823,6 +823,24 @@ Undocumented.prototype.getTitanControlPanelIframeURL = function ( emailAccountId
 };
 
 /**
+ * Checks the availability of an email address
+ *
+ * @param emailAddress The ful email address
+ * @param fn The callback function
+ */
+Undocumented.prototype.getTitanEmailAddressAvailability = function ( emailAddress, fn ) {
+	return this.wpcom.req.get(
+		{
+			path: `/emails/titan/${ encodeURIComponent(
+				emailAddress
+			) }/check-email-address-availability`,
+			apiNamespace: 'wpcom/v2',
+		},
+		fn
+	);
+};
+
+/**
  * Get a list of WordPress.com products
  *
  * @param {Function} fn The callback function

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -825,7 +825,7 @@ Undocumented.prototype.getTitanControlPanelIframeURL = function ( emailAccountId
 /**
  * Checks the availability of an email address
  *
- * @param emailAddress The ful email address
+ * @param emailAddress The full email address
  * @param fn The callback function
  */
 Undocumented.prototype.getTitanEmailAddressAvailability = function ( emailAddress, fn ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -823,17 +823,18 @@ Undocumented.prototype.getTitanControlPanelIframeURL = function ( emailAccountId
 };
 
 /**
- * Checks the availability of an email address
+ * Checks the availability of a mailbox
  *
- * @param emailAddress The full email address
+ * @param domain The domain name to check the mailbox name against
+ * @param mailbox The mailbox to check for availability
  * @param fn The callback function
  */
-Undocumented.prototype.getTitanEmailAddressAvailability = function ( emailAddress, fn ) {
+Undocumented.prototype.getTitanMailboxAvailability = function ( domain, mailbox, fn ) {
 	return this.wpcom.req.get(
 		{
 			path: `/emails/titan/${ encodeURIComponent(
-				emailAddress
-			) }/check-email-address-availability`,
+				domain
+			) }/check-mailbox-availability/${ encodeURIComponent( mailbox ) }`,
 			apiNamespace: 'wpcom/v2',
 		},
 		fn

--- a/client/my-sites/email/email-management/titan-functions.js
+++ b/client/my-sites/email/email-management/titan-functions.js
@@ -32,16 +32,3 @@ export const fetchTitanIframeURL = ( emailAccountId, context ) => {
 			} );
 	} );
 };
-
-export const checkTitanEmailAddressAvailability = ( emailAddress ) => {
-	return new Promise( ( resolve ) => {
-		wpcom
-			.undocumented()
-			.getTitanEmailAddressAvailability( emailAddress, ( serverError, result ) => {
-				resolve( {
-					error: serverError?.message,
-					available: serverError ? false : result.message === 'OK',
-				} );
-			} );
-	} );
-};

--- a/client/my-sites/email/email-management/titan-functions.js
+++ b/client/my-sites/email/email-management/titan-functions.js
@@ -32,3 +32,16 @@ export const fetchTitanIframeURL = ( emailAccountId, context ) => {
 			} );
 	} );
 };
+
+export const checkTitanEmailAddressAvailability = ( emailAddress ) => {
+	return new Promise( ( resolve ) => {
+		wpcom
+			.undocumented()
+			.getTitanEmailAddressAvailability( emailAddress, ( serverError, result ) => {
+				resolve( {
+					error: serverError?.message,
+					available: serverError ? false : result.message === 'OK',
+				} );
+			} );
+	} );
+};

--- a/client/my-sites/email/titan-mail-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-mail-add-mailboxes/index.jsx
@@ -14,6 +14,7 @@ import { withShoppingCart } from '@automattic/shopping-cart';
 import AddEmailAddressesCardPlaceholder from 'calypso/my-sites/email/gsuite-add-users/add-users-placeholder';
 import {
 	areAllMailboxesValid,
+	areAllMailboxesAvailable,
 	buildNewTitanMailbox,
 	transformMailboxForCart,
 } from 'calypso/lib/titan/new-mailbox';
@@ -56,7 +57,6 @@ import TitanNewMailboxList from 'calypso/my-sites/email/titan-mail-add-mailboxes
 import TitanUnusedMailboxesNotice from 'calypso/my-sites/email/titan-mail-add-mailboxes/titan-unused-mailbox-notice';
 
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import wp from 'calypso/lib/wp';
 
 /**
  * Style dependencies
@@ -126,22 +126,17 @@ class TitanMailAddMailboxes extends React.Component {
 		} );
 	};
 
-	checkEmailAvailability = async ( emailAddress ) => {
-		const result = await wp.undocumented().getTitanEmailAddressAvailability( emailAddress );
-		return !! result;
-	};
-
-	handleContinue = () => {
+	handleContinue = async () => {
 		const { selectedSite } = this.props;
 		const { mailboxes } = this.state;
-		const canContinue = areAllMailboxesValid( mailboxes, [ 'alternativeEmail' ] );
+		const canContinue =
+			areAllMailboxesValid( mailboxes, [ 'alternativeEmail' ] ) &&
+			( await areAllMailboxesAvailable( mailboxes, this.onMailboxesChange ) );
 
 		this.recordClickEvent( 'calypso_email_management_titan_add_mailboxes_continue_button_click', {
 			can_continue: canContinue,
 			mailbox_count: mailboxes.length,
 		} );
-
-		this.checkEmailAvailability( 'fi@sleazy.com' );
 
 		if ( canContinue ) {
 			this.setState( { isAddingToCart: true } );

--- a/client/my-sites/email/titan-mail-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-mail-add-mailboxes/index.jsx
@@ -67,6 +67,7 @@ class TitanMailAddMailboxes extends React.Component {
 	state = {
 		mailboxes: [ buildNewTitanMailbox( this.props.selectedDomainName, false ) ],
 		isAddingToCart: false,
+		isCheckingAvailability: false,
 	};
 
 	isMounted = false;
@@ -129,9 +130,21 @@ class TitanMailAddMailboxes extends React.Component {
 	handleContinue = async () => {
 		const { selectedSite } = this.props;
 		const { mailboxes } = this.state;
-		const canContinue =
-			areAllMailboxesValid( mailboxes, [ 'alternativeEmail' ] ) &&
-			( await areAllMailboxesAvailable( mailboxes, this.onMailboxesChange ) );
+		const allMailboxesAreValid = areAllMailboxesValid( mailboxes, [ 'alternativeEmail' ] );
+
+		let allMailboxesAreAvailable = false;
+		if ( allMailboxesAreValid ) {
+			this.setState( { isCheckingAvailability: true } );
+			allMailboxesAreAvailable = await areAllMailboxesAvailable(
+				mailboxes,
+				this.onMailboxesChange
+			);
+			if ( this.isMounted ) {
+				this.setState( { isCheckingAvailability: false } );
+			}
+		}
+
+		const canContinue = allMailboxesAreValid && allMailboxesAreAvailable;
 
 		this.recordClickEvent( 'calypso_email_management_titan_add_mailboxes_continue_button_click', {
 			can_continue: canContinue,
@@ -221,7 +234,7 @@ class TitanMailAddMailboxes extends React.Component {
 						<Button
 							className="titan-mail-add-mailboxes__action-continue"
 							primary
-							busy={ this.state.isAddingToCart }
+							busy={ this.state.isAddingToCart || this.state.isCheckingAvailability }
 							onClick={ this.handleContinue }
 						>
 							{ translate( 'Continue' ) }

--- a/client/my-sites/email/titan-mail-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-mail-add-mailboxes/index.jsx
@@ -56,6 +56,7 @@ import TitanNewMailboxList from 'calypso/my-sites/email/titan-mail-add-mailboxes
 import TitanUnusedMailboxesNotice from 'calypso/my-sites/email/titan-mail-add-mailboxes/titan-unused-mailbox-notice';
 
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import wp from 'calypso/lib/wp';
 
 /**
  * Style dependencies
@@ -125,6 +126,11 @@ class TitanMailAddMailboxes extends React.Component {
 		} );
 	};
 
+	checkEmailAvailability = async ( emailAddress ) => {
+		const result = await wp.undocumented().getTitanEmailAddressAvailability( emailAddress );
+		return !! result;
+	};
+
 	handleContinue = () => {
 		const { selectedSite } = this.props;
 		const { mailboxes } = this.state;
@@ -134,6 +140,8 @@ class TitanMailAddMailboxes extends React.Component {
 			can_continue: canContinue,
 			mailbox_count: mailboxes.length,
 		} );
+
+		this.checkEmailAvailability( 'fi@sleazy.com' );
 
 		if ( canContinue ) {
 			this.setState( { isAddingToCart: true } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- The `alternativeEmail` field is now validated against the active email domain to ensure that users do not erroneously set an email address on that domain as the alternative email address.
- Additional mailboxes are subjected to an availability check to ensure that the new mailbox names are not already taken.
- A new endpoint is added/consumed to check availabilities for new mailboxes ( works with D59619-code )



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  Add Email to a domain
* Attempt to add an alternate email with the same domain as the owning, active domain.
* You should see an error similar to the following ...

<img width="696" alt="Screenshot 2021-04-06 at 5 32 04 PM" src="https://user-images.githubusercontent.com/277661/113746618-6e38ae00-96fe-11eb-954a-5316db2312e5.png">

* Ensure that you already have existing mailboxes on the domain
* Attempt to add an additional existing mailbox
* You should see an error similar to the following ...

<img width="549" alt="Screenshot 2021-04-06 at 5 32 45 PM" src="https://user-images.githubusercontent.com/277661/113746970-cf608180-96fe-11eb-8c3f-332f5e6f7976.png">



