### PR TITLE
Checkout: Fix missing domain_details for some payment processors

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/apple-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/apple-pay-processor.ts
@@ -54,6 +54,7 @@ export default async function applePayProcessor(
 		siteId: siteId ? String( siteId ) : undefined,
 		country: managedContactDetails?.countryCode?.value ?? '',
 		postalCode: getPostalCode(),
+		domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 		cart: createTransactionEndpointCartFromResponseCart( {
 			siteId: siteId ? String( siteId ) : undefined,
 			contactDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ) ?? null,

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -45,13 +45,17 @@ export default async function existingCardProcessor(
 	if ( ! isValidTransactionData( transactionData ) ) {
 		throw new Error( 'Required purchase data is missing' );
 	}
-	const { stripeConfiguration, recordEvent } = dataForProcessor;
+	const {
+		stripeConfiguration,
+		recordEvent,
+		includeDomainDetails,
+		includeGSuiteDetails,
+	} = dataForProcessor;
 	if ( ! stripeConfiguration ) {
 		throw new Error( 'Stripe configuration is required' );
 	}
 
 	debug( 'formatting existing card transaction', transactionData );
-	const { includeDomainDetails, includeGSuiteDetails } = dataForProcessor;
 	const formattedTransactionData = createTransactionEndpointRequestPayload( {
 		...transactionData,
 		domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -20,6 +20,7 @@ import {
 import submitWpcomTransaction from './submit-wpcom-transaction';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type { TransactionRequest } from '../types/transaction-endpoint';
+import getDomainDetails from './get-domain-details';
 
 const debug = debugFactory( 'calypso:composite-checkout:existing-card-processor' );
 
@@ -50,8 +51,10 @@ export default async function existingCardProcessor(
 	}
 
 	debug( 'formatting existing card transaction', transactionData );
+	const { includeDomainDetails, includeGSuiteDetails } = dataForProcessor;
 	const formattedTransactionData = createTransactionEndpointRequestPayload( {
 		...transactionData,
+		domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 		cart: createTransactionEndpointCartFromResponseCart( {
 			siteId: dataForProcessor.siteId ? String( dataForProcessor.siteId ) : undefined,
 			contactDetails: transactionData.domainDetails ?? null,

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -153,6 +153,7 @@ async function ebanxCardProcessor(
 		country: submitData.countryCode,
 		siteId: siteId ? String( siteId ) : undefined,
 		deviceId: paymentMethodToken?.deviceId,
+		domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 		paymentMethodToken: paymentMethodToken.token,
 		cart: createTransactionEndpointCartFromResponseCart( {
 			siteId: transactionOptions.siteId ? String( transactionOptions.siteId ) : undefined,

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -93,6 +93,7 @@ async function stripeCardProcessor(
 		postalCode: getPostalCode(),
 		subdivisionCode: managedContactDetails?.state?.value,
 		siteId: transactionOptions.siteId ? String( transactionOptions.siteId ) : undefined,
+		domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 		paymentMethodToken,
 		cart: createTransactionEndpointCartFromResponseCart( {
 			siteId: siteId ? String( siteId ) : undefined,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Some of the payment processor functions were missing the `domain_details` property when they contacted the transactions endpoints. This fixes that oversight.

This regression was caused by https://github.com/Automattic/wp-calypso/pull/51463 (for new credit cards) and https://github.com/Automattic/wp-calypso/pull/51465 for Apple Pay. This was not an issue for any other payment methods (although the way that the stored card processor includes domainDetails is different so this PR also makes sure that it will always have that data too).

#### Testing instructions

Try to purchase a domain using a new credit card. Verify that it works.

Previously you'd get an error like `Missing contact information parameter while creating shopping cart`