### PR TITLE
Framework: Refactor away from _.assign()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -392,6 +392,7 @@ module.exports = {
 		// Disable Lodash methods that we've already migrated away from, see p4TIVU-9Bf-p2 for more details.
 		'you-dont-need-lodash-underscore/all': 'error',
 		'you-dont-need-lodash-underscore/any': 'error',
+		'you-dont-need-lodash-underscore/assign': 'error',
 		'you-dont-need-lodash-underscore/bind': 'error',
 		'you-dont-need-lodash-underscore/cast-array': 'error',
 		'you-dont-need-lodash-underscore/collect': 'error',

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/image-block-keywords/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/image-block-keywords/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { assign } from 'lodash';
 import { addFilter } from '@wordpress/hooks';
 
 const additionalKeywords = [ 'logo', 'brand', 'emblem', 'hallmark' ];
@@ -14,9 +13,10 @@ addFilter(
 			return settings;
 		}
 
-		settings = assign( {}, settings, {
+		settings = {
+			...settings,
 			keywords: settings.keywords.concat( additionalKeywords ),
-		} );
+		};
 
 		return settings;
 	}

--- a/client/blocks/conversation-follow-button/index.jsx
+++ b/client/blocks/conversation-follow-button/index.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { assign } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -39,9 +38,10 @@ class ConversationFollowButtonContainer extends Component {
 	handleFollowToggle = ( isRequestingFollow ) => {
 		const { siteId, postId, post, followSource } = this.props;
 
-		const tracksProperties = assign( getTracksPropertiesForPost( post ), {
+		const tracksProperties = {
+			...getTracksPropertiesForPost( post ),
 			follow_source: followSource,
-		} );
+		};
 
 		if ( isRequestingFollow ) {
 			this.props.recordReaderTracksEvent(

--- a/client/blocks/jitm/templates/notice.jsx
+++ b/client/blocks/jitm/templates/notice.jsx
@@ -2,7 +2,6 @@
  * External Dependencies
  */
 import React from 'react';
-import { assign } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,15 +13,15 @@ export default function NoticeTemplate( { id, CTA, tracks, ...props } ) {
 	const tracksProps = {
 		// CTA clicks
 		tracksClickName: tracks?.click?.name ?? `jitm_nudge_click`,
-		tracksClickProperties: assign( {}, jitmProps, tracks?.click?.props ),
+		tracksClickProperties: { ...jitmProps, ...tracks?.click?.props },
 
 		// Impression
 		tracksImpressionName: tracks?.display?.name ?? `jitm_nudge_impression`,
-		tracksImpressionProperties: assign( {}, jitmProps, tracks?.display?.props ),
+		tracksImpressionProperties: { ...jitmProps, ...tracks?.display?.props },
 
 		// Dismiss
 		tracksDismissName: tracks?.dismiss?.name ?? `jitm_nudge_dismiss`,
-		trackDismissProperties: assign( {}, jitmProps, tracks?.dismiss?.props ),
+		trackDismissProperties: { ...jitmProps, ...tracks?.dismiss?.props },
 	};
 
 	return (

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, find, assign } from 'lodash';
+import { get, find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -162,9 +162,10 @@ class TermFormDialog extends Component {
 		if ( ! props.term ) {
 			if ( props.searchTerm && props.searchTerm.trim().length ) {
 				this.setState(
-					assign( {}, this.constructor.initialState, {
+					{
+						...this.constructor.initialState,
 						name: props.searchTerm,
-					} ),
+					},
 					this.isValid
 				);
 				return;
@@ -175,14 +176,13 @@ class TermFormDialog extends Component {
 		}
 
 		const { name, description, parent = false } = props.term;
-		this.setState(
-			assign( {}, this.constructor.initialState, {
-				name,
-				description,
-				isTopLevel: parent ? false : true,
-				selectedParent: parent ? [ parent ] : [],
-			} )
-		);
+		this.setState( {
+			...this.constructor.initialState,
+			name,
+			description,
+			isTopLevel: parent ? false : true,
+			selectedParent: parent ? [ parent ] : [],
+		} );
 	}
 
 	UNSAFE_componentWillReceiveProps( newProps ) {

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -4,7 +4,7 @@
 
 import React, { PureComponent } from 'react';
 import ReactDom from 'react-dom';
-import { assign, filter, forEach, forOwn } from 'lodash';
+import { filter, forEach, forOwn } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -52,11 +52,11 @@ function nodeNeedsProcessing( domNode ) {
 }
 
 function loadCSS( cssUrl ) {
-	const link = assign( document.createElement( 'link' ), {
-		rel: 'stylesheet',
-		type: 'text/css',
-		href: cssUrl,
-	} );
+	const link = document.createElement( 'link' );
+
+	link.rel = 'stylesheet';
+	link.type = 'text/css';
+	link.href = cssUrl;
 
 	document.head.appendChild( link );
 }

--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { assign, omit } from 'lodash';
+import { omit } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import { translate } from 'i18n-calypso';
 
@@ -42,13 +42,11 @@ class ExternalLink extends Component {
 			'has-icon': this.props.icon,
 		} );
 
-		const props = assign(
-			omit( this.props, 'icon', 'iconSize', 'showIconFirst', 'iconClassName' ),
-			{
-				className: classes,
-				rel: 'external',
-			}
-		);
+		const props = {
+			...omit( this.props, 'icon', 'iconSize', 'showIconFirst', 'iconClassName' ),
+			className: classes,
+			rel: 'external',
+		};
 
 		if ( this.props.icon ) {
 			props.target = '_blank';

--- a/client/components/file-picker/index.jsx
+++ b/client/components/file-picker/index.jsx
@@ -4,7 +4,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { assign } from 'lodash';
 import pick from 'component-file-picker';
 
 const noop = () => {};
@@ -17,7 +16,7 @@ export default class FilePicker extends React.Component {
 
 	showPicker() {
 		this.props.onClick();
-		pick( assign( {}, this.props ), this.props.onPick );
+		pick( { ...this.props }, this.props.onPick );
 	}
 
 	render() {

--- a/client/components/forms/sortable-list/index.jsx
+++ b/client/components/forms/sortable-list/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { assign, findIndex } from 'lodash';
+import { findIndex } from 'lodash';
 import classNames from 'classnames';
 import debugFactory from 'debug';
 import Gridicon from 'calypso/components/gridicon';
@@ -280,7 +280,7 @@ class SortableList extends React.Component {
 				const isActive = this.state.activeIndex === index;
 				const isDraggable = this.props.allowDrag && ! hasTouch();
 				let events = isDraggable ? [ 'onMouseDown', 'onMouseUp' ] : [ 'onClick' ];
-				const style = { order: this.getAdjustedElementIndex( index ) };
+				let style = { order: this.getAdjustedElementIndex( index ) };
 				const classes = classNames( {
 					'sortable-list__item': true,
 					'is-active': isActive,
@@ -294,7 +294,7 @@ class SortableList extends React.Component {
 				);
 
 				if ( isActive ) {
-					assign( style, this.state.position );
+					style = { ...style, ...this.state.position };
 				}
 				const itemRef = React.createRef();
 				this.itemsRefs.set( 'wrap-' + index, itemRef );

--- a/client/components/gallery-shortcode/index.tsx
+++ b/client/components/gallery-shortcode/index.tsx
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import debugModule from 'debug';
-import { assign, pick } from 'lodash';
+import { pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -46,7 +46,8 @@ export default class GalleryShortcode extends Component< Props > {
 			return rendered;
 		}
 
-		const filtered = assign( {}, rendered, {
+		const filtered = {
+			...rendered,
 			scripts: {
 				'tiled-gallery': {
 					src: 'https://s0.wp.com/wp-content/mu-plugins/tiled-gallery/tiled-gallery.js',
@@ -60,36 +61,34 @@ export default class GalleryShortcode extends Component< Props > {
 					src: 'https://widgets.wp.com/gallery-preview/style.css',
 				},
 			},
-		} );
+		};
 
 		if ( 'slideshow' === this.getAttributes().type ) {
-			assign( filtered, {
-				scripts: {
-					'jquery-cycle': {
-						src: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/jquery.cycle.min.js',
-					},
-					'jetpack-slideshow': {
-						src: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/slideshow-shortcode.js',
-						extra:
-							'var jetpackSlideshowSettings = { "spinner": "https://s0.wp.com/wp-content/mu-plugins/shortcodes/img/slideshow-loader.gif" };',
-					},
+			filtered.scripts = {
+				'jquery-cycle': {
+					src: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/jquery.cycle.min.js',
 				},
-				styles: {
-					'jetpack-slideshow': {
-						src: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/css/slideshow-shortcode.css',
-					},
+				'jetpack-slideshow': {
+					src: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/slideshow-shortcode.js',
+					extra:
+						'var jetpackSlideshowSettings = { "spinner": "https://s0.wp.com/wp-content/mu-plugins/shortcodes/img/slideshow-loader.gif" };',
 				},
-			} );
+			};
+			filtered.styles = {
+				'jetpack-slideshow': {
+					src: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/css/slideshow-shortcode.css',
+				},
+			};
 		}
 
 		return filtered;
 	};
 
 	getAttributes = () => {
-		const attributes = pick( this.props, 'items', 'type', 'columns', 'orderBy', 'link', 'size' );
+		let attributes = pick( this.props, 'items', 'type', 'columns', 'orderBy', 'link', 'size' );
 
 		if ( this.props.children ) {
-			assign( attributes, parseShortcode( this.props.children ).attrs.named );
+			attributes = { ...attributes, ...parseShortcode( this.props.children ).attrs.named };
 		}
 
 		return attributes;

--- a/client/components/locale-suggestions/list-item.jsx
+++ b/client/components/locale-suggestions/list-item.jsx
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { assign } from 'lodash';
 import { getLocaleSlug } from 'i18n-calypso';
 
 /**
@@ -36,8 +34,8 @@ class LocaleSuggestionsListItem extends Component {
 	};
 
 	hasLocaleDirectionChanged( locale ) {
-		const localeData = assign( {}, getLanguage( locale.locale ) );
-		const currentLocaleData = assign( {}, getLanguage( getLocaleSlug() ) );
+		const localeData = getLanguage( locale.locale );
+		const currentLocaleData = getLanguage( getLocaleSlug() );
 
 		return localeData.rtl !== currentLocaleData.rtl;
 	}

--- a/client/components/track-input-changes/index.jsx
+++ b/client/components/track-input-changes/index.jsx
@@ -3,7 +3,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { assign } from 'lodash';
 
 const noop = () => {};
 
@@ -37,7 +36,8 @@ export default class TrackInputChanges extends Component {
 		// Multiple children not supported
 		const child = React.Children.only( this.props.children );
 
-		const props = assign( {}, child.props, {
+		const props = {
+			...child.props,
 			onChange: ( event ) => {
 				if ( typeof child.props.onChange === 'function' ) {
 					child.props.onChange.call( child, event );
@@ -50,7 +50,7 @@ export default class TrackInputChanges extends Component {
 				}
 				this.onInputBlur( event );
 			},
-		} );
+		};
 
 		return React.cloneElement( child, props );
 	}

--- a/client/lib/analytics/ad-tracking/floodlight.js
+++ b/client/lib/analytics/ad-tracking/floodlight.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import cookie from 'cookie';
-import { assign } from 'lodash';
 import { v4 as uuid } from 'uuid';
 
 /**
@@ -32,12 +31,13 @@ export function recordParamsInFloodlightGtag( params ) {
 	}
 
 	// Adds u4 (user id) and u5 (anonymous user id) parameters
-	const defaults = assign( floodlightUserParams(), {
+	const defaults = {
+		...floodlightUserParams(),
 		// See: https://support.google.com/searchads/answer/7566546?hl=en
 		allow_custom_scripts: true,
-	} );
+	};
 
-	const finalParams = [ 'event', 'conversion', assign( {}, defaults, params ) ];
+	const finalParams = [ 'event', 'conversion', { ...defaults, ...params } ];
 
 	debug( 'recordParamsInFloodlightGtag:', finalParams );
 

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import update from 'immutability-helper';
-import { assign, filter, find, get, isEqual, merge, some } from 'lodash';
+import { filter, find, get, isEqual, merge, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -445,10 +445,11 @@ export function themeItem( themeSlug, source ) {
  * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function domainRegistration( properties ) {
-	return assign( domainItem( properties.productSlug, properties.domain, properties.source ), {
+	return {
+		...domainItem( properties.productSlug, properties.domain, properties.source ),
 		is_domain_registration: true,
 		...( properties.extra ? { extra: properties.extra } : {} ),
-	} );
+	};
 }
 
 /**
@@ -478,12 +479,10 @@ export function siteRedirect( properties ) {
  * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function domainTransfer( properties ) {
-	return assign(
-		domainItem( domainProductSlugs.TRANSFER_IN, properties.domain, properties.source ),
-		{
-			...( properties.extra ? { extra: properties.extra } : {} ),
-		}
-	);
+	return {
+		...domainItem( domainProductSlugs.TRANSFER_IN, properties.domain, properties.source ),
+		...( properties.extra ? { extra: properties.extra } : {} ),
+	};
 }
 
 /**
@@ -528,7 +527,10 @@ export function googleApps( properties ) {
 export function googleAppsExtraLicenses( properties ) {
 	const item = domainItem( GSUITE_EXTRA_LICENSE_SLUG, properties.domain, properties.source );
 
-	return assign( item, { extra: { google_apps_users: properties.users } } );
+	return {
+		...item,
+		extra: { google_apps_users: properties.users },
+	};
 }
 
 /**
@@ -538,13 +540,15 @@ export function googleAppsExtraLicenses( properties ) {
  * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function titanMailMonthly( properties ) {
-	return assign(
-		domainItem( TITAN_MAIL_MONTHLY_SLUG, properties.meta ?? properties.domain, properties.source ),
-		{
-			quantity: properties.quantity,
-			extra: properties.extra,
-		}
-	);
+	return {
+		...domainItem(
+			TITAN_MAIL_MONTHLY_SLUG,
+			properties.meta ?? properties.domain,
+			properties.source
+		),
+		quantity: properties.quantity,
+		extra: properties.extra,
+	};
 }
 
 export function hasGoogleApps( cart ) {

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	assign,
 	camelCase,
 	debounce,
 	filter,
@@ -56,120 +55,118 @@ function Controller( options ) {
 	}
 }
 
-assign( Controller.prototype, {
-	getInitialState: function () {
-		return this._initialState;
-	},
+Controller.prototype.getInitialState = function () {
+	return this._initialState;
+};
 
-	_loadFieldValues: function () {
-		this._loadFunction(
-			function ( error, fieldValues ) {
-				if ( error ) {
-					this._onError( error );
-					return;
-				}
+Controller.prototype._loadFieldValues = function () {
+	this._loadFunction(
+		function ( error, fieldValues ) {
+			if ( error ) {
+				this._onError( error );
+				return;
+			}
 
-				this._setState( initializeFields( this._currentState, fieldValues ) );
-			}.bind( this )
-		);
-	},
+			this._setState( initializeFields( this._currentState, fieldValues ) );
+		}.bind( this )
+	);
+};
 
-	handleFieldChange: function ( change ) {
-		const formState = this._currentState;
-		const name = camelCase( change.name );
-		const value = change.value;
-		const hideError = this._hideFieldErrorsOnChange || change.hideError;
+Controller.prototype.handleFieldChange = function ( change ) {
+	const formState = this._currentState;
+	const name = camelCase( change.name );
+	const value = change.value;
+	const hideError = this._hideFieldErrorsOnChange || change.hideError;
 
-		this._setState( changeFieldValue( formState, name, value, hideError ) );
+	this._setState( changeFieldValue( formState, name, value, hideError ) );
 
-		// If we want to handle sanitize/validate differently in the component (e.g. onBlur)
-		// FormState handleSubmit() will sanitize/validate if not done yet
-		if ( ! this._skipSanitizeAndValidateOnFieldChange ) {
-			this._debouncedSanitize();
-			this._debouncedValidate();
-		}
-	},
+	// If we want to handle sanitize/validate differently in the component (e.g. onBlur)
+	// FormState handleSubmit() will sanitize/validate if not done yet
+	if ( ! this._skipSanitizeAndValidateOnFieldChange ) {
+		this._debouncedSanitize();
+		this._debouncedValidate();
+	}
+};
 
-	handleSubmit: function ( onComplete ) {
-		const isAlreadyValid =
-			! this._pendingValidation &&
-			! needsValidation( this._currentState ) &&
-			isEveryFieldInitialized( this._currentState );
+Controller.prototype.handleSubmit = function ( onComplete ) {
+	const isAlreadyValid =
+		! this._pendingValidation &&
+		! needsValidation( this._currentState ) &&
+		isEveryFieldInitialized( this._currentState );
 
-		if ( isAlreadyValid ) {
-			onComplete( hasErrors( this._currentState ) );
-			return;
-		}
+	if ( isAlreadyValid ) {
+		onComplete( hasErrors( this._currentState ) );
+		return;
+	}
 
-		this._onValidationComplete = function () {
-			this._setState( showAllErrors( this._currentState ) );
-			onComplete( hasErrors( this._currentState ) );
-		}.bind( this );
+	this._onValidationComplete = function () {
+		this._setState( showAllErrors( this._currentState ) );
+		onComplete( hasErrors( this._currentState ) );
+	}.bind( this );
 
-		if ( ! this._pendingValidation ) {
-			this.sanitize();
-			this.validate();
-		}
-	},
+	if ( ! this._pendingValidation ) {
+		this.sanitize();
+		this.validate();
+	}
+};
 
-	_setState: function ( newState ) {
-		this._currentState = newState;
-		this._onNewState( newState );
-	},
+Controller.prototype._setState = function ( newState ) {
+	this._currentState = newState;
+	this._onNewState( newState );
+};
 
-	sanitize: function () {
-		const fieldValues = getAllFieldValues( this._currentState );
+Controller.prototype.sanitize = function () {
+	const fieldValues = getAllFieldValues( this._currentState );
 
-		if ( ! this._sanitizerFunction ) {
-			return;
-		}
+	if ( ! this._sanitizerFunction ) {
+		return;
+	}
 
-		this._sanitizerFunction(
-			fieldValues,
-			function ( newFieldValues ) {
-				this._setState( changeFieldValues( this._currentState, newFieldValues ) );
-			}.bind( this )
-		);
-	},
+	this._sanitizerFunction(
+		fieldValues,
+		function ( newFieldValues ) {
+			this._setState( changeFieldValues( this._currentState, newFieldValues ) );
+		}.bind( this )
+	);
+};
 
-	validate: function () {
-		const fieldValues = getAllFieldValues( this._currentState );
-		const id = uniqueId();
+Controller.prototype.validate = function () {
+	const fieldValues = getAllFieldValues( this._currentState );
+	const id = uniqueId();
 
-		this._setState( setFieldsValidating( this._currentState ) );
+	this._setState( setFieldsValidating( this._currentState ) );
 
-		this._pendingValidation = id;
+	this._pendingValidation = id;
 
-		this._validatorFunction(
-			fieldValues,
-			function ( error, fieldErrors ) {
-				if ( id !== this._pendingValidation ) {
-					return;
-				}
+	this._validatorFunction(
+		fieldValues,
+		function ( error, fieldErrors ) {
+			if ( id !== this._pendingValidation ) {
+				return;
+			}
 
-				if ( error ) {
-					this._onError( error );
-					return;
-				}
+			if ( error ) {
+				this._onError( error );
+				return;
+			}
 
-				this._pendingValidation = null;
-				this._setState(
-					setFieldErrors( this._currentState, fieldErrors, this._hideFieldErrorsOnChange )
-				);
+			this._pendingValidation = null;
+			this._setState(
+				setFieldErrors( this._currentState, fieldErrors, this._hideFieldErrorsOnChange )
+			);
 
-				if ( this._onValidationComplete ) {
-					this._onValidationComplete();
-					this._onValidationComplete = null;
-				}
-			}.bind( this )
-		);
-	},
+			if ( this._onValidationComplete ) {
+				this._onValidationComplete();
+				this._onValidationComplete = null;
+			}
+		}.bind( this )
+	);
+};
 
-	resetFields: function ( fieldValues ) {
-		this._initialState = createInitialFormState( fieldValues );
-		this._setState( this._initialState );
-	},
-} );
+Controller.prototype.resetFields = function ( fieldValues ) {
+	this._initialState = createInitialFormState( fieldValues );
+	this._setState( this._initialState );
+};
 
 function changeFieldValue( formState, name, value, hideFieldErrorsOnChange ) {
 	const fieldState = getField( formState, name );
@@ -200,7 +197,7 @@ function changeFieldValues( formState, fieldValues ) {
 
 function updateFields( formState, callback ) {
 	return mapValues( formState, function ( field, name ) {
-		return assign( {}, field, callback( name ) );
+		return { ...field, ...callback( name ) };
 	} );
 }
 
@@ -211,20 +208,18 @@ function initializeFields( formState, fieldValues ) {
 }
 
 function setFieldsValidating( formState ) {
-	return assign(
-		{},
-		formState,
-		updateFields( formState, function () {
+	return {
+		...formState,
+		...updateFields( formState, function () {
 			return { isValidating: true };
-		} )
-	);
+		} ),
+	};
 }
 
 function setFieldErrors( formState, fieldErrors, hideFieldErrorsOnChange ) {
-	return assign(
-		{},
-		formState,
-		updateFields( getFieldsValidating( formState ), function ( name ) {
+	return {
+		...formState,
+		...updateFields( getFieldsValidating( formState ), function ( name ) {
 			const newFields = {
 				errors: fieldErrors[ name ] || [],
 				isPendingValidation: false,
@@ -236,8 +231,8 @@ function setFieldErrors( formState, fieldErrors, hideFieldErrorsOnChange ) {
 			}
 
 			return newFields;
-		} )
-	);
+		} ),
+	};
 }
 
 function showAllErrors( formState ) {

--- a/client/lib/form-state/test/index.js
+++ b/client/lib/form-state/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign, mapValues, zipObject } from 'lodash';
+import { mapValues, zipObject } from 'lodash';
 import assert from 'assert';
 
 /**
@@ -43,7 +43,7 @@ function testController( options ) {
 		debounceWait: 0,
 	};
 
-	return formState.Controller( assign( defaults, options ) );
+	return formState.Controller( { ...defaults, ...options } );
 }
 
 describe( 'index', () => {

--- a/client/lib/media-serialization/strategies/api.js
+++ b/client/lib/media-serialization/strategies/api.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-
-import { assign } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { getMimePrefix } from 'calypso/lib/media/utils';
@@ -19,12 +13,10 @@ import { MediaTypes } from '../constants';
  */
 export function deserialize( node ) {
 	const normalized = {
-		media: assign(
-			{
-				transient: false,
-			},
-			node
-		),
+		media: {
+			transient: false,
+			...node,
+		},
 		appearance: {},
 	};
 

--- a/client/lib/mixins/emitter/index.js
+++ b/client/lib/mixins/emitter/index.js
@@ -1,12 +1,10 @@
 /**
  * External dependencies
  */
-
-import { assign } from 'lodash';
 import { EventEmitter } from 'events';
 
 export default function ( prototype ) {
-	assign( prototype, EventEmitter.prototype );
+	Object.assign( prototype, EventEmitter.prototype );
 	prototype.emitChange = function () {
 		this.emit( 'change' );
 	};

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-
-import { assign, filter, map, pick, sortBy } from 'lodash';
+import { filter, map, pick, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -163,7 +162,7 @@ export function normalizeCompatibilityList( compatibilityList ) {
 }
 
 export function normalizePluginData( plugin, pluginData ) {
-	plugin = getAllowedPluginData( assign( plugin, pluginData ) );
+	plugin = getAllowedPluginData( { ...plugin, ...pluginData } );
 
 	return Object.entries( plugin ).reduce( ( returnData, [ key, item ] ) => {
 		switch ( key ) {

--- a/client/lib/products-values/format-product.js
+++ b/client/lib/products-values/format-product.js
@@ -1,10 +1,6 @@
-/**
- * External dependencies
- */
-import { assign } from 'lodash';
-
 export function formatProduct( product ) {
-	return assign( {}, product, {
+	return {
+		...product,
 		product_slug: product.product_slug || product.productSlug,
 		product_type: product.product_type || product.productType,
 		included_domain_purchase_amount:
@@ -14,5 +10,5 @@ export function formatProduct( product ) {
 				? product.is_domain_registration
 				: product.isDomainRegistration,
 		free_trial: product.free_trial || product.freeTrial,
-	} );
+	};
 }

--- a/client/lib/react-pass-to-children/index.js
+++ b/client/lib/react-pass-to-children/index.js
@@ -1,12 +1,10 @@
 /**
  * External dependencies
  */
-
-import { assign } from 'lodash';
 import React from 'react';
 
 export default function ( element, additionalProps ) {
-	const props = assign( {}, element.props, additionalProps );
+	const props = { ...element.props, ...additionalProps };
 	let childElements;
 
 	delete props.children;

--- a/client/lib/react-pass-to-children/test/index.js
+++ b/client/lib/react-pass-to-children/test/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { assign } from 'lodash';
 import ShallowRenderer from 'react-test-renderer/shallow';
 import React from 'react';
 import { expect } from 'chai';
@@ -98,11 +97,10 @@ describe( 'index', () => {
 		const result = renderer.getRenderOutput();
 
 		expect( result.type ).to.equal( 'div' );
-		expect( result.props ).to.eql(
-			assign( {}, DUMMY_PROPS, {
-				'data-preserve': true,
-			} )
-		);
+		expect( result.props ).to.eql( {
+			...DUMMY_PROPS,
+			'data-preserve': true,
+		} );
 	} );
 
 	test( 'should preserve props passed to the instance itself', () => {
@@ -114,10 +112,9 @@ describe( 'index', () => {
 		const result = renderer.getRenderOutput();
 
 		expect( result.type ).to.equal( 'div' );
-		expect( result.props ).to.eql(
-			assign( {}, DUMMY_PROPS, {
-				'data-preserve': true,
-			} )
-		);
+		expect( result.props ).to.eql( {
+			...DUMMY_PROPS,
+			'data-preserve': true,
+		} );
 	} );
 } );

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -2,17 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import {
-	assign,
-	defer,
-	difference,
-	get,
-	includes,
-	isEmpty,
-	omitBy,
-	pick,
-	startsWith,
-} from 'lodash';
+import { defer, difference, get, includes, isEmpty, omitBy, pick, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -572,13 +562,15 @@ export function createAccount(
 			type: signupType,
 		} );
 
-		const providedDependencies = assign(
-			{ username, marketing_price_group, plans_reorder_abtest_variation },
-			bearerToken
-		);
+		const providedDependencies = {
+			username,
+			marketing_price_group,
+			plans_reorder_abtest_variation,
+			...bearerToken,
+		};
 
 		if ( signupType === SIGNUP_TYPE_DEFAULT && oauth2Signup ) {
-			assign( providedDependencies, {
+			Object.assign( providedDependencies, {
 				oauth2_client_id: queryArgs.oauth2_client_id,
 				oauth2_redirect: get( response, 'oauth2_redirect', '' ).split( '@' )[ 1 ],
 			} );
@@ -601,7 +593,7 @@ export function createAccount(
 		);
 	} else {
 		wpcom.undocumented().usersNew(
-			assign(
+			Object.assign(
 				{},
 				userData,
 				{

--- a/client/lib/wpcom-undocumented/index.js
+++ b/client/lib/wpcom-undocumented/index.js
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-
 import wpcomFactory from 'wpcom';
 import inherits from 'inherits';
-import { assign } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -38,7 +36,11 @@ function WPCOMUndocumented( token, reqHandler ) {
 		if ( this.isTokenLoaded() ) {
 			// authToken is used in wpcom-xhr-request,
 			// which is used for the signup flow in the REST Proxy
-			params = assign( {}, params, { authToken: this._token, token: this._token } );
+			params = {
+				...params,
+				authToken: this._token,
+				token: this._token,
+			};
 		}
 
 		return reqHandler( params, fn );

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { assign, includes, find, flatMap } from 'lodash';
+import { includes, find, flatMap } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -89,7 +89,10 @@ class DnsAddNew extends React.Component {
 			return includes( record.types, type );
 		} );
 
-		return assign( {}, dnsRecord.initialFields, { type } );
+		return {
+			...dnsRecord.initialFields,
+			type,
+		};
 	}
 
 	UNSAFE_componentWillMount() {

--- a/client/my-sites/marketing/buttons/tray.jsx
+++ b/client/my-sites/marketing/buttons/tray.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { assign, filter, find } from 'lodash';
+import { filter, find } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -139,7 +139,7 @@ class SharingButtonsTray extends React.Component {
 			isEnabled = true;
 		}
 
-		assign( currentButton, {
+		Object.assign( currentButton, {
 			enabled: isEnabled,
 			visibility: this.props.visibility,
 		} );

--- a/client/my-sites/pages/helpers.js
+++ b/client/my-sites/pages/helpers.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign, forEach, groupBy, includes, map, reduce, sortBy } from 'lodash';
+import { forEach, groupBy, includes, map, reduce, sortBy } from 'lodash';
 
 // Helpers used by sortPagesHierarchically but not exposed externally
 const sortByMenuOrder = ( list ) => sortBy( list, 'menu_order' );
@@ -38,7 +38,7 @@ export const sortPagesHierarchically = ( pages ) => {
 		const children = pagesByParent[ pageId ] || [];
 
 		forEach( children, ( child ) => {
-			sortedPages.push( assign( {}, child, { indentLevel } ) );
+			sortedPages.push( { ...child, indentLevel } );
 			insertChildren( child.ID, indentLevel + 1 );
 		} );
 	};

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { assign, includes, times } from 'lodash';
+import { includes, times } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -41,7 +41,7 @@ export class EditorMediaModalGalleryFields extends React.Component {
 		};
 
 		if ( site && ( ! site.jetpack || isModuleActive( site, 'tiled-gallery' ) ) ) {
-			assign( options, {
+			Object.assign( options, {
 				rectangular: this.props.translate( 'Tiled Mosaic' ),
 				square: this.props.translate( 'Square Tiles' ),
 				circle: this.props.translate( 'Circles' ),
@@ -50,7 +50,7 @@ export class EditorMediaModalGalleryFields extends React.Component {
 		}
 
 		if ( site && ( ! site.jetpack || isModuleActive( site, 'shortcodes' ) ) ) {
-			assign( options, {
+			Object.assign( options, {
 				slideshow: this.props.translate( 'Slideshow' ),
 			} );
 		}

--- a/client/post-editor/media-modal/gallery/index.jsx
+++ b/client/post-editor/media-modal/gallery/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { assign, omitBy, some, isEqual, partial } from 'lodash';
+import { omitBy, some, isEqual, partial } from 'lodash';
 
 /**
  * Internal dependencies
@@ -105,7 +105,7 @@ class EditorMediaModalGallery extends React.Component {
 			return;
 		}
 
-		const defaultSettings = assign( {}, GalleryDefaultAttrs, { items } );
+		const defaultSettings = { ...GalleryDefaultAttrs, items };
 
 		if ( site && ( ! site.jetpack || isModuleActive( site, 'tiled-gallery' ) ) ) {
 			defaultSettings.type = 'rectangular';
@@ -121,7 +121,7 @@ class EditorMediaModalGallery extends React.Component {
 		}
 
 		// Merge object of settings with existing set
-		let updatedSettings = assign( {}, this.props.settings, setting );
+		let updatedSettings = { ...this.props.settings, ...setting };
 		updatedSettings = omitBy( updatedSettings, ( updatedValue ) => null === updatedValue );
 		this.props.onUpdateSettings( updatedSettings );
 	};

--- a/client/post-editor/media-modal/markup.js
+++ b/client/post-editor/media-modal/markup.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { assign } from 'lodash';
 import ReactDomServer from 'react-dom/server';
 import React from 'react';
 import classNames from 'classnames';
@@ -129,14 +128,12 @@ const Markup = {
 		 * @returns {string}         An image markup string
 		 */
 		image: function ( site, media, options ) {
-			options = assign(
-				{
-					size: 'full',
-					align: 'none',
-					forceResize: false,
-				},
-				options
-			);
+			options = {
+				size: 'full',
+				align: 'none',
+				forceResize: false,
+				...options,
+			};
 
 			let width;
 			let height;

--- a/client/reader/sidebar/helper.js
+++ b/client/reader/sidebar/helper.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { assign, some, startsWith } from 'lodash';
+import { some, startsWith } from 'lodash';
 
 const exported = {
 	itemLinkClass: function ( path, currentPath, additionalClasses ) {
@@ -28,17 +28,16 @@ const exported = {
 			isActionButtonSelected = true;
 		}
 
-		return classNames(
-			assign(
-				{ selected: selected, 'is-action-button-selected': isActionButtonSelected },
-				additionalClasses
-			)
-		);
+		return classNames( {
+			selected,
+			'is-action-button-selected': isActionButtonSelected,
+			...additionalClasses,
+		} );
 	},
 
 	itemLinkClassStartsWithOneOf: function ( paths, currentPath, additionalClasses ) {
 		const selected = this.pathStartsWithOneOf( paths, currentPath );
-		return classNames( assign( { selected }, additionalClasses ) );
+		return classNames( { selected, ...additionalClasses } );
 	},
 
 	pathStartsWithOneOf: function ( paths, currentPath ) {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign, partial, pick } from 'lodash';
+import { partial, pick } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -165,7 +165,7 @@ export const recordTracksRailcarInteract = partial(
 );
 
 export function recordTrackForPost( eventName, post = {}, additionalProps = {}, options ) {
-	recordTrack( eventName, assign( getTracksPropertiesForPost( post ), additionalProps ), options );
+	recordTrack( eventName, { ...getTracksPropertiesForPost( post ), ...additionalProps }, options );
 	if ( post.railcar && allowedTracksRailcarEventNames.has( eventName ) ) {
 		// check for overrides for the railcar
 		recordTracksRailcarInteract(

--- a/client/server/config/parser.js
+++ b/client/server/config/parser.js
@@ -7,7 +7,7 @@
  */
 const fs = require( 'fs' );
 const path = require( 'path' );
-const { assign, assignWith } = require( 'lodash' );
+const { assignWith } = require( 'lodash' );
 const debug = require( 'debug' )( 'config' );
 
 function getDataFromFile( file ) {
@@ -24,7 +24,7 @@ function getDataFromFile( file ) {
 }
 
 module.exports = function ( configPath, defaultOpts ) {
-	const opts = assign(
+	const opts = Object.assign(
 		{
 			env: 'development',
 		},
@@ -74,8 +74,8 @@ module.exports = function ( configPath, defaultOpts ) {
 	data.hostname = process.env.HOST || data.hostname;
 	data.port = process.env.PORT || data.port;
 
-	const serverData = assign( {}, data, getDataFromFile( secretsPath ) );
-	const clientData = assign( {}, data );
+	const serverData = Object.assign( {}, data, getDataFromFile( secretsPath ) );
+	const clientData = Object.assign( {}, data );
 
 	return { serverData, clientData };
 };

--- a/client/server/lib/analytics/index.js
+++ b/client/server/lib/analytics/index.js
@@ -4,7 +4,7 @@
 
 import superagent from 'superagent';
 import { v4 as uuid } from 'uuid';
-import { omit, assign, get, has } from 'lodash';
+import { omit, get, has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -95,22 +95,18 @@ const analytics = {
 			const date = new Date();
 			const acceptLanguageHeader = req.get( 'Accept-Language' ) || '';
 
-			this.createPixel(
-				assign(
-					{
-						_en: eventName,
-						_ts: date.getTime(),
-						_tz: date.getTimezoneOffset() / 60,
-						_dl: req.get( 'Referer' ),
-						_lg: acceptLanguageHeader.split( ',' )[ 0 ],
-						_pf: req.useragent.platform,
-						_via_ip: req.get( 'x-forwarded-for' ) || req.connection.remoteAddress,
-						_via_ua: req.useragent.source,
-					},
-					getUserFromRequest( req ),
-					eventProperties
-				)
-			);
+			this.createPixel( {
+				_en: eventName,
+				_ts: date.getTime(),
+				_tz: date.getTimezoneOffset() / 60,
+				_dl: req.get( 'Referer' ),
+				_lg: acceptLanguageHeader.split( ',' )[ 0 ],
+				_pf: req.useragent.platform,
+				_via_ip: req.get( 'x-forwarded-for' ) || req.connection.remoteAddress,
+				_via_ua: req.useragent.source,
+				...getUserFromRequest( req ),
+				...eventProperties,
+			} );
 		},
 	},
 };

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign, get, includes, reject } from 'lodash';
+import { get, includes, reject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -116,9 +116,10 @@ function removeUserStepFromFlow( flow ) {
 		return;
 	}
 
-	return assign( {}, flow, {
+	return {
+		...flow,
 		steps: reject( flow.steps, ( stepName ) => stepConfig[ stepName ].providesToken ),
-	} );
+	};
 }
 
 function removeP2DetailsStepFromFlow( flow ) {
@@ -126,9 +127,10 @@ function removeP2DetailsStepFromFlow( flow ) {
 		return;
 	}
 
-	return assign( {}, flow, {
+	return {
+		...flow,
 		steps: reject( flow.steps, ( stepName ) => stepName === 'p2-details' ),
-	} );
+	};
 }
 
 function filterDestination( destination, dependencies, flowName, localeSlug ) {
@@ -206,9 +208,10 @@ const Flows = {
 			return;
 		}
 
-		return assign( {}, flow, {
+		return {
+			...flow,
 			steps: reject( flow.steps, ( stepName ) => includes( Flows.excludedSteps, stepName ) ),
-		} );
+		};
 	},
 
 	resetExcludedSteps() {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -6,7 +6,6 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {
-	assign,
 	clone,
 	defer,
 	find,
@@ -615,11 +614,10 @@ class Signup extends React.Component {
 		const domainItem = get( this.props, 'signupDependencies.domainItem', false );
 		const currentStepProgress = find( this.props.progress, { stepName: this.props.stepName } );
 		const CurrentComponent = this.props.stepComponent;
-		const propsFromConfig = assign(
-			{},
-			omit( this.props, 'locale' ),
-			steps[ this.props.stepName ].props
-		);
+		const propsFromConfig = {
+			...omit( this.props, 'locale' ),
+			...steps[ this.props.stepName ].props,
+		};
 		const stepKey = this.state.shouldShowLoadingScreen ? 'processing' : this.props.stepName;
 		const flow = flows.getFlow( this.props.flowName );
 		const planWithDomain =
@@ -636,11 +634,12 @@ class Signup extends React.Component {
 
 		let propsForCurrentStep = propsFromConfig;
 		if ( this.enableManageSiteFlow ) {
-			propsForCurrentStep = assign( {}, propsFromConfig, {
+			propsForCurrentStep = {
+				...propsFromConfig,
 				showExampleSuggestions: false,
 				showSkipButton: true,
 				includeWordPressDotCom: false,
-			} );
+			};
 		}
 
 		return (

--- a/client/state/data-layer/wpcom/videos/poster/index.js
+++ b/client/state/data-layer/wpcom/videos/poster/index.js
@@ -13,7 +13,6 @@ import {
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import getMediaItem from 'calypso/state/selectors/get-media-item';
-import { assign } from 'lodash';
 import { receiveMedia } from 'calypso/state/media/actions';
 
 const fetch = ( action ) => {
@@ -46,13 +45,14 @@ const onSuccess = ( action, { poster: posterUrl } ) => ( dispatch, getState ) =>
 	// Photon does not support URLs with a querystring component.
 	const urlBeforeQuery = ( posterUrl || '' ).split( '?' )[ 0 ];
 
-	const updatedMediaItem = assign( {}, mediaItem, {
+	const updatedMediaItem = {
+		...mediaItem,
 		thumbnails: {
 			fmt_hd: urlBeforeQuery,
 			fmt_dvd: urlBeforeQuery,
 			fmt_std: urlBeforeQuery,
 		},
-	} );
+	};
 
 	dispatch( receiveMedia( siteId, updatedMediaItem ) );
 };

--- a/client/state/media/thunks/edit-media.js
+++ b/client/state/media/thunks/edit-media.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { assign } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { createTransientMedia } from 'calypso/lib/media/utils';
@@ -25,10 +20,12 @@ export const editMedia = ( siteId, item ) => ( dispatch, getState ) => {
 
 	const mediaId = item.ID;
 	const originalMediaItem = getMediaItem( getState(), siteId, mediaId );
-	const editedMediaItem = assign( {}, originalMediaItem, transientMediaItem, {
+	const editedMediaItem = {
+		...originalMediaItem,
+		...transientMediaItem,
 		ID: mediaId,
 		isDirty: true,
-	} );
+	};
 
 	dispatch( editMediaItem( siteId, editedMediaItem, item, originalMediaItem ) );
 };

--- a/client/state/media/thunks/update-media.js
+++ b/client/state/media/thunks/update-media.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { assign } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { updateMediaItem } from 'calypso/state/media/actions';
@@ -19,7 +14,7 @@ export const updateMedia = ( siteId, item ) => ( dispatch, getState ) => {
 	const mediaId = item.ID;
 
 	const originalMediaItem = getMediaItem( getState(), siteId, mediaId );
-	const updatedMediaItem = assign( {}, originalMediaItem, item );
+	const updatedMediaItem = { ...originalMediaItem, ...item };
 
 	dispatch( updateMediaItem( siteId, updatedMediaItem, originalMediaItem ) );
 };

--- a/client/state/reader/conversations/reducer.js
+++ b/client/state/reader/conversations/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign, forEach, omit, size } from 'lodash';
+import { forEach, omit, size } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,18 +23,20 @@ import { key } from './utils';
 export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case READER_CONVERSATION_FOLLOW: {
-			const newState = assign( {}, state, {
+			const newState = {
+				...state,
 				[ key(
 					action.payload.siteId,
 					action.payload.postId
 				) ]: CONVERSATION_FOLLOW_STATUS.following,
-			} );
+			};
 			return newState;
 		}
 		case READER_CONVERSATION_MUTE: {
-			const newState = assign( {}, state, {
+			const newState = {
+				...state,
 				[ key( action.payload.siteId, action.payload.postId ) ]: CONVERSATION_FOLLOW_STATUS.muting,
-			} );
+			};
 			return newState;
 		}
 		case READER_CONVERSATION_UPDATE_FOLLOW_STATUS: {
@@ -45,9 +47,10 @@ export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) =
 				return omit( state, stateKey );
 			}
 
-			const newState = assign( {}, state, {
+			const newState = {
+				...state,
 				[ stateKey ]: action.payload.followStatus,
-			} );
+			};
 
 			return newState;
 		}

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { assign, keyBy, map, omit, omitBy, reduce, merge, forEach } from 'lodash';
+import { keyBy, map, omit, omitBy, reduce, merge, forEach } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -22,15 +22,13 @@ import { safeLink } from 'calypso/lib/post-normalizer/utils';
 
 function handleRequestFailure( state, action ) {
 	// new object precedes current state to prevent new errors from overwriting existing values
-	return assign(
-		{
-			[ action.payload.feed_ID ]: {
-				feed_ID: action.payload.feed_ID,
-				is_error: true,
-			},
+	return {
+		[ action.payload.feed_ID ]: {
+			feed_ID: action.payload.feed_ID,
+			is_error: true,
 		},
-		state
-	);
+		...state,
+	};
 }
 
 function adaptFeed( feed ) {
@@ -52,14 +50,18 @@ function adaptFeed( feed ) {
 
 function handleRequestSuccess( state, action ) {
 	const feed = adaptFeed( action.payload );
-	return assign( {}, state, {
+	return {
+		...state,
 		[ feed.feed_ID ]: feed,
-	} );
+	};
 }
 
 function handleFeedUpdate( state, action ) {
 	const feeds = map( action.payload, adaptFeed );
-	return assign( {}, state, keyBy( feeds, 'feed_ID' ) );
+	return {
+		...state,
+		...keyBy( feeds, 'feed_ID' ),
+	};
 }
 
 const itemsReducer = ( state = {}, action ) => {
@@ -121,9 +123,10 @@ export const items = withSchemaValidation(
 export function queuedRequests( state = {}, action ) {
 	switch ( action.type ) {
 		case READER_FEED_REQUEST:
-			return assign( {}, state, {
+			return {
+				...state,
 				[ action.payload.feed_ID ]: true,
-			} );
+			};
 
 		case READER_FEED_REQUEST_SUCCESS:
 		case READER_FEED_REQUEST_FAILURE:
@@ -148,7 +151,7 @@ export const lastFetched = ( state = {}, action ) => {
 				},
 				{}
 			);
-			return assign( {}, state, updates );
+			return { ...state, ...updates };
 		}
 	}
 

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { assign, includes, keyBy, map, omit, omitBy, reduce, trim } from 'lodash';
+import { includes, keyBy, map, omit, omitBy, reduce, trim } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -26,13 +26,14 @@ function handleRequestFailure( state, action ) {
 		return state;
 	}
 
-	return assign( {}, state, {
+	return {
+		...state,
 		[ action.payload.ID ]: {
 			ID: action.payload.ID,
 			is_error: true,
 			error: action.error,
 		},
-	} );
+	};
 }
 
 function adaptSite( attributes ) {
@@ -67,14 +68,15 @@ function adaptSite( attributes ) {
 function handleRequestSuccess( state, action ) {
 	const site = adaptSite( action.payload );
 	// TODO do we need to normalize site entries somehow?
-	return assign( {}, state, {
+	return {
+		...state,
 		[ action.payload.ID ]: site,
-	} );
+	};
 }
 
 function handleSiteUpdate( state, action ) {
 	const sites = map( action.payload, adaptSite );
-	return assign( {}, state, keyBy( sites, 'ID' ) );
+	return { ...state, ...keyBy( sites, 'ID' ) };
 }
 
 const itemsReducer = ( state = {}, action ) => {
@@ -113,9 +115,10 @@ export const items = withSchemaValidation(
 export function queuedRequests( state = {}, action ) {
 	switch ( action.type ) {
 		case READER_SITE_REQUEST:
-			return assign( {}, state, {
+			return {
+				...state,
 				[ action.payload.ID ]: true,
-			} );
+			};
 		case READER_SITE_REQUEST_SUCCESS:
 		case READER_SITE_REQUEST_FAILURE:
 			return omit( state, action.payload.ID );
@@ -140,7 +143,7 @@ export const lastFetched = ( state = {}, action ) => {
 				},
 				{}
 			);
-			return assign( {}, state, updates );
+			return { ...state, ...updates };
 		}
 	}
 

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { assign, includes, isObjectLike, omitBy, times } from 'lodash';
+import { includes, isObjectLike, omitBy, times } from 'lodash';
 import cookie from 'cookie';
 import { EventEmitter } from 'events';
 import { loadScript } from '@automattic/load-script';
@@ -255,12 +255,12 @@ export function recordTracksPageView( urlPath: string, params: any ) {
 	// Add calypso build timestamp if set
 	const build_timestamp = typeof window !== 'undefined' && window.BUILD_TIMESTAMP;
 	if ( build_timestamp ) {
-		eventProperties = assign( eventProperties, { build_timestamp } );
+		eventProperties = Object.assign( eventProperties, { build_timestamp } );
 	}
 
 	// add optional path params
 	if ( params ) {
-		eventProperties = assign( eventProperties, params );
+		eventProperties = Object.assign( eventProperties, params );
 	}
 
 	// Record all `utm` marketing parameters as event properties on the page view event
@@ -272,7 +272,7 @@ export function recordTracksPageView( urlPath: string, params: any ) {
 			Array.from( urlParams.entries() ).filter( ( [ key ] ) => key.startsWith( 'utm_' ) );
 		const utmParams = utmParamEntries ? Object.fromEntries( utmParamEntries ) : {};
 
-		eventProperties = assign( eventProperties, utmParams );
+		eventProperties = Object.assign( eventProperties, utmParams );
 	}
 
 	recordTracksEvent( 'calypso_page_view', eventProperties );

--- a/packages/popup-monitor/src/emitter.js
+++ b/packages/popup-monitor/src/emitter.js
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-import { assign } from 'lodash';
 import { EventEmitter } from 'events';
 
 export default function ( prototype ) {
-	assign( prototype, EventEmitter.prototype );
+	Object.assign( prototype, EventEmitter.prototype );
 	prototype.emitChange = function () {
 		this.emit( 'change' );
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `assign()` is used many times in the codebase, but it's pretty straightforward to replace it with either spread or `Object.assign()`.  This PR updates all the instances.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all tests pass: `yarn run test-client`, `yarn run test-packages` and `yarn run test-server`.
* Spend some time smoke testing Calypso and verify everything works alright.

Note that there are existing ESLint errors in some of the files we're touching here.