### PR TITLE
Activity Log: Remove incorrect param from HTTP call for data

### DIFF
--- a/client/my-sites/backup/hooks.js
+++ b/client/my-sites/backup/hooks.js
@@ -49,10 +49,7 @@ export const useActivityLogs = ( siteId, filter, shouldExecute = true ) => {
 	}, [ shouldExecute, siteId, memoizedFilter ] );
 
 	const requestId = getRequestActivityLogsId( siteId, memoizedFilter );
-	const response = useSelector( () => shouldExecute && getHttpData( requestId ), [
-		shouldExecute,
-		requestId,
-	] );
+	const response = useSelector( () => shouldExecute && getHttpData( requestId ) );
 
 	return {
 		isLoadingActivityLogs: !! ( shouldExecute && isLoading( response ) ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #51966. Related to #51968, #46932.

* Removes an incorrect parameter from a `useSelector` call to get Activity Log data. (It was a typo on my part to begin with.)

#### Testing instructions

* Open Calypso (either Blue or Green) and select a self-hosted Jetpack site with an active Backup subscription.
* Open the Network panel in your browser's developer tools and navigate to the Backups page for your selected site.
* Verify that:
  * the Backups page loads correctly (i.e., page fully renders with no console errors);
  * you're able to navigate back and forth through time;
  * that network calls to get Activity Log data are only initiated when you change dates; and
  * that the network calls eventually stop (i.e., no infinite loops).
