### PR TITLE
Prevent word-wrap inside InlineSupportLink

### DIFF
--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -83,6 +83,21 @@ class InlineSupportLink extends Component {
 		};
 
 		const text = children ? children : translate( 'Learn more' );
+		let content = (
+			<>
+				{ showText && text }
+				{ supportPostId && showIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
+			</>
+		);
+		/* Prevent widows, sometimes:
+			No  Text, No Icon  = Widow not possible
+			Yes Text, No Icon  = Widow possible
+			No  Text, Yes Icon = Widow not possible
+			Yes Text, Yes Icon = Widow possible
+		*/
+		if ( showText ) {
+			content = <span className="inline-support-link__nowrap">{ content }</span>;
+		}
 
 		return (
 			<LinkComponent
@@ -99,10 +114,7 @@ class InlineSupportLink extends Component {
 				{ ...externalLinkProps }
 			>
 				{ shouldLazyLoadAlternates && <QuerySupportArticleAlternates postId={ supportPostId } /> }
-				<span className="inline-support-link__nowrap">
-					{ showText && text }
-					{ supportPostId && showIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
-				</span>
+				{ content }
 			</LinkComponent>
 		);
 	}

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -99,8 +99,10 @@ class InlineSupportLink extends Component {
 				{ ...externalLinkProps }
 			>
 				{ shouldLazyLoadAlternates && <QuerySupportArticleAlternates postId={ supportPostId } /> }
-				{ showText && text }
-				{ supportPostId && showIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
+				<span className="inline-support-link__nowrap">
+					{ showText && text }
+					{ supportPostId && showIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
+				</span>
 			</LinkComponent>
 		);
 	}

--- a/client/components/inline-support-link/style.scss
+++ b/client/components/inline-support-link/style.scss
@@ -11,3 +11,6 @@
 		cursor: pointer;
 	}
 }
+.inline-support-link__nowrap {
+	white-space: nowrap;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Prevent word-wrap inside InlineSupportLink
* In #51027 it was pointed out that you can resize the browser window on /me/account such that the phrase "Learn More (Icon)" has a line break just before the Icon, leaving the icon on its own.

![2021-04-21_16-39](https://user-images.githubusercontent.com/937354/115625891-50547700-a2c2-11eb-964a-1a73462cb8f7.png)
^ Before Fix

![2021-04-21_16-47](https://user-images.githubusercontent.com/937354/115625909-577b8500-a2c2-11eb-8bf0-60ccd793d65d.png)
^ After fix


#### Testing instructions


* Visit `/me/account`
* Try to resize your browser such that the phrase "Learn More (Icon)" has a line break just before the Icon, leaving the icon on its own. It shouldn't be possible.

Related to https://github.com/Automattic/wp-calypso/issues/51027

#### Notes

* I'm unsure about this, feel free to rip it to shreds.
* An additional condition could be added around the new span:
```jsx
				{ ( showText || ( supportPostId && showIcon ) ) && (
					<span className="inline-support-link__nowrap">
						{ showText && text }
						{ supportPostId && showIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
					</span>
				) }
```
(+) This would prevent an empty span from being rendered when both the text and the gridicon are not displayed due to settings.
(-) It's a lot of complexity added for marginal benefit.
(-) It would still render the span if we're only showing one out of the two elements. Ideally, it only shows if both are displayed. But fixing this seems like a waste of effort? Not sure.
