### PR TITLE
Rewrite menu items to always work

### DIFF
--- a/client/root.js
+++ b/client/root.js
@@ -24,7 +24,9 @@ export default function () {
 }
 
 function handleLoggedOut() {
-	if ( config.isEnabled( 'devdocs/redirect-loggedout-homepage' ) ) {
+	if ( config.isEnabled( 'desktop' ) ) {
+		page.redirect( '/' );
+	} else if ( config.isEnabled( 'devdocs/redirect-loggedout-homepage' ) ) {
 		page.redirect( '/devdocs/start' );
 	} else if ( config.isEnabled( 'jetpack-cloud' ) ) {
 		if ( config.isEnabled( 'oauth' ) ) {

--- a/desktop/app/lib/calypso-commands/index.js
+++ b/desktop/app/lib/calypso-commands/index.js
@@ -24,11 +24,6 @@ module.exports = {
 		mainWindow.webContents.send( 'new-post' );
 	},
 
-	toggleNotifications: function ( mainWindow ) {
-		log.info( 'toggleNotifications triggered' );
-		mainWindow.webContents.send( 'toggle-notification-bar' );
-	},
-
 	showHelp: function ( mainWindow ) {
 		log.info( 'showHelp triggered' );
 		mainWindow.webContents.send( 'page-help' );

--- a/desktop/app/lib/config/index.js
+++ b/desktop/app/lib/config/index.js
@@ -14,6 +14,13 @@ config.loginURL = function () {
 	return 'https://wordpress.com/log-in';
 };
 
+config.baseURL = function () {
+	if ( process.env.WP_DESKTOP_DEBUG_LOCALHOST !== undefined ) {
+		return 'http://calypso.localhost:3000/';
+	}
+	return 'https://wordpress.com/';
+};
+
 config.isRelease = function () {
 	return this.build === 'release';
 };

--- a/desktop/app/lib/is-calypso/index.js
+++ b/desktop/app/lib/is-calypso/index.js
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+const Config = require( '../../lib/config' );
+
+const webBase = Config.baseURL();
+
+module.exports = function ( mainWindow ) {
+	return mainWindow.webContents.getURL().startsWith( webBase );
+};

--- a/desktop/app/lib/menu/app-menu.js
+++ b/desktop/app/lib/menu/app-menu.js
@@ -15,6 +15,7 @@ const AppQuit = require( '../../lib/app-quit' );
 const debugMenu = require( './debug-menu' );
 const { getUpdater } = require( '../../app-handlers/updater' );
 const log = require( '../../lib/logger' )( 'desktop:menu' );
+const isCalypso = require( '../../lib/is-calypso' );
 
 /**
  * Module variables
@@ -38,9 +39,14 @@ module.exports = function ( app, mainWindow ) {
 			requiresUser: true,
 			enabled: false,
 			id: 'loggedin',
-			click: function () {
+			click: async function () {
 				mainWindow.show();
-				ipc.signOut( mainWindow );
+				if ( isCalypso( mainWindow ) ) {
+					ipc.signOut( mainWindow );
+				} else {
+					await mainWindow.webContents.session.clearStorageData();
+					mainWindow.webContents.loadURL( Config.loginURL() );
+				}
 			},
 		},
 		{

--- a/desktop/app/lib/menu/calypso-menu.js
+++ b/desktop/app/lib/menu/calypso-menu.js
@@ -2,6 +2,10 @@
  * Internal dependencies
  */
 const ipc = require( '../../lib/calypso-commands' );
+const Config = require( '../../lib/config' );
+const isCalypso = require( '../../lib/is-calypso' );
+
+const webBase = Config.baseURL();
 
 module.exports = function ( mainWindow, status ) {
 	status = status === 'enabled' ? true : false;
@@ -14,7 +18,11 @@ module.exports = function ( mainWindow, status ) {
 			accelerator: 'CmdOrCtrl+1',
 			click: function () {
 				mainWindow.show();
-				ipc.showMySites( mainWindow );
+				if ( isCalypso( mainWindow ) ) {
+					ipc.showMySites( mainWindow );
+				} else {
+					mainWindow.webContents.loadURL( webBase + 'stats/day' );
+				}
 			},
 		},
 		{
@@ -24,7 +32,11 @@ module.exports = function ( mainWindow, status ) {
 			accelerator: 'CmdOrCtrl+2',
 			click: function () {
 				mainWindow.show();
-				ipc.showReader( mainWindow );
+				if ( isCalypso( mainWindow ) ) {
+					ipc.showReader( mainWindow );
+				} else {
+					mainWindow.webContents.loadURL( webBase + 'read' );
+				}
 			},
 		},
 		{
@@ -34,17 +46,12 @@ module.exports = function ( mainWindow, status ) {
 			accelerator: 'CmdOrCtrl+3',
 			click: function () {
 				mainWindow.show();
-				ipc.showProfile( mainWindow );
-			},
-		},
-		{
-			label: 'Notifications',
-			requiresUser: true,
-			enabled: status,
-			accelerator: 'CmdOrCtrl+4',
-			click: function () {
 				mainWindow.show();
-				ipc.toggleNotifications( mainWindow );
+				if ( isCalypso( mainWindow ) ) {
+					ipc.showProfile( mainWindow );
+				} else {
+					mainWindow.webContents.loadURL( webBase + 'me' );
+				}
 			},
 		},
 		{
@@ -54,7 +61,12 @@ module.exports = function ( mainWindow, status ) {
 			accelerator: 'CmdOrCtrl+N',
 			click: function () {
 				mainWindow.show();
-				ipc.newPost( mainWindow );
+				mainWindow.show();
+				if ( isCalypso( mainWindow ) ) {
+					ipc.newPost( mainWindow );
+				} else {
+					mainWindow.webContents.loadURL( webBase + 'post' );
+				}
 			},
 		},
 	];

--- a/desktop/app/window-handlers/external-links/index.js
+++ b/desktop/app/window-handlers/external-links/index.js
@@ -12,6 +12,13 @@ const log = require( '../../lib/logger' )( 'desktop:external-links' );
 
 const isWordPress = ( url ) => url.hostname.includes( 'wordpress.com' );
 
+const isDevBuild = ( url ) => {
+	return (
+		process.env.WP_DESKTOP_DEBUG_LOCALHOST !== undefined &&
+		url.hostname.includes( 'calypso.localhost' )
+	);
+};
+
 const isJetpack = ( url ) => url.hostname.includes( 'jetpack.com' );
 
 const isWpAdmin = ( url ) => url.href.includes( 'wp-admin' );
@@ -30,6 +37,7 @@ module.exports = function ( mainWindow ) {
 
 		if (
 			isWordPress( parsed ) ||
+			isDevBuild( parsed ) ||
 			isJetpack( parsed ) ||
 			isWpAdmin( parsed ) ||
 			isWpLogin( parsed ) // Disable wp-login/self-hosted for now ?
@@ -57,6 +65,7 @@ module.exports = function ( mainWindow ) {
 
 		if (
 			isWordPress( parsed ) ||
+			isDevBuild( parsed ) ||
 			isJetpack( parsed ) ||
 			isWpAdmin( parsed ) ||
 			isWpLogin( parsed ) // Disable wp-login/self-hosted for now ?


### PR DESCRIPTION
When the user is viewing calypso use IPC hooks, when the user is not in a calypso page use URL redirection.