### PR TITLE
[Design Picker]: Add integration tests

### DIFF
--- a/packages/design-picker/src/__tests__/integration.test.tsx
+++ b/packages/design-picker/src/__tests__/integration.test.tsx
@@ -1,6 +1,47 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { isEnabled } from '@automattic/calypso-config';
+
+/**
+ * Internal dependencies
+ */
+import DesignPicker from '../components';
+import { availableDesigns } from '../utils';
+import type { Design } from '../types';
+
+jest.mock( `@automattic/calypso-config`, () => ( {
+	isEnabled: jest.fn().mockImplementation( ( feature: string ) => {
+		switch ( feature ) {
+			case `gutenboarding/landscape-preview`:
+				return false;
+			case `gutenboarding/mshot-preview`:
+				return false;
+		}
+	} ),
+} ) );
+
+const MOCK_LOCALE = `en`;
+const MOCK_DESIGN_TITLE = 'Cassel';
+
 // Design picker integration tests
 describe( '<DesignPicker /> integration', () => {
-	it( 'should be replaced with real integration tests', () => {
-		expect( 1 ).toBeTruthy();
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should select a design', async () => {
+		const mockedOnSelectCallback = jest.fn();
+
+		render( <DesignPicker locale={ MOCK_LOCALE } onSelect={ mockedOnSelectCallback } /> );
+
+		fireEvent.click( screen.getByLabelText( new RegExp( MOCK_DESIGN_TITLE, 'i' ) ) );
+
+		expect( mockedOnSelectCallback ).toHaveBeenCalledWith(
+			availableDesigns.featured.find( ( design: Design ) => design.title === MOCK_DESIGN_TITLE )
+		);
 	} );
 } );

--- a/packages/design-picker/src/__tests__/integration.test.tsx
+++ b/packages/design-picker/src/__tests__/integration.test.tsx
@@ -3,8 +3,7 @@
  */
 import * as React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { isEnabled } from '@automattic/calypso-config';
+import '@automattic/calypso-config';
 
 /**
  * Internal dependencies

--- a/packages/design-picker/src/__tests__/integration.test.tsx
+++ b/packages/design-picker/src/__tests__/integration.test.tsx
@@ -9,7 +9,7 @@ import '@automattic/calypso-config';
  * Internal dependencies
  */
 import DesignPicker from '../components';
-import { availableDesigns } from '../utils';
+import { getAvailableDesigns } from '../utils';
 import type { Design } from '../types';
 
 jest.mock( `@automattic/calypso-config`, () => ( {
@@ -40,7 +40,9 @@ describe( '<DesignPicker /> integration', () => {
 		fireEvent.click( screen.getByLabelText( new RegExp( MOCK_DESIGN_TITLE, 'i' ) ) );
 
 		expect( mockedOnSelectCallback ).toHaveBeenCalledWith(
-			availableDesigns.featured.find( ( design: Design ) => design.title === MOCK_DESIGN_TITLE )
+			getAvailableDesigns().featured.find(
+				( design: Design ) => design.title === MOCK_DESIGN_TITLE
+			)
 		);
 	} );
 } );

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -26,7 +26,7 @@ const makeOptionId = ( { slug }: Design ): string => `design-picker__option-name
 interface Props {
 	locale: string;
 	onSelect: ( design: Design ) => void;
-	designs: Design[];
+	designs?: Design[];
 	premiumBadge?: React.ReactNode;
 	isGridMinimal?: boolean;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add integration test to assert selecting designs. 

#### Testing instructions

* check out this branch and run `yarn`.
* run `yarn test-packages packages/design-picker`
* [x] all tests should pass ✅  

#### Things to consider 🤔 
With integration tests, we don't want to mock managed dependencies, hence we don't want to mock the designs (since we have full control over them). This makes our integration tests solid (i.e. we're re-enacting the user's experience completely) but we trade-in some control. 

We might want to consider mocking the designs after all and then, for example, we're able to test with premium designs too.

Fixes #51403 
