### PR TITLE
desktop: Bump version to 6.13.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "6.12.0",
+	"version": "6.13.0-beta1",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "6.13.0-beta1",
+	"version": "6.13.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/"


### PR DESCRIPTION
Copy of #51616, with the base branch cut of a more recent version of `trunk` and to ensure the a new GitHub check run on the PR. Refer to #51616 for more details.

