### PR TITLE
Update Link to Support Doc on Jetpack's Skip User Page

### DIFF
--- a/client/blocks/jetpack-connect-skip-user/index.js
+++ b/client/blocks/jetpack-connect-skip-user/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -32,7 +33,7 @@ class JetpackConnectSkipUser extends Component {
 	render() {
 		return (
 			<div className="jetpack-connect-skip-user__userless-form">
-				<h2>Or start using Jetpack now</h2>
+				<h2>{ this.props.translate( 'Or start using Jetpack now' ) }</h2>
 
 				<p>Jump in and start using Jetpack right away.</p>
 				<p>
@@ -41,18 +42,20 @@ class JetpackConnectSkipUser extends Component {
 						href="https://jetpack.com/support/why-the-wordpress-com-connection-is-important-for-jetpack/"
 						rel="noreferrer"
 					>
-						Some features
+						{ this.props.translate( 'Some features' ) }
 					</a>
-					&nbsp;will not be available, but you'll be able to connect your user account at any point
-					to unlock them.
+					&nbsp;
+					{ this.props.translate(
+						"will not be available, but you'll be able to connect your user account at any point to unlock them."
+					) }
 				</p>
 
 				<a className="jetpack-connect-skip-user__continue-link" href={ this.getPlansURL() }>
-					Continue without user account
+					{ this.props.translate( 'Continue without user account' ) }
 				</a>
 			</div>
 		);
 	}
 }
 
-export default JetpackConnectSkipUser;
+export default localize( JetpackConnectSkipUser );

--- a/client/blocks/jetpack-connect-skip-user/index.js
+++ b/client/blocks/jetpack-connect-skip-user/index.js
@@ -39,16 +39,19 @@ class JetpackConnectSkipUser extends Component {
 
 				<p>{ translate( 'Jump in and start using Jetpack right away.' ) }</p>
 				<p>
-					<a
-						target="_blank"
-						href="https://jetpack.com/support/why-the-wordpress-com-connection-is-important-for-jetpack/"
-						rel="noreferrer"
-					>
-						{ translate( 'Some features' ) }
-					</a>
-					&nbsp;
 					{ translate(
-						"will not be available, but you'll be able to connect your user account at any point to unlock them."
+						`{{link}}Some features{{/link}} will not be available, but you'll be able to connect your user account at any point to unlock them.`,
+						{
+							components: {
+								link: (
+									<a
+										target="_blank"
+										href="https://jetpack.com/support/why-the-wordpress-com-connection-is-important-for-jetpack/"
+										rel="noreferrer"
+									/>
+								),
+							},
+						}
 					) }
 				</p>
 

--- a/client/blocks/jetpack-connect-skip-user/index.js
+++ b/client/blocks/jetpack-connect-skip-user/index.js
@@ -36,7 +36,11 @@ class JetpackConnectSkipUser extends Component {
 
 				<p>Jump in and start using Jetpack right away.</p>
 				<p>
-					<a target="_blank" href="https://jetpack.com/support/features/" rel="noreferrer">
+					<a
+						target="_blank"
+						href="https://jetpack.com/support/why-the-wordpress-com-connection-is-important-for-jetpack/"
+						rel="noreferrer"
+					>
 						Some features
 					</a>
 					&nbsp;will not be available, but you'll be able to connect your user account at any point

--- a/client/blocks/jetpack-connect-skip-user/index.js
+++ b/client/blocks/jetpack-connect-skip-user/index.js
@@ -40,7 +40,7 @@ class JetpackConnectSkipUser extends Component {
 				<p>{ translate( 'Jump in and start using Jetpack right away.' ) }</p>
 				<p>
 					{ translate(
-						`{{link}}Some features{{/link}} will not be available, but you'll be able to connect your user account at any point to unlock them.`,
+						"{{link}}Some features{{/link}} will not be available, but you'll be able to connect your user account at any point to unlock them.",
 						{
 							components: {
 								link: (

--- a/client/blocks/jetpack-connect-skip-user/index.js
+++ b/client/blocks/jetpack-connect-skip-user/index.js
@@ -31,9 +31,11 @@ class JetpackConnectSkipUser extends Component {
 	}
 
 	render() {
+		const { translate } = this.props;
+
 		return (
 			<div className="jetpack-connect-skip-user__userless-form">
-				<h2>{ this.props.translate( 'Or start using Jetpack now' ) }</h2>
+				<h2>{ translate( 'Or start using Jetpack now' ) }</h2>
 
 				<p>Jump in and start using Jetpack right away.</p>
 				<p>
@@ -42,16 +44,16 @@ class JetpackConnectSkipUser extends Component {
 						href="https://jetpack.com/support/why-the-wordpress-com-connection-is-important-for-jetpack/"
 						rel="noreferrer"
 					>
-						{ this.props.translate( 'Some features' ) }
+						{ translate( 'Some features' ) }
 					</a>
 					&nbsp;
-					{ this.props.translate(
+					{ translate(
 						"will not be available, but you'll be able to connect your user account at any point to unlock them."
 					) }
 				</p>
 
 				<a className="jetpack-connect-skip-user__continue-link" href={ this.getPlansURL() }>
-					{ this.props.translate( 'Continue without user account' ) }
+					{ translate( 'Continue without user account' ) }
 				</a>
 			</div>
 		);

--- a/client/blocks/jetpack-connect-skip-user/index.js
+++ b/client/blocks/jetpack-connect-skip-user/index.js
@@ -37,7 +37,7 @@ class JetpackConnectSkipUser extends Component {
 			<div className="jetpack-connect-skip-user__userless-form">
 				<h2>{ translate( 'Or start using Jetpack now' ) }</h2>
 
-				<p>Jump in and start using Jetpack right away.</p>
+				<p>{ translate( 'Jump in and start using Jetpack right away.' ) }</p>
 				<p>
 					<a
 						target="_blank"


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Update the link in the jetpack-connect-skip-user component to point to [the new support doc](https://jetpack.com/support/why-the-wordpress-com-connection-is-important-for-jetpack/) detailing site-only vs user authenticated features. 
* Add translations

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Jetpack skip user page, ie: http://calypso.localhost:3000/log-in/jetpack?skip_user=1
* Make sure the "Some features" hyperlinked text goes to [the new page](https://jetpack.com/support/why-the-wordpress-com-connection-is-important-for-jetpack/)
* Make sure there are no other regressions.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

![Screen Shot on 2021-05-04 at 09:25:20](https://user-images.githubusercontent.com/33553323/117010307-ac53ce00-acba-11eb-9e8a-5739e0f8da37.png)


p8oabR-F6-p2#comment-5285
