### PR TITLE
Reader: Enable list management on production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -119,6 +119,7 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": false,
+		"reader/list-management": true,
 		"reader/seen-posts": true,
 		"republicize": true,
 		"rum-tracking/logstash": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Enables Reader list management in production.

See pbAPfg-1wL-p2

#### Testing instructions

Using a user account that hasn't created or subscribed to any lists, ensure that the Lists sidebar menu shows up.

I found it most helpful to manually activate the feature flag and test that way: https://wordpress.com/read?flags=reader/list-management

![image](https://user-images.githubusercontent.com/1398304/115618501-a2d46a00-a2a7-11eb-9719-39c6c3e9563d.png)
