### PR TITLE
Update CODEOWNERS file for new Letero team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,26 +15,27 @@
 # Customer Home
 /client/my-sites/customer-home @Automattic/manage
 
-# G Suite
-/client/components/data/query-gsuite-users @Automattic/cobalt
-/client/components/domains/contact-details-form-fields/index.jsx @Automattic/cobalt
-/client/components/gsuite @Automattic/cobalt
-/client/components/marketing-survey/gsuite-cancel-purchase-dialog @Automattic/cobalt
-/client/components/upgrades/gsuite @Automattic/cobalt
-/client/lib/domains/email-forwarding @Automattic/cobalt
-/client/lib/gsuite @Automattic/cobalt
-/client/me/purchases/remove-purchase/index.jsx @Automattic/cobalt
-/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx @Automattic/cobalt
-/client/my-sites/checkout/checkout-thank-you/index.jsx @Automattic/cobalt
-/client/my-sites/checkout/checkout/domain-details-form.jsx @Automattic/cobalt
-/client/my-sites/checkout/checkout/index.jsx @Automattic/cobalt
-/client/my-sites/checkout/controller.jsx @Automattic/cobalt
-/client/my-sites/checkout/gsuite-nudge @Automattic/cobalt
-/client/my-sites/domains/components/domain-warnings @Automattic/cobalt
-/client/my-sites/domains/controller.jsx @Automattic/cobalt
-/client/my-sites/email @Automattic/cobalt
-/client/state/data-layer/wpcom/gsuite-users @Automattic/cobalt
-/client/state/gsuite-users @Automattic/cobalt
+# Email services
+/client/components/data/query-gsuite-users @Automattic/letero
+/client/components/domains/contact-details-form-fields/index.jsx @Automattic/letero
+/client/components/gsuite @Automattic/letero
+/client/components/marketing-survey/gsuite-cancel-purchase-dialog @Automattic/letero
+/client/components/upgrades/gsuite @Automattic/letero
+/client/lib/domains/email-forwarding @Automattic/letero
+/client/lib/gsuite @Automattic/letero
+/client/lib/titan @Automattic/letero
+/client/me/purchases/remove-purchase/index.jsx @Automattic/letero
+/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx @Automattic/letero
+/client/my-sites/checkout/checkout-thank-you/index.jsx @Automattic/letero
+/client/my-sites/checkout/checkout/domain-details-form.jsx @Automattic/letero
+/client/my-sites/checkout/checkout/index.jsx @Automattic/letero
+/client/my-sites/checkout/controller.jsx @Automattic/letero
+/client/my-sites/checkout/gsuite-nudge @Automattic/letero
+/client/my-sites/domains/components/domain-warnings @Automattic/letero
+/client/my-sites/domains/controller.jsx @Automattic/letero
+/client/my-sites/email @Automattic/letero
+/client/state/data-layer/wpcom/gsuite-users @Automattic/letero
+/client/state/gsuite-users @Automattic/letero
 
 # Payments
 /client/blocks/credit-card-form/ @Automattic/shilling


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR changes the code ownership for various email-related directories from Cobalt to the new Letero team, and also adds `/client/lib/titan` to that list.

#### Testing instructions

No real testing necessary -- checking the directories should be enough.