### PR TITLE
Onboarding: adding new FSE designs

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -382,6 +382,48 @@
 			"categories": [ "featured" ],
 			"is_premium": false,
 			"features": [ "anchorfm" ]
+		},
+		{
+			"title": "Vesta",
+			"slug": "vesta-blocks",
+			"template": "vesta-blocks",
+			"theme": "mayland-blocks",
+			"fonts": {
+				"headings": "Cabin",
+				"base": "Raleway"
+			},
+			"categories": [ "featured" ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Easley",
+			"slug": "easley-blocks",
+			"template": "easley-blocks",
+			"theme": "mayland-blocks",
+			"fonts": {
+				"headings": "Space Mono",
+				"base": "Roboto"
+			},
+			"categories": [ "featured" ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Mayland",
+			"slug": "mayland-blocks",
+			"template": "mayland-blocks",
+			"theme": "mayland-blocks",
+			"fonts": {
+				"headings": "Raleway",
+				"base": "Cabin"
+			},
+			"categories": [ "featured" ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
 		}
 	]
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

Adds the following designs to the onboarding flow for FSE sites: 

https://vestablockstarter.wordpress.com/
https://easleyblockstarter.wordpress.com
https://maylandblockstarter.wordpress.com/

See https://github.com/Automattic/wp-calypso/issues/51476

## Testing instructions

Apply D59752-code if it hasn't been deployed already.

Head over to `/new?flags=gutenboarding/site-editor`

Ensure that, for each site, you can:

1. See the thumbnail previews (note, we won't be able to see the preview images until D59752-code is deployed to production)
2. Create a new site. The content should match the starter sites.

Related to https://github.com/Automattic/wp-calypso/issues/51476
