### PR TITLE
Reskin signup: Fix white flicker take two

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -103,7 +103,6 @@ export default {
 		if ( context.pathname.indexOf( 'new-launch' ) >= 0 ) {
 			next();
 		} else if ( currentFlowName === 'onboarding' ) {
-			document.body.classList.add( 'is-white-signup' );
 			next();
 		} else if (
 			context.pathname.indexOf( 'domain' ) >= 0 ||

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -735,7 +735,9 @@ class Signup extends React.Component {
 					}
 
 					this.isReskinned = 'treatment' === experimentAssignment?.variationName;
-					! isLoading && ! this.isReskinned && document.body.classList.remove( 'is-white-signup' );
+					this.isReskinned
+						? document.body.classList.add( 'is-white-signup' )
+						: document.body.classList.remove( 'is-white-signup' );
 					debug( `isReskinned value is ${ this.isReskinned }` );
 
 					return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This attempts to fix the white flicker issue described in https://github.com/Automattic/wp-calypso/pull/52132. The previous attempt made in https://github.com/Automattic/wp-calypso/pull/52132 did not work, so this is take two.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* At the user step of signup in the control version, click on Create account and verify you don't see a white flicker.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
