### PR TITLE
Adds renew monthly option for annual plan downgrades

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -29,9 +29,9 @@ import {
 	isTitanMail,
 	isConciergeSession,
 	getJetpackProductsDisplayNames,
-	getMonthlyPlanByYearly,
 	isWpComPlan,
 	TERM_ANNUALLY,
+	TERM_BIENNIALLY,
 } from '@automattic/calypso-products';
 import { MembershipSubscription, MembershipSubscriptionsSite } from 'calypso/lib/purchases/types';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -747,7 +747,7 @@ function shouldRenderMonthlyRenewalOption( purchase ) {
 
 	const plan = getPlan( purchase.productSlug );
 
-	if ( TERM_ANNUALLY !== plan.term ) {
+	if ( ! [ TERM_ANNUALLY, TERM_BIENNIALLY ].includes( plan.term ) ) {
 		return false;
 	}
 

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -228,7 +228,7 @@ function handleRenewMultiplePurchasesClick( purchases, siteSlug, options = {} ) 
 function handleRenewMonthlyClick( purchase, siteSlug, options = {} ) {
 	const relatedMonthlyPlanSlug = getMonthlyPlanByYearly( purchase?.productSlug );
 
-	// Track the renew now submit.
+	// Track the renew monthly submit.
 	recordTracksEvent( 'calypso_purchases_renew_monthly_click', {
 		product_slug: relatedMonthlyPlanSlug,
 		...options.tracksProps,

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -29,6 +29,9 @@ import {
 	isTitanMail,
 	isConciergeSession,
 	getJetpackProductsDisplayNames,
+	getMonthlyPlanByYearly,
+	isWpComPlan,
+	TERM_ANNUALLY,
 } from '@automattic/calypso-products';
 import { MembershipSubscription, MembershipSubscriptionsSite } from 'calypso/lib/purchases/types';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -209,6 +212,38 @@ function handleRenewMultiplePurchasesClick( purchases, siteSlug, options = {} ) 
 		renewalUrl += '?redirect_to=' + encodeURIComponent( options.redirectTo );
 	}
 	debug( 'handling renewal click', purchases, siteSlug, renewItems, renewalUrl );
+
+	page( renewalUrl );
+}
+
+/**
+ * Adds a purchase renewal to the cart and redirects to checkout.
+ *
+ * @param {object} purchase - the purchase to be renewed
+ * @param {string} siteSlug - the site slug to renew the purchase for
+ * @param {object} [options] - optional information
+ * @param {string} [options.redirectTo] - Passed as redirect_to in checkout
+ * @param {object} [options.tracksProps] - where was the renew button clicked from
+ */
+function handleRenewMonthlyClick( purchase, siteSlug, options = {} ) {
+	const relatedMonthlyPlanSlug = getMonthlyPlanByYearly( purchase?.productSlug );
+
+	// Track the renew now submit.
+	recordTracksEvent( 'calypso_purchases_renew_monthly_click', {
+		product_slug: relatedMonthlyPlanSlug,
+		...options.tracksProps,
+	} );
+
+	if ( ! relatedMonthlyPlanSlug ) {
+		reduxDispatch( errorNotice( 'Could not find product slug for renewal.' ) );
+		throw new Error( 'Could not find product slug for renewal.' );
+	}
+
+	let renewalUrl = `/checkout/${ relatedMonthlyPlanSlug }/${ siteSlug || '' }`;
+	if ( options.redirectTo ) {
+		renewalUrl += '?redirect_to=' + encodeURIComponent( options.redirectTo );
+	}
+	debug( 'handling renew monthly click', purchase, siteSlug, relatedMonthlyPlanSlug, renewalUrl );
 
 	page( renewalUrl );
 }
@@ -733,6 +768,32 @@ function getDomainRegistrationAgreementUrl( purchase ) {
 	return purchase.domainRegistrationAgreementUrl;
 }
 
+function shouldRenderMonthlyRenewalOption( purchase ) {
+	if ( ! purchase || ! purchase.expiryDate ) {
+		return false;
+	}
+
+	const isWpCom = isWpComPlan( purchase.productSlug );
+	const plan = getPlan( purchase.productSlug );
+	const isAnnualPlan = TERM_ANNUALLY === plan.term;
+	const isAutorenewalEnabled = ! isExpiring( purchase );
+	const daysTillExpiry = moment( purchase.expiryDate ).diff( Date.now(), 'days' );
+
+	if ( isWpCom && isAnnualPlan ) {
+		// Auto renew is off and their plan will expire in the next <90 days
+		if ( ! isAutorenewalEnabled && daysTillExpiry < 90 ) {
+			return true;
+		}
+
+		// We attempted to bill them <30 days prior to their annual renewal and
+		// we weren’t able to do so for any other reason besides having auto renew off.
+		if ( isAutorenewalEnabled && daysTillExpiry < 30 ) {
+			return true;
+		}
+	}
+	return false;
+}
+
 export {
 	canExplicitRenew,
 	creditCardExpiresBeforeSubscription,
@@ -748,6 +809,7 @@ export {
 	getSubscriptionsBySite,
 	handleRenewMultiplePurchasesClick,
 	handleRenewNowClick,
+	handleRenewMonthlyClick,
 	hasAmountAvailableToRefund,
 	hasIncludedDomain,
 	isAutoRenewing,
@@ -783,6 +845,7 @@ export {
 	subscribedWithinPastWeek,
 	shouldAddPaymentSourceInsteadOfRenewingNow,
 	shouldRenderExpiringCreditCard,
+	shouldRenderMonthlyRenewalOption,
 };
 
 export { isGoogleWorkspaceExtraLicence } from './is-google-workspace-extra-license';

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -216,38 +216,6 @@ function handleRenewMultiplePurchasesClick( purchases, siteSlug, options = {} ) 
 	page( renewalUrl );
 }
 
-/**
- * Adds a purchase renewal to the cart and redirects to checkout.
- *
- * @param {object} purchase - the purchase to be renewed
- * @param {string} siteSlug - the site slug to renew the purchase for
- * @param {object} [options] - optional information
- * @param {string} [options.redirectTo] - Passed as redirect_to in checkout
- * @param {object} [options.tracksProps] - where was the renew button clicked from
- */
-function handleRenewMonthlyClick( purchase, siteSlug, options = {} ) {
-	const relatedMonthlyPlanSlug = getMonthlyPlanByYearly( purchase?.productSlug );
-
-	// Track the renew monthly submit.
-	recordTracksEvent( 'calypso_purchases_renew_monthly_click', {
-		product_slug: relatedMonthlyPlanSlug,
-		...options.tracksProps,
-	} );
-
-	if ( ! relatedMonthlyPlanSlug ) {
-		reduxDispatch( errorNotice( 'Could not find product slug for renewal.' ) );
-		throw new Error( 'Could not find product slug for renewal.' );
-	}
-
-	let renewalUrl = `/checkout/${ relatedMonthlyPlanSlug }/${ siteSlug || '' }`;
-	if ( options.redirectTo ) {
-		renewalUrl += '?redirect_to=' + encodeURIComponent( options.redirectTo );
-	}
-	debug( 'handling renew monthly click', purchase, siteSlug, relatedMonthlyPlanSlug, renewalUrl );
-
-	page( renewalUrl );
-}
-
 function getProductSlugsAndPurchaseIds( renewItems ) {
 	const productSlugs = [];
 	const purchaseIds = [];
@@ -809,7 +777,6 @@ export {
 	getSubscriptionsBySite,
 	handleRenewMultiplePurchasesClick,
 	handleRenewNowClick,
-	handleRenewMonthlyClick,
 	hasAmountAvailableToRefund,
 	hasIncludedDomain,
 	isAutoRenewing,

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -741,24 +741,30 @@ function shouldRenderMonthlyRenewalOption( purchase ) {
 		return false;
 	}
 
-	const isWpCom = isWpComPlan( purchase.productSlug );
+	if ( ! isWpComPlan( purchase.productSlug ) ) {
+		return false;
+	}
+
 	const plan = getPlan( purchase.productSlug );
-	const isAnnualPlan = TERM_ANNUALLY === plan.term;
+
+	if ( TERM_ANNUALLY !== plan.term ) {
+		return false;
+	}
+
 	const isAutorenewalEnabled = ! isExpiring( purchase );
 	const daysTillExpiry = moment( purchase.expiryDate ).diff( Date.now(), 'days' );
 
-	if ( isWpCom && isAnnualPlan ) {
-		// Auto renew is off and their plan will expire in the next <90 days
-		if ( ! isAutorenewalEnabled && daysTillExpiry < 90 ) {
-			return true;
-		}
-
-		// We attempted to bill them <30 days prior to their annual renewal and
-		// we weren’t able to do so for any other reason besides having auto renew off.
-		if ( isAutorenewalEnabled && daysTillExpiry < 30 ) {
-			return true;
-		}
+	// Auto renew is off and expiration is <90 days from now
+	if ( ! isAutorenewalEnabled && daysTillExpiry < 90 ) {
+		return true;
 	}
+
+	// We attempted to bill them <30 days prior to their annual renewal and
+	// we weren’t able to do so for any other reason besides having auto renew off.
+	if ( isAutorenewalEnabled && daysTillExpiry < 30 ) {
+		return true;
+	}
+
 	return false;
 }
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -24,6 +24,7 @@ import {
 	getRenewalPrice,
 	handleRenewMultiplePurchasesClick,
 	handleRenewNowClick,
+	handleRenewMonthlyClick,
 	hasAmountAvailableToRefund,
 	hasPaymentMethod,
 	isPaidWithCredits,
@@ -38,6 +39,7 @@ import {
 	isCloseToExpiration,
 	purchaseType,
 	getName,
+	shouldRenderMonthlyRenewalOption,
 } from 'calypso/lib/purchases';
 import {
 	canEditPaymentDetails,
@@ -82,6 +84,7 @@ import {
 	JETPACK_LEGACY_PLANS,
 	JETPACK_PRODUCTS_LIST,
 	isP2Plus,
+	getMonthlyPlanByYearly,
 } from '@automattic/calypso-products';
 import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import PlanPrice from 'calypso/my-sites/plan-price';
@@ -110,6 +113,8 @@ import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/co
 import { hasCustomDomain } from 'calypso/lib/site/utils';
 import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
+import Badge from 'calypso/components/badge';
+import { getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors';
 
 /**
  * Style dependencies
@@ -186,6 +191,12 @@ class ManagePurchase extends Component {
 		handleRenewNowClick( purchase, siteSlug, options );
 	};
 
+	handleRenewMonthly = () => {
+		const { purchase, siteSlug, redirectTo } = this.props;
+		const options = redirectTo ? { redirectTo } : undefined;
+		handleRenewMonthlyClick( purchase, siteSlug, options );
+	};
+
 	handleRenewMultiplePurchases = ( purchases ) => {
 		const { siteSlug, redirectTo } = this.props;
 		const options = redirectTo ? { redirectTo } : undefined;
@@ -225,8 +236,8 @@ class ManagePurchase extends Component {
 		);
 	}
 
-	renderRenewNowNavItem() {
-		const { purchase, translate } = this.props;
+	renderRenewalNavItem( content, onClick ) {
+		const { purchase } = this.props;
 
 		if ( ! config.isEnabled( 'upgrades/checkout' ) ) {
 			return null;
@@ -241,10 +252,41 @@ class ManagePurchase extends Component {
 		}
 
 		return (
-			<CompactCard tagName="button" displayAsLink onClick={ this.handleRenew }>
-				{ translate( 'Renew Now' ) }
+			<CompactCard tagName="button" displayAsLink onClick={ onClick }>
+				{ content }
 			</CompactCard>
 		);
+	}
+
+	renderRenewNowNavItem() {
+		const { translate } = this.props;
+		return this.renderRenewalNavItem( translate( 'Renew Now' ), this.handleRenew );
+	}
+
+	renderRenewAnnuallyNavItem() {
+		const { translate, purchase, relatedMonthlyPlanPrice } = this.props;
+		const annualPrice = getRenewalPrice( purchase ) / 12;
+		const savings = Math.round(
+			( 100 * ( relatedMonthlyPlanPrice - annualPrice ) ) / relatedMonthlyPlanPrice
+		);
+		return this.renderRenewalNavItem(
+			<div>
+				{ translate( 'Renew Annually' ) }
+				<Badge className="manage-purchase__savings-badge" type="success">
+					{ translate( '%(savings)d%% cheaper than monthly', {
+						args: {
+							savings,
+						},
+					} ) }
+				</Badge>
+			</div>,
+			this.handleRenew
+		);
+	}
+
+	renderRenewMonthlyNavItem() {
+		const { translate } = this.props;
+		return this.renderRenewalNavItem( translate( 'Renew Monthly' ), this.handleRenewMonthly );
 	}
 
 	handleUpgradeClick = () => {
@@ -677,6 +719,8 @@ class ManagePurchase extends Component {
 		const siteDomain = purchase.domain;
 		const siteId = purchase.siteId;
 
+		const renderMonthlyRenewalOption = shouldRenderMonthlyRenewalOption( purchase );
+
 		return (
 			<Fragment>
 				{ this.props.showHeader && (
@@ -725,7 +769,18 @@ class ManagePurchase extends Component {
 				/>
 
 				{ isProductOwner && preventRenewal && this.renderSelectNewNavItem() }
-				{ isProductOwner && ! preventRenewal && this.renderRenewNowNavItem() }
+				{ isProductOwner &&
+					! preventRenewal &&
+					! renderMonthlyRenewalOption &&
+					this.renderRenewNowNavItem() }
+				{ isProductOwner &&
+					! preventRenewal &&
+					renderMonthlyRenewalOption &&
+					this.renderRenewAnnuallyNavItem() }
+				{ isProductOwner &&
+					! preventRenewal &&
+					renderMonthlyRenewalOption &&
+					this.renderRenewMonthlyNavItem() }
 				{ isProductOwner && ! preventRenewal && this.renderUpgradeNavItem() }
 				{ isProductOwner && this.renderEditPaymentMethodNavItem() }
 				{ isProductOwner && this.renderCancelPurchaseNavItem() }
@@ -846,6 +901,8 @@ export default connect( ( state, props ) => {
 	const site = getSite( state, siteId );
 	const hasLoadedSites = ! isRequestingSites( state );
 	const hasLoadedDomains = hasLoadedSiteDomains( state, siteId );
+	const relatedMonthlyPlanSlug = getMonthlyPlanByYearly( purchase?.productSlug );
+	const relatedMonthlyPlanPrice = getSitePlanRawPrice( state, siteId, relatedMonthlyPlanSlug );
 	return {
 		hasLoadedDomains,
 		hasLoadedSites,
@@ -867,5 +924,7 @@ export default connect( ( state, props ) => {
 		theme: isPurchaseTheme && getCanonicalTheme( state, siteId, purchase.meta ),
 		isAtomicSite: isSiteAtomic( state, siteId ),
 		userId,
+		relatedMonthlyPlanSlug,
+		relatedMonthlyPlanPrice,
 	};
 } )( localize( ManagePurchase ) );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -193,17 +193,15 @@ class ManagePurchase extends Component {
 
 	handleRenewMonthly = () => {
 		const { relatedMonthlyPlanSlug, siteSlug, redirectTo } = this.props;
-		const options = redirectTo ? { redirectTo } : undefined;
 		// Track the Renew Monthly submit.
 		recordTracksEvent( 'calypso_purchases_renew_monthly_click', {
 			product_slug: relatedMonthlyPlanSlug,
-			...options.tracksProps,
 		} );
 
 		// Redirect to the checkout page with the monthly plan in cart
 		const checkoutUrlArgs = {};
-		if ( options.redirectTo ) {
-			checkoutUrlArgs.redirect_to = options.redirectTo;
+		if ( redirectTo ) {
+			checkoutUrlArgs.redirect_to = redirectTo;
 		}
 		const checkoutUrlWithArgs = addQueryArgs(
 			checkoutUrlArgs,

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -24,7 +24,6 @@ import {
 	getRenewalPrice,
 	handleRenewMultiplePurchasesClick,
 	handleRenewNowClick,
-	handleRenewMonthlyClick,
 	hasAmountAvailableToRefund,
 	hasPaymentMethod,
 	isPaidWithCredits,
@@ -115,6 +114,7 @@ import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 import Badge from 'calypso/components/badge';
 import { getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors';
+import { addQueryArgs } from 'calypso/lib/url';
 
 /**
  * Style dependencies
@@ -192,9 +192,24 @@ class ManagePurchase extends Component {
 	};
 
 	handleRenewMonthly = () => {
-		const { purchase, siteSlug, redirectTo } = this.props;
+		const { relatedMonthlyPlanSlug, siteSlug, redirectTo } = this.props;
 		const options = redirectTo ? { redirectTo } : undefined;
-		handleRenewMonthlyClick( purchase, siteSlug, options );
+		// Track the Renew Monthly submit.
+		recordTracksEvent( 'calypso_purchases_renew_monthly_click', {
+			product_slug: relatedMonthlyPlanSlug,
+			...options.tracksProps,
+		} );
+
+		// Redirect to the checkout page with the monthly plan in cart
+		const checkoutUrlArgs = {};
+		if ( options.redirectTo ) {
+			checkoutUrlArgs.redirect_to = options.redirectTo;
+		}
+		const checkoutUrlWithArgs = addQueryArgs(
+			checkoutUrlArgs,
+			`/checkout/${ relatedMonthlyPlanSlug }/${ siteSlug || '' }`
+		);
+		page( checkoutUrlWithArgs );
 	};
 
 	handleRenewMultiplePurchases = ( purchases ) => {

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -42,6 +42,7 @@
 
 		.manage-purchase__plan-icon {
 			height: 56px;
+			/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 			border-radius: 50%;
 		}
 
@@ -130,6 +131,7 @@
 	.gridicon {
 		box-sizing: border-box;
 		padding: 4px;
+		/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		background: var( --color-accent );
 		fill: var( --color-text-inverted );
@@ -145,6 +147,7 @@
 	}
 
 	.gridicons-themes {
+		/* stylelint-disable-next-line  scales/radii */
 		border-radius: 8px;
 	}
 }
@@ -325,4 +328,8 @@
 
 .manage-purchase__detail-date-span {
 	white-space: nowrap;
+}
+
+.manage-purchase__savings-badge {
+	margin-left: 12px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Context: pcbrnV-1Zt-p2#comment-3259
* This change adds the "Renew Annually" and "Renew Monthly" links on the manage purchase page.
* Calculates the savings % for the annual plan and displays it next to "Renew Annually".
* **To be deployed only after D60535-code is shipped.**

#### Testing instructions


* Purchase any annual plan.
* Navigate to /purchases/subscriptions/ and click on the purchased plan.
* Ensure Auto-renew is on and the plan expires < 30 days from today. (Use SA to change plan expiry)
* Refresh the page and confirm that the "Renew Annually" and "Renew Monthly" links are present.
* Ensure Auto-renew is off and the plan expires < 90 days from today.
* Refresh the page and confirm that the "Renew Annually" and "Renew Monthly" links are present.
* Confirm that the savings % is correctly calculated and shown next to the "Renew Annually" link.
![image](https://user-images.githubusercontent.com/5436027/115836018-9a5d6a00-a434-11eb-9fef-0be8858390b4.png)

* Clicking on "Renew Annually" should redirect to the checkout page with the renewal for the plan in the cart.
* Clicking on "Renew Monthly" should redirect to the checkout page with the monthly plan in the cart.
* To test the purchase flow for "Renew Monthly", please see D60535-code