### PR TITLE
Fix: Save Jetpack Scan Review Prompt Preference per each siteID

### DIFF
--- a/client/state/jetpack-review-prompt/actions.ts
+++ b/client/state/jetpack-review-prompt/actions.ts
@@ -16,15 +16,28 @@ const combineDismissPreference = (
 	const fullPref = getPreference( state, PREFERENCE_NAME ) ?? {};
 	const previousPref = getExistingPreference( state, type );
 
-	return {
-		...fullPref,
-		[ type ]: {
-			...previousPref,
-			dismissCount: previousPref.dismissCount + ( reviewed ? 0 : 1 ),
-			dismissedAt,
-			reviewed,
-		},
-	};
+	return type === 'scan'
+		? {
+				...fullPref,
+				scan: {
+					...fullPref.scan,
+					[ state.ui.selectedSiteId ]: {
+						...previousPref,
+						dismissCount: previousPref.dismissCount + ( reviewed ? 0 : 1 ),
+						dismissedAt,
+						reviewed,
+					},
+				},
+		  }
+		: {
+				...fullPref,
+				[ type ]: {
+					...previousPref,
+					dismissCount: previousPref.dismissCount + ( reviewed ? 0 : 1 ),
+					dismissedAt,
+					reviewed,
+				},
+		  };
 };
 
 const dismiss = (
@@ -47,13 +60,24 @@ const combineValidPreference = (
 	const fullPref = getPreference( state, PREFERENCE_NAME ) ?? {};
 	const previousPref = getExistingPreference( state, type );
 
-	return {
-		...fullPref,
-		[ type ]: {
-			...previousPref,
-			validFrom: validFrom ?? Date.now(),
-		},
-	};
+	return type === 'scan'
+		? {
+				...fullPref,
+				scan: {
+					...fullPref.scan,
+					[ state.ui.selectedSiteId ]: {
+						...previousPref,
+						validFrom: validFrom ?? Date.now(),
+					},
+				},
+		  }
+		: {
+				...fullPref,
+				[ type ]: {
+					...previousPref,
+					validFrom: validFrom ?? Date.now(),
+				},
+		  };
 };
 
 const setValidFrom = ( type: 'restore' | 'scan', validFrom: number | null = null ) => (

--- a/client/state/jetpack-review-prompt/selectors.ts
+++ b/client/state/jetpack-review-prompt/selectors.ts
@@ -21,6 +21,11 @@ const getExistingPreference = (
 	type: 'scan' | 'restore'
 ): SinglePreferenceType => {
 	const pref = ( getPreference( state, PREFERENCE_NAME ) as PreferenceType ) || {};
+	if ( type === 'scan' ) {
+		return pref.hasOwnProperty( 'scan' )
+			? pref.scan[ state.ui.selectedSiteId ] ?? emptyPreference
+			: emptyPreference;
+	}
 	return pref[ type ] ?? emptyPreference;
 };
 

--- a/client/state/jetpack-review-prompt/test/actions.ts
+++ b/client/state/jetpack-review-prompt/test/actions.ts
@@ -11,65 +11,190 @@ import { expect } from 'chai';
 // import { TIME_BETWEEN_PROMPTS } from '../constants';
 import { combineDismissPreference, combineValidPreference } from '../actions';
 
+const TEST_SITE_ID = 123456789;
+
 describe( 'actions', () => {
-	describe( 'combineDismissPreference()', () => {
-		test( 'should set dismissedAt', () => {
-			const dismissDate = Date.now();
+	describe( 'Scan Review Prompt:', () => {
+		describe( 'combineDismissPreference()', () => {
+			test( 'should set dismissedAt', () => {
+				const dismissDate = Date.now();
 
-			expect(
-				combineDismissPreference( { preferences: {} }, 'scan', dismissDate, false ).scan
-			).to.have.property( 'dismissedAt', dismissDate );
-		} );
+				expect(
+					combineDismissPreference(
+						{
+							ui: {
+								selectedSiteId: TEST_SITE_ID,
+							},
+							preferences: {},
+						},
+						'scan',
+						dismissDate,
+						false
+					).scan[ TEST_SITE_ID ]
+				).to.have.property( 'dismissedAt', dismissDate );
+			} );
 
-		test( 'should set dismissCount to 1 on initial dismiss', () => {
-			expect(
-				combineDismissPreference( { preferences: {} }, 'scan', Date.now(), false ).scan
-			).to.have.property( 'dismissCount', 1 );
-		} );
+			test( 'should set dismissCount to 1 on initial dismiss', () => {
+				expect(
+					combineDismissPreference(
+						{
+							ui: {
+								selectedSiteId: TEST_SITE_ID,
+							},
+							preferences: {},
+						},
+						'scan',
+						Date.now(),
+						false
+					).scan[ TEST_SITE_ID ]
+				).to.have.property( 'dismissCount', 1 );
+			} );
 
-		test( 'should increment dismissCount', () => {
-			expect(
-				combineDismissPreference(
-					{
-						preferences: {
-							localValues: {
-								'jetpack-review-prompt': {
-									scan: {
-										dismissCount: 1,
-										dismissedAt: Date.now(),
-										validFrom: null,
-										reviewed: false,
+			test( 'should increment dismissCount', () => {
+				expect(
+					combineDismissPreference(
+						{
+							ui: {
+								selectedSiteId: TEST_SITE_ID,
+							},
+							preferences: {
+								localValues: {
+									'jetpack-review-prompt': {
+										scan: {
+											[ TEST_SITE_ID ]: {
+												dismissCount: 1,
+												dismissedAt: Date.now(),
+												validFrom: null,
+												reviewed: false,
+											},
+										},
 									},
 								},
 							},
 						},
-					},
-					'scan',
-					Date.now(),
-					false
-				).scan
-			).to.have.property( 'dismissCount', 2 );
-		} );
+						'scan',
+						Date.now(),
+						false
+					).scan[ TEST_SITE_ID ]
+				).to.have.property( 'dismissCount', 2 );
+			} );
 
-		test( 'should set reviewed', () => {
-			expect(
-				combineDismissPreference(
-					{
-						preferences: {},
-					},
-					'scan',
-					Date.now(),
-					true
-				).scan
-			).to.have.property( 'reviewed', true );
-		} );
+			test( 'should set reviewed', () => {
+				expect(
+					combineDismissPreference(
+						{
+							ui: {
+								selectedSiteId: TEST_SITE_ID,
+							},
+							preferences: {},
+						},
+						'scan',
+						Date.now(),
+						true
+					).scan[ TEST_SITE_ID ]
+				).to.have.property( 'reviewed', true );
+			} );
 
+			describe( 'combineValidPreference()', () => {
+				test( 'should set validFrom', () => {
+					const validFrom = Date.now();
+
+					expect(
+						combineValidPreference(
+							{
+								ui: {
+									selectedSiteId: TEST_SITE_ID,
+								},
+								preferences: {},
+							},
+							'scan',
+							validFrom
+						).scan[ TEST_SITE_ID ]
+					).to.have.property( 'validFrom', validFrom );
+				} );
+			} );
+		} );
+	} );
+	describe( 'Restore Review Prompt:', () => {
 		describe( 'combineDismissPreference()', () => {
+			test( 'should set dismissedAt', () => {
+				const dismissDate = Date.now();
+
+				expect(
+					combineDismissPreference(
+						{
+							preferences: {},
+						},
+						'restore',
+						dismissDate,
+						false
+					).restore
+				).to.have.property( 'dismissedAt', dismissDate );
+			} );
+
+			test( 'should set dismissCount to 1 on initial dismiss', () => {
+				expect(
+					combineDismissPreference(
+						{
+							preferences: {},
+						},
+						'restore',
+						Date.now(),
+						false
+					).restore
+				).to.have.property( 'dismissCount', 1 );
+			} );
+
+			test( 'should increment dismissCount', () => {
+				expect(
+					combineDismissPreference(
+						{
+							preferences: {
+								localValues: {
+									'jetpack-review-prompt': {
+										restore: {
+											dismissCount: 1,
+											dismissedAt: Date.now(),
+											validFrom: null,
+											reviewed: false,
+										},
+									},
+								},
+							},
+						},
+						'restore',
+						Date.now(),
+						false
+					).restore
+				).to.have.property( 'dismissCount', 2 );
+			} );
+
+			test( 'should set reviewed', () => {
+				expect(
+					combineDismissPreference(
+						{
+							preferences: {},
+						},
+						'restore',
+						Date.now(),
+						true
+					).restore
+				).to.have.property( 'reviewed', true );
+			} );
+		} );
+
+		describe( 'combineValidPreference()', () => {
 			test( 'should set validFrom', () => {
 				const validFrom = Date.now();
 
 				expect(
-					combineValidPreference( { preferences: {} }, 'scan', validFrom ).scan
+					combineValidPreference(
+						{
+							preferences: {},
+						},
+						'restore',
+						validFrom
+					).restore
 				).to.have.property( 'validFrom', validFrom );
 			} );
 		} );

--- a/client/state/jetpack-review-prompt/test/selectors.ts
+++ b/client/state/jetpack-review-prompt/test/selectors.ts
@@ -9,146 +9,359 @@ import { expect } from 'chai';
 import { getIsDismissed, getIsValid } from '../selectors';
 import { TIME_BETWEEN_PROMPTS } from '../constants';
 
+const TEST_SITE_ID = 123456789;
+const reduxState = {
+	ui: {
+		selectedSiteId: TEST_SITE_ID,
+	},
+};
+
 describe( 'selectors', () => {
-	describe( 'getIsDismissed()', () => {
-		test( 'should return false if no preference saved', () => {
-			const state = { preferences: {} };
-			expect( getIsDismissed( state, 'scan' ) ).to.be.false;
-		} );
-		test( 'should return true if reviewed', () => {
-			const state = {
-				preferences: {
-					localValues: {
-						'jetpack-review-prompt': {
-							scan: {
-								dismissCount: 1,
-								dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
-								reviewed: true,
-								validFrom: null,
+	describe( 'Scan Review Prompt:', () => {
+		describe( 'getIsDismissed()', () => {
+			test( 'should return false if no preference saved', () => {
+				const state = {
+					...reduxState,
+					preferences: {},
+				};
+				expect( getIsDismissed( state, 'scan' ) ).to.be.false;
+			} );
+			test( 'should return false if no preference saved for the currently selectedSiteId', () => {
+				const state = {
+					...reduxState,
+					preferences: {
+						localValues: {
+							'jetpack-review-prompt': {
+								scan: {
+									// not the currently selectedSiteId
+									[ 3458899 ]: {
+										dismissCount: 1,
+										dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+										reviewed: true,
+										validFrom: null,
+									},
+								},
 							},
 						},
 					},
-				},
-			};
-			expect( getIsDismissed( state, 'scan' ) ).to.be.true;
-		} );
-		test( 'should return false if dismissed just now', () => {
-			const state = {
-				preferences: {
-					localValues: {
-						'jetpack-review-prompt': {
-							scan: {
-								dismissCount: 1,
-								dismissedAt: Date.now(),
-								reviewed: false,
-								validFrom: null,
+				};
+				expect( getIsDismissed( state, 'scan' ) ).to.be.false;
+			} );
+			test( 'should return true if reviewed', () => {
+				const state = {
+					...reduxState,
+					preferences: {
+						localValues: {
+							'jetpack-review-prompt': {
+								scan: {
+									[ TEST_SITE_ID ]: {
+										dismissCount: 1,
+										dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+										reviewed: true,
+										validFrom: null,
+									},
+								},
 							},
 						},
 					},
-				},
-			};
-			expect( getIsDismissed( state, 'scan' ) ).to.be.true;
-		} );
-		test( 'should return true if dismissed longer than TIME_BETWEEN_PROMPTS', () => {
-			const state = {
-				preferences: {
-					localValues: {
-						'jetpack-review-prompt': {
-							scan: {
-								dismissCount: 1,
-								dismissedAt: Date.now() - ( TIME_BETWEEN_PROMPTS + 1 ),
-								reviewed: false,
-								validFrom: null,
+				};
+				expect( getIsDismissed( state, 'scan' ) ).to.be.true;
+			} );
+			test( 'should return false if dismissed just now', () => {
+				const state = {
+					...reduxState,
+					preferences: {
+						localValues: {
+							'jetpack-review-prompt': {
+								scan: {
+									[ TEST_SITE_ID ]: {
+										dismissCount: 1,
+										dismissedAt: Date.now() /* - TIME_BETWEEN_PROMPTS * 2*/,
+										reviewed: true,
+										validFrom: null,
+									},
+								},
 							},
 						},
 					},
-				},
-			};
-			expect( getIsDismissed( state, 'scan' ) ).to.be.false;
-		} );
-		test( 'should return true if dismissed twice', () => {
-			const state = {
-				preferences: {
-					localValues: {
-						'jetpack-review-prompt': {
-							scan: {
-								dismissCount: 2,
-								dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
-								reviewed: false,
-								validFrom: null,
+				};
+				expect( getIsDismissed( state, 'scan' ) ).to.be.true;
+			} );
+			test( 'should return true if dismissed longer than TIME_BETWEEN_PROMPTS', () => {
+				const state = {
+					...reduxState,
+					preferences: {
+						localValues: {
+							'jetpack-review-prompt': {
+								scan: {
+									[ TEST_SITE_ID ]: {
+										dismissCount: 1,
+										dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+										reviewed: true,
+										validFrom: null,
+									},
+								},
 							},
 						},
 					},
-				},
-			};
-			expect( getIsDismissed( state, 'scan' ) ).to.be.true;
+				};
+				expect( getIsDismissed( state, 'scan' ) ).to.be.true;
+			} );
+			test( 'should return true if dismissed twice', () => {
+				const state = {
+					...reduxState,
+					preferences: {
+						localValues: {
+							'jetpack-review-prompt': {
+								scan: {
+									[ TEST_SITE_ID ]: {
+										dismissCount: 2,
+										dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+										reviewed: true,
+										validFrom: null,
+									},
+								},
+							},
+						},
+					},
+				};
+				expect( getIsDismissed( state, 'scan' ) ).to.be.true;
+			} );
+		} );
+
+		describe( 'getIsValid()', () => {
+			test( 'should return false if preference is empty', () => {
+				const state = {
+					...reduxState,
+					preferences: {},
+				};
+				expect( getIsValid( state, 'scan' ) ).to.be.false;
+			} );
+			test( 'should return false if isValid has not been set', () => {
+				const state = {
+					...reduxState,
+					preferences: {
+						localValues: {
+							'jetpack-review-prompt': {
+								scan: {
+									[ TEST_SITE_ID ]: {
+										dismissCount: 1,
+										dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+										reviewed: true,
+										validFrom: null,
+									},
+								},
+							},
+						},
+					},
+				};
+				expect( getIsValid( state, 'scan' ) ).to.be.false;
+			} );
+			test( 'should return true if isValid has been set', () => {
+				const state = {
+					...reduxState,
+					preferences: {
+						localValues: {
+							'jetpack-review-prompt': {
+								scan: {
+									[ TEST_SITE_ID ]: {
+										dismissCount: 1,
+										dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+										reviewed: true,
+										validFrom: Date.now() - 1,
+									},
+								},
+							},
+						},
+					},
+				};
+				expect( getIsValid( state, 'scan' ) ).to.be.true;
+			} );
+			test( 'should return false if isValid is not set on the currently selectedSiteId', () => {
+				const state = {
+					ui: {
+						selectedSiteId: TEST_SITE_ID,
+					},
+					preferences: {
+						localValues: {
+							'jetpack-review-prompt': {
+								scan: {
+									// not the currently selected site ID.
+									[ 56723451 ]: {
+										dismissCount: 1,
+										dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+										reviewed: true,
+										validFrom: null,
+									},
+								},
+								restore: {
+									dismissCount: 0,
+									dismissedAt: null,
+									reviewed: false,
+									validFrom: Date.now() - 1,
+								},
+							},
+						},
+					},
+				};
+				expect( getIsValid( state, 'scan' ) ).to.be.false;
+			} );
 		} );
 	} );
+	describe( 'Restore Review Prompt:', () => {
+		describe( 'getIsDismissed()', () => {
+			test( 'should return false if no preference saved', () => {
+				const state = {
+					...reduxState,
+					preferences: {},
+				};
+				expect( getIsDismissed( state, 'restore' ) ).to.be.false;
+			} );
+			test( 'should return true if reviewed', () => {
+				const state = {
+					...reduxState,
+					preferences: {
+						localValues: {
+							'jetpack-review-prompt': {
+								restore: {
+									dismissCount: 1,
+									dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+									reviewed: true,
+									validFrom: null,
+								},
+							},
+						},
+					},
+				};
+				expect( getIsDismissed( state, 'restore' ) ).to.be.true;
+			} );
+			test( 'should return false if dismissed just now', () => {
+				const state = {
+					...reduxState,
+					preferences: {
+						localValues: {
+							'jetpack-review-prompt': {
+								restore: {
+									dismissCount: 1,
+									dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+									reviewed: true,
+									validFrom: null,
+								},
+							},
+						},
+					},
+				};
+				expect( getIsDismissed( state, 'restore' ) ).to.be.true;
+			} );
+			test( 'should return true if dismissed longer than TIME_BETWEEN_PROMPTS', () => {
+				const state = {
+					...reduxState,
+					preferences: {
+						localValues: {
+							'jetpack-review-prompt': {
+								restore: {
+									dismissCount: 1,
+									dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+									reviewed: true,
+									validFrom: null,
+								},
+							},
+						},
+					},
+				};
+				expect( getIsDismissed( state, 'restore' ) ).to.be.true;
+			} );
+			test( 'should return true if dismissed twice', () => {
+				const state = {
+					...reduxState,
+					preferences: {
+						localValues: {
+							'jetpack-review-prompt': {
+								restore: {
+									dismissCount: 2,
+									dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+									reviewed: true,
+									validFrom: null,
+								},
+							},
+						},
+					},
+				};
+				expect( getIsDismissed( state, 'restore' ) ).to.be.true;
+			} );
+		} );
 
-	describe( 'getIsValid()', () => {
-		test( 'should return false if preference is empty', () => {
-			const state = {
-				preferences: {},
-			};
-			expect( getIsValid( state, 'scan' ) ).to.be.false;
-		} );
-		test( 'should return false if isValid has not been set', () => {
-			const state = {
-				preferences: {
-					localValues: {
-						'jetpack-review-prompt': {
-							scan: {
-								dismissCount: 0,
-								dismissedAt: null,
-								reviewed: false,
-								validFrom: null,
+		describe( 'getIsValid()', () => {
+			test( 'should return false if preference is empty', () => {
+				const state = {
+					...reduxState,
+					preferences: {},
+				};
+				expect( getIsValid( state, 'restore' ) ).to.be.false;
+			} );
+			test( 'should return false if isValid has not been set', () => {
+				const state = {
+					...reduxState,
+					preferences: {
+						localValues: {
+							'jetpack-review-prompt': {
+								restore: {
+									dismissCount: 1,
+									dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+									reviewed: true,
+									validFrom: null,
+								},
 							},
 						},
 					},
-				},
-			};
-			expect( getIsValid( state, 'scan' ) ).to.be.false;
-		} );
-		test( 'should return true if isValid has been set', () => {
-			const state = {
-				preferences: {
-					localValues: {
-						'jetpack-review-prompt': {
-							scan: {
-								dismissCount: 0,
-								dismissedAt: null,
-								reviewed: false,
-								validFrom: Date.now() - 1,
+				};
+				expect( getIsValid( state, 'restore' ) ).to.be.false;
+			} );
+			test( 'should return true if isValid has been set', () => {
+				const state = {
+					...reduxState,
+					preferences: {
+						localValues: {
+							'jetpack-review-prompt': {
+								restore: {
+									dismissCount: 1,
+									dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+									reviewed: true,
+									validFrom: Date.now() - 1,
+								},
 							},
 						},
 					},
-				},
-			};
-			expect( getIsValid( state, 'scan' ) ).to.be.true;
-		} );
-		test( 'should return true if isValid has been set on correct sub-property', () => {
-			const state = {
-				preferences: {
-					localValues: {
-						'jetpack-review-prompt': {
-							scan: {
-								dismissCount: 0,
-								dismissedAt: null,
-								reviewed: false,
-								validFrom: Date.now() + 100000,
-							},
-							restore: {
-								dismissCount: 0,
-								dismissedAt: null,
-								reviewed: false,
-								validFrom: Date.now() - 1,
+				};
+				expect( getIsValid( state, 'restore' ) ).to.be.true;
+			} );
+			test( 'should return true if isValid has been set on correct sub-property', () => {
+				const state = {
+					...reduxState,
+					preferences: {
+						localValues: {
+							'jetpack-review-prompt': {
+								scan: {
+									[ TEST_SITE_ID ]: {
+										dismissCount: 1,
+										dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+										reviewed: true,
+										validFrom: Date.now() - 1,
+									},
+								},
+								restore: {
+									dismissCount: 0,
+									dismissedAt: null,
+									reviewed: false,
+									validFrom: null,
+								},
 							},
 						},
 					},
-				},
-			};
-			expect( getIsValid( state, 'restore' ) ).to.be.true;
-			expect( getIsValid( state, 'scan' ) ).to.be.false;
+				};
+				expect( getIsValid( state, 'restore' ) ).to.be.false;
+				expect( getIsValid( state, 'scan' ) ).to.be.true;
+			} );
 		} );
 	} );
 } );

--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -79,7 +79,12 @@ export const remoteValuesSchema = {
 		'jetpack-review-prompt': {
 			type: 'object',
 			properties: {
-				scan: { $ref: '#/definitions/dismissiblePrompt' },
+				scan: {
+					type: 'object',
+					properties: {
+						'/[0-9]+/': { $ref: '#/definitions/dismissiblePrompt' },
+					},
+				},
 				restore: { $ref: '#/definitions/dismissiblePrompt' },
 			},
 		},


### PR DESCRIPTION
### Changes proposed in this Pull Request

The Jetpack Review Prompt 'Preference' object (for `type: scan`) should set preference values for each selectedSiteId.  In other words, for Scan, the review prompt should display **for each site** that has successfully completed the "Fix Threats" process. (Each site may have a different preference set)

#### Testing instructions

1. Checkout and run this PR ('yarn start`)
2. Select (or create with JN) a jetpack site with Scan enabled. 
3. Choose a site and go to  'http://calypso.localhost:3000/scan/:site` 
4. Go to the `/wp-content/plugins/` directory and modify any main plugin file and add the line:
    - `$eicar = "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*";`
    - ( this will trigger a scan threat that Jetpack can auto-fix in the next steps)
5. Click "Scan now" button to start a scan.
6. When scan finishes (you should have 1 scan threat), click "Auto fix 1 threat", and confirm "Fix all threats" button. 
7. When auto-fix finishes, you should see the review prompt at the bottom of the Scan card.
8. Now verify the review prompt is set for this site only by selecting a different site (with JP Scan) and verify the review prompt disappears. And select the original site again and verify the review prompt re-appears.

#### Unit Tests

- verify `yarn test-client state/jetpack-review-prompt` passes