### PR TITLE
E2E: Make screenSize prop case consistent

### DIFF
--- a/test/e2e/lib/async-base-container.js
+++ b/test/e2e/lib/async-base-container.js
@@ -19,7 +19,7 @@ export default class AsyncBaseContainer {
 	) {
 		this.name = this.constructor.name;
 		this.driver = driver;
-		this.screenSize = driverManager.currentScreenSize().toUpperCase();
+		this.screenSize = driverManager.currentScreenSize();
 		this.expectedElementSelector = expectedElementSelector;
 		this.url = url;
 		this.explicitWaitMS = waitMS;

--- a/test/e2e/lib/components/inline-help-checklist-component.js
+++ b/test/e2e/lib/components/inline-help-checklist-component.js
@@ -19,7 +19,7 @@ class InlineHelpChecklistComponent extends AsyncBaseContainer {
 	}
 
 	async leaveInlineHelpChecklist() {
-		if ( this.screenSize === 'MOBILE' ) {
+		if ( this.screenSize === 'mobile' ) {
 			await this.driver.switchTo().defaultContent();
 			return await driverHelper.clickWhenClickable(
 				this.driver,

--- a/test/e2e/lib/components/site-preview-component.js
+++ b/test/e2e/lib/components/site-preview-component.js
@@ -40,7 +40,7 @@ class SitePreviewComponent extends AsyncBaseContainer {
 	}
 
 	async leaveSitePreview() {
-		if ( this.screenSize === 'MOBILE' ) {
+		if ( this.screenSize === 'mobile' ) {
 			await this.driver.switchTo().defaultContent();
 			return await driverHelper.clickWhenClickable(
 				this.driver,

--- a/test/e2e/lib/pages/gutenboarding/style-preview-page.js
+++ b/test/e2e/lib/pages/gutenboarding/style-preview-page.js
@@ -22,7 +22,7 @@ export default class StylePreviewPage extends AsyncBaseContainer {
 
 	async selectFontPairing( fontIndex ) {
 		let fontOptions;
-		if ( this.screenSize === 'MOBILE' ) {
+		if ( this.screenSize === 'mobile' ) {
 			const mobileExpandFontOptionsButton = By.css(
 				'.style-preview__font-options-mobile .style-preview__font-option-select'
 			);

--- a/test/e2e/lib/pages/plans-page.js
+++ b/test/e2e/lib/pages/plans-page.js
@@ -59,7 +59,7 @@ export default class PlansPage extends AsyncBaseContainer {
 	async confirmCurrentPlan( planName ) {
 		let selector = `.is-${ planName }-plan .plan-pill`;
 
-		if ( this.screenSize === 'MOBILE' ) {
+		if ( this.screenSize === 'mobile' ) {
 			selector = '.plan-features__mobile ' + selector;
 		} else {
 			selector = '.plan-features__table ' + selector;

--- a/test/e2e/lib/pages/profile-page.js
+++ b/test/e2e/lib/pages/profile-page.js
@@ -15,7 +15,7 @@ export default class ProfilePage extends AsyncBaseContainer {
 	}
 
 	async _preInit() {
-		if ( this.screenSize === 'MOBILE' ) {
+		if ( this.screenSize === 'mobile' ) {
 			// On mobile viewport, the sidebar is initially open and needs a bit to
 			// finish the slide-in animation. This is important because only after the
 			// animation is done, the sidebar items become fully interactable.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`AsyncBaseContainer.screenSize` prop is just a convenient way of getting `driverManager.currentScreenSize()`. The original `currentScreenSize` already forces the prop to be lower case. Let's stay consistent and keep it lower case everywhere.

#### Testing instructions

All specs should pass.