### PR TITLE
Fix duplicate email validation for WordPress.com Email

### DIFF
--- a/client/lib/titan/new-mailbox.js
+++ b/client/lib/titan/new-mailbox.js
@@ -60,15 +60,17 @@ const sanitizeEmailSuggestion = ( emailSuggestion ) =>
 
 const validateMailboxesAreUnique = ( mailboxes ) => {
 	const mailboxNameCounts = mailboxes.reduce( ( nameCount, mailbox ) => {
-		nameCount[ mailbox.mailbox ] = 1 + nameCount[ mailbox.mailbox ] ?? 0;
+		const mailboxName = mailbox.mailbox.value;
+		nameCount[ mailboxName ] = 1 + ( nameCount[ mailboxName ] ?? 0 );
 		return nameCount;
 	}, {} );
 
 	return mailboxes.map( ( mailbox ) => {
-		if ( mailboxNameCounts[ mailbox.mailbox ] > 1 ) {
+		const mailboxName = mailbox.mailbox.value;
+		if ( mailboxNameCounts[ mailboxName ] > 1 ) {
 			return {
 				...mailbox,
-				[ mailbox ]: { value: mailbox.mailbox, error: translate( 'Please use unique mailboxes' ) },
+				[ 'mailbox' ]: { value: mailboxName, error: translate( 'Please use unique mailboxes' ) },
 			};
 		}
 		return mailbox;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes the validation to prevent a user from adding the same email address multiple times. The logic was not working as intended.

#### Testing instructions

If you have a domain with a WordPress.com Email subscription, navigate to the email management UI for that domain (Upgrades -> Domains -> _yourdomain.tld_ -> Manage your email accounts), and then click on the "Add New Mailboxes" button.

If you have a domain without a WordPress.com Email subscription, navigate to the email comparison page for that domain (Upgrades -> Domains and then click on the "Add Email" button for your domain.)

* Enter valid details for a first email account
* Click on the "Add another mailbox button"
* Enter valid details for a second email account
* Verify that you don't see any errors
* Update one of the "Email address" fields to match the other
* Verify that you see an error for both fields with the text `Please use unique mailboxes`