### PR TITLE
Update to chrome v90 for e2e tests (Dockerfile.base)

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -122,9 +122,8 @@ ENTRYPOINT [ "/bin/bash" ]
 #### This image is used to run e2e tests. The only difference with ci-desktop is the Chrome version.
 FROM ci-desktop as ci-e2e
 
-# This chrome image is the latest version that accepts SameSite=None.
 # test/e2e/test/mocha.env.js will install a compatible chromedriver.
-ENV CHROME_VERSION="90.0.4430.93-1"
+ENV CHROME_VERSION="current"
 ENV DETECT_CHROMEDRIVER_VERSION=true
 
 RUN wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -124,7 +124,7 @@ FROM ci-desktop as ci-e2e
 
 # This chrome image is the latest version that accepts SameSite=None.
 # test/e2e/test/mocha.env.js will install a compatible chromedriver.
-ENV CHROME_VERSION="84.0.4147.135-1"
+ENV CHROME_VERSION="90.0.4430.93-1"
 ENV DETECT_CHROMEDRIVER_VERSION=true
 
 RUN wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Follow up on #52367
* Per https://github.com/Automattic/wp-calypso/pull/52007#issuecomment-826506283
* Updates system chrome to v90 and re-installs chromedriver with version autodetection. Downloaded version in the tc run should match `ChromeDriver 90.0.4430.24` listed here: https://sites.google.com/a/chromium.org/chromedriver/downloads 

#### Testing instructions

* All e2e tests should pass, check the right chrome/driver version is being used.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
