### PR TITLE
Partner Portal: Fix typo in the revoke license dialog

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -94,7 +94,7 @@ export default function RevokeLicenseDialog( {
 
 			<p>
 				{ translate(
-					'A revoked license cannot be reused and the associated site will no longer have access to the provisioned product. You will stop being billed for this license immediately.'
+					'A revoked license cannot be reused, and the associated site will no longer have access to the provisioned product. You will stop being billed for this license immediately.'
 				) }
 			</p>
 

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -94,7 +94,7 @@ export default function RevokeLicenseDialog( {
 
 			<p>
 				{ translate(
-					'A revoked license cannot be reused and the associated site will no longer have access to the provisioned product. You will stop being billing for this license immediately.'
+					'A revoked license cannot be reused and the associated site will no longer have access to the provisioned product. You will stop being billed for this license immediately.'
 				) }
 			</p>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a typo in the revoke license dialog

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If you do not have a partner key with licenses, please contact Infinity for one or you will be unable to test this PR.
* Check out this PR locally, and run yarn && yarn start-jetpack-cloud.
* Visit http://jetpack.cloud.localhost:3000/partner-portal
* Open the license detail and click the "Revoke License" button (if you don't have a license key before this step, issue one).
* Make sure the text in the Dialog looks like the screenshot below

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
![image](https://user-images.githubusercontent.com/5714212/113588582-baa0c280-9606-11eb-8903-d3a83fddc00a.png)


