### PR TITLE
Display license quantity on p2

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -43,6 +43,7 @@ import {
 	isTrafficGuide,
 	isTitanMail,
 	isMonthly,
+	isP2Plus,
 } from 'calypso/lib/products-values';
 import sortProducts from 'calypso/lib/products-values/sort';
 import { getTld } from 'calypso/lib/domains';
@@ -170,6 +171,16 @@ export function hasPlan( cart ) {
  */
 export function hasJetpackPlan( cart ) {
 	return some( getAllCartItems( cart ), isJetpackPlan );
+}
+
+/**
+ * Determines whether there is a P2+ plan in the shopping cart.
+ *
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {boolean} true if there is at least one P2+ plan, false otherwise
+ */
+export function hasP2PlusPlan( cart ) {
+	return some( getAllCartItems( cart ), isP2Plus );
 }
 
 /**

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -79,3 +79,4 @@ export { isVideoPress } from './is-video-press';
 export { isVipPlan } from './is-vip-plan';
 export { isYearly } from './is-yearly';
 export { isTrafficGuide } from './is-traffic-guide';
+export { isP2Plus } from './is-p2-plus';

--- a/client/my-sites/checkout/composite-checkout/components/bundled-domain-notice.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/bundled-domain-notice.jsx
@@ -13,6 +13,7 @@ import {
 	hasPlan,
 	hasJetpackPlan,
 	isNextDomainFree,
+	hasP2PlusPlan,
 } from 'calypso/lib/cart-values/cart-items';
 import { isMonthly, getPlan, getBillingMonthsForTerm } from '@automattic/calypso-products';
 import { REGISTER_DOMAIN } from 'calypso/lib/url/support';
@@ -39,7 +40,12 @@ function hasMonthlyPlan( cart ) {
 
 export default function BundledDomainNotice( { cart } ) {
 	// A dotcom plan should exist.
-	if ( ! hasPlan( cart ) || hasJetpackPlan( cart ) || hasMonthlyPlan( cart ) ) {
+	if (
+		! hasPlan( cart ) ||
+		hasJetpackPlan( cart ) ||
+		hasMonthlyPlan( cart ) ||
+		hasP2PlusPlan( cart )
+	) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -8,6 +8,8 @@ import { useTranslate } from 'i18n-calypso';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import type { RemoveProductFromCart, CouponStatus } from '@automattic/shopping-cart';
 import { styled } from '@automattic/wpcom-checkout';
+import { useSelector } from 'react-redux';
+import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 
 /**
  * Internal dependencies
@@ -15,12 +17,12 @@ import { styled } from '@automattic/wpcom-checkout';
 import joinClasses from './join-classes';
 import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
-import { isDomainRegistration, isDomainTransfer } from 'calypso/lib/products-values';
+import { isDomainRegistration, isDomainTransfer, isP2Plus } from 'calypso/lib/products-values';
 import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
 import type { GetProductVariants } from '../hooks/product-variants';
 import type { OnChangeItemVariant } from './item-variation-picker';
 
-const DomainURL = styled.div`
+const SiteSummary = styled.div`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 	font-size: 14px;
 	margin-top: -10px;
@@ -97,12 +99,25 @@ export default function WPCheckoutOrderReview( {
 		return removeCoupon();
 	};
 
+	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
+	const planIsP2Plus = isP2Plus( responseCart );
+
 	return (
 		<div
 			className={ joinClasses( [ className, 'checkout-review-order', isSummary && 'is-summary' ] ) }
 		>
-			{ domainUrl && 'no-user' !== domainUrl && (
-				<DomainURL>{ translate( 'Site: %s', { args: domainUrl } ) }</DomainURL>
+			{ ! planIsP2Plus && domainUrl && 'no-user' !== domainUrl && (
+				<SiteSummary>{ translate( 'Site: %s', { args: domainUrl } ) }</SiteSummary>
+			) }
+			{ planIsP2Plus && selectedSiteData?.name && (
+				<SiteSummary>
+					{ translate( 'Upgrade: {{strong}}%s{{/strong}}', {
+						args: selectedSiteData.name,
+						components: {
+							strong: <strong />,
+						},
+					} ) }
+				</SiteSummary>
 			) }
 
 			<WPOrderReviewSection>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -9,7 +9,6 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import type { RemoveProductFromCart, CouponStatus } from '@automattic/shopping-cart';
 import { styled } from '@automattic/wpcom-checkout';
 import { useSelector } from 'react-redux';
-import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 
 /**
  * Internal dependencies
@@ -22,6 +21,7 @@ import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
 import type { GetProductVariants } from '../hooks/product-variants';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import { hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
+import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 
 const SiteSummary = styled.div`
 	color: ${ ( props ) => props.theme.colors.textColorLight };

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -17,10 +17,11 @@ import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import joinClasses from './join-classes';
 import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
-import { isDomainRegistration, isDomainTransfer, isP2Plus } from 'calypso/lib/products-values';
+import { isDomainRegistration, isDomainTransfer } from 'calypso/lib/products-values';
 import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
 import type { GetProductVariants } from '../hooks/product-variants';
 import type { OnChangeItemVariant } from './item-variation-picker';
+import { hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
 
 const SiteSummary = styled.div`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
@@ -100,7 +101,7 @@ export default function WPCheckoutOrderReview( {
 	};
 
 	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
-	const planIsP2Plus = isP2Plus( responseCart );
+	const planIsP2Plus = hasP2PlusPlan( responseCart );
 
 	return (
 		<div

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -48,6 +48,7 @@ import type {
 	OnChangeItemVariant,
 } from './item-variation-picker';
 import { getIntroductoryOfferIntervalDisplay } from 'calypso/lib/purchases/utils';
+import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
 
 const WPOrderReviewList = styled.ul< { theme?: Theme } >`
 	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
@@ -560,14 +561,15 @@ function LineItemSublabelAndPrice( {
 
 	const isGSuite =
 		isGSuiteOrExtraLicenseProductSlug( productSlug ) || isGoogleWorkspaceProductSlug( productSlug );
+	// This is the price for one item for products with a quantity (eg. seats in a license).
+	const itemPrice = useSelector( ( state ) => getProductDisplayCost( state, productSlug ) );
 
 	if ( isPlan( product ) ) {
 		if ( isP2Plus( product ) ) {
 			const members = product?.current_quantity || 1;
 			const p2Options = {
 				args: {
-					itemPrice: product.product_cost_display,
-					subtotal: product.item_original_subtotal_display,
+					itemPrice: itemPrice,
 					members,
 				},
 				count: members,
@@ -575,13 +577,14 @@ function LineItemSublabelAndPrice( {
 			return (
 				<>
 					{ translate(
-						'Monthly subscription: %(itemPrice)s x %(members)s member = %(subtotal)s',
-						'Monthly subscription: %(itemPrice)s x %(members)s members = %(subtotal)s',
+						'Monthly subscription: %(itemPrice)s x %(members)s active member',
+						'Monthly subscription: %(itemPrice)s x %(members)s active members',
 						p2Options
 					) }
 				</>
 			);
 		}
+
 		const options = {
 			args: {
 				sublabel,

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -41,7 +41,7 @@ import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/s
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
 import { getSublabel, getLabel } from '../lib/translate-cart';
-import { isPlan, isMonthly, isYearly, isBiennially } from 'calypso/lib/products-values';
+import { isPlan, isMonthly, isYearly, isBiennially, isP2Plus } from 'calypso/lib/products-values';
 import type {
 	WPCOMProductSlug,
 	WPCOMProductVariant,
@@ -562,6 +562,26 @@ function LineItemSublabelAndPrice( {
 		isGSuiteOrExtraLicenseProductSlug( productSlug ) || isGoogleWorkspaceProductSlug( productSlug );
 
 	if ( isPlan( product ) ) {
+		if ( isP2Plus( product ) ) {
+			const members = product?.current_quantity || 1;
+			const p2Options = {
+				args: {
+					itemPrice: product.product_cost_display,
+					subtotal: product.item_original_subtotal_display,
+					members,
+				},
+				count: members,
+			};
+			return (
+				<>
+					{ translate(
+						'Monthly subscription: %(itemPrice)s x %(members)s member = %(subtotal)s',
+						'Monthly subscription: %(itemPrice)s x %(members)s members = %(subtotal)s',
+						p2Options
+					) }
+				</>
+			);
+		}
 		const options = {
 			args: {
 				sublabel,

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -31,6 +31,7 @@ import {
 	isGoogleWorkspaceExtraLicence,
 	isGSuiteOrGoogleWorkspace,
 	isTitanMail,
+	isP2Plus,
 } from 'calypso/lib/products-values';
 import { isRenewal } from 'calypso/lib/cart-values/cart-items';
 import doesValueExist from './does-value-exist';
@@ -202,6 +203,10 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): i18nCalypso.
 	}
 
 	if ( isPlan( serverCartItem ) ) {
+		if ( isP2Plus( serverCartItem ) ) {
+			return translate( 'Monthly subscription' );
+		}
+
 		return isRenewalItem ? translate( 'Plan Renewal' ) : translate( 'Plan Subscription' );
 	}
 

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -49,6 +49,7 @@ export function getEmptyResponseCartProduct(): ResponseCartProduct {
 		product_id: 1,
 		volume: 1,
 		quantity: null,
+		current_quantity: null,
 		item_original_cost_integer: 0,
 		item_original_cost_display: '$0',
 		item_subtotal_integer: 0,

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -145,6 +145,7 @@ export interface ResponseCartProduct {
 	months_per_bill_period: number | null;
 	volume: number;
 	quantity: number | null;
+	current_quantity: number | null;
 	extra: ResponseCartProductExtra;
 	uuid: string;
 	cost: number;


### PR DESCRIPTION
This PR adds some tweaks to the checkout for P2s plan:

* It uses the `current_quantity` that was recently added to the API to display the price broken down in number of seats.
* It adds the `current_quantity` to the `ResponseCartProduct` data type.
* A helper function `hasP2PlusPlan` is added.
* A section about domains was removed from the terms of service (for checking out the p2 product only).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a free P2 site, go to the plans page and click upgrade to P2+ (without purchasing). Your screen should look like the "After screen" from below. 
* Go add a user to the P2 site and come back to the checkout page. You should now see "2 members" instead of "1 member".

#### Before (for a P2 product):
<img width="585" alt="before" src="https://user-images.githubusercontent.com/193283/115713594-7b989e00-a376-11eb-9e5c-2e76b926baff.png">

#### After (for a P2 product):
<img width="594" alt="after" src="https://user-images.githubusercontent.com/193283/115713638-89e6ba00-a376-11eb-8c13-894ff3b54946.png">

