### PR TITLE
Framework: Refactor away from `_.identity()`

### DIFF
--- a/client/auth/auth-code-button.jsx
+++ b/client/auth/auth-code-button.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { identity } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -15,10 +14,6 @@ const initialState = { status: 'ready', errorLevel: false, errorMessage: false }
 const SMS_URL = '/sms';
 
 export class AuthCodeButton extends React.Component {
-	static defaultProps = {
-		translate: identity,
-	};
-
 	state = initialState;
 
 	componentWillUnmount() {

--- a/client/auth/test/auth-code-button.jsx
+++ b/client/auth/test/auth-code-button.jsx
@@ -19,6 +19,8 @@ const savedFetch = fetch;
 import { AuthCodeButton } from '../auth-code-button';
 import Notice from 'calypso/components/notice';
 
+const localizeProps = { translate: ( string ) => string };
+
 describe( 'AuthCodeButton', () => {
 	beforeAll( () => {
 		// Transform relative URLs to absolute URLs with a `http://localhost` base URL.
@@ -32,7 +34,7 @@ describe( 'AuthCodeButton', () => {
 	} );
 
 	test( 'button renders in ready state', () => {
-		const button = shallow( <AuthCodeButton username="usr" password="pwd" /> );
+		const button = shallow( <AuthCodeButton username="usr" password="pwd" { ...localizeProps } /> );
 		const notice = button.find( Notice );
 		expect( notice ).toHaveLength( 1 );
 		expect( notice.props().status ).toBe( 'is-info' );
@@ -44,7 +46,7 @@ describe( 'AuthCodeButton', () => {
 			.post( '/sms', { username: 'usr', password: 'pwd' } )
 			.reply( 400, { error: 'needs_2fa' } );
 
-		const button = shallow( <AuthCodeButton username="usr" password="pwd" /> );
+		const button = shallow( <AuthCodeButton username="usr" password="pwd" { ...localizeProps } /> );
 		const request = button.instance().requestSMSCode();
 
 		// synchronous check immediately after firing the request should see status as 'requesting'
@@ -62,7 +64,7 @@ describe( 'AuthCodeButton', () => {
 			.post( '/sms', { username: 'usr', password: 'pwd' } )
 			.reply( 400, { error: 'other', error_description: 'Failed' } );
 
-		const button = shallow( <AuthCodeButton username="usr" password="pwd" /> );
+		const button = shallow( <AuthCodeButton username="usr" password="pwd" { ...localizeProps } /> );
 		const request = button.instance().requestSMSCode();
 
 		// wait for the request to finish and then check the error status
@@ -77,7 +79,7 @@ describe( 'AuthCodeButton', () => {
 			.post( '/sms', { username: 'usr', password: 'pwd' } )
 			.replyWithError( 'Failed' );
 
-		const button = shallow( <AuthCodeButton username="usr" password="pwd" /> );
+		const button = shallow( <AuthCodeButton username="usr" password="pwd" { ...localizeProps } /> );
 		const request = button.instance().requestSMSCode();
 
 		// wait for the request to finish and then check the error status

--- a/client/auth/test/login.jsx
+++ b/client/auth/test/login.jsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,7 +29,7 @@ jest.mock( 'calypso/lib/analytics/ga', () => ( {
 } ) );
 
 describe( 'LoginTest', () => {
-	const page = shallow( <Auth translate={ identity } /> );
+	const page = shallow( <Auth translate={ ( string ) => string } /> );
 
 	test( 'OTP is not present on first render', () => {
 		return new Promise( ( done ) => {

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -7,7 +7,7 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { get, identity, includes } from 'lodash';
+import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -73,7 +73,6 @@ export class AppBanner extends Component {
 
 	static defaultProps = {
 		saveDismissTime: noop,
-		translate: identity,
 		recordAppBannerOpen: noop,
 		userAgent: typeof window !== 'undefined' ? window.navigator.userAgent : '',
 	};

--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { identity, sample } from 'lodash';
+import { sample } from 'lodash';
 import store from 'store';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -220,7 +220,6 @@ export class AppPromo extends React.Component {
 }
 
 AppPromo.defaultProps = {
-	translate: identity,
 	recordTracksEvent: noop,
 	saveDismissal: () => store.set( 'desktop_promo_disabled', true ),
 	getPromoLink,

--- a/client/blocks/app-promo/test/index.jsx
+++ b/client/blocks/app-promo/test/index.jsx
@@ -23,6 +23,7 @@ describe( 'AppPromo', () => {
 		location: 'reader',
 		promoItem: appPromoDetails,
 		getPromoLink: () => appPromoLink,
+		translate: ( string ) => string,
 	};
 	// The reason we don't import this higher up is this component can't be
 	// imported until the fake DOM is setup.

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -3,7 +3,7 @@
  */
 import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { identity, map } from 'lodash';
+import { map } from 'lodash';
 import React from 'react';
 
 /**
@@ -283,6 +283,11 @@ function isHardBlockingHoldType(
 }
 
 export const hasBlockingHold = ( holds: string[] ) =>
-	holds.some( ( hold ) => isHardBlockingHoldType( hold, getBlockingMessages( identity ) ) );
+	holds.some( ( hold ) =>
+		isHardBlockingHoldType(
+			hold,
+			getBlockingMessages( ( string ) => string )
+		)
+	);
 
 export default localize( HoldList );

--- a/client/blocks/get-apps/desktop-download-card.jsx
+++ b/client/blocks/get-apps/desktop-download-card.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -30,7 +29,6 @@ class DesktopDownloadCard extends Component {
 	};
 
 	static defaultProps = {
-		translate: identity,
 		trackWindowsClick: noop,
 		trackMacClick: noop,
 		trackLinuxTarClick: noop,

--- a/client/blocks/get-apps/test/apps-badge.js
+++ b/client/blocks/get-apps/test/apps-badge.js
@@ -7,7 +7,6 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,7 +25,7 @@ describe( 'AppsBadge', () => {
 		storeLink: 'https://wordpress.com',
 		storeName: 'ios',
 		titleText: 'titleText',
-		translate: identity,
+		translate: ( string ) => string,
 	};
 
 	test( 'should render', () => {

--- a/client/blocks/image-editor/test/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/test/image-editor-toolbar.jsx
@@ -7,7 +7,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { identity } from 'lodash';
 import React from 'react';
 
 /**
@@ -27,7 +26,9 @@ describe( 'ImageEditorToolbar', () => {
 	} );
 
 	beforeEach( () => {
-		wrapper = shallow( <ImageEditorToolbar { ...defaultProps } translate={ identity } /> );
+		wrapper = shallow(
+			<ImageEditorToolbar { ...defaultProps } translate={ ( string ) => string } />
+		);
 	} );
 
 	test( 'should not add `is-disabled` class to aspect ratio toolbar button by default', () => {

--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { identity } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -52,7 +51,6 @@ class InlineHelp extends Component {
 	};
 
 	static defaultProps = {
-		translate: identity,
 		isPopoverVisible: false,
 	};
 

--- a/client/blocks/inline-help/inline-help-forum-view.jsx
+++ b/client/blocks/inline-help/inline-help-forum-view.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { identity } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -18,7 +17,7 @@ const trackForumOpen = () =>
 		location: 'inline-help-popover',
 	} );
 
-const InlineHelpForumView = ( { translate = identity } ) => (
+const InlineHelpForumView = ( { translate } ) => (
 	<div className="inline-help__forum-view">
 		<h2 className="inline-help__view-heading">
 			{ preventWidows( translate( 'Ask the Community for Help' ) ) }

--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { useRef, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { identity } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -30,7 +29,7 @@ const InlineHelpSearchCard = ( {
 	isSearching,
 	isVisible = true,
 	placeholder,
-	translate = identity,
+	translate,
 } ) => {
 	const cardRef = useRef();
 

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Fragment, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { debounce, identity, isEmpty } from 'lodash';
+import { debounce, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -61,7 +61,7 @@ function HelpSearchResults( {
 	sectionName,
 	selectedResultIndex = -1,
 	selectSearchResult,
-	translate = identity,
+	translate,
 	placeholderLines,
 	track,
 } ) {

--- a/client/blocks/post-status/test/index.jsx
+++ b/client/blocks/post-status/test/index.jsx
@@ -4,8 +4,9 @@
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import Gridicon from 'calypso/components/gridicon';
-import { identity } from 'lodash';
 import React from 'react';
+
+const translate = ( string ) => string;
 
 describe( 'PostStatus', () => {
 	let PostStatus;
@@ -16,7 +17,7 @@ describe( 'PostStatus', () => {
 
 	describe( 'no post', () => {
 		test( 'should be empty', () => {
-			const PostStatusComponent = <PostStatus translate={ identity } />;
+			const PostStatusComponent = <PostStatus translate={ translate } />;
 			const wrapper = shallow( PostStatusComponent );
 
 			expect( wrapper ).to.be.empty;
@@ -26,7 +27,9 @@ describe( 'PostStatus', () => {
 	describe( 'post', () => {
 		describe( 'sticky', () => {
 			test( 'should render the primary components', () => {
-				const PostStatusComponent = <PostStatus post={ { sticky: true } } translate={ identity } />;
+				const PostStatusComponent = (
+					<PostStatus post={ { sticky: true } } translate={ translate } />
+				);
 				const wrapper = shallow( PostStatusComponent );
 
 				expect( wrapper ).to.have.descendants( 'span' );
@@ -41,7 +44,7 @@ describe( 'PostStatus', () => {
 			describe( 'pending', () => {
 				test( 'should render the primary components', () => {
 					const PostStatusComponent = (
-						<PostStatus post={ { sticky: false, status: 'pending' } } translate={ identity } />
+						<PostStatus post={ { sticky: false, status: 'pending' } } translate={ translate } />
 					);
 					const wrapper = shallow( PostStatusComponent );
 
@@ -60,7 +63,7 @@ describe( 'PostStatus', () => {
 							<PostStatus
 								post={ { sticky: false, status: 'future' } }
 								showAll
-								translate={ identity }
+								translate={ translate }
 							/>
 						);
 						const wrapper = shallow( PostStatusComponent );
@@ -76,7 +79,7 @@ describe( 'PostStatus', () => {
 				describe( 'not showAll', () => {
 					test( 'should be empty', () => {
 						const PostStatusComponent = (
-							<PostStatus post={ { sticky: false, status: 'future' } } translate={ identity } />
+							<PostStatus post={ { sticky: false, status: 'future' } } translate={ translate } />
 						);
 						const wrapper = shallow( PostStatusComponent );
 
@@ -92,7 +95,7 @@ describe( 'PostStatus', () => {
 							<PostStatus
 								post={ { sticky: false, status: 'trash' } }
 								showAll
-								translate={ identity }
+								translate={ translate }
 							/>
 						);
 						const wrapper = shallow( PostStatusComponent );
@@ -108,7 +111,7 @@ describe( 'PostStatus', () => {
 				describe( 'not showAll', () => {
 					test( 'should be empty', () => {
 						const PostStatusComponent = (
-							<PostStatus post={ { sticky: false, status: 'trash' } } translate={ identity } />
+							<PostStatus post={ { sticky: false, status: 'trash' } } translate={ translate } />
 						);
 						const wrapper = shallow( PostStatusComponent );
 
@@ -124,7 +127,7 @@ describe( 'PostStatus', () => {
 							<PostStatus
 								post={ { sticky: false, status: 'draft' } }
 								showAll
-								translate={ identity }
+								translate={ translate }
 							/>
 						);
 						const wrapper = shallow( PostStatusComponent );
@@ -140,7 +143,7 @@ describe( 'PostStatus', () => {
 				describe( 'not showAll', () => {
 					test( 'should be empty', () => {
 						const PostStatusComponent = (
-							<PostStatus post={ { sticky: false, status: 'draft' } } translate={ identity } />
+							<PostStatus post={ { sticky: false, status: 'draft' } } translate={ translate } />
 						);
 						const wrapper = shallow( PostStatusComponent );
 
@@ -156,7 +159,7 @@ describe( 'PostStatus', () => {
 							<PostStatus
 								post={ { sticky: false, status: 'publish' } }
 								showAll
-								translate={ identity }
+								translate={ translate }
 							/>
 						);
 						const wrapper = shallow( PostStatusComponent );
@@ -172,7 +175,7 @@ describe( 'PostStatus', () => {
 				describe( 'not showAll', () => {
 					test( 'should be empty', () => {
 						const PostStatusComponent = (
-							<PostStatus post={ { sticky: false, status: 'publish' } } translate={ identity } />
+							<PostStatus post={ { sticky: false, status: 'publish' } } translate={ translate } />
 						);
 						const wrapper = shallow( PostStatusComponent );
 
@@ -184,7 +187,7 @@ describe( 'PostStatus', () => {
 			describe( 'unhandled status', () => {
 				test( 'should be empty', () => {
 					const PostStatusComponent = (
-						<PostStatus post={ { sticky: false, status: 'wow' } } translate={ identity } />
+						<PostStatus post={ { sticky: false, status: 'wow' } } translate={ translate } />
 					);
 					const wrapper = shallow( PostStatusComponent );
 

--- a/client/blocks/privacy-policy-banner/index.jsx
+++ b/client/blocks/privacy-policy-banner/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flowRight as compose, get, identity } from 'lodash';
+import { flowRight as compose, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -55,10 +55,6 @@ class PrivacyPolicyBanner extends Component {
 		privacyPolicy: PropTypes.object,
 		userRegisterDate: PropTypes.number,
 		translate: PropTypes.func,
-	};
-
-	static defaultProps = {
-		translate: identity,
 	};
 
 	state = { showDialog: false };

--- a/client/blocks/sharing-preview-pane/utils.js
+++ b/client/blocks/sharing-preview-pane/utils.js
@@ -48,10 +48,7 @@ export const getExcerptForPost = ( post ) => {
 	return trim(
 		striptags(
 			formatExcerpt(
-				find(
-					[ PostMetadata.metaDescription( post ), post.excerpt, post.content ],
-					( content ) => content.length
-				)
+				find( [ PostMetadata.metaDescription( post ), post.excerpt, post.content ], Boolean )
 			)
 		)
 	);

--- a/client/blocks/sharing-preview-pane/utils.js
+++ b/client/blocks/sharing-preview-pane/utils.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-
-import { get, find, identity, trim } from 'lodash';
+import { get, find, trim } from 'lodash';
 import striptags from 'striptags';
 
 /**
@@ -49,7 +48,10 @@ export const getExcerptForPost = ( post ) => {
 	return trim(
 		striptags(
 			formatExcerpt(
-				find( [ PostMetadata.metaDescription( post ), post.excerpt, post.content ], identity )
+				find(
+					[ PostMetadata.metaDescription( post ), post.excerpt, post.content ],
+					( content ) => content.length
+				)
 			)
 		)
 	);

--- a/client/blocks/shortcode/index.js
+++ b/client/blocks/shortcode/index.js
@@ -42,7 +42,7 @@ function useRenderedShortcode( siteId, shortcode ) {
 }
 
 const Shortcode = ( props ) => {
-	const { siteId, className, children, filterRenderResult } = props;
+	const { siteId, className, children, filterRenderResult = ( result ) => result } = props;
 	const shortcode = useRenderedShortcode( siteId, children );
 
 	const classes = classNames( 'shortcode', className );
@@ -69,7 +69,6 @@ Shortcode.propTypes = {
 };
 
 Shortcode.defaultProps = {
-	filterRenderResult: ( result ) => result,
 	allowSameOrigin: false,
 };
 

--- a/client/blocks/shortcode/index.js
+++ b/client/blocks/shortcode/index.js
@@ -4,7 +4,7 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
-import { identity, omit } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -69,7 +69,7 @@ Shortcode.propTypes = {
 };
 
 Shortcode.defaultProps = {
-	filterRenderResult: identity,
+	filterRenderResult: ( result ) => result,
 	allowSameOrigin: false,
 };
 

--- a/client/components/bulk-select/test/index.js
+++ b/client/components/bulk-select/test/index.js
@@ -7,7 +7,6 @@
  */
 import { assert } from 'chai';
 import { mount, shallow } from 'enzyme';
-import { identity } from 'lodash';
 import React from 'react';
 
 /**
@@ -16,12 +15,13 @@ import React from 'react';
 import { BulkSelect } from '../index';
 
 const noop = () => {};
+const translate = ( string ) => string;
 
 describe( 'index', () => {
 	test( 'should have BulkSelect class', () => {
 		const bulkSelect = shallow(
 			<BulkSelect
-				translate={ identity }
+				translate={ translate }
 				selectedElements={ 0 }
 				totalElements={ 3 }
 				onToggle={ noop }
@@ -33,7 +33,7 @@ describe( 'index', () => {
 	test( 'should not be checked when initialized without selectedElements', () => {
 		const bulkSelect = shallow(
 			<BulkSelect
-				translate={ identity }
+				translate={ translate }
 				selectedElements={ 0 }
 				totalElements={ 3 }
 				onToggle={ noop }
@@ -45,7 +45,7 @@ describe( 'index', () => {
 	test( 'should be checked when initialized with all elements selected', () => {
 		const bulkSelect = shallow(
 			<BulkSelect
-				translate={ identity }
+				translate={ translate }
 				selectedElements={ 3 }
 				totalElements={ 3 }
 				onToggle={ noop }
@@ -57,7 +57,7 @@ describe( 'index', () => {
 	test( 'should not be checked when initialized with some elements selected', () => {
 		const bulkSelect = shallow(
 			<BulkSelect
-				translate={ identity }
+				translate={ translate }
 				selectedElements={ 2 }
 				totalElements={ 3 }
 				onToggle={ noop }
@@ -69,7 +69,7 @@ describe( 'index', () => {
 	test( 'should render line gridicon when initialized with some elements selected', () => {
 		const bulkSelect = shallow(
 			<BulkSelect
-				translate={ identity }
+				translate={ translate }
 				selectedElements={ 2 }
 				totalElements={ 3 }
 				onToggle={ noop }
@@ -81,7 +81,7 @@ describe( 'index', () => {
 	test( 'should add the aria-label to the input', () => {
 		const bulkSelect = mount(
 			<BulkSelect
-				translate={ identity }
+				translate={ translate }
 				selectedElements={ 2 }
 				totalElements={ 3 }
 				onToggle={ noop }
@@ -94,7 +94,7 @@ describe( 'index', () => {
 	test( 'should not mark the input readOnly', () => {
 		const bulkSelect = mount(
 			<BulkSelect
-				translate={ identity }
+				translate={ translate }
 				selectedElements={ 2 }
 				totalElements={ 3 }
 				onToggle={ noop }
@@ -111,7 +111,7 @@ describe( 'index', () => {
 		};
 		const bulkSelect = mount(
 			<BulkSelect
-				translate={ identity }
+				translate={ translate }
 				selectedElements={ 0 }
 				totalElements={ 3 }
 				onToggle={ callback }
@@ -129,7 +129,7 @@ describe( 'index', () => {
 			};
 			const bulkSelect = mount(
 				<BulkSelect
-					translate={ identity }
+					translate={ translate }
 					selectedElements={ 0 }
 					totalElements={ 3 }
 					onToggle={ callback }
@@ -147,7 +147,7 @@ describe( 'index', () => {
 			};
 			const bulkSelect = mount(
 				<BulkSelect
-					translate={ identity }
+					translate={ translate }
 					selectedElements={ 1 }
 					totalElements={ 3 }
 					onToggle={ callback }
@@ -165,7 +165,7 @@ describe( 'index', () => {
 			};
 			const bulkSelect = mount(
 				<BulkSelect
-					translate={ identity }
+					translate={ translate }
 					selectedElements={ 3 }
 					totalElements={ 3 }
 					onToggle={ callback }

--- a/client/components/count/test/index.jsx
+++ b/client/components/count/test/index.jsx
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { identity } from 'lodash';
 import React from 'react';
 import { spy } from 'sinon';
 
@@ -14,7 +13,7 @@ import { Count } from '../';
 
 describe( 'Count', () => {
 	test( 'should use the correct class name', () => {
-		const count = shallow( <Count count={ 23 } numberFormat={ identity } /> );
+		const count = shallow( <Count count={ 23 } numberFormat={ ( string ) => string } /> );
 		expect( count ).to.have.className( 'count' );
 	} );
 

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -39,7 +38,6 @@ EuAddressFieldset.propTypes = {
 
 EuAddressFieldset.defaultProps = {
 	getFieldProps: noop,
-	translate: identity,
 };
 
 export default localize( EuAddressFieldset );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
@@ -2,10 +2,9 @@
  * External	dependencies
  *
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { identity, includes } from 'lodash';
+import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -40,7 +39,6 @@ export class RegionAddressFieldsets extends Component {
 
 	static defaultProps = {
 		getFieldProps: noop,
-		translate: identity,
 		countryCode: 'US',
 		shouldAutoFocusAddressField: false,
 		hasCountryStates: false,

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
@@ -25,6 +25,7 @@ jest.mock( 'calypso/lib/user', () => () => {} );
 describe( 'EU Address Fieldset', () => {
 	const defaultProps = {
 		getFieldProps: ( name ) => ( { name, value: '' } ),
+		translate: ( string ) => string,
 	};
 
 	test( 'should render correctly with default props', () => {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/region-address-fieldsets.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/region-address-fieldsets.js
@@ -33,6 +33,7 @@ describe( 'Region Address Fieldsets', () => {
 			name,
 		} ),
 		hasCountryStates: false,
+		translate: ( string ) => string,
 	};
 
 	const propsWithStates = {
@@ -41,6 +42,7 @@ describe( 'Region Address Fieldsets', () => {
 			name,
 		} ),
 		hasCountryStates: true,
+		translate: ( string ) => string,
 	};
 
 	test( 'should render `<UsAddressFieldset />` with default props', () => {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
@@ -25,6 +25,7 @@ jest.mock( 'calypso/lib/user', () => () => {} );
 describe( 'UK Address Fieldset', () => {
 	const defaultProps = {
 		getFieldProps: ( name ) => ( { name, value: '' } ),
+		translate: ( string ) => string,
 	};
 
 	test( 'should render correctly with default props', () => {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
@@ -26,6 +26,7 @@ describe( 'US Address Fieldset', () => {
 	const defaultProps = {
 		countryCode: 'US',
 		getFieldProps: ( name ) => ( { name, value: '' } ),
+		translate: ( string ) => string,
 	};
 
 	test( 'should render correctly with default props', () => {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -39,6 +38,5 @@ UkAddressFieldset.propTypes = {
 
 UkAddressFieldset.defaultProps = {
 	getFieldProps: noop,
-	translate: identity,
 };
 export default localize( UkAddressFieldset );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -51,7 +50,6 @@ UsAddressFieldset.propTypes = {
 UsAddressFieldset.defaultProps = {
 	countryCode: 'US',
 	getFieldProps: noop,
-	translate: identity,
 };
 
 export default localize( UsAddressFieldset );

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -5,18 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { Component, createElement } from 'react';
 import { connect } from 'react-redux';
-import {
-	get,
-	deburr,
-	kebabCase,
-	pick,
-	head,
-	includes,
-	isEqual,
-	isEmpty,
-	camelCase,
-	identity,
-} from 'lodash';
+import { get, deburr, kebabCase, pick, head, includes, isEqual, isEmpty, camelCase } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -103,7 +92,6 @@ export class ContactDetailsFormFields extends Component {
 		needsOnlyGoogleAppsDetails: false,
 		needsAlternateEmailForGSuite: false,
 		hasCountryStates: false,
-		translate: identity,
 		userCountryCode: 'US',
 		shouldForceRenderOnPropChange: false,
 	};

--- a/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
+++ b/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
@@ -145,7 +145,6 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
       getFieldProps={[Function]}
       hasCountryStates={false}
       shouldAutoFocusAddressField={false}
-      translate={[Function]}
     />
   </div>
   <div>

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -53,6 +53,7 @@ describe( 'ContactDetailsFormFields', () => {
 			},
 		],
 		onSubmit: noop,
+		translate: ( string ) => string,
 	};
 
 	describe( 'default fields', () => {

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
-import { defaults, get, identity, isEmpty, map, set } from 'lodash';
+import { defaults, get, isEmpty, map, set } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,6 +24,7 @@ import validateContactDetails from './fr-validate-contact-details';
 import { disableSubmitButton } from './with-contact-details-validation';
 
 const noop = () => {};
+const identity = ( value ) => value;
 const debug = debugFactory( 'calypso:domains:registrant-extra-info' );
 let defaultRegistrantType;
 

--- a/client/components/domains/registrant-extra-info/test/ca-form.js
+++ b/client/components/domains/registrant-extra-info/test/ca-form.js
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,8 +12,8 @@ import { RegistrantExtraInfoCaForm } from '../ca-form';
 jest.mock( 'store', () => ( { get: () => {}, set: () => {} } ) );
 
 const mockProps = {
-	translate: identity,
-	updateContactDetailsCache: identity,
+	translate: ( string ) => string,
+	updateContactDetailsCache: () => {},
 	userWpcomLang: 'EN',
 	getFieldProps: () => ( {} ),
 };

--- a/client/components/domains/registrant-extra-info/test/uk-form.js
+++ b/client/components/domains/registrant-extra-info/test/uk-form.js
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,8 +13,8 @@ import FormInputValidation from 'calypso/components/forms/form-input-validation'
 const mockProps = {
 	contactDetails: {},
 	step: 'uk',
-	translate: identity,
-	updateContactDetailsCache: identity,
+	translate: ( string ) => string,
+	updateContactDetailsCache: () => {},
 };
 
 describe( 'uk-form', () => {

--- a/client/components/domains/registrant-extra-info/test/with-contact-details-validation.js
+++ b/client/components/domains/registrant-extra-info/test/with-contact-details-validation.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
-import { difference, identity, set } from 'lodash';
+import { difference, set } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,8 +28,8 @@ const mockStore = {
 const MockReduxProvider = ( { children } ) => <Provider store={ mockStore }>{ children }</Provider>;
 
 const mockProps = {
-	translate: identity,
-	updateContactDetailsCache: identity,
+	translate: ( string ) => string,
+	updateContactDetailsCache: () => {},
 	tld: 'uk',
 };
 

--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { identity, includes, without } from 'lodash';
+import { includes, without } from 'lodash';
 
 /**
  * Internal dependencies
@@ -46,7 +46,6 @@ export class DropZone extends React.Component {
 		onFilesDrop: noop,
 		fullScreen: false,
 		icon: <Gridicon icon="cloud-upload" size={ 48 } />,
-		translate: identity,
 		dropZoneName: null,
 	};
 

--- a/client/components/drop-zone/test/index.jsx
+++ b/client/components/drop-zone/test/index.jsx
@@ -28,6 +28,7 @@ describe( 'index', () => {
 	const requiredProps = {
 		hideDropZone: () => {},
 		showDropZone: () => {},
+		translate: ( string ) => string,
 	};
 
 	beforeAll( function () {

--- a/client/components/forms/form-country-select/test/index.jsx
+++ b/client/components/forms/form-country-select/test/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { expect } from 'chai';
-import { identity } from 'lodash';
 import { shallow } from 'enzyme';
 
 /**
@@ -12,8 +11,10 @@ import { shallow } from 'enzyme';
 import { FormCountrySelect } from 'calypso/components/forms/form-country-select';
 
 describe( 'FormCountrySelect', () => {
+	const translate = ( string ) => string;
+
 	test( 'should render a select box with a placeholder when the country list provided is empty', () => {
-		const select = shallow( <FormCountrySelect countriesList={ [] } translate={ identity } /> );
+		const select = shallow( <FormCountrySelect countriesList={ [] } translate={ translate } /> );
 
 		const options = select.find( 'option' );
 
@@ -41,7 +42,7 @@ describe( 'FormCountrySelect', () => {
 						country_name: 'Argentina',
 					},
 				] }
-				translate={ identity }
+				translate={ translate }
 			/>
 		);
 

--- a/client/components/forms/form-phone-input/index.jsx
+++ b/client/components/forms/form-phone-input/index.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { identity, find } from 'lodash';
+import { find } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -37,7 +37,6 @@ export class FormPhoneInput extends React.Component {
 		countrySelectProps: {},
 		phoneInputProps: {},
 		onChange: noop,
-		translate: identity,
 	};
 
 	state = {

--- a/client/components/forms/form-phone-input/test/index.jsx
+++ b/client/components/forms/form-phone-input/test/index.jsx
@@ -30,12 +30,15 @@ const countriesList = [
 ];
 
 describe( 'FormPhoneInput', () => {
+	const localizeProps = { translate: ( string ) => string };
+
 	describe( 'getValue()', () => {
 		test( 'should set country from props', () => {
 			const phoneComponent = shallow(
 				<FormPhoneInput
 					countriesList={ countriesList }
 					initialCountryCode={ countriesList[ 1 ].code }
+					{ ...localizeProps }
 				/>
 			);
 
@@ -45,7 +48,9 @@ describe( 'FormPhoneInput', () => {
 		} );
 
 		test( 'should set country to first element when not specified', () => {
-			const phoneComponent = shallow( <FormPhoneInput countriesList={ countriesList } /> );
+			const phoneComponent = shallow(
+				<FormPhoneInput countriesList={ countriesList } { ...localizeProps } />
+			);
 
 			expect( phoneComponent.instance().getValue().countryData ).to.deep.equal(
 				countriesList[ 0 ]
@@ -53,7 +58,9 @@ describe( 'FormPhoneInput', () => {
 		} );
 
 		test( 'should update country on change', () => {
-			const phoneComponent = mount( <FormPhoneInput countriesList={ countriesList } /> );
+			const phoneComponent = mount(
+				<FormPhoneInput countriesList={ countriesList } { ...localizeProps } />
+			);
 
 			phoneComponent.find( 'select' ).simulate( 'change', {
 				target: {
@@ -67,7 +74,9 @@ describe( 'FormPhoneInput', () => {
 		} );
 
 		test( 'should have no country with empty countryList', () => {
-			const phoneComponent = shallow( <FormPhoneInput countriesList={ [] } /> );
+			const phoneComponent = shallow(
+				<FormPhoneInput countriesList={ [] } { ...localizeProps } />
+			);
 
 			expect( phoneComponent.instance().getValue().countryData ).to.equal( undefined );
 		} );

--- a/client/components/happychat/button.jsx
+++ b/client/components/happychat/button.jsx
@@ -5,7 +5,6 @@ import { isMobile } from '@automattic/viewport';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import page from 'page';
-import { identity } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
@@ -50,7 +49,6 @@ export class HappychatButton extends Component {
 		isConnectionUninitialized: false,
 		onClick: noop,
 		openChat: noop,
-		translate: identity,
 	};
 
 	onClick = ( event ) => {

--- a/client/components/happychat/test/button.jsx
+++ b/client/components/happychat/test/button.jsx
@@ -10,6 +10,7 @@ describe( 'Button', () => {
 		component.props = {
 			initConnection: jest.fn(),
 			getAuth: jest.fn(),
+			translate: ( string ) => string,
 		};
 	} );
 

--- a/client/components/language-picker/test/index.jsx
+++ b/client/components/language-picker/test/index.jsx
@@ -7,7 +7,6 @@
  */
 import { shallow } from 'enzyme';
 import React from 'react';
-import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -48,7 +47,7 @@ const defaultProps = {
 			wpLocale: 'ko_KR',
 		},
 	],
-	translate: identity,
+	translate: ( string ) => string,
 	valueKey: 'langSlug',
 	value: 'en',
 	countryCode: 'FR',

--- a/client/components/notice/test/index.js
+++ b/client/components/notice/test/index.js
@@ -3,7 +3,6 @@
  */
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
-import { identity } from 'lodash';
 import React from 'react';
 
 /**
@@ -12,55 +11,57 @@ import React from 'react';
 import { Notice } from '../index';
 
 describe( 'Notice', () => {
+	const translate = ( string ) => string;
+
 	test( 'should output the component', () => {
-		const wrapper = shallow( <Notice translate={ identity } /> );
+		const wrapper = shallow( <Notice translate={ translate } /> );
 		assert.isOk( wrapper.find( '.notice' ).length );
 	} );
 
 	test( 'should have dismiss button when showDismiss passed as true', () => {
-		const wrapper = shallow( <Notice showDismiss={ true } translate={ identity } /> );
+		const wrapper = shallow( <Notice showDismiss={ true } translate={ translate } /> );
 		assert.isOk( wrapper.find( '.is-dismissable' ).length );
 	} );
 
 	test( 'should have dismiss button by default if isCompact is false', () => {
-		const wrapper = shallow( <Notice isCompact={ false } translate={ identity } /> );
+		const wrapper = shallow( <Notice isCompact={ false } translate={ translate } /> );
 		assert.isOk( wrapper.find( '.is-dismissable' ).length );
 	} );
 
 	test( 'should have compact look when isCompact passed as true', () => {
-		const wrapper = shallow( <Notice isCompact={ true } translate={ identity } /> );
+		const wrapper = shallow( <Notice isCompact={ true } translate={ translate } /> );
 		assert.isOk( wrapper.find( '.is-compact' ).length );
 	} );
 
 	test( 'should not have dismiss button by default if isCompact is true', () => {
-		const wrapper = shallow( <Notice isCompact={ true } translate={ identity } /> );
+		const wrapper = shallow( <Notice isCompact={ true } translate={ translate } /> );
 		assert.isOk( wrapper.find( '.is-dismissable' ).length === 0 );
 	} );
 
 	test( 'should have dismiss button when showDismiss is true and isCompact is true', () => {
 		const wrapper = shallow(
-			<Notice isCompact={ true } showDismiss={ true } translate={ identity } />
+			<Notice isCompact={ true } showDismiss={ true } translate={ translate } />
 		);
 		assert.isOk( wrapper.find( '.is-dismissable' ).length );
 	} );
 
 	test( 'should have proper class for is-info status parameter', () => {
-		const wrapper = shallow( <Notice status="is-info" translate={ identity } /> );
+		const wrapper = shallow( <Notice status="is-info" translate={ translate } /> );
 		assert.isOk( wrapper.find( '.is-info' ).length );
 	} );
 
 	test( 'should have proper class for is-success status parameter', () => {
-		const wrapper = shallow( <Notice status="is-success" translate={ identity } /> );
+		const wrapper = shallow( <Notice status="is-success" translate={ translate } /> );
 		assert.isOk( wrapper.find( '.is-success' ).length );
 	} );
 
 	test( 'should have proper class for is-error status parameter', () => {
-		const wrapper = shallow( <Notice status="is-error" translate={ identity } /> );
+		const wrapper = shallow( <Notice status="is-error" translate={ translate } /> );
 		assert.isOk( wrapper.find( '.is-error' ).length );
 	} );
 
 	test( 'should have proper class for is-warning status parameter', () => {
-		const wrapper = shallow( <Notice status="is-warning" translate={ identity } /> );
+		const wrapper = shallow( <Notice status="is-warning" translate={ translate } /> );
 		assert.isOk( wrapper.find( '.is-warning' ).length );
 	} );
 } );

--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -4,7 +4,7 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { compact, find, get, identity } from 'lodash';
+import { compact, find, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -72,7 +72,10 @@ const getSeoExcerptForPost = ( post ) => {
 	}
 
 	return formatExcerpt(
-		find( [ PostMetadata.metaDescription( post ), post.excerpt, post.content ], identity )
+		find(
+			[ PostMetadata.metaDescription( post ), post.excerpt, post.content ],
+			( content ) => content.length
+		)
 	);
 };
 
@@ -84,7 +87,7 @@ const getSeoExcerptForSite = ( site ) => {
 	return formatExcerpt(
 		find(
 			[ get( site, 'options.advanced_seo_front_page_description' ), site.description ],
-			identity
+			( content ) => content.length
 		)
 	);
 };

--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -72,10 +72,7 @@ const getSeoExcerptForPost = ( post ) => {
 	}
 
 	return formatExcerpt(
-		find(
-			[ PostMetadata.metaDescription( post ), post.excerpt, post.content ],
-			( content ) => content.length
-		)
+		find( [ PostMetadata.metaDescription( post ), post.excerpt, post.content ], Boolean )
 	);
 };
 
@@ -87,7 +84,7 @@ const getSeoExcerptForSite = ( site ) => {
 	return formatExcerpt(
 		find(
 			[ get( site, 'options.advanced_seo_front_page_description' ), site.description ],
-			( content ) => content.length
+			Boolean
 		)
 	);
 };

--- a/client/components/seo/meta-title-editor/index.jsx
+++ b/client/components/seo/meta-title-editor/index.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { get, identity } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -64,7 +63,6 @@ export class MetaTitleEditor extends Component {
 	static defaultProps = {
 		disabled: false,
 		onChange: noop,
-		translate: identity,
 	};
 
 	constructor( props ) {

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -10,7 +10,6 @@ import ReactDom from 'react-dom';
 import sinon from 'sinon';
 import TestUtils from 'react-dom/test-utils';
 import { assert } from 'chai';
-import { identity } from 'lodash';
 import { parse } from 'url';
 import { shallow } from 'enzyme';
 
@@ -36,7 +35,7 @@ describe( 'Theme', () => {
 					'https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?ssl=1',
 			},
 			buttonContents: { dummyAction: { label: 'Dummy action', action: sinon.spy() } }, // TODO: test if called when clicked
-			translate: identity,
+			translate: ( string ) => string,
 			setThemesBookmark: () => {},
 		};
 	} );
@@ -124,7 +123,7 @@ describe( 'Theme', () => {
 				React.createElement( Theme, {
 					theme: { id: 'placeholder-1', name: 'Loading' },
 					isPlaceholder: true,
-					translate: identity,
+					translate: ( string ) => string,
 				} )
 			);
 			themeNode = ReactDom.findDOMNode( themeElement );

--- a/client/components/themes-list/test/index.jsx
+++ b/client/components/themes-list/test/index.jsx
@@ -7,7 +7,6 @@
  */
 import React from 'react';
 import deepFreeze from 'deep-freeze';
-import { identity } from 'lodash';
 import { shallow } from 'enzyme';
 
 /**
@@ -37,7 +36,7 @@ const defaultProps = deepFreeze( {
 	fetchNextPage: noop,
 	getButtonOptions: noop,
 	onScreenshotClick: noop,
-	translate: identity,
+	translate: ( string ) => string,
 } );
 
 describe( 'ThemesList', () => {

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { clone, difference, each, forEach, identity, last, map, some, take } from 'lodash';
+import { clone, difference, each, forEach, last, map, some, take } from 'lodash';
 import classNames from 'classnames';
 import debugFactory from 'debug';
 
@@ -59,7 +59,7 @@ class TokenField extends PureComponent {
 		maxSuggestions: 100,
 		value: Object.freeze( [] ),
 		placeholder: '',
-		displayTransform: identity,
+		displayTransform: ( token ) => token,
 		saveTransform: function ( token ) {
 			return token.trim();
 		},

--- a/client/components/vertical-menu/index.jsx
+++ b/client/components/vertical-menu/index.jsx
@@ -4,12 +4,14 @@
 
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { identity, partial } from 'lodash';
+import { partial } from 'lodash';
 
 /**
  * Style dependencies
  */
 import './style.scss';
+
+const noop = () => {};
 
 export class VerticalMenu extends PureComponent {
 	static propTypes = {
@@ -20,7 +22,7 @@ export class VerticalMenu extends PureComponent {
 
 	static defaultProps = {
 		initialItemIndex: 0,
-		onClick: identity,
+		onClick: noop,
 	};
 
 	constructor( props ) {

--- a/client/components/vertical-menu/items/social-item.jsx
+++ b/client/components/vertical-menu/items/social-item.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { get, identity } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ import SocialLogo from 'calypso/components/social-logo';
  */
 import './style.scss';
 
-const services = ( translate ) => ( {
+const services = ( translate = ( string ) => string ) => ( {
 	facebook: { icon: 'facebook', label: translate( 'Facebook' ) },
 	google: { icon: 'google', label: translate( 'Google search' ) },
 	google_plus: { icon: 'google-plus', label: translate( 'Google+ ' ) },
@@ -27,6 +27,8 @@ const services = ( translate ) => ( {
 	twitter: { icon: 'twitter', label: translate( 'Twitter' ) },
 	wordpress: { icon: 'wordpress', label: translate( 'WordPress.com Reader' ) },
 } );
+
+const noop = () => {};
 
 export const SocialItem = ( props ) => {
 	const { isSelected, onClick, service, translate } = props;
@@ -51,14 +53,13 @@ export const SocialItem = ( props ) => {
 SocialItem.propTypes = {
 	isSelected: PropTypes.bool,
 	onClick: PropTypes.func,
-	service: PropTypes.oneOf( Object.keys( services( identity ) ) ).isRequired,
+	service: PropTypes.oneOf( Object.keys( services() ) ).isRequired,
 	translate: PropTypes.func,
 };
 
 SocialItem.defaultProps = {
 	isSelected: false,
-	onClick: identity,
-	translate: identity,
+	onClick: noop,
 };
 
 export default localize( SocialItem );

--- a/client/jetpack-connect/test/auth-form-header.js
+++ b/client/jetpack-connect/test/auth-form-header.js
@@ -6,7 +6,6 @@
  * External dependencies
  */
 import React from 'react';
-import { identity } from 'lodash';
 import { shallow } from 'enzyme';
 
 /**
@@ -35,7 +34,7 @@ const DEFAULT_PROPS = {
 		state: '1',
 		userEmail: `email@${ SITE_SLUG }`,
 	},
-	translate: identity,
+	translate: ( string ) => string,
 };
 
 describe( 'AuthFormHeader', () => {

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -7,7 +7,6 @@
  */
 import deepFreeze from 'deep-freeze';
 import React from 'react';
-import { identity } from 'lodash';
 import { shallow } from 'enzyme';
 
 /**
@@ -58,7 +57,7 @@ const DEFAULT_PROPS = deepFreeze( {
 	recordTracksEvent: noop,
 	retryAuth: noop,
 	siteSlug: SITE_SLUG,
-	translate: identity,
+	translate: ( string ) => string,
 	user: {
 		display_name: "A User's Name",
 	},

--- a/client/jetpack-connect/test/jetpack-connect-notices.js
+++ b/client/jetpack-connect/test/jetpack-connect-notices.js
@@ -6,7 +6,6 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,7 +14,7 @@ import { JetpackConnectNotices } from '../jetpack-connect-notices';
 
 const terminalErrorNoticeType = 'siteBlocked';
 const nonTerminalErrorNoticeType = 'retryAuth';
-const requiredProps = { translate: identity };
+const requiredProps = { translate: ( string ) => string };
 
 describe( 'JetpackConnectNotices', () => {
 	test( 'Should render notice', () => {

--- a/client/jetpack-connect/test/main-wrapper.jsx
+++ b/client/jetpack-connect/test/main-wrapper.jsx
@@ -9,7 +9,6 @@ jest.mock( 'calypso/components/data/document-head', () => 'DocumentHead' );
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,15 +17,17 @@ import { JetpackConnectMainWrapper } from '../main-wrapper';
 import Main from 'calypso/components/main';
 
 describe( 'JetpackConnectMainWrapper', () => {
+	const translate = ( string ) => string;
+
 	test( 'should render a <Main> instance', () => {
-		const wrapper = shallow( <JetpackConnectMainWrapper translate={ identity } /> );
+		const wrapper = shallow( <JetpackConnectMainWrapper translate={ translate } /> );
 
 		expect( wrapper.find( Main ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render the passed children as children of the component', () => {
 		const wrapper = shallow(
-			<JetpackConnectMainWrapper translate={ identity }>
+			<JetpackConnectMainWrapper translate={ translate }>
 				<span className="test__child" />
 			</JetpackConnectMainWrapper>
 		).render();
@@ -35,14 +36,14 @@ describe( 'JetpackConnectMainWrapper', () => {
 	} );
 
 	test( 'should always specify the jetpack-connect__main class', () => {
-		const wrapper = shallow( <JetpackConnectMainWrapper translate={ identity } /> );
+		const wrapper = shallow( <JetpackConnectMainWrapper translate={ translate } /> );
 
 		expect( wrapper.hasClass( 'jetpack-connect__main' ) ).toBe( true );
 	} );
 
 	test( 'should allow more classes to be added', () => {
 		const wrapper = shallow(
-			<JetpackConnectMainWrapper className="test__class" translate={ identity } />
+			<JetpackConnectMainWrapper className="test__class" translate={ translate } />
 		);
 
 		expect( wrapper.hasClass( 'jetpack-connect__main' ) ).toBe( true );
@@ -50,26 +51,26 @@ describe( 'JetpackConnectMainWrapper', () => {
 	} );
 
 	test( 'should not contain the is-wide modifier class by default', () => {
-		const wrapper = shallow( <JetpackConnectMainWrapper translate={ identity } /> );
+		const wrapper = shallow( <JetpackConnectMainWrapper translate={ translate } /> );
 
 		expect( wrapper.hasClass( 'is-wide' ) ).toBe( false );
 	} );
 
 	test( 'should contain the is-wide modifier class if prop is specified', () => {
-		const wrapper = shallow( <JetpackConnectMainWrapper isWide translate={ identity } /> );
+		const wrapper = shallow( <JetpackConnectMainWrapper isWide translate={ translate } /> );
 
 		expect( wrapper.hasClass( 'is-wide' ) ).toBe( true );
 	} );
 
 	test( 'should not contain the is-mobile-app-flow modifier class by default', () => {
-		const wrapper = shallow( <JetpackConnectMainWrapper translate={ identity } /> );
+		const wrapper = shallow( <JetpackConnectMainWrapper translate={ translate } /> );
 
 		expect( wrapper.hasClass( 'is-mobile-app-flow' ) ).toBe( false );
 	} );
 
 	test( 'should contain the is-mobile-app-flow modifier if cookie is set', () => {
 		document.cookie = 'jetpack_connect_mobile_redirect=some url';
-		const wrapper = shallow( <JetpackConnectMainWrapper isWide translate={ identity } /> );
+		const wrapper = shallow( <JetpackConnectMainWrapper isWide translate={ translate } /> );
 
 		expect( wrapper.hasClass( 'is-mobile-app-flow' ) ).toBe( true );
 	} );

--- a/client/jetpack-connect/test/signup.js
+++ b/client/jetpack-connect/test/signup.js
@@ -7,7 +7,6 @@
  */
 import deepFreeze from 'deep-freeze';
 import React from 'react';
-import { identity } from 'lodash';
 import { shallow } from 'enzyme';
 
 /**
@@ -50,7 +49,7 @@ const DEFAULT_PROPS = deepFreeze( {
 	createAccount: noop,
 	path: '/jetpack/connect/authorize',
 	recordTracksEvent: noop,
-	translate: identity,
+	translate: ( string ) => string,
 } );
 
 describe( 'JetpackSignup', () => {

--- a/client/layout/guided-tours/tour-branching.js
+++ b/client/layout/guided-tours/tour-branching.js
@@ -3,7 +3,7 @@
  */
 
 import { Children } from 'react';
-import { flatMap, identity } from 'lodash';
+import { flatMap } from 'lodash';
 
 /*
  * Transforms a React `Children` object into an array. The children of a `Step` are
@@ -11,7 +11,7 @@ import { flatMap, identity } from 'lodash';
  */
 const childrenToArray = ( children ) => {
 	if ( typeof children === 'function' ) {
-		children = children( { translate: identity } );
+		children = children( { translate: ( string ) => string } );
 	}
 
 	return Children.toArray( children );

--- a/client/lib/checkout/masking.js
+++ b/client/lib/checkout/masking.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { identity } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { getCreditCardType } from 'calypso/lib/checkout';
@@ -42,6 +37,7 @@ export function formatAmexCreditCard( cardNumber ) {
 }
 
 const fieldMasks = {};
+const unmask = ( value ) => value;
 
 fieldMasks[ 'expiration-date' ] = {
 	mask: function ( previousValue, nextValue ) {
@@ -70,7 +66,7 @@ fieldMasks[ 'expiration-date' ] = {
 		return nextValue.substring( 0, 2 ) + '/' + nextValue.substring( 2, 4 );
 	},
 
-	unmask: identity,
+	unmask,
 };
 
 fieldMasks.number = {
@@ -88,7 +84,7 @@ fieldMasks.cvv = {
 		return nextValue.replace( /[^\d]/g, '' ).substring( 0, 4 );
 	},
 
-	unmask: identity,
+	unmask,
 };
 
 fieldMasks.nik = {
@@ -97,7 +93,7 @@ fieldMasks.nik = {
 		return digitsOnly;
 	},
 
-	unmask: identity,
+	unmask,
 };
 
 // `document` is an EBANX field. Currently used for Brazilian CPF numbers
@@ -135,7 +131,7 @@ fieldMasks.document = {
 		return string.replace( /^[\s.-]+|[\s.-]+$/g, '' );
 	},
 
-	unmask: identity,
+	unmask,
 };
 
 /**

--- a/client/lib/make-json-schema-parser/index.js
+++ b/client/lib/make-json-schema-parser/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import schemaValidator from 'is-my-json-valid';
-import { get, identity } from 'lodash';
+import { get } from 'lodash';
 
 export class SchemaError extends Error {
 	constructor( errors ) {
@@ -19,6 +19,8 @@ export class TransformerError extends Error {
 	}
 }
 
+const defaultTransformer = ( data ) => data;
+
 /**
  * @typedef {Function} Parser
  * @param   {*}        data   Input data
@@ -30,13 +32,17 @@ export class TransformerError extends Error {
 /**
  * Create a parser to validate and transform data
  *
- * @param {object}   schema               JSON schema
- * @param {Function} transformer=identity Transformer function
- * @param {object}   schemaOptions={}     Options to pass to schema validator
+ * @param {object}   schema        JSON schema
+ * @param {Function} transformer   Transformer function
+ * @param {object}   schemaOptions Options to pass to schema validator
  *
- * @returns {Parser}                       Function to validate and transform data
+ * @returns {Parser}               Function to validate and transform data
  */
-export function makeJsonSchemaParser( schema, transformer = identity, schemaOptions = {} ) {
+export function makeJsonSchemaParser(
+	schema,
+	transformer = defaultTransformer,
+	schemaOptions = {}
+) {
 	let transform;
 	let validate;
 

--- a/client/me/help/help-search/test/index.js
+++ b/client/me/help/help-search/test/index.js
@@ -6,17 +6,15 @@
  * External dependencies
  */
 import React from 'react';
-import { identity } from 'lodash';
 import { shallow } from 'enzyme';
 
 /**
  * Internal dependencies
  */
-
 import { HelpSearch } from '../';
 
 const defaultProps = {
-	translate: identity,
+	translate: ( string ) => string,
 };
 
 const helpLinks = {

--- a/client/my-sites/checkout/cart/cart-buttons.jsx
+++ b/client/my-sites/checkout/cart/cart-buttons.jsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { identity } from 'lodash';
 import page from 'page';
 import { localize } from 'i18n-calypso';
 
@@ -19,10 +17,6 @@ export class CartButtons extends React.Component {
 	static propTypes = {
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 		translate: PropTypes.func.isRequired,
-	};
-
-	static defaultProps = {
-		translate: identity,
 	};
 
 	render() {

--- a/client/my-sites/checkout/cart/test/cart-buttons.js
+++ b/client/my-sites/checkout/cart/test/cart-buttons.js
@@ -23,7 +23,11 @@ describe( 'cart-buttons', () => {
 			const recordGoogleEvent = jest.fn();
 
 			const cartButtonsComponent = mount(
-				<CartButtons selectedSite={ selectedSite } recordGoogleEvent={ recordGoogleEvent } />
+				<CartButtons
+					selectedSite={ selectedSite }
+					recordGoogleEvent={ recordGoogleEvent }
+					translate={ ( string ) => string }
+				/>
 			);
 			cartButtonsComponent.find( 'button.cart-checkout-button' ).simulate( 'click' );
 

--- a/client/my-sites/checkout/cart/test/cart-item-unmocked.js
+++ b/client/my-sites/checkout/cart/test/cart-item-unmocked.js
@@ -3,11 +3,6 @@
  */
 
 /**
- * External dependencies
- */
-import { identity } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { CartItem } from '../cart-item';
@@ -48,7 +43,7 @@ const cartItem = {
 	product_slug: 'plan_value_bundle',
 };
 
-const translate = jest.fn( identity );
+const translate = jest.fn( ( string ) => string );
 const props = {
 	cartItem,
 	translate,

--- a/client/my-sites/checkout/cart/test/cart-item.js
+++ b/client/my-sites/checkout/cart/test/cart-item.js
@@ -6,7 +6,6 @@
  * External dependencies
  */
 import { shallow } from 'enzyme';
-import { identity } from 'lodash';
 import React from 'react';
 
 /**
@@ -56,7 +55,7 @@ const cartItem = {
 	product_slug: 'plan_value_bundle',
 };
 
-const translate = jest.fn( identity );
+const translate = jest.fn( ( string ) => string );
 const props = {
 	cartItem,
 	translate,
@@ -72,7 +71,7 @@ describe( 'cart-item', () => {
 		let myTranslate;
 		let instance;
 		beforeEach( () => {
-			myTranslate = jest.fn( identity );
+			myTranslate = jest.fn( ( string ) => string );
 			instance = new CartItem( {
 				translate: myTranslate,
 				cartItem: {

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -6,7 +6,6 @@ import { localize } from 'i18n-calypso';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,14 +26,7 @@ class CheckoutPending extends PureComponent {
 		siteSlug: PropTypes.string.isRequired,
 		transaction: PropTypes.object,
 		error: PropTypes.object,
-		errorNotice: PropTypes.func,
-		localize: PropTypes.func,
 		redirectTo: PropTypes.string,
-	};
-
-	static defaultProps = {
-		localize: identity,
-		errorNotice: identity,
 	};
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {

--- a/client/my-sites/checkout/checkout-thank-you/transfer-pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/transfer-pending.jsx
@@ -6,7 +6,6 @@ import { localize } from 'i18n-calypso';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { identity } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -25,15 +24,9 @@ import WordPressLogo from 'calypso/components/wordpress-logo';
 class TransferPending extends PureComponent {
 	static propTypes = {
 		error: PropTypes.object,
-		localize: PropTypes.func,
 		showErrorNotice: PropTypes.func,
 		siteId: PropTypes.number.isRequired,
 		transfer: PropTypes.object,
-	};
-
-	static defaultProps = {
-		localize: identity,
-		errorNotice: identity,
 	};
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {

--- a/client/my-sites/checkout/checkout/test/country-specific-payment-fields.js
+++ b/client/my-sites/checkout/checkout/test/country-specific-payment-fields.js
@@ -6,7 +6,6 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,7 +28,7 @@ const defaultProps = {
 	getFieldValue: jest.fn(),
 	handleFieldChange: jest.fn(),
 	fieldClassName: 'country-brazil',
-	translate: identity,
+	translate: ( string ) => string,
 };
 
 describe( '<CountrySpecificPaymentFields />', () => {

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -5,7 +5,6 @@
 /**
  * External dependencies
  */
-import { identity } from 'lodash';
 import moment from 'moment';
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
@@ -21,10 +20,12 @@ import { MAP_EXISTING_DOMAIN_UPDATE_DNS, MAP_SUBDOMAIN } from 'calypso/lib/url/s
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 
 describe( 'index', () => {
+	const translate = ( string ) => string;
+
 	describe( 'rules', () => {
 		test( "should not render anything if there's no need", () => {
 			const props = {
-				translate: identity,
+				translate,
 				domain: {
 					name: 'example.com',
 				},
@@ -39,7 +40,7 @@ describe( 'index', () => {
 
 		test( 'should render the highest priority notice when there are others', () => {
 			const props = {
-				translate: identity,
+				translate,
 				domain: {
 					name: 'example.com',
 					registrationDate: new Date().toISOString(),
@@ -61,7 +62,7 @@ describe( 'index', () => {
 	describe( 'newDomain', () => {
 		test( 'should render new warning notice if the domain is new', () => {
 			const props = {
-				translate: identity,
+				translate,
 				domain: {
 					name: 'example.com',
 					registrationDate: new Date().toISOString(),
@@ -81,7 +82,7 @@ describe( 'index', () => {
 
 		test( 'should render the multi version of the component if more than two domains match the same rule', () => {
 			const props = {
-				translate: identity,
+				translate,
 				domains: [
 					{
 						name: '1.com',
@@ -111,7 +112,7 @@ describe( 'index', () => {
 	describe( 'mapped domain with wrong NS', () => {
 		test( 'should render a warning for misconfigured mapped domains', () => {
 			const props = {
-				translate: identity,
+				translate,
 				domains: [
 					{
 						name: '1.com',
@@ -142,7 +143,7 @@ describe( 'index', () => {
 
 		test( 'should render the correct support url for multiple misconfigured mapped domains', () => {
 			const props = {
-				translate: identity,
+				translate,
 				domains: [
 					{
 						name: '1.com',
@@ -171,7 +172,7 @@ describe( 'index', () => {
 
 		test( 'should show a subdomain mapping related message for one misconfigured subdomain', () => {
 			const props = {
-				translate: identity,
+				translate,
 				domains: [
 					{
 						name: 'blog.example.com',
@@ -195,7 +196,7 @@ describe( 'index', () => {
 
 		test( 'should show a subdomain mapping related message for multiple misconfigured subdomains', () => {
 			const props = {
-				translate: identity,
+				translate,
 				domains: [
 					{
 						name: 'blog.example.com',
@@ -225,7 +226,7 @@ describe( 'index', () => {
 
 		test( 'should show a subdomain mapping related message for multiple misconfigured subdomains and domains mixed', () => {
 			const props = {
-				translate: identity,
+				translate,
 				domains: [
 					{
 						name: 'blog.example.com',
@@ -259,7 +260,7 @@ describe( 'index', () => {
 	describe( 'verification nudge', () => {
 		test( 'should not show any verification nudge for any unverified domains younger than 2 days if site is FSE eligible', () => {
 			const props = {
-				translate: identity,
+				translate,
 				domains: [
 					{
 						name: 'blog.example.com',
@@ -301,7 +302,7 @@ describe( 'index', () => {
 		} );
 		test( 'should show a verification nudge with weak message for any unverified domains younger than 2 days', () => {
 			const props = {
-				translate: identity,
+				translate,
 				domains: [
 					{
 						name: 'blog.example.com',
@@ -342,7 +343,7 @@ describe( 'index', () => {
 
 		test( 'should show a verification nudge with strong message for any unverified domains older than 2 days', () => {
 			const props = {
-				translate: identity,
+				translate,
 				domains: [
 					{
 						name: 'blog.example.com',
@@ -385,7 +386,7 @@ describe( 'index', () => {
 
 		test( "should show a verification nudge with strong message for users who can't manage the domain", () => {
 			const props = {
-				translate: identity,
+				translate,
 				domains: [
 					{
 						name: 'blog.example.com',
@@ -419,7 +420,7 @@ describe( 'index', () => {
 	describe( 'Ruleset filtering', () => {
 		test( 'should only process allowed renderers', () => {
 			const props = {
-				translate: identity,
+				translate,
 				domain: { name: 'example.com' },
 				allowedRules: [],
 				selectedSite: {},
@@ -433,7 +434,7 @@ describe( 'index', () => {
 
 		test( 'should not allow running extra functions other than defined in getPipe()', () => {
 			const props = {
-				translate: identity,
+				translate,
 				domain: { name: 'example.com' },
 				allowedRules: [ 'getDomains' ],
 				selectedSite: {},

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { find, findIndex, get, identity, times, isEmpty } from 'lodash';
+import { find, findIndex, get, times, isEmpty } from 'lodash';
 import page from 'page';
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -73,7 +73,6 @@ export class List extends React.Component {
 	};
 
 	static defaultProps = {
-		translate: identity,
 		enablePrimaryDomainMode: noop,
 		disablePrimaryDomainMode: noop,
 		changePrimary: noop,

--- a/client/my-sites/domains/domain-management/list/test/index.js
+++ b/client/my-sites/domains/domain-management/list/test/index.js
@@ -74,6 +74,7 @@ describe( 'index', () => {
 		userCanManageOptions: true,
 		successNotice: noop,
 		errorNotice: noop,
+		translate: ( string ) => string,
 	} );
 
 	function renderWithProps( props = defaultProps ) {

--- a/client/my-sites/marketing/connections/account-dialog.jsx
+++ b/client/my-sites/marketing/connections/account-dialog.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { filter, find, identity, isEqual } from 'lodash';
+import { filter, find, isEqual } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Notice from 'calypso/components/notice';
 
@@ -38,7 +38,6 @@ class AccountDialog extends Component {
 		isVisible: true,
 		onAccountSelected: () => {},
 		service: Object.freeze( {} ),
-		translate: identity,
 		warningNotice: () => {},
 	};
 

--- a/client/my-sites/marketing/connections/connection.jsx
+++ b/client/my-sites/marketing/connections/connection.jsx
@@ -5,7 +5,6 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -48,7 +47,6 @@ class SharingConnection extends Component {
 		recordGoogleEvent: () => {},
 		showDisconnect: false,
 		siteId: 0,
-		translate: identity,
 		userHasCaps: false,
 		userId: 0,
 		defaultServiceIcon: {

--- a/client/my-sites/marketing/connections/connections.jsx
+++ b/client/my-sites/marketing/connections/connections.jsx
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-
-import PropTypes from 'prop-types';
 import React from 'react';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -26,13 +23,5 @@ const SharingConnections = ( { translate } ) => (
 		<SharingServicesGroup type="other" title={ translate( 'Manage connections' ) } />
 	</div>
 );
-
-SharingConnections.propTypes = {
-	translate: PropTypes.func,
-};
-
-SharingConnections.defaultProps = {
-	translate: identity,
-};
 
 export default localize( SharingConnections );

--- a/client/my-sites/marketing/connections/service-action.jsx
+++ b/client/my-sites/marketing/connections/service-action.jsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -136,7 +134,6 @@ SharingServiceAction.defaultProps = {
 	onAction: () => {},
 	removableConnections: [],
 	status: 'unknown',
-	translate: identity,
 };
 
 export default connect(

--- a/client/my-sites/marketing/connections/service-connected-accounts.jsx
+++ b/client/my-sites/marketing/connections/service-connected-accounts.jsx
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -34,7 +32,6 @@ SharingServiceConnectedAccounts.propTypes = {
 
 SharingServiceConnectedAccounts.defaultProps = {
 	connect: () => {},
-	translate: identity,
 };
 
 export default localize( SharingServiceConnectedAccounts );

--- a/client/my-sites/marketing/connections/service-description.jsx
+++ b/client/my-sites/marketing/connections/service-description.jsx
@@ -4,7 +4,6 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -146,7 +145,6 @@ class SharingServiceDescription extends Component {
 			},
 		} ),
 		numberOfConnections: 0,
-		translate: identity,
 	};
 
 	render() {

--- a/client/my-sites/marketing/connections/service-examples.jsx
+++ b/client/my-sites/marketing/connections/service-examples.jsx
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { identity, includes } from 'lodash';
+import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -49,7 +48,6 @@ class SharingServiceExamples extends Component {
 
 	static defaultProps = {
 		site: Object.freeze( {} ),
-		translate: identity,
 	};
 
 	getSharingButtonsLink() {

--- a/client/my-sites/marketing/connections/service-placeholder.jsx
+++ b/client/my-sites/marketing/connections/service-placeholder.jsx
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 import GridIcon from 'calypso/components/gridicon';
 
@@ -17,10 +15,6 @@ import FoldableCard from 'calypso/components/foldable-card';
 class SharingServicePlaceholder extends Component {
 	static propTypes = {
 		translate: PropTypes.func,
-	};
-
-	static defaultProps = {
-		translate: identity,
 	};
 
 	render() {

--- a/client/my-sites/marketing/connections/service-tip.jsx
+++ b/client/my-sites/marketing/connections/service-tip.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { identity, includes } from 'lodash';
+import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -30,10 +29,6 @@ class SharingServiceTip extends Component {
 	static propTypes = {
 		service: PropTypes.object.isRequired,
 		translate: PropTypes.func,
-	};
-
-	static defaultProps = {
-		translate: identity,
 	};
 
 	facebook() {

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import { identity, isEqual, find, some, get } from 'lodash';
+import { isEqual, find, some, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -96,7 +96,6 @@ export class SharingService extends Component {
 		removableConnections: [],
 		siteId: 0,
 		siteUserConnections: [],
-		translate: identity,
 		updateSiteConnection: () => {},
 		warningNotice: () => {},
 	};

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { identity, includes } from 'lodash';
+import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -48,7 +48,6 @@ export class MediaLibraryFilterBar extends Component {
 		onFilterChange: noop,
 		onSourceChange: noop,
 		onSearch: noop,
-		translate: identity,
 		source: '',
 		post: false,
 		isConnected: true,

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -4,7 +4,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -58,7 +57,6 @@ MediaLibraryUpgradeNudge.propTypes = {
 };
 
 MediaLibraryUpgradeNudge.defaultProps = {
-	translate: identity,
 	filter: 'video',
 };
 

--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import classNames from 'classnames';
@@ -36,7 +35,6 @@ class BlogPostsPage extends React.Component {
 	};
 
 	static defaultProps = {
-		translate: identity,
 		recordCalloutClick: noop,
 	};
 

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -28,7 +28,6 @@ jest.mock( 'i18n-calypso', () => ( {
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -61,6 +60,7 @@ import {
 } from '@automattic/calypso-products';
 import PlanPrice from 'calypso/my-sites/plan-price/';
 
+const translate = ( string ) => string;
 const props = {
 	translate: ( x ) => x,
 	planType: PLAN_FREE,
@@ -393,7 +393,7 @@ describe( 'PlanIntervalDiscount', () => {
 		isYearly: true,
 		rawPrice: 22,
 		relatedMonthlyPlan: { raw_price: 2 },
-		translate: identity,
+		translate,
 		billingTimeFrame: '',
 		title: '',
 		planType: PLAN_JETPACK_FREE,
@@ -425,7 +425,7 @@ describe( 'PlanFeaturesHeader.renderPriceGroup()', () => {
 	const baseProps = {
 		currencyCode: 'USD',
 		isInSignup: false,
-		translate: identity,
+		translate,
 		currentSitePlan: PLAN_FREE,
 		billingTimeFrame: 'for life',
 	};
@@ -470,7 +470,7 @@ describe( 'PlanFeaturesHeader.getPlanFeaturesPrices()', () => {
 		const baseProps = {
 			currencyCode: 'USD',
 			isInSignup: false,
-			translate: identity,
+			translate,
 			currentSitePlan: PLAN_FREE,
 		};
 		test( 'Should return a placeholder when isPlaceholder=true and isInSignup=false', () => {
@@ -512,7 +512,7 @@ describe( 'PlanFeaturesHeader.getPlanFeaturesPrices()', () => {
 			availableForPurchase: true,
 			currencyCode: 'USD',
 			isInSignup: false,
-			translate: identity,
+			translate,
 			currentSitePlan: PLAN_FREE,
 			relatedMonthlyPlan: { raw_price: 5 },
 			rawPrice: 50,
@@ -558,7 +558,7 @@ describe( 'PlanFeaturesHeader.getPlanFeaturesPrices()', () => {
 			availableForPurchase: true,
 			currencyCode: 'USD',
 			isInSignup: false,
-			translate: identity,
+			translate,
 			currentSitePlan: PLAN_FREE,
 			discountPrice: 40,
 			rawPrice: 50,
@@ -595,7 +595,7 @@ describe( 'PlanFeaturesHeader.getPlanFeaturesPrices()', () => {
 			availableForPurchase: true,
 			currencyCode: 'USD',
 			isInSignup: false,
-			translate: identity,
+			translate,
 			currentSitePlan: PLAN_FREE,
 			rawPrice: 50,
 		};
@@ -628,7 +628,7 @@ describe( 'PlanFeaturesHeader.render()', () => {
 			availableForPurchase: true,
 			currencyCode: 'USD',
 			isInSignup: false,
-			translate: identity,
+			translate,
 			currentSitePlan: PLAN_FREE,
 			rawPrice: 9,
 			isJetpack: true,
@@ -690,7 +690,7 @@ describe( 'PlanFeaturesHeader.renderCreditLabel()', () => {
 		currentSitePlan: { productSlug: PLAN_PERSONAL },
 		rawPrice: 100,
 		discountPrice: 80,
-		translate: identity,
+		translate,
 		isJetpack: false,
 		isSiteAT: false,
 	};

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
-import { has, identity, mapValues, pickBy } from 'lodash';
+import { has, mapValues, pickBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,6 +35,8 @@ import getCustomizeUrl from 'calypso/state/selectors/get-customize-url';
 import { isJetpackSite, isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+
+const identity = ( theme ) => theme;
 
 function getAllThemeOptions() {
 	const purchase = config.isEnabled( 'upgrades/checkout' )

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { flow, get, head, isEmpty, identity, includes, partial, some, values } from 'lodash';
+import { flow, get, head, isEmpty, includes, partial, some, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -87,7 +87,6 @@ export class EditorMediaModal extends Component {
 		labels: Object.freeze( {} ),
 		setView: noop,
 		resetView: noop,
-		translate: identity,
 		view: ModalViews.LIST,
 		galleryViewEnabled: true,
 		imageEditorProps: {},

--- a/client/reader/search-stream/post-results.jsx
+++ b/client/reader/search-stream/post-results.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -15,6 +14,8 @@ import HeaderBack from 'calypso/reader/header-back';
 import { RelatedPostCard } from 'calypso/blocks/reader-related-card';
 import { SEARCH_RESULTS } from 'calypso/reader/follow-sources';
 import PostPlaceholder from 'calypso/reader/stream/post-placeholder';
+
+const defaultTransform = ( item ) => item;
 
 class PostResults extends Component {
 	static propTypes = {
@@ -39,7 +40,7 @@ class PostResults extends Component {
 		const transformStreamItems =
 			! query || query === ''
 				? ( postKey ) => ( { ...postKey, isRecommendation: true } )
-				: identity;
+				: defaultTransform;
 
 		return (
 			<Stream

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -3,7 +3,7 @@
  */
 import closest from 'component-closest';
 import { localize } from 'i18n-calypso';
-import { defer, startsWith, identity } from 'lodash';
+import { defer, startsWith } from 'lodash';
 import page from 'page';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -346,10 +346,6 @@ export class ReaderSidebar extends React.Component {
 		);
 	}
 }
-
-ReaderSidebar.defaultProps = {
-	translate: identity,
-};
 
 export default connect(
 	( state ) => {

--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { localize } from 'i18n-calypso';
-import { identity } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
@@ -26,10 +25,6 @@ export class ReaderSidebarLists extends Component {
 		currentListOwner: PropTypes.string,
 		currentListSlug: PropTypes.string,
 		translate: PropTypes.func,
-	};
-
-	static defaultProps = {
-		translate: identity,
 	};
 
 	render() {

--- a/client/reader/sidebar/reader-sidebar-lists/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { identity, map } from 'lodash';
+import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -19,10 +19,6 @@ export class ReaderSidebarListsList extends React.Component {
 		currentListOwner: PropTypes.string,
 		currentListSlug: PropTypes.string,
 		translate: PropTypes.func,
-	};
-
-	static defaultProps = {
-		translate: identity,
 	};
 
 	renderItems() {

--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { localize } from 'i18n-calypso';
-import { identity, startsWith } from 'lodash';
+import { startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -28,10 +28,6 @@ export class ReaderSidebarTags extends Component {
 		currentTag: PropTypes.string,
 		onFollowTag: PropTypes.func,
 		translate: PropTypes.func,
-	};
-
-	static defaultProps = {
-		translate: identity,
 	};
 
 	state = {

--- a/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { localize } from 'i18n-calypso';
-import { identity } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDom from 'react-dom';
@@ -26,10 +25,6 @@ export class ReaderSidebarTagsListItem extends Component {
 		path: PropTypes.string.isRequired,
 		currentTag: PropTypes.string,
 		translate: PropTypes.func,
-	};
-
-	static defaultProps = {
-		translate: identity,
 	};
 
 	componentDidMount() {

--- a/client/reader/sidebar/reader-sidebar-tags/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { localize } from 'i18n-calypso';
-import { identity, map } from 'lodash';
+import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
@@ -17,10 +17,6 @@ export class ReaderSidebarTagsList extends Component {
 		path: PropTypes.string.isRequired,
 		currentTag: PropTypes.string,
 		translate: PropTypes.func,
-	};
-
-	static defaultProps = {
-		translate: identity,
 	};
 
 	renderItems() {

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { identity } from 'lodash';
 import DesignPicker from '@automattic/design-picker';
 
 /**
@@ -31,7 +30,6 @@ class DesignPickerStep extends Component {
 
 	static defaultProps = {
 		useHeadstart: true,
-		translate: identity,
 	};
 
 	pickDesign = ( selectedDesign ) => {

--- a/client/signup/steps/passwordless/index.jsx
+++ b/client/signup/steps/passwordless/index.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,10 +27,6 @@ export class PasswordlessStep extends Component {
 	static propTypes = {
 		flowName: PropTypes.string,
 		translate: PropTypes.func,
-	};
-
-	static defaultProps = {
-		translate: identity,
 	};
 
 	state = {

--- a/client/signup/steps/plans-atomic-store/test/index.jsx
+++ b/client/signup/steps/plans-atomic-store/test/index.jsx
@@ -11,7 +11,6 @@ jest.mock( 'i18n-calypso', () => ( {
  */
 import { shallow } from 'enzyme';
 import React from 'react';
-import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,7 +39,7 @@ import {
 
 const noop = () => {};
 const props = {
-	translate: identity,
+	translate: ( string ) => string,
 	stepName: 'Step name',
 	stepSectionName: 'Step section name',
 	signupDependencies: { domainItem: null },

--- a/client/signup/steps/plans/test/index.jsx
+++ b/client/signup/steps/plans/test/index.jsx
@@ -6,7 +6,6 @@ jest.mock( 'calypso/my-sites/plan-features', () => 'plan-features' );
  */
 import { shallow } from 'enzyme';
 import React from 'react';
-import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,7 +42,7 @@ const props = {
 	submitSignupStep: noop,
 	goToNextStep: noop,
 	recordTracksEvent: noop,
-	translate: identity,
+	translate: ( string ) => string,
 };
 
 describe( 'Plans basic tests', () => {

--- a/client/signup/steps/site-style/test/index.js
+++ b/client/signup/steps/site-style/test/index.js
@@ -7,7 +7,6 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,7 +37,7 @@ describe( '<SiteStyleStep />', () => {
 		saveSignupStep: noop,
 		goToNextStep: noop,
 		recordTracksEvent: noop,
-		translate: identity,
+		translate: ( string ) => string,
 	};
 
 	test( 'should render', () => {

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, identity } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,7 +40,6 @@ class ThemeSelectionStep extends Component {
 
 	static defaultProps = {
 		useHeadstart: true,
-		translate: identity,
 	};
 
 	pickTheme = ( themeId ) => {

--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -34,7 +32,6 @@ class SignupThemesList extends Component {
 		designType: null,
 		quantity: 3,
 		handleScreenshotClick: noop,
-		translate: identity,
 	};
 
 	shouldComponentUpdate( nextProps ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import i18n, { localize } from 'i18n-calypso';
-import { identity, includes, isEmpty, omit, get } from 'lodash';
+import { includes, isEmpty, omit, get } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -57,8 +57,6 @@ export class UserStep extends Component {
 	};
 
 	static defaultProps = {
-		translate: identity,
-		suggestedUsername: identity,
 		isSocialSignupEnabled: false,
 	};
 

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -17,6 +17,7 @@ import sinon from 'sinon';
 import { UserStep as User } from '../';
 
 const noop = () => {};
+const translate = ( string ) => string;
 
 jest.mock( 'calypso/blocks/signup-form', () => require( 'calypso/components/empty-component' ) );
 jest.mock( 'calypso/lib/abtest', () => ( {
@@ -50,6 +51,7 @@ describe( '#signupStep User', () => {
 			subHeaderText: 'first subheader message',
 			flowName: 'userAsFirstStepInFlow',
 			saveSignupStep: noop,
+			translate,
 		} );
 		rendered = TestUtils.renderIntoDocument( testElement );
 
@@ -61,6 +63,7 @@ describe( '#signupStep User', () => {
 			subHeaderText: 'test subheader message',
 			flowName: 'someOtherFlow',
 			saveSignupStep: noop,
+			translate,
 		} );
 		rendered = TestUtils.renderIntoDocument( testElement );
 
@@ -81,6 +84,7 @@ describe( '#signupStep User', () => {
 				subHeaderText: 'test subheader message',
 				flowName: 'someOtherFlow',
 				saveSignupStep: noop,
+				translate,
 			} );
 			component = ReactDOM.render( element, node );
 		} );
@@ -94,6 +98,7 @@ describe( '#signupStep User', () => {
 				subHeaderText: 'My test message',
 				flowName: 'userAsFirstStepInFlow',
 				saveSignupStep: noop,
+				translate,
 			};
 
 			expect( spyComponentProps.calledOnce ).to.equal( false );
@@ -109,6 +114,7 @@ describe( '#signupStep User', () => {
 				subHeaderText: 'My test message',
 				flowName: 'another test message test',
 				saveSignupStep: noop,
+				translate,
 			};
 
 			expect( spyComponentProps.calledOnce ).to.equal( false );

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import deterministicStringify from 'fast-json-stable-stringify';
-import { get, identity, merge } from 'lodash';
+import { get, merge } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -15,6 +15,7 @@ import warn from '@wordpress/warning';
 import { keyedReducer } from 'calypso/state/utils';
 
 const noop = () => {};
+const identity = ( data ) => data;
 
 /**
  * Returns response data from an HTTP request success action if available

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, identity, isEmpty, map } from 'lodash';
+import { get, isEmpty, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -56,7 +56,7 @@ export const eligibilityHoldsFromApi = ( { errors = [] }, options = {} ) =>
 			}
 			return get( statusMapping, code, '' );
 		} )
-		.filter( identity );
+		.filter( ( error ) => error );
 
 /**
  * Maps from API response the issues which trigger a confirmation for automated transfer

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
@@ -56,7 +56,7 @@ export const eligibilityHoldsFromApi = ( { errors = [] }, options = {} ) =>
 			}
 			return get( statusMapping, code, '' );
 		} )
-		.filter( ( error ) => error );
+		.filter( Boolean );
 
 /**
  * Maps from API response the issues which trigger a confirmation for automated transfer

--- a/client/state/http/index.js
+++ b/client/state/http/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { identity } from 'lodash';
 import { extendAction } from '@automattic/state-utils';
 
 /**
@@ -73,7 +72,7 @@ export const httpHandler = async ( { dispatch }, action ) => {
 		serialize = JSON.stringify.bind( JSON );
 	} else {
 		// assume body is already serialized
-		serialize = identity;
+		serialize = ( serializedBody ) => serializedBody;
 	}
 
 	const queryString = encodeQueryParameters( queryParams );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `identity()` is used many times in our codebase, but it's pretty straightforward and can be replaced with a function that returns its first argument. 

Some of the instances are actually `defaultProps` and can be removed when unnecessary, and some of them are necessary only to satisfy unit tests. For those, we can alternatively provide a `translate` replacement, which is the rest that this PR is doing.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify Calypso builds and smoke test it.
* Verify all tests pass: `yarn run test-client`. Most of the changes are either in tests or covered by tests, so tests passing is a strong indicator here.
* Go through each change one by one and verify it makes sense. 

#### Note

Some pre-existing ESLint errors are expected.