### PR TITLE
Domains: Fix import path in TransferOtherUser

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -28,7 +28,7 @@ import DesignatedAgentNotice from 'calypso/my-sites/domains/domain-management/co
 import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import useUsersQuery from 'calypso/data/users//use-users-query';
+import useUsersQuery from 'calypso/data/users/use-users-query';
 
 /**
  * Style dependencies


### PR DESCRIPTION
This fixes a minor bug where we're importing a component incorrectly with `//` in the path instead of `/`. 