### PR TITLE
Remove calypso/signup/pageLoad recaptcha action

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -64,16 +64,14 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 	const localizeUrl = useLocalizeUrl();
 
 	useEffect( () => {
-		initGoogleRecaptcha(
-			'g-recaptcha',
-			'calypso/signup/pageLoad',
-			config( 'google_recaptcha_site_key' )
-		).then( ( result ) => {
-			if ( ! result ) {
-				return;
+		initGoogleRecaptcha( 'g-recaptcha', config( 'google_recaptcha_site_key' ) ).then(
+			( clientId ) => {
+				if ( clientId === null ) {
+					return;
+				}
+				setRecaptchaClientId( clientId );
 			}
-			setRecaptchaClientId( result.clientId );
-		} );
+		);
 	}, [ setRecaptchaClientId ] );
 
 	const handleSignUp = async ( event: React.FormEvent< HTMLFormElement > ) => {

--- a/client/landing/gutenboarding/lib/analytics/recaptcha.ts
+++ b/client/landing/gutenboarding/lib/analytics/recaptcha.ts
@@ -100,21 +100,17 @@ export async function recordGoogleRecaptchaAction( clientId: number, action: str
 }
 
 /**
- * @typedef RecaptchaActionResult
- * @property {string} token
- * @property {number} clientId
- */
-
-/**
  * Records reCAPTCHA action, loading Google script if necessary.
  *
- * @param {string} elementId - a DOM id in which to render the reCAPTCHA client
- * @param {string} action - name of action to record in reCAPTCHA
- * @param {string} siteKey - reCAPTCHA site key
+ * @param elementId - a DOM id in which to render the reCAPTCHA client
+ * @param siteKey - reCAPTCHA site key
  *
- * @returns {RecaptchaActionResult|null} either the reCAPTCHA token and clientId, or null if the function fails
+ * @returns either the reCAPTCHA token and clientId, or null if the function fails
  */
-export async function initGoogleRecaptcha( elementId: string, action: string, siteKey: string ) {
+export async function initGoogleRecaptcha(
+	elementId: string,
+	siteKey: string
+): Promise< number | null > {
 	if ( ! siteKey ) {
 		return null;
 	}
@@ -131,17 +127,12 @@ export async function initGoogleRecaptcha( elementId: string, action: string, si
 			return null;
 		}
 
-		const token = await recordGoogleRecaptchaAction( clientId, action );
-		if ( token == null ) {
-			return null;
-		}
-
-		debug( 'initGoogleRecaptcha: [Success]', action, token, clientId );
-		return { token, clientId };
+		debug( 'initGoogleRecaptcha: [Success]', clientId );
+		return clientId;
 	} catch ( error ) {
 		// We don't want errors interrupting our flow, so convert any exceptions
 		// into return values.
-		debug( 'initGoogleRecaptcha: [Error]', action, error );
+		debug( 'initGoogleRecaptcha: [Error]', error );
 		return null;
 	}
 }

--- a/client/lib/analytics/recaptcha.js
+++ b/client/lib/analytics/recaptcha.js
@@ -80,21 +80,14 @@ export async function recordGoogleRecaptchaAction( clientId, action ) {
 }
 
 /**
- * @typedef RecaptchaActionResult
- * @property {string} token
- * @property {number} clientId
- */
-
-/**
  * Records reCAPTCHA action, loading Google script if necessary.
  *
  * @param {string} elementId - a DOM id in which to render the reCAPTCHA client
- * @param {string} action - name of action to record in reCAPTCHA
  * @param {string} siteKey - reCAPTCHA site key
  *
- * @returns {RecaptchaActionResult|null} either the reCAPTCHA token and clientId, or null if the function fails
+ * @returns {number|null} either the reCAPTCHA clientId, or null if the function fails
  */
-export async function initGoogleRecaptcha( elementId, action, siteKey ) {
+export async function initGoogleRecaptcha( elementId, siteKey ) {
 	if ( ! siteKey ) {
 		return null;
 	}
@@ -111,17 +104,12 @@ export async function initGoogleRecaptcha( elementId, action, siteKey ) {
 			return null;
 		}
 
-		const token = await recordGoogleRecaptchaAction( clientId, action );
-		if ( token == null ) {
-			return null;
-		}
-
-		debug( 'initGoogleRecaptcha: [Success]', action, token, clientId );
-		return { token, clientId };
+		debug( 'initGoogleRecaptcha: [Success]', clientId );
+		return clientId;
 	} catch ( error ) {
 		// We don't want errors interrupting our flow, so convert any exceptions
 		// into return values.
-		debug( 'initGoogleRecaptcha: [Error]', action, error );
+		debug( 'initGoogleRecaptcha: [Error]', error );
 		return null;
 	}
 }

--- a/client/signup/recaptcha/index.jsx
+++ b/client/signup/recaptcha/index.jsx
@@ -18,18 +18,16 @@ import './style.scss';
 
 function Recaptcha( { badgePosition } ) {
 	useEffect( () => {
-		initGoogleRecaptcha(
-			'g-recaptcha',
-			'calypso/checkout/pageLoad',
-			config( 'google_recaptcha_site_key' )
-		).then( ( result ) => {
-			if ( ! result ) {
-				return;
-			}
+		initGoogleRecaptcha( 'g-recaptcha', config( 'google_recaptcha_site_key' ) ).then(
+			( clientId ) => {
+				if ( clientId === null ) {
+					return;
+				}
 
-			const { dispatch } = defaultRegistry;
-			dispatch( 'wpcom' ).setRecaptchaClientId( parseInt( result.clientId ) );
-		} );
+				const { dispatch } = defaultRegistry;
+				dispatch( 'wpcom' ).setRecaptchaClientId( parseInt( clientId ) );
+			}
+		);
 	}, [] );
 
 	return <div id="g-recaptcha" data-badge={ badgePosition }></div>;

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -179,22 +179,19 @@ export class UserStep extends Component {
 	}
 
 	initGoogleRecaptcha() {
-		initGoogleRecaptcha(
-			'g-recaptcha',
-			'calypso/signup/pageLoad',
-			config( 'google_recaptcha_site_key' )
-		).then( ( result ) => {
-			if ( ! result ) {
-				return;
+		initGoogleRecaptcha( 'g-recaptcha', config( 'google_recaptcha_site_key' ) ).then(
+			( clientId ) => {
+				if ( clientId === null ) {
+					return;
+				}
+
+				this.setState( { recaptchaClientId: clientId } );
+
+				this.props.saveSignupStep( {
+					stepName: this.props.stepName,
+				} );
 			}
-
-			this.setState( { recaptchaClientId: result.clientId } );
-
-			this.props.saveSignupStep( {
-				stepName: this.props.stepName,
-				recaptchaToken: typeof result.token === 'string' ? result.token : undefined,
-			} );
-		} );
+		);
 	}
 
 	save = ( form ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `calypso/signup/pageLoad` recaptcha action

We've been recording the page-loaded event in recaptcha, but then never do anything with the result. It's likely a hang over from development.

Removing the action reduces the number of recaptcha calls we make, which aren't free: pbAok1-25D-p2

You may notice there's code duplication between the old and new signup code:
- `client/landing/gutenboarding/lib/analytics/recaptcha.ts`
- `client/lib/analytics/recaptcha.js`
That's because early in gutenboarding it was easier to just copy the recaptcha code than to figure out how to share it between calypso and gutenboarding (should probably be moved to a package now).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `/start` in private tab and open network dev tools
* Sign up for an account and inspect the `/users/new` network request
* Verify that the `g-recaptcha-response` param is still part of the request (this verifies that we're still recording the `calypso/signup/formSubmit` action in recaptcha)
* Open `/new` in a private tab and open network dev tools (make sure preserve log is enabled)
* Proceed through gutenboarding and create a new account, inspect the `/users/new` network request
* Verify that the `g-recaptcha-response` param is still part of the request

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #51804
