### PR TITLE
Color Schemes: Modern, use custom palette for primary + accent rather than Studio Blue

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
@@ -17,7 +17,7 @@ $notification-color: $highlight-color;
 $link: $highlight-color;
 $link-focus: darken($highlight-color, 10%);
 
-Used studio-blue for the primary+accent.
+Uses custom theme highlight monochromatic palette for primary + accent
 */
 
 .color-scheme.is-modern,
@@ -34,74 +34,98 @@ Used studio-blue for the primary+accent.
 	--theme-highlight-color-rgb: 56, 88, 233; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
 	--theme-notification-color: #3858e9; /* Direct from wp-admin */
 
+	/* Theme highlight monochromatic palette */
+	--theme-highlight-color-0: #d5dffa;
+	--theme-highlight-color-0-rgb: 213, 223, 250;
+	--theme-highlight-color-10: #abc0f5;
+	--theme-highlight-color-10-rgb: 171, 192, 245;
+	--theme-highlight-color-20: #82a1f0;
+	--theme-highlight-color-20-rgb: 130, 161, 240;
+	--theme-highlight-color-30: #5882eb;
+	--theme-highlight-color-30-rgb: 88, 130, 235;
+	--theme-highlight-color-40: #2f63e6;
+	--theme-highlight-color-40-rgb: 47, 99, 230;
+	--theme-highlight-color-50: var( --theme-highlight-color );
+	--theme-highlight-color-50-rgb: var( --theme-highlight-color-rgb );
+	--theme-highlight-color-60: #2145e6; /* Direct from Gutenberg */
+	--theme-highlight-color-60-rgb: 33, 69, 230; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
+	--theme-highlight-color-70: #133ca6;
+	--theme-highlight-color-70-rgb: 19, 60, 166;
+	--theme-highlight-color-80: #0e2d7c;
+	--theme-highlight-color-80-rgb: 14, 45, 124;
+	--theme-highlight-color-90: #091e53;
+	--theme-highlight-color-90-rgb: 9, 30, 83;
+	--theme-highlight-color-100: #040f29;
+	--theme-highlight-color-100-rgb: 4, 15, 41;
+
 	/* Links */
 	--color-link: var( --theme-highlight-color );
-	--color-link-dark: #183ad6; /* Darken 10% */
-	--color-link-light: #667fee; /* Lighten 10% */
+	--color-link-dark: var( --theme-highlight-color-70 );
+	--color-link-light: var( --theme-highlight-color-30 );
 
 	/* Primary */
 	--color-primary: var( --theme-highlight-color );
 	--color-primary-rgb: var( --theme-highlight-color-rgb );
-	--color-primary-dark: var( --studio-blue-70 );
-	--color-primary-dark-rgb: var( --studio-blue-70-rgb );
-	--color-primary-light: var( --studio-blue-30 );
-	--color-primary-light-rgb: var( --studio-blue-30-rgb );
-	--color-primary-0: var( --studio-blue-0 );
-	--color-primary-0-rgb: var( --studio-blue-0-rgb );
-	--color-primary-5: var( --studio-blue-5 );
-	--color-primary-5-rgb: var( --studio-blue-5-rgb );
-	--color-primary-10: var( --studio-blue-10 );
-	--color-primary-10-rgb: var( --studio-blue-10-rgb );
-	--color-primary-20: var( --studio-blue-20 );
-	--color-primary-20-rgb: var( --studio-blue-20-rgb );
-	--color-primary-30: var( --studio-blue-30 );
-	--color-primary-30-rgb: var( --studio-blue-30-rgb );
-	--color-primary-40: var( --studio-blue-40 );
-	--color-primary-40-rgb: var( --studio-blue-40-rgb );
-	--color-primary-50: var( --studio-blue-50 );
-	--color-primary-50-rgb: var( --studio-blue-50-rgb );
-	--color-primary-60: var( --studio-blue-60 );
-	--color-primary-60-rgb: var( --studio-blue-60-rgb );
-	--color-primary-70: var( --studio-blue-70 );
-	--color-primary-70-rgb: var( --studio-blue-70-rgb );
-	--color-primary-80: var( --studio-blue-80 );
-	--color-primary-80-rgb: var( --studio-blue-80-rgb );
-	--color-primary-90: var( --studio-blue-90 );
-	--color-primary-90-rgb: var( --studio-blue-90-rgb );
-	--color-primary-100: var( --studio-blue-100 );
-	--color-primary-100-rgb: var( --studio-blue-100-rgb );
+	--color-primary-dark: var( --theme-highlight-color-70 );
+	--color-primary-dark-rgb: var( --theme-highlight-color-70-rgb );
+	--color-primary-light: var( --theme-highlight-color-30 );
+	--color-primary-light-rgb: var( --theme-highlight-color-30-rgb );
+	--color-primary-0: var( --theme-highlight-color-0 );
+	--color-primary-0-rgb: var( --theme-highlight-color-0-rgb );
+	--color-primary-5: var( --theme-highlight-color-5 );
+	--color-primary-5-rgb: var( --theme-highlight-color-5-rgb );
+	--color-primary-10: var( --theme-highlight-color-10 );
+	--color-primary-10-rgb: var( --theme-highlight-color-10-rgb );
+	--color-primary-20: var( --theme-highlight-color-20 );
+	--color-primary-20-rgb: var( --theme-highlight-color-20-rgb );
+	--color-primary-30: var( --theme-highlight-color-30 );
+	--color-primary-30-rgb: var( --theme-highlight-color-30-rgb );
+	--color-primary-40: var( --theme-highlight-color-40 );
+	--color-primary-40-rgb: var( --theme-highlight-color-40-rgb );
+	--color-primary-50: var( --theme-highlight-color-50 );
+	--color-primary-50-rgb: var( --theme-highlight-color-50-rgb );
+	--color-primary-60: var( --theme-highlight-color-60 );
+	--color-primary-60-rgb: var( --theme-highlight-color-60-rgb );
+	--color-primary-70: var( --theme-highlight-color-70 );
+	--color-primary-70-rgb: var( --theme-highlight-color-70-rgb );
+	--color-primary-80: var( --theme-highlight-color-80 );
+	--color-primary-80-rgb: var( --theme-highlight-color-80-rgb );
+	--color-primary-90: var( --theme-highlight-color-90 );
+	--color-primary-90-rgb: var( --theme-highlight-color-90-rgb );
+	--color-primary-100: var( --theme-highlight-color-100 );
+	--color-primary-100-rgb: var( --theme-highlight-color-100-rgb );
 
 	/* Accent */
 	--color-accent: var( --theme-highlight-color );
 	--color-accent-rgb: var( --theme-highlight-color-rgb );
-	--color-accent-dark: var( --studio-blue-70 );
-	--color-accent-dark-rgb: var( --studio-blue-70-rgb );
-	--color-accent-light: var( --studio-blue-30 );
-	--color-accent-light-rgb: var( --studio-blue-30-rgb );
-	--color-accent-0: var( --studio-blue-0 );
-	--color-accent-0-rgb: var( --studio-blue-0-rgb );
-	--color-accent-5: var( --studio-blue-5 );
-	--color-accent-5-rgb: var( --studio-blue-5-rgb );
-	--color-accent-10: var( --studio-blue-10 );
-	--color-accent-10-rgb: var( --studio-blue-10-rgb );
-	--color-accent-20: var( --studio-blue-20 );
-	--color-accent-20-rgb: var( --studio-blue-20-rgb );
-	--color-accent-30: var( --studio-blue-30 );
-	--color-accent-30-rgb: var( --studio-blue-30-rgb );
-	--color-accent-40: var( --studio-blue-40 );
-	--color-accent-40-rgb: var( --studio-blue-40-rgb );
-	--color-accent-50: var( --studio-blue-50 );
-	--color-accent-50-rgb: var( --studio-blue-50-rgb );
-	--color-accent-60: var( --studio-blue-60 );
-	--color-accent-60-rgb: var( --studio-blue-60-rgb );
-	--color-accent-70: var( --studio-blue-70 );
-	--color-accent-70-rgb: var( --studio-blue-70-rgb );
-	--color-accent-80: var( --studio-blue-80 );
-	--color-accent-80-rgb: var( --studio-blue-80-rgb );
-	--color-accent-90: var( --studio-blue-90 );
-	--color-accent-90-rgb: var( --studio-blue-90-rgb );
-	--color-accent-100: var( --studio-blue-100 );
-	--color-accent-100-rgb: var( --studio-blue-100-rgb );
+	--color-accent-dark: var( --theme-highlight-color-70 );
+	--color-accent-dark-rgb: var( --theme-highlight-color-70-rgb );
+	--color-accent-light: var( --theme-highlight-color-30 );
+	--color-accent-light-rgb: var( --theme-highlight-color-30-rgb );
+	--color-accent-0: var( --theme-highlight-color-0 );
+	--color-accent-0-rgb: var( --theme-highlight-color-0-rgb );
+	--color-accent-5: var( --theme-highlight-color-5 );
+	--color-accent-5-rgb: var( --theme-highlight-color-5-rgb );
+	--color-accent-10: var( --theme-highlight-color-10 );
+	--color-accent-10-rgb: var( --theme-highlight-color-10-rgb );
+	--color-accent-20: var( --theme-highlight-color-20 );
+	--color-accent-20-rgb: var( --theme-highlight-color-20-rgb );
+	--color-accent-30: var( --theme-highlight-color-30 );
+	--color-accent-30-rgb: var( --theme-highlight-color-30-rgb );
+	--color-accent-40: var( --theme-highlight-color-40 );
+	--color-accent-40-rgb: var( --theme-highlight-color-40-rgb );
+	--color-accent-50: var( --theme-highlight-color-50 );
+	--color-accent-50-rgb: var( --theme-highlight-color-50-rgb );
+	--color-accent-60: var( --theme-highlight-color-60 );
+	--color-accent-60-rgb: var( --theme-highlight-color-60-rgb );
+	--color-accent-70: var( --theme-highlight-color-70 );
+	--color-accent-70-rgb: var( --theme-highlight-color-70-rgb );
+	--color-accent-80: var( --theme-highlight-color-80 );
+	--color-accent-80-rgb: var( --theme-highlight-color-80-rgb );
+	--color-accent-90: var( --theme-highlight-color-90 );
+	--color-accent-90-rgb: var( --theme-highlight-color-90-rgb );
+	--color-accent-100: var( --theme-highlight-color-100 );
+	--color-accent-100-rgb: var( --theme-highlight-color-100-rgb );
 
 	/* Masterbar */
 	--color-masterbar-background: var( --theme-base-color );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The Studio Blue family is less saturated than the colors used in the Modern color scheme in Gutenberg and `/wp-admin`, and it's noticeable when the colors are put side by side. This change replaces the use of Studio Blue in the Modern color scheme with a custom monochromatic palette based on the `/wp-admin` blue as its 50% value.
* Any visual changes should be subtle. The most dramatic shift is the button hover color, which now matches the button hover color in Gutenberg.

**Before**

<img width="493" alt="Screen Shot 2021-04-27 at 9 31 44 AM" src="https://user-images.githubusercontent.com/2124984/116262469-8ff9e380-a746-11eb-8823-f193420a4802.png">

**After**

<img width="443" alt="Screen Shot 2021-04-27 at 10 44 21 AM" src="https://user-images.githubusercontent.com/2124984/116262487-94260100-a746-11eb-8d8f-02de44550cff.png">

#### Testing instructions

* Switch to this PR
* Navigate to `/devdocs` and check out all the components, paying particular attention to the primary and accent colors. Make sure there are no visual bugs or issues.

Fixes #48368