### PR TITLE
Update to chrome v90 for e2e tests (WebApp.kt)

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -59,7 +59,7 @@ object RunCalypsoE2eDesktopTests : BuildType({
 				sudo apt-get install -y ./google-chrome-stable_90.0.4430.93-1_amd64.deb
 				rm ./google-chrome-stable_90.0.4430.93-1_amd64.deb
 				cd test/e2e
-				google-chrome --version > .chromedriver_version
+				google-chrome --version | cut -d' ' -f3 > .chromedriver_version
       			echo -n "Google Chrome version: " && cat .chromedriver_version
 				npm install chromedriver --chromedriver-force-download --detect_chromedriver_version
 				cd ../..

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -217,10 +217,9 @@ object RunCalypsoE2eMobileTests : BuildType({
 		bashNodeScript {
 			name = "Update Chrome"
 			scriptContent = """
-				export CHROME_VERSION="90.0.4430.93-1"
-				wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb
-				apt-get install -y ./google-chrome-stable_${CHROME_VERSION}_amd64.deb
-				rm ./google-chrome-stable_${CHROME_VERSION}_amd64.deb
+				wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_90.0.4430.93-1_amd64.deb
+				apt-get install -y ./google-chrome-stable_90.0.4430.93-1_amd64.deb
+				rm ./google-chrome-stable_90.0.4430.93-1_amd64.deb
 				cd test/e2e
 				npm install chromedriver --chromedriver-force-download --detect_chromedriver_version
 				cd ../..

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -215,6 +215,19 @@ object RunCalypsoE2eMobileTests : BuildType({
 			dockerImage = "%docker_image_e2e%"
 		}
 		bashNodeScript {
+			name = "Update Chrome"
+			scriptContent = """
+				export CHROME_VERSION="90.0.4430.93-1"
+				wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb
+				apt-get install -y ./google-chrome-stable_${CHROME_VERSION}_amd64.deb
+				rm ./google-chrome-stable_${CHROME_VERSION}_amd64.deb
+				cd test/e2e
+				npm install chromedriver --chromedriver-force-download --detect_chromedriver_version
+				cd ../..
+			"""
+			dockerImage = "%docker_image_e2e%"
+		}
+		bashNodeScript {
 			name = "Run e2e tests (mobile)"
 			scriptContent = """
 				shopt -s globstar

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -215,22 +215,19 @@ object RunCalypsoE2eMobileTests : BuildType({
 			dockerImage = "%docker_image_e2e%"
 		}
 		bashNodeScript {
-			name = "Update Chrome"
+			name = "Run e2e tests (mobile)"
 			scriptContent = """
+				shopt -s globstar
+				set -x
+
+				# Chrome upgrade start
 				wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_90.0.4430.93-1_amd64.deb
 				apt-get install -y ./google-chrome-stable_90.0.4430.93-1_amd64.deb
 				rm ./google-chrome-stable_90.0.4430.93-1_amd64.deb
 				cd test/e2e
 				npm install chromedriver --chromedriver-force-download --detect_chromedriver_version
 				cd ../..
-			"""
-			dockerImage = "%docker_image_e2e%"
-		}
-		bashNodeScript {
-			name = "Run e2e tests (mobile)"
-			scriptContent = """
-				shopt -s globstar
-				set -x
+				# Chrome upgrade end
 
 				cd test/e2e
 				mkdir temp

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -58,9 +58,9 @@ object RunCalypsoE2eDesktopTests : BuildType({
 				wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_90.0.4430.93-1_amd64.deb
 				sudo apt-get install -y ./google-chrome-stable_90.0.4430.93-1_amd64.deb
 				rm ./google-chrome-stable_90.0.4430.93-1_amd64.deb
+				cd test/e2e
 				google-chrome --version > .chromedriver_version
       			echo -n "Google Chrome version: " && cat .chromedriver_version
-				cd test/e2e
 				npm install chromedriver --chromedriver-force-download --detect_chromedriver_version
 				cd ../..
 				# Chrome upgrade end
@@ -235,9 +235,9 @@ object RunCalypsoE2eMobileTests : BuildType({
 				wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_90.0.4430.93-1_amd64.deb
 				sudo apt-get install -y ./google-chrome-stable_90.0.4430.93-1_amd64.deb
 				rm ./google-chrome-stable_90.0.4430.93-1_amd64.deb
+				cd test/e2e
 				google-chrome --version > .chromedriver_version
       			echo -n "Google Chrome version: " && cat .chromedriver_version
-				cd test/e2e
 				npm install chromedriver --chromedriver-force-download --detect_chromedriver_version
 				cd ../..
 				# Chrome upgrade end

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -222,7 +222,7 @@ object RunCalypsoE2eMobileTests : BuildType({
 
 				# Chrome upgrade start
 				wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_90.0.4430.93-1_amd64.deb
-				apt-get install -y ./google-chrome-stable_90.0.4430.93-1_amd64.deb
+				sudo apt-get install -y ./google-chrome-stable_90.0.4430.93-1_amd64.deb
 				rm ./google-chrome-stable_90.0.4430.93-1_amd64.deb
 				cd test/e2e
 				npm install chromedriver --chromedriver-force-download --detect_chromedriver_version

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -236,7 +236,7 @@ object RunCalypsoE2eMobileTests : BuildType({
 				sudo apt-get install -y ./google-chrome-stable_90.0.4430.93-1_amd64.deb
 				rm ./google-chrome-stable_90.0.4430.93-1_amd64.deb
 				cd test/e2e
-				google-chrome --version > .chromedriver_version
+				google-chrome --version | cut -d' ' -f3 > .chromedriver_version
       			echo -n "Google Chrome version: " && cat .chromedriver_version
 				npm install chromedriver --chromedriver-force-download --detect_chromedriver_version
 				cd ../..

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -54,6 +54,17 @@ object RunCalypsoE2eDesktopTests : BuildType({
 				shopt -s globstar
 				set -x
 
+				# Chrome upgrade start
+				wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_90.0.4430.93-1_amd64.deb
+				sudo apt-get install -y ./google-chrome-stable_90.0.4430.93-1_amd64.deb
+				rm ./google-chrome-stable_90.0.4430.93-1_amd64.deb
+				google-chrome --version > .chromedriver_version
+      			echo -n "Google Chrome version: " && cat .chromedriver_version
+				cd test/e2e
+				npm install chromedriver --chromedriver-force-download --detect_chromedriver_version
+				cd ../..
+				# Chrome upgrade end
+
 				cd test/e2e
 				mkdir temp
 
@@ -224,6 +235,8 @@ object RunCalypsoE2eMobileTests : BuildType({
 				wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_90.0.4430.93-1_amd64.deb
 				sudo apt-get install -y ./google-chrome-stable_90.0.4430.93-1_amd64.deb
 				rm ./google-chrome-stable_90.0.4430.93-1_amd64.deb
+				google-chrome --version > .chromedriver_version
+      			echo -n "Google Chrome version: " && cat .chromedriver_version
 				cd test/e2e
 				npm install chromedriver --chromedriver-force-download --detect_chromedriver_version
 				cd ../..


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Per https://github.com/Automattic/wp-calypso/pull/52007#issuecomment-826506283
* Updates system chrome to v90 and re-installs chromedriver with version autodetection. Downloaded version in the tc run should match `ChromeDriver 90.0.4430.24` listed here: https://sites.google.com/a/chromium.org/chromedriver/downloads 

#### Testing instructions

* All e2e tests should pass, check the right chrome/driver version is being used.

Related to #
