### PR TITLE
Jetpack Cloud: redirect unauthenticated users to /log-in/jetpack when coming from pricing page

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -169,7 +169,10 @@ export function redirectJetpack( context, next ) {
 	 * because the iOS app relies on seeing a request to /log-in$ to show its
 	 * native credentials form.
 	 */
-	if ( isJetpack !== 'jetpack' && includes( redirect_to, 'jetpack/connect' ) ) {
+	if (
+		isJetpack !== 'jetpack' &&
+		( includes( redirect_to, 'jetpack/connect' ) || includes( redirect_to, 'source=jetpack' ) )
+	) {
 		return context.redirect( context.path.replace( 'log-in', 'log-in/jetpack' ) );
 	}
 	next();

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -161,6 +161,9 @@ export function redirectJetpack( context, next ) {
 	const { isJetpack } = context.params;
 	const { redirect_to } = context.query;
 
+	const isUserComingFromPricingPage =
+		includes( redirect_to, 'source=jetpack-plans' ) ||
+		includes( redirect_to, 'source=jetpack-connect-plans' );
 	/**
 	 * Send arrivals from the jetpack connect process or jetpack's pricing page
 	 * (when site user email matches a wpcom account) to the jetpack branded login.
@@ -171,7 +174,7 @@ export function redirectJetpack( context, next ) {
 	 */
 	if (
 		isJetpack !== 'jetpack' &&
-		( includes( redirect_to, 'jetpack/connect' ) || includes( redirect_to, 'source=jetpack' ) )
+		( includes( redirect_to, 'jetpack/connect' ) || isUserComingFromPricingPage )
 	) {
 		return context.redirect( context.path.replace( 'log-in', 'log-in/jetpack' ) );
 	}

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -162,8 +162,8 @@ export function redirectJetpack( context, next ) {
 	const { redirect_to } = context.query;
 
 	/**
-	 * Send arrivals from the jetpack connect process (when site user email matches
-	 * a wpcom account) to the jetpack branded login.
+	 * Send arrivals from the jetpack connect process or jetpack's pricing page
+	 * (when site user email matches a wpcom account) to the jetpack branded login.
 	 *
 	 * A direct redirect to /log-in/jetpack is not currently done at jetpack.wordpress.com
 	 * because the iOS app relies on seeing a request to /log-in$ to show its


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Related to 1164141197617539-as-1200165101336379

* Redirects unauthenticated Jetpack users to `/log-in/jetpack` rather than to `/log-in`. This creates a better UX because users are kept in a Jetpack branded flow all the time.

#### Testing instructions

**Prerequisites**
* Not being logged in WordPress.com.
* A8c proxy disabled.
* The site slug of a Jetpack site.

**Instructions**
* Download this PR and run `yarn start` (Calypso Blue).
* Visit `calypso.localhost:3000/checkout/[site]/jetpack_backup_daily?site=[site]&source=jetpack-plans` replacing `[site]` with a real Jetpack site slug. This is the URL users get redirected to when they click on the Jetpack Backup Daily card on Jetpack cloud.
* Make sure that you are redirected to `calypso.localhost:3000/log-in/jetpack`.
* Verify that you are presented with a Jetpack branded login form.
* Enter the user's credentials.
* Make sure that you are redirected to checkout with Jetpack Backup Daily in the cart.

#### Demo

#### Before

https://user-images.githubusercontent.com/3418513/115426859-4ace3280-a1d7-11eb-8dca-dc130a91e6f9.mp4

![image](https://user-images.githubusercontent.com/3418513/115426192-ae0b9500-a1d6-11eb-8a71-d5a9d74b3218.png)

#### After
![image](https://user-images.githubusercontent.com/3418513/115426095-9502e400-a1d6-11eb-81f1-02cbe9fa919e.png)