### PR TITLE
Enable gutenboarding/long-previews feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -71,6 +71,7 @@
 		"gutenboarding/show-vertical-input": false,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
+		"gutenboarding/long-previews": true,
 		"help": true,
 		"home/layout-dev": true,
 		"inline-help": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -46,6 +46,7 @@
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
+		"gutenboarding/long-previews": true,
 		"happychat": false,
 		"help": true,
 		"home/layout-dev": true,

--- a/config/production.json
+++ b/config/production.json
@@ -45,6 +45,7 @@
 		"gutenboarding/new-launch-mobile": true,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
+		"gutenboarding/long-previews": true,
 		"happychat": true,
 		"help": true,
 		"inline-help": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -47,6 +47,7 @@
 		"google-workspace-migration": true,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
+		"gutenboarding/long-previews": true,
 		"happychat": true,
 		"help": true,
 		"inline-help": true,

--- a/config/test.json
+++ b/config/test.json
@@ -44,6 +44,7 @@
 		"gutenboarding/new-launch-mobile": true,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
+		"gutenboarding/long-previews": true,
 		"help": true,
 		"inline-help": true,
 		"ive/use-external-assignment": true,


### PR DESCRIPTION
This PR enables the `gutenboarding/long-previews` feature flag that pulls longer preview images for the `/new/design` page.

#### Testing instructions

The feature effects that specific page, so it should be a pretty safe update. There's quite a number of related flags and variations, though.  These have been tested previously in #51261 and #51918), but it's worth repeating that testing before pushing it out to everyone:

1. The feature flags get corrupted, so resolve calypso.live/new/design and then add these on the end:
 - [ ] &flags=gutenboarding/site-editor: The wip-FSE view has only a few different featured designs
 - [ ]  &anchor_podcast=1234567: The Anchor onboarding design grid has a different set of designs and limits the number of columns
 - [ ]  Check some other locales (ltr, different scripts and spanish are particularly good tests)
 - [ ] Check the static vs the dynamic previews. There are three designs available-designs-config.json with the "preview": "static" flag that disables the animations and also need special handling during loading: Pollard, Fredrickson and Balan.
 - [ ] Check various screen-sizes, particularly the ones with max/min frame width just before/after the number of columns switches.
 - [ ] Check the loading state - `?flags=gutenboarding/bust-mshots-cache` will help here by forcing reloads of all the screenshots . Alternatively, you can block the mshots urls in your browser to keep them in the loading state forever.
 - [ ] Check mobile
