### PR TITLE
Jetpack Search: Show Correct Information if Disabled

### DIFF
--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -79,7 +79,7 @@ export default function JetpackSearchMain(): ReactElement {
 			<PromoCard
 				title={
 					isSearchEnabled
-						? translate( 'Jetpack Search is active on your site.' )
+						? translate( 'Jetpack Search is enabled on your site.' )
 						: translate( 'Jetpack Search is disabled on your site.' )
 				}
 				image={ { path: JetpackSearchSVG } }
@@ -89,7 +89,7 @@ export default function JetpackSearchMain(): ReactElement {
 					{ isSearchEnabled
 						? translate( 'Your visitors are getting our fastest search experience.' )
 						: translate(
-								'Enable it to ensure your visitors receive our fastest search experience.'
+								'Enable it to ensure your visitors get our fastest search experience.'
 						  ) }
 				</p>
 

--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -21,6 +21,8 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
+import getSiteSetting from 'calypso/state/selectors/get-site-setting';
+import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import JetpackSearchUpsell from './upsell';
 import JetpackSearchPlaceholder from './placeholder';
@@ -43,6 +45,9 @@ export default function JetpackSearchMain(): ReactElement {
 	const siteId = useSelector( getSelectedSiteId );
 	const checkForSearchProduct = ( purchase ) => purchase.active && isJetpackSearch( purchase );
 	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
+	const isSearchEnabled = useSelector( ( state ) =>
+		getSiteSetting( state, siteId, 'jetpack_search_enabled' )
+	);
 	const hasSearchProduct =
 		sitePurchases.find( checkForSearchProduct ) || planHasJetpackSearch( site?.plan?.product_slug );
 	const hasLoadedSitePurchases = useSelector( hasLoadedSitePurchasesFromServer );
@@ -62,6 +67,7 @@ export default function JetpackSearchMain(): ReactElement {
 			<DocumentHead title="Jetpack Search" />
 			<SidebarNavigation />
 			<PageViewTracker path="/jetpack-search/:site" title="Jetpack Search" />
+			<QuerySiteSettings siteId={ siteId } />
 
 			<FormattedHeader
 				headerText={ translate( 'Jetpack Search' ) }
@@ -71,15 +77,25 @@ export default function JetpackSearchMain(): ReactElement {
 			/>
 
 			<PromoCard
-				title={ translate( 'Jetpack Search is active on your site.' ) }
+				title={
+					isSearchEnabled
+						? translate( 'Jetpack Search is active on your site.' )
+						: translate( 'Jetpack Search is disabled on your site.' )
+				}
 				image={ { path: JetpackSearchSVG } }
 				isPrimary
 			>
-				<p>{ translate( 'Your visitors are getting our fastest search experience.' ) }</p>
+				<p>
+					{ isSearchEnabled
+						? translate( 'Your visitors are getting our fastest search experience.' )
+						: translate(
+								'Enable it to ensure your visitors receive our fastest search experience.'
+						  ) }
+				</p>
 
 				<PromoCardCTA
 					cta={ {
-						text: translate( 'Settings' ),
+						text: isSearchEnabled ? translate( 'Settings' ) : translate( 'Enable now' ),
 						action: {
 							url: `/settings/performance/${ siteSlug }`,
 							onClick: onSettingsClick,

--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -95,7 +95,7 @@ export default function JetpackSearchMain(): ReactElement {
 
 				<PromoCardCTA
 					cta={ {
-						text: isSearchEnabled ? translate( 'Settings' ) : translate( 'Enable now' ),
+						text: translate( 'Settings' ),
 						action: {
 							url: `/settings/performance/${ siteSlug }`,
 							onClick: onSettingsClick,

--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -88,9 +88,7 @@ export default function JetpackSearchMain(): ReactElement {
 				<p>
 					{ isSearchEnabled
 						? translate( 'Your visitors are getting our fastest search experience.' )
-						: translate(
-								'Enable it to ensure your visitors get our fastest search experience.'
-						  ) }
+						: translate( 'Enable it to ensure your visitors get our fastest search experience.' ) }
 				</p>
 
 				<PromoCardCTA


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Accurately convey that Jetpack Search is disabled when that's the case, and encourage people to enable it.

#### Testing instructions

Disable Jetpack Search under Settings > General > Performance and verify the screen on `/jetpack-search` accurately conveys that the product has been disabled.

<img width="747" alt="Screenshot 2021-04-30 at 17 00 40" src="https://user-images.githubusercontent.com/43215253/116721934-c5683080-a9d5-11eb-94a2-3b837c2f53d7.png">

cc @bluefuton 

Fixes #52405