### PR TITLE
Remove unused state property

### DIFF
--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -83,7 +83,6 @@ export class List extends React.Component {
 		settingPrimaryDomain: false,
 		changePrimaryDomainModeEnabled: false,
 		primaryDomainIndex: -1,
-		addMenuVisible: false,
 	};
 
 	isLoading() {


### PR DESCRIPTION
In #50762 I introduced this state var which is not used in this component as I extracted the state into separate controller. So let's clean it up

#### Changes proposed in this Pull Request

* Remove unused state property `addMenuVisible`

#### Testing instructions

* Make sure that the domains list "Add a domain" button is still working
