### PR TITLE
Reader Sidebar: removes language & country restriction from upsell nudge.

### DIFF
--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Fragment } from 'react';
 import { connect, useDispatch } from 'react-redux';
-import { localize, getLocaleSlug } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
 
 /**
@@ -11,7 +11,6 @@ import debugFactory from 'debug';
  */
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
-import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
 import isEligibleForFreeToPaidUpsell from 'calypso/state/selectors/is-eligible-for-free-to-paid-upsell';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
@@ -54,16 +53,10 @@ function mapStateToProps( state ) {
 	const siteCount = getSites( state ).length;
 	const siteId = getPrimarySiteId( state );
 	const siteSlug = getPrimarySiteSlug( state );
-	const devCountryCode = isDevelopment && global.window && global.window.userCountryCode;
-	const countryCode = devCountryCode || getCurrentUserCountryCode( state );
-	const userLocale = getLocaleSlug( state );
-	const isEnglish = [ 'en', 'en-gb' ].indexOf( userLocale ) !== -1;
 
 	isDevelopment &&
 		debug(
-			'country: %s, locale: %s, siteCount: %d, eligible: %s',
-			countryCode,
-			userLocale,
+			'siteCount: %d, eligible: %s',
 			siteCount,
 			isEligibleForFreeToPaidUpsell( state, siteId )
 		);
@@ -75,10 +68,7 @@ function mapStateToProps( state ) {
 			siteCount === 1 && // available when a user owns one site only
 			! isJetpackSite( state, siteId ) && // not for Jetpack sites
 			! isDomainOnlySite( state, siteId ) && // not for domain only sites
-			isEligibleForFreeToPaidUpsell( state, siteId ) &&
-			// This nudge only shows up to US EN users.
-			isEnglish &&
-			'US' === countryCode,
+			isEligibleForFreeToPaidUpsell( state, siteId ),
 	};
 }
 

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -10,9 +10,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
-import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isEligibleForFreeToPaidUpsell from 'calypso/state/selectors/is-eligible-for-free-to-paid-upsell';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
@@ -66,8 +64,6 @@ function mapStateToProps( state ) {
 		siteSlug,
 		isEligibleForFreeToPaidUpsellNudge:
 			siteCount === 1 && // available when a user owns one site only
-			! isJetpackSite( state, siteId ) && // not for Jetpack sites
-			! isDomainOnlySite( state, siteId ) && // not for domain only sites
 			isEligibleForFreeToPaidUpsell( state, siteId ),
 	};
 }


### PR DESCRIPTION
Currently Reader Sidebar may show an Upsell nudge, but we restrict it only to English sites in US. As it seems that this nudge drives some revenue, I guess we could benefit from removing these restrictions.

#### Changes proposed in this Pull Request

* Removes language & country restriction from upsell nudge shown in the Reader Sidebar.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Eligible users will be shown the following
![](https://cln.sh/fPBoET+)

Commeting out https://github.com/Automattic/wp-calypso/blob/7f0dd9576f5e3e009e74684fdc26dcab5123cd41/client/reader/sidebar/reader-sidebar-nudges/index.jsx#L68 in your free site should be enough.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to paYJgx-1wX-p2