### PR TITLE
Design Picker - Blank Canvas: Add tracks events

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -1,3 +1,4 @@
+import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo, useEffect } from 'react';
 import { recordOnboardingComplete } from '../lib/analytics';
@@ -38,10 +39,11 @@ export default function useOnSiteCreation(): void {
 		() => ( {
 			isNewSite: !! newSite,
 			isNewUser: !! newUser,
+			isBlankCanvas: isBlankCanvasDesign( design ),
 			blogId: newSite?.blogid,
 			hasCartItems: false,
 		} ),
-		[ newSite, newUser ]
+		[ newSite, newUser, design ]
 	);
 
 	useEffect( () => {

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -45,6 +45,7 @@ export function recordOnboardingComplete( params: OnboardingCompleteParameters )
 	const trackingParams = {
 		is_new_user: params.isNewUser,
 		is_new_site: params.isNewSite,
+		is_blank_canvas: params.isBlankCanvas,
 		blog_id: params.blogId,
 		has_cart_items: params.hasCartItems,
 		flow: params.flow,

--- a/client/landing/gutenboarding/lib/analytics/types.ts
+++ b/client/landing/gutenboarding/lib/analytics/types.ts
@@ -28,6 +28,11 @@ export interface OnboardingCompleteParameters {
 	isNewSite: boolean;
 
 	/**
+	 * Whether the blank canvas design is selected
+	 */
+	isBlankCanvas?: boolean;
+
+	/**
 	 * The blog id of the newly created site
 	 */
 	blogId: number | string | undefined;

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -25,7 +25,17 @@ export function recordSignupStart( flow, ref, optionalProps ) {
 }
 
 export function recordSignupComplete(
-	{ flow, siteId, isNewUser, hasCartItems, isNew7DUserSite, theme, intent, startingPoint },
+	{
+		flow,
+		siteId,
+		isNewUser,
+		isBlankCanvas,
+		hasCartItems,
+		isNew7DUserSite,
+		theme,
+		intent,
+		startingPoint,
+	},
 	now
 ) {
 	const isNewSite = !! siteId;
@@ -35,7 +45,17 @@ export function recordSignupComplete(
 		return addToQueue(
 			'signup',
 			'recordSignupComplete',
-			{ flow, siteId, isNewUser, hasCartItems, isNew7DUserSite, theme, intent, startingPoint },
+			{
+				flow,
+				siteId,
+				isNewUser,
+				isBlankCanvas,
+				hasCartItems,
+				isNew7DUserSite,
+				theme,
+				intent,
+				startingPoint,
+			},
 			true
 		);
 	}
@@ -49,6 +69,7 @@ export function recordSignupComplete(
 		blog_id: siteId,
 		is_new_user: isNewUser,
 		is_new_site: isNewSite,
+		is_blank_canvas: isBlankCanvas,
 		has_cart_items: hasCartItems,
 		theme,
 		intent,
@@ -86,6 +107,7 @@ export function recordSignupComplete(
 		blog_id: siteId,
 		is_new_user: isNewUser,
 		is_new_site: isNewSite,
+		is_blank_canvas: isBlankCanvas,
 		has_cart_items: hasCartItems,
 		theme,
 		intent,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -4,6 +4,7 @@ import {
 	isDomainTransfer,
 	isDomainMapping,
 } from '@automattic/calypso-products';
+import { isBlankCanvasDesign } from '@automattic/design-picker';
 import debugModule from 'debug';
 import {
 	clone,
@@ -448,6 +449,7 @@ class Signup extends Component {
 			theme: selectedDesign?.theme,
 			intent,
 			startingPoint,
+			isBlankCanvas: isBlankCanvasDesign( dependencies.selectedDesign ),
 		} );
 
 		this.handleLogin( dependencies, destination );

--- a/packages/design-picker/src/utils/__tests__/is-blank-canvas-design.ts
+++ b/packages/design-picker/src/utils/__tests__/is-blank-canvas-design.ts
@@ -24,5 +24,11 @@ describe( 'Design Picker blank canvas utils', () => {
 			mockDesign.slug = 'blank-canva';
 			expect( isBlankCanvasDesign( mockDesign ) ).toBeFalsy();
 		} );
+		it( 'should return false when no design is provided', () => {
+			expect( isBlankCanvasDesign() ).toBeFalsy();
+		} );
+		it( 'should return false when undefined is provided', () => {
+			expect( isBlankCanvasDesign( undefined ) ).toBeFalsy();
+		} );
 	} );
 } );

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -104,6 +104,9 @@ export function getAvailableDesigns( {
 	return designs;
 }
 
-export function isBlankCanvasDesign( design: Design ): boolean {
+export function isBlankCanvasDesign( design?: Design ): boolean {
+	if ( ! design ) {
+		return false;
+	}
 	return /blank-canvas/i.test( design.slug );
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* use `isBlankCanvasDesign` util from `@automattic/design-picker` to determine if the blank canvas design is selected.
* update `trackingParams` object that's been fed to `calypso_newsite_complete` and `calypso_signup_complete` tracks events.
* add `isBlankCanvas` prop to `OnboardingCompleteParameters` interface.

### Testing instructions

#### A. `/new` flow

1. Open the Network tab in DevTools. Tick `Preserve log`.
1. Go through the `/new` flow.
1. When you reach the design picker page, select the blank canvas.
1. After the site creation, filter the network tab with `is_blank_canvas` and inspect the payload.
1. Verify that there are two events: `calypso_newsite_complete` and `calypso_signup_complete`, which both have 
   - `flow`: `gutenboarding`
   - `is_blank_canvas`: `true`.
1. Now, create a new site with anything but the blank canvas design.
1. After the site creation, filter the network tab with `is_blank_canvas` and inspect the payload.
1. Verify that there are two events: `calypso_newsite_complete` and `calypso_signup_complete`, which both have 
   - `flow`: `gutenboarding`
   - `is_blank_canvas`: `false`

#### B. `/start` flow

1. Open the Network tab in DevTools. Tick `Preserve log`.
1. Go through the `/start` flow. Select the build intent.
1. When you reach the design picker page, select the blank canvas.
1. After the site creation, filter the network tab with `is_blank_canvas` and inspect the payload.
1. Verify that there are an event: `calypso_signup_complete`, which has 
   - `flow`: `setup-site`
   - `is_blank_canvas`: `true`.
1. Now, create a new site with anything but the blank canvas design.
1. After the site creation, filter the network tab with `is_blank_canvas` and inspect the payload.
1. Verify that there are an event: `calypso_signup_complete`, which has 
   - `flow`: `setup-site`
   - `is_blank_canvas`: `false`


Related to #52289
