### PR TITLE
chore(deps): Clean up dependencies for `@automattic/whats-new`

### DIFF
--- a/packages/whats-new/package.json
+++ b/packages/whats-new/package.json
@@ -43,10 +43,6 @@
 		"wpcom-proxy-request": "^6.0.0",
 		"wpcom": "^6.0.0"
 	},
-	"devDependencies": {
-		"@automattic/calypso-build": "^8.0.0",
-		"react": "^16.12.0"
-	},
 	"peerDependencies": {
 		"react": "^16.8"
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the dependency on `@automattic/calypso-build` and the extra dependencies it brings in (see #52188 for an explanation)

#### Testing instructions

Checkout this branch and run `npx @yarnpkg/doctor@2 packages/whats-new`, verify there are no errors related to dependencies.