### PR TITLE
Design Picker: Ensure minimum thumbnail size, increase `/start` design step max width

### DIFF
--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -34,6 +34,14 @@
 			margin-top: 48px;
 		}
 	}
+
+	// Ugly, but necessary to cancel out some signup styles
+	// without causing regressions to other parts of `/start`
+	button {
+		body.is-section-signup .layout:not( .dops ) & {
+			font-size: inherit;
+			padding-top: 0;
+			padding-bottom: 0;
 		}
 	}
 }

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -22,6 +22,18 @@
 			padding-right: 96px;
 		}
 	}
+
+	.step-wrapper__content {
+		margin-top: 24px;
+
+		@include break-mobile {
+			margin-top: 32px;
+		}
+
+		@include break-medium {
+			margin-top: 48px;
+		}
+	}
 		}
 	}
 }

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -6,9 +6,22 @@
 		padding-left: 24px;
 		padding-right: 24px;
 
-		@include break-xlarge {
-			padding-left: 0;
-			padding-right: 0;
+		// Ugly, but necessary to override the default max-width of the step wrapper
+		// without causing regressions to other parts of `/start`
+		body.is-section-signup .layout:not( .dops ) & {
+			max-width: 1440px;
+		}
+
+		@include break-small {
+			padding-left: 48px;
+			padding-right: 48px;
+		}
+
+		@include break-medium {
+			padding-left: 96px;
+			padding-right: 96px;
+		}
+	}
 		}
 	}
 }

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -57,12 +57,12 @@
 			margin: 0 0 30px;
 
 			@include break-mobile {
-				grid-template-columns: repeat( auto-fill, minmax( 300px, auto ) );
-				column-gap: 2%; // make gap size relative to the container
+				grid-template-columns: repeat( auto-fill, minmax( 295px, auto ) );
+				column-gap: 24px;
 			}
 
 			@include onboarding-break-gigantic {
-				column-gap: 32px; // keep it from ever-expanding with the container
+				column-gap: 32px;
 			}
 		}
 

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -57,17 +57,12 @@
 			margin: 0 0 30px;
 
 			@include break-mobile {
-				grid-template-columns: 1fr 1fr;
-				column-gap: 24px;
-			}
-
-			@include break-xlarge {
-				grid-template-columns: 1fr 1fr 1fr;
-				column-gap: 32px;
+				grid-template-columns: repeat( auto-fill, minmax( 300px, auto ) );
+				column-gap: 2%; // make gap size relative to the container
 			}
 
 			@include onboarding-break-gigantic {
-				grid-template-columns: 1fr 1fr 1fr 1fr;
+				column-gap: 32px; // keep it from ever-expanding with the container
 			}
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Update the `design` step in the `/start` signup flow to match the equivalent step in the `/new` flow:
  * change the step content's max width from `960px` to `1440px`
  * update the L/R padding and the column gap to match `/new`
  * add more vertical space between the title and the design grid
  * Fix some style leaks in `/start` flow 
* Use CSS grid to make sure that the design picker's thumbnails are never narrower than `295px` — this, combined with the width of the design picker component in the onboarding flow, ensures a responsive layout from 1 to 4 columns

## Testing instructions

This PR can be tested via the calypso.live link:

#### Check that the design picker step in the `/start` flow has the desired layout:

* Go to [`/start/with-design-picker`](https://hash-41bf5a4b84af32f96d35193b3c3d6331f3e617b6.calypso.live/start/with-design-picker)
* Advance to the 3rd step (design selection)
* Make sure that the design picker grid layout is the same as the design step in the [`/new/design`](https://hash-41bf5a4b84af32f96d35193b3c3d6331f3e617b6.calypso.live/new/design) step

#### Check for regressions

* Make sure that no regressions were introduced to the  [`/new/design`](https://hash-41bf5a4b84af32f96d35193b3c3d6331f3e617b6.calypso.live/new/design) step
* Make sure that no regressions were introduced to the rest of the `/start` flow
* Make sure that this fix works fine also [when enabling the `gutenboarding/long-previews` flag](https://hash-41bf5a4b84af32f96d35193b3c3d6331f3e617b6.calypso.live/new/design?flags=gutenboarding/long-previews)

Fixes #52017 
