### PR TITLE
Collapsed Sidebar: Fix expanding menu in mobile.

### DIFF
--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -49,6 +49,8 @@ export const MySitesSidebarUnifiedMenu = ( {
 	const reduxDispatch = useDispatch();
 	const sectionId = 'SIDEBAR_SECTION_' + slug;
 	const isExpanded = useSelector( ( state ) => isSidebarSectionOpen( state, sectionId ) );
+	const allowExpansion =
+		( isWithinBreakpoint( '>782px' ) && ! sidebarCollapsed ) || ! isWithinBreakpoint( '>782px' ); // Do not allow expansion on Desktop with sidebar collapsed.
 
 	const selectedMenuItem =
 		Array.isArray( children ) &&
@@ -97,7 +99,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 		<li>
 			<ExpandableSidebarMenu
 				onClick={ () => onClick() }
-				expanded={ ! sidebarCollapsed && isExpanded }
+				expanded={ isExpanded && allowExpansion }
 				title={ title }
 				customIcon={ <SidebarCustomIcon icon={ icon } /> }
 				className={ ( selected || childIsSelected ) && 'sidebar__menu--selected' }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a bug where Users having their sidebar collapsed in desktop breakpoints wouldn't be able to expand a submenu in mobile breakpoints.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Breakpoint >782px**
- Clicking Posts, the submenu should expand.
- Collapse the Sidebar.
- Clicking Pages, the submenu should **not** expand.

**Breakpoint <782px**
- With the Sidebar collapsed or not, clicking any menu item (Posts, Pages etc) should expand the submenu.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

