### PR TITLE
Fix gutenboarding img load fade in

### DIFF
--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -49,7 +49,8 @@
 		"@wordpress/element": "^2.19.1",
 		"@wordpress/i18n": "^3.19.0",
 		"react": "^16.12.0",
-		"react-dom": "^16.12.0"
+		"react-dom": "^16.12.0",
+		"debug": "^4.1.1"
 	},
 	"private": true
 }

--- a/packages/design-picker/src/components/mshots-image/index.tsx
+++ b/packages/design-picker/src/components/mshots-image/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState, useEffect, useLayoutEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import classnames from 'classnames';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -56,6 +56,12 @@ const useMshotsUrl = ( src: string, options: MShotsOptions ) => {
 	const [ loadedSrc, setLoadedSrc ] = useState( '' );
 	const [ count, setCount ] = useState( 0 );
 
+	// Return '' while loading and reset the count for new image requests
+	useEffect( () => {
+		setLoadedSrc( '' );
+		setCount( 0 );
+	}, [ src, options ] );
+
 	useEffect( () => {
 		const img = new Image();
 		const srcUrl = mshotsUrl( src, options, count );
@@ -94,22 +100,11 @@ const MShotsImage = ( {
 	options,
 	scrollable = false,
 }: MShotsImageProps ): JSX.Element => {
-	const [ visible, setVisible ] = useState( true );
-	const [ opacity, setOpacity ] = useState( 0 );
-
 	const src = useMshotsUrl( url, options );
+	const visible = !! src;
 	const backgroundImage = src && `url( ${ src } )`;
 
-	// Hide the images while they're loading if src changes (e.g. when locale is switched)
-	useLayoutEffect( () => {
-		// Opacity is used for fade in on load
-		// Visible is used to hide the image quickly when swapping languages
-		setVisible( !! src );
-		setOpacity( src ? 1 : 0 );
-	}, [ src ] );
-
 	const style = {
-		opacity,
 		...( scrollable ? { backgroundImage } : {} ),
 	};
 

--- a/packages/design-picker/src/components/mshots-image/index.tsx
+++ b/packages/design-picker/src/components/mshots-image/index.tsx
@@ -58,10 +58,10 @@ const useMshotsUrl = ( src: string, options: MShotsOptions ) => {
 	const [ loadedSrc, setLoadedSrc ] = useState( '' );
 	const [ count, setCount ] = useState( 0 );
 	const previousSrc = useRef( src );
-	const previousImg = useRef( null );
-	const previousOptions = useRef();
-	// Oddly, we need to assign to current to pass the equivalence check and
-	// avoid a spurious reset
+	const previousImg = useRef< HTMLImageElement >();
+	const previousOptions = useRef< MShotsOptions >();
+	// Oddly, we need to assign to current here after ref creation in order to
+	// pass the equivalence check and avoid a spurious reset
 	previousOptions.current = options;
 
 	// Note: Mshots doesn't care about the "count" param, but it is important
@@ -80,10 +80,10 @@ const useMshotsUrl = ( src: string, options: MShotsOptions ) => {
 			if ( options !== previousOptions.current ) {
 				debug( 'options changed\nfrom', previousOptions.current, '\nto', options );
 			}
-			previousImg.current?.onload && ( previousImg.current.onload = null );
+			previousImg.current && previousImg.current.onload && ( previousImg.current.onload = null );
+
 			setLoadedSrc( '' );
 			setCount( 0 );
-
 			previousImg.current = img;
 			previousOptions.current = options;
 			previousSrc.current = src;

--- a/packages/design-picker/src/components/mshots-image/index.tsx
+++ b/packages/design-picker/src/components/mshots-image/index.tsx
@@ -4,6 +4,7 @@
 import React, { useState, useEffect } from 'react';
 import classnames from 'classnames';
 import { addQueryArgs } from '@wordpress/url';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -31,6 +32,7 @@ export type MShotsOptions = {
 	screen_height?: number;
 };
 
+const debug = debugFactory( 'design-picker:mshots-image' );
 const cacheBuster = Date.now();
 
 export function mshotsUrl( url: string, options: MShotsOptions, count = 0 ): string {
@@ -64,6 +66,9 @@ const useMshotsUrl = ( src: string, options: MShotsOptions ) => {
 		// If there's been a "props" change we need to reset everything:
 		if ( options !== previousOptions || src !== previousSrc ) {
 			// Make sure an old image can't trigger a spurious state update
+			if ( options !== previousOptions ) {
+				debug( 'options changed\nfrom', previousOptions, '\nto', options );
+			}
 			previousImg?.onload && ( previousImg.onload = null );
 			setLoadedSrc( '' );
 			setCount( 0 );

--- a/packages/design-picker/src/components/mshots-image/index.tsx
+++ b/packages/design-picker/src/components/mshots-image/index.tsx
@@ -92,6 +92,11 @@ const useMshotsUrl = ( src: string, options: MShotsOptions ) => {
 		let timeoutId: number;
 		img.onload = () => {
 			// Detect default image (Don't request a 400x300 image).
+			//
+			// If this turns out to be a problem, it might help to know that the
+			// http request status for the default is a 307. Unfortunately we
+			// don't get the request through an img element so we'd need to
+			// take a completely different approach using ajax.
 			if ( img.naturalWidth !== 400 || img.naturalHeight !== 300 ) {
 				setLoadedSrc( srcUrl );
 			} else if ( count < MAXTRIES ) {

--- a/packages/design-picker/src/components/mshots-image/index.tsx
+++ b/packages/design-picker/src/components/mshots-image/index.tsx
@@ -74,7 +74,6 @@ const useMshotsUrl = ( src: string, options: MShotsOptions ) => {
 		}
 		const srcUrl = mshotsUrl( src, options, count );
 		let timeoutId: number;
-		img.src = srcUrl;
 		img.onload = () => {
 			// Detect default image (Don't request a 400x300 image).
 			if ( img.naturalWidth !== 400 || img.naturalHeight !== 300 ) {
@@ -85,6 +84,7 @@ const useMshotsUrl = ( src: string, options: MShotsOptions ) => {
 				timeoutId = setTimeout( () => setCount( count + 1 ), count * 500 );
 			}
 		};
+		img.src = srcUrl;
 
 		return () => {
 			img.onload = null;

--- a/packages/design-picker/src/components/mshots-image/index.tsx
+++ b/packages/design-picker/src/components/mshots-image/index.tsx
@@ -55,15 +55,23 @@ const MAXTRIES = 10;
 const useMshotsUrl = ( src: string, options: MShotsOptions ) => {
 	const [ loadedSrc, setLoadedSrc ] = useState( '' );
 	const [ count, setCount ] = useState( 0 );
-
-	// Return '' while loading and reset the count for new image requests
-	useEffect( () => {
-		setLoadedSrc( '' );
-		setCount( 0 );
-	}, [ src, options ] );
+	let previousSrc = src;
+	let previousOptions = options;
+	let previousImg: Image = null;
 
 	useEffect( () => {
 		const img = new Image();
+		// If there's been a "props" change we need to reset everything:
+		if ( options !== previousOptions || src !== previousSrc ) {
+			// Make sure an old image can't trigger a spurious state update
+			previousImg?.onload && ( previousImg.onload = null );
+			setLoadedSrc( '' );
+			setCount( 0 );
+
+			previousImg = img;
+			previousOptions = options;
+			previousSrc = src;
+		}
 		const srcUrl = mshotsUrl( src, options, count );
 		let timeoutId: number;
 		img.src = srcUrl;

--- a/packages/design-picker/src/components/mshots-image/index.tsx
+++ b/packages/design-picker/src/components/mshots-image/index.tsx
@@ -80,7 +80,9 @@ const useMshotsUrl = ( src: string, options: MShotsOptions ) => {
 			if ( options !== previousOptions.current ) {
 				debug( 'options changed\nfrom', previousOptions.current, '\nto', options );
 			}
-			previousImg.current && previousImg.current.onload && ( previousImg.current.onload = null );
+			if ( previousImg.current && previousImg.current.onload ) {
+				previousImg.current.onload = null;
+			}
 
 			setLoadedSrc( '' );
 			setCount( 0 );

--- a/packages/design-picker/src/components/mshots-image/style.scss
+++ b/packages/design-picker/src/components/mshots-image/style.scss
@@ -4,10 +4,6 @@
 	@include onboarding-placeholder();
 }
 
-.mshots-image-hidden {
-	display: none;
-}
-
 .mshots-image__container {
     height: 100%;
 }
@@ -23,5 +19,18 @@
 
     &:hover {
         background-position: bottom;
+    }
+}
+
+.mshots-image-visible {
+    animation: fadein 3s;
+}
+
+@keyframes fadein {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
     }
 }

--- a/packages/design-picker/src/components/mshots-image/style.scss
+++ b/packages/design-picker/src/components/mshots-image/style.scss
@@ -23,7 +23,7 @@
 }
 
 .mshots-image-visible {
-    animation: fadein 3s;
+    animation: fadein 1.5s;
 }
 
 @keyframes fadein {


### PR DESCRIPTION
This PR is a followup to https://github.com/Automattic/wp-calypso/pull/51261 to restore the fade-in animation when images are loaded.

#### Testing instructions

The two key cases to check are:
- [ ] Images fade in immediately when already cached in the browser
- [ ] Images fade in after they are loaded from mshots (`?flags=gutenboarding/bust-mshots-cache`)

The tricky bit is that there are lots of corner cases related to timing issues, so it's hard to be positive that I've got them all.
- We never want to see an image stalled on the grey box.
- We don't want to see the box go white without the picture appearing.
- check that the static themes are good (Pollard and Balan)

You can resolve the live link: https://calypso.live/new/design?branch=fix/gutenboarding-img-load-fade-in and then add some different feature flag combinations.

- Check the `&flags=gutenboarding/site-editor`
- Check the `&flags=gutenboardinglong-previews` (makes the loading a bit longer)


Sometimes it seems like the animation doesn't go off, and I _think_ that's just performance failing (i.e. the animation is being queued up, but the browser is deprioritizing it in favor of loading all the images), but look out for that, I'd like a second opinion.

Related to #51261
