### PR TITLE
Framework: Refactor away from _.isObjectLike()

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isObjectLike, omit } from 'lodash';
+import { omit } from 'lodash';
 import debug from 'debug';
 
 /**
@@ -45,7 +45,7 @@ export default ( eventName, eventProperties ) => {
 
 	if ( process.env.NODE_ENV !== 'production' && typeof console !== 'undefined' ) {
 		for ( const key in eventProperties ) {
-			if ( isObjectLike( eventProperties[ key ] ) ) {
+			if ( eventProperties[ key ] !== null && typeof eventProperties[ key ] === 'object' ) {
 				const errorMessage =
 					`Tracks: Unable to record event "${ eventName }" because nested ` +
 					`properties are not supported by Tracks. Check '${ key }' on`;

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
-import { flowRight, isEqual, isObjectLike, keys, omit, pick } from 'lodash';
+import { flowRight, isEqual, keys, omit, pick } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
@@ -98,7 +98,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 			const previousDirtyFields = this.props.dirtyFields;
 			/*eslint-disable eqeqeq*/
 			const nextDirtyFields = previousDirtyFields.filter( ( field ) =>
-				isObjectLike( currentFields[ field ] )
+				currentFields[ field ] !== null && typeof currentFields[ field ] === 'object'
 					? ! isEqual( currentFields[ field ], persistedFields[ field ] )
 					: ! ( currentFields[ field ] == persistedFields[ field ] )
 			);

--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { camelCase, isObjectLike, isPlainObject, map, reduce, set, snakeCase } from 'lodash';
+import { camelCase, isPlainObject, map, reduce, set, snakeCase } from 'lodash';
 import { extendAction } from '@automattic/state-utils';
 
 const doBypassDataLayer = {
@@ -31,7 +31,8 @@ export function convertKeysBy( obj, fn ) {
 			obj,
 			( result, value, key ) => {
 				const newKey = fn( key );
-				const newValue = isObjectLike( value ) ? convertKeysBy( value, fn ) : value;
+				const newValue =
+					value !== null && typeof value === 'object' ? convertKeysBy( value, fn ) : value;
 				return set( result, [ newKey ], newValue );
 			},
 			{}

--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -31,8 +31,7 @@ export function convertKeysBy( obj, fn ) {
 			obj,
 			( result, value, key ) => {
 				const newKey = fn( key );
-				const newValue =
-					value !== null && typeof value === 'object' ? convertKeysBy( value, fn ) : value;
+				const newValue = convertKeysBy( value, fn );
 				return set( result, [ newKey ], newValue );
 			},
 			{}

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { includes, isObjectLike, omitBy, times } from 'lodash';
+import { includes, omitBy, times } from 'lodash';
 import cookie from 'cookie';
 import { EventEmitter } from 'events';
 import { loadScript } from '@automattic/load-script';
@@ -192,7 +192,7 @@ export function recordTracksEvent( eventName: string, eventProperties?: any ) {
 		}
 
 		for ( const key in eventProperties ) {
-			if ( isObjectLike( eventProperties[ key ] ) ) {
+			if ( eventProperties[ key ] !== null && typeof eventProperties[ key ] === 'object' ) {
 				const errorMessage =
 					`Tracks: Unable to record event "${ eventName }" because nested ` +
 					`properties are not supported by Tracks. Check '${ key }' on`;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `isObjectLike()` is used several times in the codebase, but it's pretty straightforward to replace it with a `typeof value === 'object' && value !== null`. The `null` check is needed because `typeof null` yields `object` too. This PR replaces all instances. 

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all tests pass: `yarn run test-client`.
* Specific testing shouldn't be necessary, because the `typeof` checks are error-proof and the replacements are 1:1 literal to what Lodash is doing in `isObjectLike()`.