### PR TITLE
Jetpack Search: Add a non-functioning prototype configuration panel

### DIFF
--- a/client/components/promo-section/promo-card/index.tsx
+++ b/client/components/promo-section/promo-card/index.tsx
@@ -28,7 +28,7 @@ export interface Image {
 }
 
 export interface Props {
-	icon: string;
+	icon?: string;
 	image?: Image | ReactElement;
 	title: string | TranslateResult;
 	isPrimary?: boolean;

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -554,7 +554,7 @@ export const chooseDefaultCustomerType = ( { currentCustomerType, selectedPlan, 
 /**
  * Determines if a plan includes Jetpack Search by looking at the plan's features.
  *
- * @param   {string}  planSlug  Slug of the plan.
+ * @param   {string|undefined}  planSlug  Slug of the plan.
  * @returns {boolean}           Whether the specified plan includes Jetpack Search.
  */
 export const planHasJetpackSearch = ( planSlug ) =>

--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -2,6 +2,7 @@
 export interface Purchase {
 	id: number;
 	saleAmount?: number;
+	active: boolean;
 	amount: number;
 	meta?: string;
 	isRechargeable: boolean;

--- a/client/my-sites/jetpack-search/hooks/has-search-product.ts
+++ b/client/my-sites/jetpack-search/hooks/has-search-product.ts
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { isJetpackSearch } from 'calypso/lib/products-values';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import { planHasJetpackSearch } from 'calypso/lib/plans';
+import type { Purchase } from 'calypso/lib/purchases/types';
+
+const hasSearchProduct = ( state: Record< string, unknown > ): boolean => {
+	const site = getSelectedSite;
+	// const siteSlug = getSelectedSiteSlug;
+	const siteId = getSelectedSiteId( state );
+	const checkForSearchProduct = ( purchase: Purchase ) =>
+		purchase.active && isJetpackSearch( purchase );
+	const sitePurchases = getSitePurchases( state, siteId );
+	return !! (
+		sitePurchases.find( checkForSearchProduct ) ||
+		!! planHasJetpackSearch( site?.plan?.product_slug )
+	);
+};
+
+export default hasSearchProduct;

--- a/client/my-sites/jetpack-search/jetpack-instant-search-config/additional.tsx
+++ b/client/my-sites/jetpack-search/jetpack-instant-search-config/additional.tsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement, Fragment } from 'react';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '@automattic/components';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormToggle from 'calypso/components/forms/form-toggle';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+
+export default function JetpackSearchInstantSearchAdditionalConfig(): ReactElement {
+	return (
+		<Fragment>
+			<SettingsSectionHeader
+				id="jetpack-search-additional-settings"
+				showButton
+				title={ translate( 'Additional Settings', { context: 'Settings header' } ) }
+			/>
+			<Card>
+				<FormFieldset className="jetpack-instant-search-config__additional">
+					<FormToggle>{ translate( 'Show sort selector.' ) }</FormToggle>
+					<FormToggle>{ translate( 'Enable infinite scrolling.' ) }</FormToggle>
+					<FormToggle>{ translate( 'Display "Powered by Jetpack".' ) }</FormToggle>
+				</FormFieldset>
+			</Card>
+		</Fragment>
+	);
+}

--- a/client/my-sites/jetpack-search/jetpack-instant-search-config/additional.tsx
+++ b/client/my-sites/jetpack-search/jetpack-instant-search-config/additional.tsx
@@ -22,9 +22,9 @@ export default function JetpackSearchInstantSearchAdditionalConfig(): ReactEleme
 			/>
 			<Card>
 				<FormFieldset className="jetpack-instant-search-config__additional">
-					<FormToggle>{ translate( 'Show sort selector.' ) }</FormToggle>
-					<FormToggle>{ translate( 'Enable infinite scrolling.' ) }</FormToggle>
-					<FormToggle>{ translate( 'Display "Powered by Jetpack".' ) }</FormToggle>
+					<FormToggle checked>{ translate( 'Show sort selector.' ) }</FormToggle>
+					<FormToggle checked>{ translate( 'Enable infinite scrolling.' ) }</FormToggle>
+					<FormToggle checked>{ translate( 'Display "Powered by Jetpack".' ) }</FormToggle>
 				</FormFieldset>
 			</Card>
 		</Fragment>

--- a/client/my-sites/jetpack-search/jetpack-instant-search-config/behavioral.tsx
+++ b/client/my-sites/jetpack-search/jetpack-instant-search-config/behavioral.tsx
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement, Fragment } from 'react';
+import { translate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '@automattic/components';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLegend from 'calypso/components/forms/form-legend';
+import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
+import MultiCheckbox from 'calypso/components/forms/multi-checkbox';
+import QueryPostTypes from 'calypso/components/data/query-post-types';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { getPostTypes } from 'calypso/state/post-types/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+type PostType = {
+	public: boolean;
+	label: string;
+	name: string;
+};
+
+export default function JetpackSearchInstantSearchBehavioralConfig(): ReactElement {
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) as number );
+	const postTypes = useSelector(
+		( state ) => getPostTypes( state, siteId ) as Record< string, PostType >
+	);
+	const publicPostTypes: PostType[] =
+		typeof postTypes !== 'object'
+			? []
+			: Object.keys( postTypes )
+					.map( ( key ) => postTypes[ key ] )
+					.filter( ( postType ) => postType.public );
+	const checkboxOptions = publicPostTypes.map( ( postType ) => ( {
+		label: postType.label,
+		value: postType.name,
+	} ) );
+	const disableCheckboxes = false; // TODO: checked.length - 1 === checkboxOptions.length
+
+	return (
+		<Fragment>
+			{ siteId && <QueryPostTypes siteId={ siteId } /> }
+			<SettingsSectionHeader
+				id="jetpack-search-behavior-settings"
+				showButton
+				title={ translate( 'Behavioral', { context: 'Settings header' } ) }
+			/>
+			<Card>
+				<FormFieldset className="jetpack-instant-search-config__default-sort">
+					<FormLegend>{ translate( 'Default Sort' ) }</FormLegend>
+					<FormRadiosBar
+						checked="relevance"
+						items={ [
+							{
+								label: translate( 'Relevance (recommended)', { context: 'Sort option' } ),
+								value: 'relevance',
+							},
+							{
+								label: translate( 'Newest first', { context: 'Sort option' } ),
+								value: 'newest',
+							},
+							{
+								label: translate( 'Oldest first', { context: 'Sort option' } ),
+								value: 'oldest',
+							},
+						] }
+					/>
+				</FormFieldset>
+				<FormFieldset className="jetpack-instant-search-config__-overlay-trigger">
+					<FormLegend>{ translate( 'Search Input Overlay Trigger' ) }</FormLegend>
+					<FormRadiosBar
+						checked="immediate"
+						items={ [
+							{
+								label: translate( 'Open when the user starts typing' ),
+								value: 'immediate',
+							},
+							{
+								label: translate( 'Open when results are available' ),
+								value: 'results',
+							},
+						] }
+					/>
+				</FormFieldset>
+				<FormFieldset className="jetpack-instant-search-config__excluded-post-types">
+					<FormLegend>{ translate( 'Excluded Post Types' ) }</FormLegend>
+					<MultiCheckbox
+						options={ checkboxOptions }
+						checked={ [] }
+						disabled={ disableCheckboxes }
+					/>
+				</FormFieldset>
+			</Card>
+		</Fragment>
+	);
+}

--- a/client/my-sites/jetpack-search/jetpack-instant-search-config/behavioral.tsx
+++ b/client/my-sites/jetpack-search/jetpack-instant-search-config/behavioral.tsx
@@ -30,7 +30,7 @@ export default function JetpackSearchInstantSearchBehavioralConfig(): ReactEleme
 		( state ) => getPostTypes( state, siteId ) as Record< string, PostType >
 	);
 	const publicPostTypes: PostType[] =
-		typeof postTypes !== 'object'
+		postTypes === null || typeof postTypes !== 'object'
 			? []
 			: Object.keys( postTypes )
 					.map( ( key ) => postTypes[ key ] )

--- a/client/my-sites/jetpack-search/jetpack-instant-search-config/index.tsx
+++ b/client/my-sites/jetpack-search/jetpack-instant-search-config/index.tsx
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement, Fragment } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackSearchInstantSearchVisualConfig from './visual';
+import JetpackSearchInstantSearchBehavioralConfig from './behavioral';
+import JetpackSearchInstantSearchAdditionalConfig from './additional';
+
+export default function JetpackSearchInstantSearchConfig(): ReactElement {
+	return (
+		<Fragment>
+			<JetpackSearchInstantSearchVisualConfig />
+			<JetpackSearchInstantSearchBehavioralConfig />
+			<JetpackSearchInstantSearchAdditionalConfig />
+		</Fragment>
+	);
+}

--- a/client/my-sites/jetpack-search/jetpack-instant-search-config/visual.tsx
+++ b/client/my-sites/jetpack-search/jetpack-instant-search-config/visual.tsx
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement, Fragment } from 'react';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '@automattic/components';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLegend from 'calypso/components/forms/form-legend';
+import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+
+export default function JetpackSearchInstantSearchVisualConfig(): ReactElement {
+	return (
+		<Fragment>
+			<SettingsSectionHeader
+				id="jetpack-search-visualsettings"
+				showButton
+				title={ translate( 'Visuals', { context: 'Settings header' } ) }
+				// TODO: Configure the following
+				// disabled={ isRequestingSettings || isSavingSettings }
+				// isSaving={ isSavingSettings }
+				// onButtonClick={ handleSubmitForm }
+			/>
+			<Card>
+				<FormFieldset className="jetpack-instant-search-config__theme">
+					<FormLegend>{ translate( 'Theme' ) }</FormLegend>
+					<FormRadiosBar
+						checked="light"
+						isThumbnail
+						items={ [
+							{
+								label: translate( 'Light', { context: 'Jetpack search theme' } ),
+								value: 'light',
+								thumbnail: {
+									cssClass: 'some-css-class',
+								},
+							},
+							{
+								label: translate( 'Dark', { context: 'Jetpack search theme' } ),
+								value: 'dark',
+								thumbnail: {
+									cssClass: 'some-css-class',
+								},
+							},
+						] }
+					/>
+				</FormFieldset>
+				<FormFieldset className="jetpack-instant-search-config__result-format">
+					<FormLegend>{ translate( 'Result Format' ) }</FormLegend>
+					<FormRadiosBar
+						checked="minimal"
+						isThumbnail
+						items={ [
+							{
+								label: translate( 'Minimal', { context: 'Jetpack Search result format' } ),
+								value: 'minimal',
+								thumbnail: {
+									cssClass: 'some-css-class',
+								},
+							},
+							{
+								label: translate( 'Expanded', { context: 'Jetpack Search result format' } ),
+								value: 'expanded',
+								thumbnail: {
+									cssClass: 'some-css-class',
+								},
+							},
+							{
+								label: translate( 'Product', { context: 'Jetpack Search result format' } ),
+								value: 'product',
+								thumbnail: {
+									cssClass: 'some-css-class',
+								},
+							},
+						] }
+					/>
+				</FormFieldset>
+				<FormFieldset className="jetpack-instant-search-config__highlight-color">
+					<FormLegend>{ translate( 'Search Highlight Color' ) }</FormLegend>
+					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+					<input type="color" className="form-text-input" />
+				</FormFieldset>
+			</Card>
+		</Fragment>
+	);
+}

--- a/client/my-sites/jetpack-search/module-config.tsx
+++ b/client/my-sites/jetpack-search/module-config.tsx
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement, Fragment, useEffect, useState } from 'react';
+import { translate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal component dependencies
+ */
+import { Card } from '@automattic/components';
+import FormToggle from 'calypso/components/forms/form-toggle';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import QuerySiteSettings from 'calypso/components/data/query-site-settings';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+
+/**
+ * Internal state dependencies
+ */
+import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteSettings } from 'calypso/state/site-settings/selectors';
+import hasSearchProductSelector from './hooks/has-search-product';
+
+type PartialSiteSettings = { instant_search_enabled: boolean; jetpack_search_enabled: boolean };
+
+export default function JetpackSearchModuleConfig(): ReactElement {
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) as number );
+	const siteSettings = useSelector(
+		( state ) => getSiteSettings( state, siteId ) as PartialSiteSettings
+	);
+	const hasSearchProduct = useSelector( hasSearchProductSelector );
+
+	// Server-side config values
+	const isSearchActive = useSelector( ( state ) => {
+		if ( isJetpackSite( state, siteId ) ) {
+			return isJetpackModuleActive( state, siteId, 'search' );
+		}
+
+		return siteSettings && siteSettings[ 'jetpack_search_enabled' ];
+	} );
+	const isInstantSearchActive = siteSettings && siteSettings[ 'instant_search_enabled' ];
+
+	const isRequestingSettings = false;
+	const isSavingSettings = false;
+
+	// Local UI state values
+	const [ searchEnabled, onChangeSearchEnabled ] = useState( !! isSearchActive );
+	const [ instantSearchEnabled, onChangeInstantSearchEnabled ] = useState(
+		!! isInstantSearchActive
+	);
+
+	// If server side values update, update local UI state values
+	useEffect( () => {
+		searchEnabled !== isSearchActive && onChangeSearchEnabled( !! isSearchActive );
+	}, [ searchEnabled, isSearchActive ] );
+	useEffect( () => {
+		instantSearchEnabled !== isInstantSearchActive &&
+			onChangeSearchEnabled( !! isInstantSearchActive );
+	}, [ instantSearchEnabled, isInstantSearchActive ] );
+
+	return (
+		<Fragment>
+			<QuerySiteSettings siteId={ siteId } />
+			<SettingsSectionHeader
+				title={ translate( 'General', { context: 'Settings header' } ) }
+				id="site-settings__footer-credit-header"
+				showButton
+			/>
+			<Card>
+				<FormFieldset className="jetpack-search__module-settings">
+					<FormToggle
+						checked={ searchEnabled }
+						disabled={ isRequestingSettings || isSavingSettings }
+						onChange={ onChangeSearchEnabled }
+					>
+						{ translate( 'Enable Jetpack Search' ) }
+					</FormToggle>
+					<FormSettingExplanation>
+						{ translate( 'Improves built-in WordPress search performance.' ) }
+					</FormSettingExplanation>
+					<br />
+
+					<FormToggle
+						checked={ instantSearchEnabled }
+						disabled={ ! hasSearchProduct || isRequestingSettings || isSavingSettings }
+						onChange={ onChangeInstantSearchEnabled }
+					>
+						{ translate( 'Enable instant search experience (recommended)' ) }
+					</FormToggle>
+					<FormSettingExplanation>
+						{ translate(
+							'Replaces WordPress search with the new instant search interface by Jetpack Search.'
+						) }
+						{ /* The following notice is only shown for Business/Pro plan holders. */ }
+						{ ! hasSearchProduct &&
+							translate( 'Instant search is only available with a Jetpack Search subscription.' ) }
+					</FormSettingExplanation>
+				</FormFieldset>
+			</Card>
+		</Fragment>
+	);
+}

--- a/client/my-sites/jetpack-search/placeholder.tsx
+++ b/client/my-sites/jetpack-search/placeholder.tsx
@@ -25,7 +25,7 @@ import './style.scss';
 import JetpackSearchSVG from 'calypso/assets/images/illustrations/jetpack-search.svg';
 
 interface Props {
-	siteId: number;
+	siteId: number | null;
 }
 
 export default function JetpackSearchPlaceholder( { siteId }: Props ): ReactElement {

--- a/client/my-sites/site-settings/settings-section-header.jsx
+++ b/client/my-sites/site-settings/settings-section-header.jsx
@@ -11,6 +11,21 @@ import { useTranslate } from 'i18n-calypso';
 import { Button } from '@automattic/components';
 import SectionHeader from 'calypso/components/section-header';
 
+/**
+ * Returns a header for setting sections.
+ *
+ * @param {object} props React component properties.
+ * @param {React.Element?} props.children Optional React children.
+ * @param {boolean?} props.disabled Sets the save button's disabled state.
+ * @param {string?} props.id Sets the id for the SectionHeader component.
+ * @param {boolean?} props.isSaving Sets the loading state for the save button.
+ * @param {Function} props.onButtonClick Handler for clicking on the save button.
+ * @param {boolean?} props.showButton Shows/hides the save button; defaults to false.
+ * @param {string?} props.title Sets the label for the SectionHeader component.
+ * @param {undefined} props.numberFormat Unknown.
+ *
+ * @returns {React.Element} returns a SectionHeader customized for setting pages.
+ */
 const SettingsSectionHeader = ( {
 	children,
 	disabled,

--- a/client/state/ui/selectors/site-data.ts
+++ b/client/state/ui/selectors/site-data.ts
@@ -8,10 +8,16 @@ export interface SiteData {
 	domain: string;
 	locale: string;
 	options?: SiteDataOptions;
+	plan?: Plan;
 	// TODO: fill out the rest of this
 }
 
 export interface SiteDataOptions {
 	admin_url: string | undefined;
+	// TODO: fill out the rest of this
+}
+
+export interface Plan {
+	product_slug: string | undefined;
 	// TODO: fill out the rest of this
 }

--- a/config/development.json
+++ b/config/development.json
@@ -90,6 +90,7 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
+		"jetpack/search-config": true,
 		"jetpack/scan-product": true,
 		"jetpack/anti-spam-product": true,
 		"jetpack/backups-restore": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -74,6 +74,7 @@
 		"jetpack/anti-spam-product": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/backups-restore": true,
+		"jetpack/search-config": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Adds a visual prototype for Jetpack Search configuration panel behind a `jetpack/search-config` feature flag. This panel includes everything necessary for configuring Jetpack Search and Instant Search:

![Screenshot_2021-04-14 Jetpack Search ‹ Testing — WordPress com](https://user-images.githubusercontent.com/4044428/114791777-4a034f80-9d44-11eb-99a0-4be0588c24ac.png)

#### Testing instructions
* Spin up a local instance of these changes.
* Navigate to `calypso.localhost:3000/jetpack-search/<site-slug>` for a site with a Jetpack Search subscription.
* Ensure that the interface looks reasonable.