### PR TITLE
chore(eslint): Add rule `import/namespace` and fix violations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -156,7 +156,9 @@ module.exports = {
 					'@typescript-eslint/camelcase': 'off',
 
 					// TypeScript compiler already takes care of these errors
+					'import/no-extraneous-dependencies': 'off',
 					'import/named': 'off',
+					'import/namespace': 'off',
 				},
 			}
 		),
@@ -379,6 +381,7 @@ module.exports = {
 		// Force packages to declare their dependencies
 		'import/no-extraneous-dependencies': 'error',
 		'import/named': 'error',
+		'import/namespace': 'error',
 
 		'wpcalypso/no-unsafe-wp-apis': [
 			'error',

--- a/client/components/jetpack/with-server-credentials-form/test/index.js
+++ b/client/components/jetpack/with-server-credentials-form/test/index.js
@@ -42,6 +42,11 @@ jest.mock( 'calypso/state/selectors/get-jetpack-credentials-update-status', () =
 	'unsubmitted'
 );
 
+jest.mock( 'calypso/state/jetpack/credentials/actions', () => ( {
+	updateCredentials: jest.fn( () => ( { type: 'update-credentials' } ) ),
+	deleteCredentials: jest.fn( () => ( { type: 'delete-credentials' } ) ),
+} ) );
+
 /**
  * Helper functions
  */
@@ -59,17 +64,6 @@ function renderInput( name, onChange, values, type = 'text' ) {
 }
 
 function setup( { role = 'main', siteId = 9999, siteUrl = 'siteUrl' } = {} ) {
-	// Mutate action creators to make assertions on them
-	/* eslint-disable no-import-assign */
-	actions.updateCredentials = jest.fn( () => ( {
-		type: 'update-credentials',
-	} ) );
-	// eslint-disable-line
-	actions.deleteCredentials = jest.fn( () => ( {
-		type: 'delete-credentials',
-	} ) );
-	/* eslint-enable no-import-assign */
-
 	// We create a simple form to test the utilities and data provided by
 	// the withServerCredentials HOC.
 	const WrappedForm = ( {
@@ -129,6 +123,10 @@ function setup( { role = 'main', siteId = 9999, siteUrl = 'siteUrl' } = {} ) {
 }
 
 describe( 'useWithServerCredentials HOC', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
 	it( 'should not update credentials (should display error messages)', async () => {
 		const { utils } = setup( {} );
 		const submitButton = utils.getByText( 'Submit' );

--- a/client/devdocs/design/playground.jsx
+++ b/client/devdocs/design/playground.jsx
@@ -97,6 +97,7 @@ export default class DesignAssets extends React.Component {
 		return (
 			<SelectDropdown selectedText="Add a component" className="design__playground-examples">
 				{ keys( componentExamples ).map( ( name ) => {
+					// eslint-disable-next-line import/namespace
 					const ExampleComponentName = componentExamples[ name ];
 					const exampleComponent = <ExampleComponentName />;
 					const exampleCode = getExampleCodeFromComponent( exampleComponent );

--- a/client/lib/checkout/test/validation.js
+++ b/client/lib/checkout/test/validation.js
@@ -19,6 +19,14 @@ import {
 } from '../validation';
 import * as processorSpecificMethods from '../processor-specific';
 
+jest.mock( '../processor-specific', () => {
+	const realProcessorSpecificMethods = jest.requireActual( '../processor-specific' );
+	return {
+		...realProcessorSpecificMethods,
+		isValidCPF: jest.fn(),
+	};
+} );
+
 describe( 'validation', () => {
 	const validCard = {
 		name: 'John Doe',
@@ -162,7 +170,7 @@ describe( 'validation', () => {
 
 		describe( 'validate ebanx non-credit card details', () => {
 			beforeAll( () => {
-				processorSpecificMethods.isValidCPF = jest.fn().mockImplementation( () => true ); // eslint-disable-line no-import-assign
+				processorSpecificMethods.isValidCPF.mockImplementation( () => true );
 			} );
 
 			test( 'should return no errors when details are valid', () => {
@@ -238,7 +246,7 @@ describe( 'validation', () => {
 			} );
 
 			test( 'should return error when CPF is invalid', () => {
-				processorSpecificMethods.isValidCPF = jest.fn().mockImplementation( () => false ); // eslint-disable-line no-import-assign
+				processorSpecificMethods.isValidCPF.mockImplementation( () => false );
 				const invalidCPF = { ...validBrazilianEbanxCard, document: 'blah' };
 				const result = validatePaymentDetails( invalidCPF, 'ebanx' );
 				expect( result ).toEqual( {

--- a/client/my-sites/marketing/connections/services-group.jsx
+++ b/client/my-sites/marketing/connections/services-group.jsx
@@ -67,6 +67,7 @@ const SharingServicesGroup = ( { isFetching, services, title, expandedService } 
 			<ul className="sharing-services-group__services">
 				{ services.length
 					? services.map( ( service ) => {
+							// eslint-disable-next-line import/namespace
 							const Component = Components[ service.ID.replace( /-/g, '_' ) ] || Service;
 
 							if ( service.warnings ) {

--- a/client/state/data-layer/wpcom/sites/scan/test/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/test/index.js
@@ -6,15 +6,13 @@ import * as wpcomHttpActions from 'calypso/state/data-layer/wpcom-http/actions';
 import * as jetpackScanActions from 'calypso/state/jetpack-scan/actions';
 import { JETPACK_SCAN_REQUEST } from 'calypso/state/action-types';
 
+jest.mock( 'calypso/state/data-layer/wpcom-http/actions', () => ( {
+	http: jest.fn(),
+} ) );
+
 function setup( siteId ) {
 	// Set spy on action creator to verify it gets called when the component renders.
 	const requestScanStatusActionSpy = jest.spyOn( jetpackScanActions, 'requestScanStatus' );
-
-	// We don't want to make an HTTP request so we need to mock this utility.
-	wpcomHttpActions.http = jest.fn( () => ( {
-		type: JETPACK_SCAN_REQUEST,
-		meta: { dataLayer: { data: 'Fake data!' } },
-	} ) );
 
 	const store = createReduxStore(
 		{
@@ -31,6 +29,17 @@ function setup( siteId ) {
 }
 
 describe( 'Jetpack Scan data-layer', () => {
+	beforeAll( () => {
+		wpcomHttpActions.http.mockImplementation( () => ( {
+			type: JETPACK_SCAN_REQUEST,
+			meta: { dataLayer: { data: 'Fake data!' } },
+		} ) );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
 	it( 'should reach the fetch handler middleware', () => {
 		const siteId = 9999;
 		const { store, dispatchSpy, requestScanStatusActionSpy } = setup( siteId );

--- a/client/state/happychat/test/utils.js
+++ b/client/state/happychat/test/utils.js
@@ -6,6 +6,10 @@ import config from '@automattic/calypso-config';
 import * as wpcom from 'calypso/lib/wp';
 import * as selectedSite from 'calypso/state/help/selectors';
 
+jest.mock( 'calypso/state/help/selectors', () => ( {
+	getHelpSelectedSite: jest.fn(),
+} ) );
+
 describe( 'auth promise', () => {
 	const state = {
 		currentUser: {
@@ -32,7 +36,6 @@ describe( 'auth promise', () => {
 			);
 
 			// mock getHelpSelectedSite to return null
-			selectedSite.getHelpSelectedSite = jest.fn();
 			selectedSite.getHelpSelectedSite.mockReturnValue( null );
 		} );
 
@@ -58,7 +61,6 @@ describe( 'auth promise', () => {
 			);
 
 			// mock getHelpSelectedSite to return null
-			selectedSite.getHelpSelectedSite = jest.fn();
 			selectedSite.getHelpSelectedSite.mockReturnValue( null );
 		} );
 

--- a/packages/webpack-config-flag-plugin/test/__snapshots__/index.js.snap
+++ b/packages/webpack-config-flag-plugin/test/__snapshots__/index.js.snap
@@ -315,6 +315,7 @@ if ( true ) {
 }
 
 ;// CONCATENATED MODULE: ./namespace-import/config/wrong-path.js
+/* eslint-disable import/namespace */
 
 
 // Should NOT be replaced with true

--- a/packages/webpack-config-flag-plugin/test/fixtures/namespace-import/config/wrong-path.js
+++ b/packages/webpack-config-flag-plugin/test/fixtures/namespace-import/config/wrong-path.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/namespace */
 import * as config from '../config';
 
 // Should NOT be replaced with true


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enables eslint rule [`import/namespace `](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/namespace.md).
* Adds an exception for TypeScript, as the compiler already checks for those errors
* Fix existing violations of this rule

#### Testing instructions

* Verify tests still pass.