### PR TITLE
Components: Fix optional prop types for Dialog and ButtonBar

### DIFF
--- a/packages/components/src/dialog/button-bar.tsx
+++ b/packages/components/src/dialog/button-bar.tsx
@@ -18,7 +18,7 @@ export type BaseButton = {
 export type Button = ReactElement | BaseButton;
 
 type Props = {
-	buttons: Button[];
+	buttons?: Button[];
 	baseClassName: string;
 	onButtonClick: ( button: BaseButton ) => void;
 };

--- a/packages/components/src/dialog/index.tsx
+++ b/packages/components/src/dialog/index.tsx
@@ -18,18 +18,18 @@ import type { Button, BaseButton } from './button-bar';
 import './style.scss';
 
 type Props = {
-	additionalClassNames: Parameters< typeof classnames >[ 0 ];
-	baseClassName: string;
-	buttons: Button[];
-	className: string;
+	additionalClassNames?: Parameters< typeof classnames >[ 0 ];
+	baseClassName?: string;
+	buttons?: Button[];
+	className?: string;
 	children: ReactNode;
-	isBackdropVisible: boolean;
-	isFullScreen: boolean;
+	isBackdropVisible?: boolean;
+	isFullScreen?: boolean;
 	isVisible: boolean;
-	label: string;
-	leaveTimeout: number;
+	label?: string;
+	leaveTimeout?: number;
 	onClose: ( action?: string ) => void;
-	shouldCloseOnEsc: boolean;
+	shouldCloseOnEsc?: boolean;
 };
 
 const Dialog = ( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes some of the TypeScript types for `Dialog` and `ButtonBar` in the `@automattic/components` package to make some optional types optional.

Discovered while working on https://github.com/Automattic/wp-calypso/pull/51840

#### Testing instructions

Verify that each of the newly-made optional types indeed is optional.