### PR TITLE
Use magellan-mocha-plugin from the monorepo

### DIFF
--- a/test/e2e/magellan-calypso.json
+++ b/test/e2e/magellan-calypso.json
@@ -5,7 +5,7 @@
 	"max_workers": 6,
 	"suiteTag": "parallel;signup",
 	"sauce": false,
-	"framework": "testarmada-magellan-mocha-plugin",
+	"framework": "@automattic/testarmada-magellan-mocha-plugin",
 	"reporters": [ "./lib/reporter/magellan-reporter.js" ],
 	"executors": [ "testarmada-magellan-local-executor" ],
 	"local_browser": "chrome",


### PR DESCRIPTION
#### Background

In #51779 we added `@automattic/testarmada-magellan-mocha-plugin` to the monorepo and we drop the dependency from the upstream `testarmada-magellan-mocha-plugin`.

In #51742 we create a new Magellan suite to run Calypso tests. Unfortunatelly it still uses the old `testarmada-magellan-mocha-plugin`.

This causes Magellan to fail in TeamCity:

```
  [ERROR] [Magellan] Could not start Magellan.
11:45:41
  [ERROR] [Magellan] Could not load the testing framework plugin: testarmada-magellan-mocha-plugin
11:45:41
  [ERROR] [Magellan] Check and make sure your package.json includes module: testarmada-magellan-mocha-plugin
11:45:41
  [ERROR] [Magellan] Error: Cannot find module '/home/teamcity-0/buildAgent/work/c4a9d5b38c1dacde/test/e2e/node_modules/testarmada-magellan-mocha-plugin/index'

```

#### Changes proposed in this Pull Request

* Uses `@automattic/testarmada-magellan-mocha-plugin` in the new Calypso suite.

#### Testing instructions

Verify TeamCity e2e test passes