### PR TITLE
Jetpack Cloud: Update Activity Log header

### DIFF
--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -67,7 +67,7 @@ const ActivityLogV2: FunctionComponent = () => {
 
 	const jetpackCloudHeader = showUpgrade ? (
 		<Upsell
-			headerText={ translate( 'Welcome to your site’s activity' ) }
+			headerText={ translate( 'Activity Log' ) }
 			bodyText={ translate(
 				'With your free plan, you can monitor the 20 most recent events. A paid plan unlocks more powerful features. You can access all site activity for the last 30 days and filter events by type and date range to quickly find the information you need. '
 			) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the header of the Activity Log to say "Activity Log" instead of "Welcome to your site’s activity".

Before:
<img width="931" alt="image" src="https://user-images.githubusercontent.com/42627630/113936918-1497b880-97be-11eb-8a3f-b629467c5b63.png">

After:
<img width="1010" alt="image" src="https://user-images.githubusercontent.com/42627630/113936967-21b4a780-97be-11eb-8734-9e7d3d9cbba8.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. On a site that does not have Activity Log, visit `http://jetpack.cloud.localhost:3001/activity-log/{site_slug}`.
2. Verify that the header says "Activity Log".

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1164141197617539-as-1200160409999163