### PR TITLE
Calypsoify: Handle Query block link and handle links in site editor too

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -667,7 +667,6 @@ function openLinksInParentFrame( calypsoPort ) {
 		'.components-snackbar-list .components-snackbar__content a', // View Post link in success snackbar, Gutenberg >=5.9
 		'.post-publish-panel__postpublish .components-panel__body.is-opened a', // Post title link in publish panel
 		'.components-panel__body.is-opened .post-publish-panel__postpublish-buttons a.components-button', // View Post button in publish panel
-		'.wp-block-query__create-new-link a', // Create a new post link in block settings sidebar for Query block
 	].join( ',' );
 	$( '#editor, #edit-site-editor' ).on( 'click', viewPostLinkSelectors, ( e ) => {
 		e.preventDefault();
@@ -675,6 +674,15 @@ function openLinksInParentFrame( calypsoPort ) {
 			action: 'viewPost',
 			payload: { postUrl: e.target.href },
 		} );
+	} );
+
+	// Create a new post link in block settings sidebar for Query block
+	$( '#editor, #edit-site-editor' ).on( 'click', '.wp-block-query__create-new-link a', ( e ) => {
+		e.preventDefault();
+		window.open(
+			calypsoifyGutenberg.currentCalypsoUrl.replace( '/site-editor/', '/post/' ),
+			'_top'
+		);
 	} );
 
 	if ( calypsoifyGutenberg.manageReusableBlocksUrl ) {

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -773,13 +773,15 @@ async function openLinksInParentFrame( calypsoPort ) {
 	} );
 	// In the Site editor the `.interface-interface-skeleton__sidebar` element
 	// is totally removed when all the sidebars are closed.
-	// We need to observer the body to make sure we catch when a sidebar
-	// is opened or closed.
+	// We need to observe the body to make sure we catch when a sidebar is opened or closed.
+	// Block inserter sidebar, post editor
+	// Block settings sidebar, site editor
 	sidebarsObserver.observe( document.querySelector( '.interface-interface-skeleton__body' ), {
 		childList: true,
 	} );
 	// In the Post editor the `.interface-interface-skeleton__sidebar` element
 	// is always present. We can scope down our observer to the sidebar element in this case.
+	// Block settings sidebar, post editor
 	sidebarsObserver.observe( document.querySelector( '.interface-interface-skeleton__sidebar' ), {
 		childList: true,
 	} );

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -696,7 +696,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 	// Post editor only
 	const inserterManageReusableBlocksObserver = new window.MutationObserver( ( mutations ) => {
 		const node = mutations[ 0 ].target;
-		if ( node.ariaSelected === 'true' ) {
+		if ( node.attributes.getNamedItem( 'aria-selected' )?.nodeValue === 'true' ) {
 			const hyperlink = document.querySelector( 'a.block-editor-inserter__manage-reusable-blocks' );
 			if ( hyperlink ) {
 				hyperlink.href = manageReusableBlocksUrl;
@@ -761,13 +761,18 @@ async function openLinksInParentFrame( calypsoPort ) {
 			'.edit-post-more-menu button, .edit-site-more-menu button'
 		);
 		const moreMenuManageReusableBlocksObserver = new window.MutationObserver( () => {
-			const isExpanded = toggleButton.ariaExpanded === 'true';
+			const isExpanded =
+				toggleButton.attributes.getNamedItem( 'aria-expanded' )?.nodeValue === 'true';
 			if ( isExpanded ) {
-				const hyperlink = document.querySelector(
-					'a.components-menu-item__button[href*="post_type=wp_block"]'
-				);
-				hyperlink.href = manageReusableBlocksUrl;
-				hyperlink.target = '_top';
+				// The menu has not expanded at this point in Safari, so modify the link
+				// after the call stack has cleared and the menu has rendered.
+				setTimeout( () => {
+					const hyperlink = document.querySelector(
+						'a.components-menu-item__button[href*="post_type=wp_block"]'
+					);
+					hyperlink.href = manageReusableBlocksUrl;
+					hyperlink.target = '_top';
+				} );
 			}
 		} );
 		moreMenuManageReusableBlocksObserver.observe( toggleButton, {

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -667,6 +667,7 @@ function openLinksInParentFrame( calypsoPort ) {
 		'.components-snackbar-list .components-snackbar__content a', // View Post link in success snackbar, Gutenberg >=5.9
 		'.post-publish-panel__postpublish .components-panel__body.is-opened a', // Post title link in publish panel
 		'.components-panel__body.is-opened .post-publish-panel__postpublish-buttons a.components-button', // View Post button in publish panel
+		'.wp-block-query__create-new-link a', // Create a new post link in block settings sidebar for Query block
 	].join( ',' );
 	$( '#editor, #edit-site-editor' ).on( 'click', viewPostLinkSelectors, ( e ) => {
 		e.preventDefault();

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -668,7 +668,7 @@ function openLinksInParentFrame( calypsoPort ) {
 		'.post-publish-panel__postpublish .components-panel__body.is-opened a', // Post title link in publish panel
 		'.components-panel__body.is-opened .post-publish-panel__postpublish-buttons a.components-button', // View Post button in publish panel
 	].join( ',' );
-	$( '#editor' ).on( 'click', viewPostLinkSelectors, ( e ) => {
+	$( '#editor, #edit-site-editor' ).on( 'click', viewPostLinkSelectors, ( e ) => {
 		e.preventDefault();
 		calypsoPort.postMessage( {
 			action: 'viewPost',
@@ -681,7 +681,7 @@ function openLinksInParentFrame( calypsoPort ) {
 			'.block-editor-inserter__manage-reusable-blocks', // Link in the Blocks Inserter
 			'a.components-menu-item__button[href*="post_type=wp_block"]', // Link in the More Menu
 		].join( ',' );
-		$( '#editor' ).on( 'click', manageReusableBlocksLinkSelectors, ( e ) => {
+		$( '#editor, #edit-site-editor' ).on( 'click', manageReusableBlocksLinkSelectors, ( e ) => {
 			e.preventDefault();
 			window.open( calypsoifyGutenberg.manageReusableBlocksUrl, '_top' );
 		} );

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -668,7 +668,7 @@ function openLinksInParentFrame( calypsoPort ) {
 		'.post-publish-panel__postpublish .components-panel__body.is-opened a', // Post title link in publish panel
 		'.components-panel__body.is-opened .post-publish-panel__postpublish-buttons a.components-button', // View Post button in publish panel
 	].join( ',' );
-	$( '#editor, #edit-site-editor' ).on( 'click', viewPostLinkSelectors, ( e ) => {
+	$( '#editor' ).on( 'click', viewPostLinkSelectors, ( e ) => {
 		e.preventDefault();
 		calypsoPort.postMessage( {
 			action: 'viewPost',

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -677,22 +677,26 @@ function openLinksInParentFrame( calypsoPort ) {
 	} );
 
 	// Create a new post link in block settings sidebar for Query block
-	if ( calypsoifyGutenberg.createNewPostUrl ) {
-		$( '#editor, #edit-site-editor' ).on( 'click', '.wp-block-query__create-new-link a', ( e ) => {
-			e.preventDefault();
-			window.open( calypsoifyGutenberg.createNewPostUrl, '_top' );
-		} );
-	}
+	if ( calypsoifyGutenberg.createNewPostUrl || calypsoifyGutenberg.manageReusableBlocksUrl ) {
+		const $editor = $( '#editor, #edit-site-editor' );
+		const replaceLink = () => {
+			if ( calypsoifyGutenberg.createNewPostUrl ) {
+				$( '.wp-block-query__create-new-link a', $editor )
+					.attr( 'href', calypsoifyGutenberg.createNewPostUrl )
+					.attr( 'target', '_top' );
+			}
 
-	if ( calypsoifyGutenberg.manageReusableBlocksUrl ) {
-		const manageReusableBlocksLinkSelectors = [
-			'.block-editor-inserter__manage-reusable-blocks', // Link in the Blocks Inserter
-			'a.components-menu-item__button[href*="post_type=wp_block"]', // Link in the More Menu
-		].join( ',' );
-		$( '#editor, #edit-site-editor' ).on( 'click', manageReusableBlocksLinkSelectors, ( e ) => {
-			e.preventDefault();
-			window.open( calypsoifyGutenberg.manageReusableBlocksUrl, '_top' );
-		} );
+			if ( calypsoifyGutenberg.manageReusableBlocksUrl ) {
+				const manageReusableBlocksLinkSelectors = [
+					'.block-editor-inserter__manage-reusable-blocks', // Link in the Blocks Inserter
+					'a.components-menu-item__button[href*="post_type=wp_block"]', // Link in the More Menu
+				].join( ',' );
+				$( manageReusableBlocksLinkSelectors, $editor )
+					.attr( 'href', calypsoifyGutenberg.manageReusableBlocksUrl )
+					.attr( 'target', '_top' );
+			}
+		};
+		setInterval( replaceLink, 50 );
 	}
 }
 

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -723,9 +723,12 @@ async function openLinksInParentFrame( calypsoPort ) {
 	// "child" observers as the relevant sidebar settings appear and disappear in the DOM.
 	const sidebarsObserver = new window.MutationObserver( ( mutations ) => {
 		for ( const record of mutations ) {
+			// We are checking for added nodes here to start observing for more specific changes.
 			for ( const node of record.addedNodes ) {
-				// Block settings sidebar for Query block.
-				if ( shouldReplaceCreateNewPostLinksFor( node ) ) {
+				if (
+					// Block settings sidebar for Query block.
+					shouldReplaceCreateNewPostLinksFor( node )
+				) {
 					const componentsPanel = node.querySelector(
 						'.interface-interface-skeleton__sidebar .components-panel, .edit-post-sidebar .components-panel'
 					);
@@ -751,20 +754,32 @@ async function openLinksInParentFrame( calypsoPort ) {
 				}
 			}
 
+			// We are checking the removed nodes here to disconect
+			// the correct observer when a node is removed.
 			for ( const node of record.removedNodes ) {
-				if ( shouldReplaceCreateNewPostLinksFor( node ) ) {
+				if (
+					// Block settings sidebar for Query block.
+					shouldReplaceCreateNewPostLinksFor( node )
+				) {
 					createNewPostLinkObserver.disconnect();
-				} else if ( shouldReplaceManageReusableBlockLinksFor( node ) ) {
+				} else if (
+					// Block inserter sidebar, Reusable tab
+					shouldReplaceManageReusableBlockLinksFor( node )
+				) {
 					inserterManageReusableBlocksObserver.disconnect();
 				}
 			}
 		}
 	} );
-	// Site editor
+	// In the Site editor the `.interface-interface-skeleton__sidebar` element
+	// is totally removed when all the sidebars are closed.
+	// We need to observer the body to make sure we catch when a sidebar
+	// is opened or closed.
 	sidebarsObserver.observe( document.querySelector( '.interface-interface-skeleton__body' ), {
 		childList: true,
 	} );
-	// Post editor
+	// In the Post editor the `.interface-interface-skeleton__sidebar` element
+	// is always present. We can scope down our observer to the sidebar element in this case.
 	sidebarsObserver.observe( document.querySelector( '.interface-interface-skeleton__sidebar' ), {
 		childList: true,
 	} );
@@ -794,7 +809,8 @@ async function openLinksInParentFrame( calypsoPort ) {
 		} );
 	}
 
-	// Sidebar might already be open
+	// Sidebar might already be open before this script is executed.
+	// post and site editors
 	if ( createNewPostUrl ) {
 		const sidebarComponentsPanel = document.querySelector(
 			'.interface-interface-skeleton__sidebar .components-panel'

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -705,14 +705,19 @@ async function openLinksInParentFrame( calypsoPort ) {
 		}
 	} );
 
+	const shouldReplaceCreateNewPostLinksFor = ( node ) =>
+		createNewPostUrl &&
+		( node.classList.contains( 'interface-interface-skeleton__sidebar' ) || // Site editor
+			node.classList.contains( 'edit-post-sidebar' ) ); // Post editor
+
+	const shouldReplaceManageReusableBlockLinksFor = ( node ) =>
+		manageReusableBlocksUrl &&
+		node.classList.contains( 'interface-interface-skeleton__secondary-sidebar' );
+
 	const sidebarsObserver = new window.MutationObserver( ( mutations ) => {
 		for ( const record of mutations ) {
 			for ( const node of record.addedNodes ) {
-				if (
-					createNewPostUrl &&
-					( node.classList.contains( 'interface-interface-skeleton__sidebar' ) || // Site editor
-						node.classList.contains( 'edit-post-sidebar' ) ) // Post editor
-				) {
+				if ( shouldReplaceCreateNewPostLinksFor( node ) ) {
 					const componentsPanel = node.querySelector(
 						'.interface-interface-skeleton__sidebar .components-panel, .edit-post-sidebar .components-panel'
 					);
@@ -720,10 +725,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 						childList: true,
 						subtree: true,
 					} );
-				} else if (
-					manageReusableBlocksUrl &&
-					node.classList.contains( 'interface-interface-skeleton__secondary-sidebar' )
-				) {
+				} else if ( shouldReplaceManageReusableBlockLinksFor( node ) ) {
 					const resuableTab = node.querySelector(
 						'.components-tab-panel__tabs-item[id*="reusable"]'
 					);
@@ -736,16 +738,9 @@ async function openLinksInParentFrame( calypsoPort ) {
 			}
 
 			for ( const node of record.removedNodes ) {
-				if (
-					createNewPostUrl &&
-					( node.classList.contains( 'interface-interface-skeleton__sidebar' ) || // Site editor
-						node.classList.contains( 'edit-post-sidebar' ) ) // Post editor
-				) {
+				if ( shouldReplaceCreateNewPostLinksFor( node ) ) {
 					createNewPostLinkObserver.disconnect();
-				} else if (
-					manageReusableBlocksUrl &&
-					node.classList.contains( 'interface-interface-skeleton__secondary-sidebar' )
-				) {
+				} else if ( shouldReplaceManageReusableBlockLinksFor( node ) ) {
 					inserterManageReusableBlocksObserver.disconnect();
 				}
 			}

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -677,10 +677,12 @@ function openLinksInParentFrame( calypsoPort ) {
 	} );
 
 	// Create a new post link in block settings sidebar for Query block
-	$( '#editor, #edit-site-editor' ).on( 'click', '.wp-block-query__create-new-link a', ( e ) => {
-		e.preventDefault();
-		window.open( calypsoifyGutenberg.createNewPostUrl, '_top' );
-	} );
+	if ( calypsoifyGutenberg.createNewPostUrl ) {
+		$( '#editor, #edit-site-editor' ).on( 'click', '.wp-block-query__create-new-link a', ( e ) => {
+			e.preventDefault();
+			window.open( calypsoifyGutenberg.createNewPostUrl, '_top' );
+		} );
+	}
 
 	if ( calypsoifyGutenberg.manageReusableBlocksUrl ) {
 		const manageReusableBlocksLinkSelectors = [

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -684,13 +684,14 @@ async function openLinksInParentFrame( calypsoPort ) {
 	await isEditorReadyWithBlocks();
 
 	// Create a new post link in block settings sidebar for Query block
-	const createNewPostLinkObserver = new window.MutationObserver( () => {
+	const tryToReplaceCreateNewPostLink = () => {
 		const hyperlink = document.querySelector( '.wp-block-query__create-new-link a' );
 		if ( hyperlink ) {
 			hyperlink.href = createNewPostUrl;
 			hyperlink.target = '_top';
 		}
-	} );
+	};
+	const createNewPostLinkObserver = new window.MutationObserver( tryToReplaceCreateNewPostLink );
 
 	// Manage reusable blocks link in the global block inserter's Reusable tab
 	// Post editor only
@@ -725,6 +726,9 @@ async function openLinksInParentFrame( calypsoPort ) {
 						childList: true,
 						subtree: true,
 					} );
+					// If a Query block is selected, then the sidebar will
+					// directly open on the block settings tab
+					tryToReplaceCreateNewPostLink();
 				} else if ( shouldReplaceManageReusableBlockLinksFor( node ) ) {
 					const resuableTab = node.querySelector(
 						'.components-tab-panel__tabs-item[id*="reusable"]'
@@ -790,6 +794,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 				childList: true,
 				subtree: true,
 			} );
+			tryToReplaceCreateNewPostLink();
 		}
 	}
 }

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -685,11 +685,15 @@ async function openLinksInParentFrame( calypsoPort ) {
 
 	// Create a new post link in block settings sidebar for Query block
 	const tryToReplaceCreateNewPostLink = () => {
-		const hyperlink = document.querySelector( '.wp-block-query__create-new-link a' );
-		if ( hyperlink ) {
-			hyperlink.href = createNewPostUrl;
-			hyperlink.target = '_top';
-		}
+		// We need to wait for the rendering to be finished.
+		// This is mostly for Safari, but it doesn't hurt for other browsers.
+		setTimeout( () => {
+			const hyperlink = document.querySelector( '.wp-block-query__create-new-link a' );
+			if ( hyperlink ) {
+				hyperlink.href = createNewPostUrl;
+				hyperlink.target = '_top';
+			}
+		} );
 	};
 	const createNewPostLinkObserver = new window.MutationObserver( tryToReplaceCreateNewPostLink );
 

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -679,10 +679,7 @@ function openLinksInParentFrame( calypsoPort ) {
 	// Create a new post link in block settings sidebar for Query block
 	$( '#editor, #edit-site-editor' ).on( 'click', '.wp-block-query__create-new-link a', ( e ) => {
 		e.preventDefault();
-		window.open(
-			calypsoifyGutenberg.currentCalypsoUrl.replace( '/site-editor/', '/post/' ),
-			'_top'
-		);
+		window.open( calypsoifyGutenberg.createNewPostUrl, '_top' );
 	} );
 
 	if ( calypsoifyGutenberg.manageReusableBlocksUrl ) {

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -676,7 +676,6 @@ async function openLinksInParentFrame( calypsoPort ) {
 		} );
 	} );
 
-	// Create a new post link in block settings sidebar for Query block
 	const { createNewPostUrl, manageReusableBlocksUrl } = calypsoifyGutenberg;
 	if ( ! createNewPostUrl && ! manageReusableBlocksUrl ) {
 		return;
@@ -684,6 +683,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 
 	await isEditorReadyWithBlocks();
 
+	// Create a new post link in block settings sidebar for Query block
 	const createNewPostLinkObserver = new window.MutationObserver( () => {
 		const hyperlink = document.querySelector( '.wp-block-query__create-new-link a' );
 		if ( hyperlink ) {
@@ -692,6 +692,8 @@ async function openLinksInParentFrame( calypsoPort ) {
 		}
 	} );
 
+	// Manage reusable blocks link in the global block inserter's Reusable tab
+	// Post editor only
 	const inserterManageReusableBlocksObserver = new window.MutationObserver( ( mutations ) => {
 		const node = mutations[ 0 ].target;
 		if ( node.ariaSelected === 'true' ) {
@@ -708,8 +710,8 @@ async function openLinksInParentFrame( calypsoPort ) {
 			for ( const node of record.addedNodes ) {
 				if (
 					createNewPostUrl &&
-					( node.classList.contains( 'interface-interface-skeleton__sidebar' ) || // edit-site
-						node.classList.contains( 'edit-post-sidebar' ) ) // edit-post
+					( node.classList.contains( 'interface-interface-skeleton__sidebar' ) || // Site editor
+						node.classList.contains( 'edit-post-sidebar' ) ) // Post editor
 				) {
 					const componentsPanel = node.querySelector(
 						'.interface-interface-skeleton__sidebar .components-panel, .edit-post-sidebar .components-panel'
@@ -736,7 +738,8 @@ async function openLinksInParentFrame( calypsoPort ) {
 			for ( const node of record.removedNodes ) {
 				if (
 					createNewPostUrl &&
-					node.classList.contains( 'interface-interface-skeleton__sidebar' )
+					( node.classList.contains( 'interface-interface-skeleton__sidebar' ) || // Site editor
+						node.classList.contains( 'edit-post-sidebar' ) ) // Post editor
 				) {
 					createNewPostLinkObserver.disconnect();
 				} else if (
@@ -748,15 +751,16 @@ async function openLinksInParentFrame( calypsoPort ) {
 			}
 		}
 	} );
-	// edit-site
+	// Site editor
 	sidebarsObserver.observe( document.querySelector( '.interface-interface-skeleton__body' ), {
 		childList: true,
 	} );
-	// edit-post
+	// Post editor
 	sidebarsObserver.observe( document.querySelector( '.interface-interface-skeleton__sidebar' ), {
 		childList: true,
 	} );
 
+	// Manage reusable blocks link in the 3 dots more menu
 	if ( manageReusableBlocksUrl ) {
 		const toggleButton = document.querySelector(
 			'.edit-post-more-menu button, .edit-site-more-menu button'

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -715,9 +715,12 @@ async function openLinksInParentFrame( calypsoPort ) {
 		manageReusableBlocksUrl &&
 		node.classList.contains( 'interface-interface-skeleton__secondary-sidebar' );
 
+	// This observer functions as a "parent" observer, which connects and disconnects
+	// "child" observers as the relevant sidebar settings appear and disappear in the DOM.
 	const sidebarsObserver = new window.MutationObserver( ( mutations ) => {
 		for ( const record of mutations ) {
 			for ( const node of record.addedNodes ) {
+				// Block settings sidebar for Query block.
 				if ( shouldReplaceCreateNewPostLinksFor( node ) ) {
 					const componentsPanel = node.querySelector(
 						'.interface-interface-skeleton__sidebar .components-panel, .edit-post-sidebar .components-panel'
@@ -729,7 +732,10 @@ async function openLinksInParentFrame( calypsoPort ) {
 					// If a Query block is selected, then the sidebar will
 					// directly open on the block settings tab
 					tryToReplaceCreateNewPostLink();
-				} else if ( shouldReplaceManageReusableBlockLinksFor( node ) ) {
+				} else if (
+					// Block inserter sidebar, Reusable tab
+					shouldReplaceManageReusableBlockLinksFor( node )
+				) {
 					const resuableTab = node.querySelector(
 						'.components-tab-panel__tabs-item[id*="reusable"]'
 					);
@@ -759,7 +765,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 		childList: true,
 	} );
 
-	// Manage reusable blocks link in the 3 dots more menu
+	// Manage reusable blocks link in the 3 dots more menu, post and site editors
 	if ( manageReusableBlocksUrl ) {
 		const toggleButton = document.querySelector(
 			'.edit-post-more-menu button, .edit-site-more-menu button'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Redirect Query block's "Create a new post" link to the correct URL in WPcom context (both post and site editor)
* Fix "Manage reusable blocks" link in the Site Editor, in WPcom context.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Preparation**
1. Follow instructions in PCYsg-l4k-p2 to apply the changes proposed in this PR on your sandbox
2. Apply D60514-code diff on your sandbox 

**Manage reusable blocks**

**1**
1. Open WPcom post editor
2. Add a paragraph block
3. Turn it into a reusable block
4. Open global block inserter
5. Navigate to "Reusable" tab
6. Make sure the "Manage reusable blocks" link on the bottom is pointing to: wordpress.com/types/.......

**2**
1. Open WPcom post editor
2. Click 3 dots menu
3. Make sure the "Manage reusable blocks" link is pointing to: wordpress.com/types/.......

**3**
1. Open WPcom site editor
2. Click 3 dots menu
3. Make sure the "Manage reusable blocks" link is pointing to: wordpress.com/types/.......

**Create new post**
**1**
1. Open WPcom post editor
2 Add a "Query" block, choose any variation
3 Open "Block Settings" and click on the "Create a new post" link
4 "Unsaved changes" alert should popup
5 Click "Yes" to proceed on and make sure you are redirected to the new post page: wordpress.com/post/....

**2**
1. Open WPcom site editor
2. Add a "Query" block, choose any variation
3. Open "Block Settings" and click on the "Create a new post" link
4. "Unsaved changes" alert should popup
5. Click "Yes" to proceed on and make sure you are redirected to the new post page: wordpress.com/post/....

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #51206