### PR TITLE
ETK: Fix JS errors related to mediaelement.js loaded by Core

### DIFF
--- a/apps/editing-toolkit/webpack.config.js
+++ b/apps/editing-toolkit/webpack.config.js
@@ -69,8 +69,8 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 			...webpackConfig.output,
 			path: outputPath,
 			filename: '[name].js', // dynamic filename
-			// Don't output a global variable to access plugin js, as this isn't a library
-			// Also the calypso-build default value of `window` can cause errors in JS loaded by Core
+			// Use a global variable, rather than window for outputing the compiled JS.
+			// The calypso-build default value of `window` can cause errors in JS loaded by Core
 			// See https://github.com/Automattic/wp-calypso/pull/51700
 			library: { name: 'EditingToolkit', type: 'var' },
 		},

--- a/apps/editing-toolkit/webpack.config.js
+++ b/apps/editing-toolkit/webpack.config.js
@@ -71,7 +71,7 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 			filename: '[name].js', // dynamic filename
 			// Don't output a global variable to access plugin js, as this isn't a library
 			// Also the calypso-build default value of `window` can cause errors in JS loaded by Core
-			// See https://github.com/Automattic/wp-calypso/pull/51699
+			// See https://github.com/Automattic/wp-calypso/pull/51700
 			library: undefined,
 		},
 		optimization: {

--- a/apps/editing-toolkit/webpack.config.js
+++ b/apps/editing-toolkit/webpack.config.js
@@ -69,10 +69,7 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 			...webpackConfig.output,
 			path: outputPath,
 			filename: '[name].js', // dynamic filename
-			// Use a global variable, rather than window for outputing the compiled JS.
-			// The calypso-build default value of `window` can cause errors in JS loaded by Core
-			// See https://github.com/Automattic/wp-calypso/pull/51700
-			library: { name: 'EditingToolkit', type: 'var' },
+			library: 'EditingToolkit',
 		},
 		optimization: {
 			...webpackConfig.optimization,

--- a/apps/editing-toolkit/webpack.config.js
+++ b/apps/editing-toolkit/webpack.config.js
@@ -72,7 +72,7 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 			// Don't output a global variable to access plugin js, as this isn't a library
 			// Also the calypso-build default value of `window` can cause errors in JS loaded by Core
 			// See https://github.com/Automattic/wp-calypso/pull/51700
-			library: undefined,
+			library: { name: 'EditingToolkit', type: 'var' },
 		},
 		optimization: {
 			...webpackConfig.optimization,

--- a/apps/editing-toolkit/webpack.config.js
+++ b/apps/editing-toolkit/webpack.config.js
@@ -69,6 +69,10 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 			...webpackConfig.output,
 			path: outputPath,
 			filename: '[name].js', // dynamic filename
+			// Don't output a global variable to access plugin js, as this isn't a library
+			// Also the calypso-build default value of `window` can cause errors in JS loaded by Core
+			// See https://github.com/Automattic/wp-calypso/pull/51699
+			library: undefined,
 		},
 		optimization: {
 			...webpackConfig.optimization,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The [default webpack config](https://github.com/Automattic/wp-calypso/blob/862ae36255b8c7b48bdd40cf77cd3becc7498507/packages/calypso-build/webpack.config.js#L58) from `calypso-build` sets a [library target config](https://webpack.js.org/configuration/output/#outputlibrary) of `window`. When library name is not also set, the output is applied directly to `window`. In the case of the ETK plugin JS, this causes a conflict with the [media element js library](https://github.com/WordPress/WordPress/blob/master/wp-includes/js/mediaelement/mediaelement-and-player.js) loaded by WordPress Core.

The webpack config caused [`window.__esModule`](https://github.com/WordPress/WordPress/blob/master/wp-includes/js/mediaelement/mediaelement-and-player.js) to be `true`, which caused [`_window.default`](https://github.com/WordPress/WordPress/blob/master/wp-includes/js/mediaelement/mediaelement-and-player.js) to be `undefined` in `mediaelement-and-player.js`, when loaded on the same page as the block JS in the Editing Toolkit plugin.

This change adds a library name (`EditingToolkit`) to the webpack config, preventing the above issue.

Fixes #49840

#### Testing instructions

* Activate a theme with a widget area
* Create a page or post that has the Blog Posts block in the content
* Add a video widget to the widget area
* Visit the front end of the page with the both the Blog Posts block and the widget content.

Without this change, you will see an error on the JS console: `Uncaught TypeError: can't access property "mejs", _window2.default is undefined`, and the video in the widget will not load.

With this change, you will not see the JS error, and the video in the widget will load normally.

(Note that you will probably need to stop and start the build process for the webpack config change in this PR to take effect.)
