### PR TITLE
chore(deps): Add missing dependencies to `@automattic/plans-grid`

### DIFF
--- a/packages/plans-grid/package.json
+++ b/packages/plans-grid/package.json
@@ -32,6 +32,7 @@
 	},
 	"dependencies": {
 		"@automattic/data-stores": "^2.0.0",
+		"@automattic/i18n-utils": "^1.0.0",
 		"@automattic/onboarding": "^1.0.0",
 		"@wordpress/components": "^12.0.8",
 		"@wordpress/compose": "^3.24.5",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add required dependencies to fix: 

```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/plans-grid/package.json
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/plans-grid/src/plans-accordion-item/index.tsx:7:1: Undeclared dependency on @automattic/i18n-utils
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/plans-grid/src/plans-interval-toggle/index.tsx:6:1: Undeclared dependency on @automattic/i18n-utils
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/plans-grid/src/plans-table/plan-item.tsx:10:1: Undeclared dependency on @automattic/i18n-utils
➤ YN0000: └ Completed in 1s 303ms
```

#### Testing instructions

Checkout this branch and run `npx @yarnpkg/doctor@2 packages/plans-grid`, verify the error is gone.