### PR TITLE
Domains: Use destructured `selectedSite` prop in `TransferToOtherUser`

### DIFF
--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -63,12 +63,12 @@ class DomainManagementData extends React.Component {
 				<CalypsoShoppingCartProvider>
 					{ React.createElement( this.props.component, {
 						context: this.props.context,
-						domains: this.props.selectedSite ? this.props.domains : null,
+						domains: selectedSite ? this.props.domains : null,
 						hasSiteDomainsLoaded: this.props.hasSiteDomainsLoaded,
 						isRequestingSiteDomains: this.props.isRequestingSiteDomains,
 						products: this.props.products,
 						selectedDomainName: this.props.selectedDomainName,
-						selectedSite: this.props.selectedSite,
+						selectedSite: selectedSite,
 						sitePlans: this.props.sitePlans,
 						user: this.props.currentUser,
 					} ) }

--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -68,7 +68,7 @@ class DomainManagementData extends React.Component {
 						isRequestingSiteDomains: this.props.isRequestingSiteDomains,
 						products: this.props.products,
 						selectedDomainName: this.props.selectedDomainName,
-						selectedSite: selectedSite,
+						selectedSite,
 						sitePlans: this.props.sitePlans,
 						user: this.props.currentUser,
 					} ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR addresses a minor cleanup as a follow-up to #51809, as suggested in https://github.com/Automattic/wp-calypso/pull/51809#discussion_r611535174

#### Testing instructions

* Verify `/domains/manage/:domain/transfer/other-user/:site` still works as it did before for Atomic and simple sites, specifically loading users and selecting one to transfer. 