### PR TITLE
P2: fix invites redirect for new signups

### DIFF
--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -51,6 +51,8 @@ export function acceptInvite( context, next ) {
 				debug( 'Accepted invite and redirecting to:  ' + redirect );
 
 				if ( get( acceptedInvite, 'site.is_wpforteams_site', false ) ) {
+					// Using page() here will throw an error because P2 sites
+					// redirect to non-same origin.
 					window.location.href = redirect;
 				} else {
 					page( redirect );

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -6,6 +6,7 @@ import store from 'store';
 import page from 'page';
 import debugModule from 'debug';
 import i18n from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -48,7 +49,12 @@ export function acceptInvite( context, next ) {
 			.then( () => {
 				const redirect = getRedirectAfterAccept( acceptedInvite );
 				debug( 'Accepted invite and redirecting to:  ' + redirect );
-				page( redirect );
+
+				if ( get( acceptedInvite, 'site.is_wpforteams_site', false ) ) {
+					window.location.href = redirect;
+				} else {
+					page( redirect );
+				}
 			} )
 			.catch( ( error ) => {
 				debug( 'Accept invite error: ' + JSON.stringify( error ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Fixes a bug that causes P2 invites + new signups to redirect back to the `accept-invite` link even when the invite was successfully accepted and processed.
Cause: Upon successfully accepting an invite, P2 sites redirect to the front end instead of Calypso. Calling `page(...)` for this redirect throws an error because of same-origin policies. This error is then caught by the catch block which then performs a redirect to the current page (i.e. `accept-invite` page).
Fix: For P2 sites, we will use `window.location.href` instead of `page(...)` to perform the redirect.

#### Testing instructions
* Send a P2 site invite to a non-registered email address.
* Check out and build this branch.
* Open the `accept-invite` link (from the email) in an incognito browser.
* **Important:** Change the invite link's host to `calypso.localhost:3000`, from `https://wordpress.com/`
* Do a new user sign-up.
* On successful signup, the P2 invite is automatically accepted, and you should get the P2 frontend, instead of an error page.

Related to #2616-gh-Automattic/p2