### PR TITLE
Partner Portal: Add an empty view for the license list

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-list/empty-list.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/empty-list.tsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement, useContext } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+import { getLicenseCounts } from 'calypso/state/partner-portal/licenses/selectors';
+import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
+import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export default function LicenseListEmpty(): ReactElement {
+	const translate = useTranslate();
+	const { filter } = useContext( LicenseListContext );
+	const counts = useSelector( getLicenseCounts );
+	const hasAssignedLicenses = counts[ LicenseFilter.Attached ] > 0;
+
+	const licenseFilterStatusMap = {
+		[ LicenseFilter.NotRevoked ]: translate( 'active' ),
+		[ LicenseFilter.Attached ]: translate( 'assigned' ),
+		[ LicenseFilter.Detached ]: translate( 'unassigned' ),
+		[ LicenseFilter.Revoked ]: translate( 'revoked' ),
+	};
+
+	const licenseFilterStatus = licenseFilterStatusMap[ filter ];
+
+	// translators: %(status)s is the current "status" of a license. One of active, assigned, unassigned, or revoked.
+	const titleText = translate( 'No %(status)s licenses.', {
+		args: { status: licenseFilterStatus },
+	} );
+
+	return (
+		<div className="license-list__empty-list">
+			<h2>{ titleText }</h2>
+			{ filter === LicenseFilter.Detached && hasAssignedLicenses && (
+				<p>{ translate( 'Every license you own is currently attached to a site.' ) }</p>
+			) }
+			<Button href="/partner-portal/issue-license">{ translate( 'Issue New License' ) }</Button>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
@@ -25,17 +25,18 @@ export default function LicenseListEmpty(): ReactElement {
 	const hasAssignedLicenses = counts[ LicenseFilter.Attached ] > 0;
 
 	const licenseFilterStatusMap = {
-		[ LicenseFilter.NotRevoked ]: translate( 'active' ),
-		[ LicenseFilter.Attached ]: translate( 'assigned' ),
-		[ LicenseFilter.Detached ]: translate( 'unassigned' ),
-		[ LicenseFilter.Revoked ]: translate( 'revoked' ),
+		[ LicenseFilter.NotRevoked ]: translate( 'Active' ),
+		[ LicenseFilter.Attached ]: translate( 'Assigned' ),
+		[ LicenseFilter.Detached ]: translate( 'Unassigned' ),
+		[ LicenseFilter.Revoked ]: translate( 'Revoked' ),
 	};
 
-	const licenseFilterStatus = licenseFilterStatusMap[ filter ];
+	const licenseFilterStatus = licenseFilterStatusMap[ filter ] as string;
 
 	// translators: %(status)s is the current "status" of a license. One of active, assigned, unassigned, or revoked.
 	const titleText = translate( 'No %(status)s licenses.', {
-		args: { status: licenseFilterStatus },
+		// Using `toLowerCase` to reuse the strings above and avoid retranslation
+		args: { status: licenseFilterStatus.toLowerCase() },
 	} );
 
 	return (

--- a/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 
@@ -10,7 +10,6 @@ import { useSelector } from 'react-redux';
  */
 import { Button } from '@automattic/components';
 import { getLicenseCounts } from 'calypso/state/partner-portal/licenses/selectors';
-import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
 import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 
 /**
@@ -18,30 +17,27 @@ import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/typ
  */
 import './style.scss';
 
-export default function LicenseListEmpty(): ReactElement {
+interface Props {
+	filter: LicenseFilter;
+}
+
+export default function LicenseListEmpty( { filter }: Props ): ReactElement {
 	const translate = useTranslate();
-	const { filter } = useContext( LicenseListContext );
 	const counts = useSelector( getLicenseCounts );
 	const hasAssignedLicenses = counts[ LicenseFilter.Attached ] > 0;
 
-	const licenseFilterStatusMap = {
-		[ LicenseFilter.NotRevoked ]: translate( 'Active' ),
-		[ LicenseFilter.Attached ]: translate( 'Assigned' ),
-		[ LicenseFilter.Detached ]: translate( 'Unassigned' ),
-		[ LicenseFilter.Revoked ]: translate( 'Revoked' ),
+	const licenseFilterStatusTitleMap = {
+		[ LicenseFilter.NotRevoked ]: translate( 'No active licenses' ),
+		[ LicenseFilter.Attached ]: translate( 'No assigned licenses.' ),
+		[ LicenseFilter.Detached ]: translate( 'No unassigned licenses.' ),
+		[ LicenseFilter.Revoked ]: translate( 'No revoked licenses.' ),
 	};
 
-	const licenseFilterStatus = licenseFilterStatusMap[ filter ] as string;
-
-	// translators: %(status)s is the current "status" of a license. One of active, assigned, unassigned, or revoked.
-	const titleText = translate( 'No %(status)s licenses.', {
-		// Using `toLowerCase` to reuse the strings above and avoid retranslation
-		args: { status: licenseFilterStatus.toLowerCase() },
-	} );
+	const licenseFilterStatusTitle = licenseFilterStatusTitleMap[ filter ] as string;
 
 	return (
 		<div className="license-list__empty-list">
-			<h2>{ titleText }</h2>
+			<h2>{ licenseFilterStatusTitle }</h2>
 			{ filter === LicenseFilter.Detached && hasAssignedLicenses && (
 				<p>{ translate( 'Every license you own is currently attached to a site.' ) }</p>
 			) }

--- a/client/jetpack-cloud/sections/partner-portal/license-list/header.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/header.tsx
@@ -1,0 +1,121 @@
+/**
+ * External dependencies
+ */
+import React, { PropsWithChildren, ReactElement, useCallback, useContext } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import {
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
+import Gridicon from 'calypso/components/gridicon';
+import { addQueryArgs } from 'calypso/lib/route';
+import { internalToPublicLicenseSortField } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+function setSortingConfig(
+	newSortField: LicenseSortField,
+	sortField: LicenseSortField,
+	sortDirection: LicenseSortDirection
+): void {
+	let direction = LicenseSortDirection.Descending;
+
+	if ( newSortField === sortField && sortDirection === direction ) {
+		direction = LicenseSortDirection.Ascending;
+	}
+
+	const queryParams = {
+		sort_field: internalToPublicLicenseSortField( newSortField ),
+		sort_direction: direction,
+		page: 1,
+	};
+	const currentPath = window.location.pathname + window.location.search;
+
+	page( addQueryArgs( queryParams, currentPath ) );
+}
+
+interface SortButtonProps {
+	sortField: LicenseSortField;
+	currentSortField: LicenseSortField;
+	currentSortDirection: LicenseSortDirection;
+}
+
+function SortButton( {
+	sortField,
+	currentSortField,
+	currentSortDirection,
+	children,
+}: PropsWithChildren< SortButtonProps > ) {
+	const sort = useCallback( () => {
+		setSortingConfig( sortField, currentSortField, currentSortDirection );
+	}, [ sortField, currentSortField, currentSortDirection ] );
+
+	return (
+		<h2 className={ classnames( { 'is-selected': sortField === currentSortField } ) }>
+			<button onClick={ sort }>
+				{ children }
+				<Gridicon
+					icon="dropdown"
+					className={ classnames( 'license-list-item__sort-indicator', {
+						[ `is-sort-${ currentSortDirection }` ]: true,
+					} ) }
+				/>
+			</button>
+		</h2>
+	);
+}
+
+export default function LicenseListHeader(): ReactElement {
+	const translate = useTranslate();
+	const { filter, sortField, sortDirection } = useContext( LicenseListContext );
+
+	return (
+		<LicenseListItem header className="license-list__header">
+			<h2>{ translate( 'License state' ) }</h2>
+
+			<SortButton
+				sortField={ LicenseSortField.IssuedAt }
+				currentSortField={ sortField }
+				currentSortDirection={ sortDirection }
+			>
+				{ translate( 'Issued on' ) }
+			</SortButton>
+
+			{ filter !== LicenseFilter.Revoked && (
+				<SortButton
+					sortField={ LicenseSortField.AttachedAt }
+					currentSortField={ sortField }
+					currentSortDirection={ sortDirection }
+				>
+					{ translate( 'Assigned on' ) }
+				</SortButton>
+			) }
+
+			{ filter === LicenseFilter.Revoked && (
+				<SortButton
+					sortField={ LicenseSortField.RevokedAt }
+					currentSortField={ sortField }
+					currentSortDirection={ sortDirection }
+				>
+					{ translate( 'Revoked on' ) }
+				</SortButton>
+			) }
+
+			<div>{ /* Intentionally empty header. */ }</div>
+
+			<div>{ /* Intentionally empty header. */ }</div>
+		</LicenseListItem>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -41,6 +41,7 @@ function setPage( pageNumber: number ): void {
 
 interface LicenseTransitionProps {
 	key?: string;
+	exit?: boolean;
 }
 
 const LicenseTransition = ( props: PropsWithChildren< LicenseTransitionProps > ) => (
@@ -68,11 +69,13 @@ export default function LicenseList(): ReactElement {
 				page={ currentPage }
 			/>
 
-			{ ! showNoResults && <LicenseListHeader /> }
-
-			{ showNoResults && <LicenseListEmpty /> }
-
 			<TransitionGroup className="license-list__transition-group">
+				{ ! showNoResults && (
+					<LicenseTransition>
+						<LicenseListHeader />
+					</LicenseTransition>
+				) }
+
 				{ showLicenses &&
 					licenses.items.map( ( license ) => (
 						<LicenseTransition key={ license.licenseKey }>
@@ -105,6 +108,12 @@ export default function LicenseList(): ReactElement {
 							total={ licenses.totalItems }
 							pageClick={ setPage }
 						/>
+					</LicenseTransition>
+				) }
+
+				{ showNoResults && (
+					<LicenseTransition key={ filter } exit={ false }>
+						<LicenseListEmpty filter={ filter } />
 					</LicenseTransition>
 				) }
 			</TransitionGroup>

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -25,7 +25,7 @@ import Pagination from 'calypso/components/pagination';
 import QueryJetpackPartnerPortalLicenses from 'calypso/components/data/query-jetpack-partner-portal-licenses';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
 import LicenseListHeader from 'calypso/jetpack-cloud/sections/partner-portal/license-list/header';
-import LicenseListEmpty from 'calypso/jetpack-cloud/sections/partner-portal/license-list/empty-list';
+import LicenseListEmpty from 'calypso/jetpack-cloud/sections/partner-portal/license-list/empty';
 
 /**
  * Style dependencies

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -1,40 +1,32 @@
 /**
  * External dependencies
  */
-import React, { PropsWithChildren, ReactElement, useCallback, useContext } from 'react';
+import React, { PropsWithChildren, ReactElement, useContext } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import classnames from 'classnames';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
 import CSSTransition from 'react-transition-group/CSSTransition';
 
 /**
  * Internal dependencies
  */
+import { LICENSES_PER_PAGE } from 'calypso/state/partner-portal/licenses/constants';
+import { addQueryArgs } from 'calypso/lib/route';
 import { Card } from '@automattic/components';
-import {
-	LicenseFilter,
-	LicenseSortDirection,
-	LicenseSortField,
-} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { License, PaginatedItems } from 'calypso/state/partner-portal/types';
-import QueryJetpackPartnerPortalLicenses from 'calypso/components/data/query-jetpack-partner-portal-licenses';
 import {
 	getPaginatedLicenses,
 	hasFetchedLicenses,
 	isFetchingLicenses,
 } from 'calypso/state/partner-portal/licenses/selectors';
-import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
 import LicensePreview, {
 	LicensePreviewPlaceholder,
 } from 'calypso/jetpack-cloud/sections/partner-portal/license-preview';
-import { LICENSES_PER_PAGE } from 'calypso/state/partner-portal/licenses/constants';
-import Gridicon from 'calypso/components/gridicon';
 import Pagination from 'calypso/components/pagination';
-import { addQueryArgs } from 'calypso/lib/route';
-import { internalToPublicLicenseSortField } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import QueryJetpackPartnerPortalLicenses from 'calypso/components/data/query-jetpack-partner-portal-licenses';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
+import LicenseListHeader from 'calypso/jetpack-cloud/sections/partner-portal/license-list/header';
 
 /**
  * Style dependencies
@@ -48,65 +40,13 @@ function setPage( pageNumber: number ): void {
 	page( addQueryArgs( queryParams, currentPath ) );
 }
 
-function setSortingConfig(
-	newSortField: LicenseSortField,
-	sortField: LicenseSortField,
-	sortDirection: LicenseSortDirection
-): void {
-	let direction = LicenseSortDirection.Descending;
-
-	if ( newSortField === sortField && sortDirection === direction ) {
-		direction = LicenseSortDirection.Ascending;
-	}
-
-	const queryParams = {
-		sort_field: internalToPublicLicenseSortField( newSortField ),
-		sort_direction: direction,
-		page: 1,
-	};
-	const currentPath = window.location.pathname + window.location.search;
-
-	page( addQueryArgs( queryParams, currentPath ) );
-}
-
 interface LicenseTransitionProps {
 	key?: string;
 }
 
-const LicenseTransition = ( props: React.PropsWithChildren< LicenseTransitionProps > ) => (
+const LicenseTransition = ( props: PropsWithChildren< LicenseTransitionProps > ) => (
 	<CSSTransition { ...props } classNames="license-list__license-transition" timeout={ 150 } />
 );
-
-interface SortButtonProps {
-	sortField: LicenseSortField;
-	currentSortField: LicenseSortField;
-	currentSortDirection: LicenseSortDirection;
-}
-
-function SortButton( {
-	sortField,
-	currentSortField,
-	currentSortDirection,
-	children,
-}: PropsWithChildren< SortButtonProps > ) {
-	const sort = useCallback( () => {
-		setSortingConfig( sortField, currentSortField, currentSortDirection );
-	}, [ sortField, currentSortField, currentSortDirection ] );
-
-	return (
-		<h2 className={ classnames( { 'is-selected': sortField === currentSortField } ) }>
-			<button onClick={ sort }>
-				{ children }
-				<Gridicon
-					icon="dropdown"
-					className={ classnames( 'license-list-item__sort-indicator', {
-						[ `is-sort-${ currentSortDirection }` ]: true,
-					} ) }
-				/>
-			</button>
-		</h2>
-	);
-}
 
 export default function LicenseList(): ReactElement {
 	const translate = useTranslate();
@@ -130,41 +70,7 @@ export default function LicenseList(): ReactElement {
 				page={ currentPage }
 			/>
 
-			<LicenseListItem header className="license-list__header">
-				<h2>{ translate( 'License state' ) }</h2>
-
-				<SortButton
-					sortField={ LicenseSortField.IssuedAt }
-					currentSortField={ sortField }
-					currentSortDirection={ sortDirection }
-				>
-					{ translate( 'Issued on' ) }
-				</SortButton>
-
-				{ filter !== LicenseFilter.Revoked && (
-					<SortButton
-						sortField={ LicenseSortField.AttachedAt }
-						currentSortField={ sortField }
-						currentSortDirection={ sortDirection }
-					>
-						{ translate( 'Assigned on' ) }
-					</SortButton>
-				) }
-
-				{ filter === LicenseFilter.Revoked && (
-					<SortButton
-						sortField={ LicenseSortField.RevokedAt }
-						currentSortField={ sortField }
-						currentSortDirection={ sortDirection }
-					>
-						{ translate( 'Revoked on' ) }
-					</SortButton>
-				) }
-
-				<div>{ /* Intentionally empty header. */ }</div>
-
-				<div>{ /* Intentionally empty header. */ }</div>
-			</LicenseListItem>
+			<LicenseListHeader />
 
 			<TransitionGroup className="license-list__transition-group">
 				{ showLicenses &&

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -3,7 +3,6 @@
  */
 import React, { PropsWithChildren, ReactElement, useContext } from 'react';
 import { useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
 import CSSTransition from 'react-transition-group/CSSTransition';
@@ -13,7 +12,6 @@ import CSSTransition from 'react-transition-group/CSSTransition';
  */
 import { LICENSES_PER_PAGE } from 'calypso/state/partner-portal/licenses/constants';
 import { addQueryArgs } from 'calypso/lib/route';
-import { Card } from '@automattic/components';
 import { License, PaginatedItems } from 'calypso/state/partner-portal/types';
 import {
 	getPaginatedLicenses,
@@ -27,6 +25,7 @@ import Pagination from 'calypso/components/pagination';
 import QueryJetpackPartnerPortalLicenses from 'calypso/components/data/query-jetpack-partner-portal-licenses';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
 import LicenseListHeader from 'calypso/jetpack-cloud/sections/partner-portal/license-list/header';
+import LicenseListEmpty from 'calypso/jetpack-cloud/sections/partner-portal/license-list/empty-list';
 
 /**
  * Style dependencies
@@ -49,7 +48,6 @@ const LicenseTransition = ( props: PropsWithChildren< LicenseTransitionProps > )
 );
 
 export default function LicenseList(): ReactElement {
-	const translate = useTranslate();
 	const { filter, search, sortField, sortDirection, currentPage } = useContext(
 		LicenseListContext
 	);
@@ -70,7 +68,9 @@ export default function LicenseList(): ReactElement {
 				page={ currentPage }
 			/>
 
-			<LicenseListHeader />
+			{ ! showNoResults && <LicenseListHeader /> }
+
+			{ showNoResults && <LicenseListEmpty /> }
 
 			<TransitionGroup className="license-list__transition-group">
 				{ showLicenses &&
@@ -93,14 +93,6 @@ export default function LicenseList(): ReactElement {
 				{ isFetching && (
 					<LicenseTransition>
 						<LicensePreviewPlaceholder />
-					</LicenseTransition>
-				) }
-
-				{ showNoResults && (
-					<LicenseTransition>
-						<Card className="license-list__message" compact>
-							<p>{ translate( 'No licenses found.' ) }</p>
-						</Card>
 					</LicenseTransition>
 				) }
 

--- a/client/jetpack-cloud/sections/partner-portal/license-list/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/style.scss
@@ -14,14 +14,23 @@
 		}
 	}
 
-	&__message {
+	&__empty-list {
+		text-align: center;
+
+		h2 {
+			margin-top: 3rem;
+			margin-bottom: 1rem;
+			font-size: $font-title-medium;
+		}
 		p {
-			margin: 0;
-			padding: 0;
-			font-size: 0.875rem;
-			font-style: italic;
-			font-weight: normal;
-			color: var( --color-neutral-light );
+			margin-bottom: 1rem;
+			font-size: $font-body;
+		}
+
+		.button {
+			margin-top: 1.75rem;
+			margin-bottom: 1.75rem;
+			color: var( --color-accent );
 		}
 	}
 


### PR DESCRIPTION
Context:
* Project thread: pbtFPC-Um-p2
* i4 designs: pbtFPC-103-p2

#### Changes proposed in this Pull Request

* Move the license list header into its own component
* Introduce a new component for the UI of the empty views in the license list.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If you do not have a partner key, please contact Infinity for one or you will be unable to test this PR.
* Check out this PR locally, then run* yarn && yarn start-jetpack-cloud.
* Visit http://jetpack.cloud.localhost:3000/partner-portal
* Filter the list by one of the status: All Active, Unassigned, Assigned, and Revoked
* If it doesn't have licenses after a certain filter, it should show the title (eg. "No Assigned Licenses") and a button to issue a new license.
* If it doesn't have unassigned licenses and there are assigned licenses, and you are under the "Unassigned" filter, show another line with the following message: "Every license you own is currently attached to a site."

![image](https://user-images.githubusercontent.com/5714212/113923071-7ce69a00-97be-11eb-9366-035b28fcb7be.png)

![image](https://user-images.githubusercontent.com/5714212/113923280-c20acc00-97be-11eb-8b81-af1cade40aae.png)
