### PR TITLE
Removes margin and shadow from collapsed view.

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -387,6 +387,14 @@ $font-size: rem( 14px );
 
 		.site__content {
 			padding: 10px 2px;
+
+			.count {
+				margin: 0;
+			}
+
+			.site__title::after {
+				display: none;
+			}
 		}
 
 		.site__home {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes margin from site count when sidebar is collapsed
* Removes shadow from site count when sidebar is collapsed

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `https://wordpress.com/stats/day`
* Collapse the sidebar
* Inspect the site count 

Before | After
-------|------
![](https://cln.sh/M9jHY0+) | ![](https://cln.sh/0M7yAy+)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #49036
