### PR TITLE
Fix supportsPrivacyProtectionPurchase to handle an object of products

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -319,11 +319,12 @@ export function planItem( productSlug, properties ) {
  * Determines whether a domain Item supports purchasing a privacy subscription
  *
  * @param {string} productSlug - e.g. domain_reg, dotblog_domain
- * @param {Array} productsList - The list of products retrieved using getProductsList from state/products-list/selectors
+ * @param {object} productsList - The list of products retrieved using getProductsList from state/products-list/selectors
  * @returns {boolean} true if the domainItem supports privacy protection purchase
  */
 export function supportsPrivacyProtectionPurchase( productSlug, productsList ) {
-	const product = productsList.find( ( item ) => item.product_slug === productSlug ) || {};
+	const product =
+		Object.values( productsList ).find( ( item ) => item.product_slug === productSlug ) || {};
 	return product?.is_privacy_protection_product_purchase_allowed ?? false;
 }
 

--- a/client/lib/signup/cart.js
+++ b/client/lib/signup/cart.js
@@ -14,7 +14,7 @@ function addProductsToCart( cart, newCartItems ) {
 	} );
 	return {
 		...cart,
-		products: [ ...cart.products, newProducts ],
+		products: [ ...cart.products, ...newProducts ],
 	};
 }
 

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -445,7 +445,11 @@ function processItemCart(
 function addPrivacyProtectionIfSupported( item, state ) {
 	const { product_slug: productSlug } = item;
 	const productsList = getProductsList( state );
-	if ( supportsPrivacyProtectionPurchase( productSlug, productsList ) ) {
+	if (
+		productSlug &&
+		productsList &&
+		supportsPrivacyProtectionPurchase( productSlug, productsList )
+	) {
 		return updatePrivacyForDomain( item, true );
 	}
 

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -447,7 +447,7 @@ function addPrivacyProtectionIfSupported( item, state ) {
 	const productsList = getProductsList( state );
 	if (
 		productSlug &&
-		productsList &&
+		productsList?.length &&
 		supportsPrivacyProtectionPurchase( productSlug, productsList )
 	) {
 		return updatePrivacyForDomain( item, true );

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -447,7 +447,7 @@ function addPrivacyProtectionIfSupported( item, state ) {
 	const productsList = getProductsList( state );
 	if (
 		productSlug &&
-		productsList?.length &&
+		productsList &&
 		supportsPrivacyProtectionPurchase( productSlug, productsList )
 	) {
 		return updatePrivacyForDomain( item, true );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates `supportsPrivacyProtectionPurchase` so that uses an _object_ of products rather than an array (the data returned from the `getProductsList` selector is an object, not an array as suggested by the existing jsdoc).

Fixes a regression caused by replacing lodash `find` with native JS `find` in https://github.com/Automattic/wp-calypso/pull/52211

lodash `find` can handle object collections, but native JS `find` requires an array.

#### Testing instructions

- Visit `/start` and create a new site with any paid plan.
- Verify that the site is created with no JS errors.