### PR TITLE
Theme Showcase: Decode Entities on Screenshot Alt Text

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -18,6 +18,7 @@ import { Card, Ribbon, Button } from '@automattic/components';
 import ThemeMoreButton from './more-button';
 import PulsingDot from 'calypso/components/pulsing-dot';
 import InfoPopover from 'calypso/components/info-popover';
+import { decodeEntities } from 'calypso/lib/formatting';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
@@ -165,6 +166,8 @@ export class Theme extends Component {
 			'theme__badge-price-test': showUpsell,
 		} );
 
+		const themeDescription = decodeEntities( description );
+
 		// for performance testing
 		const screenshotID = this.props.index === 0 ? 'theme__firstscreenshot' : null;
 
@@ -223,7 +226,7 @@ export class Theme extends Component {
 						className="theme__thumbnail"
 						href={ this.props.screenshotClickUrl || 'javascript:;' /* fallback for a11y */ }
 						onClick={ this.onScreenshotClick }
-						title={ description }
+						title={ themeDescription }
 					>
 						{ isActionable && (
 							<div className="theme__thumbnail-label">{ this.props.actionLabel }</div>
@@ -231,7 +234,7 @@ export class Theme extends Component {
 						{ this.renderInstalling() }
 						{ screenshot ? (
 							<img
-								alt={ description }
+								alt={ themeDescription }
 								className="theme__img"
 								src={ themeImgSrc }
 								srcSet={ `${ themeImgSrcDoubleDpi } 2x` }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensure the theme's description appears properly when hovering over its screenshot in the Theme Showcase

#### Testing instructions

Visit the Theme Showcase (`/themes/site`) and inspect the text of the elements with the `theme__img` and `theme__thumbnail` class names on the Seedlet theme. The text of these should also appear if you hover over the "Info" button on a desktop device.

The description should be formatted correctly.

**Before:**
<img width="732" alt="Screenshot 2021-05-03 at 22 16 54" src="https://user-images.githubusercontent.com/43215253/116935088-c4493480-ac5d-11eb-8779-527155602e8d.png">

**After:**
<img width="733" alt="Screenshot 2021-05-03 at 22 15 59" src="https://user-images.githubusercontent.com/43215253/116935116-d0cd8d00-ac5d-11eb-9aeb-7b2b64ec3787.png">

cc @mreishus

Fixes #52524