### PR TITLE
Migration: Update content by adding an additional note (#46043)

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -472,6 +472,14 @@ class SectionMigrate extends Component {
 					{ this.renderStartTime() }
 					{ this.renderProgressBar() }
 					{ this.renderProgressList() }
+					<p class="migrate__note">
+						{ translate(
+							"You can safely navigate away from this page if you need to {{br/}} we'll send you a notification when it's done",
+							{
+								components: { br: <br /> },
+							}
+						) }
+					</p>
 				</Card>
 			</>
 		);

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -474,10 +474,7 @@ class SectionMigrate extends Component {
 					{ this.renderProgressList() }
 					<p class="migrate__note">
 						{ translate(
-							"You can safely navigate away from this page if you need to {{br/}} we'll send you a notification when it's done",
-							{
-								components: { br: <br /> },
-							}
+							"You can safely navigate away from this page if you need to; we'll send you a notification when it's done"
 						) }
 					</p>
 				</Card>

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -474,7 +474,7 @@ class SectionMigrate extends Component {
 					{ this.renderProgressList() }
 					<p class="migrate__note">
 						{ translate(
-							"You can safely navigate away from this page if you need to; we'll send you a notification when it's done"
+							"You can safely navigate away from this page if you need to; we'll send you a notification when it's done."
 						) }
 					</p>
 				</Card>

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -253,6 +253,11 @@
 	margin-bottom: 2rem;
 }
 
+.migrate__note {
+	text-align: center;
+	color: var( --color-text-subtle );
+}
+
 .migrate__start-time {
 	height: 1.5rem;
 	margin-bottom: 8px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added additional note into Migration restoring step explaining that user doesn't need to wait until the import process is finished.

#### Testing instructions

Start a WP Migration, all the way through the "Import in Progress" screen.
WP Migration requirements:
* Source site is a site not hosted on WP.com/Atomic
* Source site is connected to the user's account via Jetpack
* Target site has WP.com business plan or higher.

The user should see the additional note under the progress checklist.

![Markup on 2021-04-29 at 11:48:15](https://user-images.githubusercontent.com/1241413/116532737-e1d67100-a8e0-11eb-95ce-324f41cf7dee.png)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #46043
