### PR TITLE
layout: Sanitize only string SidebarItem labels

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -78,7 +78,12 @@ export default function SidebarItem( props ) {
 
 				{ /* eslint-disable wpcalypso/jsx-classname-namespace */ }
 				<span className="sidebar__menu-link-text menu-link-text" data-e2e-sidebar={ props.label }>
-					{ stripHTML( decodeEntities( props.label ) ) }
+					{
+						// String labels should be sanitized, whereas React components should be rendered as is
+						'string' === typeof props.label
+							? stripHTML( decodeEntities( props.label ) )
+							: props.label
+					}
 					{ !! count && <Count count={ count } /> }
 				</span>
 				{ showAsExternal && <Gridicon icon="external" size={ 24 } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Sanitize only `SidebarItem` labels with a type of string, to avoid getting empty labels for items that have received a React component as a result of a translate call for their `label` prop.

**Before:**
![image](https://user-images.githubusercontent.com/2722412/113594641-a1b50300-9640-11eb-9d76-f82023d1a204.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/113594656-a7aae400-9640-11eb-8e42-32d2fd422394.png)

#### Testing instructions

* Change UI to a non-English Mag-16 locale and activate Community Translator from your account settings.
* Go to `calypso.live/me` and enable community translator.
* Confirm sidebar items don't disappear and are getting highlighted by the community translator

Related to 229-gh-Automattic/i18n-issues

cc @Aurorum, who added the HTML sanitization
