### PR TITLE
Domains: Wrap long primary domains URL

### DIFF
--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -31,6 +31,7 @@
 	.list__header-primary-domain-url {
 		color: inherit;
 		text-decoration: none;
+		word-break: break-all;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Noticed while working on an unrelated PR. Looks like long primary domain names need `word-break`:

<img width="1111" alt="Screenshot 2021-04-26 at 16 54 17" src="https://user-images.githubusercontent.com/3392497/116121550-3e9f1500-a6b0-11eb-9d2e-7750e0cb94c7.png">

#### Testing instructions

Either create or rename an existing site to one with a very long WPCOM subdomain (see above screenshot). Then go to domain management and make sure it's set as primary. With the patch it should not overflow anymore:

<img width="1062" alt="Screenshot 2021-04-26 at 16 54 04" src="https://user-images.githubusercontent.com/3392497/116121670-61c9c480-a6b0-11eb-98e2-24628830a0d1.png">
