### PR TITLE
Display the reason for a close account error

### DIFF
--- a/client/state/data-layer/wpcom/me/account/close/index.js
+++ b/client/state/data-layer/wpcom/me/account/close/index.js
@@ -52,7 +52,7 @@ export function receiveAccountCloseError( action, error ) {
 
 	if ( error.error === 'active-memberships' ) {
 		return errorNotice(
-			translate( 'This user account cannot be closed while it has active memberships.' )
+			translate( 'This user account cannot be closed while it has active purchases.' )
 		);
 	}
 

--- a/client/state/data-layer/wpcom/me/account/close/index.js
+++ b/client/state/data-layer/wpcom/me/account/close/index.js
@@ -43,7 +43,19 @@ export function receiveAccountCloseSuccess() {
 	return closeAccountSuccess();
 }
 
-export function receiveAccountCloseError() {
+export function receiveAccountCloseError( action, error ) {
+	if ( error.error === 'active-subscriptions' ) {
+		return errorNotice(
+			translate( 'This user account cannot be closed while it has active subscriptions.' )
+		);
+	}
+
+	if ( error.error === 'active-memberships' ) {
+		return errorNotice(
+			translate( 'This user account cannot be closed while it has active memberships.' )
+		);
+	}
+
 	return errorNotice(
 		translate( 'Sorry, there was a problem closing your account. Please contact support.' )
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Displays error messages for the "active-subscriptions" and "active-memberships" errors returned from the close account API.

The error message displayed for "active-subscriptions" matches the full error message previously returned by the API: "This user account cannot be closed while it has active subscriptions.

The error message displayed for "active-memberships" will occur when an account only has Payments Block membership subscriptions remaining and of those subscriptions only non-renewing subscriptions remain. The message is "This user account cannot be closed while it has active memberships." where "memberships" refers to both payments made that may have been for unlocking some sort of content but may also have been done as a donation or for a "consumable". There may be a better error message that conveys exactly what is happening.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sign up for a Longreads subscription through WordPress.com
* Try to close your account and verify the error message shows "This user account cannot be closed while it has active subscriptions."
* Make a non-recurring payment through a site using a [Payment Block](https://wordpress.com/support/wordpress-editor/blocks/payments/) so you now have a recurring and non-recurring membership.
* Try to close your account and verify the error message shows "This user account cannot be closed while it has active subscriptions."
* Stop the Longreads subscription.
* Try to close your account and verify the error message shows "This user account cannot be closed while it has active memberships."
* Stop the Payment Block "subscription"
* Close the account without error
