### PR TITLE
Fix case of destructured variable for VerticalNavItem

### DIFF
--- a/client/components/vertical-nav/item/index.jsx
+++ b/client/components/vertical-nav/item/index.jsx
@@ -47,9 +47,9 @@ class VerticalNavItem extends Component {
 	};
 
 	render() {
-		const { isPlaceHolder, external, onClick, path, className, children } = this.props;
+		const { isPlaceholder, external, onClick, path, className, children } = this.props;
 
-		if ( isPlaceHolder ) {
+		if ( isPlaceholder ) {
 			return this.placeholder();
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The `isPlaceholder` prop was incorrectly being destructured as `isPlaceHolder`, so the UI was weird for loading states

This issue was introduced in #50922 a few weeks ago.

#### Testing instructions

This doesn't need too much direct testing - I am just using the correct prop name.

* Access a page with `VerticalNavItem` elements that use a placeholder. (The page to add a new WordPress.com Email account is one such page, but it requires an account for the testing to work.)
* Verify that the  placeholder looks correct.