### PR TITLE
people(team): use mutation to delete/remove users

### DIFF
--- a/client/data/users/use-delete-user-mutation.js
+++ b/client/data/users/use-delete-user-mutation.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { useCallback } from 'react';
+import { useMutation, useQueryClient } from 'react-query';
+
+/**
+ * Internal dependencies
+ */
+import wp from 'calypso/lib/wp';
+
+function useDeleteUserMutation( siteId ) {
+	const queryClient = useQueryClient();
+	const mutation = useMutation(
+		( { userId, variables } ) =>
+			wp.req.post( `/sites/${ siteId }/users/${ userId }/delete`, variables ),
+		{
+			onSuccess() {
+				queryClient.invalidateQueries( [ 'users', siteId ] );
+			},
+		}
+	);
+
+	const { mutate } = mutation;
+
+	const deleteUser = useCallback(
+		( userId, variables ) => {
+			mutate( { userId, variables } );
+		},
+		[ mutate ]
+	);
+
+	return { deleteUser, ...mutation };
+}
+
+export default useDeleteUserMutation;

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -21,7 +21,6 @@ import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
 import User from 'calypso/components/user';
 import AuthorSelector from 'calypso/blocks/author-selector';
-import { deleteUser } from 'calypso/lib/users/actions';
 import accept from 'calypso/lib/accept';
 import Gravatar from 'calypso/components/gravatar';
 import { localize } from 'i18n-calypso';
@@ -32,6 +31,7 @@ import {
 	requestExternalContributorsRemoval,
 } from 'calypso/state/data-getters';
 import { httpData } from 'calypso/state/data-layer/http-data';
+import withDeleteUser from './with-delete-user';
 
 /**
  * Style dependencies
@@ -168,7 +168,7 @@ class DeleteUser extends React.Component {
 							user.linked_user_ID ? user.linked_user_ID : user.ID
 						);
 					}
-					deleteUser( siteId, user.ID );
+					this.props.deleteUser( user.ID );
 				} else {
 					this.props.recordGoogleEvent(
 						'People',
@@ -183,23 +183,28 @@ class DeleteUser extends React.Component {
 
 	deleteUser = ( event ) => {
 		event.preventDefault();
+
 		const { contributorType, siteId, user } = this.props;
+		const { reassignUser, radioOption } = this.state;
+
 		if ( ! user.ID ) {
 			return;
 		}
 
-		let reassignUserId;
-		if ( this.state.reassignUser && 'reassign' === this.state.radioOption ) {
-			reassignUserId = this.state.reassignUser.ID;
+		const variables = {};
+
+		if ( reassignUser && 'reassign' === radioOption ) {
+			variables.reassign = reassignUser.ID;
 		}
+
 		if ( 'external' === contributorType ) {
 			requestExternalContributorsRemoval(
 				siteId,
 				user.linked_user_ID ? user.linked_user_ID : user.ID
 			);
 		}
-		deleteUser( siteId, user.ID, reassignUserId );
 
+		this.props.deleteUser( user.ID, variables );
 		this.props.recordGoogleEvent( 'People', 'Clicked Remove User on Edit User Single Site' );
 	};
 
@@ -341,5 +346,5 @@ export default localize(
 			};
 		},
 		{ recordGoogleEvent }
-	)( DeleteUser )
+	)( withDeleteUser( DeleteUser ) )
 );

--- a/client/my-sites/people/delete-user/with-delete-user.js
+++ b/client/my-sites/people/delete-user/with-delete-user.js
@@ -13,11 +13,12 @@ import useDeleteUserMutation from 'calypso/data/users/use-delete-user-mutation';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 const useSuccessNotice = ( isSuccess, user, isMultisite, siteSlug ) => {
+	const showNotice = React.useRef();
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	React.useEffect( () => {
-		if ( isSuccess ) {
+		showNotice.current = () => {
 			dispatch(
 				successNotice(
 					isMultisite
@@ -33,43 +34,45 @@ const useSuccessNotice = ( isSuccess, user, isMultisite, siteSlug ) => {
 				)
 			);
 			page.redirect( `/people/team${ siteSlug ? `/${ siteSlug }` : '' }` );
-		}
-		// Note: We only want to run this effect in case `isSuccess`
-		// changes and ignore changes to other deps like `user`.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
+		};
+	} );
+
+	React.useEffect( () => {
+		isSuccess && showNotice.current();
 	}, [ isSuccess ] );
 };
 
 const useErrorNotice = ( isError, user, isMultisite, error ) => {
+	const showDomainErrorNotice = React.useRef();
+	const showGeneralErrorNotice = React.useRef();
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	React.useEffect( () => {
-		if ( isError ) {
-			if ( 'user_owns_domain_subscription' === error.error ) {
-				const numDomains = error.message.split( ',' ).length;
-				dispatch(
-					errorNotice(
-						translate(
-							'@%(user)s owns following domain used on this site: {{strong}}%(domains)s{{/strong}}. This domain will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
-							'@%(user)s owns following domains used on this site: {{strong}}%(domains)s{{/strong}}. These domains will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
-							{
-								count: numDomains,
-								args: {
-									domains: error.message,
-									user: user.login,
-								},
-								components: {
-									strong: <strong />,
-								},
-							}
-						),
-						{ id: 'delete-user-notice' }
-					)
-				);
-				return;
-			}
+		showDomainErrorNotice.current = ( domainError ) => {
+			const numDomains = domainError.message.split( ',' ).length;
+			dispatch(
+				errorNotice(
+					translate(
+						'@%(user)s owns following domain used on this site: {{strong}}%(domains)s{{/strong}}. This domain will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
+						'@%(user)s owns following domains used on this site: {{strong}}%(domains)s{{/strong}}. These domains will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
+						{
+							count: numDomains,
+							args: {
+								domains: domainError.message,
+								user: user.login,
+							},
+							components: {
+								strong: <strong />,
+							},
+						}
+					),
+					{ id: 'delete-user-notice' }
+				)
+			);
+		};
 
+		showGeneralErrorNotice.current = () => {
 			dispatch(
 				errorNotice(
 					isMultisite
@@ -84,11 +87,18 @@ const useErrorNotice = ( isError, user, isMultisite, error ) => {
 					{ id: 'delete-user-notice' }
 				)
 			);
+		};
+	}, [ dispatch, isMultisite, translate, user.login ] );
+
+	React.useEffect( () => {
+		if ( isError ) {
+			if ( 'user_owns_domain_subscription' === error.error ) {
+				showDomainErrorNotice.current( error );
+				return;
+			}
+			showGeneralErrorNotice.current();
 		}
-		// Note: We only want to run this effect in case `isError`
-		// changes and ignore changes to other deps like `user`.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ isError ] );
+	}, [ isError, error ] );
 };
 
 const withDeleteUser = ( Component ) => ( props ) => {

--- a/client/my-sites/people/delete-user/with-delete-user.js
+++ b/client/my-sites/people/delete-user/with-delete-user.js
@@ -51,14 +51,30 @@ const useErrorNotice = ( isError, user, isMultisite, error ) => {
 		showNotice.current = ( errorObj ) => {
 			let message;
 			if ( 'user_owns_domain_subscription' === errorObj.error ) {
-				const numDomains = errorObj.message.split( ',' ).length;
+				const domains = errorObj.data ?? errorObj.message.split( ',' );
 				message = translate(
 					'@%(user)s owns following domain used on this site: {{strong}}%(domains)s{{/strong}}. This domain will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
 					'@%(user)s owns following domains used on this site: {{strong}}%(domains)s{{/strong}}. These domains will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
 					{
-						count: numDomains,
+						count: domains.length,
 						args: {
-							domains: errorObj.message,
+							domains: domains.join( ', ' ),
+							user: user.login,
+						},
+						components: {
+							strong: <strong />,
+						},
+					}
+				);
+			} else if ( 'user_has_active_subscriptions' === errorObj.error ) {
+				const productNames = errorObj.data ?? [];
+				message = translate(
+					'@%(user)s owns following product used on this site: {{strong}}%(productNames)s{{/strong}}. This product will have to be transferred to a different site, user, or canceled before removing or deleting @%(user)s.',
+					'@%(user)s owns following products used on this site: {{strong}}%(productNames)s{{/strong}}. These products will have to be transferred to a different site, user, or canceled before removing or deleting @%(user)s.',
+					{
+						count: productNames.length,
+						args: {
+							productNames: productNames.join( ', ' ),
 							user: user.login,
 						},
 						components: {

--- a/client/my-sites/people/delete-user/with-delete-user.js
+++ b/client/my-sites/people/delete-user/with-delete-user.js
@@ -1,0 +1,104 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import page from 'page';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import useDeleteUserMutation from 'calypso/data/users/use-delete-user-mutation';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+
+const useSuccessNotice = ( isSuccess, user, isMultisite, siteSlug ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	React.useEffect( () => {
+		if ( isSuccess ) {
+			dispatch(
+				successNotice(
+					isMultisite
+						? translate( 'Successfully removed @%(user)s', {
+								args: { user: user.login },
+								context: 'Success message after a user has been modified.',
+						  } )
+						: translate( 'Successfully deleted @%(user)s', {
+								args: { user: user.login },
+								context: 'Success message after a user has been modified.',
+						  } ),
+					{ id: 'delete-user-notice', displayOnNextPage: true }
+				)
+			);
+			page.redirect( `/people/team${ siteSlug ? `/${ siteSlug }` : '' }` );
+		}
+		// Note: We only want to run this effect in case `isSuccess`
+		// changes and ignore changes to other deps like `user`.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isSuccess ] );
+};
+
+const useErrorNotice = ( isError, user, isMultisite, error ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	React.useEffect( () => {
+		if ( isError ) {
+			if ( 'user_owns_domain_subscription' === error.error ) {
+				const numDomains = error.message.split( ',' ).length;
+				dispatch(
+					errorNotice(
+						translate(
+							'@%(user)s owns following domain used on this site: {{strong}}%(domains)s{{/strong}}. This domain will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
+							'@%(user)s owns following domains used on this site: {{strong}}%(domains)s{{/strong}}. These domains will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
+							{
+								count: numDomains,
+								args: {
+									domains: error.message,
+									user: user.login,
+								},
+								components: {
+									strong: <strong />,
+								},
+							}
+						),
+						{ id: 'delete-user-notice' }
+					)
+				);
+				return;
+			}
+
+			dispatch(
+				errorNotice(
+					isMultisite
+						? translate( 'There was an error removing @%(user)s', {
+								args: { user: user.login },
+								context: 'Error message after A site has failed to perform actions on a user.',
+						  } )
+						: translate( 'There was an error deleting @%(user)s', {
+								args: { user: user.login },
+								context: 'Error message after A site has failed to perform actions on a user.',
+						  } ),
+					{ id: 'delete-user-notice' }
+				)
+			);
+		}
+		// Note: We only want to run this effect in case `isError`
+		// changes and ignore changes to other deps like `user`.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isError ] );
+};
+
+const withDeleteUser = ( Component ) => ( props ) => {
+	const { siteId, user, isMultisite, siteSlug } = props;
+	const { deleteUser, isSuccess, isError, error } = useDeleteUserMutation( siteId );
+
+	useSuccessNotice( isSuccess, user, isMultisite, siteSlug );
+	useErrorNotice( isError, user, isMultisite, error );
+
+	return <Component { ...props } deleteUser={ deleteUser } />;
+};
+
+export default withDeleteUser;

--- a/client/my-sites/people/delete-user/with-delete-user.js
+++ b/client/my-sites/people/delete-user/with-delete-user.js
@@ -43,61 +43,47 @@ const useSuccessNotice = ( isSuccess, user, isMultisite, siteSlug ) => {
 };
 
 const useErrorNotice = ( isError, user, isMultisite, error ) => {
-	const showDomainErrorNotice = React.useRef();
-	const showGeneralErrorNotice = React.useRef();
+	const showNotice = React.useRef();
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	React.useEffect( () => {
-		showDomainErrorNotice.current = ( domainError ) => {
-			const numDomains = domainError.message.split( ',' ).length;
-			dispatch(
-				errorNotice(
-					translate(
-						'@%(user)s owns following domain used on this site: {{strong}}%(domains)s{{/strong}}. This domain will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
-						'@%(user)s owns following domains used on this site: {{strong}}%(domains)s{{/strong}}. These domains will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
-						{
-							count: numDomains,
-							args: {
-								domains: domainError.message,
-								user: user.login,
-							},
-							components: {
-								strong: <strong />,
-							},
-						}
-					),
-					{ id: 'delete-user-notice' }
-				)
-			);
-		};
+		showNotice.current = ( errorObj ) => {
+			let message;
+			if ( 'user_owns_domain_subscription' === errorObj.error ) {
+				const numDomains = errorObj.message.split( ',' ).length;
+				message = translate(
+					'@%(user)s owns following domain used on this site: {{strong}}%(domains)s{{/strong}}. This domain will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
+					'@%(user)s owns following domains used on this site: {{strong}}%(domains)s{{/strong}}. These domains will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
+					{
+						count: numDomains,
+						args: {
+							domains: errorObj.message,
+							user: user.login,
+						},
+						components: {
+							strong: <strong />,
+						},
+					}
+				);
+			} else {
+				message = isMultisite
+					? translate( 'There was an error removing @%(user)s', {
+							args: { user: user.login },
+							context: 'Error message after A site has failed to perform actions on a user.',
+					  } )
+					: translate( 'There was an error deleting @%(user)s', {
+							args: { user: user.login },
+							context: 'Error message after A site has failed to perform actions on a user.',
+					  } );
+			}
 
-		showGeneralErrorNotice.current = () => {
-			dispatch(
-				errorNotice(
-					isMultisite
-						? translate( 'There was an error removing @%(user)s', {
-								args: { user: user.login },
-								context: 'Error message after A site has failed to perform actions on a user.',
-						  } )
-						: translate( 'There was an error deleting @%(user)s', {
-								args: { user: user.login },
-								context: 'Error message after A site has failed to perform actions on a user.',
-						  } ),
-					{ id: 'delete-user-notice' }
-				)
-			);
+			dispatch( errorNotice( message, { id: 'delete-user-notice' } ) );
 		};
 	}, [ dispatch, isMultisite, translate, user.login ] );
 
 	React.useEffect( () => {
-		if ( isError ) {
-			if ( 'user_owns_domain_subscription' === error.error ) {
-				showDomainErrorNotice.current( error );
-				return;
-			}
-			showGeneralErrorNotice.current();
-		}
+		isError && showNotice.current( error );
 	}, [ isError, error ] );
 };
 

--- a/client/my-sites/people/delete-user/with-delete-user.js
+++ b/client/my-sites/people/delete-user/with-delete-user.js
@@ -35,7 +35,7 @@ const useSuccessNotice = ( isSuccess, user, isMultisite, siteSlug ) => {
 			);
 			page.redirect( `/people/team${ siteSlug ? `/${ siteSlug }` : '' }` );
 		};
-	} );
+	}, [ dispatch, isMultisite, siteSlug, translate, user.login ] );
 
 	React.useEffect( () => {
 		isSuccess && showNotice.current();


### PR DESCRIPTION
Note: This PR is based on #50992 and will be merged into it which then should fix the failing e2e tests on that PR.

#### Changes proposed in this Pull Request

* Move functionality to delete or remove users from a site to a mutation instead of flux

#### Testing instructions

Note: Go through the testing instructions with a simple site, an AT site and a Jetpack site.

* Go to `people/team/` and choose on of the users on your team which isn't you
* Attempt to delete or remove (Jetpack) from the site (try both reassigning content and deleting content)
* You should be redirected to the list of users after the deletion/removal was successful and the list should be updated
* Try the error case and block the request to delete a user

**Important**, for simple sites try this additional step:

* Use a setup where another user has a domain subscription on your site
* Attempt to delete that user
* You should be prompted with a specific error message about the domain subscription
