### PR TITLE
Enable site-specific purchase paths for domain-only sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -216,7 +216,14 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 		);
 	}
 
-	const startsWithPaths = [ '/checkout/', `/me/purchases/${ slug }` ];
+	const startsWithPaths = [
+		'/checkout/',
+		`/me/purchases/${ slug }`,
+		`/purchases/add-payment-method/${ slug }`,
+		`/purchases/billing-history/${ slug }`,
+		`/purchases/subscriptions/${ slug }`,
+		`/purchases/payment-methods/${ slug }`,
+	];
 
 	if ( some( startsWithPaths, ( startsWithPath ) => startsWith( path, startsWithPath ) ) ) {
 		return true;

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -221,8 +221,8 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 		`/me/purchases/${ slug }`,
 		`/purchases/add-payment-method/${ slug }`,
 		`/purchases/billing-history/${ slug }`,
-		`/purchases/subscriptions/${ slug }`,
 		`/purchases/payment-methods/${ slug }`,
+		`/purchases/subscriptions/${ slug }`,
 	];
 
 	if ( some( startsWithPaths, ( startsWithPath ) => startsWith( path, startsWithPath ) ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR makes it possible to see the various site-specific billing management pages for domain-only sites

#### Testing instructions

* Ensure you have a domain-only site to test with.
  - If you need to purchase one, you can do so via `wordpress.com/domains` (which does support store sandbox mode).
* Ensure that you can visit the following URLs (and sub-pages) for your site:
  - `/purchases/add-payment-method/:siteSlug`
  - `/purchases/billing-history/:siteSlug`
  - `/purchases/payment-methods/:siteSlug`
  - `/purchases/subscriptions/:siteSlug`

This PR does not take on updating the left nav structure for domain-only sites, as that will need a PR against the JetPack repo.