### PR TITLE
ExPlat: Use memoized anonId in LocalStorage

### DIFF
--- a/packages/explat-client/CHANGELOG.md
+++ b/packages/explat-client/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Change dangerouslyGetExperimentAssignment to log rather than throw
 - Store state in LocalStorage
-- Memoize getAnonId in LocalStorage
+- Cache getAnonId in LocalStorage
 
 ## 0.0.1
 

--- a/packages/explat-client/CHANGELOG.md
+++ b/packages/explat-client/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Change dangerouslyGetExperimentAssignment to log rather than throw
 - Store state in LocalStorage
+- Memoize getAnonId in LocalStorage
 
 ## 0.0.1
 

--- a/packages/explat-client/src/internal/experiment-assignment-store.ts
+++ b/packages/explat-client/src/internal/experiment-assignment-store.ts
@@ -3,41 +3,12 @@
  */
 import type { ExperimentAssignment } from '../types';
 import * as Validations from './validations';
-
-const localStorage =
-	typeof window !== 'undefined' && window.localStorage
-		? window.localStorage
-		: // LocalStorage polyfill from https://gist.github.com/juliocesar/926500
-		  {
-				_data: {} as Record< string, string >,
-				setItem: function ( id: string, val: string ) {
-					return ( this._data[ id ] = String( val ) );
-				},
-				getItem: function ( id: string ) {
-					return this._data.hasOwnProperty( id ) ? this._data[ id ] : undefined;
-				},
-				removeItem: function ( id: string ) {
-					return delete this._data[ id ];
-				},
-				clear: function () {
-					return ( this._data = {} );
-				},
-		  };
+import localStorage from './local-storage';
 
 const localStorageExperimentAssignmentKeyPrefix = 'explat-experiment-';
 
 const localStorageExperimentAssignmentKey = ( experimentName: string ): string =>
 	`${ localStorageExperimentAssignmentKeyPrefix }-${ experimentName }`;
-
-/**
- * INTERNAL USE ONLY
- *
- * Clears all ExperimentAssignments.
- * Useful for testing.
- */
-export function clearAllExperimentAssignments(): void {
-	localStorage.clear();
-}
 
 /**
  * Store an ExperimentAssignment.

--- a/packages/explat-client/src/internal/local-storage.ts
+++ b/packages/explat-client/src/internal/local-storage.ts
@@ -9,16 +9,16 @@ const localStorage =
 		  {
 				_data: {} as Record< string, string >,
 				setItem: function ( id: string, val: string ) {
-					return ( this._data[ id ] = String( val ) );
+					this._data[ id ] = val;
 				},
 				getItem: function ( id: string ) {
 					return this._data.hasOwnProperty( id ) ? this._data[ id ] : undefined;
 				},
 				removeItem: function ( id: string ) {
-					return delete this._data[ id ];
+					delete this._data[ id ];
 				},
 				clear: function () {
-					return ( this._data = {} );
+					this._data = {};
 				},
 		  };
 

--- a/packages/explat-client/src/internal/local-storage.ts
+++ b/packages/explat-client/src/internal/local-storage.ts
@@ -1,0 +1,25 @@
+/**
+ * A polyfilled LocalStorage.
+ * The polyfill is required at least for testing.
+ */
+const localStorage =
+	typeof window !== 'undefined' && window.localStorage
+		? window.localStorage
+		: // LocalStorage polyfill from https://gist.github.com/juliocesar/926500
+		  {
+				_data: {} as Record< string, string >,
+				setItem: function ( id: string, val: string ) {
+					return ( this._data[ id ] = String( val ) );
+				},
+				getItem: function ( id: string ) {
+					return this._data.hasOwnProperty( id ) ? this._data[ id ] : undefined;
+				},
+				removeItem: function ( id: string ) {
+					return delete this._data[ id ];
+				},
+				clear: function () {
+					return ( this._data = {} );
+				},
+		  };
+
+export default localStorage;

--- a/packages/explat-client/src/internal/test/experiment-assignment-store.ts
+++ b/packages/explat-client/src/internal/test/experiment-assignment-store.ts
@@ -22,9 +22,9 @@ describe( 'experiment-assignment-store', () => {
 			undefined
 		);
 		storeExperimentAssignment( validExperimentAssignment );
-		expect( retrieveExperimentAssignment( validExperimentAssignment.experimentName ) ).toEqual(
-			validExperimentAssignment
-		);
+		expect(
+			retrieveExperimentAssignment( validExperimentAssignment.experimentName )
+		).toStrictEqual( validExperimentAssignment );
 
 		expect( retrieveExperimentAssignment( validFallbackExperimentAssignment.experimentName ) ).toBe(
 			undefined
@@ -32,7 +32,7 @@ describe( 'experiment-assignment-store', () => {
 		storeExperimentAssignment( validFallbackExperimentAssignment );
 		expect(
 			retrieveExperimentAssignment( validFallbackExperimentAssignment.experimentName )
-		).toEqual( validFallbackExperimentAssignment );
+		).toStrictEqual( validFallbackExperimentAssignment );
 	} );
 
 	it( 'should throw for storing an ExperimentAssignment for a currently stored Experiment with an older date', () => {

--- a/packages/explat-client/src/internal/test/experiment-assignment-store.ts
+++ b/packages/explat-client/src/internal/test/experiment-assignment-store.ts
@@ -10,9 +10,10 @@ import {
 	storeExperimentAssignment,
 } from '../experiment-assignment-store';
 import { validExperimentAssignment, validFallbackExperimentAssignment } from '../test-common';
+import localStorage from '../local-storage';
 
 beforeEach( () => {
-	window.localStorage.clear();
+	localStorage.clear();
 } );
 
 describe( 'experiment-assignment-store', () => {

--- a/packages/explat-client/src/internal/test/requests.ts
+++ b/packages/explat-client/src/internal/test/requests.ts
@@ -12,6 +12,7 @@ import * as Requests from '../requests';
 import type { Config, ExperimentAssignment } from '../../types';
 import { delayedValue, ONE_DELAY, validExperimentAssignment } from '../test-common';
 import * as ExperimentAssignments from '../experiment-assignments';
+import localStorage from '../local-storage';
 
 const spiedMonotonicNow = jest.spyOn( Timing, 'monotonicNow' );
 
@@ -42,6 +43,10 @@ function mockFetchExperimentAssignmentToMatchExperimentAssignment(
 		)
 	);
 }
+
+beforeEach( () => {
+	localStorage.clear();
+} );
 
 describe( 'fetchExperimentAssignment', () => {
 	it( 'should successfully fetch and return a well formed response with an anonId', async () => {
@@ -196,6 +201,63 @@ describe( 'fetchExperimentAssignment', () => {
 		await expect(
 			Requests.fetchExperimentAssignment( mockedConfig, validExperimentAssignment.experimentName )
 		).rejects.toThrow( `Newly fetched experiment isn't alive.` );
+	} );
+} );
+
+describe( 'localStorageMemoizedGetAnonId', () => {
+	it( 'should memoize an anonId for non-empty strings', async () => {
+		const mockGetAnonIdA = jest.fn( async () => 'asdf' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
+		expect( mockGetAnonIdA ).toHaveBeenCalledTimes( 1 );
+
+		const mockGetAnonIdB = jest.fn( async () => 'qwer' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( 'asdf' );
+		expect( mockGetAnonIdB ).toHaveBeenCalledTimes( 0 );
+	} );
+
+	it( 'should not memoize an anonId for falsy values', async () => {
+		const mockGetAnonIdA = jest.fn( async () => null );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( null );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( null );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( null );
+		expect( mockGetAnonIdA ).toHaveBeenCalledTimes( 3 );
+
+		const mockGetAnonIdB = jest.fn( async () => undefined );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( undefined );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( undefined );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( undefined );
+		expect( mockGetAnonIdB ).toHaveBeenCalledTimes( 3 );
+
+		const mockGetAnonIdC = jest.fn( async () => '' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdC ) ).toBe( '' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdC ) ).toBe( '' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdC ) ).toBe( '' );
+		expect( mockGetAnonIdC ).toHaveBeenCalledTimes( 3 );
+
+		const mockGetAnonIdD = jest.fn( async () => 'asdf' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdD ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdD ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdD ) ).toBe( 'asdf' );
+		expect( mockGetAnonIdD ).toHaveBeenCalledTimes( 1 );
+
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
+		expect( mockGetAnonIdA ).toHaveBeenCalledTimes( 3 );
+
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( 'asdf' );
+		expect( mockGetAnonIdB ).toHaveBeenCalledTimes( 3 );
+
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdC ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdC ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdC ) ).toBe( 'asdf' );
+		expect( mockGetAnonIdC ).toHaveBeenCalledTimes( 3 );
 	} );
 } );
 

--- a/packages/explat-client/src/internal/test/requests.ts
+++ b/packages/explat-client/src/internal/test/requests.ts
@@ -204,63 +204,6 @@ describe( 'fetchExperimentAssignment', () => {
 	} );
 } );
 
-describe( 'localStorageMemoizedGetAnonId', () => {
-	it( 'should memoize an anonId for non-empty strings', async () => {
-		const mockGetAnonIdA = jest.fn( async () => 'asdf' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
-		expect( mockGetAnonIdA ).toHaveBeenCalledTimes( 1 );
-
-		const mockGetAnonIdB = jest.fn( async () => 'qwer' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( 'asdf' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( 'asdf' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( 'asdf' );
-		expect( mockGetAnonIdB ).toHaveBeenCalledTimes( 0 );
-	} );
-
-	it( 'should not memoize an anonId for falsy values', async () => {
-		const mockGetAnonIdA = jest.fn( async () => null );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( null );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( null );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( null );
-		expect( mockGetAnonIdA ).toHaveBeenCalledTimes( 3 );
-
-		const mockGetAnonIdB = jest.fn( async () => undefined );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( undefined );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( undefined );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( undefined );
-		expect( mockGetAnonIdB ).toHaveBeenCalledTimes( 3 );
-
-		const mockGetAnonIdC = jest.fn( async () => '' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdC ) ).toBe( '' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdC ) ).toBe( '' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdC ) ).toBe( '' );
-		expect( mockGetAnonIdC ).toHaveBeenCalledTimes( 3 );
-
-		const mockGetAnonIdD = jest.fn( async () => 'asdf' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdD ) ).toBe( 'asdf' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdD ) ).toBe( 'asdf' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdD ) ).toBe( 'asdf' );
-		expect( mockGetAnonIdD ).toHaveBeenCalledTimes( 1 );
-
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
-		expect( mockGetAnonIdA ).toHaveBeenCalledTimes( 3 );
-
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( 'asdf' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( 'asdf' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdB ) ).toBe( 'asdf' );
-		expect( mockGetAnonIdB ).toHaveBeenCalledTimes( 3 );
-
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdC ) ).toBe( 'asdf' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdC ) ).toBe( 'asdf' );
-		expect( await Requests.localStorageMemoizedGetAnonId( mockGetAnonIdC ) ).toBe( 'asdf' );
-		expect( mockGetAnonIdC ).toHaveBeenCalledTimes( 3 );
-	} );
-} );
-
 describe( 'isFetchExperimentAssignmentResponse', () => {
 	it( 'should return true for valid responses', () => {
 		expect(
@@ -351,5 +294,89 @@ describe( 'isFetchExperimentAssignmentResponse', () => {
 				variations: 'string',
 			} )
 		).toBe( false );
+	} );
+} );
+
+describe( 'localStorageCachedGetAnonId', () => {
+	it( 'should return a fresh anonId for non-falsy values', async () => {
+		const mockGetAnonIdA = jest.fn( async () => 'asdf' );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
+		expect( mockGetAnonIdA ).toHaveBeenCalledTimes( 3 );
+
+		const mockGetAnonIdB = jest.fn( async () => 'qwer' );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdB ) ).toBe( 'qwer' );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdB ) ).toBe( 'qwer' );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdB ) ).toBe( 'qwer' );
+		expect( mockGetAnonIdB ).toHaveBeenCalledTimes( 3 );
+	} );
+
+	it( 'should not cache an anonId for falsy values', async () => {
+		const mockGetAnonIdNull = jest.fn( async () => null );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( null );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( null );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( null );
+		expect( mockGetAnonIdNull ).toHaveBeenCalledTimes( 3 );
+
+		const mockGetAnonIdEmpty = jest.fn( async () => '' );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdEmpty ) ).toBe( null );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdEmpty ) ).toBe( null );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdEmpty ) ).toBe( null );
+		expect( mockGetAnonIdEmpty ).toHaveBeenCalledTimes( 3 );
+
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( null );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( null );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( null );
+		expect( mockGetAnonIdNull ).toHaveBeenCalledTimes( 6 );
+	} );
+
+	it( 'should return a cached anonId for falsy-values within the expiry time', async () => {
+		const mockGetAnonIdA = jest.fn( async () => 'asdf' );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
+
+		const mockGetAnonIdNull = jest.fn( async () => null );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( 'asdf' );
+		expect( mockGetAnonIdNull ).toHaveBeenCalledTimes( 3 );
+
+		const mockGetAnonIdEmpty = jest.fn( async () => '' );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdEmpty ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdEmpty ) ).toBe( 'asdf' );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdEmpty ) ).toBe( 'asdf' );
+		expect( mockGetAnonIdEmpty ).toHaveBeenCalledTimes( 3 );
+	} );
+
+	it( 'should not return the cached anonId for falsy-values outside of the expiry time', async () => {
+		const mockGetAnonIdA = jest.fn( async () => 'asdf' );
+		spiedMonotonicNow.mockImplementationOnce( () => 0 );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
+
+		const mockGetAnonIdNull = jest.fn( async () => null );
+		spiedMonotonicNow.mockImplementationOnce( () => 1 );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( 'asdf' );
+		spiedMonotonicNow.mockImplementationOnce( () => 3 * 60 * 60 * 1000 - 1 );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( 'asdf' );
+		spiedMonotonicNow.mockImplementationOnce( () => 3 * 60 * 60 * 1000 );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( null );
+		spiedMonotonicNow.mockImplementationOnce( () => 3 * 60 * 60 * 1000 + 1 );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( null );
+		spiedMonotonicNow.mockImplementationOnce( () => Infinity );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( null );
+
+		// And let's make sure we can overwrite it:
+		spiedMonotonicNow.mockImplementationOnce( () => 0 );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdA ) ).toBe( 'asdf' );
+		spiedMonotonicNow.mockImplementationOnce( () => 1 );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( 'asdf' );
+		spiedMonotonicNow.mockImplementationOnce( () => 3 * 60 * 60 * 1000 - 1 );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( 'asdf' );
+		spiedMonotonicNow.mockImplementationOnce( () => 3 * 60 * 60 * 1000 );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( null );
+		spiedMonotonicNow.mockImplementationOnce( () => 3 * 60 * 60 * 1000 + 1 );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( null );
+		spiedMonotonicNow.mockImplementationOnce( () => Infinity );
+		expect( await Requests.localStorageCachedGetAnonId( mockGetAnonIdNull ) ).toBe( null );
 	} );
 } );

--- a/packages/explat-client/src/test/create-explat-client.ts
+++ b/packages/explat-client/src/test/create-explat-client.ts
@@ -8,7 +8,6 @@ import '@automattic/calypso-polyfills';
  * Internal dependencies
  */
 import { createExPlatClient } from '../create-explat-client';
-import { clearAllExperimentAssignments } from '../internal/experiment-assignment-store';
 import {
 	delayedValue,
 	ONE_DELAY,
@@ -19,6 +18,7 @@ import {
 } from '../internal/test-common';
 import * as Timing from '../internal/timing';
 import type { Config, ExperimentAssignment } from '../types';
+import localStorage from '../internal/local-storage';
 
 type MockedFunction = ReturnType< typeof jest.fn >;
 
@@ -53,7 +53,7 @@ function mockFetchExperimentAssignmentToMatchExperimentAssignment(
 beforeEach( () => {
 	jest.resetAllMocks();
 	setBrowserContext();
-	clearAllExperimentAssignments();
+	localStorage.clear();
 } );
 
 describe( 'createExPlatClient', () => {
@@ -368,7 +368,7 @@ describe( 'ExPlatClient.loadExperimentAssignment multiple-use', () => {
 		} );
 
 		await runTest();
-		clearAllExperimentAssignments();
+		localStorage.clear();
 		await runDevelopmentModeTest();
 	} );
 

--- a/packages/explat-client/src/test/create-explat-client.ts
+++ b/packages/explat-client/src/test/create-explat-client.ts
@@ -135,6 +135,9 @@ describe( 'ExPlatClient.loadExperimentAssignment single-use', () => {
 		spiedMonotonicNow.mockImplementationOnce(
 			() => validExperimentAssignment.retrievedTimestamp + 1000
 		);
+		spiedMonotonicNow.mockImplementationOnce(
+			() => validExperimentAssignment.retrievedTimestamp + 1001
+		);
 		await expect(
 			client.loadExperimentAssignment( validExperimentAssignment.experimentName )
 		).resolves.toEqual( validExperimentAssignment );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR uses memoized anonId in LocalStorage
* Also refactors some of the localStorage code

Resolves 615-gh-Automattic/experimentation-platform

**There were a few options on where to cache the anonId:**
- Tracks
- The tracks wrapper
- In `lib/explat/internals/getAnonId`
- Within the client

I decided to go with the last option:
- Simple to implement
- Keeps our code contained and under our control
- Will be consistent across platforms
- Less for client implementors to consider

The downside is that this is less customisable per platform, but I am feeling YAGNI on it, and we can change later.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Added automated tests

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->