### PR TITLE
InlineHelp: remove the getLastRouteAction selector

### DIFF
--- a/client/state/inline-help/selectors/get-contextual-help-results.js
+++ b/client/state/inline-help/selectors/get-contextual-help-results.js
@@ -1,13 +1,7 @@
 /**
- * External Dependencies
- */
-import { flow } from 'lodash';
-
-/**
  * Internal Dependencies
  */
-import { getLastRouteAction } from 'calypso/state/ui/action-log/selectors';
-import pathToSection from 'calypso/lib/path-to-section';
+import { getSectionName } from 'calypso/state/ui/selectors';
 import { getContextResults } from 'calypso/blocks/inline-help/contextual-help';
 
 import 'calypso/state/inline-help/init';
@@ -18,10 +12,4 @@ import 'calypso/state/inline-help/init';
  * @param  {object}  state  Global state tree
  * @returns {Array}         List of contextual results based on route
  */
-export default flow(
-	getLastRouteAction,
-	( x ) => x?.path,
-	pathToSection,
-	getContextResults,
-	( x = [] ) => x
-);
+export default ( state ) => getContextResults( getSectionName( state ) );

--- a/client/state/ui/action-log/selectors.js
+++ b/client/state/ui/action-log/selectors.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { findLast, last } from 'lodash';
+import { last } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { createSelector } from '@automattic/state-utils';
-import { ROUTE_SET } from 'calypso/state/action-types';
 
 import 'calypso/state/ui/init';
 
@@ -25,30 +24,6 @@ import 'calypso/state/ui/init';
 export function getActionLog( state ) {
 	return state.ui.actionLog;
 }
-
-/**
- * Returns a log of ROUTE_SET actions that have previously been
- * dispatched for the current user.
- *
- * @param  {object}   state      Global state tree
- * @returns {Array}               Array of Redux actions of with a type of
- *                               ROUTE_SET, each with timestamp
- */
-export const getRouteHistory = createSelector(
-	( state ) => getActionLog( state ).filter( ( action ) => action.type === ROUTE_SET ),
-	( state ) => [ state.ui.actionLog ]
-);
-
-/**
- * Returns the last ROUTE_SET action that had been dispatched for the current user.
- *
- * @param  {object}   state      Global state tree
- * @returns {object}              The last Redux action of type ROUTE_SET, with timestamp
- */
-export const getLastRouteAction = createSelector(
-	( state ) => findLast( getActionLog( state ), ( action ) => action.type === ROUTE_SET ),
-	( state ) => [ state.ui.actionLog ]
-);
 
 /**
  * Returns the last item from the action log.


### PR DESCRIPTION
This PR rewrites the way how the `InlineHelp` module figures out the name of the current section. Instead of looking at last `ROUTE_SET` action in `state.actionLog` and converting the route path that to a section name with `pathToSection` (a very complex function indeed) it can simply call the `getSectionName` Redux selector.

This removes dependency of `InlineHelp` on the Action Log state, which is something I'd love to remove at some point.

I'm also removing two Action Log selectors that are unused.
