### PR TITLE
WIP: Translate "feedback" menu item in site menu

### DIFF
--- a/client/components/data/query-post-types/index.jsx
+++ b/client/components/data/query-post-types/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { isEqual, pick } from 'lodash';
+import { withLocale } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -31,11 +32,12 @@ class QueryPostTypes extends Component {
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
-		const { siteSettings, siteId, themeSlug } = this.props;
+		const { siteSettings, siteId, themeSlug, locale } = this.props;
 		const {
 			siteSettings: nextSiteSettings,
 			siteId: nextSiteId,
 			themeSlug: nextThemeSlug,
+			locale: nextLocale,
 		} = nextProps;
 
 		const hasThemeChanged = themeSlug && nextThemeSlug && themeSlug !== nextThemeSlug;
@@ -43,8 +45,15 @@ class QueryPostTypes extends Component {
 			pick( siteSettings, POST_TYPE_SETTINGS ),
 			pick( nextSiteSettings, POST_TYPE_SETTINGS )
 		);
+		const hasLocaleChanged = locale && nextLocale && locale !== nextLocale;
+		// console.log( { locale, nextLocale, hasLocaleChanged } );
 
-		if ( siteId !== nextSiteId || hasThemeChanged || hasPostTypeSettingChanged ) {
+		if (
+			siteId !== nextSiteId ||
+			hasThemeChanged ||
+			hasPostTypeSettingChanged ||
+			hasLocaleChanged
+		) {
 			this.request( nextProps );
 		}
 	}
@@ -64,4 +73,4 @@ export default connect(
 		themeSlug: getSiteOption( state, siteId, 'theme_slug' ),
 	} ),
 	{ requestPostTypes }
-)( QueryPostTypes );
+)( withLocale( QueryPostTypes ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* WIP

#### Testing instructions

* Create an ephemeral or jetpack site
* Link it to your WP.com account using the Jetpack "Green Button" on its /wp-admin page
* Visit its stats page in calypso, and add the `?flags=quick-language-switcher` to the query string
  * Example URL: `http://calypso.localhost:3000/stats/day/mysite.xyz.blog?flags=quick-language-switcher`
* Use the quick language switcher at the top to change locale.
* Before the fix, inside the Site menu, "Feedback" remained in English

![2021-04-05_17-39](https://user-images.githubusercontent.com/937354/113636049-67933380-9637-11eb-9e02-dfb614c69221.png)
The Quick Language Switcher

![2021-04-05_17-50](https://user-images.githubusercontent.com/937354/113636054-6c57e780-9637-11eb-9b7e-c4a2f107e85a.png)
Before the Fix


Related to https://github.com/Automattic/wp-calypso/issues/51064
