### PR TITLE
Event Countdown Block: Remove button classname from date picker button to fix CSS clashes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/edit.js
@@ -50,13 +50,7 @@ const edit = ( { attributes, setAttributes, className } ) => {
 				<Dropdown
 					position="bottom left"
 					renderToggle={ ( { onToggle, isOpen } ) => (
-						<Button
-							className="button"
-							onClick={ onToggle }
-							aria-expanded={ isOpen }
-							aria-live="polite"
-							isSecondary
-						>
+						<Button onClick={ onToggle } aria-expanded={ isOpen } aria-live="polite" isSecondary>
 							{ label }
 						</Button>
 					) }


### PR DESCRIPTION
While deploying https://github.com/Automattic/wp-calypso/pull/51801 I noticed an existing issue with the Event Countdown block's date picker button where some themes' styles would target that button, resulting in styling issues. It seems that we've been adding a `button` classname to this button, which might have been necessary in the past, but isn't needed anymore.

#### Changes proposed in this Pull Request

* Remove `button` class name from Event Countdown date picker button

#### Screenshots

Comparing the placeholder state of the Event Countdown block across a few different common themes:

| Before (Twenty Twenty One) | After (Twenty Twenty One) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/114495782-0c2dfa80-9c62-11eb-9963-4a8dbb278ee7.png) | ![image](https://user-images.githubusercontent.com/14988353/114495793-12bc7200-9c62-11eb-9ec0-4cd498128fa6.png) |

| Before (Barnsbury) | After (Barnsbury) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/114496103-95ddc800-9c62-11eb-9801-67121d6556b7.png) | ![image](https://user-images.githubusercontent.com/14988353/114495923-4d260f00-9c62-11eb-920b-2b0d49f2f07e.png) |

| Before (Leven) | After (Leven) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/114495952-5a42fe00-9c62-11eb-8ba8-6088419c4e46.png) | ![image](https://user-images.githubusercontent.com/14988353/114495965-60d17580-9c62-11eb-9a8e-0db7a92bcd0d.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this change in your sandbox: `install-plugin.sh etk update/event-countdown-block-to-not-set-button-class-name`
* Sandbox your test site, and work through each of the above themes (Twenty Twenty One, Barnsbury, Leven) and confirm that in the post editor, the Choose Date button renders consistently as a button with a red border and transparent background, with text that is centred vertically.
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #51801 
