### PR TITLE
Disable 3p cookies by default for all e2e tests

### DIFF
--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -74,7 +74,7 @@ export function getProxyType() {
 export async function startBrowser( {
 	useCustomUA = true,
 	resizeBrowserWindow = true,
-	disableThirdPartyCookies = false,
+	disableThirdPartyCookies = true,
 } = {} ) {
 	if ( global.__BROWSER__ ) {
 		return global.__BROWSER__;


### PR DESCRIPTION
This PR should uncover outstanding 3pc issues in calypso. We won't be able to merge this until a lot more things are fixed.

#### Changes proposed in this Pull Request

* Disables chromes access to third party cookies in e2e tests.

#### Testing instructions

* All tests should pass

Related to #52007
