### PR TITLE
Account settings: autosave interface settings on change

### DIFF
--- a/client/blocks/color-scheme-picker/index.jsx
+++ b/client/blocks/color-scheme-picker/index.jsx
@@ -26,6 +26,7 @@ class ColorSchemePicker extends PureComponent {
 		defaultSelection: PropTypes.string,
 		temporarySelection: PropTypes.bool,
 		onSelection: PropTypes.func,
+		disabled: PropTypes.bool,
 		// Connected props
 		colorSchemePreference: PropTypes.string,
 		saveColorSchemePreference: PropTypes.func,
@@ -57,6 +58,7 @@ class ColorSchemePicker extends PureComponent {
 					checked={ checkedColorScheme }
 					onChange={ this.handleColorSchemeSelection }
 					items={ colorSchemesData }
+					disabled={ this.props.disabled }
 				/>
 			</div>
 		);

--- a/client/components/forms/form-radio-with-thumbnail/index.jsx
+++ b/client/components/forms/form-radio-with-thumbnail/index.jsx
@@ -17,7 +17,7 @@ import TranslatableString from 'calypso/components/translatable/proptype';
  */
 import './style.scss';
 
-const FormRadioWithThumbnail = ( { label, thumbnail, ...otherProps } ) => {
+const FormRadioWithThumbnail = ( { label, thumbnail, disabled, ...otherProps } ) => {
 	const { cssClass, cssColor, imageUrl } = thumbnail;
 
 	return (
@@ -25,11 +25,11 @@ const FormRadioWithThumbnail = ( { label, thumbnail, ...otherProps } ) => {
 			<FormLabel>
 				<div
 					className={ classnames( 'form-radio-with-thumbnail__thumbnail', cssClass ) }
-					style={ { backgroundColor: cssColor } }
+					style={ { backgroundColor: cssColor, opacity: disabled ? 0.5 : 1 } }
 				>
 					{ imageUrl && <img src={ imageUrl } alt={ label } /> }
 				</div>
-				<FormRadio label={ label } { ...otherProps } />
+				<FormRadio label={ label } disabled={ disabled } { ...otherProps } />
 			</FormLabel>
 		</div>
 	);

--- a/client/components/forms/form-radios-bar/index.jsx
+++ b/client/components/forms/form-radios-bar/index.jsx
@@ -17,7 +17,7 @@ import FormRadioWithThumbnail from 'calypso/components/forms/form-radio-with-thu
  */
 import './style.scss';
 
-const FormRadiosBar = ( { isThumbnail, checked, onChange, items } ) => {
+const FormRadiosBar = ( { isThumbnail, checked, onChange, items, disabled } ) => {
 	return (
 		<div className={ classnames( 'form-radios-bar', { 'is-thumbnail': isThumbnail } ) }>
 			{ items.map( ( item, i ) =>
@@ -26,11 +26,17 @@ const FormRadiosBar = ( { isThumbnail, checked, onChange, items } ) => {
 						key={ item.value + i }
 						checked={ checked === item.value }
 						onChange={ onChange }
+						disabled={ disabled }
 						{ ...item }
 					/>
 				) : (
 					<FormLabel key={ item.value + i }>
-						<FormRadio checked={ checked === item.value } onChange={ onChange } { ...item } />
+						<FormRadio
+							checked={ checked === item.value }
+							disabled={ disabled }
+							onChange={ onChange }
+							{ ...item }
+						/>
 					</FormLabel>
 				)
 			) }

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -206,17 +206,17 @@ class Account extends React.Component {
 		const originalLanguage = this.getUserOriginalSetting( 'language' );
 		const originalVariant = this.getUserOriginalSetting( 'locale_variant' );
 		const newLanguage = getLanguage( value );
+		const newLanguageIsBase = ! newLanguage.parentLangSlug;
+		const newLanguageIsVariant = newLanguage.parentLangSlug !== null;
 		const languageHasChanged =
-			// Same language, different variants
-			( newLanguage.parentLangSlug &&
-				newLanguage.parentLangSlug === originalLanguage &&
-				newLanguage.langSlug !== originalVariant ) ||
-			// Different language
-			( ! newLanguage.parentLangSlug && newLanguage.langSlug !== originalLanguage ) ||
-			// Empathy mode value has changed
+			( newLanguageIsBase &&
+				( newLanguage.langSlug !== originalLanguage ||
+					( newLanguage.langSlug === originalLanguage && originalVariant ) ) ) ||
+			( newLanguageIsVariant &&
+				( newLanguage.parentLangSlug !== originalLanguage ||
+					newLanguage.langSlug !== originalVariant ) ) ||
 			( typeof empathyMode !== 'undefined' &&
 				empathyMode !== this.getUserOriginalSetting( 'i18n_empathy_mode' ) );
-
 		if ( languageHasChanged ) {
 			this.props.markChanged();
 		}

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -184,6 +184,7 @@ class Account extends React.Component {
 		this.updateUserSetting( name, checked );
 		const redirect = '/me/account';
 		this.setState( { redirect } );
+		this.saveInterfaceSettings( event );
 	};
 
 	updateLanguage = ( event ) => {
@@ -207,10 +208,7 @@ class Account extends React.Component {
 			this.getUserSetting( 'locale_variant' ) || this.getUserSetting( 'language' ) || '';
 
 		const languageHasChanged = originalSlug !== value;
-		const empathyModeHasChanged =
-			typeof empathyMode !== 'undefined' &&
-			empathyMode !== this.getUserOriginalSetting( 'i18n_empathy_mode' );
-		const formHasChanged = languageHasChanged || empathyModeHasChanged;
+		const formHasChanged = languageHasChanged;
 		if ( formHasChanged ) {
 			this.props.markChanged();
 		}

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -201,9 +201,19 @@ class Account extends React.Component {
 			);
 		}
 
+		const localeVariantSelected = isLocaleVariant( value ) ? value : '';
+
+		const originalLanguage = this.getUserOriginalSetting( 'language' );
+		const originalVariant = this.getUserOriginalSetting( 'locale_variant' );
+		const newLanguage = getLanguage( value );
 		const languageHasChanged =
-			value !== this.getUserOriginalSetting( 'language' ) ||
-			value !== this.getUserOriginalSetting( 'locale_variant' ) ||
+			// Same language, different variants
+			( newLanguage.parentLangSlug &&
+				newLanguage.parentLangSlug === originalLanguage &&
+				newLanguage.langSlug !== originalVariant ) ||
+			// Different language
+			( ! newLanguage.parentLangSlug && newLanguage.langSlug !== originalLanguage ) ||
+			// Empathy mode value has changed
 			( typeof empathyMode !== 'undefined' &&
 				empathyMode !== this.getUserOriginalSetting( 'i18n_empathy_mode' ) );
 
@@ -213,8 +223,8 @@ class Account extends React.Component {
 
 		const redirect = languageHasChanged ? '/me/account' : false;
 		// store any selected locale variant so we can test it against those with no GP translation sets
-		const localeVariantSelected = isLocaleVariant( value ) ? value : '';
 		this.setState( { redirect, localeVariantSelected } );
+
 		if ( languageHasChanged ) {
 			this.props.recordTracksEvent( 'calypso_user_language_switch', {
 				new_language: value,

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -203,29 +203,23 @@ class Account extends React.Component {
 
 		const localeVariantSelected = isLocaleVariant( value ) ? value : '';
 
-		const originalLanguage = this.getUserOriginalSetting( 'language' );
-		const originalVariant = this.getUserOriginalSetting( 'locale_variant' );
-		const newLanguage = getLanguage( value );
-		const newLanguageIsBase = ! newLanguage.parentLangSlug;
-		const newLanguageIsVariant = newLanguage.parentLangSlug !== null;
-		const languageHasChanged =
-			( newLanguageIsBase &&
-				( newLanguage.langSlug !== originalLanguage ||
-					( newLanguage.langSlug === originalLanguage && originalVariant ) ) ) ||
-			( newLanguageIsVariant &&
-				( newLanguage.parentLangSlug !== originalLanguage ||
-					newLanguage.langSlug !== originalVariant ) ) ||
-			( typeof empathyMode !== 'undefined' &&
-				empathyMode !== this.getUserOriginalSetting( 'i18n_empathy_mode' ) );
-		if ( languageHasChanged ) {
+		const originalSlug =
+			this.getUserSetting( 'locale_variant' ) || this.getUserSetting( 'language' ) || '';
+
+		const languageHasChanged = originalSlug !== value;
+		const empathyModeHasChanged =
+			typeof empathyMode !== 'undefined' &&
+			empathyMode !== this.getUserOriginalSetting( 'i18n_empathy_mode' );
+		const formHasChanged = languageHasChanged || empathyModeHasChanged;
+		if ( formHasChanged ) {
 			this.props.markChanged();
 		}
 
-		const redirect = languageHasChanged ? '/me/account' : false;
+		const redirect = formHasChanged ? '/me/account' : false;
 		// store any selected locale variant so we can test it against those with no GP translation sets
 		this.setState( { redirect, localeVariantSelected } );
 
-		if ( languageHasChanged ) {
+		if ( formHasChanged ) {
 			this.props.recordTracksEvent( 'calypso_user_language_switch', {
 				new_language: value,
 				previous_language:

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -1071,6 +1071,7 @@ class Account extends React.Component {
 								<FormToggle
 									checked={ !! this.getUserSetting( linkDestinationKey ) }
 									onChange={ this.toggleLinkDestination }
+									disabled={ this.getDisabledState( INTERFACE_FORM_NAME ) }
 								>
 									{ translate(
 										'{{spanlead}}Show advanced dashboard pages.{{/spanlead}} {{spanextra}}Enabling this will replace your dashboard pages with more advanced wp-admin equivalents when possible.{{/spanextra}}',
@@ -1099,6 +1100,7 @@ class Account extends React.Component {
 									</FormLabel>
 									<ColorSchemePicker
 										temporarySelection
+										disabled={ this.getDisabledState( INTERFACE_FORM_NAME ) }
 										defaultSelection={
 											this.props.isNavUnificationEnabled ? 'classic-dark' : 'classic-bright'
 										}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR addresses concerns that the need to click a "Save" button in the "Interface Settings" section of `/me/account` is unintuitive compared to other autosaving controls in other parts of Calypso.
* All three controls in "Interface Settings" -- Interface Language, Dashboard Appearance, and Dashboard Color Scheme -- now autosave on change, and the save button has been removed as it is no longer necessary.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR and navigate to http://calypso.localhost:3000/me/account
* Verify that you can change your interface language and have it autosave and automatically refresh to display with the updated language.
* Verify that you can toggle "Show advanced dashboard pages" on and off and have it autosave immediately.
* Verify that you can change your dashboard color scheme and have it autosave immediately.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #51464
