### PR TITLE
Jetpack Cloud: Update activity log upsell link

### DIFF
--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -71,7 +71,7 @@ const ActivityLogV2: FunctionComponent = () => {
 			bodyText={ translate(
 				'With your free plan, you can monitor the 20 most recent events. A paid plan unlocks more powerful features. You can access all site activity for the last 30 days and filter events by type and date range to quickly find the information you need. '
 			) }
-			buttonLink={ `https://wordpress.com/plans/${ selectedSiteSlug }?feature=offsite-backup-vaultpress-daily&plan=jetpack_personal_monthly` }
+			buttonLink={ `https://cloud.jetpack.com/pricing/${ selectedSiteSlug }` }
 			buttonText={ translate( 'Upgrade Now' ) }
 			onClick={ () =>
 				dispatch( recordTracksEvent( 'calypso_jetpack_activity_log_upgrade_click' ) )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the upsell link in for the Activity Log in Jetpack Cloud.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. On site that does not have activity log, visit `http://jetpack.cloud.localhost:3001/activity-log/{site-slug}`.
2. Verify that the upsell button displays and links to `https://cloud.jetpack.com/pricing/{site-slug}`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1164141197617539-as-1200165101336372