### PR TITLE
Framework: Refactor away from _.isNumber()

### DIFF
--- a/client/blocks/followers-count/index.jsx
+++ b/client/blocks/followers-count/index.jsx
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, isNumber } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,7 +23,7 @@ class FollowersCount extends Component {
 		return (
 			<div className="followers-count">
 				{ siteId && <QuerySiteStats statType="stats" siteId={ siteId } /> }
-				{ isNumber( followers ) && (
+				{ typeof followers === 'number' && (
 					<Button
 						borderless
 						href={ '/people/followers/' + slug }

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -7,7 +7,7 @@ import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize, getLocaleSlug } from 'i18n-calypso';
-import { isNumber, trim } from 'lodash';
+import { trim } from 'lodash';
 
 /**
  * Internal dependencies
@@ -142,7 +142,7 @@ export class NpsSurvey extends PureComponent {
 		return (
 			[ 'en', 'en-gb' ].indexOf( getLocaleSlug() ) >= 0 &&
 			this.props.isBusinessUser &&
-			isNumber( this.state.score ) &&
+			typeof this.state.score === 'number' &&
 			this.state.score < 7
 		);
 	}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { get, isNumber, includes } from 'lodash';
+import { get, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import classNames from 'classnames';
@@ -84,7 +84,7 @@ class DomainRegistrationSuggestion extends React.Component {
 	}
 
 	recordRender() {
-		if ( this.props.railcarId && isNumber( this.props.uiPosition ) ) {
+		if ( this.props.railcarId && typeof this.props.uiPosition === 'number' ) {
 			let resultSuffix = '';
 			if ( this.props.suggestion.isRecommended ) {
 				resultSuffix = '#recommended';

--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -5,7 +5,7 @@
 import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get, isNumber } from 'lodash';
+import { get } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -100,7 +100,7 @@ const mapStateToProps = ( state ) => {
 
 	const hasSelectedSiteLoaded =
 		! currentSlug ||
-		( isNumber( currentSlug ) && currentSlug === selectedSiteId ) ||
+		( typeof currentSlug === 'number' && currentSlug === selectedSiteId ) ||
 		currentSlug === selectedSiteSlug;
 
 	return {

--- a/client/lib/gsuite/get-annual-price.js
+++ b/client/lib/gsuite/get-annual-price.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isNumber } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { formatPrice } from 'calypso/lib/gsuite/utils/format-price';
@@ -17,7 +12,7 @@ import { formatPrice } from 'calypso/lib/gsuite/utils/format-price';
  * @returns {string} - the yearly price formatted (e.g. '$99.99'), otherwise the default value
  */
 export function getAnnualPrice( cost, currencyCode, defaultValue = '-' ) {
-	if ( ! isNumber( cost ) && typeof currencyCode !== 'string' ) {
+	if ( typeof cost !== 'number' && typeof currencyCode !== 'string' ) {
 		return defaultValue;
 	}
 

--- a/client/lib/gsuite/get-monthly-price.js
+++ b/client/lib/gsuite/get-monthly-price.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isNumber } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { formatPrice } from 'calypso/lib/gsuite/utils/format-price';
@@ -17,7 +12,7 @@ import { formatPrice } from 'calypso/lib/gsuite/utils/format-price';
  * @returns {string} - the monthly price rounded to the nearest tenth (e.g. '$8.40'), otherwise the default value
  */
 export function getMonthlyPrice( cost, currencyCode, defaultValue = '-' ) {
-	if ( ! isNumber( cost ) && typeof currencyCode !== 'string' ) {
+	if ( typeof cost !== 'number' && typeof currencyCode !== 'string' ) {
 		return defaultValue;
 	}
 

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { sortBy, camelCase, mapKeys, isNumber, get, filter, map, concat, flatten } from 'lodash';
+import { sortBy, camelCase, mapKeys, get, filter, map, concat, flatten } from 'lodash';
 import { translate, getLocaleSlug } from 'i18n-calypso';
 import moment from 'moment';
 
@@ -343,7 +343,7 @@ export const normalizers = {
 	 * @returns {object?}        Normalized stats data
 	 */
 	statsInsights: ( data ) => {
-		if ( ! data || ! isNumber( data.highest_day_of_week ) ) {
+		if ( ! data || typeof data.highest_day_of_week !== 'number' ) {
 			return {};
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `isNumber()` is used several times in the codebase, but it's pretty straightforward to replace it with a `typeof === 'number'`. This PR replaces all instances.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all tests pass: `yarn run test-client`.
* Specific testing shouldn't be necessary, because the `typeof` checks are error-proof.