### PR TITLE
Add helper to identify item as Jetpack product or plan

### DIFF
--- a/packages/calypso-products/src/constants.js
+++ b/packages/calypso-products/src/constants.js
@@ -1,3 +1,18 @@
+<<<<<<< HEAD
+=======
+export const TITAN_MAIL_MONTHLY_SLUG = 'wp_titan_mail_monthly';
+
+export const domainProductSlugs = {
+	TRANSFER_IN: 'domain_transfer',
+};
+
+export const GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY =
+	'wp_google_workspace_business_starter_yearly';
+export const GSUITE_BASIC_SLUG = 'gapps';
+export const GSUITE_BUSINESS_SLUG = 'gapps_unlimited';
+export const GSUITE_EXTRA_LICENSE_SLUG = 'gapps_extra_license';
+
+>>>>>>> Remove Jetpack products feature flags
 // Jetpack products constants
 export const PRODUCT_JETPACK_BACKUP = 'jetpack_backup';
 export const PRODUCT_JETPACK_BACKUP_DAILY = 'jetpack_backup_daily';

--- a/packages/calypso-products/src/constants.js
+++ b/packages/calypso-products/src/constants.js
@@ -1,18 +1,3 @@
-<<<<<<< HEAD
-=======
-export const TITAN_MAIL_MONTHLY_SLUG = 'wp_titan_mail_monthly';
-
-export const domainProductSlugs = {
-	TRANSFER_IN: 'domain_transfer',
-};
-
-export const GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY =
-	'wp_google_workspace_business_starter_yearly';
-export const GSUITE_BASIC_SLUG = 'gapps';
-export const GSUITE_BUSINESS_SLUG = 'gapps_unlimited';
-export const GSUITE_EXTRA_LICENSE_SLUG = 'gapps_extra_license';
-
->>>>>>> Remove Jetpack products feature flags
 // Jetpack products constants
 export const PRODUCT_JETPACK_BACKUP = 'jetpack_backup';
 export const PRODUCT_JETPACK_BACKUP_DAILY = 'jetpack_backup_daily';

--- a/packages/calypso-products/src/is-jetpack-purchasable-item.ts
+++ b/packages/calypso-products/src/is-jetpack-purchasable-item.ts
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { JETPACK_LEGACY_PLANS, JETPACK_PRODUCTS_LIST, JETPACK_RESET_PLANS } from './constants';
+
+export default function isJetpackPurchasableItem(
+	itemSlug: string,
+	options: { includeLegacy?: boolean } = {}
+): boolean {
+	return [
+		...JETPACK_PRODUCTS_LIST,
+		...JETPACK_RESET_PLANS,
+		...( options.includeLegacy ? JETPACK_LEGACY_PLANS : [] ),
+	].includes( itemSlug );
+}

--- a/packages/calypso-products/test/is-jetpack-purchasable-item.js
+++ b/packages/calypso-products/test/is-jetpack-purchasable-item.js
@@ -1,0 +1,36 @@
+/**
+ * Internal dependencies
+ */
+import isJetpackPurchasableItem from '../src/is-jetpack-purchasable-item';
+import {
+	PRODUCT_JETPACK_ANTI_SPAM,
+	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
+	PLAN_JETPACK_COMPLETE,
+	PLAN_JETPACK_COMPLETE_MONTHLY,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+} from '../src/constants';
+
+describe( 'isJetpackPurchasableItem', () => {
+	it( 'should return true if the item is a Jetpack product', () => {
+		expect( isJetpackPurchasableItem( PRODUCT_JETPACK_ANTI_SPAM ) ).toEqual( true );
+		expect( isJetpackPurchasableItem( PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ) ).toEqual( true );
+	} );
+
+	it( 'should return true if the item is a Jetpack plan', () => {
+		expect( isJetpackPurchasableItem( PLAN_JETPACK_COMPLETE ) ).toEqual( true );
+		expect( isJetpackPurchasableItem( PLAN_JETPACK_COMPLETE_MONTHLY ) ).toEqual( true );
+	} );
+
+	it( 'should return false if the item is a Jetpack legacy plan', () => {
+		expect( isJetpackPurchasableItem( PLAN_JETPACK_PERSONAL ) ).toEqual( false );
+		expect( isJetpackPurchasableItem( PLAN_JETPACK_PERSONAL_MONTHLY ) ).toEqual( false );
+	} );
+
+	it( 'should return true if the item is a Jetpack legacy plan and the `includeLegacy` option is set', () => {
+		const options = { includeLegacy: true };
+
+		expect( isJetpackPurchasableItem( PLAN_JETPACK_PERSONAL_MONTHLY, options ) ).toEqual( true );
+		expect( isJetpackPurchasableItem( PLAN_JETPACK_PERSONAL_MONTHLY, options ) ).toEqual( true );
+	} );
+} );

--- a/packages/calypso-products/test/is-jetpack-purchasable-item.js
+++ b/packages/calypso-products/test/is-jetpack-purchasable-item.js
@@ -30,7 +30,7 @@ describe( 'isJetpackPurchasableItem', () => {
 	it( 'should return true if the item is a Jetpack legacy plan and the `includeLegacy` option is set', () => {
 		const options = { includeLegacy: true };
 
-		expect( isJetpackPurchasableItem( PLAN_JETPACK_PERSONAL_MONTHLY, options ) ).toEqual( true );
+		expect( isJetpackPurchasableItem( PLAN_JETPACK_PERSONAL, options ) ).toEqual( true );
 		expect( isJetpackPurchasableItem( PLAN_JETPACK_PERSONAL_MONTHLY, options ) ).toEqual( true );
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds a helper function that identifies if an item is a Jetpack product or plan that can be purchased. I don't think such a function already exists.

### Testing instructions

- Review the code
- Run `yarn test-packages:watch` and filter by the filename (or verify that the check doesn't fail in GH)