### PR TITLE
ci(docker): Add user calypso to docker images

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -101,11 +101,17 @@ RUN apt update \
 		xfonts-base \
 		xfonts-cyrillic \
 		xfonts-scalable \
-		xvfb
+		xvfb \
+		sudo
 
 RUN wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
 	&& apt-get install -y ./google-chrome-stable_${CHROME_VERSION}_amd64.deb \
 	&& rm ./google-chrome-stable_${CHROME_VERSION}_amd64.deb
+
+# Add user calypso with 1002, give it sudo permissions
+RUN adduser --uid 1002 --disabled-password calypso \
+	&& echo "calypso ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/calypso \
+    && chmod 0440 /etc/sudoers.d/calypso
 
 ENTRYPOINT [ "/bin/bash" ]
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -37,6 +37,7 @@ ENTRYPOINT [ "/bin/bash" ]
 FROM node:14.16.0-buster as base
 
 ARG node_memory=8192
+ARG user=calypso
 ARG UID=1003
 
 WORKDIR /calypso
@@ -48,7 +49,15 @@ ENV HOME=/calypso
 ENV CHROMEDRIVER_SKIP_DOWNLOAD=true
 ENV PUPPETEER_SKIP_DOWNLOAD=true
 ENV PLAYWRIGHT_SKIP_DOWNLOAD=true
-RUN chown $UID /calypso
+
+# Add user calypso with uid 1003, give it sudo permissions
+RUN apt-get update \
+	&& apt-get install -y sudo \
+	&& adduser --uid $UID --disabled-password $user \
+	&& echo "$user ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$user \
+	&& chmod 0440 /etc/sudoers.d/$user \
+	&& chown $UID /calypso \
+	&& rm -rf /var/lib/apt/lists/*
 
 # Set bash as the default shell
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
@@ -101,17 +110,11 @@ RUN apt update \
 		xfonts-base \
 		xfonts-cyrillic \
 		xfonts-scalable \
-		xvfb \
-		sudo
+		xvfb
 
 RUN wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
 	&& apt-get install -y ./google-chrome-stable_${CHROME_VERSION}_amd64.deb \
 	&& rm ./google-chrome-stable_${CHROME_VERSION}_amd64.deb
-
-# Add user calypso with 1002, give it sudo permissions
-RUN adduser --uid 1002 --disabled-password calypso \
-	&& echo "calypso ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/calypso \
-	&& chmod 0440 /etc/sudoers.d/calypso
 
 ENTRYPOINT [ "/bin/bash" ]
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -111,7 +111,7 @@ RUN wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-
 # Add user calypso with 1002, give it sudo permissions
 RUN adduser --uid 1002 --disabled-password calypso \
 	&& echo "calypso ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/calypso \
-    && chmod 0440 /etc/sudoers.d/calypso
+	&& chmod 0440 /etc/sudoers.d/calypso
 
 ENTRYPOINT [ "/bin/bash" ]
 


### PR DESCRIPTION
#### Background

Our e2e tests run using an anonymous non-root user. This means we can't update system libraries or install new Debian packages at build time (eg: update Chrome). 

The biggest problem with it is we can't easily update Chrome: if we update `chromedriver` at build time, it will fail because the base image contains an outdated Chrome version. And if we update Chrome at image creation time, all builds will fail because they use an incompatible `chromedriver`. We could make it work if we update the base image and `trunk` at the same time, and all branches will fail until they rebase `trunk`. Not a great experience.

#### Changes proposed in this Pull Request

This PR introduces a user `calypso` with a fixed `uid` (so we can impersonate it when running docker commands), and gives that specific user the capacity to run `sudo` to update system libraries.

#### Testing instructions

* Open `Dockerfile.base` and comment out lines 24 to 31, line 58 and line 62 (otherwise it will take ages to build)
* Run `docker build -t registry.a8c.com/calypso/ci-desktop:local --target ci-desktop -f Dockerfile.base .`. It will build as simplified version of the `ci-desktop` image, it will take a few seconds.
* Run `docker run --rm -ti -u 1003 registry.a8c.com/calypso/ci-desktop:local`
  * Run `whoami`, it should say `calypso`
  * Run `sudo whoami`, it should say `root`

