### PR TITLE
AuthorMappingPane: use `useUsersQuery` to fetch total users

### DIFF
--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -10,12 +10,10 @@ import React from 'react';
  * Internal dependencies
  */
 import AuthorMapping from './author-mapping-item';
-import SiteUsersFetcher from 'calypso/components/site-users-fetcher';
-import UsersStore from 'calypso/lib/users/store';
-
 import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-action-buttons/container';
 import ImporterActionButton from 'calypso/my-sites/importer/importer-action-buttons/action-button';
 import ImporterCloseButton from 'calypso/my-sites/importer/importer-action-buttons/close-button';
+import useUsersQuery from 'calypso/data/users/use-users-query';
 
 /**
  * Style dependencies
@@ -122,13 +120,6 @@ class AuthorMappingPane extends React.PureComponent {
 		}
 	};
 
-	getUserCount = () => {
-		const fetchOptions = this.getFetchOptions( 50 );
-		const { totalUsers } = UsersStore.getPaginationData( fetchOptions );
-
-		return totalUsers;
-	};
-
 	render() {
 		const {
 			hasSingleAuthor,
@@ -141,19 +132,18 @@ class AuthorMappingPane extends React.PureComponent {
 			sourceType,
 			importerStatus,
 			site,
+			totalUsers,
 		} = this.props;
 		const canStartImport = hasSingleAuthor || sourceAuthors.some( ( author ) => author.mappedTo );
-		const targetUserCount = this.getUserCount();
 		const mappingDescription = this.getMappingDescription(
 			sourceAuthors.length,
-			targetUserCount,
+			totalUsers,
 			targetTitle,
 			sourceType
 		);
 
 		return (
 			<div className="importer__mapping-pane">
-				<SiteUsersFetcher fetchOptions={ this.getFetchOptions( { number: 50 } ) } />
 				<div className="importer__mapping-description">{ mappingDescription }</div>
 				<div className="importer__mapping-header">
 					<span className="importer__mapping-source-title">{ sourceTitle }</span>
@@ -181,4 +171,13 @@ class AuthorMappingPane extends React.PureComponent {
 	}
 }
 
-export default localize( AuthorMappingPane );
+const withTotalUsers = ( Component ) => ( props ) => {
+	const { siteId } = props;
+	const { data } = useUsersQuery( siteId, {}, { refetchOnWindowFocus: false } );
+
+	const totalUsers = data?.total ?? 0;
+
+	return <Component totalUsers={ totalUsers } { ...props } />;
+};
+
+export default localize( withTotalUsers( AuthorMappingPane ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `<AuthorMappingPane />` fetch total by using `useUsersQuery` instead of `<SiteUsersFetcher />`

#### Testing instructions

* On a site with >1 author start importing content to your site until you reach the author mapping step
* Make sure the mapping description is displayed correctly (see screenshot)

<img width="754" alt="Screenshot 2021-04-13 at 10 43 45" src="https://user-images.githubusercontent.com/9202899/114524306-640a3880-9c45-11eb-9fff-4329ef43ac6e.png">


Related to #24150 
