### PR TITLE
Checkout: URL-encode product slugs and meta when using in a URL

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -6,6 +6,7 @@ import moment from 'moment';
 import page from 'page';
 import i18n from 'i18n-calypso';
 import debugFactory from 'debug';
+import { encodeProductForUrl } from '@automattic/wpcom-checkout';
 
 /**
  * Internal dependencies
@@ -225,15 +226,15 @@ function getProductSlugsAndPurchaseIds( renewItems ) {
 			debug( 'Could not find product slug for renewal.', currentRenewItem );
 			return null;
 		}
-		// There is a product with this weird slug, but left to itself the slug will
-		// cause a routing error since it contains a slash, so we encode it here and
-		// then decode it in the checkout code before adding to the cart.
-		const productSlug =
-			currentRenewItem.product_slug === 'no-adverts/no-adverts.php'
-				? 'no-ads'
-				: currentRenewItem.product_slug;
+		// Some product slugs or meta contain slashes which will break the URL, so
+		// we encode them first. We cannot use encodeURIComponent because the
+		// calypso router seems to break if the trailing part of the URL contains
+		// an encoded slash.
+		const productSlug = encodeProductForUrl( currentRenewItem.product_slug );
 		productSlugs.push(
-			currentRenewItem.meta ? `${ productSlug }:${ currentRenewItem.meta }` : productSlug
+			currentRenewItem.meta
+				? `${ productSlug }:${ encodeProductForUrl( currentRenewItem.meta ) }`
+				: productSlug
 		);
 		purchaseIds.push( currentRenewItem.extra.purchaseId );
 	} );

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -5,6 +5,7 @@ import useDisplayCartMessages from './use-display-cart-messages';
 
 export * from './transformations';
 export * from './types';
+export * from './product-url-encoding';
 export { useDisplayCartMessages };
 export { createApplePayMethod } from './payment-methods/apple-pay';
 export * from './postal-code';

--- a/packages/wpcom-checkout/src/product-url-encoding.ts
+++ b/packages/wpcom-checkout/src/product-url-encoding.ts
@@ -1,0 +1,16 @@
+// Some product slugs or meta contain slashes which will break the URL, so we
+// encode them first. We cannot use encodeURIComponent because the calypso
+// router seems to break if the trailing part of the URL contains an encoded
+// slash (eg: /checkout/example.com/foo%2Fbar breaks routing). We cannot use
+// the same characters for encoding as for decoding if they are UTF-8 encoded
+// because they will already be decoded by the time the decoding takes place.
+const slashForEncoding = '%25';
+const slashForDecoding = '%'; // WARNING: This will be used in a RegExp so it must not contain RegExp special characters unless they are escaped!
+
+export function encodeProductForUrl( slug: string ): string {
+	return slug.replace( /\//g, slashForEncoding );
+}
+
+export function decodeProductFromUrl( slug: string ): string {
+	return slug.replace( new RegExp( slashForDecoding, 'g' ), '/' );
+}

--- a/packages/wpcom-checkout/src/product-url-encoding.ts
+++ b/packages/wpcom-checkout/src/product-url-encoding.ts
@@ -4,6 +4,10 @@
 // slash (eg: /checkout/example.com/foo%2Fbar breaks routing). We cannot use
 // the same characters for encoding as for decoding if they are UTF-8 encoded
 // because they will already be decoded by the time the decoding takes place.
+//
+// If this is ever changed, please make sure to also change the code that
+// generates renewal emails on the backend, because it uses the same encoding!
+
 const slashForEncoding = '%25';
 const slashForDecoding = '%'; // WARNING: This will be used in a RegExp so it must not contain RegExp special characters unless they are escaped!
 

--- a/packages/wpcom-checkout/src/product-url-encoding.ts
+++ b/packages/wpcom-checkout/src/product-url-encoding.ts
@@ -5,16 +5,20 @@
 // the same characters for encoding as for decoding if they are UTF-8 encoded
 // because they will already be decoded by the time the decoding takes place.
 //
+// If all of that is confusing, see the tests for these functions to understand
+// how they will be used.
+//
 // If this is ever changed, please make sure to also change the code that
 // generates renewal emails on the backend, because it uses the same encoding!
 
 const slashForEncoding = '%25';
-const slashForDecoding = '%'; // WARNING: This will be used in a RegExp so it must not contain RegExp special characters unless they are escaped!
+const slashForDecoding = '%';
 
 export function encodeProductForUrl( slug: string ): string {
 	return slug.replace( /\//g, slashForEncoding );
 }
 
 export function decodeProductFromUrl( slug: string ): string {
-	return slug.replace( new RegExp( slashForDecoding, 'g' ), '/' );
+	// This should really use String.prototype.replaceAll but it's yet not fully supported
+	return slug.split( slashForDecoding ).join( '/' );
 }

--- a/packages/wpcom-checkout/test/product-url-encoding.ts
+++ b/packages/wpcom-checkout/test/product-url-encoding.ts
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { encodeProductForUrl, decodeProductFromUrl } from '../src/product-url-encoding';
+
+describe( 'encodeProductForUrl', () => {
+	it( 'removes slashes from the string', () => {
+		expect( encodeProductForUrl( 'foo/bar/baz' ) ).not.toMatch( /\// );
+	} );
+} );
+
+describe( 'decodeProductFromUrl', () => {
+	it( 'restores slashes to a URL-decoded string encoded by encodeProductForUrl', () => {
+		expect(
+			decodeProductFromUrl( decodeURIComponent( encodeProductForUrl( 'foo/bar/baz' ) ) )
+		).toBe( 'foo/bar/baz' );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We have some product slugs that contain slashes. This is a problem for URLs that contain those products; notably renewal URLs. One of those cases is handled by https://github.com/Automattic/wp-calypso/pull/40985 wherein we create an "alias" for that particular slug which checkout knows how to decode when it comes time to add it to the cart. However, this does not handle other such products. It also doesn't handle the rare case where the `meta` value of a product (eg: the target URL of a site redirect subscription) contains slashes for products which need to specify a domain.

This PR replaces the special-case behavior that was previously there with new code that URL-encodes both the product slug and the `meta` before inserting it into the URL. Those values are then decoded by checkout before being sent to the cart endpoint. 

Unfortunately we cannot use regular URL encoding because the text in the URL is apparently _already_ decoded by the time it reaches the calypso router, meaning that a `/checkout/foo%2Fbar/example.com` is treated by the calypso router as `/checkout/foo/bar/example.com`, which is invalid. Therefore, this PR goes out of its way to encode slashes as a literal percent sign (`%`, which becomes `%25` encoded) instead. This makes the example above `/checkout/foo%25bar/example.com`, which is treated by the calypso router as `/checkout/foo%bar/example.com`. Then the new decoder function transforms the product part back into `foo/bar`. Someday it would be nice if we did not URL-decode the URL before it hits the router, but in the meantime this should be a sufficient work-around.

Fixes c/NEK942ox-tr/810-cant-manually-renew-a-site-redirect-subscription-if-it-has-a-forward-slash-in-the-url

See D60130-code for the matching backend change to emails and notifications (although that needs to happen after this is merged).

#### Testing instructions

First we need to verify that this does not break the current behavior for `no-adverts/no-adverts.php`. Visit `/checkout/example.com/no-adverts%25no-adverts.php` for your site and verify that the "no ads" product is successfully added to your cart. (This does break any code that uses the old alias of `no-ads`, but I'm pretty sure that the alias only ever existed within code changed by this PR. Feel free to search other locations for that alias.)

Next we need to verify that this does not break the current behavior for renewals of `no-adverts/no-adverts.php`. Complete the above purchase to add a subscription for the "no ads" product to your site. Then visit the purchase page for that product in calypso and click "Renew now". Verify that the renewal product is successfully added to your cart.

Next we need to verify that this does not break the current behavior for domain mapping. Visit `/checkout/example.com/domain-mapping:example.com` for your site and verify that the domain mapping product is successfully added to your cart.

Finally we need to verify that this fixes the issue for slashes in meta. Visit `/domains/add/site-redirect/example.com` for your site and add a URL _ending with a forward slash_ in the “Enter a domain” field (eg: `cape.com/`). Complete the purchase process for this product. Next go to the purchase page for that product in calypso and click "Renew now". Verify that the renewal product is successfully added to your cart.

<img width="565" alt="Screen Shot 2021-04-13 at 6 40 34 PM" src="https://user-images.githubusercontent.com/2036909/114630073-c3893800-9c87-11eb-9af5-8cfccc06e051.png">
