### PR TITLE
Banner: Don't update colors for default color scheme

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -321,16 +321,21 @@ $font-size: rem( 14px );
 	}
 
 	// client/blocks/upsell-nudge/style.scss
+	&:not( .is-classic-bright ) {
+		.upsell-nudge.banner.card.is-compact {
+			background-color: #fff;
+			color: #000;
+		}
+
+		.upsell-nudge.banner.card.is-compact .banner__info .banner__title {
+			color: #000;
+		}
+	}
+
 	.upsell-nudge.banner.card.is-compact {
-		background-color: #fff;
-		color: #000;
 		padding: 7px 12px 7px 4px;
 		line-height: 26px;
 		margin-top: 8px;
-	}
-
-	.upsell-nudge.banner.card.is-compact .banner__info .banner__title {
-		color: #000;
 	}
 
 	.upsell-nudge.banner.card.is-compact .banner__action {


### PR DESCRIPTION
Keeps the dark background in Classic Bright color scheme. This brings backwards compatibility with the old navigation styles and makes the upsell banner more visible.

#### Changes proposed in this Pull Request

* Limits changing the banner colors to color schemes other than Classic Bright.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to Classic Bright color scheme and make sure Upgrade banners have a dark background
* Switch to any other color scheme and make sure Upgrade banners have a white background.

Before | After
--- | ---
![image (5)](https://user-images.githubusercontent.com/1398304/116316226-77012a80-a766-11eb-83fd-a27cf9290e0d.png) | ![Screen Shot 2021-04-27 at 2 40 50 PM](https://user-images.githubusercontent.com/1398304/116316298-9730e980-a766-11eb-9c7f-13a73addccec.png)

