### PR TITLE
Fixes collapsed state of upsell nudges.

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -402,17 +402,23 @@ $font-size: rem( 14px );
 			margin: 8px 3px 7px;
 		}
 
-		.current-site__notices > a::before {
-			content: '\f534';
-			font-family: 'dashicons';
-			/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
-			font-size: 20px;
-			line-height: 20px;
-			background-color: #a7aaad;
-			color: white;
-			/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
-			border-radius: 50%;
-			margin: 3px 0 3px 1px;
+		.current-site__notices > .banner {
+			&::before {
+				content: '\f534';
+				font-family: 'dashicons';
+				/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
+				font-size: 20px;
+				line-height: 20px;
+				background-color: #a7aaad;
+				color: white;
+				/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
+				border-radius: 50%;
+				margin: 3px 0 3px 1px;
+			}
+
+			&.is-dismissible .gridicon {
+				display: none;
+			}
 		}
 
 		.upsell-nudge.banner.card.is-compact .banner__content {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes how upsell nudges are shown in collapsed sidebar, by targeting `.banner` class instead of `a` element.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Steps to reproduce the behavior

1. Select a site with at least one custom domain
2. Clear any saved preferences
2. Check the `Add another domain` message
3. Hit **Collapse Menu**

Alternatively you may add this code block
```
<UpsellNudge
	callToAction={ 'test' }
	compact
	href={ `/domains/add/${ site.slug }` }
	onDismissClick={ this.props.clickDomainUpsellDismiss }
	dismissPreferenceName="test"
	event="test"
	forceDisplay={ true }
	horizontal={ true }
	title={ 'test' }
	tracksClickName="test"
	tracksClickProperties={ { cta_name: 'test' } }
	tracksImpressionName="test"
	tracksImpressionProperties={ { cta_name: 'test' } }
	tracksDismissName="test"
	tracksDismissProperties={ { cta_name: 'test' } }
/>
```
here https://github.com/Automattic/wp-calypso/blob/ed3e91545e431da92beeffcbe80289eadde067c0/client/my-sites/current-site/notice.jsx#L271-L305

Before | After
-------|------
![](https://cln.sh/P7kJ1Y+) | ![](https://cln.sh/UdxCv9+)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #49314
