### PR TITLE
Site Editor: revert to opening pages in the post editor

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -45,7 +45,6 @@ import WebPreview from 'calypso/components/web-preview';
 import { editPost, trashPost } from 'calypso/state/posts/actions';
 import { getEditorPostId } from 'calypso/state/editor/selectors';
 import { protectForm, ProtectedFormProps } from 'calypso/lib/protect-form';
-import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor.js';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import getSiteUrl from 'calypso/state/selectors/get-site-url';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -826,19 +825,10 @@ const mapStateToProps = (
 		queryArgs[ 'in-editor-deprecation-group' ] = 1;
 	}
 
-	let siteAdminUrl =
+	const siteAdminUrl =
 		editorType === 'site'
 			? getSiteAdminUrl( state, siteId, 'admin.php?page=gutenberg-edit-site' )
 			: getSiteAdminUrl( state, siteId, postId ? 'post.php' : 'post-new.php' );
-
-	// Use the site editor to edit already-published pages if site editor is enabled
-	if ( postId && postType === 'page' && isSiteUsingCoreSiteEditor( state, siteId ) ) {
-		siteAdminUrl = getSiteAdminUrl(
-			state,
-			siteId,
-			`admin.php?page=gutenberg-edit-site&postId=${ postId }&postType=page`
-		);
-	}
 
 	const iframeUrl = addQueryArgs( queryArgs, siteAdminUrl );
 

--- a/client/state/selectors/is-site-using-core-site-editor.js
+++ b/client/state/selectors/is-site-using-core-site-editor.js
@@ -12,7 +12,7 @@ import getRawSite from 'calypso/state/selectors/get-raw-site';
  * Checks if a site is using the core Site Editor
  *
  * @param {object} state  Global state tree
- * @param {number|null} siteId Site ID
+ * @param {object} siteId Site ID
  * @returns {boolean} True if the site is using core Site Editor, otherwise false
  */
 export default function isSiteUsingCoreSiteEditor( state, siteId ) {

--- a/client/state/selectors/is-site-using-core-site-editor.js
+++ b/client/state/selectors/is-site-using-core-site-editor.js
@@ -12,7 +12,7 @@ import getRawSite from 'calypso/state/selectors/get-raw-site';
  * Checks if a site is using the core Site Editor
  *
  * @param {object} state  Global state tree
- * @param {object} siteId Site ID
+ * @param {number|null} siteId Site ID
  * @returns {boolean} True if the site is using core Site Editor, otherwise false
  */
 export default function isSiteUsingCoreSiteEditor( state, siteId ) {


### PR DESCRIPTION
For the next testing rounds we'll default to using the post editor for page creation/editing. This also enables us to test new template editor that's been recently added to it more.

For more details see the discussions in https://github.com/Automattic/wp-calypso/issues/52170 and pbAok1-26m-p2#comment-4363.

### Testing instructions

1. Navigate to pages list in Calypso
2. Click on a page and verify that it opens up in the post editor