### PR TITLE
Add an optional site parameter to /me/account

### DIFF
--- a/client/me/account/index.js
+++ b/client/me/account/index.js
@@ -9,7 +9,8 @@ import page from 'page';
 import { account } from './controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/me/controller';
+import { siteSelection } from 'calypso/my-sites/controller';
 
 export default function () {
-	page( '/me/account', sidebar, account, makeLayout, clientRender );
+	page( '/me/account/:site?', sidebar, account, siteSelection, makeLayout, clientRender );
 }

--- a/client/me/account/index.js
+++ b/client/me/account/index.js
@@ -8,9 +8,8 @@ import page from 'page';
  */
 import { account } from './controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { sidebar } from 'calypso/me/controller';
-import { siteSelection } from 'calypso/my-sites/controller';
+import { sidebar, siteSelectionQuery } from 'calypso/me/controller';
 
 export default function () {
-	page( '/me/account/:site?', sidebar, account, siteSelection, makeLayout, clientRender );
+	page( '/me/account', sidebar, account, siteSelectionQuery, makeLayout, clientRender );
 }

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -11,6 +11,9 @@ import i18n from 'i18n-calypso';
 import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 import SidebarComponent from 'calypso/me/sidebar';
 import AppsComponent from 'calypso/me/get-apps';
+import { requestSite } from 'calypso/state/sites/actions';
+import getSiteId from 'calypso/state/selectors/get-site-id';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 
 export function sidebar( context, next ) {
 	context.secondary = React.createElement( SidebarComponent, {
@@ -44,4 +47,49 @@ export function apps( context, next ) {
 
 export function profileRedirect() {
 	page.redirect( '/me' );
+}
+
+const getStore = ( context ) => ( {
+	getState: () => context.store.getState(),
+	dispatch: ( action ) => context.store.dispatch( action ),
+} );
+
+/*
+ * Look for a query parameter like ?site=mysite.wordpress.com and set the
+ * selected site. This is a scaled down version of siteSelection() from
+ * calypso/my-sites/controller, but it
+ * - only looks in the query string
+ * - does not redirect based on error conditions, it just declines to set the site
+ * Designed for /me/account.
+ */
+export function siteSelectionQuery( context, next ) {
+	// Guard: Do nothing if no site is provided
+	const siteFragment = context?.query?.site;
+	if ( ! siteFragment ) {
+		return next();
+	}
+
+	// If site already exists in state, select it and continue
+	const { getState, dispatch } = getStore( context );
+	const siteId = getSiteId( getState(), siteFragment );
+	if ( siteId ) {
+		dispatch( setSelectedSiteId( siteId ) );
+		return next();
+	}
+
+	// Site isn't in state yet, fetch the site by siteFragment and then try to
+	// select again
+	dispatch( requestSite( siteFragment ) ).then( () => {
+		let freshSiteId = getSiteId( getState(), siteFragment );
+
+		if ( ! freshSiteId ) {
+			const wpcomStagingFragment = siteFragment.replace( /\b.wordpress.com/, '.wpcomstaging.com' );
+			freshSiteId = getSiteId( getState(), wpcomStagingFragment );
+		}
+
+		if ( freshSiteId ) {
+			dispatch( setSelectedSiteId( freshSiteId ) );
+		}
+	} );
+	return next();
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Keep current `/me/account` urls working as-is
* Add new, optional `/me/account/mycoolsite.blog` urls that work the same as `/me/account`, but also set the "selected site" on load

#### Use-Case

* With nav unification, we can send the user back and forth between calypso and wp-admin. We want to keep the user in a 'seamless' experience. There is a specific set of steps that can cause the user to lose the site they're working on, which this PR hopes to address.

Here's how a user can lose their selected site:
  * User has a selected site on calypso that is different from their default site
  * User leaves calypso for wp-admin [Click "Feedback" to land on edit.php]
  * User returns to calypso from wp-admin by landing on the `/me/account` page [Click "Users" -> "Personal Settings"]
  * The selected site is lost [Clicking "My Sites" in the top left returns you to your default site, not the selected site]

#### Testing instructions

* ~Visit `/me/account/mycoolsite.blog`, but replace `mycoolsite.blog` with a blog that belongs to your account, preferably a non-default account.~
* Visit `/me/account?site=mycoolsite.blog`, but replace `mycoolsite.blog` with a blog that belongs to your account, preferably a non-default account.
  *  Click "My Sites" in the top left. You should go to "My Home" for that blog without
* Ensure that `/me/account` works the same as before.

You can also do a full test in conjunction with https://github.com/Automattic/jetpack/pull/19672. See full instructions over there.

Related to https://github.com/Automattic/wp-calypso/issues/50564
