### PR TITLE
Checkout: Format postal code when updating the internal contact store state

### DIFF
--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -712,9 +712,13 @@ export const managedContactDetailsUpdaters: ManagedContactDetailsUpdaters = {
 		oldDetails: ManagedContactDetails,
 		newPostalCode: string
 	): ManagedContactDetails => {
+		const formattedPostalCode = tryToGuessPostalCodeFormat(
+			newPostalCode.toUpperCase(),
+			oldDetails.countryCode?.value
+		);
 		return {
 			...oldDetails,
-			postalCode: touchIfDifferent( newPostalCode, oldDetails.postalCode ),
+			postalCode: touchIfDifferent( formattedPostalCode, oldDetails.postalCode ),
 		};
 	},
 

--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -733,6 +733,18 @@ export const managedContactDetailsUpdaters: ManagedContactDetailsUpdaters = {
 		oldDetails: ManagedContactDetails,
 		newCountryCode: string
 	): ManagedContactDetails => {
+		// Update postal code formatting if country code changes
+		if ( oldDetails.postalCode?.value ) {
+			const formattedPostalCode = tryToGuessPostalCodeFormat(
+				oldDetails.postalCode.value.toUpperCase(),
+				newCountryCode
+			);
+			return {
+				...oldDetails,
+				postalCode: touchIfDifferent( formattedPostalCode, oldDetails.postalCode ),
+				countryCode: touchIfDifferent( newCountryCode, oldDetails.countryCode ),
+			};
+		}
 		return {
 			...oldDetails,
 			countryCode: touchIfDifferent( newCountryCode, oldDetails.countryCode ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the postal code changes in the internal contact data store used by checkout, this PR formats the postal code based on the country. It also reformats the postal code if the country changes.

This should help prevent validation errors during transactions (postal codes in the tax form are being validated as of D60388-code; previously we only validated postal codes in the domain contact form).

**Before:**

<img width="564" alt="Screen Shot 2021-05-02 at 12 55 08 PM" src="https://user-images.githubusercontent.com/2036909/116821023-0b440680-ab46-11eb-9044-2836c474b4eb.png">

**Before, on submit:**

<img width="434" alt="Screen Shot 2021-05-02 at 12 55 28 PM" src="https://user-images.githubusercontent.com/2036909/116821029-0e3ef700-ab46-11eb-9e6e-271b32d1d43d.png">

**After:**

<img width="569" alt="Screen Shot 2021-05-02 at 12 56 42 PM" src="https://user-images.githubusercontent.com/2036909/116821032-11d27e00-ab46-11eb-9518-d697acf51297.png">

Fixes https://github.com/Automattic/wp-calypso/issues/51990

#### Testing instructions

- Visit checkout with a non-domain product in the cart (eg: a plan).
- In the "Billing information step", select "United Kingdom" as the country and enter the (lowercase) postal code `pr267ry`.
- Verify that as you type, the postal code is formatted so that it becomes `PR26 7RY` (note the uppercase letters and the space in the middle).
- Click to continue checkout and pay.
- Verify that the payment succeeds.