### PR TITLE
Focused Launch E2E: Can open detailed plans grid, switch to monthly plans view, and select Personal monthly plan.

### DIFF
--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -3,7 +3,7 @@
  */
 import assert from 'assert';
 import config from 'config';
-import { By } from 'selenium-webdriver';
+import { By, until } from 'selenium-webdriver';
 import { step } from 'mocha-steps';
 
 /**
@@ -15,6 +15,7 @@ import * as driverHelper from '../lib/driver-helper';
 import LoginFlow from '../lib/flows/login-flow.js';
 import DeleteSiteFlow from '../lib/flows/delete-site-flow.js';
 import GutenboardingFlow from '../lib/flows/gutenboarding-flow.js';
+import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -140,8 +141,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			const selectedFreeDomainSuggestionItemName = await driver.findElement(
 				selectedFreeDomainSuggestionItemNameSelector
 			);
-			// Disable lint for this line to be removed in another PR.
-			// eslint-disable-next-line no-unused-vars
+
+			// This is used in later step to test for selected domain persistence
 			selectedSubdomain = await selectedFreeDomainSuggestionItemName.getText();
 
 			assert(
@@ -227,6 +228,121 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 
 			assert( selectedPlanIsPersonalMonthlyPlan, 'The personal monthly plan was not selected.' );
+		} );
+
+		step( 'Can reload block editor and reopen focused launch', async function () {
+			// Reload block editor
+			await driver.navigate().refresh();
+
+			// Press "Reload" on confirmation dialog when block editor asks if user really wants to navigate away.
+			try {
+				await driver.wait( until.alertIsPresent(), 4000 );
+				const alert = await driver.switchTo().alert();
+				await alert.accept();
+			} catch ( e ) {
+				// This doesn't happen when autosave hasn't kicked in so
+				// if driver.wait throws and error we catch it here to allow
+				// the step to continue running.
+			}
+
+			// Wait for block editor to load and switch frame context to block editor
+			await GutenbergEditorComponent.Expect( driver );
+
+			// Click on the launch button
+			const launchButtonSelector = await driverHelper.getElementByText(
+				driver,
+				By.css( '.editor-gutenberg-launch__launch-button' ),
+				'Launch'
+			);
+			await driverHelper.clickWhenClickable( driver, launchButtonSelector );
+
+			// See if focused launch modal can be reopened
+			const focusedLaunchModalSelector = By.css( '.launch__focused-modal' );
+			const isFocusedLaunchModalPresent = await driverHelper.isElementPresent(
+				driver,
+				focusedLaunchModalSelector
+			);
+
+			assert( isFocusedLaunchModalPresent, 'Focused launch modal did not open.' );
+		} );
+
+		step( 'Can persist previously selected domain in focused launch', async function () {
+			const selectedDomainSuggestionContainingPreviouslySelectedSubdomainSelector = await driverHelper.getElementByText(
+				driver,
+				By.css( '.domain-picker__suggestion-item.is-selected' ),
+				new RegExp( selectedSubdomain )
+			);
+
+			const selectedDomainSuggestionIsPreviouslySelectedSubdomain = await driverHelper.isElementPresent(
+				driver,
+				selectedDomainSuggestionContainingPreviouslySelectedSubdomainSelector
+			);
+
+			assert(
+				selectedDomainSuggestionIsPreviouslySelectedSubdomain,
+				'Selected subdomain should be persisted after reloading block editor and reopening focused launch.'
+			);
+		} );
+
+		step( 'Can persist previously selected plan in focused launch', async function () {
+			// Check if the selected monthly plan item is "Personal Plan".
+			const selectedPlanIsPersonalMonthlyPlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( `.focused-launch-summary__item.is-selected` ),
+				/Personal Plan/
+			);
+
+			const selectedPlanIsPersonalMonthlyPlan = await driverHelper.isElementPresent(
+				driver,
+				selectedPlanIsPersonalMonthlyPlanSelector
+			);
+
+			assert(
+				selectedPlanIsPersonalMonthlyPlan,
+				'Selected plan should be persisted after reloading block editor and reopening focused launch'
+			);
+		} );
+
+		step( 'Can select Free plan', async function () {
+			// Click "Free Plan" button
+			const freePlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( '.focused-launch-summary__item' ),
+				/Free Plan/
+			);
+
+			await driverHelper.clickWhenClickable( driver, freePlanSelector );
+
+			// When the detailed plans grid is closed and user returns to the summary view,
+			// check if the selected monthly plan item is "Free Plan".
+			const selectedPlanIsFreePlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( '.focused-launch-summary__item.is-selected' ),
+				/Free Plan/
+			);
+
+			const selectedPlanIsFreePlan = await driverHelper.isElementPresent(
+				driver,
+				selectedPlanIsFreePlanSelector
+			);
+
+			assert( selectedPlanIsFreePlan, 'The free plan was not selected.' );
+		} );
+
+		step( 'Can launch site with Free plan.', async function () {
+			// Click on the launch button
+			const siteLaunchButtonSelector = By.css( '.focused-launch-summary__launch-button' );
+			await driverHelper.clickWhenClickable( driver, siteLaunchButtonSelector );
+
+			// Wait for the focused launch success view to show up
+			const focusedLaunchSuccessViewSelector = By.css( '.focused-launch-success__wrapper' );
+
+			const isFocusedLaunchSuccessViewPresent = await driverHelper.isElementPresent(
+				driver,
+				focusedLaunchSuccessViewSelector
+			);
+
+			assert( isFocusedLaunchSuccessViewPresent, 'Focused launch success view did not open.' );
 		} );
 
 		after( 'Delete the newly created site', async function () {

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -150,6 +150,75 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 		} );
 
+		step( 'Can open detailed plans grid', async function () {
+			// Click on "View All Plans" button
+			const viewAllPlansButtonSelector = By.xpath(
+				'//a[contains(@class, "focused-launch-summary__details-link") and .="View all plans"]'
+			);
+
+			await driverHelper.clickWhenClickable( driver, viewAllPlansButtonSelector );
+
+			// Check if detailed plans grid is displayed
+			const plansGridInDetailedViewSelector = By.css( '.focused-launch-details__body .plans-grid' );
+
+			const isPlansGridInDetailedViewPresent = await driverHelper.isElementPresent(
+				driver,
+				plansGridInDetailedViewSelector
+			);
+
+			assert(
+				isPlansGridInDetailedViewPresent,
+				'Focused launch plans grid detailed view did not open.'
+			);
+		} );
+
+		step( 'Can switch to monthly plans view', async function () {
+			// Click "Monthly" toggle button
+			const monthlyButtonSelector = By.xpath(
+				'//span[@class="plans-interval-toggle__label" and .="Monthly"]'
+			);
+
+			await driverHelper.clickWhenClickable( driver, monthlyButtonSelector );
+
+			// Check if plans grid is really switched over to monthly view
+			// by checking if the price note "per month, billed monthly" exists.
+			const perMonthBilledMonthlyPriceNoteSelector = By.xpath(
+				'//div[@class="plan-item__price-note" and .="per month, billed monthly"]'
+			);
+
+			const isPerMonthBilledMonthlyPricePresent = await driverHelper.isElementPresent(
+				driver,
+				perMonthBilledMonthlyPriceNoteSelector
+			);
+
+			assert(
+				isPerMonthBilledMonthlyPricePresent,
+				'Focused launch plans grid was unable to switch over to monthly view.'
+			);
+		} );
+
+		step( 'Can select Personal monthly plan', async function () {
+			// Click "Select Personal" button
+			const selectPersonalPlanButtonSelector = By.xpath(
+				'//button[contains(@class, "plan-item__select-button") and .="Select Personal"]'
+			);
+
+			await driverHelper.clickWhenClickable( driver, selectPersonalPlanButtonSelector );
+
+			// When the detailed plans grid is closed and user returns to the summary view,
+			// check if the selected monthly plan item is "Personal Plan".
+			const selectedPlanIsPersonalMonthlyPlanSelector = By.xpath(
+				'//button[contains(@class, "focused-launch-summary__item") and contains(@class,"is-selected")]//span[@class="focused-launch-summary-item__leading-side-label" and .="Personal Plan"]'
+			);
+
+			const selectedPlanIsPersonalMonthlyPlan = await driverHelper.isElementPresent(
+				driver,
+				selectedPlanIsPersonalMonthlyPlanSelector
+			);
+
+			assert( selectedPlanIsPersonalMonthlyPlan, 'The personal monthly plan was not selected.' );
+		} );
+
 		after( 'Delete the newly created site', async function () {
 			const deleteSite = new DeleteSiteFlow( driver );
 			await deleteSite.deleteSite( siteName + '.wordpress.com' );

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -152,8 +152,10 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 
 		step( 'Can open detailed plans grid', async function () {
 			// Click on "View All Plans" button
-			const viewAllPlansButtonSelector = By.xpath(
-				'//a[contains(@class, "focused-launch-summary__details-link") and .="View all plans"]'
+			const viewAllPlansButtonSelector = driverHelper.getElementByText(
+				driver,
+				By.css( `.focused-launch-summary__details-link` ),
+				'View all plans'
 			);
 
 			await driverHelper.clickWhenClickable( driver, viewAllPlansButtonSelector );
@@ -174,16 +176,20 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 
 		step( 'Can switch to monthly plans view', async function () {
 			// Click "Monthly" toggle button
-			const monthlyButtonSelector = By.xpath(
-				'//span[@class="plans-interval-toggle__label" and .="Monthly"]'
+			const monthlyButtonSelector = driverHelper.getElementByText(
+				driver,
+				By.css( `.plans-interval-toggle__label` ),
+				'Monthly'
 			);
 
 			await driverHelper.clickWhenClickable( driver, monthlyButtonSelector );
 
 			// Check if plans grid is really switched over to monthly view
 			// by checking if the price note "per month, billed monthly" exists.
-			const perMonthBilledMonthlyPriceNoteSelector = By.xpath(
-				'//div[@class="plan-item__price-note" and .="per month, billed monthly"]'
+			const perMonthBilledMonthlyPriceNoteSelector = driverHelper.getElementByText(
+				driver,
+				By.css( `.plan-item__price-note` ),
+				'per month, billed monthly'
 			);
 
 			const isPerMonthBilledMonthlyPricePresent = await driverHelper.isElementPresent(
@@ -199,16 +205,20 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 
 		step( 'Can select Personal monthly plan', async function () {
 			// Click "Select Personal" button
-			const selectPersonalPlanButtonSelector = By.xpath(
-				'//button[contains(@class, "plan-item__select-button") and .="Select Personal"]'
+			const selectPersonalPlanButtonSelector = driverHelper.getElementByText(
+				driver,
+				By.css( `.plan-item__select-button` ),
+				'Select Personal'
 			);
 
 			await driverHelper.clickWhenClickable( driver, selectPersonalPlanButtonSelector );
 
 			// When the detailed plans grid is closed and user returns to the summary view,
 			// check if the selected monthly plan item is "Personal Plan".
-			const selectedPlanIsPersonalMonthlyPlanSelector = By.xpath(
-				'//button[contains(@class, "focused-launch-summary__item") and contains(@class,"is-selected")]//span[@class="focused-launch-summary-item__leading-side-label" and .="Personal Plan"]'
+			const selectedPlanIsPersonalMonthlyPlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( '.focused-launch-summary__item.is-selected' ),
+				/Personal Plan/
 			);
 
 			const selectedPlanIsPersonalMonthlyPlan = await driverHelper.isElementPresent(


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Can open detailed plans grid, switch to monthly plans view, and select Personal monthly plan.

## Testing instructions

 * Run `NODE_CONFIG_ENV=personal yarn mocha --inspect specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js`.
 * Ensure the step passes.

## This PR is part of this series
- [add/focused-launch-e2e-base-spec](https://github.com/Automattic/wp-calypso/pull/51842)
  - [add/focused-launch-e2e-site-title-step](https://github.com/Automattic/wp-calypso/pull/51843)
    - [add/focused-launch-e2e-domain-step](https://github.com/Automattic/wp-calypso/pull/51844)
      - **[YOU ARE HERE]** [add/focused-launch-e2e-plan-step](https://github.com/Automattic/wp-calypso/pull/51845)
        - [add/focused-launch-e2e-reload-editor](https://github.com/Automattic/wp-calypso/pull/51846)
          - [add/focused-launch-e2e-domain-persistence](https://github.com/Automattic/wp-calypso/pull/51847)
            - [add/focused-launch-e2e-plan-persistence](https://github.com/Automattic/wp-calypso/pull/51848)
              - [add/focused-launch-e2e-select-free-plan](https://github.com/Automattic/wp-calypso/pull/51849)
                -  [add/focused-launch-e2e-launch-free-site](https://github.com/Automattic/wp-calypso/pull/51850)

Related to #51270 https://github.com/Automattic/wp-calypso/issues/46943#issuecomment-779895421
