### PR TITLE
AuthorSelector: use `useUsersQuery` to fetch data

### DIFF
--- a/client/blocks/author-selector/index.jsx
+++ b/client/blocks/author-selector/index.jsx
@@ -50,7 +50,7 @@ const AuthorSelector = ( {
 			}
 			return true;
 		} ) ?? [];
-	const listKey = [ 'followers', siteId, search ].join( '-' );
+	const listKey = [ 'authors', siteId, search ].join( '-' );
 
 	return (
 		<SwitcherShell

--- a/client/blocks/author-selector/index.jsx
+++ b/client/blocks/author-selector/index.jsx
@@ -15,7 +15,16 @@ import useUsersQuery from 'calypso/data/users/use-users-query';
  */
 import './style.scss';
 
-const AuthorSelector = ( { siteId, exclude, ...rest } ) => {
+const AuthorSelector = ( {
+	allowSingleUser,
+	children,
+	exclude,
+	ignoreContext,
+	onSelect,
+	popoverPosition,
+	siteId,
+	transformAuthor,
+} ) => {
 	const [ search, setSearch ] = React.useState( '' );
 
 	const fetchOptions = { number: 50 };
@@ -45,35 +54,40 @@ const AuthorSelector = ( { siteId, exclude, ...rest } ) => {
 
 	return (
 		<SwitcherShell
-			users={ users }
-			totalUsers={ data?.total }
-			siteId={ siteId }
-			search={ search }
-			updateSearch={ setSearch }
+			allowSingleUser={ allowSingleUser }
 			fetchNextPage={ fetchNextPage }
 			hasNextPage={ hasNextPage }
-			isLoading={ isLoading }
+			ignoreContext={ ignoreContext }
 			isFetchingNextPage={ isFetchingNextPage }
+			isLoading={ isLoading }
 			listKey={ listKey }
-			{ ...rest }
-		/>
+			onSelect={ onSelect }
+			popoverPosition={ popoverPosition }
+			search={ search }
+			siteId={ siteId }
+			transformAuthor={ transformAuthor }
+			updateSearch={ setSearch }
+			users={ users }
+		>
+			{ children }
+		</SwitcherShell>
 	);
 };
 
 AuthorSelector.propTypes = {
-	siteId: PropTypes.number.isRequired,
-	onSelect: PropTypes.func,
-	exclude: PropTypes.oneOfType( [ PropTypes.arrayOf( PropTypes.number ), PropTypes.func ] ),
 	allowSingleUser: PropTypes.bool,
+	exclude: PropTypes.oneOfType( [ PropTypes.arrayOf( PropTypes.number ), PropTypes.func ] ),
+	onSelect: PropTypes.func,
 	popoverPosition: PropTypes.string,
+	siteId: PropTypes.number.isRequired,
 	transformAuthor: PropTypes.func,
 };
 
 AuthorSelector.defaultProps = {
-	showAuthorMenu: false,
-	onClose: function () {},
 	allowSingleUser: false,
+	onClose: function () {},
 	popoverPosition: 'bottom left',
+	showAuthorMenu: false,
 };
 
 export default AuthorSelector;

--- a/client/blocks/author-selector/index.jsx
+++ b/client/blocks/author-selector/index.jsx
@@ -28,10 +28,11 @@ const AuthorSelector = ( {
 	const [ search, setSearch ] = React.useState( '' );
 
 	const fetchOptions = { number: 50 };
+	const trimmedSearch = search.trim();
 
-	if ( search ) {
+	if ( trimmedSearch ) {
 		fetchOptions.number = 20; // make search a little faster
-		fetchOptions.search = `*${ search.trim() }*`;
+		fetchOptions.search = `*${ trimmedSearch }*`;
 		fetchOptions.search_columns = [ 'user_login', 'display_name' ];
 	}
 

--- a/client/blocks/author-selector/index.jsx
+++ b/client/blocks/author-selector/index.jsx
@@ -86,7 +86,6 @@ AuthorSelector.propTypes = {
 
 AuthorSelector.defaultProps = {
 	allowSingleUser: false,
-	onClose: function () {},
 	popoverPosition: 'bottom left',
 	showAuthorMenu: false,
 };

--- a/client/blocks/author-selector/index.jsx
+++ b/client/blocks/author-selector/index.jsx
@@ -16,12 +16,12 @@ import useUsersQuery from 'calypso/data/users/use-users-query';
 import './style.scss';
 
 const AuthorSelector = ( {
-	allowSingleUser,
+	allowSingleUser = false,
 	children,
 	exclude,
 	ignoreContext,
 	onSelect,
-	popoverPosition,
+	popoverPosition = 'bottom left',
 	siteId,
 	transformAuthor,
 } ) => {
@@ -82,12 +82,6 @@ AuthorSelector.propTypes = {
 	popoverPosition: PropTypes.string,
 	siteId: PropTypes.number.isRequired,
 	transformAuthor: PropTypes.func,
-};
-
-AuthorSelector.defaultProps = {
-	allowSingleUser: false,
-	popoverPosition: 'bottom left',
-	showAuthorMenu: false,
 };
 
 export default AuthorSelector;

--- a/client/blocks/author-selector/index.jsx
+++ b/client/blocks/author-selector/index.jsx
@@ -28,7 +28,7 @@ const AuthorSelector = ( {
 	const [ search, setSearch ] = React.useState( '' );
 
 	const fetchOptions = { number: 50 };
-	const trimmedSearch = search.trim();
+	const trimmedSearch = search.trim?.();
 
 	if ( trimmedSearch ) {
 		fetchOptions.number = 20; // make search a little faster

--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -26,9 +26,6 @@ const debug = debugModule( 'calypso:author-selector' );
 class AuthorSwitcherShell extends Component {
 	static propTypes = {
 		users: PropTypes.array,
-		numUsersFetched: PropTypes.number,
-		totalUsers: PropTypes.number,
-		usersCurrentOffset: PropTypes.number,
 		allowSingleUser: PropTypes.bool,
 		popoverPosition: PropTypes.string,
 		ignoreContext: PropTypes.shape( { getDOMNode: PropTypes.func } ),

--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -42,7 +42,7 @@ class AuthorSwitcherShell extends Component {
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( ! nextProps.siteId || nextProps.siteId !== this.props.siteId ) {
-			this.props.updateSearch( false );
+			this.props.updateSearch( '' );
 		}
 	}
 
@@ -146,7 +146,7 @@ class AuthorSwitcherShell extends Component {
 		this.setState( {
 			showAuthorMenu: false,
 		} );
-		this.props.updateSearch( false );
+		this.props.updateSearch( '' );
 	};
 
 	renderAuthor = ( rawAuthor ) => {
@@ -183,7 +183,7 @@ class AuthorSwitcherShell extends Component {
 		this.setState( {
 			showAuthorMenu: false,
 		} );
-		this.props.updateSearch( false );
+		this.props.updateSearch( '' );
 	};
 
 	getAuthorItemGUID = ( author ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* AuthorSelector: use `useUsersQuery` to fetch user data

#### Testing instructions

`<AuthorSelector />` is used at three different places, please check all of them:

- `/people/edit/<slug>/<user>`
- `/import/<site>` after uploading an xml file
- `/settings/manage-connection/<site-url>` (Jetpack sites)

Basically, those dropdowns should behave exactly as on prod. Choose a user and try to apply the corresponding action or check if the state updates correctly if performing the action isn't applicable.

Also, make sure to test this with a site with more than 10 users to enable the search field and make sure that works as well.

#### Important note:

There's a preexisting bug in InfiniteList which is visible in the `<DeleteUser />` card where the bottom placeholder is shown but shouldn't. I tried to see if there's a quick fix but, unfortunately, there's not and fixing it seems to be out of scope for this PR (I'll attach a screenshot below).

<img width="337" alt="Screenshot 2021-04-13 at 10 09 10" src="https://user-images.githubusercontent.com/9202899/114519115-5c946080-9c40-11eb-806d-66c353442f7a.png">

(the red area shouldn't be there)

It seems that the position on the y-axis of the screen is necessary to be over a certain threshold so this bug becomes visible. If you move the `<DeleteCard />` to the top of the page, it works correctly 😕 


Related to #24150
