### PR TITLE
PlanTypeSelector: fix CSS specificity of interval toggle tooltip

### DIFF
--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -277,94 +277,96 @@ const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSig
 `;
 
 const StyledPopover = styled( Popover )`
-	display: none;
-	opacity: 0;
-	transition-property: opacity, transform;
-	transition-timing-function: ease-in;
+	&.popover {
+		display: none;
+		opacity: 0;
+		transition-property: opacity, transform;
+		transition-timing-function: ease-in;
 
-	&.popover-enter-active {
-		opacity: 1;
-		transition-duration: 0.3s;
-	}
-
-	&.popover-exit,
-	&.popover-enter-done {
-		opacity: 1;
-		transition-duration: 0.01s;
-	}
-
-	&.is-right,
-	.rtl &.is-left {
-		@media ( min-width: 960px ) {
-			display: block;
+		&.popover-enter-active {
+			opacity: 1;
+			transition-duration: 0.3s;
 		}
 
-		&.popover-enter {
-			transform: translate( 30px, 0 );
-		}
-
-		&.popover-enter-active,
+		&.popover-exit,
 		&.popover-enter-done {
-			transform: translate( 20px, 0 );
+			opacity: 1;
+			transition-duration: 0.01s;
 		}
 
-		.popover__arrow {
-			border-right-color: var( --color-neutral-100 );
-			&::before {
+		&.is-right,
+		.rtl &.is-left {
+			@media ( min-width: 960px ) {
+				display: block;
+			}
+
+			&.popover-enter {
+				transform: translate( 30px, 0 );
+			}
+
+			&.popover-enter-active,
+			&.popover-enter-done {
+				transform: translate( 20px, 0 );
+			}
+
+			.popover__arrow {
 				border-right-color: var( --color-neutral-100 );
+				&::before {
+					border-right-color: var( --color-neutral-100 );
+				}
 			}
 		}
-	}
 
-	.rtl &.is-left {
-		.popover__arrow {
-			right: 40px;
-			border-left-color: var( --color-neutral-100 );
-			&::before {
+		.rtl &.is-left {
+			.popover__arrow {
+				right: 40px;
 				border-left-color: var( --color-neutral-100 );
+				&::before {
+					border-left-color: var( --color-neutral-100 );
+				}
+			}
+
+			.popover__inner {
+				left: -50px;
+			}
+		}
+
+		&.is-bottom {
+			@media ( max-width: 960px ) {
+				display: block;
+			}
+
+			&.popover-enter {
+				transform: translate( 0, 22px );
+			}
+
+			&.popover-enter-active,
+			&.popover-enter-done {
+				transform: translate( 0, 12px );
+			}
+
+			.popover__arrow {
+				border-bottom-color: var( --color-neutral-100 );
+				&::before {
+					border-bottom-color: var( --color-neutral-100 );
+				}
+			}
+		}
+
+		.rtl &.is-bottom {
+			.popover__arrow {
+				border-right-color: transparent;
 			}
 		}
 
 		.popover__inner {
-			left: -50px;
+			padding: 8px 10px;
+			max-width: 210px;
+			background-color: var( --color-neutral-100 );
+			border-color: var( --color-neutral-100 );
+			color: var( --color-neutral-0 );
+			border-radius: 2px;
+			text-align: left;
 		}
-	}
-
-	&.is-bottom {
-		@media ( max-width: 960px ) {
-			display: block;
-		}
-
-		&.popover-enter {
-			transform: translate( 0, 22px );
-		}
-
-		&.popover-enter-active,
-		&.popover-enter-done {
-			transform: translate( 0, 12px );
-		}
-
-		.popover__arrow {
-			border-bottom-color: var( --color-neutral-100 );
-			&::before {
-				border-bottom-color: var( --color-neutral-100 );
-			}
-		}
-	}
-
-	.rtl &.is-bottom {
-		.popover__arrow {
-			border-right-color: transparent;
-		}
-	}
-
-	.popover__inner {
-		padding: 8px 10px;
-		max-width: 210px;
-		background-color: var( --color-neutral-100 );
-		border-color: var( --color-neutral-100 );
-		color: var( --color-neutral-0 );
-		border-radius: 2px;
-		text-align: left;
 	}
 `;


### PR DESCRIPTION
@niranjan-uma-shankar reports that this tooltip in `/start/plans` sometimes gets a white background instead of the desired black:

<img width="508" alt="Screenshot 2021-04-21 at 8 24 46" src="https://user-images.githubusercontent.com/664258/115506471-2af04a80-a27b-11eb-91d5-83a5d9f02eb9.png">

The reason why this might happen is that the black `background-color` is coming from an Emotion style rule that has the same specificity as the `.popover .popover__inner` rule that specifies the white default:

<img width="520" alt="Screenshot 2021-04-21 at 8 02 30" src="https://user-images.githubusercontent.com/664258/115506669-6b4fc880-a27b-11eb-9b85-44466b53c69a.png">

It can happen that the `.popover .popover__inner` rule is loaded twice, because the `Popover` code and styles can be shipped in multiple webpack chunks, in duplicate copies. Then the default rule can win over the Emotion rule because it was loaded later. And reset the color back to white.

The solution in this patch is to add a `.popover` prefix to the Emotion styles so that they are always more specific than the default rules. The CSS after this patch is:

<img width="523" alt="Screenshot 2021-04-21 at 8 12 07" src="https://user-images.githubusercontent.com/664258/115507073-eca75b00-a27b-11eb-9aa5-2e3f07860bc9.png">

Now the `.css-1q7khr5` rule always wins because it's more specific. Not only because it was loaded later, which is a fragile and unstable condition.
