### PR TITLE
Fixes domain upsell step visibility bug

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -806,6 +806,8 @@ export function isFreePlansDomainUpsellFulfilled( stepName, defaultDependencies,
 			{ selectedDomainUpsellItem }
 		);
 		flows.excludeStep( stepName );
+	} else {
+		flows.resetExcludedStep( stepName );
 	}
 }
 

--- a/client/lib/signup/test/mocks/signup/config/flows.js
+++ b/client/lib/signup/test/mocks/signup/config/flows.js
@@ -11,5 +11,6 @@ export default {
 	},
 
 	excludeStep: jest.fn(),
+	resetExcludedStep: jest.fn(),
 	resetExcludedSteps: jest.fn(),
 };

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -521,6 +521,7 @@ describe( 'isFreePlansDomainUpsellFulfilled()', () => {
 
 	beforeEach( () => {
 		flows.excludeStep.mockClear();
+		flows.resetExcludedStep.mockClear();
 		submitSignupStep.mockClear();
 	} );
 
@@ -538,6 +539,8 @@ describe( 'isFreePlansDomainUpsellFulfilled()', () => {
 		isFreePlansDomainUpsellFulfilled( stepName, null, nextProps );
 
 		expect( submitSignupStep ).not.toHaveBeenCalled();
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+		expect( flows.resetExcludedStep ).toHaveBeenCalledWith( stepName );
 	} );
 
 	test( 'should call submitSignupStep() when site is on a paid plan', () => {
@@ -557,6 +560,8 @@ describe( 'isFreePlansDomainUpsellFulfilled()', () => {
 			{ stepName, selectedDomainUpsellItem: null, wasSkipped: true },
 			{ selectedDomainUpsellItem: null }
 		);
+		expect( flows.excludeStep ).toHaveBeenCalledWith( stepName );
+		expect( flows.resetExcludedStep ).not.toHaveBeenCalled();
 	} );
 
 	test( 'should call submitSignupStep() when a cartItem is passed', () => {
@@ -576,6 +581,8 @@ describe( 'isFreePlansDomainUpsellFulfilled()', () => {
 			{ stepName, selectedDomainUpsellItem: null, wasSkipped: true },
 			{ selectedDomainUpsellItem: null }
 		);
+		expect( flows.excludeStep ).toHaveBeenCalledWith( stepName );
+		expect( flows.resetExcludedStep ).not.toHaveBeenCalled();
 	} );
 
 	test( 'should call submitSignupStep() when a domainItem is passed', () => {
@@ -595,5 +602,7 @@ describe( 'isFreePlansDomainUpsellFulfilled()', () => {
 			{ stepName, selectedDomainUpsellItem: null, wasSkipped: true },
 			{ selectedDomainUpsellItem: null }
 		);
+		expect( flows.excludeStep ).toHaveBeenCalledWith( stepName );
+		expect( flows.resetExcludedStep ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change fixes the bug reported here: https://github.com/Automattic/wp-calypso/pull/51622#pullrequestreview-626240090

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure you are using an English locale
2. Sign up for a free user and site
4. Start the Launch flow from the checklist. Or directly start the launch flow by removing the cart items and going to http://calypso.localhost:3000/start/launch-site/domains-launch?siteSlug=YOURSITE.wordpress.com

**Case 1**
1. Select a custom domain.
2. Hit Back in the plans step.
3. Select a free subdomain.
4. Select the free plan.
5. The domain upsell step should be shown.

**Case 2**
1. Select a free subdomain.
2. Select a free plan.
3. The domain upsell step is shown.
3. Hit Back twice to go to the domain step.
4. Select free subdomain and free plan.
5. The domain upsell step should be shown.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

