### PR TITLE
chore(deps): Add missing dependencies to @automattic/explat-client-react-helpers

### DIFF
--- a/packages/explat-client-react-helpers/package.json
+++ b/packages/explat-client-react-helpers/package.json
@@ -29,6 +29,7 @@
 	"devDependencies": {
 		"@automattic/calypso-polyfills": "^1.0.0",
 		"@testing-library/react": "^11.2.6",
-		"@testing-library/react-hooks": "5.1.1"
+		"@testing-library/react-hooks": "5.1.1",
+		"react-dom": "^16.12.0"
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #50650 by adding missing dependencies:

```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/explat-client-react-helpers/package.json
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/explat-client-react-helpers/package.json:31:29: Unmet transitive peer dependency on react-dom@*, via @testing-library/react@^11.2.6
➤ YN0000: └ Completed in 1s 218ms
```

#### Testing instructions

Checkout this branch and run `npx @yarnpkg/doctor@2 packages/explat-client-react-helpers`, verify the error is gone.