### PR TITLE
chore(deps): Add missing dependencies to `@automattic/design-picker`

### DIFF
--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -42,7 +42,9 @@
 	"devDependencies": {
 		"@testing-library/jest-dom": "^5.11.10",
 		"@testing-library/react": "^11.2.6",
-		"jest-canvas-mock": "^2.3.0"
+		"jest-canvas-mock": "^2.3.0",
+		"react": "^16.12.0",
+		"react-dom": "^16.12.0"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^4.26.8",


### PR DESCRIPTION
### Changes proposed in this Pull Request

Adds missing dependencies to fix:

```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/design-picker/package.json
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/design-picker/package.json:44:29: Unmet transitive peer dependency on react@*, via @testing-library/react@^11.2.6
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/design-picker/package.json:44:29: Unmet transitive peer dependency on react-dom@*, via @testing-library/react@^11.2.6
➤ YN0000: └ Completed in 4s 269ms
```


### Testing instructions
Checkout this branch and run `npx @yarnpkg/doctor@2 packages/design-picker`, verify the error is gone.