### PR TITLE
Update/increase size of new page previews

### DIFF
--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -29,13 +29,13 @@ $breakpoint-tablet: 783px;
 $breakpoint-desktop: 961px;
 $breakpoint-huge: 1648px;
 
-$sidebar-width: 272px;
+$sidebar-width: 230px;
 $sidebar-width-desktop: 324px;
 
 // Overrides of the Gutenberg modal component
 .page-pattern-modal {
 	@media screen and ( min-width: $breakpoint-mobile ) {
-		width: 90%;
+		width: calc( 100% - 32px );
 		height: 90vh;
 		// prevents a 1px strip of content being visible after scrolling
 		overflow-y: hidden;
@@ -43,6 +43,10 @@ $sidebar-width-desktop: 324px;
 		.components-modal__content {
 			padding: 0 32px 24px;
 		}
+	}
+
+	@media screen and ( min-width: $breakpoint-desktop ) {
+		width: calc( 100% - 64px );
 	}
 
 	.components-modal__content {
@@ -55,6 +59,7 @@ $sidebar-width-desktop: 324px;
 
 	.components-modal__header {
 		border-bottom: none;
+		margin-right: -16px;
 	}
 }
 
@@ -72,7 +77,7 @@ $sidebar-width-desktop: 324px;
 		line-height: 1.1;
 	}
 
-	@media screen and ( min-width: $breakpoint-tablet ) {
+	@media screen and ( min-width: $breakpoint-desktop ) {
 		font-size: 3rem;
 		line-height: 1.35;
 	}
@@ -111,6 +116,13 @@ $sidebar-width-desktop: 324px;
 			auto-fill,
 			minmax( 280px, 1fr )
 		); // allow grid to take over number of cols on large screens
+	}
+
+	@media screen and ( min-width: $breakpoint-huge ) {
+		grid-template-columns: repeat(
+			auto-fill,
+			minmax( 350px, 1fr )
+		);
 	}
 }
 

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -28,6 +28,7 @@ $breakpoint-mobile: 600px;
 $breakpoint-tablet: 783px;
 $breakpoint-desktop: 961px;
 $breakpoint-huge: 1648px;
+$breakpoint-xhuge: 2000px;
 
 $sidebar-width: 230px;
 $sidebar-width-desktop: 324px;
@@ -122,6 +123,12 @@ $sidebar-width-desktop: 324px;
 		grid-template-columns: repeat(
 			auto-fill,
 			minmax( 350px, 1fr )
+		);
+	}
+	@media screen and ( min-width: $breakpoint-xhuge ) {
+		grid-template-columns: repeat(
+			auto-fill,
+			minmax( 500px, 1fr )
 		);
 	}
 }

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -40,6 +40,9 @@ $sidebar-width-desktop: 324px;
 		// prevents a 1px strip of content being visible after scrolling
 		overflow-y: hidden;
 		padding-bottom: 24px;
+		.components-modal__content {
+			padding: 0 32px 24px;
+		}
 	}
 
 	.components-modal__content {
@@ -47,6 +50,7 @@ $sidebar-width-desktop: 324px;
 		-webkit-overflow-scrolling: touch;
 		// prevents a 1px strip of content being visible after scrolling
 		margin-top: -1px;
+		padding: 0 16px 16px;
 	}
 
 	.components-modal__header {

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -29,7 +29,8 @@ $breakpoint-tablet: 783px;
 $breakpoint-desktop: 961px;
 $breakpoint-huge: 1648px;
 
-$sidebar-width: 324px;
+$sidebar-width: 272px;
+$sidebar-width-desktop: 324px;
 
 // Overrides of the Gutenberg modal component
 .page-pattern-modal {
@@ -104,7 +105,7 @@ $sidebar-width: 324px;
 		margin-top: 0;
 		grid-template-columns: repeat(
 			auto-fill,
-			minmax( 260px, 1fr )
+			minmax( 280px, 1fr )
 		); // allow grid to take over number of cols on large screens
 	}
 }
@@ -174,8 +175,8 @@ $sidebar-width: 324px;
 .page-pattern-modal__sidebar {
 	@media screen and ( min-width: $breakpoint-mobile ) {
 		position: fixed;
-		width: calc( #{$sidebar-width} - 24px );
-		padding-right: 44px;
+		width: $sidebar-width;
+		padding-right: 22px;
 
 		// Manually choosing when to enable/disable pointer events so that
 		// the scroll wheel behaviour feels natural when the mouse is over
@@ -198,6 +199,10 @@ $sidebar-width: 324px;
 				pointer-events: auto;
 			}
 		}
+	}
+	@media screen and ( min-width: $breakpoint-desktop ) {
+		width: $sidebar-width-desktop;
+		padding-right: 48px;
 	}
 }
 
@@ -296,5 +301,8 @@ $sidebar-width: 324px;
 .page-pattern-modal__pattern-list-container {
 	@media screen and ( min-width: $breakpoint-mobile ) {
 		padding-left: $sidebar-width;
+	}
+	@media screen and ( min-width: $breakpoint-desktop ) {
+		padding-left: $sidebar-width-desktop;
 	}
 }


### PR DESCRIPTION
We had feedback that the preview window does not give users as much of a view of the page layout template as they used to get with the iframe.

Other planned fixes for this are implementing the scroll on hover feature and increasing the height of the images.

This change makes the images physically larger and use available space better

#### Desktop
Before:
<img width="1792" alt="Screen Shot 2021-04-12 at 9 04 05 PM" src="https://user-images.githubusercontent.com/22446385/114384989-c37b3080-9bd2-11eb-8d7e-a8285a88a982.png">
After:
<img width="1792" alt="Screen Shot 2021-04-12 at 3 41 28 PM" src="https://user-images.githubusercontent.com/22446385/114385016-cece5c00-9bd2-11eb-947b-038af3dfd6ac.png">

#### Tablet
Before: 
<img width="578" alt="Screen Shot 2021-04-12 at 9 03 32 PM" src="https://user-images.githubusercontent.com/22446385/114385081-e1489580-9bd2-11eb-8a99-b60f78bd9f3d.png">
After: 
<img width="581" alt="Screen Shot 2021-04-12 at 5 18 01 PM" src="https://user-images.githubusercontent.com/22446385/114385092-e60d4980-9bd2-11eb-9c8e-c31a204bfed0.png">

#### Mobile
Before:
<img width="413" alt="Screen Shot 2021-04-12 at 9 03 53 PM" src="https://user-images.githubusercontent.com/22446385/114385120-ef96b180-9bd2-11eb-8dfa-4cfcfb68050a.png">
After:
<img width="413" alt="Screen Shot 2021-04-12 at 5 17 47 PM" src="https://user-images.githubusercontent.com/22446385/114385138-f58c9280-9bd2-11eb-8c0e-95fd752217f2.png">

Fixes #51431


## Testing instructions

This is part of the ETK, check out this branch and sync to your sandbox with 
```
cd apps/editing-toolkit
yarn dev --sync
```

Then go to a **sandboxed** test site these changes will be visible on the new page template selector.
_wordpress.com/page/__YOUR_SANDBOXED_SITE__.wordpress.com_

It should make the previews reasonably sized on mobile, tablet and desktop