### PR TITLE
Signup: Adding some debugging lines

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -232,6 +232,7 @@ class Signup extends React.Component {
 
 		if ( ! this.isReskinned ) {
 			document.body.classList.remove( 'is-white-signup' );
+			debug( 'In componentWillReceiveProps, removed is-white-signup class' );
 		}
 	}
 
@@ -729,11 +730,13 @@ class Signup extends React.Component {
 			>
 				{ ( isLoading, experimentAssignment ) => {
 					if ( isLoading ) {
+						debug( 'Waiting for experiment status to load' );
 						return null;
 					}
 
 					this.isReskinned = 'treatment' === experimentAssignment?.variationName;
 					! isLoading && ! this.isReskinned && document.body.classList.remove( 'is-white-signup' );
+					debug( `isReskinned value is ${ this.isReskinned }` );
 
 					return (
 						<div className={ `signup is-${ kebabCase( this.props.flowName ) }` }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* A white flicker is seen when clicking on "Create account" button in the signup step. This issue seen only in production Chrome. It is not seen in production FF or Safari, nor is it seen in local calypso instances.
* Adding some debug lines, which will hopefully give some clues to the white flicker seen when c



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
