### PR TITLE
Me Sidebar: Remove redundant headings.

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -14,7 +14,6 @@ import ProfileGravatar from 'calypso/me/profile-gravatar';
 import { purchasesRoot } from 'calypso/me/purchases/paths';
 import Sidebar from 'calypso/layout/sidebar';
 import SidebarFooter from 'calypso/layout/sidebar/footer';
-import SidebarHeading from 'calypso/layout/sidebar/heading';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
 import SidebarRegion from 'calypso/layout/sidebar/region';
@@ -88,10 +87,6 @@ class MeSidebar extends React.Component {
 					</div>
 
 					<SidebarMenu>
-						<SidebarHeading>
-							<span className="sidebar__informative-title">{ translate( 'Profile' ) }</span>
-						</SidebarHeading>
-
 						<SidebarItem
 							selected={ itemLinkMatches( '', path ) }
 							link={ '/me' }
@@ -159,12 +154,6 @@ class MeSidebar extends React.Component {
 							onNavigate={ this.onNavigate }
 							preloadSectionName="site-blocks"
 						/>
-					</SidebarMenu>
-
-					<SidebarMenu>
-						<SidebarHeading>
-							<span className="sidebar__informative-title">{ translate( 'Special' ) }</span>
-						</SidebarHeading>
 
 						<SidebarItem
 							selected={ itemLinkMatches( '/get-apps', path ) }

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -105,12 +105,7 @@ $font-size: rem( 14px );
 			}
 		}
 
-		.sidebar__informative-title {
-			display: block;
-		}
-
 		.sidebar__expandable-title,
-		.sidebar__informative-title,
 		.sidebar__menu-link-text {
 			padding: $sidebar-item-padding;
 			max-height: 34px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removed redundant Headings "Profile", "Special" in Me Sidebar.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/me`

Before | After
-------|------
![](https://cln.sh/DBhBu9+) | ![](https://cln.sh/XfO65u+)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #49178
