### PR TITLE
Framework: Refactor away from `_.findLastIndex()`

### DIFF
--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { findIndex, findLastIndex, flatten, flowRight, get, range } from 'lodash';
+import { flatten, flowRight, get, range } from 'lodash';
 
 /**
  * Internal dependencies
@@ -96,8 +96,14 @@ class StatsPostSummary extends Component {
 						} );
 					} )
 				);
-				const firstNotEmpty = findIndex( months, ( item ) => item.value !== 0 );
-				const lastNotEmpty = findLastIndex( months, ( item ) => item.value !== 0 );
+				const firstNotEmpty = months.findIndex( ( item ) => item.value !== 0 );
+				const reverseLastNotEmpty = [ ...months ]
+					.reverse()
+					.findIndex( ( item ) => item.value !== 0 );
+				const lastNotEmpty =
+					reverseLastNotEmpty === -1
+						? reverseLastNotEmpty
+						: months.length - ( reverseLastNotEmpty + 1 );
 
 				return months.slice( firstNotEmpty, lastNotEmpty + 1 );
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `findLastIndex()` is only used once in the Calypso codebase, and the usage is pretty simple, so this PR replaces it with an inverted variant of `Array.prototype.findIndex()`. We also remove an instance of Lodash's `findIndex()` that is used in the affected file.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Pick several sites with lots of stats and a post from each of the sites.
* Go to `/stats/post/:postId/:site` where `:postId` is an ID of the post and `:site` is the slug of the site.
* Click on "Months".
* Compare with production and verify everything looks and works the same way, with no errors introduced in the console.