### PR TITLE
Framework: Refactor away from `_.union()`

### DIFF
--- a/client/blocks/all-sites/all-sites-icon.jsx
+++ b/client/blocks/all-sites/all-sites-icon.jsx
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
-import { union } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,7 +30,10 @@ export default class AllSitesIcon extends React.Component {
 	}
 
 	getIcons() {
-		const sites = union( this.getSitesWithIcons(), this.getMaxSites() ).slice( 0, MAX_ICONS );
+		const sites = [ ...new Set( [].concat( this.getSitesWithIcons(), this.getMaxSites() ) ) ].slice(
+			0,
+			MAX_ICONS
+		);
 		return sites.map( ( site ) => <SiteIcon site={ site } key={ site.ID } size={ 14 } /> );
 	}
 

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { union, includes } from 'lodash';
+import { includes } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import page from 'page';
@@ -188,7 +188,8 @@ function getProceedButtonText( holds: string[], translate: LocalizeProps[ 'trans
 
 function isProceedButtonDisabled( isEligible: boolean, holds: string[] ) {
 	const resolvableHolds = [ 'NO_BUSINESS_PLAN', 'SITE_UNLAUNCHED', 'SITE_NOT_PUBLIC' ];
-	const canHandleHoldsAutomatically = union( resolvableHolds, holds ).length === 3;
+	const canHandleHoldsAutomatically =
+		[ ...new Set( [].concat( resolvableHolds, holds ) ) ].length === 3;
 	return ! canHandleHoldsAutomatically && ! isEligible;
 }
 

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -188,8 +188,7 @@ function getProceedButtonText( holds: string[], translate: LocalizeProps[ 'trans
 
 function isProceedButtonDisabled( isEligible: boolean, holds: string[] ) {
 	const resolvableHolds = [ 'NO_BUSINESS_PLAN', 'SITE_UNLAUNCHED', 'SITE_NOT_PUBLIC' ];
-	const canHandleHoldsAutomatically =
-		[ ...new Set( [].concat( resolvableHolds, holds ) ) ].length === 3;
+	const canHandleHoldsAutomatically = holds.every( ( h ) => resolvableHolds.includes( h ) );
 	return ! canHandleHoldsAutomatically && ! isEligible;
 }
 

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { includes, filter, map, reduce, union } from 'lodash';
+import { includes, filter, map, reduce } from 'lodash';
 import { WindowScroller } from '@automattic/react-virtualized';
 
 /**
@@ -138,7 +138,7 @@ export class TaxonomyManagerList extends Component {
 
 	requestPages = ( pages ) => {
 		this.setState( {
-			requestedPages: union( this.state.requestedPages, pages ),
+			requestedPages: [ ...new Set( [].concat( this.state.requestedPages, pages ) ) ],
 		} );
 	};
 

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import creditcards from 'creditcards';
-import { capitalize, compact, isEmpty, mergeWith, union } from 'lodash';
+import { capitalize, compact, isEmpty, mergeWith } from 'lodash';
 import i18n from 'i18n-calypso';
 import { isValidPostalCode } from '@automattic/wpcom-checkout';
 
@@ -181,7 +181,9 @@ export function paymentFieldRules( paymentDetails, paymentType ) {
  */
 export function mergeValidationRules( ...rulesets ) {
 	return mergeWith( {}, ...rulesets, ( objValue, srcValue ) =>
-		Array.isArray( objValue ) && Array.isArray( srcValue ) ? union( objValue, srcValue ) : undefined
+		Array.isArray( objValue ) && Array.isArray( srcValue )
+			? [ ...new Set( [].concat( objValue, srcValue ) ) ]
+			: undefined
 	);
 }
 

--- a/client/lib/track-form/index.jsx
+++ b/client/lib/track-form/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { union } from 'lodash';
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:track-form' );
@@ -16,7 +15,7 @@ export const trackForm = ( WrappedComponent ) =>
 
 		updateFields = ( fields, callback ) => {
 			const newState = {
-				dirtyFields: union( this.state.dirtyFields, Object.keys( fields ) ),
+				dirtyFields: [ ...new Set( [].concat( this.state.dirtyFields, Object.keys( fields ) ) ) ],
 				fields: {
 					...this.state.fields,
 					...fields,

--- a/client/my-sites/activity/activity-log-tasklist/index.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { isEmpty, get, each, includes, union, find } from 'lodash';
+import { isEmpty, get, each, includes, find } from 'lodash';
 import page from 'page';
 
 /**
@@ -52,6 +52,8 @@ const isItemUpdating = ( updatables ) =>
  * @returns {boolean}   True if the plugin or theme is enqueued to be updated.
  */
 const isItemEnqueued = ( updateSlug, updateQueue ) => !! find( updateQueue, { slug: updateSlug } );
+
+const union = ( ...arrays ) => [ ...new Set( [].concat( ...arrays ) ) ];
 
 const MAX_UPDATED_TO_SHOW = 3;
 

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { identity, includes, union } from 'lodash';
+import { identity, includes } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -192,7 +191,7 @@ export class MediaLibraryFilterBar extends Component {
 
 	render() {
 		const disabledSources = this.props.disableLargeImageSources
-			? union( this.props.disabledDataSources, largeImageSources )
+			? [ ...new Set( [].concat( this.props.disabledDataSources, largeImageSources ) ) ]
 			: this.props.disabledDataSources;
 
 		// Dropdown is disabled when viewing any external data source

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { filter, some, find, get, includes, keyBy, map, omit, union, reject } from 'lodash';
+import { filter, some, find, get, includes, keyBy, map, omit, reject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,6 +28,8 @@ import {
 } from 'calypso/state/reader/action-types';
 import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import { itemsSchema, subscriptionsSchema, updatedListsSchema, errorsSchema } from './schema';
+
+const union = ( ...arrays ) => [ ...new Set( [].concat( ...arrays ) ) ];
 
 /**
  * Tracks all known list objects, indexed by list ID.

--- a/client/state/reader/lists/test/reducer.js
+++ b/client/state/reader/lists/test/reducer.js
@@ -104,7 +104,7 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should add a list ID when a list is updated', () => {
-			const state = updatedLists( null, {
+			const state = updatedLists( [], {
 				type: READER_LIST_UPDATE_SUCCESS,
 				data: {
 					list: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `union()` is used several times in the codebase, but it's pretty straightforward to replace it with a `[ ...new Set( [].concat( ...arrays ) ) ]`. The only thing we should make sure is that none of the arrays passed there is a `null` or `undefined`.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all tests pass: `yarn run test-client`.