### PR TITLE
Checkout: Add explicit error handling during Stripe payment intent creation

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -75,11 +75,20 @@ async function stripeCardProcessor(
 		contactDetails,
 	} = transactionOptions;
 
-	const { id: paymentMethodToken } = await createStripePaymentMethodToken( {
-		...submitData,
-		country: contactDetails?.countryCode?.value,
-		postalCode: getPostalCode( contactDetails ),
-	} );
+	let paymentMethodToken;
+	try {
+		const tokenResponse = await createStripePaymentMethodToken( {
+			...submitData,
+			country: contactDetails?.countryCode?.value,
+			postalCode: getPostalCode( contactDetails ),
+		} );
+		paymentMethodToken = tokenResponse.id;
+	} catch ( error ) {
+		debug( 'transaction failed' );
+		// Errors here are "expected" errors, meaning that they (hopefully) come
+		// from stripe and not from some bug in the frontend code.
+		return makeErrorResponse( error.message );
+	}
 
 	const formattedTransactionData = createTransactionEndpointRequestPayload( {
 		...submitData,

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.ts
@@ -236,8 +236,12 @@ describe( 'multiPartnerCardProcessor', () => {
 
 		it( 'fails to create a token if the name and address are missing', async () => {
 			const submitData = { paymentPartner: 'stripe', stripe, stripeConfiguration };
-			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
-				/billing_details.name/
+			const expected = {
+				payload: 'stripe error: missing billing_details.name',
+				type: 'ERROR',
+			};
+			await expect( multiPartnerCardProcessor( submitData, options ) ).resolves.toStrictEqual(
+				expected
 			);
 		} );
 
@@ -248,8 +252,12 @@ describe( 'multiPartnerCardProcessor', () => {
 				stripeConfiguration,
 				name: 'test name',
 			};
-			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
-				/billing_details.address.country/
+			const expected = {
+				payload: 'stripe error: missing billing_details.address.country',
+				type: 'ERROR',
+			};
+			await expect( multiPartnerCardProcessor( submitData, options ) ).resolves.toStrictEqual(
+				expected
 			);
 		} );
 
@@ -260,12 +268,16 @@ describe( 'multiPartnerCardProcessor', () => {
 				stripeConfiguration,
 				name: 'test name',
 			};
+			const expected = {
+				payload: 'stripe error: missing billing_details.address.postal_code',
+				type: 'ERROR',
+			};
 			await expect(
 				multiPartnerCardProcessor( submitData, {
 					...options,
 					contactDetails: { countryCode },
 				} )
-			).rejects.toThrowError( /billing_details.address.postal_code/ );
+			).resolves.toStrictEqual( expected );
 		} );
 
 		it( 'sends the correct data to the endpoint with no site and one product', async () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As of https://github.com/Automattic/wp-calypso/pull/51427 we are treating "expected" errors thrown during a payment method submission as different from "unexpected" errors so that we can detect and fix bugs rather than just reporting them to the user.

When paying with a new Stripe credit card, there's actually a two step process: first we create the Stripe Payment Intent (we tokenize the credit card information with Stripe) and then we submit the token and the rest of the payment info to our transactions endpoint which handles the actual payment. However, when we modified the payment processor in https://github.com/Automattic/wp-calypso/pull/51463 to explicitly report "expected" errors, we only treated errors from the second step as expected. This means that any error that comes from the tokenization process is reported to us as a fatal error.

In this PR, we modify the processor to also treat errors from the Payment Intent creation as "expected", displaying them to the user but not otherwise taking any action.

Before:

<img width="871" alt="Screen Shot 2021-04-15 at 7 03 04 PM" src="https://user-images.githubusercontent.com/2036909/114948618-5c04f100-9e1d-11eb-8029-667c7d9607e5.png">

After:

<img width="727" alt="Screen Shot 2021-04-15 at 7 03 55 PM" src="https://user-images.githubusercontent.com/2036909/114948624-61fad200-9e1d-11eb-9d36-abc3f499a4b6.png">


#### Testing instructions

Thanks to https://github.com/Automattic/wp-calypso/pull/51837 we have unit tests covering this payment processor and we are able to test the changed behavior. However, it's still worth trying at least one purchase with a new Stripe card to verify that it works as expected.

You can easily reproduce an error during a Payment Intent creation by attempting to make a purchase using the production API while using a Stripe test card like `4242 4242 4242 4242`. Prior to this PR, you'd see a React error boundary appear, and after this PR you should still see checkout loaded.