### PR TITLE
Welcome guide: Show tooltips for welcome guide buttons

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -138,7 +138,7 @@ function CardOverlayControls( { onMinimize, onDismiss, slideNumber } ) {
 		<div className="welcome-tour-card__overlay-controls">
 			<Flex>
 				<Button
-					aria-label={ __( 'Minimize Tour', 'full-site-editing' ) }
+					label={ __( 'Minimize Tour', 'full-site-editing' ) }
 					isPrimary
 					className="welcome-tour-card__minimize-icon"
 					icon={ minimize }
@@ -146,7 +146,7 @@ function CardOverlayControls( { onMinimize, onDismiss, slideNumber } ) {
 					onClick={ handleOnMinimize }
 				></Button>
 				<Button
-					aria-label={ __( 'Close Tour', 'full-site-editing' ) }
+					label={ __( 'Close Tour', 'full-site-editing' ) }
 					isPrimary
 					icon={ close }
 					iconSize={ 24 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show tooltips for welcome guide buttons

Showing a tooltip is the default behaviour of the <Button> component
when it doesn't have any child elements. Using the `label` instead of
`aria-label` is what kicks this behaviour in.

`label` is also the default value used for `aria-label` so that
behaviour still works with these changes.

<img width="443" alt="Screenshot 2021-04-12 at 8 41 27 PM" src="https://user-images.githubusercontent.com/1500769/114367165-48187f80-9bd0-11eb-9008-d903bce06bb7.png">

<img width="443" alt="Screenshot 2021-04-12 at 8 41 42 PM" src="https://user-images.githubusercontent.com/1500769/114367190-4d75ca00-9bd0-11eb-9bb2-8400d6c8b1f9.png">

#50875 also says to show a tooltip on the maximise button. I haven't added it because I don't think it's necessary given that there's already a visible label.

<img width="262" alt="Screenshot 2021-04-12 at 8 48 34 PM" src="https://user-images.githubusercontent.com/1500769/114367354-78601e00-9bd0-11eb-9430-c5f069be144b.png">

If we decide we really do need a tooltip for this icon too, despite the label, then adding it will be a bit more work (maybe another PR?) The maximise icon isn't in it's own `<Button>` component, we'll probably need to manually render a `<Tooltip>` and attach it to the `<svg>` element.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `install-plugin.sh etk add/welcome-tour-button-tooltips`
* Open Welcome Guide from the menu in the editor of a sandboxed site
* Hover over buttons, see the tooltips
* Inspect the buttons in the dev tools and verify that the `aria-label` attribute is still there

The tooltips don't appear in a very good place IMO, but it's consistent with all other tooltips in the editor

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #50875
