### PR TITLE
Marketing - Site Verification: Add Facebook Domain Manager

### DIFF
--- a/client/my-sites/site-settings/seo-settings/services.js
+++ b/client/my-sites/site-settings/seo-settings/services.js
@@ -1,0 +1,39 @@
+/**
+ * Add new Site Verification services to this file.
+ * Requires the API endpoint in Jetpack to be updated with the new service too.
+ */
+export default function ( translate = () => {} ) {
+	return [
+		{
+			name: translate( 'Google' ),
+			slug: 'google',
+			id: 'google-site-verification',
+			link: 'https://www.google.com/webmasters/tools/',
+		},
+		{
+			name: translate( 'Bing' ),
+			slug: 'bing',
+			id: 'msvalidate.01',
+			link: 'https://www.bing.com/webmaster/',
+		},
+		{
+			name: translate( 'Pinterest' ),
+			slug: 'pinterest',
+			id: 'p:domain_verify',
+			link: 'https://pinterest.com/website/verify/',
+		},
+		{
+			name: translate( 'Yandex' ),
+			slug: 'yandex',
+			id: 'yandex-verification',
+			link: 'https://webmaster.yandex.com/sites/',
+		},
+		{
+			name: translate( 'Facebook' ),
+			slug: 'facebook',
+			id: 'facebook-domain-verification',
+			link: 'https://business.facebook.com/settings/',
+			minimumJetpackVersion: '9.8-alpha',
+		},
+	];
+}

--- a/client/my-sites/site-settings/seo-settings/services.js
+++ b/client/my-sites/site-settings/seo-settings/services.js
@@ -5,7 +5,7 @@
  * Returns the Site Verification services.
  *
  * @param  {Function}  translate  Translate needed for the name.
- * @returns {object}              Site Verification services data.
+ * @returns {Array}              Site Verification services data.
  */
 export default function ( translate = () => {} ) {
 	return [

--- a/client/my-sites/site-settings/seo-settings/services.js
+++ b/client/my-sites/site-settings/seo-settings/services.js
@@ -5,7 +5,7 @@
  * Returns the Site Verification services.
  *
  * @param  {Function}  translate  Translate needed for the name.
- * @returns {Array}              Site Verification services data.
+ * @returns {Array}               Site Verification services data.
  */
 export default function ( translate = () => {} ) {
 	return [

--- a/client/my-sites/site-settings/seo-settings/services.js
+++ b/client/my-sites/site-settings/seo-settings/services.js
@@ -1,6 +1,11 @@
+// Add new Site Verification services to this file.
+// Requires the API to be updated in Jetpack in order to work.
+
 /**
- * Add new Site Verification services to this file.
- * Requires the API endpoint in Jetpack to be updated with the new service too.
+ * Returns the Site Verification services.
+ *
+ * @param  {Function}  translate  Translate needed for the name.
+ * @returns {object}              Site Verification services data.
  */
 export default function ( translate = () => {} ) {
 	return [

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -376,7 +376,7 @@ class SiteVerification extends Component {
 										<ExternalLink
 											icon={ true }
 											target="_blank"
-											href="https://developers.facebook.com/"
+											href="https://business.facebook.com/settings/"
 										/>
 									),
 								},

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 import { Card } from '@automattic/components';
 import SupportInfo from 'calypso/components/support-info';
 import ExternalLink from 'calypso/components/external-link';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import FormInput from 'calypso/components/forms/form-text-input-with-affixes';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -22,8 +23,10 @@ import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-secti
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import versionCompare from 'calypso/lib/version-compare';
 import {
 	isSiteSettingsSaveSuccessful,
 	getSiteSettingsSaveError,
@@ -32,29 +35,14 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestSite } from 'calypso/state/sites/actions';
 import { requestSiteSettings, saveSiteSettings } from 'calypso/state/site-settings/actions';
 import { protectForm } from 'calypso/lib/protect-form';
+import getSupportedServices from './services';
 
 class SiteVerification extends Component {
-	static serviceIds = {
-		google: 'google-site-verification',
-		bing: 'msvalidate.01',
-		pinterest: 'p:domain_verify',
-		yandex: 'yandex-verification',
-		facebook: 'facebook-domain-verification',
-	};
-
 	state = {
 		...this.stateForSite( this.props.site ),
 		dirtyFields: new Set(),
 		invalidatedSiteObject: this.props.site,
 	};
-
-	UNSAFE_componentWillMount() {
-		this.changeGoogleCode = this.handleVerificationCodeChange( 'googleCode' );
-		this.changeBingCode = this.handleVerificationCodeChange( 'bingCode' );
-		this.changePinterestCode = this.handleVerificationCodeChange( 'pinterestCode' );
-		this.changeYandexCode = this.handleVerificationCodeChange( 'yandexCode' );
-		this.changeFacebookCode = this.handleVerificationCodeChange( 'facebookCode' );
-	}
 
 	componentDidMount() {
 		this.refreshSite();
@@ -112,14 +100,19 @@ class SiteVerification extends Component {
 	}
 
 	stateForSite( site ) {
-		return {
-			googleCode: get( site, 'options.verification_services_codes.google', '' ),
-			bingCode: get( site, 'options.verification_services_codes.bing', '' ),
-			pinterestCode: get( site, 'options.verification_services_codes.pinterest', '' ),
-			yandexCode: get( site, 'options.verification_services_codes.yandex', '' ),
-			facebookCode: get( site, 'options.verification_services_codes.facebook', '' ),
-			isFetchingSettings: get( site, 'fetchingSettings', false ),
-		};
+		const supportedServices = getSupportedServices();
+		const stateItems = {};
+
+		supportedServices.forEach( ( service ) => {
+			stateItems[ service.slug + 'Code' ] = get(
+				site,
+				`options.verification_services_codes.${ service.slug }`,
+				''
+			);
+		} );
+		stateItems.isFetchingSettings = get( site, 'fetchingSettings', false );
+
+		return stateItems;
 	}
 
 	refreshSite() {
@@ -144,12 +137,11 @@ class SiteVerification extends Component {
 			// We were passed a meta tag already!
 			return content;
 		}
+		const serviceId = getSupportedServices()
+			.filter( ( item ) => item.slug === serviceName )
+			.map( ( item ) => item.id )[ 0 ];
 
-		return `<meta name="${ get(
-			SiteVerification.serviceIds,
-			serviceName,
-			''
-		) }" content="${ content }" />`;
+		return `<meta name="${ serviceId }" content="${ content }" />`;
 	}
 
 	isValidCode( serviceName = '', content = '' ) {
@@ -157,9 +149,13 @@ class SiteVerification extends Component {
 			return true;
 		}
 
+		const serviceId = getSupportedServices()
+			.filter( ( item ) => item.slug === serviceName )
+			.map( ( item ) => item.id )[ 0 ];
+
 		content = this.getMetaTag( serviceName, content );
 
-		return includes( content, SiteVerification.serviceIds[ serviceName ] );
+		return includes( content, serviceId );
 	}
 
 	hasError( service ) {
@@ -220,13 +216,11 @@ class SiteVerification extends Component {
 
 		this.props.removeNotice( 'site-verification-settings-error' );
 
-		const verificationCodes = {
-			google: this.state.googleCode,
-			bing: this.state.bingCode,
-			pinterest: this.state.pinterestCode,
-			yandex: this.state.yandexCode,
-			facebook: this.state.facebookCode,
-		};
+		const verificationCodes = {};
+
+		getSupportedServices().forEach( ( service ) => {
+			verificationCodes[ service.slug ] = this.state[ service.slug + 'Code' ];
+		} );
 
 		const filteredCodes = pickBy( verificationCodes, ( code ) => typeof code === 'string' );
 		const invalidCodes = Object.keys(
@@ -252,29 +246,19 @@ class SiteVerification extends Component {
 		this.props.saveSiteSettings( siteId, updatedOptions );
 		this.props.trackFormSubmitted( { path } );
 
-		if ( dirtyFields.has( 'googleCode' ) ) {
-			trackSiteVerificationUpdated( 'google', path );
-		}
-
-		if ( dirtyFields.has( 'bingCode' ) ) {
-			trackSiteVerificationUpdated( 'bing', path );
-		}
-
-		if ( dirtyFields.has( 'pinterestCode' ) ) {
-			trackSiteVerificationUpdated( 'pinterest', path );
-		}
-
-		if ( dirtyFields.has( 'yandexCode' ) ) {
-			trackSiteVerificationUpdated( 'yandex', path );
-		}
-
-		if ( dirtyFields.has( 'facebookCode' ) ) {
-			trackSiteVerificationUpdated( 'facebook', path );
-		}
+		dirtyFields.forEach( ( service ) => {
+			trackSiteVerificationUpdated( service.replace( 'Code', '' ), path );
+		} );
 	};
 
 	render() {
-		const { isVerificationToolsActive, siteId, siteIsJetpack, translate } = this.props;
+		const {
+			isVerificationToolsActive,
+			jetpackVersion,
+			siteId,
+			siteIsJetpack,
+			translate,
+		} = this.props;
 		const {
 			isSubmittingForm,
 			isFetchingSettings,
@@ -285,15 +269,21 @@ class SiteVerification extends Component {
 		const isVerificationDisabled = isDisabled || isVerificationToolsActive === false;
 		const isSaveDisabled =
 			isDisabled || isSubmittingForm || ( ! showPasteError && invalidCodes.length > 0 );
-		const placeholderTagContent = '1234';
+		const supportedServices = getSupportedServices( translate );
 
-		// The API returns 'false' for an empty array value, so we force it to an empty string if needed
-		let { googleCode, bingCode, pinterestCode, yandexCode, facebookCode } = this.state;
-		googleCode = this.getMetaTag( 'google', googleCode || '' );
-		bingCode = this.getMetaTag( 'bing', bingCode || '' );
-		pinterestCode = this.getMetaTag( 'pinterest', pinterestCode || '' );
-		yandexCode = this.getMetaTag( 'yandex', yandexCode || '' );
-		facebookCode = this.getMetaTag( 'facebook', facebookCode || '' );
+		supportedServices.forEach( ( service, index ) => {
+			const stateSlug = `${ service.slug }Code`;
+			service.stateSlug = stateSlug;
+			service.code = this.getMetaTag( service.slug, this.state[ stateSlug ] || '' );
+
+			if (
+				service.minimumJetpackVersion &&
+				jetpackVersion &&
+				versionCompare( jetpackVersion, service.minimumJetpackVersion, '<=' )
+			) {
+				supportedServices.splice( index, 1 );
+			}
+		} );
 
 		return (
 			<div className="seo-settings__site-verification">
@@ -330,130 +320,51 @@ class SiteVerification extends Component {
 							'Note that {{b}}verifying your site with these services is not necessary{{/b}} in order' +
 								' for your site to be indexed by search engines. To use these advanced search engine tools' +
 								' and verify your site with a service, paste the HTML Tag code below. Read the' +
-								' {{support}}full instructions{{/support}} if you are having trouble. Supported verification services:' +
-								' {{google}}Google Search Console{{/google}}, {{bing}}Bing Webmaster Center{{/bing}},' +
-								' {{pinterest}}Pinterest Site Verification{{/pinterest}}, {{yandex}}Yandex.Webmaster{{/yandex}},' +
-								' and {{facebook}}Facebook Domain Verification{{/facebook}}.',
+								' {{supportLink/}} if you are having trouble.',
 							{
 								components: {
 									b: <strong />,
-									support: (
-										<ExternalLink
-											icon={ true }
-											target="_blank"
-											href="https://wordpress.com/support/webmaster-tools/"
-										/>
-									),
-									google: (
-										<ExternalLink
-											icon={ true }
-											target="_blank"
-											href="https://www.google.com/webmasters/tools/"
-										/>
-									),
-									bing: (
-										<ExternalLink
-											icon={ true }
-											target="_blank"
-											href="https://www.bing.com/webmaster/"
-										/>
-									),
-									pinterest: (
-										<ExternalLink
-											icon={ true }
-											target="_blank"
-											href="https://pinterest.com/website/verify/"
-										/>
-									),
-									yandex: (
-										<ExternalLink
-											icon={ true }
-											target="_blank"
-											href="https://webmaster.yandex.com/sites/"
-										/>
-									),
-									facebook: (
-										<ExternalLink
-											icon={ true }
-											target="_blank"
-											href="https://business.facebook.com/settings/"
-										/>
+									supportLink: (
+										<InlineSupportLink
+											supportPostId={ 5022 }
+											supportLink="https://wordpress.com/support/webmaster-tools/"
+										>
+											{ translate( 'full instructions', {
+												comment: 'Full phrase: Read the full instructions',
+											} ) }
+										</InlineSupportLink>
 									),
 								},
 							}
 						) }
 					</p>
+					<p>
+						{ translate( 'Supported verification services:' ) + ' ' }
+						{ supportedServices
+							.map( ( service ) => (
+								<ExternalLink key={ service.slug } icon target="_blank" href={ service.link }>
+									{ service.name }
+								</ExternalLink>
+							) )
+							.reduce( ( prev, curr ) => [ prev, ', ', curr ] ) }
+					</p>
 					<form onChange={ this.props.markChanged } className="seo-settings__seo-form">
-						<FormFieldset>
-							<FormInput
-								prefix={ translate( 'Google' ) }
-								name="verification_code_google"
-								value={ googleCode }
-								id="verification_code_google"
-								spellCheck="false"
-								disabled={ isVerificationDisabled }
-								isError={ this.hasError( 'google' ) }
-								placeholder={ this.getMetaTag( 'google', placeholderTagContent ) }
-								onChange={ this.changeGoogleCode }
-							/>
-							{ this.hasError( 'google' ) && this.getVerificationError( showPasteError ) }
-						</FormFieldset>
-						<FormFieldset>
-							<FormInput
-								prefix={ translate( 'Bing' ) }
-								name="verification_code_bing"
-								value={ bingCode }
-								id="verification_code_bing"
-								spellCheck="false"
-								disabled={ isVerificationDisabled }
-								isError={ this.hasError( 'bing' ) }
-								placeholder={ this.getMetaTag( 'bing', placeholderTagContent ) }
-								onChange={ this.changeBingCode }
-							/>
-							{ this.hasError( 'bing' ) && this.getVerificationError( showPasteError ) }
-						</FormFieldset>
-						<FormFieldset>
-							<FormInput
-								prefix={ translate( 'Pinterest' ) }
-								name="verification_code_pinterest"
-								value={ pinterestCode }
-								id="verification_code_pinterest"
-								spellCheck="false"
-								disabled={ isVerificationDisabled }
-								isError={ this.hasError( 'pinterest' ) }
-								placeholder={ this.getMetaTag( 'pinterest', placeholderTagContent ) }
-								onChange={ this.changePinterestCode }
-							/>
-							{ this.hasError( 'pinterest' ) && this.getVerificationError( showPasteError ) }
-						</FormFieldset>
-						<FormFieldset>
-							<FormInput
-								prefix={ translate( 'Yandex' ) }
-								name="verification_code_yandex"
-								value={ yandexCode }
-								id="verification_code_yandex"
-								spellCheck="false"
-								disabled={ isVerificationDisabled }
-								isError={ this.hasError( 'yandex' ) }
-								placeholder={ this.getMetaTag( 'yandex', placeholderTagContent ) }
-								onChange={ this.changeYandexCode }
-							/>
-							{ this.hasError( 'yandex' ) && this.getVerificationError( showPasteError ) }
-						</FormFieldset>
-						<FormFieldset>
-							<FormInput
-								prefix={ translate( 'Facebook' ) }
-								name="verification_code_facebook"
-								value={ facebookCode }
-								id="verification_code_facebook"
-								spellCheck="false"
-								disabled={ isVerificationDisabled }
-								isError={ this.hasError( 'facebook' ) }
-								placeholder={ this.getMetaTag( 'facebook', placeholderTagContent ) }
-								onChange={ this.changeFacebookCode }
-							/>
-							{ this.hasError( 'facebook' ) && this.getVerificationError( showPasteError ) }
-						</FormFieldset>
+						{ supportedServices.map( ( service ) => (
+							<FormFieldset key={ service.slug }>
+								<FormInput
+									prefix={ service.name }
+									name={ `verification_code_${ service.slug }` }
+									value={ service.code }
+									id={ `verification_code_${ service.slug }` }
+									spellCheck="false"
+									disabled={ isVerificationDisabled }
+									isError={ this.hasError( service.slug ) }
+									placeholder={ this.getMetaTag( service.slug, '1234' ) }
+									onChange={ this.handleVerificationCodeChange( service.stateSlug ) }
+								/>
+								{ this.hasError( service.slug ) && this.getVerificationError( showPasteError ) }
+							</FormFieldset>
+						) ) }
 					</form>
 				</Card>
 			</div>
@@ -469,6 +380,7 @@ export default connect(
 		return {
 			isSaveSuccess: isSiteSettingsSaveSuccessful( state, siteId ),
 			isVerificationToolsActive: isJetpackModuleActive( state, siteId, 'verification-tools' ),
+			jetpackVersion: getSiteOption( state, siteId, 'jetpack_version' ),
 			saveError: getSiteSettingsSaveError( state, siteId ),
 			site,
 			siteId,

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -105,7 +105,7 @@ class SiteVerification extends Component {
 		const stateItems = {};
 
 		supportedServices.forEach( ( service ) => {
-			stateItems[ service.slug + 'Code' ] = get(
+			stateItems[ service.slug ] = get(
 				site,
 				`options.verification_services_codes.${ service.slug }`,
 				''
@@ -175,7 +175,7 @@ class SiteVerification extends Component {
 			if ( event.target.value.length === 1 ) {
 				this.setState( {
 					showPasteError: true,
-					invalidCodes: [ serviceCode.replace( 'Code', '' ) ],
+					invalidCodes: [ serviceCode ],
 				} );
 				return;
 			}
@@ -220,12 +220,9 @@ class SiteVerification extends Component {
 		const verificationCodes = {};
 		const invalidCodes = [];
 		getSupportedServices().forEach( ( service ) => {
-			const verificationCode = this.state[ service.slug + 'Code' ];
+			const verificationCode = this.state[ service.slug ];
 			verificationCodes[ service.slug ] = verificationCode;
-			if (
-				typeof verificationCode === 'string' &&
-				! this.isValidCode( service.slug, verificationCode )
-			) {
+			if ( ! this.isValidCode( service.slug, verificationCode ) ) {
 				invalidCodes.push( service.slug );
 			}
 		} );
@@ -249,7 +246,7 @@ class SiteVerification extends Component {
 		this.props.trackFormSubmitted( { path } );
 
 		dirtyFields.forEach( ( service ) => {
-			trackSiteVerificationUpdated( service.replace( 'Code', '' ), path );
+			trackSiteVerificationUpdated( service, path );
 		} );
 	};
 
@@ -274,9 +271,7 @@ class SiteVerification extends Component {
 		const supportedServices = getSupportedServices( translate );
 
 		supportedServices.forEach( ( service, index ) => {
-			const stateSlug = `${ service.slug }Code`;
-			service.stateSlug = stateSlug;
-			service.code = this.getMetaTag( service.slug, this.state[ stateSlug ] || '' );
+			service.code = this.getMetaTag( service.slug, this.state[ service.slug ] || '' );
 
 			if (
 				service.minimumJetpackVersion &&
@@ -362,7 +357,7 @@ class SiteVerification extends Component {
 									disabled={ isVerificationDisabled }
 									isError={ this.hasError( service.slug ) }
 									placeholder={ this.getMetaTag( service.slug, '1234' ) }
-									onChange={ this.handleVerificationCodeChange( service.stateSlug ) }
+									onChange={ this.handleVerificationCodeChange( service.slug ) }
 								/>
 								{ this.hasError( service.slug ) && this.getVerificationError( showPasteError ) }
 							</FormFieldset>

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -332,7 +332,7 @@ class SiteVerification extends Component {
 								' and verify your site with a service, paste the HTML Tag code below. Read the' +
 								' {{support}}full instructions{{/support}} if you are having trouble. Supported verification services:' +
 								' {{google}}Google Search Console{{/google}}, {{bing}}Bing Webmaster Center{{/bing}},' +
-								' {{pinterest}}Pinterest Site Verification{{/pinterest}}, {{yandex}}Yandex.Webmaster{{/yandex}}' +
+								' {{pinterest}}Pinterest Site Verification{{/pinterest}}, {{yandex}}Yandex.Webmaster{{/yandex}},' +
 								' and {{facebook}}Facebook Domain Verification{{/facebook}}.',
 							{
 								components: {

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -39,6 +39,7 @@ class SiteVerification extends Component {
 		bing: 'msvalidate.01',
 		pinterest: 'p:domain_verify',
 		yandex: 'yandex-verification',
+		facebook: 'facebook-domain-verification',
 	};
 
 	state = {
@@ -52,6 +53,7 @@ class SiteVerification extends Component {
 		this.changeBingCode = this.handleVerificationCodeChange( 'bingCode' );
 		this.changePinterestCode = this.handleVerificationCodeChange( 'pinterestCode' );
 		this.changeYandexCode = this.handleVerificationCodeChange( 'yandexCode' );
+		this.changeFacebookCode = this.handleVerificationCodeChange( 'facebookCode' );
 	}
 
 	componentDidMount() {
@@ -115,6 +117,7 @@ class SiteVerification extends Component {
 			bingCode: get( site, 'options.verification_services_codes.bing', '' ),
 			pinterestCode: get( site, 'options.verification_services_codes.pinterest', '' ),
 			yandexCode: get( site, 'options.verification_services_codes.yandex', '' ),
+			facebookCode: get( site, 'options.verification_services_codes.facebook', '' ),
 			isFetchingSettings: get( site, 'fetchingSettings', false ),
 		};
 	}
@@ -222,6 +225,7 @@ class SiteVerification extends Component {
 			bing: this.state.bingCode,
 			pinterest: this.state.pinterestCode,
 			yandex: this.state.yandexCode,
+			facebook: this.state.facebookCode,
 		};
 
 		const filteredCodes = pickBy( verificationCodes, ( code ) => typeof code === 'string' );
@@ -263,6 +267,10 @@ class SiteVerification extends Component {
 		if ( dirtyFields.has( 'yandexCode' ) ) {
 			trackSiteVerificationUpdated( 'yandex', path );
 		}
+
+		if ( dirtyFields.has( 'facebookCode' ) ) {
+			trackSiteVerificationUpdated( 'facebook', path );
+		}
 	};
 
 	render() {
@@ -280,11 +288,12 @@ class SiteVerification extends Component {
 		const placeholderTagContent = '1234';
 
 		// The API returns 'false' for an empty array value, so we force it to an empty string if needed
-		let { googleCode, bingCode, pinterestCode, yandexCode } = this.state;
+		let { googleCode, bingCode, pinterestCode, yandexCode, facebookCode } = this.state;
 		googleCode = this.getMetaTag( 'google', googleCode || '' );
 		bingCode = this.getMetaTag( 'bing', bingCode || '' );
 		pinterestCode = this.getMetaTag( 'pinterest', pinterestCode || '' );
 		yandexCode = this.getMetaTag( 'yandex', yandexCode || '' );
+		facebookCode = this.getMetaTag( 'facebook', facebookCode || '' );
 
 		return (
 			<div className="seo-settings__site-verification">
@@ -323,7 +332,8 @@ class SiteVerification extends Component {
 								' and verify your site with a service, paste the HTML Tag code below. Read the' +
 								' {{support}}full instructions{{/support}} if you are having trouble. Supported verification services:' +
 								' {{google}}Google Search Console{{/google}}, {{bing}}Bing Webmaster Center{{/bing}},' +
-								' {{pinterest}}Pinterest Site Verification{{/pinterest}}, and {{yandex}}Yandex.Webmaster{{/yandex}}.',
+								' {{pinterest}}Pinterest Site Verification{{/pinterest}}, {{yandex}}Yandex.Webmaster{{/yandex}}' +
+								' and {{facebook}}Facebook Domain Verification{{/facebook}}.',
 							{
 								components: {
 									b: <strong />,
@@ -360,6 +370,13 @@ class SiteVerification extends Component {
 											icon={ true }
 											target="_blank"
 											href="https://webmaster.yandex.com/sites/"
+										/>
+									),
+									facebook: (
+										<ExternalLink
+											icon={ true }
+											target="_blank"
+											href="https://developers.facebook.com/"
 										/>
 									),
 								},
@@ -422,6 +439,20 @@ class SiteVerification extends Component {
 								onChange={ this.changeYandexCode }
 							/>
 							{ this.hasError( 'yandex' ) && this.getVerificationError( showPasteError ) }
+						</FormFieldset>
+						<FormFieldset>
+							<FormInput
+								prefix={ translate( 'Facebook' ) }
+								name="verification_code_facebook"
+								value={ facebookCode }
+								id="verification_code_facebook"
+								spellCheck="false"
+								disabled={ isVerificationDisabled }
+								isError={ this.hasError( 'facebook' ) }
+								placeholder={ this.getMetaTag( 'facebook', placeholderTagContent ) }
+								onChange={ this.changeFacebookCode }
+							/>
+							{ this.hasError( 'facebook' ) && this.getVerificationError( showPasteError ) }
 						</FormFieldset>
 					</form>
 				</Card>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR covers the Calypso-side to a change in Jetpack by allowing users to verify with Facebook as part of the Site Verification Tools

#### Testing instructions

Requires Automattic/jetpack#19725

Verify that "Facebook" appears under the list of services under `/marketing/traffic/site`, and that the testing instructions in Automattic/jetpack#19725 are compatible with changes made through the setting in Calypso.

<img width="1077" alt="Screenshot 2021-05-01 at 19 39 43" src="https://user-images.githubusercontent.com/43215253/116791948-9628f080-aab5-11eb-80c5-4a921ccbb1ce.png">

