### PR TITLE
All Sites View: Update Labels for Posts & Pages

### DIFF
--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -99,7 +99,11 @@ class PagesMain extends React.Component {
 					brandFont
 					className="pages__page-heading"
 					headerText={ translate( 'Pages' ) }
-					subHeaderText={ translate( 'Create, edit, and manage the pages on your site.' ) }
+					subHeaderText={
+						siteId
+							? translate( 'Create, edit, and manage the pages on your site.' )
+							: translate( 'Create, edit, and manage the pages on your sites.' )
+					}
 					align="left"
 				/>
 				<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ status } />

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -82,7 +82,11 @@ class PostsMain extends React.Component {
 					brandFont
 					className="posts__page-heading"
 					headerText={ translate( 'Posts' ) }
-					subHeaderText={ translate( 'Create, edit, and manage the posts on your site.' ) }
+					subHeaderText={
+						siteId
+							? translate( 'Create, edit, and manage the posts on your site.' )
+							: translate( 'Create, edit, and manage the posts on your sites.' )
+					}
 					align="left"
 				/>
 				<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ statusSlug } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the `subHeaderText` of the All Sites View for posts and pages by using the plural of "site" 

#### Testing instructions

Visit `/posts` and `/pages` on an account with multiple sites and verify that the plural for "site" appears.

<img width="1133" alt="Screenshot 2021-04-14 at 18 52 49" src="https://user-images.githubusercontent.com/43215253/114756421-a1a8b780-9d52-11eb-9c3e-34af4eae71c8.png">

Fixes #51904