### PR TITLE
Button: fix borders of disabled scary buttons

### DIFF
--- a/packages/components/src/button/docs/example.jsx
+++ b/packages/components/src/button/docs/example.jsx
@@ -161,6 +161,9 @@ export default class ButtonExample extends React.PureComponent {
 					<Button primary busy>
 						Primary busy button
 					</Button>
+					<Button scary busy>
+						Scary busy button
+					</Button>
 					<Button primary scary busy>
 						<Gridicon icon="trash" />
 						<span>Primary scary busy button</span>

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -179,7 +179,7 @@
 	&:disabled {
 		color: var( --color-neutral-20 );
 		background-color: var( --color-surface );
-		border-color: var( --color-surface );
+		border-color: var( --color-neutral-5 );
 	}
 }
 
@@ -198,7 +198,7 @@
 	&:disabled {
 		color: var( --color-neutral-20 );
 		background-color: var( --color-surface );
-		border-color: var( --color-surface );
+		border-color: var( --color-neutral-5 );
 	}
 
 	&.is-busy {


### PR DESCRIPTION
Scary buttons didn't have a border when disabled. Probably a regression in #41887:

<img width="714" alt="Screenshot 2021-04-12 at 10 31 34" src="https://user-images.githubusercontent.com/664258/114367625-e7138c00-9b7c-11eb-8795-1b43771ba35d.png">

After this patch, the borders are back:

<img width="714" alt="Screenshot 2021-04-12 at 10 44 44" src="https://user-images.githubusercontent.com/664258/114367672-f2ff4e00-9b7c-11eb-9337-a84aadee3c1c.png">

@sixhours It seems to me that this particular change wasn't an intent in #41887.

The disabled button states could be further aligned with Gutenberg styles which are IMO better: primary and scary buttons in Gutenberg keep their primary/scary look. But here I'm fixing just one simple inconsistency I found when testing https://github.com/Automattic/wp-calypso/pull/51841#issuecomment-817599903

**How to test:**
Check the `/devdocs/design/button` devdocs page and verify that the styles are fixed.