### PR TITLE
chore(deps): Clean up dependencies for `@automattic/social-previews`

### DIFF
--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -48,12 +48,9 @@
 		"prop-types": "^15.7.2"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^8.0.0",
 		"enzyme": "^3.11.0",
-		"jest": "^26.4.0",
 		"react": "^16.12.0",
-		"react-dom": "^16.12.0",
-		"webpack": "^5.34.0"
+		"react-dom": "^16.12.0"
 	},
 	"peerDependencies": {
 		"react": "^16.12.0"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`@automattic/social-previews` was depending on `@automattic/calypso-build`. While that's technilcally correct (it needs that package to build), most packages in our repo don't import it and, in its current form, forces the consumer to bring in lots of potentially unneeded dependencies, like `webpack`, `postcss`, `jest`...

This PR removes the dependency on `@automattic/calypso-build` and the extra dependencies it brings in.

Going forward, I think we should split `@automattic/calypso-build` into smaller packages (for example:  `@automattic/calypso-build-test`, `@automattic/calypso-build-webpack`, `@automattic/calypso-build-typescript`...)


#### Testing instructions

Checkout this branch and run `npx @yarnpkg/doctor@2 packages/social-previews`, verify there are no errors related to dependencies.