### PR TITLE
ci(teamcity): Use the correct URL for downloading chrome

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -123,12 +123,11 @@ ENTRYPOINT [ "/bin/bash" ]
 FROM ci-desktop as ci-e2e
 
 # test/e2e/test/mocha.env.js will install a compatible chromedriver.
-ENV CHROME_VERSION="current"
 ENV DETECT_CHROMEDRIVER_VERSION=true
 
-RUN wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
-	&& apt-get install -y ./google-chrome-stable_${CHROME_VERSION}_amd64.deb \
-	&& rm ./google-chrome-stable_${CHROME_VERSION}_amd64.deb
+RUN wget --no-verbose https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+	&& apt-get install -y ./google-chrome-stable_current_amd64.deb \
+	&& rm ./google-chrome-stable_current_amd64.deb
 
 ENTRYPOINT [ "/bin/bash" ]
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Uses the correct URL for downloading Chrome.

Current URL is failing with:
```
15:29:43
  #18 0.482 https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_current_amd64.deb
15:29:43
  #18 0.482 2021-04-30 13:29:43 ERROR 404: Not Found.
```


#### Testing instructions

Verify `wget --no-verbose https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb` downloads a .deb package.