### PR TITLE
Post Type Filter: Fix Search Bar Placeholder

### DIFF
--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -20,6 +20,7 @@ import {
 } from 'calypso/state/posts/counts/selectors';
 import urlSearch from 'calypso/lib/url-search';
 import QueryPostCounts from 'calypso/components/data/query-post-counts';
+import QueryPostTypes from 'calypso/components/data/query-post-types';
 import SectionNav from 'calypso/components/section-nav';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import NavItem from 'calypso/components/section-nav/item';
@@ -144,6 +145,7 @@ export class PostTypeFilter extends Component {
 		return (
 			<div className="post-type-filter">
 				{ siteId && false === jetpack && <QueryPostCounts siteId={ siteId } type={ query.type } /> }
+				{ siteId && <QueryPostTypes siteId={ siteId } /> }
 				<SectionNav
 					selectedText={
 						<span>

--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -182,7 +182,11 @@ export class PostTypeFilter extends Component {
 							initialValue={ query.search }
 							isOpen={ this.props.getSearchOpen() }
 							onSearch={ this.props.doSearch }
-							placeholder={ `${ searchPagesPlaceholder }…` }
+							placeholder={
+								searchPagesPlaceholder
+									? `${ searchPagesPlaceholder }…`
+									: this.props.translate( 'Search…', { context: 'verb: imperative' } )
+							}
 							delaySearch={ true }
 						/>
 					) }

--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -185,7 +185,7 @@ export class PostTypeFilter extends Component {
 							placeholder={
 								searchPagesPlaceholder
 									? `${ searchPagesPlaceholder }…`
-									: this.props.translate( 'Search…', { context: 'verb: imperative' } )
+									: this.props.translate( 'Search…' )
 							}
 							delaySearch={ true }
 						/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the bug where the placeholder on the Search bar would display "null..."

From what I can tell, the only issue causing this bug was a failure to call `QueryPostTypes` - everything else looks like it should be functioning okay, which is why it would display properly after clicking around for a bit. That being said, it can take a second or two to return a result, so I thought that making the default placeholder `Search...` would be better than `null...`

#### Testing instructions

Visit `/pages/site` and press the "Search" button, then verify the placeholder displays properly.

**Before:**
<img width="1088" alt="Screenshot 2021-04-23 at 17 09 43" src="https://user-images.githubusercontent.com/43215253/115899525-bd991100-a456-11eb-9632-92ce28824510.png">

**After:**
<img width="1088" alt="Screenshot 2021-04-23 at 17 47 39" src="https://user-images.githubusercontent.com/43215253/115904002-2df66100-a45c-11eb-9e4c-90996f11f846.png">

cc @michaeldcain
Fixes #52242