### PR TITLE
TransferToOtherUser: some additional cleanups

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -13,7 +13,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  * Internal Dependencies
  */
 import { Card, Dialog } from '@automattic/components';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import Header from 'calypso/my-sites/domains/domain-management/components/header';
 import Main from 'calypso/components/main';
 import { domainManagementEdit, domainManagementTransfer } from 'calypso/my-sites/domains/paths';
@@ -42,7 +42,7 @@ const getWpcomUserId = ( user ) => user.linked_user_ID ?? user.ID;
 
 class TransferOtherUser extends React.Component {
 	static propTypes = {
-		currentUser: PropTypes.object.isRequired,
+		currentUserId: PropTypes.number.isRequired,
 		domains: PropTypes.array.isRequired,
 		isRequestingSiteDomains: PropTypes.bool.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
@@ -326,7 +326,7 @@ class TransferOtherUser extends React.Component {
 	filterAvailableUsers( users ) {
 		return users.filter(
 			( user ) =>
-				getWpcomUserId( user ) !== false && getWpcomUserId( user ) !== this.props.currentUser.ID
+				getWpcomUserId( user ) !== false && getWpcomUserId( user ) !== this.props.currentUserId
 		);
 	}
 
@@ -351,7 +351,7 @@ export default connect(
 		const domain = ! ownProps.isRequestingSiteDomains && getSelectedDomain( ownProps );
 
 		return {
-			currentUser: getCurrentUser( state ),
+			currentUserId: getCurrentUserId( state ),
 			isMapping: Boolean( domain ) && isMappedDomain( domain ),
 			hasSiteDomainsLoaded: hasLoadedSiteDomains( state, ownProps.selectedSite.ID ),
 			currentRoute: getCurrentRoute( state ),

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -38,6 +38,8 @@ import './style.scss';
 
 const wpcom = wp.undocumented();
 
+const getWpcomUserId = ( user ) => user.linked_user_ID ?? user.ID;
+
 class TransferOtherUser extends React.Component {
 	static propTypes = {
 		currentUser: PropTypes.object.isRequired,
@@ -63,8 +65,6 @@ class TransferOtherUser extends React.Component {
 		this.handleDialogClose = this.handleDialogClose.bind( this );
 		this.handleConfirmTransferDomain = this.handleConfirmTransferDomain.bind( this );
 	}
-
-	getWpcomUserId = ( user ) => user.linked_user_ID ?? user.ID;
 
 	handleUserChange( event ) {
 		event.preventDefault();
@@ -127,7 +127,7 @@ class TransferOtherUser extends React.Component {
 	getSelectedUserDisplayName() {
 		const selectedUser = find(
 			this.props.users,
-			( user ) => this.getWpcomUserId( user ) === Number( this.state.selectedUserId )
+			( user ) => getWpcomUserId( user ) === Number( this.state.selectedUserId )
 		);
 
 		if ( ! selectedUser ) {
@@ -248,7 +248,7 @@ class TransferOtherUser extends React.Component {
 								<Fragment>
 									<option value="">{ translate( '-- Select User --' ) }</option>
 									{ availableUsers.map( ( user ) => {
-										const userId = this.getWpcomUserId( user );
+										const userId = getWpcomUserId( user );
 
 										return (
 											<option key={ userId } value={ userId }>
@@ -326,7 +326,7 @@ class TransferOtherUser extends React.Component {
 	filterAvailableUsers( users ) {
 		return users.filter(
 			( user ) =>
-				! this.getWpcomUserId( user ) || this.getWpcomUserId( user ) !== this.props.currentUser.ID
+				getWpcomUserId( user ) !== false && getWpcomUserId( user ) !== this.props.currentUser.ID
 		);
 	}
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import { connect, useSelector } from 'react-redux';
-import { find, omit } from 'lodash';
+import { find } from 'lodash';
 import page from 'page';
 import { localize } from 'i18n-calypso';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -223,7 +223,8 @@ class TransferOtherUser extends React.Component {
 		);
 
 		if ( ! currentUserCanManage ) {
-			return <NonOwnerCard { ...omit( this.props, [ 'children' ] ) } />;
+			const { domains, selectedDomainName } = this.props;
+			return <NonOwnerCard domains={ domains } selectedDomainName={ selectedDomainName } />;
 		}
 
 		const { isMapping, translate, users } = this.props;

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import { connect, useSelector } from 'react-redux';
-import { find } from 'lodash';
 import page from 'page';
 import { localize } from 'i18n-calypso';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -125,8 +124,7 @@ class TransferOtherUser extends React.Component {
 	}
 
 	getSelectedUserDisplayName() {
-		const selectedUser = find(
-			this.props.users,
+		const selectedUser = this.props.users.find(
 			( user ) => getWpcomUserId( user ) === Number( this.state.selectedUserId )
 		);
 


### PR DESCRIPTION
Some additional cleanups of `TransferToOtherUser`, mainly removing Lodash.

I believe there was a bug in `filterAvailableUsers`: a wrong condition that fails to filter out users who don't have a linked wpcom account. Do you agree @tyxla?