### PR TITLE
Tag docker images with `calypso-%build.number%`

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -372,6 +372,7 @@ object BuildDockerImage : BuildType({
 					path = "Dockerfile"
 				}
 				namesAndTags = """
+					registry.a8c.com/calypso/app:calypso-%build.number%
 					registry.a8c.com/calypso/app:build-%build.number%
 					registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber}
 				""".trimIndent()
@@ -390,6 +391,7 @@ object BuildDockerImage : BuildType({
 		dockerCommand {
 			commandType = push {
 				namesAndTags = """
+					registry.a8c.com/calypso/app:calypso-%build.number%
 					registry.a8c.com/calypso/app:build-%build.number%
 					registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber}
 				""".trimIndent()
@@ -412,6 +414,11 @@ object BuildDockerImage : BuildType({
 				}
 				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
 			}
+		}
+		vcsLabeling {
+			vcsRootId = "${Settings.WpCalypso.id}"
+			labelingPattern = "calypso-%build.number%"
+			successfulOnly = true
 		}
 	}
 })

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -372,7 +372,6 @@ object BuildDockerImage : BuildType({
 					path = "Dockerfile"
 				}
 				namesAndTags = """
-					registry.a8c.com/calypso/app:calypso-%build.number%
 					registry.a8c.com/calypso/app:build-%build.number%
 					registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber}
 				""".trimIndent()
@@ -391,7 +390,6 @@ object BuildDockerImage : BuildType({
 		dockerCommand {
 			commandType = push {
 				namesAndTags = """
-					registry.a8c.com/calypso/app:calypso-%build.number%
 					registry.a8c.com/calypso/app:build-%build.number%
 					registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber}
 				""".trimIndent()


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add the tag `calypso-<number>` to git when a Docker image is generated in `trunk`.

### Testing instructions

* Check any TeamCity build and ensure there are no syntax errors in the DSL.
* Actual functionallity can only be tested once merged.