### PR TITLE
Capture and log the error nicely when we can get the console logs

### DIFF
--- a/test/e2e/lib/hooks/save-console-log.js
+++ b/test/e2e/lib/hooks/save-console-log.js
@@ -11,14 +11,22 @@ export default () => {
 	after( 'Save browser logs', async function () {
 		const driver = global.__BROWSER__;
 
-		await Promise.allSettled(
-			[
-				[ getBrowserLogs( driver ), 'console.log' ],
-				[ getPerformanceLogs( driver ), 'performance.log' ],
-			].map( async ( [ logsPromise, file ] ) => {
-				const logs = await logsPromise;
-				return fs.writeFile( generatePath( file ), JSON.stringify( logs, null, 2 ) );
-			} )
-		);
+		try {
+			await Promise.allSettled(
+				[
+					[ getBrowserLogs( driver ), 'console.log' ],
+					[ getPerformanceLogs( driver ), 'performance.log' ],
+				].map( async ( [ logsPromise, file ] ) => {
+					const logs = await logsPromise;
+					return fs.writeFile( generatePath( file ), JSON.stringify( logs, null, 2 ) );
+				} )
+			);
+		} catch ( err ) {
+			console.warn(
+				'Got an error trying to save logs from the browser. This IS NOT causing the test to break, is just a warning'
+			);
+			console.warn( 'Original error:' );
+			console.warn( err );
+		}
 	} );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a try/catch and log the error capturing Chrome logs as a warning. This error was not breaking the test (the hook waits for all promises to settle, it doesn't care if they are rejected), but it was being logged as an error in TeamCity. This could cause confusion about why a test was failing.
