### PR TITLE
Nav Unification: Taxonomies, look at the third path fragment to determine selected menu item

### DIFF
--- a/client/my-sites/sidebar-unified/utils.jsx
+++ b/client/my-sites/sidebar-unified/utils.jsx
@@ -12,9 +12,13 @@ const fragmentIsEqual = ( path, currentPath, position ) =>
  * @returns {boolean} True if paths match, false otherwise.
  */
 export const itemLinkMatches = ( path, currentPath ) => {
-	// Accounts for jetpack custom post types, eg portofolio, testimonials.
+	// Accounts for jetpack custom post types, eg portfolio, testimonials.
 	if ( pathIncludes( currentPath, 'types', 1 ) ) {
 		return fragmentIsEqual( path, currentPath, 2 );
+	}
+	// Account for taxonomies, eg. tags, categories
+	if ( pathIncludes( currentPath, 'taxonomies', 2 ) ) {
+		return fragmentIsEqual( path, currentPath, 3 );
 	}
 	// Temp fix till we remove duplicate menu entry of sharing buttons from 'Settings' menu. See https://github.com/Automattic/wp-calypso/issues/49756.
 	if ( pathIncludes( currentPath, 'marketing', 1 ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Pointing taxonomies to Calypso screens in #50568 means the selected menu items utility needs help knowing where to look for a match; similar to how post types are nested under `/types`, taxonomies are nested under `/settings/taxonomies/[third fragment]`, so the `itemLinkMatches` utility needs to look in the 3rd path fragment (should be `post_tag` or `categories`) to determine which menu item to highlight.

**Before**

<img width="278" alt="Screen Shot 2021-04-19 at 4 21 53 PM" src="https://user-images.githubusercontent.com/2124984/115307939-f4f67d80-a137-11eb-9803-9a6385ade698.png">

**After**

<img width="289" alt="Screen Shot 2021-04-19 at 5 44 34 PM" src="https://user-images.githubusercontent.com/2124984/115307927-f031c980-a137-11eb-9f05-6a96188b6f03.png">


#### Testing instructions

* Switch to this PR and apply D60379-code to your sandbox, then sandbox the API
* Make sure the Dashboard appearance advanced settings are **off** under Me -> Account Settings
* Click on Posts -> Categories; the Categories menu should be correctly highlighted
* Click on Posts -> Tags; the Tags menu item should be correctly highlighted