### PR TITLE
ExPlat: Use localStorage store

### DIFF
--- a/packages/explat-client/CHANGELOG.md
+++ b/packages/explat-client/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.0.2 (Unreleased)
 
 - Change dangerouslyGetExperimentAssignment to log rather than throw
+- Store state in LocalStorage
 
 ## 0.0.1
 

--- a/packages/explat-client/README.md
+++ b/packages/explat-client/README.md
@@ -13,7 +13,7 @@ This is a standalone client for Automattic's ExPlat, allowing use of ExPlat in a
 - Dep injects outside parts so it can be fitted to any codebase.
 - Doesn't assume much of its environment.
 - No external dependencies or libs need.
-- Stores state internally and simply.
+- Stores state in LocalStorage if available otherwise in memory.
 
 ## Type: `ExperimentAssignment`
 

--- a/packages/explat-client/src/create-explat-client.ts
+++ b/packages/explat-client/src/create-explat-client.ts
@@ -4,7 +4,10 @@
 import type { ExperimentAssignment, Config } from './types';
 import * as ExperimentAssignments from './internal/experiment-assignments';
 import * as Request from './internal/requests';
-import ExperimentAssignmentStore from './internal/experiment-assignment-store';
+import {
+	retrieveExperimentAssignment,
+	storeExperimentAssignment,
+} from './internal/experiment-assignment-store';
 import * as Timing from './internal/timing';
 import * as Validation from './internal/validations';
 import { createFallbackExperimentAssignment as createFallbackExperimentAssignment } from './internal/experiment-assignments';
@@ -65,8 +68,6 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 		throw new Error( 'Running outside of a browser context.' );
 	}
 
-	const experimentAssignmentStore = new ExperimentAssignmentStore();
-
 	/**
 	 * This bit of code is the heavy lifting behind loadExperimentAssignment, allowing it to be used intuitively.
 	 *
@@ -81,7 +82,7 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 				config,
 				experimentName
 			);
-			experimentAssignmentStore.store( fetchedExperimentAssignment );
+			storeExperimentAssignment( fetchedExperimentAssignment );
 			return fetchedExperimentAssignment;
 		} );
 	const experimentNameToWrappedExperimentAssignmentFetchAndStore: Record<
@@ -102,7 +103,7 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 					throw new Error( `Invalid experimentName: "${ experimentName }"` );
 				}
 
-				const storedExperimentAssignment = experimentAssignmentStore.retrieve( experimentName );
+				const storedExperimentAssignment = retrieveExperimentAssignment( experimentName );
 				if (
 					storedExperimentAssignment &&
 					ExperimentAssignments.isAlive( storedExperimentAssignment )
@@ -139,7 +140,7 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 			// Fetching failed and we're not in development mode.
 			try {
 				// We provide stale ExperimentAssignments, important for offline users.
-				const storedExperimentAssignment = experimentAssignmentStore.retrieve( experimentName );
+				const storedExperimentAssignment = retrieveExperimentAssignment( experimentName );
 				if ( storedExperimentAssignment ) {
 					return storedExperimentAssignment;
 				}
@@ -148,7 +149,7 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 				// be retrieved by all other loadExperimentAssignments that are currently running or will run,
 				// preventing a run on the server.
 				const fallbackExperimentAssignment = createFallbackExperimentAssignment( experimentName );
-				experimentAssignmentStore.store( fallbackExperimentAssignment );
+				storeExperimentAssignment( fallbackExperimentAssignment );
 				return fallbackExperimentAssignment;
 			} catch ( fallbackError ) {
 				safeLogError( {
@@ -167,7 +168,7 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 					throw new Error( `Invalid experimentName: ${ experimentName }` );
 				}
 
-				const storedExperimentAssignment = experimentAssignmentStore.retrieve( experimentName );
+				const storedExperimentAssignment = retrieveExperimentAssignment( experimentName );
 				if ( ! storedExperimentAssignment ) {
 					throw new Error(
 						`Trying to dangerously get an ExperimentAssignment that hasn't loaded.`

--- a/packages/explat-client/src/internal/experiment-assignment-store.ts
+++ b/packages/explat-client/src/internal/experiment-assignment-store.ts
@@ -29,6 +29,12 @@ const localStorageExperimentAssignmentKeyPrefix = 'explat-experiment-';
 const localStorageExperimentAssignmentKey = ( experimentName: string ): string =>
 	`${ localStorageExperimentAssignmentKeyPrefix }-${ experimentName }`;
 
+/**
+ * INTERNAL USE ONLY
+ *
+ * Clears all ExperimentAssignments.
+ * Useful for testing.
+ */
 export function clearAllExperimentAssignments(): void {
 	localStorage.clear();
 }

--- a/packages/explat-client/src/internal/experiment-assignment-store.ts
+++ b/packages/explat-client/src/internal/experiment-assignment-store.ts
@@ -34,46 +34,45 @@ export function clearAllExperimentAssignments(): void {
 }
 
 /**
- * Class to store existing ExperimentAssignments in localStorage
+ * Store an ExperimentAssignment.
+ *
+ * @param experimentAssignment The ExperimentAssignment
  */
-export default class ExperimentAssignmentStore {
-	/**
-	 * Store an ExperimentAssignment.
-	 *
-	 * @param experimentAssignment The ExperimentAssignment
-	 */
-	store( experimentAssignment: ExperimentAssignment ): void {
-		Validations.validateExperimentAssignment( experimentAssignment );
+export function storeExperimentAssignment( experimentAssignment: ExperimentAssignment ): void {
+	Validations.validateExperimentAssignment( experimentAssignment );
 
-		const previousExperimentAssignment = this.retrieve( experimentAssignment.experimentName );
-		if (
-			previousExperimentAssignment &&
-			experimentAssignment.retrievedTimestamp < previousExperimentAssignment.retrievedTimestamp
-		) {
-			throw new Error(
-				'Trying to store an older experiment assignment than is present in the store, likely a race condition.'
-			);
-		}
-
-		localStorage.setItem(
-			localStorageExperimentAssignmentKey( experimentAssignment.experimentName ),
-			JSON.stringify( experimentAssignment )
+	const previousExperimentAssignment = retrieveExperimentAssignment(
+		experimentAssignment.experimentName
+	);
+	if (
+		previousExperimentAssignment &&
+		experimentAssignment.retrievedTimestamp < previousExperimentAssignment.retrievedTimestamp
+	) {
+		throw new Error(
+			'Trying to store an older experiment assignment than is present in the store, likely a race condition.'
 		);
 	}
 
-	/**
-	 * Retrieve an ExperimentAssignment.
-	 *
-	 * @param experimentName The experiment name.
-	 */
-	retrieve( experimentName: string ): ExperimentAssignment | undefined {
-		const maybeExperimentAssignmentJson = localStorage.getItem(
-			localStorageExperimentAssignmentKey( experimentName )
-		);
-		if ( ! maybeExperimentAssignmentJson ) {
-			return undefined;
-		}
+	localStorage.setItem(
+		localStorageExperimentAssignmentKey( experimentAssignment.experimentName ),
+		JSON.stringify( experimentAssignment )
+	);
+}
 
-		return Validations.validateExperimentAssignment( JSON.parse( maybeExperimentAssignmentJson ) );
+/**
+ * Retrieve an ExperimentAssignment.
+ *
+ * @param experimentName The experiment name.
+ */
+export function retrieveExperimentAssignment(
+	experimentName: string
+): ExperimentAssignment | undefined {
+	const maybeExperimentAssignmentJson = localStorage.getItem(
+		localStorageExperimentAssignmentKey( experimentName )
+	);
+	if ( ! maybeExperimentAssignmentJson ) {
+		return undefined;
 	}
+
+	return Validations.validateExperimentAssignment( JSON.parse( maybeExperimentAssignmentJson ) );
 }

--- a/packages/explat-client/src/internal/test/experiment-assignment-store.ts
+++ b/packages/explat-client/src/internal/test/experiment-assignment-store.ts
@@ -5,7 +5,10 @@
 /**
  * Internal dependencies
  */
-import ExperimentAssignmentStore from '../experiment-assignment-store';
+import {
+	retrieveExperimentAssignment,
+	storeExperimentAssignment,
+} from '../experiment-assignment-store';
 import { validExperimentAssignment, validFallbackExperimentAssignment } from '../test-common';
 
 beforeEach( () => {
@@ -14,32 +17,30 @@ beforeEach( () => {
 
 describe( 'experiment-assignment-store', () => {
 	it( 'should save and retrieve valid ExperimentAssignments', () => {
-		const experimentAssignmentStore = new ExperimentAssignmentStore();
-		expect( experimentAssignmentStore.retrieve( validExperimentAssignment.experimentName ) ).toBe(
+		expect( retrieveExperimentAssignment( validExperimentAssignment.experimentName ) ).toBe(
 			undefined
 		);
-		experimentAssignmentStore.store( validExperimentAssignment );
-		expect(
-			experimentAssignmentStore.retrieve( validExperimentAssignment.experimentName )
-		).toEqual( validExperimentAssignment );
+		storeExperimentAssignment( validExperimentAssignment );
+		expect( retrieveExperimentAssignment( validExperimentAssignment.experimentName ) ).toEqual(
+			validExperimentAssignment
+		);
 
+		expect( retrieveExperimentAssignment( validFallbackExperimentAssignment.experimentName ) ).toBe(
+			undefined
+		);
+		storeExperimentAssignment( validFallbackExperimentAssignment );
 		expect(
-			experimentAssignmentStore.retrieve( validFallbackExperimentAssignment.experimentName )
-		).toBe( undefined );
-		experimentAssignmentStore.store( validFallbackExperimentAssignment );
-		expect(
-			experimentAssignmentStore.retrieve( validFallbackExperimentAssignment.experimentName )
+			retrieveExperimentAssignment( validFallbackExperimentAssignment.experimentName )
 		).toEqual( validFallbackExperimentAssignment );
 	} );
 
 	it( 'should throw for storing an ExperimentAssignment for a currently stored Experiment with an older date', () => {
-		const experimentAssignmentStore = new ExperimentAssignmentStore();
-		experimentAssignmentStore.store( validFallbackExperimentAssignment );
+		storeExperimentAssignment( validFallbackExperimentAssignment );
 		expect(
-			experimentAssignmentStore.retrieve( validFallbackExperimentAssignment.experimentName )
+			retrieveExperimentAssignment( validFallbackExperimentAssignment.experimentName )
 		).toStrictEqual( validFallbackExperimentAssignment );
 		expect( () =>
-			experimentAssignmentStore.store( {
+			storeExperimentAssignment( {
 				...validFallbackExperimentAssignment,
 				retrievedTimestamp: validFallbackExperimentAssignment.retrievedTimestamp - 1,
 			} )
@@ -49,9 +50,8 @@ describe( 'experiment-assignment-store', () => {
 	} );
 
 	it( 'should throw for storing an invalid ExperimentAssignment', () => {
-		const experimentAssignmentStore = new ExperimentAssignmentStore();
 		expect( () =>
-			experimentAssignmentStore.store( {
+			storeExperimentAssignment( {
 				...validFallbackExperimentAssignment,
 				experimentName: undefined,
 			} )

--- a/packages/explat-client/src/internal/test/experiment-assignment-store.ts
+++ b/packages/explat-client/src/internal/test/experiment-assignment-store.ts
@@ -1,8 +1,16 @@
 /**
+ * @jest-environment jsdom
+ */
+
+/**
  * Internal dependencies
  */
 import ExperimentAssignmentStore from '../experiment-assignment-store';
 import { validExperimentAssignment, validFallbackExperimentAssignment } from '../test-common';
+
+beforeEach( () => {
+	window.localStorage.clear();
+} );
 
 describe( 'experiment-assignment-store', () => {
 	it( 'should save and retrieve valid ExperimentAssignments', () => {
@@ -29,7 +37,7 @@ describe( 'experiment-assignment-store', () => {
 		experimentAssignmentStore.store( validFallbackExperimentAssignment );
 		expect(
 			experimentAssignmentStore.retrieve( validFallbackExperimentAssignment.experimentName )
-		).toBe( validFallbackExperimentAssignment );
+		).toStrictEqual( validFallbackExperimentAssignment );
 		expect( () =>
 			experimentAssignmentStore.store( {
 				...validFallbackExperimentAssignment,

--- a/packages/explat-client/src/test/create-explat-client.ts
+++ b/packages/explat-client/src/test/create-explat-client.ts
@@ -8,6 +8,7 @@ import '@automattic/calypso-polyfills';
  * Internal dependencies
  */
 import { createExPlatClient } from '../create-explat-client';
+import { clearAllExperimentAssignments } from '../internal/experiment-assignment-store';
 import {
 	delayedValue,
 	ONE_DELAY,
@@ -52,6 +53,7 @@ function mockFetchExperimentAssignmentToMatchExperimentAssignment(
 beforeEach( () => {
 	jest.resetAllMocks();
 	setBrowserContext();
+	clearAllExperimentAssignments();
 } );
 
 describe( 'createExPlatClient', () => {
@@ -366,6 +368,7 @@ describe( 'ExPlatClient.loadExperimentAssignment multiple-use', () => {
 		} );
 
 		await runTest();
+		clearAllExperimentAssignments();
 		await runDevelopmentModeTest();
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR switches `explat-client` to use a localStorage store for Experiment Assignments rather than in-memory.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Added AT
* Manually tested

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 614-gh-Automattic/experimentation-platform