### PR TITLE
Partner Portal: Add a dummy page for the upcoming Billing Dashboard

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -1,0 +1,163 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import formatCurrency from '@automattic/format-currency';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '@automattic/components';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export default function BillingDetails(): ReactElement {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+	const billing = {
+		isSuccess: true,
+		data: {
+			date: '2021-03-01',
+			costs: {
+				total: 177916,
+				assigned: 176644,
+				unassigned: 1272,
+			},
+			products: [
+				{
+					productSlug: 'jetpack-backup-daily',
+					productName: 'Jetpack Backup Daily',
+					productCost: 17,
+					counts: {
+						assigned: 44,
+						unassigned: 8,
+						total: 52,
+					},
+					productTotalCost: 884,
+				},
+				{
+					productSlug: 'jetpack-backup-realtime',
+					productName: 'Jetpack Backup Real-time',
+					productCost: 47,
+					counts: {
+						assigned: 22,
+						unassigned: 4,
+						total: 26,
+					},
+					productTotalCost: 1222,
+				},
+				{
+					productSlug: 'jetpack-security-daily',
+					productName: 'Jetpack Security Daily',
+					productCost: 79,
+					counts: {
+						assigned: 0,
+						unassigned: 12,
+						total: 12,
+					},
+					productTotalCost: 948,
+				},
+				{
+					productSlug: 'jetpack-complete',
+					productName: 'Jetpack Complete',
+					productCost: 139,
+					counts: {
+						assigned: 1258,
+						unassigned: 0,
+						total: 1258,
+					},
+					productTotalCost: 174862,
+				},
+			],
+		},
+	};
+
+	return (
+		<div className="billing-details">
+			<Card compact className="billing-details__header">
+				<div className="billing-details__row">
+					<div>{ translate( 'Products' ) }</div>
+					<div>{ translate( 'Assigned' ) }</div>
+					<div>{ translate( 'Unassigned' ) }</div>
+					<div></div>
+				</div>
+			</Card>
+
+			{ billing.isSuccess &&
+				billing.data.products.map( ( product ) => (
+					<Card compact key={ product.productSlug }>
+						<div className="billing-details__row">
+							<div className="billing-details__product">
+								{ product.productName }
+								<span className="billing-details__line-item-meta">
+									{ translate( 'Price per license: %(price)s', {
+										args: { price: formatCurrency( product.productCost, 'USD' ) },
+									} ) }
+								</span>
+							</div>
+
+							<div className="billing-details__assigned">
+								{ product.counts.assigned }
+								<span className="billing-details__line-item-meta billing-details__line-item-meta--is-mobile">
+									{ translate( 'Assigned' ) }
+								</span>
+							</div>
+
+							<div className="billing-details__unassigned">
+								{ product.counts.unassigned }
+								<span className="billing-details__line-item-meta billing-details__line-item-meta--is-mobile">
+									{ translate( 'Unassigned' ) }
+								</span>
+							</div>
+
+							<div className="billing-details__subtotal">
+								{ translate( '%(count)d License', '%(count)d Licenses', {
+									count: product.counts.total,
+									args: { count: product.counts.total },
+								} ) }
+								<span className="billing-details__line-item-meta">
+									{ translate( 'Subtotal: %(subtotal)s', {
+										args: { subtotal: formatCurrency( product.productTotalCost, 'USD' ) },
+									} ) }
+								</span>
+							</div>
+						</div>
+					</Card>
+				) ) }
+
+			<Card compact className="billing-details__footer">
+				<div className="billing-details__row billing-details__row--summary">
+					<span className="billing-details__total-label billing-details__cost-label">
+						{ billing.isSuccess &&
+							translate( 'Cost for {{bold}}%(date)s{{/bold}}', {
+								components: { bold: <strong /> },
+								args: { date: moment( billing.data.date ).format( 'MMMM, YYYY' ) },
+							} ) }
+					</span>
+					<strong className="billing-details__cost-amount">
+						{ billing.isSuccess && formatCurrency( billing.data.costs.total, 'USD' ) }
+					</strong>
+
+					<span className="billing-details__total-label billing-details__line-item-meta">
+						{ translate( 'Assigned licenses:' ) }
+					</span>
+					<span className="billing-details__line-item-meta">
+						{ billing.isSuccess && formatCurrency( billing.data.costs.assigned, 'USD' ) }
+					</span>
+
+					<span className="billing-details__total-label billing-details__line-item-meta">
+						{ translate( 'Unassigned licenses:' ) }
+					</span>
+					<span className="billing-details__line-item-meta">
+						{ billing.isSuccess && formatCurrency( billing.data.costs.unassigned, 'USD' ) }
+					</span>
+				</div>
+			</Card>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/billing-details/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/style.scss
@@ -1,0 +1,98 @@
+@import '~@wordpress/base-styles/_breakpoints.scss';
+@import '~@wordpress/base-styles/_mixins.scss';
+
+.billing-details {
+	&__row {
+		display: grid;
+		grid-template-columns: calc( 66% - 12px ) calc( 34% - 12px );
+		grid-template-areas:
+			'product assigned'
+			'subtotal unassigned';
+		align-items: center;
+		grid-gap: 24px;
+		font-size: 1.25rem;
+
+		@include break-xlarge() {
+			grid-template-columns: 1fr 150px 150px 150px;
+			grid-template-areas:
+				'product assigned unassigned subtotal';
+		}
+
+		&--summary {
+			grid-template-areas: none;
+			grid-gap: 8px 24px;
+		}
+	}
+
+	&__header {
+		display: none;
+
+		* {
+			font-weight: 400;
+			font-size: 0.875rem;
+			color: var( --studio-gray-70 );
+		}
+
+		@include break-xlarge() {
+			display: block;
+		}
+	}
+
+	&__product {
+		grid-area: product;
+	}
+
+	&__assigned {
+		grid-area: assigned;
+	}
+
+	&__unassigned {
+		grid-area: unassigned;
+	}
+
+	&__subtotal {
+		grid-area: subtotal;
+	}
+
+	&__total-label {
+		text-align: right;
+
+		@include break-xlarge() {
+			grid-column: 1 / span 3;
+		}
+	}
+
+	&__cost-label {
+		margin-bottom: 8px;
+		font-size: 1rem;
+	}
+
+	&__cost-amount {
+		margin-bottom: 8px;
+		font-size: 1.25rem;
+
+		@media ( min-width: 661px ) and ( max-width: 781px ) {
+			// Accounts for unbreakable long cost numbers breaking the layout due to the sidebar taking up
+			// a lot of the available space.
+			font-size: 1rem;
+		}
+	}
+
+	&__line-item-meta {
+		display: block;
+		font-size: 0.875rem;
+		color: var( --studio-gray-70 );
+
+		&--is-mobile {
+			@include break-xlarge() {
+				display: none;
+			}
+		}
+	}
+
+	&__placeholder {
+		@include placeholder( --color-neutral-10 );
+
+		display: block;
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
@@ -1,0 +1,120 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement, useCallback, useRef, useState } from 'react';
+import { numberFormat, useTranslate } from 'i18n-calypso';
+import formatCurrency from '@automattic/format-currency';
+
+/**
+ * Internal dependencies
+ */
+import { Button, Card } from '@automattic/components';
+import Tooltip from 'calypso/components/tooltip';
+import Gridicon from 'calypso/components/gridicon';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+function CostTooltip(): ReactElement {
+	const translate = useTranslate();
+	const tooltip = useRef< SVGSVGElement >( null );
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const open = useCallback( () => setIsOpen( true ), [ setIsOpen ] );
+	const close = useCallback( () => setIsOpen( false ), [ setIsOpen ] );
+
+	return (
+		<>
+			<Button borderless className="billing-summary__open-cost-tooltip" onClick={ open }>
+				<Gridicon ref={ tooltip } icon="info-outline" size={ 24 } />
+			</Button>
+
+			<Tooltip
+				className="billing-summary__cost-tooltip"
+				context={ tooltip.current }
+				isVisible={ isOpen }
+				position="bottom"
+				showOnMobile
+			>
+				<div>
+					<p>
+						{ translate(
+							'The total cost is being calculated based on the current date as well as the number of licenses in total.'
+						) }
+					</p>
+
+					<Button
+						borderless
+						compact
+						className="billing-summary__close-cost-tooltip"
+						onClick={ close }
+					>
+						<Gridicon icon="cross" size={ 18 } />
+					</Button>
+				</div>
+			</Tooltip>
+		</>
+	);
+}
+
+export default function BillingSummary(): ReactElement {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+	const billing = {
+		isSuccess: true,
+		data: {
+			date: '2021-03-01',
+			licenses: {
+				total: 1348,
+				assigned: 1324,
+				unassigned: 24,
+			},
+			costs: {
+				total: 177916,
+			},
+		},
+	};
+
+	return (
+		<Card className="billing-summary">
+			<div className="billing-summary__stat billing-summary__total-licenses">
+				<span className="billing-summary__label">{ translate( 'Total licenses' ) }</span>
+				<strong className="billing-summary__value">
+					{ billing.isSuccess && numberFormat( billing.data.licenses.total, 0 ) }
+				</strong>
+			</div>
+
+			<div className="billing-summary__stat billing-summary__assigned-licenses">
+				<span className="billing-summary__label">{ translate( 'Assigned licenses' ) }</span>
+				<strong className="billing-summary__value">
+					{ billing.isSuccess && numberFormat( billing.data.licenses.assigned, 0 ) }
+				</strong>
+			</div>
+
+			<div className="billing-summary__stat billing-summary__unassigned-licenses">
+				<span className="billing-summary__label">{ translate( 'Unassigned licenses' ) }</span>
+				<strong className="billing-summary__value">
+					{ billing.isSuccess && numberFormat( billing.data.licenses.unassigned, 0 ) }
+				</strong>
+			</div>
+
+			<div className="billing-summary__stat billing-summary__cost">
+				<span className="billing-summary__label">
+					{ billing.isSuccess && <CostTooltip /> }
+					{ billing.isSuccess &&
+						translate( 'Cost for %(date)s', {
+							args: { date: moment( billing.data.date ).format( 'MMMM, YYYY' ) },
+						} ) }
+
+					{ ! billing.isSuccess && <br /> }
+				</span>
+				<strong className="billing-summary__value">
+					{ billing.isSuccess && formatCurrency( billing.data.costs.total, 'USD' ) }
+				</strong>
+			</div>
+		</Card>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/billing-summary/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/billing-summary/style.scss
@@ -1,0 +1,131 @@
+@import '~@wordpress/base-styles/_breakpoints.scss';
+@import '~@wordpress/base-styles/_mixins.scss';
+
+.billing-summary {
+	display: flex;
+	flex-wrap: wrap;
+
+	@include break-xlarge() {
+		flex-wrap: nowrap;
+	}
+
+	&__stat {
+		flex: 0 1 0;
+		margin-bottom: 18px;
+	}
+
+	&__stat:nth-child( odd ) {
+		flex-basis: calc( 50% - 18px );
+	}
+
+	&__stat:nth-child( even ) {
+		flex-basis: calc( 50% - 1px - 18px );
+		margin-left: 18px;
+		padding-left: 18px;
+		border-left: 1px solid var( --studio-gray-5 );
+	}
+
+	&__stat:nth-last-child( -n + 2 ) {
+		margin-bottom: 0;
+	}
+
+	@include break-xlarge() {
+		&__stat {
+			&.billing-summary__stat {
+				flex: 1 1 0;
+				margin-bottom: 0;
+			}
+
+			& + & {
+				margin-left: 36px;
+				padding-left: 36px;
+				border-left: 1px solid var( --studio-gray-5 );
+			}
+		}
+
+		&__cost.billing-summary__stat {
+			flex-grow: 1.25;
+			margin-left: auto;
+			border-left: 0;
+			text-align: right;
+		}
+	}
+
+	&__label {
+		display: block;
+		margin-bottom: 8px;
+		font-size: 1.25rem;
+		line-height: 28px;
+		color: var( --studio-gray-80 );
+
+		@include break-wide() {
+			white-space: nowrap;
+		}
+	}
+
+	&__value {
+		display: block;
+		font-weight: 700;
+		font-size: 1.75rem;
+		line-height: 36px;
+
+		@media ( min-width: 661px ) and ( max-width: 781px ) {
+			// Accounts for unbreakable long cost numbers breaking the layout due to the sidebar taking up
+			// a lot of the available space.
+			font-size: 1.25rem;
+		}
+	}
+
+	&__cost-tooltip.popover {
+		&.is-bottom .popover__arrow {
+			border-bottom-color: #ffffff;
+		}
+
+		.popover__inner {
+			padding: 16px 58px 16px 16px;
+			color: var( --studio-gray-70 );
+			background: #ffffff;
+			border-radius: 2px;
+			box-shadow: 0 0 40px rgba( 0, 0, 0, 0.08 );
+
+			p {
+				font-size: 1rem;
+				margin: 0;
+			}
+		}
+
+		@include break-mobile() {
+			max-width: 312px;
+		}
+	}
+
+	&__open-cost-tooltip {
+		margin-right: 8px;
+
+		&.button {
+			padding: 0;
+
+			.gridicon {
+				top: 4px;
+			}
+		}
+	}
+
+	&__close-cost-tooltip {
+		position: absolute;
+		right: 16px;
+		top: 16px;
+		color: var( --studio-gray-40 );
+
+		&.button {
+			height: 18px;
+			padding: 0;
+		}
+	}
+
+	&__placeholder {
+		@include placeholder( --color-neutral-10 );
+
+		display: block;
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -25,6 +25,7 @@ import PartnerPortalSidebar from 'calypso/jetpack-cloud/sections/partner-portal/
 import PartnerAccess from 'calypso/jetpack-cloud/sections/partner-portal/primary/partner-access';
 import TermsOfServiceConsent from 'calypso/jetpack-cloud/sections/partner-portal/primary/terms-of-service-consent';
 import SelectPartnerKey from 'calypso/jetpack-cloud/sections/partner-portal/primary/select-partner-key';
+import BillingDashboard from 'calypso/jetpack-cloud/sections/partner-portal/primary/billing-dashboard';
 import Licenses from 'calypso/jetpack-cloud/sections/partner-portal/primary/licenses';
 import IssueLicense from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license';
 import {
@@ -58,7 +59,15 @@ export function partnerKeyContext( context: PageJS.Context, next: () => void ): 
 	next();
 }
 
-export function partnerPortalContext( context: PageJS.Context, next: () => void ): void {
+export function billingDashboardContext( context: PageJS.Context, next: () => void ): void {
+	context.header = <Header />;
+	context.secondary = <PartnerPortalSidebar path={ context.path } />;
+	context.primary = <BillingDashboard />;
+	context.footer = <JetpackComFooter />;
+	next();
+}
+
+export function licensesContext( context: PageJS.Context, next: () => void ): void {
 	const { s: search, sort_field, sort_direction, page } = context.query;
 	const filter = publicToInternalLicenseFilter( context.params.filter, LicenseFilter.NotRevoked );
 	const currentPage = parseInt( page ) || 1;

--- a/client/jetpack-cloud/sections/partner-portal/index.ts
+++ b/client/jetpack-cloud/sections/partner-portal/index.ts
@@ -13,6 +13,7 @@ import * as controller from './controller';
  * Style dependencies
  */
 import './style.scss';
+import config from '@automattic/calypso-config';
 
 export default function () {
 	// Load the partner for the current user.
@@ -39,14 +40,17 @@ export default function () {
 
 	// List licenses.
 	page(
-		`/partner-portal/:filter(unassigned|assigned|revoked)?`,
+		`/partner-portal/licenses/:filter(unassigned|assigned|revoked)?`,
 		controller.requireAccessContext,
 		controller.requireTermsOfServiceConsentContext,
 		controller.requireSelectedPartnerKeyContext,
-		controller.partnerPortalContext,
+		controller.licensesContext,
 		makeLayout,
 		clientRender
 	);
+
+	// Redirect invalid license list filters back to the main portal page.
+	page( `/partner-portal/licenses/*`, '/partner-portal/licenses' );
 
 	// Issue a license.
 	page(
@@ -59,6 +63,19 @@ export default function () {
 		clientRender
 	);
 
-	// Redirect invalid URLs back to the main portal page.
-	page( `/partner-portal/*`, '/partner-portal' );
+	if ( config.isEnabled( 'jetpack-cloud/partner-portal/billing-dashboard' ) ) {
+		// Billing Dashboard.
+		page(
+			`/partner-portal`,
+			controller.requireAccessContext,
+			controller.requireTermsOfServiceConsentContext,
+			controller.requireSelectedPartnerKeyContext,
+			controller.billingDashboardContext,
+			makeLayout,
+			clientRender
+		);
+	} else {
+		// Billing Dashboard is not enabled, redirect to the license listing.
+		page( `/partner-portal`, '/partner-portal/licenses' );
+	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -44,7 +44,9 @@ export default function IssueLicenseForm(): ReactElement {
 	} );
 	const issueLicense = useIssueLicenseMutation( {
 		onSuccess: ( license ) => {
-			page.redirect( addQueryArgs( { highlight: license.license_key }, '/partner-portal' ) );
+			page.redirect(
+				addQueryArgs( { highlight: license.license_key }, '/partner-portal/licenses' )
+			);
 		},
 		onError: ( error: Error ) => {
 			dispatch( errorNotice( error.message ) );
@@ -86,7 +88,7 @@ export default function IssueLicenseForm(): ReactElement {
 			) }
 
 			<div className="issue-license-form__actions">
-				<Button href="/partner-portal" disabled={ issueLicense.isLoading }>
+				<Button href="/partner-portal/licenses" disabled={ issueLicense.isLoading }>
 					{ translate( 'Go back' ) }
 				</Button>
 

--- a/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
@@ -34,7 +34,7 @@ function LicenseStateFilter( { doSearch }: Props ): ReactElement {
 	const translate = useTranslate();
 	const { filter, search } = useContext( LicenseListContext );
 	const counts = useSelector( getLicenseCounts );
-	const basePath = '/partner-portal/';
+	const basePath = '/partner-portal/licenses/';
 
 	const navItems = [
 		{

--- a/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement } from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'calypso/components/main';
+import CardHeading from 'calypso/components/card-heading';
+import BillingSummary from 'calypso/jetpack-cloud/sections/partner-portal/billing-summary';
+import BillingDetails from 'calypso/jetpack-cloud/sections/partner-portal/billing-details';
+
+export default function BillingDashboard(): ReactElement {
+	const translate = useTranslate();
+
+	return (
+		<Main wideLayout={ true } className="billing-dashboard">
+			<CardHeading size={ 36 }>{ translate( 'Billing' ) }</CardHeading>
+
+			<BillingSummary />
+			<BillingDetails />
+		</Main>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
@@ -19,6 +19,7 @@ import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
  * Style dependencies
  */
 import 'calypso/components/jetpack/sidebar/style.scss';
+import config from '@automattic/calypso-config';
 
 interface Props {
 	path: string;
@@ -41,15 +42,28 @@ class PartnerPortalSidebar extends Component< Props > {
 			<Sidebar className="sidebar__jetpack-cloud">
 				<SidebarRegion>
 					<SidebarMenu>
+						{ config.isEnabled( 'jetpack-cloud/partner-portal/billing-dashboard' ) && (
+							<SidebarItem
+								materialIcon="credit_card"
+								materialIconStyle="outline"
+								label={ translate( 'Billing', {
+									comment: 'Jetpack sidebar navigation item',
+								} ) }
+								link="/partner-portal"
+								onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal' ) }
+								selected={ path === '/partner-portal' }
+							/>
+						) }
+
 						<SidebarItem
 							materialIcon="vpn_key"
 							materialIconStyle="filled"
 							label={ translate( 'Licenses', {
 								comment: 'Jetpack sidebar navigation item',
 							} ) }
-							link="/partner-portal"
+							link="/partner-portal/licenses"
 							onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal / Licenses' ) }
-							selected={ itemLinkMatches( [ '/partner-portal' ], path ) }
+							selected={ itemLinkMatches( [ '/partner-portal/licenses' ], path ) }
 						/>
 					</SidebarMenu>
 				</SidebarRegion>

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -37,6 +37,7 @@
 		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,
 		"jetpack-cloud/connect": true,
+		"jetpack-cloud/partner-portal/billing-dashboard": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/backups-restore": true,
 		"jetpack/scan-product": true,


### PR DESCRIPTION
Context: p1HpG7-bsW-p2

This is a split from #51692 to introduce the new page and route changes.

#### Changes proposed in this Pull Request

* Add a dummy page for the upcoming Billing Dashboard in the development environment only.

#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view test this PR.
* Check out this PR locally, then run `yarn && yarn start-jetpack-cloud`.
* The license listing was moved to /partner-portal/licenses - this PR should not affect the behavior except to make sure all relevant redirects lead to /partner-portal/licenses instead of /partner-portal (e.g. issuing licenses, filtering the license list, pagination etc.).
* A new Billing page with placeholder data should now be the default page for the Partner Portal.
* Make sure the UI matches the designs.

![Screenshot](https://user-images.githubusercontent.com/22746396/113739409-70076f00-9708-11eb-9b47-a114a6dbaac7.png)
