### PR TITLE
Disable reCAPTCHA in wpcom signup

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -138,6 +138,5 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "desktop",
 	"google_analytics_key": "UA-10673494-10",
-	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true
 }

--- a/config/development.json
+++ b/config/development.json
@@ -17,7 +17,6 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "development",
 	"google_analytics_key": "UA-10673494-15",
-	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true,
 	"signup_url": "/start",
 	"gutenboarding_url": "/new",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -149,6 +149,5 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "horizon",
 	"google_analytics_key": "UA-10673494-20",
-	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true
 }

--- a/config/production.json
+++ b/config/production.json
@@ -182,6 +182,5 @@
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "production",
 	"google_analytics_key": "UA-10673494-10",
-	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true
 }

--- a/config/stage.json
+++ b/config/stage.json
@@ -183,7 +183,6 @@
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": false,
 	"google_analytics_key": "UA-10673494-15",
-	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"boom_analytics_enabled": true,
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "stage",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -194,6 +194,5 @@
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "wpcalypso",
 	"google_analytics_key": "UA-10673494-15",
-	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `google_recaptcha_site_key` from config

Removing google_recaptcha_site_key from the config is a quick way to
disable recaptcha that doesn't impact the user and is easily revertable.

Discussion around disabling recaptcha: pbAok1-25D-p2, specifically pbAok1-25D-p2#comment-4296

Signup already doesn't block on recaptcha not being available because we
need to deal with the situation where the user has blocked recaptcha
using a browser extension. So if recaptcha fails to init /start/signup
will just record a recaptcha_didnt_load error and carry on.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/start` in an incognito tab
   * Notice the recaptcha logo doesn't appear in the bottom-right
   * Verify that you can create an account with no errors
* `/new` in an incognito tab
   * Advance through flow to the signup step (new users don't currently go through this flow, but still worth testing)
   * Notice the recaptcha logo doesn't appear in the bottom-right
   * Verify that you can create an account with no errors

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

