### PR TITLE
Focused Launch E2E: Changing site title will update domain suggestions.

### DIFF
--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -97,8 +97,10 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			const normalizedSiteTitle = siteTitle.toLowerCase().replace( / /g, '' );
 
 			// Check if there are domain suggestions that contains user entered site title
-			const domainSuggestionsContainUserEnteredSiteTitleSelector = By.xpath(
-				`//span[@class="domain-picker__domain-sub-domain" and .="${ normalizedSiteTitle }"]`
+			const domainSuggestionsContainUserEnteredSiteTitleSelector = driverHelper.getElementByText(
+				driver,
+				By.css( `.domain-picker__domain-sub-domain` ),
+				normalizedSiteTitle
 			);
 
 			const domainSuggestionsContainUserEnteredSiteTitle = await driverHelper.isElementPresent(

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -110,7 +110,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 
 			assert(
 				domainSuggestionsContainUserEnteredSiteTitle,
-				'Domain suggestions did not include user entered site title.'
+				`Domain suggestions did not include user entered site title. Site title used was ${ siteTitle }.`
 			);
 		} );
 

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -63,7 +63,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			const siteTitleInputSelector = By.css( '.focused-launch-summary__input input[type=text]' );
 
 			// Site title step is not displayed when it has been set by user.
-			// Site title is not set during `/start` flow, site title is can be set during `/new` flow.
+			// Site title is not set during `/start` flow, site title can be set during `/new` flow.
 			// If the site title input is not rendered, skip this step.
 			// Note: This is currently parked here but unused as we are using the `/start` flow.
 			const isSiteTitleInputPresent = await driverHelper.isElementPresent(

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -3,7 +3,7 @@
  */
 import assert from 'assert';
 import config from 'config';
-import { By } from 'selenium-webdriver';
+import { By, until } from 'selenium-webdriver';
 import { step } from 'mocha-steps';
 
 /**
@@ -15,6 +15,7 @@ import * as driverHelper from '../lib/driver-helper';
 import LoginFlow from '../lib/flows/login-flow.js';
 import DeleteSiteFlow from '../lib/flows/delete-site-flow.js';
 import GutenboardingFlow from '../lib/flows/gutenboarding-flow.js';
+import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -25,6 +26,7 @@ const screenSize = driverManager.currentScreenSize();
 describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
 	let driver;
+	let selectedSubdomain;
 
 	before( 'Start browser', async function () {
 		this.timeout( startBrowserTimeoutMS );
@@ -112,6 +114,235 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 				domainSuggestionsContainUserEnteredSiteTitle,
 				`Domain suggestions did not include user entered site title. Site title used was ${ siteTitle }.`
 			);
+		} );
+
+		step( 'Can select free domain suggestion item', async function () {
+			// Click on the free domain suggestion item
+			const freeDomainButtonSelector = By.css( '.domain-picker__suggestion-item.is-free' );
+
+			await driverHelper.clickWhenClickable( driver, freeDomainButtonSelector );
+
+			// Check if the free domain suggestion item is now selected
+			const selectedFreeDomainSuggestionItemSelector = By.css(
+				'.domain-picker__suggestion-item.is-free.is-selected'
+			);
+
+			const isSelectedFreeDomainSuggestionItemPresent = await driverHelper.isElementPresent(
+				driver,
+				selectedFreeDomainSuggestionItemSelector
+			);
+
+			// Get the domain name from the free domain suggestion item
+			// This is to check for persistence in the later step
+			const selectedFreeDomainSuggestionItemNameSelector = By.css(
+				'.domain-picker__suggestion-item.is-free.is-selected .domain-picker__suggestion-item-name'
+			);
+
+			const selectedFreeDomainSuggestionItemName = await driver.findElement(
+				selectedFreeDomainSuggestionItemNameSelector
+			);
+
+			// This is used in later step to test for selected domain persistence
+			selectedSubdomain = await selectedFreeDomainSuggestionItemName.getText();
+
+			assert(
+				isSelectedFreeDomainSuggestionItemPresent,
+				'Free domain suggestion item was not selected.'
+			);
+		} );
+
+		step( 'Can open detailed plans grid', async function () {
+			// Click on "View All Plans" button
+			const viewAllPlansButtonSelector = driverHelper.getElementByText(
+				driver,
+				By.css( `.focused-launch-summary__details-link` ),
+				'View all plans'
+			);
+
+			await driverHelper.clickWhenClickable( driver, viewAllPlansButtonSelector );
+
+			// Check if detailed plans grid is displayed
+			const plansGridInDetailedViewSelector = By.css( '.focused-launch-details__body .plans-grid' );
+
+			const isPlansGridInDetailedViewPresent = await driverHelper.isElementPresent(
+				driver,
+				plansGridInDetailedViewSelector
+			);
+
+			assert(
+				isPlansGridInDetailedViewPresent,
+				'Focused launch plans grid detailed view did not open.'
+			);
+		} );
+
+		step( 'Can switch to monthly plans view', async function () {
+			// Click "Monthly" toggle button
+			const monthlyButtonSelector = driverHelper.getElementByText(
+				driver,
+				By.css( `.plans-interval-toggle__label` ),
+				'Monthly'
+			);
+
+			await driverHelper.clickWhenClickable( driver, monthlyButtonSelector );
+
+			// Check if plans grid is really switched over to monthly view
+			// by checking if the price note "per month, billed monthly" exists.
+			const perMonthBilledMonthlyPriceNoteSelector = driverHelper.getElementByText(
+				driver,
+				By.css( `.plan-item__price-note` ),
+				'per month, billed monthly'
+			);
+
+			const isPerMonthBilledMonthlyPricePresent = await driverHelper.isElementPresent(
+				driver,
+				perMonthBilledMonthlyPriceNoteSelector
+			);
+
+			assert(
+				isPerMonthBilledMonthlyPricePresent,
+				'Focused launch plans grid was unable to switch over to monthly view.'
+			);
+		} );
+
+		step( 'Can select Personal monthly plan', async function () {
+			// Click "Select Personal" button
+			const selectPersonalPlanButtonSelector = driverHelper.getElementByText(
+				driver,
+				By.css( `.plan-item__select-button` ),
+				'Select Personal'
+			);
+
+			await driverHelper.clickWhenClickable( driver, selectPersonalPlanButtonSelector );
+
+			// When the detailed plans grid is closed and user returns to the summary view,
+			// check if the selected monthly plan item is "Personal Plan".
+			const selectedPlanIsPersonalMonthlyPlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( '.focused-launch-summary__item.is-selected' ),
+				/Personal Plan/
+			);
+
+			const selectedPlanIsPersonalMonthlyPlan = await driverHelper.isElementPresent(
+				driver,
+				selectedPlanIsPersonalMonthlyPlanSelector
+			);
+
+			assert( selectedPlanIsPersonalMonthlyPlan, 'The personal monthly plan was not selected.' );
+		} );
+
+		step( 'Can reload block editor and reopen focused launch', async function () {
+			// Reload block editor
+			await driver.navigate().refresh();
+
+			// Press "Reload" on confirmation dialog when block editor asks if user really wants to navigate away.
+			try {
+				await driver.wait( until.alertIsPresent(), 4000 );
+				const alert = await driver.switchTo().alert();
+				await alert.accept();
+			} catch ( e ) {
+				// This doesn't happen when autosave hasn't kicked in so
+				// if driver.wait throws and error we catch it here to allow
+				// the step to continue running.
+			}
+
+			// Wait for block editor to load and switch frame context to block editor
+			await GutenbergEditorComponent.Expect( driver );
+
+			// Click on the launch button
+			const launchButtonSelector = await driverHelper.getElementByText(
+				driver,
+				By.css( '.editor-gutenberg-launch__launch-button' ),
+				'Launch'
+			);
+			await driverHelper.clickWhenClickable( driver, launchButtonSelector );
+
+			// See if focused launch modal can be reopened
+			const focusedLaunchModalSelector = By.css( '.launch__focused-modal' );
+			const isFocusedLaunchModalPresent = await driverHelper.isElementPresent(
+				driver,
+				focusedLaunchModalSelector
+			);
+
+			assert( isFocusedLaunchModalPresent, 'Focused launch modal did not open.' );
+		} );
+
+		step( 'Can persist previously selected domain in focused launch', async function () {
+			const selectedDomainSuggestionContainingPreviouslySelectedSubdomainSelector = await driverHelper.getElementByText(
+				driver,
+				By.css( '.domain-picker__suggestion-item.is-selected' ),
+				new RegExp( selectedSubdomain )
+			);
+
+			const selectedDomainSuggestionIsPreviouslySelectedSubdomain = await driverHelper.isElementPresent(
+				driver,
+				selectedDomainSuggestionContainingPreviouslySelectedSubdomainSelector
+			);
+
+			assert(
+				selectedDomainSuggestionIsPreviouslySelectedSubdomain,
+				'Selected subdomain should be persisted after reloading block editor and reopening focused launch.'
+			);
+		} );
+
+		step( 'Can persist previously selected plan in focused launch', async function () {
+			// Check if the selected monthly plan item is "Personal Plan".
+			const selectedPlanIsPersonalMonthlyPlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( `.focused-launch-summary__item.is-selected` ),
+				/Personal Plan/
+			);
+
+			const selectedPlanIsPersonalMonthlyPlan = await driverHelper.isElementPresent(
+				driver,
+				selectedPlanIsPersonalMonthlyPlanSelector
+			);
+
+			assert(
+				selectedPlanIsPersonalMonthlyPlan,
+				'Selected plan should be persisted after reloading block editor and reopening focused launch'
+			);
+		} );
+
+		step( 'Can select Free plan', async function () {
+			// Click "Free Plan" button
+			const freePlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( '.focused-launch-summary__item' ),
+				/Free Plan/
+			);
+
+			await driverHelper.clickWhenClickable( driver, freePlanSelector );
+
+			// When the detailed plans grid is closed and user returns to the summary view,
+			// check if the selected monthly plan item is "Free Plan".
+			const selectedPlanIsFreePlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( '.focused-launch-summary__item.is-selected' ),
+				/Free Plan/
+			);
+
+			const selectedPlanIsFreePlan = await driverHelper.isElementPresent(
+				driver,
+				selectedPlanIsFreePlanSelector
+			);
+
+			assert( selectedPlanIsFreePlan, 'The free plan was not selected.' );
+		} );
+
+		step( 'Can launch site with Free plan.', async function () {
+			// Click on the launch button
+			const siteLaunchButtonSelector = By.css( '.focused-launch-summary__launch-button' );
+			await driverHelper.clickWhenClickable( driver, siteLaunchButtonSelector );
+
+			// Wait for the focused launch success view to show up
+			const focusedLaunchSuccessViewSelector = By.css( '.focused-launch-success__wrapper' );
+
+			const isFocusedLaunchSuccessViewPresent = await driverHelper.isElementPresent(
+				driver,
+				focusedLaunchSuccessViewSelector
+			);
+
+			assert( isFocusedLaunchSuccessViewPresent, 'Focused launch success view did not open.' );
 		} );
 
 		after( 'Delete the newly created site', async function () {


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Changing site title will show relevant domain suggestions.

## Testing instructions

 * Run `NODE_CONFIG_ENV=personal yarn mocha --inspect specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js`.
 * Ensure the step passes.

## This PR is part of this series
- [add/focused-launch-e2e-base-spec](https://github.com/Automattic/wp-calypso/pull/51842)
  - **[YOU ARE HERE]** [add/focused-launch-e2e-site-title-step](https://github.com/Automattic/wp-calypso/pull/51843)
    - [add/focused-launch-e2e-domain-step](https://github.com/Automattic/wp-calypso/pull/51844)
      - [add/focused-launch-e2e-plan-step](https://github.com/Automattic/wp-calypso/pull/51845)
        - [add/focused-launch-e2e-reload-editor](https://github.com/Automattic/wp-calypso/pull/51846)
          - [add/focused-launch-e2e-domain-persistence](https://github.com/Automattic/wp-calypso/pull/51847)
            - [add/focused-launch-e2e-plan-persistence](https://github.com/Automattic/wp-calypso/pull/51848)
              - [add/focused-launch-e2e-select-free-plan](https://github.com/Automattic/wp-calypso/pull/51849)
                -  [add/focused-launch-e2e-launch-free-site](https://github.com/Automattic/wp-calypso/pull/51850)

Related to #51270 https://github.com/Automattic/wp-calypso/issues/46943#issuecomment-779895421
