### PR TITLE
Remove Security Realtime in most popular section experiment

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -59,13 +59,4 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: false,
 	},
-	pricingPagePopularProducts: {
-		datestamp: '20210324',
-		variations: {
-			withComplete_control: 50,
-			withSecurityRT_test: 50,
-		},
-		defaultVariation: 'withComplete_control',
-		allowExistingUsers: true,
-	},
 };

--- a/client/my-sites/plans/jetpack-plans/iterations.ts
+++ b/client/my-sites/plans/jetpack-plans/iterations.ts
@@ -1,16 +1,13 @@
 /**
  * Internal dependencies
  */
-import { abtest } from 'calypso/lib/abtest';
 import { getUrlParts } from 'calypso/lib/url/url-parts';
 
 /**
  * Iterations
  */
 
-export enum Iterations {
-	SECURITY = 'securityPopularProducts',
-}
+export enum Iterations {}
 
 const iterationNames: string[] = Object.values( Iterations );
 
@@ -41,9 +38,7 @@ const getCurrentCROIterationName = (): Iterations | null => {
 		}
 	}
 
-	return abtest( 'pricingPagePopularProducts' ) === 'withSecurityRT_test'
-		? Iterations.SECURITY
-		: null;
+	return null;
 };
 
 type IterationValueFunction< T > = ( key: Iterations | null ) => T | undefined;

--- a/client/my-sites/plans/jetpack-plans/product-grid/products-order.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/products-order.ts
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { getForCurrentCROIteration, Iterations } from '../iterations';
 import {
 	PLAN_JETPACK_SECURITY_DAILY,
 	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
@@ -45,27 +44,5 @@ const PRODUCT_POSITION_IN_GRID: Record< string, number > = {
 	...setProductsInPosition( JETPACK_CRM_FREE_PRODUCTS, 80 ),
 };
 
-const PRODUCT_POSITION_IN_GRID_SECURITY: Record< string, number > = {
-	[ PRODUCT_JETPACK_BACKUP_DAILY ]: 1,
-	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: 1,
-	[ PLAN_JETPACK_SECURITY_DAILY ]: 10,
-	[ PLAN_JETPACK_SECURITY_DAILY_MONTHLY ]: 10,
-	[ PLAN_JETPACK_SECURITY_REALTIME ]: 20,
-	[ PLAN_JETPACK_SECURITY_REALTIME_MONTHLY ]: 20,
-	...setProductsInPosition( JETPACK_COMPLETE_PLANS, 30 ),
-	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: 40,
-	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: 40,
-	...setProductsInPosition( JETPACK_SCAN_PRODUCTS, 50 ),
-	...setProductsInPosition( JETPACK_ANTI_SPAM_PRODUCTS, 60 ),
-	...setProductsInPosition( JETPACK_SEARCH_PRODUCTS, 70 ),
-	...setProductsInPosition( JETPACK_CRM_FREE_PRODUCTS, 80 ),
-};
-
-export const getProductPosition = ( slug: JetpackPlanSlugs | JetpackProductSlug ): number => {
-	const positions =
-		getForCurrentCROIteration( {
-			[ Iterations.SECURITY ]: PRODUCT_POSITION_IN_GRID_SECURITY,
-		} ) || PRODUCT_POSITION_IN_GRID;
-
-	return positions[ slug ] ?? 100;
-};
+export const getProductPosition = ( slug: JetpackPlanSlugs | JetpackProductSlug ): number =>
+	PRODUCT_POSITION_IN_GRID[ slug ] ?? 100;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR removes the experiment that put Security products in the Most popular section of the pricing page in cloud.

See 1196108640073826-as-1199946500089743.

### Testing instructions

- Download the PR and run Calypso
- Make sure the A/B test menu doesn't show the `pricingPagePopularProducts` experiment (see capture below)
- Visit the plans page
- Make sure it looks and behaves as the `withComplete_control` variation in production (checking the product order should be enough)

### Screenshots

_A/B test menu_
<img width="343" alt="Screen Shot 2021-04-06 at 5 10 21 PM" src="https://user-images.githubusercontent.com/1620183/113778824-dc7b7180-96fa-11eb-8169-4b4124e85c37.png">


