### PR TITLE
Cancel purchase form: detect if it's Jetpack product and tweak copy

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -646,6 +646,9 @@ class CancelPurchaseForm extends React.Component {
 	surveyContent() {
 		const { translate, isImport, showSurvey, purchase } = this.props;
 		const { surveyStep } = this.state;
+		const isJetpack =
+			isJetpackProductSlug( purchase.productSlug ) || isJetpackPlanSlug( purchase.productSlug );
+		const productName = isJetpack ? translate( 'Jetpack' ) : translate( 'WordPress.com' );
 
 		if ( showSurvey ) {
 			if ( surveyStep === steps.INITIAL_STEP ) {
@@ -654,7 +657,10 @@ class CancelPurchaseForm extends React.Component {
 						<FormSectionHeading>{ translate( 'Your thoughts are needed.' ) }</FormSectionHeading>
 						<p>
 							{ translate(
-								'Before you go, please answer a few quick questions to help us improve WordPress.com.'
+								'Before you go, please answer a few quick questions to help us improve %(productName)s.',
+								{
+									args: { productName },
+								}
 							) }
 						</p>
 						{ this.renderQuestionOne() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Detect if customer is removing a Jetpack product.
* Tweak copy if Jetpack product is detected.

#### Testing instructions

1. Fire up this PR.
1. In Calypso, open a Jetpack site that has an existing plan.
1. Head to the purchase page (`/purchases/subscriptions/SITE_URL/12345`).
1. Click to remove product and ensure you see the mention of Jetpack in the cancel purchase form.
1. Repeat steps 2–4 with a Simple dotcom site and ensure nothing has changed (i.e.: that you still see the mention of WordPress.com).

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/114708568-6a6ee200-9d23-11eb-9b8a-8e06ae037456.png) | ![image](https://user-images.githubusercontent.com/390760/114708520-5a570280-9d23-11eb-9f9d-62eb8bb4395b.png)

