### PR TITLE
Revert "Nav Unification: Taxonomies, look at the third path fragment to determine selected menu item"

### DIFF
--- a/client/my-sites/sidebar-unified/utils.jsx
+++ b/client/my-sites/sidebar-unified/utils.jsx
@@ -12,13 +12,9 @@ const fragmentIsEqual = ( path, currentPath, position ) =>
  * @returns {boolean} True if paths match, false otherwise.
  */
 export const itemLinkMatches = ( path, currentPath ) => {
-	// Accounts for jetpack custom post types, eg portfolio, testimonials.
+	// Accounts for jetpack custom post types, eg portofolio, testimonials.
 	if ( pathIncludes( currentPath, 'types', 1 ) ) {
 		return fragmentIsEqual( path, currentPath, 2 );
-	}
-	// Account for taxonomies, eg. tags, categories
-	if ( pathIncludes( currentPath, 'taxonomies', 2 ) ) {
-		return fragmentIsEqual( path, currentPath, 3 );
 	}
 	// Temp fix till we remove duplicate menu entry of sharing buttons from 'Settings' menu. See https://github.com/Automattic/wp-calypso/issues/49756.
 	if ( pathIncludes( currentPath, 'marketing', 1 ) ) {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#52076

In some cases a path may contain "taxonomies" (a plugin name, for example) but have no 3rd fragment, which causes an error.