### PR TITLE
Post Editor: fix featured image preview size

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/editor.js
+++ b/apps/wpcom-block-editor/src/wpcom/editor.js
@@ -12,6 +12,7 @@ import './features/fix-block-invalidation-errors';
 import './features/reorder-block-categories';
 import './features/tracking';
 import './features/use-classic-block-guide';
+import './features/fix-featured-image-preview-size';
 
 /**
  * Style dependencies

--- a/apps/wpcom-block-editor/src/wpcom/features/fix-featured-image-preview-size.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/fix-featured-image-preview-size.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+
+import { addFilter } from '@wordpress/hooks';
+
+// Use the `medium` size for the Featured Image media instead of the fallback
+// `thumbnail` size, since that's too small for the preview.
+// See https://github.com/Automattic/wp-calypso/issues/52010 for more context.
+function fixFeaturedImagePreviewSize() {
+	const withImageSize = function () {
+		return 'medium';
+	};
+	addFilter(
+		'editor.PostFeaturedImage.imageSize',
+		'a8c/wpcom-block-editor/fixFeaturedImagePreviewSize',
+		withImageSize
+	);
+}
+
+fixFeaturedImagePreviewSize();


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Hook into the `editor.PostFeaturedImage.imageSize` Gutenberg filter to change the `size` used to display the Featured Image preview to be `medium` instead of `thumbnail`

**Note:** this is one way of fixing the issue. Another way would be to edit the WPCOM backend and add the `post-thumbnail` size in the return value of the API (see #52010 for more context).

### Testing instructions

#### To reproduce the bug:

1. On a WordPress.com simple site, create a new post
2. Open the settings sidebar (by clicking the cog icon in the top right of the editor)
3. Select the "Post" tab and scroll to the "Featured Image" section
4. Add a Featured Image
5. Notice how the Featured Image preview is too small and doesn't fill all of the available space
6. Save the post.

#### To test the fix:

1. Add the WPCom Simple site used in the previous steps to your sandbox
2. In the `public_html` folder of your sandbox, run `install-plugin.sh wbe fix/featured-image-preview-size`
3. Visit the same post saved while reproducing the bug
   - [ ] Notice how the Featured Image preview size is now correct and fills up the area reserved for it
5. Remove the Feature image, and replace it with a new one
   - [ ] Make sure that the Feature Image preview size keeps being correct also when a new image is set
6. Check that the fix works both in the iframed editor and in WP Admin

e2e test failures don't seem related.

### Screenshots

| Before | After |
|---|---|
| ![Screenshot 2021-04-16 at 17 05 33](https://user-images.githubusercontent.com/1083581/115045327-b44bf980-9ed6-11eb-8f77-72ab90f48ba1.png) | ![Screenshot 2021-04-16 at 17 04 56](https://user-images.githubusercontent.com/1083581/115045376-bdd56180-9ed6-11eb-9ad0-6d7fb459ba57.png) |


Fixes #52010