### PR TITLE
Plans: Remove the 'jetpack_pricing_switch_plan_sides2' experiment

### DIFF
--- a/client/my-sites/plans/jetpack-plans/experiments.ts
+++ b/client/my-sites/plans/jetpack-plans/experiments.ts
@@ -1,6 +1,0 @@
-/**
- * ExPlat experiment: jetpack_pricing_switch_plan_sides
- */
-export const SWITCH_PLAN_SIDES_EXPERIMENT = 'jetpack_pricing_switch_plan_sides2';
-export const SWITCH_PLAN_SIDES_CONTROL = 'control';
-export const SWITCH_PLAN_SIDES_TREATMENT = 'treatment';

--- a/client/my-sites/plans/jetpack-plans/plans-filter-bar/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-filter-bar/index.tsx
@@ -38,19 +38,17 @@ interface FilterBarProps {
 	duration?: Duration;
 	onDurationChange?: DurationChangeCallback;
 	onProductTypeChange?: ( arg0: ProductType ) => void;
-	withTreatmentVariant: boolean;
 }
 
 type DiscountMessageProps = {
 	primary?: boolean;
-	withTreatmentVariant: boolean;
 };
 
 const CLOUD_MASTERBAR_STICKY = false;
 const CALYPSO_MASTERBAR_HEIGHT = 47;
 const CLOUD_MASTERBAR_HEIGHT = CLOUD_MASTERBAR_STICKY ? 94 : 0;
 
-const DiscountMessage: React.FC< DiscountMessageProps > = ( { primary, withTreatmentVariant } ) => {
+const DiscountMessage: React.FC< DiscountMessageProps > = ( { primary } ) => {
 	const translate = useTranslate();
 	const isMobile: boolean = useMobileBreakpoint();
 
@@ -71,7 +69,6 @@ const DiscountMessage: React.FC< DiscountMessageProps > = ( { primary, withTreat
 		<div
 			className={ classNames( 'plans-filter-bar__discount-message', {
 				primary,
-				treatment: withTreatmentVariant,
 			} ) }
 		>
 			<div>
@@ -96,7 +93,6 @@ const PlansFilterBar: React.FC< FilterBarProps > = ( {
 	showDiscountMessage,
 	duration,
 	onDurationChange,
-	withTreatmentVariant,
 } ) => {
 	const translate = useTranslate();
 	const isInConnectStore = useMemo( isConnectStore, [] );
@@ -129,12 +125,7 @@ const PlansFilterBar: React.FC< FilterBarProps > = ( {
 				/>
 				<span className="plans-filter-bar__toggle-on-label">{ translate( 'Bill yearly' ) }</span>
 			</div>
-			{ showDiscountMessage && (
-				<DiscountMessage
-					primary={ durationChecked }
-					withTreatmentVariant={ withTreatmentVariant }
-				/>
-			) }
+			{ showDiscountMessage && <DiscountMessage primary={ durationChecked } /> }
 		</div>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -10,7 +10,6 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { SWITCH_PLAN_SIDES_TREATMENT } from '../experiments';
 import PlansFilterBar from '../plans-filter-bar';
 import ProductCard from '../product-card';
 import { getProductPosition } from '../product-grid/products-order';
@@ -59,7 +58,6 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const currentPlanSlug =
 		useSelector( ( state ) => getSitePlan( state, siteId ) )?.product_slug || null;
-	const exPlatVariation = null;
 
 	const { availableProducts, purchasedProducts, includedInPlanProducts } = useGetPlansGridProducts(
 		siteId
@@ -137,7 +135,6 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 						showDiscountMessage
 						onDurationChange={ onDurationChange }
 						duration={ duration }
-						withTreatmentVariant={ exPlatVariation === SWITCH_PLAN_SIDES_TREATMENT }
 					/>
 				</div>
 				<ul


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Relates to #51951.

* Removes the `jetpack_pricing_switch_plan_sides2` experiment, since it's been closed for a while now.

#### Testing instructions

* Verify that no changes are visible on the pricing page.
