### PR TITLE
Hides free domain feature on /plans for upgrades

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -75,6 +75,7 @@ import {
 	isWpComEcommercePlan,
 	isWpComBusinessPlan,
 	getPlanClass,
+	FEATURE_CUSTOM_DOMAIN,
 } from '@automattic/calypso-products';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import PlanFeaturesScroller from './scroller';
@@ -753,14 +754,18 @@ export class PlanFeatures extends Component {
 	}
 
 	renderPlanFeatureColumns( rowIndex ) {
-		const { planProperties, selectedFeature, withScroll } = this.props;
+		const { planProperties, selectedFeature, withScroll, hideCustomDomainFeature } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const { features, planName } = properties;
 
 			const featureKeys = Object.keys( features );
 			const key = featureKeys[ rowIndex ];
-			const currentFeature = features[ key ];
+			let currentFeature = features[ key ];
+
+			if ( hideCustomDomainFeature && FEATURE_CUSTOM_DOMAIN === currentFeature?.getSlug() ) {
+				currentFeature = null;
+			}
 
 			const classes = classNames( 'plan-features__table-item', getPlanClass( planName ), {
 				'has-partial-border': ! withScroll && rowIndex + 1 < featureKeys.length,
@@ -1089,6 +1094,8 @@ const ConnectedPlanFeatures = connect(
 
 		const purchaseId = getCurrentPlanPurchaseId( state, siteId );
 
+		const hideCustomDomainFeature = isPaid && ! isMonthly( sitePlan?.product_slug );
+
 		return {
 			productsList: getProductsList( state ),
 			canPurchase,
@@ -1108,6 +1115,7 @@ const ConnectedPlanFeatures = connect(
 				planCredits &&
 				! isJetpackNotAtomic &&
 				! isInSignup,
+			hideCustomDomainFeature,
 		};
 	},
 	{

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -754,18 +754,14 @@ export class PlanFeatures extends Component {
 	}
 
 	renderPlanFeatureColumns( rowIndex ) {
-		const { planProperties, selectedFeature, withScroll, hideCustomDomainFeature } = this.props;
+		const { planProperties, selectedFeature, withScroll } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const { features, planName } = properties;
 
 			const featureKeys = Object.keys( features );
 			const key = featureKeys[ rowIndex ];
-			let currentFeature = features[ key ];
-
-			if ( hideCustomDomainFeature && FEATURE_CUSTOM_DOMAIN === currentFeature?.getSlug() ) {
-				currentFeature = null;
-			}
+			const currentFeature = features[ key ];
 
 			const classes = classNames( 'plan-features__table-item', getPlanClass( planName ), {
 				'has-partial-border': ! withScroll && rowIndex + 1 < featureKeys.length,
@@ -1053,6 +1049,18 @@ const ConnectedPlanFeatures = connect(
 					);
 				}
 
+				// Strip the "Free domain for one year" feature out for the site's /plans page
+				// if the user is already on a paid annual plan
+				if (
+					isPaid &&
+					! isMonthly( sitePlan?.product_slug ) &&
+					( ! isInSignup || isPlaceholder )
+				) {
+					planFeatures = planFeatures.filter(
+						( feature ) => FEATURE_CUSTOM_DOMAIN !== feature.getSlug()
+					);
+				}
+
 				return {
 					availableForPurchase,
 					cartItemForPlan: getCartItemForPlan( getPlanSlug( state, planProductId ) ),
@@ -1094,8 +1102,6 @@ const ConnectedPlanFeatures = connect(
 
 		const purchaseId = getCurrentPlanPurchaseId( state, siteId );
 
-		const hideCustomDomainFeature = isPaid && ! isMonthly( sitePlan?.product_slug );
-
 		return {
 			productsList: getProductsList( state ),
 			canPurchase,
@@ -1115,7 +1121,6 @@ const ConnectedPlanFeatures = connect(
 				planCredits &&
 				! isJetpackNotAtomic &&
 				! isInSignup,
-			hideCustomDomainFeature,
 		};
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: pau2Xa-2Ce-p2

Hides the "Free domain for one year" feature on the /plans page for users on any annual paid plan.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site with a free plan. The "Free domain for one year" feature on the /plans page should be visible. Clicking on "Pay Monthly/Pay Annually" should still show the feature. (It shows crossed out when "Pay Monthly" is selected)
![image](https://user-images.githubusercontent.com/5436027/115020197-dc882800-9ed7-11eb-9ee3-103979207d5d.png)

* Create a site with a monthly plan. The "Free domain for one year" feature on the /plans page should be visible. Clicking on "Pay Monthly/Pay Annually" should still show the feature. (It shows crossed out when "Pay Monthly" is selected)
![image](https://user-images.githubusercontent.com/5436027/115020229-e90c8080-9ed7-11eb-8bf7-602d1619d0e8.png)

* Create a site with an annual plan. The "Free domain for one year" feature on the /plans page should NOT be visible.
![image](https://user-images.githubusercontent.com/5436027/115020261-f590d900-9ed7-11eb-9e60-c8fcb69112a7.png)

Fixes #52015 