### PR TITLE
desktop: Bump version to 6.15.0

### DIFF
--- a/desktop/app/lib/updater/index.js
+++ b/desktop/app/lib/updater/index.js
@@ -17,7 +17,7 @@ const isMacOSBigSur =
 // FIXME: Auto-restart does not work on MacOS Big Sur and requires an upgrade of Electron v11: https://github.com/electron/electron/issues/25626
 const defaultConfirmLabel = isMacOSBigSur ? 'Update & Quit' : 'Update & Restart';
 const defaultDialogMessage = isMacOSBigSur
-	? '{name} {newVersion} is now available — you have {currentVersion}.\n\nPlease quit and restart the app to apply changes.'
+	? '{name} {newVersion} is now available — you have {currentVersion}.\n\nUpdate requires manual restart.'
 	: '{name} {newVersion} is now available — you have {currentVersion}. Would you like to update now?';
 
 class Updater extends EventEmitter {

--- a/desktop/app/lib/updater/index.js
+++ b/desktop/app/lib/updater/index.js
@@ -11,15 +11,22 @@ const platform = require( '../../lib/platform' );
 const config = require( '../../lib/config' );
 const log = require( '../../lib/logger' )( 'desktop:updater' );
 
+const isMacOSBigSur =
+	process.platform === 'darwin' && process.getSystemVersion().startsWith( '11' );
+
+// FIXME: Auto-restart does not work on MacOS Big Sur and requires an upgrade of Electron v11: https://github.com/electron/electron/issues/25626
+const defaultConfirmLabel = isMacOSBigSur ? 'Update & Quit' : 'Update & Restart';
+const defaultDialogMessage = isMacOSBigSur
+	? '{name} {newVersion} is now available — you have {currentVersion}.\n\nPlease quit and restart the app to apply changes.'
+	: '{name} {newVersion} is now available — you have {currentVersion}. Would you like to update now?';
+
 class Updater extends EventEmitter {
 	constructor( options ) {
 		super();
 
-		this.confirmLabel = options.confirmLabel || 'Update & Restart';
+		this.confirmLabel = options.confirmLabel || defaultConfirmLabel;
 		this.dialogTitle = options.dialogTitle || 'A new version of {name} is available!';
-		this.dialogMessage =
-			options.dialogMessage ||
-			'{name} {newVersion} is now available — you have {currentVersion}. Would you like to update now?';
+		this.dialogMessage = options.dialogMessage || defaultDialogMessage;
 		this.beta = options.beta || false;
 
 		this._version = '';

--- a/desktop/desktop-config/config-development.json
+++ b/desktop/desktop-config/config-development.json
@@ -6,7 +6,7 @@
 	"server_host": "calypso.localhost",
 	"updater": {
 		"downloadUrl": "https://apps.wordpress.com/desktop/",
-		"apiUrl": "https://api.github.com/repos/Automattic/wp-calypso/releases",
+		"apiUrl": "https://api.github.com/repos/Automattic/wp-desktop/releases",
 		"delay": 2000,
 		"interval": 600000
 	},

--- a/desktop/desktop-config/config-release.json
+++ b/desktop/desktop-config/config-release.json
@@ -2,7 +2,7 @@
 	"build": "release",
 	"updater": {
 		"downloadUrl": "https://apps.wordpress.com/desktop/",
-		"apiUrl": "https://api.github.com/repos/Automattic/wp-calypso/releases",
+		"apiUrl": "https://api.github.com/repos/Automattic/wp-desktop/releases",
 		"delay": 2000,
 		"interval": 43200000
 	}

--- a/desktop/desktop-config/config-updater.json
+++ b/desktop/desktop-config/config-updater.json
@@ -7,8 +7,8 @@
 		"colors": true
 	},
 	"updater": {
-		"downloadUrl": "https://github.com/Automattic/wp-calypso/releases",
-		"apiUrl": "https://api.github.com/repos/Automattic/wp-calypso/releases",
+		"downloadUrl": "https://github.com/Automattic/wp-desktop/releases",
+		"apiUrl": "https://api.github.com/repos/Automattic/wp-desktop/releases",
 		"delay": 2000,
 		"interval": 600000
 	}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "6.15.0-beta1",
+	"version": "6.15.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "7.0.0",
+	"version": "6.15.0-beta1",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/"


### PR DESCRIPTION
This is the first step of the release cycle.