### PR TITLE
Jetpack plans: adjust plan comparison styles

### DIFF
--- a/client/my-sites/plans/jetpack-plans/plan-upgrade/style.scss
+++ b/client/my-sites/plans/jetpack-plans/plan-upgrade/style.scss
@@ -34,14 +34,13 @@
 	@include break-wide {
 		flex-direction: row;
 		justify-content: center;
-		align-items: center;
+		align-items: flex-start;
 	}
 
 	.with-single-reco & {
 		@include break-xlarge {
 			flex-direction: row;
 			justify-content: center;
-			align-items: center;
 		}
 	}
 }
@@ -70,6 +69,7 @@
 
 .plan-upgrade__separator {
 	display: flex;
+	align-self: center;
 
 	margin: 24px auto;
 

--- a/client/my-sites/plans/jetpack-plans/plan-upgrade/style.scss
+++ b/client/my-sites/plans/jetpack-plans/plan-upgrade/style.scss
@@ -151,3 +151,7 @@
 		margin-left: 0;
 	}
 }
+
+.jetpack-product-card.is-deprecated {
+	box-shadow: none;
+}

--- a/client/my-sites/plans/jetpack-plans/plan-upgrade/style.scss
+++ b/client/my-sites/plans/jetpack-plans/plan-upgrade/style.scss
@@ -126,8 +126,10 @@
 			flex: 1;
 
 			max-width: 350px;
-			margin-left: 16px;
-			margin-right: 16px;
+
+			& + li {
+				margin-left: 16px;
+			}
 		}
 	}
 
@@ -143,5 +145,9 @@
 				margin-top: 0;
 			}
 		}
+	}
+
+	.jetpack-product-card.is-featured.is-aligned {
+		margin-left: 0;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Align cards to the top.
* Adjust cards margins.
* Gets rid of box-shadow in a deprecated plan card.

#### Testing instructions

* Fire up this PR.
* Head to:
  * `/plans/SITE_URL?compare_plans=jetpack_personal,jetpack_backup_daily,jetpack_anti_spam`
  * `/plans/SITE_URL?compare_plans=jetpack_premium,jetpack_security_daily`.
* Ensure all cards are aligned and the spacing is consistent.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/116710585-d317b900-a9c9-11eb-81cb-28efda54c320.png) | ![image](https://user-images.githubusercontent.com/390760/116710641-e165d500-a9c9-11eb-97ce-7027fbc80d98.png)
![image](https://user-images.githubusercontent.com/390760/116710435-acf21900-a9c9-11eb-89f2-b6274ed1519c.png) | ![image](https://user-images.githubusercontent.com/390760/116710483-b7acae00-a9c9-11eb-8554-23493d2d778d.png)
