### PR TITLE
Use the correct comparison component in the new email home page

### DIFF
--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -28,7 +28,7 @@ import QueryGSuiteUsers from 'calypso/components/data/query-gsuite-users';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
-import EmailProvidersComparison from '../email-providers-comparison';
+import EmailProvidersStackedComparison from '../email-providers-stacked-comparison';
 import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
@@ -85,7 +85,7 @@ class EmailManagementHome extends React.Component {
 
 			if ( ! domainHasEmail( selectedDomain ) ) {
 				return this.renderContentWithHeader(
-					<EmailProvidersComparison
+					<EmailProvidersStackedComparison
 						domain={ selectedDomain }
 						isGSuiteSupported={ hasGSuiteSupportedDomain( [ selectedDomain ] ) }
 					/>
@@ -108,7 +108,7 @@ class EmailManagementHome extends React.Component {
 		if ( domainsWithEmail.length < 1 && domainsWithNoEmail.length === 1 ) {
 			const firstDomainWithNoEmail = domainsWithNoEmail[ 0 ];
 			return this.renderContentWithHeader(
-				<EmailProvidersComparison
+				<EmailProvidersStackedComparison
 					domain={ firstDomainWithNoEmail }
 					isGSuiteSupported={ hasGSuiteSupportedDomain( [ firstDomainWithNoEmail ] ) }
 				/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR changes the component we use when we try to add email to a domain from the new email home page - the initial implementation was using an older UI component.

#### Testing instructions

First, identify the site slug for a site where you have at least one domain without any email subscriptions.

* Using a local Calypso environment or the [live branch](https://calypso.live/?branch=fix/new-email-home-using-wrong-comparison-component), navigate to `/email/:siteSlug?fags=email/centralized-home`
* For one of the domains in the "Other domains" list towards the bottom of the page, click on the "Add Email" button.
* Verify that we should the email comparison page with the cards stacked vertically, and not the older design with the cards displayed next to each other.