### PR TITLE
Make test resilient to stale element reference errors

### DIFF
--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -9,6 +9,7 @@ import webdriver, {
 	WebDriver,
 	WebElement,
 	WebElementCondition,
+	error as webdriverError,
 } from 'selenium-webdriver';
 import config from 'config';
 import { forEach } from 'lodash';
@@ -486,10 +487,25 @@ export async function waitUntilElementWithTextLocated(
 				if ( locatedElements.length === 0 ) {
 					return null;
 				}
-				const elementsWithText = await webdriver.promise.filter(
-					locatedElements,
-					getInnerTextMatcherFunction( text )
-				);
+
+				let elementsWithText;
+				try {
+					elementsWithText = await webdriver.promise.filter(
+						locatedElements,
+						getInnerTextMatcherFunction( text )
+					);
+				} catch ( err ) {
+					if ( err instanceof webdriverError.StaleElementReferenceError ) {
+						// The element was removed from the DOM after we found it. Likely it was an animation
+						// or react re-render. Return null so WebElementCondition retries again.
+						return null;
+					}
+					throw err;
+				}
+
+				if ( elementsWithText.length === 0 ) {
+					return null;
+				}
 
 				return elementsWithText[ 0 ];
 			}


### PR DESCRIPTION
### Background

Fixes #52443

When adding comments to the Reader they get rendered twice, once with a highlight animation and then again when the animation is done.

WebDriver was capturing elements matching the comment selector and asserting the text inside as two separate operations. There is a chance that the first match captures the animated comment, and before it can assert the text content, it gets removed from the DOM (replaced by the final comment).

#### Changes proposed in this Pull Request

Refactors `waitUntilElementWithTextLocated` to return gracefully if the found elements are stale. This will instruct WebDriver to run the whole `WebElementCondition` again. In the next cycle hopefully it will capture the final comment and it will be able to assert the text inside.

It is hard to know when the flakiness is gone, but I just got 5 runs in a row without a flaky test. That's not very common:

![image](https://user-images.githubusercontent.com/975703/117006636-f81d6c00-ace8-11eb-81c1-966e551c3e38.png)



#### Testing instructions

* Verify e2e tests pass
* Verify there are no more instances of #52443 

