### PR TITLE
Focused Launch E2E: Can persist selected subdomain.

### DIFF
--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -263,19 +263,19 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 		} );
 
 		step( 'Can persist previously selected domain in focused launch', async function () {
-			const selectedDomainSuggestionItemNameSelector = By.css(
-				'.domain-picker__suggestion-item.is-selected .domain-picker__suggestion-item-name'
+			const selectedDomainSuggestionContainingPreviouslySelectedSubdomainSelector = await driverHelper.getElementByText(
+				driver,
+				By.css( '.domain-picker__suggestion-item.is-selected' ),
+				new RegExp( selectedSubdomain )
 			);
 
-			const selectedDomainSuggestionItemName = await driver.findElement(
-				selectedDomainSuggestionItemNameSelector
+			const selectedDomainSuggestionIsPreviouslySelectedSubdomain = await driverHelper.isElementPresent(
+				driver,
+				selectedDomainSuggestionContainingPreviouslySelectedSubdomainSelector
 			);
 
-			const selectedSubdomainAfterRefresh = await selectedDomainSuggestionItemName.getText();
-
-			assert.strictEqual(
-				selectedSubdomainAfterRefresh,
-				selectedSubdomain,
+			assert(
+				selectedDomainSuggestionIsPreviouslySelectedSubdomain,
 				'Selected subdomain should be persisted after reloading block editor and reopening focused launch.'
 			);
 		} );

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -141,8 +141,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			const selectedFreeDomainSuggestionItemName = await driver.findElement(
 				selectedFreeDomainSuggestionItemNameSelector
 			);
-			// Disable lint for this line to be removed in another PR.
-			// eslint-disable-next-line no-unused-vars
+
+			// This is used in later step to test for selected domain persistence
 			selectedSubdomain = await selectedFreeDomainSuggestionItemName.getText();
 
 			assert(
@@ -260,6 +260,24 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 
 			assert( isFocusedLaunchModalPresent, 'Focused launch modal did not open.' );
+		} );
+
+		step( 'Can persist previously selected domain in focused launch', async function () {
+			const selectedDomainSuggestionItemNameSelector = By.css(
+				'.domain-picker__suggestion-item.is-selected .domain-picker__suggestion-item-name'
+			);
+
+			const selectedDomainSuggestionItemName = await driver.findElement(
+				selectedDomainSuggestionItemNameSelector
+			);
+
+			const selectedSubdomainAfterRefresh = await selectedDomainSuggestionItemName.getText();
+
+			assert.strictEqual(
+				selectedSubdomainAfterRefresh,
+				selectedSubdomain,
+				'Selected subdomain should be persisted after reloading block editor and reopening focused launch.'
+			);
 		} );
 
 		after( 'Delete the newly created site', async function () {

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -280,6 +280,67 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 		} );
 
+		step( 'Can persist previously selected plan in focused launch', async function () {
+			// Check if the selected monthly plan item is "Personal Plan".
+			const selectedPlanIsPersonalMonthlyPlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( `.focused-launch-summary__item.is-selected` ),
+				/Personal Plan/
+			);
+
+			const selectedPlanIsPersonalMonthlyPlan = await driverHelper.isElementPresent(
+				driver,
+				selectedPlanIsPersonalMonthlyPlanSelector
+			);
+
+			assert(
+				selectedPlanIsPersonalMonthlyPlan,
+				'Selected plan should be persisted after reloading block editor and reopening focused launch'
+			);
+		} );
+
+		step( 'Can select Free plan', async function () {
+			// Click "Free Plan" button
+			const freePlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( '.focused-launch-summary__item' ),
+				/Free Plan/
+			);
+
+			await driverHelper.clickWhenClickable( driver, freePlanSelector );
+
+			// When the detailed plans grid is closed and user returns to the summary view,
+			// check if the selected monthly plan item is "Free Plan".
+			const selectedPlanIsFreePlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( '.focused-launch-summary__item.is-selected' ),
+				/Free Plan/
+			);
+
+			const selectedPlanIsFreePlan = await driverHelper.isElementPresent(
+				driver,
+				selectedPlanIsFreePlanSelector
+			);
+
+			assert( selectedPlanIsFreePlan, 'The free plan was not selected.' );
+		} );
+
+		step( 'Can launch site with Free plan.', async function () {
+			// Click on the launch button
+			const siteLaunchButtonSelector = By.css( '.focused-launch-summary__launch-button' );
+			await driverHelper.clickWhenClickable( driver, siteLaunchButtonSelector );
+
+			// Wait for the focused launch success view to show up
+			const focusedLaunchSuccessViewSelector = By.css( '.focused-launch-success__wrapper' );
+
+			const isFocusedLaunchSuccessViewPresent = await driverHelper.isElementPresent(
+				driver,
+				focusedLaunchSuccessViewSelector
+			);
+
+			assert( isFocusedLaunchSuccessViewPresent, 'Focused launch success view did not open.' );
+		} );
+
 		after( 'Delete the newly created site', async function () {
 			const deleteSite = new DeleteSiteFlow( driver );
 			await deleteSite.deleteSite( siteName + '.wordpress.com' );


### PR DESCRIPTION
## Changes proposed in this Pull Request

* After reloading block editor, ensure the previously selected subdomain is persisted.

## Testing instructions

 * Run `NODE_CONFIG_ENV=personal yarn mocha --inspect specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js`.
 * Ensure the step passes.

## This PR is part of this series
- [add/focused-launch-e2e-base-spec](https://github.com/Automattic/wp-calypso/pull/51842)
  - [add/focused-launch-e2e-site-title-step](https://github.com/Automattic/wp-calypso/pull/51843)
    - [add/focused-launch-e2e-domain-step](https://github.com/Automattic/wp-calypso/pull/51844)
      - [add/focused-launch-e2e-plan-step](https://github.com/Automattic/wp-calypso/pull/51845)
        - [add/focused-launch-e2e-reload-editor](https://github.com/Automattic/wp-calypso/pull/51846)
          - **[YOU ARE HERE]** [add/focused-launch-e2e-domain-persistence](https://github.com/Automattic/wp-calypso/pull/51847)
            - [add/focused-launch-e2e-plan-persistence](https://github.com/Automattic/wp-calypso/pull/51848)
              - [add/focused-launch-e2e-select-free-plan](https://github.com/Automattic/wp-calypso/pull/51849)
                -  [add/focused-launch-e2e-launch-free-site](https://github.com/Automattic/wp-calypso/pull/51850)

Related to #51270 https://github.com/Automattic/wp-calypso/issues/46943#issuecomment-779895421
