### PR TITLE
New Onboarding: Fix flaky select free domain suggestion E2E test.

### DIFF
--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -82,6 +82,14 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 		step( 'Can see Domains Page and pick a free domain and continue', async function () {
 			const domainsPage = await DomainsPage.Expect( driver );
 			await domainsPage.enterDomainQuery( domainQuery );
+
+			// Wait for domain suggestions to reload.
+			// This fixes the "stale element reference: element is not attached to the page document" error
+			// because selectFreeDomain() might be clicking on the free suggestion item too quickly
+			// before the list of domain suggestions are reloaded, causing the driver to target the
+			// element that has already been removed from DOM.
+			await driver.sleep( 2000 );
+
 			newSiteDomain = await domainsPage.selectFreeDomain();
 			await domainsPage.continueToNextStep();
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The E2E failure `stale element reference: element is not attached to the page document` sometimes crops up because because selectFreeDomain() might be clicking on the free suggestion item too quickly before the list of domain suggestions are reloaded, causing the driver to target the element that has already been removed from DOM.

The solution is just to add a delay.

#### Testing instructions

* Since this is intermittent, just rerun the E2E desktop on TeamCity and see if the `stale element reference` error still persist on the **'Can see Domains Page and pick a free domain and continue'** step. 

Fixes #51857.