### PR TITLE
Bump treeselect to latest tslib

### DIFF
--- a/packages/tree-select/package.json
+++ b/packages/tree-select/package.json
@@ -36,6 +36,6 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"tslib": "^1.10.0"
+		"tslib": "^2.1.0"
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Working on something unrelated, I noticed that `tslib` in the tree-select package was at a different version than the one used by the rest of the repo. It doesn't seem to update `yarn.lock`, so it might not have much of an effect either way

#### Testing instructions
Unit tests should pass (includes typecheck and duplicated packages check)
