### PR TITLE
Jetpack Plans Page: Fix incorrect rendered price

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -119,8 +119,10 @@ const DisplayPrice = ( {
 		);
 	}
 
-	const couponOriginalPrice = discountedPrice ?? originalPrice;
-	const couponDiscountedPrice = ( discountedPrice ?? originalPrice ) * FRESHPACK_PERCENTAGE;
+	const couponOriginalPrice = parseFloat( ( discountedPrice ?? originalPrice ).toFixed( 2 ) );
+	const couponDiscountedPrice = parseFloat(
+		( ( discountedPrice ?? originalPrice ) * FRESHPACK_PERCENTAGE ).toFixed( 2 )
+	);
 
 	return (
 		<div className="jetpack-product-card__price">


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes a bug where, on the Jetpack plans/pricing page, the product price (for Jetpack Backup Daily and Scan) was being incorrectly rendered as  6.00 when the price is supposed to be 7. (When viewing the page with CAD currency.)
See _before_ and _after_ screenshots below:

Related to: p1618146049033800-slack-CQXNTE9K9

#### Implementation notes
- The `getCurrencyObject` function (imported from '@automattic/format-currency') used by the [PlanPrice component](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/plan-price/index.jsx) was returning the rounded down price of 6.00 when passing it a rawPrice of 6.99999.  
- Although the PlanPrice component will return the proper formatting for the currently-loaded locale (i.e., locale-specific thousands and decimal separators), I believe the  component expects the rawPrice value to be properly rounded already.
- As a solution I rounded the `rawPrice` value first before passing it into the PlanPrice component, using `parseFloat(  priceValue.toFixed( 2 ) )`

#### Before:
<img width="406" alt="Markup 2021-04-12 at 16 36 51" src="https://user-images.githubusercontent.com/11078128/114458728-910b0c80-9bad-11eb-9409-643dfb01adab.png">

#### After: 
<img width="420" alt="Screenshot on 2021-04-12 at 16-37-54" src="https://user-images.githubusercontent.com/11078128/114458797-ac761780-9bad-11eb-89ef-ea7c208ec0dc.png">

### Testing instructions

- From in the Store Admin, set your user **Currency** to `CAD`.
- Open wordpress.com, select a site with Jetpack Free, and visit the Plans page, `https://wordpress.com/plans:site`.
- Verify you see the **incorrect** price of `6.00` for Jetpack Backup Daily, and Scan.
- Now checkout and run this PR in Calypso blue (or green).
- Select the site with Jetpack _Free_ plan and visit the Plans page, `http://calypso.localhost:3000/plans/:site`
- Verify that the price for both 'Jetpack Backup Daily' and 'Scan' are now displaying the **correct** price of `7`.
- Compare all the other product prices and make sure all other prices look correct.

