### PR TITLE
Preserve sidebar collapse state after switching site

### DIFF
--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -18,8 +18,10 @@
 	}
 
 	&.is-group-sites.is-sidebar-collapsed {
-		--sidebar-width-max: 36px;
-		--sidebar-width-min: 36px;
+		.layout:not( .focus-sites ) {
+			--sidebar-width-max: 36px;
+			--sidebar-width-min: 36px;
+		}
 	}
 
 	$nav-unification-primary: #23282d;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -226,7 +226,11 @@ class Layout extends Component {
 				bodyClass.push( 'is-nav-unification' );
 			}
 
-			if ( this.props.sidebarIsCollapsed && isWithinBreakpoint( '>800px' ) ) {
+			if (
+				this.props.currentLayoutFocus !== 'sites' &&
+				this.props.sidebarIsCollapsed &&
+				isWithinBreakpoint( '>800px' )
+			) {
 				bodyClass.push( 'is-sidebar-collapsed' );
 			}
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -87,6 +87,33 @@ function SidebarScrollSynchronizer( { enabled } ) {
 	return null;
 }
 
+function SidebarOverflowDelay( { layoutFocus } ) {
+	const setSidebarOverflowClass = ( overflow ) => {
+		const classList = document.querySelector( 'body' ).classList;
+		if ( overflow ) {
+			classList.add( 'is-sidebar-overflow' );
+		} else {
+			classList.remove( 'is-sidebar-overflow' );
+		}
+	};
+
+	React.useEffect( () => {
+		if ( layoutFocus !== 'sites' ) {
+			// Since `overflow` isn't an animated CSS property, we need to set it
+			// after the CSS transition of the layout elements finishes.
+			// @see https://github.com/Automattic/wp-calypso/blob/0c1176ddf16227307480fa4852e47cfe089bf181/client/layout/style.scss#L18
+			// @see https://github.com/Automattic/wp-calypso/issues/47019
+			setTimeout( () => {
+				setSidebarOverflowClass( true );
+			}, 500 );
+		} else {
+			setSidebarOverflowClass( false );
+		}
+	}, [ layoutFocus ] );
+
+	return null;
+}
+
 class Layout extends Component {
 	static propTypes = {
 		primary: PropTypes.element,
@@ -245,6 +272,7 @@ class Layout extends Component {
 		return (
 			<div className={ sectionClass }>
 				<SidebarScrollSynchronizer enabled={ this.props.isNavUnificationEnabled } />
+				<SidebarOverflowDelay layoutFocus={ this.props.currentLayoutFocus } />
 				<BodySectionCssClass
 					group={ this.props.sectionGroup }
 					section={ this.props.sectionName }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -253,11 +253,7 @@ class Layout extends Component {
 				bodyClass.push( 'is-nav-unification' );
 			}
 
-			if (
-				this.props.currentLayoutFocus !== 'sites' &&
-				this.props.sidebarIsCollapsed &&
-				isWithinBreakpoint( '>800px' )
-			) {
+			if ( this.props.sidebarIsCollapsed && isWithinBreakpoint( '>800px' ) ) {
 				bodyClass.push( 'is-sidebar-collapsed' );
 			}
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -99,9 +99,11 @@ function SidebarOverflowDelay( { layoutFocus } ) {
 
 	React.useEffect( () => {
 		if ( layoutFocus !== 'sites' ) {
-			// Since `overflow` isn't an animated CSS property, we need to set it
-			// after the CSS transition of the layout elements finishes.
-			// @see https://github.com/Automattic/wp-calypso/blob/0c1176ddf16227307480fa4852e47cfe089bf181/client/layout/style.scss#L18
+			// The sidebar menu uses a flyout design that requires the overflowing content
+			// to be visible. However, `overflow` isn't an animatable CSS property, so we
+			// need to set it after the sliding transition finishes. We wait for 150ms (the
+			// CSS transition time) + a grace period of 350ms (since the sidebar menu is
+			// rendered asynchronously).
 			// @see https://github.com/Automattic/wp-calypso/issues/47019
 			setTimeout( () => {
 				setSidebarOverflowClass( true );

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -16,7 +16,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import Site from 'calypso/blocks/site';
 import Gridicon from 'calypso/components/gridicon';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
-import { getSelectedSite, getSidebarIsCollapsed } from 'calypso/state/ui/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
@@ -38,18 +38,10 @@ class CurrentSite extends Component {
 		translate: PropTypes.func.isRequired,
 		anySiteSelected: PropTypes.array,
 		forceAllSitesView: PropTypes.bool,
-		sidebarIsCollapsed: PropTypes.bool,
 		isNavUnificationEnabled: PropTypes.bool.isRequired,
 	};
 
-	expandUnifiedNavSidebar = () => {
-		if ( this.props.isNavUnificationEnabled && this.props.sidebarIsCollapsed ) {
-			this.props.savePreference( 'sidebarCollapsed', false );
-		}
-	};
-
 	switchSites = ( event ) => {
-		this.expandUnifiedNavSidebar();
 		event.preventDefault();
 		event.stopPropagation();
 		this.props.setLayoutFocus( 'sites' );
@@ -135,7 +127,6 @@ export default connect(
 		anySiteSelected: getSelectedOrAllSites( state ),
 		siteCount: getCurrentUserSiteCount( state ),
 		hasAllSitesList: hasAllSitesList( state ),
-		sidebarIsCollapsed: getSidebarIsCollapsed( state ),
 		isNavUnificationEnabled: isNavUnificationEnabled( state ),
 	} ),
 	{

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -371,6 +371,13 @@ $font-size: rem( 14px );
 	}
 
 	&.is-sidebar-collapsed {
+		.layout__primary .main,
+		.layout__secondary,
+		.layout__secondary .sidebar,
+		.layout__secondary .site-selector {
+			transition: none;
+		}
+
 		.dashicons-admin-collapse::before {
 			transform: rotate( 180deg );
 		}
@@ -393,7 +400,7 @@ $font-size: rem( 14px );
 			display: none;
 		}
 
-		.site__content {
+		.sidebar .site__content {
 			padding: 10px 2px;
 
 			.count {
@@ -409,7 +416,7 @@ $font-size: rem( 14px );
 			left: 2px;
 		}
 
-		.site .site-icon {
+		.sidebar .site .site-icon {
 			margin-bottom: 4px;
 		}
 

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -559,12 +559,14 @@ $font-size: rem( 14px );
 		// TODO: For prototype only, this prevents the sidebar from being scrollable.
 		// In wp-admin there's custom JS to a) position the sidebar based on the scroll
 		// position and b) position the flyout menu based on available screen space.
-		.focus-content,
-		.focus-sidebar {
-			.sidebar,
-			.layout__secondary {
-				z-index: z-index( 'root', '.is-nav-unification .layout__secondary' );
-				overflow: initial;
+		&.is-sidebar-overflow {
+			.focus-content,
+			.focus-sidebar {
+				.sidebar,
+				.layout__secondary {
+					z-index: z-index( 'root', '.is-nav-unification .layout__secondary' );
+					overflow: initial;
+				}
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Preserves the collapse state of the sidebar when a user switches to a different site. This exposed more prominently the styling issue during the sliding transition described in https://github.com/Automattic/wp-calypso/issues/47019, so this PR also tries to fix that by changing the overflowing styles once the CSS animation finishes.

#### Testing instructions

* Open Calypso.
* Click on "Collapse menu".
* Make sure the sidebar has been collapsed.
* Click on "Switch site".
* Make sure the sidebar has been expanded.
* Pick a different site.
* Make sure the sidebar is now collapsed.

Fixes https://github.com/Automattic/wp-calypso/issues/52261
Fixes https://github.com/Automattic/wp-calypso/issues/47019