### PR TITLE
Enable Jetpack legacy plan redirect in production

### DIFF
--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -38,7 +38,7 @@
 		"jetpack/backups-date-picker": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,
-		"jetpack/redirect-legacy-plans": false,
+		"jetpack/redirect-legacy-plans": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,

--- a/config/production.json
+++ b/config/production.json
@@ -13,11 +13,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"facebook_app_id": "2373049596",
 	"rebrand_cities_prefix": "rebrandcitiessite",
-	"livechat_support_locales": [
-		"en",
-		"es",
-		"pt-br"
-	],
+	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": true,
 		"async-payments": false,
@@ -69,7 +65,7 @@
 		"jetpack/personal-plan": false,
 		"jetpack/magic-link-signup": true,
 		"jetpack/userless-checkout": false,
-		"jetpack/redirect-legacy-plans": false,
+		"jetpack/redirect-legacy-plans": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR enables the feature flag for redirecting users hitting the checkout page with a Jetpack legacy plan to the plans page, in production.

Fixes 1200196139286276-as-1200247506453119

### Testing instructions

Review code.