### PR TITLE
Add mailbox list placeholder in new email list

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -2,7 +2,9 @@
  * External dependencies
  */
 import React from 'react';
+import classNames from 'classnames';
 import { CompactCard } from '@automattic/components';
+import PropTypes from 'prop-types';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -13,18 +15,49 @@ import SectionHeader from 'calypso/components/section-header';
 import Badge from 'calypso/components/badge';
 import { isEmailUserAdmin } from 'calypso/lib/emails';
 
-function EmailPlanMailboxesList( { emails } ) {
+function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
 	const translate = useTranslate();
+
+	const MailboxListHeader = ( { children } ) => {
+		return (
+			<div className="email-plan-mailboxes-list__mailbox-list">
+				<SectionHeader label={ translate( 'Mailboxes' ) } />
+				{ children }
+			</div>
+		);
+	};
+
+	const MailboxListItem = ( { children, isPlaceholder, noEmails } ) => {
+		const className = classNames( 'email-plan-mailboxes-list__mailbox-list-item', {
+			'is-placeholder': isPlaceholder,
+			'no-emails': noEmails,
+		} );
+		return <CompactCard className={ className }>{ children }</CompactCard>;
+	};
+
+	if ( isLoadingEmails ) {
+		return (
+			<MailboxListHeader>
+				<MailboxListItem isPlaceholder>
+					<span> </span>
+				</MailboxListItem>
+			</MailboxListHeader>
+		);
+	}
+
 	if ( ! emails || emails.length < 1 ) {
-		return null;
+		return (
+			<MailboxListHeader>
+				<MailboxListItem noEmails>
+					<span>{ translate( 'No mailboxes' ) }</span>
+				</MailboxListItem>
+			</MailboxListHeader>
+		);
 	}
 
 	const emailsItems = emails.map( ( email ) => {
 		return (
-			<CompactCard
-				key={ `email-row-${ email.mailbox }` }
-				className="email-plan-mailboxes-list__mailbox-list-item"
-			>
+			<MailboxListItem key={ `email-row-${ email.mailbox }` }>
 				<MaterialIcon icon="email" />
 				<span>
 					{ email.mailbox }@{ email.domain }
@@ -36,16 +69,16 @@ function EmailPlanMailboxesList( { emails } ) {
 						} ) }
 					</Badge>
 				) }
-			</CompactCard>
+			</MailboxListItem>
 		);
 	} );
 
-	return (
-		<div className="email-plan-mailboxes-list__mailbox-list">
-			<SectionHeader label={ translate( 'Mailboxes' ) } />
-			{ emailsItems }
-		</div>
-	);
+	return <MailboxListHeader>{ emailsItems }</MailboxListHeader>;
 }
+
+EmailPlanMailboxesList.propTypes = {
+	emails: PropTypes.array,
+	isLoadingEmails: PropTypes.bool,
+};
 
 export default EmailPlanMailboxesList;

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import { CompactCard } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -13,42 +13,39 @@ import SectionHeader from 'calypso/components/section-header';
 import Badge from 'calypso/components/badge';
 import { isEmailUserAdmin } from 'calypso/lib/emails';
 
-class EmailPlanMailboxesList extends React.Component {
-	render() {
-		const { emails, translate } = this.props;
-
-		if ( ! emails || emails.length < 1 ) {
-			return null;
-		}
-
-		const emailsItems = emails.map( ( email ) => {
-			return (
-				<CompactCard
-					key={ `email-row-${ email.mailbox }` }
-					className="email-plan-mailboxes-list__mailbox-list-item"
-				>
-					<MaterialIcon icon="email" />
-					<span>
-						{ email.mailbox }@{ email.domain }
-					</span>
-					{ isEmailUserAdmin( email ) && (
-						<Badge type="info">
-							{ translate( 'Admin', {
-								comment: 'Email user role displayed as a badge',
-							} ) }
-						</Badge>
-					) }
-				</CompactCard>
-			);
-		} );
-
-		return (
-			<div className="email-plan-mailboxes-list__mailbox-list">
-				<SectionHeader label={ translate( 'Mailboxes' ) } />
-				{ emailsItems }
-			</div>
-		);
+function EmailPlanMailboxesList( { emails } ) {
+	const translate = useTranslate();
+	if ( ! emails || emails.length < 1 ) {
+		return null;
 	}
+
+	const emailsItems = emails.map( ( email ) => {
+		return (
+			<CompactCard
+				key={ `email-row-${ email.mailbox }` }
+				className="email-plan-mailboxes-list__mailbox-list-item"
+			>
+				<MaterialIcon icon="email" />
+				<span>
+					{ email.mailbox }@{ email.domain }
+				</span>
+				{ isEmailUserAdmin( email ) && (
+					<Badge type="info">
+						{ translate( 'Admin', {
+							comment: 'Email user role displayed as a badge',
+						} ) }
+					</Badge>
+				) }
+			</CompactCard>
+		);
+	} );
+
+	return (
+		<div className="email-plan-mailboxes-list__mailbox-list">
+			<SectionHeader label={ translate( 'Mailboxes' ) } />
+			{ emailsItems }
+		</div>
+	);
 }
 
-export default localize( EmailPlanMailboxesList );
+export default EmailPlanMailboxesList;

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -15,31 +15,34 @@ import SectionHeader from 'calypso/components/section-header';
 import Badge from 'calypso/components/badge';
 import { isEmailUserAdmin } from 'calypso/lib/emails';
 
-function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
+const MailboxListHeader = ( { children } ) => {
 	const translate = useTranslate();
 
-	const MailboxListHeader = ( { children } ) => {
-		return (
-			<div className="email-plan-mailboxes-list__mailbox-list">
-				<SectionHeader label={ translate( 'Mailboxes' ) } />
-				{ children }
-			</div>
-		);
-	};
+	return (
+		<div className="email-plan-mailboxes-list__mailbox-list">
+			<SectionHeader label={ translate( 'Mailboxes' ) } />
+			{ children }
+		</div>
+	);
+};
 
-	const MailboxListItem = ( { children, isPlaceholder, noEmails } ) => {
-		const className = classNames( 'email-plan-mailboxes-list__mailbox-list-item', {
-			'is-placeholder': isPlaceholder,
-			'no-emails': noEmails,
-		} );
-		return <CompactCard className={ className }>{ children }</CompactCard>;
-	};
+const MailboxListItem = ( { children, isPlaceholder, hasNoEmails } ) => {
+	const className = classNames( 'email-plan-mailboxes-list__mailbox-list-item', {
+		'is-placeholder': isPlaceholder,
+		'no-emails': hasNoEmails,
+	} );
+	return <CompactCard className={ className }>{ children }</CompactCard>;
+};
+
+function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
+	const translate = useTranslate();
 
 	if ( isLoadingEmails ) {
 		return (
 			<MailboxListHeader>
 				<MailboxListItem isPlaceholder>
-					<span> </span>
+					<MaterialIcon icon="email" />
+					<span />
 				</MailboxListItem>
 			</MailboxListHeader>
 		);
@@ -48,7 +51,7 @@ function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
 	if ( ! emails || emails.length < 1 ) {
 		return (
 			<MailboxListHeader>
-				<MailboxListItem noEmails>
+				<MailboxListItem hasNoEmails>
 					<span>{ translate( 'No mailboxes' ) }</span>
 				</MailboxListItem>
 			</MailboxListHeader>
@@ -57,7 +60,7 @@ function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
 
 	const emailsItems = emails.map( ( email ) => {
 		return (
-			<MailboxListItem key={ `email-row-${ email.mailbox }` }>
+			<MailboxListItem key={ email.mailbox }>
 				<MaterialIcon icon="email" />
 				<span>
 					{ email.mailbox }@{ email.domain }

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -255,6 +255,7 @@ class EmailPlan extends React.Component {
 
 		const cardClasses = classnames( 'email-plan__general', statusClass );
 		const addMailboxProps = this.getAddMailboxProps();
+		const { isLoadingEmailAccounts } = this.state;
 
 		return (
 			<>
@@ -283,7 +284,10 @@ class EmailPlan extends React.Component {
 					/>
 				) }
 
-				<EmailPlanMailboxesList emails={ this.getEmails() } />
+				<EmailPlanMailboxesList
+					emails={ this.getEmails() }
+					isLoadingEmails={ isLoadingEmailAccounts }
+				/>
 
 				<div className="email-plan__actions">
 					<VerticalNav>

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -142,6 +142,13 @@
 .email-plan-mailboxes-list__mailbox-list-item {
 	display: flex;
 	align-items: center;
+	&.is-placeholder > span {
+		@include placeholder( --color-neutral-5 );
+		width: 50%;
+	}
+	&.no-emails > span {
+		font-style: italic;
+	}
 	> svg {
 		fill: var( --studio-gray-50 );
 		margin-right: 10px;

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -147,6 +147,7 @@
 		width: 50%;
 	}
 	&.no-emails > span {
+		color: var( --color-text-subtle );
 		font-style: italic;
 	}
 	> svg {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The core goal of this PR is to add a loading indicator to the list of mailboxes in the domain-specific email management screen, and to show a basic "No mailboxes" message when no emails are specified.
* While working on the component, I refactored it to be functional, and also included some internal helper components to ensure we use the same structural elements for all paths through the code.

_Note: This PR is based on PR #51452, so needs that change to be reviewed and merged first._

#### Testing instructions

* Either load (http://calypso.localhost:3000) or the [live branch](http://calypso.localhost:3000/email/ddptestdomain808080.domains/manage/ddp-test-domain.com), and then navigate to `/email/:siteSlug?flags=email/centralized-home` for a site with test domains and email subscriptions.
* For some of your domains with email, click on the row and verify that you see a loading row for the mailbox section, and then the list of mailboxes.
* To verify the "No mailboxes" message, you may need to interfere with the REST API or the code to simulate that situation. You may also have one or more WordPress.com Email accounts where you haven't created any mailboxes yet, which would also test this case.

#### Screenshot

<img width="1068" alt="Screenshot 2021-04-22 at 22 31 33" src="https://user-images.githubusercontent.com/3376401/115781457-b15f7600-a3ba-11eb-9914-289f113ef939.png">
