### PR TITLE
Plugins: redirect to Woo onboarding when site is transferred

### DIFF
--- a/client/my-sites/plugins/plugin-install-button-wpcom/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button-wpcom/index.jsx
@@ -33,6 +33,7 @@ export const WpcomPluginInstallButton = ( props ) => {
 		initiateTransfer,
 		transferState,
 		trackButtonAction,
+		isTransferring,
 	} = props;
 
 	if ( transferStates.COMPLETE === transferState ) {
@@ -56,9 +57,11 @@ export const WpcomPluginInstallButton = ( props ) => {
 		}
 	}
 
+	const label = isTransferring ? translate( 'Installing…' ) : translate( 'Install' );
+
 	return (
 		<Button onClick={ installButtonAction } primary={ true } disabled={ disabled }>
-			{ translate( 'Install' ) }
+			{ label }
 		</Button>
 	);
 };

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -263,8 +263,9 @@ export class PluginInstallButton extends Component {
 	}
 
 	renderButton() {
-		const { translate, isInstalling, isEmbed, disabled } = this.props;
-		const label = isInstalling ? translate( 'Installing…' ) : translate( 'Install' );
+		const { translate, isInstalling, isTransferring, isEmbed, disabled } = this.props;
+		const label =
+			isInstalling || isTransferring ? translate( 'Installing…' ) : translate( 'Install' );
 
 		if ( isEmbed ) {
 			return (
@@ -287,7 +288,7 @@ export class PluginInstallButton extends Component {
 				<Button
 					onClick={ this.installAction }
 					primary={ true }
-					disabled={ isInstalling || disabled }
+					disabled={ isInstalling || isTransferring || disabled }
 				>
 					{ label }
 				</Button>

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -303,6 +303,7 @@ export class PluginMeta extends Component {
 			return (
 				<WpcomPluginInstallButton
 					disabled={ this.isWpcomInstallDisabled() }
+					isTransferring={ this.props.isTransferring }
 					plugin={ this.props.plugin }
 				/>
 			);

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -281,9 +281,9 @@ export class PluginMeta extends Component {
 	}
 
 	isWpcomInstallDisabled() {
-		const { isTransfering, plugin } = this.props;
+		const { isTransferring, plugin } = this.props;
 
-		return ! this.hasBusinessPlan() || ! isCompatiblePlugin( plugin.slug ) || isTransfering;
+		return ! this.hasBusinessPlan() || ! isCompatiblePlugin( plugin.slug ) || isTransferring;
 	}
 
 	isJetpackInstallDisabled() {

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -31,7 +31,11 @@ import PluginSectionsCustom from 'calypso/my-sites/plugins/plugin-sections/custo
 import DocumentHead from 'calypso/components/data/document-head';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
-import { isJetpackSite, isRequestingSites } from 'calypso/state/sites/selectors';
+import {
+	isJetpackSite,
+	isRequestingSites,
+	getSiteWoocommerceUrl,
+} from 'calypso/state/sites/selectors';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import canCurrentUserManagePlugins from 'calypso/state/selectors/can-current-user-manage-plugins';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
@@ -45,6 +49,7 @@ import {
 	getSiteObjectsWithPlugin,
 	getSitesWithoutPlugin,
 	isPluginActionInProgress,
+	isPluginActionCompleted,
 	isRequestingForSites,
 } from 'calypso/state/plugins/installed/selectors';
 import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
@@ -67,6 +72,18 @@ class SinglePlugin extends React.Component {
 
 	componentWillUnmount() {
 		this.hasAlreadyShownTheTour = false;
+	}
+
+	UNSAFE_componentWillReceiveProps( nextProps ) {
+		// WooCommerce plugin has just been installed. Redirect to Woo.
+		if (
+			this.props.pluginSlug === 'woocommerce' &&
+			nextProps.hasPluginJustBeenInstalled &&
+			this.props.woocommerceUrl
+		) {
+			window.location.href = this.props.woocommerceUrl;
+			return;
+		}
 	}
 
 	getPageTitle() {
@@ -333,6 +350,12 @@ export default connect(
 				props.pluginSlug,
 				INSTALL_PLUGIN
 			),
+			hasPluginJustBeenInstalled: isPluginActionCompleted(
+				state,
+				selectedSiteId,
+				props.pluginSlug,
+				INSTALL_PLUGIN
+			),
 			isRequestingSites: isRequestingSites( state ),
 			requestingPluginsForSites: isRequestingForSites( state, siteIds ),
 			userCanManagePlugins: selectedSiteId
@@ -342,6 +365,7 @@ export default connect(
 			sites,
 			toursHistory: getToursHistory( state ),
 			navigated: hasNavigated( state ),
+			woocommerceUrl: getSiteWoocommerceUrl( state, selectedSiteId ),
 		};
 	},
 	{

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -56,6 +56,7 @@ import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
+import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
 
 function goBack() {
 	window.history.back();
@@ -77,12 +78,27 @@ class SinglePlugin extends React.Component {
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
+		// Jetpack site
 		// WooCommerce plugin has just been installed. Redirect to Woo.
 		if (
+			this.props.isJetpackSite &&
 			this.props.pluginSlug === 'woocommerce' &&
 			this.props.woocommerceWizardUrl &&
-			( nextProps.hasPluginJustBeenInstalled ||
-				this.props.transferState === transferStates?.COMPLETE )
+			nextProps.hasPluginJustBeenInstalled &&
+			nextProps.siteIsConnected
+		) {
+			window.location.href = this.props.woocommerceWizardUrl;
+			return;
+		}
+
+		// Atomic site
+		// WooCommerce plugin has just been installed. Redirect to Woo.
+		if (
+			this.props.isAtomicSite &&
+			this.props.pluginSlug === 'woocommerce' &&
+			this.props.woocommerceWizardUrl &&
+			this.props.transferState === transferStates?.COMPLETE &&
+			nextProps.siteIsConnected
 		) {
 			window.location.href = this.props.woocommerceWizardUrl;
 			return;
@@ -347,6 +363,7 @@ export default connect(
 			sitesWithoutPlugin: getSitesWithoutPlugin( state, siteIds, props.pluginSlug ),
 			isAtomicSite: isSiteAutomatedTransfer( state, selectedSiteId ),
 			isJetpackSite: selectedSiteId && isJetpackSite( state, selectedSiteId ),
+			siteIsConnected: getSiteConnectionStatus( state, selectedSiteId ),
 			isInstallingPlugin: isPluginActionInProgress(
 				state,
 				selectedSiteId,

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -54,6 +54,8 @@ import {
 } from 'calypso/state/plugins/installed/selectors';
 import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
+import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
 
 function goBack() {
 	window.history.back();
@@ -78,8 +80,9 @@ class SinglePlugin extends React.Component {
 		// WooCommerce plugin has just been installed. Redirect to Woo.
 		if (
 			this.props.pluginSlug === 'woocommerce' &&
-			nextProps.hasPluginJustBeenInstalled &&
-			this.props.woocommerceUrl
+			this.props.woocommerceUrl &&
+			( nextProps.hasPluginJustBeenInstalled ||
+				this.props.transferState === transferStates?.COMPLETE )
 		) {
 			window.location.href = this.props.woocommerceUrl;
 			return;
@@ -366,6 +369,7 @@ export default connect(
 			toursHistory: getToursHistory( state ),
 			navigated: hasNavigated( state ),
 			woocommerceUrl: getSiteWoocommerceUrl( state, selectedSiteId ),
+			transferState: getAutomatedTransferStatus( state, selectedSiteId ),
 		};
 	},
 	{

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -34,7 +34,7 @@ import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import {
 	isJetpackSite,
 	isRequestingSites,
-	getSiteWoocommerceUrl,
+	getSiteWoocommerceWizardUrl,
 } from 'calypso/state/sites/selectors';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import canCurrentUserManagePlugins from 'calypso/state/selectors/can-current-user-manage-plugins';
@@ -80,11 +80,11 @@ class SinglePlugin extends React.Component {
 		// WooCommerce plugin has just been installed. Redirect to Woo.
 		if (
 			this.props.pluginSlug === 'woocommerce' &&
-			this.props.woocommerceUrl &&
+			this.props.woocommerceWizardUrl &&
 			( nextProps.hasPluginJustBeenInstalled ||
 				this.props.transferState === transferStates?.COMPLETE )
 		) {
-			window.location.href = this.props.woocommerceUrl;
+			window.location.href = this.props.woocommerceWizardUrl;
 			return;
 		}
 	}
@@ -368,7 +368,7 @@ export default connect(
 			sites,
 			toursHistory: getToursHistory( state ),
 			navigated: hasNavigated( state ),
-			woocommerceUrl: getSiteWoocommerceUrl( state, selectedSiteId ),
+			woocommerceWizardUrl: getSiteWoocommerceWizardUrl( state, selectedSiteId ),
 			transferState: getAutomatedTransferStatus( state, selectedSiteId ),
 		};
 	},

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -211,6 +211,19 @@ export function isPluginActionInProgress( state, siteId, pluginId, action ) {
 }
 
 /**
+ * Whether the plugin's status for one or more recent actions is completed.
+ *
+ * @param  {object}       state    Global state tree
+ * @param  {number}       siteId   ID of the site
+ * @param  {string}       pluginId ID of the plugin
+ * @param  {string|Array} action   Action, or array of actions of interest
+ * @returns {boolean}              True if one or more specified actions are completed, false otherwise.
+ */
+export function isPluginActionCompleted( state, siteId, pluginId, action ) {
+	return isPluginActionStatus( state, siteId, pluginId, action, 'completed' );
+}
+
+/**
  * Retrieve all plugin statuses of a certain type.
  *
  * @param  {object} state    Global state tree

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -63,7 +63,6 @@ export const SITE_REQUEST_OPTIONS = [
 	'unmapped_url',
 	'verification_services_codes',
 	'videopress_enabled',
-	'woocommerce_is_active',
 	'wordads',
 	'site_creation_flow',
 ].join();

--- a/client/state/sites/selectors/get-site-woocommerce-wizard-url.js
+++ b/client/state/sites/selectors/get-site-woocommerce-wizard-url.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import getSiteAdminUrl from './get-site-admin-url';
+
+/**
+ * Returns a site's wp-admin WooCommerce Wizrd plugin URL,
+ * or null if the admin URL for the site cannot be determined.
+ *
+ * @param  {object}  state  Global state tree
+ * @param  {number}  siteId Site ID
+ * @returns {?string}       Full URL to WooCommerce Aizard plugin in wp-admin
+ */
+export default function getSiteWoocommerceWizardUrl( state, siteId ) {
+	return getSiteAdminUrl(
+		state,
+		siteId,
+		'admin.php?page=wc-admin&from-calypso&path=%2Fsetup-wizard'
+	);
+}

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -57,3 +57,4 @@ export { default as isSSOEnabled } from './is-sso-enabled';
 export { default as verifyJetpackModulesActive } from './verify-jetpack-modules-active';
 export { default as getSelectedSiteWithFallback } from './get-site-with-fallback';
 export { default as getSiteWoocommerceUrl } from './get-site-woocommerce-url';
+export { default as getSiteWoocommerceWizardUrl } from './get-site-woocommerce-wizard-url';


### PR DESCRIPTION
## IMPORTANT

it has been branched off from https://github.com/Automattic/wp-calypso/pull/52246. Let's merge & ship `52246` before continuing with this PR.

Fixes https://github.com/Automattic/wp-calypso/issues/51327

#### Changes proposed in this Pull Request

This PR performs a redirection to the WooCommerce onboarding (wp-admin) once a Simple site is transferred to the Atomic platform when uploading the WooCommerce plugin. Once the plugin is installed, the app redirects to the WooCommerce Wizard page.

#### Testing instructions

* Test with a **SIMPLE** site
* Buy a **Business** plan
* Go to WooCommerce plugin page in calypso: `<hostname>/plugins/woocommerce/<site-id>`

![image](https://user-images.githubusercontent.com/77539/116113080-8b71f400-a68e-11eb-893a-3af2a7da5251.png)

* Click on the Install button to trigger the transferring process.

Now, in this PR, the uploading button changes its text to `__( 'Installing...' )`, and also it gets disabled.

Initial | Installing
------|-------
![image](https://user-images.githubusercontent.com/77539/116130003-1a880780-a6a1-11eb-953c-5800ef0a301b.png) | ![image](https://user-images.githubusercontent.com/77539/116130080-312e5e80-a6a1-11eb-829a-ffde4b95d008.png)

* Once the plugin is installed, the client should redirect to the WooCoomerce onboarding page (wp-admin)

![image](https://user-images.githubusercontent.com/77539/116130332-7783bd80-a6a1-11eb-8278-53c109531948.png)

Related to https://github.com/Automattic/wp-calypso/issues/51327
