### PR TITLE
Add unit tests to cover the new `<PlanUpgradeSection>` component's behavior

### DIFF
--- a/client/my-sites/plans/jetpack-plans/plan-upgrade/test/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/plan-upgrade/test/index.tsx
@@ -1,0 +1,91 @@
+/** @jest-environment jsdom */
+
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { render, screen } from 'calypso/test-helpers/config/testing-library';
+
+/**
+ * Internal dependencies
+ */
+import { TERM_MONTHLY } from '@automattic/calypso-products';
+import productsList from 'calypso/state/products-list/reducer';
+import { reducer as purchases } from 'calypso/state/purchases/reducer';
+
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	getCurrentUserCurrencyCode: jest.fn( () => 'USD' ),
+} ) );
+
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSelectedSiteId: jest.fn( () => 100 ),
+} ) );
+
+import PlanUpgradeSection from '../index';
+
+const initialState = {
+	sites: {
+		items: {},
+		products: {},
+	},
+	purchases: {
+		data: [],
+	},
+	productsList: {
+		isFetching: false,
+	},
+};
+
+describe( '<PlanUpgradeSection />', () => {
+	it( 'renders one legacy product card and one new plan product card', () => {
+		render(
+			<PlanUpgradeSection
+				planRecommendation={ [ 'jetpack_personal', [ 'jetpack_scan' ] ] }
+				duration={ TERM_MONTHLY }
+				filterBar={ null }
+				onSelectProduct={ () => null }
+			/>,
+			{ initialState, reducers: { purchases, productsList } }
+		);
+
+		const sectionHeader = screen.getByRole( 'heading', { level: 2 } );
+		expect( sectionHeader.outerHTML ).toContain( 'Scan' );
+
+		const productHeaders = screen.getAllByRole( 'heading', { level: 3 } );
+
+		expect( productHeaders ).toHaveLength( 2 );
+
+		const [ personalHeader, scanHeader ] = productHeaders;
+
+		expect( personalHeader.outerHTML ).toContain( 'Personal' );
+		expect( scanHeader.outerHTML ).toContain( 'Scan' );
+	} );
+
+	it( 'renders one legacy product card and two new plan product cards', () => {
+		render(
+			<PlanUpgradeSection
+				planRecommendation={ [
+					'jetpack_premium',
+					[ 'jetpack_anti_spam', 'jetpack_backup_daily' ],
+				] }
+				duration={ TERM_MONTHLY }
+				filterBar={ null }
+				onSelectProduct={ () => null }
+			/>,
+			{ initialState, reducers: { purchases, productsList } }
+		);
+
+		const sectionHeader = screen.getByRole( 'heading', { level: 2 } );
+		expect( sectionHeader.outerHTML ).toContain( 'Anti-spam &amp; Backup' );
+
+		const productHeaders = screen.getAllByRole( 'heading', { level: 3 } );
+
+		expect( productHeaders ).toHaveLength( 3 );
+
+		const [ personalHeader, antiSpamHeader, backupDailyHeader ] = productHeaders;
+
+		expect( personalHeader.outerHTML ).toContain( 'Premium' );
+		expect( antiSpamHeader.outerHTML ).toContain( 'Anti-spam' );
+		expect( backupDailyHeader.outerHTML ).toContain( 'Backup <em>Daily</em>' );
+	} );
+} );

--- a/client/my-sites/plans/jetpack-plans/plan-upgrade/test/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/plan-upgrade/test/utils.ts
@@ -1,0 +1,102 @@
+/**
+ * Internal dependencies
+ */
+import { TERM_ANNUALLY, TERM_MONTHLY } from '@automattic/calypso-products';
+import {
+	getComparePlansFromContext,
+	getItemSlugByDuration,
+	getPlanRecommendationFromContext,
+} from '../utils';
+import { COMPARE_PLANS_QUERY_PARAM } from '../constants';
+
+const PURCHASABLE_ITEMS = [ 'jetpack_personal', 'jetpack_backup_daily', 'jetpack_scan' ];
+const NON_PURCHASABLE_ITEMS = [ 'jetpack_abc', 'jetpack_qwerty' ];
+
+function buildContextQueryObject( plans?: string ) {
+	if ( ! plans ) {
+		return { query: {} };
+	}
+	return { query: { [ COMPARE_PLANS_QUERY_PARAM ]: plans } };
+}
+
+describe( 'getComparePlansFromContext', () => {
+	it( 'returns an empty array if there are no query parameters', () => {
+		expect( getComparePlansFromContext( buildContextQueryObject() ) ).toEqual( [] );
+	} );
+
+	it( 'returns the list of purchasable Jetpack items', () => {
+		expect(
+			getComparePlansFromContext( buildContextQueryObject( PURCHASABLE_ITEMS.join( ',' ) ) )
+		).toEqual( [ 'jetpack_personal', 'jetpack_backup_daily', 'jetpack_scan' ] );
+	} );
+
+	it( 'filters out non purchasable items', () => {
+		expect(
+			getComparePlansFromContext(
+				buildContextQueryObject( [ ...PURCHASABLE_ITEMS, ...NON_PURCHASABLE_ITEMS ].join( ',' ) )
+			)
+		).toEqual( [ 'jetpack_personal', 'jetpack_backup_daily', 'jetpack_scan' ] );
+
+		expect(
+			getComparePlansFromContext( buildContextQueryObject( NON_PURCHASABLE_ITEMS.join( ',' ) ) )
+		).toEqual( [] );
+	} );
+} );
+
+describe( 'getPlanRecommendationFromContext', () => {
+	it( 'returns undefined when no plans are provided', () => {
+		expect( getPlanRecommendationFromContext( buildContextQueryObject() ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined when only one plan is provided', () => {
+		expect(
+			getPlanRecommendationFromContext( buildContextQueryObject( 'jetpack_personal' ) )
+		).toBeUndefined();
+	} );
+
+	it( 'returns undefined if the first item is not a legacy plan', () => {
+		expect(
+			getPlanRecommendationFromContext( buildContextQueryObject( 'jetpack_scan,jetpack_personal' ) )
+		).toBeUndefined();
+
+		expect(
+			getPlanRecommendationFromContext(
+				buildContextQueryObject( 'jetpack_personal,jetpack_backup_daily' )
+			)
+		).toBeTruthy();
+	} );
+
+	it( 'returns undefined if all provided plans are legacy plans', () => {
+		expect(
+			getPlanRecommendationFromContext(
+				buildContextQueryObject( 'jetpack_premium,jetpack_personal' )
+			)
+		).toBeUndefined();
+		expect(
+			getPlanRecommendationFromContext(
+				buildContextQueryObject( 'jetpack_premium,jetpack_personal,jetpack_business' )
+			)
+		).toBeUndefined();
+	} );
+
+	it( 'returns a tupe being the first element the legacy item and the second an array of new items', () => {
+		const [ legacyItem, ...newItems ] = PURCHASABLE_ITEMS;
+		expect(
+			getPlanRecommendationFromContext( buildContextQueryObject( PURCHASABLE_ITEMS.join( ',' ) ) )
+		).toEqual( [ legacyItem, newItems ] );
+	} );
+} );
+
+describe( 'getItemSlugByDuration', () => {
+	it( 'returns the monthly version of an item slug', () => {
+		expect( getItemSlugByDuration( 'jetpack_scan', TERM_MONTHLY ) ).toBe( 'jetpack_scan_monthly' );
+		expect( getItemSlugByDuration( 'jetpack_scan_monthly', TERM_MONTHLY ) ).toBe(
+			'jetpack_scan_monthly'
+		);
+	} );
+
+	it( 'returns the yearly version of an item slug', () => {
+		expect( getItemSlugByDuration( 'jetpack_scan', TERM_ANNUALLY ) ).toBe( 'jetpack_scan' );
+		expect( getItemSlugByDuration( 'jetpack_scan_monthly', TERM_ANNUALLY ) ).toBe( 'jetpack_scan' );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add unit test to cover the basic functionality of the new `PlanUpgradeSection` component.
* Add unit test to cover utility functions used by the same component.

#### Testing instructions

* Download this PR.
* Run `yarn test-client client/my-sites/plans/jetpack-plans/plan-upgrade/test/index.tsx`.
* Make sure all tests passed.
* Run `yarn test-client client/my-sites/plans/jetpack-plans/plan-upgrade/test/utils.ts`.
* Make sure all tests passed.

Related to 1200196139286276-as-1200259578331169