### PR TITLE
Framework: Refactor away from `_.flattenDeep()`

### DIFF
--- a/client/blocks/product-selector/utils.js
+++ b/client/blocks/product-selector/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flattenDeep, pickBy } from 'lodash';
+import { pickBy } from 'lodash';
 
 /**
  * Extract the product slugs out of an array of product objects.
@@ -10,7 +10,7 @@ import { flattenDeep, pickBy } from 'lodash';
  * @returns {Array} Array of the product slugs.
  */
 export const extractProductSlugs = ( products ) => [
-	...new Set( flattenDeep( products.map( ( product ) => Object.values( product.options ) ) ) ),
+	...new Set( products.map( ( product ) => Object.values( product.options ) ).flat( 2 ) ),
 ];
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `flattenDeep()` is only used once in the Calypso codebase, and the usage is pretty simple, so this PR replaces it with an instance of `Array.prototype.flat()`. 

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all tests pass: `yarn run test-client client/blocks/product-selector`.
* Smoke test the plans page on a Jetpack site and verify it works well.
* This will also be testable on devdocs (`/devdocs/blocks/product-selector`), but we need #51975 as well.