### PR TITLE
Use the new mocha hooks

### DIFF
--- a/test/e2e/.mocharc.yml
+++ b/test/e2e/.mocharc.yml
@@ -2,6 +2,7 @@ require:
   - 'esm'
   - 'test/mocha.env.js'
   - 'mocha-steps'
+  - 'lib/hooks'
 file:
   - 'lib/before.js'
   - 'lib/mocha-hooks.js'

--- a/test/e2e/lib/hooks/index.js
+++ b/test/e2e/lib/hooks/index.js
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { startVideo, stopVideo, takeScreenshot } from './video-recorder';
+
+export const mochaHooks = {
+	afterAll: [ stopVideo ],
+	beforeAll: [ startVideo ],
+	afterEach: [ takeScreenshot ],
+};

--- a/test/e2e/lib/hooks/video-recorder.js
+++ b/test/e2e/lib/hooks/video-recorder.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import * as videoRecorder from '../lib/video-recorder';
+import * as videoRecorder from '../video-recorder';
 
 export const startVideo = async function () {
 	await videoRecorder.startDisplay();

--- a/test/e2e/lib/hooks/video-recorder.js
+++ b/test/e2e/lib/hooks/video-recorder.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import * as videoRecorder from '../lib/video-recorder';
+
+export const startVideo = async function () {
+	await videoRecorder.startDisplay();
+	await videoRecorder.startVideo();
+};
+
+export const takeScreenshot = async function () {
+	if ( this.currentTest && this.currentTest.state === 'failed' ) {
+		await videoRecorder.takeScreenshot( this.currentTest );
+	}
+};
+
+export const stopVideo = async function () {
+	await videoRecorder.stopVideo();
+	await videoRecorder.stopDisplay();
+};

--- a/test/e2e/lib/mocha-hooks.js
+++ b/test/e2e/lib/mocha-hooks.js
@@ -14,7 +14,6 @@ import * as slackNotifier from './slack-notifier';
 import * as mediaHelper from './media-helper';
 
 import * as driverManager from './driver-manager';
-import * as videoRecorder from '../lib/video-recorder';
 import { default as saveConsoleLog } from './hooks/save-console-log';
 
 const afterHookTimeoutMS = config.get( 'afterHookTimeoutMS' );
@@ -25,16 +24,6 @@ before( function () {
 		const isCalypsoLiveURL = config.get( 'calypsoBaseURL' ).includes( 'calypso.live' );
 		assert.strictEqual( isCalypsoLiveURL, true );
 	}
-} );
-
-// Start xvfb display and recording
-before( async function () {
-	await videoRecorder.startDisplay();
-} );
-
-// Start xvfb display and recording
-before( async function () {
-	await videoRecorder.startVideo();
 } );
 
 // Sauce Breakpoint
@@ -133,13 +122,6 @@ afterEach( function () {
 	}
 } );
 
-// Stop video recording if the test has failed
-afterEach( async function () {
-	if ( this.currentTest && this.currentTest.state === 'failed' ) {
-		await videoRecorder.stopVideo( this.currentTest );
-	}
-} );
-
 // Push SauceLabs job status update (if applicable)
 after( async function () {
 	await this.timeout( afterHookTimeoutMS );
@@ -167,14 +149,4 @@ after( function () {
 	) {
 		return driverManager.quitBrowser( driver );
 	}
-} );
-
-// Stop video
-after( async function () {
-	await videoRecorder.stopVideo();
-} );
-
-// Stop xvfb display
-after( async function () {
-	await videoRecorder.stopDisplay();
 } );

--- a/test/e2e/lib/video-recorder.js
+++ b/test/e2e/lib/video-recorder.js
@@ -73,29 +73,31 @@ export function startVideo() {
 	] );
 }
 
-export function stopVideo( currentTest = null ) {
-	if ( ! isVideoEnabled() ) {
+export function stopVideo() {
+	if ( ! isVideoEnabled() || ! ffVideo || ffVideo.killed ) {
 		return;
 	}
-	if ( currentTest && ffVideo ) {
-		const currentTestName = currentTest.title.replace( /[^a-z0-9]/gi, '-' ).toLowerCase();
-		const dateTime = new Date().toISOString().split( '.' )[ 0 ].replace( /:/g, '-' );
-		const fileName = `${ currentTestName }-${ dateTime }.mpg`;
-		const newFile = path.resolve( path.join( './screenshots/videos', fileName ) );
-		ffVideo.kill();
+	ffVideo.kill();
+	fs.unlink( file, function ( err ) {
+		if ( err ) {
+			console.log( 'Deleting of file for passed test failed.' );
+		}
+	} );
+}
 
-		fs.rename( file, newFile, function ( err ) {
-			if ( err ) {
-				console.log( 'Screencast Video:' + file );
-			}
-			console.log( 'Screencast Video:' + newFile );
-		} );
-	} else if ( ffVideo && ! ffVideo.killed ) {
-		ffVideo.kill();
-		fs.unlink( file, function ( err ) {
-			if ( err ) {
-				console.log( 'Deleting of file for passed test failed.' );
-			}
-		} );
+export function takeScreenshot( currentTest ) {
+	if ( ! isVideoEnabled() || ! ffVideo ) {
+		return;
 	}
+	const currentTestName = currentTest.title.replace( /[^a-z0-9]/gi, '-' ).toLowerCase();
+	const dateTime = new Date().toISOString().split( '.' )[ 0 ].replace( /:/g, '-' );
+	const fileName = `${ currentTestName }-${ dateTime }.mpg`;
+	const newFile = path.resolve( path.join( './screenshots/videos', fileName ) );
+
+	fs.rename( file, newFile, function ( err ) {
+		if ( err ) {
+			console.log( 'Screencast Video:' + file );
+		}
+		console.log( 'Screencast Video:' + newFile );
+	} );
 }


### PR DESCRIPTION
### Background

Mocha v8 introduced a different way to set up [Root Hooks](https://mochajs.org/#root-hook-plugins), and they recommend migrating to this new system.

We use root hooks extensively in e2e tests, most of them defined in https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/lib/mocha-hooks.js. 

### Changes proposed in this Pull Request

* Introduce Root Hooks. This PR uses hooks related to video recording as a proof of concept. If it works, I'll migrate the rest of the hooks in a separate PR.
* Refactor the Video Recorder API to make it more "hook friendly" (specifically, extract the screenshot functionality from `stopVideo()` to its own `takeScreenshot()` method.

### Testing instructions

Check that the e2e builds are still working and screenshots/videos are being captured.