### PR TITLE
Rename "Create a site menu" checklist item

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -183,7 +183,7 @@ export const getTask = (
 		case CHECKLIST_KNOWN_TASKS.SITE_MENU_UPDATED:
 			taskData = {
 				timing: 10,
-				title: translate( 'Create a site menu' ),
+				title: translate( 'Edit the site menu' ),
 				description: (
 					<>
 						{ translate(


### PR DESCRIPTION
Simple text change so that the onboarding checklist makes more sense as site menus are automatically created

fixes https://github.com/Automattic/wp-calypso/issues/44240

#### Testing instructions 

https://calypso.live/new?branch=update/update-text-on-checklist
Create a site with the `/new` flow
the checklist text should now say "Edit the site menu"
