### PR TITLE
Supports displaying inline-text in Sidebar Heading

### DIFF
--- a/client/layout/sidebar/expandable-heading.jsx
+++ b/client/layout/sidebar/expandable-heading.jsx
@@ -27,6 +27,7 @@ const ExpandableSidebarHeading = ( {
 	expanded,
 	menuId,
 	hideExpandableIcon,
+	inlineText,
 	...props
 } ) => {
 	return (
@@ -48,6 +49,7 @@ const ExpandableSidebarHeading = ( {
 			<span className="sidebar__expandable-title">
 				{ decodeEntities( title ) }
 				{ undefined !== count && <Count count={ count } /> }
+				{ inlineText && <span className="sidebar__inline-text">{ inlineText }</span> }
 			</span>
 			{ ! hideExpandableIcon && (
 				<MaterialIcon icon="keyboard_arrow_down" className="sidebar__expandable-arrow" />

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -62,14 +62,6 @@ class PlansNavigation extends React.Component {
 					onMobileNavPanelOpen={ this.onMobileNavPanelOpen }
 				>
 					<NavTabs label="Section" selectedText={ sectionTitle }>
-						<NavItem
-							path={ `/plans/${ site.slug }` }
-							selected={
-								path === '/plans' || path === '/plans/monthly' || path === '/plans/yearly'
-							}
-						>
-							{ translate( 'Plans' ) }
-						</NavItem>
 						{ shouldShowMyPlan && (
 							<NavItem
 								path={ `/plans/my-plan/${ site.slug }` }
@@ -78,6 +70,14 @@ class PlansNavigation extends React.Component {
 								{ translate( 'My Plan' ) }
 							</NavItem>
 						) }
+						<NavItem
+							path={ `/plans/${ site.slug }` }
+							selected={
+								path === '/plans' || path === '/plans/monthly' || path === '/plans/yearly'
+							}
+						>
+							{ translate( 'Plans' ) }
+						</NavItem>
 					</NavTabs>
 					<CartToggleButton
 						site={ this.props.site }

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -43,6 +43,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 	isHappychatSessionActive,
 	isJetpackNonAtomicSite,
 	continueInCalypso,
+	...props
 } ) => {
 	const hasAutoExpanded = useRef( false );
 	const reduxDispatch = useDispatch();
@@ -101,6 +102,8 @@ export const MySitesSidebarUnifiedMenu = ( {
 				className={ ( selected || childIsSelected ) && 'sidebar__menu--selected' }
 				count={ count }
 				hideExpandableIcon={ true }
+				inlineText={ props.inlineText }
+				{ ...props }
 			>
 				{ children.map( ( item ) => {
 					const isSelected = selectedMenuItem?.url === item.url;

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -436,6 +436,10 @@ $font-size: rem( 14px );
 			display: none;
 		}
 
+		.sidebar__inline-text {
+			display: none;
+		}
+
 		.sidebar__heading,
 		.sidebar__menu-link,
 		.sidebar__menu.is-togglable .sidebar__heading {

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -153,6 +153,15 @@ $font-size: rem( 14px );
 			}
 		}
 
+		.sidebar__inline-text {
+			position: absolute;
+			right: 0;
+			top: 50%;
+			transform: translateY( -50% );
+			margin-right: 20px;
+			opacity: 0.8;
+		}
+
 		.sidebar__menu-icon {
 			color: var( --color-sidebar-gridicon-fill );
 			margin-right: 8px;

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -155,10 +155,9 @@ $font-size: rem( 14px );
 
 		.sidebar__inline-text {
 			position: absolute;
-			right: 0;
+			right: 20px;
 			top: 50%;
 			transform: translateY( -50% );
-			margin-right: 20px;
 			opacity: 0.8;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Shows my-plan in secondary navigation first.
* Supports displaying inline-text in Sidebar Heading 

#### Testing instructions

**For Simple sites**
- Apply D60392-code in your sandbox (generated from https://github.com/Automattic/jetpack/pull/19574)
- Spin up calypso live
- Inspect that the correct plan of your **Simple** sites is shown next to "Upgrades"
- Click "Upgrades"
- Check that you are landed to "My Plan" instead of "Plans"
- Go to your sandboxed site, make sure you can still see your Plan

**For Atomic sites**
- Load `update/show_plan_in_sidebar` branch in Jetpack Beta and repeat the sequence above.

Before | After
-------|------
![](https://cln.sh/Ks1A7d+) |  ![](https://cln.sh/wEywPA+)

Related to https://github.com/Automattic/wp-calypso/issues/49660