### PR TITLE
Plugins: redirect to WooCommerce onboarding once plugin is installed

### DIFF
--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -39,7 +39,7 @@ import {
 	INSTALL_PLUGIN,
 	REMOVE_PLUGIN,
 } from 'calypso/lib/plugins/constants';
-import { getSite, getSiteWoocommerceUrl } from 'calypso/state/sites/selectors';
+import { getSite, getSiteWoocommerceWizardUrl } from 'calypso/state/sites/selectors';
 import { bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { sitePluginUpdated } from 'calypso/state/sites/actions';
@@ -400,7 +400,7 @@ function installPluginHelper( siteId, plugin, isMainNetworkSite = false ) {
 			}
 
 			const state = getState();
-			const woocommerceUrl = getSiteWoocommerceUrl( state, data.siteId );
+			const woocommerceUrl = getSiteWoocommerceWizardUrl( state, data.siteId );
 
 			if ( ! woocommerceUrl ) {
 				return;

--- a/client/state/sites/selectors/get-site-woocommerce-wizard-url.js
+++ b/client/state/sites/selectors/get-site-woocommerce-wizard-url.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import getSiteAdminUrl from './get-site-admin-url';
+
+/**
+ * Returns a site's wp-admin WooCommerce Wizrd plugin URL,
+ * or null if the admin URL for the site cannot be determined.
+ *
+ * @param  {object}  state  Global state tree
+ * @param  {number}  siteId Site ID
+ * @returns {?string}       Full URL to WooCommerce Aizard plugin in wp-admin
+ */
+export default function getSiteWoocommerceWizardUrl( state, siteId ) {
+	return getSiteAdminUrl(
+		state,
+		siteId,
+		'admin.php?page=wc-admin&from-calypso&path=%2Fsetup-wizard'
+	);
+}

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -57,3 +57,4 @@ export { default as isSSOEnabled } from './is-sso-enabled';
 export { default as verifyJetpackModulesActive } from './verify-jetpack-modules-active';
 export { default as getSelectedSiteWithFallback } from './get-site-with-fallback';
 export { default as getSiteWoocommerceUrl } from './get-site-woocommerce-url';
+export { default as getSiteWoocommerceWizardUrl } from './get-site-woocommerce-wizard-url';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR performs a client redirect to the WooCommerce onboarding (wp-admin) once the plugin is installed.

#### Testing instructions

Test with **JETPACK**  site.

* Go to WooCommerce plugin page in calypso: `<hostname>/plugins/woocommerce/<site-id>`

<img width="1078" alt="Screen Shot 2021-04-26 at 9 30 50 AM" src="https://user-images.githubusercontent.com/77539/116083029-8606b080-a672-11eb-987e-0a6edc481c81.png">

* Click on the Install button to trigger the install process.
* Once the plugin is installed, the client should redirect to the WooCoomerce onboarding page (wp-admin)

<img width="1081" alt="Screen Shot 2021-04-26 at 9 34 57 AM" src="https://user-images.githubusercontent.com/77539/116083166-b3ebf500-a672-11eb-9765-3854c621daab.png">



Related to https://github.com/Automattic/wp-calypso/issues/51327
