### PR TITLE
Nav Unification: Remove `from` query param

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -9,7 +9,7 @@ import Gridicon from 'calypso/components/gridicon';
 /**
  * Internal dependencies
  */
-import { addQueryArgs, isExternal, getUrlParts } from 'calypso/lib/url';
+import { isExternal } from 'calypso/lib/url';
 import MaterialIcon from 'calypso/components/material-icon';
 import Count from 'calypso/components/count';
 import { preload } from 'calypso/sections-helper';
@@ -24,15 +24,6 @@ export default function SidebarItem( props ) {
 		'has-unseen': props.hasUnseen,
 	} );
 	const { materialIcon, materialIconStyle, icon, customIcon, count } = props;
-
-	let url = props.link;
-	if ( isExternalLink ) {
-		const { search } = getUrlParts( url );
-		if ( ! search.includes( 'from=' ) ) {
-			// `from` param is used by WP Admin on Atomic sites for disabling Nav Unification in that context. Can be removed after rolling Nav Unification out to 100% of users.
-			url = addQueryArgs( { from: 'calypso-old-menu', calypsoify: 0 }, url );
-		}
-	}
 
 	let _preloaded = false;
 
@@ -60,7 +51,7 @@ export default function SidebarItem( props ) {
 			<a
 				className="sidebar__menu-link"
 				onClick={ props.onNavigate }
-				href={ url }
+				href={ props.link }
 				onMouseEnter={ itemPreload }
 				{ ...linkProps }
 			>

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -90,7 +90,7 @@ import { isUnderEmailManagementAll } from 'calypso/my-sites/email/paths';
 import JetpackSidebarMenuItems from 'calypso/components/jetpack/sidebar/menu-items/calypso';
 import InfoPopover from 'calypso/components/info-popover';
 import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
-import { getUrlParts, getUrlFromParts, addQueryArgs } from 'calypso/lib/url';
+import { getUrlParts, getUrlFromParts } from 'calypso/lib/url';
 import { isP2PlusPlan } from 'calypso/lib/plans';
 
 /**
@@ -944,11 +944,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		// `from` param is used by WP Admin on Atomic sites for disabling Nav Unification in that context. Can be removed after rolling Nav Unification out to 100% of users.
-		let adminUrl = addQueryArgs(
-			{ from: 'calypso-old-menu', calypsoify: 0 },
-			site.options.admin_url
-		);
+		let adminUrl = site.options.admin_url;
 
 		if ( this.props.isJetpack && ! this.props.isAtomicSite && ! this.props.isVip ) {
 			const urlParts = getUrlParts( site.options.admin_url + 'admin.php' );

--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -30,7 +30,6 @@ const sanitizeUrl = ( url, wpAdminUrl ) => {
 		url = addQueryArgs(
 			{
 				return: document.location.href, // Gives WP Admin a chance to return to where we started from.
-				from: 'calypso-unified-menu', // `from` param is used by WP Admin on Atomic sites for enabling Nav Unification in that context. Can be removed after rolling Nav Unification out to 100% of users.
 			},
 			url
 		);

--- a/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
@@ -93,7 +93,6 @@ describe( 'handlers', () => {
 		sanitizedMenu[ 1 ].children[ 0 ].url = addQueryArgs(
 			{
 				return: document.location.href,
-				from: 'calypso-unified-menu',
 			},
 			sanitizedMenu[ 1 ].children[ 0 ].url
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reverts the changes we introduced in https://github.com/Automattic/wp-calypso/pull/50839 since Nav Unification has been enabled for 100% of users for more than a week now. The `from` param was only a temporary workaround to avoid a caching issue on Atomic sites, which shouldn't longer be the case now that the feature has been live for more than a week.

This also helps fixing some side effects that are unexpectedly caused by the `from` param like https://github.com/Automattic/wp-calypso/issues/50961.

#### Testing instructions

* Switch to an Atomic site.
* Click on a menu item that links to a WP Admin screen.
* Make sure the URL does not contain any `from` param.
* Make sure Nav Unification is enabled.

Fixes https://github.com/Automattic/wp-calypso/issues/50961
