### PR TITLE
Changes Upgrades selector to contain the plan, properly navigates to Plans.

### DIFF
--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -86,12 +86,12 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async selectPlans() {
-		await this.expandDrawerItem( 'Upgrades' );
+		await this.expandDrawerItem( 'Upgrades\nPremium' );
 		return await this._scrollToAndClickMenuItem( 'Plans' );
 	}
 
 	async selectDomains() {
-		await this.expandDrawerItem( 'Upgrades' );
+		await this.expandDrawerItem( 'Upgrades\nPremium' );
 		return await this._scrollToAndClickMenuItem( 'Domains' );
 	}
 

--- a/test/e2e/specs/wp-plan-purchase-spec.js
+++ b/test/e2e/specs/wp-plan-purchase-spec.js
@@ -46,6 +46,7 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 
 		step( 'Can Compare Plans', async function () {
 			const plansPage = await PlansPage.Expect( driver );
+			await plansPage.openPlansTab();
 			return await plansPage.waitForComparison();
 		} );
 
@@ -94,6 +95,7 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 
 		step( 'Can Compare Plans', async function () {
 			const plansPage = await PlansPage.Expect( driver );
+			await plansPage.openPlansTab();
 			if ( host === 'WPCOM' ) {
 				await plansPage.openAdvancedPlansSegment();
 			}
@@ -191,6 +193,7 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 			const sidebarComponent = await SidebarComponent.Expect( driver );
 			await sidebarComponent.selectPlans();
 			const plansPage = await PlansPage.Expect( driver );
+			await plansPage.openPlansTab();
 			return await plansPage.selectPaidPlan();
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the Upgrades selector in tests to include the plan
* Navigates to Plans after clicking Upgrades

The above are needed as a result of the changes introduced here https://github.com/Automattic/wp-calypso/pull/52111

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that e2e tests in teamcity pass

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #52111
