### PR TITLE
Event Countdown Block: Update date picker button to use secondary sty…

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/edit.js
@@ -55,6 +55,7 @@ const edit = ( { attributes, setAttributes, className } ) => {
 							onClick={ onToggle }
 							aria-expanded={ isOpen }
 							aria-live="polite"
+							isSecondary
 						>
 							{ label }
 						</Button>


### PR DESCRIPTION
This is a tiny change to the button to select a date within the Event Countdown block. I noticed the button didn't have border styling while testing in the new FSE site editor (/wp-admin/admin.php?page=gutenberg-edit-site running tt1-blocks theme), so this change should help give us consistency with other Jetpack blocks.

#### Changes proposed in this Pull Request

* In the Event Countdown block, update the button to select the date to use the `isSecondary` styling to be consistent with the placeholder state for other Jetpack blocks.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* From a sandbox run `install-plugin.sh etk update/event-countdown-block-date-button-to-use-secondary-styling` to apply the change
* On a site running FSE, e.g. create a site via https://horizon.wordpress.com/new?flags=gutenboarding/site-editor and select the tt1-blocks theme (Twenty Twenty One), then sandbox your site
* In the site editor, within the footer template part, insert an Event Countdown block
* Observe that the button to add a date should now have a border

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/114132584-ffe72c00-9947-11eb-80e0-4506be662cbc.png) | ![image](https://user-images.githubusercontent.com/14988353/114132571-f958b480-9947-11eb-91b9-93a69c58de3e.png) |

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 256-gh-Automattic/view-design