### PR TITLE
Nav Unification: Welcome Modal - Fix Typo

### DIFF
--- a/client/blocks/nav-unification-modal/index.jsx
+++ b/client/blocks/nav-unification-modal/index.jsx
@@ -116,7 +116,7 @@ const Modal = () => {
 							}
 							heading={ translate( 'Do even more' ) }
 							content={ translate(
-								'Advanced admin features have a new home! You can find it in your account settings'
+								'Advanced admin features have a new home! You can find it in your Account Settings.'
 							) }
 						/>
 					),
@@ -135,7 +135,7 @@ const Modal = () => {
 							}
 							heading={ translate( 'Create in color' ) }
 							content={ translate(
-								'Now you can choose a new color for your dashboard in {{a}}account settings{{/a}}.',
+								'Now you can choose a new color for your dashboard in {{a}}Account Settings{{/a}}.',
 								{
 									components: {
 										a: <a href="/me/account" />,

--- a/client/blocks/nav-unification-modal/index.jsx
+++ b/client/blocks/nav-unification-modal/index.jsx
@@ -116,7 +116,7 @@ const Modal = () => {
 							}
 							heading={ translate( 'Do even more' ) }
 							content={ translate(
-								'Advanced admin features have a new home! You can find it in your {{a}}Account Settings{{/a}}.',
+								'Advanced admin features have a new home! You can find them in your {{a}}Account Settings{{/a}}.',
 								{
 									components: {
 										a: <a href="/me/account" target="_blank" rel="noopener noreferrer" />,

--- a/client/blocks/nav-unification-modal/index.jsx
+++ b/client/blocks/nav-unification-modal/index.jsx
@@ -116,7 +116,12 @@ const Modal = () => {
 							}
 							heading={ translate( 'Do even more' ) }
 							content={ translate(
-								'Advanced admin features have a new home! You can find it in your Account Settings.'
+								'Advanced admin features have a new home! You can find it in your {{a}}Account Settings{{/a}}.',
+								{
+									components: {
+										a: <a href="/me/account" target="_blank" rel="noopener noreferrer" />,
+									},
+								}
 							) }
 						/>
 					),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a typo in the Welcome Modal

The original issue reports that there should be a full stop at the end of the sentence. While I've added that, I'm also strongly inclined to think that "account settings" should be replaced with "Account Settings". It's the name of a section, and that's consistent with some of the references elsewhere. 

https://github.com/Automattic/wp-calypso/blob/38c37bbfe35b8c741c4e346637987ddc0fb3ab59/client/blocks/inline-help/contextual-help.js#L205

Happy to change that if it's intentional though! :)

#### Testing instructions

It's probably enough to just check the code, to be honest.

<img width="848" alt="Screenshot 2021-04-12 at 22 34 05" src="https://user-images.githubusercontent.com/43215253/114465703-620d8e80-9bdf-11eb-8539-e87e5554cd35.png">

Fixes #51869 
cc @tjcafferkey, @cpapazoglou 