### PR TITLE
Always show the tour on new blogs

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -63,7 +63,7 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 
 		if ( defined( 'FORCE_SHOW_WPCOM_WELCOME_GUIDE' ) && FORCE_SHOW_WPCOM_WELCOME_GUIDE ) {
 			return true;
-		} elseif ( $blog_age < self::NEW_SITE_AGE_SECONDS ) { // Always show the tour on newly created blogs.
+		} elseif ( $blog_age < self::NEW_SITE_AGE_SECONDS ) {
 			return true;
 		}
 		return 'enabled' === $nux_status;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -11,6 +11,9 @@ namespace A8C\FSE;
  * Class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller.
  */
 class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controller {
+	/**
+	 * Use 30 minutes in case the user isn't taken to the editor immediately. See pbxlJb-Ly-p2#comment-1028.
+	 */
 	const NEW_SITE_AGE_SECONDS = 30 * 60;
 
 	/**
@@ -64,6 +67,10 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 
 	/**
 	 * Return the WPCOM NUX status
+	 *
+	 * This is only called for sites where the user hasn't already dismissed the tour.
+	 * Once the tour has been dismissed, the closed state is saved in local storage (for the current site)
+	 * see src/block-editor-nux.js
 	 *
 	 * @return WP_REST_Response
 	 */

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -57,7 +57,11 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 	 * @return boolean
 	 */
 	public function show_wpcom_welcome_guide( $nux_status ) {
+		$blog_age = time() - strtotime( get_blog_details()->registered );
+
 		if ( defined( 'FORCE_SHOW_WPCOM_WELCOME_GUIDE' ) && FORCE_SHOW_WPCOM_WELCOME_GUIDE ) {
+			return true;
+		} elseif ( $blog_age < 300 ) { // Always show the tour on newly created blogs.
 			return true;
 		}
 		return 'enabled' === $nux_status;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -11,6 +11,8 @@ namespace A8C\FSE;
  * Class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller.
  */
 class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controller {
+	const NEW_SITE_AGE_SECONDS = 30 * 60;
+
 	/**
 	 * WP_REST_WPCOM_Block_Editor_NUX_Status_Controller constructor.
 	 */
@@ -61,7 +63,7 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 
 		if ( defined( 'FORCE_SHOW_WPCOM_WELCOME_GUIDE' ) && FORCE_SHOW_WPCOM_WELCOME_GUIDE ) {
 			return true;
-		} elseif ( $blog_age < 300 ) { // Always show the tour on newly created blogs.
+		} elseif ( $blog_age < self::NEW_SITE_AGE_SECONDS ) { // Always show the tour on newly created blogs.
 			return true;
 		}
 		return 'enabled' === $nux_status;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -59,13 +59,6 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 	 * @return boolean
 	 */
 	public function show_wpcom_welcome_guide( $nux_status ) {
-		$blog_age = time() - strtotime( get_blog_details()->registered );
-
-		if ( defined( 'FORCE_SHOW_WPCOM_WELCOME_GUIDE' ) && FORCE_SHOW_WPCOM_WELCOME_GUIDE ) {
-			return true;
-		} elseif ( $blog_age < self::NEW_SITE_AGE_SECONDS ) {
-			return true;
-		}
 		return 'enabled' === $nux_status;
 	}
 
@@ -83,7 +76,11 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 			$variant = 'tour';
 		}
 
-		if ( has_filter( 'wpcom_block_editor_nux_get_status' ) ) {
+		$blog_age = time() - strtotime( get_blog_details()->registered );
+
+		if ( $blog_age < self::NEW_SITE_AGE_SECONDS ) {
+			$nux_status = 'enabled';
+		} elseif ( has_filter( 'wpcom_block_editor_nux_get_status' ) ) {
 			$nux_status = apply_filters( 'wpcom_block_editor_nux_get_status', false );
 		} elseif ( ! metadata_exists( 'user', get_current_user_id(), 'wpcom_block_editor_nux_status' ) ) {
 			$nux_status = 'enabled';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -29,7 +29,7 @@ registerPlugin( 'wpcom-block-editor-nux', {
 
 		const { fetchWelcomeGuideStatus } = useDispatch( 'automattic/wpcom-welcome-guide' );
 
-		// On mount check if the WPCOM welcome guide status exists in state, otherwise fetch it from the API.
+		// On mount check if the WPCOM welcome guide status exists in state (from local storage), otherwise fetch it from the API.
 		useEffect( () => {
 			if ( ! isLoaded ) {
 				fetchWelcomeGuideStatus();


### PR DESCRIPTION
Experiment with showing the welcome tour on any blog created in the last 30 minutes (30*60 seconds)
fixes https://github.com/Automattic/wp-calypso/issues/52049

### Testing instructions
`yarn dev --sync` or `install-plugin.sh etk add/always-show-welcome-tour-on-new-blogs` the changes to your sandbox
Sandbox the name that will be used for your new blog e.g. `yourtestsite.wordpress.com`
Force reconnect the a8c  proxy for the sandbox changes to take effect
**Test Part 1**
create a site with the name that you sandboxed (`yourtestsite.wordpress.com`)
the tour should show up again
dismiss the tour and refresh the page
the fact that the tour has been closed is saved to local storage so the tour will not be loaded again
**Test Part 2**
navigate to an existing blog  and open the editor 
the tour should not be shown
**Test Part 3**
wait 30 minutes and test again on `yourtestsite.wordpress.com`
clear local storage for `yourtestsite.wordpress.com`
reload the page
the tour should not be shown