### PR TITLE
Media: Fix date handling in media item groups

### DIFF
--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -151,8 +151,13 @@ export class MediaLibraryList extends React.Component {
 		return this.props.moment( date ).format( 'LL' );
 	};
 
-	getItemGroup = ( item ) =>
-		Math.min( item.date.slice( 0, 10 ), this.props.moment( new Date() ).format( 'YYYY-MM-DD' ) );
+	getItemGroup = ( item ) => {
+		const minDate = Math.min(
+			new Date( item.date.slice( 0, 10 ) ).getTime(),
+			new Date().getTime()
+		);
+		return this.props.moment( minDate ).format( 'YYYY-MM-DD' );
+	};
 
 	renderItem = ( item ) => {
 		const index = findIndex( this.props.media, { ID: item.ID } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a bug with how we're handling dates for media item groups. That bug was introduced in #51681.

#### Testing instructions

* Go to `/media/images/:site` for a site where you have some media
* Verify dates for each group appear well.
