### PR TITLE
Design Picker: add FSE-enabled blank canvas option

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -435,6 +435,16 @@
 			"is_fse": false,
 			"is_alpha": true,
 			"features": []
+		},
+		{
+			"title": "Start with an empty page",
+			"slug": "blank-canvas-blocks",
+			"template": "blank-canvas-blocks",
+			"theme": "blank-canvas-blocks",
+			"categories": [ "featured" ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
 		}
 	]
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add a new FSE-enabled Blank Canvas design based on the "Blank Canvas Blocks" theme and templates

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### In Gutenboarding:

* Visit [`/new/design?flags=gutenboarding/site-editor`](https://hash-b0dad8a908d4da7c77759ffb16602212108d9f61.calypso.live/new/design?flags=gutenboarding/site-editor), pick the Blank Canvas design option and create a new site
* Verify that:
    * [ ] The new site is created correctly, without errors
    * [ ] The new site uses the Blank Canvas Blocks theme (and therefore, it uses FSE)
    * [ ] The homepage is prepopulated with an _empty page template_ (Note: this A/C needs revision)

#### In `/start` signup flow:

TBD (it may be out of this PR's scope)

Related to #52172