### PR TITLE
chore: Migrate `@automattic/magellan-mocha-plugin` tests to Jest

### DIFF
--- a/packages/magellan-mocha-plugin/jest.config.js
+++ b/packages/magellan-mocha-plugin/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+};

--- a/packages/magellan-mocha-plugin/lib/get_tests.js
+++ b/packages/magellan-mocha-plugin/lib/get_tests.js
@@ -6,6 +6,7 @@ const spawnSync = require( 'child_process' ).spawnSync;
 const Locator = require( './locator' );
 const mochaSettings = require( './settings' );
 const logger = require( 'testarmada-logger' );
+const pkgUp = require( 'pkg-up' );
 
 module.exports = function ( settings ) {
 	logger.prefix = 'Mocha Plugin';
@@ -16,7 +17,10 @@ module.exports = function ( settings ) {
 		fs.mkdirSync( settings.tempDir );
 	}
 
-	const cmd = path.resolve( require.resolve( 'mocha' ), '../bin/mocha' );
+	const mochaDir = path.dirname(
+		pkgUp.sync( { cwd: path.dirname( require.resolve( 'mocha' ) ) } )
+	);
+	const cmd = path.join( mochaDir, './bin/mocha' );
 	let args = [];
 
 	if ( mochaSettings.suiteTag !== undefined ) {

--- a/packages/magellan-mocha-plugin/lib/get_tests.js
+++ b/packages/magellan-mocha-plugin/lib/get_tests.js
@@ -16,7 +16,7 @@ module.exports = function ( settings ) {
 		fs.mkdirSync( settings.tempDir );
 	}
 
-	const cmd = './node_modules/.bin/mocha';
+	const cmd = path.resolve( require.resolve( 'mocha' ), '../bin/mocha' );
 	let args = [];
 
 	if ( mochaSettings.suiteTag !== undefined ) {

--- a/packages/magellan-mocha-plugin/lib/get_tests.js
+++ b/packages/magellan-mocha-plugin/lib/get_tests.js
@@ -30,16 +30,14 @@ module.exports = function ( settings ) {
 
 	args.push( '--reporter', reporter );
 
-	/* istanbul ignore else */
-	if ( mochaSettings.mochaOpts ) {
-		args.push( '--opts', mochaSettings.mochaOpts );
+	if ( mochaSettings.mochaConfig ) {
+		args.push( '--config', mochaSettings.mochaConfig );
 	}
 
 	args = args.concat( mochaSettings.mochaTestFolders );
 	const env = _.extend( {}, process.env, { MOCHA_CAPTURE_PATH: OUTPUT_PATH } );
 	const capture = spawnSync( cmd, args, { env: env } );
 
-	/* istanbul ignore next */
 	if ( capture.status !== 0 ) {
 		logger.err(
 			'Could not capture mocha tests. To debug, run the following command:\n' +

--- a/packages/magellan-mocha-plugin/lib/settings.js
+++ b/packages/magellan-mocha-plugin/lib/settings.js
@@ -1,11 +1,11 @@
 const settings = {
-	mochaOpts: undefined, // --mocha_opts opts_file
+	mochaConfig: undefined, // --mocha_config config file
 	mochaArgs: undefined, // --mocha_args command line arguments
 	mochaTestFolders: undefined, // --mocha_tests location (or array in magellan.json)
 	suiteTag: undefined,
 
 	initialize: function ( argv ) {
-		settings.mochaOpts = argv.mocha_opts;
+		settings.mochaConfig = argv.mocha_config;
 		settings.mochaArgs = argv.mocha_args;
 		settings.mochaTestFolders = argv.mocha_tests;
 		settings.suiteTag = argv.suiteTag;

--- a/packages/magellan-mocha-plugin/lib/test_run.js
+++ b/packages/magellan-mocha-plugin/lib/test_run.js
@@ -33,8 +33,8 @@ MochaTestRun.prototype.getArguments = function () {
 
 	let args = [ '--mocking_port=' + this.mockingPort, '--worker=1', '-g', grepString ];
 
-	if ( mochaSettings.mochaOpts ) {
-		args.push( '--opts', mochaSettings.mochaOpts );
+	if ( mochaSettings.mochaConfig ) {
+		args.push( '--config', mochaSettings.mochaConfig );
 	}
 
 	if ( mochaSettings.mochaArgs !== undefined ) {

--- a/packages/magellan-mocha-plugin/package.json
+++ b/packages/magellan-mocha-plugin/package.json
@@ -24,6 +24,6 @@
 	},
 	"devDependencies": {
 		"coffee-script": "^1.10.0",
-		"mocha": "^3.2.0"
+		"mocha": "^8.1.3"
 	}
 }

--- a/packages/magellan-mocha-plugin/package.json
+++ b/packages/magellan-mocha-plugin/package.json
@@ -22,6 +22,7 @@
 		"testarmada-logger": "1.1.1"
 	},
 	"devDependencies": {
-		"coffee-script": "^1.10.0"
+		"coffee-script": "^1.10.0",
+		"mocha": "^3.2.0"
 	}
 }

--- a/packages/magellan-mocha-plugin/package.json
+++ b/packages/magellan-mocha-plugin/package.json
@@ -19,6 +19,7 @@
 	"dependencies": {
 		"cli-color": "^1.2.0",
 		"lodash": "^4.17.21",
+		"pkg-up": "^3.1.0",
 		"testarmada-logger": "1.1.1"
 	},
 	"devDependencies": {

--- a/packages/magellan-mocha-plugin/package.json
+++ b/packages/magellan-mocha-plugin/package.json
@@ -16,12 +16,6 @@
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
 	"license": "MIT",
-	"scripts": {
-		"test": "mocha --slow 400 && npm run coverage && npm run check-coverage",
-		"lint": "eslint lib/** test/**",
-		"coverage": "istanbul cover _mocha",
-		"check-coverage": "istanbul check-coverage --statement 95 --function 95 --branch 90"
-	},
 	"dependencies": {
 		"cli-color": "^1.2.0",
 		"lodash": "^4.17.21",

--- a/packages/magellan-mocha-plugin/package.json
+++ b/packages/magellan-mocha-plugin/package.json
@@ -22,10 +22,6 @@
 		"testarmada-logger": "1.1.1"
 	},
 	"devDependencies": {
-		"chai": "^3.4.1",
-		"coffee-script": "^1.10.0",
-		"istanbul": "^0.4.5",
-		"mocha": "^3.2.0",
-		"sinon": "^1.17.3"
+		"coffee-script": "^1.10.0"
 	}
 }

--- a/packages/magellan-mocha-plugin/test/amend_node_config.spec.js
+++ b/packages/magellan-mocha-plugin/test/amend_node_config.spec.js
@@ -1,5 +1,3 @@
-const chai = require( 'chai' );
-const expect = chai.expect;
 const amendNodeConfig = require( '../lib/amend_node_config' );
 
 describe( 'amendNodeConfig', function () {
@@ -11,7 +9,7 @@ describe( 'amendNodeConfig', function () {
 				},
 				{ b: 2 }
 			)
-		).to.eql( { a: 2, b: 2 } );
+		).toEqual( { a: 2, b: 2 } );
 	} );
 
 	it( 'should look for node config with bad data', function () {
@@ -22,7 +20,7 @@ describe( 'amendNodeConfig', function () {
 				},
 				{ b: 2 }
 			)
-		).to.eql( { b: 2 } );
+		).toEqual( { b: 2 } );
 	} );
 
 	it( 'should look for node config with an object', function () {
@@ -33,7 +31,7 @@ describe( 'amendNodeConfig', function () {
 				},
 				{ b: 2 }
 			)
-		).to.eql( { a: 2, b: 2 } );
+		).toEqual( { a: 2, b: 2 } );
 	} );
 
 	it( 'should look for node config with a number', function () {
@@ -44,6 +42,6 @@ describe( 'amendNodeConfig', function () {
 				},
 				{ b: 2 }
 			)
-		).to.eql( { b: 2 } );
+		).toEqual( { b: 2 } );
 	} );
 } );

--- a/packages/magellan-mocha-plugin/test/get_suites.spec.js
+++ b/packages/magellan-mocha-plugin/test/get_suites.spec.js
@@ -1,8 +1,10 @@
 const path = require( 'path' );
 const Locator = require( '../lib/locator' );
 const testFramework = require( '../index' );
+const fs = require( 'fs' ).promises;
+const os = require( 'os' );
 
-function getTestsFrom( specs ) {
+async function getTestsFrom( specs ) {
 	if ( ! Array.isArray( specs ) ) {
 		specs = [ specs ];
 	}
@@ -11,14 +13,15 @@ function getTestsFrom( specs ) {
 		mocha_config: path.join( specs[ 0 ], '.mocharc.js' ),
 		suiteTag: 'suite;multiple',
 	} );
-	return testFramework.iterator( { tempDir: path.resolve( '.' ) } );
+	const tempDir = await fs.mkdtemp( path.join( os.tmpdir(), 'magellan-mocha-plugin' ) );
+	return testFramework.iterator( { tempDir } );
 }
 
 describe( 'suite iterator', function () {
 	let suites;
 
-	beforeEach( function () {
-		suites = getTestsFrom( path.join( __dirname, '../test_support/suite' ) );
+	beforeAll( async function () {
+		suites = await getTestsFrom( path.join( __dirname, '../test_support/suite' ) );
 	} );
 
 	it( 'finds suites', function () {

--- a/packages/magellan-mocha-plugin/test/get_suites.spec.js
+++ b/packages/magellan-mocha-plugin/test/get_suites.spec.js
@@ -8,7 +8,7 @@ function getTestsFrom( specs ) {
 	}
 	testFramework.initialize( {
 		mocha_tests: specs,
-		mocha_opts: path.join( specs[ 0 ], 'mocha.opts' ),
+		mocha_config: path.join( specs[ 0 ], '.mocharc.js' ),
 		suiteTag: 'suite;multiple',
 	} );
 	return testFramework.iterator( { tempDir: path.resolve( '.' ) } );

--- a/packages/magellan-mocha-plugin/test/get_suites.spec.js
+++ b/packages/magellan-mocha-plugin/test/get_suites.spec.js
@@ -1,6 +1,4 @@
 const path = require( 'path' );
-const chai = require( 'chai' );
-const expect = chai.expect;
 const Locator = require( '../lib/locator' );
 const testFramework = require( '../index' );
 
@@ -19,21 +17,21 @@ function getTestsFrom( specs ) {
 describe( 'suite iterator', function () {
 	let suites;
 
-	before( function () {
-		suites = getTestsFrom( './test_support/suite' );
+	beforeEach( function () {
+		suites = getTestsFrom( path.join( __dirname, '../test_support/suite' ) );
 	} );
 
 	it( 'finds suites', function () {
-		expect( suites ).to.have.length( 3 );
+		expect( suites ).toHaveLength( 3 );
 	} );
 
 	it( 'instantiates tests as Locators', function () {
-		expect( suites[ 0 ] ).to.be.an.instanceOf( Locator );
+		expect( suites[ 0 ] ).toBeInstanceOf( Locator );
 	} );
 
 	it( 'collects details of a test', function () {
 		const suite = suites[ 0 ];
-		expect( suite.name ).to.equal( 'Suite @suite' );
-		expect( suites[ 0 ].filename ).to.contain( 'test_support/suite/spec.js' );
+		expect( suite.name ).toBe( 'Suite @suite' );
+		expect( suites[ 0 ].filename ).toEqual( expect.stringMatching( 'test_support/suite/spec.js' ) );
 	} );
 } );

--- a/packages/magellan-mocha-plugin/test/get_tests.spec.js
+++ b/packages/magellan-mocha-plugin/test/get_tests.spec.js
@@ -1,8 +1,10 @@
 const path = require( 'path' );
 const Locator = require( '../lib/locator' );
 const testFramework = require( '../index' );
+const fs = require( 'fs' ).promises;
+const os = require( 'os' );
 
-function getTestsFrom( specs ) {
+async function getTestsFrom( specs ) {
 	if ( ! Array.isArray( specs ) ) {
 		specs = [ specs ];
 	}
@@ -10,14 +12,15 @@ function getTestsFrom( specs ) {
 		mocha_tests: specs,
 		mocha_config: path.join( specs[ 0 ], '.mocharc.js' ),
 	} );
-	return testFramework.iterator( { tempDir: path.resolve( '.' ) } );
+	const tempDir = await fs.mkdtemp( path.join( os.tmpdir(), 'magellan-mocha-plugin' ) );
+	return testFramework.iterator( { tempDir } );
 }
 
 describe( 'test iterator', function () {
 	let tests;
 
-	beforeAll( function () {
-		tests = getTestsFrom( path.join( __dirname, '../test_support/basic' ) );
+	beforeAll( async function () {
+		tests = await getTestsFrom( path.join( __dirname, '../test_support/basic' ) );
 	} );
 
 	it( 'finds tests', function () {
@@ -45,19 +48,19 @@ describe( 'test iterator', function () {
 	} );
 } );
 
-describe( 'test iterator plus mocha.opts', function () {
-	it( 'supports coffeescript', function () {
-		const tests = getTestsFrom( path.join( __dirname, '../test_support/coffee' ) );
+describe( 'test iterator plus .mocharc.js', function () {
+	it( 'supports coffeescript', async function () {
+		const tests = await getTestsFrom( path.join( __dirname, '../test_support/coffee' ) );
 		expect( tests ).toHaveLength( 2 );
 	} );
 
-	it( 'respects grep option and ignores non-matching', function () {
-		const tests = getTestsFrom( path.join( __dirname, '../test_support/grep' ) );
+	it( 'respects grep option and ignores non-matching', async function () {
+		const tests = await getTestsFrom( path.join( __dirname, '../test_support/grep' ) );
 		expect( tests ).toHaveLength( 3 );
 	} );
 
-	it( 'supports recursive collection', function () {
-		const tests = getTestsFrom( path.join( __dirname, '../test_support/recursive' ) );
+	it( 'supports recursive collection', async function () {
+		const tests = await getTestsFrom( path.join( __dirname, '../test_support/recursive' ) );
 		expect( tests ).toHaveLength( 4 );
 	} );
 } );

--- a/packages/magellan-mocha-plugin/test/get_tests.spec.js
+++ b/packages/magellan-mocha-plugin/test/get_tests.spec.js
@@ -8,7 +8,7 @@ function getTestsFrom( specs ) {
 	}
 	testFramework.initialize( {
 		mocha_tests: specs,
-		mocha_opts: path.join( specs[ 0 ], 'mocha.opts' ),
+		mocha_config: path.join( specs[ 0 ], '.mocharc.js' ),
 	} );
 	return testFramework.iterator( { tempDir: path.resolve( '.' ) } );
 }

--- a/packages/magellan-mocha-plugin/test/get_tests.spec.js
+++ b/packages/magellan-mocha-plugin/test/get_tests.spec.js
@@ -1,6 +1,4 @@
 const path = require( 'path' );
-const chai = require( 'chai' );
-const expect = chai.expect;
 const Locator = require( '../lib/locator' );
 const testFramework = require( '../index' );
 
@@ -18,46 +16,48 @@ function getTestsFrom( specs ) {
 describe( 'test iterator', function () {
 	let tests;
 
-	before( function () {
-		tests = getTestsFrom( './test_support/basic' );
+	beforeAll( function () {
+		tests = getTestsFrom( path.join( __dirname, '../test_support/basic' ) );
 	} );
 
 	it( 'finds tests', function () {
-		expect( tests ).to.have.length( 2 );
+		expect( tests ).toHaveLength( 2 );
 	} );
 
 	it( 'instantiates tests as Locators', function () {
-		expect( tests[ 0 ] ).to.be.an.instanceOf( Locator );
+		expect( tests[ 0 ] ).toBeInstanceOf( Locator );
 	} );
 
 	it( 'collects details of a test', function () {
 		const test = tests[ 0 ];
-		expect( test.name ).to.equal( 'Suite passes' );
-		expect( test.title ).to.equal( 'passes' );
-		expect( tests[ 0 ].filename ).to.contain( 'test_support/basic/spec.js' );
-		expect( test.pending ).to.be.false;
+		expect( test.name ).toBe( 'Suite passes' );
+		expect( test.title ).toBe( 'passes' );
+		expect( tests[ 0 ].filename ).toEqual(
+			expect.stringContaining( 'test_support/basic/spec.js' )
+		);
+		expect( test.pending ).toBe( false );
 	} );
 
 	it( 'collects pending tests', function () {
 		const test = tests[ 1 ];
-		expect( test.title ).to.equal( 'contains pending' );
-		expect( test.pending ).to.be.true;
+		expect( test.title ).toBe( 'contains pending' );
+		expect( test.pending ).toBe( true );
 	} );
 } );
 
 describe( 'test iterator plus mocha.opts', function () {
 	it( 'supports coffeescript', function () {
-		const tests = getTestsFrom( './test_support/coffee' );
-		expect( tests ).to.have.length( 2 );
+		const tests = getTestsFrom( path.join( __dirname, '../test_support/coffee' ) );
+		expect( tests ).toHaveLength( 2 );
 	} );
 
 	it( 'respects grep option and ignores non-matching', function () {
-		const tests = getTestsFrom( './test_support/grep' );
-		expect( tests ).to.have.length( 3 );
+		const tests = getTestsFrom( path.join( __dirname, '../test_support/grep' ) );
+		expect( tests ).toHaveLength( 3 );
 	} );
 
 	it( 'supports recursive collection', function () {
-		const tests = getTestsFrom( './test_support/recursive' );
-		expect( tests ).to.have.length( 4 );
+		const tests = getTestsFrom( path.join( __dirname, '../test_support/recursive' ) );
+		expect( tests ).toHaveLength( 4 );
 	} );
 } );

--- a/packages/magellan-mocha-plugin/test/group_filter.spec.js
+++ b/packages/magellan-mocha-plugin/test/group_filter.spec.js
@@ -1,5 +1,3 @@
-const chai = require( 'chai' );
-const expect = chai.expect;
 const testFramework = require( '../index' );
 const filters = testFramework.filters;
 const tests = [ 'a', 'b', 'b/x', 'c', 'd' ].map( function ( f ) {
@@ -9,18 +7,18 @@ const tests = [ 'a', 'b', 'b/x', 'c', 'd' ].map( function ( f ) {
 describe( 'group filter', function () {
 	it( 'returns all tests when no partial given', function () {
 		const filtered = filters.group( tests );
-		expect( filtered ).to.equal( tests );
+		expect( filtered ).toBe( tests );
 	} );
 
 	it( 'filters by a single partial', function () {
 		const filtered = filters.group( tests, 'b' );
-		expect( filtered ).to.have.length( 2 );
-		expect( filtered[ 1 ] ).to.have.property( 'filename' ).that.equals( 'b/x/spec.js' );
+		expect( filtered ).toHaveLength( 2 );
+		expect( filtered[ 1 ] ).toHaveProperty( 'filename', 'b/x/spec.js' );
 	} );
 
 	it( 'filters by multiple partials', function () {
 		const filtered = filters.group( tests, [ 'b', 'd' ] );
-		expect( filtered ).to.have.length( 3 );
-		expect( filtered[ 2 ] ).to.have.property( 'filename' ).that.equals( 'd/spec.js' );
+		expect( filtered ).toHaveLength( 3 );
+		expect( filtered[ 2 ] ).toHaveProperty( 'filename', 'd/spec.js' );
 	} );
 } );

--- a/packages/magellan-mocha-plugin/test/locator.spec.js
+++ b/packages/magellan-mocha-plugin/test/locator.spec.js
@@ -1,10 +1,8 @@
-const chai = require( 'chai' );
-const expect = chai.expect;
 const Locator = require( '../lib/locator' );
 
 describe( 'locator', function () {
 	it( 'should convert to string', function () {
 		const a = new Locator( 'a' );
-		expect( a.toString() ).to.eql( 'a' );
+		expect( a.toString() ).toBe( 'a' );
 	} );
 } );

--- a/packages/magellan-mocha-plugin/test/profile.spec.js
+++ b/packages/magellan-mocha-plugin/test/profile.spec.js
@@ -1,21 +1,19 @@
-const chai = require( 'chai' );
-const expect = chai.expect;
 const profile = require( '../lib/profile' );
 
 describe( 'profile', function () {
 	it( 'no browser is passed', function () {
-		expect( profile.getProfiles( [] ) ).to.eql( [] );
+		expect( profile.getProfiles( [] ) ).toEqual( [] );
 	} );
 
 	it( 'browser is passed', function () {
-		expect( profile.getProfiles( [ 'chrome' ] ) ).to.eql( [ { id: 'mocha' } ] );
+		expect( profile.getProfiles( [ 'chrome' ] ) ).toEqual( [ { id: 'mocha' } ] );
 	} );
 
 	it( 'getCapabilities', function () {
-		expect( profile.getCapabilities() ).to.eql( { id: 'mocha' } );
+		expect( profile.getCapabilities() ).toEqual( { id: 'mocha' } );
 	} );
 
 	it( 'listBrowsers', function () {
-		expect( profile.listBrowsers() ).to.eql( [ 'mocha' ] );
+		expect( profile.listBrowsers() ).toEqual( [ 'mocha' ] );
 	} );
 } );

--- a/packages/magellan-mocha-plugin/test/settings.spec.js
+++ b/packages/magellan-mocha-plugin/test/settings.spec.js
@@ -1,12 +1,12 @@
 const testFramework = require( '../index' );
 
 describe( 'settings', function () {
-	it( 'stores paths to tests and mocha.opts', function () {
+	it( 'stores paths to tests and mocha config', function () {
 		testFramework.initialize( {
 			mocha_tests: [ './test_support/basic' ],
-			mocha_opts: './test_support/basic/mocha.opts',
+			mocha_config: './test_support/basic/.mocharc.js',
 		} );
 		expect( testFramework.settings.mochaTestFolders ).toEqual( [ './test_support/basic' ] );
-		expect( testFramework.settings.mochaOpts ).toBe( './test_support/basic/mocha.opts' );
+		expect( testFramework.settings.mochaConfig ).toBe( './test_support/basic/.mocharc.js' );
 	} );
 } );

--- a/packages/magellan-mocha-plugin/test/settings.spec.js
+++ b/packages/magellan-mocha-plugin/test/settings.spec.js
@@ -1,5 +1,3 @@
-const chai = require( 'chai' );
-const expect = chai.expect;
 const testFramework = require( '../index' );
 
 describe( 'settings', function () {
@@ -8,7 +6,7 @@ describe( 'settings', function () {
 			mocha_tests: [ './test_support/basic' ],
 			mocha_opts: './test_support/basic/mocha.opts',
 		} );
-		expect( testFramework.settings.mochaTestFolders ).to.deep.equal( [ './test_support/basic' ] );
-		expect( testFramework.settings.mochaOpts ).to.equal( './test_support/basic/mocha.opts' );
+		expect( testFramework.settings.mochaTestFolders ).toEqual( [ './test_support/basic' ] );
+		expect( testFramework.settings.mochaOpts ).toBe( './test_support/basic/mocha.opts' );
 	} );
 } );

--- a/packages/magellan-mocha-plugin/test/single_test_filter.spec.js
+++ b/packages/magellan-mocha-plugin/test/single_test_filter.spec.js
@@ -1,7 +1,3 @@
-const path = require( 'path' );
-const sinon = require( 'sinon' );
-const chai = require( 'chai' );
-const expect = chai.expect;
 const testFramework = require( '../index' );
 const filters = testFramework.filters;
 const tests = [];
@@ -14,19 +10,9 @@ const tests = [];
 } );
 
 describe( 'single test filter', function () {
-	beforeEach( function () {
-		sinon.stub( path, 'resolve', function ( p ) {
-			return p;
-		} );
-	} );
-
-	afterEach( function () {
-		path.resolve.restore();
-	} );
-
 	it( 'returns the tests matching the given file', function () {
 		const filtered = filters.test( tests, 'path/to/b.js' );
-		expect( filtered ).to.have.length( 2 );
-		expect( filtered[ 0 ] ).to.have.property( 'filename' ).that.equals( 'path/to/b.js' );
+		expect( filtered ).toHaveLength( 2 );
+		expect( filtered[ 0 ] ).toHaveProperty( 'filename', 'path/to/b.js' );
 	} );
 } );

--- a/packages/magellan-mocha-plugin/test/tag_filter.spec.js
+++ b/packages/magellan-mocha-plugin/test/tag_filter.spec.js
@@ -1,5 +1,3 @@
-const chai = require( 'chai' );
-const expect = chai.expect;
 const testFramework = require( '../index' );
 const tagFilter = require( '../lib/tag_filter' );
 const filters = testFramework.filters;
@@ -9,27 +7,27 @@ const tests = [ 'a @foo', 'b', 'c @bar', 'd @bar', 'e @foo @bar' ].map( function
 
 describe( 'tag filter', function () {
 	it( 'is offered on both tag and tags', function () {
-		expect( filters.tag ).to.equal( filters.tags );
+		expect( filters.tag ).toBe( filters.tags );
 	} );
 
 	it( 'handle no array', function () {
 		filters.tag( tests, 'bar' );
-		expect( tagFilter( [ { a: 1 } ], null ) ).to.eql( [ { a: 1 } ] );
+		expect( tagFilter( [ { a: 1 } ], null ) ).toEqual( [ { a: 1 } ] );
 	} );
 
 	it( 'matches a single tag string', function () {
 		const filtered = filters.tag( tests, 'bar' );
-		expect( filtered ).to.have.length( 3 );
-		expect( filtered[ 0 ] ).to.have.property( 'name' ).that.equals( 'c @bar' );
+		expect( filtered ).toHaveLength( 3 );
+		expect( filtered[ 0 ] ).toHaveProperty( 'name', 'c @bar' );
 	} );
 
 	it( 'matches multiple tags in string', function () {
 		const filtered = filters.tag( tests, 'bar , foo' );
-		expect( filtered ).to.have.length( 1 );
+		expect( filtered ).toHaveLength( 1 );
 	} );
 
 	it( 'matches tags array', function () {
 		const filtered = filters.tag( tests, [ 'bar', 'foo' ] );
-		expect( filtered ).to.have.length( 1 );
+		expect( filtered ).toHaveLength( 1 );
 	} );
 } );

--- a/packages/magellan-mocha-plugin/test/test_run.spec.js
+++ b/packages/magellan-mocha-plugin/test/test_run.spec.js
@@ -1,5 +1,3 @@
-const chai = require( 'chai' );
-const expect = chai.expect;
 const testFramework = require( '../index' );
 const TestRun = testFramework.TestRun;
 
@@ -16,12 +14,12 @@ describe( 'TestRun class', function () {
 	} );
 
 	it( 'instantiates', function () {
-		expect( run.locator.name ).to.equal( 'The full name of the test to run' );
-		expect( run.mockingPort ).to.equal( 10 );
+		expect( run.locator.name ).toBe( 'The full name of the test to run' );
+		expect( run.mockingPort ).toBe( 10 );
 	} );
 
 	it( 'returns path to mocha', function () {
-		expect( run.getCommand() ).to.equal( './node_modules/.bin/mocha' );
+		expect( run.getCommand() ).toBe( './node_modules/.bin/mocha' );
 	} );
 
 	it( 'returns the environment for a run', function () {
@@ -30,7 +28,7 @@ describe( 'TestRun class', function () {
 		} );
 
 		// these values are super important, to be used by the testing tools in the worker processes
-		expect( env ).to.deep.equal( {
+		expect( env ).toEqual( {
 			NODE_CONFIG: { foo: 'bar' },
 		} );
 	} );
@@ -49,7 +47,7 @@ describe( 'TestRun class', function () {
 		} );
 
 		const args = localRun.getArguments();
-		expect( args ).to.deep.equal( [
+		expect( args ).toEqual( [
 			'--mocking_port=10',
 			'--worker=1',
 			'-g',

--- a/packages/magellan-mocha-plugin/test/test_run.spec.js
+++ b/packages/magellan-mocha-plugin/test/test_run.spec.js
@@ -36,9 +36,10 @@ describe( 'TestRun class', function () {
 	it( 'returns the arguments for a run', function () {
 		testFramework.initialize( {
 			mocha_tests: [ 'path/to/specs', 'another/path/to/specs' ],
-			mocha_opts: 'path/to/mocha.opts',
+			mocha_config: 'path/to/.mocharc.js',
 		} );
 
+		debugger;
 		const localRun = new TestRun( {
 			locator: {
 				name: 'The full name of the test to run',
@@ -52,8 +53,8 @@ describe( 'TestRun class', function () {
 			'--worker=1',
 			'-g',
 			'The full name of the test to run',
-			'--opts',
-			'path/to/mocha.opts',
+			'--config',
+			'path/to/.mocharc.js',
 			'path/to/specs',
 			'another/path/to/specs',
 		] );

--- a/packages/magellan-mocha-plugin/test/test_run.spec.js
+++ b/packages/magellan-mocha-plugin/test/test_run.spec.js
@@ -39,7 +39,6 @@ describe( 'TestRun class', function () {
 			mocha_config: 'path/to/.mocharc.js',
 		} );
 
-		debugger;
 		const localRun = new TestRun( {
 			locator: {
 				name: 'The full name of the test to run',

--- a/packages/magellan-mocha-plugin/test_support/coffee/.mocharc.js
+++ b/packages/magellan-mocha-plugin/test_support/coffee/.mocharc.js
@@ -1,0 +1,4 @@
+module.exports = {
+	require: [ 'coffeescript/register' ],
+	extension: [ 'coffee' ],
+};

--- a/packages/magellan-mocha-plugin/test_support/coffee/mocha.opts
+++ b/packages/magellan-mocha-plugin/test_support/coffee/mocha.opts
@@ -1,1 +1,0 @@
---compilers coffee:coffee-script/register

--- a/packages/magellan-mocha-plugin/test_support/grep/.mocharc.js
+++ b/packages/magellan-mocha-plugin/test_support/grep/.mocharc.js
@@ -1,0 +1,3 @@
+module.exports = {
+	grep: '@match',
+};

--- a/packages/magellan-mocha-plugin/test_support/grep/mocha.opts
+++ b/packages/magellan-mocha-plugin/test_support/grep/mocha.opts
@@ -1,1 +1,0 @@
---grep @match

--- a/packages/magellan-mocha-plugin/test_support/recursive/.mocharc.js
+++ b/packages/magellan-mocha-plugin/test_support/recursive/.mocharc.js
@@ -1,0 +1,3 @@
+module.exports = {
+	recursive: true,
+};

--- a/packages/magellan-mocha-plugin/test_support/recursive/mocha.opts
+++ b/packages/magellan-mocha-plugin/test_support/recursive/mocha.opts
@@ -1,1 +1,0 @@
---recursive

--- a/yarn.lock
+++ b/yarn.lock
@@ -7621,11 +7621,6 @@ browser-resolve@^1.11.0, browser-resolve@^1.7.0:
   dependencies:
     resolve "1.1.7"
 
-browser-stdout@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
-  integrity sha1-81HTKWnTL6XXpVZxVCY9korjvR8=
-
 browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
@@ -8928,13 +8923,6 @@ commander@2.8.x:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@2.9.0, commander@~2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
-  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
-  dependencies:
-    graceful-readlink ">= 1.0.0"
-
 commander@^2.11.0, commander@^2.15.1, commander@^2.19.0, commander@^2.20.0, commander@^2.9.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -8969,6 +8957,13 @@ commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+
+commander@~2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
+  dependencies:
+    graceful-readlink ">= 1.0.0"
 
 comment-parser@1.1.2:
   version "1.1.2"
@@ -10187,13 +10182,6 @@ dateformat@~1.0.12:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
-debug@2.6.8:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
-  integrity sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=
-  dependencies:
-    ms "2.0.0"
-
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -10604,11 +10592,6 @@ diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
-
-diff@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
-  integrity sha1-yc45Okt8vQsFinJck98pkCeGj/k=
 
 diff@4.0.2, diff@^4.0.2:
   version "4.0.2"
@@ -11495,11 +11478,6 @@ escape-regexp-component@^1.0.2:
   resolved "https://registry.yarnpkg.com/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz#9c63b6d0b25ff2a88c3adbd18c5b61acc3b9faa2"
   integrity sha1-nGO20LJf8qiMOtvRjFthrMO5+qI=
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
 escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
@@ -11509,6 +11487,11 @@ escape-string-regexp@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 escodegen@^1.9.1:
   version "1.14.1"
@@ -13450,18 +13433,6 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
-  integrity sha1-gFIR3wT6rxxjo2ADBs31reULLsg=
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@7.1.6, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1, glob@~7.1.2:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
@@ -13766,11 +13737,6 @@ growl@1.10.5:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
-growl@1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
-  integrity sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=
-
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -14065,11 +14031,6 @@ hawk@~1.0.0:
     cryptiles "0.2.x"
     hoek "0.9.x"
     sntp "0.2.x"
-
-he@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
-  integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
 
 he@1.2.0, he@1.2.x, he@^1.2.0:
   version "1.2.0"
@@ -16692,11 +16653,6 @@ json2php@^0.0.4:
   resolved "https://registry.yarnpkg.com/json2php/-/json2php-0.0.4.tgz#6bd85a1dda6a5dd7e91022bb24403cc1b7c2ee34"
   integrity sha1-a9haHdpqXdfpECK7JEA8wbfC7jQ=
 
-json3@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
-  integrity sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=
-
 json5@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.4.0.tgz#054352e4c4c80c86c0923877d449de176a732c8d"
@@ -17216,24 +17172,6 @@ lodash-es@^4.17.15, lodash-es@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
-lodash._baseassign@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
-  integrity sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=
-  dependencies:
-    lodash._basecopy "^3.0.0"
-    lodash.keys "^3.0.0"
-
-lodash._basecopy@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
-  integrity sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=
-
-lodash._basecreate@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
-  integrity sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=
-
 lodash._baseisequal@^3.0.0:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz#d8025f76339d29342767dcc887ce5cb95a5b51f1"
@@ -17252,11 +17190,6 @@ lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
-
-lodash._isiterateecall@^3.0.0:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
-  integrity sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -17277,15 +17210,6 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
-
-lodash.create@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
-  integrity sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=
-  dependencies:
-    lodash._baseassign "^3.0.0"
-    lodash._basecreate "^3.0.0"
-    lodash._isiterateecall "^3.0.0"
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -18341,11 +18265,6 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
 minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
@@ -18487,13 +18406,6 @@ mkdirp-infer-owner@^2.0.0:
     infer-owner "^1.0.4"
     mkdirp "^1.0.3"
 
-mkdirp@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  dependencies:
-    minimist "0.0.8"
-
 "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
@@ -18526,24 +18438,6 @@ mocha-teamcity-reporter@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/mocha-teamcity-reporter/-/mocha-teamcity-reporter-3.0.0.tgz#2c4776288f23dac61aa0fee5930571cc2a51df1a"
   integrity sha512-FyGgmtFfW2nDwEZU3mrjQShAAK/zhGivwY4HCsqoDoyeS8vV8HGdq1Dn2P+SFaIoCeXTQ0Z+5xVRyikYaKrW5w==
-
-mocha@^3.2.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
-  integrity sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==
-  dependencies:
-    browser-stdout "1.3.0"
-    commander "2.9.0"
-    debug "2.6.8"
-    diff "3.2.0"
-    escape-string-regexp "1.0.5"
-    glob "7.1.1"
-    growl "1.9.2"
-    he "1.1.1"
-    json3 "3.3.2"
-    lodash.create "3.1.1"
-    mkdirp "0.5.1"
-    supports-color "3.1.2"
 
 mocha@^8.1.3:
   version "8.1.3"
@@ -25602,13 +25496,6 @@ supertest@^4.0.2:
   dependencies:
     methods "^1.1.2"
     superagent "^3.8.3"
-
-supports-color@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
-  integrity sha1-cqJiiU2dQIuVbKBf83su2KbiotU=
-  dependencies:
-    has-flag "^1.0.0"
 
 supports-color@6.1.0, supports-color@^6.1.0:
   version "6.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7621,6 +7621,11 @@ browser-resolve@^1.11.0, browser-resolve@^1.7.0:
   dependencies:
     resolve "1.1.7"
 
+browser-stdout@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
+  integrity sha1-81HTKWnTL6XXpVZxVCY9korjvR8=
+
 browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
@@ -8923,6 +8928,13 @@ commander@2.8.x:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commander@2.9.0, commander@~2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
 commander@^2.11.0, commander@^2.15.1, commander@^2.19.0, commander@^2.20.0, commander@^2.9.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -8957,13 +8969,6 @@ commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
-
-commander@~2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
-  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
-  dependencies:
-    graceful-readlink ">= 1.0.0"
 
 comment-parser@1.1.2:
   version "1.1.2"
@@ -10182,6 +10187,13 @@ dateformat@~1.0.12:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
+debug@2.6.8:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+  integrity sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=
+  dependencies:
+    ms "2.0.0"
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -10592,6 +10604,11 @@ diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
+diff@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
+  integrity sha1-yc45Okt8vQsFinJck98pkCeGj/k=
 
 diff@4.0.2, diff@^4.0.2:
   version "4.0.2"
@@ -11478,6 +11495,11 @@ escape-regexp-component@^1.0.2:
   resolved "https://registry.yarnpkg.com/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz#9c63b6d0b25ff2a88c3adbd18c5b61acc3b9faa2"
   integrity sha1-nGO20LJf8qiMOtvRjFthrMO5+qI=
 
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
 escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
@@ -11487,11 +11509,6 @@ escape-string-regexp@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
-
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 escodegen@^1.9.1:
   version "1.14.1"
@@ -13433,6 +13450,18 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
+glob@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  integrity sha1-gFIR3wT6rxxjo2ADBs31reULLsg=
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@7.1.6, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1, glob@~7.1.2:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
@@ -13737,6 +13766,11 @@ growl@1.10.5:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
+growl@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
+  integrity sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -14031,6 +14065,11 @@ hawk@~1.0.0:
     cryptiles "0.2.x"
     hoek "0.9.x"
     sntp "0.2.x"
+
+he@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+  integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
 
 he@1.2.0, he@1.2.x, he@^1.2.0:
   version "1.2.0"
@@ -16653,6 +16692,11 @@ json2php@^0.0.4:
   resolved "https://registry.yarnpkg.com/json2php/-/json2php-0.0.4.tgz#6bd85a1dda6a5dd7e91022bb24403cc1b7c2ee34"
   integrity sha1-a9haHdpqXdfpECK7JEA8wbfC7jQ=
 
+json3@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
+  integrity sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=
+
 json5@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.4.0.tgz#054352e4c4c80c86c0923877d449de176a732c8d"
@@ -17172,6 +17216,24 @@ lodash-es@^4.17.15, lodash-es@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
+lodash._baseassign@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
+  integrity sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=
+  dependencies:
+    lodash._basecopy "^3.0.0"
+    lodash.keys "^3.0.0"
+
+lodash._basecopy@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
+  integrity sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=
+
+lodash._basecreate@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
+  integrity sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=
+
 lodash._baseisequal@^3.0.0:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz#d8025f76339d29342767dcc887ce5cb95a5b51f1"
@@ -17190,6 +17252,11 @@ lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
+
+lodash._isiterateecall@^3.0.0:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
+  integrity sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -17210,6 +17277,15 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
+lodash.create@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
+  integrity sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=
+  dependencies:
+    lodash._baseassign "^3.0.0"
+    lodash._basecreate "^3.0.0"
+    lodash._isiterateecall "^3.0.0"
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -18265,6 +18341,11 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
+
 minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
@@ -18406,6 +18487,13 @@ mkdirp-infer-owner@^2.0.0:
     infer-owner "^1.0.4"
     mkdirp "^1.0.3"
 
+mkdirp@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  dependencies:
+    minimist "0.0.8"
+
 "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
@@ -18438,6 +18526,24 @@ mocha-teamcity-reporter@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/mocha-teamcity-reporter/-/mocha-teamcity-reporter-3.0.0.tgz#2c4776288f23dac61aa0fee5930571cc2a51df1a"
   integrity sha512-FyGgmtFfW2nDwEZU3mrjQShAAK/zhGivwY4HCsqoDoyeS8vV8HGdq1Dn2P+SFaIoCeXTQ0Z+5xVRyikYaKrW5w==
+
+mocha@^3.2.0:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
+  integrity sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==
+  dependencies:
+    browser-stdout "1.3.0"
+    commander "2.9.0"
+    debug "2.6.8"
+    diff "3.2.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.1"
+    growl "1.9.2"
+    he "1.1.1"
+    json3 "3.3.2"
+    lodash.create "3.1.1"
+    mkdirp "0.5.1"
+    supports-color "3.1.2"
 
 mocha@^8.1.3:
   version "8.1.3"
@@ -25496,6 +25602,13 @@ supertest@^4.0.2:
   dependencies:
     methods "^1.1.2"
     superagent "^3.8.3"
+
+supports-color@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
+  integrity sha1-cqJiiU2dQIuVbKBf83su2KbiotU=
+  dependencies:
+    has-flag "^1.0.0"
 
 supports-color@6.1.0, supports-color@^6.1.0:
   version "6.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5678,11 +5678,6 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-abbrev@1.0.x:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
-  integrity sha1-kbR5JYinc4wl813W9jdSovh3YTU=
-
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -6281,7 +6276,7 @@ assert@^1.1.1, assert@^1.4.0:
     object-assign "^4.1.1"
     util "0.10.3"
 
-assertion-error@^1.0.1, assertion-error@^1.1.0:
+assertion-error@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
@@ -6353,7 +6348,7 @@ async@0.9.x, async@~0.9.0:
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
   integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
 
-async@1.x, async@^1.2.1, async@~1.5.2:
+async@^1.2.1, async@~1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
@@ -7626,11 +7621,6 @@ browser-resolve@^1.11.0, browser-resolve@^1.7.0:
   dependencies:
     resolve "1.1.7"
 
-browser-stdout@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
-  integrity sha1-81HTKWnTL6XXpVZxVCY9korjvR8=
-
 browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
@@ -8199,15 +8189,6 @@ chai-enzyme@^1.0.0-beta.1:
   integrity sha512-vWT101M7qjq6kM/29G4vHrgLM4Mj1gCnKuvOSF03s8pFVsqol4B6USoGM/aYRKqaaIHs8/AxmHjWGFplQWhIQw==
   dependencies:
     html "^1.0.0"
-
-chai@^3.4.1:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"
-  integrity sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=
-  dependencies:
-    assertion-error "^1.0.1"
-    deep-eql "^0.1.3"
-    type-detect "^1.0.0"
 
 chai@^4.2.0:
   version "4.2.0"
@@ -8942,13 +8923,6 @@ commander@2.8.x:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@2.9.0, commander@~2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
-  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
-  dependencies:
-    graceful-readlink ">= 1.0.0"
-
 commander@^2.11.0, commander@^2.15.1, commander@^2.19.0, commander@^2.20.0, commander@^2.9.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -8983,6 +8957,13 @@ commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+
+commander@~2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
+  dependencies:
+    graceful-readlink ">= 1.0.0"
 
 comment-parser@1.1.2:
   version "1.1.2"
@@ -10201,13 +10182,6 @@ dateformat@~1.0.12:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
-debug@2.6.8:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
-  integrity sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=
-  dependencies:
-    ms "2.0.0"
-
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -10303,13 +10277,6 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
-
-deep-eql@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
-  integrity sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=
-  dependencies:
-    type-detect "0.1.1"
 
 deep-eql@^3.0.1:
   version "3.0.1"
@@ -10625,11 +10592,6 @@ diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
-
-diff@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
-  integrity sha1-yc45Okt8vQsFinJck98pkCeGj/k=
 
 diff@4.0.2, diff@^4.0.2:
   version "4.0.2"
@@ -11516,11 +11478,6 @@ escape-regexp-component@^1.0.2:
   resolved "https://registry.yarnpkg.com/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz#9c63b6d0b25ff2a88c3adbd18c5b61acc3b9faa2"
   integrity sha1-nGO20LJf8qiMOtvRjFthrMO5+qI=
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
 escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
@@ -11531,17 +11488,10 @@ escape-string-regexp@4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-escodegen@1.8.x:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.8.1.tgz#5a5b53af4693110bebb0867aa3430dd3b70a1018"
-  integrity sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=
-  dependencies:
-    esprima "^2.7.1"
-    estraverse "^1.9.1"
-    esutils "^2.0.2"
-    optionator "^0.8.1"
-  optionalDependencies:
-    source-map "~0.2.0"
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 escodegen@^1.9.1:
   version "1.14.1"
@@ -11966,7 +11916,7 @@ espree@^7.3.0, espree@^7.3.1:
     acorn-jsx "^5.3.1"
     eslint-visitor-keys "^1.3.0"
 
-esprima@2.7.x, esprima@^2.0, esprima@^2.7.1:
+esprima@^2.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
   integrity sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=
@@ -11994,11 +11944,6 @@ esrecurse@^4.1.0, esrecurse@^4.3.0:
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
     estraverse "^5.2.0"
-
-estraverse@^1.9.1:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
-  integrity sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=
 
 estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
@@ -13001,13 +12946,6 @@ format@^0.2.0:
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
 
-formatio@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
-  integrity sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=
-  dependencies:
-    samsam "~1.1"
-
 formidable@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
@@ -13495,18 +13433,6 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
-  integrity sha1-gFIR3wT6rxxjo2ADBs31reULLsg=
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@7.1.6, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1, glob@~7.1.2:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
@@ -13519,10 +13445,10 @@ glob@7.1.6, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.0, glob@^7.1.1, glo
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^5.0.15, glob@~5.0.0:
-  version "5.0.15"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
-  integrity sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  integrity sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=
   dependencies:
     inflight "^1.0.4"
     inherits "2"
@@ -13530,10 +13456,10 @@ glob@^5.0.15, glob@~5.0.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^6.0.1:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
-  integrity sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=
+glob@~5.0.0:
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
+  integrity sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=
   dependencies:
     inflight "^1.0.4"
     inherits "2"
@@ -13811,11 +13737,6 @@ growl@1.10.5:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
-growl@1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
-  integrity sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=
-
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -13945,7 +13866,7 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
-handlebars@^4.0.1, handlebars@^4.7.6:
+handlebars@^4.7.6:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -14110,11 +14031,6 @@ hawk@~1.0.0:
     cryptiles "0.2.x"
     hoek "0.9.x"
     sntp "0.2.x"
-
-he@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
-  integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
 
 he@1.2.0, he@1.2.x, he@^1.2.0:
   version "1.2.0"
@@ -15886,26 +15802,6 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-istanbul@^0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/istanbul/-/istanbul-0.4.5.tgz#65c7d73d4c4da84d4f3ac310b918fb0b8033733b"
-  integrity sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=
-  dependencies:
-    abbrev "1.0.x"
-    async "1.x"
-    escodegen "1.8.x"
-    esprima "2.7.x"
-    glob "^5.0.15"
-    handlebars "^4.0.1"
-    js-yaml "3.x"
-    mkdirp "0.5.x"
-    nopt "3.x"
-    once "1.x"
-    resolve "1.1.x"
-    supports-color "^3.1.0"
-    which "^1.1.1"
-    wordwrap "^1.0.0"
-
 iterate-iterator@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/iterate-iterator/-/iterate-iterator-1.0.1.tgz#1693a768c1ddd79c969051459453f082fe82e9f6"
@@ -16544,7 +16440,7 @@ js-yaml@3.14.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@3.x, js-yaml@^3.13.1, js-yaml@^3.14.0:
+js-yaml@^3.13.1, js-yaml@^3.14.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -16756,11 +16652,6 @@ json2php@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/json2php/-/json2php-0.0.4.tgz#6bd85a1dda6a5dd7e91022bb24403cc1b7c2ee34"
   integrity sha1-a9haHdpqXdfpECK7JEA8wbfC7jQ=
-
-json3@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
-  integrity sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=
 
 json5@0.4.0:
   version "0.4.0"
@@ -17281,24 +17172,6 @@ lodash-es@^4.17.15, lodash-es@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
-lodash._baseassign@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
-  integrity sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=
-  dependencies:
-    lodash._basecopy "^3.0.0"
-    lodash.keys "^3.0.0"
-
-lodash._basecopy@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
-  integrity sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=
-
-lodash._basecreate@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
-  integrity sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=
-
 lodash._baseisequal@^3.0.0:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz#d8025f76339d29342767dcc887ce5cb95a5b51f1"
@@ -17317,11 +17190,6 @@ lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
-
-lodash._isiterateecall@^3.0.0:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
-  integrity sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -17342,15 +17210,6 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
-
-lodash.create@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
-  integrity sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=
-  dependencies:
-    lodash._baseassign "^3.0.0"
-    lodash._basecreate "^3.0.0"
-    lodash._isiterateecall "^3.0.0"
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -17578,11 +17437,6 @@ logform@^2.1.1:
     fecha "^2.3.3"
     ms "^2.1.1"
     triple-beam "^1.3.0"
-
-lolex@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
-  integrity sha1-fD2mL/yzDw9agKJWbKJORdigHzE=
 
 long@^3.2.0:
   version "3.2.0"
@@ -18411,11 +18265,6 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
 minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
@@ -18557,14 +18406,7 @@ mkdirp-infer-owner@^2.0.0:
     infer-owner "^1.0.4"
     mkdirp "^1.0.3"
 
-mkdirp@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  dependencies:
-    minimist "0.0.8"
-
-mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -18596,24 +18438,6 @@ mocha-teamcity-reporter@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/mocha-teamcity-reporter/-/mocha-teamcity-reporter-3.0.0.tgz#2c4776288f23dac61aa0fee5930571cc2a51df1a"
   integrity sha512-FyGgmtFfW2nDwEZU3mrjQShAAK/zhGivwY4HCsqoDoyeS8vV8HGdq1Dn2P+SFaIoCeXTQ0Z+5xVRyikYaKrW5w==
-
-mocha@^3.2.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
-  integrity sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==
-  dependencies:
-    browser-stdout "1.3.0"
-    commander "2.9.0"
-    debug "2.6.8"
-    diff "3.2.0"
-    escape-string-regexp "1.0.5"
-    glob "7.1.1"
-    growl "1.9.2"
-    he "1.1.1"
-    json3 "3.3.2"
-    lodash.create "3.1.1"
-    mkdirp "0.5.1"
-    supports-color "3.1.2"
 
 mocha@^8.1.3:
   version "8.1.3"
@@ -19194,7 +19018,7 @@ noop-logger@^0.1.1:
   resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
   integrity sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
 
-"nopt@2 || 3", nopt@3.x, nopt@~3.0.6:
+"nopt@2 || 3", nopt@~3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
@@ -19642,7 +19466,7 @@ on-headers@~1.0.2:
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
   integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
 
-once@1.x, once@^1.3.0, once@^1.3.1, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -23939,7 +23763,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@1.1.7, resolve@1.1.x, resolve@~1.1.0:
+resolve@1.1.7, resolve@~1.1.0:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
@@ -24161,16 +23985,6 @@ safe-regex@^1.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
-samsam@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
-  integrity sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=
-
-samsam@~1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.3.tgz#9f5087419b4d091f232571e7fa52e90b0f552621"
-  integrity sha1-n1CHQZtNCR8jJXHn+lLpCw9VJiE=
 
 sane@^4.0.3:
   version "4.1.0"
@@ -24678,16 +24492,6 @@ sinon-chai@^3.5.0:
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.5.0.tgz#c9a78304b0e15befe57ef68e8a85a00553f5c60e"
   integrity sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==
 
-sinon@^1.17.3:
-  version "1.17.7"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
-  integrity sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=
-  dependencies:
-    formatio "1.1.1"
-    lolex "1.3.2"
-    samsam "1.1.2"
-    util ">=0.10.3 <1"
-
 sinon@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.0.2.tgz#b9017e24633f4b1c98dfb6e784a5f0509f5fd85d"
@@ -25007,13 +24811,6 @@ source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
-
-source-map@~0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
-  integrity sha1-2rc/vPwrqBm03gO9b26qSBZLP50=
-  dependencies:
-    amdefine ">=0.0.4"
 
 sourcemap-codec@^1.4.4:
   version "1.4.8"
@@ -25700,13 +25497,6 @@ supertest@^4.0.2:
     methods "^1.1.2"
     superagent "^3.8.3"
 
-supports-color@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
-  integrity sha1-cqJiiU2dQIuVbKBf83su2KbiotU=
-  dependencies:
-    has-flag "^1.0.0"
-
 supports-color@6.1.0, supports-color@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
@@ -25726,7 +25516,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^3.1.0, supports-color@^3.2.3:
+supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
@@ -26645,20 +26435,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
-  integrity sha1-C6XsKohWQORw6k6FBZcZANrFiCI=
-
 type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
-
-type-detect@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
-  integrity sha1-diIXzAbbJY7EiQihKY6LlRIejqI=
 
 type-fest@^0.10.0:
   version "0.10.0"
@@ -27270,7 +27050,14 @@ util@0.10.3:
   dependencies:
     inherits "2.0.1"
 
-"util@>=0.10.3 <1", util@^0.12.3:
+util@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
+  integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
+  dependencies:
+    inherits "2.0.3"
+
+util@^0.12.3:
   version "0.12.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.3.tgz#971bb0292d2cc0c892dab7c6a5d37c2bec707888"
   integrity sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==
@@ -27281,13 +27068,6 @@ util@0.10.3:
     is-typed-array "^1.1.3"
     safe-buffer "^5.1.2"
     which-typed-array "^1.1.2"
-
-util@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
-  integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
-  dependencies:
-    inherits "2.0.3"
 
 util@~0.10.1:
   version "0.10.4"
@@ -27910,7 +27690,7 @@ which-typed-array@^1.1.2:
     has-symbols "^1.0.1"
     is-typed-array "^1.1.3"
 
-which@1, which@^1.1.1, which@^1.2.12, which@^1.2.14, which@^1.2.8, which@^1.2.9, which@^1.3.1, which@~1.3.0:
+which@1, which@^1.2.12, which@^1.2.14, which@^1.2.8, which@^1.2.9, which@^1.3.1, which@~1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
#### Background

In #51779 we forked the package `magellan-mocha-plugin` and incorporated it to our repo.

However, in order to keep the PR small, we didn't migrate the tests from `mocha` (the framework originally used by the package) to `jest` (the main test framework of the repo). This PR refactors those tests.

#### Changes proposed in this Pull Request

* Convert tests to `jest` syntax using https://github.com/skovhus/jest-codemods. Some asserts were converted manually.

* Refactor the code that assumes `mocha` is located in `./packages/magellan-mocha-plugin/node_modules/mocha`. In this case we want these tests to use `./node_modules/mocha`.

* In a similar way, refactor tests that assumed test fixtures are located in `./test_support/`.

* Refactor tests that write to the filesystem to use a random temporary directory, so tests can run in parallel.

* Update to latest `mocha` (otherwise the changes required to make the tests work will be incompatible with the `mocha` version used by e2e tests, specifically when using the deprecated option `--opts`).

* Drop unused dependencies (sinon, chai, eslint).

#### Testing instructions

* Verify unit tests pass.
* Inspect the test logs to ensure the new tests are run.