### PR TITLE
Add team calypso platform to all renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,7 @@
 		{
 			"extends": "monorepo:wordpress",
 			"separateMajorMinor": false,
-			"prPriority": 2,
-			"reviewers": [ "team:@Automattic/cylon", "team:@Automattic/ganon", "team:@Automattic/luna" ]
+			"prPriority": 2
 		},
 		{
 			"extends": "monorepo:babel",
@@ -43,12 +42,6 @@
 		{
 			"extends": "monorepo:storybook",
 			"prPriority": 1
-		},
-		{
-			"paths": [ "apps/editing-toolkit/package.json" ],
-			"packageName": "newspack-blocks",
-			"reviewers": [ "team:@Automattic/create", "team:@Automattic/ajax" ],
-			"groupName": "Newspack Blog Posts Block Update"
 		}
 	],
 	"statusCheckVerify": true,
@@ -65,5 +58,6 @@
 	"semanticCommits": true,
 	"semanticCommitType": "chore",
 	"masterIssue": true,
-	"masterIssueTitle": "Renovate Dependency Updates"
+	"masterIssueTitle": "Renovate Dependency Updates",
+	"reviewers": [ "team:@Automattic/team-calypso" ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -59,5 +59,5 @@
 	"semanticCommitType": "chore",
 	"masterIssue": true,
 	"masterIssueTitle": "Renovate Dependency Updates",
-	"reviewers": [ "team:@Automattic/team-calypso" ]
+	"reviewers": [ "team:@Automattic/team-calypso-platform" ]
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
I've noticed that team calypso is not being added for renovate PRs. For example: #51724, and #51723. I believe renovate is actually not adding _anyone_ to PRs. It just "looks" like it is because GitHub codeowners formats it like `renovate bot requested a review from Automattic/shilling as a code owner`. 

This leads me to think that something else might be wrong, and this might not fix the problem. All of the sections of the config that I removed were not doing anything anyways.

Alternative ideas:
- use `additionalReviewers` instead to see if that fixes the problem
- does removing the `@` symbol make it work?
- Should we just be codeowners on the root package.json?

#### Testing instructions
🤷 not sure 
