### PR TITLE
Checkout: Add explicit error handling during Ebanx token creation

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -152,13 +152,22 @@ async function ebanxCardProcessor(
 		contactDetails,
 	} = transactionOptions;
 
-	const paymentMethodToken: EbanxToken = await createEbanxToken( 'new_purchase', {
-		country: submitData.countryCode,
-		name: submitData.name,
-		number: submitData.number,
-		cvv: submitData.cvv,
-		'expiration-date': submitData[ 'expiration-date' ],
-	} );
+	let paymentMethodToken;
+	try {
+		const ebanxTokenResponse: EbanxToken = await createEbanxToken( 'new_purchase', {
+			country: submitData.countryCode,
+			name: submitData.name,
+			number: submitData.number,
+			cvv: submitData.cvv,
+			'expiration-date': submitData[ 'expiration-date' ],
+		} );
+		paymentMethodToken = ebanxTokenResponse;
+	} catch ( error ) {
+		debug( 'transaction failed' );
+		// Errors here are "expected" errors, meaning that they (hopefully) come
+		// from Ebanx and not from some bug in the frontend code.
+		return makeErrorResponse( error.message );
+	}
 
 	const formattedTransactionData = createTransactionEndpointRequestPayload( {
 		...submitData,

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.ts
@@ -410,8 +410,9 @@ describe( 'multiPartnerCardProcessor', () => {
 				...ebanxCardTransactionRequest,
 				countryCode: undefined,
 			};
-			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
-				/missing country/
+			const expected = { payload: 'ebanx error: missing country', type: 'ERROR' };
+			await expect( multiPartnerCardProcessor( submitData, options ) ).resolves.toStrictEqual(
+				expected
 			);
 		} );
 
@@ -421,8 +422,9 @@ describe( 'multiPartnerCardProcessor', () => {
 				...ebanxCardTransactionRequest,
 				name: undefined,
 			};
-			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
-				/missing name/
+			const expected = { payload: 'ebanx error: missing name', type: 'ERROR' };
+			await expect( multiPartnerCardProcessor( submitData, options ) ).resolves.toStrictEqual(
+				expected
 			);
 		} );
 
@@ -432,8 +434,9 @@ describe( 'multiPartnerCardProcessor', () => {
 				...ebanxCardTransactionRequest,
 				number: undefined,
 			};
-			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
-				/missing number/
+			const expected = { payload: 'ebanx error: missing number', type: 'ERROR' };
+			await expect( multiPartnerCardProcessor( submitData, options ) ).resolves.toStrictEqual(
+				expected
 			);
 		} );
 
@@ -443,8 +446,9 @@ describe( 'multiPartnerCardProcessor', () => {
 				...ebanxCardTransactionRequest,
 				cvv: undefined,
 			};
-			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
-				/missing cvv/
+			const expected = { payload: 'ebanx error: missing cvv', type: 'ERROR' };
+			await expect( multiPartnerCardProcessor( submitData, options ) ).resolves.toStrictEqual(
+				expected
 			);
 		} );
 
@@ -454,8 +458,9 @@ describe( 'multiPartnerCardProcessor', () => {
 				...ebanxCardTransactionRequest,
 				'expiration-date': undefined,
 			};
-			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
-				/missing expiration-date/
+			const expected = { payload: 'ebanx error: missing expiration-date', type: 'ERROR' };
+			await expect( multiPartnerCardProcessor( submitData, options ) ).resolves.toStrictEqual(
+				expected
 			);
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Similar to https://github.com/Automattic/wp-calypso/pull/51998 but for Ebanx.

As of https://github.com/Automattic/wp-calypso/pull/51427 we are treating "expected" errors thrown during a payment method submission as different from "unexpected" errors so that we can detect and fix bugs rather than just reporting them to the user.

When paying with a new Ebanx credit card, there's actually a two step process: first we create the Ebanx token and then we submit the token and the rest of the payment info to our transactions endpoint which handles the actual payment. However, when we modified the payment processor in https://github.com/Automattic/wp-calypso/pull/51463 to explicitly report "expected" errors, we only treated errors from the second step as expected. This means that any error that comes from the tokenization process is reported to us as a fatal error.

In this PR, we modify the processor to also treat errors from the tokenization as "expected", displaying them to the user but not otherwise taking any action.

#### Testing instructions

Thanks to https://github.com/Automattic/wp-calypso/pull/51837 we have unit tests covering this payment processor and we are able to test the changed behavior. However, it's still worth trying at least one purchase with a new Ebanx card to verify that it works as expected.

- Make sure your account currency is set to BRL.
- Add a product to your cart and visit checkout. 
- Select Brazil in the contact form.
- Verify that the form asks for all the Ebanx fields in addition to the credit card fields (Taxpayer Identification Number, Phone, etc.)
- Use an [ebanx test card](https://developer.ebanx.com/docs/resources/testCreditCards/) and [test customer info](https://developer.ebanx.com/docs/resources/testCustomerData/).
- Submit the purchase and verify that the payment succeeds.