### PR TITLE
E2E: Fix navbarComponent.clickMySites() selectors.

### DIFF
--- a/test/e2e/lib/components/nav-bar-component.js
+++ b/test/e2e/lib/components/nav-bar-component.js
@@ -39,11 +39,13 @@ export default class NavBarComponent extends AsyncBaseContainer {
 		return await driverHelper.clickWhenClickable( this.driver, profileSelector );
 	}
 	async clickMySites() {
-		const mySitesSelector = by.css( 'header.masterbar a.masterbar__item' );
+		const mySitesSelector = by.css(
+			'header.masterbar a.masterbar__item[data-tip-target="my-sites"]'
+		);
 		await driverHelper.clickWhenClickable( this.driver, mySitesSelector );
 		await driverHelper.isEventuallyPresentAndDisplayed(
 			this.driver,
-			by.css( '.sidebar__menu-wrapper' )
+			by.css( 'ul[data-tip-target="sidebar"]' )
 		);
 		return await driverHelper.isEventuallyPresentAndDisplayed(
 			this.driver,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When running `wp-plan-purchase-spec` & `wp-invite-users-spec`, I'm getting stuck at the first step `await loginFlow.loginAndSelectMySite();`.

When drilling down, I noticed that `loginAndSelectMySite()` calls `await navbarComponent.clickMySites();` and this is where it got stuck.

The `clickMySites()` function seems:
- to be having a selector that is too generic to target specifically "My Sites" button.
- to be checking for presence of the sidebar element with an outdated selector.

The error it fixes is `stale element reference: element is not attached to the page document` as seen on the E2E log.

#### Testing instructions

* Run `yarn mocha specs/wp-plan-purchase-spec.js` &  `yarn mocha specs/wp-invite-users-spec.js` locally and see if tests passes.
OR
* Check the TC tests and see if the `Comparing Plans:  @parallel @jetpack` & `Inviting new user as an Editor: @parallel @jetpack'` passes.
