### PR TITLE
Update stalebot workflow definition to include PRs.

### DIFF
--- a/.github/workflows/mark-issue-stale.yml
+++ b/.github/workflows/mark-issue-stale.yml
@@ -12,16 +12,23 @@ jobs:
       - uses: actions/stale@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # Message to be added to stale issues.
           stale-issue-message: 'This issue is stale because it has been 180 days with no activity. You can keep the issue open by adding a comment. If you do, please provide additional context and explain why you’d like it to remain open. You can also close the issue yourself — if you do, please add a brief explanation and apply one of relevant issue close labels.'
           # Days before issue is considered stale.
           days-before-issue-stale: 180
-          # Exempt issue labels.
-          exempt-issue-labels: '[Pri] High,[Pri] BLOCKER,[Status] Keep Open'
+          # Exempted issue labels.
+          exempt-issue-labels: '[Pri] High,[Pri] BLOCKER,[Status] Keep Open,[Status] Blocked / Hold'
+          # Message to be added to stale PRs.
+          stale-pr-message: 'This PR has been marked as stale due to lack of activity within the last 30 days.'
+          # Exempted PR labels.
+          exempt-pr-labels: '[Pri] High,[Pri] BLOCKER'
           # Disable auto-close of both issues and PRs.
           days-before-close: -1
           # Get issues in ascending (oldest first) order.
           ascending: true
           # Label to apply when issue is marked stale.
           stale-issue-label: '[Status] Stale'
+          # Label to apply when PR is marked as stale.
+          stale-pr-label: '[Status] Stale'
           # Increase number of operations executed per run.
           operations-per-run: 525

--- a/.github/workflows/mark-issue-stale.yml
+++ b/.github/workflows/mark-issue-stale.yml
@@ -21,7 +21,7 @@ jobs:
           # Message to be added to stale PRs.
           stale-pr-message: 'This PR has been marked as stale due to lack of activity within the last 30 days.'
           # Exempted PR labels.
-          exempt-pr-labels: '[Pri] High,[Pri] BLOCKER'
+          exempt-pr-labels: '[Pri] High,[Pri] BLOCKER,[Status] Keep Open,[Status] Blocked / Hold'
           # Disable auto-close of both issues and PRs.
           days-before-close: -1
           # Get issues in ascending (oldest first) order.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Begin including PRs in the stale sweep done by the bot.

Previously, only issues were marked as stale. 
There are currently close to 300 open PRs of varying age. From experience, PRs age much quicker than issues and rarely is there a reason to keep one open for prolonged period of time.

The proposal here is to tag a PR with the stale marker once the 30-day timeframe has been met. 

#### Testing instructions


Related to #52461
