### PR TITLE
chore(eslint): Fix violations of import/default

### DIFF
--- a/client/state/selectors/test/get-active-discount.js
+++ b/client/state/selectors/test/get-active-discount.js
@@ -5,7 +5,7 @@ import getActiveDiscount, { isDiscountActive } from 'calypso/state/selectors/get
 import { hasActivePromotion } from 'calypso/state/active-promotions/selectors';
 import { getSitePlanSlug } from 'calypso/state/sites/selectors';
 import { abtest } from 'calypso/lib/abtest';
-import discounts from 'calypso/lib/discounts';
+import { activeDiscounts } from 'calypso/lib/discounts';
 import {
 	PLAN_PREMIUM_2_YEARS,
 	TYPE_FREE,
@@ -212,9 +212,11 @@ describe( 'getActiveDiscount()', () => {
 		hasActivePromotion.mockImplementation( () => true );
 		abtest.mockImplementation( () => 'upsell' );
 	} );
+	afterEach( () => {
+		activeDiscounts.length = 0;
+	} );
 
 	test( 'should return null when there are no discounts', () => {
-		discounts.activeDiscounts = [];
 		expect( getActiveDiscount( {} ) ).toBe( null );
 	} );
 
@@ -223,7 +225,7 @@ describe( 'getActiveDiscount()', () => {
 			startsAt: DatePlusTime( -10 ),
 			endsAt: DatePlusTime( 100 ),
 		};
-		discounts.activeDiscounts = [ promo ];
+		activeDiscounts.push( promo );
 		expect( getActiveDiscount( {} ) ).toEqual( promo );
 	} );
 
@@ -238,7 +240,7 @@ describe( 'getActiveDiscount()', () => {
 				},
 			},
 		};
-		discounts.activeDiscounts = [ promo ];
+		activeDiscounts.push( promo );
 		expect( getActiveDiscount( {} ) ).toEqual( {
 			...promo,
 			name: 'upsell10 name',

--- a/client/state/selectors/test/is-site-google-my-business-eligible.js
+++ b/client/state/selectors/test/is-site-google-my-business-eligible.js
@@ -16,7 +16,7 @@ import {
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_2_YEARS,
 } from '@automattic/calypso-products';
-import selectors from 'calypso/state/sites/selectors';
+import { getSitePlanSlug } from 'calypso/state/sites/selectors';
 
 jest.mock( 'calypso/state/sites/selectors', () => ( {
 	getSitePlanSlug: jest.fn(),
@@ -33,7 +33,7 @@ describe( 'siteHasEligibleWpcomPlan()', () => {
 		];
 
 		plans.forEach( ( plan ) => {
-			selectors.getSitePlanSlug.mockImplementation( () => plan );
+			getSitePlanSlug.mockImplementation( () => plan );
 
 			expect( siteHasEligibleWpcomPlan() ).toBe( true );
 		} );
@@ -51,7 +51,7 @@ describe( 'siteHasEligibleWpcomPlan()', () => {
 		];
 
 		plans.forEach( ( plan ) => {
-			selectors.getSitePlanSlug.mockImplementation( () => plan );
+			getSitePlanSlug.mockImplementation( () => plan );
 
 			expect( siteHasEligibleWpcomPlan() ).toBe( false );
 		} );

--- a/packages/webpack-config-flag-plugin/test/fixtures/.eslintrc.js
+++ b/packages/webpack-config-flag-plugin/test/fixtures/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
 	rules: {
 		// Test fixtures import fake modules a lot just for testing the behaviour of this plugin
 		'import/no-extraneous-dependencies': 'off',
+		'import/default': 'off',
 		'wpcalypso/import-docblock': 0,
 		'no-unused-vars': 0,
 		'no-empty': 0,

--- a/packages/wpcom.js/.eslintrc.js
+++ b/packages/wpcom.js/.eslintrc.js
@@ -10,5 +10,16 @@ module.exports = {
 				'no-console': 'off',
 			},
 		},
+		{
+			files: './test/**/*',
+			rules: {
+				// These files use a weird mixture of CJS and ESM. Disabling the rules for now until they can
+				// get refactored.
+				'import/default': 'off',
+
+				// Test can use Node modules
+				'import/no-nodejs-modules': 'off',
+			},
+		},
 	],
 };


### PR DESCRIPTION
### Background

In #52409 I introduced the rule `import/default`, but forgot to fix some files. This has caused the number of eslint errors to go up in `trunk`.

### Changes proposed in this Pull Request

* Fix violations of `import/default`
* Disable `import/default` for wpcom.js tests

Note: `packages/wpcom.js` tests can use some refactor. They have some weird combination of ESM `import`s and CJS `module.exports`, which makes eslint confused. As those tests don't seem to be run (they are written in Mocha, not in Jest), I rather not change them for now. We'll need to rewrite them to Jest first.

### Testing instructions

Verify there are no eslint errors