### PR TITLE
Add spinner check to highlight failure

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -66,6 +66,11 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async publish( { visit = false, closePanel = true } = {} ) {
 		await driverHelper.clickWhenClickable( this.driver, this.prePublishButtonSelector );
 		await driverHelper.clickWhenClickable( this.driver, this.publishButtonSelector );
+
+		// Ensure the spinner is seen before we confirm it is no longer present.
+		// Without this check, we see "Publish panel already closed" errors when the above misfire occurs.
+		await driverHelper.waitUntilLocatedAndVisible( this.driver, this.publishingSpinnerSelector );
+
 		// Let's give publishing request enough time to finish. Sometimes it takes
 		// way more than the default 20 seconds, and the cost of waiting a bit
 		// longer is definitely lower than the cost of repeating the whole spec.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Not for merge: trying to trigger a specific e2e failure mode

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
