### PR TITLE
Plans Grid: Show placeholder instead of NaN in discount

### DIFF
--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -79,6 +79,8 @@ export class PlanFeaturesComparisonHeader extends Component {
 		const { isMonthlyPlan, rawPriceForMonthlyPlan, annualPricePerMonth, translate } = this.props;
 
 		if ( ! isMonthlyPlan ) {
+			const isLoading = ! rawPriceForMonthlyPlan;
+
 			const discountRate = Math.round(
 				( 100 * ( rawPriceForMonthlyPlan - annualPricePerMonth ) ) / rawPriceForMonthlyPlan
 			);
@@ -87,7 +89,11 @@ export class PlanFeaturesComparisonHeader extends Component {
 			} );
 
 			return (
-				<div className={ 'plan-features-comparison__header-annual-discount' }>
+				<div
+					className={ classNames( 'plan-features-comparison__header-annual-discount', {
+						'plan-features-comparison__header-annual-discount-is-loading': isLoading,
+					} ) }
+				>
 					<span>{ annualDiscountText }</span>
 				</div>
 			);

--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -79,7 +79,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 		const { isMonthlyPlan, rawPriceForMonthlyPlan, annualPricePerMonth, translate } = this.props;
 
 		if ( ! isMonthlyPlan ) {
-			const isLoading = ! rawPriceForMonthlyPlan;
+			const isLoading = typeof rawPriceForMonthlyPlan !== 'number';
 
 			const discountRate = Math.round(
 				( 100 * ( rawPriceForMonthlyPlan - annualPricePerMonth ) ) / rawPriceForMonthlyPlan

--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -1,3 +1,5 @@
+@import '~@automattic/onboarding/styles/mixins';
+
 $plan-features-header-banner-height: 20px;
 $plan-features-sidebar-width: 272px;
 
@@ -182,6 +184,9 @@ $plan-features-sidebar-width: 272px;
 
 		.plan-features-comparison__header-annual-discount {
 			color: var( --studio-green-60 );
+			&-is-loading {
+				@include onboarding-placeholder();
+			}
 		}
 
 		.plan-price.is-original {
@@ -234,7 +239,7 @@ $plan-features-sidebar-width: 272px;
 		@include breakpoint-deprecated( '<1040px' ) {
 			padding: 0 12px 12px;
 		}
-	
+
 		@include breakpoint-deprecated( '<660px' ) {
 			padding: 0 20px 20px;
 			border-bottom: solid 1px var( --color-neutral-0 );
@@ -349,7 +354,7 @@ $plan-features-sidebar-width: 272px;
 		border: 1px solid;
 		border-radius: 6px; /* stylelint-disable-line */
 		border-color: var( --studio-gray-5 );
-		
+
 		&.is-selected {
 			padding: 1px 0 0 1px;
 		}
@@ -375,7 +380,8 @@ $plan-features-sidebar-width: 272px;
 			border-radius: 5px; /* stylelint-disable-line */
 			background-color: var( --studio-white );
 			border-color: var( --studio-white );
-			box-shadow: 0 4px 4px rgba( 0, 0, 0, 0.25 ), 0 3px 8px rgba( 0, 0, 0, 0.12 ), inset 0 0 0 rgba( 0, 0, 0, 0.2 );
+			box-shadow: 0 4px 4px rgba( 0, 0, 0, 0.25 ), 0 3px 8px rgba( 0, 0, 0, 0.12 ),
+				inset 0 0 0 rgba( 0, 0, 0, 0.2 );
 			border: 0.5px solid rgba( 0, 0, 0, 0.07 );
 			padding: 11px 20px;
 			color: var( --color-text );
@@ -435,7 +441,6 @@ body.is-section-signup.is-white-signup {
 		}
 	}
 
-
 	.plan-pill.is-in-signup {
 		font-size: 0.75rem;
 		font-weight: 500; /* stylelint-disable-line */
@@ -449,7 +454,8 @@ body.is-section-signup.is-white-signup {
 	}
 
 	.plan-features-comparison__item.plan-features-comparison__item-available {
-		.plan-features-comparison__item-annual-plan-container .plan-features-comparison__item-annual-plan {
+		.plan-features-comparison__item-annual-plan-container
+			.plan-features-comparison__item-annual-plan {
 			color: var( --studio-orange-40 );
 		}
 	}

--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -1,5 +1,3 @@
-@import '~@automattic/onboarding/styles/mixins';
-
 $plan-features-header-banner-height: 20px;
 $plan-features-sidebar-width: 272px;
 
@@ -185,7 +183,7 @@ $plan-features-sidebar-width: 272px;
 		.plan-features-comparison__header-annual-discount {
 			color: var( --studio-green-60 );
 			&-is-loading {
-				@include onboarding-placeholder();
+				@include placeholder();
 			}
 		}
 


### PR DESCRIPTION
_1-2 minute review._

#### Changes proposed in this Pull Request

Fixes https://github.com/Automattic/wp-calypso/issues/52416

#### Testing instructions

1. Go to https://calypso.live/start?branch=fix/show-placeholder-instead-of-NaN
2. Advance to the plans grid.
3. In the discount line, instead of NaN, you see a placeholder while the prices are being fetched.
