### PR TITLE
State: Fix isUnlaunchedSite selector precision

### DIFF
--- a/client/state/selectors/is-unlaunched-site.js
+++ b/client/state/selectors/is-unlaunched-site.js
@@ -14,5 +14,5 @@ import getRawSite from 'calypso/state/selectors/get-raw-site';
 export default function isUnlaunchedSite( state, siteId ) {
 	const site = getRawSite( state, siteId );
 
-	return !! ( site && site.launch_status && site.launch_status === 'unlaunched' );
+	return site?.launch_status === 'unlaunched';
 }

--- a/client/state/selectors/is-unlaunched-site.js
+++ b/client/state/selectors/is-unlaunched-site.js
@@ -14,5 +14,5 @@ import getRawSite from 'calypso/state/selectors/get-raw-site';
 export default function isUnlaunchedSite( state, siteId ) {
 	const site = getRawSite( state, siteId );
 
-	return site && site.launch_status && site.launch_status === 'unlaunched';
+	return !! ( site && site.launch_status && site.launch_status === 'unlaunched' );
 }

--- a/client/state/selectors/test/is-unlaunched-site.js
+++ b/client/state/selectors/test/is-unlaunched-site.js
@@ -4,7 +4,7 @@
 import isUnlaunchedSite from '../is-unlaunched-site';
 
 describe( 'isUnlaunchedSite()', () => {
-	test( 'should be falsy when there is no such site', () => {
+	test( 'should return false when there is no such site', () => {
 		expect(
 			isUnlaunchedSite(
 				{
@@ -14,10 +14,10 @@ describe( 'isUnlaunchedSite()', () => {
 				},
 				222
 			)
-		).toBeFalsy();
+		).toBe( false );
 	} );
 
-	test( 'should be falsy when site has no launch status', () => {
+	test( 'should return false when site has no launch status', () => {
 		expect(
 			isUnlaunchedSite(
 				{
@@ -29,7 +29,7 @@ describe( 'isUnlaunchedSite()', () => {
 				},
 				222
 			)
-		).toBeFalsy();
+		).toBe( false );
 	} );
 
 	test( 'should return false when site has non "launched" launch status', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, if you visit for example `/plans/:site` for an Atomic site, you'll see this error:

![](https://cldup.com/C8H-nM_ZMI.png)

This happens because `launch_status` is an empty string while the site object is loading, but the `DomainWarnings` component expects a `boolean`. It works correctly because the empty string will evaluate to `false`, but it's imprecise - the selector is expected to always return a boolean.

This PR improves the precision in the tests of the selector to showcase that problem, and fixes the actual selector to fix the selector precision. 

#### Testing instructions

* Go to `/plans/:site` where `:site` is an Atomic site.
* Verify you don't see the warning in the console.
* Verify tests pass: `yarn run test-client client/state/selectors/test/is-unlaunched-site.js`