### PR TITLE
Framework: Refactor away from `_.max()`

### DIFF
--- a/client/lib/path-to-section/index.js
+++ b/client/lib/path-to-section/index.js
@@ -1,14 +1,14 @@
 /**
  * Internal dependencies
  */
-import { filter, get, max, maxBy, startsWith } from 'lodash';
+import { filter, get, maxBy, startsWith } from 'lodash';
 import { getSections } from 'calypso/sections-helper';
 
 export default function pathToSection( path ) {
 	// rank matches by the number of characters that match so e.g. /media won't map to /me
 	const bestMatch = maxBy( getSections(), ( section ) =>
-		max(
-			section.paths.map( ( sectionPath ) =>
+		Math.max(
+			...section.paths.map( ( sectionPath ) =>
 				startsWith( path, sectionPath ) ? sectionPath.length : 0
 			)
 		)

--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { max, throttle, values } from 'lodash';
+import { throttle, values } from 'lodash';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
 
@@ -124,7 +124,7 @@ class PostTrends extends React.Component {
 	getMonthComponents = () => {
 		const { streakData } = this.props;
 		// Compute maximum per-day post count from the streakData. It's used to scale the chart.
-		const maxPosts = max( values( streakData ) );
+		const maxPosts = Math.max( ...values( streakData ) );
 		const months = [];
 
 		for ( let i = 11; i >= 0; i-- ) {

--- a/client/my-sites/stats/stats-views/months.jsx
+++ b/client/my-sites/stats/stats-views/months.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { map, range, flatten, max, keys, zipObject, times, size, concat, merge } from 'lodash';
+import { map, range, flatten, keys, zipObject, times, size, concat, merge } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 
@@ -107,7 +107,7 @@ const StatsViewsMonths = ( props ) => {
 		} )
 	);
 
-	const highestMonth = max( allMonths );
+	const highestMonth = Math.max( ...allMonths );
 	const yearsObject = zipObject(
 		keys( data ),
 		times( size( data ), () => {

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { max } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { getPlan, getMonthlyPlanByYearly, getBillingMonthsForTerm } from 'calypso/lib/plans';
@@ -37,10 +32,10 @@ export const computeFullAndMonthlyPricesForPlan = (
 	return {
 		priceFullBeforeDiscount: getPlanRawPrice( state, planObject.getProductId(), false ),
 		priceFull: getPlanPrice( state, siteId, planObject, false ),
-		priceFinal: max( [
+		priceFinal: Math.max(
 			getPlanPrice( state, siteId, planObject, false ) - credits - couponDiscount,
-			0,
-		] ),
+			0
+		),
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `max()` is essentially natively supported by `Math.max()`, with some minor behavioral exceptions (when no values are passed). This PR replaces all the `_.max()` usage with native `Math.max()`, except for the ones in `TitleFormatEditor` that are handled separately in #51679.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all usages are sane and preserve the original logic.
* Smoke test stats and monthly plans page on a site and verify everything still works well and there are no errors in the console.
* Verify all tests pass.