### PR TITLE
Nav Unification: Add special logic for handling taxonomies when highlighting current menu item

### DIFF
--- a/client/my-sites/sidebar-unified/utils.jsx
+++ b/client/my-sites/sidebar-unified/utils.jsx
@@ -20,6 +20,18 @@ export const itemLinkMatches = ( path, currentPath ) => {
 	if ( pathIncludes( currentPath, 'taxonomies', 2 ) ) {
 		return fragmentIsEqual( path, currentPath, 3 );
 	}
+	if ( pathIncludes( currentPath, 'settings', 1 ) ) {
+		/*
+		 * If the menu item URL contains 'taxonomies', ignore it when on Settings screens.
+		 * Taxonomies are located under the Posts parent menu; this prevents the Posts parent
+		 * from being highlighted when Settings screens are active.
+		 */
+		if ( pathIncludes( path, 'taxonomies', 2 ) ) {
+			return false;
+		}
+		//Match the first path for other Settings screens as usual
+		return fragmentIsEqual( path, currentPath, 1 );
+	}
 	// Temp fix till we remove duplicate menu entry of sharing buttons from 'Settings' menu. See https://github.com/Automattic/wp-calypso/issues/49756.
 	if ( pathIncludes( currentPath, 'marketing', 1 ) ) {
 		return fragmentIsEqual( path, currentPath, 1 ) && fragmentIsEqual( path, '//tools', 2 );

--- a/client/my-sites/sidebar-unified/utils.jsx
+++ b/client/my-sites/sidebar-unified/utils.jsx
@@ -20,17 +20,13 @@ export const itemLinkMatches = ( path, currentPath ) => {
 	if ( pathIncludes( currentPath, 'taxonomies', 2 ) ) {
 		return fragmentIsEqual( path, currentPath, 3 );
 	}
-	if ( pathIncludes( currentPath, 'settings', 1 ) ) {
-		/*
-		 * If the menu item URL contains 'taxonomies', ignore it when on Settings screens.
-		 * Taxonomies are located under the Posts parent menu; this prevents the Posts parent
-		 * from being highlighted when Settings screens are active.
-		 */
-		if ( pathIncludes( path, 'taxonomies', 2 ) ) {
-			return false;
-		}
-		//Match the first path for other Settings screens as usual
-		return fragmentIsEqual( path, currentPath, 1 );
+	/*
+	 * If the menu item URL contains 'taxonomies', ignore it when on Settings screens.
+	 * Taxonomies are located under the Posts parent menu; this prevents the Posts parent
+	 * from being highlighted when Settings screens are active.
+	 */
+	if ( pathIncludes( currentPath, 'settings', 1 ) && pathIncludes( path, 'taxonomies', 2 ) ) {
+		return false;
 	}
 	// Temp fix till we remove duplicate menu entry of sharing buttons from 'Settings' menu. See https://github.com/Automattic/wp-calypso/issues/49756.
 	if ( pathIncludes( currentPath, 'marketing', 1 ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Part of Automattic/jetpack#19569 and #50568
* Because taxonomies (Categories and Tags) are listed under the Posts menu for nav unification purposes, but have Calypso screens located in the Settings section, we need to do some special handling of these paths so they don't incorrectly highlight the wrong menu items.
* This PR adds logic that makes sure when we're viewing the Settings section, we're not looking for matches against menu item URL fragments that contain `taxonomies`, else the Posts menu item will be incorrectly highlighted, because that's where the taxonomies live in the nav menu.

If this is a bit confusing, I'm right there with you. :) But it's a little easier to see with visuals:

**Before**

I'm viewing Settings -> Writing, but Posts -> Categories is also highlighted in the menu. Bad. :(

<img width="1662" alt="Screen Shot 2021-04-20 at 4 03 57 PM" src="https://user-images.githubusercontent.com/2124984/115457151-13b94a80-a1f2-11eb-98c1-9e0f7ae46039.png">

**After**

I'm viewing Settings -> Performance and Posts are not highlighted in the menu. Good!

<img width="1665" alt="Screen Shot 2021-04-20 at 3 56 49 PM" src="https://user-images.githubusercontent.com/2124984/115456385-1a938d80-a1f1-11eb-88d3-12b64628ff67.png">

Likewise, I'm viewing Posts -> Categories and those menu items are properly highlighted, but Settings is not. Good!

<img width="1667" alt="Screen Shot 2021-04-20 at 3 56 37 PM" src="https://user-images.githubusercontent.com/2124984/115456382-19faf700-a1f1-11eb-8722-899842a0f5be.png">


#### Testing instructions

* Switch to this PR, apply D60379-code to your sandbox, and sandbox the API
* Make sure "Show advanced dashboard pages" setting is **off** under Me -> Account Settings (ie. you're viewing mostly Calypso URLs)
* Check Posts -> Categories, Posts -> Tags, and Settings -> General screens; the menu items highlighted should correspond to the page you're viewing.
* Click around Calypso to make sure other highlighted menu items behave as expected.
* Enable "Show advanced dashboard pages" and make sure this doesn't break things there (it shouldn't! It doesn't touch /wp-admin logic, only Calypso logic)