### PR TITLE
Framework: Refactor away from `_.sumBy()`

### DIFF
--- a/client/components/pie-chart/index.js
+++ b/client/components/pie-chart/index.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { pie as d3Pie, arc as d3Arc } from 'd3-shape';
-import { sortBy, sumBy } from 'lodash';
+import { sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -60,7 +60,7 @@ class PieChart extends Component {
 		if ( nextProps.data !== prevState.data ) {
 			return {
 				data: nextProps.data,
-				dataTotal: sumBy( nextProps.data, ( datum ) => datum.value ),
+				dataTotal: nextProps.data.reduce( ( sum, datum ) => sum + datum.value, 0 ),
 				transformedData: transformData( nextProps.data ),
 			};
 		}

--- a/client/components/pie-chart/index.js
+++ b/client/components/pie-chart/index.js
@@ -60,7 +60,7 @@ class PieChart extends Component {
 		if ( nextProps.data !== prevState.data ) {
 			return {
 				data: nextProps.data,
-				dataTotal: nextProps.data.reduce( ( sum, datum ) => sum + datum.value, 0 ),
+				dataTotal: nextProps.data.reduce( ( sum, { value } ) => sum + value, 0 ),
 				transformedData: transformData( nextProps.data ),
 			};
 		}

--- a/client/components/pie-chart/legend.js
+++ b/client/components/pie-chart/legend.js
@@ -36,7 +36,7 @@ class PieChartLegend extends Component {
 		if ( nextProps.data !== prevState.data ) {
 			return {
 				data: nextProps.data,
-				dataTotal: nextProps.data.reduce( ( sum, datum ) => sum + datum.value, 0 ),
+				dataTotal: nextProps.data.reduce( ( sum, { value } ) => sum + value, 0 ),
 				transformedData: transformData( nextProps.data ),
 			};
 		}

--- a/client/components/pie-chart/legend.js
+++ b/client/components/pie-chart/legend.js
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { sortBy, sumBy } from 'lodash';
+import { sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,7 +36,7 @@ class PieChartLegend extends Component {
 		if ( nextProps.data !== prevState.data ) {
 			return {
 				data: nextProps.data,
-				dataTotal: sumBy( nextProps.data, ( datum ) => datum.value ),
+				dataTotal: nextProps.data.reduce( ( sum, datum ) => sum + datum.value, 0 ),
 				transformedData: transformData( nextProps.data ),
 			};
 		}

--- a/client/my-sites/google-my-business/stats/chart.js
+++ b/client/my-sites/google-my-business/stats/chart.js
@@ -237,7 +237,7 @@ class GoogleMyBusinessStatsChart extends Component {
 			return false;
 		}
 
-		return flatten( transformedData ).reduce( ( sum, datum ) => sum + datum.value, 0 ) === 0;
+		return flatten( transformedData ).reduce( ( sum, { value } ) => sum + value, 0 ) === 0;
 	}
 
 	renderChartNotice() {

--- a/client/my-sites/google-my-business/stats/chart.js
+++ b/client/my-sites/google-my-business/stats/chart.js
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { flatten, partialRight, sumBy } from 'lodash';
+import { flatten, partialRight } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -237,7 +237,7 @@ class GoogleMyBusinessStatsChart extends Component {
 			return false;
 		}
 
-		return sumBy( flatten( transformedData ), 'value' ) === 0;
+		return flatten( transformedData ).reduce( ( sum, datum ) => sum + datum.value, 0 ) === 0;
 	}
 
 	renderChartNotice() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `sumBy()` is used only 3 times in the codebase, but it's pretty straightforward to replace it with an inline-customizable version of `Array.prototype.reduce( ( sum, item ) => sum + item, 0 )`. 

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Go to `/devdocs/design/pie-chart`.
* Click "Show Data Controls"
* Tinker with the controls and play the data points.
* Verify the component still behaves as it did before.
* Verify the pie chart on `/google-my-business/stats/:site` below "How customers search for your business" still works well. This has to be tested with a site that is eligible for Google My Business, which at the time of this PR means, either an E-commerce or a Business plan. Furthermore, you need to have connected that site to Google My Business. cc @stephanethomas for giving a shot at this one.