### PR TITLE
Blocks: Fix missing product link prop in ProductSelector

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -560,9 +560,12 @@ export class ProductSelector extends Component {
 			const selectedSlug = this.state[ stateKey ];
 			const productObject = storeProducts[ selectedSlug ];
 
-			const linkUrl = selectedSiteSlug
-				? addQueryArgs( { site: selectedSiteSlug }, product.link.url )
-				: product.link.url;
+			let linkUrl;
+			if ( product.link ) {
+				linkUrl = selectedSiteSlug
+					? addQueryArgs( { site: selectedSiteSlug }, product.link.url )
+					: product.link.url;
+			}
 
 			let purchase;
 			let isCurrent;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes an error that occurs when accessing `/devdocs/blocks/product-selector` and picking a Jetpack site:

#### Testing instructions

* Go to `/devdocs/blocks/product-selector`
* Pick a Jetpack site.
* Verify the products are rendered correctly and there are no errors in the console.

#### Notes

Discovered while working on #51974.