### PR TITLE
Partner Portal: Add a link to the Licensing docs in the Revoke License dialog

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -48,7 +48,6 @@ export default function RevokeLicenseDialog( {
 			dispatch( errorNotice( error.message ) );
 		},
 	} );
-	const helpUrl = '';
 
 	close = useCallback( () => {
 		if ( ! mutation.isLoading ) {
@@ -70,15 +69,17 @@ export default function RevokeLicenseDialog( {
 		</Button>,
 	];
 
-	if ( helpUrl ) {
-		buttons.unshift(
-			<a href={ helpUrl } target="_blank" rel="noreferrer noopener">
-				{ translate( 'Learn more about revoking licenses' ) }
-				&nbsp;
-				<Gridicon icon="external" size={ 18 } />
-			</a>
-		);
-	}
+	buttons.unshift(
+		<a
+			href="https://github.com/Automattic/jetpack-licensing-api/tree/master/integration-docs#glossary"
+			target="_blank"
+			rel="noreferrer noopener"
+		>
+			{ translate( 'Learn more about revoking licenses' ) }
+			&nbsp;
+			<Gridicon icon="external" size={ 18 } />
+		</a>
+	);
 
 	return (
 		<Dialog


### PR DESCRIPTION
Context: 1187494150150258-as-1200130607012259

#### Changes proposed in this Pull Request

* Partner Portal: Add a link to the Licensing docs in the Revoke License dialog

#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view test this PR.
* Check out this PR locally, then run `yarn && yarn start-jetpack-cloud`.
* Revoke a license and make sure the following link appears in the dialog and links to the Glossary section of our documentation:
![Screenshot 2021-04-15 at 18 00 52](https://user-images.githubusercontent.com/22746396/114891862-ed239a00-9e14-11eb-8ab6-30da21054645.png)
