### PR TITLE
Checkout: Convert one-click upsell PurchaseModal to TypeScript

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -8,6 +8,7 @@ import { useTranslate } from 'i18n-calypso';
 import { CheckoutProvider } from '@automattic/composite-checkout';
 import { useStripe } from '@automattic/calypso-stripe';
 import { useShoppingCart } from '@automattic/shopping-cart';
+import type { ResponseCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -20,6 +21,8 @@ import useCreatePaymentCompleteCallback from 'calypso/my-sites/checkout/composit
 import existingCardProcessor from 'calypso/my-sites/checkout/composite-checkout/lib/existing-card-processor';
 import getContactDetailsType from 'calypso/my-sites/checkout/composite-checkout/lib/get-contact-details-type';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { PaymentProcessorOptions } from 'calypso/my-sites/checkout/composite-checkout/types/payment-processors';
+import type { StoredCard } from 'calypso/my-sites/checkout/composite-checkout/types/stored-cards';
 
 /**
  * Style dependencies
@@ -28,7 +31,23 @@ import './style.scss';
 
 const noop = () => null;
 
-export function PurchaseModal( { cart, cards, isCartUpdating, onClose, siteSlug, siteId } ) {
+type PurchaseModalProps = {
+	cart: ResponseCart;
+	cards: StoredCard[];
+	isCartUpdating: boolean;
+	onClose: () => void;
+	siteSlug: string;
+	siteId: number;
+};
+
+export function PurchaseModal( {
+	cart,
+	cards,
+	isCartUpdating,
+	onClose,
+	siteSlug,
+	siteId,
+}: PurchaseModalProps ): JSX.Element {
 	const translate = useTranslate();
 	const [ step, setStep ] = useState( BEFORE_SUBMIT );
 	const submitTransaction = useSubmitTransaction( {
@@ -55,7 +74,7 @@ export function PurchaseModal( { cart, cards, isCartUpdating, onClose, siteSlug,
 	);
 }
 
-export default function PurchaseModalWrapper( props ) {
+export default function PurchaseModalWrapper( props: PurchaseModalProps ): JSX.Element {
 	const onComplete = useCreatePaymentCompleteCallback( {
 		isComingFromUpsell: true,
 	} );
@@ -67,8 +86,7 @@ export default function PurchaseModalWrapper( props ) {
 	const contactDetailsType = getContactDetailsType( props.cart );
 	const includeDomainDetails = contactDetailsType === 'domain';
 	const includeGSuiteDetails = contactDetailsType === 'gsuite';
-	// NOTE: dataForProcessor must satisfy the PaymentProcessorOptions type
-	const dataForProcessor = useMemo(
+	const dataForProcessor: PaymentProcessorOptions = useMemo(
 		() => ( {
 			createUserAndSiteBeforeTransaction: false,
 			getThankYouUrl: () => '/plans',
@@ -78,7 +96,7 @@ export default function PurchaseModalWrapper( props ) {
 			reduxDispatch,
 			responseCart,
 			siteSlug: selectedSite?.slug ?? '',
-			siteId: selectedSite?.ID ?? '',
+			siteId: selectedSite?.ID,
 			stripeConfiguration,
 		} ),
 		[


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This converts the `PurchaseModal` component which runs the one-click upsell after checkout to TypeScript. This will help to prevent errors as the API of the payment processor changes in the future.

#### Testing instructions

This should not make any functional changes. A quick look should be sufficient.