### PR TITLE
Event Countdown Block: Fix event title input field overflowing container in Safari

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/editor.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/editor.scss
@@ -9,12 +9,13 @@
 
 	.event-countdown__event-title {
 		min-width: 240px;
+		width: 100%;
 	}
 }
 
 // Fix so datetime picker doesn't have horizontal scrollbar.
 // This is a global fix, unscoped, and not very nice.
-// @todo: It won't be necessary once https://github.com/WordPress/gutenberg/pull/18235/files gets merged. 
+// @todo: It won't be necessary once https://github.com/WordPress/gutenberg/pull/18235/files gets merged.
 .components-datetime {
 	padding: 8px;
 }


### PR DESCRIPTION
I noticed while testing the Event Countdown Block in the site editor on a test site running TT1-blocks, that the event title input field was overflowing the placeholder container in Safari (but it didn't do this in Chrome and Firefox). Setting the width to the field to 100% should fix this.

#### Changes proposed in this Pull Request

* Add `width: 100%` to the Event Countdown's title input field so that it is full width to the container, but doesn't overflow in Safari. Note: this will also make the field a little wider than it is currently in FF and Chrome on some themes, but I think it looks a bit neater if it's always full width to the placeholder.

#### Screenshots

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/114831084-52c15780-9e10-11eb-8708-1a738cde4987.png) | ![image](https://user-images.githubusercontent.com/14988353/114831111-59e86580-9e10-11eb-9621-04efca90630e.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this change in your sandbox: `install-plugin.sh etk fix/event-countdown-block-event-title-overflowing-container`
* Create an FSE test site if you haven't already (e.g. via https://horizon.wordpress.com/new?flags=gutenboarding/site-editor and select the TT1-blocks theme)
* Sandbox your test site and follow PCYsg-e-p2 if you have trouble testing in Safari (like I did!)
* In the site editor (e.g. `/wp-admin/admin.php?page=gutenberg-edit-site`) add an event countdown block to the footer template part, and ensure that the event title input field is full width
* Test in the post/page editor of a test site running a non-FSE theme 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/19504
