### PR TITLE
Fix stats/store tab for jetpack connected sites

### DIFF
--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -20,6 +20,7 @@ import StoreSidebar from './store-sidebar';
 import { tracksStore, bumpStat } from './lib/analytics';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { getSelectedSiteWithFallback, getSiteOption } from 'calypso/state/sites/selectors';
+import isSiteStore from 'calypso/state/selectors/is-site-store';
 
 /**
  * Style dependencies
@@ -162,6 +163,12 @@ function redirectIfWooCommerceNotInstalled( context, next ) {
 	const state = context.store.getState();
 	const site = getSelectedSiteWithFallback( state );
 	const siteId = site ? site.ID : null;
+	const isStore = isSiteStore( state, siteId );
+
+	if ( isStore ) {
+		next();
+		return;
+	}
 	const isSiteWpcomStore = getSiteOption( state, siteId, 'is_wpcom_store' );
 
 	if ( ! isSiteWpcomStore ) {


### PR DESCRIPTION
This PR fixes https://github.com/Automattic/wc-calypso-bridge/issues/667

#### Changes proposed in this Pull Request

This PR adds an extra check before wordpress.com store check to make sure we're not redirecting those external sites that are connected to wordpress.com via Jetpack.

#### Testing instructions

Let's reproduce the bug before confirming the fix as it's a bit confusing at first.

1. Create a JN site.
2. Install & Activate WooCommerce
3. Connect to Jetpack.
4. Checkout `trunk` version of `wp-calypso` and run it locally.
5. Open http://calypso.localhost:3000 and choose the JN site you just created from step #1
6. Navigate to Stats and click `Store` tab
7. You should be redirected back to the default Stats page.

Confirming the fix

1. Clone this branch and start `wp-calypso` locally
2. Repeat the steps from above. You should be able to click `Store` tab.


