### PR TITLE
Hide privacy settings when site is unlaunched

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -573,28 +573,6 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
-	disablePrivacySettings = ( e ) => {
-		e.target.blur();
-	};
-
-	privacySettingsWrapper() {
-		if ( this.props.isUnlaunchedSite ) {
-			return (
-				<>
-					{ this.renderLaunchSite() }
-					<div
-						className="site-settings__disable-privacy-settings"
-						onFocus={ this.disablePrivacySettings }
-					>
-						{ this.privacySettings() }
-					</div>
-				</>
-			);
-		}
-
-		return <>{ this.privacySettings() }</>;
-	}
-
 	render() {
 		const {
 			handleSubmitForm,
@@ -634,7 +612,7 @@ export class SiteSettingsFormGeneral extends Component {
 					</form>
 				</Card>
 
-				{ this.privacySettingsWrapper() }
+				{ this.props.isUnlaunchedSite ? this.renderLaunchSite() : this.privacySettings() }
 
 				{ ! isWPForTeamsSite && ! siteIsJetpack && (
 					<div className="site-settings__footer-credit-container">

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -508,7 +508,6 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 .site-settings__general-settings-launch-site {
 	display: flex;
 	justify-content: space-between;
-	margin-bottom: 1px;
 }
 
 .site-settings__general-settings-launch-site-text {

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -232,22 +232,6 @@ describe( 'SiteSettingsFormGeneral ', () => {
 
 			// We want to show the coming soon setting for existing coming soon v1 sites that have not migrated
 			describe( 'support existing coming soon v1 sites that have not migrated', () => {
-				test( 'Coming soon option should be selected when a site is private and unlaunched (coming soon mode v1 by default)', () => {
-					const newProps = {
-						...testProps,
-						fields: {
-							blog_public: -1,
-						},
-						isUnlaunchedSite: true,
-						// So renderLaunchSite() runs smoothly.
-						siteDomains: [ 'test.com' ],
-					};
-
-					const { getByLabelText } = renderWithRedux( <SiteSettingsFormGeneral { ...newProps } /> );
-					const radioButton = getByLabelText( 'Coming soon', { exact: false } );
-					expect( radioButton ).toBeChecked();
-				} );
-
 				test( 'Should check private option when site is private, but not in coming soon v1 and not private and unlaunched', () => {
 					const newProps = {
 						...testProps,

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -290,6 +290,20 @@ describe( 'SiteSettingsFormGeneral ', () => {
 			} );
 		} );
 
+		describe( 'unlaunched site', () => {
+			it( 'Should not show the site settings UI', () => {
+				testProps = {
+					...testProps,
+					isUnlaunchedSite: true,
+					siteDomains: [ 'example.wordpress.com' ],
+				};
+
+				const { container } = renderWithRedux( <SiteSettingsFormGeneral { ...testProps } /> );
+
+				expect( container.querySelectorAll( '#site-privacy-settings' ) ).toHaveLength( 0 );
+			} );
+		} );
+
 		describe( 'Coming soon plugin availability', () => {
 			test( 'Should hide Coming Soon form element when the site is not atomic or the editing toolkit plugin is not disabled', () => {
 				const newProps = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Currently privacy settings are disabled but still visible
with coming soon v2, the *public* radio button is selected which appears incorrect
this was originally worked on by @Aurorum in https://github.com/Automattic/wp-calypso/pull/46757 but I've picked it up to get this through the CI tests, rebased, and merged.
Fixes #46629

#### Test instructions
for an unlaunched site, the site settings should no longer be visible
<img width="930" alt="Screen Shot 2021-04-13 at 7 40 17 PM" src="https://user-images.githubusercontent.com/22446385/114532373-21ba1900-9c90-11eb-937d-a28c59baf6d4.png">
An existing site can be "unlaunched" like so

```
  wp option --url=yoursite.wordpress.com update launch-status unlaunched

```

Run tests for this feature
```
npx jest --config=test/client/jest.config.js -i client/my-sites/site-settings/test/form-general.jsx
```

fixes #46629