### PR TITLE
Checkout: Add price tier and renewal frequency to Jetpack Search products

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -560,12 +560,7 @@ function canItemBeDeleted( item: ResponseCartProduct ): boolean {
 }
 
 function JetpackSearchMeta( { product }: { product: ResponseCartProduct } ): JSX.Element {
-	return (
-		<>
-			<ProductTier product={ product } />
-			<RenewalFrequency product={ product } />
-		</>
-	);
+	return <ProductTier product={ product } />;
 }
 
 function ProductTier( { product }: { product: ResponseCartProduct } ): JSX.Element | null {
@@ -592,22 +587,6 @@ function ProductTier( { product }: { product: ResponseCartProduct } ): JSX.Eleme
 				</LineItemMeta>
 			);
 		}
-	}
-	return null;
-}
-
-function RenewalFrequency( { product }: { product: ResponseCartProduct } ): JSX.Element | null {
-	const translate = useTranslate();
-	if ( isMonthlyProduct( product ) ) {
-		return <LineItemMeta>{ translate( 'Renews monthly' ) }</LineItemMeta>;
-	}
-
-	if ( isYearly( product ) ) {
-		return <LineItemMeta>{ translate( 'Renews annually' ) }</LineItemMeta>;
-	}
-
-	if ( isBiennially( product ) ) {
-		return <LineItemMeta>{ translate( 'Renews every two years' ) }</LineItemMeta>;
 	}
 	return null;
 }

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -560,7 +560,12 @@ function canItemBeDeleted( item: ResponseCartProduct ): boolean {
 }
 
 function JetpackSearchMeta( { product }: { product: ResponseCartProduct } ): JSX.Element {
-	return <ProductTier product={ product } />;
+	return (
+		<>
+			<ProductTier product={ product } />
+			<RenewalFrequency product={ product } />
+		</>
+	);
 }
 
 function ProductTier( { product }: { product: ResponseCartProduct } ): JSX.Element | null {
@@ -587,6 +592,22 @@ function ProductTier( { product }: { product: ResponseCartProduct } ): JSX.Eleme
 				</LineItemMeta>
 			);
 		}
+	}
+	return null;
+}
+
+function RenewalFrequency( { product }: { product: ResponseCartProduct } ): JSX.Element | null {
+	const translate = useTranslate();
+	if ( isMonthlyProduct( product ) ) {
+		return <LineItemMeta>{ translate( 'Renews monthly' ) }</LineItemMeta>;
+	}
+
+	if ( isYearly( product ) ) {
+		return <LineItemMeta>{ translate( 'Renews annually' ) }</LineItemMeta>;
+	}
+
+	if ( isBiennially( product ) ) {
+		return <LineItemMeta>{ translate( 'Renews every two years' ) }</LineItemMeta>;
 	}
 	return null;
 }
@@ -655,8 +676,15 @@ function LineItemSublabelAndPrice( {
 		const premiumLabel = product.extra?.premium ? translate( 'Premium' ) : null;
 		return (
 			<>
-				<LineItemMeta>{ premiumLabel }</LineItemMeta>
-				<LineItemMeta>{ sublabel }</LineItemMeta>
+				{ translate( '%(premiumLabel)s %(sublabel)s: %(interval)s', {
+					args: {
+						premiumLabel,
+						sublabel: sublabel,
+						interval: translate( 'billed annually' ),
+					},
+					comment:
+						'premium label, product type and billing interval, separated by a colon. ex: ".blog domain registration: billed annually" or "Premium .blog domain registration: billed annually"',
+				} ) }
 			</>
 		);
 	}

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -575,12 +575,20 @@ function ProductTier( { product }: { product: ResponseCartProduct } ): JSX.Eleme
 	);
 
 	if ( isJetpackSearch( product ) && product.current_quantity ) {
-		const tierMaximum = getPriceTierForUnits( priceTierList, product.current_quantity )
-			?.maximum_units;
+		const tier = getPriceTierForUnits( priceTierList, product.current_quantity );
+		const tierMaximum = tier?.maximum_units;
+		const tierMinimum = tier?.minimum_units;
 		if ( tierMaximum ) {
 			return (
 				<LineItemMeta>
 					{ translate( 'Up to %(tierMaximum)s records', { args: { tierMaximum } } ) }
+				</LineItemMeta>
+			);
+		}
+		if ( tier && ! tierMaximum ) {
+			return (
+				<LineItemMeta>
+					{ translate( 'More than %(tierMinimum) records', { args: { tierMinimum } } ) }
 				</LineItemMeta>
 			);
 		}

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -563,7 +563,7 @@ function LineItemSublabelAndPrice( {
 	const isDomainRegistration = product.is_domain_registration;
 	const isDomainMap = product.product_slug === 'domain_map';
 	const productSlug = product.product_slug;
-	const sublabel = String( getSublabel( product ) );
+	const sublabel = getSublabel( product );
 
 	const isGSuite =
 		isGSuiteOrExtraLicenseProductSlug( productSlug ) || isGoogleWorkspaceProductSlug( productSlug );
@@ -794,7 +794,7 @@ function WPLineItem( {
 
 	const isTitanMail = productSlug === TITAN_MAIL_MONTHLY_SLUG;
 
-	const sublabel = String( getSublabel( product ) );
+	const sublabel = getSublabel( product );
 	const label = getLabel( product );
 
 	const originalAmountDisplay = product.item_original_subtotal_display;

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -655,15 +655,8 @@ function LineItemSublabelAndPrice( {
 		const premiumLabel = product.extra?.premium ? translate( 'Premium' ) : null;
 		return (
 			<>
-				{ translate( '%(premiumLabel)s %(sublabel)s: %(interval)s', {
-					args: {
-						premiumLabel,
-						sublabel: sublabel,
-						interval: translate( 'billed annually' ),
-					},
-					comment:
-						'premium label, product type and billing interval, separated by a colon. ex: ".blog domain registration: billed annually" or "Premium .blog domain registration: billed annually"',
-				} ) }
+				<LineItemMeta>{ premiumLabel }</LineItemMeta>
+				<LineItemMeta>{ sublabel }</LineItemMeta>
 			</>
 		);
 	}

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -15,14 +15,6 @@ import type {
 	TransactionRequest,
 	WPCOMCart,
 } from '@automattic/wpcom-checkout';
-
-/**
- * Internal dependencies
- */
-import {
-	readWPCOMPaymentMethodClass,
-	translateWpcomPaymentMethodToCheckoutPaymentMethod,
-} from './translate-payment-method-names';
 import {
 	isPlan,
 	isDomainTransferProduct,
@@ -32,7 +24,16 @@ import {
 	isGSuiteOrGoogleWorkspace,
 	isTitanMail,
 	isP2Plus,
+	isJetpackSearch,
 } from '@automattic/calypso-products';
+
+/**
+ * Internal dependencies
+ */
+import {
+	readWPCOMPaymentMethodClass,
+	translateWpcomPaymentMethodToCheckoutPaymentMethod,
+} from './translate-payment-method-names';
 import { isRenewal } from 'calypso/lib/cart-values/cart-items';
 import doesValueExist from './does-value-exist';
 import { isGSuiteOrGoogleWorkspaceProductSlug } from 'calypso/lib/gsuite';
@@ -196,6 +197,11 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 	const isRenewalItem = isRenewal( serverCartItem );
 	const { meta, product_name: productName } = serverCartItem;
 
+	// Jetpack Search has its own special sublabel
+	if ( ! isRenewalItem && isJetpackSearch( serverCartItem ) ) {
+		return '';
+	}
+
 	if ( isDotComPlan( serverCartItem ) || ( ! isRenewalItem && isTitanMail( serverCartItem ) ) ) {
 		if ( isRenewalItem ) {
 			return String( translate( 'Plan Renewal' ) );
@@ -235,14 +241,6 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 
 	if ( ! isRenewalItem && serverCartItem.months_per_bill_period === 1 ) {
 		return String( translate( 'Billed monthly' ) );
-	}
-
-	if ( ! isRenewalItem && serverCartItem.months_per_bill_period === 12 ) {
-		return String( translate( 'Billed annually' ) );
-	}
-
-	if ( ! isRenewalItem && serverCartItem.months_per_bill_period === 24 ) {
-		return String( translate( 'Billed every two years' ) );
 	}
 
 	if ( isRenewalItem ) {

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -192,30 +192,32 @@ export function createTransactionEndpointRequestPayload( {
 	};
 }
 
-export function getSublabel( serverCartItem: ResponseCartProduct ): i18nCalypso.TranslateResult {
+export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 	const isRenewalItem = isRenewal( serverCartItem );
 	const { meta, product_name: productName } = serverCartItem;
 
 	if ( isDotComPlan( serverCartItem ) || ( ! isRenewalItem && isTitanMail( serverCartItem ) ) ) {
 		if ( isRenewalItem ) {
-			return translate( 'Plan Renewal' );
+			return String( translate( 'Plan Renewal' ) );
 		}
 	}
 
 	if ( isPlan( serverCartItem ) ) {
 		if ( isP2Plus( serverCartItem ) ) {
-			return translate( 'Monthly subscription' );
+			return String( translate( 'Monthly subscription' ) );
 		}
 
-		return isRenewalItem ? translate( 'Plan Renewal' ) : translate( 'Plan Subscription' );
+		return isRenewalItem
+			? String( translate( 'Plan Renewal' ) )
+			: String( translate( 'Plan Subscription' ) );
 	}
 
 	if ( isGSuiteOrGoogleWorkspace( serverCartItem ) ) {
 		if ( isRenewalItem ) {
-			return translate( 'Productivity and Collaboration Tools Renewal' );
+			return String( translate( 'Productivity and Collaboration Tools Renewal' ) );
 		}
 
-		return translate( 'Productivity and Collaboration Tools' );
+		return String( translate( 'Productivity and Collaboration Tools' ) );
 	}
 
 	if (
@@ -227,16 +229,16 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): i18nCalypso.
 		}
 
 		if ( productName ) {
-			return translate( '%(productName)s Renewal', { args: { productName } } );
+			return String( translate( '%(productName)s Renewal', { args: { productName } } ) );
 		}
 	}
 
 	if ( ! isRenewalItem && serverCartItem.months_per_bill_period === 1 ) {
-		return translate( 'Billed monthly' );
+		return String( translate( 'Billed monthly' ) );
 	}
 
 	if ( isRenewalItem ) {
-		return translate( 'Renewal' );
+		return String( translate( 'Renewal' ) );
 	}
 
 	return '';

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -237,6 +237,14 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 		return String( translate( 'Billed monthly' ) );
 	}
 
+	if ( ! isRenewalItem && serverCartItem.months_per_bill_period === 12 ) {
+		return String( translate( 'Billed annually' ) );
+	}
+
+	if ( ! isRenewalItem && serverCartItem.months_per_bill_period === 24 ) {
+		return String( translate( 'Billed every two years' ) );
+	}
+
 	if ( isRenewalItem ) {
 		return String( translate( 'Renewal' ) );
 	}

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -276,7 +276,10 @@ export function slugIsFeaturedProduct( productSlug: string ): boolean {
 	return FEATURED_PRODUCTS.includes( productSlug );
 }
 
-function getPriceTierForUnits( tiers: PriceTierEntry[], units: number ): PriceTierEntry | null {
+export function getPriceTierForUnits(
+	tiers: PriceTierEntry[],
+	units: number
+): PriceTierEntry | null {
 	const firstUnboundedTier = tiers.find( ( tier ) => ! tier.maximum_units );
 	let matchingTier = tiers.find( ( tier ) => {
 		if ( ! tier.maximum_units ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a sub-label to Jetpack Search products in checkout so that they display their current tier maximum and their renewal frequency.

Before:

![before-jetpack-search-without](https://user-images.githubusercontent.com/2036909/116164861-934e8a00-a6c8-11eb-89d7-fc48f59629a8.png)


After:

![jetpack-search-item-with-sublabel](https://user-images.githubusercontent.com/2036909/116164776-639f8200-a6c8-11eb-8122-e6a0018ec076.png)

Here's how it compares to a plan product's sub-label:

<img width="573" alt="Screen Shot 2021-04-26 at 7 51 43 PM" src="https://user-images.githubusercontent.com/2036909/116165005-df99ca00-a6c8-11eb-8043-4dc6626688a1.png">

Fixes https://github.com/Automattic/wp-calypso/issues/46934

#### Testing instructions

- Add Jetpack search to your cart. You can do this on a Jetpack site by visiting `/plans` for that site and clicking the button under the "Search" product.
- Visit checkout and verify that the product sub-label includes information on the maximum number of units in the current tier and a "Renews ..." line explaining how often the product renews.