### PR TITLE
Enable gutenboarding/long-previews on wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -57,6 +57,7 @@
 		"google-workspace-migration": true,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
+		"gutenboarding/long-previews": true,
 		"gutenboarding/alpha-templates": true,
 		"happychat": true,
 		"help": true,


### PR DESCRIPTION
This PR enables the  `gutenboarding/long-previews` feature flag on wpcalypso. This flag is already enabled on production, development, test, stage and horizon so this change is mostly about consistency (and hopefully enabling the feature on calypso.live links)
