### PR TITLE
Enables font smoothing on wpcom interfaces for Automatticians

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
@@ -1,12 +1,34 @@
 body.hide-homepage-title {
-
 	// Allow homepage title to be edited even when hidden
 	// Lighter color to signify not visible from front page
 	.editor-post-title {
-		opacity: .4;
+		opacity: 0.4;
 	}
 }
 
-.interface-interface-skeleton__editor {
-	max-width: 100%;
+body.slider-width-workaround {
+	.interface-interface-skeleton__editor {
+		max-width: 100%;
+	}
+}
+
+%font-smoothing-antialiased {
+	text-rendering: optimizeLegibility;
+	-moz-osx-font-smoothing: grayscale;
+	-webkit-font-smoothing: antialiased;
+}
+
+body.font-smoothing-antialiased {
+	@extend %font-smoothing-antialiased;
+
+	// Overriding an existing core WP rule so the ID selector is necessary
+	// stylelint-disable-next-line selector-max-id
+	#wpwrap {
+		@extend %font-smoothing-antialiased;
+	}
+
+	// stylelint-disable-next-line selector-max-id
+	#wpadminbar * {
+		@extend %font-smoothing-antialiased;
+	}
 }

--- a/apps/notifications/src/panel/Notifications.jsx
+++ b/apps/notifications/src/panel/Notifications.jsx
@@ -75,7 +75,7 @@ export class Notifications extends PureComponent {
 			customEnhancer,
 			customMiddleware: mergeHandlers( customMiddleware, {
 				APP_REFRESH_NOTES: [
-					( store, action ) => {
+					( _store, action ) => {
 						if ( ! client ) {
 							return;
 						}
@@ -100,7 +100,7 @@ export class Notifications extends PureComponent {
 		 * Initialize store with actions that need to occur on
 		 * transitions from open to close or close to open
 		 *
-		 * @TODO: Pass this information directly into the Redux initial state
+		 * @todo Pass this information directly into the Redux initial state
 		 */
 		store.dispatch( { type: SET_IS_SHOWING, isShowing } );
 

--- a/apps/notifications/src/panel/Notifications.jsx
+++ b/apps/notifications/src/panel/Notifications.jsx
@@ -19,6 +19,7 @@ import repliesCache from './comment-replies-cache';
 import { init as initAPI } from './rest-client/wpcom';
 
 import Layout from './templates';
+import FontSmoothing from './utils/font-smoothing';
 
 /**
  * Style dependencies
@@ -48,6 +49,7 @@ export class Notifications extends PureComponent {
 		locale: PropTypes.string,
 		receiveMessage: PropTypes.func,
 		wpcom: PropTypes.object.isRequired,
+		isStandalone: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -131,6 +133,7 @@ export class Notifications extends PureComponent {
 	render() {
 		return (
 			<Provider store={ store }>
+				{ this.props.isStandalone && <FontSmoothing /> }
 				<RestClientContext.Provider value={ client }>
 					<Layout
 						client={ client }

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -14,6 +14,12 @@
 	// Fixes font anti-aliasing in iframes: andrewmoreton.co.uk/typekit-iframes-safari-weird-antialiasing/
 	-webkit-font-smoothing: subpixel-antialiased;
 
+	body.font-smoothing-antialiased & {
+		text-rendering: optimizeLegibility;
+		-moz-osx-font-smoothing: grayscale;
+		-webkit-font-smoothing: antialiased;
+	}
+
 	@media only screen and ( max-width: 799px ) {
 		background-color: var( --color-neutral-0 );
 	}

--- a/apps/notifications/src/panel/rest-client/wpcom.js
+++ b/apps/notifications/src/panel/rest-client/wpcom.js
@@ -79,3 +79,14 @@ export const sendLastSeenTime = ( time ) =>
 
 export const subscribeToNoteStream = ( callback ) =>
 	wpcom().pinghub.connect( '/wpcom/me/newest-note-data', callback );
+
+export const fetchReaderTeams = ( callback ) =>
+	wpcom().req.get(
+		{
+			path: '/read/teams',
+		},
+		{
+			apiVersion: '1.2',
+		},
+		callback
+	);

--- a/apps/notifications/src/panel/utils/font-smoothing.js
+++ b/apps/notifications/src/panel/utils/font-smoothing.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { fetchReaderTeams } from '../rest-client/wpcom';
+
+export default function FontSmoothing() {
+	useEffect( () => {
+		let cancel = false;
+
+		fetchReaderTeams( ( error, response ) => {
+			if ( cancel || error ) {
+				return;
+			}
+
+			if ( ( response?.teams || [] ).find( ( team ) => team?.slug === 'a8c' ) ) {
+				document.body.classList.add( 'font-smoothing-antialiased' );
+			}
+		} );
+
+		return () => {
+			cancel = true;
+			document.body.classList.remove( 'font-smoothing-antialiased' );
+		};
+	}, [] );
+
+	return null;
+}

--- a/apps/notifications/src/standalone/index.js
+++ b/apps/notifications/src/standalone/index.js
@@ -84,6 +84,8 @@ const render = () => {
 			isVisible,
 			locale,
 			receiveMessage: sendMessage,
+			redirectPath: '/',
+			isStandalone: true,
 		} ),
 		document.getElementsByClassName( 'wpnc__main' )[ 0 ]
 	);

--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -60,6 +60,12 @@ body {
 	@include breakpoint-deprecated( '<660px' ) {
 		cursor: pointer;
 	}
+
+	&.font-smoothing-antialiased {
+		text-rendering: optimizeLegibility;
+		-moz-osx-font-smoothing: grayscale;
+		-webkit-font-smoothing: antialiased;
+	}
 }
 
 ::selection {

--- a/client/assets/stylesheets/gutenboarding.scss
+++ b/client/assets/stylesheets/gutenboarding.scss
@@ -28,4 +28,10 @@ html,
 body {
 	font-family: $default-font;
 	font-size: $font-body;
+
+	&.font-smoothing-antialiased {
+		text-rendering: optimizeLegibility;
+		-moz-osx-font-smoothing: grayscale;
+		-webkit-font-smoothing: antialiased;
+	}
 }

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -8,6 +8,7 @@ import { createBlock, registerBlockType } from '@wordpress/blocks';
 import '@wordpress/format-library';
 import { useI18n } from '@wordpress/react-i18n';
 import { FontPair, getFontTitle } from '@automattic/design-picker';
+import { useSelect } from '@wordpress/data';
 
 // Uncomment and remove the redundant sass import from `./style.css` when a release after @wordpress/components@8.5.0 is published.
 // See https://github.com/WordPress/gutenberg/pull/19535
@@ -27,6 +28,8 @@ import useOnLogin from './hooks/use-on-login';
 import useSiteTitle from './hooks/use-site-title';
 import useTrackOnboardingStart from './hooks/use-track-onboarding-start';
 import { useFontPairings } from './fonts';
+import { useBodyClass } from './hooks/use-body-class';
+import { READER_STORE } from './stores/reader';
 
 import './style.scss';
 
@@ -42,6 +45,9 @@ const Gutenboard: React.FunctionComponent = () => {
 	useSiteTitle();
 	const { showSignupDialog, onSignupDialogClose } = useSignup();
 	const effectiveFontPairings = useFontPairings();
+
+	const isA8cTeamMember = useSelect( ( select ) => select( READER_STORE ).isA8cTeamMember() );
+	useBodyClass( 'font-smoothing-antialiased', isA8cTeamMember );
 
 	// TODO: Explore alternatives for loading fonts and optimizations
 	// TODO: Don't load like this

--- a/client/landing/gutenboarding/hooks/test/use-body-class.test.ts
+++ b/client/landing/gutenboarding/hooks/test/use-body-class.test.ts
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import { useBodyClass } from '../use-body-class';
+
+const classList = new Set();
+const add = jest.fn( ( className ) => classList.add( className ) );
+const remove = jest.fn( ( className ) => classList.delete( className ) );
+
+// @ts-expect-error intentionally mocking `window` with an incomplete type
+global.window = { document: { body: { classList: { add, remove } } } };
+
+test( "doesn't change class list when boolean is false", () => {
+	renderHook( () => useBodyClass( 'test-class', false ) );
+	expect( classList ).not.toContain( 'test-class' );
+} );
+
+test( 'adds class when boolean is true', () => {
+	renderHook( () => useBodyClass( 'test-class', true ) );
+	expect( classList ).toContain( 'test-class' );
+} );
+
+test( 'adds class when boolean changes from false to true', () => {
+	let applyClass = false;
+	const { rerender } = renderHook( () => useBodyClass( 'test-class', applyClass ) );
+
+	expect( classList ).not.toContain( 'test-class' );
+
+	applyClass = true;
+	rerender();
+
+	expect( classList ).toContain( 'test-class' );
+} );
+
+test( 'removes class when boolean changes from true to false', () => {
+	let applyClass = true;
+	const { rerender } = renderHook( () => useBodyClass( 'test-class', applyClass ) );
+
+	expect( classList ).toContain( 'test-class' );
+
+	applyClass = false;
+	rerender();
+
+	expect( classList ).not.toContain( 'test-class' );
+} );
+
+test( 'removes old class when class name changes', () => {
+	let className = 'class1';
+	const { rerender } = renderHook( () => useBodyClass( className, true ) );
+
+	expect( classList ).toContain( 'class1' );
+	expect( classList ).not.toContain( 'class2' );
+
+	className = 'class2';
+	rerender();
+
+	expect( classList ).not.toContain( 'class1' );
+	expect( classList ).toContain( 'class2' );
+} );
+
+test( "doesn't add new class when boolean is always false", () => {
+	let className = 'class1';
+	const { rerender } = renderHook( () => useBodyClass( className, false ) );
+
+	expect( classList ).not.toContain( 'class1' );
+	expect( classList ).not.toContain( 'class2' );
+
+	className = 'class2';
+	rerender();
+
+	expect( classList ).not.toContain( 'class1' );
+	expect( classList ).not.toContain( 'class2' );
+} );
+
+test( 'add new class when class name changes _and_ boolean switches to true', () => {
+	let className = 'class1';
+	let applyClass = false;
+	const { rerender } = renderHook( () => useBodyClass( className, applyClass ) );
+
+	expect( classList ).not.toContain( 'class1' );
+	expect( classList ).not.toContain( 'class2' );
+
+	className = 'class2';
+	applyClass = true;
+	rerender();
+
+	expect( classList ).not.toContain( 'class1' );
+	expect( classList ).toContain( 'class2' );
+} );
+
+test( 'remove old class when class name changes _and_ boolean switches to false', () => {
+	let className = 'class1';
+	let applyClass = true;
+	const { rerender } = renderHook( () => useBodyClass( className, applyClass ) );
+
+	expect( classList ).toContain( 'class1' );
+	expect( classList ).not.toContain( 'class2' );
+
+	className = 'class2';
+	applyClass = false;
+	rerender();
+
+	expect( classList ).not.toContain( 'class1' );
+	expect( classList ).not.toContain( 'class2' );
+} );

--- a/client/landing/gutenboarding/hooks/use-body-class.ts
+++ b/client/landing/gutenboarding/hooks/use-body-class.ts
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from 'react';
+
+export function useBodyClass( classname: string, shouldApplyClass: boolean ): void {
+	const appliedClass = useRef( '' );
+
+	useEffect( () => {
+		if ( shouldApplyClass ) {
+			appliedClass.current = classname;
+			window.document.body.classList.add( classname );
+		}
+
+		return () => {
+			if ( appliedClass.current ) {
+				window.document.body.classList.remove( appliedClass.current );
+				appliedClass.current = '';
+			}
+		};
+	}, [ shouldApplyClass, classname ] );
+}

--- a/client/landing/gutenboarding/stores/reader/index.ts
+++ b/client/landing/gutenboarding/stores/reader/index.ts
@@ -1,0 +1,6 @@
+/**
+ * External dependencies
+ */
+import { Reader } from '@automattic/data-stores';
+
+export const READER_STORE = Reader.register();

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -54,6 +54,8 @@ import { getShouldShowAppBanner, handleScroll } from './utils';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { isWithinBreakpoint } from '@automattic/viewport';
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
 
 /**
  * Style dependencies
@@ -129,6 +131,7 @@ class Layout extends Component {
 		sectionName: PropTypes.string,
 		colorSchemePreference: PropTypes.string,
 		shouldShowAppBanner: PropTypes.bool,
+		useFontSmoothAntialiased: PropTypes.bool,
 	};
 
 	componentDidMount() {
@@ -262,6 +265,10 @@ class Layout extends Component {
 
 			if ( this.props.sidebarIsCollapsed && isWithinBreakpoint( '>800px' ) ) {
 				bodyClass.push( 'is-sidebar-collapsed' );
+			}
+
+			if ( this.props.useFontSmoothAntialiased ) {
+				bodyClass.push( 'font-smoothing-antialiased' );
 			}
 
 			return {
@@ -442,6 +449,7 @@ export default compose(
 			isCheckoutFromGutenboarding,
 			isNavUnificationEnabled: isNavUnificationEnabled( state ),
 			sidebarIsCollapsed: getSidebarIsCollapsed( state ),
+			useFontSmoothAntialiased: isAutomatticTeamMember( getReaderTeams( state ) ),
 		};
 	} )
 )( Layout );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -54,8 +54,10 @@ import { getShouldShowAppBanner, handleScroll } from './utils';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { isWithinBreakpoint } from '@automattic/viewport';
+import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
 /**
  * Style dependencies
@@ -131,6 +133,7 @@ class Layout extends Component {
 		sectionName: PropTypes.string,
 		colorSchemePreference: PropTypes.string,
 		shouldShowAppBanner: PropTypes.bool,
+		shouldRequestReaderTeams: PropTypes.bool,
 		useFontSmoothAntialiased: PropTypes.bool,
 	};
 
@@ -279,8 +282,11 @@ class Layout extends Component {
 
 		const loadInlineHelp = this.shouldLoadInlineHelp();
 
+		const { shouldRequestReaderTeams } = this.props;
+
 		return (
 			<div className={ sectionClass }>
+				{ shouldRequestReaderTeams && <QueryReaderTeams /> }
 				<SidebarScrollSynchronizer enabled={ this.props.isNavUnificationEnabled } />
 				<SidebarOverflowDelay layoutFocus={ this.props.currentLayoutFocus } />
 				<BodySectionCssClass
@@ -449,6 +455,7 @@ export default compose(
 			isCheckoutFromGutenboarding,
 			isNavUnificationEnabled: isNavUnificationEnabled( state ),
 			sidebarIsCollapsed: getSidebarIsCollapsed( state ),
+			shouldRequestReaderTeams: !! getCurrentUser( state ),
 			useFontSmoothAntialiased: isAutomatticTeamMember( getReaderTeams( state ) ),
 		};
 	} )

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -27,6 +27,10 @@ import GdprBanner from 'calypso/blocks/gdpr-banner';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { withCurrentRoute } from 'calypso/components/route';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
 
 /**
  * Style dependencies
@@ -49,6 +53,8 @@ const LayoutLoggedOut = ( {
 	sectionTitle,
 	redirectUri,
 	useOAuth2Layout,
+	shouldRequestReaderTeams,
+	useFontSmoothAntialiased,
 } ) => {
 	const isCheckout = sectionName === 'checkout';
 	const isJetpackCheckout =
@@ -111,9 +117,15 @@ const LayoutLoggedOut = ( {
 		);
 	}
 
+	const bodyClass = [];
+	if ( useFontSmoothAntialiased ) {
+		bodyClass.push( 'font-smoothing-antialiased' );
+	}
+
 	return (
 		<div className={ classNames( 'layout', classes ) }>
-			<BodySectionCssClass group={ sectionGroup } section={ sectionName } />
+			{ shouldRequestReaderTeams && <QueryReaderTeams /> }
+			<BodySectionCssClass group={ sectionGroup } section={ sectionName } bodyClass={ bodyClass } />
 			{ masterbar }
 			<div id="content" className="layout__content">
 				<AsyncLoad require="calypso/components/global-notices" placeholder={ null } id="notices" />
@@ -140,6 +152,8 @@ LayoutLoggedOut.propTypes = {
 	section: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 	redirectUri: PropTypes.string,
 	showOAuth2Layout: PropTypes.bool,
+	shouldRequestReaderTeams: PropTypes.bool,
+	useFontSmoothAntialiased: PropTypes.bool,
 };
 
 export default compose(
@@ -173,6 +187,8 @@ export default compose(
 			sectionTitle,
 			oauth2Client: getCurrentOAuth2Client( state ),
 			useOAuth2Layout: showOAuth2Layout( state ),
+			shouldRequestReaderTeams: !! getCurrentUser( state ),
+			useFontSmoothAntialiased: isAutomatticTeamMember( getReaderTeams( state ) ),
 		};
 	} )
 )( LayoutLoggedOut );

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -36,6 +36,12 @@ $autobar-height: 20px;
 		border-bottom: 1px solid var( --color-jetpack-masterbar-border );
 		color: var( --color-jetpack-masterbar-text );
 	}
+
+	body.font-smoothing-antialiased & {
+		text-rendering: optimizeLegibility;
+		-moz-osx-font-smoothing: grayscale;
+		-webkit-font-smoothing: antialiased;
+	}
 }
 
 .pride .masterbar {

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -12,6 +12,7 @@ import * as Launch from './launch';
 import * as WPCOMFeatures from './wpcom-features';
 import * as VerticalsTemplates from './verticals-templates';
 import * as I18n from './i18n';
+import * as Reader from './reader';
 
 export {
 	Auth,
@@ -24,6 +25,7 @@ export {
 	Plans,
 	Launch,
 	WPCOMFeatures,
+	Reader,
 	persistenceConfigFactory,
 };
 

--- a/packages/data-stores/src/reader/actions.ts
+++ b/packages/data-stores/src/reader/actions.ts
@@ -1,0 +1,20 @@
+export interface ReaderTeam {
+	slug: string;
+	team: string;
+}
+
+export interface ReaderTeamsResponse {
+	number: number;
+	teams: ReaderTeam[];
+}
+
+export const fetchReaderTeamsSuccess = ( response: ReaderTeamsResponse ) =>
+	( {
+		type: 'FETCH_READER_TEAMS_SUCCESS',
+		response,
+	} as const );
+
+export type ReaderAction =
+	| ReturnType< typeof fetchReaderTeamsSuccess >
+	// Dummy action used during testing
+	| { type: 'DUMMY_ACTION' };

--- a/packages/data-stores/src/reader/constants.ts
+++ b/packages/data-stores/src/reader/constants.ts
@@ -1,0 +1,1 @@
+export const STORE_KEY = 'automattic/reader';

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { plugins, registerStore, use } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY } from './constants';
+import reducer, { State } from './reducer';
+import * as resolvers from './resolvers';
+import * as actions from './actions';
+import * as selectors from './selectors';
+import persistOptions from './persist';
+import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
+import { controls } from '../wpcom-request-controls';
+
+export type { State };
+export { STORE_KEY };
+
+use( plugins.persistence, persistOptions );
+
+let isRegistered = false;
+
+export function register(): typeof STORE_KEY {
+	if ( ! isRegistered ) {
+		isRegistered = true;
+		registerStore< State >( STORE_KEY, {
+			actions,
+			controls: controls as any,
+			reducer: reducer as any,
+			resolvers,
+			selectors,
+			persist: [ 'teams' ],
+		} );
+	}
+	return STORE_KEY;
+}
+
+declare module '@wordpress/data' {
+	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof actions >;
+	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
+}

--- a/packages/data-stores/src/reader/persist.ts
+++ b/packages/data-stores/src/reader/persist.ts
@@ -1,0 +1,6 @@
+/**
+ * External dependencies
+ */
+import persistenceConfigFactory from '../persistence-config-factory';
+
+export default persistenceConfigFactory( 'WP_READER' );

--- a/packages/data-stores/src/reader/reducer.ts
+++ b/packages/data-stores/src/reader/reducer.ts
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import type { Reducer } from 'redux';
+import { combineReducers } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import type { ReaderTeam, ReaderAction } from './actions';
+
+const teams: Reducer< ReaderTeam[] | null, ReaderAction > = ( state = null, action ) => {
+	if ( action.type === 'FETCH_READER_TEAMS_SUCCESS' ) {
+		return action.response.teams;
+	}
+	return state;
+};
+
+const reducer = combineReducers( {
+	teams,
+} );
+
+export type State = ReturnType< typeof reducer >;
+
+export default reducer;

--- a/packages/data-stores/src/reader/resolvers.ts
+++ b/packages/data-stores/src/reader/resolvers.ts
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { fetchReaderTeamsSuccess, ReaderTeamsResponse } from './actions';
+import { wpcomRequest } from '../wpcom-request-controls';
+
+export function* isA8cTeamMember(): Generator {
+	try {
+		const response = yield wpcomRequest( {
+			method: 'GET',
+			path: '/read/teams',
+			apiVersion: '1.2',
+		} );
+		yield fetchReaderTeamsSuccess( response as ReaderTeamsResponse );
+	} catch {
+		// Ignore errors
+	}
+}

--- a/packages/data-stores/src/reader/selectors.ts
+++ b/packages/data-stores/src/reader/selectors.ts
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import type { State } from './reducer';
+
+export const isA8cTeamMember = ( state: State ): boolean =>
+	!! ( state.teams || [] ).find( ( team ) => team.slug === 'a8c' );

--- a/packages/data-stores/src/reader/test/reader-store.test.ts
+++ b/packages/data-stores/src/reader/test/reader-store.test.ts
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import waitForExpect from 'wait-for-expect';
+import wpcomRequest from 'wpcom-proxy-request';
+
+/**
+ * Internal dependencies
+ */
+import { dispatch, select } from '@wordpress/data';
+import { register } from '../index';
+import { STORE_KEY } from '../constants';
+import readerReducer from '../reducer';
+
+jest.mock( 'wpcom-proxy-request', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+	requestAllBlogsAccess: jest.fn( () => Promise.resolve() ),
+} ) );
+
+beforeAll( () => {
+	register();
+} );
+
+beforeEach( () => {
+	// Reset the store back to default state
+	dispatch( STORE_KEY ).fetchReaderTeamsSuccess( { teams: null } as any );
+} );
+
+test( 'teams state defaults to `null`', () => {
+	const defaultState = readerReducer( undefined, { type: 'DUMMY_ACTION' } );
+	expect( defaultState.teams ).toBe( null );
+} );
+
+test( 'selecting isA8cTeamMember requests teams data from API', async () => {
+	( wpcomRequest as jest.Mock ).mockResolvedValue( {
+		count: 0,
+		teams: [ { name: '', slug: 'a8c' } ],
+	} );
+
+	const isTeamMember = select( STORE_KEY ).isA8cTeamMember();
+
+	// Returns false while response is loading
+	expect( isTeamMember ).toBe( false );
+
+	await waitForExpect( () => {
+		const isTeamMember = select( STORE_KEY ).isA8cTeamMember();
+		expect( isTeamMember ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds the `-webkit-font-smoothing: antialiased` rule to wpcom interfaces for Automatticians
Context: p9Jlb4-2ur-p2

Rolling out to a12s first so we can work out any issues and get feedback.

This is a biggish PR so I've tried to split the commits into logical chunks.

Smoothing added to:
- [x] Calypso
- [x] `/log-in` page (this is a special case because you can still be logged in on this page so we can check whether is a11n)
- [x] wp-admin (including editor)
- [x] New onboarding
- [x] Calypso masterbar
- [x] wp-admin masterbar
- [x] Notifications

Not done:
- `/themes` and `/domains`, these landing pages don't appear to be part of the Calypso project
- Atomic. The `a8c_use_font_smoothing_antialiased` filter will allow us to enable smoothing on atomic too, but it'll require a change to `wpcomsh` before it's enabled there.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Testing everything requires a sandbox due to the changes to the Editing Toolkit plugin and notifications panel.

You can test the changes in the main Calypso UI at https://calypso.live/?branch=update/use-font-smoothing-antialiased

To test everything:
- Apply D60560-code to sandbox
- Run `install-plugin.sh etk update/use-font-smoothing-antialiased` in your sandbox
- Run `install-plugin.sh notifications update/use-font-smoothing-antialiased` in your sandbox
- Sandbox a simple site (this change won't work on Atomic sites until a new wpcomsh version has shipped)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #52192

#### Some screenshots

|   | non-a11n | a11n |
| ---- | -------- | ----- |
| **Calypso** | <img width="1392" alt="non-a8c-calypso" src="https://user-images.githubusercontent.com/1500769/116354317-57dcc880-a84c-11eb-9d62-889b90dc5245.png"> | <img width="1392" alt="a8c-calypso" src="https://user-images.githubusercontent.com/1500769/116353359-bacd6000-a84a-11eb-8d39-1d3aca014aa3.png"> |
| **wp-admin** | <img width="1392" alt="non-a8c-wp-admin" src="https://user-images.githubusercontent.com/1500769/116354296-501d2400-a84c-11eb-8868-96079782692a.png"> | <img width="1392" alt="a8c-wp-admin" src="https://user-images.githubusercontent.com/1500769/116353399-cc166c80-a84a-11eb-852a-b2341ec47be7.png"> |
| **New onboarding** | <img width="1392" alt="non-a8c-new" src="https://user-images.githubusercontent.com/1500769/116354329-5b704f80-a84c-11eb-9ba2-9cccaa8c7b87.png"> | <img width="1392" alt="a8c-new" src="https://user-images.githubusercontent.com/1500769/116353840-90c86d80-a84b-11eb-8b64-cbedeb1ff74c.png"> |
| **Logged in log in** | <img width="1348" alt="non-a8c-login" src="https://user-images.githubusercontent.com/1500769/116353905-b2295980-a84b-11eb-8496-15a84cef1a7b.png"> | <img width="1348" alt="a8c-login" src="https://user-images.githubusercontent.com/1500769/116353866-a0e04d00-a84b-11eb-9c7d-2fb225ee2b06.png"> |
