### PR TITLE
Jetpack Plans: fix upgrade to yearly CTA

### DIFF
--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -9,11 +9,13 @@ import { useDispatch, useSelector } from 'react-redux';
  */
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { EXTERNAL_PRODUCTS_LIST } from 'calypso/my-sites/plans/jetpack-plans/constants';
-import { checkout, manageSitePurchase } from 'calypso/my-sites/plans/jetpack-plans/utils';
+import {
+	checkout,
+	getYearlySlugFromMonthly,
+	manageSitePurchase,
+} from 'calypso/my-sites/plans/jetpack-plans/utils';
 import QueryProducts from 'calypso/my-sites/plans/jetpack-plans/query-products';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { getYearlyPlanByMonthly } from '@automattic/calypso-products';
-import { getProductYearlyVariant, isJetpackPlan } from 'calypso/lib/products-values';
 import { TERM_ANNUALLY } from '@automattic/calypso-products';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import Main from 'calypso/components/main';
@@ -31,7 +33,6 @@ import type {
 	SelectorProduct,
 	PurchaseCallback,
 } from 'calypso/my-sites/plans/jetpack-plans/types';
-import type { ProductSlug } from 'calypso/lib/products-values/types';
 
 import './style.scss';
 
@@ -82,12 +83,10 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 			);
 
 			const { productSlug: slug } = product;
-			const yearlyItem = isJetpackPlan( slug )
-				? getYearlyPlanByMonthly( slug )
-				: getProductYearlyVariant( slug as ProductSlug );
+			const yearlySlug = getYearlySlugFromMonthly( slug );
 
-			if ( yearlyItem ) {
-				checkout( siteSlug, yearlyItem, urlQueryArgs );
+			if ( yearlySlug ) {
+				checkout( siteSlug, yearlySlug, urlQueryArgs );
 			}
 			return;
 		}

--- a/client/my-sites/plans/jetpack-plans/test/utils.js
+++ b/client/my-sites/plans/jetpack-plans/test/utils.js
@@ -113,10 +113,11 @@ describe( 'getHighestAnnualDiscount', () => {
 } );
 
 describe( 'getMonthlySlugFromYearly', () => {
-	const jetpackSlugs = [
+	const yearlySlugs = [
 		'jetpack_personal',
 		'jetpack_premium',
 		'jetpack_business',
+		'jetpack_anti_spam',
 		'jetpack_backup_daily',
 		'jetpack_backup_realtime',
 		'jetpack_scan',
@@ -126,7 +127,7 @@ describe( 'getMonthlySlugFromYearly', () => {
 		'jetpack_complete',
 	];
 
-	jetpackSlugs.forEach( ( slug ) => {
+	yearlySlugs.forEach( ( slug ) => {
 		test( `returns ${ slug } monthly version`, () => {
 			expect( getMonthlySlugFromYearly( slug ) ).toBe( `${ slug }_monthly` );
 		} );
@@ -142,10 +143,11 @@ describe( 'getMonthlySlugFromYearly', () => {
 } );
 
 describe( 'getYearlySlugFromMonthly', () => {
-	const jetpackSlugs = [
+	const monthlySlugs = [
 		'jetpack_personal_monthly',
 		'jetpack_premium_monthly',
 		'jetpack_business_monthly',
+		'jetpack_anti_spam_monthly',
 		'jetpack_backup_daily_monthly',
 		'jetpack_backup_realtime_monthly',
 		'jetpack_scan_monthly',
@@ -155,9 +157,11 @@ describe( 'getYearlySlugFromMonthly', () => {
 		'jetpack_complete_monthly',
 	];
 
-	jetpackSlugs.forEach( ( slug ) => {
+	monthlySlugs.forEach( ( slug ) => {
 		test( `returns ${ slug } yearly version`, () => {
+			// jetpack_scan_monthly => ['jetpack', 'scan', 'monthly']
 			const slugParts = slug.split( '_' );
+			// ['jetpack', 'scan', 'monthly'] => ['jetpack', 'scan'] => 'jetpack_scan'
 			const slugWithoutTerm = slugParts.slice( 0, slugParts.length - 1 ).join( '_' );
 			expect( getYearlySlugFromMonthly( slug ) ).toBe( slugWithoutTerm );
 		} );

--- a/client/my-sites/plans/jetpack-plans/test/utils.js
+++ b/client/my-sites/plans/jetpack-plans/test/utils.js
@@ -16,7 +16,11 @@ import {
 	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
 } from '@automattic/calypso-products';
 import { getProductCost } from 'calypso/state/products-list/selectors/get-product-cost';
-import { getHighestAnnualDiscount } from 'calypso/my-sites/plans/jetpack-plans/utils';
+import {
+	getHighestAnnualDiscount,
+	getMonthlySlugFromYearly,
+	getYearlySlugFromMonthly,
+} from 'calypso/my-sites/plans/jetpack-plans/utils';
 
 let mockProductPrices;
 
@@ -105,5 +109,65 @@ describe( 'getHighestAnnualDiscount', () => {
 
 		const discount = getHighestAnnualDiscount( null, [ PLAN_JETPACK_SECURITY_DAILY ] );
 		expect( discount ).toEqual( null );
+	} );
+} );
+
+describe( 'getMonthlySlugFromYearly', () => {
+	const jetpackSlugs = [
+		'jetpack_personal',
+		'jetpack_premium',
+		'jetpack_business',
+		'jetpack_backup_daily',
+		'jetpack_backup_realtime',
+		'jetpack_scan',
+		'jetpack_search',
+		'jetpack_security_daily',
+		'jetpack_security_realtime',
+		'jetpack_complete',
+	];
+
+	jetpackSlugs.forEach( ( slug ) => {
+		test( `returns ${ slug } monthly version`, () => {
+			expect( getMonthlySlugFromYearly( slug ) ).toBe( `${ slug }_monthly` );
+		} );
+	} );
+
+	test( 'returns null when the slug is already the yearly version slug', () => {
+		expect( getMonthlySlugFromYearly( 'jetpack_scan_monthly' ) ).toBeNull();
+	} );
+
+	test( 'returns null when slug does not correspond to a Jetpack product', () => {
+		expect( getMonthlySlugFromYearly( 'not_a_product' ) ).toBeNull();
+	} );
+} );
+
+describe( 'getYearlySlugFromMonthly', () => {
+	const jetpackSlugs = [
+		'jetpack_personal_monthly',
+		'jetpack_premium_monthly',
+		'jetpack_business_monthly',
+		'jetpack_backup_daily_monthly',
+		'jetpack_backup_realtime_monthly',
+		'jetpack_scan_monthly',
+		'jetpack_search_monthly',
+		'jetpack_security_daily_monthly',
+		'jetpack_security_realtime_monthly',
+		'jetpack_complete_monthly',
+	];
+
+	jetpackSlugs.forEach( ( slug ) => {
+		test( `returns ${ slug } yearly version`, () => {
+			const slugParts = slug.split( '_' );
+			const slugWithoutTerm = slugParts.slice( 0, slugParts.length - 1 ).join( '_' );
+			expect( getYearlySlugFromMonthly( slug ) ).toBe( slugWithoutTerm );
+		} );
+	} );
+
+	test( 'returns null when the slug is already the yearly version slug', () => {
+		expect( getYearlySlugFromMonthly( 'jetpack_scan' ) ).toBeNull();
+	} );
+
+	test( 'returns null when slug does not correspond to a Jetpack product', () => {
+		expect( getYearlySlugFromMonthly( 'not_a_product' ) ).toBeNull();
 	} );
 } );

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -134,21 +134,43 @@ export function getProductWithOptionDisplayName(
 	return slugToSelectorProduct( optionSlug )?.displayName || item.displayName;
 }
 
-// Takes any annual Jetpack product or plan slug and returns its corresponding monthly equivalent
-function getMonthlySlugFromYearly( yearlySlug: string | null ) {
+function getSlugInTerm( yearlySlug: string | null, slugTerm: Duration ) {
+	const mainTerm = slugTerm === TERM_MONTHLY ? 'monthly' : 'yearly';
+	const oppositeTerm = mainTerm === 'monthly' ? 'yearly' : 'monthly';
+
 	const matchingProduct = JETPACK_PRODUCTS_BY_TERM.find(
-		( product ) => product.yearly === yearlySlug
+		( product ) => product[ mainTerm ] === yearlySlug
 	);
 	if ( matchingProduct ) {
-		return matchingProduct.monthly;
+		return matchingProduct[ oppositeTerm ];
 	}
 
-	const matchingPlan = JETPACK_PLANS_BY_TERM.find( ( plan ) => plan.yearly === yearlySlug );
+	const matchingPlan = JETPACK_PLANS_BY_TERM.find( ( plan ) => plan[ mainTerm ] === yearlySlug );
 	if ( matchingPlan ) {
-		return matchingPlan.monthly;
+		return matchingPlan[ oppositeTerm ];
 	}
 
 	return null;
+}
+
+/**
+ * Get the monthly version of a product slug.
+ *
+ * @param {string} yearlySlug a yearly term product slug
+ * @returns {string} a monthly term product slug
+ */
+export function getMonthlySlugFromYearly( yearlySlug: string | null ): string | null {
+	return getSlugInTerm( yearlySlug, TERM_ANNUALLY );
+}
+
+/**
+ * Get the yearly version of a product slug.
+ *
+ * @param {string} monthlySlug a monthly term product slug
+ * @returns {string} a yearly term product slug
+ */
+export function getYearlySlugFromMonthly( monthlySlug: string | null ): string | null {
+	return getSlugInTerm( monthlySlug, TERM_MONTHLY );
 }
 
 /**

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -139,15 +139,17 @@ function getSlugInTerm( yearlySlug: string | null, slugTerm: Duration ) {
 	const oppositeTerm = mainTerm === 'monthly' ? 'yearly' : 'monthly';
 
 	const matchingProduct = JETPACK_PRODUCTS_BY_TERM.find(
-		( product ) => product[ mainTerm ] === yearlySlug
+		( product ) => product[ oppositeTerm ] === yearlySlug
 	);
 	if ( matchingProduct ) {
-		return matchingProduct[ oppositeTerm ];
+		return matchingProduct[ mainTerm ];
 	}
 
-	const matchingPlan = JETPACK_PLANS_BY_TERM.find( ( plan ) => plan[ mainTerm ] === yearlySlug );
+	const matchingPlan = JETPACK_PLANS_BY_TERM.find(
+		( plan ) => plan[ oppositeTerm ] === yearlySlug
+	);
 	if ( matchingPlan ) {
-		return matchingPlan[ oppositeTerm ];
+		return matchingPlan[ mainTerm ];
 	}
 
 	return null;
@@ -160,7 +162,7 @@ function getSlugInTerm( yearlySlug: string | null, slugTerm: Duration ) {
  * @returns {string} a monthly term product slug
  */
 export function getMonthlySlugFromYearly( yearlySlug: string | null ): string | null {
-	return getSlugInTerm( yearlySlug, TERM_ANNUALLY );
+	return getSlugInTerm( yearlySlug, TERM_MONTHLY );
 }
 
 /**
@@ -170,7 +172,7 @@ export function getMonthlySlugFromYearly( yearlySlug: string | null ): string | 
  * @returns {string} a yearly term product slug
  */
 export function getYearlySlugFromMonthly( monthlySlug: string | null ): string | null {
-	return getSlugInTerm( monthlySlug, TERM_MONTHLY );
+	return getSlugInTerm( monthlySlug, TERM_ANNUALLY );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The upgrade button that allows users to go from a monthly to a yearly subscription does nothing. This is happening because `getYearlyPlanByMonthly` doesn't work with Jetpack products, it does only with Jetpack plans.

* Replace `getYearlyPlanByMonthly` with a new function that supports both Jetpack plans and products.
* Add unit tests to make sure the new utils work as expected.

#### Testing instructions

Prerequisite: a Jetpack site with a monthly subscription.

* Download this PR.
* Run `yarn start` to start Calypso Blue.
* Visit `/plans/:site` and replace `:site` with your Jetpack site's slug.
* Make sure to select `Bill yearly`.
* Verify that the product card of your site's subscription says "Upgrade to Yearly".
* Click the product card's CTA.
* Make sure that you're redirected to Checkout with the right product in the cart.

Related to 1164141197617539-as-1200215135703301

#### Demo

https://user-images.githubusercontent.com/3418513/115778586-46e41100-a38d-11eb-920a-3634c525b549.mp4

