### PR TITLE
Removes nav unification atomic launch workarounds.

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -30,7 +30,7 @@ export default function SidebarItem( props ) {
 		const { search } = getUrlParts( url );
 		if ( ! search.includes( 'from=' ) ) {
 			// `from` param is used by WP Admin on Atomic sites for disabling Nav Unification in that context. Can be removed after rolling Nav Unification out to 100% of users.
-			url = addQueryArgs( { from: 'calypso-old-menu', calypsoify: 0 }, url );
+			url = addQueryArgs( { calypsoify: 0 }, url );
 		}
 	}
 

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -945,10 +945,7 @@ export class MySitesSidebar extends Component {
 		}
 
 		// `from` param is used by WP Admin on Atomic sites for disabling Nav Unification in that context. Can be removed after rolling Nav Unification out to 100% of users.
-		let adminUrl = addQueryArgs(
-			{ from: 'calypso-old-menu', calypsoify: 0 },
-			site.options.admin_url
-		);
+		let adminUrl = addQueryArgs( { calypsoify: 0 }, site.options.admin_url );
 
 		if ( this.props.isJetpack && ! this.props.isAtomicSite && ! this.props.isVip ) {
 			const urlParts = getUrlParts( site.options.admin_url + 'admin.php' );

--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -30,7 +30,6 @@ const sanitizeUrl = ( url, wpAdminUrl ) => {
 		url = addQueryArgs(
 			{
 				return: document.location.href, // Gives WP Admin a chance to return to where we started from.
-				from: 'calypso-unified-menu', // `from` param is used by WP Admin on Atomic sites for enabling Nav Unification in that context. Can be removed after rolling Nav Unification out to 100% of users.
 			},
 			url
 		);

--- a/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
@@ -93,7 +93,6 @@ describe( 'handlers', () => {
 		sanitizedMenu[ 1 ].children[ 0 ].url = addQueryArgs(
 			{
 				return: document.location.href,
-				from: 'calypso-unified-menu',
 			},
 			sanitizedMenu[ 1 ].children[ 0 ].url
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes nav unification atomic launch workarounds so that we don't depend on Jetpack connection data. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* None

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 665-gh-Automattic/wpcomsh