### PR TITLE
Framework: Refactor away from `_.curry()` and others

### DIFF
--- a/client/state/analytics/actions/with-analytics.js
+++ b/client/state/analytics/actions/with-analytics.js
@@ -19,8 +19,10 @@ const joinAnalytics = ( analytics, action ) =>
 				},
 		  };
 
-export const withAnalytics = ( ...args ) => {
-	return args.length >= joinAnalytics.length
-		? joinAnalytics( ...args )
-		: ( ...args2 ) => withAnalytics( ...args.concat( args2 ) );
-};
+export function withAnalytics( analytics, action ) {
+	if ( typeof action === 'undefined' ) {
+		return ( a ) => joinAnalytics( analytics, a );
+	}
+
+	return joinAnalytics( analytics, action );
+}

--- a/client/state/analytics/actions/with-analytics.js
+++ b/client/state/analytics/actions/with-analytics.js
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import { merge } from 'lodash';
-
 const mergedMetaData = ( a, b ) => [
 	...( a?.meta?.analytics ?? [] ),
 	...( b?.meta?.analytics ?? [] ),
@@ -14,7 +9,15 @@ const joinAnalytics = ( analytics, action ) =>
 				dispatch( analytics );
 				dispatch( action );
 		  }
-		: merge( {}, action, { meta: { analytics: mergedMetaData( analytics, action ) } } );
+		: {
+				...action,
+				...{
+					meta: {
+						...action?.meta,
+						analytics: mergedMetaData( analytics, action ),
+					},
+				},
+		  };
 
 export const withAnalytics = ( ...args ) => {
 	return args.length >= joinAnalytics.length

--- a/client/state/analytics/actions/with-analytics.js
+++ b/client/state/analytics/actions/with-analytics.js
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import { get, merge } from 'lodash';
+import { merge } from 'lodash';
 
 const mergedMetaData = ( a, b ) => [
-	...get( a, 'meta.analytics', [] ),
-	...get( b, 'meta.analytics', [] ),
+	...( a?.meta?.analytics ?? [] ),
+	...( b?.meta?.analytics ?? [] ),
 ];
 
 const joinAnalytics = ( analytics, action ) =>

--- a/client/state/analytics/actions/with-analytics.js
+++ b/client/state/analytics/actions/with-analytics.js
@@ -13,7 +13,7 @@ const joinAnalytics = ( analytics, action ) =>
 				...action,
 				...{
 					meta: {
-						...action?.meta,
+						...action.meta,
 						analytics: mergedMetaData( analytics, action ),
 					},
 				},

--- a/client/state/analytics/actions/with-analytics.js
+++ b/client/state/analytics/actions/with-analytics.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { curry, get, merge } from 'lodash';
+import { get, merge } from 'lodash';
 
 const mergedMetaData = ( a, b ) => [
 	...get( a, 'meta.analytics', [] ),
@@ -16,4 +16,8 @@ const joinAnalytics = ( analytics, action ) =>
 		  }
 		: merge( {}, action, { meta: { analytics: mergedMetaData( analytics, action ) } } );
 
-export const withAnalytics = curry( joinAnalytics );
+export const withAnalytics = ( ...args ) => {
+	return args.length >= joinAnalytics.length
+		? joinAnalytics( ...args )
+		: ( ...args2 ) => withAnalytics( ...args.concat( args2 ) );
+};

--- a/client/state/analytics/actions/with-analytics.js
+++ b/client/state/analytics/actions/with-analytics.js
@@ -1,6 +1,6 @@
 const mergedMetaData = ( a, b ) => [
-	...( a?.meta?.analytics ?? [] ),
-	...( b?.meta?.analytics ?? [] ),
+	...( a.meta?.analytics ?? [] ),
+	...( b.meta?.analytics ?? [] ),
 ];
 
 const joinAnalytics = ( analytics, action ) =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `curry()` is only used once in the Calypso codebase, and the usage is pretty simple, so this PR replaces it with a custom implementation in `withAnalytics`. We also use the opportunity to remove some `get()` and `merge()` instances in the same file.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all usages are sane and preserve the original logic.
* Verify all tests pass: `yarn run test-client client/state/analytics/test/actions.js`.
* Do some smoke testing in the comments management area to verify analytics still works as it did before.