### PR TITLE
My Sites Sidebar: be more specific of the group to collapse the sidebar.

### DIFF
--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -17,7 +17,7 @@
 		--masterbar-height: 32px;
 	}
 
-	&.is-sidebar-collapsed:not( .is-section-reader ):not( .is-section-me ) {
+	&.is-group-sites.is-sidebar-collapsed {
 		--sidebar-width-max: 36px;
 		--sidebar-width-min: 36px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Initially thought that `is-section-me` applies to all **Me** pages but that's not the case. The correct selector would be `is-group-me`. Anyway, I used `is-group-sites` in order to be explicit where the sidebar can be collapsed.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to My Sites
* Collapse the sidebar
* Go to `/me/account`
* Inspect that the sidebar is not collapsed at any case

Before | After
-------|------
![](https://cln.sh/U0L1se+)|![](https://cln.sh/3Eko6x+) 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #52260
