### PR TITLE
Checkout: Allow redirecting to same site from thank you page

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -95,7 +95,7 @@ export default function getThankYouPageUrl( {
 			return redirectTo;
 		}
 		if ( ! isExternal( redirectTo ) ) {
-			debug( 'has external redirectTo, so returning that', redirectTo );
+			debug( 'has a redirectTo that is not external, so returning that', redirectTo );
 			return redirectTo;
 		}
 		// We cannot simply compare `hostname` to `siteSlug`, since the latter

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -10,7 +10,7 @@ const debug = debugFactory( 'calypso:composite-checkout:get-thank-you-page-url' 
 /**
  * Internal dependencies
  */
-import {isExternal, resemblesUrl, urlToSlug} from 'calypso/lib/url';
+import { isExternal, resemblesUrl, urlToSlug } from 'calypso/lib/url';
 import config from '@automattic/calypso-config';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -967,4 +967,14 @@ describe( 'getThankYouPageUrl', () => {
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd?d=traffic-guide' );
 	} );
+
+	it( 'redirects to a url on the site we are checking out', () => {
+		const redirectTo = 'https://foo.bar/some-path?with-args=yes';
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			redirectTo,
+			siteSlug: 'foo.bar',
+		} );
+		expect( url ).toBe( redirectTo );
+	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Right now, if the `redirect_to` query arg is added to a checkout url, the user is redirected to the generic thank you page unless the url is an admin url or an url within Calypso.

Since a checkout (cart) is bound to a site it should be safe to redirect back to the same site. This PR adds that possibility.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Add a plan or product to the shopping cart and add `?redirect_to=site` where "site" is the same site as the `/checkout/:site` part of the checkout url. Verify that you are redirected to "site". 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

