### PR TITLE
Add Hide eCommerce Experiment from Launch Site Flow

### DIFF
--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -14,6 +14,13 @@ $plan-features-sidebar-width: 272px;
 	margin-top: 300px;
 }
 
+.plan-features-comparison__table.has-3-cols {
+	display: block;
+	margin-left: auto;
+	margin-right: auto;
+	max-width: 980px;
+}
+
 .plan-features-comparison__table.has-2-cols {
 	display: block;
 	margin-left: auto;

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -521,14 +521,13 @@ export class PlansFeaturesMain extends Component {
 			customHeader,
 			redirectToAddDomainFlow,
 			shouldShowPlansFeatureComparison,
-			isLaunchPage,
-			isInSignup,
+			flowName,
 		} = this.props;
 
 		return (
 			<ProvideExperimentData
 				name="hide_ecommerce_launch_site"
-				options={ { isEligible: isLaunchPage && isInSignup } }
+				options={ { isEligible: 'launch-site' === flowName } }
 			>
 				{ ( isLoading, experimentAssignment ) => {
 					if ( isLoading ) {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -78,6 +78,7 @@ import { isDiscountActive } from 'calypso/state/selectors/get-active-discount.js
 import { selectSiteId as selectHappychatSiteId } from 'calypso/state/help/actions';
 import PlanTypeSelector from './plan-type-selector';
 import { ProvideExperimentData } from 'calypso/lib/explat';
+import PulsingDot from 'calypso/components/pulsing-dot';
 
 /**
  * Style dependencies
@@ -130,7 +131,7 @@ export class PlansFeaturesMain extends Component {
 		}
 	}
 
-	showFeatureComparison( experimentVariation = null ) {
+	showFeatureComparison( experimentVariation ) {
 		const {
 			basePlansPath,
 			customerType,
@@ -275,7 +276,7 @@ export class PlansFeaturesMain extends Component {
 		return plans[ intervalType ] || defaultValue || TERM_ANNUALLY;
 	}
 
-	getPlansForPlanFeatures( experimentVariation = null ) {
+	getPlansForPlanFeatures( experimentVariation ) {
 		const {
 			displayJetpackPlans,
 			intervalType,
@@ -531,7 +532,12 @@ export class PlansFeaturesMain extends Component {
 			>
 				{ ( isLoading, experimentAssignment ) => {
 					if ( isLoading ) {
-						return null;
+						const loadingContainerClass = 'plans__loading-container';
+						return (
+							<div className={ loadingContainerClass }>
+								<PulsingDot delay={ 400 } active />
+							</div>
+						);
 					}
 
 					const experimentVariation = experimentAssignment?.variationName;

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -100,6 +100,7 @@ export default {
 	redirectTests( context, next ) {
 		const currentFlowName = getFlowName( context.params );
 		currentFlowName === 'onboarding' && loadExperimentAssignment( 'refined_reskin_v1' );
+		currentFlowName === 'launch-site' && loadExperimentAssignment( 'hide_ecommerce_launch_site' );
 		if ( context.pathname.indexOf( 'new-launch' ) >= 0 ) {
 			next();
 		} else if ( currentFlowName === 'onboarding' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Hides the eCommerce plan for 50% of the users in the launch-site flow

<img width="1185" alt="Screenshot 2021-04-15 at 16 37 26" src="https://user-images.githubusercontent.com/82778/114885202-1b9e7680-9e0f-11eb-9cd8-172bb87cc345.png">

I previously prepared #51068 but the new ExPlat client was introduced when I worked on it plus several other changes happened, including the PlanFeaturesComparison.

#### Testing instructions

Make sure to check each step on mobile resolutions!

1. Assign yourself to the test variation of the `hide_ecommerce_launch_site ` in ExPlat
2. Create a new user and site. Make sure that on the Signup Plans step, the eCommerce plan is visible
3. Go to /plans - eCommerce should be visible
3. Launch the site, stop at the plans step
4. Make sure that on the Plans step, the eCommerce plan is not visible
5. Switch between Annual and Monthly plans. It should keep the eCommerce hidden
6. Switch to Control and reload
7. No eCommerce should now be visible

There's some duplication but it is because the code I change is duplicated. I don't think additional helpers are needed given that it's an experiment.

