### PR TITLE
Top bar: Spacing tweaks to match front end

### DIFF
--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -20,6 +20,11 @@
 	$nav-unification-secondary: #101517;
 	$nav-unification-masterbar-font-size: 13px;
 
+	// breakpoint used in wp-admin
+	@media only screen and ( max-width: 782px ) {
+		$nav-unification-masterbar-font-size: 14px;
+	}
+
 	// packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
 	--color-masterbar-background: #101517;
 	--color-masterbar-border: #333;
@@ -43,6 +48,20 @@
 	}
 
 	// client/layout/masterbar/style.scss
+	@media only screen and ( max-width: 782px ) {
+		.masterbar__item .gridicon + .masterbar__item-content {
+			padding-left: 8px;
+		}
+	}
+
+	// breakpoint used in wp-admin
+	@media only screen and ( max-width: 782px ) {
+		.masterbar__item {
+			padding: 0 15px;
+		}
+	}
+
+	// client/layout/masterbar/style.scss
 	.masterbar__item-bubble {
 		top: calc( 50% - 14px );
 		left: -7px;
@@ -52,13 +71,15 @@
 	.masterbar__item-new,
 	.masterbar__toggle-drafts.button.is-borderless {
 		height: 24px;
-		margin: 4px 8px;
+		margin: 4px 6px 4px 8px;
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 5px;
 	}
 
 	.masterbar__item-new {
 		padding: 0 10px;
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		font-size: 13px; /* visual parity with front-end top bar */
 
 		&:hover {
 			background: #e9e9ea;
@@ -78,6 +99,13 @@
 		}
 	}
 
+	// breakpoint used in wp-admin
+	@media only screen and ( max-width: 782px ) {
+		.masterbar__item-new {
+			padding: 0 15px;
+		}
+	}
+
 	.masterbar__toggle-drafts.button.is-borderless {
 		margin-left: -20px;
 
@@ -93,13 +121,24 @@
 
 	// client/layout/masterbar/style.scss
 	.masterbar__item-me {
-		padding-right: 8px;
+		padding-right: 10px;
 		padding-left: 8px;
 
 		.gravatar {
 			top: 50%;
 			left: 50%;
 			transform: translate( -50%, -50% );
+		}
+	}
+	// breakpoint used in wp-admin
+	@media only screen and ( max-width: 782px ) {
+		.masterbar__item-me {
+			padding: 0 15px;
+
+			.gravatar {
+				width: 22px;
+				height: 22px;
+			}
 		}
 	}
 
@@ -109,6 +148,12 @@
 
 		.gridicon {
 			margin-top: 1px;
+		}
+	}
+	// breakpoint used in wp-admin
+	@media only screen and ( max-width: 782px ) {
+		.masterbar__item-notifications {
+			padding: 0 15px;
 		}
 	}
 

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -100,7 +100,7 @@
 	.masterbar__item-new,
 	.masterbar__toggle-drafts.button.is-borderless {
 		height: 24px;
-		margin: 4px 6px 4px 8px;
+		margin: 4px 8px;
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 5px;
 	}

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -52,6 +52,10 @@
 		.masterbar__item .gridicon + .masterbar__item-content {
 			padding-left: 8px;
 		}
+
+		.masterbar__reader .gridicon + .masterbar__item-content {
+			padding-left: 6px;
+		}
 	}
 
 	// breakpoint used in wp-admin
@@ -133,11 +137,20 @@
 	// breakpoint used in wp-admin
 	@media only screen and ( max-width: 782px ) {
 		.masterbar__item-me {
-			padding: 0 15px;
+			padding: 0 13px 0 15px;
 
 			.gravatar {
 				width: 22px;
 				height: 22px;
+			}
+		}
+	}
+
+	@include breakpoint-deprecated( '<480px' ) {
+		.masterbar__item-me {
+			.gravatar {
+				width: 19px;
+				height: 19px;
 			}
 		}
 	}
@@ -153,9 +166,23 @@
 	// breakpoint used in wp-admin
 	@media only screen and ( max-width: 782px ) {
 		.masterbar__item-notifications {
+			margin-right: 10px;
 			padding: 0 15px;
+			width: 26px;
+
+			.gridicon {
+				flex-shrink: 0;
+			}
 		}
 	}
+
+	@include breakpoint-deprecated( '<480px' ) {
+		.masterbar__item-notifications {
+			margin-left: auto;
+			margin-right: auto;
+		}
+	}
+	
 
 	// client/layout/masterbar/style.scss
 	.masterbar__item-notifications .masterbar__notifications-bubble {
@@ -186,8 +213,17 @@
 		// client/layout/masterbar/style.scss
 		.masterbar__item-new,
 		.masterbar__toggle-drafts.button.is-borderless {
-			height: 36px;
-			margin-top: 5px;
+			height: 34px;
+			margin-top: 6px;
+		}
+
+		// breakpoint used in wp-admin
+		@media screen and ( max-width: 782px ) {
+			.masterbar__item-new,
+			.masterbar__toggle-drafts.button.is-borderless {
+				margin-right: 9px;
+				padding: 0 16px 0 14px;
+			}
 		}
 
 		// client/layout/masterbar/style.scss

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -169,6 +169,9 @@
 			// fix for profile picture currently hidden in production
 			.masterbar__item-content {
 				display: block;
+			}
+
+			.gridicon {
 				position: relative;
 				left: 4px;
 			}
@@ -182,7 +185,7 @@
 
 	@include breakpoint-deprecated( '<480px' ) {
 		.masterbar__item-me {
-			padding: 0 15px;
+			padding: 0 11px;
 
 			.gravatar {
 				width: 19px;
@@ -227,6 +230,7 @@
 
 	@include breakpoint-deprecated( '<480px' ) {
 		.masterbar__item-notifications {
+			margin-top: 0;
 			margin-left: auto;
 			margin-right: auto;
 			padding: 0 8px;

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -32,6 +32,7 @@
 		border-right: none;
 	}
 
+	// General Top bar styles
 	// client/layout/masterbar/style.scss
 	.masterbar {
 		font-size: $nav-unification-masterbar-font-size;
@@ -44,13 +45,15 @@
 	}
 
 	// client/layout/masterbar/style.scss
-	@media only screen and ( max-width: 782px ) {
-		.masterbar__item .gridicon + .masterbar__item-content {
-			padding-left: 8px;
-		}
+	.masterbar__item-bubble {
+		top: calc( 50% - 14px );
+		left: -7px;
+	}
 
-		.masterbar__reader .gridicon + .masterbar__item-content {
-			padding-left: 6px;
+	// client/layout/masterbar/style.scss
+	@include breakpoint-deprecated( '<480px' ) {
+		.masterbar__item-bubble {
+			left: calc( 50% - 14px );
 		}
 	}
 
@@ -60,14 +63,17 @@
 			font-size: $nav-unification-masterbar-mobile-font-size;
 			padding: 0 15px;
 		}
+
+		.masterbar__item .gridicon + .masterbar__item-content {
+			padding-left: 8px;
+		}
+
+		.masterbar__reader .gridicon + .masterbar__item-content {
+			padding-left: 6px;
+		}
 	}
 
-	// client/layout/masterbar/style.scss
-	.masterbar__item-bubble {
-		top: calc( 50% - 14px );
-		left: -7px;
-	}
-
+	// New post button
 	.masterbar__item-new {
 		padding: 0 10px;
 		font-size: $nav-unification-masterbar-font-size;
@@ -133,8 +139,11 @@
 		.masterbar__toggle-drafts.button.is-borderless {
 			height: 36px;
 			margin-top: 5px;
+			width: auto;
 		}
 	}
+
+	// Account button
 
 	// client/layout/masterbar/style.scss
 	.masterbar__item-me {
@@ -166,6 +175,8 @@
 
 	@include breakpoint-deprecated( '<480px' ) {
 		.masterbar__item-me {
+			padding: 0 15px;
+
 			.gravatar {
 				width: 19px;
 				height: 19px;
@@ -173,6 +184,7 @@
 		}
 	}
 
+	// Notifications button
 	.masterbar__item-notifications {
 		padding-right: 5px;
 		padding-left: 5px;
@@ -181,6 +193,13 @@
 			margin-top: 1px;
 		}
 	}
+
+	// client/layout/masterbar/style.scss
+	.masterbar__item-notifications .masterbar__notifications-bubble {
+		top: 3px;
+		transform: translateX( 1px );
+	}
+
 	// breakpoint used in wp-admin
 	@media only screen and ( max-width: 782px ) {
 		.masterbar__item-notifications {
@@ -192,25 +211,19 @@
 				flex-shrink: 0;
 			}
 		}
+
+		// client/layout/masterbar/style.scss
+		.masterbar__item-notifications .masterbar__notifications-bubble {
+			top: 10px;
+		}
 	}
 
 	@include breakpoint-deprecated( '<480px' ) {
 		.masterbar__item-notifications {
 			margin-left: auto;
 			margin-right: auto;
-		}
-	}
-
-	// client/layout/masterbar/style.scss
-	.masterbar__item-notifications .masterbar__notifications-bubble {
-		top: 3px;
-		transform: translateX( 1px );
-	}
-
-	// client/layout/masterbar/style.scss
-	@include breakpoint-deprecated( '>960px' ) {
-		.masterbar__toggle-drafts.button.is-borderless {
-			margin-left: -23px;
+			padding: 0 8px;
+			width: auto;
 		}
 	}
 
@@ -225,18 +238,6 @@
 		.layout.focus-sites:not( .is-section-post-editor ) .layout__primary .main,
 		.layout.focus-sidebar:not( .is-section-post-editor ) .layout__primary .main {
 			transform: translateX( 100% );
-		}
-
-		// client/layout/masterbar/style.scss
-		.masterbar__item-notifications .masterbar__notifications-bubble {
-			top: 10px;
-		}
-	}
-
-	// client/layout/masterbar/style.scss
-	@include breakpoint-deprecated( '<480px' ) {
-		.masterbar__item-bubble {
-			left: calc( 50% - 14px );
 		}
 	}
 }

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -68,15 +68,6 @@
 		left: -7px;
 	}
 
-	// client/layout/masterbar/style.scss
-	.masterbar__item-new,
-	.masterbar__toggle-drafts.button.is-borderless {
-		height: 24px;
-		margin: 4px 6px 4px 8px;
-		/* stylelint-disable-next-line scales/radii */
-		border-radius: 5px;
-	}
-
 	.masterbar__item-new {
 		padding: 0 10px;
 		font-size: $nav-unification-masterbar-font-size;
@@ -99,18 +90,13 @@
 		}
 	}
 
-	// breakpoint used in wp-admin
-	@media only screen and ( max-width: 782px ) {
-		.masterbar__item-new {
-			padding: 0 15px;
-		}
-	}
-
-	@include breakpoint-deprecated( '<480px' ) {
-		.masterbar__item-new {
-			height: 36px;
-			margin-top: 5px;
-		}
+	// client/layout/masterbar/style.scss
+	.masterbar__item-new,
+	.masterbar__toggle-drafts.button.is-borderless {
+		height: 24px;
+		margin: 4px 6px 4px 8px;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 5px;
 	}
 
 	.masterbar__toggle-drafts.button.is-borderless {
@@ -123,6 +109,30 @@
 				border-color: $nav-unification-primary;
 				color: $nav-unification-primary;
 			}
+		}
+	}
+
+	// breakpoint used in wp-admin
+	@media only screen and ( max-width: 782px ) {
+		.masterbar__item-new,
+		.masterbar__toggle-drafts.button.is-borderless {
+			height: 34px;
+			margin-top: 6px;
+			margin-right: 9px;
+			padding: 0 16px 0 14px;
+		}
+
+		.masterbar__toggle-drafts.button.is-borderless {
+			padding: 0 14px 0 8px;
+			margin-left: -26px;
+		}
+	}
+
+	@include breakpoint-deprecated( '<480px' ) {
+		.masterbar__item-new,
+		.masterbar__toggle-drafts.button.is-borderless {
+			height: 36px;
+			margin-top: 5px;
 		}
 	}
 
@@ -141,6 +151,11 @@
 	@media only screen and ( max-width: 782px ) {
 		.masterbar__item-me {
 			padding: 0 13px 0 15px;
+
+			// fix for profile picture currently hidden in production
+			.masterbar__item-content {
+				display: block;
+			}
 
 			.gravatar {
 				width: 22px;
@@ -185,7 +200,6 @@
 			margin-right: auto;
 		}
 	}
-	
 
 	// client/layout/masterbar/style.scss
 	.masterbar__item-notifications .masterbar__notifications-bubble {
@@ -211,30 +225,6 @@
 		.layout.focus-sites:not( .is-section-post-editor ) .layout__primary .main,
 		.layout.focus-sidebar:not( .is-section-post-editor ) .layout__primary .main {
 			transform: translateX( 100% );
-		}
-
-		// client/layout/masterbar/style.scss
-		.masterbar__item-new,
-		.masterbar__toggle-drafts.button.is-borderless {
-			height: 34px;
-			margin-top: 6px;
-		}
-
-		// breakpoint used in wp-admin
-		@media screen and ( max-width: 782px ) {
-			.masterbar__item-new,
-			.masterbar__toggle-drafts.button.is-borderless {
-				margin-right: 9px;
-				padding: 0 16px 0 14px;
-			}
-		}
-
-		// client/layout/masterbar/style.scss
-		.masterbar__item-me {
-			// fix for profile picture currently hidden in production
-			.masterbar__item-content {
-				display: block;
-			}
 		}
 
 		// client/layout/masterbar/style.scss

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -19,11 +19,7 @@
 	$nav-unification-primary: #23282d;
 	$nav-unification-secondary: #101517;
 	$nav-unification-masterbar-font-size: 13px;
-
-	// breakpoint used in wp-admin
-	@media only screen and ( max-width: 782px ) {
-		$nav-unification-masterbar-font-size: 14px;
-	}
+	$nav-unification-masterbar-mobile-font-size: 14px;
 
 	// packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
 	--color-masterbar-background: #101517;
@@ -61,6 +57,7 @@
 	// breakpoint used in wp-admin
 	@media only screen and ( max-width: 782px ) {
 		.masterbar__item {
+			font-size: $nav-unification-masterbar-mobile-font-size;
 			padding: 0 15px;
 		}
 	}

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -79,8 +79,7 @@
 
 	.masterbar__item-new {
 		padding: 0 10px;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		font-size: 13px; /* visual parity with front-end top bar */
+		font-size: $nav-unification-masterbar-font-size;
 
 		&:hover {
 			background: #e9e9ea;
@@ -104,6 +103,13 @@
 	@media only screen and ( max-width: 782px ) {
 		.masterbar__item-new {
 			padding: 0 15px;
+		}
+	}
+
+	@include breakpoint-deprecated( '<480px' ) {
+		.masterbar__item-new {
+			height: 36px;
+			margin-top: 5px;
 		}
 	}
 

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -140,6 +140,11 @@
 			height: 36px;
 			margin-top: 5px;
 			width: auto;
+			padding: 0 8px;
+		}
+
+		.masterbar__toggle-drafts.button.is-borderless {
+			margin-left: -18px;
 		}
 	}
 
@@ -164,6 +169,8 @@
 			// fix for profile picture currently hidden in production
 			.masterbar__item-content {
 				display: block;
+				position: relative;
+				left: 4px;
 			}
 
 			.gravatar {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Lots of minor spacing tweaks to the top bar for closer visual alignment with the front end
* Rearranged the top bar portions of the stylesheet because I couldn't keep track of where I was otherwise. :P 

You'll notice that in some cases the top bar is still not a 1:1 replica between Calypso and the front end; I didn't want to go down the rabbit hole of pixel-perfection, this should iron out the most obvious kinks. If we want 100% visual parity I can continue picking away at pixels. :) 

**Visual differences by screen size**

The front end toolbar has not changed in this PR; I only include the images for comparison

* **Small - few differences before and after**

Before

<img width="660" alt="Screen Shot 2021-04-07 at 12 17 07 PM" src="https://user-images.githubusercontent.com/2124984/113900782-308a6280-979c-11eb-821d-e8ff98d0d650.png">

After

<img width="659" alt="Screen Shot 2021-04-07 at 12 17 01 PM" src="https://user-images.githubusercontent.com/2124984/113900812-384a0700-979c-11eb-8b88-4cc13ce6c4b0.png">

Front end

<img width="666" alt="Screen Shot 2021-04-07 at 12 16 54 PM" src="https://user-images.githubusercontent.com/2124984/113900692-19e40b80-979c-11eb-9200-2a686871570e.png">


* **Medium - most notable differences before and after, particularly around padding/spacing**

Before
<img width="1154" alt="Screen Shot 2021-04-07 at 11 11 46 AM" src="https://user-images.githubusercontent.com/2124984/113900525-e86b4000-979b-11eb-8fac-bed036635178.png">

After
<img width="1147" alt="Screen Shot 2021-04-07 at 11 11 57 AM" src="https://user-images.githubusercontent.com/2124984/113900556-f0c37b00-979b-11eb-9d8d-45117c24f699.png">

Front end
<img width="1143" alt="Screen Shot 2021-04-07 at 11 12 05 AM" src="https://user-images.githubusercontent.com/2124984/113900578-f6b95c00-979b-11eb-8ed4-22fbdf55d5ba.png">

* **Large - should be barely any differences before and after**

Before

<img width="1665" alt="Screen Shot 2021-04-07 at 12 18 09 PM" src="https://user-images.githubusercontent.com/2124984/113900994-69c2d280-979c-11eb-8948-0e6e1790a015.png">

After

<img width="1665" alt="Screen Shot 2021-04-07 at 12 18 29 PM" src="https://user-images.githubusercontent.com/2124984/113901033-72b3a400-979c-11eb-8b0f-6cc90d391831.png">

Front end

<img width="1666" alt="Screen Shot 2021-04-07 at 12 25 23 PM" src="https://user-images.githubusercontent.com/2124984/113900926-56176c00-979c-11eb-9837-48de8a8a763f.png">


#### Testing instructions

* Switch to this PR
* Check out the top bar in Calypso on multiple pages, multiple devices, multiple screen sizes. Any edge cases I've missed? Anything that looks visibly broken?

Related to #49154
