### PR TITLE
Focused Launch E2E: Can launch site with Free plan.

### DIFF
--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -325,6 +325,32 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			assert( selectedPlanIsFreePlan, 'The free plan was not selected.' );
 		} );
 
+		step( 'Can launch site with Free plan.', async function () {
+			// Click on the launch button
+			const siteLaunchButtonSelector = By.css( '.focused-launch-summary__launch-button' );
+			await driverHelper.clickWhenClickable( driver, siteLaunchButtonSelector );
+
+			// Switch to Calypso parent window
+			await driver.switchTo().defaultContent();
+
+			// Click on the complete checkout button
+			const completeCheckoutButtonSelector = By.css( '.checkout-submit-button .checkout-button' );
+			await driverHelper.clickWhenClickable( driver, completeCheckoutButtonSelector );
+
+			// Switch back to the iframed block editor.
+			await GutenbergEditorComponent.Expect( driver );
+
+			// Wait for the focused launch success view to show up
+			const focusedLaunchSuccessViewSelector = By.css( '.focused-launch-success__wrapper' );
+
+			const isFocusedLaunchSuccessViewPresent = await driverHelper.isElementPresent(
+				driver,
+				focusedLaunchSuccessViewSelector
+			);
+
+			assert( isFocusedLaunchSuccessViewPresent, 'Focused launch success view did not open.' );
+		} );
+
 		after( 'Delete the newly created site', async function () {
 			const deleteSite = new DeleteSiteFlow( driver );
 			await deleteSite.deleteSite( siteName + '.wordpress.com' );

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -330,16 +330,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			const siteLaunchButtonSelector = By.css( '.focused-launch-summary__launch-button' );
 			await driverHelper.clickWhenClickable( driver, siteLaunchButtonSelector );
 
-			// Switch to Calypso parent window
-			await driver.switchTo().defaultContent();
-
-			// Click on the complete checkout button
-			const completeCheckoutButtonSelector = By.css( '.checkout-submit-button .checkout-button' );
-			await driverHelper.clickWhenClickable( driver, completeCheckoutButtonSelector );
-
-			// Switch back to the iframed block editor.
-			await GutenbergEditorComponent.Expect( driver );
-
 			// Wait for the focused launch success view to show up
 			const focusedLaunchSuccessViewSelector = By.css( '.focused-launch-success__wrapper' );
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

* When clicking on the Launch button, the Success view should appear.

## Testing instructions

 * Run `NODE_CONFIG_ENV=personal yarn mocha --inspect specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js`.
 * Ensure the step passes.

## This PR is part of this series
- [add/focused-launch-e2e-base-spec](https://github.com/Automattic/wp-calypso/pull/51842)
  - [add/focused-launch-e2e-site-title-step](https://github.com/Automattic/wp-calypso/pull/51843)
    - [add/focused-launch-e2e-domain-step](https://github.com/Automattic/wp-calypso/pull/51844)
      - [add/focused-launch-e2e-plan-step](https://github.com/Automattic/wp-calypso/pull/51845)
        - [add/focused-launch-e2e-reload-editor](https://github.com/Automattic/wp-calypso/pull/51846)
          - [add/focused-launch-e2e-domain-persistence](https://github.com/Automattic/wp-calypso/pull/51847)
            - [add/focused-launch-e2e-plan-persistence](https://github.com/Automattic/wp-calypso/pull/51848)
              - [add/focused-launch-e2e-select-free-plan](https://github.com/Automattic/wp-calypso/pull/51849)
                -  **[YOU ARE HERE]** [add/focused-launch-e2e-launch-free-site](https://github.com/Automattic/wp-calypso/pull/51850)

Related to #51270 https://github.com/Automattic/wp-calypso/issues/46943#issuecomment-779895421
