### PR TITLE
Domains: Remove users from transfer types that don't need them

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -251,7 +251,6 @@ export default {
 				component={ DomainManagement.Transfer }
 				context={ pageContext }
 				needsDomains
-				needsUsers
 				selectedDomainName={ pageContext.params.domain }
 			/>
 		);
@@ -266,7 +265,6 @@ export default {
 				component={ DomainManagement.TransferToOtherSite }
 				context={ pageContext }
 				needsDomains
-				needsUsers
 				selectedDomainName={ pageContext.params.domain }
 			/>
 		);
@@ -296,7 +294,6 @@ export default {
 				component={ DomainManagement.TransferOut }
 				context={ pageContext }
 				needsDomains
-				needsUsers
 				selectedDomainName={ pageContext.params.domain }
 			/>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're in the process of removing the `lib/users` flux store from this world.

While auditing the last remaining usages, we noticed that the `DomainManagementData` component uses it to provide domains components with users data (toggled by the `needsUsers` prop). However, only 1 of the instances that has `needsUsers` actually needs the users data. For the other 3 we can omit it. This is what this PR is doing, as a preparatory step for the next move.

As a next step for a subsequent PR, we'll be refactoring that last instance (`TransferOtherUser`) to use `react-query` (`useUsersQuery`) and completely ditch the `needsUsers` prop from  `DomainManagementData`.

This PR is part of #24150.

#### Testing instructions

* Verify that the following domain transfer components don't need the `users` prop:
  * `Transfer`
  * `TransferOut`
  * `TransferToOtherSite`