### PR TITLE
Revert "Shopping Cart: Clean up lib/cart-values and remove unused functions"

### DIFF
--- a/client/lib/analytics/ad-tracking/criteo.js
+++ b/client/lib/analytics/ad-tracking/criteo.js
@@ -72,7 +72,7 @@ export function recordPlansViewInCriteo() {
 /**
  * Records that a user viewed the checkout page
  *
- * @param {object} cart - cart as `ResponseCart` object
+ * @param {object} cart - cart as `CartValue` object
  * @returns {void}
  */
 export function recordViewCheckoutInCriteo( cart ) {
@@ -99,7 +99,7 @@ export function recordViewCheckoutInCriteo( cart ) {
 /**
  * Converts the products in a cart to the format Criteo expects for its `items` property
  *
- * @param {object} cart - cart as `ResponseCart` object
+ * @param {object} cart - cart as `CartValue` object
  * @returns {Array} - An array of items to include in the Criteo tracking call
  */
 export function cartToCriteoItems( cart ) {

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -44,7 +44,7 @@ import './setup';
 /**
  * Tracks a purchase conversion
  *
- * @param {object} cart - cart as `ResponseCart` object
+ * @param {object} cart - cart as `CartValue` object
  * @param {number} orderId - the order id
  * @returns {void}
  */
@@ -200,7 +200,7 @@ function splitWpcomJetpackCartInfo( cart ) {
 /**
  * Records an order in Quantcast
  *
- * @param {object} cart - cart as `ResponseCart` object
+ * @param {object} cart - cart as `CartValue` object
  * @param {number} orderId - the order id
  * @param {object} wpcomJetpackCartInfo - info about WPCOM and Jetpack in the cart
  * @returns {void}
@@ -258,7 +258,7 @@ function recordOrderInQuantcast( cart, orderId, wpcomJetpackCartInfo ) {
 /**
  * Records an order in DCM Floodlight
  *
- * @param {object} cart - cart as `ResponseCart` object
+ * @param {object} cart - cart as `CartValue` object
  * @param {number} orderId - the order id
  * @param {object} wpcomJetpackCartInfo - info about WPCOM and Jetpack in the cart
  * @returns {void}
@@ -317,7 +317,7 @@ function recordOrderInFloodlight( cart, orderId, wpcomJetpackCartInfo ) {
 /**
  * Records an order in Facebook (a single event for the entire order)
  *
- * @param {object} cart - cart as `ResponseCart` object
+ * @param {object} cart - cart as `CartValue` object
  * @param {number} orderId - the order id
  * @param {object} wpcomJetpackCartInfo - info about WPCOM and Jetpack in the cart
  * @returns {void}
@@ -377,7 +377,7 @@ function recordOrderInFacebook( cart, orderId, wpcomJetpackCartInfo ) {
 /**
  * Records a signup|purchase in Bing.
  *
- * @param {object} cart - cart as `ResponseCart` object.
+ * @param {object} cart - cart as `CartValue` object.
  * @param {number} orderId - the order ID.
  * @param {object} wpcomJetpackCartInfo - info about WPCOM and Jetpack in the cart
  * @returns {void}
@@ -423,7 +423,7 @@ function recordOrderInBing( cart, orderId, wpcomJetpackCartInfo ) {
 /**
  * Records an order/sign_up in Google Ads Gtag
  *
- * @param {object} cart - cart as `ResponseCart` object
+ * @param {object} cart - cart as `CartValue` object
  * @param {number} orderId - the order id
  * @returns {void}
  */
@@ -512,7 +512,7 @@ function recordOrderInGAEnhancedEcommerce( cart, orderId, wpcomJetpackCartInfo )
 /**
  * Records an order in Criteo
  *
- * @param {object} cart - cart as `ResponseCart` object
+ * @param {object} cart - cart as `CartValue` object
  * @param {number} orderId - the order id
  * @returns {void}
  */

--- a/client/lib/analytics/ad-tracking/record-view-checkout.js
+++ b/client/lib/analytics/ad-tracking/record-view-checkout.js
@@ -10,7 +10,7 @@ import './setup';
 /**
  * Records that a user viewed the checkout page
  *
- * @param {object} cart - cart as `ResponseCart` object
+ * @param {object} cart - cart as `CartValue` object
  */
 export function recordViewCheckout( cart ) {
 	if ( isCriteoEnabled ) {

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import update from 'immutability-helper';
+import { filter, find, get, isEqual, merge, some } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import config from '@automattic/calypso-config';
@@ -13,6 +19,7 @@ import {
 	isCustomDesign,
 	isDomainMapping,
 	isDomainProduct,
+	isDomainRedemption,
 	isDomainRegistration,
 	isDomainTransfer,
 	isEcommerce,
@@ -37,6 +44,7 @@ import {
 	isTitanMail,
 	isP2Plus,
 	isMonthlyProduct,
+	sortProducts,
 	getTermDuration,
 	getPlan,
 	isBloggerPlan,
@@ -47,19 +55,96 @@ import { getTld } from 'calypso/lib/domains';
 import { domainProductSlugs } from 'calypso/lib/domains/constants';
 
 /**
+ * @typedef { import("./types").CartItemValue} CartItemValue
+ * @typedef { import("./types").CartItemExtra} CartItemExtra
+ * @typedef { import("./types").CartValue } CartValue
+ */
+
+/**
+ * Adds the specified item to a shopping cart.
+ *
+ * @param {CartItemValue} newCartItem - new item as `CartItemValue` object
+ * @returns {Function} the function that adds the item to a shopping cart
+ */
+export function addCartItem( newCartItem ) {
+	function appendItem( products ) {
+		products = products || [];
+
+		const isDuplicate = products.some( function ( existingCartItem ) {
+			return isEqual( newCartItem, existingCartItem );
+		} );
+
+		return isDuplicate ? products : products.concat( [ newCartItem ] );
+	}
+
+	return function ( cart ) {
+		if ( cartItemShouldReplaceCart( newCartItem, cart ) ) {
+			return update( cart, { products: { $set: [ newCartItem ] } } );
+		}
+
+		return update( cart, { products: { $apply: appendItem } } );
+	};
+}
+
+/**
+ * Determines if the given cart item should replace the cart.
+ * This can happen if the given item:
+ * - will result in mixed renewals/non-renewals or multiple renewals (excluding privacy protection).
+ *
+ * @param {CartItemValue} cartItem - `CartItemValue` object
+ * @param {object} cart - the existing shopping cart
+ * @returns {boolean} whether or not the item should replace the cart
+ */
+export function cartItemShouldReplaceCart( cartItem, cart ) {
+	if ( isRenewal( cartItem ) && ! isDomainRedemption( cartItem ) ) {
+		// adding a renewal replaces the cart unless it is a privacy protection
+		return true;
+	}
+
+	if ( ! isRenewal( cartItem ) && hasRenewalItem( cart ) ) {
+		// all items should replace the cart if the cart contains a renewal
+		return true;
+	}
+
+	if ( isJetpackPlan( cartItem ) ) {
+		// adding a jetpack bundle should replace the cart
+		return true;
+	}
+
+	if ( isJetpackProduct( cartItem ) ) {
+		// adding a Jetpack product should replace the cart
+
+		// Jetpack Offer Reset allows users to purchase multiple Jetpack products at the same time.
+		return false;
+	}
+
+	return false;
+}
+
+/**
  * Retrieves all the items in the specified shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct[]} the list of items in the shopping cart as `ResponseCartProduct` objects
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {CartItemValue[]} the list of items in the shopping cart as `CartItemValue` objects
  */
 export function getAllCartItems( cart ) {
 	return ( cart && cart.products ) || [];
 }
 
 /**
+ * Retrieves all the items in the shopping cart sorted
+ *
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {object[]} the sorted list of items in the shopping cart
+ */
+export function getAllCartItemsSorted( cart ) {
+	return sortProducts( getAllCartItems( cart ) );
+}
+
+/**
  * Gets the renewal items from the specified shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {Array} an array of renewal items
  */
 export function getRenewalItems( cart ) {
@@ -69,57 +154,57 @@ export function getRenewalItems( cart ) {
 /**
  * Determines whether there is any kind of plan (e.g. Premium or Business) in the shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one plan, false otherwise
  */
 export function hasPlan( cart ) {
-	return cart && getAllCartItems( cart ).some( isPlan );
+	return cart && some( getAllCartItems( cart ), isPlan );
 }
 
 /**
  * Determines whether there is a Jetpack plan in the shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one Jetpack plan, false otherwise
  */
 export function hasJetpackPlan( cart ) {
-	return getAllCartItems( cart ).some( isJetpackPlan );
+	return some( getAllCartItems( cart ), isJetpackPlan );
 }
 
 /**
  * Determines whether there is a P2+ plan in the shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one P2+ plan, false otherwise
  */
 export function hasP2PlusPlan( cart ) {
-	return getAllCartItems( cart ).some( isP2Plus );
+	return some( getAllCartItems( cart ), isP2Plus );
 }
 
 /**
  * Determines whether there is an ecommerce plan in the shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one plan, false otherwise
  */
 export function hasEcommercePlan( cart ) {
-	return cart && getAllCartItems( cart ).some( isEcommerce );
+	return cart && some( getAllCartItems( cart ), isEcommerce );
 }
 
 export function hasBloggerPlan( cart ) {
-	return getAllCartItems( cart ).some( isBlogger );
+	return some( getAllCartItems( cart ), isBlogger );
 }
 
 export function hasPersonalPlan( cart ) {
-	return getAllCartItems( cart ).some( isPersonal );
+	return some( getAllCartItems( cart ), isPersonal );
 }
 
 export function hasPremiumPlan( cart ) {
-	return getAllCartItems( cart ).some( isPremium );
+	return some( getAllCartItems( cart ), isPremium );
 }
 
 export function hasBusinessPlan( cart ) {
-	return getAllCartItems( cart ).some( isBusiness );
+	return some( getAllCartItems( cart ), isBusiness );
 }
 
 export function hasDomainCredit( cart ) {
@@ -127,13 +212,13 @@ export function hasDomainCredit( cart ) {
 }
 
 export function hasMonthlyCartItem( cart ) {
-	return getAllCartItems( cart ).some( isMonthlyProduct );
+	return some( getAllCartItems( cart ), isMonthlyProduct );
 }
 
 /**
  * Determines whether there is at least one item of a given product in the specified shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @param {string} productSlug - the unique string that identifies the product
  * @returns {boolean} true if there is at least one item of the specified product type, false otherwise
  */
@@ -146,37 +231,37 @@ export function hasProduct( cart, productSlug ) {
 /**
  * Determines whether there is at least one domain registration item in the specified shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one domain registration item, false otherwise
  */
 export function hasDomainRegistration( cart ) {
-	return getAllCartItems( cart ).some( isDomainRegistration );
+	return some( getAllCartItems( cart ), isDomainRegistration );
 }
 
 /**
  * Determines whether there is at least one new domain registration item in the specified shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one new domain registration item, false otherwise
  */
 export function hasNewDomainRegistration( cart ) {
-	return getAllCartItems( cart ).some( isNewDomainRegistration );
+	return some( getAllCartItems( cart ), isNewDomainRegistration );
 }
 
 /**
  * Determines whether there is at least one domain registration renewal item in the specified shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one domain registration renewal item, false otherwise
  */
 export function hasDomainRenewal( cart ) {
-	return getAllCartItems( cart ).some( isDomainRenewal );
+	return some( getAllCartItems( cart ), isDomainRenewal );
 }
 
 /**
  * Determines whether the supplied cart item is a new domain registration (i.e. not a renewal).
  *
- * @param {import('@automattic/shopping-cart').ResponseCartProduct} cartItem - cart item
+ * @param {CartItemValue} cartItem - cart item as `CartItemValue` object
  * @returns {boolean} true if the cart item is a new domain registration, false otherwise.
  */
 function isNewDomainRegistration( cartItem ) {
@@ -186,7 +271,7 @@ function isNewDomainRegistration( cartItem ) {
 /**
  * Determines whether the supplied cart item is a domain renewal.
  *
- * @param {import('@automattic/shopping-cart').ResponseCartProduct} cartItem - cart item
+ * @param {CartItemValue} cartItem - cart item as `CartItemValue` object
  * @returns {boolean} true if the cart item is a domain renewal, false otherwise.
  */
 function isDomainRenewal( cartItem ) {
@@ -194,7 +279,7 @@ function isDomainRenewal( cartItem ) {
 }
 
 export function hasDomainBeingUsedForPlan( cart ) {
-	return getDomainRegistrations( cart ).some( ( registration ) =>
+	return some( getDomainRegistrations( cart ), ( registration ) =>
 		isDomainBeingUsedForPlan( cart, registration.meta )
 	);
 }
@@ -202,33 +287,31 @@ export function hasDomainBeingUsedForPlan( cart ) {
 /**
  * Determines whether there is at least one renewal item in the specified shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one renewal item, false otherwise
  */
 export function hasRenewalItem( cart ) {
-	return getAllCartItems( cart ).some( isRenewal );
+	return some( getAllCartItems( cart ), isRenewal );
 }
 
 /**
  * Determines whether there is at least one domain transfer item in the specified shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one domain transfer item, false otherwise
  */
 export function hasTransferProduct( cart ) {
-	return getAllCartItems( cart ).some( isDomainTransfer );
+	return some( getAllCartItems( cart ), isDomainTransfer );
 }
 
 /**
  * Retrieves all the domain transfer items in the specified shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct[]} the list of the corresponding items in the shopping cart as `ResponseCartProduct` objects
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {CartItemValue[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
  */
 export function getDomainTransfers( cart ) {
-	return getAllCartItems( cart ).filter(
-		( product ) => product.product_slug === domainProductSlugs.TRANSFER_IN
-	);
+	return filter( getAllCartItems( cart ), { product_slug: domainProductSlugs.TRANSFER_IN } );
 }
 
 /**
@@ -236,7 +319,7 @@ export function getDomainTransfers( cart ) {
  *
  * Ignores partial credits, which aren't really a line item in this sense.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there are only renewal items, false otherwise
  */
 export function hasOnlyRenewalItems( cart ) {
@@ -246,21 +329,21 @@ export function hasOnlyRenewalItems( cart ) {
 /**
  * Determines whether there is at least one concierge session item in the specified shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one concierge session item, false otherwise
  */
 export function hasConciergeSession( cart ) {
-	return getAllCartItems( cart ).some( isConciergeSession );
+	return some( getAllCartItems( cart ), isConciergeSession );
 }
 
 /**
  * Determines whether there is a traffic guide item in the specified shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is a traffic guide item, false otherwise
  */
 export function hasTrafficGuide( cart ) {
-	return getAllCartItems( cart ).some( isTrafficGuide );
+	return some( getAllCartItems( cart ), isTrafficGuide );
 }
 
 /**
@@ -284,13 +367,13 @@ export function getCartItemBillPeriod( cartItem ) {
  * Determines whether any product in the specified shopping cart is a renewable subscription.
  * Will return false if the cart is empty.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if any product in the cart renews
  */
 export function hasRenewableSubscription( cart ) {
 	return (
 		cart.products &&
-		getAllCartItems( cart ).some( ( cartItem ) => getCartItemBillPeriod( cartItem ) > 0 )
+		some( getAllCartItems( cart ), ( cartItem ) => getCartItemBillPeriod( cartItem ) > 0 )
 	);
 }
 
@@ -299,7 +382,7 @@ export function hasRenewableSubscription( cart ) {
  *
  * @param {string} productSlug - the unique string that identifies the product
  * @param {object} [properties] - list of properties
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct | null} the new item
+ * @returns {CartItemValue | null} the new item as `CartItemValue` object
  */
 export function planItem( productSlug, properties ) {
 	// Free plan doesn't have shopping cart.
@@ -307,7 +390,7 @@ export function planItem( productSlug, properties ) {
 		return null;
 	}
 
-	const domainToBundle = properties?.domainToBundle ?? '';
+	const domainToBundle = get( properties, 'domainToBundle', '' );
 
 	return {
 		product_slug: productSlug,
@@ -323,8 +406,8 @@ export function planItem( productSlug, properties ) {
  * @returns {boolean} true if the domainItem supports privacy protection purchase
  */
 export function supportsPrivacyProtectionPurchase( productSlug, productsList ) {
-	const product = productsList.find( ( item ) => item.product_slug === productSlug ) || {};
-	return product?.is_privacy_protection_product_purchase_allowed ?? false;
+	const product = find( productsList, [ 'product_slug', productSlug ] ) || {};
+	return get( product, 'is_privacy_protection_product_purchase_allowed', false );
 }
 
 /**
@@ -333,7 +416,7 @@ export function supportsPrivacyProtectionPurchase( productSlug, productsList ) {
  * @param {string} productSlug - the unique string that identifies the product
  * @param {string} domain - domain name
  * @param {string} source - optional source for the domain item, e.g. `getdotblog`.
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function domainItem( productSlug, domain, source ) {
 	const extra = source ? { extra: { source: source } } : undefined;
@@ -352,7 +435,7 @@ export function domainItem( productSlug, domain, source ) {
  *
  * @param {string} themeSlug - the unique string that identifies the product
  * @param {string} [source] - optional source for the domain item, e.g. `getdotblog`.
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function themeItem( themeSlug, source ) {
 	return {
@@ -368,7 +451,7 @@ export function themeItem( themeSlug, source ) {
  * Creates a new shopping cart item for a domain registration.
  *
  * @param {object} properties - list of properties
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function domainRegistration( properties ) {
 	return {
@@ -382,7 +465,7 @@ export function domainRegistration( properties ) {
  * Creates a new shopping cart item for a domain mapping.
  *
  * @param {object} properties - list of properties
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function domainMapping( properties ) {
 	return domainItem( 'domain_map', properties.domain, properties.source );
@@ -392,7 +475,7 @@ export function domainMapping( properties ) {
  * Creates a new shopping cart item for Site Redirect.
  *
  * @param {object} properties - list of properties
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function siteRedirect( properties ) {
 	return domainItem( 'offsite_redirect', properties.domain, properties.source );
@@ -402,7 +485,7 @@ export function siteRedirect( properties ) {
  * Creates a new shopping cart item for an incoming domain transfer.
  *
  * @param {object} properties - list of properties
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function domainTransfer( properties ) {
 	return {
@@ -414,18 +497,18 @@ export function domainTransfer( properties ) {
 /**
  * Retrieves all the items in the specified shopping cart for G Suite or Google Workspace.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct[]} the list of the corresponding items in the shopping cart as `ResponseCartProduct` objects
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {CartItemValue[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
  */
 export function getGoogleApps( cart ) {
-	return getAllCartItems( cart ).filter( isGSuiteOrExtraLicenseOrGoogleWorkspace );
+	return filter( getAllCartItems( cart ), isGSuiteOrExtraLicenseOrGoogleWorkspace );
 }
 
 /**
  * Creates a new shopping cart item for G Suite or Google Workspace.
  *
  * @param {object} properties - list of properties
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {CartItemValue} the new item
  */
 export function googleApps( properties ) {
 	const { domain, meta, product_slug, quantity, new_quantity, users } = properties;
@@ -463,7 +546,7 @@ export function googleAppsExtraLicenses( properties ) {
  * Creates a new shopping cart item for Titan Mail Monthly.
  *
  * @param {object} properties - list of properties
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function titanMailMonthly( properties ) {
 	return {
@@ -478,11 +561,11 @@ export function titanMailMonthly( properties ) {
 }
 
 export function hasGoogleApps( cart ) {
-	return getAllCartItems( cart ).some( isGSuiteOrExtraLicenseOrGoogleWorkspace );
+	return some( getAllCartItems( cart ), isGSuiteOrExtraLicenseOrGoogleWorkspace );
 }
 
 export function hasTitanMail( cart ) {
-	return getAllCartItems( cart ).some( isTitanMail );
+	return some( getAllCartItems( cart ), isTitanMail );
 }
 
 export function customDesignItem() {
@@ -525,7 +608,7 @@ export function spaceUpgradeItem( slug ) {
  * Creates a new shopping cart item for a jetpack product.
  *
  * @param {string} slug - the slug for the product
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function jetpackProductItem( slug ) {
 	return {
@@ -536,21 +619,21 @@ export function jetpackProductItem( slug ) {
 /**
  * Retrieves all the domain registration items in the specified shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct[]} the list of the corresponding items in the shopping cart as `import('@automattic/shopping-cart').ResponseCartProduct` objects
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {CartItemValue[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
  */
 export function getDomainRegistrations( cart ) {
-	return getAllCartItems( cart ).filter( ( product ) => product.is_domain_registration === true );
+	return filter( getAllCartItems( cart ), { is_domain_registration: true } );
 }
 
 /**
  * Retrieves all the domain mapping items in the specified shopping cart.
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct[]} the list of the corresponding items in the shopping cart as `import('@automattic/shopping-cart').ResponseCartProduct` objects
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {CartItemValue[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
  */
 export function getDomainMappings( cart ) {
-	return getAllCartItems( cart ).filter( ( product ) => product.product_slug === 'domain_map' );
+	return filter( getAllCartItems( cart ), { product_slug: 'domain_map' } );
 }
 
 /**
@@ -558,7 +641,7 @@ export function getDomainMappings( cart ) {
  *
  * @param {string|object} product - the product object
  * @param {object} [properties] - properties to be included in the new CartItem object
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} a CartItem object
+ * @returns {CartItemValue} a CartItem object
  */
 export function getRenewalItemFromProduct( product, properties ) {
 	product = formatProduct( product );
@@ -623,49 +706,43 @@ export function getRenewalItemFromProduct( product, properties ) {
 /**
  * Returns a renewal CartItem object from the given cartItem and properties.
  *
- * @param {import('@automattic/shopping-cart').ResponseCartProduct} cartItem - item
+ * @param {CartItemValue} cartItem - item as `CartItemValue` object
  * @param {object} properties - properties to be included in the new CartItem object
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} a CartItem object
+ * @returns {CartItemValue} a CartItem object
  */
 export function getRenewalItemFromCartItem( cartItem, properties ) {
-	return {
-		...cartItem,
+	return merge( {}, cartItem, {
 		extra: {
-			...cartItem.extra,
 			purchaseId: properties.id,
 			purchaseType: 'renewal',
 		},
-	};
+	} );
 }
 
 export function hasDomainInCart( cart, domain ) {
-	return getAllCartItems( cart ).some( ( product ) => {
-		return product.is_domain_registration === true && product.meta === domain;
-	} );
+	return some( getAllCartItems( cart ), { is_domain_registration: true, meta: domain } );
 }
 
 /**
  * Changes presence of a privacy protection for the given domain cart item.
  *
- * @param {import('@automattic/shopping-cart').ResponseCartProduct} item - the object for domain registrations
+ * @param {CartItemValue} item - the `CartItemValue` object for domain registrations
  * @param {boolean} value - whether privacy is on or off
  *
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new ResponseCartProduct with added/removed privacy
+ * @returns {CartItemValue} the new `CartItemValue` with added/removed privacy
  */
 export function updatePrivacyForDomain( item, value ) {
-	return {
-		...item,
+	return merge( {}, item, {
 		extra: {
-			...item.extra,
 			privacy: value,
 		},
-	};
+	} );
 }
 
 /**
  * Determines whether a cart item is partial credits
  *
- * @param {import('@automattic/shopping-cart').ResponseCartProduct} cartItem - the cart product
+ * @param {CartItemValue} cartItem - `CartItemValue` object
  * @returns {boolean} true if item is credits
  */
 function isPartialCredits( cartItem ) {
@@ -675,7 +752,7 @@ function isPartialCredits( cartItem ) {
 /**
  * Determines whether a cart item is a renewal
  *
- * @param {{extra?: import('@automattic/shopping-cart').ResponseCartProductExtra}} cartItem - object with `extra` property
+ * @param {{extra?: CartItemExtra}} cartItem - object with `CartItemExtra` `extra` property
  * @returns {boolean} true if item is a renewal
  */
 export function isRenewal( cartItem ) {
@@ -704,7 +781,8 @@ export function isNextDomainFree( cart, domain = '' ) {
 }
 
 export function isDomainBundledWithPlan( cart, domain ) {
-	const bundledDomain = cart?.bundledDomain ?? '';
+	const bundledDomain = get( cart, 'bundled_domain', '' );
+
 	return '' !== bundledDomain && ( domain ?? '' ).toLowerCase() === bundledDomain.toLowerCase();
 }
 
@@ -868,11 +946,11 @@ export function getDomainPriceRule(
 /**
  * Determines whether any items in the cart were added more than X time ago (10 minutes)
  *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one cart item added more than X time ago, false otherwise
  */
 export function hasStaleItem( cart ) {
-	return getAllCartItems( cart ).some( function ( cartItem ) {
+	return some( getAllCartItems( cart ), function ( cartItem ) {
 		// time_added_to_cart is in seconds, Date.now() returns milliseconds
 		return (
 			cartItem.time_added_to_cart &&

--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import url from 'url'; // eslint-disable-line no-restricted-imports
 import update, { extend as extendImmutabilityHelper } from 'immutability-helper';
 import { translate } from 'i18n-calypso';
 
@@ -18,6 +19,58 @@ import {
 extendImmutabilityHelper( '$auto', function ( value, object ) {
 	return object ? update( object, value ) : update( {}, value );
 } );
+
+/**
+ * Preprocesses cart for server.
+ *
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart Cart object.
+ * @returns {import('@automattic/shopping-cart').RequestCart} A new cart object.
+ */
+export function preprocessCartForServer( {
+	coupon,
+	is_coupon_applied,
+	is_coupon_removed,
+	currency,
+	temporary,
+	extra,
+	products,
+	tax,
+} ) {
+	const needsUrlCoupon = ! (
+		coupon ||
+		is_coupon_applied ||
+		is_coupon_removed ||
+		typeof document === 'undefined'
+	);
+	const urlCoupon = needsUrlCoupon ? url.parse( document.URL, true ).query.coupon : '';
+
+	return Object.assign(
+		{
+			coupon,
+			is_coupon_applied,
+			is_coupon_removed,
+			currency,
+			tax,
+			temporary,
+			extra,
+			products: products.map(
+				( { product_id, meta, free_trial, volume, quantity, extra: productExtra } ) => ( {
+					product_id,
+					meta,
+					free_trial,
+					volume,
+					quantity,
+					extra: productExtra,
+				} )
+			),
+		},
+		needsUrlCoupon &&
+			urlCoupon && {
+				coupon: urlCoupon,
+				is_coupon_applied: false,
+			}
+	);
+}
 
 export function canRemoveFromCart( cart, cartItem ) {
 	if ( isCredits( cartItem ) ) {

--- a/client/lib/cart-values/test/index.js
+++ b/client/lib/cart-values/test/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import assert from 'assert';
+import { flow } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -23,6 +24,34 @@ describe( 'index', () => {
 			domain: 'testdomain.com',
 		} );
 		PREMIUM_PRODUCT = cartItems.planItem( 'value_bundle', { isFreeTrial: false } );
+	} );
+
+	describe( 'cart change functions', () => {
+		describe( 'flow( changeFunctions... )', () => {
+			test( 'should combine multiple cart operations into a single step', () => {
+				const addTwo = flow(
+					cartItems.addCartItem( PREMIUM_PRODUCT ),
+					cartItems.addCartItem( DOMAIN_REGISTRATION_PRODUCT )
+				);
+
+				const newCart = addTwo( { blog_id: TEST_BLOG_ID, products: [] } );
+				assert( cartItems.hasProduct( newCart, 'value_bundle' ) );
+				assert( cartItems.hasProduct( newCart, 'dotcom_domain' ) );
+			} );
+		} );
+
+		describe( 'cartItems.addCartItem( cartItem )', () => {
+			test( 'should add the cartItem to the products array', () => {
+				const initialCart = { blog_id: TEST_BLOG_ID, products: [] };
+				const newCart = cartItems.addCartItem( PREMIUM_PRODUCT )( initialCart );
+				const expectedCart = {
+					blog_id: TEST_BLOG_ID,
+					products: [ PREMIUM_PRODUCT ],
+				};
+
+				assert.deepEqual( newCart, expectedCart );
+			} );
+		} );
 	} );
 
 	describe( 'cartItems.hasProduct( cart, productSlug )', () => {

--- a/client/lib/cart-values/types.ts
+++ b/client/lib/cart-values/types.ts
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import {
+	ResponseCart,
+	ResponseCartProduct,
+	ResponseCartProductExtra,
+} from '@automattic/shopping-cart';
+
+// These types are deprecated. Please use types from @automattic/shopping-cart directly.
+
+export type CartItemValue = ResponseCartProduct;
+
+export type CartItemExtra = ResponseCartProductExtra;
+
+export type CartValue = ResponseCart;

--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -5,11 +5,11 @@ import emailValidator from 'email-validator';
 import { translate, TranslateResult } from 'i18n-calypso';
 import { countBy, find, includes, groupBy, map, mapValues } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
-import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
  */
+import { CartItemValue } from 'calypso/lib/cart-values/types';
 import { googleApps, googleAppsExtraLicenses } from 'calypso/lib/cart-values/cart-items';
 import {
 	getGSuiteMailboxCount,
@@ -347,7 +347,7 @@ const getItemsForCart = (
 	domains: { name: string },
 	productSlug: string,
 	users: GSuiteNewUser[]
-): MinimalRequestCartProduct => {
+): CartItemValue => {
 	const usersGroupedByDomain: { [ domain: string ]: GSuiteProductUser[] } = mapValues(
 		groupBy( users, 'domain.value' ),
 		( groupedUsers ) => groupedUsers.map( transformUserForCart )

--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -3,6 +3,11 @@
  */
 import { camelCase } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import { sortProducts } from '@automattic/calypso-products';
+
 function createPurchaseObject( purchase ) {
 	const object = {
 		id: Number( purchase.ID ),
@@ -101,5 +106,5 @@ export function createPurchasesArray( dataTransferObject ) {
 		return [];
 	}
 
-	return dataTransferObject.map( createPurchaseObject );
+	return sortProducts( dataTransferObject.map( createPurchaseObject ) );
 }

--- a/client/lib/signup/cart.js
+++ b/client/lib/signup/cart.js
@@ -1,21 +1,28 @@
 /**
+ * External dependencies
+ */
+import { forEach } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import wpcom from 'calypso/lib/wp';
 import productsListFactory from 'calypso/lib/products-list';
 const productsList = productsListFactory();
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
+import { preprocessCartForServer, fillInAllCartItemAttributes } from 'calypso/lib/cart-values';
+import { addCartItem } from 'calypso/lib/cart-values/cart-items';
 
 function addProductsToCart( cart, newCartItems ) {
-	const productsData = productsList.get();
-	const newProducts = newCartItems.map( function ( cartItem ) {
-		cartItem.extra = { ...cartItem.extra, context: 'signup' };
-		return fillInSingleCartItemAttributes( cartItem, productsData );
+	forEach( newCartItems, function ( cartItem ) {
+		cartItem.extra = Object.assign( cartItem.extra || {}, {
+			context: 'signup',
+		} );
+		const addFunction = addCartItem( cartItem );
+
+		cart = fillInAllCartItemAttributes( addFunction( cart ), productsList.get() );
 	} );
-	return {
-		...cart,
-		products: [ ...cart.products, newProducts ],
-	};
+
+	return cart;
 }
 
 export default {
@@ -27,6 +34,7 @@ export default {
 		};
 
 		newCart = addProductsToCart( newCart, newCartItems );
+		newCart = preprocessCartForServer( newCart );
 
 		wpcom.undocumented().setCart( cartKey, newCart, function ( postError ) {
 			callback( postError );
@@ -42,7 +50,8 @@ export default {
 				newCartItems = [ newCartItems ];
 			}
 
-			const newCart = addProductsToCart( data, newCartItems );
+			let newCart = addProductsToCart( data, newCartItems );
+			newCart = preprocessCartForServer( newCart );
 
 			wpcom.undocumented().setCart( cartKey, newCart, callback );
 		} );

--- a/client/my-sites/checkout/cart/cart-items.jsx
+++ b/client/my-sites/checkout/cart/cart-items.jsx
@@ -9,7 +9,7 @@ import React from 'react';
  * Internal dependencies
  */
 import CartItem from './cart-item';
-import { getAllCartItems } from 'calypso/lib/cart-values/cart-items';
+import { getAllCartItems, getAllCartItemsSorted } from 'calypso/lib/cart-values/cart-items';
 import { localize } from 'i18n-calypso';
 
 const COLLAPSED_ITEMS_COUNT = 2;
@@ -66,7 +66,7 @@ export class CartItems extends React.Component {
 			return;
 		}
 
-		let items = getAllCartItems( cart ).map( ( cartItem, index ) => {
+		let items = getAllCartItemsSorted( cart ).map( ( cartItem, index ) => {
 			return (
 				<CartItem
 					cart={ cart }

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -84,3 +84,4 @@ export { isTrafficGuide } from './is-traffic-guide';
 export * from './is-p2-plus';
 export * from './products-list';
 export * from './translations';
+export { default as sortProducts } from './sort';

--- a/packages/calypso-products/src/sort.js
+++ b/packages/calypso-products/src/sort.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+
+import { difference, flatten, groupBy, sortBy } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getDomainProductRanking, isCredits, isDomainProduct, isPlan } from '.';
+
+/**
+ * Sorts all products in the following order:
+ *
+ * 1. Plan
+ * 2. Domain Cart Items. Included in plans come first.
+ *   a. Domain Registration
+ *   b. Domain Mapping
+ *   c. Privacy Protection
+ * 3. Other Cart Items
+ * 4. Credits Cart Item
+ *
+ * @param {object[]} products
+ *
+ * @returns {object[]} the sorted list of items in the shopping cart
+ */
+
+function sortProducts( products ) {
+	let domainItems;
+
+	const planItems = products.filter( isPlan );
+
+	const includedItems = products.filter( isIncludedWithPlan );
+
+	domainItems = difference( products, includedItems );
+	domainItems = domainItems.filter( isDomainProduct );
+	domainItems = Object.entries( groupBy( domainItems, 'meta' ) );
+	domainItems = sortBy( domainItems, function ( pair ) {
+		if ( pair[ 1 ][ 0 ] && pair[ 1 ][ 0 ].cost === 0 ) {
+			return -1;
+		}
+		return pair[ 0 ];
+	} );
+	domainItems = domainItems.map( function ( pair ) {
+		return sortBy( pair[ 1 ], getDomainProductRanking );
+	} );
+	domainItems = flatten( domainItems );
+
+	const creditItems = products.filter( isCredits );
+
+	const otherItems = difference( products, planItems, domainItems, includedItems, creditItems );
+
+	return planItems
+		.concat( includedItems )
+		.concat( domainItems )
+		.concat( otherItems )
+		.concat( creditItems );
+}
+
+function isIncludedWithPlan( purchase ) {
+	return 'included' === purchase.expiryStatus;
+}
+
+export default sortProducts;

--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -203,7 +203,7 @@ function shouldProductReplaceCart(
 		product.extra?.purchaseType === 'renewal' &&
 		product.product_slug !== 'domain_redemption'
 	) {
-		// adding a renewal replaces the cart unless it is a privacy protection (comment copied from original code from old checkout; is domain_redemption really privacy protection?)
+		// adding a renewal replaces the cart unless it is a privacy protection (comment copied from cartItemShouldReplaceCart; is domain_redemption really privacy protection?)
 		return true;
 	}
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#52211 as it seems to be causing problems adding items to the cart in signup.