### PR TITLE
Swapping logo maker partner logos to Fiverr

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -34,7 +34,7 @@ import { expandHomeQuickLinks, collapseHomeQuickLinks } from 'calypso/state/home
 /**
  * Image dependencies
  */
-import logotronIcon from 'calypso/assets/images/customer-home/logotron-logo-grey.svg';
+import fiverrIcon from 'calypso/assets/images/customer-home/fiverr-logo-grey.svg';
 import anchorLogoIcon from 'calypso/assets/images/customer-home/anchor-logo-grey.svg';
 
 /**
@@ -146,7 +146,7 @@ export const QuickLinks = ( {
 				target="_blank"
 				label={ translate( 'Create a logo' ) }
 				external
-				iconSrc={ logotronIcon }
+				iconSrc={ fiverrIcon }
 			/>
 			<ActionBox
 				href="https://anchor.fm/wordpressdotcom"

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -32,7 +32,7 @@ import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
  * Images
  */
 import earnIllustration from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
-import logotronLogo from 'calypso/assets/images/illustrations/logotron-logo.svg';
+import fiverrLogo from 'calypso/assets/images/customer-home/fiverr-logo.svg';
 import facebookLogo from 'calypso/assets/images/illustrations/facebook-logo.png';
 import canvaLogo from 'calypso/assets/images/illustrations/canva-logo.svg';
 import sendinblueLogo from 'calypso/assets/images/illustrations/sendinblue-logo.svg';
@@ -130,7 +130,7 @@ export const MarketingTools: FunctionComponent = () => {
 					description={ translate(
 						'A custom logo helps your brand pop and makes your site memorable. Make a professional logo in a few clicks with our partner today.'
 					) }
-					imagePath={ logotronLogo }
+					imagePath={ fiverrLogo }
 				>
 					<Button
 						onClick={ handleCreateALogoClick }


### PR DESCRIPTION
This PR swaps our logo maker partner back to Fiverr. Context in pbBQWj-LT-p2.

The specific updates are:
* Small gray logo on My Home
* Color logo on Marketing / Tools

Copy is evergreen so that does not need to be updated. The redirect url is updated in D60311-code.

#### Testing instructions

* Apply D60311-code to your sandbox and update your hosts file to point wp.me to your sandbox.
* Checkout this PR and start Calypso.
* Navigate to My Home and confirm that the small gray Fiverr logo appears in Quick Links section on the right.
* Click the link and confirm that you navigate to the Fiverr logo maker page.
* Navigate to marketing/tools/SITESLUG and confirm that the Fiverr logo appears in the logo partner card. 
* Click the link and confirm that you navigate to the Fiverr logo maker page.
