### PR TITLE
Focused Launch: remove sub-domain from suggestions

### DIFF
--- a/packages/domain-picker/src/components/index.tsx
+++ b/packages/domain-picker/src/components/index.tsx
@@ -160,10 +160,11 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		retryRequest: retryDomainSuggestionRequest,
 	} = useDomainSuggestions( domainSearch.trim(), quantityExpanded, domainCategory, locale ) || {};
 
-	// don't list the already existing free domain as part of the suggestions
-	const domainSuggestions = allDomainSuggestions
-		?.filter( ( suggestion ) => suggestion.domain_name !== existingSubdomain?.domain_name )
-		.slice( 0, isExpanded ? quantityExpanded : quantity );
+	// filter out the free sub-domain from suggestions (1st position in the suggestions Array) when existingSubdomain prop has value
+	const domainSuggestions = allDomainSuggestions?.slice(
+		existingSubdomain ? 1 : 0,
+		isExpanded ? quantityExpanded : quantity
+	);
 
 	// we need this index because it refers to the recommended (most relevant) paid domain
 	const firstPaidDomainIndex = domainSuggestions?.findIndex(

--- a/packages/domain-picker/src/components/index.tsx
+++ b/packages/domain-picker/src/components/index.tsx
@@ -32,6 +32,7 @@ import { getDomainSuggestionsVendor } from '../utils';
 import {
 	PAID_DOMAINS_TO_SHOW,
 	PAID_DOMAINS_TO_SHOW_EXPANDED,
+	FREE_DOMAIN_SUGGESTIONS_COUNT,
 	domainIsAvailableStatus,
 } from '../constants';
 
@@ -160,11 +161,17 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		retryRequest: retryDomainSuggestionRequest,
 	} = useDomainSuggestions( domainSearch.trim(), quantityExpanded, domainCategory, locale ) || {};
 
-	// filter out the free sub-domain from suggestions (1st position in the suggestions Array) when existingSubdomain prop has value
-	const domainSuggestions = allDomainSuggestions?.slice(
-		existingSubdomain ? 1 : 0,
-		isExpanded ? quantityExpanded : quantity
-	);
+	// filter out the free sub-domain suggestion when existingSubdomain prop has value
+	const domainSuggestions = existingSubdomain
+		? allDomainSuggestions
+				?.filter( ( suggestion ) => ! suggestion.is_free )
+				.slice(
+					0,
+					isExpanded
+						? quantityExpanded - FREE_DOMAIN_SUGGESTIONS_COUNT
+						: quantity - FREE_DOMAIN_SUGGESTIONS_COUNT
+				)
+		: allDomainSuggestions?.slice( 0, isExpanded ? quantityExpanded : quantity );
 
 	// we need this index because it refers to the recommended (most relevant) paid domain
 	const firstPaidDomainIndex = domainSuggestions?.findIndex(

--- a/packages/domain-picker/src/components/index.tsx
+++ b/packages/domain-picker/src/components/index.tsx
@@ -30,9 +30,8 @@ import {
 } from '../hooks';
 import { getDomainSuggestionsVendor } from '../utils';
 import {
-	PAID_DOMAINS_TO_SHOW,
-	PAID_DOMAINS_TO_SHOW_EXPANDED,
-	FREE_DOMAIN_SUGGESTIONS_COUNT,
+	DOMAIN_SUGGESTIONS_TO_SHOW,
+	DOMAIN_SUGGESTIONS_TO_SHOW_EXPANDED,
 	domainIsAvailableStatus,
 } from '../constants';
 
@@ -71,10 +70,10 @@ export interface Props {
 
 	onExistingSubdomainSelect?: ( existingSubdomain: string ) => void;
 
-	/** Paid domain suggestions to show when the picker isn't expanded */
+	/** Total number of domain suggestions to show when the picker isn't expanded */
 	quantity?: number;
 
-	/** Domain suggestions to show when the picker is expanded */
+	/** Total number of suggestions to show when the picker is expanded */
 	quantityExpanded?: number;
 
 	/** Called when the user leaves the search box */
@@ -127,8 +126,8 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	showDomainCategories,
 	onDomainSelect,
 	onExistingSubdomainSelect,
-	quantity = PAID_DOMAINS_TO_SHOW,
-	quantityExpanded = PAID_DOMAINS_TO_SHOW_EXPANDED,
+	quantity = DOMAIN_SUGGESTIONS_TO_SHOW,
+	quantityExpanded = DOMAIN_SUGGESTIONS_TO_SHOW_EXPANDED,
 	onDomainSearchBlur,
 	analyticsFlowId,
 	analyticsUiAlgo,
@@ -162,16 +161,9 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	} = useDomainSuggestions( domainSearch.trim(), quantityExpanded, domainCategory, locale ) || {};
 
 	// filter out the free sub-domain suggestion when existingSubdomain prop has value
-	const domainSuggestions = existingSubdomain
-		? allDomainSuggestions
-				?.filter( ( suggestion ) => ! suggestion.is_free )
-				.slice(
-					0,
-					isExpanded
-						? quantityExpanded - FREE_DOMAIN_SUGGESTIONS_COUNT
-						: quantity - FREE_DOMAIN_SUGGESTIONS_COUNT
-				)
-		: allDomainSuggestions?.slice( 0, isExpanded ? quantityExpanded : quantity );
+	const domainSuggestions = allDomainSuggestions
+		?.filter( ( suggestion ) => ! ( existingSubdomain && suggestion.is_free ) )
+		.slice( 0, isExpanded ? quantityExpanded - 1 : quantity - 1 );
 
 	// we need this index because it refers to the recommended (most relevant) paid domain
 	const firstPaidDomainIndex = domainSuggestions?.findIndex(

--- a/packages/domain-picker/src/constants.ts
+++ b/packages/domain-picker/src/constants.ts
@@ -3,8 +3,8 @@
  */
 import { DomainSuggestions } from '@automattic/data-stores';
 
-export const PAID_DOMAINS_TO_SHOW = 5;
-export const PAID_DOMAINS_TO_SHOW_EXPANDED = 10;
+export const DOMAIN_SUGGESTIONS_TO_SHOW = 5;
+export const DOMAIN_SUGGESTIONS_TO_SHOW_EXPANDED = 10;
 export const DOMAIN_QUERY_MINIMUM_LENGTH = 2;
 
 /**
@@ -20,6 +20,3 @@ export const DOMAIN_SEARCH_DEBOUNCE_INTERVAL = 300;
 export const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register();
 
 export const domainIsAvailableStatus = [ 'available', 'available_premium' ];
-
-// number of free subdomain suggestions returned by the API
-export const FREE_DOMAIN_SUGGESTIONS_COUNT = 1;

--- a/packages/domain-picker/src/constants.ts
+++ b/packages/domain-picker/src/constants.ts
@@ -20,3 +20,6 @@ export const DOMAIN_SEARCH_DEBOUNCE_INTERVAL = 300;
 export const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register();
 
 export const domainIsAvailableStatus = [ 'available', 'available_premium' ];
+
+// number of free subdomain suggestions returned by the API
+export const FREE_DOMAIN_SUGGESTIONS_COUNT = 1;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Revert a recent `DomainPicker` change that introduced a regression in Focused Launch. See https://github.com/Automattic/wp-calypso/pull/50998/files#r610417981

#### Testing instructions

* Create a site using /new and sandbox it
* Open focused launch from editor
* No sub-domain suggestion should be displayed in Summary view or Domain Details view. Only the existing sub-domain should be available for selection.

Related to #

Mentioned in: p1617903103117300-slack-C013QHLF28Y