### PR TITLE
create `useProtectForm` custom hook

### DIFF
--- a/client/lib/protect-form/index.tsx
+++ b/client/lib/protect-form/index.tsx
@@ -13,7 +13,7 @@ import { Subtract } from 'utility-types';
  */
 const debug = debugModule( 'calypso:protect-form' );
 
-type ComponentMarkedWithFormChanges = Component;
+type ComponentMarkedWithFormChanges = Component | string;
 
 let formsChanged: ComponentMarkedWithFormChanges[] = [];
 let listenerCount = 0;
@@ -142,4 +142,28 @@ export const checkFormHandler: PageJS.Callback = ( context, next ) => {
 			page.replace( currentPath, null, false, false );
 		}, 0 );
 	}
+};
+
+type ProtectForm = {
+	markChanged: () => void;
+	markSaved: () => void;
+};
+
+export const useProtectForm = ( id: string ): ProtectForm => {
+	const _markSaved = React.useCallback( () => markSaved( id ), [ id ] );
+	const _markChanged = React.useCallback( () => markChanged( id ), [ id ] );
+
+	React.useEffect( () => {
+		addBeforeUnloadListener();
+
+		return () => {
+			removeBeforeUnloadListener();
+			_markSaved();
+		};
+	}, [ _markSaved ] );
+
+	return {
+		markChanged: _markChanged,
+		markSaved: _markSaved,
+	};
 };

--- a/client/lib/protect-form/index.tsx
+++ b/client/lib/protect-form/index.tsx
@@ -12,7 +12,7 @@ import { Subtract } from 'utility-types';
  */
 const debug = debugModule( 'calypso:protect-form' );
 
-type FormId = Record< string, unknown >;
+type FormId = [  ];
 
 let formsChanged = new Set< FormId >();
 let listenerCount = 0;
@@ -42,9 +42,7 @@ function removeBeforeUnloadListener() {
 }
 
 function markChanged( formId: FormId ) {
-	if ( ! formsChanged.has( formId ) ) {
-		formsChanged.add( formId );
-	}
+	formsChanged.add( formId );
 }
 
 function markSaved( formId: FormId ) {
@@ -57,7 +55,7 @@ type ProtectForm = {
 };
 
 export const useProtectForm = (): ProtectForm => {
-	const formId = React.useRef< FormId >( {} );
+	const formId = React.useRef< FormId >( [] );
 	const _markSaved = React.useCallback( () => markSaved( formId.current ), [] );
 	const _markChanged = React.useCallback( () => markChanged( formId.current ), [] );
 
@@ -96,28 +94,18 @@ export const protectForm = < P extends ProtectedFormProps >(
 	);
 };
 
-interface ProtectFormGuardProps {
-	isChanged: boolean;
-}
-
 /*
  * Declarative variant that takes a 'isChanged' prop.
  */
-export const ProtectFormGuard = ( { isChanged }: ProtectFormGuardProps ): null => {
+export const ProtectFormGuard = ( { isChanged }: { isChanged: boolean } ): null => {
 	const { markChanged, markSaved } = useProtectForm();
 
 	React.useEffect( () => {
 		if ( isChanged ) {
 			markChanged();
-			return;
+			return () => markSaved();
 		}
-
-		markSaved();
-
-		() => {
-			markSaved();
-		};
-	}, [ isChanged, markSaved, markChanged ] );
+	}, [ isChanged, markChanged, markSaved ] );
 
 	return null;
 };

--- a/client/lib/protect-form/index.tsx
+++ b/client/lib/protect-form/index.tsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import React, { ComponentType } from 'react';
+import React from 'react';
 import debugModule from 'debug';
 import page from 'page';
 import i18n from 'i18n-calypso';
-import { Subtract } from 'utility-types';
+import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
  * Module variables
@@ -82,17 +82,13 @@ export interface ProtectedFormProps {
 /*
  * HOC that passes markChanged/markSaved props to the wrapped component instance
  */
-export const protectForm = < P extends ProtectedFormProps >(
-	WrappedComponent: ComponentType< P >
-): ComponentType< Subtract< P, ProtectedFormProps > > => (
-	props: Subtract< P, ProtectedFormProps >
-) => {
-	const { markChanged, markSaved } = useProtectForm();
+export const protectForm = createHigherOrderComponent( ( Component ) => {
+	return ( props ) => {
+		const { markChanged, markSaved } = useProtectForm();
 
-	return (
-		<WrappedComponent { ...( props as P ) } markChanged={ markChanged } markSaved={ markSaved } />
-	);
-};
+		return <Component { ...props } markChanged={ markChanged } markSaved={ markSaved } />;
+	};
+}, 'protectForm' );
 
 /*
  * Declarative variant that takes a 'isChanged' prop.

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -54,7 +54,7 @@ class AccountPassword extends React.Component {
 			! this.props.hasUserSettingsRequestFailed
 		) {
 			this.props.markSaved();
-			window.location = window.location.pathname + '?updated=password';
+			window.location = '?updated=password';
 		}
 	}
 

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -13,7 +13,7 @@ import Main from 'calypso/components/main';
 import HeaderCake from 'calypso/components/header-cake';
 import { Card } from '@automattic/components';
 import PeopleProfile from 'calypso/my-sites/people/people-profile';
-import { protectForm } from 'calypso/lib/protect-form';
+import { useProtectForm } from 'calypso/lib/protect-form';
 import DeleteUser from 'calypso/my-sites/people/delete-user';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -33,8 +33,6 @@ export const EditTeamMemberForm = ( {
 	userLogin,
 	isJetpack,
 	isMultisite,
-	markChanged,
-	markSaved,
 	previousRoute,
 	siteSlug,
 	recordGoogleEvent,
@@ -52,6 +50,7 @@ export const EditTeamMemberForm = ( {
 		page( '/people/team' );
 	};
 
+	const { markChanged, markSaved } = useProtectForm( `edit-${ siteId }-${ userLogin }` );
 	const { data: user, error, isLoading } = useUserQuery( siteId, userLogin, { retry: false } );
 
 	React.useEffect( () => {
@@ -101,4 +100,4 @@ export default connect(
 		};
 	},
 	{ recordGoogleEvent: recordGoogleEventAction }
-)( protectForm( EditTeamMemberForm ) );
+)( EditTeamMemberForm );

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -50,7 +50,7 @@ export const EditTeamMemberForm = ( {
 		page( '/people/team' );
 	};
 
-	const { markChanged, markSaved } = useProtectForm( `edit-${ siteId }-${ userLogin }` );
+	const { markChanged, markSaved } = useProtectForm();
 	const { data: user, error, isLoading } = useUserQuery( siteId, userLogin, { retry: false } );
 
 	React.useEffect( () => {

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -114,11 +114,6 @@ export const userSettingsSaveSuccess = ( { settingsOverride }, data ) => ( dispa
 	dispatch( saveUserSettingsSuccess( fromApi( data ) ) );
 	dispatch( clearUnsavedUserSettings( settingsOverride ? Object.keys( settingsOverride ) : null ) );
 
-	if ( settingsOverride?.password ) {
-		// Since changing a user's password invalidates the session, we reload.
-		window.location = window.location.pathname + '?updated=password';
-		return;
-	}
 	// Refetch the user data after saving user settings
 	// The require() trick is used to avoid excessive mocking in unit tests.
 	// TODO: Replace it with standard 'import' when the `lib/user` module is Reduxized


### PR DESCRIPTION
During my work on reduxification a few times I encountered that it would have been nice to have the protect form functionality available as a custom hook.

~~❗ **Note**: this is still in an experimental phase and the goal is to gather feedback.~~

#### Changes proposed in this Pull Request

* Create a `useProtectForm` custom hook
* Use `useProtectForm` in `<EditTeamMemberForm />`

#### Testing instructions

Use a site with more than one user on your team:

1. Go to `/people` and select a user which isn't you
2. Change user settings and try to navigate away, you should be warned about unsaved settings
3. Change settings back to the original settings and navigate away, that should work without a warning

If you change settings and navigate away anyway (i.e. ignore the warning), go back to the edit user form and try to navigate away without doing any changes. That should verify we properly cleaned up after navigating away the first time.

