### PR TITLE
Display email forward details in new email pages

### DIFF
--- a/client/lib/emails/email-provider-constants.js
+++ b/client/lib/emails/email-provider-constants.js
@@ -1,1 +1,2 @@
+export const EMAIL_TYPE_FORWARD = 'email_forward';
 export const EMAIL_USER_ROLE_ADMIN = 'admin';

--- a/client/lib/emails/get-email-forward-address.js
+++ b/client/lib/emails/get-email-forward-address.js
@@ -1,0 +1,3 @@
+export function getEmailForwardAddress( emailUser ) {
+	return emailUser?.target;
+}

--- a/client/lib/emails/index.js
+++ b/client/lib/emails/index.js
@@ -1,1 +1,4 @@
+export { getEmailForwardAddress } from './get-email-forward-address';
+export { isEmailForward } from './is-email-forward';
+export { isEmailForwardVerified } from './is-email-forward-verified';
 export { isEmailUserAdmin } from './is-email-user-admin';

--- a/client/lib/emails/is-email-forward-verified.js
+++ b/client/lib/emails/is-email-forward-verified.js
@@ -1,0 +1,3 @@
+export function isEmailForwardVerified( emailUser ) {
+	return !! emailUser?.is_verified;
+}

--- a/client/lib/emails/is-email-forward.js
+++ b/client/lib/emails/is-email-forward.js
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { EMAIL_TYPE_FORWARD } from './email-provider-constants';
+
+export function isEmailForward( emailUser ) {
+	return EMAIL_TYPE_FORWARD === emailUser.email_type;
+}

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -13,7 +13,13 @@ import { useTranslate } from 'i18n-calypso';
 import MaterialIcon from 'calypso/components/material-icon';
 import SectionHeader from 'calypso/components/section-header';
 import Badge from 'calypso/components/badge';
-import { isEmailUserAdmin } from 'calypso/lib/emails';
+import {
+	getEmailForwardAddress,
+	isEmailForward,
+	isEmailForwardVerified,
+	isEmailUserAdmin,
+} from 'calypso/lib/emails';
+import Gridicon from 'calypso/components/gridicon';
 
 const MailboxListHeader = ( { children } ) => {
 	const translate = useTranslate();
@@ -36,6 +42,15 @@ const MailboxListItem = ( { children, isPlaceholder, hasNoEmails } ) => {
 
 function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
 	const translate = useTranslate();
+
+	const MailboxListItemWarning = ( { warningText } ) => {
+		return (
+			<div className="email-plan-mailboxes-list__mailbox-list-item-warning">
+				<Gridicon icon="info-outline" size={ 18 } />
+				<span>{ warningText }</span>
+			</div>
+		);
+	};
 
 	if ( isLoadingEmails ) {
 		return (
@@ -71,6 +86,15 @@ function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
 							comment: 'Email user role displayed as a badge',
 						} ) }
 					</Badge>
+				) }
+				{ isEmailForward( email ) && (
+					<>
+						<Gridicon icon="chevron-right" />
+						<span> { getEmailForwardAddress( email ) } </span>
+						{ ! isEmailForwardVerified( email ) && (
+							<MailboxListItemWarning warningText={ translate( 'Verification required' ) } />
+						) }
+					</>
 				) }
 			</MailboxListItem>
 		);

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -48,7 +48,10 @@ const MailboxListItem = ( { children, isError = false, isPlaceholder, hasNoEmail
 };
 
 const MailboxListItemSecondaryDetails = ( { children, className } ) => {
-	const fullClassName = classNames( 'email-plan-mailboxes-list__mailbox-secondary', className );
+	const fullClassName = classNames(
+		'email-plan-mailboxes-list__mailbox-secondary-details',
+		className
+	);
 	return <div className={ fullClassName }>{ children }</div>;
 };
 

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -62,7 +62,7 @@ const getWarningForMailbox = ( mailbox, translate ) => {
 	return null;
 };
 
-function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
+function EmailPlanMailboxesList( { mailboxes, isLoadingEmails } ) {
 	const translate = useTranslate();
 
 	if ( isLoadingEmails ) {
@@ -76,7 +76,7 @@ function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
 		);
 	}
 
-	if ( ! emails || emails.length < 1 ) {
+	if ( ! mailboxes || mailboxes.length < 1 ) {
 		return (
 			<MailboxListHeader>
 				<MailboxListItem hasNoEmails>
@@ -86,8 +86,8 @@ function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
 		);
 	}
 
-	const emailsItems = emails.map( ( email ) => {
-		const warningForMailbox = getWarningForMailbox( email, translate );
+	const mailboxItems = mailboxes.map( ( mailbox ) => {
+		const warningForMailbox = getWarningForMailbox( mailbox, translate );
 
 		return (
 			<MailboxListItem key={ email.mailbox }>
@@ -95,17 +95,17 @@ function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
 					<div>
 						<MaterialIcon icon="email" />
 						<span>
-							{ email.mailbox }@{ email.domain }
+							{ mailbox.mailbox }@{ mailbox.domain }
 						</span>
 					</div>
-					{ isEmailForward( email ) && (
+					{ isEmailForward( mailbox ) && (
 						<MailboxListItemSecondaryDetails className="email-plan-mailboxes-list__mailbox-list-forward">
 							<Gridicon icon="chevron-right" />
-							<span> { getEmailForwardAddress( email ) } </span>
+							<span> { getEmailForwardAddress( mailbox ) } </span>
 						</MailboxListItemSecondaryDetails>
 					) }
 				</div>
-				{ isEmailUserAdmin( email ) && (
+				{ isEmailUserAdmin( mailbox ) && (
 					<Badge type="info">
 						{ translate( 'Admin', {
 							comment: 'Email user role displayed as a badge',
@@ -117,7 +117,7 @@ function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
 		);
 	} );
 
-	return <MailboxListHeader>{ emailsItems }</MailboxListHeader>;
+	return <MailboxListHeader>{ mailboxItems }</MailboxListHeader>;
 }
 
 EmailPlanMailboxesList.propTypes = {

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -81,7 +81,7 @@ const getActionsForMailbox = ( mailbox, translate, dispatch ) => {
 		return {
 			action: (
 				<Button compact onClick={ () => resendEmailForwardVerification( mailbox, dispatch ) }>
-					{ translate( 'Resend verification' ) }
+					{ translate( 'Resend verification email' ) }
 				</Button>
 			),
 			warning: <MailboxListItemWarning warningText={ translate( 'Verification required' ) } />,
@@ -123,7 +123,7 @@ function EmailPlanMailboxesList( { mailboxes, isLoadingEmails } ) {
 		const { action, warning } = getActionsForMailbox( mailbox, translate, dispatch );
 
 		return (
-			<MailboxListItem key={ email.mailbox } isError={ !! warning }>
+			<MailboxListItem key={ mailbox.mailbox } isError={ !! warning }>
 				<div className="email-plan-mailboxes-list__mailbox-list-item-main">
 					<div>
 						<MaterialIcon icon="email" />

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -40,17 +40,17 @@ const MailboxListItem = ( { children, isPlaceholder, hasNoEmails } ) => {
 	return <CompactCard className={ className }>{ children }</CompactCard>;
 };
 
+const MailboxListItemWarning = ( { warningText } ) => {
+	return (
+		<div className="email-plan-mailboxes-list__mailbox-list-item-warning">
+			<Gridicon icon="info-outline" size={ 18 } />
+			<span>{ warningText }</span>
+		</div>
+	);
+};
+
 function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
 	const translate = useTranslate();
-
-	const MailboxListItemWarning = ( { warningText } ) => {
-		return (
-			<div className="email-plan-mailboxes-list__mailbox-list-item-warning">
-				<Gridicon icon="info-outline" size={ 18 } />
-				<span>{ warningText }</span>
-			</div>
-		);
-	};
 
 	if ( isLoadingEmails ) {
 		return (

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -40,6 +40,11 @@ const MailboxListItem = ( { children, isPlaceholder, hasNoEmails } ) => {
 	return <CompactCard className={ className }>{ children }</CompactCard>;
 };
 
+const MailboxListItemSecondaryDetails = ( { children, className } ) => {
+	const fullClassName = classNames( 'email-plan-mailboxes-list__mailbox-secondary', className );
+	return <div className={ fullClassName }>{ children }</div>;
+};
+
 const MailboxListItemWarning = ( { warningText } ) => {
 	return (
 		<div className="email-plan-mailboxes-list__mailbox-list-item-warning">
@@ -47,6 +52,14 @@ const MailboxListItemWarning = ( { warningText } ) => {
 			<span>{ warningText }</span>
 		</div>
 	);
+};
+
+const getWarningForMailbox = ( mailbox, translate ) => {
+	if ( isEmailForward( mailbox ) && ! isEmailForwardVerified( mailbox ) ) {
+		return <MailboxListItemWarning warningText={ translate( 'Verification required' ) } />;
+	}
+
+	return null;
 };
 
 function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
@@ -87,14 +100,12 @@ function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
 						} ) }
 					</Badge>
 				) }
+				{ getWarningForMailbox( email, translate ) }
 				{ isEmailForward( email ) && (
-					<>
+					<MailboxListItemSecondaryDetails className="email-plan-mailboxes-list__mailbox-list-forward">
 						<Gridicon icon="chevron-right" />
 						<span> { getEmailForwardAddress( email ) } </span>
-						{ ! isEmailForwardVerified( email ) && (
-							<MailboxListItemWarning warningText={ translate( 'Verification required' ) } />
-						) }
-					</>
+					</MailboxListItemSecondaryDetails>
 				) }
 			</MailboxListItem>
 		);

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -87,12 +87,24 @@ function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
 	}
 
 	const emailsItems = emails.map( ( email ) => {
+		const warningForMailbox = getWarningForMailbox( email, translate );
+
 		return (
 			<MailboxListItem key={ email.mailbox }>
-				<MaterialIcon icon="email" />
-				<span>
-					{ email.mailbox }@{ email.domain }
-				</span>
+				<div class="email-plan-mailboxes-list__mailbox-list-item-main">
+					<div>
+						<MaterialIcon icon="email" />
+						<span>
+							{ email.mailbox }@{ email.domain }
+						</span>
+					</div>
+					{ isEmailForward( email ) && (
+						<MailboxListItemSecondaryDetails className="email-plan-mailboxes-list__mailbox-list-forward">
+							<Gridicon icon="chevron-right" />
+							<span> { getEmailForwardAddress( email ) } </span>
+						</MailboxListItemSecondaryDetails>
+					) }
+				</div>
 				{ isEmailUserAdmin( email ) && (
 					<Badge type="info">
 						{ translate( 'Admin', {
@@ -100,13 +112,7 @@ function EmailPlanMailboxesList( { emails, isLoadingEmails } ) {
 						} ) }
 					</Badge>
 				) }
-				{ getWarningForMailbox( email, translate ) }
-				{ isEmailForward( email ) && (
-					<MailboxListItemSecondaryDetails className="email-plan-mailboxes-list__mailbox-list-forward">
-						<Gridicon icon="chevron-right" />
-						<span> { getEmailForwardAddress( email ) } </span>
-					</MailboxListItemSecondaryDetails>
-				) }
+				{ warningForMailbox }
 			</MailboxListItem>
 		);
 	} );

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -76,6 +76,18 @@ const resendEmailForwardVerification = ( mailbox, dispatch ) => {
 	dispatch( resendVerificationEmail( mailbox.domain, mailbox.mailbox, destination ) );
 };
 
+const getSecondaryContentForMailbox = ( mailbox ) => {
+	if ( isEmailForward( mailbox ) ) {
+		return (
+			<MailboxListItemSecondaryDetails className="email-plan-mailboxes-list__mailbox-list-forward">
+				<Gridicon icon="chevron-right" />
+				<span>{ getEmailForwardAddress( mailbox ) }</span>
+			</MailboxListItemSecondaryDetails>
+		);
+	}
+	return null;
+};
+
 const getActionsForMailbox = ( mailbox, translate, dispatch ) => {
 	if ( isEmailForward( mailbox ) && ! isEmailForwardVerified( mailbox ) ) {
 		return {
@@ -131,12 +143,7 @@ function EmailPlanMailboxesList( { mailboxes, isLoadingEmails } ) {
 							{ mailbox.mailbox }@{ mailbox.domain }
 						</span>
 					</div>
-					{ isEmailForward( mailbox ) && (
-						<MailboxListItemSecondaryDetails className="email-plan-mailboxes-list__mailbox-list-forward">
-							<Gridicon icon="chevron-right" />
-							<span> { getEmailForwardAddress( mailbox ) } </span>
-						</MailboxListItemSecondaryDetails>
-					) }
+					{ getSecondaryContentForMailbox( mailbox ) }
 				</div>
 				{ isEmailUserAdmin( mailbox ) && (
 					<Badge type="info">

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -108,7 +108,7 @@ class EmailPlan extends React.Component {
 			);
 	}
 
-	getEmails() {
+	getMailboxes() {
 		if ( this.state.emailAccounts[ 0 ] ) {
 			return this.state.emailAccounts[ 0 ].emails;
 		}
@@ -285,7 +285,7 @@ class EmailPlan extends React.Component {
 				) }
 
 				<EmailPlanMailboxesList
-					emails={ this.getEmails() }
+					mailboxes={ this.getMailboxes() }
 					isLoadingEmails={ isLoadingEmailAccounts }
 				/>
 

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -157,15 +157,14 @@
 		color: var( --color-text-subtle );
 		font-style: italic;
 	}
-	.email-plan-mailboxes-list__mailbox-list-item-main {
-		span {
-			vertical-align: middle;
-		}
-		svg {
-			fill: var( --studio-gray-40 );
-			margin-right: 10px;
-			vertical-align: middle;
-		}
+	> svg,
+	.email-plan-mailboxes-list__mailbox-list-item-main svg {
+		fill: var( --studio-gray-40 );
+		margin-right: 10px;
+		vertical-align: middle;
+	}
+	.email-plan-mailboxes-list__mailbox-list-item-main span {
+		vertical-align: middle;
 	}
 	> .badge {
 		margin-left: 10px;

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -141,8 +141,15 @@
 
 .email-plan-mailboxes-list__mailbox-list-item {
 	display: flex;
-	align-items: center;
-	&.is-placeholder > span {
+	.email-plan-mailboxes-list__mailbox-list-item-main {
+		display: flex;
+		flex-direction: column;
+		> div:not( :first-child ) {
+			margin-top: 0.5em;
+		}
+	}
+	&.is-placeholder > span,
+	&.is-placeholder .email-plan-mailboxes-list__mailbox-list-item-main {
 		@include placeholder( --color-neutral-5 );
 		width: 50%;
 	}
@@ -150,13 +157,14 @@
 		color: var( --color-text-subtle );
 		font-style: italic;
 	}
-	> svg {
-		fill: var( --studio-gray-50 );
-		margin-left: 8px;
-		margin-right: 8px;
-		&:first-child {
-			margin-left: 0;
+	.email-plan-mailboxes-list__mailbox-list-item-main {
+		span {
+			vertical-align: middle;
+		}
+		svg {
+			fill: var( --studio-gray-40 );
 			margin-right: 10px;
+			vertical-align: middle;
 		}
 	}
 	> .badge {

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -152,10 +152,28 @@
 	}
 	> svg {
 		fill: var( --studio-gray-50 );
-		margin-right: 10px;
+		margin-left: 8px;
+		margin-right: 8px;
+		&:first-child {
+			margin-left: 0;
+			margin-right: 10px;
+		}
 	}
 	> .badge {
 		margin-left: 10px;
+	}
+	.email-plan-mailboxes-list__mailbox-list-item-warning {
+		color: var( --color-error );
+		font-size: $font-body-small;
+		line-height: 24px;
+		margin-left: 16px;
+		> svg {
+			margin-right: 6px;
+			vertical-align: middle;
+		}
+		> span {
+			vertical-align: middle;
+		}
 	}
 }
 

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -183,6 +183,11 @@
 			vertical-align: middle;
 		}
 	}
+
+	.button {
+		margin-left: auto;
+		max-height: 2rem;
+	}
 }
 
 .email-plan-subscription__card {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds in additional details for email forwards as per the most recent design iteration in pcDL0W-al-p2

#### Testing instructions

* Navigate to a local dev branch or the Calypso live branch.
* Identify a site where you have a domain with email forwards configured.
* Add `email/:siteSlug?flags=email/centralized-home` to the URL.
* You should see the new email home page listing the domains for your site.
* Click on the row for your domain with forwards configured.
* Verify that we now display the target email address on a separate line for each forward,
* Ensure that you have at least one unverified receiving address.
  - To do this, click on "Add a new mailbox" to create a new email forward with a previously unused destination address that you can access.
  - After creating the forward, verify that you get a confirmation email to this address, but don't take any action on the email.
* For this email forward that hasn't been fully verified, confirm that you see all of the following:
   - A "Verification required" warning
   - A red highlight to the left of the card
   - A "Resend verification email" button is visible on the right of the row
* Click on the "Resend verification email" button, and verify that the resend succeeds, both via feedback in the UI and by confirming that you get the email, Also confirm that we log a Tracks event for the click.

#### Screenshot

<img width="1114" alt="Screenshot 2021-04-29 at 23 40 00" src="https://user-images.githubusercontent.com/3376401/116621980-41b23380-a944-11eb-9dcb-17aff68e42ef.png">

