### PR TITLE
ci(teamcity): Add a Keep-Rule for tagged trunk builds

### DIFF
--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -147,20 +147,4 @@ open class PluginBaseBuild : Template({
 			"""
 		}
 	}
-
-	cleanup {
-		keepRule {
-			keepAtLeast = allBuilds()
-			applyToBuilds {
-				inBranches {
-					branchFilter = patterns("+:<default>")
-				}
-				withStatus = successful()
-				withTags = anyOf(releaseTag)
-			}
-			dataToKeep = everything()
-			applyPerEachBranch = true
-			preserveArtifactsDependencies = true
-		}
-	}
 })

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -147,4 +147,20 @@ open class PluginBaseBuild : Template({
 			"""
 		}
 	}
+
+	cleanup {
+		keepRule {
+			keepAtLeast = allBuilds()
+			applyToBuilds {
+				inBranches {
+					branchFilter = patterns("+:<default>")
+				}
+				withStatus = successful()
+				withTags = anyOf(releaseTag)
+			}
+			dataToKeep = everything()
+			applyPerEachBranch = true
+			preserveArtifactsDependencies = true
+		}
+	}
 })

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -30,6 +30,23 @@ object WPComPlugins : Project({
 
 	// For some reason, TeamCity needs this to reference the Template.
 	template(PluginBaseBuild())
+
+	cleanup {
+		keepRule {
+			id = "keepReleaseBuilds"
+			keepAtLeast = allBuilds()
+			applyToBuilds {
+				inBranches {
+					branchFilter = patterns("+:<default>")
+				}
+				withStatus = successful()
+				withTags = anyOf("notifications-release-build", "etk-release-build", "wpcom-block-editor-release-build", "o2-blocks-release-build")
+			}
+			dataToKeep = everything()
+			applyPerEachBranch = true
+			preserveArtifactsDependencies = true
+		}
+	}
 })
 
 
@@ -82,23 +99,6 @@ private object EditingToolkit : BuildType({
 			"""
 		}
 	}
-
-	cleanup {
-		keepRule {
-			id = "keepReleaseBuilds"
-			keepAtLeast = allBuilds()
-			applyToBuilds {
-				inBranches {
-					branchFilter = patterns("+:<default>")
-				}
-				withStatus = successful()
-				withTags = anyOf("etk-release-build")
-			}
-			dataToKeep = everything()
-			applyPerEachBranch = true
-			preserveArtifactsDependencies = true
-		}
-	}
 })
 
 private object WpcomBlockEditor : BuildType({
@@ -110,23 +110,6 @@ private object WpcomBlockEditor : BuildType({
 		param("plugin_slug", "wpcom-block-editor")
 		param("archive_dir", "./dist/")
 		param("build_env", "development")
-	}
-
-	cleanup {
-		keepRule {
-			id = "keepReleaseBuilds"
-			keepAtLeast = allBuilds()
-			applyToBuilds {
-				inBranches {
-					branchFilter = patterns("+:<default>")
-				}
-				withStatus = successful()
-				withTags = anyOf("wpcom-block-editor-release-build")
-			}
-			dataToKeep = everything()
-			applyPerEachBranch = true
-			preserveArtifactsDependencies = true
-		}
 	}
 })
 
@@ -162,23 +145,6 @@ private object Notifications : BuildType({
 			sed -i "s~${'$'}old_cache_buster~${'$'}new_cache_buster~g" release-archive/index.html release-archive/rtl.html
 		""".trimIndent())
 	}
-
-	cleanup {
-		keepRule {
-			id = "keepReleaseBuilds"
-			keepAtLeast = allBuilds()
-			applyToBuilds {
-				inBranches {
-					branchFilter = patterns("+:<default>")
-				}
-				withStatus = successful()
-				withTags = anyOf("notifications-release-build")
-			}
-			dataToKeep = everything()
-			applyPerEachBranch = true
-			preserveArtifactsDependencies = true
-		}
-	}
 })
 
 private object O2Blocks : BuildType({
@@ -204,23 +170,6 @@ private object O2Blocks : BuildType({
 				# Add index.php file
 				cp index.php release-files/
 			"""
-		}
-	}
-
-	cleanup {
-		keepRule {
-			id = "keepReleaseBuilds"
-			keepAtLeast = allBuilds()
-			applyToBuilds {
-				inBranches {
-					branchFilter = patterns("+:<default>")
-				}
-				withStatus = successful()
-				withTags = anyOf("o2-blocks-release-build")
-			}
-			dataToKeep = everything()
-			applyPerEachBranch = true
-			preserveArtifactsDependencies = true
 		}
 	}
 })

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -82,6 +82,23 @@ private object EditingToolkit : BuildType({
 			"""
 		}
 	}
+
+	cleanup {
+		keepRule {
+			id = "keepReleaseBuilds"
+			keepAtLeast = allBuilds()
+			applyToBuilds {
+				inBranches {
+					branchFilter = patterns("+:<default>")
+				}
+				withStatus = successful()
+				withTags = anyOf("etk-release-build")
+			}
+			dataToKeep = everything()
+			applyPerEachBranch = true
+			preserveArtifactsDependencies = true
+		}
+	}
 })
 
 private object WpcomBlockEditor : BuildType({
@@ -93,6 +110,23 @@ private object WpcomBlockEditor : BuildType({
 		param("plugin_slug", "wpcom-block-editor")
 		param("archive_dir", "./dist/")
 		param("build_env", "development")
+	}
+
+	cleanup {
+		keepRule {
+			id = "keepReleaseBuilds"
+			keepAtLeast = allBuilds()
+			applyToBuilds {
+				inBranches {
+					branchFilter = patterns("+:<default>")
+				}
+				withStatus = successful()
+				withTags = anyOf("wpcom-block-editor-release-build")
+			}
+			dataToKeep = everything()
+			applyPerEachBranch = true
+			preserveArtifactsDependencies = true
+		}
 	}
 })
 
@@ -128,6 +162,23 @@ private object Notifications : BuildType({
 			sed -i "s~${'$'}old_cache_buster~${'$'}new_cache_buster~g" release-archive/index.html release-archive/rtl.html
 		""".trimIndent())
 	}
+
+	cleanup {
+		keepRule {
+			id = "keepReleaseBuilds"
+			keepAtLeast = allBuilds()
+			applyToBuilds {
+				inBranches {
+					branchFilter = patterns("+:<default>")
+				}
+				withStatus = successful()
+				withTags = anyOf("notifications-release-build")
+			}
+			dataToKeep = everything()
+			applyPerEachBranch = true
+			preserveArtifactsDependencies = true
+		}
+	}
 })
 
 private object O2Blocks : BuildType({
@@ -153,6 +204,23 @@ private object O2Blocks : BuildType({
 				# Add index.php file
 				cp index.php release-files/
 			"""
+		}
+	}
+
+	cleanup {
+		keepRule {
+			id = "keepReleaseBuilds"
+			keepAtLeast = allBuilds()
+			applyToBuilds {
+				inBranches {
+					branchFilter = patterns("+:<default>")
+				}
+				withStatus = successful()
+				withTags = anyOf("o2-blocks-release-build")
+			}
+			dataToKeep = everything()
+			applyPerEachBranch = true
+			preserveArtifactsDependencies = true
 		}
 	}
 })


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Excludes successful `trunk` builds tagged by `<release-tag>` from the system clean-up.

Docs: https://www.jetbrains.com/help/teamcity/2020.2/clean-up.html
DSL docs: https://teamcity.jetbrains.com/app/dsl-documentation/jetbrains.build-server.configs.kotlin.v2019_2/-cleanup/index.html

#### Testing instructions

* Functionality can't be tested until merged
* Verify TeamCity builds still work, it will mean there are no syntax errors in the template.