### PR TITLE
desktop: fetch notifications with cookie auth

### DIFF
--- a/desktop/app/lib/notifications/api/index.js
+++ b/desktop/app/lib/notifications/api/index.js
@@ -50,7 +50,7 @@ class WPNotificationsAPI extends EventEmitter {
 			{
 				headers: {
 					Origin: `https://public-api.wordpress.com`,
-					Cookie: `wp_api_sec=${ decodeURIComponent( cookie ) }`,
+					Cookie: `wp_api_sec=${ cookie }`,
 				},
 			}
 		);

--- a/desktop/app/lib/session/index.js
+++ b/desktop/app/lib/session/index.js
@@ -47,6 +47,7 @@ class SessionManager extends EventEmitter {
 		}
 
 		const wp_api = await getCookie( window, null, 'wp_api' );
+		// FIXME: For some reason unable to filter this cookie by domain 'https://public-api.wordpress.com'
 		if ( this.loggedIn && wp_api ) {
 			await keychainWrite( 'wp_api', decodeURIComponent( wp_api.value ) );
 		}
@@ -88,7 +89,7 @@ class SessionManager extends EventEmitter {
 					}
 
 					// Listen for wp_api cookie (Notifications REST API)
-					// if ( cookie.name === 'wp_api' && cookie.domain === 'https://public-api.wordpress.com' ) {
+					// FIXME: For some reason unable to filter this cookie by domain 'https://public-api.wordpress.com'
 					if ( cookie.name === 'wp_api' ) {
 						if ( this.loggedIn ) {
 							log.info( 'wp_api: ', cookie.value, cookie.domain );

--- a/desktop/app/window-handlers/notifications/index.js
+++ b/desktop/app/window-handlers/notifications/index.js
@@ -105,7 +105,7 @@ module.exports = function ( mainWindow ) {
 				if ( navigate ) {
 					// if we have a specific URL, then navigate Calypso there
 					log.info( `Navigating user to URL: ${ navigate }` );
-					if ( isCalypso() ) {
+					if ( isCalypso( mainWindow ) ) {
 						log.info( `Navigating to '${ navigate }'` );
 						mainWindow.webContents.send( 'navigate', navigate );
 					} else {
@@ -114,7 +114,7 @@ module.exports = function ( mainWindow ) {
 					}
 				} else {
 					// else just display the notifications panel
-					if ( isCalypso() ) {
+					if ( isCalypso( mainWindow ) ) {
 						mainWindow.webContents.send( 'navigate', '/' );
 					} else {
 						mainWindow.webContents.loadURL( webBase );

--- a/desktop/app/window-handlers/notifications/index.js
+++ b/desktop/app/window-handlers/notifications/index.js
@@ -106,8 +106,10 @@ module.exports = function ( mainWindow ) {
 					// if we have a specific URL, then navigate Calypso there
 					log.info( `Navigating user to URL: ${ navigate }` );
 					if ( isCalypso() ) {
+						log.info( `Navigating to '${ navigate }'` );
 						mainWindow.webContents.send( 'navigate', navigate );
 					} else {
+						log.info( `Navigating to '${ webBase + navigate }'` );
 						mainWindow.webContents.loadURL( webBase + navigate );
 					}
 				} else {


### PR DESCRIPTION
### Description

Fixes notification data fetch via cookie authentication.

### To Test

1. Start Calypso with `yarn start`
2. Start the desktop app with `yarn dev:localhost` (from Desktop folder)

Ensure that `Electron` is allowed notification permissions in the Mac system preferences (may also require keychain permissions if prompted).