### PR TITLE
Add term switch in plans recommendation section

### DIFF
--- a/client/my-sites/plans/jetpack-plans/plan-upgrade/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/plan-upgrade/index.tsx
@@ -31,12 +31,14 @@ import type { Duration, PurchaseCallback, SelectorProduct } from '../types';
 type Props = {
 	planRecommendation: PlanRecommendation;
 	duration: Duration;
+	filterBar: React.ReactNode;
 	onSelectProduct: PurchaseCallback;
 };
 
 const PlanUpgradeSection: React.FC< Props > = ( {
 	planRecommendation,
 	duration,
+	filterBar,
 	onSelectProduct,
 } ) => {
 	const translate = useTranslate();
@@ -88,6 +90,7 @@ const PlanUpgradeSection: React.FC< Props > = ( {
 					}
 				) }
 			</p>
+			{ filterBar }
 			<ul className="plan-upgrade__list">
 				<li className="plan-upgrade__legacy-item">
 					<ProductCard

--- a/client/my-sites/plans/jetpack-plans/plan-upgrade/style.scss
+++ b/client/my-sites/plans/jetpack-plans/plan-upgrade/style.scss
@@ -11,7 +11,7 @@
 
 .plan-upgrade__description {
 	max-width: 400px;
-	margin: 2rem auto 3rem;
+	margin: 2rem auto;
 
 	font-size: 1rem;
 	text-align: center;
@@ -21,23 +21,13 @@
 
 		font-size: 1.25rem;
 	}
-
-	@include break-wide {
-		margin-bottom: 6rem;
-	}
-
-	.with-single-reco & {
-		@include break-xlarge {
-			margin-bottom: 6rem;
-		}
-	}
 }
 
 .plan-upgrade__list {
 	display: flex;
 	flex-direction: column;
 
-	margin: 0 auto 132px;
+	margin: 72px auto 132px;
 
 	list-style-type: none;
 

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -129,23 +129,28 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 		return () => window.removeEventListener( 'resize', onResize );
 	}, [ onResize ] );
 
+	const filterBar = (
+		<div className="product-grid__filter-bar">
+			<PlansFilterBar
+				showDiscountMessage
+				onDurationChange={ onDurationChange }
+				duration={ duration }
+			/>
+		</div>
+	);
+
 	return (
 		<>
 			{ planRecommendation && (
 				<PlanUpgradeSection
 					planRecommendation={ planRecommendation }
 					duration={ duration }
+					filterBar={ filterBar }
 					onSelectProduct={ onSelectProduct }
 				/>
 			) }
 			<ProductGridSection title={ translate( 'Most Popular' ) }>
-				<div className="product-grid__filter-bar">
-					<PlansFilterBar
-						showDiscountMessage
-						onDurationChange={ onDurationChange }
-						duration={ duration }
-					/>
-				</div>
+				{ ! planRecommendation && filterBar }
 				<ul
 					className={ classNames( 'product-grid__plan-grid', {
 						'is-wrapping': isPlanRowWrapping,

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -45,6 +45,7 @@
 }
 
 .product-grid__plan-grid:not( .is-wrapping ) {
+	margin-top: 72px;
 	grid-gap: 24px 0;
 
 	// Considering there are 3 plans


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds the term switch in the recommendation section of the plans page, when the section is shown.

Fixes 1200196139286276-as-1200247484326048

### Implementation notes

In the mockups, the switch is shown both in the recommendation and most popular sections. This doesn't quite work, since the  filter bar is docked when you scroll. Since it's available at any time, there's no need to have it twice.

### Testing instructions

- Download the PR and run Calypso
- Visit `plans/:site` and check that the term switch behaves as usual
- Visit `/plans/:site?compare_plans=:legacy-slug,new-slug` and check that the term switch is in the recommendation section, and behaves as expected

### Screenshots

<img width="1119" alt="Screen Shot 2021-04-28 at 4 14 08 PM" src="https://user-images.githubusercontent.com/1620183/116466877-08db6700-a83d-11eb-94a6-e82db49a1265.png">
