### PR TITLE
Jetpack Cloud: Add product card for legacy Jetpack plans

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -59,6 +59,7 @@ export type Props = OwnProps & Partial< FeaturesProps >;
 const FRESHPACK_PERCENTAGE = 1 - 0.4; // 40% off
 
 const DisplayPrice = ( {
+	isDeprecated,
 	isOwned,
 	isIncludedInPlan,
 	isFree,
@@ -70,8 +71,24 @@ const DisplayPrice = ( {
 	expiryDate,
 	billingTerm,
 	tooltipText,
+	productName,
 } ) => {
 	const translate = useTranslate();
+
+	if ( isDeprecated ) {
+		return (
+			<div className="jetpack-product-card__price">
+				<p className="jetpack-product-card__price-deprecated">
+					{ translate( 'The %(productName)s plan is no longer available', {
+						args: {
+							productName,
+						},
+						comment: 'productName is the name of Jetpack plan such as Personal',
+					} ) }
+				</p>
+			</div>
+		);
+	}
 
 	if ( isOwned ) {
 		return (
@@ -223,6 +240,7 @@ const JetpackProductCard: React.FC< Props > = ( {
 				) }
 
 				<DisplayPrice
+					isDeprecated={ isDeprecated }
 					isOwned={ isOwned }
 					isIncludedInPlan={ isIncludedInPlan }
 					isFree={ isFree }
@@ -234,6 +252,7 @@ const JetpackProductCard: React.FC< Props > = ( {
 					expiryDate={ expiryDate }
 					billingTerm={ billingTerm }
 					tooltipText={ tooltipText }
+					productName={ productName }
 				/>
 
 				{ aboveButtonText && (
@@ -249,7 +268,7 @@ const JetpackProductCard: React.FC< Props > = ( {
 						primary={ buttonPrimary }
 						className="jetpack-product-card__button"
 						onClick={ onButtonClick }
-						disabled={ isDisabled }
+						disabled={ isDisabled || isDeprecated }
 					>
 						{ buttonLabel }
 					</Button>

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -113,13 +113,15 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 		return ! [ ...JETPACK_BACKUP_PRODUCTS, ...JETPACK_SCAN_PRODUCTS ].includes( item.productSlug );
 	}, [ item.productSlug ] );
 
+	const isDeprecated = Boolean( item.legacy );
+
 	// Disable the product card if it's an incompatible multisite product or CRM monthly product
 	// (CRM is not offered with "Monthly" billing. Only Yearly.)
 	const isDisabled = ( ( isMultisite && ! isMultisiteCompatible ) || isCrmMonthlyProduct ) ?? false;
 
 	let disabledMessage;
 	if ( isDisabled ) {
-		if ( ! isMultisiteCompatible ) {
+		if ( ! isMultisiteCompatible && ! isDeprecated ) {
 			disabledMessage = translate( 'Not available for multisite WordPress installs' );
 		} else if ( isCrmMonthlyProduct ) {
 			disabledMessage = translate( 'Only available in yearly billing' );
@@ -136,7 +138,13 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 			originalPrice={ originalPrice }
 			discountedPrice={ discountedPrice }
 			billingTerm={ item.displayTerm || item.term }
-			buttonLabel={ productButtonLabel( item, isOwned, isUpgradeableToYearly, sitePlan ) }
+			buttonLabel={ productButtonLabel( {
+				product: item,
+				isOwned,
+				isUpgradeableToYearly,
+				isDeprecated,
+				currentPlan: sitePlan,
+			} ) }
 			buttonPrimary={ ! ( isOwned || isItemPlanFeature ) }
 			onButtonClick={ () => onClick( item, isUpgradeableToYearly, purchase ) }
 			expiryDate={ showExpiryNotice && purchase ? moment( purchase.expiryDate ) : undefined }
@@ -144,7 +152,7 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 			isOwned={ isOwned }
 			isIncludedInPlan={ ! isOwned && isItemPlanFeature }
 			isFree={ item.isFree }
-			isDeprecated={ item.legacy }
+			isDeprecated={ isDeprecated }
 			isAligned={ isAligned }
 			features={ item.features }
 			displayFrom={ ! siteId && priceTierList.length > 0 }

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -227,12 +227,25 @@ export const getHighestAnnualDiscount = createSelector(
  * Product UI utils.
  */
 
-export function productButtonLabel(
-	product: SelectorProduct,
-	isOwned: boolean,
-	isUpgradeableToYearly: boolean,
-	currentPlan?: SitePlan | null
-): TranslateResult {
+interface productButtonLabelProps {
+	product: SelectorProduct;
+	isOwned: boolean;
+	isUpgradeableToYearly: boolean;
+	isDeprecated: boolean;
+	currentPlan?: SitePlan | null;
+}
+
+export function productButtonLabel( {
+	product,
+	isOwned,
+	isUpgradeableToYearly,
+	isDeprecated,
+	currentPlan,
+}: productButtonLabelProps ): TranslateResult {
+	if ( isDeprecated ) {
+		return translate( 'No longer available' );
+	}
+
 	if ( isUpgradeableToYearly ) {
 		return translate( 'Upgrade to Yearly' );
 	}

--- a/packages/calypso-products/src/plans-list.js
+++ b/packages/calypso-products/src/plans-list.js
@@ -1057,6 +1057,12 @@ export const PLANS_LIST = {
 				constants.FEATURE_ADVANCED_SEO,
 				constants.FEATURE_GOOGLE_ANALYTICS,
 			] ),
+		getPlanCardFeatures: () => [
+			constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
+			constants.FEATURE_PRODUCT_SCAN_DAILY_V2,
+			constants.FEATURE_ANTISPAM_V2,
+			constants.FEATURE_VIDEO_HOSTING_V2,
+		],
 		getSignupFeatures: ( currentPlan ) => {
 			const showPersonalPlan =
 				isEnabled( 'jetpack/personal-plan' ) || constants.PLAN_JETPACK_PERSONAL === currentPlan;
@@ -1134,6 +1140,12 @@ export const PLANS_LIST = {
 				constants.FEATURE_ADVANCED_SEO,
 				constants.FEATURE_GOOGLE_ANALYTICS,
 			] ),
+		getPlanCardFeatures: () => [
+			constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
+			constants.FEATURE_PRODUCT_SCAN_DAILY_V2,
+			constants.FEATURE_ANTISPAM_V2,
+			constants.FEATURE_VIDEO_HOSTING_V2,
+		],
 		getSignupFeatures: ( currentPlan ) => {
 			const showPersonalPlan =
 				isEnabled( 'jetpack/personal-plan' ) || constants.PLAN_JETPACK_PERSONAL === currentPlan;
@@ -1196,6 +1208,11 @@ export const PLANS_LIST = {
 			constants.FEATURE_EASY_SITE_MIGRATION,
 			constants.FEATURE_PREMIUM_SUPPORT,
 		],
+		getPlanCardFeatures: () => [
+			constants.FEATURE_BACKUP_DAILY_V2,
+			constants.FEATURE_ACTIVITY_LOG,
+			constants.FEATURE_PREMIUM_SUPPORT,
+		],
 		getSignupFeatures: () => [
 			constants.FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 			constants.FEATURE_SPAM_AKISMET_PLUS,
@@ -1244,6 +1261,11 @@ export const PLANS_LIST = {
 			constants.FEATURE_AUTOMATED_RESTORES,
 			constants.FEATURE_SPAM_AKISMET_PLUS,
 			constants.FEATURE_EASY_SITE_MIGRATION,
+			constants.FEATURE_PREMIUM_SUPPORT,
+		],
+		getPlanCardFeatures: () => [
+			constants.FEATURE_BACKUP_DAILY_V2,
+			constants.FEATURE_ACTIVITY_LOG,
 			constants.FEATURE_PREMIUM_SUPPORT,
 		],
 		getSignupFeatures: () => [
@@ -1315,6 +1337,12 @@ export const PLANS_LIST = {
 				constants.FEATURE_GOOGLE_ANALYTICS,
 				constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 			] ),
+		getPlanCardFeatures: () => [
+			constants.FEATURE_PLAN_SECURITY_DAILY,
+			constants.FEATURE_PRODUCT_BACKUP_REALTIME_V2,
+			constants.FEATURE_PRODUCT_SCAN_REALTIME_V2,
+			constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
+		],
 		getSignupFeatures: () =>
 			compact( [
 				constants.FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
@@ -1387,6 +1415,12 @@ export const PLANS_LIST = {
 				constants.FEATURE_GOOGLE_ANALYTICS,
 				constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 			] ),
+		getPlanCardFeatures: () => [
+			constants.FEATURE_PLAN_SECURITY_DAILY,
+			constants.FEATURE_PRODUCT_BACKUP_REALTIME_V2,
+			constants.FEATURE_PRODUCT_SCAN_REALTIME_V2,
+			constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
+		],
 		getSignupFeatures: () =>
 			compact( [
 				constants.FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add support for legacy plans in product cards.

#### Notes

I added to legacy plans features in order to have them shown in the product cards. I tried to match the same features the current plans have. However, since there is no 1-1 replacement for Jetpack Personal, its features won't be the same as Jetpack Backup's.

#### Testing instructions

* Download this PR.
* Open the `client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts` file, and add right after the the `return` statement the following lines (you will have to import all of those constants):

````js
availableProducts = [
		...availableProducts,
		PLAN_JETPACK_PERSONAL,
		PLAN_JETPACK_PERSONAL_MONTHLY,
		PLAN_JETPACK_PREMIUM,
		PLAN_JETPACK_PREMIUM_MONTHLY,
		PLAN_JETPACK_BUSINESS,
		PLAN_JETPACK_BUSINESS_MONTHLY,
	];
````

* Run Calypso Green with `yarn start-jetpack-cloud`. 
* Visit `http://jetpack.cloud.localhost:3000/pricing`.
* Scroll down to the bottom of the list of products.
* Make sure you see product cards for Jetpack Personal, Jetpack Premium, and Jetpack Business.
* Make sure that the cards match the design provided in the card linked below.

Related to 1200196139286276-as-1200247484326042

#### Demo

![image](https://user-images.githubusercontent.com/3418513/116292477-c09c4600-a763-11eb-93e0-3ed4346dbfa0.png)
