### PR TITLE
Add env badge helpers to enable ReactQuery devtools

### DIFF
--- a/client/components/environment-badge/index.jsx
+++ b/client/components/environment-badge/index.jsx
@@ -4,6 +4,12 @@ import ExternalLink from 'calypso/components/external-link';
 
 import './style.scss';
 
+export function ReactQueryDevtoolsHelper() {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	return <div className="environment is-react-query-devtools" />;
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
+}
+
 export function PreferencesHelper() {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return <div className="environment is-prefs" />;

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -11,6 +11,7 @@ import { RouteProvider } from 'calypso/components/route';
 import Layout from 'calypso/layout';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
 import { login } from 'calypso/lib/paths';
+import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
 import { getSiteFragment } from 'calypso/lib/route';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
@@ -56,6 +57,7 @@ export const ProviderWrappedLayout = ( {
 					<ReduxProvider store={ store }>
 						<MomentProvider>{ layout }</MomentProvider>
 					</ReduxProvider>
+					<CalypsoReactQueryDevtools />
 				</QueryClientProvider>
 			</RouteProvider>
 		</CalypsoI18nProvider>

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -9,6 +9,7 @@ import EnvironmentBadge, {
 	DevDocsLink,
 	PreferencesHelper,
 	FeaturesHelper,
+	ReactQueryDevtoolsHelper,
 } from 'calypso/components/environment-badge';
 import Head from 'calypso/components/head';
 import JetpackLogo from 'calypso/components/jetpack-logo';
@@ -41,6 +42,7 @@ class Document extends Component {
 			env,
 			badge,
 			preferencesHelper,
+			reactQueryDevtoolsHelper,
 			branchName,
 			commitChecksum,
 			devDocs,
@@ -147,6 +149,7 @@ class Document extends Component {
 					) }
 					{ badge && (
 						<EnvironmentBadge badge={ badge } feedbackURL={ feedbackURL }>
+							{ reactQueryDevtoolsHelper && <ReactQueryDevtoolsHelper /> }
 							{ preferencesHelper && <PreferencesHelper /> }
 							{ featuresHelper && <FeaturesHelper /> }
 							{ authHelper && <AuthHelper /> }

--- a/client/lib/load-dev-helpers/index.js
+++ b/client/lib/load-dev-helpers/index.js
@@ -23,4 +23,11 @@ export default function loadDevHelpers( reduxStore ) {
 			asyncRequire( 'calypso/lib/features-helper', ( helper ) => helper( el ) );
 		}
 	}
+
+	if ( config.isEnabled( 'dev/react-query-devtools' ) ) {
+		const el = document.querySelector( '.environment.is-react-query-devtools' );
+		if ( el ) {
+			asyncRequire( 'calypso/lib/react-query-devtools-helper', ( helper ) => helper( el ) );
+		}
+	}
 }

--- a/client/lib/react-query-devtools-helper/index.jsx
+++ b/client/lib/react-query-devtools-helper/index.jsx
@@ -1,0 +1,55 @@
+import config from '@automattic/calypso-config';
+import { useEffect, useState } from 'react';
+import ReactDom from 'react-dom';
+import { ReactQueryDevtools } from 'react-query/devtools';
+import { setStoredItem, getStoredItem } from 'calypso/lib/browser-storage';
+
+import './style.scss';
+
+function useDevtoolsEnabled() {
+	const [ enableDevtools, setEnableDevtools ] = useState();
+
+	useEffect( () => {
+		getStoredItem( 'enable-react-query-devtools' ).then( setEnableDevtools );
+	}, [] );
+
+	return enableDevtools;
+}
+
+export function CalypsoReactQueryDevtools() {
+	const enableDevtools = useDevtoolsEnabled();
+
+	if ( config.isEnabled( 'dev/react-query-devtools' ) ) {
+		return enableDevtools ? <ReactQueryDevtools /> : null;
+	}
+
+	return null;
+}
+
+function ReactQueryDevtoolsHelper() {
+	const enableDevtools = useDevtoolsEnabled();
+
+	async function toggleDevtools( event ) {
+		await setStoredItem( 'enable-react-query-devtools', event.target.checked );
+		window.location.reload();
+	}
+
+	return (
+		<>
+			<div>ReactQuery</div>
+			<div className="react-query-devtools-helper__popover">
+				<label className="react-query-devtools-helper__label">
+					<input
+						type="checkbox"
+						name="react-query-devtools"
+						checked={ enableDevtools ?? false }
+						onChange={ toggleDevtools }
+					/>
+					<span>Enable Devtools</span>
+				</label>
+			</div>
+		</>
+	);
+}
+
+export default ( element ) => ReactDom.render( <ReactQueryDevtoolsHelper />, element );

--- a/client/lib/react-query-devtools-helper/index.jsx
+++ b/client/lib/react-query-devtools-helper/index.jsx
@@ -10,8 +10,8 @@ function useDevtoolsEnabled() {
 	const [ devtoolsEnabled, setEnabled ] = useState( false );
 
 	useEffect( () => {
-		getStoredItem( 'enable-react-query-devtools' ).then( ( value ) =>
-			setEnabled( value ?? false )
+		getStoredItem( 'enable-react-query-devtools' ).then( ( status ) =>
+			setEnabled( status ?? false )
 		);
 	}, [] );
 
@@ -20,11 +20,11 @@ function useDevtoolsEnabled() {
 		setEnabled( status );
 	};
 
-	return { devtoolsEnabled, setDevtoolsEnabled };
+	return [ devtoolsEnabled, setDevtoolsEnabled ];
 }
 
 export function CalypsoReactQueryDevtools() {
-	const { devtoolsEnabled } = useDevtoolsEnabled();
+	const [ devtoolsEnabled ] = useDevtoolsEnabled();
 
 	if ( config.isEnabled( 'dev/react-query-devtools' ) ) {
 		return devtoolsEnabled ? <ReactQueryDevtools /> : null;
@@ -34,7 +34,7 @@ export function CalypsoReactQueryDevtools() {
 }
 
 function ReactQueryDevtoolsHelper() {
-	const { devtoolsEnabled, setDevtoolsEnabled } = useDevtoolsEnabled();
+	const [ devtoolsEnabled, setDevtoolsEnabled ] = useDevtoolsEnabled();
 
 	async function toggleDevtools( event ) {
 		await setDevtoolsEnabled( event.target.checked );

--- a/client/lib/react-query-devtools-helper/index.jsx
+++ b/client/lib/react-query-devtools-helper/index.jsx
@@ -7,42 +7,49 @@ import { setStoredItem, getStoredItem } from 'calypso/lib/browser-storage';
 import './style.scss';
 
 function useDevtoolsEnabled() {
-	const [ enableDevtools, setEnableDevtools ] = useState();
+	const [ devtoolsEnabled, setEnabled ] = useState( false );
 
 	useEffect( () => {
-		getStoredItem( 'enable-react-query-devtools' ).then( setEnableDevtools );
+		getStoredItem( 'enable-react-query-devtools' ).then( ( value ) =>
+			setEnabled( value ?? false )
+		);
 	}, [] );
 
-	return enableDevtools;
+	const setDevtoolsEnabled = async ( status ) => {
+		await setStoredItem( 'enable-react-query-devtools', status );
+		setEnabled( status );
+	};
+
+	return { devtoolsEnabled, setDevtoolsEnabled };
 }
 
 export function CalypsoReactQueryDevtools() {
-	const enableDevtools = useDevtoolsEnabled();
+	const { devtoolsEnabled } = useDevtoolsEnabled();
 
 	if ( config.isEnabled( 'dev/react-query-devtools' ) ) {
-		return enableDevtools ? <ReactQueryDevtools /> : null;
+		return devtoolsEnabled ? <ReactQueryDevtools /> : null;
 	}
 
 	return null;
 }
 
 function ReactQueryDevtoolsHelper() {
-	const enableDevtools = useDevtoolsEnabled();
+	const { devtoolsEnabled, setDevtoolsEnabled } = useDevtoolsEnabled();
 
 	async function toggleDevtools( event ) {
-		await setStoredItem( 'enable-react-query-devtools', event.target.checked );
+		await setDevtoolsEnabled( event.target.checked );
 		window.location.reload();
 	}
 
 	return (
 		<>
-			<div>ReactQuery</div>
+			<div>React Query</div>
 			<div className="react-query-devtools-helper__popover">
 				<label className="react-query-devtools-helper__label">
 					<input
 						type="checkbox"
 						name="react-query-devtools"
-						checked={ enableDevtools ?? false }
+						checked={ devtoolsEnabled }
 						onChange={ toggleDevtools }
 					/>
 					<span>Enable Devtools</span>

--- a/client/lib/react-query-devtools-helper/style.scss
+++ b/client/lib/react-query-devtools-helper/style.scss
@@ -1,0 +1,24 @@
+.react-query-devtools-helper__popover {
+	display: none;
+}
+
+.environment.is-react-query-devtools:hover .react-query-devtools-helper__popover {
+	display: block;
+	position: absolute;
+	bottom: 100%;
+	padding: 4px;
+	background: var( --color-surface );
+	box-shadow: 0 0 0 1px var( --color-border-subtle );
+}
+
+.react-query-devtools-helper__label {
+	display: block;
+	margin-bottom: 4px;
+	line-height: 16px;
+
+	input[type='checkbox'] {
+		appearance: auto;
+		vertical-align: middle;
+		margin: 0 4px 0 0;
+	}
+}

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -119,6 +119,7 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 		request.query[ 'wccom-from' ] &&
 		isWooOAuth2Client( { id: parseInt( oauthClientId ) } );
 
+	const reactQueryDevtoolsHelper = config.isEnabled( 'dev/react-query-devtools' );
 	const authHelper = config.isEnabled( 'dev/auth-helper' );
 	// preferences helper requires a Redux store, which doesn't exist in Gutenboarding
 	const preferencesHelper =
@@ -139,6 +140,7 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 		lang: config( 'i18n_default_locale_slug' ),
 		entrypoint: request.getFilesForEntrypoint( entrypoint ),
 		manifests: request.getAssets().manifests,
+		reactQueryDevtoolsHelper,
 		authHelper,
 		preferencesHelper,
 		featuresHelper,

--- a/config/development.json
+++ b/config/development.json
@@ -38,6 +38,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"devdocs/color-scheme-picker": true,
+		"dev/react-query-devtools": true,
 		"dev/auth-helper": true,
 		"dev/features-helper": true,
 		"dev/preferences-helper": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `<ReactQueryDevtools />` (see [documentation](https://react-query.tanstack.com/devtools))

#### Testing instructions

* Start a local calypso dev build
* On the Environment badge hover over _ReactQuery_
* Check _Enable Devtools_
* After a reload, the ReactQueryDevtools flower should appear on the bottom left
* Uncheck _Enable Devtools_ and the flower should disappear after a reload

<img width="144" alt="Screenshot 2022-04-22 at 14 34 02" src="https://user-images.githubusercontent.com/9202899/164715328-1a057d7b-7188-4a67-8a3d-b834ec6bac21.png">

