### PR TITLE
Update variable for sidebar count bubble

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -171,8 +171,8 @@
 
 		.count {
 			background-color: transparent;
-			border-color: var( --color-sidebar-menu-selected-text );
-			color: var( --color-sidebar-menu-selected-text );
+			border-color: var( --color-sidebar-submenu-selected-text );
+			color: var( --color-sidebar-submenu-selected-text );
 		}
 	}
 
@@ -235,8 +235,8 @@
 
 			.count {
 				background-color: transparent;
-				border-color: var( --color-sidebar-menu-selected-text );
-				color: var( --color-sidebar-menu-selected-text );
+				border-color: var( --color-sidebar-submenu-selected-text );
+				color: var( --color-sidebar-submenu-selected-text );
 			}
 		}
 	}
@@ -260,8 +260,8 @@
 		}
 		.count {
 			background-color: transparent;
-			border-color: var( --color-sidebar-menu-selected-text );
-			color: var( --color-sidebar-menu-selected-text );
+			border-color: var( --color-sidebar-submenu-selected-text );
+			color: var( --color-sidebar-submenu-selected-text );
 		}
 	}
 }

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -171,8 +171,8 @@
 
 		.count {
 			background-color: transparent;
-			border-color: var( --color-sidebar-submenu-selected-text );
-			color: var( --color-sidebar-submenu-selected-text );
+			border-color: var( --color-sidebar-menu-selected-text );
+			color: var( --color-sidebar-menu-selected-text );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `--color-sidebar-submenu-selected-text` rather than `--color-sidebar-menu-selected-text` on count bubbles in the sidebar for toggle-able menus and hover effects; this provides better contrast with the sidebar background for all color schemes.

**Before**

<img width="289" alt="Screen Shot 2021-04-27 at 1 50 00 PM" src="https://user-images.githubusercontent.com/2124984/116293448-e6761a80-a764-11eb-8f77-32371f0d0f5d.png">

<img width="283" alt="Screen Shot 2021-04-27 at 1 47 23 PM" src="https://user-images.githubusercontent.com/2124984/116293486-f5f56380-a764-11eb-860b-017679e2128c.png">

<img width="287" alt="Screen Shot 2021-04-27 at 1 48 44 PM" src="https://user-images.githubusercontent.com/2124984/116293554-0ad1f700-a765-11eb-8ee4-1d05eded8eb2.png">

<img width="447" alt="Screen Shot 2021-04-27 at 2 23 04 PM" src="https://user-images.githubusercontent.com/2124984/116293624-19b8a980-a765-11eb-9b92-f0efcc94a27a.png">


**After**

<img width="290" alt="Screen Shot 2021-04-27 at 2 21 22 PM" src="https://user-images.githubusercontent.com/2124984/116293461-eb3ace80-a764-11eb-80bb-3a18820ac0ae.png">

<img width="291" alt="Screen Shot 2021-04-27 at 2 21 35 PM" src="https://user-images.githubusercontent.com/2124984/116293525-06a5d980-a765-11eb-9448-9404bc164e8e.png">

<img width="285" alt="Screen Shot 2021-04-27 at 2 22 00 PM" src="https://user-images.githubusercontent.com/2124984/116293592-13c2c880-a765-11eb-8289-f1ee4bc3ec67.png">

<img width="447" alt="Screen Shot 2021-04-27 at 2 23 12 PM" src="https://user-images.githubusercontent.com/2124984/116293661-20dfb780-a765-11eb-9200-d6b19b05000d.png">



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, navigate to `/me/account-settings` and change your color scheme Aquatic
* View an Atomic site's dashboard and click on the "My Home" menu to open the submenu; make sure the site has some updates to apply
* The count bubble next to Updates should have sufficient contrast with the menu background.
* Make sure the count bubble next to Plugins and Comments menu items also have sufficient contrast on hover.
* Test these areas on all color schemes by changing your color scheme under Account Settings to ensure there's adequate contrast between background and foreground.

Fixes #50826
