### PR TITLE
chore(eslint): Add rule `import/named` and fix violations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -154,6 +154,9 @@ module.exports = {
 					'@typescript-eslint/no-var-requires': 'off',
 					// REST API objects include underscores
 					'@typescript-eslint/camelcase': 'off',
+
+					// TypeScript compiler already takes care of these errors
+					'import/named': 'off',
 				},
 			}
 		),
@@ -375,6 +378,7 @@ module.exports = {
 
 		// Force packages to declare their dependencies
 		'import/no-extraneous-dependencies': 'error',
+		'import/named': 'error',
 
 		'wpcalypso/no-unsafe-wp-apis': [
 			'error',

--- a/client/components/data/query-user-settings/README.md
+++ b/client/components/data/query-user-settings/README.md
@@ -10,7 +10,7 @@ Render the component. It does not accept any children, nor does it render any el
 import React from 'react';
 import { useSelector } from 'react-redux';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
-import { getUserSettings } from 'calypso/state/selectors/get-user-settings';
+import { default as getUserSettings } from 'calypso/state/selectors/get-user-settings';
 
 export default function CurrentUser() {
 	const userSettings = useSelector( ( state ) => getUserSettings( state ) );

--- a/client/components/site-offset/README.md
+++ b/client/components/site-offset/README.md
@@ -39,7 +39,7 @@ in `withApplySiteOffset`. It's just a different implementation of the same conce
 
 ```jsx
 import React from 'react';
-import { useApplySiteOffset } from 'calypso/components/localized-moment';
+import { useApplySiteOffset } from 'calypso/components/site-offset';
 
 export default function Label( { date } ) {
 	const applySiteOffset = useApplySiteOffset();

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -47,3 +47,11 @@ const ProviderWrappedLoggedOutLayout = ( {
  * `context.primary` and `context.secondary` to populate it.
  */
 export const makeLayout = makeLayoutMiddleware( ProviderWrappedLoggedOutLayout );
+
+/**
+ * These functions are not used by Node. It is here to provide an APi compatible with `./index.web.js`
+ */
+export const redirectLoggedOut = () => {};
+export const render = () => {};
+export const ProviderWrappedLayout = () => null;
+export const notFound = () => null;

--- a/client/lib/abtest/test/index.js
+++ b/client/lib/abtest/test/index.js
@@ -11,7 +11,7 @@ import { get as getStoreStub, set as setSpy } from 'store';
  * Internal dependencies
  */
 import { abtest } from 'calypso/lib/abtest';
-import { getUserStub } from 'calypso/lib/user';
+import user from 'calypso/lib/user';
 
 const NODE_ENV = process.env.NODE_ENV;
 beforeAll( () => {
@@ -81,12 +81,12 @@ jest.mock( 'calypso/lib/abtest/active-tests', () => ( {
 jest.mock( 'calypso/lib/user', () => {
 	const getStub = jest.fn();
 
-	const user = () => ( {
+	const userInstance = () => ( {
 		get: getStub,
 	} );
-	user.getUserStub = getStub;
+	userInstance.getUserStub = getStub;
 
-	return user;
+	return userInstance;
 } );
 jest.mock( 'store', () => ( {
 	enabled: () => true,
@@ -107,7 +107,7 @@ describe( 'abtest', () => {
 		} );
 
 		test( 'should return stored value and skip store.set for existing users', () => {
-			getUserStub.mockReturnValueOnce( {
+			user.getUserStub.mockReturnValueOnce( {
 				localeSlug: 'en',
 				date: DATE_BEFORE,
 			} );
@@ -120,7 +120,7 @@ describe( 'abtest', () => {
 		} );
 
 		test( 'should return stored value and skip store.set for any user, including new, non-English users', () => {
-			getUserStub.mockReturnValueOnce( {
+			user.getUserStub.mockReturnValueOnce( {
 				localeSlug: 'de',
 				date: DATE_AFTER,
 			} );
@@ -129,7 +129,7 @@ describe( 'abtest', () => {
 		} );
 
 		test( 'should return stored value and skip store.set for a logged-out user', () => {
-			getUserStub.mockReturnValueOnce( null );
+			user.getUserStub.mockReturnValueOnce( null );
 			expect( abtest( 'mockedTest' ) ).toBe( 'show' );
 			expect( setSpy ).not.toHaveBeenCalled();
 		} );
@@ -142,7 +142,7 @@ describe( 'abtest', () => {
 
 		describe( 'existing users', () => {
 			beforeEach( () => {
-				getUserStub.mockReturnValue( {
+				user.getUserStub.mockReturnValue( {
 					localeSlug: 'en',
 					date: DATE_BEFORE,
 				} );
@@ -160,7 +160,7 @@ describe( 'abtest', () => {
 		describe( 'new users', () => {
 			describe( 'English only users allowed (default)', () => {
 				test( 'should call store.set for new users with English settings', () => {
-					getUserStub.mockReturnValue( {
+					user.getUserStub.mockReturnValue( {
 						localeSlug: 'en',
 						date: DATE_AFTER,
 					} );
@@ -168,7 +168,7 @@ describe( 'abtest', () => {
 					expect( setSpy ).toHaveBeenCalledTimes( 1 );
 				} );
 				test( 'should call store.set for new users with English-Canada settings', () => {
-					getUserStub.mockReturnValue( {
+					user.getUserStub.mockReturnValue( {
 						localeSlug: 'en-ca',
 						date: DATE_AFTER,
 					} );
@@ -176,7 +176,7 @@ describe( 'abtest', () => {
 					expect( setSpy ).toHaveBeenCalledTimes( 1 );
 				} );
 				test( 'should return default and skip store.set for new users with non-English settings', () => {
-					getUserStub.mockReturnValue( {
+					user.getUserStub.mockReturnValue( {
 						localeSlug: 'de',
 						date: DATE_AFTER,
 					} );
@@ -187,7 +187,7 @@ describe( 'abtest', () => {
 
 			describe( 'all locales allowed', () => {
 				test( 'should call store.set for new users with English settings', () => {
-					getUserStub.mockReturnValue( {
+					user.getUserStub.mockReturnValue( {
 						localeSlug: 'en',
 						date: DATE_AFTER,
 					} );
@@ -195,7 +195,7 @@ describe( 'abtest', () => {
 					expect( setSpy ).toHaveBeenCalledTimes( 1 );
 				} );
 				test( 'should call store.set for new users with non-English settings', () => {
-					getUserStub.mockReturnValue( {
+					user.getUserStub.mockReturnValue( {
 						localeSlug: 'de',
 						date: DATE_AFTER,
 					} );
@@ -206,7 +206,7 @@ describe( 'abtest', () => {
 
 			describe( 'specific locales only', () => {
 				test( 'should return default and skip store.set for new users with English settings', () => {
-					getUserStub.mockReturnValue( {
+					user.getUserStub.mockReturnValue( {
 						localeSlug: 'en',
 						date: DATE_AFTER,
 					} );
@@ -214,7 +214,7 @@ describe( 'abtest', () => {
 					expect( setSpy ).not.toHaveBeenCalled();
 				} );
 				test( 'should call store.set for new users with non-English settings', () => {
-					getUserStub.mockReturnValue( {
+					user.getUserStub.mockReturnValue( {
 						localeSlug: 'de',
 						date: DATE_AFTER,
 					} );
@@ -225,7 +225,7 @@ describe( 'abtest', () => {
 
 			describe( 'fr locale only', () => {
 				test( 'should return default and skip store.set for new users with non-french settings', () => {
-					getUserStub.mockReturnValue( {
+					user.getUserStub.mockReturnValue( {
 						localeSlug: 'de',
 						date: DATE_AFTER,
 					} );
@@ -233,7 +233,7 @@ describe( 'abtest', () => {
 					expect( setSpy ).not.toHaveBeenCalled();
 				} );
 				test( 'should call store.set for new users with fr settings', () => {
-					getUserStub.mockReturnValue( {
+					user.getUserStub.mockReturnValue( {
 						localeSlug: 'fr',
 						date: DATE_AFTER,
 					} );
@@ -244,7 +244,7 @@ describe( 'abtest', () => {
 
 			describe( 'IL/IN countryCodeTargets only', () => {
 				beforeEach( () => {
-					getUserStub.mockReturnValue( {
+					user.getUserStub.mockReturnValue( {
 						localeSlug: 'en',
 						date: DATE_AFTER,
 					} );
@@ -279,7 +279,7 @@ describe( 'abtest', () => {
 
 		describe( 'new-user-no-locale', () => {
 			beforeEach( () => {
-				getUserStub.mockReturnValue( {
+				user.getUserStub.mockReturnValue( {
 					localeSlug: false,
 					date: DATE_AFTER,
 				} );
@@ -297,7 +297,7 @@ describe( 'abtest', () => {
 
 		describe( 'logged-out users', () => {
 			beforeEach( () => {
-				getUserStub.mockReturnValue( false );
+				user.getUserStub.mockReturnValue( false );
 			} );
 			test( 'should call store.set for logged-out users with English locale', () => {
 				global.navigator.__defineGetter__( 'language', () => 'en' );

--- a/client/lib/feature-detection/README.md
+++ b/client/lib/feature-detection/README.md
@@ -5,6 +5,7 @@
 ## Usage
 
 ```javascript
+// eslint-disable-next-line import/named
 import { supportsFeatureToDetect } from 'calypso/lib/feature-detection';
 
 if ( supportsFeatureToDetect() ) {

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -15,19 +15,19 @@ import {
 import { useNock } from 'calypso/test-helpers/use-nock';
 import flows from 'calypso/signup/config/flows';
 import { isDomainStepSkippable } from 'calypso/signup/config/steps';
-import { getUserStub } from 'calypso/lib/user';
+import user from 'calypso/lib/user';
 
 jest.mock( 'calypso/lib/abtest', () => ( { abtest: () => '' } ) );
 
 jest.mock( 'calypso/lib/user', () => {
 	const getStub = jest.fn();
 
-	const user = () => ( {
+	const userInstance = () => ( {
 		get: getStub,
 	} );
-	user.getUserStub = getStub;
+	userInstance.getUserStub = getStub;
 
-	return user;
+	return userInstance;
 } );
 
 jest.mock( 'calypso/signup/config/steps', () => require( './mocks/signup/config/steps' ) );
@@ -55,7 +55,7 @@ describe( 'createSiteWithCart()', () => {
 
 	beforeEach( () => {
 		isDomainStepSkippable.mockReset();
-		getUserStub.mockReset();
+		user.getUserStub.mockReset();
 	} );
 
 	test( 'should use the vertical field in the survey tree if the site topic one is empty.', () => {
@@ -148,7 +148,7 @@ describe( 'createSiteWithCart()', () => {
 
 	test( 'use username for blog_name if user data available', () => {
 		isDomainStepSkippable.mockReturnValue( true );
-		getUserStub.mockReturnValue( { username: 'alex' } );
+		user.getUserStub.mockReturnValue( { username: 'alex' } );
 
 		const fakeStore = {
 			getState: () => ( {} ),

--- a/client/state/analytics/test/middleware.js
+++ b/client/state/analytics/test/middleware.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import {
@@ -19,67 +14,46 @@ import {
 	loadTrackingTool,
 } from '../actions';
 import { analyticsMiddleware } from '../middleware.js';
-import { spy as mockAdTracking } from 'calypso/lib/analytics/ad-tracking';
-import { spy as mockMC } from 'calypso/lib/analytics/mc';
-import { spy as mockGA } from 'calypso/lib/analytics/ga';
-import { spy as mockPageView } from 'calypso/lib/analytics/page-view';
-import { spy as mockTracks } from 'calypso/lib/analytics/tracks';
+import {
+	trackCustomFacebookConversionEvent,
+	trackCustomAdWordsRemarketingEvent,
+} from 'calypso/lib/analytics/ad-tracking';
+import { bumpStat as mcBumpStat } from 'calypso/lib/analytics/mc';
+import { gaRecordPageView, gaRecordEvent } from 'calypso/lib/analytics/ga';
+import { recordPageView as pageviewRecordPageView } from 'calypso/lib/analytics/page-view';
+import {
+	setTracksOptOut as tracksSetTracksOptOut,
+	recordTracksEvent as tracksRecordTracksEvent,
+} from 'calypso/lib/analytics/tracks';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 
 const noop = () => {};
 
-jest.mock( 'calypso/lib/analytics/page-view', () => {
-	const pageViewSpy = require( 'sinon' ).spy();
-	const { pageViewMock } = require( './helpers/analytics-mock' );
+jest.mock( 'calypso/lib/analytics/page-view', () => ( {
+	recordPageView: jest.fn(),
+} ) );
 
-	const mock = pageViewMock( pageViewSpy );
-	mock.spy = pageViewSpy;
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	setTracksOptOut: jest.fn(),
+	recordTracksEvent: jest.fn(),
+} ) );
 
-	return mock;
-} );
+jest.mock( 'calypso/lib/analytics/ad-tracking', () => ( {
+	trackCustomFacebookConversionEvent: jest.fn(),
+	trackCustomAdWordsRemarketingEvent: jest.fn(),
+} ) );
 
-jest.mock( 'calypso/lib/analytics/tracks', () => {
-	const tracksSpy = require( 'sinon' ).spy();
-	const { tracksMock } = require( './helpers/analytics-mock' );
+jest.mock( 'calypso/lib/analytics/mc', () => ( {
+	bumpStat: jest.fn(),
+} ) );
 
-	const mock = tracksMock( tracksSpy );
-	mock.spy = tracksSpy;
-
-	return mock;
-} );
-
-jest.mock( 'calypso/lib/analytics/ad-tracking', () => {
-	const adTrackingSpy = require( 'sinon' ).spy();
-	const { adTrackingMock } = require( './helpers/analytics-mock' );
-
-	const mock = adTrackingMock( adTrackingSpy );
-	mock.spy = adTrackingSpy;
-
-	return mock;
-} );
-
-jest.mock( 'calypso/lib/analytics/mc', () => {
-	const mcSpy = require( 'sinon' ).spy();
-	const { mcMock } = require( './helpers/analytics-mock' );
-
-	const mock = mcMock( mcSpy );
-	mock.spy = mcSpy;
-
-	return mock;
-} );
-
-jest.mock( 'calypso/lib/analytics/ga', () => {
-	const gaSpy = require( 'sinon' ).spy();
-	const { gaMock } = require( './helpers/analytics-mock' );
-
-	const mock = gaMock( gaSpy );
-	mock.spy = gaSpy;
-
-	return mock;
-} );
+jest.mock( 'calypso/lib/analytics/ga', () => ( {
+	gaRecordPageView: jest.fn(),
+	gaRecordEvent: jest.fn(),
+} ) );
 
 jest.mock( 'calypso/lib/analytics/hotjar', () => ( {
-	addHotJarScript: require( 'sinon' ).spy(),
+	addHotJarScript: jest.fn(),
 } ) );
 
 const dispatch = analyticsMiddleware()( noop );
@@ -87,21 +61,19 @@ const dispatch = analyticsMiddleware()( noop );
 describe( 'middleware', () => {
 	describe( 'analytics dispatching', () => {
 		beforeEach( () => {
-			mockPageView.resetHistory();
-			mockTracks.resetHistory();
-			mockAdTracking.resetHistory();
+			jest.resetAllMocks();
 		} );
 
 		test( 'should call mc.bumpStat', () => {
 			dispatch( bumpStat( 'test', 'value' ) );
 
-			expect( mockMC ).to.have.been.calledWithExactly( 'bumpStat', 'test', 'value' );
+			expect( mcBumpStat ).toHaveBeenCalledWith( 'test', 'value' );
 		} );
 
 		test( 'should call tracks.recordEvent', () => {
 			dispatch( recordTracksEvent( 'test', { name: 'value' } ) );
 
-			expect( mockTracks ).to.have.been.calledWithExactly( 'recordTracksEvent', 'test', {
+			expect( tracksRecordTracksEvent ).toHaveBeenCalledWith( 'test', {
 				name: 'value',
 			} );
 		} );
@@ -109,7 +81,7 @@ describe( 'middleware', () => {
 		test( 'should call pageView.record', () => {
 			dispatch( recordPageView( 'path', 'title', 'default', { name: 'value' } ) );
 
-			expect( mockPageView ).to.have.been.calledWithExactly( 'recordPageView', 'path', 'title', {
+			expect( pageviewRecordPageView ).toHaveBeenCalledWith( 'path', 'title', {
 				name: 'value',
 			} );
 		} );
@@ -117,55 +89,44 @@ describe( 'middleware', () => {
 		test( 'should call gaRecordEvent', () => {
 			dispatch( recordGoogleEvent( 'category', 'action', 'label', 'value' ) );
 
-			expect( mockGA ).to.have.been.calledWithExactly(
-				'gaRecordEvent',
-				'category',
-				'action',
-				'label',
-				'value'
-			);
+			expect( gaRecordEvent ).toHaveBeenCalledWith( 'category', 'action', 'label', 'value' );
 		} );
 
 		test( 'should call ga.recordPageView', () => {
 			dispatch( recordGooglePageView( 'path', 'title' ) );
 
-			expect( mockGA ).to.have.been.calledWithExactly( 'gaRecordPageView', 'path', 'title' );
+			expect( gaRecordPageView ).toHaveBeenCalledWith( 'path', 'title' );
 		} );
 
 		test( 'should call trackCustomFacebookConversionEvent', () => {
 			dispatch( recordCustomFacebookConversionEvent( 'event', { name: 'value' } ) );
 
-			expect( mockAdTracking ).to.have.been.calledWithExactly(
-				'trackCustomFacebookConversionEvent',
-				'event',
-				{ name: 'value' }
-			);
+			expect( trackCustomFacebookConversionEvent ).toHaveBeenCalledWith( 'event', {
+				name: 'value',
+			} );
 		} );
 
 		test( 'should call trackCustomAdWordsRemarketingEvent', () => {
 			dispatch( recordCustomAdWordsRemarketingEvent( { name: 'value' } ) );
 
-			expect( mockAdTracking ).to.have.been.calledWithExactly(
-				'trackCustomAdWordsRemarketingEvent',
-				{ name: 'value' }
-			);
+			expect( trackCustomAdWordsRemarketingEvent ).toHaveBeenCalledWith( { name: 'value' } );
 		} );
 
 		test( 'should call analytics events with wrapped actions', () => {
 			dispatch( withAnalytics( bumpStat( 'name', 'value' ), { type: 'TEST_ACTION' } ) );
 
-			expect( mockMC ).to.have.been.calledWithExactly( 'bumpStat', 'name', 'value' );
+			expect( mcBumpStat ).toHaveBeenCalledWith( 'name', 'value' );
 		} );
 
 		test( 'should call `setOptOut`', () => {
 			dispatch( setTracksOptOut( false ) );
 
-			expect( mockTracks ).to.have.been.calledWithExactly( 'setTracksOptOut', false );
+			expect( tracksSetTracksOptOut ).toHaveBeenCalledWith( false );
 		} );
 
 		test( 'should call hotjar.addHotJarScript', () => {
 			dispatch( loadTrackingTool( 'HotJar' ) );
-			expect( addHotJarScript ).to.have.been.calledOnce;
+			expect( addHotJarScript ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/lists/tags/new/index.js
+++ b/client/state/data-layer/wpcom/read/lists/tags/new/index.js
@@ -10,7 +10,7 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { READER_LIST_ITEM_ADD_TAG } from 'calypso/state/reader/action-types';
-import { receiveReaderListAddTag } from 'calypso/state/reader/lists/actions';
+import { receiveAddReaderListTag } from 'calypso/state/reader/lists/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { DEFAULT_NOTICE_DURATION } from 'calypso/state/notices/constants';
 
@@ -31,7 +31,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/tags/new/index.js', {
 				),
 			onSuccess: ( action, apiResponse ) => {
 				return [
-					receiveReaderListAddTag(
+					receiveAddReaderListTag(
 						action.listOwner,
 						action.listSlug,
 						action.tagSlug,

--- a/client/state/editor/test/actions.js
+++ b/client/state/editor/test/actions.js
@@ -1,21 +1,21 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { forEach } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { MODAL_VIEW_STAT_MAPPING, setEditorMediaModalView } from '../actions';
+import { MODAL_VIEW_STATS, setEditorMediaModalView } from '../actions';
 import { ANALYTICS_STAT_BUMP } from 'calypso/state/action-types';
 import { setMediaModalView } from 'calypso/state/ui/media-modal/actions';
 
 describe( 'actions', () => {
 	describe( 'setEditorMediaModalView()', () => {
 		test( 'should dispatch setMediaModalView with analytics', () => {
-			forEach( MODAL_VIEW_STAT_MAPPING, ( stat, view ) => {
-				expect( setEditorMediaModalView( view ) ).to.eql( {
+			expect.assertions( Object.entries( MODAL_VIEW_STATS ).length );
+			forEach( MODAL_VIEW_STATS, ( stat, view ) => {
+				expect( setEditorMediaModalView( view ) ).toEqual( {
 					...setMediaModalView( view ),
 					meta: {
 						analytics: [

--- a/client/state/preferences/test/actions.js
+++ b/client/state/preferences/test/actions.js
@@ -8,7 +8,7 @@ import sinon from 'sinon';
  * Internal dependencies
  */
 import { receivePreferences, fetchPreferences, savePreference, setPreference } from '../actions';
-import { DEFAULT_PREFERENCES, USER_SETTING_KEY } from '../constants';
+import { DEFAULT_PREFERENCE_VALUES, USER_SETTING_KEY } from '../constants';
 import {
 	PREFERENCES_RECEIVE,
 	PREFERENCES_FETCH,
@@ -31,7 +31,7 @@ describe( 'actions', () => {
 		spy = sandbox.spy();
 	} );
 	const responseShape = {
-		[ USER_SETTING_KEY ]: DEFAULT_PREFERENCES,
+		[ USER_SETTING_KEY ]: DEFAULT_PREFERENCE_VALUES,
 	};
 
 	describe( 'receivePreferences()', () => {
@@ -62,11 +62,19 @@ describe( 'actions', () => {
 			} );
 		} );
 
+		test( 'should dispatch PREFERENCES_RECEIVE when request completes', () => {
+			return fetchPreferences()( spy ).then( () => {
+				expect( spy ).to.have.been.calledWithMatch( {
+					type: PREFERENCES_RECEIVE,
+					values: responseShape[ USER_SETTING_KEY ],
+				} );
+			} );
+		} );
+
 		test( 'should dispatch success action when request completes', () => {
 			return fetchPreferences()( spy ).then( () => {
 				expect( spy ).to.have.been.calledWithMatch( {
 					type: PREFERENCES_FETCH_SUCCESS,
-					values: responseShape[ USER_SETTING_KEY ],
 				} );
 			} );
 		} );

--- a/packages/webpack-config-flag-plugin/test/__snapshots__/index.js.snap
+++ b/packages/webpack-config-flag-plugin/test/__snapshots__/index.js.snap
@@ -188,6 +188,7 @@ if ( true ) {
 }
 
 ;// CONCATENATED MODULE: ./named-import/config/wrong-path.js
+// eslint-disable-next-line import/named
 
 
 // Should NOT be replaced with true

--- a/packages/webpack-config-flag-plugin/test/fixtures/named-import/config/wrong-path.js
+++ b/packages/webpack-config-flag-plugin/test/fixtures/named-import/config/wrong-path.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/named
 import { isEnabled } from '../config';
 
 // Should NOT be replaced with true


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enables eslint rule [`import/named`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md).
* Adds an exception for TypeScript, as the compiler already checks named imports
* Fix existing violations of this rule (see comments on individual files for more detais) 

#### Testing instructions

* Verify tests still pass.