### PR TITLE
Checkout: Include additional information in the introductory offers terms of service

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -42,6 +42,7 @@ export const INCOMING_DOMAIN_TRANSFER = `${ root }/incoming-domain-transfer/`;
 export const INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK = `${ root }/incoming-domain-transfer/prepare-domain-for-transfer/#unlock`;
 export const INCOMING_DOMAIN_TRANSFER_PREPARE_AUTH_CODE = `${ root }/incoming-domain-transfer/prepare-domain-for-transfer/#auth-code`;
 export const INCOMING_DOMAIN_TRANSFER_AUTH_CODE_INVALID = `${ root }/incoming-domain-transfer/#auth-code-invalid`;
+export const EDIT_PAYMENT_DETAILS = `${ root }/payment/#edit-payment-details`;
 export const EMAIL_FORWARDING = `${ root }/email-forwarding`;
 export const EMAIL_VALIDATION_AND_VERIFICATION = `${ root }/domains/register-domain/#email-validation-and-verification`;
 export const EMPTY_SITE = `${ root }/empty-site/`;

--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -74,14 +74,14 @@ function getMessageForTermsOfServiceRecord(
 			if (
 				( locale === 'en' ||
 					i18nCalypso.hasTranslation(
-						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time'
+						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.'
 					) ) &&
 				args.subscription_start_date &&
 				args.subscription_expiry_date &&
 				args.subscription_auto_renew_date
 			) {
 				return translate(
-					'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time',
+					'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.',
 					{
 						args: {
 							startDate: moment( args.subscription_start_date ).format( 'll' ),
@@ -136,14 +136,14 @@ function getMessageForTermsOfServiceRecord(
 			if (
 				( locale === 'en' ||
 					i18nCalypso.hasTranslation(
-						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time'
+						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.'
 					) ) &&
 				args.subscription_start_date &&
 				args.subscription_expiry_date &&
 				args.subscription_auto_renew_date
 			) {
 				return translate(
-					'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (%(cardType)s ****%(cardLast4)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time',
+					'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (%(cardType)s ****%(cardLast4)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.',
 					{
 						args: {
 							startDate: moment( args.subscription_start_date ).format( 'll' ),

--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -7,10 +7,12 @@ import i18nCalypso, { useTranslate, TranslateResult } from 'i18n-calypso';
 import { useLocale } from '@automattic/i18n-utils';
 import { useSelector } from 'react-redux';
 import debugFactory from 'debug';
+import moment from 'moment';
 
 /**
  * Internal dependencies
  */
+import { EDIT_PAYMENT_DETAILS } from 'calypso/lib/url/support';
 import Gridicon from 'calypso/components/gridicon';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -70,12 +72,39 @@ function getMessageForTermsOfServiceRecord(
 				return '';
 			}
 			if (
-				locale !== 'en' &&
-				! i18nCalypso.hasTranslation(
-					'At the end of the promotional period we will begin charging your PayPal account (%(email)s) the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}'
-				)
+				( locale === 'en' ||
+					i18nCalypso.hasTranslation(
+						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time'
+					) ) &&
+				args.subscription_start_date &&
+				args.subscription_expiry_date &&
+				args.subscription_auto_renew_date
 			) {
-				return '';
+				return translate(
+					'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time',
+					{
+						args: {
+							startDate: moment( args.subscription_start_date ).format( 'll' ),
+							endDate: moment( args.subscription_expiry_date ).format( 'll' ),
+							renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
+							email: args.email,
+							renewalPrice: args.renewal_price,
+							numberOfDays: args.subscription_pre_renew_reminder_days || 7,
+						},
+						components: {
+							updatePaymentMethodLink: (
+								<a href={ EDIT_PAYMENT_DETAILS } target="_blank" rel="noopener noreferrer" />
+							),
+							manageSubscriptionlink: (
+								<a
+									href={ `/purchases/subscriptions/${ siteSlug }` }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
+				);
 			}
 			return translate(
 				'At the end of the promotional period we will begin charging your PayPal account (%(email)s) the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}',
@@ -105,12 +134,40 @@ function getMessageForTermsOfServiceRecord(
 				return '';
 			}
 			if (
-				locale !== 'en' &&
-				! i18nCalypso.hasTranslation(
-					'At the end of the promotional period we will begin charging your %(cardType)s card ending in %(cardLast4)s the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}'
-				)
+				( locale === 'en' ||
+					i18nCalypso.hasTranslation(
+						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time'
+					) ) &&
+				args.subscription_start_date &&
+				args.subscription_expiry_date &&
+				args.subscription_auto_renew_date
 			) {
-				return '';
+				return translate(
+					'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (%(cardType)s ****%(cardLast4)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time',
+					{
+						args: {
+							startDate: moment( args.subscription_start_date ).format( 'll' ),
+							endDate: moment( args.subscription_expiry_date ).format( 'll' ),
+							renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
+							cardType: args.card_type,
+							cardLast4: args.card_last_4,
+							renewalPrice: args.renewal_price,
+							numberOfDays: args.subscription_pre_renew_reminder_days || 7,
+						},
+						components: {
+							updatePaymentMethodLink: (
+								<a href={ EDIT_PAYMENT_DETAILS } target="_blank" rel="noopener noreferrer" />
+							),
+							manageSubscriptionlink: (
+								<a
+									href={ `/purchases/subscriptions/${ siteSlug }` }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
+				);
 			}
 			return translate(
 				'At the end of the promotional period we will begin charging your %(cardType)s card ending in %(cardLast4)s the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}',


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Requires D60597-code
* Changes the message introduced in #51359 to include the start, end, and auto renewal date of the subscription.

PayPal
![image](https://user-images.githubusercontent.com/15204776/116887110-87deef80-abef-11eb-9394-14f4315f9690.png)

Credit Card
![image](https://user-images.githubusercontent.com/15204776/116886774-1bfc8700-abef-11eb-960f-3efea44e0f86.png)


#### Testing instructions

* Follow the instructions from D60597-code to setup the backend response
* Verify that the UI renders as displayed in the images
* Verify that you can continue and complete the purchase
