### PR TITLE
Patner Portal: Change date format on license details

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -32,6 +32,8 @@ interface Props {
 	onCopyLicense?: () => void;
 }
 
+const DETAILS_DATE_FORMAT = 'YYYY-MM-DD h:mm:ss A';
+
 export default function LicenseDetails( {
 	licenseKey,
 	product,
@@ -69,13 +71,13 @@ export default function LicenseDetails( {
 
 				<li className="license-details__list-item">
 					<h4 className="license-details__label">{ translate( 'Issued on' ) }</h4>
-					<FormattedDate date={ issuedAt } format="LLL" />
+					<FormattedDate date={ issuedAt } format={ DETAILS_DATE_FORMAT } />
 				</li>
 
 				{ licenseState === LicenseState.Attached && (
 					<li className="license-details__list-item">
 						<h4 className="license-details__label">{ translate( 'Assigned on' ) }</h4>
-						<FormattedDate date={ attachedAt } format="LLL" />
+						<FormattedDate date={ attachedAt } format={ DETAILS_DATE_FORMAT } />
 					</li>
 				) }
 
@@ -89,7 +91,7 @@ export default function LicenseDetails( {
 				{ licenseState === LicenseState.Revoked && (
 					<li className="license-details__list-item">
 						<h4 className="license-details__label">{ translate( 'Revoked on' ) }</h4>
-						<FormattedDate date={ revokedAt } format="LLL" />
+						<FormattedDate date={ revokedAt } format={ DETAILS_DATE_FORMAT } />
 					</li>
 				) }
 


### PR DESCRIPTION
Context: 1187494150150258-as-1200043581561264

#### Changes proposed in this Pull Request

* Change the date format in the license details to "YYYY-MM-DD h:mm:ss A"

#### Testing instructions
* If you do not have a partner key, please contact Infinity for one or you will be unable to view test this PR.
* Check out this PR locally, then run* yarn && yarn start-jetpack-cloud.
* Visit http://jetpack.cloud.localhost:3000/partner-portal
* If you don't have any license keys, issue one
* Check the date formats on "Issued On", "Attached On" and "Revoked On" match the date format in the screenshot


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* ![image](https://user-images.githubusercontent.com/5714212/113583664-51b64c00-9600-11eb-88a3-1b1e8c68fb77.png)
