### PR TITLE
Partner Portal: Fix the key selection dropdown being visible when there's only one key to select from

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown/index.tsx
@@ -34,11 +34,11 @@ export default function SelectPartnerKeyDropdown(): ReactElement | null {
 			label: key.name,
 		} ) );
 
-	options?.unshift( { label: translate( 'Partner Key' ) as string, value: '', isLabel: true } );
-
-	if ( ! options || options.length < 2 ) {
+	if ( ! options || options.length <= 1 ) {
 		return null;
 	}
+
+	options?.unshift( { label: translate( 'Partner Key' ) as string, value: '', isLabel: true } );
 
 	return (
 		<SelectDropdown


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Partner Portal: Fix the key selection dropdown being visible when there's only one key to select from

#### Testing instructions

* If you do not have a partner key, please contact Infinity for one or you will be unable to view test this PR.
* Check out this PR locally, then run `yarn && yarn start-jetpack-cloud`.
* Make sure you only have 1 active partner key associated with your account.
* Open up http://jetpack.cloud.localhost:3000/partner-portal/ and confirm that neither a key selection screen nor a key selection dropdown is visible.
* Activate more than 1 partner key for your account. Confirm that the key selection dropdown is now visible.
