### PR TITLE
Fix/coming soon link styles leak

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -281,7 +281,7 @@ nocache_headers();
 					</div>
 					<div class="wpcom-coming-soon-marketing-buttons">
 						<p><a class="button button-secondary" href="<?php echo esc_url( get_login_url() ); ?>"><?php esc_html_e( 'Log in', 'full-site-editing' ); ?></a></p>
-						<p><a class="button button-primary " href="<?php echo esc_url( get_onboarding_url() ); ?>"><?php esc_html_e( 'Start your website', 'full-site-editing' ); ?></a></p>
+						<p><a class="button button-primary has-background" href="<?php echo esc_url( get_onboarding_url() ); ?>"><?php esc_html_e( 'Start your website', 'full-site-editing' ); ?></a></p>
 					</div>
 				<?php endif; ?>
 			</div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -150,6 +150,9 @@ nocache_headers();
 				margin-right: 16px;
 				margin-bottom: 0;
 			}
+			.wpcom-coming-soon-wplogo a {
+				border: none;
+			}
 			.wpcom-coming-soon-marketing-copy-text {
 				line-height: 1.4;
 				margin: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix style leaks in the Coming Soon page when using the Blank Canvas (seedlet) theme

#### Testing instructions

Requirements:
* Visit `/new` and create a free site that uses the Blank Canvas theme (e.g. "Balan")

To reproduce the bug:
* In an incognito window, visit https://[TEST_SITE_ID].wordpress.com
* Notice how the W logo in the bottom left corner has a dark line under it
* Hover over and focus the "Start your website" button and notice how the background and text colors change to an unexpected combination

To reproduce the fix:
* In the `public_html` folder of your sandbox, run `install-plugin.sh etk fix/coming-soon-link-styles-leak`
* Add `[TEST_SITE_ID].wordpress.com` to your sandbox and enable your sandbox
* In an incognito window, visit https://[TEST_SITE_ID].wordpress.com
* Notice how the W logo in the bottom left corner doesn't have a visual glitch anymore (black underline)
* Hover over and focus the "Start your website" button and notice how the hover/focus effect looks as expected
* Check for potential regressions by switching the theme and making sure that the Coming Soon page still looks alright


#### Before

https://user-images.githubusercontent.com/1083581/114589507-064b1000-9c88-11eb-8477-0192f51fb84c.mp4

#### After

https://user-images.githubusercontent.com/1083581/114589500-04814c80-9c88-11eb-830a-df26cafafd0e.mp4

Fixes #51894