### PR TITLE
Jetpack Connection: fixing checkout for skipped user connection.

### DIFF
--- a/client/blocks/jetpack-connect-skip-user/index.js
+++ b/client/blocks/jetpack-connect-skip-user/index.js
@@ -23,6 +23,7 @@ class JetpackConnectSkipUser extends Component {
 			{
 				redirect: redirectAfterAuth,
 				site: slug,
+				unlinked: '1',
 			},
 			`https://cloud.jetpack.com/pricing/${ slug }`
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixing the Jetpack Cloud plans page and checkout for users who skip user connection

Related to #52303

#### Testing instructions

1. Log out of WP.com
2. Initiate Jetpack connection via Calypso flow, skip the user connection.
3. On the Jetpack Cloud "Plans" page, choose a non-free plan.
4. You should get redirected to the login page, then - to user connection flow.
5. After approving the connection, you should end up in the Checkout with the product added into your shopping cart.