### PR TITLE
Design Picker: Add experiment code to signup controller

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -301,43 +301,12 @@ export default {
 			context.store.dispatch( setSelectedSiteId( null ) );
 		}
 
+      let actualFlowName = flowName
 		if ( flowName === 'onboarding' || flowName === 'with-design-picker' ) {
-			context.primary = (
-				<ProvideExperimentData name="design_picker_after_onboarding">
-					{ ( isLoading, experimentAssignment ) => {
-						debug(
-							`design_picker_after_onboarding experiment variation: ${ experimentAssignment?.variationName }`
-						);
-
-						if ( isLoading ) {
-							debug( 'Waiting for design_picker_after_onboarding experiment status to load' );
-							return null;
-						}
-
-						const actualFlowName =
-							'treatment' === experimentAssignment?.variationName
-								? 'with-design-picker'
-								: 'onboarding';
-
-						return (
-							<SignupComponent
-								store={ context.store }
-								path={ context.path }
-								initialContext={ initialContext }
-								locale={ context.params.lang }
-								flowName={ actualFlowName }
-								queryObject={ query }
-								refParameter={ query && query.ref }
-								stepName={ stepName }
-								stepSectionName={ stepSectionName }
-								stepComponent={ stepComponent }
-								pageTitle={ getFlowPageTitle( actualFlowName ) }
-							/>
-						);
-					} }
-				</ProvideExperimentData>
-			);
-			next();
+		    const experimentAssignment = await loadExperiment('design_picker_after_onboarding')
+		    if ('treatment' === experimentAssignment?.variationName) {
+		        actualFlowName = 'with-design-picker';
+		    }
 		}
 
 		context.primary = React.createElement( SignupComponent, {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -102,7 +102,9 @@ export const removeP2SignupClassName = function () {
 export default {
 	redirectTests( context, next ) {
 		const currentFlowName = getFlowName( context.params );
-		currentFlowName === 'onboarding' && loadExperimentAssignment( 'refined_reskin_v1' );
+		currentFlowName === 'onboarding' &&
+			loadExperimentAssignment( 'refined_reskin_v1' ) &&
+			loadExperimentAssignment( 'design_picker_after_onboarding' );
 		currentFlowName === 'launch-site' && loadExperimentAssignment( 'hide_ecommerce_launch_site' );
 		if ( context.pathname.indexOf( 'new-launch' ) >= 0 ) {
 			next();

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -301,7 +301,7 @@ export default {
 			context.store.dispatch( setSelectedSiteId( null ) );
 		}
 
-		if ( flowName === 'onboarding' ) {
+		if ( flowName === 'onboarding' || flowName === 'with-design-picker' ) {
 			context.primary = (
 				<ProvideExperimentData name="design_picker_after_onboarding">
 					{ ( isLoading, experimentAssignment ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Implement `design_picker_after_onboarding` experiment in signup controller. This will replace the previous LOHP implementation (D59839-code)

#### Testing instructions

* For debugging, run in console: `localStorage.setItem( 'debug', 'calypso:signup' );` 

**Main things to test:**
- [x] no significant delay should be perceived by the user when loading `/start` compared to production
- [x] when navigating to `/start` while assigned to `treatment` of `design_picker_after_onboarding` experiment, you should get the `with-design-picker` flow
  - [x] when advancing from `/start/domains` step you should land on `/start/with-design-picker/plans`
  - [x] after `/start/with-design-picker/plans` step you should land on `/start/with-design-picker/design` step 
  - [x] navigating back should work as expected
  - [x] all the above should work also when starting as a logged-out user

Fixes #51233