### PR TITLE
create-calypso-config: Fix error string interpolation

### DIFF
--- a/packages/create-calypso-config/src/index.ts
+++ b/packages/create-calypso-config/src/index.ts
@@ -44,7 +44,7 @@ const config = ( data: ConfigData ) => < T >( key: string ): T | undefined => {
 		// eslint-disable-next-line no-console
 		console.error(
 			'%cCore Error: ' +
-				'%cCould not find config value for key %c${ key }%c. ' +
+				`%cCould not find config value for key %c${ key }%c. ` +
 				'Please make sure that if you need it then it has a default value assigned in ' +
 				'%cconfig/_shared.json' +
 				'%c.',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Both of the two early error messages in `create-calypso-config` use string interpolation to display the `key` that is missing from the config, but the second one does not use backticks for its string and so the key is never rendered. This fixes what I believe is that oversight.

#### Testing instructions

I ran into this because I tried to use `create-calypso-config` with a test that accesses an option that is not set. This was extracted from the work on unit tests in https://github.com/Automattic/wp-calypso/pull/51797 (despite the comment in this file that says that it won't be shown for tests, test environments that include `window` will still show it).

However, a simple visual inspection of this change should be sufficient.