### PR TITLE
Signup: fix crash in setSelectedSiteForSignup handler

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -313,6 +313,10 @@ export default {
 		const signupDependencies = getSignupDependencyStore( getState() );
 
 		const siteSlug = signupDependencies?.siteSlug || query?.siteSlug;
+		if ( ! siteSlug ) {
+			next();
+			return;
+		}
 		const siteId = getSiteId( getState(), siteSlug );
 		if ( siteId ) {
 			dispatch( setSelectedSiteId( siteId ) );
@@ -323,7 +327,7 @@ export default {
 				let freshSiteId = getSiteId( getState(), siteSlug );
 
 				if ( ! freshSiteId ) {
-					const wpcomStagingFragment = siteSlug.replace( /\b.wordpress.com/, '.wpcomstaging.com' );
+					const wpcomStagingFragment = siteSlug.replace( /\.wordpress\.com$/, '.wpcomstaging.com' );
 					freshSiteId = getSiteId( getState(), wpcomStagingFragment );
 				}
 


### PR DESCRIPTION
When there is no `siteSlug` anywhere in dependencies or query string, the `setSelectedSiteForSignup` still tries to work with it and sometimes crashes:

<img width="555" alt="Screenshot 2021-04-19 at 9 19 36" src="https://user-images.githubusercontent.com/664258/115207492-f1dd9c00-a0fb-11eb-9db9-478d470d6692.png">

This patch fixes that (returns early when `siteSlug` is empty) and also fixes a suspicious regexp that checks if a string ends with `.wordpress.com`. 

@hambai There are two more subtle bugs in the `setSelectedSiteForSignup`:
- when looking for a `.wpcomstaging.com` alternative site, it doesn't try to `requestSite` and wait -- the site must be in local state immediately, otherwise the handler will fail to select it.
- after issuing the `requestSite` request, it calls `next()` immediately and then calls it once again after the request finishes. That leads to the Signup UI being rendered once without a selected site, and then once again with a selected site. I think we should wait with calling `next()` until the async request finishes and the site selection is done.

Let me know if you agree there issues are real and worth fixing. I can help with the patch.

**How to test:**
As a logged out user, go to `/start/simple` and observe the crash in console before the patch and that the crash disappears after the patch.