### PR TITLE
Use MShotImage (Hover-Scroll) in Page Layout Picker

### DIFF
--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/design-picker",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Design picker.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/design-picker",
-	"version": "1.0.1",
+	"version": "1.0.0",
 	"description": "Design picker.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -13,6 +13,7 @@ import { isEnabled } from '@automattic/calypso-config';
  * Internal dependencies
  */
 import MShotsImage from './mshots-image';
+export { default as MShotsImage } from './mshots-image';
 import {
 	getAvailableDesigns,
 	getDesignImageUrl,

--- a/packages/design-picker/src/components/mshots-image/index.tsx
+++ b/packages/design-picker/src/components/mshots-image/index.tsx
@@ -7,11 +7,6 @@ import { addQueryArgs } from '@wordpress/url';
 import debugFactory from 'debug';
 
 /**
- * Internal dependencies
- */
-import { isEnabled } from '@automattic/calypso-config';
-
-/**
  * Style dependencies
  */
 import './style.scss';
@@ -33,17 +28,9 @@ export type MShotsOptions = {
 };
 
 const debug = debugFactory( 'design-picker:mshots-image' );
-const cacheBuster = Date.now();
 
-export function mshotsUrl( url: string, options: MShotsOptions, count = 0 ): string {
-	const mshotsUrl = isEnabled( 'gutenboarding/local-mshots' )
-		? 'http://127.0.0.1:8000/mshots/v1/'
-		: 'https://s0.wp.com/mshots/v1/';
-
-	const targetUrl = ! isEnabled( 'gutenboarding/bust-mshots-cache' )
-		? url
-		: addQueryArgs( url, { cache_buster: cacheBuster } );
-
+export function mshotsUrl( targetUrl: string, options: MShotsOptions, count = 0 ): string {
+	const mshotsUrl = 'https://s0.wp.com/mshots/v1/';
 	const mshotsRequest = addQueryArgs( mshotsUrl + encodeURIComponent( targetUrl ), {
 		...options,
 		count,

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -3,6 +3,7 @@
  */
 export { default } from './components';
 
+export { default as MShotsImage } from './components/mshots-image';
 export { getAvailableDesigns, availableDesignsConfig, getFontTitle } from './utils';
 export { FONT_PAIRINGS, ANCHORFM_FONT_PAIRINGS, DESIGN_IMAGE_FOLDER } from './constants';
 export type { FontPair, Design } from './types';

--- a/packages/page-pattern-modal/jest.config.js
+++ b/packages/page-pattern-modal/jest.config.js
@@ -1,3 +1,6 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
+	globals: {
+		configData: {},
+	},
 };

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -30,7 +30,7 @@
 	"types": "dist/types",
 	"dependencies": {
 		"@automattic/typography": "1.0.0",
-		"@automattic/design-picker": "^1.0.1",
+		"@automattic/design-picker": "^1.0.0",
 		"@wordpress/blocks": "^8.0.3",
 		"@wordpress/components": "^13.0.3",
 		"@wordpress/compose": "^3.25.3",

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -30,6 +30,7 @@
 	"types": "dist/types",
 	"dependencies": {
 		"@automattic/typography": "1.0.0",
+		"@automattic/design-picker": "^1.0.1",
 		"@wordpress/blocks": "^8.0.3",
 		"@wordpress/components": "^13.0.3",
 		"@wordpress/compose": "^3.25.3",

--- a/packages/page-pattern-modal/src/components/pattern-selector-item.tsx
+++ b/packages/page-pattern-modal/src/components/pattern-selector-item.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { MShotsImage } from '@automattic/design-picker';
+
 interface PatternSelectorItemProps {
 	description?: string;
 	locale: string;
@@ -15,7 +20,6 @@ const PatternSelectorItem = ( props: PatternSelectorItemProps ): JSX.Element | n
 		return null;
 	}
 
-	const mshotsUrl = 'https://s0.wordpress.com/mshots/v1/';
 	const designsEndpoint = 'https://public-api.wordpress.com/rest/v1/template/demo/';
 	const sourceSiteUrl = 'dotcompatterns.wordpress.com';
 
@@ -25,27 +29,20 @@ const PatternSelectorItem = ( props: PatternSelectorItemProps ): JSX.Element | n
 		locale
 	) }`;
 
-	const staticPreviewImg =
-		mshotsUrl + encodeURIComponent( previewUrl ) + '?vpw=1024&vph=1024&w=660&h=430';
-
-	const refreshSourceImg = ( e: React.SyntheticEvent< HTMLImageElement > ) => {
-		const img = e.currentTarget;
-
-		if ( -1 !== img.src.indexOf( 'reload=1' ) ) {
-			return;
-		}
-
-		setTimeout( () => {
-			img.src = img.src + '&reload=1';
-		}, 10000 );
+	const mShotsOptions = {
+		vpw: 1024,
+		vph: 1024,
+		w: 660,
+		screen_height: 3600,
 	};
 
 	const innerPreview = (
-		<img
-			className="pattern-selector-item__media"
-			src={ staticPreviewImg }
-			alt={ title }
-			onLoad={ refreshSourceImg }
+		<MShotsImage
+			url={ previewUrl }
+			aria-labelledby={ '' /*makeOptionId( design )*/ }
+			alt=""
+			options={ mShotsOptions }
+			scrollable={ true /*design.preview !== 'static'*/ }
 		/>
 	);
 
@@ -56,7 +53,9 @@ const PatternSelectorItem = ( props: PatternSelectorItemProps ): JSX.Element | n
 			value={ value }
 			onClick={ () => onSelect( value ) }
 		>
-			<span className="pattern-selector-item__preview-wrap">{ innerPreview }</span>
+			<span className="pattern-selector-item__preview-wrap">
+				<div className="pattern-selector-item__preview-wrap-inner-position">{ innerPreview }</div>
+			</span>
 			{ description }
 		</button>
 	);

--- a/packages/page-pattern-modal/src/components/pattern-selector-item.tsx
+++ b/packages/page-pattern-modal/src/components/pattern-selector-item.tsx
@@ -39,10 +39,10 @@ const PatternSelectorItem = ( props: PatternSelectorItemProps ): JSX.Element | n
 	const innerPreview = (
 		<MShotsImage
 			url={ previewUrl }
-			aria-labelledby={ '' /*makeOptionId( design )*/ }
-			alt=""
+			aria-label={ title }
+			alt={ title }
 			options={ mShotsOptions }
-			scrollable={ true /*design.preview !== 'static'*/ }
+			scrollable={ true }
 		/>
 	);
 

--- a/packages/page-pattern-modal/src/components/pattern-selector-item.tsx
+++ b/packages/page-pattern-modal/src/components/pattern-selector-item.tsx
@@ -36,10 +36,12 @@ const PatternSelectorItem = ( props: PatternSelectorItemProps ): JSX.Element | n
 		screen_height: 3600,
 	};
 
+	const descriptionClass = `pattern-selector-item__preview-label__${ value }`;
+
 	const innerPreview = (
 		<MShotsImage
 			url={ previewUrl }
-			aria-label={ title }
+			aria-labelledby={ descriptionClass }
 			alt={ title }
 			options={ mShotsOptions }
 			scrollable={ true }
@@ -56,7 +58,7 @@ const PatternSelectorItem = ( props: PatternSelectorItemProps ): JSX.Element | n
 			<span className="pattern-selector-item__preview-wrap">
 				<div className="pattern-selector-item__preview-wrap-inner-position">{ innerPreview }</div>
 			</span>
-			{ description }
+			<div id={ descriptionClass }>{ description }</div>
 		</button>
 	);
 };

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -185,6 +185,15 @@ $sidebar-width-desktop: 324px;
 	}
 }
 
+// Correct position for child elements inside preview-wrap
+.pattern-selector-item__preview-wrap-inner-position {
+	position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
 .pattern-selector-item__media {
 	width: 100%;
 	height: 100%;

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -174,7 +174,6 @@ $sidebar-width-desktop: 324px;
 	// Aspect ratio of boxes. Height will be 65% of width.
 	padding-top: 65%;
 	position: relative;
-	pointer-events: none;
 	opacity: 1;
 	transform: translateZ( 0 ); // Fix for Safari rounded border overflow (2/2).
 	border: solid 1px $pattern-selector-border-color;


### PR DESCRIPTION
This PR refactors the page-pattern-modal used in the layout selector for a new page to use the MShotsImage component and its mouse-over scroll animation.

#### Testing instructions

- Run `install-plugin.sh etk update/page-layout-picker-mshots-previews` on your sandbox
- Create a new page (not post) on a sandboxed site `https://wordpress.com/page/${ sitename }`
- Check that we get nice long hover-on-scroll preview images for the different styles.

- [ ] Please check the scrolling and clicking behaviour in the layout modal and the layout options with particular vigour. I've stripped the `pointer-events: none` style from the preview-wrap element and I'm not entirely sure why it was there in the first place. It was introduced back in #33318 when the element was converted from a radio-button into a normal one, and copied through in #33375 and #38065, so I'm fairly confident it's vestigial now, but if I'm wrong it'd great to catch that before we ship.

#### Discussion

I've ripped out some handy debug toggles from the MShotsImage element because they were using calypso config, which is not available in the editor. If we need to iterate on the MShotsImage element more in the future it might make sense to re-introduce these using query parameters that aren't tied to calypso, but for now I think we can do without.

Out of scope for this PR: The mayland theme has a big chunk of whitespace at the bottom due to an mshots issue. I had a fiddle with a work-around here, but I think it needs to be fixed in mshots. The question is whether to hold this PR up for that?

Note: I've seen a couple of odd things in the i18n sphere:
The layout UI is rendered in the user's locale, while the screenshots are rendered in the site's locale, e.g.:

That actually seems correct, but it seems like the labels and categories should be rendered in the user locale while they're actually being rendered in the blog locale. Given that this is only going to effect non-english speaking atomic users who have a blog locale that's different from their user locale, I'm pretty confident this falls into the "Will Not Fix" bucket.

![新建頁面_‹_Julesaus_Test_Headstart_KO_—_WordPress_com](https://user-images.githubusercontent.com/5952255/117246710-6f393880-ae80-11eb-8719-44b1792f6d61.jpg)


The slightly more concerning thing I've seen is mojibake coming out of mshots on a Japanese site, but this is another mshots issue:

![新建頁面_‹_My_Test_Blog_—_WordPress_com](https://user-images.githubusercontent.com/5952255/117247175-28980e00-ae81-11eb-8b67-1fbedaf6d6b2.jpg)

Fixes #50310
