### PR TITLE
chore(deps): Add missing dependencies for `@automattic/search`

### DIFF
--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -45,7 +45,10 @@
 	"devDependencies": {
 		"@storybook/addon-actions": "^6.1.10",
 		"@testing-library/react": "^11.2.6",
-		"@testing-library/user-event": "^12.8.3"
+		"@testing-library/user-event": "^12.8.3",
+		"@testing-library/dom": "^7.28.1",
+		"react": "^16.12.0",
+		"react-dom": "^16.12.0"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add required dependencies to fix:

```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/search/package.json
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/search/package.json:47:29: Unmet transitive peer dependency on react@*, via @testing-library/react@^11.2.6
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/search/package.json:47:29: Unmet transitive peer dependency on react-dom@*, via @testing-library/react@^11.2.6
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/search/package.json:48:34: Unmet transitive peer dependency on @testing-library/dom@>=7.21.4, via @testing-library/user-event@^12.8.3
➤ YN0000: └ Completed in 12s 909ms
```


#### Testing instructions

Checkout this branch and run `npx @yarnpkg/doctor@2 packages/search`, verify the error is gone.