### PR TITLE
TC: Pin current plugin release build

### DIFF
--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -108,7 +108,7 @@ open class PluginBaseBuild : Template({
 				# 1. Download and unzip current release build.
 				mkdir ./release-archive
 				wget "%teamcity.serverUrl%/repository/download/%system.teamcity.buildType.id%/$releaseTag.tcbuildtag/$pluginSlug.zip?guest=1&branch=trunk" -O ./tmp-release-archive-download.zip
-				unzip ./tmp-release-archive-download.zip -d ./release-archive
+				unzip -q ./tmp-release-archive-download.zip -d ./release-archive
 				echo "Diffing against current trunk release build (`grep build_number ./release-archive/build_meta.txt | sed s/build_number=//`).";
 
 				# 2. Change anything from the release build which is "unstable", like the version number and build metadata.
@@ -160,7 +160,7 @@ open class PluginBaseBuild : Template({
 
 				# 5. Create artifact of cwd.
 				echo
-				zip -r ../../../$pluginSlug.zip .
+				zip -rq ../../../$pluginSlug.zip .
 			"""
 		}
 	}

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -124,21 +124,6 @@ open class PluginBaseBuild : Template({
 					tag_response=`curl -s -X POST -H "Content-Type: text/plain" --data "$releaseTag" $baseBuildRequest/id:%teamcity.build.id%/tags/`
 					echo -e "Build tagging status: ${'$'}tag_response\n"
 
-					# This will be the new trunk build which other builds compare against.
-					# Therefore, we need to pin the build so it isn't deleted.
-					if [ "%teamcity.build.branch.is_default%" == "false" ] ; then
-						# Get the current pinned build before pinning another one.
-						current_pinned_build=${'$'}(curl -s -H "Accept: application/json" $baseBuildRequest/pinned:true,buildType:%system.teamcity.buildType.id% | jq ".id")
-
-						# Pin the current build.
-						pin_response=`curl -s -X PUT $baseBuildRequest/id:%teamcity.build.id%/pin/`
-						echo "Pin build response: ${'$'}pin_response"
-
-						# Delete the previous pinned build.
-						delete_pin_response=`curl -s -X DELETE $baseBuildRequest/id:${'$'}current_pinned_build/pin/`
-						echo "Delete pin response: ${'$'}delete_pin_response"
-					fi
-
 					# Ping commit merger in Slack if we're on the main branch and the build has changed.
 					if [ "%teamcity.build.branch.is_default%" == "true" ] && [ "%with_slack_notify%" == "true" ] ; then
 						echo "Posting slack reminder."

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -121,7 +121,7 @@ open class PluginBaseBuild : Template({
 				# Note: we exclude asset changes because we only really care if the build files (JS/CSS) change. That file is basically just metadata.
 				if ! diff -rq --exclude="*.asset.php" --exclude="cache-buster.txt" --exclude="README.md" $archiveDir ./release-archive/ ; then
 					echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
-					tag_response=`curl -s -X POST -H "Content-Type: text/plain" --data "$releaseTag" $baseBuildRequest/id:%teamcity.build.id%/tags/`
+					tag_response=`curl -X POST -H "Content-Type: text/plain" --data "$releaseTag" $curl_build/id:%teamcity.build.id%/tags/`
 					echo -e "Build tagging status: ${'$'}tag_response\n"
 
 					# Ping commit merger in Slack if we're on the main branch and the build has changed.

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -16,8 +16,6 @@ open class PluginBaseBuild : Template({
 	val archiveDir = "%archive_dir%"
 	val releaseTag = "%release_tag%"
 
-	val baseBuildRequest = "-u '%system.teamcity.auth.userId%:%system.teamcity.auth.password%' %teamcity.serverUrl%/httpAuth/app/rest/builds"
-
 	artifactRules = "$pluginSlug.zip"
 	buildNumberPattern = "%build.prefix%.%build.counter%"
 

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -16,6 +16,8 @@ open class PluginBaseBuild : Template({
 	val archiveDir = "%archive_dir%"
 	val releaseTag = "%release_tag%"
 
+	val baseBuildRequest = "-u '%system.teamcity.auth.userId%:%system.teamcity.auth.password%' %teamcity.serverUrl%/httpAuth/app/rest/builds"
+
 	artifactRules = "$pluginSlug.zip"
 	buildNumberPattern = "%build.prefix%.%build.counter%"
 
@@ -119,8 +121,23 @@ open class PluginBaseBuild : Template({
 				# Note: we exclude asset changes because we only really care if the build files (JS/CSS) change. That file is basically just metadata.
 				if ! diff -rq --exclude="*.asset.php" --exclude="cache-buster.txt" --exclude="README.md" $archiveDir ./release-archive/ ; then
 					echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
-					tag_response=`curl -s -X POST -H "Content-Type: text/plain" --data "$releaseTag" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`
+					tag_response=`curl -s -X POST -H "Content-Type: text/plain" --data "$releaseTag" $baseBuildRequest/id:%teamcity.build.id%/tags/`
 					echo -e "Build tagging status: ${'$'}tag_response\n"
+
+					# This will be the new trunk build which other builds compare against.
+					# Therefore, we need to pin the build so it isn't deleted.
+					if [ "%teamcity.build.branch.is_default%" == "false" ] ; then
+						# Get the current pinned build before pinning another one.
+						current_pinned_build=${'$'}(curl -s -H "Accept: application/json" $baseBuildRequest/pinned:true,buildType:%system.teamcity.buildType.id% | jq ".id")
+
+						# Pin the current build.
+						pin_response=`curl -s -X PUT $baseBuildRequest/id:%teamcity.build.id%/pin/`
+						echo "Pin build response: ${'$'}pin_response"
+
+						# Delete the previous pinned build.
+						delete_pin_response=`curl -s -X DELETE $baseBuildRequest/id:${'$'}current_pinned_build/pin/`
+						echo "Delete pin response: ${'$'}delete_pin_response"
+					fi
 
 					# Ping commit merger in Slack if we're on the main branch and the build has changed.
 					if [ "%teamcity.build.branch.is_default%" == "true" ] && [ "%with_slack_notify%" == "true" ] ; then

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -8,6 +8,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 
 object WPComPlugins : Project({
 	id("WPComPlugins")
@@ -198,6 +199,7 @@ private object PinReleaseBuild : BuildType({
 						echo "The latest release has not changed."
 					fi
 				"""
+			}
 		}
 	}
 })

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -181,17 +181,17 @@ private object PinReleaseBuild : BuildType({
 				name = "Pin $plugin release build"
 				scriptContent = """
 					# Get the currently pinned build.
-					current_pinned_build=${'$'}(curl -s -H "Accept: application/json" $baseBuildRequest/pinned:true,tag:$tag | jq ".id")
+					current_pinned_build=${'$'}(curl ${_self.curl_build}/pinned:true,tag:$tag | jq ".id")
 
 					# Get the current tagged build, regardless of pin status.
-					latest_release_id=${'$'}(curl -s -H "Accept: application/json" $baseBuildRequest/tag:$tag | jq ".id")
+					latest_release_id=${'$'}(curl ${_self.curl_build}/tag:$tag | jq ".id")
 
 					if [ "${'$'}current_pinned_build" != "${'$'}latest_release_id" ] ; then
 						# Pin the current build.
-						curl -s -X PUT $baseBuildRequest/id:${'$'}latest_release_id/pin/
+						curl -X PUT ${_self.curl_build}/id:${'$'}latest_release_id/pin/
 
 						# Delete the previous pinned build.
-						curl -s -X DELETE $baseBuildRequest/id:${'$'}current_pinned_build/pin/
+						curl -X DELETE ${_self.curl_build}/id:${'$'}current_pinned_build/pin/
 
 						echo "Successfully updated the pinned build to the latest release."
 					else

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -28,6 +28,7 @@ object WPComPlugins : Project({
 	buildType(Notifications)
 	buildType(O2Blocks)
 	buildType(Gutenberg)
+	buildType(PinReleaseBuild)
 
 	// For some reason, TeamCity needs this to reference the Template.
 	template(PluginBaseBuild())

--- a/.teamcity/_self/yarnInstall.kt
+++ b/.teamcity/_self/yarnInstall.kt
@@ -15,3 +15,8 @@ val yarn_install_cmd = """
 	# Install modules.
 	yarn install
 """.trimIndent()
+
+/**
+ * Used for curl. Example: `curl -X DELETE $baseBuildRequest/build:12345/pin`
+ */
+val curl_build = "-s -H 'Accept: application/json' -u '%system.teamcity.auth.userId%:%system.teamcity.auth.password%' %teamcity.serverUrl%/httpAuth/app/rest/builds"

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -240,7 +240,7 @@ function load_wpcom_block_editor_nux() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_nux' );
 
 /**
- * Load editing toolkit block patterns from the API
+ * Load editing toolkit block patterns from the API.
  *
  * @param obj $current_screen The current screen object.
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request
TeamCity automatically cleans up old builds. If a plugin does not introduce changes frequently, its "current release build" will become stale and get deleted. As a result, new builds will fail because they cannot compare against the current release to see if they have changed anything.

To fix this, we will pin the current trunk release build. This prevents the build from becoming stale. We delete the current pinned build after adding the new pinned build to keep things cleaned up.

Since you cannot pin a build while it's still running, I've added a new build which runs on a schedule. It'll basically keep the pinned build for each wpcom plugin up-to-date once a day. That way, older builds should never get stale.

#### Testing instructions
The branch will attempt to run the logic on the non-trunk branch to test it out.
