### PR TITLE
Exporter: Fix Alignment of "Export All" Button

### DIFF
--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -23,6 +23,10 @@
 	justify-content: flex-end;
 }
 
+.export-card__export-button {
+	margin-right: 0;
+}
+
 .export-card__spinner-button {
 	float: right;
 	padding: 8px;

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -18,6 +18,11 @@
 	color: var( --color-neutral-70 );
 }
 
+.export-card .foldable-card__summary div {
+	display: flex;
+	justify-content: flex-end;
+}
+
 .export-card__spinner-button {
 	float: right;
 	padding: 8px;
@@ -69,8 +74,4 @@
 	select {
 		width: 100%;
 	}
-}
-
-div.export-card .foldable-card__summary div {
-	display: flex;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the alignment of the "Export all" button

This bug was introduced in #51492, but the `display: flex` which it introduced is still necessary to ensure #32111 doesn't become an issue again.

#### Testing instructions

Firstly, verify that the button is aligned better on `/export/site`

<img width="769" alt="Screenshot 2021-04-29 at 18 09 19" src="https://user-images.githubusercontent.com/43215253/116591153-6db6c000-a916-11eb-873e-31ca4fd5b98a.png">

In another language, such as Italian, also verify that #32111 doesn't return.

<img width="796" alt="Screenshot 2021-04-29 at 18 06 13" src="https://user-images.githubusercontent.com/43215253/116591219-7b6c4580-a916-11eb-88e5-de3553b59e89.png">

cc @sixhours, @akirk 

Fixes #52424