### PR TITLE
People: Handle external contributor check properly

### DIFF
--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -273,9 +273,11 @@ export default localize(
 	connect(
 		( state, { siteId, user } ) => {
 			const externalContributors = ( siteId && requestExternalContributors( siteId ).data ) || [];
+			const userId = user?.linked_user_ID || user?.ID;
+
 			return {
 				currentUser: getCurrentUser( state ),
-				isExternalContributor: externalContributors.includes( user?.linked_user_ID ?? user?.ID ),
+				isExternalContributor: userId && externalContributors.includes( userId ),
 				isVip: isVipSite( state, siteId ),
 				isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
 			};

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -80,7 +80,7 @@ class EditUserForm extends React.Component {
 		const { currentUser, user, isJetpack } = this.props;
 		const allowedSettings = [];
 
-		if ( ! user?.ID ) {
+		if ( ! user.ID ) {
 			return allowedSettings;
 		}
 
@@ -239,7 +239,7 @@ class EditUserForm extends React.Component {
 	};
 
 	render() {
-		if ( ! this.props.user?.ID ) {
+		if ( ! this.props.user.ID ) {
 			return null;
 		}
 
@@ -273,7 +273,7 @@ export default localize(
 	connect(
 		( state, { siteId, user } ) => {
 			const externalContributors = ( siteId && requestExternalContributors( siteId ).data ) || [];
-			const userId = user?.linked_user_ID || user?.ID;
+			const userId = user.linked_user_ID || user.ID;
 
 			return {
 				currentUser: getCurrentUser( state ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As explained by @jsnajdr in https://github.com/Automattic/wp-calypso/commit/2c332d34027d97ec1da28bbe564b4c618fd2ec95#r49403087 there is a bug with how we handle user IDs when checking for contributors in the team edit page: 

> There seems to be a subtle bug here with how `linked_user_ID` is handled. The REST endpoint returns `false` for Jetpack site users that don't have a wpcom mapping. Look up the `linked_user_ID_on_users_endpoints` function in wpcom PHP source to verify that. But here we're looking only for `undefined`. The `??` operator will never be satisfied and `user?.ID` won't be used as fallback.

This PR takes care of that.

#### Testing instructions

@jsnajdr - I'm not so sure about the steps here, but I was hoping you'll know. Generally, knowing that the API can return `false` for the `linked_user_ID`, verifying that the code makes sense and we're covering that case should generally be enough.