### PR TITLE
Checkout: Format postalCode in TaxFields

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
@@ -2,12 +2,11 @@
  * External dependencies
  */
 import React from 'react';
-import styled from '@emotion/styled';
 import { useSelect, useDispatch } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import type { ContactDetailsType, ManagedContactDetails } from '@automattic/wpcom-checkout';
-import { Field } from '@automattic/wpcom-checkout';
+import { Field, styled } from '@automattic/wpcom-checkout';
 
 /**
  * Internal dependencies

--- a/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
-import { Field } from '@automattic/wpcom-checkout';
+import { Field, tryToGuessPostalCodeFormat } from '@automattic/wpcom-checkout';
 
 /**
  * Internal dependencies
@@ -61,7 +61,11 @@ export default function TaxFields( {
 					label={ String( translate( 'Postal code' ) ) }
 					value={ postalCode?.value ?? '' }
 					disabled={ isDisabled }
-					onChange={ updatePostalCode }
+					onChange={ ( newValue ) =>
+						updatePostalCode(
+							tryToGuessPostalCodeFormat( newValue.toUpperCase(), countryCode?.value )
+						)
+					}
 					autoComplete={ section + ' postal-code' }
 					isError={ postalCode?.isTouched && ! isValid( postalCode ) }
 					errorMessage={ String( translate( 'This field is required.' ) ) }

--- a/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
@@ -77,6 +77,12 @@ export default function TaxFields( {
 					translate={ translate }
 					onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) => {
 						updateCountryCode( event.target.value );
+						// Reformat the postal code if the country changes
+						if ( postalCode ) {
+							updatePostalCode(
+								tryToGuessPostalCodeFormat( postalCode?.value, event.target.value )
+							);
+						}
 					} }
 					isError={ countryCode?.isTouched && ! isValid( countryCode ) }
 					isDisabled={ isDisabled }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This formats postal codes as they're being entered in the checkout tax contact form. This should help prevent validation errors during transactions (postal codes in the tax form are being validated as of D60388-code; previously we only validated postal codes in the domain contact form).

**Before:**

<img width="564" alt="Screen Shot 2021-05-02 at 12 55 08 PM" src="https://user-images.githubusercontent.com/2036909/116821023-0b440680-ab46-11eb-9044-2836c474b4eb.png">

**Before, on submit:**

<img width="434" alt="Screen Shot 2021-05-02 at 12 55 28 PM" src="https://user-images.githubusercontent.com/2036909/116821029-0e3ef700-ab46-11eb-9e6e-271b32d1d43d.png">

**After:**

<img width="569" alt="Screen Shot 2021-05-02 at 12 56 42 PM" src="https://user-images.githubusercontent.com/2036909/116821032-11d27e00-ab46-11eb-9518-d697acf51297.png">

Fixes https://github.com/Automattic/wp-calypso/issues/51990

#### Testing instructions

- Visit checkout with a non-domain product in the cart (eg: a plan).
- In the "Billing information step", select "United Kingdom" as the country and enter the (lowercase) postal code `pr267ry`.
- Verify that as you type, the postal code is formatted so that it becomes `PR26 7RY` (note the uppercase letters and the space in the middle).
- Click to continue checkout and pay.
- Verify that the payment succeeds.