### PR TITLE
Run new branch protection on synchronize

### DIFF
--- a/.github/workflows/is-pull-request.yml
+++ b/.github/workflows/is-pull-request.yml
@@ -14,7 +14,7 @@ name: Is Pull Request
 
 on:
   pull_request:
-    types: [opened]
+    types: [ opened, synchronize ]
 
 jobs:
   is-pull-request:


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Run on synchronize so that rebasing will allow the check to pass. Mostly just so that people can continue working on existing PRs.