### PR TITLE
Checkout: Validate tax contact information in contact step

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -663,6 +663,42 @@ function mapKeysRecursively( object, fn ) {
 	}, {} );
 }
 
+Undocumented.prototype.validateTaxContactInformation = function ( contactInformation ) {
+	return new Promise( ( resolve, reject ) => {
+		let data = {
+			contactInformation,
+		};
+
+		debug( '/me/tax-contact-information/validate query' );
+		data = mapKeysRecursively( data, snakeCase );
+
+		this.wpcom.req.post(
+			{ path: '/me/tax-contact-information/validate' },
+			undefined,
+			data,
+			function ( error, successData ) {
+				if ( error ) {
+					reject( error );
+				}
+
+				// Reshape the error messages to a nested object
+				if ( successData.messages ) {
+					successData.messages = Object.keys( successData.messages ).reduce( ( obj, key ) => {
+						set( obj, key, successData.messages[ key ] );
+						return obj;
+					}, {} );
+				}
+
+				const newData = mapKeysRecursively( successData, function ( key ) {
+					return key === '_headers' ? key : camelCase( key );
+				} );
+
+				resolve( newData );
+			}
+		);
+	} );
+};
+
 /**
  * Validates the specified domain contact information against a list of domain names.
  *

--- a/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
@@ -68,7 +68,9 @@ export default function TaxFields( {
 					}
 					autoComplete={ section + ' postal-code' }
 					isError={ postalCode?.isTouched && ! isValid( postalCode ) }
-					errorMessage={ String( translate( 'This field is required.' ) ) }
+					errorMessage={
+						postalCode?.errors[ 0 ] ?? String( translate( 'This field is required.' ) )
+					}
 				/>
 			</LeftColumn>
 
@@ -86,7 +88,7 @@ export default function TaxFields( {
 					} }
 					isError={ countryCode?.isTouched && ! isValid( countryCode ) }
 					isDisabled={ isDisabled }
-					errorMessage={ translate( 'This field is required.' ) }
+					errorMessage={ countryCode?.errors[ 0 ] ?? translate( 'This field is required.' ) }
 					currentValue={ countryCode?.value }
 					countriesList={ countriesList }
 				/>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -218,7 +218,7 @@ export default function WPCheckout( {
 			}
 		}
 
-		if ( contactDetailsType === 'domain' ) {
+		if ( contactDetailsType === 'domain' || contactDetailsType === 'tax' ) {
 			const validationResult = await getDomainValidationResult(
 				responseCart.products,
 				contactInfo
@@ -267,7 +267,7 @@ export default function WPCheckout( {
 			}
 		}
 
-		if ( contactDetailsType === 'domain' ) {
+		if ( contactDetailsType === 'domain' || contactDetailsType === 'tax' ) {
 			const validationResult = await getDomainValidationResult(
 				responseCart.products,
 				contactInfo

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -44,6 +44,7 @@ import {
 	handleContactValidationResult,
 	isContactValidationResponseValid,
 	getDomainValidationResult,
+	getTaxValidationResult,
 	getSignupEmailValidationResult,
 	getGSuiteValidationResult,
 } from 'calypso/my-sites/checkout/composite-checkout/contact-validation';
@@ -218,7 +219,18 @@ export default function WPCheckout( {
 			}
 		}
 
-		if ( contactDetailsType === 'domain' || contactDetailsType === 'tax' ) {
+		if ( contactDetailsType === 'tax' ) {
+			const validationResult = await getTaxValidationResult( contactInfo );
+			debug( 'validating contact details result', validationResult );
+			handleContactValidationResult( {
+				recordEvent: onEvent,
+				showErrorMessage: showErrorMessageBriefly,
+				paymentMethodId: activePaymentMethod?.id ?? '',
+				validationResult,
+				applyDomainContactValidationResults,
+			} );
+			return isContactValidationResponseValid( validationResult, contactInfo );
+		} else if ( contactDetailsType === 'domain' ) {
 			const validationResult = await getDomainValidationResult(
 				responseCart.products,
 				contactInfo
@@ -267,7 +279,11 @@ export default function WPCheckout( {
 			}
 		}
 
-		if ( contactDetailsType === 'domain' || contactDetailsType === 'tax' ) {
+		if ( contactDetailsType === 'tax' ) {
+			const validationResult = await getTaxValidationResult( contactInfo );
+			debug( 'validating contact details result', validationResult );
+			return isContactValidationResponseValid( validationResult, contactInfo );
+		} else if ( contactDetailsType === 'domain' ) {
 			const validationResult = await getDomainValidationResult(
 				responseCart.products,
 				contactInfo

--- a/client/my-sites/checkout/composite-checkout/contact-validation.js
+++ b/client/my-sites/checkout/composite-checkout/contact-validation.js
@@ -35,6 +35,7 @@ const wpcomValidateDomainContactInformation = ( ...args ) =>
 			{ apiVersion: '1.2' }
 		);
 	} );
+
 async function wpcomValidateSignupEmail( ...args ) {
 	return wpcom.validateNewUser( ...args, null );
 }
@@ -43,6 +44,11 @@ async function wpcomValidateSignupEmail( ...args ) {
 // otherwise we get `this is not defined` errors.
 const wpcomValidateGSuiteContactInformation = ( ...args ) =>
 	wpcom.validateGoogleAppsContactInformation( ...args );
+
+// Aliasing wpcom functions explicitly bound to wpcom is required here;
+// otherwise we get `this is not defined` errors.
+const wpcomValidateTaxContactInformation = ( ...args ) =>
+	wpcom.validateTaxContactInformation( ...args );
 
 export function handleContactValidationResult( {
 	recordEvent,
@@ -81,7 +87,7 @@ export function isContactValidationResponseValid( data, contactDetails ) {
 }
 
 export function prepareContactDetailsForValidation( type, contactDetails ) {
-	if ( type === 'domains' ) {
+	if ( type === 'domains' || type === 'tax' ) {
 		const { contact_information } = prepareDomainContactValidationRequest( contactDetails );
 		return contact_information;
 	}
@@ -90,6 +96,11 @@ export function prepareContactDetailsForValidation( type, contactDetails ) {
 		return contact_information;
 	}
 	throw new Error( `Unknown validation type: ${ type }` );
+}
+
+export async function getTaxValidationResult( contactInfo ) {
+	const formattedContactDetails = prepareContactDetailsForValidation( 'tax', contactInfo );
+	return wpcomValidateTaxContactInformation( formattedContactDetails );
 }
 
 export async function getDomainValidationResult( products, contactInfo ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When no domain products are being purchased, the domain contact validation endpoint still tries to validate all the required domain contact fields (eg: first name, last name, etc.). However, in checkout those fields do not exist. As a result, checkout does not use the contact validation endpoint for non-domain purchases.

Unfortunately for the user, checkout does still show postal code and country fields (the "tax" fields) for non-domain purchases, but these are not validated until the transaction is submitted (they weren't validated at all until D60388-code). This means that if there is a validation error in one of these fields, the user will be forced to return to the contact step to correct the issue, then return to the payment step to try again. This is very poor UX and is one of the main reasons we have the validation endpoint in the first place.

This PR adds validation to the "tax" fields using a new validation endpoint.

Requires D60922-code which creates the tax validation endpoint.

<img width="586" alt="Screen Shot 2021-05-03 at 3 57 06 PM" src="https://user-images.githubusercontent.com/2036909/116926427-56cee100-ac28-11eb-8d65-4f0874510378.png">

Fixes https://github.com/Automattic/wp-calypso/issues/52456

#### Testing instructions

First check for regressions:

- Make sure D60922-code is applied and you have sandboxed the API.
- Visit checkout with a domain product (eg: a domain registration).
- In the contact details step, leave the "first name" field empty.
- Click "Continue".
- Verify that you are presented with an error and that the "first name" field is highlighted.
- Fill in the required field.
- Click "Continue".
- Verify that the step completes and you are presented with the next step of checkout.

Then check to make sure the changes work:

- Make sure D60922-code is applied and you have sandboxed the API.
- Visit checkout with a non-domain product (eg: a plan).
- In the contact details step, enter an invalid postal code (eg: `ADAF ADFADGDGDG`).
- Click "Continue".
- Verify that you are presented with an error and that the "postal code" field is highlighted.
- Enter a valid postal code.
- Click "Continue".
- Verify that the step completes and you are presented with the next step of checkout.