### PR TITLE
Update recommended label in plans upgrade section

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -53,6 +53,7 @@ type OwnProps = {
 	displayFrom?: boolean;
 	tooltipText?: TranslateResult | ReactNode;
 	aboveButtonText?: TranslateResult | ReactNode;
+	featuredLabel?: TranslateResult;
 	hideSavingLabel?: boolean;
 };
 
@@ -211,6 +212,7 @@ const JetpackProductCard: React.FC< Props > = ( {
 	displayFrom,
 	belowPriceText,
 	tooltipText,
+	featuredLabel,
 	hideSavingLabel,
 	aboveButtonText = null,
 }: Props ) => {
@@ -234,7 +236,7 @@ const JetpackProductCard: React.FC< Props > = ( {
 			{ isFeatured && (
 				<div className="jetpack-product-card__header">
 					<img className="jetpack-product-card__header-icon" src={ starIcon } alt="" />
-					<span>{ translate( 'Recommended' ) }</span>
+					<span>{ featuredLabel || translate( 'Recommended' ) }</span>
 				</div>
 			) }
 			<div className="jetpack-product-card__body">

--- a/client/my-sites/plans/jetpack-plans/plan-upgrade/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/plan-upgrade/index.tsx
@@ -115,6 +115,7 @@ const PlanUpgradeSection: React.FC< Props > = ( {
 									currencyCode={ currencyCode }
 									selectedTerm={ duration }
 									featuredPlans={ newPlans }
+									featuredLabel={ translate( 'Recommended for you' ) }
 									isAligned
 									hideSavingLabel
 									onClick={ onSelectProduct }

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -42,6 +42,7 @@ interface ProductCardProps {
 	selectedTerm?: Duration;
 	isAligned?: boolean;
 	featuredPlans?: string[];
+	featuredLabel?: TranslateResult;
 	hideSavingLabel?: boolean;
 }
 
@@ -53,6 +54,7 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 	selectedTerm,
 	isAligned,
 	featuredPlans,
+	featuredLabel,
 	hideSavingLabel,
 } ) => {
 	const translate = useTranslate();
@@ -163,6 +165,7 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 			aboveButtonText={ productAboveButtonText( item, siteProduct, isOwned, isItemPlanFeature ) }
 			isDisabled={ isDisabled }
 			disabledMessage={ disabledMessage }
+			featuredLabel={ featuredLabel }
 			hideSavingLabel={ hideSavingLabel }
 		/>
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the label at the top of the recommended cards in the recommendation section of the plans page. See capture below.

### Testing instructions

- Download the PR and run Calypso
- Visit `/plans/:site?compare_plans=jetpack_personal,jetpack_backup_daily,jetpack_anti_spam`
- Check that label is "Recommended for you"

### Screenshots

![screenshot](https://user-images.githubusercontent.com/1620183/116704800-ce3b1100-a999-11eb-8ef6-ce9df619b9bb.png)
