### PR TITLE
Show per month copy for discounted price

### DIFF
--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -114,13 +114,13 @@ export class PlanFeaturesComparisonHeader extends Component {
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ rawPrice }
-							displayPerMonthNotation={ false }
+							displayPerMonthNotation={ true }
 							original
 						/>
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ discountPrice }
-							displayPerMonthNotation={ false }
+							displayPerMonthNotation={ true }
 							discounted
 						/>
 					</div>

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -388,14 +388,14 @@ export class PlanFeaturesHeader extends Component {
 							currencyCode={ currencyCode }
 							rawPrice={ fullPrice }
 							displayFlatPrice={ displayFlatPrice }
-							displayPerMonthNotation={ false }
+							displayPerMonthNotation={ true }
 							original
 						/>
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ discountedPrice }
 							displayFlatPrice={ displayFlatPrice }
-							displayPerMonthNotation={ false }
+							displayPerMonthNotation={ true }
 							discounted
 						/>
 					</div>

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -453,7 +453,7 @@ describe( 'PlanFeaturesHeader.renderPriceGroup()', () => {
 		expect( props1.discounted ).toBe( false );
 		expect( props1.original ).toBe( true );
 		expect( props1.currencyCode ).toBe( 'USD' );
-		expect( props1.displayPerMonthNotation ).toBe( false );
+		expect( props1.displayPerMonthNotation ).toBe( true );
 
 		// We need the dive() here to pick up defaultProps
 		const props2 = wrapper.find( PlanPrice ).at( 1 ).dive().props();
@@ -461,7 +461,7 @@ describe( 'PlanFeaturesHeader.renderPriceGroup()', () => {
 		expect( props2.discounted ).toBe( true );
 		expect( props2.original ).toBe( false );
 		expect( props2.currencyCode ).toBe( 'USD' );
-		expect( props2.displayPerMonthNotation ).toBe( false );
+		expect( props2.displayPerMonthNotation ).toBe( true );
 	} );
 } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In INR, PHP and MXN currencies, we show a discounted pricing in the signup plans step. The "per month" copy was missing, and this PR adds back the copy.

### BEFORE

<img width="1626" alt="Screenshot 2021-04-12 at 6 54 28 PM" src="https://user-images.githubusercontent.com/1269602/114430373-fd9d0000-9bdb-11eb-99d0-e0de8c788985.png">

### AFTER

<img width="1613" alt="Screenshot 2021-04-12 at 6 53 54 PM" src="https://user-images.githubusercontent.com/1269602/114430405-04c40e00-9bdc-11eb-9103-72fcd7d77e22.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In INR currency, go through the signup flow and in the signup plans step, verify that you see "per month" next to the plan price.
* Confirm Calypso's /plans page is unaffected.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

