### PR TITLE
Design Picker: add Blank Canvas to available designs configuration

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -424,6 +424,21 @@
 			"is_premium": false,
 			"is_fse": true,
 			"features": []
+		},
+		{
+			"title": "Start with an empty page",
+			"slug": "blank-canvas",
+			"template": "blank-canvas",
+			"theme": "blank-canvas",
+			"fonts": {
+				"headings": "Source Sans Pro",
+				"base": "Source Sans Pro"
+			},
+			"categories": [ "featured" ],
+			"is_premium": false,
+			"is_fse": false,
+			"is_alpha": true,
+			"features": []
 		}
 	]
 }

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -32,8 +32,7 @@ export interface Design {
 
 	/**
 	 * Quickly hide a design from the picker without having to remove
-	 * it from the list of available design configs (stored in the
-	 * `@automattic/design-picker` package)
+	 * it from the list of available design configs
 	 */
 	hide?: boolean;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add blank canvas to `available-designs-config.json` in `@automattic/design-picker` component, hidden behind alpha flag
* The design preview, its order and other features are tracked in separate issues

On hold until #52107 is solved

Adds "blank canvas" prototype design, hidden behind alpha-flag.
Doesn't ensure it's location or appearance otherwise, but that should be fairly straightforward to add.
#### Testing instructions

TBD

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #51979
