### PR TITLE
My Home: Remove support for 'Edit the site menu' dashboard task

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -7,11 +7,9 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 import { requestSiteChecklistTaskUpdate } from 'calypso/state/checklist/actions';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/launch/actions';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { verifyEmail } from 'calypso/state/current-user/email-verification/actions';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 
@@ -55,7 +53,6 @@ export const getTask = (
 		isDomainUnverified,
 		isEmailUnverified,
 		isPodcastingSite,
-		menusUrl,
 		siteId,
 		siteSlug,
 		taskUrls,
@@ -178,32 +175,6 @@ export const getTask = (
 				),
 				actionText: translate( 'Edit homepage' ),
 				actionUrl: taskUrls?.front_page_updated,
-			};
-			break;
-		case CHECKLIST_KNOWN_TASKS.SITE_MENU_UPDATED:
-			taskData = {
-				timing: 10,
-				title: translate( 'Edit the site menu' ),
-				description: (
-					<>
-						{ translate(
-							"Building an effective navigation menu makes it easier for someone to find what they're looking for and improve search engine rankings."
-						) }{ ' ' }
-						<InlineSupportLink
-							supportPostId={ 59580 }
-							supportLink={ localizeUrl( 'https://wordpress.com/support/menus/' ) }
-							showIcon={ false }
-							tracksEvent="calypso_customer_home_menus_support_page_view"
-							statsGroup="calypso_customer_home"
-							statsName="menus_view_tutorial"
-						>
-							{ translate( 'View tutorial.' ) }
-						</InlineSupportLink>
-					</>
-				),
-				actionText: translate( 'Add a menu' ),
-				isSkippable: true,
-				actionUrl: menusUrl,
 			};
 			break;
 		case CHECKLIST_KNOWN_TASKS.SITE_THEME_SELECTED:

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -22,7 +22,6 @@ import { getCurrentUser, isCurrentUserEmailVerified } from 'calypso/state/curren
 import getChecklistTaskUrls from 'calypso/state/selectors/get-checklist-task-urls';
 import getSiteChecklist from 'calypso/state/selectors/get-site-checklist';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
-import getMenusUrl from 'calypso/state/selectors/get-menus-url';
 import { getSiteOption, getSiteSlug } from 'calypso/state/sites/selectors';
 import { requestGuidedTour } from 'calypso/state/guided-tours/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -106,7 +105,6 @@ const SiteSetupList = ( {
 	firstIncompleteTask,
 	isEmailUnverified,
 	isPodcastingSite,
-	menusUrl,
 	siteId,
 	siteSlug,
 	tasks,
@@ -176,7 +174,6 @@ const SiteSetupList = ( {
 				isDomainUnverified,
 				isEmailUnverified,
 				isPodcastingSite,
-				menusUrl,
 				siteId,
 				siteSlug,
 				taskUrls,
@@ -192,7 +189,6 @@ const SiteSetupList = ( {
 		isDomainUnverified,
 		isEmailUnverified,
 		isPodcastingSite,
-		menusUrl,
 		siteId,
 		siteSlug,
 		tasks,
@@ -328,7 +324,6 @@ export default connect( ( state ) => {
 		firstIncompleteTask: taskList.getFirstIncompleteTask(),
 		isEmailUnverified: ! isCurrentUserEmailVerified( state ),
 		isPodcastingSite: !! getSiteOption( state, siteId, 'anchor_podcast' ),
-		menusUrl: getMenusUrl( state, siteId ),
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 		tasks: taskList.getAll(),

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -23,7 +23,6 @@ export const CHECKLIST_KNOWN_TASKS = {
 	MOBILE_APP_INSTALLED: 'mobile_app_installed',
 	SITE_LAUNCHED: 'site_launched',
 	FRONT_PAGE_UPDATED: 'front_page_updated',
-	SITE_MENU_UPDATED: 'site_menu_updated',
 	SITE_THEME_SELECTED: 'site_theme_selected',
 	JETPACK_BACKUPS: 'jetpack_backups',
 	JETPACK_MONITOR: 'jetpack_monitor',


### PR DESCRIPTION
Changes in D60892-code mean the `site_menu_updated` task is never returned
by the server, so we can remove that unused code from the client.

Rationale for removing the task: #47334

#### Changes proposed in this Pull Request

* Removes the code for the `site_theme_selected` task card from the client
* Remove the `menusUrl` prop from `<SiteSetupList>` which is no longer needed.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D60892-code
* Smoke test the dashboard and confirm everything still works (e.g. the quicklink to the menu customiser should still work)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #47334
