### PR TITLE
Fix failing e2e for the signup plans redesign rollout

### DIFF
--- a/test/e2e/lib/pages/signup/pick-a-plan-page.js
+++ b/test/e2e/lib/pages/signup/pick-a-plan-page.js
@@ -41,8 +41,8 @@ export default class PickAPlanPage extends AsyncBaseContainer {
 		// one visible and one hidden in control and only one button in the test variation.
 		const planSelector =
 			driverManager.currentScreenSize() === 'mobile'
-				? `.plan-features__mobile button.is-${ level }-plan, .plan-features-comparison__table button.is-${ level }-plan`
-				: `.plan-features-comparison__table button.is-${ level }-plan`;
+				? `.plan-features__mobile button.is-${ level }-plan, .plan-features-comparison__table button.is-${ level }-plan, .plan-features__table button.is-${ level }-plan`
+				: `.plan-features-comparison__table button.is-${ level }-plan, .plan-features__table button.is-${ level }-plan`;
 
 		let selector = By.css( planSelector );
 
@@ -56,7 +56,7 @@ export default class PickAPlanPage extends AsyncBaseContainer {
 		await driverHelper.waitUntilLocatedAndVisible(
 			this.driver,
 			By.css(
-				'.plan-features__mobile button.is-business-plan, .plan-features-comparison__table button.is-business-plan'
+				'.plan-features__mobile button.is-business-plan, .plan-features-comparison__table button.is-business-plan, .plan-features__table button.is-business-plan'
 			)
 		);
 		await this.scrollPlanInToView( level );

--- a/test/e2e/lib/pages/signup/pick-a-plan-page.js
+++ b/test/e2e/lib/pages/signup/pick-a-plan-page.js
@@ -41,8 +41,8 @@ export default class PickAPlanPage extends AsyncBaseContainer {
 		// one visible and one hidden in control and only one button in the test variation.
 		const planSelector =
 			driverManager.currentScreenSize() === 'mobile'
-				? `.plan-features__mobile button.is-${ level }-plan, .plan-features__table button.is-${ level }-plan`
-				: `.plan-features__table button.is-${ level }-plan`;
+				? `.plan-features__mobile button.is-${ level }-plan, .plan-features-comparison__table button.is-${ level }-plan`
+				: `.plan-features-comparison__table button.is-${ level }-plan`;
 
 		let selector = By.css( planSelector );
 
@@ -56,7 +56,7 @@ export default class PickAPlanPage extends AsyncBaseContainer {
 		await driverHelper.waitUntilLocatedAndVisible(
 			this.driver,
 			By.css(
-				'.plan-features__mobile button.is-business-plan, .plan-features__table button.is-business-plan'
+				'.plan-features__mobile button.is-business-plan, .plan-features-comparison__table button.is-business-plan'
 			)
 		);
 		await this.scrollPlanInToView( level );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the failing e2e reported in p1618318720010500-slack-e2e-testing-discuss, caused by the rollout of the plans redesign experiment https://github.com/Automattic/wp-calypso/pull/51734

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* E2E tests should pass

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

