### PR TITLE
Remove app builds from unit test suite

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -539,22 +539,6 @@ object RunAllUnitTests : BuildType({
 			"""
 		}
 		bashNodeScript {
-			name = "Build artifacts"
-			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
-			scriptContent = """
-				export NODE_ENV="production"
-
-				# Build o2-blocks
-				(cd apps/o2-blocks/ && yarn build --output-path="../../artifacts/o2-blocks")
-
-				# Build wpcom-block-editor
-				(cd apps/wpcom-block-editor/ &&  NODE_ENV=development yarn build --output-path="../../artifacts/wpcom-block-editor")
-
-				# Build notifications
-				(cd apps/notifications/ && yarn build --output-path="../../artifacts/notifications")
-			"""
-		}
-		bashNodeScript {
 			name = "Build components storybook"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = """


### PR DESCRIPTION
#### Changes proposed in this Pull Request
These are now covered by the wpcom app builds so they can be removed.

#### Testing instructions
- [ ] Unit test suite should pass