### PR TITLE
P2: add more tracking

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -530,6 +530,8 @@ class InvitePeople extends React.Component {
 			isGeneratingInviteLinks: true,
 		} );
 
+		this.props.recordTracksEventAction( 'calypso_invite_people_generate_new_link_button_click' );
+
 		return this.props.generateInviteLinks( this.props.siteId );
 	};
 

--- a/client/signup/steps/p2-details/index.jsx
+++ b/client/signup/steps/p2-details/index.jsx
@@ -13,6 +13,7 @@ import P2StepWrapper from 'calypso/signup/p2-step-wrapper';
 import { Button } from '@automattic/components';
 import { login } from 'calypso/lib/paths';
 import { getStepUrl } from 'calypso/signup/utils';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 /**
  * Style dependencies
@@ -82,6 +83,8 @@ function P2Details( {
 								stepName: stepName,
 							} );
 
+							recordTracksEvent( 'calypso_signup_p2_details_login_button_click' );
+
 							page( getLoginLink( { flowName, locale } ) );
 						} }
 					>
@@ -92,6 +95,8 @@ function P2Details( {
 							submitSignupStep( {
 								stepName: stepName,
 							} );
+
+							recordTracksEvent( 'calypso_signup_p2_details_signup_button_click' );
 
 							goToNextStep();
 						} }


### PR DESCRIPTION
In this PR, we add a bit more P2 tracking:
- When clicking the "Generate new link" on the Invite People section
- When clicking to Login with WP.com or Sign up with WP.com on the P2 Details screen in P2 signup.

## Testing instructions

Code review.