### PR TITLE
Components: Fix key in GravatarCaterpillar

### DIFF
--- a/client/components/gravatar-caterpillar/index.jsx
+++ b/client/components/gravatar-caterpillar/index.jsx
@@ -51,7 +51,12 @@ class GravatarCaterpillar extends React.Component {
 					}
 
 					return (
-						<Gravatar className={ gravClasses } key={ user.email } user={ user } size={ 32 } />
+						<Gravatar
+							className={ gravClasses }
+							key={ user.email || user.avatar_URL }
+							user={ user }
+							size={ 32 }
+						/>
 					);
 				} ) }
 			</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the following issue with keys in the Reader Conversations page:

![](https://cldup.com/x3cd6dBdRp.png)

I'm able to repro it by having followed `ma.tt` and seeing one of the recent posts from there in the Conversations post list, but it'll likely happen with other sites / posts. 

#### Testing instructions

* Go to `/read/conversations`
* Verify you don't see the warning from the screenshot above, and everything is working well.

#### Context

Discovered while working on #51681.