### PR TITLE
chore(eslint): Add rule `import/default` and fix violations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -159,6 +159,7 @@ module.exports = {
 					'import/no-extraneous-dependencies': 'off',
 					'import/named': 'off',
 					'import/namespace': 'off',
+					'import/default': 'off',
 				},
 			}
 		),
@@ -382,6 +383,7 @@ module.exports = {
 		'import/no-extraneous-dependencies': 'error',
 		'import/named': 'error',
 		'import/namespace': 'error',
+		'import/default': 'error',
 
 		'wpcalypso/no-unsafe-wp-apis': [
 			'error',

--- a/client/lib/i18n-utils/README.md
+++ b/client/lib/i18n-utils/README.md
@@ -5,7 +5,7 @@ I18n-related utilities, for use both client- and server-side.
 ## Usage
 
 ```js
-import i18nUtils from 'calypso/lib/i18n-utils';
+import * as i18nUtils from 'calypso/lib/i18n-utils';
 ```
 
 ### Loading Waiting User Translations

--- a/client/me/help/help-courses/test/index.jsx
+++ b/client/me/help/help-courses/test/index.jsx
@@ -28,6 +28,7 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from '@automattic/calypso-products';
+import { getUserPurchases } from 'calypso/state/purchases/selectors';
 
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/lib/user', () => () => {} );
@@ -62,8 +63,6 @@ jest.mock( 'i18n-calypso', () => ( {
 	numberFormat: ( x ) => x,
 } ) );
 
-import purchasesSelectors from 'calypso/state/purchases/selectors';
-
 describe( 'mapStateToProps should return correct value for isBusinessPlanUser', () => {
 	[
 		PLAN_FREE,
@@ -82,7 +81,7 @@ describe( 'mapStateToProps should return correct value for isBusinessPlanUser', 
 		PLAN_JETPACK_BUSINESS_MONTHLY,
 	].forEach( ( productSlug ) => {
 		test( `False for plan ${ productSlug }`, () => {
-			purchasesSelectors.getUserPurchases.mockImplementation( () => [ { productSlug } ] );
+			getUserPurchases.mockImplementation( () => [ { productSlug } ] );
 			expect( mapStateToProps( {}, {} ).isBusinessPlanUser ).toBe( false );
 		} );
 	} );
@@ -95,7 +94,7 @@ describe( 'mapStateToProps should return correct value for isBusinessPlanUser', 
 		PLAN_ECOMMERCE_2_YEARS,
 	].forEach( ( productSlug ) => {
 		test( `True for plan ${ productSlug }`, () => {
-			purchasesSelectors.getUserPurchases.mockImplementation( () => [ { productSlug } ] );
+			getUserPurchases.mockImplementation( () => [ { productSlug } ] );
 			expect( mapStateToProps( {}, {} ).isBusinessPlanUser ).toBe( true );
 		} );
 	} );

--- a/client/me/help/test/main.jsx
+++ b/client/me/help/test/main.jsx
@@ -28,6 +28,7 @@ import {
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from '@automattic/calypso-products';
 import { mapStateToProps } from '../main';
+import { getUserPurchases } from 'calypso/state/purchases/selectors';
 
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/user', () => jest.fn() );
@@ -58,8 +59,6 @@ jest.mock( 'i18n-calypso', () => ( {
 	numberFormat: ( x ) => x,
 } ) );
 
-import purchasesSelectors from 'calypso/state/purchases/selectors';
-
 describe( 'mapStateToProps should return correct value for isBusinessPlanUser', () => {
 	[
 		PLAN_FREE,
@@ -79,7 +78,7 @@ describe( 'mapStateToProps should return correct value for isBusinessPlanUser', 
 		undefined,
 	].forEach( ( productSlug ) => {
 		test( `False for plan ${ JSON.stringify( productSlug ) }`, () => {
-			purchasesSelectors.getUserPurchases.mockImplementation( () => [ { productSlug } ] );
+			getUserPurchases.mockImplementation( () => [ { productSlug } ] );
 			expect( mapStateToProps( {}, {} ).isBusinessPlanUser ).toBe( false );
 		} );
 	} );
@@ -92,18 +91,18 @@ describe( 'mapStateToProps should return correct value for isBusinessPlanUser', 
 		PLAN_ECOMMERCE_2_YEARS,
 	].forEach( ( productSlug ) => {
 		test( `True for plan ${ JSON.stringify( productSlug ) }`, () => {
-			purchasesSelectors.getUserPurchases.mockImplementation( () => [ { productSlug } ] );
+			getUserPurchases.mockImplementation( () => [ { productSlug } ] );
 			expect( mapStateToProps( {}, {} ).isBusinessPlanUser ).toBe( true );
 		} );
 	} );
 
 	test( 'Should be false for purchases not loaded', () => {
-		purchasesSelectors.getUserPurchases.mockImplementation( () => null );
+		getUserPurchases.mockImplementation( () => null );
 		expect( mapStateToProps( {}, {} ).isBusinessPlanUser ).toBe( false );
 	} );
 
 	test( 'Should be false for no purchases', () => {
-		purchasesSelectors.getUserPurchases.mockImplementation( () => [] );
+		getUserPurchases.mockImplementation( () => [] );
 		expect( mapStateToProps( {}, {} ).isBusinessPlanUser ).toBe( false );
 	} );
 } );

--- a/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
@@ -8,24 +8,27 @@ import { expect } from 'chai';
  */
 import { cancellationEffectDetail, cancellationEffectHeadline } from '../cancellation-effect';
 import productsValues from '@automattic/calypso-products';
-import purchases from 'calypso/lib/purchases';
+import { isRefundable, getSubscriptionEndDate } from 'calypso/lib/purchases';
 
 jest.mock( '@automattic/calypso-products', () => ( {} ) );
-jest.mock( 'calypso/lib/purchases', () => ( {} ) );
+jest.mock( 'calypso/lib/purchases', () => ( {
+	getName: jest.fn( () => 'purchase name' ),
+	isRefundable: jest.fn(),
+	getSubscriptionEndDate: jest.fn(),
+} ) );
 
 describe( 'cancellation-effect', () => {
 	const purchase = { domain: 'example.com' };
 	let translate;
 
 	beforeEach( () => {
-		purchases.getName = () => 'purchase name';
 		translate = ( text, args ) => ( { args, text } );
 	} );
 
 	describe( 'cancellationEffectHeadline', () => {
 		describe( 'when refundable', () => {
 			beforeEach( () => {
-				purchases.isRefundable = () => true;
+				isRefundable.mockImplementation( () => true );
 			} );
 
 			test( 'should return translation of cancel and return', () => {
@@ -38,7 +41,7 @@ describe( 'cancellation-effect', () => {
 
 		describe( 'when not refundable', () => {
 			beforeEach( () => {
-				purchases.isRefundable = () => false;
+				isRefundable.mockImplementation( () => false );
 			} );
 
 			test( 'should return translation of cancel', () => {
@@ -53,7 +56,7 @@ describe( 'cancellation-effect', () => {
 	describe( 'cancellationEffectDetail', () => {
 		describe( 'when refundable', () => {
 			beforeEach( () => {
-				purchases.isRefundable = () => true;
+				isRefundable.mockImplementation( () => true );
 			} );
 
 			test( 'should return translation of theme message when product is a theme', () => {
@@ -107,8 +110,8 @@ describe( 'cancellation-effect', () => {
 
 		describe( 'when not refundable', () => {
 			beforeEach( () => {
-				purchases.isRefundable = () => false;
-				purchases.getSubscriptionEndDate = () => '15/12/2093';
+				isRefundable.mockImplementation( () => false );
+				getSubscriptionEndDate.mockImplementation( () => '15/12/2093' );
 			} );
 
 			test( 'should return translation of g suite message when product is g suite', () => {

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -28,6 +28,7 @@ import {
  * Internal dependencies
  */
 import { CheckoutThankYou } from '../index';
+import { isRebrandCitiesSiteUrl } from 'calypso/lib/rebrand-cities';
 
 jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
@@ -57,8 +58,6 @@ jest.mock( 'calypso/lib/rebrand-cities', () => ( {
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
 jest.mock( 'calypso/lib/user', () => () => {} );
-
-import RebrandCities from 'calypso/lib/rebrand-cities';
 
 const translate = ( x ) => x;
 
@@ -142,12 +141,12 @@ describe( 'CheckoutThankYou', () => {
 
 	describe( 'Presence of <RebrandCitiesThankYou /> in render() output', () => {
 		afterAll( () => {
-			RebrandCities.isRebrandCitiesSiteUrl.mockImplementation( () => false );
+			isRebrandCitiesSiteUrl.mockImplementation( () => false );
 		} );
 
 		[ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ].forEach( ( product_slug ) => {
 			test( 'Should be there for a business plan', () => {
-				RebrandCities.isRebrandCitiesSiteUrl.mockImplementation( () => true );
+				isRebrandCitiesSiteUrl.mockImplementation( () => true );
 				const props = {
 					...defaultProps,
 					selectedSite: {
@@ -163,7 +162,7 @@ describe( 'CheckoutThankYou', () => {
 
 		[ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ].forEach( ( product_slug ) => {
 			test( 'Should not be there for a business plan if isRebrandCitiesSiteUrl is false', () => {
-				RebrandCities.isRebrandCitiesSiteUrl.mockImplementation( () => false );
+				isRebrandCitiesSiteUrl.mockImplementation( () => false );
 				const props = {
 					...defaultProps,
 					selectedSite: {
@@ -192,7 +191,7 @@ describe( 'CheckoutThankYou', () => {
 			PLAN_JETPACK_BUSINESS_MONTHLY,
 		].forEach( ( product_slug ) => {
 			test( 'Should not be there for any no-business plan', () => {
-				RebrandCities.isRebrandCitiesSiteUrl.mockImplementation( () => true );
+				isRebrandCitiesSiteUrl.mockImplementation( () => true );
 				const props = {
 					...defaultProps,
 					selectedSite: {

--- a/client/state/data-layer/wpcom/sites/stats/google-my-business/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/google-my-business/index.js
@@ -64,3 +64,5 @@ registerHandlers( 'state/data-layer/wpcom/sites/stats/google-my-business/index.j
 		} ),
 	],
 } );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/stats/views/posts/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/views/posts/index.js
@@ -43,3 +43,5 @@ registerHandlers( 'state/data-layer/wpcom/sites/stats/views/posts/index.js', {
 		} ),
 	],
 } );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/stats/visits/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/visits/index.js
@@ -62,3 +62,5 @@ registerHandlers( 'state/data-layer/wpcom/sites/stats/visits/index.js', {
 		} ),
 	],
 } );
+
+export default {};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enables eslint rule [`import/default`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/default.md).
* Adds an exception for TypeScript, as the compiler already checks for those errors
* Fix existing violations of this rule

#### Testing instructions

* Verify tests still pass.