### PR TITLE
Framework: Refactor away from `_.replace()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -425,6 +425,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/pad-start': 'error',
 		'you-dont-need-lodash-underscore/reduce-right': 'error',
 		'you-dont-need-lodash-underscore/repeat': 'error',
+		'you-dont-need-lodash-underscore/replace': 'error',
 		'you-dont-need-lodash-underscore/reverse': 'error',
 		'you-dont-need-lodash-underscore/select': 'error',
 		'you-dont-need-lodash-underscore/slice': 'error',

--- a/client/components/domains/registrant-extra-info/with-contact-details-validation.jsx
+++ b/client/components/domains/registrant-extra-info/with-contact-details-validation.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import validatorFactory from 'is-my-json-valid';
-import { get, isEmpty, map, once, reduce, replace, update } from 'lodash';
+import { get, isEmpty, map, once, reduce, update } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:domains:with-contact-details-validation' );
 
@@ -65,7 +65,7 @@ export function interpretIMJVError( error, schema ) {
 	}
 
 	// use field from error
-	const path = explicitPath || replace( error.field, /^data\./, '' );
+	const path = explicitPath || ( error.field ?? '' ).replace( /^data\./, '' );
 
 	return { errorMessage, errorCode, path };
 }

--- a/client/lib/domains/get-domain-product-slug.js
+++ b/client/lib/domains/get-domain-product-slug.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes, replace } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,7 +10,7 @@ import { getTld } from './get-tld';
 
 export function getDomainProductSlug( domain ) {
 	const tld = getTld( domain );
-	const tldSlug = replace( tld, /\./g, 'dot' );
+	const tldSlug = tld.replace( /\./g, 'dot' );
 
 	if ( includes( [ 'com', 'net', 'org' ], tldSlug ) ) {
 		return 'domain_reg';

--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -3,7 +3,6 @@
  */
 import debugFactory from 'debug';
 import { get as webauthn_auth } from '@github/webauthn-json';
-import { replace } from 'lodash';
 
 const debug = debugFactory( 'calypso:two-step-authorization' );
 
@@ -146,7 +145,7 @@ TwoStepAuthorization.prototype.validateCode = function ( args, callback ) {
 	wpcom.me().validateTwoStepCode(
 		{
 			...args,
-			code: replace( args.code, /\s/g, '' ),
+			code: args.code.replace( /\s/g, '' ),
 		},
 		function ( error, data ) {
 			if ( ! error && data.success ) {
@@ -236,7 +235,7 @@ TwoStepAuthorization.prototype.backupCodes = function ( callback ) {
  */
 TwoStepAuthorization.prototype.validateBackupCode = function ( code, callback ) {
 	const args = {
-		code: replace( code, /\s/g, '' ),
+		code: code.replace( /\s/g, '' ),
 		action: 'create-backup-receipt',
 	};
 

--- a/client/my-sites/domains/domain-management/name-servers/dns-templates.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/dns-templates.jsx
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-import { find, replace } from 'lodash';
+import { find } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -58,7 +57,7 @@ class DnsTemplates extends React.Component {
 					dnsTemplateService: dnsTemplates.MICROSOFT_OFFICE365.SERVICE,
 					modifyVariables: ( variables ) =>
 						Object.assign( {}, variables, {
-							mxdata: replace( variables.domain, '.', '-' ) + '.mail.protection.outlook.com',
+							mxdata: variables.domain.replace( '.', '-' ) + '.mail.protection.outlook.com',
 						} ),
 				},
 				{

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import { identity, isEqual, find, replace, some, get } from 'lodash';
+import { identity, isEqual, find, some, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -469,7 +469,7 @@ export class SharingService extends Component {
 		return (
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			<SocialLogo
-				icon={ replace( this.props.service.ID, /_/g, '-' ) }
+				icon={ this.props.service.ID.replace( /_/g, '-' ) }
 				size={ 48 }
 				className="sharing-service__logo"
 			/>

--- a/client/state/account-recovery/settings/actions.js
+++ b/client/state/account-recovery/settings/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { replace } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import wpcom from 'calypso/lib/wp';
@@ -287,7 +282,7 @@ export const validateAccountRecoveryPhone = ( code ) => ( dispatch ) => {
 	return wpcom
 		.undocumented()
 		.me()
-		.validateAccountRecoveryPhone( replace( code, /\s/g, '' ) )
+		.validateAccountRecoveryPhone( code?.replace( /\s/g, '' ) )
 		.then( () => {
 			dispatch( validateAccountRecoveryPhoneSuccess() );
 			dispatch( onAccountRecoveryPhoneValidationSuccess() );

--- a/client/state/account-recovery/settings/actions.js
+++ b/client/state/account-recovery/settings/actions.js
@@ -282,7 +282,7 @@ export const validateAccountRecoveryPhone = ( code ) => ( dispatch ) => {
 	return wpcom
 		.undocumented()
 		.me()
-		.validateAccountRecoveryPhone( code?.replace( /\s/g, '' ) )
+		.validateAccountRecoveryPhone( code.replace( /\s/g, '' ) )
 		.then( () => {
 			dispatch( validateAccountRecoveryPhoneSuccess() );
 			dispatch( onAccountRecoveryPhoneValidationSuccess() );

--- a/client/state/account-recovery/settings/test/actions.js
+++ b/client/state/account-recovery/settings/test/actions.js
@@ -497,7 +497,7 @@ describe( 'account-recovery actions', () => {
 			successResponse: { success: true },
 			errorResponse: errorResponse,
 		},
-		thunk: () => validateAccountRecoveryPhone()( spy ),
+		thunk: () => validateAccountRecoveryPhone( '' )( spy ),
 		preCondition: () =>
 			assert(
 				spy.calledWith( {

--- a/client/state/login/actions/login-user-with-two-factor-verification-code.js
+++ b/client/state/login/actions/login-user-with-two-factor-verification-code.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, replace } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,7 +36,7 @@ export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, twoFactorAu
 	return postLoginRequest( 'two-step-authentication-endpoint', {
 		user_id: getTwoFactorUserId( getState() ),
 		auth_type: twoFactorAuthType,
-		two_step_code: replace( twoStepCode, /\s/g, '' ),
+		two_step_code: twoStepCode.replace( /\s/g, '' ),
 		two_step_nonce: getTwoFactorAuthNonce( getState(), twoFactorAuthType ),
 		remember_me: true,
 		client_id: config( 'wpcom_signup_id' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `replace()` is used several times in the codebase, but it's pretty straightforward to replace it with a `String.prototype.replace()`, with the exception that we need to ensure that we're not calling it on a nullish value.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all tests pass: `yarn run test-client`.
* Follow all code paths and verify that any of the instances we're calling without safeguards will always be strings.
* Try importing `replace` from `lodash` and verify you're getting an ESLint error.