### PR TITLE
Framework: Refactor away from `_.first()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -404,6 +404,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/every': 'error',
 		'you-dont-need-lodash-underscore/extend-own': 'error',
 		'you-dont-need-lodash-underscore/fill': 'error',
+		'you-dont-need-lodash-underscore/first': 'error',
 		'you-dont-need-lodash-underscore/foldl': 'error',
 		'you-dont-need-lodash-underscore/foldr': 'error',
 		'you-dont-need-lodash-underscore/index-of': 'error',

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -1485,8 +1485,8 @@ export function getContextResults( section ) {
 
 	// make sure editorially to show at most one tour and one video at once
 	// `first` is a safe-guard in case that fails
-	const video = get( videosForSection, section )?.shift();
-	const tour = get( toursForSection, section )?.shift();
+	const video = get( videosForSection, section )?.[ 0 ];
+	const tour = get( toursForSection, section )?.[ 0 ];
 	const links = get( contextLinksForSection, section, fallbackLinks );
 
 	// If true, still display fallback links in addition (as opposed to instead

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { compact, first, get } from 'lodash';
+import { compact, get } from 'lodash';
 import i18n, { translate } from 'i18n-calypso';
 
 /**
@@ -1485,8 +1485,8 @@ export function getContextResults( section ) {
 
 	// make sure editorially to show at most one tour and one video at once
 	// `first` is a safe-guard in case that fails
-	const video = first( get( videosForSection, section ) );
-	const tour = first( get( toursForSection, section ) );
+	const video = get( videosForSection, section )?.shift();
+	const tour = get( toursForSection, section )?.shift();
 	const links = get( contextLinksForSection, section, fallbackLinks );
 
 	// If true, still display fallback links in addition (as opposed to instead

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { get, includes, times, first } from 'lodash';
+import { get, includes, times } from 'lodash';
 
 /**
  * Internal dependencies
@@ -273,10 +273,10 @@ class DomainSearchResults extends React.Component {
 					key="featured"
 					onButtonClick={ this.props.onClickResult }
 					premiumDomains={ this.props.premiumDomains }
-					primarySuggestion={ first( bestMatchSuggestions ) }
+					primarySuggestion={ bestMatchSuggestions.shift() }
 					query={ this.props.lastDomainSearched }
 					railcarId={ this.props.railcarId }
-					secondarySuggestion={ first( bestAlternativeSuggestions ) }
+					secondarySuggestion={ bestAlternativeSuggestions.shift() }
 					selectedSite={ this.props.selectedSite }
 					pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 					unavailableDomains={ this.props.unavailableDomains }

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -273,10 +273,10 @@ class DomainSearchResults extends React.Component {
 					key="featured"
 					onButtonClick={ this.props.onClickResult }
 					premiumDomains={ this.props.premiumDomains }
-					primarySuggestion={ bestMatchSuggestions.shift() }
+					primarySuggestion={ bestMatchSuggestions[ 0 ] }
 					query={ this.props.lastDomainSearched }
 					railcarId={ this.props.railcarId }
-					secondarySuggestion={ bestAlternativeSuggestions.shift() }
+					secondarySuggestion={ bestAlternativeSuggestions[ 0 ] }
 					selectedSite={ this.props.selectedSite }
 					pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 					unavailableDomains={ this.props.unavailableDomains }

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -193,21 +193,22 @@ class LineChart extends Component {
 			const drawFullSeries = dataSeries.length < POINTS_MAX;
 			const colorNum = dataSeriesIndex % NUM_SERIES;
 
-			const firstDatum = [ ...dataSeries ].shift();
-			( drawFullSeries ? dataSeries : [ firstDatum, last( dataSeries ) ] ).forEach( ( datum ) => {
-				svg
-					.append( 'circle' )
-					.attr(
-						'class',
-						`line-chart__line-point line-chart__line${
-							drawFullSeries ? '' : '-end'
-						}-point-color-${ colorNum }`
-					)
-					.attr( 'cx', xScale( datum.date ) )
-					.attr( 'cy', yScale( datum.value ) )
-					.attr( 'r', drawFullSeries ? POINTS_SIZE : POINTS_END_SIZE )
-					.datum( { ...datum, dataSeriesIndex } );
-			} );
+			( drawFullSeries ? dataSeries : [ dataSeries[ 0 ], last( dataSeries ) ] ).forEach(
+				( datum ) => {
+					svg
+						.append( 'circle' )
+						.attr(
+							'class',
+							`line-chart__line-point line-chart__line${
+								drawFullSeries ? '' : '-end'
+							}-point-color-${ colorNum }`
+						)
+						.attr( 'cx', xScale( datum.date ) )
+						.attr( 'cy', yScale( datum.value ) )
+						.attr( 'r', drawFullSeries ? POINTS_SIZE : POINTS_END_SIZE )
+						.datum( { ...datum, dataSeriesIndex } );
+				}
+			);
 		} );
 	};
 

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -8,7 +8,7 @@ import { line as d3Line, area as d3Area, curveMonotoneX as d3MonotoneXCurve } fr
 import { scaleLinear as d3ScaleLinear, scaleTime as d3TimeScale } from 'd3-scale';
 import { axisBottom as d3AxisBottom, axisRight as d3AxisRight } from 'd3-axis';
 import { select as d3Select, mouse as d3Mouse } from 'd3-selection';
-import { concat, first, last, throttle } from 'lodash';
+import { concat, last, throttle } from 'lodash';
 
 /**
  * Internal dependencies
@@ -193,22 +193,21 @@ class LineChart extends Component {
 			const drawFullSeries = dataSeries.length < POINTS_MAX;
 			const colorNum = dataSeriesIndex % NUM_SERIES;
 
-			( drawFullSeries ? dataSeries : [ first( dataSeries ), last( dataSeries ) ] ).forEach(
-				( datum ) => {
-					svg
-						.append( 'circle' )
-						.attr(
-							'class',
-							`line-chart__line-point line-chart__line${
-								drawFullSeries ? '' : '-end'
-							}-point-color-${ colorNum }`
-						)
-						.attr( 'cx', xScale( datum.date ) )
-						.attr( 'cy', yScale( datum.value ) )
-						.attr( 'r', drawFullSeries ? POINTS_SIZE : POINTS_END_SIZE )
-						.datum( { ...datum, dataSeriesIndex } );
-				}
-			);
+			const firstDatum = [ ...dataSeries ].shift();
+			( drawFullSeries ? dataSeries : [ firstDatum, last( dataSeries ) ] ).forEach( ( datum ) => {
+				svg
+					.append( 'circle' )
+					.attr(
+						'class',
+						`line-chart__line-point line-chart__line${
+							drawFullSeries ? '' : '-end'
+						}-point-color-${ colorNum }`
+					)
+					.attr( 'cx', xScale( datum.date ) )
+					.attr( 'cy', yScale( datum.value ) )
+					.attr( 'r', drawFullSeries ? POINTS_SIZE : POINTS_END_SIZE )
+					.datum( { ...datum, dataSeriesIndex } );
+			} );
 		} );
 	};
 

--- a/client/me/notification-settings/settings-form/device-selector.jsx
+++ b/client/me/notification-settings/settings-form/device-selector.jsx
@@ -24,7 +24,7 @@ class NotificationSettingsFormDeviceSelector extends PureComponent {
 	render() {
 		const { devices } = this.props;
 		if ( size( devices ) === 1 ) {
-			return <StreamHeader title={ devices.shift().name } />;
+			return <StreamHeader title={ devices[ 0 ].name } />;
 		}
 
 		return (

--- a/client/me/notification-settings/settings-form/device-selector.jsx
+++ b/client/me/notification-settings/settings-form/device-selector.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { size, map, first } from 'lodash';
+import { size, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,7 +24,7 @@ class NotificationSettingsFormDeviceSelector extends PureComponent {
 	render() {
 		const { devices } = this.props;
 		if ( size( devices ) === 1 ) {
-			return <StreamHeader title={ first( devices ).name } />;
+			return <StreamHeader title={ devices.shift().name } />;
 		}
 
 		return (

--- a/client/me/notification-settings/settings-form/stream.jsx
+++ b/client/me/notification-settings/settings-form/stream.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { find, first, size } from 'lodash';
+import { find, size } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,7 +30,7 @@ class NotificationSettingsFormStream extends PureComponent {
 		let { stream, settings } = this.props;
 
 		if ( this.props.devices && size( this.props.devices ) > 0 ) {
-			stream = parseInt( this.state.selectedDeviceId || first( this.props.devices ).id, 10 );
+			stream = parseInt( this.state.selectedDeviceId || [ ...this.props.devices ].shift().id, 10 );
 			settings = find( this.props.settings, { device_id: stream } );
 		}
 

--- a/client/me/notification-settings/settings-form/stream.jsx
+++ b/client/me/notification-settings/settings-form/stream.jsx
@@ -30,7 +30,7 @@ class NotificationSettingsFormStream extends PureComponent {
 		let { stream, settings } = this.props;
 
 		if ( this.props.devices && size( this.props.devices ) > 0 ) {
-			stream = parseInt( this.state.selectedDeviceId || [ ...this.props.devices ].shift().id, 10 );
+			stream = parseInt( this.state.selectedDeviceId || this.props.devices[ 0 ].id, 10 );
 			settings = find( this.props.settings, { device_id: stream } );
 		}
 

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -6,7 +6,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { debounce, filter, first, get, has, last, map, throttle } from 'lodash';
+import { debounce, filter, get, has, last, map, throttle } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -163,7 +163,7 @@ class EditorDiffViewer extends PureComponent {
 	};
 
 	scrollBelow = () => {
-		this.centerScrollingOnOffset( first( this.changesBelowViewport ) );
+		this.centerScrollingOnOffset( [ ...this.changesBelowViewport ].shift() );
 		this.props.recordTracksEvent( 'calypso_editor_post_revisions_scroll_hint_used', {
 			direction: 'below',
 		} );

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -163,7 +163,7 @@ class EditorDiffViewer extends PureComponent {
 	};
 
 	scrollBelow = () => {
-		this.centerScrollingOnOffset( [ ...this.changesBelowViewport ].shift() );
+		this.centerScrollingOnOffset( this.changesBelowViewport[ 0 ] );
 		this.props.recordTracksEvent( 'calypso_editor_post_revisions_scroll_hint_used', {
 			direction: 'below',
 		} );

--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -76,7 +76,7 @@ export const flags = withSchemaValidation( flagsSchema, ( state = [], action ) =
 export const currencyCode = withSchemaValidation( currencyCodeSchema, ( state = null, action ) => {
 	switch ( action.type ) {
 		case PRODUCTS_LIST_RECEIVE: {
-			return Object.values( action.productsList ).shift()?.currency_code ?? state;
+			return Object.values( action.productsList )[ 0 ]?.currency_code ?? state;
 		}
 		case PLANS_RECEIVE: {
 			return get( action.plans, [ 0, 'currency_code' ], state );

--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, isEqual, reduce, keys, first } from 'lodash';
+import { get, isEqual, reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -76,11 +76,7 @@ export const flags = withSchemaValidation( flagsSchema, ( state = [], action ) =
 export const currencyCode = withSchemaValidation( currencyCodeSchema, ( state = null, action ) => {
 	switch ( action.type ) {
 		case PRODUCTS_LIST_RECEIVE: {
-			return get(
-				action.productsList,
-				[ first( keys( action.productsList ) ), 'currency_code' ],
-				state
-			);
+			return Object.values( action.productsList ).shift()?.currency_code ?? state;
 		}
 		case PLANS_RECEIVE: {
 			return get( action.plans, [ 0, 'currency_code' ], state );

--- a/client/state/immediate-login/test/selectors.js
+++ b/client/state/immediate-login/test/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { first, last } from 'lodash';
+import { last } from 'lodash';
 
 /**
  * Internal dependencies
@@ -48,7 +48,7 @@ describe( 'immediate-login/selectors', () => {
 		test( 'should return correct value from state [3]', () => {
 			expect(
 				wasManualRenewalImmediateLoginAttempted( {
-					immediateLogin: { reason: first( REASONS_FOR_MANUAL_RENEWAL ) },
+					immediateLogin: { reason: REASONS_FOR_MANUAL_RENEWAL[ 0 ] },
 				} )
 			).toEqual( true );
 		} );

--- a/client/state/immediate-login/test/utils.js
+++ b/client/state/immediate-login/test/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { first, last } from 'lodash';
+import { last } from 'lodash';
 
 /**
  * Internal dependencies
@@ -120,7 +120,7 @@ describe( 'immediate-login/utils', () => {
 
 		const messages = [
 			createImmediateLoginMessage( '', 'test@wordpress.com' ),
-			createImmediateLoginMessage( first( REASONS_FOR_MANUAL_RENEWAL ), 'test@wordpress.com' ),
+			createImmediateLoginMessage( REASONS_FOR_MANUAL_RENEWAL[ 0 ], 'test@wordpress.com' ),
 			createImmediateLoginMessage( last( REASONS_FOR_MANUAL_RENEWAL ), 'test@wordpress.com' ),
 		];
 		test( 'should put an email in every message', () => {

--- a/client/state/stats/chart-tabs/reducer.js
+++ b/client/state/stats/chart-tabs/reducer.js
@@ -30,7 +30,7 @@ const countsReducer = ( state = [], action ) => {
 			// See https://github.com/Automattic/wp-calypso/pull/41441#discussion_r415918092
 			if (
 				action.data.length !== state.length ||
-				! isEqual( [ ...action.data ].shift().period, [ ...state ].shift().period )
+				! isEqual( action.data[ 0 ].period, state[ 0 ].period )
 			) {
 				return action.data;
 			}

--- a/client/state/stats/chart-tabs/reducer.js
+++ b/client/state/stats/chart-tabs/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { pick, set, isEqual, first } from 'lodash';
+import { pick, set, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,7 +30,7 @@ const countsReducer = ( state = [], action ) => {
 			// See https://github.com/Automattic/wp-calypso/pull/41441#discussion_r415918092
 			if (
 				action.data.length !== state.length ||
-				! isEqual( first( action.data ).period, first( state ).period )
+				! isEqual( [ ...action.data ].shift().period, [ ...state ].shift().period )
 			) {
 				return action.data;
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `first()` is only several times the Calypso codebase, and the usage is pretty simple, so this PR replaces it with `[ 0 ]` and optional chaining where necessary. 

I'm consciously not refactoring other neighboring or related instances that can be touched (`head()` or `last()`) - these will be addressed separately, as I'm trying to keep changes small, contained, and easier to test.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all tests pass.
* Verify `/home/:site` still works well - specifically, inline help.
* Verify domain search (`/domains/add/:site`) still works well.
* Verify Line Chart still works well (`/devdocs/design/line-chart`)
* Verify notification settings still works well (`/me/notifications`)
* Verify revision comparison still in post editor still works well.