### PR TITLE
Add an option to disable 3rd party cookies in e2e tests

### DIFF
--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -74,7 +74,7 @@ export function getProxyType() {
 export async function startBrowser( {
 	useCustomUA = true,
 	resizeBrowserWindow = true,
-	disableThirdPartyCookies = false,
+	disableThirdPartyCookies = true,
 } = {} ) {
 	if ( global.__BROWSER__ ) {
 		return global.__BROWSER__;

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -74,7 +74,7 @@ export function getProxyType() {
 export async function startBrowser( {
 	useCustomUA = true,
 	resizeBrowserWindow = true,
-	disableThirdPartyCookies = true,
+	disableThirdPartyCookies = false,
 } = {} ) {
 	if ( global.__BROWSER__ ) {
 		return global.__BROWSER__;
@@ -145,16 +145,18 @@ export async function startBrowser( {
 					enable_do_not_track: true,
 					credentials_enable_service: false,
 					intl: { accept_languages: locale },
+					profile: {
+						// 1 = allow all cookies (default), 2 = block all cookies
+						default_content_setting_values: { cookies: 1 },
+						block_third_party_cookies: false, // For chrome v84. (ci)
+						// 0 = allow 3pc, 1 = block 3pc, 2 = block 3pc in incognito (default)
+						cookie_controls_mode: 2, // For chrome v90.
+					},
 				};
 
 				if ( disableThirdPartyCookies ) {
-					prefs.profile = {
-						// 1 = allow all cookies (default), 2 = block all cookies
-						default_content_setting_values: { cookies: 1 },
-						// 0 = allow 3pc, 1 = block 3pc, 2 = block 3pc in incognito (default)
-						cookie_controls_mode: 1, // For chrome v90.
-						block_third_party_cookies: true, // For chrome v84. (ci)
-					};
+					prefs.profile.cookie_controls_mode = 1;
+					prefs.profile.block_third_party_cookies = true;
 				}
 
 				options.setUserPreferences( prefs );

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -152,7 +152,8 @@ export async function startBrowser( {
 						// 1 = allow all cookies (default), 2 = block all cookies
 						default_content_setting_values: { cookies: 1 },
 						// 0 = allow 3pc, 1 = block 3pc, 2 = block 3pc in incognito (default)
-						cookie_controls_mode: 1,
+						cookie_controls_mode: 1, // For chrome v90.
+						block_third_party_cookies: true, // For chrome v84. (ci)
 					};
 				}
 

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -148,8 +148,14 @@ export async function startBrowser( {
 				};
 
 				if ( disableThirdPartyCookies ) {
-					prefs.default_content_settings = { cookies: 2 };
+					prefs.profile = {
+						// 1 = allow all cookies (default), 2 = block all cookies
+						default_content_setting_values: { cookies: 1 },
+						// 0 = allow 3pc, 1 = block 3pc, 2 = block 3pc in incognito (default)
+						cookie_controls_mode: 1,
+					};
 				}
+
 				options.setUserPreferences( prefs );
 				options.setProxy( getProxyType() );
 				options.addArguments( '--no-first-run' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds an option to disable third party cookies in the browser settings used by e2e tests.
* nb: This change also adds previously omitted chrome browser settings in the saucelabs section (we can remove this, it just looks like an omission rather than something intentional) 

#### Testing instructions

I was testing this against #51618 but any spec will do.

I've added the commit 
f9adcf2 to disable 3pc for all tests to identify whether we can do this by default or if there are features that need fixing. (which would also be useful for us to know over at c3pop2.) 

If everything passes or the large majority of things do we should leave this disabled by default and enable them for the failing tests. If lots is failing we can remove the commit.

```
NODE_CONFIG_ENV=decrypted BROWSERSIZE=desktop ./node_modules/.bin/mocha specs/wp-likes-spec.js
```

Related to #51618
