### PR TITLE
Remove old chrome version cookie blocking settings

### DIFF
--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -148,7 +148,6 @@ export async function startBrowser( {
 					profile: {
 						// 1 = allow all cookies (default), 2 = block all cookies
 						default_content_setting_values: { cookies: 1 },
-						block_third_party_cookies: false, // For chrome v84. (ci)
 						// 0 = allow 3pc, 1 = block 3pc, 2 = block 3pc in incognito (default)
 						cookie_controls_mode: 2, // For chrome v90.
 					},
@@ -156,7 +155,6 @@ export async function startBrowser( {
 
 				if ( disableThirdPartyCookies ) {
 					prefs.profile.cookie_controls_mode = 1;
-					prefs.profile.block_third_party_cookies = true;
 				}
 
 				options.setUserPreferences( prefs );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Cleans up old settings values after #52367 / #52369 (wait for merge)
* Chrome used different profile settings values in different versions.
* This change removes the old cookie settings used for older versions of chrome.

#### Testing instructions

* Tests should pass.
* Visit `chrome://settings/cookies` to check the right settings are applied during tests

Related to #
