### PR TITLE
State: Remove unused getHttpData selector

### DIFF
--- a/client/state/selectors/get-http-data.js
+++ b/client/state/selectors/get-http-data.js
@@ -1,1 +1,0 @@
-export { getHttpData as default } from 'calypso/state/data-layer/http-data';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the unused `getHttpData` selector. We're already consuming `getHttpData`, but not from `state/selectors`. This PR only removes the duplicate unused export.

#### Testing instructions

* Verify the removed selector is not in use.