### PR TITLE
Focused Launch E2E: Can reload editor and reopen focused launch.

### DIFF
--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -3,7 +3,7 @@
  */
 import assert from 'assert';
 import config from 'config';
-import { By } from 'selenium-webdriver';
+import { By, until } from 'selenium-webdriver';
 import { step } from 'mocha-steps';
 
 /**
@@ -227,6 +227,38 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 
 			assert( selectedPlanIsPersonalMonthlyPlan, 'The personal monthly plan was not selected.' );
+		} );
+
+		step( 'Can reload block editor and reopen focused launch', async function () {
+			// Reload block editor
+			await driver.navigate().refresh();
+
+			// Press "Reload" on confirmation dialog when block editor asks if user really wants to navigate away.
+			try {
+				await driver.wait( until.alertIsPresent(), 4000 );
+				const alert = await driver.switchTo().alert();
+				await alert.accept();
+			} catch ( e ) {
+				// This doesn't happen when autosave hasn't kicked in so
+				// if driver.wait throws and error we catch it here to allow
+				// the step to continue running.
+			}
+
+			// Wait for block editor to load and switch frame context to block editor
+			await GutenbergEditorComponent.Expect( driver );
+
+			// Click on the launch button
+			const launchButtonSelector = By.css( '.editor-gutenberg-launch__launch-button' );
+			await driverHelper.clickWhenClickable( driver, launchButtonSelector );
+
+			// See if focused launch modal can be reopened
+			const focusedLaunchModalSelector = By.css( '.launch__focused-modal' );
+			const isFocusedLaunchModalPresent = await driverHelper.isElementPresent(
+				driver,
+				focusedLaunchModalSelector
+			);
+
+			assert( isFocusedLaunchModalPresent, 'Focused launch modal did not open.' );
 		} );
 
 		after( 'Delete the newly created site', async function () {

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -249,7 +249,11 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			await GutenbergEditorComponent.Expect( driver );
 
 			// Click on the launch button
-			const launchButtonSelector = By.css( '.editor-gutenberg-launch__launch-button' );
+			const launchButtonSelector = await driverHelper.getElementByText(
+				driver,
+				By.css( '.editor-gutenberg-launch__launch-button' ),
+				'Launch'
+			);
 			await driverHelper.clickWhenClickable( driver, launchButtonSelector );
 
 			// See if focused launch modal can be reopened

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -15,6 +15,7 @@ import * as driverHelper from '../lib/driver-helper';
 import LoginFlow from '../lib/flows/login-flow.js';
 import DeleteSiteFlow from '../lib/flows/delete-site-flow.js';
 import GutenboardingFlow from '../lib/flows/gutenboarding-flow.js';
+import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -141,8 +141,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			const selectedFreeDomainSuggestionItemName = await driver.findElement(
 				selectedFreeDomainSuggestionItemNameSelector
 			);
-			// Disable lint for this line to be removed in another PR.
-			// eslint-disable-next-line no-unused-vars
+
+			// This is used in later step to test for selected domain persistence
 			selectedSubdomain = await selectedFreeDomainSuggestionItemName.getText();
 
 			assert(
@@ -260,6 +260,85 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 
 			assert( isFocusedLaunchModalPresent, 'Focused launch modal did not open.' );
+		} );
+
+		step( 'Can persist previously selected domain in focused launch', async function () {
+			const selectedDomainSuggestionContainingPreviouslySelectedSubdomainSelector = await driverHelper.getElementByText(
+				driver,
+				By.css( '.domain-picker__suggestion-item.is-selected' ),
+				new RegExp( selectedSubdomain )
+			);
+
+			const selectedDomainSuggestionIsPreviouslySelectedSubdomain = await driverHelper.isElementPresent(
+				driver,
+				selectedDomainSuggestionContainingPreviouslySelectedSubdomainSelector
+			);
+
+			assert(
+				selectedDomainSuggestionIsPreviouslySelectedSubdomain,
+				'Selected subdomain should be persisted after reloading block editor and reopening focused launch.'
+			);
+		} );
+
+		step( 'Can persist previously selected plan in focused launch', async function () {
+			// Check if the selected monthly plan item is "Personal Plan".
+			const selectedPlanIsPersonalMonthlyPlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( `.focused-launch-summary__item.is-selected` ),
+				/Personal Plan/
+			);
+
+			const selectedPlanIsPersonalMonthlyPlan = await driverHelper.isElementPresent(
+				driver,
+				selectedPlanIsPersonalMonthlyPlanSelector
+			);
+
+			assert(
+				selectedPlanIsPersonalMonthlyPlan,
+				'Selected plan should be persisted after reloading block editor and reopening focused launch'
+			);
+		} );
+
+		step( 'Can select Free plan', async function () {
+			// Click "Free Plan" button
+			const freePlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( '.focused-launch-summary__item' ),
+				/Free Plan/
+			);
+
+			await driverHelper.clickWhenClickable( driver, freePlanSelector );
+
+			// When the detailed plans grid is closed and user returns to the summary view,
+			// check if the selected monthly plan item is "Free Plan".
+			const selectedPlanIsFreePlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( '.focused-launch-summary__item.is-selected' ),
+				/Free Plan/
+			);
+
+			const selectedPlanIsFreePlan = await driverHelper.isElementPresent(
+				driver,
+				selectedPlanIsFreePlanSelector
+			);
+
+			assert( selectedPlanIsFreePlan, 'The free plan was not selected.' );
+		} );
+
+		step( 'Can launch site with Free plan.', async function () {
+			// Click on the launch button
+			const siteLaunchButtonSelector = By.css( '.focused-launch-summary__launch-button' );
+			await driverHelper.clickWhenClickable( driver, siteLaunchButtonSelector );
+
+			// Wait for the focused launch success view to show up
+			const focusedLaunchSuccessViewSelector = By.css( '.focused-launch-success__wrapper' );
+
+			const isFocusedLaunchSuccessViewPresent = await driverHelper.isElementPresent(
+				driver,
+				focusedLaunchSuccessViewSelector
+			);
+
+			assert( isFocusedLaunchSuccessViewPresent, 'Focused launch success view did not open.' );
 		} );
 
 		after( 'Delete the newly created site', async function () {


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Reload the block editor & reopen the focused launch modal. This is to test domain & plan persistence in the next steps.

## Testing instructions

 * Run `NODE_CONFIG_ENV=personal yarn mocha --inspect specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js`.
 * Ensure the step passes.

## This PR is part of this series
- [add/focused-launch-e2e-base-spec](https://github.com/Automattic/wp-calypso/pull/51842)
  - [add/focused-launch-e2e-site-title-step](https://github.com/Automattic/wp-calypso/pull/51843)
    - [add/focused-launch-e2e-domain-step](https://github.com/Automattic/wp-calypso/pull/51844)
      - [add/focused-launch-e2e-plan-step](https://github.com/Automattic/wp-calypso/pull/51845)
        - **[YOU ARE HERE]** [add/focused-launch-e2e-reload-editor](https://github.com/Automattic/wp-calypso/pull/51846)
          - [add/focused-launch-e2e-domain-persistence](https://github.com/Automattic/wp-calypso/pull/51847)
            - [add/focused-launch-e2e-plan-persistence](https://github.com/Automattic/wp-calypso/pull/51848)
              - [add/focused-launch-e2e-select-free-plan](https://github.com/Automattic/wp-calypso/pull/51849)
                -  [add/focused-launch-e2e-launch-free-site](https://github.com/Automattic/wp-calypso/pull/51850)

Related to #51270 https://github.com/Automattic/wp-calypso/issues/46943#issuecomment-779895421
