### PR TITLE
Focused Launch success view: fix CTA rendering conditions

### DIFF
--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -22,7 +22,7 @@ export const hasPaidDomain = ( state: State ): boolean => {
 	if ( ! state.domain ) {
 		return false;
 	}
-	return ! state.domain.is_free;
+	return ! state.domain.is_free; // @TODO: check if we are ever storing a paid domain
 };
 export const getSelectedDomain = ( state: State ): DomainSuggestions.DomainSuggestion | undefined =>
 	state.domain;
@@ -50,7 +50,7 @@ export const isSelectedPlanPaid = ( state: State ): boolean =>
  *
  * @param state State
  */
-export const hasSelectedDomain = ( state: State ): boolean =>
+export const hasSelectedDomainOrSubdomain = ( state: State ): boolean =>
 	!! getSelectedDomain( state ) || state.confirmedDomainSelection;
 
 // Completion status of steps is derived from the state of the launch flow
@@ -68,7 +68,7 @@ export const isStepCompleted = ( state: State, step: LaunchStepType ): boolean =
 		return !! site?.title;
 	}
 	if ( step === LaunchStep.Domain ) {
-		return select( LAUNCH_STORE ).hasSelectedDomain();
+		return select( LAUNCH_STORE ).hasSelectedDomainOrSubdomain();
 	}
 	return false;
 };

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -26,7 +26,7 @@ const FocusedLaunch: React.FunctionComponent = () => {
 	const [ hasSelectedDomain, selectedPlanProductId ] = useSelect( ( select ) => {
 		const { planProductId } = select( LAUNCH_STORE ).getState();
 
-		return [ select( LAUNCH_STORE ).hasSelectedDomain(), planProductId ];
+		return [ select( LAUNCH_STORE ).hasSelectedDomainOrSubdomain(), planProductId ];
 	} );
 
 	// @TODO: extract to some hook for reusability (Eg: use-products-from-cart)

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -32,10 +32,11 @@ const Success: React.FunctionComponent = () => {
 		[]
 	);
 
-	const isSelectedPlanPaid = useSelect(
-		( select ) => select( LAUNCH_STORE ).isSelectedPlanPaid(),
-		[]
-	);
+	const [ isSelectedPlanPaid, selectedDomain ] = useSelect( ( select ) => {
+		const launchStore = select( LAUNCH_STORE );
+
+		return [ launchStore.isSelectedPlanPaid(), launchStore.getSelectedDomain() ];
+	}, [] );
 
 	// Save the post before displaying the action buttons and launch succes message
 	const [ isPostSaved, setIsPostSaved ] = React.useState( false );
@@ -58,9 +59,13 @@ const Success: React.FunctionComponent = () => {
 	const [ displayedSiteUrl, setDisplayedSiteUrl ] = React.useState( '' );
 	const [ hasCopied, setHasCopied ] = React.useState( false );
 
-	// if the user has an ecommerce plan or they're using focused launch from wp-admin
-	// they will be automatically redirected to /checkout, in which case the CTAs are not needed
-	const shouldShowCTAs = ! useHasEcommercePlan() && ! isInIframe;
+	// Show CTA buttons needed to dismiss the success view only if the user is not going to be redirected to /checkout after launch.
+	// Conditions to show the CTA buttons:
+	// 1. If the selected plan isn't Ecommerce.
+	// 2. In wp-admin, for the free flow (no selected custom domain or paid plan).
+	const isEcommerce = useHasEcommercePlan();
+	const isFreeFlow = ! selectedDomain && ! isSelectedPlanPaid;
+	const shouldShowCTAs = ! isEcommerce && ( isInIframe || isFreeFlow );
 
 	React.useEffect( () => {
 		setDisplayedSiteUrl( `https://${ sitePrimaryDomain?.domain }` );

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -60,12 +60,12 @@ const Success: React.FunctionComponent = () => {
 	const [ hasCopied, setHasCopied ] = React.useState( false );
 
 	// Show CTA buttons needed to dismiss the success view only if the user is not going to be redirected to /checkout after launch.
-	// Conditions to show the CTA buttons:
-	// 1. If the selected plan isn't Ecommerce.
-	// 2. In wp-admin, for the free flow (no selected custom domain or paid plan).
+	// When we display the CTA buttons?
+	// 1. All the time for the free flow (no selected custom domain or paid plan).
+	// 2. If the selected plan isn't Ecommerce and we are in the iframed editor (conditions when we display Checkout Modal).
 	const isEcommerce = useHasEcommercePlan();
 	const isFreeFlow = ! selectedDomain && ! isSelectedPlanPaid;
-	const shouldShowCTAs = ! isEcommerce && ( isInIframe || isFreeFlow );
+	const shouldShowCTAs = isFreeFlow || ( ! isEcommerce && isInIframe );
 
 	React.useEffect( () => {
 		setDisplayedSiteUrl( `https://${ sitePrimaryDomain?.domain }` );

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -13,7 +13,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { useSiteDomains, useWillRedirectAfterSuccess } from '../../hooks';
+import { useSiteDomains, useHasEcommercePlan } from '../../hooks';
 import Confetti from './confetti';
 import LaunchContext from '../../context';
 import { LAUNCH_STORE, SITE_STORE } from '../../stores';
@@ -23,7 +23,9 @@ import './style.scss';
 // Success is shown when the site is launched but also while the site is still launching.
 // This view is technically going to be the selected view in the modal even while the user goes through the checkout flow (which is rendered on top of this view).
 const Success: React.FunctionComponent = () => {
-	const { redirectTo, siteId, getCurrentLaunchFlowUrl } = React.useContext( LaunchContext );
+	const { redirectTo, siteId, getCurrentLaunchFlowUrl, isInIframe } = React.useContext(
+		LaunchContext
+	);
 
 	const isSiteLaunching = useSelect(
 		( select ) => select( SITE_STORE ).isSiteLaunching( siteId ),
@@ -58,7 +60,7 @@ const Success: React.FunctionComponent = () => {
 
 	// if the user has an ecommerce plan or they're using focused launch from wp-admin
 	// they will be automatically redirected to /checkout, in which case the CTAs are not needed
-	const willUserBeRedirectedAutomatically = useWillRedirectAfterSuccess();
+	const shouldShowCTAs = ! useHasEcommercePlan() && ! isInIframe;
 
 	React.useEffect( () => {
 		setDisplayedSiteUrl( `https://${ sitePrimaryDomain?.domain }` );
@@ -105,7 +107,7 @@ const Success: React.FunctionComponent = () => {
 			<SubTitle tagName="h3">
 				{ isLaunchComplete ? subtitleTextLaunched : subtitleTextLaunching }
 			</SubTitle>
-			{ ! willUserBeRedirectedAutomatically && isLaunchComplete && (
+			{ shouldShowCTAs && isLaunchComplete && (
 				<>
 					<div className="focused-launch-success__url-wrapper">
 						<span className="focused-launch-success__url-field">{ displayedSiteUrl }</span>

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -534,7 +534,12 @@ const Summary: React.FunctionComponent = () => {
 		const launchStore = select( LAUNCH_STORE );
 		const { isSiteTitleStepVisible, domain, planProductId } = launchStore.getState();
 
-		return [ launchStore.hasSelectedDomain(), isSiteTitleStepVisible, domain, planProductId ];
+		return [
+			launchStore.hasSelectedDomainOrSubdomain(),
+			isSiteTitleStepVisible,
+			domain,
+			planProductId,
+		];
 	}, [] );
 
 	const isSelectedPlanPaid = useSelect(
@@ -632,7 +637,7 @@ const Summary: React.FunctionComponent = () => {
 		<PlanStep
 			highlighted={ isPlansStepHighlighted }
 			hasPaidPlan={ hasPaidPlan }
-			selectedPaidDomain={ selectedDomain && ! selectedDomain.is_free }
+			selectedPaidDomain={ selectedDomain && ! selectedDomain.is_free } // @TODO: check if selectedDomain can ever be free
 			hasPaidDomain={ hasPaidDomain }
 			stepIndex={ forwardStepIndex ? stepIndex : undefined }
 			key={ stepIndex }

--- a/packages/launch/src/hooks/index.ts
+++ b/packages/launch/src/hooks/index.ts
@@ -7,4 +7,4 @@ export * from './use-title';
 export * from './use-site-domains';
 export * from './use-plans';
 export * from './use-cart';
-export * from './use-will-redirect-after-success';
+export * from './use-has-ecommerce-plan';

--- a/packages/launch/src/hooks/use-cart.ts
+++ b/packages/launch/src/hooks/use-cart.ts
@@ -11,7 +11,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { LAUNCH_STORE, SITE_STORE, PLANS_STORE } from '../stores';
 import LaunchContext from '../context';
 import { getDomainProduct, getPlanProductForFlow } from '../utils';
-import { useSiteDomains, useWillRedirectAfterSuccess } from '../hooks';
+import { useSiteDomains, useHasEcommercePlan } from '../hooks';
 
 type LaunchCart = {
 	goToCheckout: () => Promise< void >; // used in gutenboarding-launch
@@ -20,7 +20,7 @@ type LaunchCart = {
 };
 
 export function useCart(): LaunchCart {
-	const { siteId, flow, openCheckout } = React.useContext( LaunchContext );
+	const { siteId, flow, openCheckout, isInIframe } = React.useContext( LaunchContext );
 
 	const locale = useLocale();
 
@@ -49,7 +49,7 @@ export function useCart(): LaunchCart {
 
 	const [ isCartUpdating, setIsCartUpdating ] = React.useState( false );
 
-	const willRedirectAfterSuccess = useWillRedirectAfterSuccess();
+	const hasEcommercePlan = useHasEcommercePlan();
 
 	const addProductsToCart = async () => {
 		if ( isCartUpdating ) {
@@ -77,7 +77,7 @@ export function useCart(): LaunchCart {
 	};
 
 	const goToCheckoutAndLaunch = async () => {
-		if ( willRedirectAfterSuccess ) {
+		if ( ! isInIframe || hasEcommercePlan ) {
 			// We launch the site first and then open Checkout in these cases:
 			// - Focused Launch is loaded outside Calypso iframe (in wp-admin)
 			// - eCommerce plan is selected so Checkout will handle thank-you redirect after purchase

--- a/packages/launch/src/hooks/use-has-ecommerce-plan.ts
+++ b/packages/launch/src/hooks/use-has-ecommerce-plan.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
 import { useSelect } from '@wordpress/data';
 import { useLocale } from '@automattic/i18n-utils';
 
@@ -9,18 +8,8 @@ import { useLocale } from '@automattic/i18n-utils';
  * Internal dependencies
  */
 import { LAUNCH_STORE, PLANS_STORE } from '../stores';
-import LaunchContext from '../context';
 
-/**
- * When the user has an ecommerce plan or they're using focused launch in wp-admin
- * they will be automatically redirected to /checkout after site launch.
- * This hook returns true when this is the case
- *
- * @returns boolean
- */
-export function useWillRedirectAfterSuccess(): boolean {
-	const { isInIframe } = React.useContext( LaunchContext );
-
+export function useHasEcommercePlan(): boolean {
 	const locale = useLocale();
 
 	const planProductId = useSelect(
@@ -37,5 +26,5 @@ export function useWillRedirectAfterSuccess(): boolean {
 		[ planProductId, locale ]
 	);
 
-	return ! isInIframe || isEcommercePlan;
+	return isEcommercePlan;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR readjusts the conditions we need to show the CTAs in success view of focused launch.

#### Testing instructions

1. Create a free unlaunched site using `/new`.
2. Let's say it's called http://test123.wordpress.com.
3. Sandbox this site.
4. In Calypso, run `yarn start`, in `apps/editing-toolkit` run `yarn dev --sync`.

### Calypso - free plan and domain

5. Go to http://calypso.localhost:3000/page/test123.wordpress.com/5.
6. Pick a free plan and a free domain.
7. Launch. You should see "Continue editing" button.

### Calypso - premium plan
(you need a new site)

5. Go to http://calypso.localhost:3000/page/test123.wordpress.com/5.
6. Click Launch.
7. Pick a premium plan and a free domain.
8. Launch. You should be taken to checkout without seeing success view. Checkout Modal should open over the editor and if closed, focused launch summary should be displayed.

### wp-admin - free plan
(you need a new site)

5. Go to http://test123.wordpress.com/wp-admin/post-new.php.
6. Click Launch.
7. Pick a free plan and a free domain.
8. Launch. Success view should have CTA buttons.

### wp-admin - premium plan
(you need a new site)

5. Go to http://test123.wordpress.com/wp-admin/post-new.php.
6. Click Launch.
7. Pick a premium plan and a free domain.
8. Launch. Success view shouldn't have any buttons.

### wp-admin or calypso - Ecommerce
(you need a new site)

5. Go to http://test123.wordpress.com/wp-admin/post-new.php.
6. Click Launch.
7. Pick an ecommerce plan and a free domain.
8. Launch. Success view shouldn't have any buttons.

Fixes https://github.com/Automattic/wp-calypso/issues/51780
