### PR TITLE
Emails: Hide trash button of first user/mailbox in Add New Users and Add New Mailboxes forms

### DIFF
--- a/client/components/gsuite/gsuite-learn-more/test/__snapshots__/index.js.snap
+++ b/client/components/gsuite/gsuite-learn-more/test/__snapshots__/index.js.snap
@@ -11,7 +11,7 @@ exports[`GSuiteLearnMore it renders GSuiteLearnMore with no props 1`] = `
      
     <a
       className="gsuite-learn-more__link"
-      href="https://wordpress.com/support/add-email/adding-g-suite-to-your-site/"
+      href="https://wordpress.com/support/add-email/adding-google-workspace-to-your-site/"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"

--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -81,7 +81,7 @@ const GSuiteNewUserList: FunctionComponent< Props > = ( {
 
 	return (
 		<div>
-			{ users.map( ( user ) => (
+			{ users.map( ( user, index ) => (
 				<Fragment key={ user.uuid }>
 					<GSuiteNewUser
 						autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
@@ -91,6 +91,7 @@ const GSuiteNewUserList: FunctionComponent< Props > = ( {
 						onUserRemove={ onUserRemove( user.uuid ) }
 						onReturnKeyPress={ onReturnKeyPress }
 						showLabels={ showLabels }
+						showTrashButton={ index > 0 }
 					/>
 
 					<hr className="gsuite-new-user-list__user-divider" />

--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -44,6 +44,7 @@ interface Props {
 	onUserValueChange: ( field: string, value: string ) => void;
 	onReturnKeyPress: ( event: Event ) => void;
 	showLabels: boolean;
+	showTrashButton: boolean;
 	user: NewUser;
 }
 
@@ -61,6 +62,7 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 		password: { value: password, error: passwordError },
 	},
 	showLabels = false,
+	showTrashButton = true,
 } ) => {
 	const translate = useTranslate();
 
@@ -179,13 +181,15 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 						{ hasLastNameError && <FormInputValidation text={ lastNameError } isError /> }
 					</div>
 
-					<Button
-						className="gsuite-new-user-list__new-user-remove-user-button"
-						onClick={ onUserRemove }
-					>
-						<Gridicon icon="trash" />
-						<span>{ translate( 'Remove user' ) }</span>
-					</Button>
+					{ showTrashButton && (
+						<Button
+							className="gsuite-new-user-list__new-user-remove-user-button"
+							onClick={ onUserRemove }
+						>
+							<Gridicon icon="trash" />
+							<span>{ translate( 'Remove user' ) }</span>
+						</Button>
+					) }
 				</div>
 			</FormFieldset>
 

--- a/client/components/gsuite/gsuite-new-user-list/style.scss
+++ b/client/components/gsuite/gsuite-new-user-list/style.scss
@@ -120,7 +120,7 @@
 
 	@include breakpoint-deprecated( '>800px' ) {
 		margin-bottom: 20px;
-		width: 44%;
+		width: 50%;
 	}
 }
 

--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -6,7 +6,7 @@ import { localizeUrl } from 'calypso/lib/i18n-utils';
 const root = localizeUrl( 'https://wordpress.com/support/' ).replace( /\/$/, '' );
 
 export const ACCOUNT_RECOVERY = `${ root }/account-recovery`;
-export const ADDING_GSUITE_TO_YOUR_SITE = `${ root }/add-email/adding-g-suite-to-your-site/`;
+export const ADDING_GSUITE_TO_YOUR_SITE = `${ root }/add-email/adding-google-workspace-to-your-site/`;
 export const ADDING_USERS = `${ root }/adding-users`;
 export const AUTO_RENEWAL = `${ root }/auto-renewal`;
 export const BANDPAGE_WIDGET = `${ root }/widgets/bandpage-widget`;

--- a/client/my-sites/email/titan-mail-add-mailboxes/style.scss
+++ b/client/my-sites/email/titan-mail-add-mailboxes/style.scss
@@ -30,11 +30,11 @@
 
 		.form-fieldset:first-child {
 			flex-grow: 2;
-			margin-right: 1em;
 		}
 
 		.titan-mail-add-mailboxes__new-mailbox-remove-mailbox-button {
 			height: 40px;
+			margin-left: 1em;
 			width: 50px;
 
 			.gridicon {
@@ -50,7 +50,7 @@
 	.titan-mail-add-mailboxes__new-mailbox-remove-mailbox-button,
 	.form-fieldset:not( :first-child ) {
 		margin-bottom: 1em;
-		margin-left: 0;
+		margin-left: 1em;
 		margin-top: 0;
 
 		.components-toggle-control p {

--- a/client/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox-list.jsx
+++ b/client/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox-list.jsx
@@ -67,7 +67,7 @@ const TitanNewMailboxList = ( {
 
 	return (
 		<div className="titan-new-mailbox-list__main">
-			{ mailboxes.map( ( mailbox ) => (
+			{ mailboxes.map( ( mailbox, index ) => (
 				<TitanNewMailbox
 					key={ mailbox.uuid }
 					onMailboxAdd={ onMailboxAdd }
@@ -76,6 +76,7 @@ const TitanNewMailboxList = ( {
 					mailbox={ mailbox }
 					onReturnKeyPress={ onReturnKeyPress }
 					showLabels={ showLabels }
+					showTrashButton={ index > 0 }
 				/>
 			) ) }
 

--- a/client/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox.jsx
+++ b/client/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox.jsx
@@ -35,6 +35,7 @@ const TitanNewMailbox = ( {
 		password: { value: password, error: passwordError },
 	},
 	showLabels = true,
+	showTrashButton = true,
 } ) => {
 	const translate = useTranslate();
 
@@ -90,13 +91,15 @@ const TitanNewMailbox = ( {
 						{ hasNameError && <FormInputValidation text={ nameError } isError /> }
 					</FormFieldset>
 
-					<Button
-						className="titan-mail-add-mailboxes__new-mailbox-remove-mailbox-button"
-						onClick={ onMailboxRemove }
-					>
-						<Gridicon icon="trash" />
-						<span>{ translate( 'Remove mailbox' ) }</span>
-					</Button>
+					{ showTrashButton && (
+						<Button
+							className="titan-mail-add-mailboxes__new-mailbox-remove-mailbox-button"
+							onClick={ onMailboxRemove }
+						>
+							<Gridicon icon="trash" />
+							<span>{ translate( 'Remove mailbox' ) }</span>
+						</Button>
+					) }
 				</div>
 
 				<div className="titan-mail-add-mailboxes__new-mailbox-email-and-password">

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -48,7 +48,7 @@
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,
-		"email/centralized-home": false,
+		"email/centralized-home": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
This pull request updates forms on the `Email Comparison`, `Add New Users`, and `Add New Mailboxes` pages to only show a trash icon for the first user or mailbox:

###### Before

`Email Comparison` | `Add New Users` | `Add New Mailboxes` 
------ | ----- | -----
![01](https://user-images.githubusercontent.com/594356/116895427-7ddee000-ac33-11eb-98fe-e878e711e4d2.png) | ![02](https://user-images.githubusercontent.com/594356/116895444-82a39400-ac33-11eb-864d-b77328f5f8e1.png) | ![03](https://user-images.githubusercontent.com/594356/116895463-86cfb180-ac33-11eb-8a5f-df48fbc5d481.png)

###### After

`Email Comparison` | `Add New Users` | `Add New Mailboxes` 
------ | ----- | -----
![01](https://user-images.githubusercontent.com/594356/116877188-e753f400-ac1d-11eb-8156-33a05db16dea.png) | ![02](https://user-images.githubusercontent.com/594356/116877189-e7ec8a80-ac1d-11eb-8ac2-c5597d6d15a1.png) | ![03](https://user-images.githubusercontent.com/594356/116877191-e7ec8a80-ac1d-11eb-975e-35922e684765.png)

Note this pull request doesn't touch the `Upsell` page (shown when purchasing a new domain) as it is in the process of being redesigned. However, it fixes https://github.com/Automattic/en.support-docs-content/issues/1060, and enables the new email management section in `wpcalypso`.

#### Testing instructions

1. Run `git checkout update/add-new-user-page` and start your server, or open a [live branch](https://calypso.live/?branch=update/add-new-user-page)
2. Open the [`Email` page](http://calypso.localhost:3000/email)
3. Click the `Add New Users` button for a Google Workspace account
4. Assert that no trash icon is displayed for the first user
5. Click the `Add another user` button
6. Assert the trash icon looks good and works fine for that new user
7. Navigate back to the `Email` page
8. Click the `Add New Mailboxes` button for an Email account
9. Assert that no trash icon is displayed for the first mailbox
10. Click the `Add another mailbox` button
11. Assert the trash icon looks good and works fine for that new mailbox
12. Navigate to the `Email Comparison` page of a domain with no email yet
13. Check both Email and Google Workspace forms