### PR TITLE
Invites: don't use page() when navigating to another domain

### DIFF
--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -51,7 +51,7 @@ export function acceptInvite( context, next ) {
 
 				// Using page() for cross origin navigations would throw a `History.pushState` exception
 				// about creating state object with a cross-origin URL.
-				if ( new URL( redirect ).origin !== window.location.origin ) {
+				if ( new URL( redirect, window.location.href ).origin !== window.location.origin ) {
 					window.location = redirect;
 				} else {
 					page( redirect );

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -6,7 +6,6 @@ import store from 'store';
 import page from 'page';
 import debugModule from 'debug';
 import i18n from 'i18n-calypso';
-import { get } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -50,10 +49,10 @@ export function acceptInvite( context, next ) {
 				const redirect = getRedirectAfterAccept( acceptedInvite );
 				debug( 'Accepted invite and redirecting to:  ' + redirect );
 
-				if ( get( acceptedInvite, 'site.is_wpforteams_site', false ) ) {
-					// Using page() here will throw an error because P2 sites
-					// redirect to non-same origin.
-					window.location.href = redirect;
+				// Using page() for cross origin navigations would throw a `History.pushState` exception
+				// about creating state object with a cross-origin URL.
+				if ( new URL( redirect ).origin !== window.location.origin ) {
+					window.location = redirect;
 				} else {
 					page( redirect );
 				}

--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -31,7 +31,15 @@ class InviteAcceptLoggedIn extends React.Component {
 		this.props
 			.acceptInvite( this.props.invite )
 			.then( () => {
-				page( this.props.redirectTo );
+				const { redirectTo } = this.props;
+
+				// Using page() for cross origin navigations would throw a `History.pushState` exception
+				// about creating state object with a cross-origin URL.
+				if ( new URL( redirectTo ).origin !== window.location.origin ) {
+					window.location = redirectTo;
+				} else {
+					page( redirectTo );
+				}
 			} )
 			.catch( () => {
 				this.setState( { submitting: false } );

--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -35,7 +35,7 @@ class InviteAcceptLoggedIn extends React.Component {
 
 				// Using page() for cross origin navigations would throw a `History.pushState` exception
 				// about creating state object with a cross-origin URL.
-				if ( new URL( redirectTo ).origin !== window.location.origin ) {
+				if ( new URL( redirectTo, window.location.href ).origin !== window.location.origin ) {
 					window.location = redirectTo;
 				} else {
 					page( redirectTo );

--- a/client/my-sites/invites/utils.js
+++ b/client/my-sites/invites/utils.js
@@ -152,23 +152,21 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 }
 
 export function getRedirectAfterAccept( invite ) {
-	const isWPForTeamsSite = get( invite, 'site.is_wpforteams_site', false );
-
-	if ( isWPForTeamsSite ) {
+	if ( invite.site.is_wpforteams_site ) {
 		return `https://${ invite.site.domain }`;
 	}
 
 	const readerPath = '/read';
 	const postsListPath = '/posts/' + invite.site.ID;
 
-	if ( get( invite, 'site.is_vip' ) ) {
+	if ( invite.site.is_vip ) {
 		switch ( invite.role ) {
 			case 'viewer':
 			case 'follower':
-				return get( invite, 'site.URL' ) || readerPath;
+				return invite.site.URL || readerPath;
 
 			default:
-				return get( invite, 'site.admin_url' ) || postsListPath;
+				return invite.site.admin_url || postsListPath;
 		}
 	}
 


### PR DESCRIPTION
An incremental improvement to @annemirasol's fix in #52323 that makes sure that external P2 URLs are navigated to with `window.location` assignment, not with a `page()` call.

The improvement is that we do a generic same-origin check of the target URL instead of checking the `invite.site.is_wpforteams_site` flag. This also covers the `invite.site.is_vip` case where the redirect navigates to wp-admin.

This PR undoes the damage I did in #51133 (namely in the https://github.com/Automattic/wp-calypso/pull/51133/commits/8799aa845cabebe9e9915e3d29c0ebc70bbc2ded commit) where I converted all navigations to `page()`.

See also: https://github.com/Automattic/wp-calypso/pull/52323#issuecomment-828323852

As a drive-by, I'm removing `get` usages from `getRedirectAfterAccept`. There are pre-existing unguarded accesses to `invite.site.ID` in the surrounding code, so it's kind of guaranteed that the access is safe.