### PR TITLE
ABTest: Reverse featured Jetpack product ordering for some users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -59,4 +59,16 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: false,
 	},
+	// Change the ordering of featured Jetpack products:
+	// least to most expensive (control) vs most to least expensive (test)
+	jetpackReverseFeaturedProducts: {
+		datestamp: '20210422',
+		variations: {
+			highToLow_test: 50,
+			lowToHigh_control: 50,
+		},
+		localeTargets: 'any',
+		defaultVariation: 'lowToHigh_control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/plans/jetpack-plans/iterations.ts
+++ b/client/my-sites/plans/jetpack-plans/iterations.ts
@@ -13,7 +13,7 @@ import { abtest } from 'calypso/lib/abtest';
  */
 
 export enum Iterations {
-	REVERSE_FEATURED = 'jetpackReverseFeaturedProducts',
+	REVERSE_FEATURED = 'highToLow_test',
 }
 
 const iterationNames: string[] = Object.values( Iterations );
@@ -43,9 +43,15 @@ const getCurrentCROIterationName = (): Iterations | null => {
 		if ( iterationQuery && iterationNames.includes( iterationQuery ) ) {
 			return iterationQuery as Iterations;
 		}
+
+		// Allow for people to explicitly look at the control/default variation
+		if ( iterationQuery === 'default' ) {
+			return null;
+		}
 	}
 
-	const shouldReverseFeaturedProducts = abtest( Iterations.REVERSE_FEATURED ) === 'highToLow_test';
+	const shouldReverseFeaturedProducts =
+		abtest( 'jetpackReverseFeaturedProducts' ) === Iterations.REVERSE_FEATURED;
 
 	return shouldReverseFeaturedProducts ? Iterations.REVERSE_FEATURED : null;
 };

--- a/client/my-sites/plans/jetpack-plans/iterations.ts
+++ b/client/my-sites/plans/jetpack-plans/iterations.ts
@@ -1,13 +1,20 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
 import { getUrlParts } from '@automattic/calypso-url';
+
+/**
+ * Internal dependencies
+ */
+import { abtest } from 'calypso/lib/abtest';
 
 /**
  * Iterations
  */
 
-export enum Iterations {}
+export enum Iterations {
+	REVERSE_FEATURED = 'jetpackReverseFeaturedProducts',
+}
 
 const iterationNames: string[] = Object.values( Iterations );
 
@@ -38,7 +45,9 @@ const getCurrentCROIterationName = (): Iterations | null => {
 		}
 	}
 
-	return null;
+	const shouldReverseFeaturedProducts = abtest( Iterations.REVERSE_FEATURED ) === 'highToLow_test';
+
+	return shouldReverseFeaturedProducts ? Iterations.REVERSE_FEATURED : null;
 };
 
 type IterationValueFunction< T > = ( key: Iterations | null ) => T | undefined;

--- a/client/my-sites/plans/jetpack-plans/product-grid/products-order.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/products-order.ts
@@ -1,7 +1,8 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
 import {
+	JetpackPlanSlugs,
 	PLAN_JETPACK_SECURITY_DAILY,
 	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 	PLAN_JETPACK_SECURITY_REALTIME,
@@ -18,10 +19,14 @@ import {
 } from '@automattic/calypso-products';
 
 /**
+ * Internal dependencies
+ */
+import { getForCurrentCROIteration, Iterations } from '../iterations';
+
+/**
  * Type dependencies
  */
 import type { JetpackProductSlug } from 'calypso/lib/products-values/types';
-import type { JetpackPlanSlugs } from '@automattic/calypso-products';
 
 const setProductsInPosition = ( slugs: string[], position: number ) =>
 	slugs.reduce( ( map, slug ) => ( { ...map, [ slug ]: position } ), {} );
@@ -42,5 +47,27 @@ const PRODUCT_POSITION_IN_GRID: Record< string, number > = {
 	...setProductsInPosition( JETPACK_CRM_FREE_PRODUCTS, 80 ),
 };
 
-export const getProductPosition = ( slug: JetpackPlanSlugs | JetpackProductSlug ): number =>
-	PRODUCT_POSITION_IN_GRID[ slug ] ?? 100;
+const REVERSE_FEATURED_PRODUCTS_POSITION_IN_GRID: Record< string, number > = {
+	...setProductsInPosition( JETPACK_COMPLETE_PLANS, 1 ),
+	[ PLAN_JETPACK_SECURITY_DAILY ]: 10,
+	[ PLAN_JETPACK_SECURITY_DAILY_MONTHLY ]: 10,
+	[ PRODUCT_JETPACK_BACKUP_DAILY ]: 20,
+	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: 20,
+	[ PLAN_JETPACK_SECURITY_REALTIME ]: 30,
+	[ PLAN_JETPACK_SECURITY_REALTIME_MONTHLY ]: 30,
+	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: 40,
+	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: 40,
+	...setProductsInPosition( JETPACK_SCAN_PRODUCTS, 50 ),
+	...setProductsInPosition( JETPACK_ANTI_SPAM_PRODUCTS, 60 ),
+	...setProductsInPosition( JETPACK_SEARCH_PRODUCTS, 70 ),
+	...setProductsInPosition( JETPACK_CRM_FREE_PRODUCTS, 80 ),
+};
+
+export const getProductPosition = ( slug: JetpackPlanSlugs | JetpackProductSlug ): number => {
+	const positions =
+		getForCurrentCROIteration( {
+			[ Iterations.REVERSE_FEATURED ]: REVERSE_FEATURED_PRODUCTS_POSITION_IN_GRID,
+		} ) ?? PRODUCT_POSITION_IN_GRID;
+
+	return positions[ slug ] ?? 100;
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Relates to `1196108640073826-as-1199946500089749`.

* Create a new test, `jetpackReverseFeaturedProducts`, in which the test variation sees the order of the Featured products on Jetpack pricing pages reversed (i.e., Complete / Security Daily / Backup, from left to right).
* Update/re-categorize some imports as external dependencies instead of internal dependencies, to reflect that they're now coming from the `@automattic` package namespace.

#### Testing instructions

* Open Calypso Blue.
* In the A/B test helper in the lower-right corner, verify that the `jetpackReverseFeaturedProducts` test is visible.

##### Control variation

* Assign yourself to the `lowToHigh_control` variation.
* Visit the **Upgrades > Plans** page for a self-hosted Jetpack site.
* Verify that the featured products (top row) in the grid are ordered as follows: Backup, Security Daily, Complete.
* Verify that toggling the billing term selector has no effect on the product ordering.
* Repeat the above verification for Calypso Green (`/pricing`) and for Jetpack Connect (`/jetpack/connect/store`).

##### Test variation

* In the Calypso Blue A/B test helper (as explained above), assign yourself to the `highToLow_test` variation.
* Re-visit all the pages from the **Control variation** test steps, verifying that the order of the featured products is now reversed; i.e., Complete, Security Daily, Backup.
* Verify that toggling the billing term selector has no effect on the product ordering.

#### Reference screenshots

##### Control (`lowToHigh_control`) / Variation (`highToLow_test`)

<img height="400" alt="Screen Shot 2021-04-21 at 13 24 38" src="https://user-images.githubusercontent.com/670067/115606539-70c40780-a2a9-11eb-9b89-f37677d2ecb4.png"> <img height="400" alt="Screen Shot 2021-04-21 at 13 24 11" src="https://user-images.githubusercontent.com/670067/115606552-74f02500-a2a9-11eb-8875-85d870ca9b33.png">