### PR TITLE
Share Preview: Twitter Modal Design Tweaks

### DIFF
--- a/client/components/share/twitter-share-preview/style.scss
+++ b/client/components/share/twitter-share-preview/style.scss
@@ -21,7 +21,7 @@
 }
 
 .twitter-share-preview__profile-picture {
-	border-radius: 2px;
+	border-radius: 50%;
 	display: block;
 }
 
@@ -31,7 +31,7 @@
 	margin-right: 5px;
 
 	&:hover {
-		color: #0084b4;
+		color: #14171a;
 		text-decoration: underline;
 	}
 }
@@ -39,6 +39,10 @@
 .twitter-share-preview__profile-handle {
 	color: #657786;
 	font-size: $font-body-small;
+
+	&:hover {
+		color: #657786;
+	}
 }
 
 .twitter-share-preview__message,
@@ -61,7 +65,7 @@
 }
 
 .twitter-share-preview__image {
-	border: 1px solid rgba( 0, 0, 0, 0.1 );
-	border-radius: 2px;
+	border: 1px solid #c4cfd6;
+	border-radius: 16px;
 	display: block;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the Share Preview modal for Twitter to reflect their updated design (mainly just some colour and border changes)

#### Testing instructions

On a site with a Publicize connection set up: go to `/posts/site` > click the ellipses > "Share" button > "Preview" button > "Twitter". Then compare the different styling.

| Before                                                                                                                                                                | After                                                                                                                                                                 |
|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="584" alt="Screenshot 2021-04-18 at 10 12 15" src="https://user-images.githubusercontent.com/43215253/115140320-90033080-a02e-11eb-9b2c-ec59cbd6c156.png"> | <img width="584" alt="Screenshot 2021-04-18 at 10 11 52" src="https://user-images.githubusercontent.com/43215253/115140303-85e13200-a02e-11eb-8c43-f388ac07c2c9.png"> |

For contrast, here's the display on Twitter itself which this modal should replicate as closely as possible.

<img width="589" alt="Screenshot 2021-04-18 at 10 02 08" src="https://user-images.githubusercontent.com/43215253/115140262-5e8a6500-a02e-11eb-9e20-a303c215d8fa.png">

cc @sixhours 
