### PR TITLE
Remove the jetpackReverseFeaturedProducts test, resetting to the control variation

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -59,16 +59,4 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: false,
 	},
-	// Change the ordering of featured Jetpack products:
-	// least to most expensive (control) vs most to least expensive (test)
-	jetpackReverseFeaturedProducts: {
-		datestamp: '20210422',
-		variations: {
-			highToLow_test: 50,
-			lowToHigh_control: 50,
-		},
-		localeTargets: 'any',
-		defaultVariation: 'lowToHigh_control',
-		allowExistingUsers: true,
-	},
 };

--- a/client/my-sites/plans/jetpack-plans/iterations.ts
+++ b/client/my-sites/plans/jetpack-plans/iterations.ts
@@ -4,17 +4,10 @@
 import { getUrlParts } from '@automattic/calypso-url';
 
 /**
- * Internal dependencies
- */
-import { abtest } from 'calypso/lib/abtest';
-
-/**
  * Iterations
  */
 
-export enum Iterations {
-	REVERSE_FEATURED = 'highToLow_test',
-}
+export enum Iterations {}
 
 const iterationNames: string[] = Object.values( Iterations );
 
@@ -50,10 +43,7 @@ const getCurrentCROIterationName = (): Iterations | null => {
 		}
 	}
 
-	const shouldReverseFeaturedProducts =
-		abtest( 'jetpackReverseFeaturedProducts' ) === Iterations.REVERSE_FEATURED;
-
-	return shouldReverseFeaturedProducts ? Iterations.REVERSE_FEATURED : null;
+	return null;
 };
 
 type IterationValueFunction< T > = ( key: Iterations | null ) => T | undefined;

--- a/client/my-sites/plans/jetpack-plans/product-grid/products-order.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/products-order.ts
@@ -18,11 +18,6 @@ import {
 } from '@automattic/calypso-products';
 
 /**
- * Internal dependencies
- */
-import { getForCurrentCROIteration, Iterations } from '../iterations';
-
-/**
  * Type dependencies
  */
 import type { JetpackPlanSlugs, JetpackProductSlug } from '@automattic/calypso-products';
@@ -46,27 +41,5 @@ const PRODUCT_POSITION_IN_GRID: Record< string, number > = {
 	...setProductsInPosition( JETPACK_CRM_FREE_PRODUCTS, 80 ),
 };
 
-const REVERSE_FEATURED_PRODUCTS_POSITION_IN_GRID: Record< string, number > = {
-	...setProductsInPosition( JETPACK_COMPLETE_PLANS, 1 ),
-	[ PLAN_JETPACK_SECURITY_DAILY ]: 10,
-	[ PLAN_JETPACK_SECURITY_DAILY_MONTHLY ]: 10,
-	[ PRODUCT_JETPACK_BACKUP_DAILY ]: 20,
-	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: 20,
-	[ PLAN_JETPACK_SECURITY_REALTIME ]: 30,
-	[ PLAN_JETPACK_SECURITY_REALTIME_MONTHLY ]: 30,
-	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: 40,
-	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: 40,
-	...setProductsInPosition( JETPACK_SCAN_PRODUCTS, 50 ),
-	...setProductsInPosition( JETPACK_ANTI_SPAM_PRODUCTS, 60 ),
-	...setProductsInPosition( JETPACK_SEARCH_PRODUCTS, 70 ),
-	...setProductsInPosition( JETPACK_CRM_FREE_PRODUCTS, 80 ),
-};
-
-export const getProductPosition = ( slug: JetpackPlanSlugs | JetpackProductSlug ): number => {
-	const positions =
-		getForCurrentCROIteration( {
-			[ Iterations.REVERSE_FEATURED ]: REVERSE_FEATURED_PRODUCTS_POSITION_IN_GRID,
-		} ) ?? PRODUCT_POSITION_IN_GRID;
-
-	return positions[ slug ] ?? 100;
-};
+export const getProductPosition = ( slug: JetpackPlanSlugs | JetpackProductSlug ): number =>
+	PRODUCT_POSITION_IN_GRID[ slug ] ?? 100;


### PR DESCRIPTION
Resolves `1196108640073826-as-1199946500089749`.
Relates to #52171, `pbtFFM-T1-p2`.

#### Changes proposed in this Pull Request

* Remove the `REVERSE_FEATURED` iteration and all the changes from #52171, effectively reverting back to what we had before the test.

#### Testing instructions

##### Calypso Blue

* Open Calypso Blue.
* In the A/B test helper in the lower-right corner, verify that the `jetpackReverseFeaturedProducts` test is no longer present.
* On the **Upgrades > Plans** page for any self-hosted Jetpack site, verify that the row of featured products shows (from left to right): Backup Daily, Security Daily, Complete.
* Make sure that there are no concerning or surprising errors in the browser's console.

##### Calypso Green

* Open Calypso Green.
* Verify that on the Pricing page (`/pricing`), the row of featured products is in the same order as in Calypso Blue.
* Make sure that there are no concerning or surprising errors in the browser's console.

![image](https://user-images.githubusercontent.com/670067/117011752-c3db8880-acb3-11eb-9a9b-61e74823ed0d.png)