### PR TITLE
Add translation calls for Jetpack Backup and Scan menu items

### DIFF
--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -66,7 +66,9 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 				<SidebarItem
 					materialIcon={ showIcons ? 'backup' : undefined }
 					materialIconStyle="filled"
-					label="Backup"
+					label={ translate( 'Backup', {
+						comment: 'Jetpack sidebar menu item',
+					} ) }
 					link={ backupPath( siteSlug ) }
 					onNavigate={ onNavigate( tracksEventNames.backupClicked ) }
 					selected={ currentPathMatches( backupPath( siteSlug ) ) }
@@ -77,7 +79,9 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 				<SidebarItem
 					materialIcon={ showIcons ? 'security' : undefined }
 					materialIconStyle="filled"
-					label="Scan"
+					label={ translate( 'Scan', {
+						comment: 'Jetpack sidebar menu item',
+					} ) }
 					link={ scanPath( siteSlug ) }
 					onNavigate={ onNavigate( tracksEventNames.scanClicked ) }
 					selected={ currentPathMatches( scanPath( siteSlug ) ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `translation()` calls for Jetpack's "Backup" and "Scan" menu items

#### Testing instructions

* Create an ephemeral or jetpack site
* Link it to your WP.com account using the Jetpack "Green Button" on its /wp-admin page
* Visit its stats page in calypso, and add the `?flags=quick-language-switcher` to the query string
  * Example URL: `http://calypso.localhost:3000/stats/day/mysite.xyz.blog?flags=quick-language-switcher`
* Use the quick language switcher at the top to change locale.
* Before the fix, inside the Jetpack menu, "Backup" and "Scan" remained in English
* After the fix, they should be translated

![2021-04-05_17-39](https://user-images.githubusercontent.com/937354/113635656-a379c900-9636-11eb-9b9e-b89d9d7f22d3.png)
The Quick Language Switcher

![2021-04-05_17-40](https://user-images.githubusercontent.com/937354/113635667-a8d71380-9636-11eb-8464-ec5e477d263f.png)
Before the fix

![2021-04-05_17-41](https://user-images.githubusercontent.com/937354/113635678-ac6a9a80-9636-11eb-9193-3fb7dd207d52.png)
After the fix

Related to https://github.com/Automattic/wp-calypso/issues/51064

