### PR TITLE
FSE: remove Seedlet Blocks from onboarding flow

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -1,20 +1,6 @@
 {
 	"featured": [
 		{
-			"title": "Seedlet",
-			"slug": "seedlet-blocks",
-			"template": "seedlet-blocks",
-			"theme": "seedlet-blocks",
-			"fonts": {
-				"headings": "Playfair Display",
-				"base": "Fira Sans"
-			},
-			"categories": [ "featured" ],
-			"is_premium": false,
-			"is_fse": true,
-			"features": []
-		},
-		{
 			"title": "Twenty Twenty One",
 			"slug": "tt1-blocks",
 			"template": "tt1-blocks",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Seedlet Blocks hasn't seen much active development lately and is falling behind the Site Editor developments. We'd also like to reduce the number of options for internal testing and limit the options to just one theme/layout for now.

#### Testing instructions

1. Start the onboarding flow at http://calypso.localhost:3000/new?flags=gutenboarding/site-editor
2. Verify that Seedlet Blocks is no longer shown as an option. Only TT1-blocks should be visible.
3. http://calypso.localhost:3000/new should remain unchanged

