### PR TITLE
Calypso Products: Untangle internal dependency loops and remove functions from constants file

### DIFF
--- a/packages/calypso-products/src/constants.js
+++ b/packages/calypso-products/src/constants.js
@@ -147,7 +147,6 @@ export const WPCOM_TRAFFIC_GUIDE = 'traffic-guide';
 export const JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN = true;
 export const JETPACK_REDIRECT_URL =
 	'https://jetpack.com/redirect/?source=jetpack-checkout-thankyou';
-export const redirectCloudCheckoutToWpAdmin = () => !! JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN;
 
 // Jetpack versions prior to this one are not fully compatible with new plans
 export const JETPACK_LEGACY_PLANS_MAX_PLUGIN_VERSION = '8.9.1';
@@ -482,38 +481,3 @@ export const TYPE_ALL = 'TYPE_ALL';
 export const TYPE_P2_PLUS = 'TYPE_P2_PLUS';
 
 export const STORE_DEPRECATION_START_DATE = new Date( '2021-01-19T19:30:00+00:00' );
-
-export function isMonthly( plan ) {
-	return WPCOM_MONTHLY_PLANS.includes( plan ) || JETPACK_MONTHLY_PLANS.includes( plan );
-}
-
-export function isNew( plan ) {
-	return NEW_PLANS.includes( plan );
-}
-
-export function isBestValue( plan ) {
-	return BEST_VALUE_PLANS.includes( plan );
-}
-
-/**
- * Return estimated duration of given PLAN_TERM in days
- *
- * @param {string} term TERM_ constant
- * @returns {number} Term duration
- */
-export function getTermDuration( term ) {
-	switch ( term ) {
-		case TERM_MONTHLY:
-			return PLAN_MONTHLY_PERIOD;
-
-		case TERM_ANNUALLY:
-			return PLAN_ANNUAL_PERIOD;
-
-		case TERM_BIENNIALLY:
-			return PLAN_BIENNIAL_PERIOD;
-	}
-
-	if ( process.env.NODE_ENV === 'development' ) {
-		console.error( `Unexpected argument ${ term }, expected one of TERM_ constants` ); // eslint-disable-line no-console
-	}
-}

--- a/packages/calypso-products/src/get-product-term-variants.ts
+++ b/packages/calypso-products/src/get-product-term-variants.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { TERMS_LIST } from './index';
+import { TERMS_LIST } from './constants';
 import { PRODUCTS_LIST } from './products-list';
 
 /**

--- a/packages/calypso-products/src/get-product-yearly-variant.ts
+++ b/packages/calypso-products/src/get-product-yearly-variant.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { TERM_ANNUALLY } from './index';
+import { TERM_ANNUALLY } from './constants';
 import { PRODUCTS_LIST } from './products-list';
 
 /**

--- a/packages/calypso-products/src/get-products-slugs.js
+++ b/packages/calypso-products/src/get-products-slugs.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { JETPACK_PRODUCTS_LIST } from './index';
+import { JETPACK_PRODUCTS_LIST } from './constants';
 
 export function getProductsSlugs() {
 	return JETPACK_PRODUCTS_LIST;

--- a/packages/calypso-products/src/index.ts
+++ b/packages/calypso-products/src/index.ts
@@ -1,5 +1,6 @@
 export * from './main';
 export * from './types';
+export * from './plans-utilities';
 export * from './constants';
 export * from './product-values';
 export * from './get-interval-type-for-term';

--- a/packages/calypso-products/src/is-biennially.js
+++ b/packages/calypso-products/src/is-biennially.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { PLAN_BIENNIAL_PERIOD } from './index';
+import { PLAN_BIENNIAL_PERIOD } from './constants';
 import { formatProduct } from './format-product';
 
 export function isBiennially( rawProduct ) {

--- a/packages/calypso-products/src/is-blogger.js
+++ b/packages/calypso-products/src/is-blogger.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isBloggerPlan } from './index';
+import { isBloggerPlan } from './main';
 import { formatProduct } from './format-product';
 
 export function isBlogger( product ) {

--- a/packages/calypso-products/src/is-business.js
+++ b/packages/calypso-products/src/is-business.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isBusinessPlan } from './index';
+import { isBusinessPlan } from './main';
 import { formatProduct } from './format-product';
 
 export function isBusiness( product ) {

--- a/packages/calypso-products/src/is-chargeback.js
+++ b/packages/calypso-products/src/is-chargeback.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { PLAN_CHARGEBACK } from './index';
+import { PLAN_CHARGEBACK } from './constants';
 import { formatProduct } from './format-product';
 
 export function isChargeback( product ) {

--- a/packages/calypso-products/src/is-complete.js
+++ b/packages/calypso-products/src/is-complete.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isCompletePlan } from './index';
+import { isCompletePlan } from './main';
 import { formatProduct } from './format-product';
 
 export function isComplete( product ) {

--- a/packages/calypso-products/src/is-dependent-product.js
+++ b/packages/calypso-products/src/is-dependent-product.js
@@ -14,7 +14,7 @@ import {
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_2_YEARS,
-} from './index';
+} from './constants';
 
 const productDependencies = {
 	domain: {

--- a/packages/calypso-products/src/is-ecommerce.js
+++ b/packages/calypso-products/src/is-ecommerce.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isEcommercePlan } from './index';
+import { isEcommercePlan } from './main';
 import { formatProduct } from './format-product';
 
 export function isEcommerce( product ) {

--- a/packages/calypso-products/src/is-enterprise.js
+++ b/packages/calypso-products/src/is-enterprise.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { PLAN_WPCOM_ENTERPRISE } from './index';
+import { PLAN_WPCOM_ENTERPRISE } from './constants';
 import { formatProduct } from './format-product';
 
 export function isEnterprise( product ) {

--- a/packages/calypso-products/src/is-free-jetpack-plan.js
+++ b/packages/calypso-products/src/is-free-jetpack-plan.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { PLAN_JETPACK_FREE } from './index';
+import { PLAN_JETPACK_FREE } from './constants';
 import { formatProduct } from './format-product';
 
 export function isFreeJetpackPlan( product ) {

--- a/packages/calypso-products/src/is-free-plan.js
+++ b/packages/calypso-products/src/is-free-plan.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { PLAN_FREE } from './index';
+import { PLAN_FREE } from './constants';
 import { formatProduct } from './format-product';
 
 export function isFreePlanProduct( product ) {

--- a/packages/calypso-products/src/is-gsuite.js
+++ b/packages/calypso-products/src/is-gsuite.js
@@ -6,7 +6,7 @@ import {
 	isGSuiteProductSlug,
 	isGSuiteOrExtraLicenseProductSlug,
 	isGSuiteOrGoogleWorkspaceProductSlug,
-} from './index';
+} from './gsuite-product-slug';
 import { formatProduct } from './format-product';
 
 export function isGoogleWorkspace( product ) {

--- a/packages/calypso-products/src/is-jetpack-anti-spam-slug.js
+++ b/packages/calypso-products/src/is-jetpack-anti-spam-slug.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { JETPACK_ANTI_SPAM_PRODUCTS } from './index';
+import { JETPACK_ANTI_SPAM_PRODUCTS } from './constants';
 
 export function isJetpackAntiSpamSlug( productSlug ) {
 	return JETPACK_ANTI_SPAM_PRODUCTS.includes( productSlug );

--- a/packages/calypso-products/src/is-jetpack-backup-slug.js
+++ b/packages/calypso-products/src/is-jetpack-backup-slug.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { JETPACK_BACKUP_PRODUCTS } from './index';
+import { JETPACK_BACKUP_PRODUCTS } from './constants';
 
 export function isJetpackBackupSlug( productSlug ) {
 	return JETPACK_BACKUP_PRODUCTS.includes( productSlug );

--- a/packages/calypso-products/src/is-jetpack-cloud-product-slug.js
+++ b/packages/calypso-products/src/is-jetpack-cloud-product-slug.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { JETPACK_BACKUP_PRODUCTS, JETPACK_SCAN_PRODUCTS } from './index';
+import { JETPACK_BACKUP_PRODUCTS, JETPACK_SCAN_PRODUCTS } from './constants';
 
 export function isJetpackCloudProductSlug( productSlug ) {
 	return (

--- a/packages/calypso-products/src/is-jetpack-plan-slug.js
+++ b/packages/calypso-products/src/is-jetpack-plan-slug.js
@@ -1,7 +1,8 @@
 /**
  * Internal dependencies
  */
-import { planMatches, GROUP_JETPACK } from './index';
+import { planMatches } from './main';
+import { GROUP_JETPACK } from './constants';
 
 export function isJetpackPlanSlug( productSlug ) {
 	return planMatches( productSlug, { group: GROUP_JETPACK } );

--- a/packages/calypso-products/src/is-jetpack-product-slug.js
+++ b/packages/calypso-products/src/is-jetpack-product-slug.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { JETPACK_PRODUCTS_LIST } from './index';
+import { JETPACK_PRODUCTS_LIST } from './constants';
 
 export function isJetpackProductSlug( productSlug ) {
 	return JETPACK_PRODUCTS_LIST.includes( productSlug );

--- a/packages/calypso-products/src/is-jetpack-scan-slug.js
+++ b/packages/calypso-products/src/is-jetpack-scan-slug.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { JETPACK_SCAN_PRODUCTS } from './index';
+import { JETPACK_SCAN_PRODUCTS } from './constants';
 
 export function isJetpackScanSlug( productSlug ) {
 	return JETPACK_SCAN_PRODUCTS.includes( productSlug );

--- a/packages/calypso-products/src/is-jetpack-search.js
+++ b/packages/calypso-products/src/is-jetpack-search.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { JETPACK_SEARCH_PRODUCTS } from './index';
+import { JETPACK_SEARCH_PRODUCTS } from './constants';
 import { formatProduct } from './format-product';
 
 export function isJetpackSearch( product ) {

--- a/packages/calypso-products/src/is-jpphp-bundle.js
+++ b/packages/calypso-products/src/is-jpphp-bundle.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { PLAN_HOST_BUNDLE } from './index';
+import { PLAN_HOST_BUNDLE } from './constants';
 import { formatProduct } from './format-product';
 
 export function isJpphpBundle( product ) {

--- a/packages/calypso-products/src/is-monthly.js
+++ b/packages/calypso-products/src/is-monthly.js
@@ -2,10 +2,15 @@
  * Internal dependencies
  */
 import { PLAN_MONTHLY_PERIOD } from './index';
+import { WPCOM_MONTHLY_PLANS, JETPACK_MONTHLY_PLANS } from './constants';
 import { formatProduct } from './format-product';
 
 export function isMonthlyProduct( rawProduct ) {
 	const product = formatProduct( rawProduct );
 
 	return parseInt( product.bill_period, 10 ) === PLAN_MONTHLY_PERIOD;
+}
+
+export function isMonthly( plan ) {
+	return WPCOM_MONTHLY_PLANS.includes( plan ) || JETPACK_MONTHLY_PLANS.includes( plan );
 }

--- a/packages/calypso-products/src/is-monthly.js
+++ b/packages/calypso-products/src/is-monthly.js
@@ -1,8 +1,7 @@
 /**
  * Internal dependencies
  */
-import { PLAN_MONTHLY_PERIOD } from './index';
-import { WPCOM_MONTHLY_PLANS, JETPACK_MONTHLY_PLANS } from './constants';
+import { JETPACK_MONTHLY_PLANS, PLAN_MONTHLY_PERIOD, WPCOM_MONTHLY_PLANS } from './constants';
 import { formatProduct } from './format-product';
 
 export function isMonthlyProduct( rawProduct ) {

--- a/packages/calypso-products/src/is-p2-plus.js
+++ b/packages/calypso-products/src/is-p2-plus.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isP2PlusPlan } from './index';
+import { isP2PlusPlan } from './main';
 import { formatProduct } from './format-product';
 
 export function isP2Plus( product ) {

--- a/packages/calypso-products/src/is-personal.js
+++ b/packages/calypso-products/src/is-personal.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isPersonalPlan } from './index';
+import { isPersonalPlan } from './main';
 import { formatProduct } from './format-product';
 
 export function isPersonal( product ) {

--- a/packages/calypso-products/src/is-premium.js
+++ b/packages/calypso-products/src/is-premium.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isPremiumPlan } from './index';
+import { isPremiumPlan } from './main';
 import { formatProduct } from './format-product';
 
 export function isPremium( product ) {

--- a/packages/calypso-products/src/is-security-daily.js
+++ b/packages/calypso-products/src/is-security-daily.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isSecurityDailyPlan } from './index';
+import { isSecurityDailyPlan } from './main';
 import { formatProduct } from './format-product';
 
 export function isSecurityDaily( product ) {

--- a/packages/calypso-products/src/is-security-realtime.js
+++ b/packages/calypso-products/src/is-security-realtime.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isSecurityRealTimePlan } from './index';
+import { isSecurityRealTimePlan } from './main';
 import { formatProduct } from './format-product';
 
 export function isSecurityRealTime( product ) {

--- a/packages/calypso-products/src/is-traffic-guide.js
+++ b/packages/calypso-products/src/is-traffic-guide.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { formatProduct } from './format-product';
-import { WPCOM_TRAFFIC_GUIDE } from './index';
+import { WPCOM_TRAFFIC_GUIDE } from './constants';
 
 export function isTrafficGuide( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/is-yearly.js
+++ b/packages/calypso-products/src/is-yearly.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { PLAN_ANNUAL_PERIOD } from './index';
+import { PLAN_ANNUAL_PERIOD } from './constants';
 import { formatProduct } from './format-product';
 
 export function isYearly( rawProduct ) {

--- a/packages/calypso-products/src/plans-utilities.js
+++ b/packages/calypso-products/src/plans-utilities.js
@@ -1,0 +1,47 @@
+/**
+ * Internal dependencies
+ */
+import {
+	JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN,
+	NEW_PLANS,
+	BEST_VALUE_PLANS,
+	TERM_MONTHLY,
+	PLAN_MONTHLY_PERIOD,
+	TERM_ANNUALLY,
+	PLAN_ANNUAL_PERIOD,
+	TERM_BIENNIALLY,
+	PLAN_BIENNIAL_PERIOD,
+} from './constants';
+
+export function isNew( plan ) {
+	return NEW_PLANS.includes( plan );
+}
+
+export function isBestValue( plan ) {
+	return BEST_VALUE_PLANS.includes( plan );
+}
+
+/**
+ * Return estimated duration of given PLAN_TERM in days
+ *
+ * @param {string} term TERM_ constant
+ * @returns {number} Term duration
+ */
+export function getTermDuration( term ) {
+	switch ( term ) {
+		case TERM_MONTHLY:
+			return PLAN_MONTHLY_PERIOD;
+
+		case TERM_ANNUALLY:
+			return PLAN_ANNUAL_PERIOD;
+
+		case TERM_BIENNIALLY:
+			return PLAN_BIENNIAL_PERIOD;
+	}
+
+	if ( process.env.NODE_ENV === 'development' ) {
+		console.error( `Unexpected argument ${ term }, expected one of TERM_ constants` ); // eslint-disable-line no-console
+	}
+}
+
+export const redirectCloudCheckoutToWpAdmin = () => !! JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN;

--- a/packages/calypso-products/src/product-values-types.ts
+++ b/packages/calypso-products/src/product-values-types.ts
@@ -18,7 +18,7 @@ import type {
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
 	PRODUCT_WPCOM_SEARCH,
 	PRODUCT_WPCOM_SEARCH_MONTHLY,
-} from './index';
+} from './constants';
 
 export type JetpackProductSlug =
 	| typeof PRODUCT_JETPACK_BACKUP_DAILY

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -64,7 +64,7 @@ export { isJetpackSearch } from './is-jetpack-search';
 export { isJpphpBundle } from './is-jpphp-bundle';
 export { default as isJetpackLegacyItem } from './is-jetpack-legacy-item';
 export { default as isJetpackPurchasableItem } from './is-jetpack-purchasable-item';
-export { isMonthlyProduct } from './is-monthly';
+export * from './is-monthly';
 export { isNoAds } from './is-no-ads';
 export { isPersonal } from './is-personal';
 export { isPlan } from './is-plan';

--- a/packages/calypso-products/src/products-list.ts
+++ b/packages/calypso-products/src/products-list.ts
@@ -37,7 +37,7 @@ import {
 	PRODUCT_JETPACK_SCAN_REALTIME_MONTHLY,
 	PRODUCT_JETPACK_ANTI_SPAM,
 	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
-} from './index';
+} from './constants';
 
 /**
  * Type dependencies

--- a/packages/calypso-products/src/translations.js
+++ b/packages/calypso-products/src/translations.js
@@ -33,7 +33,7 @@ import {
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
 	PRODUCT_WPCOM_SEARCH,
 	PRODUCT_WPCOM_SEARCH_MONTHLY,
-} from './index';
+} from './constants';
 
 // Translatable strings
 export const getJetpackProductsShortNames = () => {

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -54,9 +54,9 @@ import {
 	PLAN_P2_PLUS,
 	PLAN_P2_FREE,
 } from '../src/constants';
-import { PLANS_LIST } from '../src/plans-list';
 import {
 	getPlan,
+	getPlans,
 	getPlanClass,
 	isBusinessPlan,
 	isPersonalPlan,
@@ -81,6 +81,8 @@ import {
 	planHasFeature,
 	planHasSuperiorFeature,
 } from '../src/index';
+
+const PLANS_LIST = getPlans();
 
 describe( 'isFreePlan', () => {
 	test( 'should return true for free plans', () => {

--- a/packages/calypso-products/test/plan-other.js
+++ b/packages/calypso-products/test/plan-other.js
@@ -5,8 +5,8 @@
 /**
  * Internal dependencies
  */
-import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY, getTermDuration } from '../src/constants';
-import { calculateMonthlyPrice, getBillingMonthsForTerm } from '../src/index';
+import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from '../src/constants';
+import { calculateMonthlyPrice, getBillingMonthsForTerm, getTermDuration } from '../src/index';
 
 describe( 'calculateMonthlyPrice', () => {
 	test( 'should return same number for monthly term', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is the third of several PRs (after https://github.com/Automattic/wp-calypso/pull/52251 and https://github.com/Automattic/wp-calypso/pull/52252) to clean up the product identification code that's been moved to the `calypso-products` package by https://github.com/Automattic/wp-calypso/pull/52249 and https://github.com/Automattic/wp-calypso/pull/51955.

Specifically, this PR:

- Moves all functions out of the constants files.
- Changes all `import x from './index'` to import from the specific file where `x` is defined. This should remove internal dependency loops.

#### Testing instructions

Automated tests should be sufficient.