### PR TITLE
Add links to last slide of welcome tour

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
@@ -62,7 +62,7 @@ class WPCOM_Block_Editor_NUX {
 		wp_localize_script(
 			'wpcom-block-editor-nux-script',
 			'wpcomBlockEditorNuxLocale',
-			determine_locale()
+			\A8C\FSE\Common\get_iso_639_locale( determine_locale() )
 		);
 
 		wp_set_script_translations( 'wpcom-block-editor-nux-script', 'full-site-editing' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
@@ -59,6 +59,11 @@ class WPCOM_Block_Editor_NUX {
 			'wpcomBlockEditorNuxAssetsUrl',
 			plugins_url( 'dist/', __FILE__ )
 		);
+		wp_localize_script(
+			'wpcom-block-editor-nux-script',
+			'wpcomBlockEditorNuxLocale',
+			determine_locale()
+		);
 
 		wp_set_script_translations( 'wpcom-block-editor-nux-script', 'full-site-editing' );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -9,6 +9,7 @@ import { Guide, GuidePage } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
+import { LocaleProvider, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -41,7 +42,11 @@ registerPlugin( 'wpcom-block-editor-nux', {
 		}
 
 		if ( variant === 'tour' ) {
-			return <LaunchWpcomWelcomeTour />;
+			return (
+				<LocaleProvider localeSlug={ window.wpcomBlockEditorNuxLocale ?? i18nDefaultLocaleSlug }>
+					<LaunchWpcomWelcomeTour />;
+				</LocaleProvider>
+			);
 		}
 
 		if ( variant === 'modal' && Guide && GuidePage ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { ExternalLink } from '@wordpress/components';
 
 const addBlock = 'https://s0.wp.com/i/editor-welcome-tour/slide-add-block.gif';
 const allBlocks = 'https://s0.wp.com/i/editor-welcome-tour/slide-all-blocks.gif';
@@ -75,9 +77,21 @@ function getTourContent() {
 		},
 		{
 			heading: __( 'Congratulations!', 'full-site-editing' ),
-			description: __(
-				'You’ve now learned the basics. Remember, your site is always private until you decide to launch.',
-				'full-site-editing'
+			description: createInterpolateElement(
+				__(
+					'You’ve now learned the basics. Remember, your site is <link_to_launch_site_docs>always private until you decide to launch</link_to_launch_site_docs>. Check out the docs to <link_to_editor_docs>learn more about Block Editing</link_to_editor_docs>.',
+					'full-site-editing'
+				),
+				{
+					link_to_launch_site_docs: (
+						<ExternalLink
+							href={ 'https://wordpress.com/support/settings/privacy-settings/#launch-your-site' }
+						/>
+					),
+					link_to_editor_docs: (
+						<ExternalLink href={ 'https://wordpress.com/support/wordpress-editor/' } />
+					),
+				}
 			),
 			imgSrc: finish,
 			animation: 'block-inserter',

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
@@ -78,7 +78,7 @@ function getTourContent( localeSlug ) {
 			animation: 'undo-button',
 		},
 		{
-			heading: __( 'Congratulations!', 'full-site-editing' ).replace( '&nbsp;', ' ' ),
+			heading: __( 'Congratulations!', 'full-site-editing' ),
 			description: createInterpolateElement(
 				__(
 					"You've learned the basics. Remember, your site is private until you <link_to_launch_site_docs>decide to launch</link_to_launch_site_docs>. View the <link_to_editor_docs>block editing docs</link_to_editor_docs> to learn more.",

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
@@ -77,7 +77,7 @@ function getTourContent() {
 			animation: 'undo-button',
 		},
 		{
-			heading: __( 'Congratulations!', 'full-site-editing' ),
+			heading: __( 'Congratulations!', 'full-site-editing' ).replace( '&nbsp;', ' ' ),
 			description: createInterpolateElement(
 				__(
 					'You’ve now learned the basics. Remember, your site is <link_to_launch_site_docs>always private until you decide to launch</link_to_launch_site_docs>. Check out the docs to <link_to_editor_docs>learn more about Block Editing</link_to_editor_docs>.',

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
@@ -18,9 +18,10 @@ const welcome = 'https://s0.wp.com/i/editor-welcome-tour/slide-welcome.png';
 /**
  * This function returns a collection of NUX Tour slide data
  *
+ * @param { string } localeSlug the users locale
  * @returns { Array } a collection of <WelcomeTourCard /> props
  */
-function getTourContent() {
+function getTourContent( localeSlug ) {
 	return [
 		{
 			heading: __( 'Welcome to WordPress!', 'full-site-editing' ),
@@ -87,13 +88,14 @@ function getTourContent() {
 					link_to_launch_site_docs: (
 						<ExternalLink
 							href={ localizeUrl(
-								'https://wordpress.com/support/settings/privacy-settings/#launch-your-site'
+								'https://wordpress.com/support/settings/privacy-settings/#launch-your-site',
+								localeSlug
 							) }
 						/>
 					),
 					link_to_editor_docs: (
 						<ExternalLink
-							href={ localizeUrl( 'https://wordpress.com/support/wordpress-editor/' ) }
+							href={ localizeUrl( 'https://wordpress.com/support/wordpress-editor/', localeSlug ) }
 						/>
 					),
 				}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
@@ -80,7 +80,7 @@ function getTourContent() {
 			heading: __( 'Congratulations!', 'full-site-editing' ).replace( '&nbsp;', ' ' ),
 			description: createInterpolateElement(
 				__(
-					'You’ve now learned the basics. Remember, your site is <link_to_launch_site_docs>always private until you decide to launch</link_to_launch_site_docs>. Check out the docs to <link_to_editor_docs>learn more about Block Editing</link_to_editor_docs>.',
+					"You've learned the basics. Remember, your site is private until you <link_to_launch_site_docs>decide to launch</link_to_launch_site_docs>. View the <link_to_editor_docs>block editing docs</link_to_editor_docs> to learn more.",
 					'full-site-editing'
 				),
 				{

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { ExternalLink } from '@wordpress/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 
 const addBlock = 'https://s0.wp.com/i/editor-welcome-tour/slide-add-block.gif';
 const allBlocks = 'https://s0.wp.com/i/editor-welcome-tour/slide-all-blocks.gif';
@@ -85,11 +86,15 @@ function getTourContent() {
 				{
 					link_to_launch_site_docs: (
 						<ExternalLink
-							href={ 'https://wordpress.com/support/settings/privacy-settings/#launch-your-site' }
+							href={ localizeUrl(
+								'https://wordpress.com/support/settings/privacy-settings/#launch-your-site'
+							) }
 						/>
 					),
 					link_to_editor_docs: (
-						<ExternalLink href={ 'https://wordpress.com/support/wordpress-editor/' } />
+						<ExternalLink
+							href={ localizeUrl( 'https://wordpress.com/support/wordpress-editor/' ) }
+						/>
 					),
 				}
 			),

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
@@ -15,6 +15,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { createPortal, useEffect, useState, useRef } from '@wordpress/element';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { __ } from '@wordpress/i18n';
+import { useLocale } from '@automattic/i18n-utils';
 
 function LaunchWpcomWelcomeTour() {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
@@ -28,9 +29,10 @@ function LaunchWpcomWelcomeTour() {
 	} ) );
 
 	const { closeGeneralSidebar } = useDispatch( 'core/edit-post' );
+	const localeSlug = useLocale();
 
 	// Preload first card image (others preloaded after open state confirmed)
-	new window.Image().src = getTourContent()[ 0 ].imgSrc;
+	new window.Image().src = getTourContent( localeSlug )[ 0 ].imgSrc;
 
 	// Hide editor sidebar first time user sees the editor
 	useEffect( () => {
@@ -62,7 +64,8 @@ function LaunchWpcomWelcomeTour() {
 }
 
 function WelcomeTourFrame() {
-	const cardContent = getTourContent();
+	const localeSlug = useLocale();
+	const cardContent = getTourContent( localeSlug );
 	const [ isMinimized, setIsMinimized ] = useState( false );
 	const [ currentCardIndex, setCurrentCardIndex ] = useState( 0 );
 	const [ justMaximized, setJustMaximized ] = useState( false );

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -19,7 +19,7 @@ export const LocaleProvider: React.FC< Props > = ( { children, localeSlug } ) =>
  * Get the current locale slug from the @wordpress/i18n locale data
  */
 function getWpI18nLocaleSlug(): string | undefined {
-	return i18n.getLocaleData()?.[ '' ]?.language;
+	return i18n.getLocaleData()?.[ '' ]?.language || i18n.getLocaleData()?.[ '' ]?.lang;
 }
 
 /**

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -19,7 +19,7 @@ export const LocaleProvider: React.FC< Props > = ( { children, localeSlug } ) =>
  * Get the current locale slug from the @wordpress/i18n locale data
  */
 function getWpI18nLocaleSlug(): string | undefined {
-	return i18n.getLocaleData()?.[ '' ]?.language || i18n.getLocaleData()?.[ '' ]?.lang;
+	return i18n.getLocaleData()?.[ '' ]?.language;
 }
 
 /**


### PR DESCRIPTION
Fixes #50874

BEFORE:
'You’ve now learned the basics. Remember, your site is always private until you decide to launch.',

AFTER:
'You’ve learned the basics. Remember, your site is [ private until you decide to launch](https://wordpress.com/support/settings/privacy-settings/#launch-your-site). View the  [block editing docs](https://wordpress.com/support/wordpress-editor/) to learn more.',

'You've learned the basics. Remember, your site is private until you decide to launch. View the block editing docs to learn more.'


#### Testing instructions
install to sandbox 
```
./install-plugin.sh etk update/add-links-to-welcome-tour
```
go to the editor for a sandboxed site and open the welcome tour from the menu, if the old modal based nux tour appears, try clearing local storage for the sandboxed test site and reloading.

![image](https://user-images.githubusercontent.com/5665959/118591102-f6729e80-b7e6-11eb-865a-b3d5bb980a95.png)
