### PR TITLE
Add build and suite for gutenberg tests

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -2,10 +2,12 @@ package _self.projects
 
 import _self.PluginBaseBuild
 import _self.bashNodeScript
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
-import jetbrains.buildServer.configs.kotlin.v2019_2.Parametrized
-import jetbrains.buildServer.configs.kotlin.v2019_2.ParametrizedWithType
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
 
 object WPComPlugins : Project({
 	id("WPComPlugins")
@@ -24,6 +26,7 @@ object WPComPlugins : Project({
 	buildType(WpcomBlockEditor)
 	buildType(Notifications)
 	buildType(O2Blocks)
+	buildType(Gutenberg)
 
 	// For some reason, TeamCity needs this to reference the Template.
 	template(PluginBaseBuild())
@@ -150,6 +153,113 @@ private object O2Blocks : BuildType({
 				# Add index.php file
 				cp index.php release-files/
 			"""
+		}
+	}
+})
+
+private object Gutenberg : BuildType({
+	name = "Gutenberg tests (desktop)"
+	description = "Runs Gutenberg E2E tests using desktop screen resolution"
+
+	artifactRules = """
+		reports => reports
+		logs.tgz => logs.tgz
+		screenshots => screenshots
+	""".trimIndent()
+
+	vcs {
+		root(Settings.WpCalypso)
+		cleanCheckout = true
+	}
+
+	params {
+		text(name="URL", value="https://wordpress.com", label = "Test URL", description = "URL to test against", allowEmpty = false)
+		checkbox(name="GUTENBERG_EDGE", value="true", label = "Use gutenberg-edge", description = "Use a blog with gutenberg-edge sticker", checked="true", unchecked = "false")
+	}
+
+	steps {
+		bashNodeScript {
+			name = "Prepare environment"
+			scriptContent = """
+				export NODE_ENV="test"
+
+				# Install modules
+				${_self.yarn_install_cmd}
+			"""
+			dockerImage = "%docker_image_e2e%"
+		}
+		bashNodeScript {
+			name = "Run e2e tests (desktop)"
+			scriptContent = """
+				shopt -s globstar
+				set -x
+
+				cd test/e2e
+				mkdir temp
+
+				export LIVEBRANCHES=false
+				export NODE_CONFIG_ENV=test
+				export TEST_VIDEO=true
+				export HIGHLIGHT_ELEMENT=true
+				export GUTENBERG_EDGE=%GUTENBERG_EDGE%
+				export BROWSERSIZE=desktop
+				export BROWSERLOCALE=en
+				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{%URL%}\"}"
+
+				# Instructs Magellan to not hide the output from individual `mocha` processes. This is required for
+				# mocha-teamcity-reporter to work.
+				export MAGELLANDEBUG=true
+
+				# Decrypt config
+				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
+
+				# Run the test
+				yarn magellan --config=magellan-gutenberg.json --max_workers=%E2E_WORKERS% --suiteTag=parallel --local_browser=chrome --mocha_args="--reporter mocha-teamcity-reporter"
+			""".trimIndent()
+			dockerImage = "%docker_image_e2e%"
+			dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"
+		}
+		bashNodeScript {
+			name = "Collect results"
+			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+			scriptContent = """
+				set -x
+
+				mkdir -p screenshots
+				find test/e2e -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
+
+				mkdir -p logs
+				find test/e2e -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
+			""".trimIndent()
+			dockerImage = "%docker_image_e2e%"
+		}
+	}
+
+	features {
+		perfmon {
+		}
+	}
+
+	failureConditions {
+		executionTimeoutMin = 20
+		// TeamCity will mute a test if it fails and then succeeds within the same build. Otherwise TeamCity UI will not
+		// display a difference between real errors and retries, making it hard to understand what is actually failing.
+		supportTestRetry = true
+
+		// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have
+		// been muted previously.
+		nonZeroExitCode = false
+
+		// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner
+		// crashes and no tests are run.
+		failOnMetricChange {
+			metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
+			threshold = 50
+			units = BuildFailureOnMetric.MetricUnit.PERCENTS
+			comparison = BuildFailureOnMetric.MetricComparison.LESS
+			compareTo = build {
+				buildRule = lastSuccessful()
+			}
 		}
 	}
 })

--- a/test/e2e/magellan-gutenberg.json
+++ b/test/e2e/magellan-gutenberg.json
@@ -1,0 +1,13 @@
+{
+	"mocha_tests": [ "specs-gutenberg" ],
+	"mocha_args": "-R spec-junit-reporter",
+	"max_test_attempts": 3,
+	"max_workers": 6,
+	"suiteTag": "parallel",
+	"sauce": false,
+	"framework": "@automattic/testarmada-magellan-mocha-plugin",
+	"reporters": [ "./lib/reporter/magellan-reporter.js" ],
+	"executors": [ "testarmada-magellan-local-executor" ],
+	"local_browser": "chrome",
+	"bail_time": 360000
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Creates a separate Magellan suite to run Gutenberg tests.
* Adds a new TeamCity to run Gutenberg tests

#### Testing instructions

* Verify unit tests pass. This mean the new TeamCity build spec doesn't have syntax errors
* The new TeamCity build can't be tested until merged