### PR TITLE
Partner Portal: Fix navbar title and menu alignment

### DIFF
--- a/client/components/jetpack/portal-nav/style.scss
+++ b/client/components/jetpack/portal-nav/style.scss
@@ -2,8 +2,13 @@
 	flex: 1 1 180px;
 	max-width: 280px;
 	margin: 0;
+	margin-right: auto;
 	background: none;
 	box-shadow: none;
+
+	& + .masterbar__item-title {
+		display: none;
+	}
 
 	.section-nav-tabs {
 		// Using a deprecated breakpoint in order to match the usage in the section component we are overriding.


### PR DESCRIPTION
Context: 1187494150150258-as-1200043581561256

#### Changes proposed in this Pull Request

* Fixes the Partner Portal navbar alignment when there's no title (this usually happens when you are on the page to select the partner key you wanna use)
* Removes the Partner Portal navbar title when the Manage Sites/Partner Portal menu is shown.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If you do not have a partner key, please contact Infinity for one or you will be unable to test this PR.
* Check out this PR locally, then run* yarn && yarn start-jetpack-cloud.
* Visit http://jetpack.cloud.localhost:3000/partner-portal
* If you have more than one key, make sure the navbar is aligned to the left when you land on http://jetpack.cloud.localhost:3000/partner-portal/partner-key?return=%2Fpartner-portal
* Select a key and make sure the navbar title is not shown

Before:
![image](https://user-images.githubusercontent.com/5714212/114711073-e73e9380-9d04-11eb-8650-753c35f9a34e.png)

![image](https://user-images.githubusercontent.com/5714212/114711092-eefe3800-9d04-11eb-9cc2-849394582d2f.png)


After:

![image](https://user-images.githubusercontent.com/5714212/114710893-aa729c80-9d04-11eb-82c3-6a99cc37a8ea.png)

![image](https://user-images.githubusercontent.com/5714212/114710958-bfe7c680-9d04-11eb-9a65-a6bda05a1fb3.png)


