### PR TITLE
Fix missing dispatch calls for recordEvent thunk

### DIFF
--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -271,7 +271,7 @@ export function enableAutoupdatePlugin( siteId, plugin ) {
 		dispatch( { ...defaultAction, type: PLUGIN_AUTOUPDATE_ENABLE_REQUEST } );
 
 		const afterEnableAutoupdateCallback = ( error ) => {
-			recordEvent( 'calypso_plugin_autoupdate_enabled', plugin, siteId, error );
+			dispatch( recordEvent( 'calypso_plugin_autoupdate_enabled', plugin, siteId, error ) );
 		};
 
 		const successCallback = ( data ) => {
@@ -306,7 +306,7 @@ export function disableAutoupdatePlugin( siteId, plugin ) {
 		dispatch( { ...defaultAction, type: PLUGIN_AUTOUPDATE_DISABLE_REQUEST } );
 
 		const afterDisableAutoupdateCallback = ( error ) => {
-			recordEvent( 'calypso_plugin_autoupdate_disabled', plugin, siteId, error );
+			dispatch( recordEvent( 'calypso_plugin_autoupdate_disabled', plugin, siteId, error ) );
 		};
 
 		const successCallback = ( data ) => {
@@ -355,9 +355,7 @@ function refreshNetworkSites( siteId ) {
 }
 
 function installPluginHelper( siteId, plugin, isMainNetworkSite = false ) {
-	return ( dispatch, getState ) => {
-		const state = getState();
-		const site = getSite( state, siteId );
+	return ( dispatch ) => {
 		const pluginId = plugin.id || plugin.slug;
 		const defaultAction = {
 			action: INSTALL_PLUGIN,
@@ -386,7 +384,7 @@ function installPluginHelper( siteId, plugin, isMainNetworkSite = false ) {
 			if ( INSTALL_PLUGIN === type ) {
 				return;
 			}
-			recordEvent( 'calypso_plugin_installed', plugin, site, error );
+			dispatch( recordEvent( 'calypso_plugin_installed', plugin, siteId, error ) );
 		};
 
 		const successCallback = ( data ) => {
@@ -444,9 +442,7 @@ export function installPluginOnMultisite( siteId, plugin ) {
 }
 
 export function removePlugin( siteId, plugin ) {
-	return ( dispatch, getState ) => {
-		const state = getState();
-		const site = getSite( state, siteId );
+	return ( dispatch ) => {
 		const pluginId = plugin.id || plugin.slug;
 		const defaultAction = {
 			action: REMOVE_PLUGIN,
@@ -456,7 +452,7 @@ export function removePlugin( siteId, plugin ) {
 		dispatch( { ...defaultAction, type: PLUGIN_REMOVE_REQUEST } );
 
 		const recordRemovePluginEvent = ( type, error ) => {
-			recordEvent( 'calypso_plugin_removed', plugin, site, error );
+			dispatch( recordEvent( 'calypso_plugin_removed', plugin, siteId, error ) );
 		};
 
 		const doDeactivate = function ( pluginData ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR attempts to fix the issue with the following tracks are not consistently recorded:
- `calypso_plugin_installed_success`
- `calypso_plugin_installed_error`
- `calypso_plugin_activated_success`
- `calypso_plugin_activated_error`

Upon my investigation, it seemed that refactoring done for reduxifying actions somewhen in December 2020 might have affected the tracking done. It was found that:
- Dispatch call was missing for `recordEvent`
- `site` parameter was used instead of `siteId`

<img src="https://user-images.githubusercontent.com/3747241/114688873-b92e7300-9d47-11eb-9110-9268de67f671.png" width="300">

This change also attempts to fix possible similar issue for the following tracks and mcstats:
- `calypso_plugin_autoupdate_enabled_*`
- `calypso_plugin_autoupdate_disabled_*`
- `calypso_plugin_removed_*`

#### Testing instructions

Unfortunately, I do not know if there are ways to test all of the changes, but I think testing one of these should verify that the change works across the board, since the pattern used is the same.

The following is the instruction to test with plugin installation and activation, please let me know if you do know how to test others:

1. Run calypso in your development environment.
4. Create a new business site.
5. Install `Hello Dolly` plugin to turn it into Atomic site.
6. Navigate to `/woocommerce-installation/{your new site}`.
9. Open up developer console, type in `localStorage.setItem( 'debug', 'calypso:analytics*' )` to debug tracks.
7. Click on `Set up my store!`.
8. The site will redirect once setup is completed, so it's good to select `Preserve log` so that it stays after redirect.
8. If you successfully set up WooCommerce, notice the `calypso_plugin_installed_success` track appears in console

Sample screenshot of my developer console:

![image](https://user-images.githubusercontent.com/3747241/114688012-df9fde80-9d46-11eb-855c-2f8e66b7cf57.png)

