### PR TITLE
Update/1438 account creation connection flow copy update

### DIFF
--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -125,21 +125,16 @@ export class AuthFormHeader extends Component {
 		}
 
 		if ( wooDnaConfig && wooDnaConfig.isWooDnaFlow() ) {
-			if (
-				currentState === 'logged-in' &&
-				wooDnaConfig.getFlowName() === 'woodna:woocommerce-payments'
-			) {
-				return translate(
-					'Approve your connection. Your account will enable you to start using the features and benefits offered by WooCommerce Payments'
-				);
-			}
-
 			switch ( currentState ) {
 				case 'logged-in-success':
 				case 'auth-in-progress':
 					return translate( 'Connecting your store' );
-				case 'logged-in':
 				default:
+					if ( wooDnaConfig.getFlowName() === 'woodna:woocommerce-payments' ) {
+						return translate(
+							'Approve your connection. Your account will enable you to start using the features and benefits offered by WooCommerce Payments'
+						);
+					}
 					return translate( 'Approve your connection' );
 			}
 		}

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -125,10 +125,20 @@ export class AuthFormHeader extends Component {
 		}
 
 		if ( wooDnaConfig && wooDnaConfig.isWooDnaFlow() ) {
+			if (
+				currentState === 'logged-in' &&
+				wooDnaConfig.getFlowName() === 'woodna:woocommerce-payments'
+			) {
+				return translate(
+					'Approve your connection. Your account will enable you to start using the features and benefits offered by WooCommerce Payments'
+				);
+			}
+
 			switch ( currentState ) {
 				case 'logged-in-success':
 				case 'auth-in-progress':
 					return translate( 'Connecting your store' );
+				case 'logged-in':
 				default:
 					return translate( 'Approve your connection' );
 			}

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -382,7 +382,13 @@ export class JetpackSignup extends Component {
 				);
 			} else {
 				header = wooDna.getServiceName();
-				subHeader = translate( 'Enter your email address to get started' );
+				if ( wooDna.getFlowName() === 'woodna:woocommerce-payments' ) {
+					subHeader = translate(
+						'Enter your email address to get started. Your account will enable you to start using the features and benefits offered by WooCommerce Payments'
+					);
+				} else {
+					subHeader = translate( 'Enter your email address to get started' );
+				}
 				pageTitle = translate( 'Connect' );
 			}
 			content = (

--- a/client/jetpack-connect/test/auth-form-header.js
+++ b/client/jetpack-connect/test/auth-form-header.js
@@ -13,6 +13,8 @@ import { shallow } from 'enzyme';
  * Internal dependencies
  */
 import { AuthFormHeader } from '../auth-form-header';
+import FormattedHeader from 'calypso/components/formatted-header';
+import wooDnaConfig from '../woo-dna-config';
 
 const CLIENT_ID = 98765;
 const SITE_SLUG = 'an.example.site';
@@ -43,5 +45,28 @@ describe( 'AuthFormHeader', () => {
 		const wrapper = shallow( <AuthFormHeader { ...DEFAULT_PROPS } /> );
 
 		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	test( 'should render WC Payments specific sub header copy', () => {
+		const authQuery = {
+			...DEFAULT_PROPS.authQuery,
+			from: 'woocommerce-payments',
+			woodna_service_name: 'WooCommerce Payments',
+		};
+		const props = {
+			...DEFAULT_PROPS,
+			authQuery,
+			wooDnaConfig: wooDnaConfig( authQuery ),
+		};
+
+		// Notice we have \xa0. This is needed when we compare translated text.
+		// Please refer to https://stackoverflow.com/questions/54242039/intl-numberformat-space-character-does-not-match
+		const expectedText =
+			'Approve your connection. Your account will enable you to start using the features and benefits offered by WooCommerce\xa0Payments';
+		const wrapper = shallow( <AuthFormHeader { ...props } /> )
+			.find( FormattedHeader )
+			.render();
+
+		expect( wrapper.find( '.formatted-header__subtitle' ).text() ).toEqual( expectedText );
 	} );
 } );

--- a/client/jetpack-connect/test/signup.js
+++ b/client/jetpack-connect/test/signup.js
@@ -15,6 +15,7 @@ import { shallow } from 'enzyme';
  */
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import { JetpackSignup } from '../signup.js';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 const noop = () => {};
 const CLIENT_ID = 98765;
@@ -75,5 +76,27 @@ describe( 'JetpackSignup', () => {
 
 		expect( wrapper ).toMatchSnapshot();
 		expect( wrapper.find( LocaleSuggestions ) ).toHaveLength( 1 );
+	} );
+
+	test( 'should render WC Payments specific sub header copy', () => {
+		const props = {
+			...DEFAULT_PROPS,
+			authQuery: {
+				...DEFAULT_PROPS.authQuery,
+				from: 'woocommerce-payments',
+				woodna_service_name: 'WooCommerce Payments',
+				isFullLoginFormVisible: false,
+			},
+		};
+
+		// Notice we have \xa0. This is needed when we compare translated text.
+		// Please refer to https://stackoverflow.com/questions/54242039/intl-numberformat-space-character-does-not-match
+		const expectedText =
+			'Enter your email address to get started. Your account will enable you to start using the features and benefits offered by WooCommerce\xa0Payments';
+		const wrapper = shallow( <JetpackSignup { ...props } /> )
+			.find( FormattedHeader )
+			.render();
+
+		expect( wrapper.find( '.formatted-header__subtitle' ).text() ).toEqual( expectedText );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes https://github.com/Automattic/woocommerce-payments/issues/1438

This PR updates the subheader copy for WooCommerce Payments on the Jetpack authorization page.

#### Testing instructions

1. Create a new Jurassic Ninja site. Install and activate WooCommerce. 
2. Navigate to WooCommerce -> Home and finish the onboarding wizard. Make sure to choose a US-based address. Make sure to check "Install recommended free business features" on the Product Types step. This will install WooCommerce Payments for you.
3. Click "Payments" from the main sidebar or navigate to http://your-jn-site/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect
4. Click "Setup"
5. When you get redirected to the Jetpack authorization page, copy the URL. Your URL should look something like below.
```
http://wordpress.com/jetpack/connect/authorize?client=....
```

6. Replace http://wordpress.com with your local Calypso and access the new URL. Your new URL should look something like below.

```
http://calypso.localhost:3000/jetpack/connect/authorize?client_id=...
```

7. You should see the new subheader copy (screenshot 1)
8. Open a new incognito window and access the same URL again.
9. You should see the new subheader for the logged-out state (screenshot 2)

#### Screenshots

Screenshot 1
![Screen Shot 2021-04-07 at 12 30 19 PM](https://user-images.githubusercontent.com/4723145/113924049-2bc6ae00-979e-11eb-9ae1-254e9473ae2b.jpg)

Screenshot 2
![Screen Shot 2021-04-07 at 12 30 40 PM](https://user-images.githubusercontent.com/4723145/113924066-32edbc00-979e-11eb-836b-b257832388b7.jpg)
