### PR TITLE
Reader: Fix Gutenberg for Comments autocompleters

### DIFF
--- a/client/blocks/comments/block-editor/autocompleters/index.js
+++ b/client/blocks/comments/block-editor/autocompleters/index.js
@@ -2,13 +2,13 @@
  * Internal dependencies
  */
 import makeUserCompleter from './user';
-import xPostCompleter from './xpost';
+import makeXPostCompleter from './xpost';
 
 import './style.scss';
 
 export default function addAutocompleters( userSuggestions ) {
 	return ( completers = [] ) => {
-		completers.push( xPostCompleter );
+		completers.push( makeXPostCompleter() );
 		// Override the standard user completer with a custom one
 		const userCompleterPos = completers.findIndex( ( item ) => item.name === 'users' );
 

--- a/client/blocks/comments/block-editor/autocompleters/index.js
+++ b/client/blocks/comments/block-editor/autocompleters/index.js
@@ -2,14 +2,13 @@
  * Internal dependencies
  */
 import makeUserCompleter from './user';
-import makeXPostCompleter from './xpost';
+import xPostCompleter from './xpost';
 
 import './style.scss';
 
-export default async function addAutocompleters( userSuggestions ) {
-	const xpostCompleter = await makeXPostCompleter();
+export default function addAutocompleters( userSuggestions ) {
 	return ( completers = [] ) => {
-		completers.push( xpostCompleter );
+		completers.push( xPostCompleter );
 		// Override the standard user completer with a custom one
 		const userCompleterPos = completers.findIndex( ( item ) => item.name === 'users' );
 

--- a/client/blocks/comments/block-editor/autocompleters/xpost.jsx
+++ b/client/blocks/comments/block-editor/autocompleters/xpost.jsx
@@ -9,42 +9,27 @@ import React from 'react';
  */
 import wpcom from 'calypso/lib/wp';
 
-let results;
-let request;
-
 export default {
 	name: 'xpost',
 	className: 'autocompleters__xpost',
 	triggerPrefix: '+',
-	async options() {
-		if ( results ) {
-			// if we've already gotten results, use them instead of requesting new ones
-			return results;
-		}
-
-		if ( request ) {
-			// if a request is already underway, use the results from that
-			return await request;
-		}
-
-		// otherwise make a new request
-		request = wpcom.req
-			.get( {
-				path: '/internal/P2s',
-				apiVersion: '1.1',
-			} )
-			.then( ( result ) =>
-				Object.entries( result.list ).map( ( [ subdomain, p2 ] ) => ( {
-					...p2,
-					subdomain,
-				} ) )
-			);
-
-		// cache the results
-		results = await request;
-
-		return results;
-	},
+	/**
+	 * The autocompleter will pass `options` to `Promise.resolve` so we can safely assign this to a promise that
+	 * will eventually resolve and can just be used over and over again, instead of caching the result manually
+	 *
+	 * @see https://github.com/WordPress/gutenberg/blob/a947375ea7df8e2257fecedeea5f323ebffa38f6/packages/components/src/autocomplete/index.js#L171
+	 */
+	options: wpcom.req
+		.get( {
+			path: '/internal/P2s',
+			apiVersion: '1.1',
+		} )
+		.then( ( result ) =>
+			Object.entries( result.list ).map( ( [ subdomain, p2 ] ) => ( {
+				...p2,
+				subdomain,
+			} ) )
+		),
 	getOptionKeywords( p2 ) {
 		return [ p2.title, p2.subdomain ];
 	},

--- a/client/blocks/comments/block-editor/autocompleters/xpost.jsx
+++ b/client/blocks/comments/block-editor/autocompleters/xpost.jsx
@@ -9,7 +9,7 @@ import React from 'react';
  */
 import wpcom from 'calypso/lib/wp';
 
-export default {
+export default () => ( {
 	name: 'xpost',
 	className: 'autocompleters__xpost',
 	triggerPrefix: '+',
@@ -55,4 +55,4 @@ export default {
 	getOptionCompletion( site ) {
 		return `+${ site.subdomain }`;
 	},
-};
+} );

--- a/client/blocks/comments/block-editor/index.jsx
+++ b/client/blocks/comments/block-editor/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import IsolatedBlockEditor from 'isolated-block-editor';
 
 /**
@@ -28,15 +28,26 @@ const allowedBlocks = [
 ];
 
 const BlockEditor = ( { onChange, suggestions } ) => {
+	const [ isLoaded, setIsLoaded ] = useState( false );
+
 	useEffect( () => {
-		getAddAutocompleters( suggestions ).then( ( addAutoCompleters ) => {
-			addFilter(
-				'editor.Autocomplete.completers',
-				'readerComments/autocompleters',
-				addAutoCompleters
-			);
-		} );
+		// ensure that the addAutoCompleters filter is added before the IsolatedBlockEditor is loaded
+		// so that the filters are definitely run
+		new Promise( ( resolve ) => {
+			getAddAutocompleters( suggestions ).then( ( addAutoCompleters ) => {
+				addFilter(
+					'editor.Autocomplete.completers',
+					'readerComments/autocompleters',
+					addAutoCompleters
+				);
+				resolve();
+			} );
+		} ).then( () => setIsLoaded( true ) );
 	}, [ suggestions ] );
+
+	if ( ! isLoaded ) {
+		return null;
+	}
 
 	return (
 		<IsolatedBlockEditor

--- a/client/blocks/comments/block-editor/index.jsx
+++ b/client/blocks/comments/block-editor/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import IsolatedBlockEditor from 'isolated-block-editor';
 
 /**
@@ -28,24 +28,16 @@ const allowedBlocks = [
 ];
 
 const BlockEditor = ( { onChange, suggestions } ) => {
-	const [ isLoaded, setIsLoaded ] = useState( false );
-
 	useEffect( () => {
 		// ensure that the addAutoCompleters filter is added before the IsolatedBlockEditor is loaded
 		// so that the filters are definitely run
-		getAddAutocompleters( suggestions ).then( ( addAutoCompleters ) => {
-			addFilter(
-				'editor.Autocomplete.completers',
-				'readerComments/autocompleters',
-				addAutoCompleters
-			);
-			setIsLoaded( true );
-		} );
+		const addAutoCompleters = getAddAutocompleters( suggestions );
+		addFilter(
+			'editor.Autocomplete.completers',
+			'readerComments/autocompleters',
+			addAutoCompleters
+		);
 	}, [ suggestions ] );
-
-	if ( ! isLoaded ) {
-		return null;
-	}
 
 	return (
 		<IsolatedBlockEditor

--- a/client/blocks/comments/block-editor/index.jsx
+++ b/client/blocks/comments/block-editor/index.jsx
@@ -29,8 +29,6 @@ const allowedBlocks = [
 
 const BlockEditor = ( { onChange, suggestions } ) => {
 	useEffect( () => {
-		// ensure that the addAutoCompleters filter is added before the IsolatedBlockEditor is loaded
-		// so that the filters are definitely run
 		const addAutoCompleters = getAddAutocompleters( suggestions );
 		addFilter(
 			'editor.Autocomplete.completers',

--- a/client/blocks/comments/block-editor/index.jsx
+++ b/client/blocks/comments/block-editor/index.jsx
@@ -33,16 +33,14 @@ const BlockEditor = ( { onChange, suggestions } ) => {
 	useEffect( () => {
 		// ensure that the addAutoCompleters filter is added before the IsolatedBlockEditor is loaded
 		// so that the filters are definitely run
-		new Promise( ( resolve ) => {
-			getAddAutocompleters( suggestions ).then( ( addAutoCompleters ) => {
-				addFilter(
-					'editor.Autocomplete.completers',
-					'readerComments/autocompleters',
-					addAutoCompleters
-				);
-				resolve();
-			} );
-		} ).then( () => setIsLoaded( true ) );
+		getAddAutocompleters( suggestions ).then( ( addAutoCompleters ) => {
+			addFilter(
+				'editor.Autocomplete.completers',
+				'readerComments/autocompleters',
+				addAutoCompleters
+			);
+			setIsLoaded( true );
+		} );
 	}, [ suggestions ] );
 
 	if ( ! isLoaded ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I'm not sure if this is the best way to solve this, but asynchronously adding filters like this doesn't seem to be a supported pattern.

The problem is that we need to request the list of P2s and add the autocompleters filter _before_ the IsolatedBlockEditor is loaded thereby causing the filters to run. The filters only run once when the editor is loaded so if we haven't registered the autocompleter before then the block editor will have already loaded and the filter will be added too late in the process.

This PR blocks the editor from loading until the filter is added (basically waiting for the list of P2s to resolve in the `xpost` auto-completer.

I really hate this solution so I'm totally open to alternatives, including alternative approaches to initializing the auto-completers to begin with as I think what I've concocted here is a total hack.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a reader page and turn on the `reader/gutenberg-for-comments` flag (append `?flags=reader/gutenberg-for-comments`) and ensure that the user and P2 autocompleteres (prefixed with `@` and `+` respectively) work. Note: the styles are super janky, but that's not the point of this PR. They definitely need to be addressed but that's a conversation for a different day, today I'm just trying to get them to initialize and actually run 🙂)

