### PR TITLE
E2E: Fix flakiness in the gutenberg editor publish flow.

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -33,6 +33,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		this.publishingSpinnerSelector = By.css(
 			'.editor-post-publish-panel__content .components-spinner'
 		);
+		this.closePublishPanelButtonSelector = By.css(
+			'.editor-post-publish-panel__header button[aria-label="Close panel"]'
+		);
 	}
 
 	static async Expect( driver, editorType ) {
@@ -71,10 +74,14 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async publish( { visit = false, closePanel = true } = {} ) {
 		await driverHelper.clickWhenClickable( this.driver, this.prePublishButtonSelector );
 		await driverHelper.clickWhenClickable( this.driver, this.publishButtonSelector );
-		// Let's give publishing request enough time to finish. Sometimes it takes
-		// way more than the default 20 seconds, and the cost of waiting a bit
-		// longer is definitely lower than the cost of repeating the whole spec.
-		await driverHelper.waitTillNotPresent( this.driver, this.publishingSpinnerSelector, 60000 );
+
+		// When publishing request completes, the close button appears.
+		// We use the existence of the close button to determine that the publishing request is completed
+		// before moving on to the next step.
+		await driverHelper.waitUntilLocatedAndVisible(
+			this.driver,
+			this.closePublishPanelButtonSelector
+		);
 
 		if ( closePanel ) {
 			try {
@@ -547,7 +554,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async closePublishedPanel() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.editor-post-publish-panel__header button[aria-label="Close panel"]' )
+			this.closePublishPanelButtonSelector
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `GutenbergEditorComponent.publish()` function determines whether a publishing API request is complete checking if the publishing spinner icon disappears.

The flakiness comes in when the spinner icon disappears too quickly before the driver has a chance to look for the spinner icon.

Another way to determine whether or not the publishing API request is to check for the existence of the Close Button of the publishing panel.

This is because the Close Button only appears when the publishing API request completes.

#### Testing instructions

* Check the TeamCity/CircleCI E2E desktop test and ensure that the `Can publish and view content` step passes (after running the test multiple times).
OR
* Run `yarn mocha --inspect specs-gutenberg/wp-calypso-gutenberg-post-editor-spec.js` locally, for multiple times, and ensure that `Can publish and view content` passes.
