### PR TITLE
New Onboarding: alternative to fix flaky select free domain suggestion E2E test

### DIFF
--- a/test/e2e/lib/pages/gutenboarding/domains-page.js
+++ b/test/e2e/lib/pages/gutenboarding/domains-page.js
@@ -24,6 +24,10 @@ export default class DomainsPage extends AsyncBaseContainer {
 	async enterDomainQuery( query ) {
 		const searchFieldSelector = By.css( '.domain-picker__search input[type="text"]' );
 		await driverHelper.setWhenSettable( this.driver, searchFieldSelector, query );
+		// After typing the new query value, wait for domain suggestions to reload.
+		// The sleep value should be higher than the DOMAIN_SEARCH_DEBOUNCE_INTERVAL defined in domain-picker.
+		//https://github.com/Automattic/wp-calypso/blob/trunk/packages/domain-picker/src/constants.ts#L18
+		await this.driver.sleep( 500 );
 	}
 
 	async waitForDomainSuggestionsToLoad() {

--- a/test/e2e/lib/pages/gutenboarding/domains-page.js
+++ b/test/e2e/lib/pages/gutenboarding/domains-page.js
@@ -26,8 +26,8 @@ export default class DomainsPage extends AsyncBaseContainer {
 		await driverHelper.setWhenSettable( this.driver, searchFieldSelector, query );
 		// After typing the new query value, wait for domain suggestions to reload.
 		// The sleep value should be higher than the DOMAIN_SEARCH_DEBOUNCE_INTERVAL defined in domain-picker.
-		//https://github.com/Automattic/wp-calypso/blob/trunk/packages/domain-picker/src/constants.ts#L18
-		await this.driver.sleep( 500 );
+		// https://github.com/Automattic/wp-calypso/blob/trunk/packages/domain-picker/src/constants.ts#L18
+		await this.driver.sleep( 400 );
 	}
 
 	async waitForDomainSuggestionsToLoad() {

--- a/test/e2e/lib/pages/gutenboarding/domains-page.js
+++ b/test/e2e/lib/pages/gutenboarding/domains-page.js
@@ -21,13 +21,22 @@ export default class DomainsPage extends AsyncBaseContainer {
 		);
 	}
 
+	async enterDomainQuery( query ) {
+		const searchFieldSelector = By.css( '.domain-picker__search input[type="text"]' );
+		await driverHelper.setWhenSettable( this.driver, searchFieldSelector, query );
+	}
+
+	async waitForDomainSuggestionsToLoad() {
+		const placeholderSelector = By.css( '.domain-picker__suggestion-item.placeholder' );
+		await driverHelper.waitTillNotPresent( this.driver, placeholderSelector );
+	}
+
 	/**
-	 * Selects the free domain from the list of search results
+	 * Get the free domain name from the list of search results
 	 *
-	 * @returns {Promise<string>} The selected domain
+	 * @returns {Promise<string>} The free domain
 	 */
-	async selectFreeDomain() {
-		const freeDomainButtonSelector = By.css( '.domain-picker__suggestion-item.is-free' );
+	async getFreeDomainName() {
 		const freeDomainNameSelector = By.css(
 			'.domain-picker__suggestion-item.is-free .domain-picker__suggestion-item-name'
 		);
@@ -35,9 +44,12 @@ export default class DomainsPage extends AsyncBaseContainer {
 			this.driver,
 			freeDomainNameSelector
 		);
-		const domainName = await domainNameElement.getText();
+		return await domainNameElement.getText();
+	}
+
+	async selectFreeDomain() {
+		const freeDomainButtonSelector = By.css( '.domain-picker__suggestion-item.is-free' );
 		await driverHelper.clickWhenClickable( this.driver, freeDomainButtonSelector );
-		return domainName;
 	}
 
 	async continueToNextStep() {
@@ -48,10 +60,5 @@ export default class DomainsPage extends AsyncBaseContainer {
 	async skipStep() {
 		const skipButtonSelector = By.css( '.action-buttons__skip' );
 		return await driverHelper.clickWhenClickable( this.driver, skipButtonSelector );
-	}
-
-	async enterDomainQuery( query ) {
-		const searchFieldSelector = By.css( '.domain-picker__search input[type="text"]' );
-		return await driverHelper.setWhenSettable( this.driver, searchFieldSelector, query );
 	}
 }

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -79,20 +79,28 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 			await acquireIntentPage.goToNextStep();
 		} );
 
-		step( 'Can see Domains Page and pick a free domain and continue', async function () {
-			const domainsPage = await DomainsPage.Expect( driver );
-			await domainsPage.enterDomainQuery( domainQuery );
+		step(
+			'Can see Domains Page, search for domains, pick a free domain, and continue',
+			async function () {
+				const domainsPage = await DomainsPage.Expect( driver );
+				await domainsPage.enterDomainQuery( domainQuery );
 
-			// Wait for domain suggestions to reload.
-			// This fixes the "stale element reference: element is not attached to the page document" error
-			// because selectFreeDomain() might be clicking on the free suggestion item too quickly
-			// before the list of domain suggestions are reloaded, causing the driver to target the
-			// element that has already been removed from DOM.
-			await driver.sleep( 2000 );
+				try {
+					await domainsPage.waitForDomainSuggestionsToLoad();
+				} catch ( e ) {
+					console.log( 'Domain suggestions not loaded. Retrying' ); // eslint-disable-line no-console
 
-			newSiteDomain = await domainsPage.selectFreeDomain();
-			await domainsPage.continueToNextStep();
-		} );
+					const newDomainQuery = dataHelper.randomPhrase();
+					await domainsPage.enterDomainQuery( newDomainQuery );
+					await domainsPage.waitForDomainSuggestionsToLoad();
+				}
+
+				newSiteDomain = await domainsPage.getFreeDomainName();
+
+				await domainsPage.selectFreeDomain();
+				await domainsPage.continueToNextStep();
+			}
+		);
 
 		step( 'Can see Design Selector and select a random free design', async function () {
 			const designSelectorPage = await DesignSelectorPage.Expect( driver );

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -84,19 +84,8 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 			async function () {
 				const domainsPage = await DomainsPage.Expect( driver );
 				await domainsPage.enterDomainQuery( domainQuery );
-
-				try {
-					await domainsPage.waitForDomainSuggestionsToLoad();
-				} catch ( e ) {
-					console.log( 'Domain suggestions not loaded. Retrying' ); // eslint-disable-line no-console
-
-					const newDomainQuery = dataHelper.randomPhrase();
-					await domainsPage.enterDomainQuery( newDomainQuery );
-					await domainsPage.waitForDomainSuggestionsToLoad();
-				}
-
+				await domainsPage.waitForDomainSuggestionsToLoad();
 				newSiteDomain = await domainsPage.getFreeDomainName();
-
 				await domainsPage.selectFreeDomain();
 				await domainsPage.continueToNextStep();
 			}

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -82,6 +82,14 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 		step( 'Can see Domains Page and pick a free domain and continue', async function () {
 			const domainsPage = await DomainsPage.Expect( driver );
 			await domainsPage.enterDomainQuery( domainQuery );
+
+			// Wait for domain suggestions to reload.
+			// This fixes the "stale element reference: element is not attached to the page document" error
+			// because selectFreeDomain() might be clicking on the free suggestion item too quickly
+			// before the list of domain suggestions are reloaded, causing the driver to target the
+			// element that has already been removed from DOM.
+			await driver.sleep( 2000 );
+
 			newSiteDomain = await domainsPage.selectFreeDomain();
 			await domainsPage.continueToNextStep();
 		} );


### PR DESCRIPTION
**Changes proposed in this Pull Request**
The E2E failure stale element reference: element is not attached to the page document sometimes crops up because because selectFreeDomain() might be clicking on the free suggestion item too quickly before the list of domain suggestions are reloaded, causing the driver to target the element that has already been removed from DOM.

The solution is to add a delay bigger than the debounce interval when getting domain suggestions.

**Testing instructions**
Since this is intermittent, just rerun the E2E desktop on TeamCity and see if the stale element reference error still persist on the 'Can see Domains Page and pick a free domain and continue' step.

Related to https://github.com/Automattic/wp-calypso/pull/51858#pullrequestreview-635335624
Fixes #51857.