### PR TITLE
Framework: Refactor away from _.isObject()

### DIFF
--- a/client/extensions/woocommerce/state/helpers.js
+++ b/client/extensions/woocommerce/state/helpers.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isObject } from 'lodash';
-
-/**
  * Dispatch an action or function with additional properties.
  *
  * If the action is an object, it adds props as properties to the action.
@@ -21,7 +16,7 @@ export function dispatchWithProps( dispatch, getState, action, props ) {
 	if ( typeof action === 'function' ) {
 		const returnValue = action( dispatch, getState, props );
 		dispatchWithProps( dispatch, getState, returnValue, props );
-	} else if ( isObject( action ) ) {
+	} else if ( action !== null && typeof action === 'object' ) {
 		dispatch( { ...action, ...props } );
 	}
 }

--- a/client/extensions/woocommerce/state/sites/request.js
+++ b/client/extensions/woocommerce/state/sites/request.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { omit, mapValues, isObject } from 'lodash';
+import { omit, mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,7 +14,7 @@ const omitDeep = ( input, props ) => {
 		return input.map( ( elem ) => omitDeep( elem, props ) );
 	}
 
-	if ( isObject( input ) ) {
+	if ( input !== null && typeof input === 'object' ) {
 		return mapValues( omit( input, props ), ( value ) => omitDeep( value, props ) );
 	}
 

--- a/client/extensions/woocommerce/state/sites/setup-choices/selectors.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { get, isEmpty, isObject } from 'lodash';
+import { get, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,7 +21,7 @@ const getSetupChoices = ( state, siteId ) => {
  */
 export const areSetupChoicesLoaded = ( state, siteId = getSelectedSiteId( state ) ) => {
 	const setupChoices = getSetupChoices( state, siteId );
-	return isObject( setupChoices ) && ! isEmpty( setupChoices );
+	return typeof setupChoices === 'object' && ! isEmpty( setupChoices );
 };
 
 /**

--- a/client/lib/products-values/products-list.ts
+++ b/client/lib/products-values/products-list.ts
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isObject } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { getJetpackProductsShortNames } from './translations';
@@ -234,7 +229,7 @@ export const PRODUCTS_LIST: Record< ProductSlug, Product > = {
 };
 
 export function objectIsProduct( item: unknown ): item is Product {
-	if ( isObject( item ) ) {
+	if ( item !== null && typeof item === 'object' ) {
 		const requiredKeys = [ 'product_slug', 'product_name', 'term', 'bill_period' ];
 		return requiredKeys.every( ( k ) => k in item );
 	}

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, includes, isObject } from 'lodash';
+import { find, includes } from 'lodash';
 import moment from 'moment';
 import page from 'page';
 import i18n from 'i18n-calypso';
@@ -306,6 +306,10 @@ function hasPaymentMethod( purchase ) {
 
 function isPendingTransfer( purchase ) {
 	return purchase.pendingTransfer;
+}
+
+function isObject( value ) {
+	return value !== null && typeof value === 'object';
 }
 
 /**

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { translate, TranslateResult, numberFormat } from 'i18n-calypso';
-import { compact, isObject } from 'lodash';
+import { compact } from 'lodash';
 import page from 'page';
 import React, { createElement, Fragment } from 'react';
 import { createSelector } from '@automattic/state-utils';
@@ -564,7 +564,7 @@ export function buildCardFeaturesFromFeatureKeys(
 	}
 
 	// With sections (JetpackPlanCardFeatureSection)
-	if ( isObject( features ) ) {
+	if ( features !== null && typeof features === 'object' ) {
 		const result = [] as SelectorProductFeaturesSection[];
 
 		Object.getOwnPropertySymbols( features ).map( ( key ) => {

--- a/client/state/data-layer/wpcom/read/tags/utils.js
+++ b/client/state/data-layer/wpcom/read/tags/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, compact, concat, isObject } from 'lodash';
+import { map, compact, concat } from 'lodash';
 import { decodeEntities } from 'calypso/lib/formatting';
 
 /**
@@ -24,7 +24,7 @@ export function fromApi( apiResponse ) {
 	const tags = compact(
 		concat(
 			[],
-			isObject( apiResponse.tag ) && apiResponse.tag,
+			typeof apiResponse.tag === 'object' && apiResponse.tag,
 			Array.isArray( apiResponse.tags ) && apiResponse.tags
 		)
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `isObject()` is used several times in the codebase, but it's pretty straightforward to replace it with a `typeof value === 'object' && value !== null`. The `null` check is needed because `typeof null` yields `object` too. This PR replaces all instances. Note that in some we already have a truthiness check, so the `null` check is unnecessary.

Not to be confused with `isObjectLike()`.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all tests pass: `yarn run test-client`.
* Specific testing shouldn't be necessary, because the `typeof` checks are error-proof.