### PR TITLE
Show proper error message when no logs are available for the selected time range

### DIFF
--- a/client/my-sites/hosting/web-server-logs-card/index.js
+++ b/client/my-sites/hosting/web-server-logs-card/index.js
@@ -148,8 +148,13 @@ const WebServerLogsCard = ( props ) => {
 					scrollId = get( response, 'data.scroll_id', null );
 
 					if ( isEmpty( logs ) ) {
-						logs = [ Object.keys( newLogData[ 0 ] ).join( ',' ) + '\n' ];
-						totalLogs = get( response, 'data.total_results', 1 );
+						if ( isEmpty( newLogData ) ) {
+							downloadErrorNotice( translate( 'No logs available for this time range' ) );
+							isError = true;
+						} else {
+							logs = [ Object.keys( newLogData[ 0 ] ).join( ',' ) + '\n' ];
+							totalLogs = get( response, 'data.total_results', 1 );
+						}
 					}
 
 					logs = [


### PR DESCRIPTION
If there are no logs available for a selected time range, you currently get the following error notice along with an error in the console:

<img width="401" alt="Screen Shot 2021-04-07 at 11 42 28 AM" src="https://user-images.githubusercontent.com/1379730/113900167-8c082080-979b-11eb-9bf7-e46108827e41.png">

After this change, you will see the following notice and no error in the console:

<img width="370" alt="Screen Shot 2021-04-07 at 12 20 10 PM" src="https://user-images.githubusercontent.com/1379730/113900347-b823a180-979b-11eb-816c-da33f1347bfa.png">

#### Testing instructions

Try downloading just 1 second worth of data for a test site with no traffic.
Make sure you see the notice and that no file is downloaded.