### PR TITLE
Reskin signup: Fix white flicker when clicking on create account button in user step

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -102,9 +102,6 @@ export default {
 		currentFlowName === 'onboarding' && loadExperimentAssignment( 'refined_reskin_v1' );
 		if ( context.pathname.indexOf( 'new-launch' ) >= 0 ) {
 			next();
-		} else if ( currentFlowName === 'onboarding' ) {
-			document.body.classList.add( 'is-white-signup' );
-			next();
 		} else if (
 			context.pathname.indexOf( 'domain' ) >= 0 ||
 			context.pathname.indexOf( 'plan' ) >= 0 ||
@@ -112,6 +109,7 @@ export default {
 			context.pathname.indexOf( 'wpcc' ) >= 0 ||
 			context.pathname.indexOf( 'launch-site' ) >= 0 ||
 			context.pathname.indexOf( 'launch-only' ) >= 0 ||
+			context.params.flowName === 'user' ||
 			context.params.flowName === 'account' ||
 			context.params.flowName === 'crowdsignal' ||
 			context.params.flowName === 'pressable-nux' ||
@@ -164,6 +162,7 @@ export default {
 						);
 						window.location = urlWithLocale;
 					} else {
+						removeWhiteBackground();
 						next();
 					}
 				} )

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -727,7 +727,7 @@ class Signup extends React.Component {
 					}
 
 					const isReskinned = 'treatment' === experimentAssignment?.variationName;
-					! isLoading && ! isReskinned && document.body.classList.remove( 'is-white-signup' );
+					! isLoading && isReskinned && this.addCssClassToBodyForReskinnedFlow();
 
 					return (
 						<div className={ `signup is-${ kebabCase( this.props.flowName ) }` }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When clicking on create account button in the user step, there's a white flicker in the control experience - https://d.pr/v/2EYqcd. This PR fixes this issue which was introduced by https://github.com/Automattic/wp-calypso/pull/50512.
* I'm pushing this without a review since it essentially restores the original code for the signup controller and removes the related changes introduced by the reskin signup PR. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through signup flow and confirm that it works well.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


