### PR TITLE
Remove QueryReaderTeams from Layout

### DIFF
--- a/client/components/data/query-reader-teams/index.jsx
+++ b/client/components/data/query-reader-teams/index.jsx
@@ -1,27 +1,19 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { requestTeams } from 'calypso/state/teams/actions';
 
-class QueryReaderTeams extends Component {
-	UNSAFE_componentWillMount() {
-		this.props.requestTeams();
-	}
+export default function QueryReaderTeams() {
+	const dispatch = useDispatch();
+	useEffect( () => {
+		dispatch( requestTeams() );
+	}, [ dispatch ] );
 
-	render() {
-		return null;
-	}
+	return null;
 }
-
-QueryReaderTeams.propTypes = {
-	request: PropTypes.func,
-};
-
-export default connect( null, { requestTeams } )( QueryReaderTeams );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -48,7 +48,6 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import LayoutLoader from './loader';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { withCurrentRoute } from 'calypso/components/route';
-import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { getShouldShowAppBanner, handleScroll } from './utils';
@@ -334,7 +333,6 @@ class Layout extends Component {
 				{ config.isEnabled( 'legal-updates-banner' ) && (
 					<AsyncLoad require="calypso/blocks/legal-updates-banner" placeholder={ null } />
 				) }
-				<QueryReaderTeams />
 			</div>
 		);
 	}

--- a/client/state/selectors/is-nav-unification-enabled.js
+++ b/client/state/selectors/is-nav-unification-enabled.js
@@ -1,21 +1,9 @@
 /**
- * External dependencies
- */
-import cookie from 'cookie';
-
-/**
  * Internal dependencies
  */
-import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
-import { getReaderTeams } from 'calypso/state/teams/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import isNavUnificationNewUser from 'calypso/state/selectors/is-nav-unification-new-user';
-
-// Gradual rollout (segment of existing users + all new users registered after March 5, 2021).
-const CURRENT_ROLLOUT_SEGMENT_PERCENTAGE = 100;
 
 export default ( state ) => {
 	const hasDocument = 'undefined' !== typeof document;
@@ -31,31 +19,5 @@ export default ( state ) => {
 		return false;
 	}
 
-	const userId = getCurrentUserId( state );
-
-	// Users belonging to the current segment OR New Users.
-	const userInCurrentRolloutSegment = userId % 100 < CURRENT_ROLLOUT_SEGMENT_PERCENTAGE;
-	if ( userInCurrentRolloutSegment || isNavUnificationNewUser( state ) ) {
-		return true;
-	}
-
-	// Enable nav-unification for all a12s.
-	if ( isAutomatticTeamMember( getReaderTeams( state ) ) ) {
-		return true;
-	}
-
-	// By this point we're checking the cookies which can't be done on the server.
-	if ( ! hasDocument ) {
-		return false;
-	}
-
-	// Enable for E2E tests checking Nav Unification.
-	// @see https://github.com/Automattic/wp-calypso/pull/50144.
-	const cookies = cookie.parse( document.cookie );
-	if ( cookies.flags && cookies.flags.includes( 'nav-unification' ) ) {
-		return true;
-	}
-
-	// Disabled by default.
-	return false;
+	return true;
 };

--- a/client/state/selectors/test/get-editor-close-config.js
+++ b/client/state/selectors/test/get-editor-close-config.js
@@ -29,6 +29,7 @@ describe( 'getEditorCloseConfig()', () => {
 				},
 			},
 			ui: { selectedSiteId: siteId },
+			userSettings: { settings: {} },
 		};
 
 		expect( getEditorCloseConfig( state, siteId, postType ).url ).toEqual( customerHomeUrl );
@@ -47,6 +48,7 @@ describe( 'getEditorCloseConfig()', () => {
 			ui: {
 				selectedSiteId: siteId,
 			},
+			userSettings: { settings: {} },
 		};
 
 		const allPostsUrl = getPostTypeAllPostsUrl( state, postType );
@@ -80,6 +82,7 @@ describe( 'getEditorCloseConfig()', () => {
 				},
 			},
 			ui: { selectedSiteId: siteId },
+			userSettings: { settings: {} },
 		};
 
 		const parentPostEditorUrl = getEditorUrl( state, siteId, parentPostId, pagePostType );
@@ -102,6 +105,7 @@ describe( 'getEditorCloseConfig()', () => {
 			ui: {
 				selectedSiteId: siteId,
 			},
+			userSettings: { settings: {} },
 		};
 
 		expect( getEditorCloseConfig( state, siteId, postType, '' ).url ).toEqual( customerHomeUrl );
@@ -120,6 +124,7 @@ describe( 'getEditorCloseConfig()', () => {
 			ui: {
 				selectedSiteId: siteId,
 			},
+			userSettings: { settings: {} },
 		};
 
 		expect( getEditorCloseConfig( state, siteId, postType, '' ).url ).toEqual( customerHomeUrl );
@@ -138,6 +143,7 @@ describe( 'getEditorCloseConfig()', () => {
 			ui: {
 				selectedSiteId: siteId,
 			},
+			userSettings: { settings: {} },
 		};
 
 		expect( getEditorCloseConfig( state, siteId, siteEditorPostType ).url ).toEqual(
@@ -158,6 +164,7 @@ describe( 'getEditorCloseConfig()', () => {
 			ui: {
 				selectedSiteId: siteId,
 			},
+			userSettings: { settings: {} },
 		};
 
 		expect( getEditorCloseConfig( state, siteId, siteEditorPostType, '' ).url ).toEqual(


### PR DESCRIPTION
Removes the "is a11n" check from the `isNavUnificationEnabled` selector, along with other checks that are outdated since it's been rolled out to 100% of users, and then removes the `QueryReaderTeams` component from layout because we don't need it there any more.

Should make the main entrypoint chunk a bit lighter again.