### PR TITLE
Increase subtitle font size for legacy plan card

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -136,6 +136,11 @@
 	margin-inline-end: 16px;
 }
 
+.jetpack-product-card__price-deprecated {
+	font-size: 1.5rem;
+	font-weight: 700;
+}
+
 .jetpack-product-card__you-save,
 .jetpack-product-card__get-started {
 	display: inline-block;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR increases the font size of the subtitle in the legacy card.

Fixes 1200196139286276-as-1200259578331177

### Testing instructions

- Download the PR and run Calypso
- Visit `/plans/:site?compare_plans=jetpack_personal,jetpack_backup_daily`, for instance
- Check that the card subtitle in the legacy product card looks like in the capture below

### Screenshots

<img width="383" alt="Screen Shot 2021-04-28 at 12 22 22 PM" src="https://user-images.githubusercontent.com/1620183/116438168-31069e00-a81c-11eb-818d-51e87361c7df.png">
