### PR TITLE
Add helper to detect Jetpack legacy plan

### DIFF
--- a/packages/calypso-products/src/index.ts
+++ b/packages/calypso-products/src/index.ts
@@ -3,3 +3,5 @@ export * from './types';
 export * from './constants';
 export * from './utils';
 export { default as getIntervalTypeForTerm } from './get-interval-type-for-term';
+export { default as isJetpackLegacyItem } from './is-jetpack-legacy-item';
+export { default as isJetpackPurchasableItem } from './is-jetpack-purchasable-item';

--- a/packages/calypso-products/src/is-jetpack-legacy-item.ts
+++ b/packages/calypso-products/src/is-jetpack-legacy-item.ts
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { JETPACK_LEGACY_PLANS } from './constants';
+
+/**
+ * Type dependencies
+ */
+import type { JetpackLegacyPlanSlugs } from './types';
+
+export default function isJetpackLegacyItem(
+	itemSlug: string
+): itemSlug is JetpackLegacyPlanSlugs {
+	return JETPACK_LEGACY_PLANS.includes( itemSlug );
+}

--- a/packages/calypso-products/src/is-jetpack-purchasable-item.ts
+++ b/packages/calypso-products/src/is-jetpack-purchasable-item.ts
@@ -3,10 +3,15 @@
  */
 import { JETPACK_LEGACY_PLANS, JETPACK_PRODUCTS_LIST, JETPACK_RESET_PLANS } from './constants';
 
+/**
+ * Type dependencies
+ */
+import type { JetpackPurchasableItem } from './types';
+
 export default function isJetpackPurchasableItem(
 	itemSlug: string,
 	options: { includeLegacy?: boolean } = {}
-): boolean {
+): itemSlug is JetpackPurchasableItem {
 	return [
 		...JETPACK_PRODUCTS_LIST,
 		...JETPACK_RESET_PLANS,

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -26,6 +26,25 @@ export type JetpackPlanSlugs =
 	| JetpackResetPlanSlugs
 	| JetpackLegacyPlanSlugs;
 
+export type JetpackProductSlug =
+	| typeof constants.PRODUCT_JETPACK_BACKUP_DAILY
+	| typeof constants.PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY
+	| typeof constants.PRODUCT_JETPACK_BACKUP_REALTIME
+	| typeof constants.PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY
+	| typeof constants.PRODUCT_JETPACK_SCAN
+	| typeof constants.PRODUCT_JETPACK_SCAN_MONTHLY
+	| typeof constants.PRODUCT_JETPACK_SCAN_REALTIME
+	| typeof constants.PRODUCT_JETPACK_SCAN_REALTIME_MONTHLY
+	| typeof constants.PRODUCT_JETPACK_ANTI_SPAM
+	| typeof constants.PRODUCT_JETPACK_ANTI_SPAM_MONTHLY
+	| typeof constants.PRODUCT_JETPACK_SEARCH
+	| typeof constants.PRODUCT_JETPACK_SEARCH_MONTHLY;
+
+export type JetpackPurchasableItem =
+	| JetpackProductSlug
+	| JetpackResetPlanSlugs
+	| JetpackLegacyPlanSlugs;
+
 export type JetpackPlanCardFeature = symbol | [ symbol, symbol[] ];
 export type JetpackPlanCardFeatureSection = Record< symbol, JetpackPlanCardFeature[] >;
 

--- a/packages/calypso-products/test/is-jetpack-legacy-item.js
+++ b/packages/calypso-products/test/is-jetpack-legacy-item.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import isJetpackLegacyItem from '../src/is-jetpack-legacy-item';
+import {
+	PRODUCT_JETPACK_ANTI_SPAM,
+	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
+	PLAN_JETPACK_COMPLETE,
+	PLAN_JETPACK_COMPLETE_MONTHLY,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+} from '../src/constants';
+
+describe( 'isJetpackLegacyItem', () => {
+	it( 'should return true if the item is a Jetpack legacy item', () => {
+		expect( isJetpackLegacyItem( PLAN_JETPACK_PERSONAL ) ).toEqual( true );
+		expect( isJetpackLegacyItem( PLAN_JETPACK_PERSONAL_MONTHLY ) ).toEqual( true );
+	} );
+
+	it( 'should return false otherwise', () => {
+		expect( isJetpackLegacyItem( PRODUCT_JETPACK_ANTI_SPAM ) ).toEqual( false );
+		expect( isJetpackLegacyItem( PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ) ).toEqual( false );
+		expect( isJetpackLegacyItem( PLAN_JETPACK_COMPLETE ) ).toEqual( false );
+		expect( isJetpackLegacyItem( PLAN_JETPACK_COMPLETE_MONTHLY ) ).toEqual( false );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds a helper function that checks if a product slug matches the slug of a Jetpack legacy plan.

### Implementation notes

It also makes helpers importable from the package root.

### Testing instructions

- Review the code
- Run `yarn test-packages:watch` and filter by the filename (or verify that the check doesn't fail in GH)