### PR TITLE
Docs: fix broken links

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Consistent coding style makes the code so much easier to read. Here are ours:
   - [CSS/Sass](../docs/coding-guidelines/css.md)
   - [HTML](../docs/coding-guidelines/html.md)
   - [React Components](../docs/components.md)
-- [I18n Guidelines](https://github.com/Automattic/i18n-calypso/blob/HEAD/README.md)
+- [I18n Guidelines](../packages/i18n-calypso/README.md)
 - [A11y Checklist](../docs/accessibility-checklist.md)
 
 ### Lifecycle of a Pull Request
@@ -90,7 +90,7 @@ Once you know what the first small piece of your feature will be, follow this ge
    - Add unit tests, or at a minimum, provide helpful instructions for the reviewer so they can test your changes. This will help speed up the review process.
    - Ensure that your commit messages are [meaningful](http://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message).
 6. Mention that the PR is ready for review or if you have write access remove the **<span class="label status-in-progress">[Status] In Progress</span>** label from the pull request and add the **<span class="label status-needs-review">[Status] Needs Review</span>** label - someone will provide feedback on the latest unreviewed changes. The reviewer will also mark the pull request as **<span class="label status-needs-author-reply">[Status] Needs Author Reply</span>** if they think you need to change anything.
-7. If you get a 👍, 💥, 🚢, <img src="https://github.githubassets.com/images/icons/emoji/shipit.png" class="emoji" />, or a LGTM and the status has been changed to **<span class="label status-ready-to-merge">[Status] Ready to Merge</span>** – this is great – the pull request is ready to be merged into `trunk`.
+7. If you get a 👍, 💥, 🚢, <img src="https://github.githubassets.com/images/icons/emoji/shipit.png" class="emoji" height="14px" />, or a LGTM and the status has been changed to **<span class="label status-ready-to-merge">[Status] Ready to Merge</span>** – this is great – the pull request is ready to be merged into `trunk`.
 
 Whether somebody is reviewing your code or you are reviewing somebody else’s code, [a positive mindset towards code reviews](https://medium.com/medium-eng/the-code-review-mindset-3280a4af0a89) helps a ton. We’re building something together that is greater than the sum of its parts.
 

--- a/docs/guide/design-tutorial.md
+++ b/docs/guide/design-tutorial.md
@@ -4,42 +4,42 @@ This document is for designers who are new to Calypso and the design patterns we
 
 ## Resources
 
-- [UI Components](/devdocs/design)
+- [UI Components](https://wpcalypso.wordpress.com/devdocs/design)
 - [Colors](https://dotcombrand.wordpress.com/color)
-- [Typography](/devdocs/typography)
-- [Icons](/devdocs/docs/icons.md)
-- [IA Model](/devdocs/docs/ia-model.md)
+- [Typography](https://wpcalypso.wordpress.com/devdocs/typography)
+- [Icons](https://wpcalypso.wordpress.com/devdocs/docs/icons.md)
+- [IA Model](https://wpcalypso.wordpress.com/devdocs/docs/ia-model.md)
 
 ## Common elements
 
-### [SectionNav](/devdocs/design/section-nav) (aka ‘Filter Bar’)
+### [SectionNav](https://wpcalypso.wordpress.com/devdocs/design/section-nav) (aka ‘Filter Bar’)
 
 Contains the main actions and ‘tabs’ for a section:
 ![Section Nav](https://cldup.com/fu2XX6KTu6.png 'Section Nav')
 
-[SectionHeader](/devdocs/design/section-header) is essentially the same thing, but without tabs.
+[SectionHeader](https://wpcalypso.wordpress.com/devdocs/design/section-header) is essentially the same thing, but without tabs.
 
-### [Headers](/devdocs/design/headers) (aka ‘Header Cake’)
+### [Headers](https://wpcalypso.wordpress.com/devdocs/design/headers) (aka ‘Header Cake’)
 
 - Essentially it’s a SectionHeader, with centered title and a back button.
 - It’s used for navigating between views when you need more space for the UI you want to present.
 
-### [Cards](/devdocs/design/cards) (also, FoldableCard)
+### [Cards](https://wpcalypso.wordpress.com/devdocs/design/cards) (also, FoldableCard)
 
 Cards are the basic canvases we use to put UI in. They can take many forms. Many components require the base Card component.
 
-### [Notices](/devdocs/design/notice)
+### [Notices](https://wpcalypso.wordpress.com/devdocs/design/notice)
 
 - These are temporary messages to alert the user. They can be persistent, but should have an action or a way to close it.
 - They appear inline with the rest of the UI.
-- [GlobalNotices](/devdocs/design/global-notices) are notices that float/appear on top of the UI, and disappear after a certain amount of time.
+- [GlobalNotices](https://wpcalypso.wordpress.com/devdocs/design/global-notices) are notices that float/appear on top of the UI, and disappear after a certain amount of time.
 - Notices should be used for important and urgent messages. Notices are not to be used for promotions, or anything that is not an alert.
 
-### [Banners](/devdocs/design/banner)
+### [Banners](https://wpcalypso.wordpress.com/devdocs/design/banner)
 
 - Often confused with notices, Banners are generic cards that inform users of promotions, help, or information that is not pertinent.
 
-### [EmptyContent](/devdocs/design/empty-content)
+### [EmptyContent](https://wpcalypso.wordpress.com/devdocs/design/empty-content)
 
 - Use when there is no content to show.
 - Change the illustration based on the context, and provide a CTA so users don’t feel lost.

--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -30,7 +30,7 @@ First thing is to enable your new feature in Calypso. We'll do that by opening `
 "hello-world": true
 ```
 
-Feature flags are a great way to enable/disable certain features in specific environments. For example, we can merge our "Hello, World!" code in `trunk,` but hide it behind a feature flag. We have [more documentation on feature flags](../../client/config).
+Feature flags are a great way to enable/disable certain features in specific environments. For example, we can merge our "Hello, World!" code in `trunk,` but hide it behind a feature flag. We have [more documentation on feature flags](../../config/README.md#feature-flags).
 
 ### 2. Set up folder structure
 

--- a/docs/guide/tech-behind-calypso.md
+++ b/docs/guide/tech-behind-calypso.md
@@ -21,7 +21,7 @@ Here are few resources to get up to speed with “modern” JavaScript and ES6:
 Key concepts checklist:
 
 - [Module pattern with CommonJS](http://darrenderidder.github.io/talks/ModulePatterns/) and [npm](https://docs.npmjs.com)
-- [Scope](https://github.com/getify/You-Dont-Know-JS/tree/HEAD/scope%20%26%20closures), context, and [function binding](https://github.com/getify/You-Dont-Know-JS/tree/HEAD/this%20%26%20object%20prototypes)
+- [Scope](You-Dont-Know-JS/tree/2nd-ed/scope-closures), context, and [function binding](https://github.com/getify/You-Dont-Know-JS/blob/1st-ed/this%20&%20object%20prototypes/README.md#you-dont-know-js-this--object-prototypes)
 - [Basic prototypes – creating new objects, inheritance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain)
 - Higher-level functions – [`map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map), [`filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter), [`reduce`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce)
 - Async primitives – [callbacks](https://docs.nodejitsu.com/articles/getting-started/control-flow/what-are-callbacks), [promises](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise)

--- a/docs/testing/unit-tests.md
+++ b/docs/testing/unit-tests.md
@@ -177,7 +177,7 @@ Because we're passing the list as an argument, we can pass mock `validValuesList
 
 Often our code will use methods and properties from imported external and internal libraries in multiple places, which makes passing around arguments messy and impracticable. For these cases `jest.mock` offers a neat way to stub these dependencies.
 
-For instance, in Calypso, we use the ['config'](https://github.com/Automattic/wp-calypso/tree/HEAD/client/config) module to control a great deal of functionality via feature flags.
+For instance, in Calypso, we use the ['config'](https://github.com/Automattic/wp-calypso/tree/HEAD/config) module to control a great deal of functionality via feature flags.
 
 ```javascript
 // bilbo.js


### PR DESCRIPTION
While looking for docs on feature flags, I noticed that a lot of links in our documentation were broken - either pointing to moved files, old repos, broken resources, or devdocs (which need to point to a hosted resource). This just updates the links 
and not the content itself. It's probably not a complete list, because we have a ton of docs, but I followed the rabbit hole for a bit and tried to do some creative searching for common broken links (i.e. `/client/config` when `/config` was meant).

**To test:**
- open the branch in an IDE
- navigate to /docs
- click around and make sure links resolve