### PR TITLE
Nav Unification: Remove temporary fix for sharing buttons under Settings and Marketing

### DIFF
--- a/client/my-sites/sidebar-unified/test/index.jsx
+++ b/client/my-sites/sidebar-unified/test/index.jsx
@@ -59,10 +59,10 @@ describe( 'MySitesSidebar', () => {
 	} );
 
 	describe( '#itemLinkMatches() edge cases', () => {
-		test( 'clicking a marketing panel should not activate sharing-buttons in settings menu', () => {
+		test( 'clicking a settings panel should not activate the posts menu', () => {
 			const isSelected = itemLinkMatches(
-				'/marketing/sharing-buttons/example.wordpress.com',
-				'/marketing/traffic/cpapfree.wordpress.com'
+				'/settings/taxonomies/category/example.wordpress.com',
+				'/settings/discussion/cpapfree.wordpress.com'
 			);
 
 			expect( isSelected ).to.be.false;

--- a/client/my-sites/sidebar-unified/utils.jsx
+++ b/client/my-sites/sidebar-unified/utils.jsx
@@ -28,9 +28,6 @@ export const itemLinkMatches = ( path, currentPath ) => {
 	if ( pathIncludes( currentPath, 'settings', 1 ) && pathIncludes( path, 'taxonomies', 2 ) ) {
 		return false;
 	}
-	// Temp fix till we remove duplicate menu entry of sharing buttons from 'Settings' menu. See https://github.com/Automattic/wp-calypso/issues/49756.
-	if ( pathIncludes( currentPath, 'marketing', 1 ) ) {
-		return fragmentIsEqual( path, currentPath, 1 ) && fragmentIsEqual( path, '//tools', 2 );
-	}
+
 	return fragmentIsEqual( path, currentPath, 1 );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the interests of leaving things better than we found them, let's remove this temp fix which is no longer needed. Sharing settings are no longer located under both Settings and Marketing menus in the nav so we don't need to create an exception for path matching. Ref: https://github.com/Automattic/wp-calypso/pull/52131#issuecomment-824309543
* This also adds an edge case test to account for changes added in #52131 

#### Testing instructions

* Switch to this PR on a site that uses the unified navigation and make sure nothing breaks.
* Check under Marketing -> Sharing Buttons and Marketing -> Connections to make sure the correct nav menu items are highlighted as active (should be Tools -> Marketing)
* Make sure you can still access the Sharing settings from `/wp-admin` on a Simple site (`/wp-admin/options-general.php?page=sharing`) without getting an error
* Make sure unit tests pass.