### PR TITLE
Calypso doctor: Allow larger Node memory values

### DIFF
--- a/packages/calypso-doctor/evaluations/node-memory.js
+++ b/packages/calypso-doctor/evaluations/node-memory.js
@@ -24,7 +24,7 @@ module.exports = {
 
 		const currentValue = Number( match[ 1 ] );
 		const desiredValue = getMemInMb() * 0.75;
-		if ( desiredValue > currentValue ) {
+		if ( currentValue < desiredValue ) {
 			fail( `Memory set to ${ currentValue } mb, at least ${ desiredValue } mb expected` );
 			return;
 		}

--- a/packages/calypso-doctor/evaluations/node-memory.js
+++ b/packages/calypso-doctor/evaluations/node-memory.js
@@ -24,8 +24,8 @@ module.exports = {
 
 		const currentValue = Number( match[ 1 ] );
 		const desiredValue = getMemInMb() * 0.75;
-		if ( desiredValue !== currentValue ) {
-			fail( `Memory set to ${ currentValue } mb, ${ desiredValue } mb expected` );
+		if ( desiredValue > currentValue ) {
+			fail( `Memory set to ${ currentValue } mb, at least ${ desiredValue } mb expected` );
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
For some reason, my system has 2476mb of memory allocated to node, which is larger than the value Calypso doctor expects. I'm not exactly sure what the implications of this are, but my intuition is that larger node memory values wouldn't be bad. If there are other considerations, let me know!

