### PR TITLE
Framework: Remove unnecessary bindActionCreators

### DIFF
--- a/client/blocks/comments/comment-edit-form.jsx
+++ b/client/blocks/comments/comment-edit-form.jsx
@@ -1,12 +1,10 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -201,6 +199,4 @@ PostCommentForm.defaultProps = {
 	onCommentSubmit: noop,
 };
 
-const mapDispatchToProps = ( dispatch ) => bindActionCreators( { editComment }, dispatch );
-
-export default connect( null, mapDispatchToProps )( PostCommentForm );
+export default connect( null, { editComment } )( PostCommentForm );

--- a/client/blocks/dismissible-card/docs/example.jsx
+++ b/client/blocks/dismissible-card/docs/example.jsx
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { partial } from 'lodash';
 
 /**

--- a/client/components/data/query-posts/index.jsx
+++ b/client/components/data/query-posts/index.jsx
@@ -4,7 +4,6 @@
 import { Component } from 'react';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import debug from 'debug';
 
 /**
@@ -72,14 +71,9 @@ export default connect(
 			requestingPosts: isRequestingPostsForQuery( state, siteId, query ),
 		};
 	},
-	( dispatch ) => {
-		return bindActionCreators(
-			{
-				requestSitePosts,
-				requestAllSitesPosts,
-				requestSitePost,
-			},
-			dispatch
-		);
+	{
+		requestSitePosts,
+		requestAllSitesPosts,
+		requestSitePost,
 	}
 )( QueryPosts );

--- a/client/components/data/query-reader-feed/index.jsx
+++ b/client/components/data/query-reader-feed/index.jsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -50,12 +48,7 @@ export default connect(
 			shouldFeedBeFetched: shouldFeedBeFetched( state, feedId ),
 		};
 	},
-	( dispatch ) => {
-		return bindActionCreators(
-			{
-				requestFeed,
-			},
-			dispatch
-		);
+	{
+		requestFeed,
 	}
 )( QueryReaderFeed );

--- a/client/components/data/query-reader-list/index.jsx
+++ b/client/components/data/query-reader-list/index.jsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -54,12 +52,7 @@ export default connect(
 			isRequestingList: isRequestingList( state, owner, slug ),
 		};
 	},
-	( dispatch ) => {
-		return bindActionCreators(
-			{
-				requestList,
-			},
-			dispatch
-		);
+	{
+		requestList,
 	}
 )( QueryReaderList );

--- a/client/components/data/query-reader-lists/index.jsx
+++ b/client/components/data/query-reader-lists/index.jsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -42,12 +40,7 @@ export default connect(
 			isRequestingSubscribedLists: isRequestingSubscribedLists( state ),
 		};
 	},
-	( dispatch ) => {
-		return bindActionCreators(
-			{
-				requestSubscribedLists,
-			},
-			dispatch
-		);
+	{
+		requestSubscribedLists,
 	}
 )( QueryReaderLists );

--- a/client/components/data/query-reader-site/index.jsx
+++ b/client/components/data/query-reader-site/index.jsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -50,12 +48,7 @@ export default connect(
 			shouldSiteBeFetched: shouldSiteBeFetched( state, siteId ),
 		};
 	},
-	( dispatch ) => {
-		return bindActionCreators(
-			{
-				requestSite,
-			},
-			dispatch
-		);
+	{
+		requestSite,
 	}
 )( QueryReaderSite );

--- a/client/components/data/query-reader-tag-images/index.jsx
+++ b/client/components/data/query-reader-tag-images/index.jsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -50,12 +48,7 @@ export default connect(
 			shouldRequestTagImages: shouldRequestTagImages( state, ownProps.tag ),
 		};
 	},
-	( dispatch ) => {
-		return bindActionCreators(
-			{
-				requestTagImages,
-			},
-			dispatch
-		);
+	{
+		requestTagImages,
 	}
 )( QueryReaderTagImages );

--- a/client/components/data/query-reader-thumbnails/index.jsx
+++ b/client/components/data/query-reader-thumbnails/index.jsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -45,6 +43,4 @@ const mapStateToProps = ( state, ownProps ) => ( {
 	shouldRequestThumbnail: ! getThumbnailForIframe( state, ownProps.embedUrl ),
 } );
 
-const mapDispatchToProps = ( dispatch ) => bindActionCreators( { requestThumbnail }, dispatch );
-
-export default connect( mapStateToProps, mapDispatchToProps )( QueryReaderThumbnails );
+export default connect( mapStateToProps, { requestThumbnail } )( QueryReaderThumbnails );

--- a/client/components/data/query-site-guided-transfer/index.jsx
+++ b/client/components/data/query-site-guided-transfer/index.jsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -53,7 +51,6 @@ const mapStateToProps = ( state, ownProps ) => ( {
 	isRequesting: isRequestingGuidedTransferStatus( state, ownProps.siteId ),
 } );
 
-const mapDispatchToProps = ( dispatch ) =>
-	bindActionCreators( { requestGuidedTransferStatus }, dispatch );
-
-export default connect( mapStateToProps, mapDispatchToProps )( QuerySiteGuidedTransfer );
+export default connect( mapStateToProps, { requestGuidedTransferStatus } )(
+	QuerySiteGuidedTransfer
+);

--- a/client/extensions/hello-dolly/hello-dolly-page.js
+++ b/client/extensions/hello-dolly/hello-dolly-page.js
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 /**
@@ -106,13 +104,4 @@ function mapStateToProps( state ) {
 	};
 }
 
-function mapDispatchToProps( dispatch ) {
-	return bindActionCreators(
-		{
-			nextLyric,
-		},
-		dispatch
-	);
-}
-
-export default connect( mapStateToProps, mapDispatchToProps )( HelloDollyPage );
+export default connect( mapStateToProps, { nextLyric } )( HelloDollyPage );

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import page from 'page';
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { filter, get, range } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -581,5 +580,5 @@ export default connect(
 			siteId,
 		};
 	},
-	( dispatch ) => bindActionCreators( { requestSites, fetchPluginData, installPlugin }, dispatch )
+	{ requestSites, fetchPluginData, installPlugin }
 )( localize( PlansSetup ) );

--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import debugModule from 'debug';
 import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -209,5 +208,5 @@ export default connect(
 			syncProgress: syncSelectors.getSyncProgressPercentage( state, siteId ),
 		};
 	},
-	( dispatch ) => bindActionCreators( { getSyncStatus, scheduleJetpackFullysync }, dispatch )
+	{ getSyncStatus, scheduleJetpackFullysync }
 )( localize( withLocalizedMoment( JetpackSyncPanel ) ) );

--- a/client/my-sites/woocommerce/dashboard/required-plugins-install-view.jsx
+++ b/client/my-sites/woocommerce/dashboard/required-plugins-install-view.jsx
@@ -3,7 +3,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { find } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -627,20 +626,10 @@ function mapStateToProps( state ) {
 	};
 }
 
-function mapDispatchToProps( dispatch ) {
-	return bindActionCreators(
-		{
-			activatePlugin,
-			fetchPluginData,
-			installAndActivatePlugin,
-			fetchPlugins,
-			logToLogstash,
-		},
-		dispatch
-	);
-}
-
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps
-)( localize( RequiredPluginsInstallView ) );
+export default connect( mapStateToProps, {
+	activatePlugin,
+	fetchPluginData,
+	installAndActivatePlugin,
+	fetchPlugins,
+	logToLogstash,
+} )( localize( RequiredPluginsInstallView ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes a bunch of `bindActionCreators` instances that aren't really necessary, because action creators are bound automatically when `mapDispatchToProps` is defined as an object of action creators.

#### Testing instructions

* Do some smoke testing on Reader and Posts pages and verify everything still works alright.