### PR TITLE
Remove unused helpers from lib/paths

### DIFF
--- a/client/lib/paths/index.js
+++ b/client/lib/paths/index.js
@@ -22,30 +22,3 @@ export function newPost( site ) {
 	const sitePath = editorPathFromSite( site );
 	return '/post' + sitePath;
 }
-
-/**
- * Returns a URL to the editor for a new page on a given site.
- *
- * @param  {object|string} site Site object or site slug
- * @returns {string}      URL to page editor
- */
-export function newPage( site ) {
-	const sitePath = editorPathFromSite( site );
-	return '/page' + sitePath;
-}
-
-/**
- * Returns a URL to manage Publicize connections for a given site.
- *
- * @param  {object} site Site object
- * @returns {string}      URL to manage Publicize connections
- */
-export function publicizeConnections( site ) {
-	let url = '/marketing/connections';
-
-	if ( site ) {
-		url += '/' + site.slug;
-	}
-
-	return url;
-}

--- a/client/lib/paths/test/index.js
+++ b/client/lib/paths/test/index.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
-import { newPage, newPost, publicizeConnections } from '../index';
+import { newPost } from '../index';
 
 /**
  * Module variables
@@ -19,33 +14,11 @@ const DUMMY_SITE = {
 describe( 'index', () => {
 	describe( '#newPost()', () => {
 		test( 'should return the Calypso root post path no site', () => {
-			expect( newPost() ).to.equal( '/post' );
+			expect( newPost() ).toBe( '/post' );
 		} );
 
 		test( 'should return a Calypso site-prefixed post path if site exists', () => {
-			expect( newPost( DUMMY_SITE ) ).to.equal( '/post/' + DUMMY_SITE.slug );
-		} );
-	} );
-
-	describe( '#newPage()', () => {
-		test( 'should return the Calypso root page path no site', () => {
-			expect( newPage() ).to.equal( '/page' );
-		} );
-
-		test( 'should return a Calypso site-prefixed page path if site exists', () => {
-			expect( newPage( DUMMY_SITE ) ).to.equal( '/page/' + DUMMY_SITE.slug );
-		} );
-	} );
-
-	describe( '#publicizeConnections()', () => {
-		test( 'should return the root sharing path if no site specified', () => {
-			expect( publicizeConnections() ).to.equal( '/marketing/connections' );
-		} );
-
-		test( 'should return a Calypso site-suffixed sharing path if site specified', () => {
-			expect( publicizeConnections( DUMMY_SITE ) ).to.equal(
-				'/marketing/connections/' + DUMMY_SITE.slug
-			);
+			expect( newPost( DUMMY_SITE ) ).toBe( '/post/' + DUMMY_SITE.slug );
 		} );
 	} );
 } );


### PR DESCRIPTION
The only exports from `lib/paths` that are used are `login` and `newPost`. The rest can be removed.
