### PR TITLE
Focused Launch E2E: Can persist selected plan.

### DIFF
--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -299,6 +299,48 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 		} );
 
+		step( 'Can select Free plan', async function () {
+			// Click "Free Plan" button
+			const freePlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( '.focused-launch-summary__item' ),
+				/Free Plan/
+			);
+
+			await driverHelper.clickWhenClickable( driver, freePlanSelector );
+
+			// When the detailed plans grid is closed and user returns to the summary view,
+			// check if the selected monthly plan item is "Free Plan".
+			const selectedPlanIsFreePlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( '.focused-launch-summary__item.is-selected' ),
+				/Free Plan/
+			);
+
+			const selectedPlanIsFreePlan = await driverHelper.isElementPresent(
+				driver,
+				selectedPlanIsFreePlanSelector
+			);
+
+			assert( selectedPlanIsFreePlan, 'The free plan was not selected.' );
+		} );
+
+		step( 'Can launch site with Free plan.', async function () {
+			// Click on the launch button
+			const siteLaunchButtonSelector = By.css( '.focused-launch-summary__launch-button' );
+			await driverHelper.clickWhenClickable( driver, siteLaunchButtonSelector );
+
+			// Wait for the focused launch success view to show up
+			const focusedLaunchSuccessViewSelector = By.css( '.focused-launch-success__wrapper' );
+
+			const isFocusedLaunchSuccessViewPresent = await driverHelper.isElementPresent(
+				driver,
+				focusedLaunchSuccessViewSelector
+			);
+
+			assert( isFocusedLaunchSuccessViewPresent, 'Focused launch success view did not open.' );
+		} );
+
 		after( 'Delete the newly created site', async function () {
 			const deleteSite = new DeleteSiteFlow( driver );
 			await deleteSite.deleteSite( siteName + '.wordpress.com' );

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -282,8 +282,10 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 
 		step( 'Can persist previously selected plan in focused launch', async function () {
 			// Check if the selected monthly plan item is "Personal Plan".
-			const selectedPlanIsPersonalMonthlyPlanSelector = By.xpath(
-				'//button[contains(@class, "focused-launch-summary__item") and contains(@class, "is-selected")]//span[@class="focused-launch-summary-item__leading-side-label" and .="Personal Plan"]'
+			const selectedPlanIsPersonalMonthlyPlanSelector = driverHelper.getElementByText(
+				driver,
+				By.css( `.focused-launch-summary__item.is-selected` ),
+				/Personal Plan/
 			);
 
 			const selectedPlanIsPersonalMonthlyPlan = await driverHelper.isElementPresent(

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -280,6 +280,23 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 		} );
 
+		step( 'Can persist previously selected plan in focused launch', async function () {
+			// Check if the selected monthly plan item is "Personal Plan".
+			const selectedPlanIsPersonalMonthlyPlanSelector = By.xpath(
+				'//button[contains(@class, "focused-launch-summary__item") and contains(@class, "is-selected")]//span[@class="focused-launch-summary-item__leading-side-label" and .="Personal Plan"]'
+			);
+
+			const selectedPlanIsPersonalMonthlyPlan = await driverHelper.isElementPresent(
+				driver,
+				selectedPlanIsPersonalMonthlyPlanSelector
+			);
+
+			assert(
+				selectedPlanIsPersonalMonthlyPlan,
+				'Selected plan should be persisted after reloading block editor and reopening focused launch'
+			);
+		} );
+
 		after( 'Delete the newly created site', async function () {
 			const deleteSite = new DeleteSiteFlow( driver );
 			await deleteSite.deleteSite( siteName + '.wordpress.com' );


### PR DESCRIPTION
## Changes proposed in this Pull Request

* After reloading block editor, ensure the previously selected Personal Monthly plan is persisted.

## Testing instructions

 * Run `NODE_CONFIG_ENV=personal yarn mocha --inspect specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js`.
 * Ensure the step passes.

## This PR is part of this series
- [add/focused-launch-e2e-base-spec](https://github.com/Automattic/wp-calypso/pull/51842)
  - [add/focused-launch-e2e-site-title-step](https://github.com/Automattic/wp-calypso/pull/51843)
    - [add/focused-launch-e2e-domain-step](https://github.com/Automattic/wp-calypso/pull/51844)
      - [add/focused-launch-e2e-plan-step](https://github.com/Automattic/wp-calypso/pull/51845)
        - [add/focused-launch-e2e-reload-editor](https://github.com/Automattic/wp-calypso/pull/51846)
          - [add/focused-launch-e2e-domain-persistence](https://github.com/Automattic/wp-calypso/pull/51847)
            - **[YOU ARE HERE]** [add/focused-launch-e2e-plan-persistence](https://github.com/Automattic/wp-calypso/pull/51848)
              - [add/focused-launch-e2e-select-free-plan](https://github.com/Automattic/wp-calypso/pull/51849)
                -  [add/focused-launch-e2e-launch-free-site](https://github.com/Automattic/wp-calypso/pull/51850)

Related to #51270 https://github.com/Automattic/wp-calypso/issues/46943#issuecomment-779895421
