### PR TITLE
Signup plans step: Direct 100% mobile traffic to vertical plans layout

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -388,14 +388,14 @@ export class PlanFeaturesHeader extends Component {
 							currencyCode={ currencyCode }
 							rawPrice={ fullPrice }
 							displayFlatPrice={ displayFlatPrice }
-							displayPerMonthNotation={ true }
+							displayPerMonthNotation={ false }
 							original
 						/>
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ discountedPrice }
 							displayFlatPrice={ displayFlatPrice }
-							displayPerMonthNotation={ true }
+							displayPerMonthNotation={ false }
 							discounted
 						/>
 					</div>

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -207,7 +207,7 @@ export class PlanFeaturesHeader extends Component {
 		const price = formatCurrency( rawPrice, currencyCode );
 		const isDiscounted = !! discountPrice;
 
-		if ( planMatches( currentSitePlan.productSlug, { type: TYPE_FREE } ) ) {
+		if ( planMatches( currentSitePlan?.productSlug, { type: TYPE_FREE } ) ) {
 			return isDiscounted
 				? translate(
 						"You'll receive a discount for the first year. The plan will renew at %(price)s.",
@@ -388,14 +388,14 @@ export class PlanFeaturesHeader extends Component {
 							currencyCode={ currencyCode }
 							rawPrice={ fullPrice }
 							displayFlatPrice={ displayFlatPrice }
-							displayPerMonthNotation={ false }
+							displayPerMonthNotation={ true }
 							original
 						/>
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ discountedPrice }
 							displayFlatPrice={ displayFlatPrice }
-							displayPerMonthNotation={ false }
+							displayPerMonthNotation={ true }
 							discounted
 						/>
 					</div>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -374,6 +374,7 @@ export class PlanFeatures extends Component {
 						audience={ planConstantObj.getAudience() }
 						isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 						isLoggedInMonthlyPricing={ this.props.isLoggedInMonthlyPricing }
+						isInSignup={ isInSignup }
 					/>
 					<p className="plan-features__description">{ planDescription }</p>
 					<PlanFeaturesActions

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -20,6 +20,10 @@ $plan-features-sidebar-width: 272px;
 
 		//To be moved to line 66 approximately
 		.plan-features__mobile {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+
 			@media ( min-width: 660px ) and ( max-width: 1040px ) {
 				.plan-features__summary, .plan-features__description {
 					padding: 16px 33px;
@@ -28,10 +32,6 @@ $plan-features-sidebar-width: 272px;
 				.plan-features--signup .plan-features__pricing {
 					padding: 0 7px;
 				}
-			}
-
-			@media ( max-width: 1040px ) {
-				display: block;
 			}
 
 			.plan-features__header {
@@ -99,6 +99,10 @@ $plan-features-sidebar-width: 272px;
 				line-height: normal;
 				text-align: center;
 			}
+
+			.plan-features__mobile-plan {
+				max-width: 408px;
+			}
 		}
 	}
 }
@@ -132,7 +136,6 @@ $plan-features-sidebar-width: 272px;
 .plan-features__mobile {
 	color: var( --color-text-subtle );
 	margin: 0 16px;
-	display: block;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		display: none;
@@ -793,6 +796,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	.plan-features__pricing {
 		margin: 20px 20px -12px;
 		padding: 0;
+		text-align: center;
 
 		@include breakpoint-deprecated( '>660px' ) {
 			margin-bottom: 0;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -349,8 +349,11 @@ export default connect(
 		showTreatmentPlansReorderTest:
 			'treatment' === plans_reorder_abtest_variation || isTreatmentPlansReorderTest( state ),
 		isLoadingExperiment: isLoading( state ),
+		// IMPORTANT NOTE: The following is always set to true. It's a hack to resolve the bug reported
+		// in https://github.com/Automattic/wp-calypso/issues/50896, till a proper cleanup and deploy of
+		// treatment for the `vertical_plan_listing_v2` experiment is implemented.
 		isInVerticalScrollingPlansExperiment:
-			'treatment' === getVariationForUser( state, 'vertical_plan_listing_v2' ),
+			true || 'treatment' === getVariationForUser( state, 'vertical_plan_listing_v2' ),
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep }
 )( localize( PlansStep ) );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -36,7 +36,7 @@ import { isTreatmentPlansReorderTest } from 'calypso/state/marketing/selectors';
  */
 import './style.scss';
 import { Experiment } from 'calypso/components/experiment';
-import { getVariationForUser, isLoading } from 'calypso/state/experiments/selectors';
+import { isLoading } from 'calypso/state/experiments/selectors';
 import PulsingDot from 'calypso/components/pulsing-dot';
 import { isTabletResolution, isDesktop } from '@automattic/viewport';
 
@@ -187,9 +187,7 @@ export class PlansStep extends Component {
 						domainName={ this.getDomainName() }
 						customerType={ this.getCustomerType() }
 						disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
-						plansWithScroll={
-							isInVerticalScrollingPlansExperiment ? this.state.plansWithScroll : true
-						}
+						plansWithScroll={ isDesktop() }
 						planTypes={ planTypes }
 						flowName={ flowName }
 						customHeader={ this.getGutenboardingHeader() }
@@ -352,8 +350,7 @@ export default connect(
 		// IMPORTANT NOTE: The following is always set to true. It's a hack to resolve the bug reported
 		// in https://github.com/Automattic/wp-calypso/issues/50896, till a proper cleanup and deploy of
 		// treatment for the `vertical_plan_listing_v2` experiment is implemented.
-		isInVerticalScrollingPlansExperiment:
-			true || 'treatment' === getVariationForUser( state, 'vertical_plan_listing_v2' ),
+		isInVerticalScrollingPlansExperiment: true,
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep }
 )( localize( PlansStep ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We launched an A/B test to change the onboarding plans step layout to be vertical instead of the horizontal scroll. The treatment is a winner, so we're launching 100% traffic to traffic. The experiment P2 post is in pbxNRc-D0-p2, and the experiment was launched by https://github.com/Automattic/wp-calypso/pull/48728.
* This PR does not do a proper cleanup of the experiment code, it simply directs traffic to treatment. The urgency is because we've a high priority bug for `ar` locale which will be fixed with the treatment UI. Bug https://github.com/Automattic/wp-calypso/issues/50896.
* This PR does a slight CSS tweak for tablet views to not take the full width since that looks ugly. 

### Mobile
<img width="309" alt="Screenshot 2021-04-12 at 8 21 14 PM" src="https://user-images.githubusercontent.com/1269602/114427948-3be4f000-9bd9-11eb-810f-96c3075b8d56.png">

`ar` locale:

<img width="306" alt="Screenshot 2021-04-12 at 8 31 06 PM" src="https://user-images.githubusercontent.com/1269602/114429131-a4809c80-9bda-11eb-9bdb-0e0ca14f2f9b.png">


### Tablet (small)

<img width="386" alt="Screenshot 2021-04-12 at 8 21 42 PM" src="https://user-images.githubusercontent.com/1269602/114428016-4f905680-9bd9-11eb-8fb1-9ab069bb37d7.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In a mobile viewport, visit /start and signup for a new account
* In the signup flow plans step, verify the UI displays the plans in vertical order. as per the screenshots shown in the experiment post pbxNRc-D0-p2. Verify also for tablet viewports. Desktop viewport should be unaffected by this change.
* Verify the above for non-EN locales, especially `ar`. 
* Confirm that Calypso's /plans page UI is unaffected, in both desktop and mobile viewports.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
