### PR TITLE
Fix incorrect constants imports in calypso-products

### DIFF
--- a/packages/calypso-products/src/plans-list.js
+++ b/packages/calypso-products/src/plans-list.js
@@ -9,6 +9,7 @@ import i18n, { translate } from 'i18n-calypso';
  */
 import { isEnabled } from '@automattic/calypso-config';
 import {
+	FEATURE_BACKUP_DAILY_V2,
 	FEATURE_13GB_STORAGE,
 	FEATURE_200GB_STORAGE,
 	FEATURE_3GB_STORAGE,
@@ -1174,10 +1175,10 @@ export const PLANS_LIST = {
 				FEATURE_GOOGLE_ANALYTICS,
 			] ),
 		getPlanCardFeatures: () => [
-			constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
-			constants.FEATURE_PRODUCT_SCAN_DAILY_V2,
-			constants.FEATURE_ANTISPAM_V2,
-			constants.FEATURE_VIDEO_HOSTING_V2,
+			FEATURE_PRODUCT_BACKUP_DAILY_V2,
+			FEATURE_PRODUCT_SCAN_DAILY_V2,
+			FEATURE_ANTISPAM_V2,
+			FEATURE_VIDEO_HOSTING_V2,
 		],
 		getSignupFeatures: ( currentPlan ) => {
 			const showPersonalPlan =
@@ -1250,10 +1251,10 @@ export const PLANS_LIST = {
 				FEATURE_GOOGLE_ANALYTICS,
 			] ),
 		getPlanCardFeatures: () => [
-			constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
-			constants.FEATURE_PRODUCT_SCAN_DAILY_V2,
-			constants.FEATURE_ANTISPAM_V2,
-			constants.FEATURE_VIDEO_HOSTING_V2,
+			FEATURE_PRODUCT_BACKUP_DAILY_V2,
+			FEATURE_PRODUCT_SCAN_DAILY_V2,
+			FEATURE_ANTISPAM_V2,
+			FEATURE_VIDEO_HOSTING_V2,
 		],
 		getSignupFeatures: ( currentPlan ) => {
 			const showPersonalPlan =
@@ -1317,9 +1318,9 @@ export const PLANS_LIST = {
 			FEATURE_PREMIUM_SUPPORT,
 		],
 		getPlanCardFeatures: () => [
-			constants.FEATURE_BACKUP_DAILY_V2,
-			constants.FEATURE_ACTIVITY_LOG,
-			constants.FEATURE_PREMIUM_SUPPORT,
+			FEATURE_BACKUP_DAILY_V2,
+			FEATURE_ACTIVITY_LOG,
+			FEATURE_PREMIUM_SUPPORT,
 		],
 		getSignupFeatures: () => [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
@@ -1372,9 +1373,9 @@ export const PLANS_LIST = {
 			FEATURE_PREMIUM_SUPPORT,
 		],
 		getPlanCardFeatures: () => [
-			constants.FEATURE_BACKUP_DAILY_V2,
-			constants.FEATURE_ACTIVITY_LOG,
-			constants.FEATURE_PREMIUM_SUPPORT,
+			FEATURE_BACKUP_DAILY_V2,
+			FEATURE_ACTIVITY_LOG,
+			FEATURE_PREMIUM_SUPPORT,
 		],
 		getSignupFeatures: () => [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
@@ -1443,10 +1444,10 @@ export const PLANS_LIST = {
 				FEATURE_UNLIMITED_PREMIUM_THEMES,
 			] ),
 		getPlanCardFeatures: () => [
-			constants.FEATURE_PLAN_SECURITY_DAILY,
-			constants.FEATURE_PRODUCT_BACKUP_REALTIME_V2,
-			constants.FEATURE_PRODUCT_SCAN_REALTIME_V2,
-			constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
+			FEATURE_PLAN_SECURITY_DAILY,
+			FEATURE_PRODUCT_BACKUP_REALTIME_V2,
+			FEATURE_PRODUCT_SCAN_REALTIME_V2,
+			FEATURE_ACTIVITY_LOG_1_YEAR_V2,
 		],
 		getSignupFeatures: () => [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
@@ -1517,10 +1518,10 @@ export const PLANS_LIST = {
 				FEATURE_UNLIMITED_PREMIUM_THEMES,
 			] ),
 		getPlanCardFeatures: () => [
-			constants.FEATURE_PLAN_SECURITY_DAILY,
-			constants.FEATURE_PRODUCT_BACKUP_REALTIME_V2,
-			constants.FEATURE_PRODUCT_SCAN_REALTIME_V2,
-			constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
+			FEATURE_PLAN_SECURITY_DAILY,
+			FEATURE_PRODUCT_BACKUP_REALTIME_V2,
+			FEATURE_PRODUCT_SCAN_REALTIME_V2,
+			FEATURE_ACTIVITY_LOG_1_YEAR_V2,
 		],
 		getSignupFeatures: () => [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a rebase error in https://github.com/Automattic/wp-calypso/pull/52252 missing some new code from https://github.com/Automattic/wp-calypso/pull/52341. Specifically, there were several uses of the no-longer-existing `constants` variable that remained in the code.

#### Testing instructions

Tests should be sufficient.