### PR TITLE
Removed unused Jetpack legacy plan code in jetpack connect

### DIFF
--- a/client/jetpack-connect/main-header.jsx
+++ b/client/jetpack-connect/main-header.jsx
@@ -19,7 +19,6 @@ import {
 	PRODUCTS_LIST,
 } from '@automattic/calypso-products';
 import { FLOW_TYPES } from 'calypso/jetpack-connect/flow-types';
-import { retrievePlan } from './persistence-utils';
 
 class JetpackConnectMainHeader extends Component {
 	static propTypes = {
@@ -28,49 +27,6 @@ class JetpackConnectMainHeader extends Component {
 
 	getTexts() {
 		const { translate, type } = this.props;
-		const selectedPlan = retrievePlan();
-
-		if (
-			type === 'pro' ||
-			selectedPlan === 'jetpack_business' ||
-			selectedPlan === 'jetpack_business_monthly'
-		) {
-			return {
-				title: translate( 'Get Jetpack Professional' ),
-				subtitle: translate(
-					'WordPress sites from start to finish: unlimited premium themes, ' +
-						'business class security, and marketing automation.'
-				),
-			};
-		}
-
-		if (
-			type === 'premium' ||
-			selectedPlan === 'jetpack_premium' ||
-			selectedPlan === 'jetpack_premium_monthly'
-		) {
-			return {
-				title: translate( 'Get Jetpack Premium' ),
-				subtitle: translate(
-					'Automated backups and malware scanning, expert priority support, ' +
-						'marketing automation, and more.'
-				),
-			};
-		}
-
-		if (
-			type === 'personal' ||
-			selectedPlan === 'jetpack_personal' ||
-			selectedPlan === 'jetpack_personal_monthly'
-		) {
-			return {
-				title: translate( 'Get Jetpack Personal' ),
-				subtitle: translate(
-					'Security essentials for your WordPress site ' +
-						'including automated backups and priority support.'
-				),
-			};
-		}
 
 		if ( type === 'install' ) {
 			return {

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -57,15 +57,6 @@ export class JetpackConnectMain extends Component {
 		if ( this.props.type === 'install' ) {
 			from = 'jpdotcom';
 		}
-		if ( this.props.type === 'pro' ) {
-			from = 'ad';
-		}
-		if ( this.props.type === 'premium' ) {
-			from = 'ad';
-		}
-		if ( this.props.type === 'personal' ) {
-			from = 'ad';
-		}
 
 		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
 			jpc_from: from,


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR removes unused code related to Jetpack legacy plans in the jetpack connect section

### Testing instructions

- Review code
- Download the PR and run Calypso
- Visit `/jetpack/connect/pro`
- Enter a site URL
- Check that you're redirected to the plans page, and shown a recommended product (see capture below)

### Capture

<img width="1006" alt="Screen Shot 2021-05-03 at 3 11 42 PM" src="https://user-images.githubusercontent.com/1620183/116921196-acec5600-ac21-11eb-9eba-e64fa4861077.png">

