### PR TITLE
Wrap log promises into an async function

### DIFF
--- a/test/e2e/lib/hooks/save-console-log.js
+++ b/test/e2e/lib/hooks/save-console-log.js
@@ -14,10 +14,10 @@ export default () => {
 		try {
 			await Promise.allSettled(
 				[
-					[ getBrowserLogs( driver ), 'console.log' ],
-					[ getPerformanceLogs( driver ), 'performance.log' ],
+					[ () => getBrowserLogs( driver ), 'console.log' ],
+					[ () => getPerformanceLogs( driver ), 'performance.log' ],
 				].map( async ( [ logsPromise, file ] ) => {
-					const logs = await logsPromise;
+					const logs = await logsPromise();
 					return fs.writeFile( generatePath( file ), JSON.stringify( logs, null, 2 ) );
 				} )
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Before this change, `getBrowserLogs( driver )` was called "outside" the main Promise. If that function fails it will trigger the try/catch block. This makes `mocha` wait for the `after` hook until it times out, and at that point it throws an error and doesn't run any other `after` hook.

By wrapping `getBrowserLogs(driver)` into a function that is called inside the `.map()` function, the worst that can happen is that it throws and therefore `Promise.allSettled()` receives an array with some rejected promises. That is fine, as it is not doing anything with the promises. `mocha` will wait for all promises to settle (even if they are rejected) and then continue with the next hook.

#### Testing instructions

Verify Gutenberg e2e tests don't fail with errors about "undefined `.manage()`" that were caused by the premature execution of `getBrowserLogs( driver)`