### PR TITLE
Stop blocking installation of Autoptimize plugin

### DIFF
--- a/client/my-sites/plugins/plugin-compatibility.js
+++ b/client/my-sites/plugins/plugin-compatibility.js
@@ -13,7 +13,6 @@ const incompatiblePlugins = new Set( [
 	'advanced-database-cleaner',
 	'advanced-reset-wp',
 	'advanced-wp-reset',
-	'autoptimize',
 	'backup',
 	'better-wp-security',
 	'cf7-pipedrive-integration',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The Atomic platform is now allowing the Autoptimize plugin to be
installed, so Calypso can stop blocking installation of the plugin
on Atomic sites.

#### Testing instructions

* Pick an Atomic site used for testing
* Try to install Autoptimize on the site and confirm it is allowed
* Double-check the Atomic site and confirm the plugin is indeed installed