### PR TITLE
Reskin signup: Restart experiment

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -102,7 +102,7 @@ export const removeP2SignupClassName = function () {
 export default {
 	redirectTests( context, next ) {
 		const currentFlowName = getFlowName( context.params );
-		currentFlowName === 'onboarding' && loadExperimentAssignment( 'refined_reskin_v1' );
+		currentFlowName === 'onboarding' && loadExperimentAssignment( 'refined_reskin_v2' );
 		currentFlowName === 'launch-site' && loadExperimentAssignment( 'hide_ecommerce_launch_site' );
 		if ( context.pathname.indexOf( 'new-launch' ) >= 0 ) {
 			next();

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -717,7 +717,7 @@ class Signup extends React.Component {
 
 		return (
 			<ProvideExperimentData
-				name="refined_reskin_v1"
+				name="refined_reskin_v2"
 				options={ { isEligible: 'onboarding' === this.props.flowName } }
 			>
 				{ ( isLoading, experimentAssignment ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The reskin signup experiment, originally launched in https://github.com/Automattic/wp-calypso/pull/50512, had to be paused due to the reasons explained in pbmo2S-J7-p2. This PR restarts the experiment. 


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In Abacus, assign yourself to the treatment of `refined_reskin_v2` experiment. Go through the signup flow at /start, and verify that the reskin treatment experience is visible.
* Assign yourself to control, and verify that the experience matches the current production experience in the `onboarding` flow.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
