### PR TITLE
Force load Gutenframe when choosing to share a post to a Simple site.

### DIFF
--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -71,7 +71,7 @@ function buildQuerystringForPost( post ) {
 	args.title = `${ post.title } — ${ post.site_name }`;
 	args.text = post.excerpt;
 	args.url = post.URL;
-	args.is_post_share = true;
+	args.is_post_share = true; // There is a dependency on this here https://github.com/Automattic/wp-calypso/blob/a69ded693a99fa6a957b590b1a538f32a581eb8a/client/gutenberg/editor/controller.js#L209
 
 	const params = new URLSearchParams( args );
 	return params.toString();

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -12,6 +12,7 @@ import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import { hasUserSettingsRequestFailed } from 'calypso/state/user-settings/selectors';
 import { EDITOR_START, POST_EDIT } from 'calypso/state/action-types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import CalypsoifyIframe from './calypsoify-iframe';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import { addQueryArgs } from 'calypso/lib/route';
@@ -205,6 +206,12 @@ export const redirect = async ( context, next ) => {
 
 	const state = getState();
 	const siteId = getSelectedSiteId( state );
+	const isPostShare = context.query.is_post_share; // Added here https://github.com/Automattic/wp-calypso/blob/4b5fdb65b115e02baf743d2487eeca94fbd28a18/client/blocks/reader-share/index.jsx#L74
+
+	// Force load Gutenframe when choosing to share a post to a Simple site.
+	if ( isPostShare && isPostShare === 'true' && ! isAtomicSite( state, siteId ) ) {
+		return next();
+	}
 
 	if ( ! shouldLoadGutenframe( state, siteId ) ) {
 		const postType = determinePostType( context );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a conditional so that User who choose to share a Post to their Simple site are not redirected to WP Admin

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Before applying this patch**
1. Go to https://wordpress.com/me/account and toggle **on** `Show advanced dashboard pages`
2. Go to Reader and find a post to reblog
3. Click the share icon, and select a Simple site to share to
4. Notice that you are redirected to WP Admin with a blank post

**After applying this patch**
1. Go to https://wordpress.com/me/account and toggle **on** `Show advanced dashboard pages`
2. Go to Reader and find a post to reblog
3. Click the share icon, and select a Simple site to share to
4. Notice that you are redirected to Gutenframe and the post is prefiled with Title, Image and part of the Text
5. Repeat the above for an Atomic site, it should load WP Admin with the post is prefiled with Title, Image and part of the Text

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #51746
