### PR TITLE
Partner Portal: Exclude legacy plans from the Issue License dropdown

### DIFF
--- a/client/state/partner-portal/licenses/hooks/use-products-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-products-query.ts
@@ -10,10 +10,27 @@ import { APIProductFamily } from 'calypso/state/partner-portal/types';
 import wpcom from 'calypso/lib/wp';
 
 function queryProducts(): Promise< APIProductFamily[] > {
-	return wpcom.req.get( {
-		apiNamespace: 'wpcom/v2',
-		path: '/jetpack-licensing/product-families',
-	} );
+	return wpcom.req
+		.get( {
+			apiNamespace: 'wpcom/v2',
+			path: '/jetpack-licensing/product-families',
+		} )
+		.then( ( data: APIProductFamily[] ) => {
+			const exclude = [ 'free', 'personal', 'premium', 'professional' ];
+
+			return data
+				.map( ( family ) => {
+					return {
+						...family,
+						products: family.products.filter( ( product ) => {
+							return exclude.indexOf( product.slug ) === -1;
+						} ),
+					};
+				} )
+				.filter( ( family ) => {
+					return family.products.length > 0;
+				} );
+		} );
 }
 
 export default function useProductsQuery< TError = unknown, TData = unknown >(

--- a/client/state/partner-portal/licenses/test/hooks.js
+++ b/client/state/partner-portal/licenses/test/hooks.js
@@ -76,12 +76,40 @@ describe( 'useRefreshLicenseList', () => {
 } );
 
 describe( 'useProductsQuery', () => {
-	it( 'returns successful request data', async () => {
+	it( 'returns filtered list of products', async () => {
 		const queryClient = new QueryClient();
 		const wrapper = ( { children } ) => (
 			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
 		);
-		const stub = [
+		const unexpected = [
+			{
+				name: 'Jetpack Plans',
+				slug: 'jetpack-plans',
+				products: [
+					{
+						name: 'Free',
+						product_id: 0,
+						slug: 'free',
+					},
+					{
+						name: 'Personal',
+						product_id: 0,
+						slug: 'personal',
+					},
+					{
+						name: 'Premium',
+						product_id: 0,
+						slug: 'premium',
+					},
+					{
+						name: 'Professional',
+						product_id: 0,
+						slug: 'professional',
+					},
+				],
+			},
+		];
+		const expected = [
 			{
 				name: 'Jetpack Scan',
 				slug: 'jetpack-scan',
@@ -113,7 +141,7 @@ describe( 'useProductsQuery', () => {
 
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/wpcom/v2/jetpack-licensing/product-families' )
-			.reply( 200, stub );
+			.reply( 200, [ ...unexpected, ...expected ] );
 
 		const { result, waitFor } = renderHook( () => useProductsQuery(), {
 			wrapper,
@@ -121,7 +149,7 @@ describe( 'useProductsQuery', () => {
 
 		await waitFor( () => result.current.isSuccess );
 
-		expect( result.current.data ).toEqual( stub );
+		expect( result.current.data ).toEqual( expected );
 	} );
 } );
 


### PR DESCRIPTION
Context: 1187494150150258-as-1200247996536489

#### Changes proposed in this Pull Request

* Partner Portal: Exclude legacy plans from the Issue License dropdown

#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view test this PR.
* Check out this PR locally, then run `yarn && yarn start-jetpack-cloud`.
* Open up http://jetpack.cloud.localhost:3000/partner-portal/issue-license and confirm the following plans are no longer available in the product dropdown:
  - Free
  - Personal
  - Premium
  - Professional