### PR TITLE
[E2E] Simplify CommentsAreaComponent and related specs

### DIFF
--- a/test/e2e/lib/pages/frontend/comments-area-component.js
+++ b/test/e2e/lib/pages/frontend/comments-area-component.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { By, until } from 'selenium-webdriver';
+import { By } from 'selenium-webdriver';
 
 /**
  * Internal dependencies
  */
 import * as driverHelper from '../../driver-helper';
-import * as dataHelper from '../../data-helper';
 
 import AsyncBaseContainer from '../../async-base-container';
 
@@ -16,50 +15,46 @@ export default class CommentsAreaComponent extends AsyncBaseContainer {
 		super( driver, By.css( '#comments.comments-area' ) );
 	}
 
-	async _postComment( { comment } ) {
-		const commentForm = By.css( '#commentform' );
+	/**
+	 * Posts the first comment to a post (under "Join the Conversation" in the footer).
+	 *
+	 * @param { string } comment The comment text.
+	 */
+	async _postComment( comment ) {
 		const commentField = By.css( '#comment' );
 		const submitButton = By.css( '.form-submit #comment-submit' );
-		const commentContent = By.xpath( `//div[@class='comment-content']/p[.='${ comment }']` );
 
-		await driverHelper.scrollIntoView( this.driver, commentForm, 'end' );
-		await driverHelper.clickWhenClickable( this.driver, commentForm );
-		await driverHelper.scrollIntoView( this.driver, commentForm, 'end' );
-		await this.switchToFrameIfJetpack();
-
-		await driverHelper.clickWhenClickable( this.driver, commentForm );
-		await driverHelper.waitUntilLocatedAndVisible( this.driver, submitButton );
 		await driverHelper.scrollIntoView( this.driver, submitButton );
 		await driverHelper.setWhenSettable( this.driver, commentField, comment );
 		await driverHelper.clickWhenClickable( this.driver, submitButton );
-		await this.driver.switchTo().defaultContent();
-		return await driverHelper.waitUntilLocatedAndVisible( this.driver, commentContent );
 	}
 
-	async reply( commentObj, depth = 2 ) {
+	/**
+	 * Posts a reply to a comment. Re-uses most of @see _postComment, but starts
+	 * the action by clicking the "Reply" link for an existing comment.
+	 *
+	 * @param {*} comment The comment text.
+	 */
+	async reply( comment ) {
 		const replyButton = By.css( '.comment-reply-link' );
-		const replyContent = By.xpath(
-			`//li[contains(@class,'depth-${ depth }')]//div[@class='comment-content']/p[.='${ commentObj.comment }']`
-		);
+
 		await driverHelper.clickWhenClickable( this.driver, replyButton );
-		await this._postComment( commentObj );
-		return await driverHelper.waitUntilLocatedAndVisible( this.driver, replyContent );
+		await this._postComment( comment );
 	}
 
-	async switchToFrameIfJetpack() {
-		if ( dataHelper.getJetpackHost() === 'WPCOM' ) {
-			return false;
-		}
-		await this.driver.sleep( 1000 );
-
-		const iFrameSelector = By.css( 'iframe.jetpack_remote_comment' );
-
-		await this.driver.switchTo().defaultContent();
-		await driverHelper.waitUntilLocatedAndVisible( this.driver, iFrameSelector );
-		await this.driver.wait(
-			until.ableToSwitchToFrame( iFrameSelector ),
-			this.explicitWaitMS,
-			'Could not switch to comment form iFrame'
+	/**
+	 * Verifies if a comment is visible. If you tweak the depth, you can also
+	 * "point" it to a reply comment.
+	 *
+	 * @param { string } comment The comment text.
+	 * @param { number } depth How nested you want to check. The first comment has
+	 * a depth of 1, while the first reply to it would have a depth of 2.
+	 */
+	async verifyCommentIsVisible( comment, depth = 1 ) {
+		const commentLocator = By.xpath(
+			`//li[contains(@class,'depth-${ depth }')]//div[@class='comment-content']/p[.='${ comment }']`
 		);
+
+		await driverHelper.waitUntilLocatedAndVisible( this.driver, commentLocator );
 	}
 }

--- a/test/e2e/specs-gutenberg/wp-comments-spec.js
+++ b/test/e2e/specs-gutenberg/wp-comments-spec.js
@@ -43,7 +43,7 @@ describe( `[${ host }] Comments: (${ screenSize })`, function () {
 			await this.loginFlow.loginAndStartNewPost( null, true );
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.enterTitle( blogPostTitle );
-			return await gEditorComponent.enterText( blogPostQuote );
+			await gEditorComponent.enterText( blogPostQuote );
 		} );
 
 		step( 'Can publish and visit site', async function () {
@@ -53,23 +53,20 @@ describe( `[${ host }] Comments: (${ screenSize })`, function () {
 
 		step( 'Can post a comment', async function () {
 			const commentArea = await CommentsAreaComponent.Expect( driver );
-			return await commentArea._postComment( {
-				comment: dataHelper.randomPhrase(),
-				name: 'e2eTestName',
-				email: 'e2eTestName@test.com',
-			} );
+			const comment = dataHelper.randomPhrase();
+
+			await commentArea._postComment( comment );
+
+			await commentArea.verifyCommentIsVisible( comment );
 		} );
 
 		step( 'Can post a reply', async function () {
 			const commentArea = await CommentsAreaComponent.Expect( driver );
-			await commentArea.reply(
-				{
-					comment: dataHelper.randomPhrase(),
-					name: 'e2eTestName',
-					email: 'e2eTestName@test.com',
-				},
-				2
-			);
+			const comment = dataHelper.randomPhrase();
+
+			await commentArea.reply( comment );
+
+			await commentArea.verifyCommentIsVisible( comment, 2 );
 		} );
 	} );
 } );

--- a/test/e2e/specs/wp-likes-spec.js
+++ b/test/e2e/specs/wp-likes-spec.js
@@ -66,11 +66,7 @@ describe( `[${ host }] Likes: (${ screenSize })`, function () {
 
 			// commentArea.reply fails to find .comment-reply-link at times,
 			// as we're not concerned with the assertion just call postComment directly
-			await commentArea._postComment( {
-				comment: comment,
-				name: 'e2eTestName',
-				email: 'e2eTestName@test.com',
-			} );
+			await commentArea._postComment( comment );
 		} );
 
 		step( 'Like comment', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Started as an investigation on how to fix https://github.com/Automattic/wp-calypso/issues/51946.

I could see why the spec would fail, but I couldn't reproduce the exact same error locally. I then just tried to investigate ways to tidy it up. 

Document the methods in `CommentsAreaComponent`, too.

#### Testing instructions

* The specs should pass :)


Possibly fixes https://github.com/Automattic/wp-calypso/issues/51946.
