### PR TITLE
Add try catch around isDisplayed to avoid stale element failures

### DIFF
--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -111,9 +111,17 @@ export function waitUntilLocatedAndVisible( driver, locator, timeout = explicitW
 				if ( ! element ) {
 					return null;
 				}
-				const isDisplayed = await element.isDisplayed();
-
-				return isDisplayed ? element : null;
+				try {
+					const isDisplayed = await element.isDisplayed();
+					return isDisplayed ? element : null;
+				} catch ( error ) {
+					// This can happen due to react re-rendering (or similar dom modification) between
+					// when we resolve `findElements` and check isDisplayed.
+					if ( error.name === 'StaleElementReferenceError' ) {
+						return null;
+					}
+					throw error;
+				}
 			}
 		),
 		timeout

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -118,6 +118,9 @@ export function waitUntilLocatedAndVisible( driver, locator, timeout = explicitW
 					// This can happen due to react re-rendering (or similar dom modification) between
 					// when we resolve `findElements` and check isDisplayed.
 					if ( error.name === 'StaleElementReferenceError' ) {
+						console.log(
+							`Ignoring StaleElementReferenceError in waitUntilLocatedAndVisible called with ${ locatorStr }`
+						);
 						return null;
 					}
 					throw error;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Try and catch StaleElementReferenceError's in wait for located and visible assertions.

#### Testing instructions

This error seems to happen in various tests, see [this build](https://teamcity.a8c.com/viewLog.html?buildId=6113067&buildTypeId=calypso_RunCalypsoE2eDesktopTests) for the specific error

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #52002, #52003
