### PR TITLE
ci(e2e): Disable `GUTENBERG_EDGE` and `COBLOCKS_EDGE` by default

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -174,8 +174,8 @@ private object Gutenberg : BuildType({
 
 	params {
 		text(name="URL", value="https://wordpress.com", label = "Test URL", description = "URL to test against", allowEmpty = false)
-		checkbox(name="GUTENBERG_EDGE", value="true", label = "Use gutenberg-edge", description = "Use a blog with gutenberg-edge sticker", checked="true", unchecked = "false")
-		checkbox(name="COBLOCKS_EDGE", value="true", label = "Use coblocks-edge", description = "Use a blog with coblocks-edge sticker", checked="true", unchecked = "false")
+		checkbox(name="GUTENBERG_EDGE", value="false", label = "Use gutenberg-edge", description = "Use a blog with gutenberg-edge sticker", checked="true", unchecked = "false")
+		checkbox(name="COBLOCKS_EDGE", value="false", label = "Use coblocks-edge", description = "Use a blog with coblocks-edge sticker", checked="true", unchecked = "false")
 
 		// Unused by this Build, but the Project expects it
 		param("plugin_slug", "")


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable `GUTENBERG_EDGE` and `COBLOCKS_EDGE` by default
