### PR TITLE
Fix/partner portal header UI mobile

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -37,7 +37,6 @@ import { ToSConsent } from 'calypso/state/partner-portal/types';
 
 export function partnerContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
-	context.secondary = <PartnerPortalSidebar path={ context.path } />;
 	context.primary = <PartnerAccess />;
 	context.footer = <JetpackComFooter />;
 	next();
@@ -45,7 +44,6 @@ export function partnerContext( context: PageJS.Context, next: () => void ): voi
 
 export function termsOfServiceContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
-	context.secondary = <PartnerPortalSidebar path={ context.path } />;
 	context.primary = <TermsOfServiceConsent />;
 	context.footer = <JetpackComFooter />;
 	next();
@@ -53,7 +51,6 @@ export function termsOfServiceContext( context: PageJS.Context, next: () => void
 
 export function partnerKeyContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
-	context.secondary = <PartnerPortalSidebar path={ context.path } />;
 	context.primary = <SelectPartnerKey />;
 	context.footer = <JetpackComFooter />;
 	next();

--- a/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
@@ -9,7 +9,8 @@ import { useTranslate } from 'i18n-calypso';
  */
 import Main from 'calypso/components/main';
 import CardHeading from 'calypso/components/card-heading';
-import SidebarNavigation from 'calypso/components/sidebar-navigation';
+import DocumentHead from 'calypso/components/data/document-head';
+import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import BillingSummary from 'calypso/jetpack-cloud/sections/partner-portal/billing-summary';
 import BillingDetails from 'calypso/jetpack-cloud/sections/partner-portal/billing-details';
 import SelectPartnerKeyDropdown from 'calypso/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown';
@@ -24,7 +25,8 @@ export default function BillingDashboard(): ReactElement {
 
 	return (
 		<Main wideLayout={ true } className="billing-dashboard">
-			<SidebarNavigation sectionTitle={ translate( 'Billing' ) } />
+			<DocumentHead title={ translate( 'Billing' ) } />
+			<SidebarNavigation />
 
 			<div className="billing-dashboard__header">
 				<CardHeading size={ 36 }>{ translate( 'Billing' ) }</CardHeading>

--- a/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
@@ -9,6 +9,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import Main from 'calypso/components/main';
 import CardHeading from 'calypso/components/card-heading';
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import BillingSummary from 'calypso/jetpack-cloud/sections/partner-portal/billing-summary';
 import BillingDetails from 'calypso/jetpack-cloud/sections/partner-portal/billing-details';
 import SelectPartnerKeyDropdown from 'calypso/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown';
@@ -23,6 +24,8 @@ export default function BillingDashboard(): ReactElement {
 
 	return (
 		<Main wideLayout={ true } className="billing-dashboard">
+			<SidebarNavigation sectionTitle={ translate( 'Billing' ) } />
+
 			<div className="billing-dashboard__header">
 				<CardHeading size={ 36 }>{ translate( 'Billing' ) }</CardHeading>
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/style.scss
@@ -3,7 +3,7 @@
 		display: flex;
 		align-items: center;
 
-		@include breakpoint-deprecated( '>660px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			> * + * {
 				margin-left: 24px;
 			}

--- a/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/style.scss
@@ -3,8 +3,10 @@
 		display: flex;
 		align-items: center;
 
-		> * + * {
-			margin-left: 24px;
+		@include breakpoint-deprecated( '>660px' ) {
+			> * + * {
+				margin-left: 24px;
+			}
 		}
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -9,6 +9,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import Main from 'calypso/components/main';
 import CardHeading from 'calypso/components/card-heading';
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import IssueLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/issue-license-form';
 
 export default function IssueLicense(): ReactElement {
@@ -27,6 +28,7 @@ export default function IssueLicense(): ReactElement {
 
 	return (
 		<Main className="issue-license">
+			<SidebarNavigation sectionTitle={ translate( 'Issue a new License' ) } />
 			<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
 
 			<IssueLicenseForm />

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -9,7 +9,8 @@ import { useTranslate } from 'i18n-calypso';
  */
 import Main from 'calypso/components/main';
 import CardHeading from 'calypso/components/card-heading';
-import SidebarNavigation from 'calypso/components/sidebar-navigation';
+import DocumentHead from 'calypso/components/data/document-head';
+import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import IssueLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/issue-license-form';
 
 export default function IssueLicense(): ReactElement {
@@ -28,7 +29,8 @@ export default function IssueLicense(): ReactElement {
 
 	return (
 		<Main className="issue-license">
-			<SidebarNavigation sectionTitle={ translate( 'Issue a new License' ) } />
+			<DocumentHead title={ translate( 'Issue a new License' ) } />
+			<SidebarNavigation />
 			<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
 
 			<IssueLicenseForm />

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -11,6 +11,7 @@ import { Button } from '@automattic/components';
 import Main from 'calypso/components/main';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import LicenseList from 'calypso/jetpack-cloud/sections/partner-portal/license-list';
 import {
 	LicenseFilter,
@@ -54,6 +55,7 @@ export default function Licenses( {
 	return (
 		<Main wideLayout={ true } className="licenses">
 			<DocumentHead title={ translate( 'Licenses' ) } />
+			<SidebarNavigation sectionTitle={ translate( 'Licenses' ) } />
 
 			<div className="licenses__header">
 				<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -11,7 +11,7 @@ import { Button } from '@automattic/components';
 import Main from 'calypso/components/main';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
-import SidebarNavigation from 'calypso/components/sidebar-navigation';
+import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import LicenseList from 'calypso/jetpack-cloud/sections/partner-portal/license-list';
 import {
 	LicenseFilter,
@@ -55,7 +55,7 @@ export default function Licenses( {
 	return (
 		<Main wideLayout={ true } className="licenses">
 			<DocumentHead title={ translate( 'Licenses' ) } />
-			<SidebarNavigation sectionTitle={ translate( 'Licenses' ) } />
+			<SidebarNavigation />
 
 			<div className="licenses__header">
 				<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
@@ -5,6 +5,23 @@
 
 		> * + * {
 			margin-left: 24px;
+
+		}
+
+	}
+}
+
+@include breakpoint-deprecated( '<660px' ) {
+	.licenses__header {
+		flex-wrap: wrap;
+
+		> *, .select-dropdown__container {
+			width: 100%;
+		}
+
+		> * + * {
+			margin-left: 0;
+			margin-bottom: 16px;
 		}
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
@@ -5,9 +5,7 @@
 
 		> * + * {
 			margin-left: 24px;
-
 		}
-
 	}
 }
 
@@ -15,13 +13,13 @@
 	.licenses__header {
 		flex-wrap: wrap;
 
-		> *, .select-dropdown__container {
+		> * {
 			width: 100%;
+			margin-bottom: 16px;
 		}
 
 		> * + * {
 			margin-left: 0;
-			margin-bottom: 16px;
 		}
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
@@ -9,7 +9,7 @@
 	}
 }
 
-@include breakpoint-deprecated( '<660px' ) {
+@include breakpoint-deprecated( '<960px' ) {
 	.licenses__header {
 		flex-wrap: wrap;
 

--- a/client/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown/index.tsx
@@ -15,6 +15,11 @@ import {
 import { setActivePartnerKey } from 'calypso/state/partner-portal/partner/actions';
 import SelectDropdown from 'calypso/components/select-dropdown';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default function SelectPartnerKeyDropdown(): ReactElement | null {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -42,6 +47,7 @@ export default function SelectPartnerKeyDropdown(): ReactElement | null {
 
 	return (
 		<SelectDropdown
+			className="select-partner-key-dropdown"
 			initialSelected={ activeKeyId.toString() }
 			options={ options }
 			onSelect={ onKeySelect }

--- a/client/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown/style.scss
@@ -1,5 +1,5 @@
 .select-partner-key-dropdown {
-	@include breakpoint-deprecated( '<660px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		width: 100%;
 		margin-bottom: 16px;
 		margin-left: 0;

--- a/client/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown/style.scss
@@ -1,0 +1,11 @@
+.select-partner-key-dropdown {
+	@include breakpoint-deprecated( '<660px' ) {
+		width: 100%;
+		margin-bottom: 16px;
+		margin-left: 0;
+
+		.select-dropdown__container {
+			width: 100%;
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/sidebar-navigation/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar-navigation/index.tsx
@@ -11,6 +11,11 @@ import { useSelector } from 'react-redux';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import { getDocumentHeadTitle } from 'calypso/state/document-head/selectors/get-document-head-title';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default function PartnerPortalSidebarNavigation(): ReactElement {
 	const headerTitle = useSelector( getDocumentHeadTitle );
 

--- a/client/jetpack-cloud/sections/partner-portal/sidebar-navigation/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar-navigation/index.tsx
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+
+import React, { ReactElement } from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal Dependencies
+ */
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
+import { getDocumentHeadTitle } from 'calypso/state/document-head/selectors/get-document-head-title';
+
+export default function PartnerPortalSidebarNavigation(): ReactElement {
+	const headerTitle = useSelector( getDocumentHeadTitle );
+
+	return <SidebarNavigation sectionTitle={ headerTitle } />;
+}

--- a/client/jetpack-cloud/sections/partner-portal/sidebar-navigation/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar-navigation/style.scss
@@ -1,0 +1,7 @@
+.is-section-jetpack-cloud-partner-portal header.current-section {
+	margin-bottom: 16px;
+
+	button {
+		padding: 8px;
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/style.scss
@@ -7,3 +7,10 @@
 	// Important since there's some imperative code that applies an inline min-height style to do some scroll hacks.
 	min-height: 100vh !important;
 }
+
+.current-section + .card-heading,
+.licenses__header .card-heading {
+	@include breakpoint-deprecated( '<660px' ) {
+		display: none;
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/style.scss
@@ -9,6 +9,7 @@
 }
 
 .current-section + .card-heading,
+.billing-dashboard__header .card-heading,
 .licenses__header .card-heading {
 	@include breakpoint-deprecated( '<660px' ) {
 		display: none;


### PR DESCRIPTION
Context:
* Project thread: pbtFPC-Um-p2
* i4 designs: pbtFPC-103-p2
* Mobile designs: pbtFPC-103-p2#comment-2526

#### Changes proposed in this Pull Request
* Removes the sidebar on views that the partner hasn't selected a key yet
* Adds the sidebar navigation on mobile
* Fixes the header style to match the proposed design

<img src="https://user-images.githubusercontent.com/5714212/115473387-06ac5380-a212-11eb-8af1-dba265a42a3f.png" width="400" />

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/partner-portal and select your partner key, if prompted.
* Make sure the design looks like the screenshot below