### PR TITLE
Enable gutenboarding/long-previews on horizon

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -72,6 +72,7 @@
 		"gutenboarding/show-vertical-input": false,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
+		"gutenboarding/long-previews": true,
 		"help": true,
 		"home/layout-dev": true,
 		"inline-help": true,

--- a/config/development.json
+++ b/config/development.json
@@ -72,7 +72,6 @@
 		"gutenboarding/show-vertical-input": false,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
-		"gutenboarding/long-previews": true,
 		"help": true,
 		"home/layout-dev": true,
 		"inline-help": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -46,6 +46,7 @@
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
+		"gutenboarding/long-previews": true,
 		"happychat": false,
 		"help": true,
 		"home/layout-dev": true,


### PR DESCRIPTION
This PR enables the long mshots previews from #51261 on horizon.

This will facilitate primarily internal testing and provide a safety check with the new mshots functionality while we finish up the animations.

#### Testing instructions

Primarily we want to confirm that https://horizon.wordpress.com/new/design/?flags=gutenboarding/long-previews works, but see #51261 for more extensive testing instructions covering different flags/screen-sizes that affect this page.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #51261
