### PR TITLE
Scrolls to top before navigating away.

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -138,6 +138,7 @@ class MasterbarLoggedIn extends React.Component {
 
 	clickMe = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_me_clicked' );
+		window.scrollTo( 0, 0 );
 		this.handleLayoutFocus( 'me' );
 	};
 

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -41,6 +41,7 @@ export const MySitesSidebarUnifiedItem = ( {
 	const onNavigate = () => {
 		reduxDispatch( collapseAllMySitesSidebarSections() );
 		reduxDispatch( expandMySitesSidebarSection( sectionId ) );
+		window.scrollTo( 0, 0 );
 	};
 
 	return (

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -88,6 +88,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 			}
 		}
 
+		window.scrollTo( 0, 0 );
 		reduxDispatch( toggleSection( sectionId ) );
 	};
 


### PR DESCRIPTION
While the old `sidebar` component did a `window.scrollTo( 0, 0 );` when clicking on each Sidebar Item, on `MySitesSidebarUnified` we didn't handle it at all. Also, it seems that clicking `Me` or `Reader` from the masterbar didn't scroll to top either with `nav-unification` enabled or disabled. I fixed `Me` but opted for not scrolling to top for the `Reader` so that if a user has scrolled down reading X articles they don't get scrolled to the top. I would like your opinion on this though!

#### Changes proposed in this Pull Request

* Scroll to top before navigating while clicking a Sidebar Item.
* Scroll to top before navigating while clicking a Sidebar Menu.
* Scroll to top before navigating while `Me` in masterbar.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up calypso live
* Resize the height of your browser so that it is shorter than `http://calypso.localhost:3000/me`.

**Scenario 1**
* Scroll down to My Sites Home page
* Click `Users` -> `Personal Settings`
* You should be scrolled to the top

**Scenario 2**
* Scroll down to My Sites Home page
* Click `Tools` 
* You should be scrolled to the top

**Scenario 3**
* Scroll down to My Sites Home page
* Click `Me` in the masterbar
* You should be scrolled to the top

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #49577
