### PR TITLE
ci: Run TeamCity e2e tests in trunk

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -154,7 +154,6 @@ object RunCalypsoE2eDesktopTests : BuildType({
 		vcs {
 			branchFilter = """
 				+:*
-				-:trunk
 				-:pull*
 			""".trimIndent()
 		}
@@ -321,7 +320,6 @@ object RunCalypsoE2eMobileTests : BuildType({
 		vcs {
 			branchFilter = """
 				+:*
-				-:trunk
 				-:pull*
 			""".trimIndent()
 		}


### PR DESCRIPTION
### Background

Calypso e2e tests (both desktop and mobile) run only for branches.

### Changes proposed in this Pull Request

Update our config so they also run for `trunk`.

This should give is a better baseline to judge test evolution (test duration, number of runs...). As a nice side effect, it will create Docker images that can be loaded into calypso.live to quickly diagnose which PR introduced a bug.


### Testing instructions

Can't be tested until merged.