### PR TITLE
Timeline block: remove specific margin declaration

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/blocks/src/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/blocks/src/style.scss
@@ -12,7 +12,6 @@ $timeline-border-width: 4px;
 
 	// This padding needs extra specificity.
 	&.wp-block-jetpack-timeline {
-		margin: 0;
 		padding: 0;
 	}
 


### PR DESCRIPTION
## What this PR does

Many themes have center-aligned content, provided by `margin: auto`. 

Some themes have deep specificity to enforce this property, some do not. Examples of the latter include the current crop   of FSE themes on horizon.

For example, compare:

```
.wp-container > *  {
    margin-left: auto;
    margin-right: auto;
}
```

with the overriding

```
.entry-content > *:not(.wp-block-button) {
    margin-left: auto;
    margin-right: auto;
}
```

The margin declaration we're removing in this PR has the noticeable effect of overriding the instructions of some themes' margin CSS declarations. 

Removing it fixes the alignment in all block-based FSE themes and doesn't seem to have any effect in current themes (so far).

### Before
<img width="500" alt="Screen Shot 2021-04-16 at 3 03 58 pm" src="https://user-images.githubusercontent.com/6458278/114975907-603a1880-9ec8-11eb-961c-300cce973b69.png">

### After
<img width="500" alt="Screen Shot 2021-04-16 at 3 19 58 pm" src="https://user-images.githubusercontent.com/6458278/114975902-5ca69180-9ec8-11eb-8314-6bab80d5e666.png">

## Testing instructions

1. Settle in with a tea and some soothing music. This might take a while.
2. Create new sites for the FSE themes in the horizon onboarding flow: https://horizon.wordpress.com/new?flags=gutenboarding/site-editor
2. In both the site and block editors, insert a timeline block and preview the frontend site
3. The timeline block should align itself according to the theme's rules, that is, it should align itself in the centre if all other blocks are doing so.
4. Test this block in other non-FSE themes to make sure we've not broken anything. Preferably a few :)
5. Know that your efforts are appreciated.

Fixes #51802
