### PR TITLE
Happychat: remove usages of createReactClass

### DIFF
--- a/client/components/happychat/README.md
+++ b/client/components/happychat/README.md
@@ -17,8 +17,8 @@ function render() {
 
 ## Autoscroll
 
-Happychat uses the `./autoscroll.js` mixin to provide scroll-to-bottom functionality as chat messages are received.
+Happychat uses the `./autoscroll.js` hook and higher-order component to provide scroll-to-bottom functionality as chat messages are received.
 
 ## Scrollbleed
 
-Happychat uses the `./scrollbleed.js` mixin to prevent mousewheel scroll events from scrolling DOM nodes unexpectedly (e.g. scrolling the whole page once the end of the chat has been reached).
+Happychat uses the `./scrollbleed.js` hook and higher-order component to prevent `wheel` scroll events from scrolling DOM nodes unexpectedly (e.g. scrolling the whole page once the end of the chat has been reached).

--- a/client/components/happychat/composer.jsx
+++ b/client/components/happychat/composer.jsx
@@ -3,15 +3,15 @@
  */
 import classNames from 'classnames';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import { get, isEmpty, throttle } from 'lodash';
+import { isEmpty, throttle } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import FormTextarea from 'calypso/components/forms/form-textarea';
-import scrollbleed from './scrollbleed';
+import { withScrollbleed } from './scrollbleed';
 import { Button } from '@automattic/components';
 
 /**
@@ -30,12 +30,8 @@ const sendThrottledTyping = throttle(
 /*
  * Renders a textarea to be used to comopose a message for the chat.
  */
-// eslint-disable-next-line react/prefer-es6-class
-export const Composer = createReactClass( {
-	displayName: 'Composer',
-	mixins: [ scrollbleed ],
-
-	propTypes: {
+class Composer extends React.Component {
+	static propTypes = {
 		disabled: PropTypes.bool,
 		message: PropTypes.string,
 		onFocus: PropTypes.func,
@@ -44,47 +40,46 @@ export const Composer = createReactClass( {
 		onSendNotTyping: PropTypes.func,
 		onSetCurrentMessage: PropTypes.func,
 		translate: PropTypes.func, // localize HOC
-	},
+	};
 
-	onChange( event ) {
+	onChange = ( event ) => {
 		const { onSendTyping, onSendNotTyping, onSetCurrentMessage } = this.props;
 
-		const msg = get( event, 'target.value' );
+		const msg = event.target.value;
 		onSetCurrentMessage( msg );
 		isEmpty( msg ) ? onSendNotTyping() : sendThrottledTyping( onSendTyping, msg );
-	},
+	};
 
-	onKeyDown( event ) {
+	onKeyDown = ( event ) => {
 		const RETURN_KEYCODE = 13;
-		if ( get( event, 'which' ) === RETURN_KEYCODE ) {
+		if ( event.which === RETURN_KEYCODE ) {
 			event.preventDefault();
 			this.sendMessage();
 		}
-	},
+	};
 
-	sendMessage() {
+	sendMessage = () => {
 		const { message, onSendMessage, onSendNotTyping } = this.props;
 		if ( ! isEmpty( message ) ) {
 			onSendMessage( message );
 			onSendNotTyping();
 		}
-	},
+	};
 
 	render() {
 		const { disabled, message, onFocus, translate } = this.props;
-		const composerClasses = classNames( 'happychat__composer', {
-			'is-disabled': disabled,
-		} );
+		const composerClasses = classNames( 'happychat__composer', { 'is-disabled': disabled } );
+
 		return (
 			<div
 				className={ composerClasses }
-				onMouseEnter={ this.scrollbleedLock }
-				onMouseLeave={ this.scrollbleedUnlock }
+				onMouseEnter={ this.props.scrollbleed.lock }
+				onMouseLeave={ this.props.scrollbleed.unlock }
 			>
 				<div className="happychat__message">
 					<FormTextarea
 						aria-label="Enter your support request"
-						forwardedRef={ this.setScrollbleedTarget }
+						forwardedRef={ this.props.scrollbleed.setTarget }
 						onFocus={ onFocus }
 						placeholder={ translate( 'Type a message…' ) }
 						onChange={ this.onChange }
@@ -105,5 +100,7 @@ export const Composer = createReactClass( {
 				</Button>
 			</div>
 		);
-	},
-} );
+	}
+}
+
+export default localize( withScrollbleed( Composer ) );

--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -5,7 +5,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -34,10 +33,10 @@ import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open
 import isHappychatServerReachable from 'calypso/state/happychat/selectors/is-happychat-server-reachable';
 // UI components
 import HappychatConnection from './connection-connected';
-import { Title } from './title';
-import { Composer } from './composer';
-import { Notices } from './notices';
-import { Timeline } from './timeline';
+import Title from './title';
+import Composer from './composer';
+import Notices from './notices';
+import Timeline from './timeline';
 
 /**
  * Style dependencies
@@ -82,7 +81,6 @@ export class Happychat extends Component {
 			onSendTyping,
 			onSetCurrentMessage,
 			timeline,
-			translate,
 			twemojiUrl,
 		} = this.props;
 
@@ -95,20 +93,18 @@ export class Happychat extends Component {
 						'is-minimizing': isMinimizing,
 					} ) }
 				>
-					<Title onCloseChat={ this.onCloseChatTitle } translate={ translate } />
+					<Title onCloseChat={ this.onCloseChatTitle } />
 					<Timeline
 						currentUserEmail={ currentUserEmail }
 						isCurrentUser={ isCurrentUser }
 						isExternalUrl={ isExternalUrl }
 						timeline={ timeline }
-						translate={ translate }
 						twemojiUrl={ twemojiUrl }
 					/>
 					<Notices
 						chatStatus={ chatStatus }
 						connectionStatus={ connectionStatus }
 						isServerReachable={ isServerReachable }
-						translate={ translate }
 					/>
 					<Composer
 						disabled={ disabled }
@@ -117,7 +113,6 @@ export class Happychat extends Component {
 						onSendNotTyping={ onSendNotTyping }
 						onSendTyping={ onSendTyping }
 						onSetCurrentMessage={ onSetCurrentMessage }
-						translate={ translate }
 					/>
 				</div>
 			</div>
@@ -146,7 +141,6 @@ Happychat.propTypes = {
 	setBlurred: PropTypes.func,
 	setFocused: PropTypes.func,
 	timeline: PropTypes.array,
-	translate: PropTypes.func,
 	twemojiUrl: PropTypes.string,
 };
 
@@ -184,4 +178,4 @@ const mapDispatch = {
 	setFocused: focus,
 };
 
-export default connect( mapState, mapDispatch )( localize( Happychat ) );
+export default connect( mapState, mapDispatch )( Happychat );

--- a/client/components/happychat/notices.jsx
+++ b/client/components/happychat/notices.jsx
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -28,7 +29,14 @@ import './notices.scss';
 /*
  * Renders any notices about the chat session to the user
  */
-export class Notices extends Component {
+class Notices extends Component {
+	static propTypes = {
+		chatStatus: PropTypes.string,
+		connectionStatus: PropTypes.string,
+		isServerReachable: PropTypes.bool,
+		translate: PropTypes.func,
+	};
+
 	statusNotice() {
 		const { isServerReachable, connectionStatus, chatStatus, translate } = this.props;
 
@@ -86,9 +94,4 @@ export class Notices extends Component {
 	}
 }
 
-Notices.propTypes = {
-	chatStatus: PropTypes.string,
-	connectionStatus: PropTypes.string,
-	isServerReachable: PropTypes.bool,
-	translate: PropTypes.func,
-};
+export default localize( Notices );

--- a/client/components/happychat/scrollbleed.js
+++ b/client/components/happychat/scrollbleed.js
@@ -1,24 +1,15 @@
 /**
- * A mixin that prevents scrolling events triggered by the mousewheel from moving scrollable containers
- * not directly under the mouse.
- *
- * By default when scrolling a scrollable HTML element, once the boundary is reached the scrolling events
- * will continue up the DOM tree and ultimately end up scrolling the page.
- *
+ * External dependencies
  */
+import React, { useEffect, useState } from 'react';
+import { createHigherOrderComponent } from '@wordpress/compose';
 
-export default {
-	componentWillUnmount() {
-		this.scrollbleedUnlock();
-	},
+function createScrollbleed() {
+	let scrollbleedNode = null;
 
-	setScrollbleedTarget( node ) {
-		this._scrollbleed_node = node;
-	},
-
-	_scrollbleed_handleScroll( e ) {
+	function handleScroll( e ) {
 		let delta = null;
-		if ( ! this._scrollbleed_node ) {
+		if ( ! scrollbleedNode ) {
 			return;
 		}
 
@@ -50,24 +41,51 @@ export default {
 			}
 		}
 
-		this._scrollbleed_node.scrollTop -= delta;
-	},
+		scrollbleedNode.scrollTop -= delta;
+	}
 
-	scrollbleedLock() {
-		if ( window.addEventListener ) {
-			// older FF
-			window.addEventListener( 'DOMMouseScroll', this._scrollbleed_handleScroll, false );
-		}
-		window.onwheel = this._scrollbleed_handleScroll;
-		window.onmousewheel = document.onmousewheel = this._scrollbleed_handleScroll;
-	},
+	return {
+		setTarget( node ) {
+			scrollbleedNode = node;
+		},
+		lock() {
+			if ( window.addEventListener ) {
+				// older FF
+				window.addEventListener( 'DOMMouseScroll', handleScroll, false );
+			}
+			window.onwheel = handleScroll;
+			window.onmousewheel = document.onmousewheel = handleScroll;
+		},
+		unlock() {
+			if ( window.removeEventListener ) {
+				// older FF
+				window.removeEventListener( 'DOMMouseScroll', handleScroll, false );
+			}
+			window.onwheel = null;
+			window.onmousewheel = document.onmousewheel = null;
+		},
+	};
+}
+/**
+ * A hook that prevents scrolling events triggered by the mousewheel from moving scrollable containers
+ * not directly under the mouse.
+ *
+ * By default when scrolling a scrollable HTML element, once the boundary is reached the scrolling events
+ * will continue up the DOM tree and ultimately end up scrolling the page.
+ *
+ */
+export function useScrollbleed() {
+	const [ scrollbleed ] = useState( createScrollbleed );
 
-	scrollbleedUnlock() {
-		if ( window.removeEventListener ) {
-			// older FF
-			window.removeEventListener( 'DOMMouseScroll', this._scrollbleed_handleScroll, false );
-		}
-		window.onwheel = null;
-		window.onmousewheel = document.onmousewheel = null;
+	useEffect( () => scrollbleed.unlock, [ scrollbleed ] );
+
+	return scrollbleed;
+}
+
+export const withScrollbleed = createHigherOrderComponent(
+	( Wrapped ) => ( props ) => {
+		const scrollbleed = useScrollbleed();
+		return <Wrapped { ...props } scrollbleed={ scrollbleed } />;
 	},
-};
+	'WithScrollbleed'
+);

--- a/client/components/happychat/scrollbleed.js
+++ b/client/components/happychat/scrollbleed.js
@@ -49,20 +49,10 @@ function createScrollbleed() {
 			scrollbleedNode = node;
 		},
 		lock() {
-			if ( window.addEventListener ) {
-				// older FF
-				window.addEventListener( 'DOMMouseScroll', handleScroll, false );
-			}
-			window.onwheel = handleScroll;
-			window.onmousewheel = document.onmousewheel = handleScroll;
+			window.addEventListener( 'wheel', handleScroll, { passive: false } );
 		},
 		unlock() {
-			if ( window.removeEventListener ) {
-				// older FF
-				window.removeEventListener( 'DOMMouseScroll', handleScroll, false );
-			}
-			window.onwheel = null;
-			window.onmousewheel = document.onmousewheel = null;
+			window.removeEventListener( 'wheel', handleScroll );
 		},
 	};
 }

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -190,7 +190,7 @@
 	// be more specific in scope to override the panel mode
 	.layout.has-chat:not( .is-group-editor ):not( .is-section-theme ):not( .is-group-reader ):not( .has-no-sidebar ) .happychat__container.is-open {
 		position: fixed;
-		height: calc( 100% - 47px );
+		height: calc( 100% - var( --masterbar-height ) );
 		bottom: 0;
 		right: 0;
 		width: 272px;

--- a/client/components/happychat/test/composer.jsx
+++ b/client/components/happychat/test/composer.jsx
@@ -11,7 +11,7 @@ import { mount } from 'enzyme';
 /**
  * Internal dependencies
  */
-import { Composer } from '../composer';
+import Composer from '../composer';
 
 const noop = () => {};
 

--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -5,15 +5,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { isEmpty } from 'lodash';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { first, when } from './functional';
-import { withAutoscroll } from './autoscroll';
+import { useAutoscroll } from './autoscroll';
 import Emojify from 'calypso/components/emojify';
-import { withScrollbleed } from './scrollbleed';
+import { useScrollbleed } from './scrollbleed';
 import { addSchemeIfMissing, setUrlScheme } from './url';
 
 /**
@@ -193,30 +193,35 @@ const renderTimeline = ( {
 
 const chatTimeline = when( timelineHasContent, renderTimeline, welcomeMessage );
 
-class Timeline extends React.Component {
-	static propTypes = {
-		currentUserEmail: PropTypes.string,
-		isCurrentUser: PropTypes.func,
-		isExternalUrl: PropTypes.func,
-		timeline: PropTypes.array,
-		twemojiUrl: PropTypes.string,
-	};
+function Timeline( props ) {
+	const translate = useTranslate();
+	const autoscroll = useAutoscroll();
+	const scrollbleed = useScrollbleed();
 
-	static defaultProps = {
-		isExternalUrl: () => true,
-	};
-
-	onScrollContainer = ( el ) => {
-		this.props.autoscroll.setTarget( el );
-		this.props.scrollbleed.setTarget( el );
-	};
-
-	render() {
-		return chatTimeline( {
-			...this.props,
-			onScrollContainer: this.onScrollContainer,
-		} );
+	function onScrollContainer( el ) {
+		autoscroll.setTarget( el );
+		scrollbleed.setTarget( el );
 	}
+
+	return chatTimeline( {
+		...props,
+		translate,
+		autoscroll,
+		scrollbleed,
+		onScrollContainer,
+	} );
 }
 
-export default localize( withScrollbleed( withAutoscroll( Timeline ) ) );
+Timeline.propTypes = {
+	currentUserEmail: PropTypes.string,
+	isCurrentUser: PropTypes.func,
+	isExternalUrl: PropTypes.func,
+	timeline: PropTypes.array,
+	twemojiUrl: PropTypes.string,
+};
+
+Timeline.defaultProps = {
+	isExternalUrl: () => true,
+};
+
+export default Timeline;

--- a/client/components/happychat/title.jsx
+++ b/client/components/happychat/title.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import GridIcon from 'calypso/components/gridicon';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Style dependencies
@@ -12,13 +13,17 @@ import './title.scss';
 /*
  * React component for rendering title bar
  */
-export const Title = ( { onCloseChat, translate } ) => (
-	<div className="happychat__title">
-		<div className="happychat__active-toolbar">
-			<h4>{ translate( 'Support Chat' ) }</h4>
-			<div onClick={ onCloseChat }>
-				<GridIcon icon="cross" />
+export default function Title( { onCloseChat } ) {
+	const translate = useTranslate();
+
+	return (
+		<div className="happychat__title">
+			<div className="happychat__active-toolbar">
+				<h4>{ translate( 'Support Chat' ) }</h4>
+				<div onClick={ onCloseChat }>
+					<GridIcon icon="cross" />
+				</div>
 			</div>
 		</div>
-	</div>
-);
+	);
+}

--- a/client/me/happychat/main.jsx
+++ b/client/me/happychat/main.jsx
@@ -4,7 +4,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -24,9 +23,9 @@ import getHappychatTimeline from 'calypso/state/happychat/selectors/get-happycha
 import isHappychatServerReachable from 'calypso/state/happychat/selectors/is-happychat-server-reachable';
 // UI components
 import HappychatConnection from 'calypso/components/happychat/connection-connected';
-import { Composer } from 'calypso/components/happychat/composer';
-import { Notices } from 'calypso/components/happychat/notices';
-import { Timeline } from 'calypso/components/happychat/timeline';
+import Composer from 'calypso/components/happychat/composer';
+import Notices from 'calypso/components/happychat/notices';
+import Timeline from 'calypso/components/happychat/timeline';
 
 /**
  * Style dependencies
@@ -60,7 +59,6 @@ export class HappychatPage extends Component {
 			onSendTyping,
 			onSetCurrentMessage,
 			timeline,
-			translate,
 			twemojiUrl,
 		} = this.props;
 
@@ -72,14 +70,12 @@ export class HappychatPage extends Component {
 					isCurrentUser={ isCurrentUser }
 					isExternalUrl={ isExternalUrl }
 					timeline={ timeline }
-					translate={ translate }
 					twemojiUrl={ twemojiUrl }
 				/>
 				<Notices
 					chatStatus={ chatStatus }
 					connectionStatus={ connectionStatus }
 					isServerReachable={ isServerReachable }
-					translate={ translate }
 				/>
 				<Composer
 					disabled={ disabled }
@@ -88,7 +84,6 @@ export class HappychatPage extends Component {
 					onSendNotTyping={ onSendNotTyping }
 					onSendTyping={ onSendTyping }
 					onSetCurrentMessage={ onSetCurrentMessage }
-					translate={ translate }
 				/>
 			</div>
 		);
@@ -111,7 +106,6 @@ HappychatPage.propTypes = {
 	setBlurred: PropTypes.func,
 	setFocused: PropTypes.func,
 	timeline: PropTypes.array,
-	translate: PropTypes.func,
 	twemojiUrl: PropTypes.string,
 };
 
@@ -144,4 +138,4 @@ const mapDispatch = {
 	setFocused: focus,
 };
 
-export default connect( mapState, mapDispatch )( localize( HappychatPage ) );
+export default connect( mapState, mapDispatch )( HappychatPage );

--- a/client/package.json
+++ b/client/package.json
@@ -108,7 +108,6 @@
 		"cookie": "^0.4.0",
 		"cookie-parser": "^1.4.5",
 		"cpf_cnpj": "^0.2.0",
-		"create-react-class": "^15.6.3",
 		"creditcards": "^3.1.0",
 		"d3-array": "^2.4.0",
 		"d3-axis": "^1.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9162,15 +9162,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.3, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.6.3:
-  version "15.6.3"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
-  integrity sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 create-react-context@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
@@ -12069,7 +12060,7 @@ fbjs-css-vars@^1.0.0:
   resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
   integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
 
-fbjs@^0.8.0, fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.4:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=


### PR DESCRIPTION
Removes last two `createReactClass` usages from the Happychat UI components.

The `autoscroll` and `scrollbleed` mixins are converted to `useAutoscroll` and `useScrollbleed` hooks and `withAutoscroll` and `withScrollbleed` HOCs.

The scrollbleed behavior was broken on Chrome before this PR. Because Chrome treats `wheel` listeners as passive by default (https://www.chromestatus.com/features/6662647093133312), `e.preventDefault()` is treated as noop and scroll was not prevented. I fixed this by declaring the listener non-passive explicitly.

I also simplifed the implementation to use the `wheel` event only. It should work on all modern browsers.

Some drive-by cleanups:
- push `localize` down to individual components instead of passing `translate` prop from above
- remove several `lodash` usages
- fix alignment with unified masterbar which has a smaller height

After this PR, Calypso no longer uses the `create-react-class` legacy API and all React mixins are also gone 🎉 

**How to test:**
- open a testing Happychat session by logging in to hud-staging.happychat.io and chatting with yourself from Calypso development instance
- verify that scrolling inside Happychat timeline and edit box never scrolls the surrounding Calypso UI
- verify that after window resize, the Happychat timeline keeps being scrolled to bottom