### PR TITLE
Editor: Fix spacing in editor placeholder shown during loading

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -37,7 +37,7 @@
 	.placeholder-title {
 		height: 40px;
 		border-radius: 20px;
-		margin: 0 8px;
+		margin: 18px;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added vertical space between the header and what represents the page title (or perhaps a block)
* Added horizontal space so the page title placeholder lines up with the leftmost element in the header

| Before | After |
| ---- | -- |
| <img width="1124" alt="before" src="https://user-images.githubusercontent.com/1500769/116631342-fc741d00-a9a8-11eb-8ed1-446a040eff69.png"> | <img width="1125" alt="after" src="https://user-images.githubusercontent.com/1500769/116631348-0007a400-a9a9-11eb-94b1-f0345aff5fb9.png"> |


The left-alignment of the placeholder elements looks a little bit funky to me. The placeholder title and editor buttons are lined up now, but because they have different border radiuses they don't feel very aligned. Perhaps just a trick of the eye?
For comparison this is what it looks like with no border raius, which is what most of the placeholders I've seen in Calypso look like.
<img width="400" alt="square" src="https://user-images.githubusercontent.com/1500769/116631354-039b2b00-a9a9-11eb-92d7-ce924e5bc3ba.png">
Looks very austere by comparison, but more aligned. Anyway just an idea, this PR as submitted leaves the border radiuses as they are in production.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Can test using calypso.live
* Open the editor from within Calypso
* Try various browsers and screen sizes
* If the loading state disappears too fast you can throttle the network in the Chrome dev tools write before navigating to the editor

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #52363
