### PR TITLE
[Plans Interval Toggle]: Add text-domain to hasTranslation in the Plans Interval Toggle component

### DIFF
--- a/packages/plans-grid/src/plans-interval-toggle/index.tsx
+++ b/packages/plans-grid/src/plans-interval-toggle/index.tsx
@@ -64,7 +64,8 @@ const PlansIntervalToggle: React.FunctionComponent< PlansIntervalToggleProps > =
 	// Translators: intended as "pay monthly", as opposed to "pay annually"
 	const newMonthlyLabel = _x( 'Monthly', 'Adverb (as in "Pay monthly")', __i18n_text_domain__ );
 	const monthlyLabel =
-		locale === 'en' || hasTranslation( 'Monthly', 'Adverb (as in "Pay monthly")' )
+		locale === 'en' ||
+		hasTranslation( 'Monthly', 'Adverb (as in "Pay monthly")', __i18n_text_domain__ )
 			? newMonthlyLabel
 			: fallbackMonthlyLabel;
 
@@ -72,7 +73,8 @@ const PlansIntervalToggle: React.FunctionComponent< PlansIntervalToggleProps > =
 	// Translators: intended as "pay annually", as opposed to "pay monthly"
 	const newAnnuallyLabel = _x( 'Annually', 'Adverb (as in "Pay annually")', __i18n_text_domain__ );
 	const annuallyLabel =
-		locale === 'en' || hasTranslation( 'Annually', 'Adverb (as in "Pay annually")' )
+		locale === 'en' ||
+		hasTranslation( 'Annually', 'Adverb (as in "Pay annually")', __i18n_text_domain__ )
 			? newAnnuallyLabel
 			: fallbackAnnuallyLabel;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `__i18n_text_domain__` as third argument to `hasTranslation` on all occurrences in `<PlansIntervalToggle/>`

#### Testing instructions

* Follow the testing instructions from #51572


Fixes #51805
