### PR TITLE
Domain Settings: Add "Manage Domain" Button

### DIFF
--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import DomainStatus from '../card/domain-status';
@@ -300,7 +300,14 @@ class RegisteredDomainType extends React.Component {
 	};
 
 	render() {
-		const { domain, selectedSite, purchase, isLoadingPurchase, isDomainOnlySite } = this.props;
+		const {
+			domain,
+			selectedSite,
+			purchase,
+			isLoadingPurchase,
+			isDomainOnlySite,
+			translate,
+		} = this.props;
 		const { name: domain_name } = domain;
 
 		const { statusText, statusClass, icon } = resolveDomainStatus( domain, purchase, {
@@ -346,7 +353,17 @@ class RegisteredDomainType extends React.Component {
 				</DomainStatus>
 				<Card compact={ true } className="domain-types__expiration-row">
 					<DomainExpiryOrRenewal { ...this.props } />
-					{ this.renderDefaultRenewButton() }
+					<div className="domain-types__actions-container">
+						{ this.renderDefaultRenewButton() }
+						{ domain.currentUserCanManage && domain.subscriptionId !== null && (
+							<Button
+								compact
+								href={ `/me/purchases/${ selectedSite.slug }/${ domain.subscriptionId }` }
+							>
+								{ translate( 'Manage domain' ) }
+							</Button>
+						) }
+					</div>
 					{ domain.currentUserCanManage && this.renderAutoRenew() }
 				</Card>
 				<DomainManagementNavigationEnhanced

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -180,7 +180,12 @@
 		align-items: center;
 		padding: 0;
 		> div {
+			display: flex;
 			margin: 16px 0 16px 24px;
+			&.domain-types__actions-container,
+			.button {
+				margin-left: 12px;
+			}
 		}
 		> div:nth-last-child( 2 ) {
 			margin-right: auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a button under the Domain Settings so users can easily find a location where they can cancel their domain or update their payment settings

#### Testing instructions

For domains which the user is able to manage the settings and there is a valid `/me/purchases` link, you should see a button which takes you there. 

<img width="929" alt="Screenshot 2021-05-02 at 14 05 49" src="https://user-images.githubusercontent.com/43215253/116814207-8cec6200-ab4f-11eb-9014-12300624b6fb.png">

cc @fditrapani, @hambai

Fixes #52477
