### PR TITLE
BodySectionCssClass: remove old classes only when we have a new one to add

### DIFF
--- a/client/layout/body-section-css-class.js
+++ b/client/layout/body-section-css-class.js
@@ -15,17 +15,19 @@ import React from 'react';
  */
 function useBodyClass( prefix, value ) {
 	React.useEffect( () => {
-		// remove any existing classes with the same prefix, coming from example from a
-		// server HTML markup.
+		// if value is empty-ish, don't add or remove any CSS classes
+		if ( ! value ) {
+			return;
+		}
+
+		// Remove any existing classes with the same prefix, coming from example from a
+		// server HTML markup. There should be max one class name with a gived `prefix`
+		// at any one time. We're removing existing classes only when `value` is not `null`,
+		// i.e., when we actually have a class name to add and want to prevent duplicate one.
 		for ( const className of document.body.classList ) {
 			if ( className.startsWith( prefix ) ) {
 				document.body.classList.remove( className );
 			}
-		}
-
-		// if value is empty-ish, don't add any CSS classes
-		if ( ! value ) {
-			return;
 		}
 
 		// convert the value (section or group name) to a CSS class name


### PR DESCRIPTION
Fixes a regression caused by #52055. @niranjan-uma-shankar discovered that when loading the `/start` page, you'll see an undesired flash with logged out masterbar:
1. First you'll see a white WordPress logo placeholder screen -- that's the HTML sent from server
2. Then you'll see an empty `<Layout />` component with a logged-out masterbar, rendered from here. At this time, `section` and `group` are `null` and therefore `BodySectionCssClass` removed the `is-section-signup` CSS class from `body`.
3. Finally the `/start` route handler renders the Signup UI, with `is-section-signup` correctly set.

What we want is to keep the `is-section-signup` CSS class at step 2. The `section` is `null` there, so we don't have a new section to replace `is-section-signup` with.

We want to do the replacement only when we have a new section, e.g., `home`, and want to prevent `is-section-signup` and `is-section-home` being both set at the same time.

**How to test:**
- verify that the bug from #52055 (broken styling after `/start/simple` -> `/home` redirect) is still fixed
- verify that when loading `/start`, there is no flash with logged-out masterbar. The progression should be from white WP placeholder directly to Signup UI.