### PR TITLE
Taxonomy Manager: Improve Alignment of Count Bubble

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -165,12 +165,14 @@ class TaxonomyManagerListItem extends Component {
 					) }
 				</span>
 				{ typeof term.post_count !== 'undefined' && (
-					<Count
-						ref="count"
-						count={ term.post_count }
-						onMouseEnter={ this.showTooltip }
-						onMouseLeave={ this.hideTooltip }
-					/>
+					<div className="taxonomy-manager__count">
+						<Count
+							ref="count"
+							count={ term.post_count }
+							onMouseEnter={ this.showTooltip }
+							onMouseLeave={ this.hideTooltip }
+						/>
+					</div>
 				) }
 				<Tooltip
 					context={ this.refs && this.refs.count }

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -95,8 +95,8 @@
 		}
 	}
 
-	.count {
-		margin: 18px 2px;
+	.taxonomy-manager__count {
+		margin: auto;
 	}
 
 	.ellipsis-menu {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Improves the alignment of the number inside the "Count" component when managing categories

#### Testing instructions

Visit `/settings/taxonomies/category/site` and compare the alignment of the number in the Count bubble, especially for the "Default" category. 

**Before:**
<img width="710" alt="Screenshot 2021-04-19 at 19 30 51" src="https://user-images.githubusercontent.com/43215253/115285451-c97a8f80-a145-11eb-9d3c-b97794df7d36.png">

**After:**
<img width="707" alt="Screenshot 2021-04-19 at 19 30 46" src="https://user-images.githubusercontent.com/43215253/115285481-d13a3400-a145-11eb-8f5c-4a7dff0af946.png">

cc @sixhours 

Fixes #52071