### PR TITLE
BodySectionCssClass: remove leftover prefixed CSS classes on mount

### DIFF
--- a/client/layout/body-section-css-class.js
+++ b/client/layout/body-section-css-class.js
@@ -13,29 +13,35 @@ import React from 'react';
  * `div.layout` has the advantage of being maintained by React, where class names can be
  * specified declaratively and the DOM diffing and patching is done by React itself.
  */
-const addBodyClass = ( toClass ) => ( value ) => () => {
-	// if value is empty-ish, don't add any CSS classes
-	if ( ! value ) {
-		return;
-	}
+function useBodyClass( prefix, value ) {
+	React.useEffect( () => {
+		// remove any existing classes with the same prefix, coming from example from a
+		// server HTML markup.
+		for ( const className of document.body.classList ) {
+			if ( className.startsWith( prefix ) ) {
+				document.body.classList.remove( className );
+			}
+		}
 
-	// convert the value (section or group name) to a CSS class name
-	const className = toClass( value );
+		// if value is empty-ish, don't add any CSS classes
+		if ( ! value ) {
+			return;
+		}
 
-	// add the CSS class to body when performing the effect
-	document.body.classList.add( className );
+		// convert the value (section or group name) to a CSS class name
+		const className = prefix + value;
 
-	// remove the CSS class from body in the effect cleanup function
-	return () => document.body.classList.remove( className );
-};
+		// add the CSS class to body when performing the effect
+		document.body.classList.add( className );
 
-// two effect creators for groups and sections
-const addGroupClass = addBodyClass( ( g ) => `is-group-${ g }` );
-const addSectionClass = addBodyClass( ( s ) => `is-section-${ s }` );
+		// remove the CSS class from body in the effect cleanup function
+		return () => document.body.classList.remove( className );
+	}, [ prefix, value ] );
+}
 
 export default function BodySectionCssClass( { group, section, bodyClass } ) {
-	React.useEffect( addGroupClass( group ), [ group ] );
-	React.useEffect( addSectionClass( section ), [ section ] );
+	useBodyClass( 'is-group-', group );
+	useBodyClass( 'is-section-', section );
 	React.useEffect( () => {
 		if ( ! Array.isArray( bodyClass ) || bodyClass.length === 0 ) {
 			return;


### PR DESCRIPTION
Fixes a bug in the `BodySectionCssClass` component where, in cooperation with the [server code that produces the initial HTML markup](https://github.com/Automattic/wp-calypso/blob/trunk/client/document/index.jsx#L123), there could be unwanted `is-section-*` classes on the `<body>`.

How to reproduce:
1. Being logged in, visit `/start/simple`. The server will send markup with `is-section-signup` CSS class on the `<body>` element, so that the page has correct styles from the very beginning.
2. For a logged-in user, `/start/simple` will immediately redirect to `/`, without ever rendering the Signup section React UI. That way, the `BodySectionCssClass` never gets to "own" the `is-section-signup` CSS class on `<body>`.
3. The Home section will have both `is-section-signup` and `is-section-home` CSS classes on `<body>`. There was no one to remove the old `signup` one. The result is a broken Home page:

<img width="936" alt="Screenshot 2021-04-19 at 10 22 27" src="https://user-images.githubusercontent.com/664258/115204831-33b91300-a0f9-11eb-81fd-58f350795352.png">

To fix this, I added code that removes any leftover `is-section-*` or `is-group-*` classes before adding a new one.

I also rewrote the `addBodyClass` helper to a `useBodyClass` hook to avoid ESLint warnings on the `React.useEffect` usages:
```
React Hook useEffect received a function whose dependencies are unknown. Pass an inline function instead. 
```