### PR TITLE
Checkout: add unit tests for payment processors

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -460,7 +460,7 @@ export default function CompositeCheckout( {
 		includeDomainDetails,
 		includeGSuiteDetails,
 	} );
-	const postalCode = getPostalCode();
+	const postalCode = getPostalCode( contactDetails );
 
 	const paymentProcessors = useMemo(
 		() => ( {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -367,9 +367,9 @@ export default function CompositeCheckout( {
 		// Only wait for apple pay to load if we are using apple pay
 		( allowedPaymentMethods.includes( 'apple-pay' ) && isApplePayLoading );
 
-	const contactInfo: ManagedContactDetails | undefined = select( 'wpcom' )?.getContactInfo();
-	const countryCode: string = contactInfo?.countryCode?.value ?? '';
-	const subdivisionCode: string = contactInfo?.state?.value ?? '';
+	const contactDetails: ManagedContactDetails | undefined = select( 'wpcom' )?.getContactInfo();
+	const countryCode: string = contactDetails?.countryCode?.value ?? '';
+	const subdivisionCode: string = contactDetails?.state?.value ?? '';
 
 	const paymentMethods = arePaymentMethodsLoading
 		? []
@@ -439,8 +439,10 @@ export default function CompositeCheckout( {
 			siteId,
 			siteSlug,
 			stripeConfiguration,
+			contactDetails,
 		} ),
 		[
+			contactDetails,
 			createUserAndSiteBeforeTransaction,
 			getThankYouUrl,
 			includeDomainDetails,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -456,7 +456,7 @@ export default function CompositeCheckout( {
 		]
 	);
 
-	const domainDetails = getDomainDetails( {
+	const domainDetails = getDomainDetails( contactDetails, {
 		includeDomainDetails,
 		includeGSuiteDetails,
 	} );

--- a/client/my-sites/checkout/composite-checkout/lib/apple-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/apple-pay-processor.ts
@@ -50,10 +50,14 @@ export default async function applePayProcessor(
 		siteId: siteId ? String( siteId ) : undefined,
 		country: contactDetails?.countryCode?.value ?? '',
 		postalCode: getPostalCode( contactDetails ),
-		domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+		domainDetails: getDomainDetails( contactDetails, {
+			includeDomainDetails,
+			includeGSuiteDetails,
+		} ),
 		cart: createTransactionEndpointCartFromResponseCart( {
 			siteId: siteId ? String( siteId ) : undefined,
-			contactDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ) ?? null,
+			contactDetails:
+				getDomainDetails( contactDetails, { includeDomainDetails, includeGSuiteDetails } ) ?? null,
 			responseCart: responseCart,
 		} ),
 		paymentMethodType: 'WPCOM_Billing_Stripe_Payment_Method',

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -50,6 +50,7 @@ export default async function existingCardProcessor(
 		recordEvent,
 		includeDomainDetails,
 		includeGSuiteDetails,
+		contactDetails,
 	} = dataForProcessor;
 	if ( ! stripeConfiguration ) {
 		throw new Error( 'Stripe configuration is required' );
@@ -58,7 +59,10 @@ export default async function existingCardProcessor(
 	debug( 'formatting existing card transaction', transactionData );
 	const formattedTransactionData = createTransactionEndpointRequestPayload( {
 		...transactionData,
-		domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+		domainDetails: getDomainDetails( contactDetails, {
+			includeDomainDetails,
+			includeGSuiteDetails,
+		} ),
 		cart: createTransactionEndpointCartFromResponseCart( {
 			siteId: dataForProcessor.siteId ? String( dataForProcessor.siteId ) : undefined,
 			contactDetails: transactionData.domainDetails ?? null,

--- a/client/my-sites/checkout/composite-checkout/lib/free-purchase-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/free-purchase-processor.ts
@@ -27,14 +27,23 @@ type SubmitFreePurchaseTransactionData = Omit<
 export default async function freePurchaseProcessor(
 	transactionOptions: PaymentProcessorOptions
 ): Promise< PaymentProcessorResponse > {
-	const { siteId, responseCart, includeDomainDetails, includeGSuiteDetails } = transactionOptions;
+	const {
+		siteId,
+		responseCart,
+		includeDomainDetails,
+		includeGSuiteDetails,
+		contactDetails,
+	} = transactionOptions;
 
 	const formattedTransactionData = prepareFreePurchaseTransaction(
 		{
 			name: '',
 			couponId: responseCart.coupon,
 			siteId: siteId ? String( siteId ) : '',
-			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+			domainDetails: getDomainDetails( contactDetails, {
+				includeDomainDetails,
+				includeGSuiteDetails,
+			} ),
 			// this data is intentionally empty so we do not charge taxes
 			country: '',
 			postalCode: '',

--- a/client/my-sites/checkout/composite-checkout/lib/full-credits-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/full-credits-processor.ts
@@ -41,7 +41,10 @@ export default async function fullCreditsProcessor(
 			name: '',
 			couponId: responseCart.coupon,
 			siteId: siteId ? String( siteId ) : '',
-			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+			domainDetails: getDomainDetails( contactDetails, {
+				includeDomainDetails,
+				includeGSuiteDetails,
+			} ),
 			country: contactDetails?.countryCode?.value ?? '',
 			postalCode: getPostalCode( contactDetails ),
 			subdivisionCode: contactDetails?.state?.value,

--- a/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
@@ -2,11 +2,7 @@
  * External dependencies
  */
 import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-line no-restricted-imports
-import {
-	defaultRegistry,
-	makeRedirectResponse,
-	makeErrorResponse,
-} from '@automattic/composite-checkout';
+import { makeRedirectResponse, makeErrorResponse } from '@automattic/composite-checkout';
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 
 /**
@@ -20,9 +16,6 @@ import prepareRedirectTransaction from '../lib/prepare-redirect-transaction';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type { WPCOMTransactionEndpointResponse } from '../types/transaction-endpoint';
 import type { CheckoutPaymentMethodSlug } from '../types/checkout-payment-method-slug';
-import type { ManagedContactDetails } from '../types/wpcom-store-state';
-
-const { select } = defaultRegistry;
 
 type RedirectTransactionRequest = {
 	name: string | undefined;
@@ -42,6 +35,7 @@ export default async function genericRedirectProcessor(
 		includeGSuiteDetails,
 		reduxDispatch,
 		responseCart,
+		contactDetails,
 	} = transactionOptions;
 	if ( ! isValidTransactionData( submitData ) ) {
 		throw new Error( 'Required purchase data is missing' );
@@ -78,10 +72,6 @@ export default async function genericRedirectProcessor(
 		reduxDispatch,
 	} );
 
-	const managedContactDetails: ManagedContactDetails | undefined = select(
-		'wpcom'
-	)?.getContactInfo();
-
 	const formattedTransactionData = prepareRedirectTransaction(
 		paymentMethodId,
 		{
@@ -90,9 +80,9 @@ export default async function genericRedirectProcessor(
 			successUrl,
 			cancelUrl,
 			couponId: responseCart.coupon,
-			country: managedContactDetails?.countryCode?.value ?? '',
-			postalCode: getPostalCode(),
-			subdivisionCode: managedContactDetails?.state?.value,
+			country: contactDetails?.countryCode?.value ?? '',
+			postalCode: getPostalCode( contactDetails ),
+			subdivisionCode: contactDetails?.state?.value,
 			siteId: siteId ? String( siteId ) : '',
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 		},

--- a/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
@@ -84,7 +84,10 @@ export default async function genericRedirectProcessor(
 			postalCode: getPostalCode( contactDetails ),
 			subdivisionCode: contactDetails?.state?.value,
 			siteId: siteId ? String( siteId ) : '',
-			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+			domainDetails: getDomainDetails( contactDetails, {
+				includeDomainDetails,
+				includeGSuiteDetails,
+			} ),
 		},
 		transactionOptions
 	);

--- a/client/my-sites/checkout/composite-checkout/lib/get-domain-details.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-domain-details.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { defaultRegistry } from '@automattic/composite-checkout';
 import type { DomainContactDetails } from '@automattic/shopping-cart';
 
 /**
@@ -10,21 +9,19 @@ import type { DomainContactDetails } from '@automattic/shopping-cart';
 import { prepareDomainContactDetailsForTransaction } from 'calypso/my-sites/checkout/composite-checkout/types/wpcom-store-state';
 import type { ManagedContactDetails } from '../types/wpcom-store-state';
 
-const { select } = defaultRegistry;
-
-export default function getDomainDetails( {
-	includeDomainDetails,
-	includeGSuiteDetails,
-}: {
-	includeDomainDetails: boolean;
-	includeGSuiteDetails: boolean;
-} ): DomainContactDetails | undefined {
-	const managedContactDetails: ManagedContactDetails | undefined = select(
-		'wpcom'
-	)?.getContactInfo();
-	if ( ! managedContactDetails ) {
+export default function getDomainDetails(
+	contactDetails: ManagedContactDetails | undefined,
+	{
+		includeDomainDetails,
+		includeGSuiteDetails,
+	}: {
+		includeDomainDetails: boolean;
+		includeGSuiteDetails: boolean;
+	}
+): DomainContactDetails | undefined {
+	if ( ! contactDetails ) {
 		return undefined;
 	}
-	const domainDetails = prepareDomainContactDetailsForTransaction( managedContactDetails );
+	const domainDetails = prepareDomainContactDetailsForTransaction( contactDetails );
 	return includeDomainDetails || includeGSuiteDetails ? domainDetails : undefined;
 }

--- a/client/my-sites/checkout/composite-checkout/lib/get-postal-code.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-postal-code.ts
@@ -1,24 +1,14 @@
 /**
- * External dependencies
- */
-import { defaultRegistry } from '@automattic/composite-checkout';
-
-/**
  * Internal dependencies
  */
 import { tryToGuessPostalCodeFormat } from 'calypso/lib/postal-code';
 import type { ManagedContactDetails } from '../types/wpcom-store-state';
 
-const { select } = defaultRegistry;
-
-export default function getPostalCode(): string {
-	const managedContactDetails: ManagedContactDetails | undefined = select(
-		'wpcom'
-	)?.getContactInfo();
-	if ( ! managedContactDetails ) {
+export default function getPostalCode( contactDetails: ManagedContactDetails | undefined ): string {
+	if ( ! contactDetails ) {
 		return '';
 	}
-	const countryCode = managedContactDetails.countryCode?.value ?? '';
-	const postalCode = managedContactDetails.postalCode?.value ?? '';
+	const countryCode = contactDetails.countryCode?.value ?? '';
+	const postalCode = contactDetails.postalCode?.value ?? '';
 	return tryToGuessPostalCodeFormat( postalCode.toUpperCase(), countryCode );
 }

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -87,11 +87,15 @@ async function stripeCardProcessor(
 		postalCode: getPostalCode( contactDetails ),
 		subdivisionCode: contactDetails?.state?.value,
 		siteId: transactionOptions.siteId ? String( transactionOptions.siteId ) : undefined,
-		domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+		domainDetails: getDomainDetails( contactDetails, {
+			includeDomainDetails,
+			includeGSuiteDetails,
+		} ),
 		paymentMethodToken,
 		cart: createTransactionEndpointCartFromResponseCart( {
 			siteId: siteId ? String( siteId ) : undefined,
-			contactDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ) ?? null,
+			contactDetails:
+				getDomainDetails( contactDetails, { includeDomainDetails, includeGSuiteDetails } ) ?? null,
 			responseCart: responseCart,
 		} ),
 		paymentMethodType: 'WPCOM_Billing_Stripe_Payment_Method',
@@ -153,11 +157,15 @@ async function ebanxCardProcessor(
 		country: submitData.countryCode,
 		siteId: siteId ? String( siteId ) : undefined,
 		deviceId: paymentMethodToken?.deviceId,
-		domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+		domainDetails: getDomainDetails( contactDetails, {
+			includeDomainDetails,
+			includeGSuiteDetails,
+		} ),
 		paymentMethodToken: paymentMethodToken.token,
 		cart: createTransactionEndpointCartFromResponseCart( {
 			siteId: transactionOptions.siteId ? String( transactionOptions.siteId ) : undefined,
-			contactDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ) ?? null,
+			contactDetails:
+				getDomainDetails( contactDetails, { includeDomainDetails, includeGSuiteDetails } ) ?? null,
 			responseCart: transactionOptions.responseCart,
 		} ),
 		paymentMethodType: 'WPCOM_Billing_Ebanx',

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -32,6 +32,7 @@ export default async function payPalProcessor(
 		responseCart,
 		siteId,
 		siteSlug,
+		contactDetails,
 	} = transactionOptions;
 	recordTransactionBeginAnalytics( {
 		reduxDispatch,
@@ -59,7 +60,8 @@ export default async function payPalProcessor(
 		successUrl,
 		cancelUrl,
 		siteId,
-		domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ) || null,
+		domainDetails:
+			getDomainDetails( contactDetails, { includeDomainDetails, includeGSuiteDetails } ) || null,
 	} );
 	debug( 'sending paypal transaction', formattedTransactionData );
 	return wpcomPayPalExpress( formattedTransactionData, transactionOptions )

--- a/client/my-sites/checkout/composite-checkout/lib/we-chat-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/we-chat-processor.ts
@@ -87,7 +87,10 @@ export default async function weChatProcessor(
 			postalCode: getPostalCode( contactDetails ),
 			subdivisionCode: contactDetails?.state?.value,
 			siteId: siteId ? String( siteId ) : '',
-			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+			domainDetails: getDomainDetails( contactDetails, {
+				includeDomainDetails,
+				includeGSuiteDetails,
+			} ),
 		},
 		options
 	);

--- a/client/my-sites/checkout/composite-checkout/lib/we-chat-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/we-chat-processor.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	defaultRegistry,
 	makeRedirectResponse,
 	makeManualResponse,
 	makeErrorResponse,
@@ -20,10 +19,7 @@ import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import prepareRedirectTransaction from '../lib/prepare-redirect-transaction';
 import submitWpcomTransaction from './submit-wpcom-transaction';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
-import type { ManagedContactDetails } from '../types/wpcom-store-state';
 import type { WPCOMTransactionEndpointResponse } from '../types/transaction-endpoint';
-
-const { select } = defaultRegistry;
 
 type WeChatTransactionRequest = {
 	name: string | undefined;
@@ -46,6 +42,7 @@ export default async function weChatProcessor(
 		includeGSuiteDetails,
 		reduxDispatch,
 		responseCart,
+		contactDetails,
 	} = options;
 	const paymentMethodId = 'wechat';
 	recordTransactionBeginAnalytics( {
@@ -78,10 +75,6 @@ export default async function weChatProcessor(
 		query: cancelUrlQuery,
 	} );
 
-	const managedContactDetails: ManagedContactDetails | undefined = select(
-		'wpcom'
-	)?.getContactInfo();
-
 	const formattedTransactionData = prepareRedirectTransaction(
 		paymentMethodId,
 		{
@@ -90,9 +83,9 @@ export default async function weChatProcessor(
 			successUrl,
 			cancelUrl,
 			couponId: responseCart.coupon,
-			country: managedContactDetails?.countryCode?.value ?? '',
-			postalCode: getPostalCode(),
-			subdivisionCode: managedContactDetails?.state?.value,
+			country: contactDetails?.countryCode?.value ?? '',
+			postalCode: getPostalCode( contactDetails ),
+			subdivisionCode: contactDetails?.state?.value,
 			siteId: siteId ? String( siteId ) : '',
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 		},

--- a/client/my-sites/checkout/composite-checkout/test/apple-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/apple-pay-processor.ts
@@ -1,0 +1,241 @@
+/**
+ * External dependencies
+ */
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+
+/**
+ * Internal dependencies
+ */
+import applePayProcessor from '../lib/apple-pay-processor';
+import wp from 'calypso/lib/wp';
+
+jest.mock( 'calypso/lib/wp' );
+
+describe( 'applePayProcessor', () => {
+	const stripeConfiguration = {
+		processor_id: 'IE',
+		js_url: 'https://stripe-js-url',
+		public_key: 'stripe-public-key',
+		setup_intent_id: null,
+	};
+	const product = getEmptyResponseCartProduct();
+	const domainProduct = {
+		...getEmptyResponseCartProduct(),
+		meta: 'example.com',
+		is_domain_registration: true,
+	};
+	const cart = { ...getEmptyResponseCart(), products: [ product ] };
+	const options = {
+		includeDomainDetails: false,
+		includeGSuiteDetails: false,
+		createUserAndSiteBeforeTransaction: false,
+		stripeConfiguration,
+		recordEvent: () => null,
+		reduxDispatch: () => null,
+		responseCart: cart,
+		getThankYouUrl: () => '',
+		siteSlug: undefined,
+		siteId: undefined,
+		contactDetails: undefined,
+	};
+
+	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
+	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
+	const stripe = {};
+
+	const basicExpectedStripeRequest = {
+		cart: {
+			blog_id: '0',
+			cart_key: 'no-site',
+			coupon: '',
+			create_new_blog: true,
+			currency: 'USD',
+			extra: [],
+			products: [ product ],
+			tax: {
+				display_taxes: false,
+				location: {},
+			},
+			temporary: false,
+		},
+		domainDetails: undefined,
+		payment: {
+			address: undefined,
+			cancelUrl: undefined,
+			city: undefined,
+			country: 'US',
+			countryCode: 'US',
+			deviceId: undefined,
+			document: undefined,
+			email: undefined,
+			gstin: undefined,
+			idealBank: undefined,
+			name: 'test name',
+			nik: undefined,
+			pan: undefined,
+			paymentKey: 'apple-pay-token',
+			paymentMethod: 'WPCOM_Billing_Stripe_Payment_Method',
+			paymentPartner: 'IE',
+			phoneNumber: undefined,
+			postalCode: '10001',
+			state: undefined,
+			storedDetailsId: undefined,
+			streetNumber: undefined,
+			successUrl: undefined,
+			tefBank: undefined,
+			zip: '10001',
+		},
+	};
+
+	const basicExpectedDomainDetails = {
+		address1: undefined,
+		address2: undefined,
+		alternateEmail: undefined,
+		city: undefined,
+		countryCode: 'US',
+		email: undefined,
+		extra: {
+			ca: null,
+			fr: null,
+			uk: null,
+		},
+		fax: undefined,
+		firstName: undefined,
+		lastName: undefined,
+		organization: undefined,
+		phone: undefined,
+		postalCode: '10001',
+		state: undefined,
+	};
+
+	const transactionsEndpoint = jest.fn();
+	const undocumentedFunctions = {
+		transactions: transactionsEndpoint,
+	};
+	wp.undocumented = jest.fn().mockReturnValue( undocumentedFunctions );
+
+	beforeEach( () => {
+		transactionsEndpoint.mockClear();
+		transactionsEndpoint.mockReturnValue( Promise.resolve( 'test success' ) );
+	} );
+
+	it( 'throws an error if there is no stripe object', async () => {
+		const submitData = { paymentPartner: 'stripe' };
+		await expect( applePayProcessor( submitData, options ) ).rejects.toThrowError(
+			/requires stripe and none was provided/
+		);
+	} );
+
+	it( 'throws an error if there is no stripeConfiguration object', async () => {
+		const submitData = { paymentPartner: 'stripe', stripe };
+		await expect( applePayProcessor( submitData, options ) ).rejects.toThrowError(
+			/requires stripeConfiguration and none was provided/
+		);
+	} );
+
+	it( 'sends the correct data to the endpoint with no site and one product', async () => {
+		const submitData = {
+			stripe,
+			stripeConfiguration,
+			paymentMethodToken: 'apple-pay-token',
+			name: 'test name',
+		};
+		const expected = { payload: 'test success', type: 'SUCCESS' };
+		await expect(
+			applePayProcessor( submitData, {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( basicExpectedStripeRequest );
+	} );
+
+	it( 'returns an explicit error response if the transaction fails', async () => {
+		const submitData = {
+			stripe,
+			stripeConfiguration,
+			paymentMethodToken: 'apple-pay-token',
+			name: 'test name',
+		};
+		transactionsEndpoint.mockReturnValue( Promise.reject( new Error( 'test error' ) ) );
+		const expected = { payload: 'test error', type: 'ERROR' };
+		await expect(
+			applePayProcessor( submitData, {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+	} );
+
+	it( 'sends the correct data to the endpoint with a site and one product', async () => {
+		const submitData = {
+			stripe,
+			stripeConfiguration,
+			paymentMethodToken: 'apple-pay-token',
+			name: 'test name',
+		};
+		const expected = { payload: 'test success', type: 'SUCCESS' };
+		await expect(
+			applePayProcessor( submitData, {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+			},
+		} );
+	} );
+
+	it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
+		const submitData = {
+			stripe,
+			stripeConfiguration,
+			paymentMethodToken: 'apple-pay-token',
+			name: 'test name',
+		};
+		const expected = { payload: 'test success', type: 'SUCCESS' };
+		await expect(
+			applePayProcessor( submitData, {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+				responseCart: { ...cart, products: [ domainProduct ] },
+				includeDomainDetails: true,
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+				products: [ domainProduct ],
+			},
+			domainDetails: basicExpectedDomainDetails,
+		} );
+	} );
+} );

--- a/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
@@ -1,0 +1,287 @@
+/**
+ * External dependencies
+ */
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+
+/**
+ * Internal dependencies
+ */
+import existingCardProcessor from '../lib/existing-card-processor';
+import wp from 'calypso/lib/wp';
+
+jest.mock( 'calypso/lib/wp' );
+
+describe( 'existingCardProcessor', () => {
+	const stripeConfiguration = {
+		processor_id: 'IE',
+		js_url: 'https://stripe-js-url',
+		public_key: 'stripe-public-key',
+		setup_intent_id: null,
+	};
+	const product = getEmptyResponseCartProduct();
+	const domainProduct = {
+		...getEmptyResponseCartProduct(),
+		meta: 'example.com',
+		is_domain_registration: true,
+	};
+	const cart = { ...getEmptyResponseCart(), products: [ product ] };
+	const options = {
+		includeDomainDetails: false,
+		includeGSuiteDetails: false,
+		createUserAndSiteBeforeTransaction: false,
+		stripeConfiguration,
+		recordEvent: () => null,
+		reduxDispatch: () => null,
+		responseCart: cart,
+		getThankYouUrl: () => '',
+		siteSlug: undefined,
+		siteId: undefined,
+		contactDetails: undefined,
+	};
+
+	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
+	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
+
+	const basicExpectedStripeRequest = {
+		cart: {
+			blog_id: '0',
+			cart_key: 'no-site',
+			coupon: '',
+			create_new_blog: true,
+			currency: 'USD',
+			extra: [],
+			products: [ product ],
+			tax: {
+				display_taxes: false,
+				location: {},
+			},
+			temporary: false,
+		},
+		domainDetails: undefined,
+		payment: {
+			address: undefined,
+			cancelUrl: undefined,
+			city: undefined,
+			country: 'US',
+			countryCode: 'US',
+			deviceId: undefined,
+			document: undefined,
+			email: undefined,
+			gstin: undefined,
+			idealBank: undefined,
+			name: 'test name',
+			nik: undefined,
+			pan: undefined,
+			paymentKey: 'stripe-token',
+			paymentMethod: 'WPCOM_Billing_MoneyPress_Stored',
+			paymentPartner: 'IE',
+			phoneNumber: undefined,
+			postalCode: '10001',
+			state: undefined,
+			storedDetailsId: 'stored-details-id',
+			streetNumber: undefined,
+			successUrl: undefined,
+			tefBank: undefined,
+			zip: '10001',
+		},
+	};
+
+	const basicExpectedDomainDetails = {
+		address1: undefined,
+		address2: undefined,
+		alternateEmail: undefined,
+		city: undefined,
+		countryCode: 'US',
+		email: undefined,
+		extra: {
+			ca: null,
+			fr: null,
+			uk: null,
+		},
+		fax: undefined,
+		firstName: undefined,
+		lastName: undefined,
+		organization: undefined,
+		phone: undefined,
+		postalCode: '10001',
+		state: undefined,
+	};
+
+	const transactionsEndpoint = jest.fn();
+	const undocumentedFunctions = {
+		transactions: transactionsEndpoint,
+	};
+	wp.undocumented = jest.fn().mockReturnValue( undocumentedFunctions );
+
+	beforeEach( () => {
+		transactionsEndpoint.mockClear();
+		transactionsEndpoint.mockReturnValue( Promise.resolve( 'success' ) );
+	} );
+
+	it( 'throws an error if there is no country passed', async () => {
+		const submitData = {};
+		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrowError(
+			/requires country code and none was provided/
+		);
+	} );
+
+	it( 'throws an error if there is no postalCode passed', async () => {
+		const submitData = { country: 'US' };
+		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrowError(
+			/requires postal code and none was provided/
+		);
+	} );
+
+	it( 'throws an error if there is no storedDetailsId passed', async () => {
+		const submitData = { country: 'US', postalCode: '10001' };
+		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrowError(
+			/requires saved card information and none was provided/
+		);
+	} );
+
+	it( 'throws an error if there is no name passed', async () => {
+		const submitData = { country: 'US', postalCode: '10001', storedDetailsId: 'stored-details-id' };
+		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrowError(
+			/requires cardholder name and none was provided/
+		);
+	} );
+
+	it( 'throws an error if there is no paymentMethodToken passed', async () => {
+		const submitData = {
+			country: 'US',
+			postalCode: '10001',
+			storedDetailsId: 'stored-details-id',
+			name: 'test name',
+		};
+		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrowError(
+			/requires a Stripe token and none was provided/
+		);
+	} );
+
+	it( 'throws an error if there is no paymentPartnerProcessorId passed', async () => {
+		const submitData = {
+			country: 'US',
+			postalCode: '10001',
+			storedDetailsId: 'stored-details-id',
+			name: 'test name',
+			paymentMethodToken: 'stripe-token',
+		};
+		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrowError(
+			/requires a processor id and none was provided/
+		);
+	} );
+
+	it( 'sends the correct data to the endpoint with no site and one product', async () => {
+		const submitData = {
+			country: 'US',
+			postalCode: '10001',
+			storedDetailsId: 'stored-details-id',
+			name: 'test name',
+			paymentMethodToken: 'stripe-token',
+			paymentPartnerProcessorId: 'IE',
+		};
+		const expected = { payload: 'success', type: 'SUCCESS' };
+		await expect(
+			existingCardProcessor( submitData, {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( basicExpectedStripeRequest );
+	} );
+
+	it( 'returns an explicit error response if the transaction fails', async () => {
+		const submitData = {
+			country: 'US',
+			postalCode: '10001',
+			storedDetailsId: 'stored-details-id',
+			name: 'test name',
+			paymentMethodToken: 'stripe-token',
+			paymentPartnerProcessorId: 'IE',
+		};
+		transactionsEndpoint.mockReturnValue( Promise.reject( new Error( 'test error' ) ) );
+		const expected = { payload: 'test error', type: 'ERROR' };
+		await expect(
+			existingCardProcessor( submitData, {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+	} );
+
+	it( 'sends the correct data to the endpoint with a site and one product', async () => {
+		const submitData = {
+			country: 'US',
+			postalCode: '10001',
+			storedDetailsId: 'stored-details-id',
+			name: 'test name',
+			paymentMethodToken: 'stripe-token',
+			paymentPartnerProcessorId: 'IE',
+		};
+		const expected = { payload: 'success', type: 'SUCCESS' };
+		await expect(
+			existingCardProcessor( submitData, {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+			},
+		} );
+	} );
+
+	it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
+		const submitData = {
+			country: 'US',
+			postalCode: '10001',
+			storedDetailsId: 'stored-details-id',
+			name: 'test name',
+			paymentMethodToken: 'stripe-token',
+			paymentPartnerProcessorId: 'IE',
+		};
+		const expected = { payload: 'success', type: 'SUCCESS' };
+		await expect(
+			existingCardProcessor( submitData, {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+				responseCart: { ...cart, products: [ domainProduct ] },
+				includeDomainDetails: true,
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+				products: [ domainProduct ],
+			},
+			domainDetails: basicExpectedDomainDetails,
+		} );
+	} );
+} );

--- a/client/my-sites/checkout/composite-checkout/test/free-purchase-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/free-purchase-processor.ts
@@ -1,0 +1,202 @@
+/**
+ * External dependencies
+ */
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+
+/**
+ * Internal dependencies
+ */
+import freePurchaseProcessor from '../lib/free-purchase-processor';
+import wp from 'calypso/lib/wp';
+
+jest.mock( 'calypso/lib/wp' );
+
+describe( 'freePurchaseProcessor', () => {
+	const stripeConfiguration = {
+		processor_id: 'IE',
+		js_url: 'https://stripe-js-url',
+		public_key: 'stripe-public-key',
+		setup_intent_id: null,
+	};
+	const product = getEmptyResponseCartProduct();
+	const domainProduct = {
+		...getEmptyResponseCartProduct(),
+		meta: 'example.com',
+		is_domain_registration: true,
+	};
+	const cart = { ...getEmptyResponseCart(), products: [ product ] };
+	const options = {
+		includeDomainDetails: false,
+		includeGSuiteDetails: false,
+		createUserAndSiteBeforeTransaction: false,
+		stripeConfiguration,
+		recordEvent: () => null,
+		reduxDispatch: () => null,
+		responseCart: cart,
+		getThankYouUrl: () => '',
+		siteSlug: undefined,
+		siteId: undefined,
+		contactDetails: undefined,
+	};
+
+	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
+	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
+
+	const basicExpectedStripeRequest = {
+		cart: {
+			blog_id: '0',
+			cart_key: 'no-site',
+			coupon: '',
+			create_new_blog: true,
+			currency: 'USD',
+			extra: [],
+			products: [ product ],
+			tax: {
+				display_taxes: false,
+				location: {},
+			},
+			temporary: false,
+		},
+		domainDetails: undefined,
+		payment: {
+			address: undefined,
+			cancelUrl: undefined,
+			city: undefined,
+			country: '',
+			countryCode: '',
+			deviceId: undefined,
+			document: undefined,
+			email: undefined,
+			gstin: undefined,
+			idealBank: undefined,
+			name: '',
+			nik: undefined,
+			pan: undefined,
+			paymentKey: undefined,
+			paymentMethod: 'WPCOM_Billing_WPCOM',
+			paymentPartner: undefined,
+			phoneNumber: undefined,
+			postalCode: '',
+			state: undefined,
+			storedDetailsId: undefined,
+			streetNumber: undefined,
+			successUrl: undefined,
+			tefBank: undefined,
+			zip: '',
+		},
+	};
+
+	const basicExpectedDomainDetails = {
+		address1: undefined,
+		address2: undefined,
+		alternateEmail: undefined,
+		city: undefined,
+		countryCode: 'US',
+		email: undefined,
+		extra: {
+			ca: null,
+			fr: null,
+			uk: null,
+		},
+		fax: undefined,
+		firstName: undefined,
+		lastName: undefined,
+		organization: undefined,
+		phone: undefined,
+		postalCode: '10001',
+		state: undefined,
+	};
+
+	const transactionsEndpoint = jest.fn();
+	const undocumentedFunctions = {
+		transactions: transactionsEndpoint,
+	};
+	wp.undocumented = jest.fn().mockReturnValue( undocumentedFunctions );
+
+	beforeEach( () => {
+		transactionsEndpoint.mockClear();
+		transactionsEndpoint.mockReturnValue( Promise.resolve( 'success' ) );
+	} );
+
+	it( 'sends the correct data to the endpoint with no site and one product', async () => {
+		const expected = { payload: 'success', type: 'SUCCESS' };
+		await expect(
+			freePurchaseProcessor( {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( basicExpectedStripeRequest );
+	} );
+
+	it( 'returns an explicit error response if the transaction fails', async () => {
+		transactionsEndpoint.mockReturnValue( Promise.reject( new Error( 'test error' ) ) );
+		const expected = { payload: 'test error', type: 'ERROR' };
+		await expect(
+			freePurchaseProcessor( {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+	} );
+
+	it( 'sends the correct data to the endpoint with a site and one product', async () => {
+		const expected = { payload: 'success', type: 'SUCCESS' };
+		await expect(
+			freePurchaseProcessor( {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+			},
+		} );
+	} );
+
+	it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
+		const expected = { payload: 'success', type: 'SUCCESS' };
+		await expect(
+			freePurchaseProcessor( {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+				responseCart: { ...cart, products: [ domainProduct ] },
+				includeDomainDetails: true,
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+				products: [ domainProduct ],
+			},
+			domainDetails: basicExpectedDomainDetails,
+		} );
+	} );
+} );

--- a/client/my-sites/checkout/composite-checkout/test/full-credits-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/full-credits-processor.ts
@@ -1,0 +1,202 @@
+/**
+ * External dependencies
+ */
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+
+/**
+ * Internal dependencies
+ */
+import fullCreditsProcessor from '../lib/full-credits-processor';
+import wp from 'calypso/lib/wp';
+
+jest.mock( 'calypso/lib/wp' );
+
+describe( 'fullCreditsProcessor', () => {
+	const stripeConfiguration = {
+		processor_id: 'IE',
+		js_url: 'https://stripe-js-url',
+		public_key: 'stripe-public-key',
+		setup_intent_id: null,
+	};
+	const product = getEmptyResponseCartProduct();
+	const domainProduct = {
+		...getEmptyResponseCartProduct(),
+		meta: 'example.com',
+		is_domain_registration: true,
+	};
+	const cart = { ...getEmptyResponseCart(), products: [ product ] };
+	const options = {
+		includeDomainDetails: false,
+		includeGSuiteDetails: false,
+		createUserAndSiteBeforeTransaction: false,
+		stripeConfiguration,
+		recordEvent: () => null,
+		reduxDispatch: () => null,
+		responseCart: cart,
+		getThankYouUrl: () => '',
+		siteSlug: undefined,
+		siteId: undefined,
+		contactDetails: undefined,
+	};
+
+	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
+	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
+
+	const basicExpectedStripeRequest = {
+		cart: {
+			blog_id: '0',
+			cart_key: 'no-site',
+			coupon: '',
+			create_new_blog: true,
+			currency: 'USD',
+			extra: [],
+			products: [ product ],
+			tax: {
+				display_taxes: false,
+				location: {},
+			},
+			temporary: false,
+		},
+		domainDetails: undefined,
+		payment: {
+			address: undefined,
+			cancelUrl: undefined,
+			city: undefined,
+			country: 'US',
+			countryCode: 'US',
+			deviceId: undefined,
+			document: undefined,
+			email: undefined,
+			gstin: undefined,
+			idealBank: undefined,
+			name: '',
+			nik: undefined,
+			pan: undefined,
+			paymentKey: undefined,
+			paymentMethod: 'WPCOM_Billing_WPCOM',
+			paymentPartner: undefined,
+			phoneNumber: undefined,
+			postalCode: '10001',
+			state: undefined,
+			storedDetailsId: undefined,
+			streetNumber: undefined,
+			successUrl: undefined,
+			tefBank: undefined,
+			zip: '10001',
+		},
+	};
+
+	const basicExpectedDomainDetails = {
+		address1: undefined,
+		address2: undefined,
+		alternateEmail: undefined,
+		city: undefined,
+		countryCode: 'US',
+		email: undefined,
+		extra: {
+			ca: null,
+			fr: null,
+			uk: null,
+		},
+		fax: undefined,
+		firstName: undefined,
+		lastName: undefined,
+		organization: undefined,
+		phone: undefined,
+		postalCode: '10001',
+		state: undefined,
+	};
+
+	const transactionsEndpoint = jest.fn();
+	const undocumentedFunctions = {
+		transactions: transactionsEndpoint,
+	};
+	wp.undocumented = jest.fn().mockReturnValue( undocumentedFunctions );
+
+	beforeEach( () => {
+		transactionsEndpoint.mockClear();
+		transactionsEndpoint.mockReturnValue( Promise.resolve( 'success' ) );
+	} );
+
+	it( 'sends the correct data to the endpoint with no site and one product', async () => {
+		const expected = { payload: 'success', type: 'SUCCESS' };
+		await expect(
+			fullCreditsProcessor( {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( basicExpectedStripeRequest );
+	} );
+
+	it( 'returns an explicit error response if the transaction fails', async () => {
+		transactionsEndpoint.mockReturnValue( Promise.reject( new Error( 'test error' ) ) );
+		const expected = { payload: 'test error', type: 'ERROR' };
+		await expect(
+			fullCreditsProcessor( {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+	} );
+
+	it( 'sends the correct data to the endpoint with a site and one product', async () => {
+		const expected = { payload: 'success', type: 'SUCCESS' };
+		await expect(
+			fullCreditsProcessor( {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+			},
+		} );
+	} );
+
+	it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
+		const expected = { payload: 'success', type: 'SUCCESS' };
+		await expect(
+			fullCreditsProcessor( {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+				responseCart: { ...cart, products: [ domainProduct ] },
+				includeDomainDetails: true,
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+				products: [ domainProduct ],
+			},
+			domainDetails: basicExpectedDomainDetails,
+		} );
+	} );
+} );

--- a/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
@@ -1,0 +1,231 @@
+/**
+ * External dependencies
+ */
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+
+/**
+ * Internal dependencies
+ */
+import genericRedirectProcessor from '../lib/generic-redirect-processor';
+import wp from 'calypso/lib/wp';
+
+jest.mock( 'calypso/lib/wp' );
+
+describe( 'genericRedirectProcessor', () => {
+	const stripeConfiguration = {
+		processor_id: 'IE',
+		js_url: 'https://stripe-js-url',
+		public_key: 'stripe-public-key',
+		setup_intent_id: null,
+	};
+	const product = getEmptyResponseCartProduct();
+	const domainProduct = {
+		...getEmptyResponseCartProduct(),
+		meta: 'example.com',
+		is_domain_registration: true,
+	};
+	const cart = { ...getEmptyResponseCart(), products: [ product ] };
+	const options = {
+		includeDomainDetails: false,
+		includeGSuiteDetails: false,
+		createUserAndSiteBeforeTransaction: false,
+		stripeConfiguration,
+		recordEvent: () => null,
+		reduxDispatch: () => null,
+		responseCart: cart,
+		getThankYouUrl: () => '',
+		siteSlug: undefined,
+		siteId: undefined,
+		contactDetails: undefined,
+	};
+
+	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
+	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
+
+	const basicExpectedStripeRequest = {
+		cart: {
+			blog_id: '0',
+			cart_key: 'no-site',
+			coupon: '',
+			create_new_blog: true,
+			currency: 'USD',
+			extra: [],
+			products: [ product ],
+			tax: {
+				display_taxes: false,
+				location: {},
+			},
+			temporary: false,
+		},
+		domainDetails: undefined,
+		payment: {
+			address: undefined,
+			cancelUrl: 'https://wordpress.com/',
+			city: undefined,
+			country: 'US',
+			countryCode: 'US',
+			deviceId: undefined,
+			document: undefined,
+			email: 'test@example.com',
+			gstin: undefined,
+			idealBank: undefined,
+			name: 'test name',
+			nik: undefined,
+			pan: undefined,
+			paymentKey: undefined,
+			paymentMethod: 'WPCOM_Billing_Stripe_Source_Bancontact',
+			paymentPartner: 'IE',
+			phoneNumber: undefined,
+			postalCode: '10001',
+			state: undefined,
+			storedDetailsId: undefined,
+			streetNumber: undefined,
+			successUrl:
+				'https://wordpress.com/checkout/thank-you/no-site/pending?redirectTo=https%3A%2F%2Fwordpress.com',
+			tefBank: undefined,
+			zip: '10001',
+		},
+	};
+
+	const basicExpectedDomainDetails = {
+		address1: undefined,
+		address2: undefined,
+		alternateEmail: undefined,
+		city: undefined,
+		countryCode: 'US',
+		email: undefined,
+		extra: {
+			ca: null,
+			fr: null,
+			uk: null,
+		},
+		fax: undefined,
+		firstName: undefined,
+		lastName: undefined,
+		organization: undefined,
+		phone: undefined,
+		postalCode: '10001',
+		state: undefined,
+	};
+
+	const transactionsEndpoint = jest.fn();
+	const undocumentedFunctions = {
+		transactions: transactionsEndpoint,
+	};
+	wp.undocumented = jest.fn().mockReturnValue( undocumentedFunctions );
+
+	beforeEach( () => {
+		transactionsEndpoint.mockClear();
+		transactionsEndpoint.mockReturnValue(
+			Promise.resolve( { redirect_url: 'https://test-redirect-url' } )
+		);
+	} );
+
+	it( 'sends the correct data to the endpoint with no site and one product', async () => {
+		const submitData = {
+			name: 'test name',
+			email: 'test@example.com',
+		};
+		const expected = { payload: 'https://test-redirect-url', type: 'REDIRECT' };
+		await expect(
+			genericRedirectProcessor( 'bancontact', submitData, {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( basicExpectedStripeRequest );
+	} );
+
+	it( 'returns an explicit error response if the transaction fails', async () => {
+		const submitData = {
+			name: 'test name',
+			email: 'test@example.com',
+		};
+		transactionsEndpoint.mockReturnValue( Promise.reject( new Error( 'test error' ) ) );
+		const expected = { payload: 'test error', type: 'ERROR' };
+		await expect(
+			genericRedirectProcessor( 'bancontact', submitData, {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+	} );
+
+	it( 'sends the correct data to the endpoint with a site and one product', async () => {
+		const submitData = {
+			name: 'test name',
+			email: 'test@example.com',
+		};
+		const expected = { payload: 'https://test-redirect-url', type: 'REDIRECT' };
+		await expect(
+			genericRedirectProcessor( 'bancontact', submitData, {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+			},
+			payment: {
+				...basicExpectedStripeRequest.payment,
+				successUrl:
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=https%3A%2F%2Fwordpress.com',
+			},
+		} );
+	} );
+
+	it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
+		const submitData = {
+			name: 'test name',
+			email: 'test@example.com',
+		};
+		const expected = { payload: 'https://test-redirect-url', type: 'REDIRECT' };
+		await expect(
+			genericRedirectProcessor( 'bancontact', submitData, {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+				responseCart: { ...cart, products: [ domainProduct ] },
+				includeDomainDetails: true,
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+				products: [ domainProduct ],
+			},
+			domainDetails: basicExpectedDomainDetails,
+			payment: {
+				...basicExpectedStripeRequest.payment,
+				successUrl:
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=https%3A%2F%2Fwordpress.com',
+			},
+		} );
+	} );
+} );

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.ts
@@ -1,0 +1,537 @@
+/**
+ * External dependencies
+ */
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+
+/**
+ * Internal dependencies
+ */
+import multiPartnerCardProcessor from '../lib/multi-partner-card-processor';
+import wp from 'calypso/lib/wp';
+import { createEbanxToken } from 'calypso/lib/store-transactions';
+
+jest.mock( 'calypso/lib/wp' );
+jest.mock( 'calypso/lib/store-transactions', () => ( {
+	createEbanxToken: jest.fn(),
+} ) );
+
+async function createMockStripeToken(
+	type: string,
+	args: { billing_details: Record< string, unknown > }
+) {
+	if ( type !== 'card' ) {
+		return { error: new Error( 'stripe error: unknown type' ) };
+	}
+	if ( ! args.billing_details ) {
+		return { error: new Error( 'stripe error: missing billing_details' ) };
+	}
+	if ( ! args.billing_details.name ) {
+		return { error: new Error( 'stripe error: missing billing_details.name' ) };
+	}
+	if ( ! args.billing_details.address ) {
+		return { error: new Error( 'stripe error: missing billing_details.address' ) };
+	}
+	if ( ! ( args.billing_details.address as Record< string, string > )?.country ) {
+		return { error: new Error( 'stripe error: missing billing_details.address.country' ) };
+	}
+	if ( ! ( args.billing_details.address as Record< string, string > )?.postal_code ) {
+		return { error: new Error( 'stripe error: missing billing_details.address.postal_code' ) };
+	}
+	return { paymentMethod: { id: 'stripe-token' } };
+}
+
+async function createMockEbanxToken( requestType: string, cardDetails: Record< string, string > ) {
+	if ( requestType !== 'new_purchase' ) {
+		throw new Error( 'ebanx error: invalid requestType' );
+	}
+	if ( ! cardDetails.country ) {
+		throw new Error( 'ebanx error: missing country' );
+	}
+	if ( ! cardDetails.name ) {
+		throw new Error( 'ebanx error: missing name' );
+	}
+	if ( ! cardDetails.number ) {
+		throw new Error( 'ebanx error: missing number' );
+	}
+	if ( ! cardDetails.cvv ) {
+		throw new Error( 'ebanx error: missing cvv' );
+	}
+	if ( ! cardDetails[ 'expiration-date' ] ) {
+		throw new Error( 'ebanx error: missing expiration-date' );
+	}
+	return {
+		deviceId: 'mock-ebanx-device',
+		token: 'ebanx-token',
+	};
+}
+
+describe( 'multiPartnerCardProcessor', () => {
+	const stripeConfiguration = {
+		processor_id: 'IE',
+		js_url: 'https://stripe-js-url',
+		public_key: 'stripe-public-key',
+		setup_intent_id: null,
+	};
+	const product = getEmptyResponseCartProduct();
+	const domainProduct = {
+		...getEmptyResponseCartProduct(),
+		meta: 'example.com',
+		is_domain_registration: true,
+	};
+	const cart = { ...getEmptyResponseCart(), products: [ product ] };
+	const options = {
+		includeDomainDetails: false,
+		includeGSuiteDetails: false,
+		createUserAndSiteBeforeTransaction: false,
+		stripeConfiguration,
+		recordEvent: () => null,
+		reduxDispatch: () => null,
+		responseCart: cart,
+		getThankYouUrl: () => '',
+		siteSlug: undefined,
+		siteId: undefined,
+		contactDetails: undefined,
+	};
+	const stripe = {
+		createPaymentMethod: createMockStripeToken,
+	};
+
+	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
+	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
+
+	const basicExpectedStripeRequest = {
+		cart: {
+			blog_id: '0',
+			cart_key: 'no-site',
+			coupon: '',
+			create_new_blog: true,
+			currency: 'USD',
+			extra: [],
+			products: [ product ],
+			tax: {
+				display_taxes: false,
+				location: {},
+			},
+			temporary: false,
+		},
+		domainDetails: undefined,
+		payment: {
+			address: undefined,
+			cancelUrl: undefined,
+			city: undefined,
+			country: 'US',
+			countryCode: 'US',
+			deviceId: undefined,
+			document: undefined,
+			email: undefined,
+			gstin: undefined,
+			idealBank: undefined,
+			name: 'test name',
+			nik: undefined,
+			pan: undefined,
+			paymentKey: 'stripe-token',
+			paymentMethod: 'WPCOM_Billing_Stripe_Payment_Method',
+			paymentPartner: 'IE',
+			phoneNumber: undefined,
+			postalCode: '10001',
+			state: undefined,
+			storedDetailsId: undefined,
+			streetNumber: undefined,
+			successUrl: undefined,
+			tefBank: undefined,
+			zip: '10001',
+		},
+	};
+
+	const basicExpectedEbanxRequest = {
+		...basicExpectedStripeRequest,
+		payment: {
+			address: '100 Main Street',
+			cancelUrl: undefined,
+			city: 'New York',
+			country: 'US',
+			countryCode: 'US',
+			deviceId: 'mock-ebanx-device',
+			document: 'ebanx-document-code',
+			email: undefined,
+			gstin: undefined,
+			idealBank: undefined,
+			name: 'test name',
+			nik: undefined,
+			pan: undefined,
+			paymentKey: 'ebanx-token',
+			paymentMethod: 'WPCOM_Billing_Ebanx',
+			paymentPartner: undefined,
+			phoneNumber: '1111111111',
+			postalCode: '10001',
+			state: 'NY',
+			storedDetailsId: undefined,
+			streetNumber: '100',
+			successUrl: undefined,
+			tefBank: undefined,
+			zip: '10001',
+		},
+	};
+
+	const basicExpectedDomainDetails = {
+		address1: undefined,
+		address2: undefined,
+		alternateEmail: undefined,
+		city: undefined,
+		countryCode: 'US',
+		email: undefined,
+		extra: {
+			ca: null,
+			fr: null,
+			uk: null,
+		},
+		fax: undefined,
+		firstName: undefined,
+		lastName: undefined,
+		organization: undefined,
+		phone: undefined,
+		postalCode: '10001',
+		state: undefined,
+	};
+
+	const transactionsEndpoint = jest.fn();
+	const undocumentedFunctions = {
+		transactions: transactionsEndpoint,
+	};
+	wp.undocumented = jest.fn().mockReturnValue( undocumentedFunctions );
+
+	beforeEach( () => {
+		transactionsEndpoint.mockClear();
+		transactionsEndpoint.mockReturnValue( Promise.resolve( 'test success' ) );
+	} );
+
+	it( 'throws an error if there is no paymentPartner', async () => {
+		const submitData = {};
+		await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+			/paymentPartner/
+		);
+	} );
+
+	it( 'throws an error if there is an unknown paymentPartner', async () => {
+		const submitData = { paymentPartner: 'unknown' };
+		await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+			/Unrecognized card payment partner/
+		);
+	} );
+
+	describe( 'for a stripe paymentPartner', () => {
+		it( 'throws an error if there is no stripe object', async () => {
+			const submitData = { paymentPartner: 'stripe' };
+			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+				/requires stripe and none was provided/
+			);
+		} );
+
+		it( 'throws an error if there is no stripeConfiguration object', async () => {
+			const submitData = { paymentPartner: 'stripe', stripe };
+			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+				/requires stripeConfiguration and none was provided/
+			);
+		} );
+
+		it( 'fails to create a token if the name and address are missing', async () => {
+			const submitData = { paymentPartner: 'stripe', stripe, stripeConfiguration };
+			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+				/billing_details.name/
+			);
+		} );
+
+		it( 'fails to create a token if the countryCode and postalCode are missing', async () => {
+			const submitData = {
+				paymentPartner: 'stripe',
+				stripe,
+				stripeConfiguration,
+				name: 'test name',
+			};
+			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+				/billing_details.address.country/
+			);
+		} );
+
+		it( 'fails to create a token if the postalCode is missing', async () => {
+			const submitData = {
+				paymentPartner: 'stripe',
+				stripe,
+				stripeConfiguration,
+				name: 'test name',
+			};
+			await expect(
+				multiPartnerCardProcessor( submitData, {
+					...options,
+					contactDetails: { countryCode },
+				} )
+			).rejects.toThrowError( /billing_details.address.postal_code/ );
+		} );
+
+		it( 'sends the correct data to the endpoint with no site and one product', async () => {
+			const submitData = {
+				paymentPartner: 'stripe',
+				stripe,
+				stripeConfiguration,
+				name: 'test name',
+			};
+			const expected = { payload: 'test success', type: 'SUCCESS' };
+			await expect(
+				multiPartnerCardProcessor( submitData, {
+					...options,
+					contactDetails: {
+						countryCode,
+						postalCode,
+					},
+				} )
+			).resolves.toStrictEqual( expected );
+			expect( transactionsEndpoint ).toHaveBeenCalledWith( basicExpectedStripeRequest );
+		} );
+
+		it( 'returns an explicit error response if the transaction fails', async () => {
+			const submitData = {
+				paymentPartner: 'stripe',
+				stripe,
+				stripeConfiguration,
+				name: 'test name',
+			};
+			transactionsEndpoint.mockReturnValue( Promise.reject( new Error( 'test error' ) ) );
+			const expected = { payload: 'test error', type: 'ERROR' };
+			await expect(
+				multiPartnerCardProcessor( submitData, {
+					...options,
+					contactDetails: {
+						countryCode,
+						postalCode,
+					},
+				} )
+			).resolves.toStrictEqual( expected );
+		} );
+
+		it( 'sends the correct data to the endpoint with a site and one product', async () => {
+			const submitData = {
+				paymentPartner: 'stripe',
+				stripe,
+				stripeConfiguration,
+				name: 'test name',
+			};
+			const expected = { payload: 'test success', type: 'SUCCESS' };
+			await expect(
+				multiPartnerCardProcessor( submitData, {
+					...options,
+					siteSlug: 'example.wordpress.com',
+					siteId: 1234567,
+					contactDetails: {
+						countryCode,
+						postalCode,
+					},
+				} )
+			).resolves.toStrictEqual( expected );
+			expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+				...basicExpectedStripeRequest,
+				cart: {
+					...basicExpectedStripeRequest.cart,
+					blog_id: '1234567',
+					cart_key: '1234567',
+					coupon: '',
+					create_new_blog: false,
+				},
+			} );
+		} );
+
+		it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
+			const submitData = {
+				paymentPartner: 'stripe',
+				stripe,
+				stripeConfiguration,
+				name: 'test name',
+			};
+			const expected = { payload: 'test success', type: 'SUCCESS' };
+			await expect(
+				multiPartnerCardProcessor( submitData, {
+					...options,
+					siteSlug: 'example.wordpress.com',
+					siteId: 1234567,
+					contactDetails: {
+						countryCode,
+						postalCode,
+					},
+					responseCart: { ...cart, products: [ domainProduct ] },
+					includeDomainDetails: true,
+				} )
+			).resolves.toStrictEqual( expected );
+			expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+				...basicExpectedStripeRequest,
+				cart: {
+					...basicExpectedStripeRequest.cart,
+					blog_id: '1234567',
+					cart_key: '1234567',
+					coupon: '',
+					create_new_blog: false,
+					products: [ domainProduct ],
+				},
+				domainDetails: basicExpectedDomainDetails,
+			} );
+		} );
+	} );
+
+	describe( 'for a ebanx paymentPartner', () => {
+		const ebanxCardTransactionRequest = {
+			name: 'test name',
+			countryCode: 'US',
+			number: '4242424242424242',
+			cvv: '222',
+			'expiration-date': '02/22',
+			state: 'NY',
+			city: 'New York',
+			postalCode: '10001',
+			address: '100 Main Street',
+			streetNumber: '100',
+			phoneNumber: '1111111111',
+			document: 'ebanx-document-code',
+		};
+		createEbanxToken.mockImplementation( createMockEbanxToken );
+
+		it( 'throws an error if there is no countryCode in the submitted data', async () => {
+			const submitData = {
+				paymentPartner: 'ebanx',
+				...ebanxCardTransactionRequest,
+				countryCode: undefined,
+			};
+			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+				/missing country/
+			);
+		} );
+
+		it( 'throws an error if there is no name in the submitted data', async () => {
+			const submitData = {
+				paymentPartner: 'ebanx',
+				...ebanxCardTransactionRequest,
+				name: undefined,
+			};
+			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+				/missing name/
+			);
+		} );
+
+		it( 'throws an error if there is no number in the submitted data', async () => {
+			const submitData = {
+				paymentPartner: 'ebanx',
+				...ebanxCardTransactionRequest,
+				number: undefined,
+			};
+			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+				/missing number/
+			);
+		} );
+
+		it( 'throws an error if there is no cvv in the submitted data', async () => {
+			const submitData = {
+				paymentPartner: 'ebanx',
+				...ebanxCardTransactionRequest,
+				cvv: undefined,
+			};
+			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+				/missing cvv/
+			);
+		} );
+
+		it( 'throws an error if there is no expiration-date in the submitted data', async () => {
+			const submitData = {
+				paymentPartner: 'ebanx',
+				...ebanxCardTransactionRequest,
+				'expiration-date': undefined,
+			};
+			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+				/missing expiration-date/
+			);
+		} );
+
+		it( 'sends the correct data to the endpoint with no site and one product', async () => {
+			const submitData = {
+				paymentPartner: 'ebanx',
+				...ebanxCardTransactionRequest,
+			};
+			const expected = { payload: 'test success', type: 'SUCCESS' };
+			await expect( multiPartnerCardProcessor( submitData, options ) ).resolves.toStrictEqual(
+				expected
+			);
+			expect( transactionsEndpoint ).toHaveBeenCalledWith( basicExpectedEbanxRequest );
+		} );
+
+		it( 'returns an explicit error response if the transaction fails', async () => {
+			const submitData = {
+				paymentPartner: 'ebanx',
+				...ebanxCardTransactionRequest,
+			};
+			transactionsEndpoint.mockReturnValue( Promise.reject( new Error( 'test error' ) ) );
+			const expected = { payload: 'test error', type: 'ERROR' };
+			await expect( multiPartnerCardProcessor( submitData, options ) ).resolves.toStrictEqual(
+				expected
+			);
+		} );
+
+		it( 'sends the correct data to the endpoint with a site and one product', async () => {
+			const submitData = {
+				paymentPartner: 'ebanx',
+				...ebanxCardTransactionRequest,
+			};
+			const expected = { payload: 'test success', type: 'SUCCESS' };
+			await expect(
+				multiPartnerCardProcessor( submitData, {
+					...options,
+					siteSlug: 'example.wordpress.com',
+					siteId: 1234567,
+					contactDetails: {
+						countryCode,
+						postalCode,
+					},
+				} )
+			).resolves.toStrictEqual( expected );
+			expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+				...basicExpectedEbanxRequest,
+				cart: {
+					...basicExpectedStripeRequest.cart,
+					blog_id: '1234567',
+					cart_key: '1234567',
+					coupon: '',
+					create_new_blog: false,
+					products: [ product ],
+				},
+			} );
+		} );
+
+		it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
+			const submitData = {
+				paymentPartner: 'ebanx',
+				...ebanxCardTransactionRequest,
+			};
+			const expected = { payload: 'test success', type: 'SUCCESS' };
+			await expect(
+				multiPartnerCardProcessor( submitData, {
+					...options,
+					siteSlug: 'example.wordpress.com',
+					siteId: 1234567,
+					contactDetails: {
+						countryCode,
+						postalCode,
+					},
+					responseCart: { ...cart, products: [ domainProduct ] },
+					includeDomainDetails: true,
+				} )
+			).resolves.toStrictEqual( expected );
+			expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+				...basicExpectedEbanxRequest,
+				cart: {
+					...basicExpectedStripeRequest.cart,
+					blog_id: '1234567',
+					cart_key: '1234567',
+					coupon: '',
+					create_new_blog: false,
+					products: [ domainProduct ],
+				},
+				domainDetails: basicExpectedDomainDetails,
+			} );
+		} );
+	} );
+} );

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -1,0 +1,184 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+
+/**
+ * Internal dependencies
+ */
+import payPalExpressProcessor from '../lib/paypal-express-processor';
+import wp from 'calypso/lib/wp';
+
+jest.mock( 'calypso/lib/wp' );
+
+describe( 'payPalExpressProcessor', () => {
+	const stripeConfiguration = {
+		processor_id: 'IE',
+		js_url: 'https://stripe-js-url',
+		public_key: 'stripe-public-key',
+		setup_intent_id: null,
+	};
+	const product = getEmptyResponseCartProduct();
+	const domainProduct = {
+		...getEmptyResponseCartProduct(),
+		meta: 'example.com',
+		is_domain_registration: true,
+	};
+	const cart = { ...getEmptyResponseCart(), products: [ product ] };
+	const options = {
+		includeDomainDetails: false,
+		includeGSuiteDetails: false,
+		createUserAndSiteBeforeTransaction: false,
+		stripeConfiguration,
+		recordEvent: () => null,
+		reduxDispatch: () => null,
+		responseCart: cart,
+		getThankYouUrl: () => '',
+		siteSlug: undefined,
+		siteId: undefined,
+		contactDetails: undefined,
+	};
+
+	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
+	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
+
+	const basicExpectedRequest = {
+		cancelUrl: 'https://example.com/',
+		cart: {
+			blog_id: '0',
+			cart_key: 'no-site',
+			coupon: '',
+			create_new_blog: true,
+			currency: 'USD',
+			extra: [],
+			products: [ product ],
+			tax: {
+				display_taxes: false,
+				location: {},
+			},
+			temporary: false,
+		},
+		country: '',
+		domainDetails: null,
+		postalCode: '',
+		successUrl: 'https://example.com/',
+	};
+
+	const basicExpectedDomainDetails = {
+		address1: undefined,
+		address2: undefined,
+		alternateEmail: undefined,
+		city: undefined,
+		countryCode: 'US',
+		email: undefined,
+		extra: {
+			ca: null,
+			fr: null,
+			uk: null,
+		},
+		fax: undefined,
+		firstName: undefined,
+		lastName: undefined,
+		organization: undefined,
+		phone: undefined,
+		postalCode: '10001',
+		state: undefined,
+	};
+
+	const transactionsEndpoint = jest.fn();
+	const undocumentedFunctions = {
+		paypalExpressUrl: transactionsEndpoint,
+	};
+	wp.undocumented = jest.fn().mockReturnValue( undocumentedFunctions );
+
+	beforeEach( () => {
+		transactionsEndpoint.mockClear();
+		transactionsEndpoint.mockReturnValue( Promise.resolve( 'https://test-redirect-url' ) );
+	} );
+
+	it( 'sends the correct data to the endpoint with no site and one product', async () => {
+		const expected = { payload: 'https://test-redirect-url', type: 'REDIRECT' };
+		await expect(
+			payPalExpressProcessor( {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( basicExpectedRequest );
+	} );
+
+	it( 'returns an explicit error response if the transaction fails', async () => {
+		transactionsEndpoint.mockReturnValue( Promise.reject( new Error( 'test error' ) ) );
+		const expected = { payload: 'test error', type: 'ERROR' };
+		await expect(
+			payPalExpressProcessor( {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+	} );
+
+	it( 'sends the correct data to the endpoint with a site and one product', async () => {
+		const expected = { payload: 'https://test-redirect-url', type: 'REDIRECT' };
+		await expect(
+			payPalExpressProcessor( {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedRequest,
+			cart: {
+				...basicExpectedRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+			},
+		} );
+	} );
+
+	it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
+		const expected = { payload: 'https://test-redirect-url', type: 'REDIRECT' };
+		await expect(
+			payPalExpressProcessor( {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+				responseCart: { ...cart, products: [ domainProduct ] },
+				includeDomainDetails: true,
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedRequest,
+			cart: {
+				...basicExpectedRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+				products: [ domainProduct ],
+			},
+			domainDetails: basicExpectedDomainDetails,
+		} );
+	} );
+} );

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -65,7 +65,7 @@ describe( 'payPalExpressProcessor', () => {
 		country: '',
 		domainDetails: null,
 		postalCode: '',
-		successUrl: 'https://example.com/',
+		successUrl: 'https://example.com',
 	};
 
 	const basicExpectedDomainDetails = {

--- a/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
@@ -1,0 +1,230 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+
+/**
+ * Internal dependencies
+ */
+import weChatProcessor from '../lib/we-chat-processor';
+import wp from 'calypso/lib/wp';
+
+jest.mock( 'calypso/lib/wp' );
+
+describe( 'weChatProcessor', () => {
+	const stripeConfiguration = {
+		processor_id: 'IE',
+		js_url: 'https://stripe-js-url',
+		public_key: 'stripe-public-key',
+		setup_intent_id: null,
+	};
+	const product = getEmptyResponseCartProduct();
+	const domainProduct = {
+		...getEmptyResponseCartProduct(),
+		meta: 'example.com',
+		is_domain_registration: true,
+	};
+	const cart = { ...getEmptyResponseCart(), products: [ product ] };
+	const options = {
+		includeDomainDetails: false,
+		includeGSuiteDetails: false,
+		createUserAndSiteBeforeTransaction: false,
+		stripeConfiguration,
+		recordEvent: () => null,
+		reduxDispatch: () => null,
+		responseCart: cart,
+		getThankYouUrl: () => '',
+		siteSlug: undefined,
+		siteId: undefined,
+		contactDetails: undefined,
+	};
+
+	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
+	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
+
+	const basicExpectedStripeRequest = {
+		cart: {
+			blog_id: '0',
+			cart_key: 'no-site',
+			coupon: '',
+			create_new_blog: true,
+			currency: 'USD',
+			extra: [],
+			products: [ product ],
+			tax: {
+				display_taxes: false,
+				location: {},
+			},
+			temporary: false,
+		},
+		domainDetails: undefined,
+		payment: {
+			address: undefined,
+			cancelUrl: 'https://example.com/',
+			city: undefined,
+			country: 'US',
+			countryCode: 'US',
+			deviceId: undefined,
+			document: undefined,
+			email: undefined,
+			gstin: undefined,
+			idealBank: undefined,
+			name: 'test name',
+			nik: undefined,
+			pan: undefined,
+			paymentKey: undefined,
+			paymentMethod: 'WPCOM_Billing_Stripe_Source_Wechat',
+			paymentPartner: 'IE',
+			phoneNumber: undefined,
+			postalCode: '10001',
+			state: undefined,
+			storedDetailsId: undefined,
+			streetNumber: undefined,
+			successUrl:
+				'https://example.com/checkout/thank-you/no-site/pending?redirectTo=https%3A%2F%2Fexample.com',
+			tefBank: undefined,
+			zip: '10001',
+		},
+	};
+
+	const basicExpectedDomainDetails = {
+		address1: undefined,
+		address2: undefined,
+		alternateEmail: undefined,
+		city: undefined,
+		countryCode: 'US',
+		email: undefined,
+		extra: {
+			ca: null,
+			fr: null,
+			uk: null,
+		},
+		fax: undefined,
+		firstName: undefined,
+		lastName: undefined,
+		organization: undefined,
+		phone: undefined,
+		postalCode: '10001',
+		state: undefined,
+	};
+
+	const transactionsEndpoint = jest.fn();
+	const undocumentedFunctions = {
+		transactions: transactionsEndpoint,
+	};
+	wp.undocumented = jest.fn().mockReturnValue( undocumentedFunctions );
+	const redirect_url = 'https://test-redirect-url';
+
+	beforeEach( () => {
+		transactionsEndpoint.mockClear();
+		transactionsEndpoint.mockReturnValue( Promise.resolve( { redirect_url } ) );
+	} );
+
+	it( 'sends the correct data to the endpoint with no site and one product', async () => {
+		const submitData = {
+			name: 'test name',
+		};
+		const expected = { payload: { redirect_url }, type: 'MANUAL' };
+		await expect(
+			weChatProcessor( submitData, {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( basicExpectedStripeRequest );
+	} );
+
+	it( 'returns an explicit error response if the transaction fails', async () => {
+		const submitData = {
+			name: 'test name',
+		};
+		transactionsEndpoint.mockReturnValue( Promise.reject( new Error( 'test error' ) ) );
+		const expected = { payload: 'test error', type: 'ERROR' };
+		await expect(
+			weChatProcessor( submitData, {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+	} );
+
+	it( 'sends the correct data to the endpoint with a site and one product', async () => {
+		const submitData = {
+			name: 'test name',
+		};
+		const expected = { payload: { redirect_url }, type: 'MANUAL' };
+		await expect(
+			weChatProcessor( submitData, {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+			},
+			payment: {
+				...basicExpectedStripeRequest.payment,
+				successUrl:
+					'https://example.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=https%3A%2F%2Fexample.com',
+			},
+		} );
+	} );
+
+	it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
+		const submitData = {
+			name: 'test name',
+		};
+		const expected = { payload: { redirect_url }, type: 'MANUAL' };
+		await expect(
+			weChatProcessor( submitData, {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+				responseCart: { ...cart, products: [ domainProduct ] },
+				includeDomainDetails: true,
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+				products: [ domainProduct ],
+			},
+			domainDetails: basicExpectedDomainDetails,
+			payment: {
+				...basicExpectedStripeRequest.payment,
+				successUrl:
+					'https://example.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=https%3A%2F%2Fexample.com',
+			},
+		} );
+	} );
+} );

--- a/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
+++ b/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
@@ -10,6 +10,7 @@ import type { ResponseCart } from '@automattic/shopping-cart';
  */
 import type { ReactStandardAction } from '../types/analytics';
 import type { GetThankYouUrl } from '../hooks/use-get-thank-you-url';
+import type { ManagedContactDetails } from '../types/wpcom-store-state';
 
 export interface PaymentProcessorOptions {
 	includeDomainDetails: boolean;
@@ -22,4 +23,5 @@ export interface PaymentProcessorOptions {
 	getThankYouUrl: GetThankYouUrl;
 	siteSlug: string | undefined;
 	siteId: number | undefined;
+	contactDetails: ManagedContactDetails | undefined;
 }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -98,6 +98,7 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ): JSX.E
 			siteSlug: selectedSite?.slug ?? '',
 			siteId: selectedSite?.ID,
 			stripeConfiguration,
+			contactDetails: undefined,
 		} ),
 		[
 			includeDomainDetails,

--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -51,3 +51,7 @@ It takes one argument, an object which contains some or all of the properties in
 ## getEmptyResponseCart
 
 A function that returns an empty but valid `ResponseCart` object. Useful for tests where we need to mock the shopping cart response.
+
+## getEmptyResponseCartProduct
+
+A function that returns an empty but valid `ResponseCartProduct` object. Useful for tests where we need to mock the shopping cart response.

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import type { ResponseCart } from './shopping-cart-endpoint';
+import type { ResponseCart, ResponseCartProduct } from './shopping-cart-endpoint';
 
 export function getEmptyResponseCart(): ResponseCart {
 	return {
@@ -35,5 +35,38 @@ export function getEmptyResponseCart(): ResponseCart {
 		tax: { location: {}, display_taxes: false },
 		is_signup: false,
 		next_domain_is_free: false,
+	};
+}
+
+export function getEmptyResponseCartProduct(): ResponseCartProduct {
+	return {
+		time_added_to_cart: Date.now(),
+		product_name: 'Replace me',
+		product_slug: 'replace-me',
+		currency: 'USD',
+		extra: {},
+		meta: '',
+		product_id: 1,
+		volume: 1,
+		quantity: null,
+		item_original_cost_integer: 0,
+		item_original_cost_display: '$0',
+		item_subtotal_integer: 0,
+		item_subtotal_display: '$0',
+		product_cost_integer: 0,
+		product_cost_display: '$0',
+		item_subtotal_monthly_cost_display: '$0',
+		item_subtotal_monthly_cost_integer: 0,
+		item_original_subtotal_integer: 0,
+		item_original_subtotal_display: '$0',
+		is_domain_registration: false,
+		is_bundled: false,
+		is_sale_coupon_applied: false,
+		months_per_bill_period: null,
+		uuid: 'product001',
+		cost: 0,
+		price: 0,
+		product_type: 'test',
+		included_domain_purchase_amount: 0,
 	};
 }

--- a/packages/shopping-cart/src/index.ts
+++ b/packages/shopping-cart/src/index.ts
@@ -2,5 +2,5 @@ export { default as useShoppingCart } from './use-shopping-cart';
 export { default as withShoppingCart } from './with-shopping-cart';
 export { default as ShoppingCartProvider } from './shopping-cart-provider';
 export { default as createRequestCartProduct } from './create-request-cart-product';
-export { getEmptyResponseCart } from './empty-carts';
+export * from './empty-carts';
 export * from './types';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds basic functionality unit tests to all the payment processor functions.

In order for this to work, we needed to make sure that all the data used by the processors comes from their arguments, so we had to add the contact details data to the options passed to every processor. Previously every processor pulled the contact details from the `wpcom` data store itself, but this is very difficult to mock and I wasn't able to find a way to make it work. This change could be moved into its own PR once all these tests are complete and the tests themselves can prove that it works.

Note: This does not currently create tests for the 3DS authentication flows of `multiCardProcessor` and `existingCardProcessor` because I can't easily mock `confirmStripePaymentIntent` and that function directly accesses the `window.Stripe` object. It's possible to create tests there but I think it's of lower importance and they can be added later.

- [x] multiCardProcessor
- [x] existingCardProcessor
- [x] genericRedirectProcessor
- [x] freePurchaseProcessor
- [x] fullCreditsProcessor
- [x] payPalExpressProcessor
- [x] applePayProcessor
- [x] weChatProcessor

#### Testing instructions

Make sure tests pass.

```
yarn run test-client client/my-sites/checkout/composite-checkout/test/
```