### PR TITLE
E2E: Remove unnecessary presence checks from clickMySites helper

### DIFF
--- a/test/e2e/lib/components/nav-bar-component.js
+++ b/test/e2e/lib/components/nav-bar-component.js
@@ -41,14 +41,6 @@ export default class NavBarComponent extends AsyncBaseContainer {
 	async clickMySites() {
 		const mySitesSelector = by.css( 'header.masterbar a.masterbar__item' );
 		await driverHelper.clickWhenClickable( this.driver, mySitesSelector );
-		await driverHelper.isEventuallyPresentAndDisplayed(
-			this.driver,
-			by.css( '.sidebar__menu-wrapper' )
-		);
-		return await driverHelper.isEventuallyPresentAndDisplayed(
-			this.driver,
-			by.css( '.is-group-sites' )
-		);
 	}
 	hasUnreadNotifications() {
 		return this.driver

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -203,28 +203,17 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async ensureSidebarMenuVisible() {
-		const allSitesSelector = By.css( '.current-section button' );
-		const sidebarSelector = By.css( '.sidebar .sidebar__region' );
-		const sidebar = await this.driver.findElement( sidebarSelector );
-		const sidebarRect = await sidebar.getRect();
-		const sidebarVisible = sidebar.isDisplayed() && sidebarRect.x >= -100;
-
-		if ( ! sidebarVisible ) {
-			try {
-				await driverHelper.clickWhenClickable(
-					this.driver,
-					allSitesSelector,
-					this.explicitWaitMS / 4
-				);
-			} catch ( e ) {
-				console.log( 'All sites button did not click' );
-				await driverHelper.clickWhenClickable(
-					this.driver,
-					By.css( 'a[data-tip-target="my-sites"]' )
-				);
-			}
+		if ( this.screenSize === 'desktop' ) {
+			return;
 		}
-		return await driverHelper.waitUntilLocatedAndVisible( this.driver, sidebarSelector );
+		const openSidebarLocator = By.css( '.layout.focus-sidebar .sidebar' );
+		const isOpen = await driverHelper.isElementPresent( this.driver, openSidebarLocator );
+
+		if ( ! isOpen ) {
+			const mySitesButtonLocator = By.css( 'a[data-tip-target="my-sites"]' );
+			await driverHelper.clickWhenClickable( this.driver, mySitesButtonLocator );
+			await driverHelper.waitUntilElementStopsMoving( this.driver, openSidebarLocator );
+		}
 	}
 
 	async selectSiteSwitcher() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove unnecessary element presence checks from clickMySites helper. Waiting for those elements causes an additional delay of ~20 seconds on each call (tested locally). That helper is used 17 times in our suites which means this tweak should save us a lot of time :)

_update_: Re-run [the build](https://teamcity.a8c.com/viewType.html?buildTypeId=calypso_RunCalypsoE2eDesktopTests&branch_calypso_WebApp=fix%2Fe2e-click-my-sites&tab=buildTypeStatusDiv) a few times - looks like we're consistently 🟢 and ~10-25% faster than [trunk](https://teamcity.a8c.com/viewType.html?buildTypeId=calypso_RunCalypsoE2eDesktopTests&branch_calypso_WebApp=%3Cdefault%3E&tab=buildTypeStatusDiv)!  🎉

#### Testing instructions

All specs should pass.