### PR TITLE
Redirect `/checkout/:product/:site` with a legacy products to the plan page

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -112,7 +112,7 @@ export function checkout( context, next ) {
 	next();
 }
 
-export function redirectJetpackLegacyPlans( context ) {
+export function redirectJetpackLegacyPlans( context, next ) {
 	const product = getDomainOrProductFromContext( context );
 
 	if ( JETPACK_LEGACY_PLANS.includes( product ) ) {
@@ -120,7 +120,11 @@ export function redirectJetpackLegacyPlans( context ) {
 		const selectedSite = getSelectedSite( state );
 
 		page( ( isJetpackCloud() ? '/pricing/' : CALYPSO_PLANS_PAGE ) + ( selectedSite?.slug || '' ) );
+
+		return;
 	}
+
+	next();
 }
 
 export function checkoutPending( context, next ) {

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -13,11 +13,13 @@ import {
 	gsuiteNudge,
 	upsellNudge,
 	redirectToSupportSession,
+	redirectJetpackLegacyPlans,
 } from './controller';
+import { noop } from './utils';
 import SiftScience from 'calypso/lib/siftscience';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'calypso/controller';
 import { noSite, siteSelection } from 'calypso/my-sites/controller';
-import config from '@automattic/calypso-config';
+import { isEnabled } from '@automattic/calypso-config';
 import userFactory from 'calypso/lib/user';
 
 export default function () {
@@ -95,7 +97,7 @@ export default function () {
 		clientRender
 	);
 
-	if ( config.isEnabled( 'upsell/concierge-session' ) ) {
+	if ( isEnabled( 'upsell/concierge-session' ) ) {
 		// For backwards compatibility, retaining the old URL structure.
 		page( '/checkout/:site/add-support-session/:receiptId?', redirectToSupportSession );
 
@@ -140,9 +142,23 @@ export default function () {
 		clientRender
 	);
 
-	page( '/checkout/:domainOrProduct', siteSelection, checkout, makeLayout, clientRender );
+	page(
+		'/checkout/:domainOrProduct',
+		siteSelection,
+		isEnabled( 'jetpack/redirect-legacy-plans' ) ? redirectJetpackLegacyPlans : noop,
+		checkout,
+		makeLayout,
+		clientRender
+	);
 
-	page( '/checkout/:product/:domainOrProduct', siteSelection, checkout, makeLayout, clientRender );
+	page(
+		'/checkout/:product/:domainOrProduct',
+		siteSelection,
+		isEnabled( 'jetpack/redirect-legacy-plans' ) ? redirectJetpackLegacyPlans : noop,
+		checkout,
+		makeLayout,
+		clientRender
+	);
 
 	// Visiting /renew without a domain is invalid and should be redirected to /me/purchases
 	page( '/checkout/:product/renew/:purchaseId', '/me/purchases' );
@@ -164,7 +180,7 @@ export default function () {
 	);
 
 	// Visiting /checkout without a plan or product should be redirected to /plans
-	page( '/checkout', config.isEnabled( 'jetpack-cloud/connect' ) ? '/plans' : '/pricing' );
+	page( '/checkout', isEnabled( 'jetpack-cloud/connect' ) ? '/plans' : '/pricing' );
 
 	page(
 		'/checkout/:site/offer-plan-upgrade/:upgradeItem/:receiptId?',

--- a/client/my-sites/checkout/test/controller.js
+++ b/client/my-sites/checkout/test/controller.js
@@ -39,37 +39,42 @@ describe( 'redirectJetpackLegacyPlans', () => {
 	} );
 
 	let spy;
+	let next;
 
 	beforeEach( () => {
 		spy = jest.spyOn( page, 'default' );
+		next = jest.fn();
 	} );
 
 	afterEach( () => {
 		spy.mockRestore();
+		next.mockRestore();
 	} );
 
 	it( 'should not redirect if the plan is not a Jetpack legacy plan', () => {
 		utils.getDomainOrProductFromContext.mockReturnValue( PRODUCT_JETPACK_BACKUP );
 
-		redirectJetpackLegacyPlans();
+		redirectJetpackLegacyPlans( {}, next );
 
 		expect( spy ).not.toHaveBeenCalled();
+		expect( next ).toHaveBeenCalled();
 	} );
 
 	it( 'should redirect if the plan is a Jetpack legacy plan', () => {
 		utils.getDomainOrProductFromContext.mockReturnValue( PLAN_JETPACK_PERSONAL );
 		isJetpackCloud.mockReturnValue( false );
 
-		redirectJetpackLegacyPlans( { store } );
+		redirectJetpackLegacyPlans( { store }, next );
 
 		expect( spy ).toHaveBeenCalledWith( `/plans/${ siteSlug }` );
+		expect( next ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should redirect to the pricing page in Jetpack cloud', () => {
 		utils.getDomainOrProductFromContext.mockReturnValue( PLAN_JETPACK_PERSONAL );
 		isJetpackCloud.mockReturnValue( true );
 
-		redirectJetpackLegacyPlans( { store } );
+		redirectJetpackLegacyPlans( { store }, next );
 
 		expect( spy ).toHaveBeenCalledWith( `/pricing/${ siteSlug }` );
 	} );

--- a/client/my-sites/checkout/test/controller.js
+++ b/client/my-sites/checkout/test/controller.js
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import * as page from 'page';
+import configureStore from 'redux-mock-store';
+
+/**
+ * Internal dependencies
+ */
+import { redirectJetpackLegacyPlans } from '../controller';
+import * as utils from '../utils';
+import { PRODUCT_JETPACK_BACKUP, PLAN_JETPACK_PERSONAL } from '@automattic/calypso-products';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+
+jest.mock( 'page' );
+jest.mock( '../utils' );
+jest.mock( 'calypso/lib/jetpack/is-jetpack-cloud' );
+
+const mockStore = configureStore();
+
+describe( 'redirectJetpackLegacyPlans', () => {
+	const siteId = 1;
+	const siteSlug = 'example.com';
+	const store = mockStore( {
+		ui: {
+			selectedSiteId: siteId,
+		},
+		sites: {
+			items: {
+				[ siteId ]: {
+					slug: siteSlug,
+				},
+			},
+		},
+	} );
+
+	let spy;
+
+	beforeEach( () => {
+		spy = jest.spyOn( page, 'default' );
+	} );
+
+	afterEach( () => {
+		spy.mockRestore();
+	} );
+
+	it( 'should not redirect if the plan is not a Jetpack legacy plan', () => {
+		utils.getDomainOrProductFromContext.mockReturnValue( PRODUCT_JETPACK_BACKUP );
+
+		redirectJetpackLegacyPlans();
+
+		expect( spy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should redirect if the plan is a Jetpack legacy plan', () => {
+		utils.getDomainOrProductFromContext.mockReturnValue( PLAN_JETPACK_PERSONAL );
+		isJetpackCloud.mockReturnValue( false );
+
+		redirectJetpackLegacyPlans( { store } );
+
+		expect( spy ).toHaveBeenCalledWith( `/plans/${ siteSlug }` );
+	} );
+
+	it( 'should redirect to the pricing page in Jetpack cloud', () => {
+		utils.getDomainOrProductFromContext.mockReturnValue( PLAN_JETPACK_PERSONAL );
+		isJetpackCloud.mockReturnValue( true );
+
+		redirectJetpackLegacyPlans( { store } );
+
+		expect( spy ).toHaveBeenCalledWith( `/pricing/${ siteSlug }` );
+	} );
+} );

--- a/client/my-sites/checkout/test/utils.js
+++ b/client/my-sites/checkout/test/utils.js
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import configureStore from 'redux-mock-store';
+
+/**
+ * Internal dependencies
+ */
+import { getDomainOrProductFromContext } from '../utils';
+
+const mockStore = configureStore();
+
+describe( 'getDomainOrProductFromContext', () => {
+	const siteId = 1;
+	const siteSlug = 'example.com';
+	const newDomain = 'mydomain.com';
+	const newProduct = 'jetpack-product';
+	const store = mockStore( {
+		ui: {
+			selectedSiteId: siteId,
+		},
+		sites: {
+			items: {
+				[ siteId ]: {
+					slug: siteSlug,
+				},
+			},
+		},
+	} );
+
+	it( "should return the `domainOrProduct` parameter if it's not the selected site slug", () => {
+		const product = getDomainOrProductFromContext( {
+			store,
+			params: {
+				domainOrProduct: newDomain,
+			},
+		} );
+
+		expect( product ).toEqual( newDomain );
+	} );
+
+	it( 'should return the `product` parameter if `domainOrProduct` is the selected site slug', () => {
+		const product = getDomainOrProductFromContext( {
+			store,
+			params: {
+				domainOrProduct: siteSlug,
+				product: newProduct,
+			},
+		} );
+
+		expect( product ).toEqual( newProduct );
+	} );
+
+	it( "should return the `product` parameter if there's no selected site", () => {
+		const product = getDomainOrProductFromContext( {
+			store: mockStore( {
+				ui: {},
+			} ),
+			params: {
+				product: newProduct,
+			},
+		} );
+
+		expect( product ).toEqual( newProduct );
+	} );
+
+	it( "should return the `product` parameter if there's no `domainOrProduct` parameter", () => {
+		const product = getDomainOrProductFromContext( {
+			store,
+			params: {
+				product: newProduct,
+			},
+		} );
+
+		expect( product ).toEqual( newProduct );
+	} );
+} );

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+export function noop( context: PageJS.Context, next: () => void ): void {
+	next();
+}
+
+export function getDomainOrProductFromContext( { params, store }: PageJS.Context ): string {
+	const { domainOrProduct, product } = params;
+	const state = store.getState();
+	const selectedSite = getSelectedSite( state );
+
+	let result;
+
+	if ( selectedSite?.slug !== domainOrProduct && domainOrProduct ) {
+		result = domainOrProduct;
+	} else {
+		result = product;
+	}
+
+	return result || '';
+}

--- a/config/development.json
+++ b/config/development.json
@@ -97,6 +97,7 @@
 		"jetpack/personal-plan": false,
 		"jetpack/magic-link-signup": true,
 		"jetpack/userless-checkout": true,
+		"jetpack/redirect-legacy-plans": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,
 		"lasagna": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -68,6 +68,7 @@
 		"jetpack/personal-plan": false,
 		"jetpack/magic-link-signup": true,
 		"jetpack/userless-checkout": false,
+		"jetpack/redirect-legacy-plans": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,
 		"lasagna": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -42,6 +42,7 @@
 		"jetpack/connect/remote-install": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,
+		"jetpack/redirect-legacy-plans": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -38,6 +38,7 @@
 		"jetpack/connect/remote-install": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,
+		"jetpack/redirect-legacy-plans": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -38,6 +38,7 @@
 		"jetpack/backups-date-picker": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,
+		"jetpack/redirect-legacy-plans": false,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -39,6 +39,7 @@
 		"jetpack/connect/remote-install": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,
+		"jetpack/redirect-legacy-plans": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,

--- a/config/production.json
+++ b/config/production.json
@@ -69,6 +69,7 @@
 		"jetpack/personal-plan": false,
 		"jetpack/magic-link-signup": true,
 		"jetpack/userless-checkout": false,
+		"jetpack/redirect-legacy-plans": false,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -71,6 +71,7 @@
 		"jetpack/personal-plan": false,
 		"jetpack/magic-link-signup": true,
 		"jetpack/userless-checkout": false,
+		"jetpack/redirect-legacy-plans": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR redirects users that hit the checkout URL with a Jetpack legacy plan to the plans page.

Fixes 1200196139286276-as-1200203224784811

### Implementation notes

Behaviour is hidden behind the `jetpack/redirect-legacy-plans` feature flag, in case we need to revert it quickly. This PR does not activate the flag in production.

The list of legacy plans slugs is:
- `jetpack_personal`
- `jetpack_personal_monthly`
- `jetpack_premium`
- `jetpack_premium_monthly`
- `jetpack_business`
- `jetpack_business_monthly`

### Testing instructions

Download the PR and run Calypso

#### Regression testing

- Visit the plans page, and verify that you can still go through the purchase flow
- Deactivate the feature flag aforementioned, and check that hitting both `/checkout/:product/:site` and `/checkout/:site/:product/` where `:product` is one of the legacy plans slugs directs you to the checkout page with the legacy plan in cart

#### New behaviour

- With the feature flag activated, check that hitting both `/checkout/:product/:site` and `/checkout/:site/:product/` where `:product` is one of the legacy plans slugs redirects you to the plans page