### PR TITLE
Sidebar nudge: fix bg color in contrast color scheme.

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -316,7 +316,7 @@ $font-size: rem( 14px );
 	}
 
 	// client/blocks/upsell-nudge/style.scss
-	&:not( .is-classic-bright ) {
+	&:not( .is-classic-bright ):not( .is-contrast ) {
 		.upsell-nudge.banner.card.is-compact {
 			background-color: #fff;
 			color: #000;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Inverts colors in sidebar nudge for `contrast` color scheme

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before | After
-------|------
![](https://cln.sh/9JRdl9+) | ![](https://cln.sh/AMkum6+)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #52357
