### PR TITLE
Stats: Fix "Average Per Day" Calculation for Current Month

### DIFF
--- a/client/state/selectors/test/get-site-stats-view-summary.js
+++ b/client/state/selectors/test/get-site-stats-view-summary.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -9,6 +10,9 @@ import { expect } from 'chai';
 import { getSiteStatsViewSummary } from 'calypso/state/stats/lists/selectors';
 
 describe( 'getSiteStatsViewSummary()', () => {
+	const today = moment();
+	const daysSinceStartOfMonth = moment( new Date() ).diff( today.startOf( 'month' ), 'days' ) + 1;
+
 	test( 'should return null if no data exists', () => {
 		const data = getSiteStatsViewSummary(
 			{
@@ -63,6 +67,7 @@ describe( 'getSiteStatsViewSummary()', () => {
 											[ '2014-01-02', 4 ],
 											[ '2014-01-03', 23 ],
 											[ '2015-01-01', 10 ],
+											[ today.format( 'YYYY-MM-DD' ), 12 ],
 										],
 										fields: [ 'period', 'views' ],
 										unit: 'day',
@@ -97,6 +102,44 @@ describe( 'getSiteStatsViewSummary()', () => {
 					data: [ [ '2015-01-01', 10 ] ],
 				},
 			},
+			[ today.year() ]: {
+				[ today.month() ]: {
+					total: 12,
+					average: Math.round( 12 / daysSinceStartOfMonth ),
+					daysInMonth: daysSinceStartOfMonth,
+					data: [ [ today.format( 'YYYY-MM-DD' ), 12 ] ],
+				},
+			},
+		} );
+	} );
+
+	test( 'should calculate the average based on the days so far in the current month', () => {
+		const data = getSiteStatsViewSummary(
+			{
+				stats: {
+					lists: {
+						items: {
+							2916284: {
+								statsVisits: {
+									'[["quantity",-1],["stat_fields","views"]]': {
+										data: [ [ today.format( 'YYYY-MM-DD' ), 96 ] ],
+										fields: [ 'period', 'views' ],
+										unit: 'day',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			2916284
+		);
+
+		expect( data[ today.year() ][ today.month() ] ).to.eql( {
+			total: 96,
+			average: Math.round( 96 / daysSinceStartOfMonth ),
+			daysInMonth: daysSinceStartOfMonth,
+			data: [ [ today.format( 'YYYY-MM-DD' ), 96 ] ],
 		} );
 	} );
 } );

--- a/client/state/selectors/test/get-site-stats-view-summary.js
+++ b/client/state/selectors/test/get-site-stats-view-summary.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -10,8 +9,9 @@ import moment from 'moment';
 import { getSiteStatsViewSummary } from 'calypso/state/stats/lists/selectors';
 
 describe( 'getSiteStatsViewSummary()', () => {
-	const today = moment();
-	const daysSinceStartOfMonth = moment( new Date() ).diff( today.startOf( 'month' ), 'days' ) + 1;
+	const today = new Date();
+	const todayFormatted = today.toISOString().slice( 0, 10 );
+	const daysSinceStartOfMonth = today.getDate();
 
 	test( 'should return null if no data exists', () => {
 		const data = getSiteStatsViewSummary(
@@ -67,7 +67,7 @@ describe( 'getSiteStatsViewSummary()', () => {
 											[ '2014-01-02', 4 ],
 											[ '2014-01-03', 23 ],
 											[ '2015-01-01', 10 ],
-											[ today.format( 'YYYY-MM-DD' ), 12 ],
+											[ todayFormatted, 12 ],
 										],
 										fields: [ 'period', 'views' ],
 										unit: 'day',
@@ -102,12 +102,12 @@ describe( 'getSiteStatsViewSummary()', () => {
 					data: [ [ '2015-01-01', 10 ] ],
 				},
 			},
-			[ today.year() ]: {
-				[ today.month() ]: {
+			[ today.getFullYear() ]: {
+				[ today.getMonth() ]: {
 					total: 12,
 					average: Math.round( 12 / daysSinceStartOfMonth ),
 					daysInMonth: daysSinceStartOfMonth,
-					data: [ [ today.format( 'YYYY-MM-DD' ), 12 ] ],
+					data: [ [ todayFormatted, 12 ] ],
 				},
 			},
 		} );
@@ -122,7 +122,7 @@ describe( 'getSiteStatsViewSummary()', () => {
 							2916284: {
 								statsVisits: {
 									'[["quantity",-1],["stat_fields","views"]]': {
-										data: [ [ today.format( 'YYYY-MM-DD' ), 96 ] ],
+										data: [ [ todayFormatted, 96 ] ],
 										fields: [ 'period', 'views' ],
 										unit: 'day',
 									},
@@ -135,11 +135,11 @@ describe( 'getSiteStatsViewSummary()', () => {
 			2916284
 		);
 
-		expect( data[ today.year() ][ today.month() ] ).to.eql( {
+		expect( data[ today.getFullYear() ][ today.getMonth() ] ).to.eql( {
 			total: 96,
 			average: Math.round( 96 / daysSinceStartOfMonth ),
 			daysInMonth: daysSinceStartOfMonth,
-			data: [ [ today.format( 'YYYY-MM-DD' ), 96 ] ],
+			data: [ [ todayFormatted, 96 ] ],
 		} );
 	} );
 } );

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, map, flatten, round } from 'lodash';
+import { get, map, flatten } from 'lodash';
 import moment from 'moment';
 
 /**
@@ -201,15 +201,18 @@ export function getSiteStatsViewSummary( state, siteId ) {
 		viewSummary[ years ][ months ].data.push( item );
 		const average =
 			viewSummary[ years ][ months ].total / viewSummary[ years ][ months ].daysInMonth;
-		viewSummary[ years ][ months ].average = round( average, 0 );
+		viewSummary[ years ][ months ].average = Math.round( average );
 	} );
 
 	// With the current month, calculate the average based on the days passed so far in the month
-	const thisMonth = viewSummary[ moment().year() ][ moment().month() ];
+	const momentTime = moment();
+	const thisMonth = viewSummary[ momentTime.year() ][ momentTime.month() ];
+
 	if ( thisMonth ) {
 		const daysSinceStartOfMonth =
-			moment( new Date() ).diff( moment().startOf( 'month' ), 'days' ) + 1;
-		thisMonth.average = round( thisMonth.total / daysSinceStartOfMonth, 0 );
+			moment( new Date() ).diff( momentTime.startOf( 'month' ), 'days' ) + 1;
+		thisMonth.daysInMonth = daysSinceStartOfMonth;
+		thisMonth.average = Math.round( thisMonth.total / thisMonth.daysInMonth );
 	}
 
 	return viewSummary;

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -182,8 +182,9 @@ export function getSiteStatsViewSummary( state, siteId ) {
 
 	viewData.data.forEach( ( item ) => {
 		const [ date, value ] = item;
-		const momentDate = moment( date );
-		const { years, months } = momentDate.toObject();
+		const newDate = new Date( date );
+		const years = newDate.getFullYear();
+		const months = newDate.getMonth();
 
 		if ( ! viewSummary[ years ] ) {
 			viewSummary[ years ] = {};
@@ -194,7 +195,7 @@ export function getSiteStatsViewSummary( state, siteId ) {
 				total: 0,
 				data: [],
 				average: 0,
-				daysInMonth: momentDate.daysInMonth(),
+				daysInMonth: new Date( years, months + 1, 0 ).getDate(),
 			};
 		}
 		viewSummary[ years ][ months ].total += value;

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -205,14 +205,13 @@ export function getSiteStatsViewSummary( state, siteId ) {
 	} );
 
 	// With the current month, calculate the average based on the days passed so far in the month
-	if ( viewData.data.length ) {
-		const date = new Date();
-		const thisMonth = viewSummary[ date.getFullYear() ][ date.getMonth() ];
+	const date = new Date();
+	const thisMonth =
+		viewSummary[ date.getFullYear() ] && viewSummary[ date.getFullYear() ][ date.getMonth() ];
 
-		if ( thisMonth ) {
-			thisMonth.daysInMonth = date.getDate();
-			thisMonth.average = Math.round( thisMonth.total / thisMonth.daysInMonth );
-		}
+	if ( thisMonth ) {
+		thisMonth.daysInMonth = date.getDate();
+		thisMonth.average = Math.round( thisMonth.total / thisMonth.daysInMonth );
 	}
 
 	return viewSummary;

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -206,13 +206,11 @@ export function getSiteStatsViewSummary( state, siteId ) {
 
 	// With the current month, calculate the average based on the days passed so far in the month
 	if ( viewData.data.length ) {
-		const momentTime = moment();
-		const thisMonth = viewSummary[ momentTime.year() ][ momentTime.month() ];
+		const date = new Date();
+		const thisMonth = viewSummary[ date.getFullYear() ][ date.getMonth() ];
 
 		if ( thisMonth ) {
-			const daysSinceStartOfMonth =
-				moment( new Date() ).diff( momentTime.startOf( 'month' ), 'days' ) + 1;
-			thisMonth.daysInMonth = daysSinceStartOfMonth;
+			thisMonth.daysInMonth = date.getDate();
 			thisMonth.average = Math.round( thisMonth.total / thisMonth.daysInMonth );
 		}
 	}

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -206,9 +206,11 @@ export function getSiteStatsViewSummary( state, siteId ) {
 
 	// With the current month, calculate the average based on the days passed so far in the month
 	const thisMonth = viewSummary[ moment().year() ][ moment().month() ];
-	const daysSinceStartOfMonth =
-		moment( new Date() ).diff( moment().startOf( 'month' ), 'days' ) + 1;
-	thisMonth.average = round( thisMonth.total / daysSinceStartOfMonth, 0 );
+	if ( thisMonth ) {
+		const daysSinceStartOfMonth =
+			moment( new Date() ).diff( moment().startOf( 'month' ), 'days' ) + 1;
+		thisMonth.average = round( thisMonth.total / daysSinceStartOfMonth, 0 );
+	}
 
 	return viewSummary;
 }

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -204,6 +204,12 @@ export function getSiteStatsViewSummary( state, siteId ) {
 		viewSummary[ years ][ months ].average = round( average, 0 );
 	} );
 
+	// With the current month, calculate the average based on the days passed so far in the month
+	const thisMonth = viewSummary[ moment().year() ][ moment().month() ];
+	const daysSinceStartOfMonth =
+		moment( new Date() ).diff( moment().startOf( 'month' ), 'days' ) + 1;
+	thisMonth.average = round( thisMonth.total / daysSinceStartOfMonth, 0 );
+
 	return viewSummary;
 }
 

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -205,14 +205,16 @@ export function getSiteStatsViewSummary( state, siteId ) {
 	} );
 
 	// With the current month, calculate the average based on the days passed so far in the month
-	const momentTime = moment();
-	const thisMonth = viewSummary[ momentTime.year() ][ momentTime.month() ];
+	if ( viewData.data.length ) {
+		const momentTime = moment();
+		const thisMonth = viewSummary[ momentTime.year() ][ momentTime.month() ];
 
-	if ( thisMonth ) {
-		const daysSinceStartOfMonth =
-			moment( new Date() ).diff( momentTime.startOf( 'month' ), 'days' ) + 1;
-		thisMonth.daysInMonth = daysSinceStartOfMonth;
-		thisMonth.average = Math.round( thisMonth.total / thisMonth.daysInMonth );
+		if ( thisMonth ) {
+			const daysSinceStartOfMonth =
+				moment( new Date() ).diff( momentTime.startOf( 'month' ), 'days' ) + 1;
+			thisMonth.daysInMonth = daysSinceStartOfMonth;
+			thisMonth.average = Math.round( thisMonth.total / thisMonth.daysInMonth );
+		}
 	}
 
 	return viewSummary;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The "Average Per Day" section of Stats is calculated by "total views in the month / total days in the month". This PR would change that formula only for the current month so that it becomes "total views so far in the month / total days **so far** in the month".

#### Testing instructions

This is a bit painful, but manually add up all the views obtained this month (April 2021). 

**Before:**
If you divide that number by 30, you should find the existing number.

<img width="1085" alt="Screenshot 2021-04-05 at 14 22 13" src="https://user-images.githubusercontent.com/43215253/113579889-d020e700-961c-11eb-86e6-63fd7073d2bf.png">

**After:**
If you divide that number by how many days have passed in the month (at the time of writing, it's the 5th of April so five), you should find the new number. 

<img width="1109" alt="Screenshot 2021-04-05 at 14 21 55" src="https://user-images.githubusercontent.com/43215253/113579879-cdbe8d00-961c-11eb-8e5c-c39d195e74e5.png">
 
Also, verify none of the other numbers are affected.

Fixes #51673
cc @sixhours, @tyxla 