### PR TITLE
desktop: calypso.localhost for built app

### DIFF
--- a/desktop/app/config.json
+++ b/desktop/app/config.json
@@ -1,9 +1,9 @@
 {
 	"build": "release",
 	"calypso_config": "desktop",
-	"server_port": 41050,
-	"server_url": "http://127.0.0.1",
-	"server_host": "127.0.0.1",
+	"server_port": 3000,
+	"server_url": "http://calypso.localhost",
+	"server_host": "calypso.localhost",
 	"wordpress_host": "wordpress.com",
 	"debug": false,
 	"appName": "WordPress.com",

--- a/desktop/desktop-config/README.md
+++ b/desktop/desktop-config/README.md
@@ -12,7 +12,7 @@ The build process is:
 
 `server_port` - Calypso server port
 
-`server_url` - Calypso server URL
+`server_url` - Calypso server URL for development against localhost
 
 `server_host` - Calypso server host name
 

--- a/desktop/desktop-config/config-base.json
+++ b/desktop/desktop-config/config-base.json
@@ -1,9 +1,9 @@
 {
 	"build": "local",
 	"calypso_config": "desktop",
-	"server_port": 41050,
-	"server_url": "http://127.0.0.1",
-	"server_host": "127.0.0.1",
+	"server_port": 3000,
+	"server_url": "http://calypso.localhost",
+	"server_host": "calypso.localhost",
 	"wordpress_host": "wordpress.com",
 	"debug": false,
 	"appName": "WordPress.com",


### PR DESCRIPTION
### Description

Adds some changes necessary to get the built app working with `calypso.localhost`.

With these changes you should be able to point the built app to `calypso.localhost` by doing the following:

1. Generate the built app with `yarn run build` from the desktop folder (or `ELECTRON_BUILDER_ARGS=-c.mac.target=dir yarn run build` to build _only_ the app without the installers and other artifacts
2. Boot Calypso with `yarn start`
3. Run th`WP_DESKTOP_DEBUG_LOCALHOST=1 ./release/mac/WordPress.com.app/Contents/MacOS/WordPress.com`