### PR TITLE
Use window.location.origin to figure out origin

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -489,15 +489,13 @@ const navigateToSite = ( siteId, { allSitesPath, allSitesSingleUser, siteBasePat
 			const urlType = determineUrlType( base );
 
 			// Get URL parts and modify the path.
-			const { protocol, hostname, port, pathname: urlPathname, search } = getUrlParts( base );
+			const { origin, pathname: urlPathname, search } = getUrlParts( base );
 			const newPathname = `${ urlPathname }/${ site.slug }`;
 
 			try {
 				// Get an absolute URL from the original URL, the modified path, and some defaults.
 				const absoluteUrl = getUrlFromParts( {
-					protocol: protocol || window.location.protocol,
-					hostname: hostname || window.location.hostname,
-					port: port || window.location.port,
+					origin: origin || window.location.origin,
 					pathname: newPathname,
 					search,
 				} );

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -163,10 +163,7 @@ export const authenticate = ( context, next ) => {
 	// We could use `window.location.href` to generate the return URL but there are some potential race conditions that
 	// can cause the browser to not update it before redirecting to WP Admin. To avoid that, we manually generate the
 	// URL from the relevant parts.
-	let origin = `${ window.location.protocol }//${ window.location.hostname }`;
-	if ( window.location.port ) {
-		origin += `:${ window.location.port }`;
-	}
+	const origin = window.location.origin;
 	const returnUrl = addQueryArgs(
 		{ ...context.query, authWpAdmin: true },
 		`${ origin }${ context.path }`

--- a/client/jetpack-cloud/sections/auth/controller.tsx
+++ b/client/jetpack-cloud/sections/auth/controller.tsx
@@ -24,12 +24,7 @@ const debug = debugFactory( 'calypso:jetpack-cloud-connect' );
 
 export const connect: PageJS.Callback = ( context, next ) => {
 	if ( config.isEnabled( 'oauth' ) && config( 'oauth_client_id' ) ) {
-		const protocol = window.location.protocol;
-		const host = window.location.hostname;
-		const port = window.location.port;
-		const redirectUri = port
-			? `${ protocol }//${ host }:${ port }${ authTokenRedirectPath() }`
-			: `${ protocol }//${ host }${ authTokenRedirectPath() }`;
+		const redirectUri = window.location.origin + authTokenRedirectPath();
 
 		const params = {
 			response_type: 'token',

--- a/client/my-sites/site-settings/press-this/link.jsx
+++ b/client/my-sites/site-settings/press-this/link.jsx
@@ -13,6 +13,7 @@ import { newPost } from 'calypso/lib/paths';
 /**
  * Retrieves selection, title, and URL from current page and pops
  * open new editor window with contents
+ *
  * @param  {string} postURL Editor URL for selected site
  */
 const pressThis = function ( postURL ) {
@@ -65,18 +66,13 @@ class PressThisLink extends React.Component {
 
 	/**
 	 * generate press-this link pointing to current environment
+	 *
 	 * @returns {string} javascript pseudo-protocol link
 	 */
 	buildPressThisLink() {
 		const functionText = pressThis.toString();
-		// IE does not reliably support window.location.origin
-		let postDomain =
-			typeof window !== 'undefined' && window.location
-				? `${ window.location.protocol }//${ window.location.hostname }`
-				: 'https://wordpress.com';
-		if ( window.location.port ) {
-			postDomain += `:${ window.location.port }`;
-		}
+		const postDomain =
+			typeof window !== 'undefined' ? window.location.origin : 'https://wordpress.com';
 		const postURL = postDomain + newPost( this.props.site );
 		return `javascript:( ${ functionText } )( '${ postURL }' )`;
 	}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -489,18 +489,11 @@ class Signup extends React.Component {
 	}
 
 	loginRedirectTo = ( path ) => {
-		let redirectTo;
-
 		if ( startsWith( path, 'https://' ) || startsWith( path, 'http://' ) ) {
 			return path;
 		}
 
-		redirectTo = window.location.protocol + '//' + window.location.hostname; // Don't force https because of local development
-
-		if ( window.location.port ) {
-			redirectTo += ':' + window.location.port;
-		}
-		return redirectTo + path;
+		return window.location.origin + path;
 	};
 
 	// `flowName` is an optional parameter used to redirect to another flow, i.e., from `main`

--- a/client/signup/steps/p2-details/index.jsx
+++ b/client/signup/steps/p2-details/index.jsx
@@ -19,17 +19,8 @@ import { getStepUrl } from 'calypso/signup/utils';
  */
 import './style.scss';
 
-function getOriginUrl() {
-	return (
-		window.location.protocol +
-		'//' +
-		window.location.hostname +
-		( window.location.port ? ':' + window.location.port : '' )
-	);
-}
-
 function getRedirectToAfterLoginUrl( { flowName } ) {
-	return getOriginUrl() + getStepUrl( flowName, 'p2-site' );
+	return window.location.origin + getStepUrl( flowName, 'p2-site' );
 }
 
 function getLoginLink( { flowName, locale } ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -412,16 +412,9 @@ export class UserStep extends Component {
 		const queryArgsString = queryArgs.toString() ? '?' + queryArgs.toString() : '';
 
 		return (
-			this.originUrl() + getStepUrl( this.props.flowName, stepAfterRedirect ) + queryArgsString
-		);
-	}
-
-	originUrl() {
-		return (
-			window.location.protocol +
-			'//' +
-			window.location.hostname +
-			( window.location.port ? ':' + window.location.port : '' )
+			window.location.origin +
+			getStepUrl( this.props.flowName, stepAfterRedirect ) +
+			queryArgsString
 		);
 	}
 


### PR DESCRIPTION
There are several places in our codebase where we tediously construct an `origin` string from `window.location.{protocol,hostname,port}`. But we can simply use `window.location.origin` and this PR does that.

One downside is that `window.location.origin` is [empty in certain IE11 configurations](https://stackoverflow.com/questions/32722032/how-does-ie11-populate-window-location-origin). After removing support from IE11, this limitation is acceptable. And we already use `window.location.origin` at plenty of places even before this PR.

**How to test:**
This PR touches many diverse parts of the codebase (Signup, Press This, Jetpack Cloud auth...). Either test them all or review the changes very carefully.