### PR TITLE
withTrackingTool HOC: use createHigherOrderComponent and hooks

### DIFF
--- a/client/lib/analytics/with-tracking-tool/index.jsx
+++ b/client/lib/analytics/with-tracking-tool/index.jsx
@@ -1,30 +1,24 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { loadTrackingTool } from 'calypso/state/analytics/actions';
 
-export default ( trackingTool ) => ( EnhancedComponent ) => {
-	class WithTrackingTool extends Component {
-		static displayName = `WithTrackingTool( ${
-			EnhancedComponent.displayName || EnhancedComponent.name || ''
-		} )`;
+export default ( trackingTool ) =>
+	createHigherOrderComponent(
+		( EnhancedComponent ) => ( props ) => {
+			const dispatch = useDispatch();
+			React.useEffect( () => {
+				dispatch( loadTrackingTool( trackingTool ) );
+			}, [ dispatch ] );
 
-		componentDidMount() {
-			this.props.loadTrackingTool( trackingTool );
-		}
-
-		render() {
-			return <EnhancedComponent { ...this.props } />;
-		}
-	}
-
-	return connect( null, {
-		loadTrackingTool,
-	} )( WithTrackingTool );
-};
+			return <EnhancedComponent { ...props } />;
+		},
+		'WithTrackingTool'
+	);


### PR DESCRIPTION
Inspired by a recent conversation with @sgomes about `withTrackingTool` in `/home`. Use `createHigherOrderComponent` to wrangle the `displayName` for us, and use `useDispatch` and `useEffect` to do the loading.

**How to test:**
No behavior changes expected. Go to `/home` and verify in Network Devtool that the HotJar scripts are loaded.