### PR TITLE
ci(e2e): Save console logs from Chrome

### DIFF
--- a/test/e2e/lib/async-base-container.js
+++ b/test/e2e/lib/async-base-container.js
@@ -56,7 +56,6 @@ export default class AsyncBaseContainer {
 		}
 		await this.waitForPage();
 		await this.checkForUnknownABTestKeys();
-		await this.checkForConsoleErrors();
 		if ( typeof this._postInit === 'function' ) {
 			await this._postInit();
 		}
@@ -84,10 +83,6 @@ export default class AsyncBaseContainer {
 
 	async urlDisplayed() {
 		return await this.driver.getCurrentUrl();
-	}
-
-	async checkForConsoleErrors() {
-		return await driverHelper.checkForConsoleErrors( this.driver );
 	}
 
 	async checkForUnknownABTestKeys() {

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -1,7 +1,14 @@
 /**
  * External dependencies
  */
-import webdriver, { Key, By, WebDriver, WebElement, WebElementCondition } from 'selenium-webdriver';
+import webdriver, {
+	Key,
+	By,
+	WebDriver,
+	WebElement,
+	WebElementCondition,
+	logging,
+} from 'selenium-webdriver';
 import config from 'config';
 import { forEach } from 'lodash';
 
@@ -320,36 +327,11 @@ export function checkForConsoleErrors( driver ) {
 	}
 }
 
-export function printConsole( driver ) {
-	if ( config.get( 'printConsoleLogs' ) === true ) {
-		driver
-			.manage()
-			.logs()
-			.get( 'browser' )
-			.then( ( logs ) => {
-				logs.forEach( ( log ) => console.log( log ) );
-			} );
-	}
+export function getBrowserLogs( driver ) {
+	return driver.manage().logs().get( logging.Type.BROWSER );
 }
-
-export function logPerformance( driver ) {
-	if ( config.get( 'logNetworkRequests' ) === true ) {
-		driver
-			.manage()
-			.logs()
-			.get( 'performance' )
-			.then( ( browserLogs ) => {
-				browserLogs.forEach( ( browserLog ) => {
-					const message = JSON.parse( browserLog.message ).message;
-					if (
-						message.method === 'Network.responseReceived' ||
-						message.method === 'Network.requestWillBeSent'
-					) {
-						console.log( JSON.stringify( message ) );
-					}
-				} );
-			} );
-	}
+export function getPerformanceLogs( driver ) {
+	return driver.manage().logs().get( logging.Type.PERFORMANCE );
 }
 
 export async function ensureMobileMenuOpen( driver ) {

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -10,12 +10,12 @@ import proxy from 'selenium-webdriver/proxy';
 import SauceLabs from 'saucelabs';
 import { times } from 'lodash';
 import { readFileSync } from 'fs';
-
 import * as remote from 'selenium-webdriver/remote';
 
 /**
  * Internal dependencies
  */
+import { generatePath } from './test-utils';
 import * as dataHelper from './data-helper';
 
 const webDriverImplicitTimeOutMS = 2000;
@@ -83,8 +83,9 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 	const chromeVersion = await readFileSync( './.chromedriver_version', 'utf8' ).trim();
 	const userAgent = `user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${ chromeVersion } Safari/537.36`;
 	const pref = new webdriver.logging.Preferences();
-	pref.setLevel( 'browser', webdriver.logging.Level.ALL );
-	pref.setLevel( 'performance', webdriver.logging.Level.ALL );
+	pref.setLevel( webdriver.logging.Type.BROWSER, webdriver.logging.Level.ALL );
+	pref.setLevel( webdriver.logging.Type.PERFORMANCE, webdriver.logging.Level.ALL );
+
 	if ( config.has( 'sauce' ) && config.get( 'sauce' ) ) {
 		const sauceURL = 'http://ondemand.saucelabs.com:80/wd/hub';
 		const sauceConfig = config.get( 'sauceConfig' );
@@ -165,14 +166,11 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 
 				// eslint-disable-next-line no-case-declarations
 				const service = new chrome.ServiceBuilder( chromedriver.path )
-					.loggingTo( './chromedriver.' + process.pid + '.log' )
-					.enableVerboseLogging()
+					.loggingTo( generatePath( 'chromedriver.log' ) )
 					.build();
 				chrome.setDefaultService( service );
-				options.setChromeLogFile( './chrome.' + process.pid + '.log' );
+				options.setChromeLogFile( generatePath( './chrome.log' ) );
 				options.addArguments( '--enable-logging' );
-				options.addArguments( '--log-level 0' );
-				options.addArguments( '--log-net-log ./chrome.net.' + process.pid + '.log' );
 
 				builder = new webdriver.Builder();
 				builder.setChromeOptions( options );

--- a/test/e2e/lib/hooks/save-console-log.js
+++ b/test/e2e/lib/hooks/save-console-log.js
@@ -1,0 +1,24 @@
+/* eslint-disable mocha/no-top-level-hooks */
+import fs from 'fs/promises';
+
+/**
+ * Internal dependencies
+ */
+import { getBrowserLogs, getPerformanceLogs } from '../driver-helper';
+import { generatePath } from '../test-utils';
+
+export default () => {
+	after( 'Save browser logs', async function () {
+		const driver = global.__BROWSER__;
+
+		await Promise.allSettled(
+			[
+				[ getBrowserLogs( driver ), 'console.log' ],
+				[ getPerformanceLogs( driver ), 'performance.log' ],
+			].map( async ( [ logsPromise, file ] ) => {
+				const logs = await logsPromise;
+				return fs.writeFile( generatePath( file ), JSON.stringify( logs, null, 2 ) );
+			} )
+		);
+	} );
+};

--- a/test/e2e/lib/mocha-hooks.js
+++ b/test/e2e/lib/mocha-hooks.js
@@ -14,8 +14,8 @@ import * as slackNotifier from './slack-notifier';
 import * as mediaHelper from './media-helper';
 
 import * as driverManager from './driver-manager';
-import * as driverHelper from './driver-helper';
 import * as videoRecorder from '../lib/video-recorder';
+import { default as saveConsoleLog } from './hooks/save-console-log';
 
 const afterHookTimeoutMS = config.get( 'afterHookTimeoutMS' );
 let allPassed = true; // For SauceLabs status
@@ -122,19 +122,7 @@ afterEach( async function () {
 	}
 } );
 
-// Check for console errors
-afterEach( async function () {
-	this.timeout( afterHookTimeoutMS );
-	const driver = global.__BROWSER__;
-	await driverHelper.logPerformance( driver );
-	return await driverHelper.checkForConsoleErrors( driver );
-} );
-
-afterEach( async function () {
-	this.timeout( afterHookTimeoutMS );
-	const driver = global.__BROWSER__;
-	await driverHelper.printConsole( driver );
-} );
+saveConsoleLog();
 
 // Update Sauce Job Status locally
 afterEach( function () {

--- a/test/e2e/lib/test-utils.js
+++ b/test/e2e/lib/test-utils.js
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import path from 'path';
+
+const BASE_PATH = process.env.TEMP_ASSET_PATH || path.join( __dirname, '..' );
+
+export const generatePath = ( name ) => path.join( BASE_PATH, name );

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-checkout-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-checkout-spec.js
@@ -35,7 +35,7 @@ describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize
 
 	before( 'Start browser', async function () {
 		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
+		driver = global.__BROWSER__ = await driverManager.startBrowser();
 	} );
 
 	describe( 'Can trigger the checkout modal via post editor', function () {

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-upgrade-spec.js
@@ -168,7 +168,7 @@ describe( `[${ host }, ${ screenSize }] Test Gutenberg upgrade against most popu
 
 	before( 'Start browser', async function () {
 		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
+		driver = global.__BROWSER__ = await driverManager.startBrowser();
 	} );
 
 	after( async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Configure chromedriver to save browser (aka console logs) and performance logs.

Example:

![image](https://user-images.githubusercontent.com/975703/115206273-b8586100-a0fa-11eb-8748-848a60cacad1.png)



#### Testing instructions

* Open a TeamCity e2e test for this PR and check the artifacts.