### PR TITLE
State: Use `Object.values()` instead of `_.values()`

### DIFF
--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -12,7 +12,6 @@ import {
 	get,
 	zipObject,
 	includes,
-	values,
 	omit,
 	startsWith,
 } from 'lodash';
@@ -229,7 +228,7 @@ const isValidExpansionsAction = ( action ) => {
 		siteId &&
 		postId &&
 		Array.isArray( commentIds ) &&
-		includes( values( POST_COMMENT_DISPLAY_TYPES ), displayType )
+		includes( Object.values( POST_COMMENT_DISPLAY_TYPES ), displayType )
 	);
 };
 

--- a/client/state/domains/dns/test/utils.js
+++ b/client/state/domains/dns/test/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, values } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ describe( 'utils', () => {
 
 			const errors = validateAllFields( initialData );
 
-			expect( values( errors ).every( isEmpty ) ).toBe( true );
+			expect( Object.values( errors ).every( isEmpty ) ).toBe( true );
 		} );
 	} );
 } );

--- a/client/state/editor/image-editor/constants.js
+++ b/client/state/editor/image-editor/constants.js
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import { values as objectValues } from 'lodash';
-
 export const AspectRatios = {
 	FREE: 'FREE',
 	ORIGINAL: 'ORIGINAL',
@@ -17,4 +12,4 @@ export const MinimumImageDimensions = {
 	HEIGHT: 50,
 };
 
-export const AspectRatiosValues = objectValues( AspectRatios );
+export const AspectRatiosValues = Object.values( AspectRatios );

--- a/client/state/invites/selectors.js
+++ b/client/state/invites/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, find, values } from 'lodash';
+import { get, find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -167,6 +167,7 @@ export function didInviteDeletionSucceed( state, siteId, inviteId ) {
  */
 export function isDeletingAnyInvite( state, siteId ) {
 	return (
-		-1 !== values( get( state, [ 'invites', 'deleting', siteId ], {} ) ).indexOf( 'requesting' )
+		-1 !==
+		Object.values( get( state, [ 'invites', 'deleting', siteId ], {} ) ).indexOf( 'requesting' )
 	);
 }

--- a/client/state/notices/selectors.js
+++ b/client/state/notices/selectors.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { values } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { createSelector } from '@automattic/state-utils';
@@ -17,7 +12,7 @@ import 'calypso/state/notices/init';
  * @returns {Array}        Notice objects as array
  */
 export const getNotices = createSelector(
-	( state ) => values( state.notices.items ),
+	( state ) => Object.values( state.notices.items ),
 	( state ) => state.notices.items
 );
 

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, find, get, pick, reduce, some, sortBy, values } from 'lodash';
+import { filter, find, get, pick, reduce, some, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -89,7 +89,7 @@ export function getPlugins( state, siteIds, pluginFilter ) {
 		pluginList = filter( pluginList, _filters[ pluginFilter ] );
 	}
 
-	return values( sortBy( pluginList, ( item ) => item.slug.toLowerCase() ) );
+	return sortBy( pluginList, ( item ) => item.slug.toLowerCase() );
 }
 
 export function getPluginsWithUpdates( state, siteIds ) {

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-import { values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -200,7 +199,9 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getSitePosts( state, 2916284 ) ).to.have.members( values( postObjects[ 2916284 ] ) );
+			expect( getSitePosts( state, 2916284 ) ).to.have.members(
+				Object.values( postObjects[ 2916284 ] )
+			);
 		} );
 	} );
 

--- a/client/state/reader/conversations/schema.js
+++ b/client/state/reader/conversations/schema.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { values } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { CONVERSATION_FOLLOW_STATUS } from './follow-status';
@@ -13,7 +8,7 @@ export const itemsSchema = {
 	type: 'object',
 	patternProperties: {
 		'^[0-9]+-[0-9]+$': {
-			enum: values( CONVERSATION_FOLLOW_STATUS ),
+			enum: Object.values( CONVERSATION_FOLLOW_STATUS ),
 		},
 	},
 	additionalProperties: false,

--- a/client/state/reader/follows/selectors/get-reader-followed-sites.js
+++ b/client/state/reader/follows/selectors/get-reader-followed-sites.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { values, sortBy } from 'lodash';
+import { sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,7 +19,9 @@ const getReaderFollowedSites = createSelector(
 	( state ) => {
 		// remove subs where the sub has an error
 		return sortBy(
-			values( state.reader.follows.items ).filter( ( blog ) => blog.organization_id === NO_ORG_ID ),
+			Object.values( state.reader.follows.items ).filter(
+				( blog ) => blog.organization_id === NO_ORG_ID
+			),
 			sorter
 		);
 	},

--- a/client/state/reader/follows/selectors/get-reader-follows-organization.js
+++ b/client/state/reader/follows/selectors/get-reader-follows-organization.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { values, sortBy } from 'lodash';
+import { sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,7 +17,7 @@ const getOrganizationSites = createSelector(
 	( state, organizationId ) => {
 		// remove subs where the sub has an error
 		return sortBy(
-			values( state.reader.follows.items ).filter(
+			Object.values( state.reader.follows.items ).filter(
 				( blog ) => blog.organization_id === organizationId
 			),
 			sorter

--- a/client/state/reader/follows/selectors/get-reader-follows.js
+++ b/client/state/reader/follows/selectors/get-reader-follows.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { values, reject } from 'lodash';
+import { reject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,7 +21,7 @@ import 'calypso/state/reader/init';
 const getReaderFollows = createSelector(
 	( state ) => {
 		// remove subs where the sub has an error
-		const items = reject( values( state.reader.follows.items ), 'error' );
+		const items = reject( Object.values( state.reader.follows.items ), 'error' );
 
 		// this is important. don't mutate the original items.
 		const withSiteAndFeed = items.map( ( item ) => ( {

--- a/client/state/selectors/get-filtered-billing-transactions.js
+++ b/client/state/selectors/get-filtered-billing-transactions.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { getLocaleSlug } from 'i18n-calypso';
-import { compact, flatMap, omit, some, values } from 'lodash';
+import { compact, flatMap, omit, some } from 'lodash';
 import moment from 'moment';
 
 /**
@@ -35,9 +35,9 @@ function formatDate( date ) {
  * @returns {Array}             list of searchable strings
  */
 function getSearchableStrings( transaction ) {
-	const rootStrings = values( omit( transaction, [ 'date', 'items' ] ) );
+	const rootStrings = Object.values( omit( transaction, [ 'date', 'items' ] ) );
 	const dateString = transaction.date ? formatDate( transaction.date ) : null;
-	const itemStrings = flatMap( transaction.items, values );
+	const itemStrings = flatMap( transaction.items, ( item ) => Object.values( item ) );
 
 	return compact( [ ...rootStrings, dateString, ...itemStrings ] );
 }
@@ -122,6 +122,6 @@ export default createSelector(
 		// Ideally, we shouldn't allow for full-text search matching against localized dates.
 		getCurrentLocaleSlug( state ),
 		getBillingTransactionsByType( state, transactionType ),
-		...values( getBillingTransactionFilters( state, transactionType ) ),
+		...Object.values( getBillingTransactionFilters( state, transactionType ) ),
 	]
 );

--- a/client/state/selectors/get-media-sorted-by-date.js
+++ b/client/state/selectors/get-media-sorted-by-date.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { values } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import getMediaQueryManager from './get-media-query-manager';
@@ -28,7 +23,9 @@ export default function getMediaSortedByDate( state, siteId ) {
 	}
 
 	const mediaItems = queryManager.getItemsIgnoringPage( query );
-	const transientItems = values( state.media.transientItems[ siteId ]?.transientItems );
+	const transientItems = Object.values(
+		state.media.transientItems[ siteId ]?.transientItems ?? {}
+	);
 
 	return sortItemsByDate( transientItems.concat( mediaItems ).filter( ( i ) => i ) );
 }

--- a/client/state/selectors/get-user-devices.js
+++ b/client/state/selectors/get-user-devices.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { values } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import 'calypso/state/user-devices/init';
@@ -15,6 +10,6 @@ import 'calypso/state/user-devices/init';
  * @param  {object} options.userDevices user's devices slice of the state tree
  * @returns {Array}                     current user's devices
  */
-export const getUserDevices = ( { userDevices } ) => values( userDevices );
+export const getUserDevices = ( { userDevices } ) => Object.values( userDevices ?? {} );
 
 export default getUserDevices;

--- a/client/state/sharing/keyring/selectors.js
+++ b/client/state/sharing/keyring/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, values } from 'lodash';
+import { filter } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,7 +17,7 @@ import 'calypso/state/sharing/init';
  * @returns {Array}        Keyring connections, if known.
  */
 export function getKeyringConnections( state ) {
-	return values( state.sharing.keyring.items );
+	return Object.values( state.sharing.keyring.items );
 }
 
 /**

--- a/client/state/site-settings/utils.js
+++ b/client/state/site-settings/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isPlainObject, values } from 'lodash';
+import { isPlainObject } from 'lodash';
 
 /**
  * Normalize API Settings
@@ -18,7 +18,7 @@ export function normalizeSettings( settings ) {
 				break;
 			case 'sharing_show':
 				if ( isPlainObject( settings[ key ] ) ) {
-					memo[ key ] = values( settings[ key ] );
+					memo[ key ] = Object.values( settings[ key ] );
 				} else {
 					memo[ key ] = settings[ key ];
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `_.values()` usage in state to use `Object.values()` instead.

There are more instances of `_.values()` in Calypso, but I'm going to address them separately.

#### Testing instructions

* Verify all tests still pass: `yarn run test-client client/state`