### PR TITLE
Account settings: update advanced dashboard toggle text

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -1079,7 +1079,7 @@ class Account extends React.Component {
 									onChange={ this.toggleLinkDestination }
 								>
 									{ translate(
-										'{{spanlead}}Show advanced dashboard pages.{{/spanlead}} {{spanextra}}Enabling this will replace your dashboard pages with more advanced wp-admin equivalents when possible.{{/spanextra}}',
+										'{{spanlead}}Show wp-admin pages if available{{/spanlead}} {{spanextra}}Replace your dashboard pages with more advanced wp-admin equivalents.{{/spanextra}}',
 										{
 											components: {
 												spanlead: <strong className="account__link-destination-label-lead" />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the description text for the toggle on `/me/account` that enables wp-admin pages where available.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR locally.
* Navigate to `/me/account`
* Verify that the text next to the `Dashboard Appearance` toggle has been updated.

Before:
![image](https://user-images.githubusercontent.com/13437011/115613515-18453800-a2b2-11eb-96df-27650445b187.png)

After:
![image](https://user-images.githubusercontent.com/13437011/115613472-0a8fb280-a2b2-11eb-87d4-d725e6264e95.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #50964 
