### PR TITLE
Components: Remove Lodash usage from TitleFormatEditor

### DIFF
--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -5,7 +5,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { get, head, map, max, min } from 'lodash';
 import moment from 'moment';
 
 /**
@@ -122,14 +121,15 @@ export class TitleFormatEditor extends Component {
 
 		// okay if cursor is at the spot
 		// right before the token
-		if ( offset === head( indices ) ) {
+		const [ firstIndex ] = indices;
+		if ( offset === firstIndex ) {
 			return editorState;
 		}
 
 		const outside =
 			direction > 0
-				? Math.min( max( indices ) + 1, block.getLength() )
-				: Math.max( min( indices ), 0 );
+				? Math.min( Math.max( ...indices ) + 1, block.getLength() )
+				: Math.max( Math.min( ...indices ), 0 );
 
 		return EditorState.forceSelection(
 			editorState,
@@ -191,8 +191,8 @@ export class TitleFormatEditor extends Component {
 			}, [] );
 
 			const range = SelectionState.createEmpty( block.key )
-				.set( 'anchorOffset', min( indices ) )
-				.set( 'focusOffset', max( indices ) );
+				.set( 'anchorOffset', Math.min( ...indices ) )
+				.set( 'focusOffset', Math.max( ...indices ) );
 
 			const withoutToken = EditorState.push(
 				editorState,
@@ -202,7 +202,9 @@ export class TitleFormatEditor extends Component {
 
 			const selectionBeforeToken = EditorState.forceSelection(
 				withoutToken,
-				range.set( 'anchorOffset', min( indices ) ).set( 'focusOffset', min( indices ) )
+				range
+					.set( 'anchorOffset', Math.min( ...indices ) )
+					.set( 'focusOffset', Math.min( ...indices ) )
 			);
 
 			this.updateEditor( selectionBeforeToken );
@@ -243,7 +245,7 @@ export class TitleFormatEditor extends Component {
 			<div className={ editorClassNames }>
 				<div className="title-format-editor__header">
 					<span className="title-format-editor__title">{ type.label }</span>
-					{ map( tokens, ( title, name ) => (
+					{ Object.entries( tokens ).map( ( [ name, title ] ) => (
 						/* eslint-disable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
 						<span
 							key={ name }
@@ -273,7 +275,9 @@ export class TitleFormatEditor extends Component {
 const mapStateToProps = ( state, ownProps ) => {
 	const site = getSelectedSite( state );
 	const { translate } = ownProps;
-	const formattedDate = moment().locale( get( site, 'lang', '' ) ).format( 'MMMM YYYY' );
+	const formattedDate = moment()
+		.locale( site?.lang ?? '' )
+		.format( 'MMMM YYYY' );
 
 	// Add example content for post/page title, tag name and archive dates
 	return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes Lodash usage from the `TitleFormatEditor` component. All the usages are pretty straightforward and it's pretty easy for them to be cleaned up.

If you want to find out why we're moving away from Lodash, see #50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Go to `/marketing/traffic/:site` where `:site` is a WP.com site with a premium or business plan.
* Tinker with one of the Page Title Structure fields, add and remove tokens and any characters, save and refresh the page as well.
* Verify everything still works well.
* Verify tests still pass.
