### PR TITLE
withEnhancers: support nested thunks

### DIFF
--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -15,7 +15,6 @@ import {
 	isValidStateWithSchema,
 	withPersistence,
 	withoutPersistence,
-	withEnhancers,
 	serialize,
 	deserialize,
 } from 'calypso/state/utils';
@@ -572,82 +571,6 @@ describe( 'utils', () => {
 
 		test( 'should serialize to `undefined`', () => {
 			expect( serialize( wrapped, 10 ) ).toBeUndefined();
-		} );
-	} );
-
-	describe( '#withEnhancers', () => {
-		it( 'should enhance action creator', () => {
-			const actionCreator = () => ( { type: 'HELLO' } );
-			const enhancedActionCreator = withEnhancers( actionCreator, ( action ) =>
-				Object.assign( { name: 'test' }, action )
-			);
-			const thunk = enhancedActionCreator();
-			const getState = () => ( {} );
-			let dispatchedAction = null;
-			const dispatch = ( action ) => ( dispatchedAction = action );
-			thunk( dispatch, getState );
-
-			expect( dispatchedAction ).toEqual( {
-				name: 'test',
-				type: 'HELLO',
-			} );
-		} );
-
-		it( 'should enhance with multiple enhancers, from last to first', () => {
-			const actionCreator = () => ( { type: 'HELLO' } );
-			const enhancedActionCreator = withEnhancers( actionCreator, [
-				( action ) => Object.assign( { name: 'test' }, action ),
-				( action ) => Object.assign( { name: 'test!!!' }, action ),
-				( action ) => Object.assign( { meetup: 'akumal' }, action ),
-			] );
-			const thunk = enhancedActionCreator();
-			const getState = () => ( {} );
-			let dispatchedAction = null;
-			const dispatch = ( action ) => ( dispatchedAction = action );
-			thunk( dispatch, getState );
-
-			expect( dispatchedAction ).toEqual( {
-				name: 'test',
-				type: 'HELLO',
-				meetup: 'akumal',
-			} );
-		} );
-
-		it( 'should provider enhancers with getState function', () => {
-			let providedGetState = null;
-			const actionCreator = () => ( { type: 'HELLO' } );
-			const enhancedActionCreator = withEnhancers( actionCreator, [
-				( action, getState ) => {
-					providedGetState = getState;
-					Object.assign( { name: 'test' }, action );
-				},
-			] );
-			const thunk = enhancedActionCreator();
-			const getState = () => ( {} );
-			const dispatch = ( action ) => action;
-			thunk( dispatch, getState );
-
-			expect( providedGetState ).toEqual( getState );
-		} );
-
-		it( 'should accept an action creator as first parameter', () => {
-			const actionCreator = () => ( { type: 'HELLO' } );
-			const enhancedActionCreator = withEnhancers(
-				withEnhancers( actionCreator, ( action ) => Object.assign( { name: 'test' }, action ) ),
-				( action ) => Object.assign( { hello: 'world' }, action )
-			);
-
-			const thunk = enhancedActionCreator();
-			const getState = () => ( {} );
-			let dispatchedAction = null;
-			const dispatch = ( action ) => ( dispatchedAction = action );
-			thunk( dispatch, getState );
-
-			expect( dispatchedAction ).toEqual( {
-				name: 'test',
-				hello: 'world',
-				type: 'HELLO',
-			} );
 		} );
 	} );
 } );

--- a/client/state/test/with-enhancers.js
+++ b/client/state/test/with-enhancers.js
@@ -1,0 +1,80 @@
+/**
+ * Internal dependencies
+ */
+import { withEnhancers } from 'calypso/state/utils';
+
+describe( '#withEnhancers', () => {
+	it( 'should enhance action creator', () => {
+		const actionCreator = () => ( { type: 'HELLO' } );
+		const enhancedActionCreator = withEnhancers( actionCreator, ( action ) =>
+			Object.assign( { name: 'test' }, action )
+		);
+		const thunk = enhancedActionCreator();
+		const getState = () => ( {} );
+		let dispatchedAction = null;
+		const dispatch = ( action ) => ( dispatchedAction = action );
+		thunk( dispatch, getState );
+
+		expect( dispatchedAction ).toEqual( {
+			name: 'test',
+			type: 'HELLO',
+		} );
+	} );
+
+	it( 'should enhance with multiple enhancers, from last to first', () => {
+		const actionCreator = () => ( { type: 'HELLO' } );
+		const enhancedActionCreator = withEnhancers( actionCreator, [
+			( action ) => Object.assign( { name: 'test' }, action ),
+			( action ) => Object.assign( { name: 'test!!!' }, action ),
+			( action ) => Object.assign( { meetup: 'akumal' }, action ),
+		] );
+		const thunk = enhancedActionCreator();
+		const getState = () => ( {} );
+		let dispatchedAction = null;
+		const dispatch = ( action ) => ( dispatchedAction = action );
+		thunk( dispatch, getState );
+
+		expect( dispatchedAction ).toEqual( {
+			name: 'test',
+			type: 'HELLO',
+			meetup: 'akumal',
+		} );
+	} );
+
+	it( 'should provider enhancers with getState function', () => {
+		let providedGetState = null;
+		const actionCreator = () => ( { type: 'HELLO' } );
+		const enhancedActionCreator = withEnhancers( actionCreator, [
+			( action, getState ) => {
+				providedGetState = getState;
+				Object.assign( { name: 'test' }, action );
+			},
+		] );
+		const thunk = enhancedActionCreator();
+		const getState = () => ( {} );
+		const dispatch = ( action ) => action;
+		thunk( dispatch, getState );
+
+		expect( providedGetState ).toEqual( getState );
+	} );
+
+	it( 'should accept an action creator as first parameter', () => {
+		const actionCreator = () => ( { type: 'HELLO' } );
+		const enhancedActionCreator = withEnhancers(
+			withEnhancers( actionCreator, ( action ) => Object.assign( { name: 'test' }, action ) ),
+			( action ) => Object.assign( { hello: 'world' }, action )
+		);
+
+		const thunk = enhancedActionCreator();
+		const getState = () => ( {} );
+		let dispatchedAction = null;
+		const dispatch = ( action ) => ( dispatchedAction = action );
+		thunk( dispatch, getState );
+
+		expect( dispatchedAction ).toEqual( {
+			name: 'test',
+			hello: 'world',
+			type: 'HELLO',
+		} );
+	} );
+} );

--- a/client/state/utils/with-enhancers.js
+++ b/client/state/utils/with-enhancers.js
@@ -21,11 +21,11 @@ export const withEnhancers = ( actionCreator, enhancers ) => ( ...args ) => (
 
 	const enhanceAction = ( actionValue ) =>
 		enhancers.reduce( ( result, enhancer ) => enhancer( result, getState ), actionValue );
+	const enhancedDispatch = ( actionValue ) => dispatch( enhanceAction( actionValue ) );
 
 	if ( typeof action === 'function' ) {
-		const newDispatch = ( actionValue ) => dispatch( enhanceAction( actionValue ) );
-		return action( newDispatch, getState );
+		return action( enhancedDispatch, getState );
 	}
 
-	return dispatch( enhanceAction( action ) );
+	return enhancedDispatch( action );
 };

--- a/client/state/utils/with-enhancers.js
+++ b/client/state/utils/with-enhancers.js
@@ -9,23 +9,22 @@
  * @see client/state/analytics/actions/enhanceWithSiteType for an example
  * @see extendAction from @automattic/state-utils for a simpler alternative
  */
-export const withEnhancers = ( actionCreator, enhancers ) => ( ...args ) => (
-	dispatch,
-	getState
-) => {
+export const withEnhancers = ( actionCreator, enhancers ) => ( ...args ) => {
 	const action = actionCreator( ...args );
 
 	if ( ! Array.isArray( enhancers ) ) {
 		enhancers = [ enhancers ];
 	}
 
-	const enhanceAction = ( actionValue ) =>
-		enhancers.reduce( ( result, enhancer ) => enhancer( result, getState ), actionValue );
-	const enhancedDispatch = ( actionValue ) => dispatch( enhanceAction( actionValue ) );
+	return ( dispatch, getState ) => {
+		const enhanceAction = ( actionValue ) =>
+			enhancers.reduce( ( result, enhancer ) => enhancer( result, getState ), actionValue );
+		const enhancedDispatch = ( actionValue ) => dispatch( enhanceAction( actionValue ) );
 
-	if ( typeof action === 'function' ) {
-		return action( enhancedDispatch, getState );
-	}
+		if ( typeof action === 'function' ) {
+			return action( enhancedDispatch, getState );
+		}
 
-	return enhancedDispatch( action );
+		return enhancedDispatch( action );
+	};
 };

--- a/client/state/utils/with-enhancers.js
+++ b/client/state/utils/with-enhancers.js
@@ -20,11 +20,14 @@ export const withEnhancers = ( actionCreator, enhancers ) => ( ...args ) => {
 		const enhanceAction = ( actionValue ) =>
 			enhancers.reduce( ( result, enhancer ) => enhancer( result, getState ), actionValue );
 		const enhancedDispatch = ( actionValue ) => dispatch( enhanceAction( actionValue ) );
+		const thunkDispatch = ( actionValue ) => {
+			if ( typeof actionValue === 'function' ) {
+				return actionValue( thunkDispatch, getState );
+			}
 
-		if ( typeof action === 'function' ) {
-			return action( enhancedDispatch, getState );
-		}
+			return enhancedDispatch( actionValue );
+		};
 
-		return enhancedDispatch( action );
+		return thunkDispatch( action );
 	};
 };

--- a/client/state/utils/with-enhancers.js
+++ b/client/state/utils/with-enhancers.js
@@ -19,15 +19,13 @@ export const withEnhancers = ( actionCreator, enhancers ) => ( ...args ) => (
 		enhancers = [ enhancers ];
 	}
 
+	const enhanceAction = ( actionValue ) =>
+		enhancers.reduce( ( result, enhancer ) => enhancer( result, getState ), actionValue );
+
 	if ( typeof action === 'function' ) {
-		const newDispatch = ( actionValue ) =>
-			dispatch(
-				enhancers.reduce( ( result, enhancer ) => enhancer( result, getState ), actionValue )
-			);
+		const newDispatch = ( actionValue ) => dispatch( enhanceAction( actionValue ) );
 		return action( newDispatch, getState );
 	}
 
-	return dispatch(
-		enhancers.reduce( ( result, enhancer ) => enhancer( result, getState ), action )
-	);
+	return dispatch( enhanceAction( action ) );
 };


### PR DESCRIPTION
Fixes a somewhat esoteric bug in `withEnhancers` that I noticed while reviewing #51865. Let's create a nested thunk action creator that in the end dispatches a plain `HELLO` action:
```js
const thunkCreator = dispatch => {
  dispatch( dispatch2 => {
    dispatch2( { type: HELLO } );
  } );
};
```
and enhance it with an enhancer:
```js
const enhancedCreator = withEnhancers( thunkCreator, ( action ) => ( { ...action, extra: 'x' } ) );
```
This enhanced creator is supposed to traverse all the nested thunks and enhance the plain leaf action(s), adding a field to them:
```
{ type: HELLO, extra: 'x' }
```

The current `withEnhancers` can only traverse one level of thunks, however. This patch makes the traversal recursive.

The patch adds a test that verifies the desired behavior. I broke up the patch into several very small commits that each do a small reasonable change.

**Tip for reviewers:** One way to think about `withEnhancers` is that it adds something almost identical to regular Redux middleware, but doesn't add it to the entire store, but just to one individual action.

To process thunks, we need to add our own version of the `redux-thunk` middleware to the front, and then the array of the enhancer middlewares behind it. Only then we dispatch the resulting actions to the Redux store.