### PR TITLE
Jetpack Connect: show the user's email address when authorizing a connection

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -623,6 +623,13 @@ export class JetpackAuthorize extends Component {
 	getUserText() {
 		const { translate } = this.props;
 		const { authorizeSuccess } = this.props.authorizationData;
+
+		// Accounts created through the new Magic Link-based signup flow (enabled with the
+		// 'jetpack/magic-link-signup' feature flag) are created with a username based on the user's
+		// email address. For this reason, we want to display both the username and the email address
+		// so users can start making the connection between the two immediately. Otherwise, users might
+		// not recognize their username since they didn't created it.
+
 		// translators: %(user) is user's Display Name (Eg Connecting as John Doe) and %(email) is the user's email address
 		let text = translate(
 			'Connecting as {{strong}}%(user)s{{/strong}} ({{strong}}%(email)s{{/strong}})',

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -623,18 +623,24 @@ export class JetpackAuthorize extends Component {
 	getUserText() {
 		const { translate } = this.props;
 		const { authorizeSuccess } = this.props.authorizationData;
-		// translators: %(user) is user's Display Name (Eg Connecting as John Doe)
-		let text = translate( 'Connecting as {{strong}}%(user)s{{/strong}}', {
-			args: { user: this.props.user.display_name },
-			components: { strong: <strong /> },
-		} );
+		// translators: %(user) is user's Display Name (Eg Connecting as John Doe) and %(email) is the user's email address
+		let text = translate(
+			'Connecting as {{strong}}%(user)s{{/strong}} ({{strong}}%(email)s{{/strong}})',
+			{
+				args: { email: this.props.user.email, user: this.props.user.display_name },
+				components: { strong: <strong /> },
+			}
+		);
 
 		if ( authorizeSuccess || this.props.isAlreadyOnSitesList ) {
-			// translators: %(user) is user's Display Name (Eg Connected as John Doe)
-			text = translate( 'Connected as {{strong}}%(user)s{{/strong}}', {
-				args: { user: this.props.user.display_name },
-				components: { strong: <strong /> },
-			} );
+			// translators: %(user) is user's Display Name (Eg Connecting as John Doe) and %(email) is the user's email address
+			text = translate(
+				'Connected as {{strong}}%(user)s{{/strong}} ({{strong}}%(email)s{{/strong}})',
+				{
+					args: { email: this.props.user.email, user: this.props.user.display_name },
+					components: { strong: <strong /> },
+				}
+			);
 		}
 
 		return text;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -230,7 +230,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .jetpack-connect__logged-in-form {
 	.jetpack-connect__logged-in-form-user-text {
-		margin-bottom: 0;
 		text-align: center;
 	}
 

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -69,7 +69,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
         <p
           className="jetpack-connect__logged-in-form-user-text"
         >
-          Connecting as {{strong}}%(user)s{{/strong}}
+          Connecting as {{strong}}%(user)s{{/strong}} ({{strong}}%(email)s{{/strong}})
         </p>
         <LoggedOutFormFooter
           className="jetpack-connect__action-disclaimer"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* On the authorization step, show the user's email address right beside the user's display name.

#### Testing instructions

* Download this PR.
* Run Calypso Blue with `yarn start`.
* Visit `/jetpack/connect`.
* Go through the connection flow.
* Make sure that the authorization step shows your email address.

Related to 1164141197617539-as-1200101795064984

#### Demo – before
<img width="1138" alt="Screen Shot 2021-04-09 at 09 30 59" src="https://user-images.githubusercontent.com/3418513/114187964-fbf2e400-991e-11eb-87e1-bd5d60ef6e4b.png">
<img width="1138" alt="Screen Shot 2021-04-09 at 09 30 57" src="https://user-images.githubusercontent.com/3418513/114187971-fd241100-991e-11eb-9d91-b7182aeb07b9.png">


#### Demo – after
<img width="1138" alt="Screen Shot 2021-04-09 at 09 24 09" src="https://user-images.githubusercontent.com/3418513/114187979-feedd480-991e-11eb-8376-5a4254d12bf9.png">
<img width="1138" alt="Screen Shot 2021-04-09 at 09 24 06" src="https://user-images.githubusercontent.com/3418513/114187985-001f0180-991f-11eb-87ce-7827d8a6414f.png">
