### PR TITLE
E2E: Fix window switch in pop up logins

### DIFF
--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -107,13 +107,14 @@ export function waitUntilLocatedAndVisible( driver, locator, timeout = explicitW
 		new WebElementCondition(
 			`for the element to become located and visible ${ locatorStr }`,
 			async function () {
-				const element = ( await driver.findElements( locator ) )[ 0 ];
-				if ( ! element ) {
+				try {
+					const element = await driver.findElement( locator );
+					const isDisplayed = await element.isDisplayed();
+
+					return isDisplayed ? element : null;
+				} catch {
 					return null;
 				}
-				const isDisplayed = await element.isDisplayed();
-
-				return isDisplayed ? element : null;
 			}
 		),
 		timeout

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import webdriver, {
-	Key,
 	By,
+	Condition,
+	Key,
+	logging,
 	WebDriver,
 	WebElement,
 	WebElementCondition,
-	logging,
 } from 'selenium-webdriver';
 import config from 'config';
 import { forEach } from 'lodash';
@@ -563,10 +564,36 @@ export async function waitTillTextPresent( driver, selector, text, waitOverride 
  * Upon successful resolution, the driver will be left focused on the new frame.
  *
  * @param {WebDriver} driver The parent WebDriver instance
- * @param {By} locator The element's locator
+ * @param {By} locator The frame element's locator
  * @param {number} [timeout=explicitWaitMS] The timeout in milliseconds
- * @returns {Promise<boolean>} A promise that will resolve with true if the switch was succesfull
+ * @returns {Promise<boolean>} A promise that will resolve with true if the
+ * switch was succesfull
  */
 export function waitUntilAbleToSwitchToFrame( driver, locator, timeout = explicitWaitMS ) {
 	return driver.wait( until.ableToSwitchToFrame( locator ), timeout );
+}
+
+/**
+ * Waits until a window of a given index is ready to be switched to and switches
+ * to it.
+ *
+ * @param {WebDriver} driver The parent WebDriver instance
+ * @param {number} windowIndex The index of the window to switch to
+ * @param {number} [timeout=explicitWaitMS] The timeout in milliseconds
+ * @returns {Promise<boolean>} A promise that will resolve with true if the
+ * switch was succesfull
+ */
+export function waitUntilAbleToSwitchToWindow( driver, windowIndex, timeout = explicitWaitMS ) {
+	return driver.wait(
+		new Condition( `to be able to switch to window #${ windowIndex }`, async function () {
+			try {
+				await switchToWindowByIndex( driver, windowIndex );
+			} catch {
+				return null;
+			}
+
+			return true;
+		} ),
+		timeout
+	);
 }

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -367,9 +367,12 @@ export function waitForInfiniteListLoad( driver, elementSelector, { numElements 
 export async function switchToWindowByIndex( driver, index ) {
 	const currentScreenSize = driverManager.currentScreenSize();
 	const handles = await driver.getAllWindowHandles();
+
 	await driver.switchTo().window( handles[ index ] );
-	// Resize target window to ensure we stay in the same viewport size:
-	await driverManager.resizeBrowser( driver, currentScreenSize );
+	if ( currentScreenSize !== 'desktop' ) {
+		// Resize target window to ensure we stay in the same viewport size:
+		await driverManager.resizeBrowser( driver, currentScreenSize );
+	}
 }
 
 export async function numberOfOpenWindows( driver ) {

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -260,6 +260,12 @@ export default class LoginFlow {
 
 	async loginUsingPopup() {
 		await driverHelper.waitForNumberOfWindows( this.driver, 2 );
+
+		// waitForNumberOfWindows returns after the new window has been created but
+		// before the window is fully loaded. Switching to the new window is possible
+		// but our switchToWindowByIndex attempts a window resize which sometimes fails.
+		// A short sleep here is enough to alleviate this problem.
+		await this.driver.sleep( 100 );
 		await driverHelper.switchToWindowByIndex( this.driver, 1 );
 
 		const loginPage = await LoginPage.Expect( this.driver );

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -259,15 +259,7 @@ export default class LoginFlow {
 	}
 
 	async loginUsingPopup() {
-		await driverHelper.waitForNumberOfWindows( this.driver, 2 );
-
-		// waitForNumberOfWindows returns after the new window has been created but
-		// before the window is fully loaded. Switching to the new window is possible
-		// but our switchToWindowByIndex attempts a window resize which sometimes fails.
-		// A short sleep here is enough to alleviate this problem.
-		await this.driver.sleep( 100 );
-		await driverHelper.switchToWindowByIndex( this.driver, 1 );
-
+		await driverHelper.waitUntilAbleToSwitchToWindow( this.driver, 1 );
 		const loginPage = await LoginPage.Expect( this.driver );
 
 		try {
@@ -285,7 +277,7 @@ export default class LoginFlow {
 		}
 
 		// Make sure we've switched back to the post window
-		await driverHelper.switchToWindowByIndex( this.driver, 0 );
+		await driverHelper.waitUntilAbleToSwitchToWindow( this.driver, 0 );
 	}
 
 	async loginAndOpenWooStore() {


### PR DESCRIPTION
Switching to new windows is triggering a resize that can't always yet be fulfilled.

#### Changes proposed in this Pull Request

* ~Add sleep between login popup display and switch attempt~ _edit: see https://github.com/Automattic/wp-calypso/pull/52090#discussion_r620233108_

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

```
NODE_CONFIG_ENV=decrypted BROWSERSIZE=desktop ./node_modules/.bin/mocha specs/wp-likes-spec.js
```
