### PR TITLE
Earn: Fix Refer-a-Friend Link for Other Languages

### DIFF
--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -85,6 +85,7 @@ const urlLocalizationMapping: UrlLocalizationMapping = {
 	'wordpress.com/tos/': prefixLocalizedUrlPath( magnificentNonEnLocales ),
 	'wordpress.com/wp-admin/': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
 	'wordpress.com/wp-login.php': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
+	'wordpress.com/refer-a-friend/': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
 	'jetpack.com': setLocalizedUrlHost( 'jetpack.com', jetpackComLocales ),
 	'en.support.wordpress.com': setLocalizedWpComPath( '/support', supportSiteLocales ),
 	'en.blog.wordpress.com': setLocalizedWpComPath( '/blog', localesWithBlog, /^\/$/ ),

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -312,7 +312,7 @@ describe( '#localizeUrl', () => {
 
 	test( 'refer-a-friend', () => {
 		expect( localizeUrl( 'https://wordpress.com/refer-a-friend', 'en' ) ).toEqual(
-			'https://wordpress.com/refer-a-friend'
+			'https://wordpress.com/refer-a-friend/'
 		);
 		expect( localizeUrl( 'https://wordpress.com/refer-a-friend', 'de' ) ).toEqual(
 			'https://de.wordpress.com/refer-a-friend'

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -310,6 +310,24 @@ describe( '#localizeUrl', () => {
 		);
 	} );
 
+	test( 'refer-a-friend', () => {
+		expect( localizeUrl( 'https://wordpress.com/refer-a-friend', 'en' ) ).toEqual(
+			'https://wordpress.com/refer-a-friend'
+		);
+		expect( localizeUrl( 'https://wordpress.com/refer-a-friend', 'de' ) ).toEqual(
+			'https://de.wordpress.com/refer-a-friend'
+		);
+		expect( localizeUrl( 'https://wordpress.com/refer-a-friend', 'pt-br' ) ).toEqual(
+			'https://br.wordpress.com/refer-a-friend'
+		);
+		expect( localizeUrl( 'https://wordpress.com/refer-a-friend', 'zh-tw' ) ).toEqual(
+			'https://zh-tw.wordpress.com/refer-a-friend'
+		);
+		expect( localizeUrl( 'https://wordpress.com/refer-a-friend', 'pl' ) ).toEqual(
+			'https://wordpress.com/refer-a-friend'
+		);
+	} );
+
 	test( 'jetpack', () => {
 		expect( localizeUrl( 'https://jetpack.com/features/comparison/', 'en' ) ).toEqual(
 			'https://jetpack.com/features/comparison/'

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -315,16 +315,16 @@ describe( '#localizeUrl', () => {
 			'https://wordpress.com/refer-a-friend/'
 		);
 		expect( localizeUrl( 'https://wordpress.com/refer-a-friend', 'de' ) ).toEqual(
-			'https://de.wordpress.com/refer-a-friend'
+			'https://de.wordpress.com/refer-a-friend/'
 		);
 		expect( localizeUrl( 'https://wordpress.com/refer-a-friend', 'pt-br' ) ).toEqual(
-			'https://br.wordpress.com/refer-a-friend'
+			'https://br.wordpress.com/refer-a-friend/'
 		);
 		expect( localizeUrl( 'https://wordpress.com/refer-a-friend', 'zh-tw' ) ).toEqual(
-			'https://zh-tw.wordpress.com/refer-a-friend'
+			'https://zh-tw.wordpress.com/refer-a-friend/'
 		);
 		expect( localizeUrl( 'https://wordpress.com/refer-a-friend', 'pl' ) ).toEqual(
-			'https://wordpress.com/refer-a-friend'
+			'https://wordpress.com/refer-a-friend/'
 		);
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the Refer-a-Friend link for languages other than English

#### Testing instructions

The link structure on the `/earn` page should now be slightly different, with the language prefix being placed before the "wordpress.com".

**Before:** https://wordpress.com/fr/refer-a-friend/eA86JowiXYNPzqnAJyA7/ (invalid)
**After:** https://fr.wordpress.com/refer-a-friend/eA86JowiXYNPzqnAJyA7/ (valid)

<img width="553" alt="Screenshot 2021-04-26 at 17 50 53" src="https://user-images.githubusercontent.com/43215253/116121333-685c3a00-a6b8-11eb-8b82-b414eb6ef00b.png">

I've also already verified that all the languages marked under `magnificentNonEnLocales` are compatible with this page!

cc @taggon, @akirk, @lsl

Fixes #52281