### PR TITLE
Add zip and jq to base Docker image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -52,7 +52,7 @@ ENV PLAYWRIGHT_SKIP_DOWNLOAD=true
 
 # Add user calypso with uid 1003, give it sudo permissions
 RUN apt-get update \
-	&& apt-get install -y sudo \
+	&& apt-get install -y sudo zip jq \
 	&& adduser --uid $UID --disabled-password $user \
 	&& echo "$user ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$user \
 	&& chmod 0440 /etc/sudoers.d/$user \
@@ -142,7 +142,7 @@ COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 COPY --from=cache --chown=$UID /calypso/composer.* /calypso/
 
 RUN apt update &&\
-	apt-get install -y apt-transport-https zip &&\
+	apt-get install -y apt-transport-https &&\
 	wget https://packages.sury.org/php/apt.gpg -O /etc/apt/trusted.gpg.d/php-sury.gpg &&\
 	echo "deb https://packages.sury.org/php/ buster main" > /etc/apt/sources.list.d/php-sury.list &&\
 	apt update &&\


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This installs `jq` and `zip` in the base docker image so they are available across all our CI. They're pretty common tools, so I think they'd be useful to have in all images instead of just the wpcom one.

This is motivated by #52359, which needs `jq` to parse JSON from a TeamCity API response.

#### Testing instructions
- [x] Build a test image from this branch
- [x] Use test image in #52359 to make sure tools work

