### PR TITLE
Framework: Refactor away from `_.isDate()`

### DIFF
--- a/client/state/comments/selectors/get-post-comments-count-at-date.js
+++ b/client/state/comments/selectors/get-post-comments-count-at-date.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, isDate, size } from 'lodash';
+import { filter, size } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,7 +21,7 @@ import 'calypso/state/comments/init';
  */
 export function getPostCommentsCountAtDate( state, siteId, postId, date ) {
 	// Check the provided date
-	if ( ! isDate( date ) ) {
+	if ( ! ( date instanceof Date && ! isNaN( date ) ) ) {
 		return 0;
 	}
 

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { compact, get, isDate, startsWith, pickBy, map } from 'lodash';
+import { compact, get, startsWith, pickBy, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,6 +27,8 @@ import {
 } from 'calypso/state/comments/selectors';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+const isDate = ( date ) => date instanceof Date && ! isNaN( date );
 
 export const commentsFromApi = ( comments ) =>
 	map( comments, ( comment ) =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `isDate()` is only used a couple of times in the Calypso codebase, and the usage is pretty simple, so this PR replaces it with a standard `instanceof Date && ! isNaN()` logic.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Changed code is covered by tests, so verify all tests pass: `yarn run test-client comments`.