### PR TITLE
i18n: Fix translation of "Expired today" for purchases

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -223,24 +223,24 @@ class PurchaseItem extends Component {
 		}
 
 		if ( isExpired( purchase ) ) {
-			const expiredToday = moment().diff( expiry, 'hours' ) < 24;
-			const expiredText = expiredToday ? expiry.format( '[today]' ) : expiry.fromNow();
-
 			if ( isConciergeSession( purchase ) ) {
 				return translate( 'Session used on %s', {
 					args: expiry.format( 'LL' ),
 				} );
 			}
 
+			const isExpiredToday = moment().diff( expiry, 'hours' ) < 24;
+			const expiredTodayText = translate( 'Expired today' );
+			const expiredFromNowText = translate( 'Expired %(timeSinceExpiry)s', {
+				args: {
+					timeSinceExpiry: expiry.fromNow(),
+				},
+				context: 'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
+			} );
+
 			return (
 				<span className="purchase-item__is-error">
-					{ translate( 'Expired %(timeSinceExpiry)s', {
-						args: {
-							timeSinceExpiry: expiredText,
-						},
-						context:
-							'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
-					} ) }
+					{ isExpiredToday ? expiredTodayText : expiredFromNowText }
 					{ this.trackImpression( 'purchase-expired' ) }
 				</span>
 			);

--- a/client/me/purchases/purchase-item/test/index.js
+++ b/client/me/purchases/purchase-item/test/index.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import moment from 'moment';
+import React from 'react';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import PurchaseItem from '../';
+import i18n from 'i18n-calypso';
+
+describe( 'PurchaseItem', () => {
+	describe( 'a purchase that expired < 24 hours ago', () => {
+		const purchase = {
+			productSlug: 'business-bundle',
+			expiryStatus: 'expired',
+			expiryDate: moment().subtract( 10, 'hours' ).format(),
+		};
+
+		const store = createStore( () => {}, {} );
+		const wrapper = shallow(
+			<Provider store={ store }>
+				<PurchaseItem purchase={ purchase } />
+			</Provider>
+		);
+
+		test( 'should be described as "Expired today"', () => {
+			expect( wrapper.html() ).toContain( 'Expired today' );
+		} );
+
+		test( 'should be described with a translated label', () => {
+			const translation = 'Vandaag verlopen';
+			i18n.addTranslations( { 'Expired today': [ translation ] } );
+			expect( wrapper.html() ).toContain( translation );
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the translation of "Expired today" status texts in the purchase list at `/me/purchases`
* Uses an existing obsolete translated string: "Expired today"

#### Before: the word "today" was not translated

![image](https://user-images.githubusercontent.com/75777864/115850891-a4786c00-a426-11eb-82a6-1924eea198a7.png)

#### After: the word "today" is translated as well

![image](https://user-images.githubusercontent.com/75777864/115850977-bb1ec300-a426-11eb-83a7-b87e0fb7f708.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review code changes and confirm tests are passing in `client/me/purchases/purchase-item/test/index.js`
* As long as the translations of "Expired today" have not been deployed, the English text will be shown. To check the UI anyway:
    1. Simulate a purchase that expired today by adding the following after [this line](https://github.com/Automattic/wp-calypso/blob/c2781de55db6732700b6833b509d8c104d1af7e6/client/me/purchases/purchase-item/index.jsx#L58):
        ```js
        purchase.expiryStatus = 'expired';
        purchase.expiryDate = "2021-04-23T00:00:00+00:00";  // Use the current date here.
        ```

    2. Manually add a translation in the code:
        ```js
        i18n.addTranslations({"Expired today": ["Vandaag verlopen"]});
        ```


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 189-gh-Automattic/i18n-issues