### PR TITLE
build: Disable babel cache compression

### DIFF
--- a/client/webpack.config.desktop.js
+++ b/client/webpack.config.desktop.js
@@ -43,6 +43,7 @@ module.exports = {
 				configFile: path.resolve( 'babel.config.js' ),
 				cacheDirectory,
 				cacheIdentifier,
+				cacheCompression: false,
 				exclude: /node_modules\//,
 			} ),
 			TranspileConfig.loader( {
@@ -50,6 +51,7 @@ module.exports = {
 				presets: [ require.resolve( '@automattic/calypso-build/babel/dependencies' ) ],
 				cacheDirectory,
 				cacheIdentifier,
+				cacheCompression: false,
 				include: shouldTranspileDependency,
 			} ),
 			{

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -220,6 +220,7 @@ const webpackConfig = {
 				configFile: path.resolve( 'babel.config.js' ),
 				cacheDirectory: path.resolve( cachePath, 'babel-client' ),
 				cacheIdentifier,
+				cacheCompression: false,
 				exclude: /node_modules\//,
 			} ),
 			TranspileConfig.loader( {
@@ -227,6 +228,7 @@ const webpackConfig = {
 				presets: [ require.resolve( '@automattic/calypso-build/babel/dependencies' ) ],
 				cacheDirectory: path.resolve( cachePath, 'babel-client' ),
 				cacheIdentifier,
+				cacheCompression: false,
 				include: shouldTranspileDependency,
 			} ),
 			SassConfig.loader( {

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -113,6 +113,7 @@ const webpackConfig = {
 				configFile: path.resolve( 'babel.config.js' ),
 				cacheDirectory,
 				cacheIdentifier,
+				cacheCompression: false,
 				exclude: /node_modules\//,
 			} ),
 			TranspileConfig.loader( {
@@ -120,6 +121,7 @@ const webpackConfig = {
 				presets: [ require.resolve( '@automattic/calypso-build/babel/dependencies' ) ],
 				cacheDirectory,
 				cacheIdentifier,
+				cacheCompression: false,
 				include: shouldTranspileDependency,
 			} ),
 			fileLoader,

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -10,6 +10,7 @@
   Instead they will fallback to the [default resolution methods from browserslist](https://github.com/browserslist/browserslist#queries)
 - Breaking: `webpack/minify` API has changed. Now it only accepts 4 options: `terserOptions`, `cssMinimizerOptions`, `parallel` and `extractComments`.
 - Added: `webpack/minify` will use CssMinimizerWebpackPlugin to minimize CSS files.
+- Added: option `cacheCompression` to toggle babel cache compression
 - Added dependencies:
   - css-minimizer-webpack-plugin ^1.3.0
   - postcss ^8.2.6 (peer dependency)

--- a/packages/calypso-build/webpack/transpile.js
+++ b/packages/calypso-build/webpack/transpile.js
@@ -1,13 +1,15 @@
 /**
  * Return a Webpack loader configuration object containing for JavaScript transpilation.
  *
- * @param {object} _                  Options
- * @param {number} _.workerCount      Number of workers that are being used by the thread-loader
- * @param {string} _.configFile       Babel config file
- * @param {string} _.cacheDirectory   Babel cache directory
- * @param {string} _.cacheIdentifier  Babel cache identifier
- * @param {RegExp|Function} _.exclude Directories to exclude when looking for files to transpile
- * @param {RegExp|Function} _.include Directories to inclued when looking for files to transpile
+ * @param {object} _                   Options
+ * @param {number} _.workerCount       Number of workers that are being used by the thread-loader
+ * @param {string} _.configFile        Babel config file
+ * @param {string} _.cacheDirectory    Babel cache directory
+ * @param {string} _.cacheIdentifier   Babel cache identifier
+ * @param {boolean} _.cacheCompression Whether to apply gzip compression to the cached files (defauls to true)
+ * @param {RegExp|Function} _.exclude  Directories to exclude when looking for files to transpile
+ * @param {RegExp|Function} _.include  Directories to inclued when looking for files to transpile
+ * @param {string[]} _.presets         Babel presets
  *
  * @returns {object} Webpack loader object
  */
@@ -16,6 +18,7 @@ module.exports.loader = ( {
 	configFile,
 	cacheDirectory,
 	cacheIdentifier,
+	cacheCompression = true,
 	exclude,
 	include,
 	presets,
@@ -37,6 +40,7 @@ module.exports.loader = ( {
 				babelrc: false,
 				cacheDirectory,
 				cacheIdentifier,
+				cacheCompression,
 				presets,
 			},
 		},


### PR DESCRIPTION
#### Background

See p4TIVU-9Eh-p2

#### Changes proposed in this Pull Request

* Add a flag to `calypso-build` to disable babel cache compression.
* Disable said cache in Calypso config.

#### Testing instructions

This should only affect local dev. Verifying tests are green should be enough.