### PR TITLE
Domains: Cleanup TransferToOtherUser component

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import { connect, useSelector } from 'react-redux';
-import { find, head, omit } from 'lodash';
+import { find, omit } from 'lodash';
 import page from 'page';
 import { localize } from 'i18n-calypso';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -42,7 +42,6 @@ class TransferOtherUser extends React.Component {
 	static propTypes = {
 		currentUser: PropTypes.object.isRequired,
 		domains: PropTypes.array.isRequired,
-		isAtomic: PropTypes.bool.isRequired,
 		isRequestingSiteDomains: PropTypes.bool.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
@@ -53,9 +52,8 @@ class TransferOtherUser extends React.Component {
 	constructor( props ) {
 		super( props );
 
-		const defaultUser = head( this.filterAvailableUsers( props.users ) );
 		this.state = {
-			selectedUserId: defaultUser ? this.getWpcomUserId( defaultUser ) : '',
+			selectedUserId: '',
 			showConfirmationDialog: false,
 			disableDialogButtons: false,
 		};
@@ -67,15 +65,6 @@ class TransferOtherUser extends React.Component {
 	}
 
 	getWpcomUserId = ( user ) => user.linked_user_ID ?? user.ID;
-
-	UNSAFE_componentWillUpdate( nextProps, nextState ) {
-		if ( nextState && ! nextState.selectedUserId ) {
-			const defaultUser = head( this.filterAvailableUsers( nextProps.users ) );
-			if ( defaultUser ) {
-				this.setState( { selectedUserId: this.getWpcomUserId( defaultUser ) } );
-			}
-		}
-	}
 
 	handleUserChange( event ) {
 		event.preventDefault();
@@ -255,15 +244,18 @@ class TransferOtherUser extends React.Component {
 							value={ this.state.selectedUserId }
 						>
 							{ availableUsers.length ? (
-								availableUsers.map( ( user ) => {
-									const userId = this.getWpcomUserId( user );
+								<Fragment>
+									<option value="">{ translate( '-- Select user --' ) }</option>
+									{ availableUsers.map( ( user ) => {
+										const userId = this.getWpcomUserId( user );
 
-									return (
-										<option key={ userId } value={ userId }>
-											{ this.getUserDisplayName( user ) }
-										</option>
-									);
-								} )
+										return (
+											<option key={ userId } value={ userId }>
+												{ this.getUserDisplayName( user ) }
+											</option>
+										);
+									} ) }
+								</Fragment>
 							) : (
 								<option value="">{ translate( '-- Site has no other administrators --' ) }</option>
 							) }

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import { connect, useSelector } from 'react-redux';
-import { find, get, head, omit } from 'lodash';
+import { find, head, omit } from 'lodash';
 import page from 'page';
 import { localize } from 'i18n-calypso';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -26,7 +26,6 @@ import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import DesignatedAgentNotice from 'calypso/my-sites/domains/domain-management/components/designated-agent-notice';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -67,13 +66,7 @@ class TransferOtherUser extends React.Component {
 		this.handleConfirmTransferDomain = this.handleConfirmTransferDomain.bind( this );
 	}
 
-	getWpcomUserId = ( user ) => {
-		if ( this.props.isAtomic ) {
-			return get( user, 'linked_user_ID', '' );
-		}
-
-		return user.ID;
-	};
+	getWpcomUserId = ( user ) => user.linked_user_ID ?? user.ID;
 
 	UNSAFE_componentWillUpdate( nextProps, nextState ) {
 		if ( nextState && ! nextState.selectedUserId ) {
@@ -366,7 +359,6 @@ export default connect(
 
 		return {
 			currentUser: getCurrentUser( state ),
-			isAtomic: isSiteAutomatedTransfer( state, ownProps.selectedSite.ID ),
 			isMapping: Boolean( domain ) && isMappedDomain( domain ),
 			hasSiteDomainsLoaded: hasLoadedSiteDomains( state, ownProps.selectedSite.ID ),
 			currentRoute: getCurrentRoute( state ),

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -245,7 +245,7 @@ class TransferOtherUser extends React.Component {
 						>
 							{ availableUsers.length ? (
 								<Fragment>
-									<option value="">{ translate( '-- Select user --' ) }</option>
+									<option value="">{ translate( '-- Select User --' ) }</option>
 									{ availableUsers.map( ( user ) => {
 										const userId = this.getWpcomUserId( user );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR contains a couple of cleanups as a follow-up to #51809, as suggested in https://github.com/Automattic/wp-calypso/pull/51809#pullrequestreview-633410918

Namely, here we:

* Simplify the `getWpcomUserId` method and remove unnecessary `get` usage
* Cleanup the logic to set a default selected user

IMHO, transferring a domain to another user is a dangerous action, so I'd strongly recommend against preselecting a user. So this PR adds a default empty option "Select user", and allows the user to select a user on their own if they want to. This also allows us to clean up the unnecessary logic to set a default user, which was relying on asynchronously loaded data that could come later.

#### Testing instructions

* Verify `/domains/manage/:domain/transfer/other-user/:site` still works like it did before for Atomic and simple sites, specifically loading users and selecting one to transfer. 