### PR TITLE
State: persist selected site ID across reloads

### DIFF
--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -8,7 +8,7 @@ import {
 	PREVIEW_IS_SHOWING,
 	NOTIFICATIONS_PANEL_TOGGLE,
 } from 'calypso/state/action-types';
-import { combineReducers, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import actionLog from './action-log/reducer';
 import checkout from './checkout/reducer';
 import language from './language/reducer';
@@ -26,23 +26,29 @@ import section from './section/reducer';
  * @param  {object} action Action payload
  * @returns {object}        Updated state
  */
-export function selectedSiteId( state = null, action ) {
-	switch ( action.type ) {
-		case SELECTED_SITE_SET:
-			return action.siteId || null;
+export const selectedSiteId = withSchemaValidation(
+	{ type: [ 'number', 'null' ] },
+	( state = null, action ) => {
+		switch ( action.type ) {
+			case SELECTED_SITE_SET:
+				return action.siteId || null;
+		}
+
+		return state;
 	}
+);
 
-	return state;
-}
+export const siteSelectionInitialized = withSchemaValidation(
+	{ type: 'boolean' },
+	( state = false, action ) => {
+		switch ( action.type ) {
+			case SELECTED_SITE_SET:
+				return true;
+		}
 
-export const siteSelectionInitialized = withoutPersistence( ( state = false, action ) => {
-	switch ( action.type ) {
-		case SELECTED_SITE_SET:
-			return true;
+		return state;
 	}
-
-	return state;
-} );
+);
 
 export function isSectionLoading( state = false, action ) {
 	switch ( action.type ) {
@@ -52,7 +58,7 @@ export function isSectionLoading( state = false, action ) {
 	return state;
 }
 
-export const isPreviewShowing = withoutPersistence( ( state = false, action ) => {
+export function isPreviewShowing( state = false, action ) {
 	switch ( action.type ) {
 		case PREVIEW_IS_SHOWING: {
 			const { isShowing } = action;
@@ -61,7 +67,7 @@ export const isPreviewShowing = withoutPersistence( ( state = false, action ) =>
 	}
 
 	return state;
-} );
+}
 
 /**
  * Tracks if the notifications panel is open
@@ -71,12 +77,12 @@ export const isPreviewShowing = withoutPersistence( ( state = false, action ) =>
  * @param   {string} action.type The action type identifier. In this case it's looking for NOTIFICATIONS_PANEL_TOGGLE
  * @returns {object}             Updated state
  */
-export const isNotificationsOpen = function ( state = false, { type } ) {
+export function isNotificationsOpen( state = false, { type } ) {
 	if ( type === NOTIFICATIONS_PANEL_TOGGLE ) {
 		return ! state;
 	}
 	return state;
-};
+}
 
 const reducer = combineReducers( {
 	actionLog,


### PR DESCRIPTION
Persists the `state.ui.selectedSiteId` info to local storage so that it's recovered on full page reload.

Should fix the navigation issues reported in #52306, namely this flow:
1. go to Home of a non-default site
2. click the avatar in Masterbar and navigate to `/me`
3. fully reload the page
4. click My Sites

Clicking My Sites should navigate back to the non-default site selected in step 1. And it should work equally well when navigating from Calypso to wp-admin and back.