### PR TITLE
Nav unification: Hide taxonomies on settings for advanced dashboard users

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -29,6 +29,8 @@ import Widgets from './widgets';
 import PublishingTools from './publishing-tools';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
 
 class SiteSettingsFormWriting extends Component {
 	isMobile() {
@@ -55,6 +57,7 @@ class SiteSettingsFormWriting extends Component {
 			siteIsJetpack,
 			translate,
 			updateFields,
+			showAdvancedDashboard,
 		} = this.props;
 
 		return (
@@ -63,13 +66,16 @@ class SiteSettingsFormWriting extends Component {
 				onSubmit={ handleSubmitForm }
 				className="site-settings__writing-settings"
 			>
-				{ config.isEnabled( 'manage/site-settings/categories' ) && (
-					<div className="site-settings__taxonomies">
-						<QueryTaxonomies siteId={ siteId } postType="post" />
-						<TaxonomyCard taxonomy="category" postType="post" />
-						<TaxonomyCard taxonomy="post_tag" postType="post" />
-					</div>
-				) }
+				{
+					// Only show taxonomy management for non-advanced dashboard user setting
+					config.isEnabled( 'manage/site-settings/categories' ) && ! showAdvancedDashboard && (
+						<div className="site-settings__taxonomies">
+							<QueryTaxonomies siteId={ siteId } postType="post" />
+							<TaxonomyCard taxonomy="category" postType="post" />
+							<TaxonomyCard taxonomy="post_tag" postType="post" />
+						</div>
+					)
+				}
 
 				<SettingsSectionHeader
 					disabled={ isRequestingSettings || isSavingSettings }
@@ -195,6 +201,9 @@ const connectComponent = connect(
 		const siteIsJetpack = isJetpackSite( state, siteId );
 		const siteIsAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
 		const isPodcastingSupported = ! siteIsJetpack || siteIsAutomatedTransfer;
+		const isNavUnification = isNavUnificationEnabled( state );
+		const showAdvancedDashboard =
+			isNavUnification && getUserSettings( state )?.calypso_preferences?.linkDestination;
 
 		return {
 			siteIsJetpack,
@@ -204,6 +213,7 @@ const connectComponent = connect(
 				// Masterbar can't be turned off on Atomic sites - don't show the toggle in that case
 				! siteIsAutomatedTransfer,
 			isPodcastingSupported,
+			showAdvancedDashboard,
 		};
 	},
 	{ requestPostTypes },

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -29,6 +29,7 @@ import Widgets from './widgets';
 import PublishingTools from './publishing-tools';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 
 class SiteSettingsFormWriting extends Component {
@@ -200,7 +201,9 @@ const connectComponent = connect(
 		const siteIsJetpack = isJetpackSite( state, siteId );
 		const siteIsAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
 		const isPodcastingSupported = ! siteIsJetpack || siteIsAutomatedTransfer;
-		const showAdvancedDashboard = getUserSettings( state )?.calypso_preferences?.linkDestination;
+		const isNavUnification = isNavUnificationEnabled( state );
+		const showAdvancedDashboard =
+			isNavUnification && getUserSettings( state )?.calypso_preferences?.linkDestination;
 
 		return {
 			siteIsJetpack,

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -29,7 +29,6 @@ import Widgets from './widgets';
 import PublishingTools from './publishing-tools';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
-import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 
 class SiteSettingsFormWriting extends Component {
@@ -201,9 +200,7 @@ const connectComponent = connect(
 		const siteIsJetpack = isJetpackSite( state, siteId );
 		const siteIsAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
 		const isPodcastingSupported = ! siteIsJetpack || siteIsAutomatedTransfer;
-		const isNavUnification = isNavUnificationEnabled( state );
-		const showAdvancedDashboard =
-			isNavUnification && getUserSettings( state )?.calypso_preferences?.linkDestination;
+		const showAdvancedDashboard = getUserSettings( state )?.calypso_preferences?.linkDestination;
 
 		return {
 			siteIsJetpack,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When "Show advanced dashboard pages" is turned **on**, hide the taxonomy management settings under Settings -> Writing to avoid confusion. See #50568 

**Show advanced dashboard pages off**

<img width="804" alt="Screen Shot 2021-04-20 at 12 37 46 PM" src="https://user-images.githubusercontent.com/2124984/115433303-66383e00-a1d5-11eb-96df-d3218dc061ac.png">

**Show advanced dashboard pages on**

<img width="802" alt="Screen Shot 2021-04-20 at 12 35 20 PM" src="https://user-images.githubusercontent.com/2124984/115433324-6b958880-a1d5-11eb-85c5-4e596b02244f.png">

#### Testing instructions

* Switch to this PR
* Enable "Show advanced dashboard pages" under Me -> Account Settings
* Go to `/settings/writing/[site]` and confirm the taxonomies management is not visible here.
* You should still be able to access `/settings/taxonomies/[taxonomy]/[site]` directly
* Disabling "Show advanced dashboard pages" should un-hide the taxonomy settings under Settings -> Writing
