### PR TITLE
Calypso Products: Remove lodash and assertValidProduct

### DIFF
--- a/packages/calypso-products/package.json
+++ b/packages/calypso-products/package.json
@@ -40,7 +40,6 @@
 		"@automattic/calypso-config": "^1.0.0-alpha.0",
 		"@automattic/calypso-url": "^1.0.0",
 		"i18n-calypso": "^5.0.0",
-		"lodash": "^4.17.21",
 		"react": "^16.12.0"
 	},
 	"devDependencies": {

--- a/packages/calypso-products/src/get-domain-product-ranking.js
+++ b/packages/calypso-products/src/get-domain-product-ranking.js
@@ -1,14 +1,12 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { isDomainRegistration } from './is-domain-registration';
 import { isDomainMapping } from './is-domain-mapping';
 
 export function getDomainProductRanking( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	if ( isDomainRegistration( product ) ) {
 		return 0;

--- a/packages/calypso-products/src/get-domain.js
+++ b/packages/calypso-products/src/get-domain.js
@@ -5,11 +5,5 @@ import { formatProduct } from './format-product';
 
 export function getDomain( product ) {
 	product = formatProduct( product );
-
-	const domainToBundle = product.extra?.domain_to_bundle;
-	if ( domainToBundle ) {
-		return domainToBundle;
-	}
-
-	return product.meta;
+	return product.extra?.domain_to_bundle ?? product.meta;
 }

--- a/packages/calypso-products/src/get-domain.js
+++ b/packages/calypso-products/src/get-domain.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { assertValidProduct } from './utils/assert-valid-product';
@@ -13,7 +8,7 @@ export function getDomain( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	const domainToBundle = get( product, 'extra.domain_to_bundle', false );
+	const domainToBundle = product.extra?.domain_to_bundle;
 	if ( domainToBundle ) {
 		return domainToBundle;
 	}

--- a/packages/calypso-products/src/get-domain.js
+++ b/packages/calypso-products/src/get-domain.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function getDomain( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	const domainToBundle = product.extra?.domain_to_bundle;
 	if ( domainToBundle ) {

--- a/packages/calypso-products/src/get-included-domain-purchase-amount.js
+++ b/packages/calypso-products/src/get-included-domain-purchase-amount.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function getIncludedDomainPurchaseAmount( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return product.included_domain_purchase_amount;
 }

--- a/packages/calypso-products/src/get-jetpack-product-call-to-action.ts
+++ b/packages/calypso-products/src/get-jetpack-product-call-to-action.ts
@@ -6,7 +6,6 @@ import { TranslateResult } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { getJetpackProductsCallToAction } from './translations';
 
@@ -23,7 +22,6 @@ import type { Product } from './products-list';
  */
 export function getJetpackProductCallToAction( product: object ): TranslateResult | undefined {
 	product = formatProduct( product );
-	assertValidProduct( product );
 	const jetpackProductsCallToActions = getJetpackProductsCallToAction() as Record<
 		string,
 		TranslateResult

--- a/packages/calypso-products/src/get-jetpack-product-description.js
+++ b/packages/calypso-products/src/get-jetpack-product-description.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { getJetpackProductsDescriptions } from './translations';
 
@@ -13,7 +12,6 @@ import { getJetpackProductsDescriptions } from './translations';
  */
 export function getJetpackProductDescription( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 	const jetpackProductsDescriptions = getJetpackProductsDescriptions();
 
 	return jetpackProductsDescriptions?.[ product.product_slug ];

--- a/packages/calypso-products/src/get-jetpack-product-display-name.js
+++ b/packages/calypso-products/src/get-jetpack-product-display-name.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { getJetpackProductsDisplayNames } from './translations';
 
@@ -13,7 +12,6 @@ import { getJetpackProductsDisplayNames } from './translations';
  */
 export function getJetpackProductDisplayName( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 	const jetpackProductsDisplayNames = getJetpackProductsDisplayNames();
 
 	return jetpackProductsDisplayNames?.[ product.product_slug ];

--- a/packages/calypso-products/src/get-jetpack-product-short-name.js
+++ b/packages/calypso-products/src/get-jetpack-product-short-name.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { getJetpackProductsShortNames } from './translations';
 
@@ -13,7 +12,6 @@ import { getJetpackProductsShortNames } from './translations';
  */
 export function getJetpackProductShortName( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 	const jetpackProductShortNames = getJetpackProductsShortNames();
 
 	return jetpackProductShortNames?.[ product.product_slug ];

--- a/packages/calypso-products/src/get-jetpack-product-tagline.js
+++ b/packages/calypso-products/src/get-jetpack-product-tagline.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { getJetpackProductsTaglines } from './translations';
 
@@ -14,7 +13,6 @@ import { getJetpackProductsTaglines } from './translations';
  */
 export function getJetpackProductTagline( product, isOwned = false ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 	const jetpackProductsTaglines = getJetpackProductsTaglines();
 
 	const productTagline = jetpackProductsTaglines?.[ product.product_slug ];

--- a/packages/calypso-products/src/includes-product.js
+++ b/packages/calypso-products/src/includes-product.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function includesProduct( products, product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return products.indexOf( product.product_slug ) >= 0;
 }

--- a/packages/calypso-products/src/index.ts
+++ b/packages/calypso-products/src/index.ts
@@ -1,7 +1,6 @@
 export * from './main';
 export * from './types';
 export * from './constants';
-export * from './utils';
 export * from './product-values';
 export * from './get-interval-type-for-term';
 export * from './gsuite-product-slug';

--- a/packages/calypso-products/src/is-biennially.js
+++ b/packages/calypso-products/src/is-biennially.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { PLAN_BIENNIAL_PERIOD } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isBiennially( rawProduct ) {
 	const product = formatProduct( rawProduct );
-	assertValidProduct( product );
 
 	return parseInt( product.bill_period, 10 ) === PLAN_BIENNIAL_PERIOD;
 }

--- a/packages/calypso-products/src/is-blogger.js
+++ b/packages/calypso-products/src/is-blogger.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { isBloggerPlan } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isBlogger( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isBloggerPlan( product.product_slug );
 }

--- a/packages/calypso-products/src/is-bundled.js
+++ b/packages/calypso-products/src/is-bundled.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isBundled( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return !! product.is_bundled;
 }

--- a/packages/calypso-products/src/is-business.js
+++ b/packages/calypso-products/src/is-business.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { isBusinessPlan } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isBusiness( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isBusinessPlan( product.product_slug );
 }

--- a/packages/calypso-products/src/is-chargeback.js
+++ b/packages/calypso-products/src/is-chargeback.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { PLAN_CHARGEBACK } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isChargeback( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return product.product_slug === PLAN_CHARGEBACK;
 }

--- a/packages/calypso-products/src/is-complete.js
+++ b/packages/calypso-products/src/is-complete.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { isCompletePlan } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isComplete( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isCompletePlan( product.product_slug );
 }

--- a/packages/calypso-products/src/is-concierge-session.js
+++ b/packages/calypso-products/src/is-concierge-session.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isConciergeSession( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return 'concierge-session' === product.product_slug;
 }

--- a/packages/calypso-products/src/is-credits.js
+++ b/packages/calypso-products/src/is-credits.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isCredits( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return 'wordpress-com-credits' === product.product_slug;
 }

--- a/packages/calypso-products/src/is-custom-design.js
+++ b/packages/calypso-products/src/is-custom-design.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isCustomDesign( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return 'custom-design' === product.product_slug;
 }

--- a/packages/calypso-products/src/is-dependent-product.js
+++ b/packages/calypso-products/src/is-dependent-product.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { getDomain } from './get-domain';
 import { isDomainMapping } from './is-domain-mapping';
@@ -51,7 +50,6 @@ export function isDependentProduct( product, dependentProduct, domainsWithPlansO
 	let isPlansOnlyDependent = false;
 
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	const slug = isDomainRegistration( product ) ? 'domain' : product.product_slug;
 	const dependentSlug = isDomainRegistration( dependentProduct )

--- a/packages/calypso-products/src/is-domain-mapping.js
+++ b/packages/calypso-products/src/is-domain-mapping.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isDomainMapping( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return product.product_slug === 'domain_map';
 }

--- a/packages/calypso-products/src/is-domain-product.js
+++ b/packages/calypso-products/src/is-domain-product.js
@@ -1,14 +1,12 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { isDomainMapping } from './is-domain-mapping';
 import { isDomainRegistration } from './is-domain-registration';
 
 export function isDomainProduct( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isDomainMapping( product ) || isDomainRegistration( product );
 }

--- a/packages/calypso-products/src/is-domain-redemption.js
+++ b/packages/calypso-products/src/is-domain-redemption.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isDomainRedemption( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return product.product_slug === 'domain_redemption';
 }

--- a/packages/calypso-products/src/is-domain-registration.js
+++ b/packages/calypso-products/src/is-domain-registration.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isDomainRegistration( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return !! product.is_domain_registration;
 }

--- a/packages/calypso-products/src/is-domain-transfer-product.js
+++ b/packages/calypso-products/src/is-domain-transfer-product.js
@@ -1,13 +1,11 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { isDomainTransfer } from './is-domain-transfer';
 
 export function isDomainTransferProduct( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isDomainTransfer( product );
 }

--- a/packages/calypso-products/src/is-domain-transfer.js
+++ b/packages/calypso-products/src/is-domain-transfer.js
@@ -1,13 +1,11 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { domainProductSlugs } from './constants';
 
 export function isDomainTransfer( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return product.product_slug === domainProductSlugs.TRANSFER_IN;
 }

--- a/packages/calypso-products/src/is-ecommerce.js
+++ b/packages/calypso-products/src/is-ecommerce.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { isEcommercePlan } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isEcommerce( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isEcommercePlan( product.product_slug );
 }

--- a/packages/calypso-products/src/is-enterprise.js
+++ b/packages/calypso-products/src/is-enterprise.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { PLAN_WPCOM_ENTERPRISE } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isEnterprise( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return product.product_slug === PLAN_WPCOM_ENTERPRISE;
 }

--- a/packages/calypso-products/src/is-free-jetpack-plan.js
+++ b/packages/calypso-products/src/is-free-jetpack-plan.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { PLAN_JETPACK_FREE } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isFreeJetpackPlan( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return product.product_slug === PLAN_JETPACK_FREE;
 }

--- a/packages/calypso-products/src/is-free-plan.js
+++ b/packages/calypso-products/src/is-free-plan.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { PLAN_FREE } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isFreePlanProduct( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return product.product_slug === PLAN_FREE;
 }

--- a/packages/calypso-products/src/is-free-wordpress-com-domain.js
+++ b/packages/calypso-products/src/is-free-wordpress-com-domain.js
@@ -1,11 +1,9 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isFreeWordPressComDomain( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 	return product.is_free === true;
 }

--- a/packages/calypso-products/src/is-gsuite.js
+++ b/packages/calypso-products/src/is-gsuite.js
@@ -7,12 +7,10 @@ import {
 	isGSuiteOrExtraLicenseProductSlug,
 	isGSuiteOrGoogleWorkspaceProductSlug,
 } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isGoogleWorkspace( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isGoogleWorkspaceProductSlug( product.product_slug );
 }
@@ -26,7 +24,6 @@ export function isGoogleWorkspace( product ) {
  */
 export function isGoogleWorkspaceExtraLicence( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	if ( ! isGoogleWorkspaceProductSlug( product.product_slug ) ) {
 		return false;
@@ -38,21 +35,18 @@ export function isGoogleWorkspaceExtraLicence( product ) {
 
 export function isGSuite( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isGSuiteProductSlug( product.product_slug );
 }
 
 export function isGSuiteOrExtraLicense( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isGSuiteOrExtraLicenseProductSlug( product.product_slug );
 }
 
 export function isGSuiteOrExtraLicenseOrGoogleWorkspace( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return (
 		isGSuiteOrExtraLicenseProductSlug( product.product_slug ) ||
@@ -62,7 +56,6 @@ export function isGSuiteOrExtraLicenseOrGoogleWorkspace( product ) {
 
 export function isGSuiteOrGoogleWorkspace( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isGSuiteOrGoogleWorkspaceProductSlug( product.product_slug );
 }

--- a/packages/calypso-products/src/is-guided-transfer.js
+++ b/packages/calypso-products/src/is-guided-transfer.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isGuidedTransfer( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return 'guided_transfer' === product.product_slug;
 }

--- a/packages/calypso-products/src/is-jetpack-anti-spam.js
+++ b/packages/calypso-products/src/is-jetpack-anti-spam.js
@@ -1,13 +1,11 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { isJetpackAntiSpamSlug } from './is-jetpack-anti-spam-slug';
 
 export function isJetpackAntiSpam( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isJetpackAntiSpamSlug( product.product_slug );
 }

--- a/packages/calypso-products/src/is-jetpack-backup-slug.js
+++ b/packages/calypso-products/src/is-jetpack-backup-slug.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import { includes } from 'lodash';
 import { JETPACK_BACKUP_PRODUCTS } from './index';
 
 export function isJetpackBackupSlug( productSlug ) {
-	return includes( JETPACK_BACKUP_PRODUCTS, productSlug );
+	return JETPACK_BACKUP_PRODUCTS.includes( productSlug );
 }

--- a/packages/calypso-products/src/is-jetpack-backup.js
+++ b/packages/calypso-products/src/is-jetpack-backup.js
@@ -1,13 +1,11 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { isJetpackBackupSlug } from './is-jetpack-backup-slug';
 
 export function isJetpackBackup( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isJetpackBackupSlug( product.product_slug );
 }

--- a/packages/calypso-products/src/is-jetpack-business.js
+++ b/packages/calypso-products/src/is-jetpack-business.js
@@ -1,14 +1,12 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { isJetpackPlan } from './is-jetpack-plan';
 import { isBusiness } from './is-business';
 
 export function isJetpackBusiness( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isBusiness( product ) && isJetpackPlan( product );
 }

--- a/packages/calypso-products/src/is-jetpack-plan.js
+++ b/packages/calypso-products/src/is-jetpack-plan.js
@@ -1,13 +1,11 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { isJetpackPlanSlug } from './is-jetpack-plan-slug';
 
 export function isJetpackPlan( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isJetpackPlanSlug( product.product_slug );
 }

--- a/packages/calypso-products/src/is-jetpack-premium.js
+++ b/packages/calypso-products/src/is-jetpack-premium.js
@@ -1,14 +1,12 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { isJetpackPlan } from './is-jetpack-plan';
 import { isPremium } from './is-premium';
 
 export function isJetpackPremium( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isPremium( product ) && isJetpackPlan( product );
 }

--- a/packages/calypso-products/src/is-jetpack-product-slug.js
+++ b/packages/calypso-products/src/is-jetpack-product-slug.js
@@ -1,13 +1,8 @@
 /**
  * External dependencies
  */
-import { includes } from 'lodash';
-
-/**
- * External dependencies
- */
 import { JETPACK_PRODUCTS_LIST } from './index';
 
 export function isJetpackProductSlug( productSlug ) {
-	return includes( JETPACK_PRODUCTS_LIST, productSlug );
+	return JETPACK_PRODUCTS_LIST.includes( productSlug );
 }

--- a/packages/calypso-products/src/is-jetpack-product.js
+++ b/packages/calypso-products/src/is-jetpack-product.js
@@ -1,13 +1,11 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { isJetpackProductSlug } from './is-jetpack-product-slug';
 
 export function isJetpackProduct( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isJetpackProductSlug( product.product_slug );
 }

--- a/packages/calypso-products/src/is-jetpack-scan.js
+++ b/packages/calypso-products/src/is-jetpack-scan.js
@@ -1,13 +1,11 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { isJetpackScanSlug } from './is-jetpack-scan-slug';
 
 export function isJetpackScan( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isJetpackScanSlug( product.product_slug );
 }

--- a/packages/calypso-products/src/is-jetpack-search.js
+++ b/packages/calypso-products/src/is-jetpack-search.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { JETPACK_SEARCH_PRODUCTS } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isJetpackSearch( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return JETPACK_SEARCH_PRODUCTS.includes( product.product_slug );
 }

--- a/packages/calypso-products/src/is-jpphp-bundle.js
+++ b/packages/calypso-products/src/is-jpphp-bundle.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { PLAN_HOST_BUNDLE } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isJpphpBundle( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return product.product_slug === PLAN_HOST_BUNDLE;
 }

--- a/packages/calypso-products/src/is-monthly.js
+++ b/packages/calypso-products/src/is-monthly.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { PLAN_MONTHLY_PERIOD } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isMonthlyProduct( rawProduct ) {
 	const product = formatProduct( rawProduct );
-	assertValidProduct( product );
 
 	return parseInt( product.bill_period, 10 ) === PLAN_MONTHLY_PERIOD;
 }

--- a/packages/calypso-products/src/is-no-ads.js
+++ b/packages/calypso-products/src/is-no-ads.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isNoAds( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return 'no-adverts/no-adverts.php' === product.product_slug;
 }

--- a/packages/calypso-products/src/is-p2-plus.js
+++ b/packages/calypso-products/src/is-p2-plus.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { isP2PlusPlan } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isP2Plus( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isP2PlusPlan( product.product_slug );
 }

--- a/packages/calypso-products/src/is-personal.js
+++ b/packages/calypso-products/src/is-personal.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { isPersonalPlan } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isPersonal( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isPersonalPlan( product.product_slug );
 }

--- a/packages/calypso-products/src/is-plan.js
+++ b/packages/calypso-products/src/is-plan.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { isBlogger } from './is-blogger';
 import { isBusiness } from './is-business';
@@ -15,7 +14,6 @@ import { isP2Plus } from './is-p2-plus';
 
 export function isPlan( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return (
 		isBlogger( product ) ||

--- a/packages/calypso-products/src/is-premium.js
+++ b/packages/calypso-products/src/is-premium.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { isPremiumPlan } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isPremium( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isPremiumPlan( product.product_slug );
 }

--- a/packages/calypso-products/src/is-security-daily.js
+++ b/packages/calypso-products/src/is-security-daily.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { isSecurityDailyPlan } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isSecurityDaily( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isSecurityDailyPlan( product.product_slug );
 }

--- a/packages/calypso-products/src/is-security-realtime.js
+++ b/packages/calypso-products/src/is-security-realtime.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { isSecurityRealTimePlan } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isSecurityRealTime( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return isSecurityRealTimePlan( product.product_slug );
 }

--- a/packages/calypso-products/src/is-site-redirect.js
+++ b/packages/calypso-products/src/is-site-redirect.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isSiteRedirect( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return product.product_slug === 'offsite_redirect';
 }

--- a/packages/calypso-products/src/is-space-upgrade.js
+++ b/packages/calypso-products/src/is-space-upgrade.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isSpaceUpgrade( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return (
 		'1gb_space_upgrade' === product.product_slug ||

--- a/packages/calypso-products/src/is-theme.js
+++ b/packages/calypso-products/src/is-theme.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isTheme( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return 'premium_theme' === product.product_slug;
 }

--- a/packages/calypso-products/src/is-titan-mail.js
+++ b/packages/calypso-products/src/is-titan-mail.js
@@ -1,13 +1,11 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { TITAN_MAIL_MONTHLY_SLUG } from './constants';
 
 export function isTitanMail( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return product.product_slug === TITAN_MAIL_MONTHLY_SLUG;
 }

--- a/packages/calypso-products/src/is-traffic-guide.js
+++ b/packages/calypso-products/src/is-traffic-guide.js
@@ -1,13 +1,11 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 import { WPCOM_TRAFFIC_GUIDE } from './index';
 
 export function isTrafficGuide( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return WPCOM_TRAFFIC_GUIDE === product.product_slug;
 }

--- a/packages/calypso-products/src/is-unlimited-space.js
+++ b/packages/calypso-products/src/is-unlimited-space.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isUnlimitedSpace( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return 'unlimited_space' === product.product_slug;
 }

--- a/packages/calypso-products/src/is-unlimited-themes.js
+++ b/packages/calypso-products/src/is-unlimited-themes.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isUnlimitedThemes( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return 'unlimited_themes' === product.product_slug;
 }

--- a/packages/calypso-products/src/is-video-press.js
+++ b/packages/calypso-products/src/is-video-press.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isVideoPress( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return 'videopress' === product.product_slug;
 }

--- a/packages/calypso-products/src/is-vip-plan.js
+++ b/packages/calypso-products/src/is-vip-plan.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isVipPlan( product ) {
 	product = formatProduct( product );
-	assertValidProduct( product );
 
 	return 'vip' === product.product_slug;
 }

--- a/packages/calypso-products/src/is-yearly.js
+++ b/packages/calypso-products/src/is-yearly.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { PLAN_ANNUAL_PERIOD } from './index';
-import { assertValidProduct } from './utils/assert-valid-product';
 import { formatProduct } from './format-product';
 
 export function isYearly( rawProduct ) {
 	const product = formatProduct( rawProduct );
-	assertValidProduct( product );
 
 	return parseInt( product.bill_period, 10 ) === PLAN_ANNUAL_PERIOD;
 }

--- a/packages/calypso-products/src/main.js
+++ b/packages/calypso-products/src/main.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { difference, get, has, includes, pick, values } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import {
@@ -44,7 +39,7 @@ export function getPlansSlugs() {
 
 export function getPlan( planKey ) {
 	if ( Object.prototype.toString.apply( planKey ) === '[object Object]' ) {
-		if ( values( PLANS_LIST ).indexOf( planKey ) !== -1 ) {
+		if ( Object.values( PLANS_LIST ).includes( planKey ) ) {
 			return planKey;
 		}
 	}
@@ -133,13 +128,13 @@ export function planHasFeature( plan, feature ) {
 		'getHiddenFeatures',
 	].reduce(
 		( featuresArray, featureMethodName ) => [
-			...get( planConstantObj, featureMethodName, () => [] )(),
+			...( planConstantObj?.[ featureMethodName ]?.() ?? [] ),
 			...featuresArray,
 		],
 		[]
 	);
 
-	return includes( allFeatures, feature );
+	return allFeatures.includes( feature );
 }
 
 /**
@@ -152,7 +147,7 @@ export function planHasFeature( plan, feature ) {
 export function planHasSuperiorFeature( plan, feature ) {
 	const planConstantObj = getPlan( plan );
 
-	return includes( planConstantObj.getInferiorHiddenFeatures(), feature );
+	return planConstantObj.getInferiorHiddenFeatures().includes( feature );
 }
 
 export function shouldFetchSitePlans( sitePlans, selectedSite ) {
@@ -168,7 +163,7 @@ export function shouldFetchSitePlans( sitePlans, selectedSite ) {
  */
 export function getMonthlyPlanByYearly( planSlug ) {
 	const plan = getPlan( planSlug );
-	if ( has( plan, 'getMonthlySlug' ) ) {
+	if ( plan?.getMonthlySlug ) {
 		return plan.getMonthlySlug();
 	}
 	return findFirstSimilarPlanKey( planSlug, { term: TERM_MONTHLY } ) || '';
@@ -183,7 +178,7 @@ export function getMonthlyPlanByYearly( planSlug ) {
  */
 export function getYearlyPlanByMonthly( planSlug ) {
 	const plan = getPlan( planSlug );
-	if ( has( plan, 'getAnnualSlug' ) ) {
+	if ( plan?.getAnnualSlug ) {
 		return plan.getAnnualSlug();
 	}
 	return findFirstSimilarPlanKey( planSlug, { term: TERM_ANNUALLY } ) || '';
@@ -343,7 +338,9 @@ export function findSimilarPlansKeys( planKey, diff = {} ) {
 		return [];
 	}
 	return findPlansKeys( {
-		...pick( plan, 'type', 'group', 'term' ),
+		type: plan.type,
+		group: plan.group,
+		term: plan.term,
 		...diff,
 	} );
 }
@@ -382,7 +379,7 @@ export function findPlansKeys( query = {} ) {
  */
 export function planMatches( planKey, query = {} ) {
 	const acceptedKeys = [ 'type', 'group', 'term' ];
-	const unknownKeys = difference( Object.keys( query ), acceptedKeys );
+	const unknownKeys = Object.keys( query ).filter( ( key ) => ! acceptedKeys.includes( key ) );
 	if ( unknownKeys.length ) {
 		throw new Error(
 			`planMatches can only match against ${ acceptedKeys.join( ',' ) }, ` +

--- a/packages/calypso-products/src/plans-list.js
+++ b/packages/calypso-products/src/plans-list.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { compact, includes } from 'lodash';
 import i18n, { translate } from 'i18n-calypso';
 
 /**
@@ -10,6 +9,11 @@ import i18n, { translate } from 'i18n-calypso';
  */
 import { isEnabled } from '@automattic/calypso-config';
 import * as constants from './constants';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+function compact( elements ) {
+	return elements.filter( Boolean );
+}
 
 const WPComGetBillingTimeframe = () => i18n.translate( 'per month, billed annually' );
 const WPComGetBiennialBillingTimeframe = () => i18n.translate( '/month, billed every two years' );
@@ -28,16 +32,15 @@ const getMonthlyTimeframe = () => ( {
 
 const getDotcomPlanDetails = () => ( {
 	// Features only available for annual plans
-	getAnnualPlansOnlyFeatures: () =>
-		compact( [
-			constants.FEATURE_FREE_DOMAIN,
-			constants.FEATURE_CUSTOM_DOMAIN,
-			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS,
-			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
-			constants.FEATURE_LIVE_CHAT_SUPPORT,
-			constants.FEATURE_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
-			constants.FEATURE_LIVE_CHAT_SUPPORT_ALL_DAYS,
-		] ),
+	getAnnualPlansOnlyFeatures: () => [
+		constants.FEATURE_FREE_DOMAIN,
+		constants.FEATURE_CUSTOM_DOMAIN,
+		constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS,
+		constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
+		constants.FEATURE_LIVE_CHAT_SUPPORT,
+		constants.FEATURE_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
+		constants.FEATURE_LIVE_CHAT_SUPPORT_ALL_DAYS,
+	],
 } );
 
 const plansDescriptionHeadingComponent = {
@@ -132,12 +135,11 @@ const getPlanPersonalDetails = () => ( {
 		constants.FEATURE_MEMBERSHIPS,
 		constants.FEATURE_PREMIUM_CONTENT_BLOCK,
 	],
-	getSignupFeatures: () =>
-		compact( [
-			constants.FEATURE_FREE_DOMAIN,
-			constants.FEATURE_EMAIL_SUPPORT_SIGNUP,
-			constants.FEATURE_FREE_THEMES,
-		] ),
+	getSignupFeatures: () => [
+		constants.FEATURE_FREE_DOMAIN,
+		constants.FEATURE_EMAIL_SUPPORT_SIGNUP,
+		constants.FEATURE_FREE_THEMES,
+	],
 	getBlogSignupFeatures: () => [
 		constants.FEATURE_FREE_DOMAIN,
 		constants.FEATURE_EMAIL_SUPPORT_SIGNUP,
@@ -319,12 +321,11 @@ const getPlanPremiumDetails = () => ( {
 		constants.FEATURE_ADVANCED_DESIGN,
 		constants.FEATURE_13GB_STORAGE,
 	],
-	getSignupFeatures: () =>
-		compact( [
-			constants.FEATURE_LIVE_CHAT_SUPPORT,
-			constants.FEATURE_ADVANCED_CUSTOMIZATION,
-			constants.FEATURE_ALL_PERSONAL_FEATURES,
-		] ),
+	getSignupFeatures: () => [
+		constants.FEATURE_LIVE_CHAT_SUPPORT,
+		constants.FEATURE_ADVANCED_CUSTOMIZATION,
+		constants.FEATURE_ALL_PERSONAL_FEATURES,
+	],
 	getBlogSignupFeatures: () => [
 		constants.FEATURE_MONETISE,
 		constants.FEATURE_PREMIUM_THEMES,
@@ -650,7 +651,7 @@ export const PLANS_LIST = {
 		...getPlanBloggerDetails(),
 		term: constants.TERM_ANNUALLY,
 		getBillingTimeFrame: WPComGetBillingTimeframe,
-		availableFor: ( plan ) => includes( [ constants.PLAN_FREE ], plan ),
+		availableFor: ( plan ) => [ constants.PLAN_FREE ].includes( plan ),
 		getProductId: () => 1010,
 		getStoreSlug: () => constants.PLAN_BLOGGER,
 		getPathSlug: () => 'blogger',
@@ -660,7 +661,7 @@ export const PLANS_LIST = {
 		...getPlanBloggerDetails(),
 		term: constants.TERM_BIENNIALLY,
 		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
-		availableFor: ( plan ) => includes( [ constants.PLAN_FREE, constants.PLAN_BLOGGER ], plan ),
+		availableFor: ( plan ) => [ constants.PLAN_FREE, constants.PLAN_BLOGGER ].includes( plan ),
 		getProductId: () => 1030,
 		getStoreSlug: () => constants.PLAN_BLOGGER_2_YEARS,
 		getPathSlug: () => 'blogger-2-years',
@@ -670,8 +671,7 @@ export const PLANS_LIST = {
 		...getPlanPersonalDetails(),
 		...getMonthlyTimeframe(),
 		availableFor: ( plan ) =>
-			includes(
-				[ constants.PLAN_FREE, constants.PLAN_BLOGGER, constants.PLAN_BLOGGER_2_YEARS ],
+			[ constants.PLAN_FREE, constants.PLAN_BLOGGER, constants.PLAN_BLOGGER_2_YEARS ].includes(
 				plan
 			),
 		getProductId: () => 1019,
@@ -684,15 +684,12 @@ export const PLANS_LIST = {
 		term: constants.TERM_ANNUALLY,
 		getBillingTimeFrame: WPComGetBillingTimeframe,
 		availableFor: ( plan ) =>
-			includes(
-				[
-					constants.PLAN_FREE,
-					constants.PLAN_BLOGGER,
-					constants.PLAN_BLOGGER_2_YEARS,
-					constants.PLAN_PERSONAL_MONTHLY,
-				],
-				plan
-			),
+			[
+				constants.PLAN_FREE,
+				constants.PLAN_BLOGGER,
+				constants.PLAN_BLOGGER_2_YEARS,
+				constants.PLAN_PERSONAL_MONTHLY,
+			].includes( plan ),
 		getProductId: () => 1009,
 		getStoreSlug: () => constants.PLAN_PERSONAL,
 		getPathSlug: () => 'personal',
@@ -703,16 +700,13 @@ export const PLANS_LIST = {
 		term: constants.TERM_BIENNIALLY,
 		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
 		availableFor: ( plan ) =>
-			includes(
-				[
-					constants.PLAN_FREE,
-					constants.PLAN_BLOGGER,
-					constants.PLAN_BLOGGER_2_YEARS,
-					constants.PLAN_PERSONAL_MONTHLY,
-					constants.PLAN_PERSONAL,
-				],
-				plan
-			),
+			[
+				constants.PLAN_FREE,
+				constants.PLAN_BLOGGER,
+				constants.PLAN_BLOGGER_2_YEARS,
+				constants.PLAN_PERSONAL_MONTHLY,
+				constants.PLAN_PERSONAL,
+			].includes( plan ),
 		getProductId: () => 1029,
 		getStoreSlug: () => constants.PLAN_PERSONAL_2_YEARS,
 		getPathSlug: () => 'personal-2-years',
@@ -722,17 +716,14 @@ export const PLANS_LIST = {
 		...getPlanPremiumDetails(),
 		...getMonthlyTimeframe(),
 		availableFor: ( plan ) =>
-			includes(
-				[
-					constants.PLAN_FREE,
-					constants.PLAN_BLOGGER,
-					constants.PLAN_BLOGGER_2_YEARS,
-					constants.PLAN_PERSONAL_MONTHLY,
-					constants.PLAN_PERSONAL,
-					constants.PLAN_PERSONAL_2_YEARS,
-				],
-				plan
-			),
+			[
+				constants.PLAN_FREE,
+				constants.PLAN_BLOGGER,
+				constants.PLAN_BLOGGER_2_YEARS,
+				constants.PLAN_PERSONAL_MONTHLY,
+				constants.PLAN_PERSONAL,
+				constants.PLAN_PERSONAL_2_YEARS,
+			].includes( plan ),
 		getProductId: () => 1013,
 		getStoreSlug: () => constants.PLAN_PREMIUM_MONTHLY,
 		getPathSlug: () => 'premium-monthly',
@@ -743,18 +734,15 @@ export const PLANS_LIST = {
 		term: constants.TERM_ANNUALLY,
 		getBillingTimeFrame: WPComGetBillingTimeframe,
 		availableFor: ( plan ) =>
-			includes(
-				[
-					constants.PLAN_FREE,
-					constants.PLAN_BLOGGER,
-					constants.PLAN_BLOGGER_2_YEARS,
-					constants.PLAN_PERSONAL_MONTHLY,
-					constants.PLAN_PERSONAL,
-					constants.PLAN_PERSONAL_2_YEARS,
-					constants.PLAN_PREMIUM_MONTHLY,
-				],
-				plan
-			),
+			[
+				constants.PLAN_FREE,
+				constants.PLAN_BLOGGER,
+				constants.PLAN_BLOGGER_2_YEARS,
+				constants.PLAN_PERSONAL_MONTHLY,
+				constants.PLAN_PERSONAL,
+				constants.PLAN_PERSONAL_2_YEARS,
+				constants.PLAN_PREMIUM_MONTHLY,
+			].includes( plan ),
 		getProductId: () => 1003,
 		getStoreSlug: () => constants.PLAN_PREMIUM,
 		getPathSlug: () => 'premium',
@@ -765,19 +753,16 @@ export const PLANS_LIST = {
 		term: constants.TERM_BIENNIALLY,
 		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
 		availableFor: ( plan ) =>
-			includes(
-				[
-					constants.PLAN_FREE,
-					constants.PLAN_BLOGGER,
-					constants.PLAN_BLOGGER_2_YEARS,
-					constants.PLAN_PERSONAL_MONTHLY,
-					constants.PLAN_PERSONAL,
-					constants.PLAN_PERSONAL_2_YEARS,
-					constants.PLAN_PREMIUM_MONTHLY,
-					constants.PLAN_PREMIUM,
-				],
-				plan
-			),
+			[
+				constants.PLAN_FREE,
+				constants.PLAN_BLOGGER,
+				constants.PLAN_BLOGGER_2_YEARS,
+				constants.PLAN_PERSONAL_MONTHLY,
+				constants.PLAN_PERSONAL,
+				constants.PLAN_PERSONAL_2_YEARS,
+				constants.PLAN_PREMIUM_MONTHLY,
+				constants.PLAN_PREMIUM,
+			].includes( plan ),
 		getProductId: () => 1023,
 		getStoreSlug: () => constants.PLAN_PREMIUM_2_YEARS,
 		getPathSlug: () => 'premium-2-years',
@@ -788,20 +773,17 @@ export const PLANS_LIST = {
 		...getMonthlyTimeframe(),
 		availableFor: ( plan ) =>
 			isEnabled( 'upgrades/wpcom-monthly-plans' ) &&
-			includes(
-				[
-					constants.PLAN_FREE,
-					constants.PLAN_BLOGGER,
-					constants.PLAN_BLOGGER_2_YEARS,
-					constants.PLAN_PERSONAL_MONTHLY,
-					constants.PLAN_PERSONAL,
-					constants.PLAN_PERSONAL_2_YEARS,
-					constants.PLAN_PREMIUM_MONTHLY,
-					constants.PLAN_PREMIUM,
-					constants.PLAN_PREMIUM_2_YEARS,
-				],
-				plan
-			),
+			[
+				constants.PLAN_FREE,
+				constants.PLAN_BLOGGER,
+				constants.PLAN_BLOGGER_2_YEARS,
+				constants.PLAN_PERSONAL_MONTHLY,
+				constants.PLAN_PERSONAL,
+				constants.PLAN_PERSONAL_2_YEARS,
+				constants.PLAN_PREMIUM_MONTHLY,
+				constants.PLAN_PREMIUM,
+				constants.PLAN_PREMIUM_2_YEARS,
+			].includes( plan ),
 		getProductId: () => 1018,
 		getStoreSlug: () => constants.PLAN_BUSINESS_MONTHLY,
 		getPathSlug: () => 'business-monthly',
@@ -812,21 +794,18 @@ export const PLANS_LIST = {
 		term: constants.TERM_ANNUALLY,
 		getBillingTimeFrame: WPComGetBillingTimeframe,
 		availableFor: ( plan ) =>
-			includes(
-				[
-					constants.PLAN_FREE,
-					constants.PLAN_BLOGGER,
-					constants.PLAN_BLOGGER_2_YEARS,
-					constants.PLAN_PERSONAL_MONTHLY,
-					constants.PLAN_PERSONAL,
-					constants.PLAN_PERSONAL_2_YEARS,
-					constants.PLAN_PREMIUM_MONTHLY,
-					constants.PLAN_PREMIUM,
-					constants.PLAN_PREMIUM_2_YEARS,
-					constants.PLAN_BUSINESS_MONTHLY,
-				],
-				plan
-			),
+			[
+				constants.PLAN_FREE,
+				constants.PLAN_BLOGGER,
+				constants.PLAN_BLOGGER_2_YEARS,
+				constants.PLAN_PERSONAL_MONTHLY,
+				constants.PLAN_PERSONAL,
+				constants.PLAN_PERSONAL_2_YEARS,
+				constants.PLAN_PREMIUM_MONTHLY,
+				constants.PLAN_PREMIUM,
+				constants.PLAN_PREMIUM_2_YEARS,
+				constants.PLAN_BUSINESS_MONTHLY,
+			].includes( plan ),
 		getProductId: () => 1008,
 		getStoreSlug: () => constants.PLAN_BUSINESS,
 		getPathSlug: () => 'business',
@@ -837,22 +816,19 @@ export const PLANS_LIST = {
 		term: constants.TERM_BIENNIALLY,
 		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
 		availableFor: ( plan ) =>
-			includes(
-				[
-					constants.PLAN_FREE,
-					constants.PLAN_BLOGGER,
-					constants.PLAN_BLOGGER_2_YEARS,
-					constants.PLAN_PERSONAL_MONTHLY,
-					constants.PLAN_PERSONAL,
-					constants.PLAN_PERSONAL_2_YEARS,
-					constants.PLAN_PREMIUM_MONTHLY,
-					constants.PLAN_PREMIUM,
-					constants.PLAN_PREMIUM_2_YEARS,
-					constants.PLAN_BUSINESS,
-					constants.PLAN_BUSINESS_MONTHLY,
-				],
-				plan
-			),
+			[
+				constants.PLAN_FREE,
+				constants.PLAN_BLOGGER,
+				constants.PLAN_BLOGGER_2_YEARS,
+				constants.PLAN_PERSONAL_MONTHLY,
+				constants.PLAN_PERSONAL,
+				constants.PLAN_PERSONAL_2_YEARS,
+				constants.PLAN_PREMIUM_MONTHLY,
+				constants.PLAN_PREMIUM,
+				constants.PLAN_PREMIUM_2_YEARS,
+				constants.PLAN_BUSINESS,
+				constants.PLAN_BUSINESS_MONTHLY,
+			].includes( plan ),
 		getProductId: () => 1028,
 		getStoreSlug: () => constants.PLAN_BUSINESS_2_YEARS,
 		getPathSlug: () => 'business-2-years',
@@ -862,23 +838,20 @@ export const PLANS_LIST = {
 		...getPlanEcommerceDetails(),
 		...getMonthlyTimeframe(),
 		availableFor: ( plan ) =>
-			includes(
-				[
-					constants.PLAN_FREE,
-					constants.PLAN_BLOGGER,
-					constants.PLAN_BLOGGER_2_YEARS,
-					constants.PLAN_PERSONAL_MONTHLY,
-					constants.PLAN_PERSONAL,
-					constants.PLAN_PERSONAL_2_YEARS,
-					constants.PLAN_PREMIUM_MONTHLY,
-					constants.PLAN_PREMIUM,
-					constants.PLAN_PREMIUM_2_YEARS,
-					constants.PLAN_BUSINESS_MONTHLY,
-					constants.PLAN_BUSINESS,
-					constants.PLAN_BUSINESS_2_YEARS,
-				],
-				plan
-			),
+			[
+				constants.PLAN_FREE,
+				constants.PLAN_BLOGGER,
+				constants.PLAN_BLOGGER_2_YEARS,
+				constants.PLAN_PERSONAL_MONTHLY,
+				constants.PLAN_PERSONAL,
+				constants.PLAN_PERSONAL_2_YEARS,
+				constants.PLAN_PREMIUM_MONTHLY,
+				constants.PLAN_PREMIUM,
+				constants.PLAN_PREMIUM_2_YEARS,
+				constants.PLAN_BUSINESS_MONTHLY,
+				constants.PLAN_BUSINESS,
+				constants.PLAN_BUSINESS_2_YEARS,
+			].includes( plan ),
 		getProductId: () => 1021,
 		getStoreSlug: () => constants.PLAN_ECOMMERCE_MONTHLY,
 		getPathSlug: () => 'ecommerce-monthly',
@@ -889,24 +862,21 @@ export const PLANS_LIST = {
 		term: constants.TERM_ANNUALLY,
 		getBillingTimeFrame: WPComGetBillingTimeframe,
 		availableFor: ( plan ) =>
-			includes(
-				[
-					constants.PLAN_FREE,
-					constants.PLAN_BLOGGER,
-					constants.PLAN_BLOGGER_2_YEARS,
-					constants.PLAN_PERSONAL_MONTHLY,
-					constants.PLAN_PERSONAL,
-					constants.PLAN_PERSONAL_2_YEARS,
-					constants.PLAN_PREMIUM_MONTHLY,
-					constants.PLAN_PREMIUM,
-					constants.PLAN_PREMIUM_2_YEARS,
-					constants.PLAN_BUSINESS_MONTHLY,
-					constants.PLAN_BUSINESS,
-					constants.PLAN_BUSINESS_2_YEARS,
-					constants.PLAN_ECOMMERCE_MONTHLY,
-				],
-				plan
-			),
+			[
+				constants.PLAN_FREE,
+				constants.PLAN_BLOGGER,
+				constants.PLAN_BLOGGER_2_YEARS,
+				constants.PLAN_PERSONAL_MONTHLY,
+				constants.PLAN_PERSONAL,
+				constants.PLAN_PERSONAL_2_YEARS,
+				constants.PLAN_PREMIUM_MONTHLY,
+				constants.PLAN_PREMIUM,
+				constants.PLAN_PREMIUM_2_YEARS,
+				constants.PLAN_BUSINESS_MONTHLY,
+				constants.PLAN_BUSINESS,
+				constants.PLAN_BUSINESS_2_YEARS,
+				constants.PLAN_ECOMMERCE_MONTHLY,
+			].includes( plan ),
 		getProductId: () => 1011,
 		getStoreSlug: () => constants.PLAN_ECOMMERCE,
 		getPathSlug: () => 'ecommerce',
@@ -917,25 +887,22 @@ export const PLANS_LIST = {
 		term: constants.TERM_BIENNIALLY,
 		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
 		availableFor: ( plan ) =>
-			includes(
-				[
-					constants.PLAN_FREE,
-					constants.PLAN_BLOGGER,
-					constants.PLAN_BLOGGER_2_YEARS,
-					constants.PLAN_PERSONAL_MONTHLY,
-					constants.PLAN_PERSONAL,
-					constants.PLAN_PERSONAL_2_YEARS,
-					constants.PLAN_PREMIUM_MONTHLY,
-					constants.PLAN_PREMIUM,
-					constants.PLAN_PREMIUM_2_YEARS,
-					constants.PLAN_BUSINESS_MONTHLY,
-					constants.PLAN_BUSINESS,
-					constants.PLAN_BUSINESS_2_YEARS,
-					constants.PLAN_ECOMMERCE_MONTHLY,
-					constants.PLAN_ECOMMERCE,
-				],
-				plan
-			),
+			[
+				constants.PLAN_FREE,
+				constants.PLAN_BLOGGER,
+				constants.PLAN_BLOGGER_2_YEARS,
+				constants.PLAN_PERSONAL_MONTHLY,
+				constants.PLAN_PERSONAL,
+				constants.PLAN_PERSONAL_2_YEARS,
+				constants.PLAN_PREMIUM_MONTHLY,
+				constants.PLAN_PREMIUM,
+				constants.PLAN_PREMIUM_2_YEARS,
+				constants.PLAN_BUSINESS_MONTHLY,
+				constants.PLAN_BUSINESS,
+				constants.PLAN_BUSINESS_2_YEARS,
+				constants.PLAN_ECOMMERCE_MONTHLY,
+				constants.PLAN_ECOMMERCE,
+			].includes( plan ),
 		getProductId: () => 1031,
 		getStoreSlug: () => constants.PLAN_ECOMMERCE_2_YEARS,
 		getPathSlug: () => 'ecommerce-2-years',
@@ -1019,15 +986,12 @@ export const PLANS_LIST = {
 		getProductId: () => 2000,
 		getStoreSlug: () => constants.PLAN_JETPACK_PREMIUM,
 		availableFor: ( plan ) =>
-			includes(
-				[
-					constants.PLAN_JETPACK_FREE,
-					constants.PLAN_JETPACK_PERSONAL,
-					constants.PLAN_JETPACK_PERSONAL_MONTHLY,
-					constants.PLAN_JETPACK_PREMIUM_MONTHLY,
-				],
-				plan
-			),
+			[
+				constants.PLAN_JETPACK_FREE,
+				constants.PLAN_JETPACK_PERSONAL,
+				constants.PLAN_JETPACK_PERSONAL_MONTHLY,
+				constants.PLAN_JETPACK_PREMIUM_MONTHLY,
+			].includes( plan ),
 		getPathSlug: () => 'premium',
 		getDescription: () =>
 			i18n.translate(
@@ -1104,14 +1068,11 @@ export const PLANS_LIST = {
 		getStoreSlug: () => constants.PLAN_JETPACK_PREMIUM_MONTHLY,
 		getPathSlug: () => 'premium-monthly',
 		availableFor: ( plan ) =>
-			includes(
-				[
-					constants.PLAN_JETPACK_FREE,
-					constants.PLAN_JETPACK_PERSONAL,
-					constants.PLAN_JETPACK_PERSONAL_MONTHLY,
-				],
-				plan
-			),
+			[
+				constants.PLAN_JETPACK_FREE,
+				constants.PLAN_JETPACK_PERSONAL,
+				constants.PLAN_JETPACK_PERSONAL_MONTHLY,
+			].includes( plan ),
 		getDescription: () =>
 			i18n.translate(
 				'{{strong}}Best for small businesses:{{/strong}} Comprehensive, automated scanning for security vulnerabilities, ' +
@@ -1186,7 +1147,7 @@ export const PLANS_LIST = {
 		getProductId: () => 2005,
 		getStoreSlug: () => constants.PLAN_JETPACK_PERSONAL,
 		availableFor: ( plan ) =>
-			includes( [ constants.PLAN_JETPACK_FREE, constants.PLAN_JETPACK_PERSONAL_MONTHLY ], plan ),
+			[ constants.PLAN_JETPACK_FREE, constants.PLAN_JETPACK_PERSONAL_MONTHLY ].includes( plan ),
 		getPathSlug: () => 'jetpack-personal',
 		getDescription: () =>
 			i18n.translate(
@@ -1242,7 +1203,7 @@ export const PLANS_LIST = {
 		getStoreSlug: () => constants.PLAN_JETPACK_PERSONAL_MONTHLY,
 		getProductId: () => 2006,
 		getPathSlug: () => 'jetpack-personal-monthly',
-		availableFor: ( plan ) => includes( [ constants.PLAN_JETPACK_FREE ], plan ),
+		availableFor: ( plan ) => [ constants.PLAN_JETPACK_FREE ].includes( plan ),
 		getDescription: () =>
 			i18n.translate(
 				'{{strong}}Best for personal use:{{/strong}} Security essentials for your WordPress site, including ' +
@@ -1297,17 +1258,14 @@ export const PLANS_LIST = {
 		getStoreSlug: () => constants.PLAN_JETPACK_BUSINESS,
 		getProductId: () => 2001,
 		availableFor: ( plan ) =>
-			includes(
-				[
-					constants.PLAN_JETPACK_BUSINESS_MONTHLY,
-					constants.PLAN_JETPACK_FREE,
-					constants.PLAN_JETPACK_PREMIUM,
-					constants.PLAN_JETPACK_PREMIUM_MONTHLY,
-					constants.PLAN_JETPACK_PERSONAL,
-					constants.PLAN_JETPACK_PERSONAL_MONTHLY,
-				],
-				plan
-			),
+			[
+				constants.PLAN_JETPACK_BUSINESS_MONTHLY,
+				constants.PLAN_JETPACK_FREE,
+				constants.PLAN_JETPACK_PREMIUM,
+				constants.PLAN_JETPACK_PREMIUM_MONTHLY,
+				constants.PLAN_JETPACK_PERSONAL,
+				constants.PLAN_JETPACK_PERSONAL_MONTHLY,
+			].includes( plan ),
 		getPathSlug: () => 'professional',
 		getDescription: () =>
 			i18n.translate(
@@ -1343,12 +1301,11 @@ export const PLANS_LIST = {
 			constants.FEATURE_PRODUCT_SCAN_REALTIME_V2,
 			constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
 		],
-		getSignupFeatures: () =>
-			compact( [
-				constants.FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
-				constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
-				constants.FEATURE_ALL_PREMIUM_FEATURES_JETPACK,
-			] ),
+		getSignupFeatures: () => [
+			constants.FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
+			constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
+			constants.FEATURE_ALL_PREMIUM_FEATURES_JETPACK,
+		],
 		getBillingTimeFrame: () => i18n.translate( 'per year' ),
 		getSignupBillingTimeFrame: () => i18n.translate( 'per year' ),
 		getHiddenFeatures: () => [
@@ -1377,16 +1334,13 @@ export const PLANS_LIST = {
 		getStoreSlug: () => constants.PLAN_JETPACK_BUSINESS_MONTHLY,
 		getPathSlug: () => 'professional-monthly',
 		availableFor: ( plan ) =>
-			includes(
-				[
-					constants.PLAN_JETPACK_FREE,
-					constants.PLAN_JETPACK_PREMIUM,
-					constants.PLAN_JETPACK_PREMIUM_MONTHLY,
-					constants.PLAN_JETPACK_PERSONAL,
-					constants.PLAN_JETPACK_PERSONAL_MONTHLY,
-				],
-				plan
-			),
+			[
+				constants.PLAN_JETPACK_FREE,
+				constants.PLAN_JETPACK_PREMIUM,
+				constants.PLAN_JETPACK_PREMIUM_MONTHLY,
+				constants.PLAN_JETPACK_PERSONAL,
+				constants.PLAN_JETPACK_PERSONAL_MONTHLY,
+			].includes( plan ),
 		getDescription: () =>
 			i18n.translate(
 				'{{strong}}Best for organizations:{{/strong}} The most powerful WordPress sites: real-time backups ' +
@@ -1421,12 +1375,11 @@ export const PLANS_LIST = {
 			constants.FEATURE_PRODUCT_SCAN_REALTIME_V2,
 			constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
 		],
-		getSignupFeatures: () =>
-			compact( [
-				constants.FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
-				constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
-				constants.FEATURE_ALL_PREMIUM_FEATURES_JETPACK,
-			] ),
+		getSignupFeatures: () => [
+			constants.FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
+			constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
+			constants.FEATURE_ALL_PREMIUM_FEATURES_JETPACK,
+		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
 		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
 		getHiddenFeatures: () => [
@@ -1532,7 +1485,7 @@ export const PLANS_LIST = {
 		getAudience: () => i18n.translate( 'Best for bloggers' ),
 
 		...getMonthlyTimeframe(),
-		availableFor: ( plan ) => includes( [ constants.PLAN_FREE ], plan ), //TODO: only for P2 sites.
+		availableFor: ( plan ) => [ constants.PLAN_FREE ].includes( plan ), //TODO: only for P2 sites.
 		getProductId: () => 1040,
 		getStoreSlug: () => constants.PLAN_P2_PLUS,
 		getPathSlug: () => 'p2-plus',

--- a/packages/calypso-products/src/plans-list.js
+++ b/packages/calypso-products/src/plans-list.js
@@ -10,7 +10,6 @@ import i18n, { translate } from 'i18n-calypso';
 import { isEnabled } from '@automattic/calypso-config';
 import * as constants from './constants';
 
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 function compact( elements ) {
 	return elements.filter( Boolean );
 }
@@ -43,11 +42,13 @@ const getDotcomPlanDetails = () => ( {
 	],
 } );
 
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 const plansDescriptionHeadingComponent = {
 	components: {
 		strong: <strong className="plans__features plan-features__targeted-description-heading" />,
 	},
 };
+/* eslint-enable */
 
 const getPlanBloggerDetails = () => ( {
 	...getDotcomPlanDetails(),

--- a/packages/calypso-products/src/utils.js
+++ b/packages/calypso-products/src/utils.js
@@ -3,6 +3,5 @@
  */
 
 export const findCurrencyFromPlans = ( plans ) => {
-	const firstPlanWithCurrency = plans.find( ( plan ) => plan.currency_code );
-	return firstPlanWithCurrency?.currency_code ?? 'USD';
+	return plans[ 0 ]?.currency_code ?? 'USD';
 };

--- a/packages/calypso-products/src/utils.js
+++ b/packages/calypso-products/src/utils.js
@@ -1,7 +1,0 @@
-/**
- * External dependencies
- */
-
-export const findCurrencyFromPlans = ( plans ) => {
-	return plans[ 0 ]?.currency_code ?? 'USD';
-};

--- a/packages/calypso-products/src/utils.js
+++ b/packages/calypso-products/src/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { map, head, property } from 'lodash';
-
-export const findCurrencyFromPlans = ( plans ) =>
-	head( map( plans, property( 'currency_code' ) ) ) || 'USD';
+export const findCurrencyFromPlans = ( plans ) => {
+	const firstPlanWithCurrency = plans.find( ( plan ) => plan.currency_code );
+	return firstPlanWithCurrency?.currency_code ?? 'USD';
+};

--- a/packages/calypso-products/src/utils/assert-valid-product.js
+++ b/packages/calypso-products/src/utils/assert-valid-product.js
@@ -1,5 +1,0 @@
-export function assertValidProduct( product ) {
-	if ( ! Object.keys( product ).includes( 'product_slug' ) ) {
-		throw new Error( 'Missing required attributes for ProductValue: [product_slug]' );
-	}
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is the first of several PRs to clean up the product identification code that's been moved to the `calypso-products` package by https://github.com/Automattic/wp-calypso/pull/52249 and https://github.com/Automattic/wp-calypso/pull/51955.

Specifically, this PR:

- Removes lodash from the package. All of its uses could be easily handled by native JS.
- Removes `assertValidProduct`. It was being used to validate that objects passed to product identification functions contained a `product_slug`, but most of those functions don't need a `product_slug`, and for those that do, their existing code will handle it.

#### Testing instructions

Automated tests should be sufficient.