### PR TITLE
Drop prime-calypso-live

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -523,27 +523,6 @@ jobs:
       - save_cache: *save-jest-cache
       - store-artifacts-and-test-results
 
-  # Prime calypso.live so it has a build ready
-  #
-  # We can send a request to calypso.live so that it gets a build ready.
-  # This saves time waiting later when waiting for the calypso.live
-  #
-  # Expected usage:
-  #   - After setup
-  #   - Only on branches (not the primary branch)
-  #
-  prime-calypso-live:
-    docker:
-      - image: buildpack-deps
-    working_directory: ~/wp-calypso
-    steps:
-      - run:
-          name: Prime calypso.live
-          command: |
-            if [[ -z $CIRCLE_PR_USERNAME ]]; then
-              curl --silent "https://hash-$CIRCLE_SHA1.calypso.live"
-            fi
-
   test-e2e:
     <<: *defaults
     working_directory: ~/wp-calypso/test/e2e
@@ -981,10 +960,6 @@ workflows:
   calypso:
     jobs:
       - setup
-      - prime-calypso-live:
-          filters:
-            branches:
-              ignore: trunk
       - build-notifications:
           requires:
             - setup


### PR DESCRIPTION
### Background

We have a CircleCI job to "prime" the `calypso.live` URL. This will fetch the URL so `calypso.live` can start the build process. The goal is to have the image already built and ready in case a developer clicks on the `calypso.live` link

In #52101 we introduced an action to handle `calypos.live` messages, including priming the URL.

### Changes proposed in this Pull Request

* Disable `prime-calypso-live` job in CircleCI as it is handled by an action now.

