### PR TITLE
Framework: Refactor away from `_.min()`

### DIFF
--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { map, zipObject, size, filter, get, compact, partition, min } from 'lodash';
+import { map, zipObject, size, filter, get, compact, partition } from 'lodash';
 
 /**
  * Internal dependencies
@@ -172,7 +172,7 @@ export class ConversationCommentList extends React.Component {
 	getCommentsToShow = () => {
 		const { commentIds, expansions, commentsTree, sortedComments } = this.props;
 
-		const minId = min( commentIds );
+		const minId = Math.min( ...commentIds );
 		const startingCommentIds = ( sortedComments || [] )
 			.filter( ( comment ) => {
 				return comment.ID >= minId || comment.isPlaceholder;

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRtl } from 'i18n-calypso';
-import { clone, filter, findIndex, min } from 'lodash';
+import { clone, filter, findIndex } from 'lodash';
 import ReactDom from 'react-dom';
 import React from 'react';
 
@@ -152,7 +152,7 @@ export class MediaLibraryList extends React.Component {
 	};
 
 	getItemGroup = ( item ) =>
-		min( [ item.date.slice( 0, 10 ), this.props.moment( new Date() ).format( 'YYYY-MM-DD' ) ] );
+		Math.min( item.date.slice( 0, 10 ), this.props.moment( new Date() ).format( 'YYYY-MM-DD' ) );
 
 	renderItem = ( item ) => {
 		const index = findIndex( this.props.media, { ID: item.ID } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `min()` is essentially natively supported by `Math.min()`, with some minor behavioral exceptions (when no values are passed). This PR replaces all the `_.min()` usage with native `Math.min()`, except for the ones in `TitleFormatEditor` that are handled separately in #51679.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all usages are sane and preserve the original logic.
* Smoke test Conversations in Reader and Media library and verify they still work well.
* Verify all tests pass.