### PR TITLE
New Onboarding with Blank Canvas: try to skip Style step

### DIFF
--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -8,12 +8,14 @@ import { useLocale } from '@automattic/i18n-utils';
 /**
  * Internal dependencies
  */
-import { GutenLocationStateType, Step, usePath, useCurrentStep, useAnchorFmParams } from '../path';
+import { GutenLocationStateType, useAnchorFmParams } from '../path';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
 import { useNewSiteVisibility } from './use-selected-plan';
 import useSignup from './use-signup';
 import useSteps from './use-steps';
+
+import type { StepType } from '../path';
 
 /**
  * A React hook that returns callback to navigate to previous and next steps in Gutenboarding flow
@@ -24,13 +26,14 @@ import useSteps from './use-steps';
  *
  * @returns { Navigation } An object with callbacks to navigate to previous and next steps
  */
-export default function useStepNavigation(): { goBack: () => void; goNext: () => void } {
-	const makePath = usePath();
+export default function useStepNavigation(): {
+	goBack: () => void;
+	goNext: ( excludedSteps: Array< StepType > ) => void;
+} {
 	const history = useHistory();
-	const currentStep = useCurrentStep();
-	const locale = useLocale();
 
-	const steps = useSteps();
+	const locale = useLocale();
+	const { previousStepPath, getNextStepPath, isLastStep } = useSteps();
 
 	// @TODO: move site creation to a separate hook or an action on the ONBOARD store
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
@@ -67,17 +70,6 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 		return onSignupDialogOpen();
 	};
 
-	const currentStepIndex = steps.findIndex( ( step ) => step === Step[ currentStep ] );
-
-	const previousStepPath = currentStepIndex > 0 ? makePath( steps[ currentStepIndex - 1 ] ) : '';
-	const nextStepPath =
-		currentStepIndex !== -1 && // check first if current step still exists
-		currentStepIndex < steps.length - 1
-			? makePath( steps[ currentStepIndex + 1 ] )
-			: '';
-
-	const isLastStep = currentStepIndex === steps.length - 1;
-
 	// Transfer anchor podcast ID, episode ID from the query string to the location state, if needed
 	const locationState = useLocation< GutenLocationStateType >().state ?? {};
 	if ( anchorFmPodcastId ) {
@@ -90,12 +82,14 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 		locationState.anchorFmSpotifyUrl = anchorFmSpotifyUrl;
 	}
 
+	// we ignore handling back for now
 	const handleBack = () => history.push( previousStepPath, locationState );
-	const handleNext = () =>
-		isLastStep ? handleSiteCreation() : history.push( nextStepPath, locationState );
 
 	return {
 		goBack: handleBack,
-		goNext: handleNext,
+		goNext: ( excludedSteps ) =>
+			isLastStep
+				? handleSiteCreation()
+				: history.push( getNextStepPath( excludedSteps ), locationState ),
 	};
 }

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -28,7 +28,7 @@ import type { StepType } from '../path';
  */
 export default function useStepNavigation(): {
 	goBack: () => void;
-	goNext: ( excludedSteps: Array< StepType > ) => void;
+	goNext: ( excludedSteps?: Array< StepType > ) => void;
 } {
 	const history = useHistory();
 

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -17,7 +17,7 @@ import Badge from '../../components/badge';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { useTrackStep } from '../../hooks/use-track-step';
 import useStepNavigation from '../../hooks/use-step-navigation';
-import { useIsAnchorFm } from '../../path';
+import { Step, useIsAnchorFm } from '../../path';
 
 /**
  * Style dependencies
@@ -73,7 +73,7 @@ const Designs: React.FunctionComponent = () => {
 					// Update fonts to the design defaults
 					setFonts( design.fonts );
 
-					goNext();
+					goNext( design?.slug === 'blank-canvas' ? [ Step.Style ] : [] );
 				} }
 				premiumBadge={
 					<Badge className="designs__premium-badge">

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useLocale } from '@automattic/i18n-utils';
@@ -28,6 +28,7 @@ const Designs: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const locale = useLocale();
 	const { goBack, goNext } = useStepNavigation();
+	const { goNext: goNextBySkippingStyleStep } = useStepNavigation( [ Step.Style ] );
 
 	const { setSelectedDesign, setFonts } = useDispatch( ONBOARD_STORE );
 	const { getSelectedDesign, hasPaidDesign, getRandomizedDesigns } = useSelect( ( select ) =>
@@ -39,6 +40,15 @@ const Designs: React.FunctionComponent = () => {
 		selected_design: getSelectedDesign()?.slug,
 		is_selected_design_premium: hasPaidDesign(),
 	} ) );
+
+	const hasInitialized = React.useRef( false );
+	useEffect( () => {
+		// start by clearing design selection if blank-canvas design is selected
+		if ( ! hasInitialized.current && getSelectedDesign()?.slug === 'blank-canvas' ) {
+			setSelectedDesign( undefined );
+		}
+		hasInitialized.current = true;
+	}, [ getSelectedDesign, setSelectedDesign ] );
 
 	return (
 		<div className="gutenboarding-page designs">
@@ -73,7 +83,7 @@ const Designs: React.FunctionComponent = () => {
 					// Update fonts to the design defaults
 					setFonts( design.fonts );
 
-					goNext( design?.slug === 'blank-canvas' ? [ Step.Style ] : [] );
+					design?.slug === 'blank-canvas' ? goNextBySkippingStyleStep() : goNext();
 				} }
 				premiumBadge={
 					<Badge className="designs__premium-badge">

--- a/client/landing/gutenboarding/onboarding-block/features/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/features/index.tsx
@@ -79,9 +79,9 @@ const FeaturesStep: React.FunctionComponent = () => {
 				<ActionButtons>
 					<BackButton onClick={ goBack } />
 					{ hasSelectedFeatures ? (
-						<NextButton onClick={ goNext } />
+						<NextButton onClick={ () => goNext() } />
 					) : (
-						<SkipButton onClick={ goNext } />
+						<SkipButton onClick={ () => goNext() } />
 					) }
 				</ActionButtons>
 			</div>

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -57,7 +57,7 @@ const StylePreview: React.FunctionComponent = () => {
 					<ViewportSelect selected={ selectedViewport } onSelect={ setSelectedViewport } />
 					<ActionButtons className="style-preview__actions">
 						<BackButton onClick={ goBack } />
-						<NextButton onClick={ goNext } />
+						<NextButton onClick={ () => goNext() } />
 					</ActionButtons>
 				</div>
 				<div className="style-preview__content">


### PR DESCRIPTION
<s>Possible solution for skipping Style step in https://github.com/Automattic/wp-calypso/issues/52107

By passing an optional `excludedSteps` Array when calling `useStepNavigation` hook let us "prepare" any dynamic changes to the navigation at the component mount time so we can use them synchronously when handling some events (almost the same as having static `href` attributes pre-computed). In this way, we can successfully instruct the removal of Style step when the user selects Blank Canvas on Design step.

**Changes included:**
- Add `excludedSteps` to `useStepNavigation` hook => this will take care of the navigation from Design to Style step
- Update `useSteps` hook to filter Style step if Blank Canvas is currently selected => this will take care of the navigation afterwards.
- Call `useStepNavigation` hook twice on Designs step to get the two different `onNext` handlers needed for the two different actions: 
  - When selecting any design: regular behavior, as described in the `usePlans` hook
  - When selecting Blank Canvas: exclude Style step</s>
____

Use these 👇🏼  for the PR that is going to fix Style step skipping for [ #52107 ]:

**Testing instructions**
- Go to `/new`
- On `/new/design`, select Blank Canvas design
  - You should land on the next step after Style step (can be either Domains if you skipped site title or Features if you entered site title)
  - Navigation (back and next) should work as expected after that.
  - By manually navigating to `/new/style` you should be redirected to:
    - `/new/features` if you entered a site title at the beginning of the flow
    - `/new/domains` if you skipped site title step
- After selecting Blank Canvas design, go back to Designs step and select a design other than Blank Canvas
  - Style step should be displayed 
  - The navigation (back/next) should continue to work
- As a bit of regression testing, go to `/new?fresh` 
  - Go to `/new/style` => you should be redirected to `/new`
  - Select a design other than Blank Canvas and then go back. Manually navigating to `/new/style` should work
  - Go to `/new/create-site` => you should be redirected to `/new/plans`

See p1618932653252500-slack-C0KDTA48Y for a brief history