### PR TITLE
Partner Portal: Fix licenses assigned to URLs without a protocol not displaying any URL

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -56,7 +56,7 @@ export default function LicensePreview( {
 	const isHighlighted = getQueryArg( window.location.href, 'highlight' ) === licenseKey;
 	const [ isOpen, setOpen ] = useState( isHighlighted );
 	const licenseState = getLicenseState( attachedAt, revokedAt );
-	const domain = siteUrl ? getUrlParts( siteUrl ).hostname : '';
+	const domain = siteUrl ? getUrlParts( siteUrl ).hostname || siteUrl : '';
 	const showDomain =
 		domain && [ LicenseState.Attached, LicenseState.Revoked ].indexOf( licenseState ) !== -1;
 	const justIssued =


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Partner Portal: Fix licenses assigned to URLs without a protocol not displaying any URL

#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view test this PR.
* Check out this PR locally, then run `yarn && yarn start-jetpack-cloud`.
* Have an assigned license to a URL without a protocol (e.g. `example.org`).
* Prior to this fix the domain will be missing; after applying this fix the URL should show up.