### PR TITLE
Add update prompt to show to Jetpack sites with older versions of the plugin 

### DIFF
--- a/client/blocks/jetpack-plugin-update-warning/index.tsx
+++ b/client/blocks/jetpack-plugin-update-warning/index.tsx
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import React, { FC, useCallback, useMemo, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ExternalLink from 'calypso/components/external-link';
+import Notice from 'calypso/components/notice';
+import { preventWidows } from 'calypso/lib/formatting';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
+import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
+
+interface ExternalProps {
+	siteId: number;
+	minJetpackVersion: string;
+}
+
+/**
+ * Show a warning Notice if the current site has a Jetpack version prior to `minJetpackVersion`.
+ *
+ * @param {object} props - the id of the current site
+ * @param {number} props.siteId – the ID of the current site
+ * @param {string} props.minJetpackVersion – the minimum accepted Jetpack version
+ */
+export const JetpackPluginUpdateWarning: FC< ExternalProps > = ( {
+	siteId,
+	minJetpackVersion,
+}: ExternalProps ) => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const [ isDismissed, setIsDismissed ] = useState( false );
+
+	const siteJetpackVersion = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'jetpack_version' )
+	);
+
+	const pluginUpgradeUrl = useSelector( ( state ) =>
+		getSiteAdminUrl( state, siteId, 'update-core.php#update-plugins-table' )
+	);
+
+	const hideWarning = useMemo(
+		() => siteJetpackVersion >= minJetpackVersion || ! pluginUpgradeUrl,
+		[ minJetpackVersion, pluginUpgradeUrl, siteJetpackVersion ]
+	);
+
+	const dismissClick = useCallback( () => {
+		setIsDismissed( true );
+		dispatch( recordTracksEvent( 'calypso_jetpack_plugin_update_warning_dismiss' ) );
+	}, [ dispatch, setIsDismissed ] );
+
+	const updatePluginClick = useCallback( () => {
+		setIsDismissed( true );
+		dispatch( recordTracksEvent( 'calypso_jetpack_plugin_update_warning_click' ) );
+	}, [ dispatch, setIsDismissed ] );
+
+	if ( hideWarning || isDismissed ) {
+		return null;
+	}
+
+	return (
+		<Notice onDismissClick={ dismissClick }>
+			{ preventWidows(
+				translate(
+					'Your Jetpack plugin is out of date. ' +
+						'To make sure it will work with our recommended' +
+						' plans, {{JetpackUpdateLink}}update Jetpack{{/JetpackUpdateLink}}.',
+					{
+						components: {
+							JetpackUpdateLink: (
+								<ExternalLink
+									href={ pluginUpgradeUrl }
+									onClick={ updatePluginClick }
+									target="_blank"
+								/>
+							),
+						},
+					}
+				)
+			) }
+		</Notice>
+	);
+};
+
+export default JetpackPluginUpdateWarning;

--- a/client/blocks/jetpack-plugin-update-warning/index.tsx
+++ b/client/blocks/jetpack-plugin-update-warning/index.tsx
@@ -63,7 +63,7 @@ export const JetpackPluginUpdateWarning: FC< ExternalProps > = ( {
 	}
 
 	return (
-		<Notice onDismissClick={ dismissClick }>
+		<Notice onDismissClick={ dismissClick } status="is-warning">
 			{ preventWidows(
 				translate(
 					'Your Jetpack plugin is out of date. ' +

--- a/client/my-sites/plans/jetpack-plans/plans-header.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-header.tsx
@@ -9,6 +9,8 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { getPlanRecommendationFromContext } from './plan-upgrade/utils';
+import { JETPACK_LEGACY_PLANS_MAX_PLUGIN_VERSION } from '@automattic/calypso-products/src/constants';
+import JetpackPluginUpdateWarning from 'calypso/blocks/jetpack-plugin-update-warning';
 import { preventWidows } from 'calypso/lib/formatting';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -24,10 +26,21 @@ type HeaderProps = {
 	shouldShowPlanRecommendation?: boolean;
 };
 
-const StandardPlansHeader = ( { shouldShowPlanRecommendation }: HeaderProps ) => (
+type StandardHeaderProps = {
+	shouldShowPlanRecommendation?: boolean;
+	siteId: number | null;
+};
+
+const StandardPlansHeader = ( { shouldShowPlanRecommendation, siteId }: StandardHeaderProps ) => (
 	<>
 		<FormattedHeader headerText={ translate( 'Plans' ) } align="left" brandFont />
 		<PlansNavigation path={ '/plans' } />
+		{ shouldShowPlanRecommendation && siteId && (
+			<JetpackPluginUpdateWarning
+				siteId={ siteId }
+				minJetpackVersion={ JETPACK_LEGACY_PLANS_MAX_PLUGIN_VERSION }
+			/>
+		) }
 		{ ! shouldShowPlanRecommendation && (
 			<h2 className="jetpack-plans__pricing-header">
 				{ preventWidows(
@@ -80,8 +93,8 @@ const PlansHeader = ( { context, shouldShowPlanRecommendation }: HeaderProps ) =
 		</>
 	) : (
 		<StandardPlansHeader
-			context={ context }
 			shouldShowPlanRecommendation={ shouldShowPlanRecommendation }
+			siteId={ siteId }
 		/>
 	);
 };

--- a/packages/calypso-products/src/constants.js
+++ b/packages/calypso-products/src/constants.js
@@ -149,6 +149,9 @@ export const JETPACK_REDIRECT_URL =
 	'https://jetpack.com/redirect/?source=jetpack-checkout-thankyou';
 export const redirectCloudCheckoutToWpAdmin = () => !! JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN;
 
+// Jetpack versions prior to this one are not fully compatible with new plans
+export const JETPACK_LEGACY_PLANS_MAX_PLUGIN_VERSION = '8.9.1';
+
 // plans constants
 export const PLAN_BUSINESS_MONTHLY = 'business-bundle-monthly';
 export const PLAN_BUSINESS = 'business-bundle';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a new Notice component that displays a warning to any site that has a Jetpack version prior to the one required by the component.

#### Testing instructions

**Prerequisite**
* Site with a version of the Jetpack plugin prior to 8.9.1.
* Site with a version of the Jetpack plugin equal to or higher than 8.9.1.

**Instructions**
* Download this PR.
* Run Calypso Blue with `yarn start`.

Site with an older version of Jetpack
* Visit `http://calypso.localhost:3000/plans/[site]?compare_plans=jetpack_personal,jetpack_backup_daily`, replacing `[site]` with your site that has a Jetpack version prior to 8.9.1.
* Verify that you see the warning notice.
* Open the Network panel (Dev Console).
* Click on the `update Jetpack` link.
* Make sure that a new tab was opened and that you were redirected to your site's wp-admin. Make sure also that you landed on the page where you can update the plugin.
* Close the tab and review the Network panel.
* Make sure that the `calypso_jetpack_plugin_update_warning_click` event was dispatched.

Site with an up-to-date version of Jetpack
* Visit `http://calypso.localhost:3000/plans/[site]?compare_plans=jetpack_personal,jetpack_backup_daily`, replacing `[site]` with your site that has a Jetpack version equal to or higher than 8.9.1.
* Verify that you _don't_ see the warning notice.

Related to 1200196139286276-as-1200247484326057

#### Demo

https://user-images.githubusercontent.com/3418513/116461253-09243400-a836-11eb-8bad-76b3cac7b1aa.mp4



