### PR TITLE
Welcome Tour: Avoid the text cursor when the text is not selectable

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -13,6 +13,8 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 	left: 16px;
 	position: fixed;
 	z-index: 9999;
+	// Avoid the text cursor when the text is not selectable
+	cursor: default;
 }
 
 .welcome-tour-card__heading {
@@ -69,7 +71,7 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 
 	&.components-card {
 		border: none;
-		border-radius: 4px;
+		border-radius: 4px; /* stylelint-disable-line */
 	}
 
 	.components-card__body {
@@ -91,7 +93,7 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 
 		.welcome-tour__end-icon.components-button.has-icon {
 			background-color: #f6f7f7;
-			border-radius: 50%;
+			border-radius: 50%; /* stylelint-disable-line */
 			color: $gray-600;
 			margin-left: 8px;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR inhibits the text cursor no the welcome tour to reflect the fact that the text is not selectable[<sup>*</sup>]

#### Testing instructions

1. `install-plugin.sh etk fix/51612-default-cursor-for-unselectable-text`
2. Navigate to the welcome tour in the editor in a sandboxed site. If you've already dismissed it, you can reactivate it here:
![Edit_Page_‹_Julesaus_Test_Headstart_KO_—_WordPress](https://user-images.githubusercontent.com/5952255/115823255-5de83900-a449-11eb-9dfd-7baba658100b.jpg)
3. Confirm that hovering over the text throughout the welcome tour shows the default cursor (arrow), not the text cursor (also confirm you can't select easily the text. It is possible to get the text selected by dragging from outside the welcome-tour, though).
3. Confirm that all the elements that should be clickable still have the click cursor (i.e. the little hand). Notably links and the thumb-up/thumbs-down buttons.

![Edit_Page_‹_Julesaus_Test_Headstart_KO_—_WordPress](https://user-images.githubusercontent.com/5952255/115823037-f3cf9400-a448-11eb-950a-ed1f4589a97f.jpg)

Fixes #51612

[<sup>*</sup>] The "why" here is a bit puzzling. I didn't see The `user-select` property or it's variants anywhere in the elements ancestry. I also checked out z-index and the mouse click event handlers without finding the cause, although it wasn't an exhaustive search as this issue doesn't really warrant a lot of digging. If you happen to know what's going on here, though, please do let me know.
