### PR TITLE
Partner Portal: Fix license list columns alignment

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
@@ -30,7 +30,7 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 	> *:nth-child(#{$column-toggle}) {
 		grid-column-end: -1;
 		display: inherit;
-		text-align: center;
+		padding: 0;
 	}
 
 	@include break-xlarge() {
@@ -44,12 +44,14 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 		}
 
 		> * + * {
-			margin-left: 14px;
-			text-align: right;
+			margin-left: 0;
+			padding-right: 7px;
+			padding-left: 7px;
+			text-align: center;
 		}
 
 		> *:last-child {
-			margin-left: 6px;
+			margin-left: auto;
 		}
 
 		> *:nth-child(#{$column-actions}) {
@@ -67,10 +69,6 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 
 	@include break-wide() {
 		grid-template-columns: $grid-wide;
-
-		> * + * {
-			margin-left: 28px;
-		}
 
 		> *:last-child {
 			margin-left: 12px;
@@ -100,6 +98,7 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 		}
 
 		h2, h2 button {
+			justify-self: center;
 			font-size: 0.875rem;
 			line-height: 1.25rem;
 			white-space: nowrap;
@@ -107,7 +106,6 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 		}
 
 		h2 {
-			justify-self: end;
 			font-weight: 400;
 		}
 
@@ -118,7 +116,6 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 		button {
 			display: flex;
 			align-items: center;
-			justify-self: end;
 			padding: 16px 0;
 			font-weight: inherit;
 			cursor: pointer;


### PR DESCRIPTION
Context: 1187494150150258-as-1200043581561258/f
Design: pbtFPC-103-p2

#### Changes proposed in this Pull Request

* Fix the CSS to adjust the "Issued On", "Assigned On", and "Revoked On" columns alignment. In this PR they are centered, instead of aligned to the right.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If you do not have a partner key, please contact Infinity for one or you will be unable to test this PR.
* Check out this PR locally, then run* yarn && yarn start-jetpack-cloud.
* Visit http://jetpack.cloud.localhost:3000/partner-portal, make sure the columns are aligned to the center, and that they look like the screenshot below
* You can also compare between the local and staging version to see the difference between them

**Before:**
![image](https://user-images.githubusercontent.com/5714212/113922192-61c75a80-97bd-11eb-9e01-8d7f999a17e9.png)


**After:**
![image](https://user-images.githubusercontent.com/5714212/113922246-7146a380-97bd-11eb-9a37-3bed8c6f0375.png)
