### PR TITLE
Onboarding: allow designs without font configuration, skip 'style' step in Gutenboarding when such a design is selected

### DIFF
--- a/client/landing/gutenboarding/hooks/use-steps.ts
+++ b/client/landing/gutenboarding/hooks/use-steps.ts
@@ -15,7 +15,7 @@ import { usePlanFromPath } from './use-selected-plan';
 
 export default function useSteps(): Array< StepType > {
 	const locale = useLocale();
-	const { hasSiteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ) );
+	const { hasSiteTitle, getSelectedDesign } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 	const isAnchorFmSignup = useIsAnchorFm();
 
 	let steps: StepType[];
@@ -44,8 +44,13 @@ export default function useSteps(): Array< StepType > {
 		];
 	}
 
+	// This should come from a hook which updates as a design in the design step is selected
+	const selectedDesign = getSelectedDesign();
+	const selectedDesignHasNoFonts =
+		typeof selectedDesign !== 'undefined' && ! selectedDesign.hasOwnProperty( 'fonts' );
+
 	// Remove the Style (fonts) step from the Site Editor flow.
-	if ( isEnabled( 'gutenboarding/site-editor' ) ) {
+	if ( isEnabled( 'gutenboarding/site-editor' ) || selectedDesignHasNoFonts ) {
 		steps = steps.filter( ( step ) => step !== Step.Style );
 	}
 

--- a/client/landing/gutenboarding/hooks/use-steps.ts
+++ b/client/landing/gutenboarding/hooks/use-steps.ts
@@ -15,7 +15,16 @@ import { usePlanFromPath } from './use-selected-plan';
 
 export default function useSteps(): Array< StepType > {
 	const locale = useLocale();
-	const { hasSiteTitle, getSelectedDesign } = useSelect( ( select ) => select( ONBOARD_STORE ) );
+	const { hasSiteTitle, hasSelectedDesignWithoutFonts } = useSelect(
+		( select ) => {
+			const onboardSelect = select( ONBOARD_STORE );
+			return {
+				hasSiteTitle: onboardSelect.hasSiteTitle(),
+				hasSelectedDesignWithoutFonts: onboardSelect.hasSelectedDesignWithoutFonts(),
+			};
+		},
+		[ ONBOARD_STORE ]
+	);
 	const isAnchorFmSignup = useIsAnchorFm();
 
 	let steps: StepType[];
@@ -24,7 +33,7 @@ export default function useSteps(): Array< StepType > {
 	if ( isAnchorFmSignup ) {
 		steps = [ Step.IntentGathering, Step.DesignSelection, Step.Style ];
 		// If site title is skipped, we're showing Domains step before Features step. If not, we are showing Domains step next.
-	} else if ( hasSiteTitle() ) {
+	} else if ( hasSiteTitle ) {
 		steps = [
 			Step.IntentGathering,
 			Step.Domains,
@@ -44,13 +53,8 @@ export default function useSteps(): Array< StepType > {
 		];
 	}
 
-	// This should come from a hook which updates as a design in the design step is selected
-	const selectedDesign = getSelectedDesign();
-	const selectedDesignHasNoFonts =
-		typeof selectedDesign !== 'undefined' && ! selectedDesign.hasOwnProperty( 'fonts' );
-
 	// Remove the Style (fonts) step from the Site Editor flow.
-	if ( isEnabled( 'gutenboarding/site-editor' ) || selectedDesignHasNoFonts ) {
+	if ( isEnabled( 'gutenboarding/site-editor' ) || hasSelectedDesignWithoutFonts ) {
 		steps = steps.filter( ( step ) => step !== Step.Style );
 	}
 

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -46,6 +46,10 @@ const Designs: React.FunctionComponent = () => {
 
 	React.useEffect( () => {
 		if ( selectedDesign && userHasSelectedDesign ) {
+			// The `userHasSelectedDesign` local state variable is used to delay
+			// the call to `goNext()` by at least 1 re-render. This is to allow
+			// time for the `goNext()` function to update and correctly skip the
+			// `style` step when necessary
 			goNext();
 		}
 	}, [ goNext, userHasSelectedDesign, selectedDesign ] );

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -29,16 +29,26 @@ const Designs: React.FunctionComponent = () => {
 	const locale = useLocale();
 	const { goBack, goNext } = useStepNavigation();
 
-	const { setSelectedDesign, setFonts } = useDispatch( ONBOARD_STORE );
+	const { setSelectedDesign, setFonts, resetFonts } = useDispatch( ONBOARD_STORE );
 	const { getSelectedDesign, hasPaidDesign, getRandomizedDesigns } = useSelect( ( select ) =>
 		select( ONBOARD_STORE )
 	);
 	const isAnchorFmSignup = useIsAnchorFm();
 
+	const selectedDesign = getSelectedDesign();
+
 	useTrackStep( 'DesignSelection', () => ( {
-		selected_design: getSelectedDesign()?.slug,
+		selected_design: selectedDesign?.slug,
 		is_selected_design_premium: hasPaidDesign(),
 	} ) );
+
+	const [ userHasSelectedDesign, setUserHasSelectedDesign ] = React.useState( false );
+
+	React.useEffect( () => {
+		if ( selectedDesign && userHasSelectedDesign ) {
+			goNext();
+		}
+	}, [ goNext, userHasSelectedDesign, selectedDesign ] );
 
 	return (
 		<div className="gutenboarding-page designs">
@@ -69,6 +79,7 @@ const Designs: React.FunctionComponent = () => {
 				locale={ locale }
 				onSelect={ ( design: Design ) => {
 					setSelectedDesign( design );
+					setUserHasSelectedDesign( true );
 
 					if ( design.fonts ) {
 						setFonts( design.fonts );

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -70,10 +70,12 @@ const Designs: React.FunctionComponent = () => {
 				onSelect={ ( design: Design ) => {
 					setSelectedDesign( design );
 
-					// Update fonts to the design defaults
-					setFonts( design.fonts );
-
-					goNext();
+					if ( design.fonts ) {
+						setFonts( design.fonts );
+					} else {
+						// Some designs may not specify font pairings
+						resetFonts();
+					}
 				} }
 				premiumBadge={
 					<Badge className="designs__premium-badge">

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -41,8 +41,18 @@ import './colors.scss';
 import './style.scss';
 
 const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = () => {
-	const { selectedDesign, siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
-	const isRedirecting = useSelect( ( select ) => select( STORE_KEY ).getIsRedirecting() );
+	const { hasSiteTitle, hasSelectedDesign, isRedirecting } = useSelect(
+		( select ) => {
+			const onboardSelect = select( STORE_KEY );
+
+			return {
+				hasSiteTitle: onboardSelect.hasSiteTitle(),
+				hasSelectedDesign: onboardSelect.hasSelectedDesign(),
+				isRedirecting: onboardSelect.getIsRedirecting(),
+			};
+		},
+		[ STORE_KEY ]
+	);
 	const isCreatingSite = useSelect( ( select ) => select( SITE_STORE ).isFetchingSite() );
 	const newSiteError = useSelect( ( select ) => select( SITE_STORE ).getNewSiteError() );
 	const shouldTriggerCreate = useNewQueryParam();
@@ -83,19 +93,19 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 	);
 
 	const canUseDesignStep = React.useCallback( (): boolean => {
-		return !! siteTitle;
-	}, [ siteTitle ] );
+		return hasSiteTitle;
+	}, [ hasSiteTitle ] );
 
 	const canUseStyleStep = React.useCallback( (): boolean => {
-		return !! selectedDesign;
-	}, [ selectedDesign ] );
+		return hasSelectedDesign;
+	}, [ hasSelectedDesign ] );
 
 	const canUseCreateSiteStep = React.useCallback( (): boolean => {
 		return isCreatingSite || isRedirecting;
 	}, [ isCreatingSite, isRedirecting ] );
 
 	const getLatestStepPath = () => {
-		if ( canUseStyleStep() && ! isAnchorFmSignup ) {
+		if ( hasSelectedDesign && ! isAnchorFmSignup ) {
 			return makePathWithState( Step.Plans );
 		}
 

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -100,6 +100,14 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 		return hasSelectedDesign;
 	}, [ hasSelectedDesign ] );
 
+	const canUseFeatureStep = React.useCallback( (): boolean => {
+		return hasSelectedDesign;
+	}, [ hasSelectedDesign ] );
+
+	const canUsePlanStep = React.useCallback( (): boolean => {
+		return hasSelectedDesign;
+	}, [ hasSelectedDesign ] );
+
 	const canUseCreateSiteStep = React.useCallback( (): boolean => {
 		return isCreatingSite || isRedirecting;
 	}, [ isCreatingSite, isRedirecting ] );
@@ -174,7 +182,7 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 				</Route>
 
 				<Route path={ makePath( Step.Features ) }>
-					{ canUseStyleStep() ? <Features /> : redirectToLatestStep }
+					{ canUseFeatureStep() ? <Features /> : redirectToLatestStep }
 				</Route>
 
 				<Route path={ makePath( Step.Domains ) }>
@@ -186,7 +194,7 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 				</Route>
 
 				<Route path={ makePath( Step.Plans ) }>
-					{ canUseStyleStep() ? <Plans /> : redirectToLatestStep }
+					{ canUsePlanStep() ? <Plans /> : redirectToLatestStep }
 				</Route>
 
 				<Route path={ makePath( Step.PlansModal ) }>

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -59,8 +59,17 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 		},
 		[ STORE_KEY ]
 	);
-	const isCreatingSite = useSelect( ( select ) => select( SITE_STORE ).isFetchingSite() );
-	const newSiteError = useSelect( ( select ) => select( SITE_STORE ).getNewSiteError() );
+	const { isCreatingSite, newSiteError } = useSelect(
+		( select ) => {
+			const { isFetchingSite, getNewSiteError } = select( SITE_STORE );
+
+			return {
+				isCreatingSite: isFetchingSite(),
+				newSiteError: getNewSiteError(),
+			};
+		},
+		[ SITE_STORE ]
+	);
 	const shouldTriggerCreate = useNewQueryParam();
 	const isAnchorFmSignup = useIsAnchorFm();
 	const { isAnchorFmPodcastIdError } = useAnchorFmParams();

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -36,3 +36,8 @@ export const getDomainSearch = ( state: State ) =>
 	state.domainSearch ||
 	( isGoodDefaultDomainQuery( getSelectedSiteTitle( state ) ) && getSelectedSiteTitle( state ) ) ||
 	getSelectedVertical( state )?.label;
+
+export const hasSelectedDesign = ( state: State ) => !! state.selectedDesign;
+
+export const hasSelectedDesignWithoutFonts = ( state: State ) =>
+	hasSelectedDesign( state ) && ! state.selectedFonts;

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -222,9 +222,12 @@ function getNewSiteParams( {
 		// If there's a selected design, it means that the current flow contains the "design" step.
 		newSiteParams.options.theme = `pub/${ selectedDesign.theme }`;
 		newSiteParams.options.template = selectedDesign.template;
-		newSiteParams.options.font_base = selectedDesign.fonts.base;
-		newSiteParams.options.font_headings = selectedDesign.fonts.headings;
 		newSiteParams.options.use_patterns = true;
+
+		if ( selectedDesign.fonts ) {
+			newSiteParams.options.font_base = selectedDesign.fonts.base;
+			newSiteParams.options.font_headings = selectedDesign.fonts.headings;
+		}
 	}
 
 	return newSiteParams;

--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -424,6 +424,17 @@
 			"is_premium": false,
 			"is_fse": true,
 			"features": []
+		},
+		{
+			"title": "Start with an empty page",
+			"slug": "blank-canvas",
+			"template": "blank-canvas",
+			"theme": "blank-canvas",
+			"categories": [ "featured" ],
+			"is_premium": false,
+			"is_fse": false,
+			"is_alpha": true,
+			"features": []
 		}
 	]
 }

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -19,7 +19,7 @@ export type DesignFeatures = 'anchorfm'; // For additional features, = 'anchorfm
 
 export interface Design {
 	categories: Array< string >;
-	fonts: FontPair;
+	fonts?: FontPair;
 	is_alpha?: boolean;
 	is_fse?: boolean;
 	is_premium: boolean;

--- a/packages/design-picker/src/utils/__tests__/available-designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/available-designs.test.ts
@@ -18,7 +18,6 @@ jest.mock( '@automattic/calypso-config', () => ( {
 	isEnabled: () => false,
 } ) );
 
-// TODO: add a mock / test for when fonts are undefined
 jest.mock( '../available-designs-config', () => {
 	const mockDesign: Design = {
 		title: 'Mock',

--- a/packages/design-picker/src/utils/__tests__/available-designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/available-designs.test.ts
@@ -34,6 +34,16 @@ jest.mock( '../available-designs-config', () => {
 		features: [],
 	};
 
+	const mockDesignWithoutFonts: Design = {
+		title: 'Mock',
+		slug: 'mock-premium-design-slug',
+		template: 'mock-premium-design-template',
+		theme: 'mock-premium-design-theme',
+		categories: [ 'featured' ],
+		is_premium: false,
+		features: [],
+	};
+
 	const mockDesignPremium: Design = {
 		title: 'Mock',
 		slug: 'mock-premium-design-slug',
@@ -80,7 +90,13 @@ jest.mock( '../available-designs-config', () => {
 
 	return {
 		availableDesignsConfig: {
-			featured: [ mockDesign, mockDesignPremium, mockDesignFse, mockDesignAlpha ],
+			featured: [
+				mockDesign,
+				mockDesignWithoutFonts,
+				mockDesignPremium,
+				mockDesignFse,
+				mockDesignAlpha,
+			],
 		},
 	};
 } );
@@ -96,6 +112,14 @@ describe( 'Design Picker design utils', () => {
 				`https://public-api.wordpress.com/rest/v1/template/demo/${ mockDesign.theme }/${ mockDesign.template }?font_headings=${ mockDesign.fonts.headings }&font_base=${ mockDesign.fonts.base }&site_title=${ mockDesign.title }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true`
 			);
 		} );
+
+		it( 'should compose the correct design API URL when a design has no fonts specified', () => {
+			const mockDesignWithoutFonts = availableDesignsConfig.featured[ 1 ];
+
+			expect( getDesignUrl( mockDesignWithoutFonts, mockLocale ) ).toEqual(
+				`https://public-api.wordpress.com/rest/v1/template/demo/${ mockDesignWithoutFonts.theme }/${ mockDesignWithoutFonts.template }?site_title=${ mockDesignWithoutFonts.title }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true`
+			);
+		} );
 	} );
 
 	describe( 'getDesignImageUrl', () => {
@@ -109,26 +133,27 @@ describe( 'Design Picker design utils', () => {
 	} );
 
 	describe( 'getAvailableDesigns', () => {
-		it( 'should get FSE and alpha designs', () => {
-			const mockDesignFSE = availableDesignsConfig.featured[ 2 ];
+		it( 'should get only FSE designs (both alpha and non alpha)', () => {
+			const mockDesignFSE = availableDesignsConfig.featured[ 3 ];
 			expect( getAvailableDesigns( { includeAlphaDesigns: true, useFseDesigns: true } ) ).toEqual( {
 				featured: [ mockDesignFSE ],
 			} );
 		} );
 
-		it( 'should get alpha designs and exclude FSE designs', () => {
+		it( 'should include alpha designs and exclude FSE designs', () => {
 			const mockDesign = availableDesignsConfig.featured[ 0 ];
-			const mockDesignPremium = availableDesignsConfig.featured[ 1 ];
-			const mockDesignAlpha = availableDesignsConfig.featured[ 3 ];
+			const mockDesignWithoutFonts = availableDesignsConfig.featured[ 1 ];
+			const mockDesignPremium = availableDesignsConfig.featured[ 2 ];
+			const mockDesignAlpha = availableDesignsConfig.featured[ 4 ];
 			expect( getAvailableDesigns( { includeAlphaDesigns: true, useFseDesigns: false } ) ).toEqual(
 				{
-					featured: [ mockDesign, mockDesignPremium, mockDesignAlpha ],
+					featured: [ mockDesign, mockDesignWithoutFonts, mockDesignPremium, mockDesignAlpha ],
 				}
 			);
 		} );
 
 		it( 'should get only FSE, non-alpha designs', () => {
-			const mockDesignFSE = availableDesignsConfig.featured[ 2 ];
+			const mockDesignFSE = availableDesignsConfig.featured[ 3 ];
 			expect( getAvailableDesigns( { includeAlphaDesigns: false, useFseDesigns: true } ) ).toEqual(
 				{
 					featured: [ mockDesignFSE ],
@@ -138,10 +163,11 @@ describe( 'Design Picker design utils', () => {
 
 		it( 'should get all non-alpha, non-FSE designs', () => {
 			const mockDesign = availableDesignsConfig.featured[ 0 ];
-			const mockDesignPremium = availableDesignsConfig.featured[ 1 ];
+			const mockDesignWithoutFonts = availableDesignsConfig.featured[ 1 ];
+			const mockDesignPremium = availableDesignsConfig.featured[ 2 ];
 			expect( getAvailableDesigns( { includeAlphaDesigns: false, useFseDesigns: false } ) ).toEqual(
 				{
-					featured: [ mockDesign, mockDesignPremium ],
+					featured: [ mockDesign, mockDesignWithoutFonts, mockDesignPremium ],
 				}
 			);
 		} );

--- a/packages/design-picker/src/utils/__tests__/available-designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/available-designs.test.ts
@@ -18,6 +18,7 @@ jest.mock( '@automattic/calypso-config', () => ( {
 	isEnabled: () => false,
 } ) );
 
+// TODO: add a mock / test for when fonts are undefined
 jest.mock( '../available-designs-config', () => {
 	const mockDesign: Design = {
 		title: 'Mock',

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -31,8 +31,8 @@ export const getDesignUrl = ( design: Design, locale: string ): string => {
 	return addQueryArgs(
 		`https://public-api.wordpress.com/rest/v1/template/demo/${ theme }/${ template }`,
 		{
-			font_headings: design.fonts.headings,
-			font_base: design.fonts.base,
+			font_headings: design.fonts?.headings,
+			font_base: design.fonts?.base,
 			site_title: design.title,
 			viewport_height: 700,
 			language: locale,


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Allow design configurations defined in the `@automattic/design-picker` package to avoid specifying the `fonts` option
* Adjust site creation functions to avoid font-related options when a selected design doesn't specify fonts, therefore falling back to the theme's default
* Add logic to Gutenboarding so that, when a _fontless_ design is selected, the `style` step gets skipped

### Testing instructions

#### Step logic

- Go to `/new`
- On `/new/design`, select Blank Canvas design
  - You should land on the next step after Style step (can be either Domains if you skipped site title or Features if you entered site title)
  - Navigation (back and next) should work as expected after that.
  - By manually navigating to `/new/style` you should be redirected to:
    - `/new/features` if you entered a site title at the beginning of the flow
    - `/new/domains` if you skipped site title step
- After selecting Blank Canvas design, go back to Designs step and select a design other than Blank Canvas
  - Style step should be displayed 
  - The navigation (back/next) should continue to work
- As a bit of regression testing, go to `/new?fresh` 
  - Go to `/new/style` => you should be redirected to `/new`
  - Select a design other than Blank Canvas and then go back. Manually navigating to `/new/style` should work
  - Go to `/new/create-site` => you should be redirected to `/new/plans`

#### Site creation

- Go to `/new` and create a new site selecting the Blank Canvas design and the free plan
    - [ ] Make sure that the site is created without any errors
    - [ ] Make sure that the site is using the Blank Canvas theme
    - [ ] Make sure the site is using the Theme Fonts (this can be verified in the block editor, by clicking the "A" icon in the top right and checking the fonts settings under the global styles) 
- Go to `/start/with-design-picker/` and create a new site selecting the Blank Canvas design and the free plan
    - [ ] Make sure that the site is created without any errors
    - [ ] Make sure that the site is using the Blank Canvas theme
    - [ ] Make sure the site is using the Theme Fonts (this can be verified in the block editor, by clicking the "A" icon in the top right and checking the fonts settings under the global styles) 

See p1618932653252500-slack-C0KDTA48Y for a brief history

Closes #52107
Closes #51979