### PR TITLE
Adds persistence to sidebarIsCollapsed reducer.

### DIFF
--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -16,6 +16,12 @@
 		// client/assets/stylesheets/shared/_variables.scss
 		--masterbar-height: 32px;
 	}
+
+	&.is-sidebar-collapsed:not( .is-section-reader ):not( .is-section-me ) {
+		--sidebar-width-max: 36px;
+		--sidebar-width-min: 36px;
+	}
+
 	$nav-unification-primary: #23282d;
 	$nav-unification-secondary: #101517;
 	$nav-unification-masterbar-font-size: 13px;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -21,7 +21,12 @@ import QueryPreferences from 'calypso/components/data/query-preferences';
 import QuerySites from 'calypso/components/data/query-sites';
 import QuerySiteSelectedEditor from 'calypso/components/data/query-site-selected-editor';
 import { isOffline } from 'calypso/state/application/selectors';
-import { getSelectedSiteId, masterbarIsVisible, getSelectedSite } from 'calypso/state/ui/selectors';
+import {
+	getSelectedSiteId,
+	masterbarIsVisible,
+	getSelectedSite,
+	getSidebarIsCollapsed,
+} from 'calypso/state/ui/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
@@ -51,6 +56,7 @@ import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { getShouldShowAppBanner, handleScroll } from './utils';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import { useBreakpoint } from '@automattic/viewport-react';
+import { isWithinBreakpoint } from '@automattic/viewport';
 
 /**
  * Style dependencies
@@ -222,11 +228,15 @@ class Layout extends Component {
 			if ( this.props.isNavUnificationEnabled ) {
 				bodyClass.push( 'is-nav-unification' );
 			}
+
+			if ( this.props.sidebarIsCollapsed && isWithinBreakpoint( '>800px' ) ) {
+				bodyClass.push( 'is-sidebar-collapsed' );
+			}
+
 			return {
 				bodyClass,
 			};
 		};
-
 		const { shouldShowAppBanner } = this.props;
 
 		const loadInlineHelp = this.shouldLoadInlineHelp();
@@ -402,6 +412,7 @@ export default compose(
 			isNewLaunchFlow,
 			isCheckoutFromGutenboarding,
 			isNavUnificationEnabled: isNavUnificationEnabled( state ),
+			sidebarIsCollapsed: getSidebarIsCollapsed( state ),
 		};
 	} )
 )( Layout );

--- a/client/my-sites/sidebar-unified/collapse-sidebar.jsx
+++ b/client/my-sites/sidebar-unified/collapse-sidebar.jsx
@@ -6,10 +6,9 @@
 /**
  * External dependencies
  */
-import React, { useLayoutEffect } from 'react';
+import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { isWithinBreakpoint } from '@automattic/viewport';
 
 /**
  * Internal dependencies
@@ -23,22 +22,6 @@ import TranslatableString from 'calypso/components/translatable/proptype';
 export const CollapseSidebar = ( { title, icon } ) => {
 	const reduxDispatch = useDispatch();
 	const sidebarIsCollapsed = useSelector( getSidebarIsCollapsed );
-	const collapsed = sidebarIsCollapsed && isWithinBreakpoint( '>800px' );
-
-	useLayoutEffect( () => {
-		// Adding / removing clear-secondary-layout-transitions is a workaround to avoid site-selector being transitioning while expanding the sidebar (client/my-sites/sidebar-unified/style.scss).
-		collapsed
-			? document.body.classList.add( 'is-sidebar-collapsed', 'clear-secondary-layout-transitions' )
-			: document.body.classList.remove( 'is-sidebar-collapsed' );
-
-		// Needs to be queued for removal after is-sidebar-collapsed is removed
-		if ( ! collapsed ) {
-			const timer = setTimeout( () => {
-				document.body.classList.remove( 'clear-secondary-layout-transitions' );
-			} );
-			return () => clearTimeout( timer );
-		}
-	}, [ collapsed ] );
 
 	return (
 		<SidebarItem

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -26,11 +26,6 @@
 	--color-sidebar-submenu-hover-text: #00b9eb;
 	--color-sidebar-submenu-selected-background: transparent;
 	--color-sidebar-submenu-selected-text: white;
-
-	&.is-sidebar-collapsed:not( .is-section-reader ):not( .is-section-me ) {
-		--sidebar-width-max: 36px;
-		--sidebar-width-min: 36px;
-	}
 }
 
 // Local Vars

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -9,7 +9,7 @@ import {
 	SIDEBAR_TOGGLE_VISIBILITY,
 	NOTIFICATIONS_PANEL_TOGGLE,
 } from 'calypso/state/action-types';
-import { combineReducers, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers, withoutPersistence, withPersistence } from 'calypso/state/utils';
 import actionLog from './action-log/reducer';
 import checkout from './checkout/reducer';
 import language from './language/reducer';
@@ -87,12 +87,12 @@ export const isNotificationsOpen = function ( state = false, { type } ) {
  * @returns {object}        Updated state
  */
 
-export const sidebarIsCollapsed = ( state = false, { type, collapsed } ) => {
+export const sidebarIsCollapsed = withPersistence( ( state = false, { type, collapsed } ) => {
 	if ( SIDEBAR_TOGGLE_VISIBILITY === type ) {
 		return collapsed;
 	}
 	return state;
-};
+} );
 
 const reducer = combineReducers( {
 	actionLog,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds the sidebarIsCollapsed in the persisted Indexed DB.
* Moves JS adding the class and CSS to files that don't load async so that there aren't any layout shifts https://github.com/Automattic/wp-calypso/issues/51703#issuecomment-814169800

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Changing the collapse state should change the Indexed DB value (needs refresh)
![](https://cln.sh/FGeCVs+)
* Changing the collapse state and refreshing the page should reflect the last state selected

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #51703
