### PR TITLE
Checkout: Format tax postalCode for transactions endpoint

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/free-purchase-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/free-purchase-processor.ts
@@ -5,6 +5,7 @@ import debugFactory from 'debug';
 import { makeSuccessResponse, makeErrorResponse } from '@automattic/composite-checkout';
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import type { TransactionRequest } from '@automattic/wpcom-checkout';
+import type { ResponseCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -66,10 +67,20 @@ function prepareFreePurchaseTransaction(
 		cart: createTransactionEndpointCartFromResponseCart( {
 			siteId: transactionOptions.siteId ? String( transactionOptions.siteId ) : undefined,
 			contactDetails: transactionData.domainDetails ?? null,
-			responseCart: transactionOptions.responseCart,
+			responseCart: removeTaxInformationFromCart( transactionOptions.responseCart ),
 		} ),
 		paymentMethodType: 'WPCOM_Billing_WPCOM',
 	} );
 	debug( 'submitting free transaction', formattedTransactionData );
 	return formattedTransactionData;
+}
+
+function removeTaxInformationFromCart( cart: ResponseCart ): ResponseCart {
+	return {
+		...cart,
+		tax: {
+			display_taxes: false,
+			location: {},
+		},
+	};
 }

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -3,6 +3,7 @@
  */
 import debugFactory from 'debug';
 import { makeRedirectResponse, makeErrorResponse } from '@automattic/composite-checkout';
+import { tryToGuessPostalCodeFormat } from '@automattic/wpcom-checkout';
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import type { ResponseCart, DomainContactDetails } from '@automattic/shopping-cart';
 import type { PayPalExpressEndpointRequestPayload } from '@automattic/wpcom-checkout';
@@ -110,6 +111,8 @@ function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 	domainDetails: DomainContactDetails | null;
 	responseCart: ResponseCart;
 } ): PayPalExpressEndpointRequestPayload {
+	const postalCode = responseCart.tax.location.postal_code ?? '';
+	const country = responseCart.tax.location.country_code ?? '';
 	return {
 		successUrl,
 		cancelUrl,
@@ -118,8 +121,8 @@ function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 			contactDetails: domainDetails,
 			responseCart,
 		} ),
-		country: responseCart.tax.location.country_code ?? '',
-		postalCode: responseCart.tax.location.postal_code ?? '',
+		country,
+		postalCode: postalCode ? tryToGuessPostalCodeFormat( postalCode.toUpperCase(), country ) : '',
 		domainDetails,
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -126,8 +126,8 @@ function createTransactionEndpointTaxFromResponseCartTax(
 		: undefined;
 	return {
 		location: {
-			country_code,
-			postal_code: formattedPostalCode,
+			...( country_code ? { country_code } : {} ),
+			...( formattedPostalCode ? { postal_code: formattedPostalCode } : {} ),
 		},
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -2,11 +2,12 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { getTotalLineItemFromCart } from '@automattic/wpcom-checkout';
+import { getTotalLineItemFromCart, tryToGuessPostalCodeFormat } from '@automattic/wpcom-checkout';
 import type { LineItem } from '@automattic/composite-checkout';
 import type {
 	ResponseCart,
 	ResponseCartProduct,
+	ResponseCartTaxData,
 	DomainContactDetails,
 } from '@automattic/shopping-cart';
 import type {
@@ -112,7 +113,22 @@ export function createTransactionEndpointCartFromResponseCart( {
 		products: responseCart.products.map( ( item ) =>
 			addRegistrationDataToGSuiteCartProduct( item, contactDetails )
 		),
-		tax: responseCart.tax,
+		tax: createTransactionEndpointTaxFromResponseCartTax( responseCart.tax ),
+	};
+}
+
+function createTransactionEndpointTaxFromResponseCartTax(
+	tax: ResponseCartTaxData
+): Omit< ResponseCartTaxData, 'display_taxes' > {
+	const { country_code, postal_code } = tax.location;
+	const formattedPostalCode = postal_code
+		? tryToGuessPostalCodeFormat( postal_code.toUpperCase(), country_code )
+		: undefined;
+	return {
+		location: {
+			country_code,
+			postal_code: formattedPostalCode,
+		},
 	};
 }
 

--- a/client/my-sites/checkout/composite-checkout/test/apple-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/apple-pay-processor.ts
@@ -53,7 +53,6 @@ describe( 'applePayProcessor', () => {
 			extra: [],
 			products: [ product ],
 			tax: {
-				display_taxes: false,
 				location: {},
 			},
 			temporary: false,

--- a/client/my-sites/checkout/composite-checkout/test/apple-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/apple-pay-processor.ts
@@ -203,6 +203,48 @@ describe( 'applePayProcessor', () => {
 		} );
 	} );
 
+	it( 'sends the correct data to the endpoint with tax information', async () => {
+		const submitData = {
+			stripe,
+			stripeConfiguration,
+			paymentMethodToken: 'apple-pay-token',
+			name: 'test name',
+		};
+		const expected = { payload: 'test success', type: 'SUCCESS' };
+		await expect(
+			applePayProcessor( submitData, {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+				responseCart: {
+					...options.responseCart,
+					tax: {
+						display_taxes: true,
+						location: {
+							postal_code: 'pr267ry',
+							country_code: 'GB',
+						},
+					},
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+				tax: { location: { postal_code: 'PR26 7RY', country_code: 'GB' } },
+			},
+		} );
+	} );
+
 	it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
 		const submitData = {
 			stripe,

--- a/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
@@ -247,6 +247,50 @@ describe( 'existingCardProcessor', () => {
 		} );
 	} );
 
+	it( 'sends the correct data to the endpoint with tax information', async () => {
+		const submitData = {
+			country: 'US',
+			postalCode: '10001',
+			storedDetailsId: 'stored-details-id',
+			name: 'test name',
+			paymentMethodToken: 'stripe-token',
+			paymentPartnerProcessorId: 'IE',
+		};
+		const expected = { payload: 'success', type: 'SUCCESS' };
+		await expect(
+			existingCardProcessor( submitData, {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+				responseCart: {
+					...options.responseCart,
+					tax: {
+						display_taxes: true,
+						location: {
+							postal_code: 'pr267ry',
+							country_code: 'GB',
+						},
+					},
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+				tax: { location: { postal_code: 'PR26 7RY', country_code: 'GB' } },
+			},
+		} );
+	} );
+
 	it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
 		const submitData = {
 			country: 'US',

--- a/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
@@ -52,7 +52,6 @@ describe( 'existingCardProcessor', () => {
 			extra: [],
 			products: [ product ],
 			tax: {
-				display_taxes: false,
 				location: {},
 			},
 			temporary: false,

--- a/client/my-sites/checkout/composite-checkout/test/free-purchase-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/free-purchase-processor.ts
@@ -52,7 +52,6 @@ describe( 'freePurchaseProcessor', () => {
 			extra: [],
 			products: [ product ],
 			tax: {
-				display_taxes: false,
 				location: {},
 			},
 			temporary: false,

--- a/client/my-sites/checkout/composite-checkout/test/free-purchase-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/free-purchase-processor.ts
@@ -170,6 +170,41 @@ describe( 'freePurchaseProcessor', () => {
 		} );
 	} );
 
+	it( 'sends the correct data to the endpoint with empty tax information', async () => {
+		const expected = { payload: 'success', type: 'SUCCESS' };
+		await expect(
+			freePurchaseProcessor( {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+				responseCart: {
+					...options.responseCart,
+					tax: {
+						display_taxes: true,
+						location: {
+							postal_code: 'pr267ry',
+							country_code: 'GB',
+						},
+					},
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+			},
+		} );
+	} );
+
 	it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
 		const expected = { payload: 'success', type: 'SUCCESS' };
 		await expect(

--- a/client/my-sites/checkout/composite-checkout/test/full-credits-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/full-credits-processor.ts
@@ -52,7 +52,6 @@ describe( 'fullCreditsProcessor', () => {
 			extra: [],
 			products: [ product ],
 			tax: {
-				display_taxes: false,
 				location: {},
 			},
 			temporary: false,

--- a/client/my-sites/checkout/composite-checkout/test/full-credits-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/full-credits-processor.ts
@@ -170,6 +170,42 @@ describe( 'fullCreditsProcessor', () => {
 		} );
 	} );
 
+	it( 'sends the correct data to the endpoint with tax information', async () => {
+		const expected = { payload: 'success', type: 'SUCCESS' };
+		await expect(
+			fullCreditsProcessor( {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+				responseCart: {
+					...options.responseCart,
+					tax: {
+						display_taxes: true,
+						location: {
+							postal_code: 'pr267ry',
+							country_code: 'GB',
+						},
+					},
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+				tax: { location: { postal_code: 'PR26 7RY', country_code: 'GB' } },
+			},
+		} );
+	} );
+
 	it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
 		const expected = { payload: 'success', type: 'SUCCESS' };
 		await expect(

--- a/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
@@ -52,7 +52,6 @@ describe( 'genericRedirectProcessor', () => {
 			extra: [],
 			products: [ product ],
 			tax: {
-				display_taxes: false,
 				location: {},
 			},
 			temporary: false,

--- a/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
@@ -190,6 +190,51 @@ describe( 'genericRedirectProcessor', () => {
 		} );
 	} );
 
+	it( 'sends the correct data to the endpoint with tax information', async () => {
+		const submitData = {
+			name: 'test name',
+			email: 'test@example.com',
+		};
+		const expected = { payload: 'https://test-redirect-url', type: 'REDIRECT' };
+		await expect(
+			genericRedirectProcessor( 'bancontact', submitData, {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+				responseCart: {
+					...options.responseCart,
+					tax: {
+						display_taxes: true,
+						location: {
+							postal_code: 'pr267ry',
+							country_code: 'GB',
+						},
+					},
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+				tax: { location: { postal_code: 'PR26 7RY', country_code: 'GB' } },
+			},
+			payment: {
+				...basicExpectedStripeRequest.payment,
+				successUrl:
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=https%3A%2F%2Fwordpress.com',
+			},
+		} );
+	} );
+
 	it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
 		const submitData = {
 			name: 'test name',

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.ts
@@ -350,6 +350,48 @@ describe( 'multiPartnerCardProcessor', () => {
 			} );
 		} );
 
+		it( 'sends the correct data to the endpoint with tax information', async () => {
+			const submitData = {
+				paymentPartner: 'stripe',
+				stripe,
+				stripeConfiguration,
+				name: 'test name',
+			};
+			const expected = { payload: 'test success', type: 'SUCCESS' };
+			await expect(
+				multiPartnerCardProcessor( submitData, {
+					...options,
+					siteSlug: 'example.wordpress.com',
+					siteId: 1234567,
+					contactDetails: {
+						countryCode,
+						postalCode,
+					},
+					responseCart: {
+						...options.responseCart,
+						tax: {
+							display_taxes: true,
+							location: {
+								postal_code: 'pr267ry',
+								country_code: 'GB',
+							},
+						},
+					},
+				} )
+			).resolves.toStrictEqual( expected );
+			expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+				...basicExpectedStripeRequest,
+				cart: {
+					...basicExpectedStripeRequest.cart,
+					blog_id: '1234567',
+					cart_key: '1234567',
+					coupon: '',
+					create_new_blog: false,
+					tax: { location: { postal_code: 'PR26 7RY', country_code: 'GB' } },
+				},
+			} );
+		} );
+
 		it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
 			const submitData = {
 				paymentPartner: 'stripe',

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.ts
@@ -109,7 +109,6 @@ describe( 'multiPartnerCardProcessor', () => {
 			extra: [],
 			products: [ product ],
 			tax: {
-				display_taxes: false,
 				location: {},
 			},
 			temporary: false,

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -57,7 +57,6 @@ describe( 'payPalExpressProcessor', () => {
 			extra: [],
 			products: [ product ],
 			tax: {
-				display_taxes: false,
 				location: {},
 			},
 			temporary: false,

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -152,6 +152,44 @@ describe( 'payPalExpressProcessor', () => {
 		} );
 	} );
 
+	it( 'sends the correct data to the endpoint with tax information', async () => {
+		const expected = { payload: 'https://test-redirect-url', type: 'REDIRECT' };
+		await expect(
+			payPalExpressProcessor( {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+				responseCart: {
+					...options.responseCart,
+					tax: {
+						display_taxes: true,
+						location: {
+							postal_code: 'pr267ry',
+							country_code: 'GB',
+						},
+					},
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedRequest,
+			cart: {
+				...basicExpectedRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+				tax: { location: { postal_code: 'PR26 7RY', country_code: 'GB' } },
+			},
+			postalCode: 'PR26 7RY',
+			country: 'GB',
+		} );
+	} );
+
 	it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
 		const expected = { payload: 'https://test-redirect-url', type: 'REDIRECT' };
 		await expect(

--- a/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
@@ -190,6 +190,50 @@ describe( 'weChatProcessor', () => {
 		} );
 	} );
 
+	it( 'sends the correct data to the endpoint with tax information', async () => {
+		const submitData = {
+			name: 'test name',
+		};
+		const expected = { payload: { redirect_url }, type: 'MANUAL' };
+		await expect(
+			weChatProcessor( submitData, {
+				...options,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+				responseCart: {
+					...options.responseCart,
+					tax: {
+						display_taxes: true,
+						location: {
+							postal_code: 'pr267ry',
+							country_code: 'GB',
+						},
+					},
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+				tax: { location: { postal_code: 'PR26 7RY', country_code: 'GB' } },
+			},
+			payment: {
+				...basicExpectedStripeRequest.payment,
+				successUrl:
+					'https://example.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=https%3A%2F%2Fexample.com',
+			},
+		} );
+	} );
+
 	it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
 		const submitData = {
 			name: 'test name',

--- a/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
@@ -56,7 +56,6 @@ describe( 'weChatProcessor', () => {
 			extra: [],
 			products: [ product ],
 			tax: {
-				display_taxes: false,
 				location: {},
 			},
 			temporary: false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This formats postal codes in the cart when submitting them to the transactions endpoint. This should help prevent validation errors during transactions (postal codes in the tax form are being validated as of D60388-code; previously we only validated postal codes in the domain contact form).

This is related to https://github.com/Automattic/wp-calypso/pull/52475 which will also format postal codes in the UI.

#### Testing instructions

- Visit checkout with a non-domain product in the cart (eg: a plan).
- In the "Billing information step", select "United Kingdom" as the country and enter the (lowercase) postal code `pr267ry`.
- Click to continue checkout and pay.
- Verify that the payment succeeds.