### PR TITLE
Framework: Refactor away from `_.toArray()`

### DIFF
--- a/client/lib/highlight/index.js
+++ b/client/lib/highlight/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { compact, toArray } from 'lodash';
+import { compact } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:highlight' );
 
@@ -72,7 +72,7 @@ function walk( node, term, wrapperNode ) {
 	let children;
 	debug( 'Node type', node.nodeName );
 	if ( node.childNodes.length ) {
-		children = toArray( node.childNodes );
+		children = Array.from( node.childNodes );
 
 		for ( let i = 0; i < children.length; i++ ) {
 			walk( children[ i ], term, wrapperNode );

--- a/client/lib/highlight/index.js
+++ b/client/lib/highlight/index.js
@@ -69,13 +69,10 @@ function highlightNode( node, term, wrapperNode ) {
  * @private
  */
 function walk( node, term, wrapperNode ) {
-	let children;
 	debug( 'Node type', node.nodeName );
 	if ( node.childNodes.length ) {
-		children = Array.from( node.childNodes );
-
-		for ( let i = 0; i < children.length; i++ ) {
-			walk( children[ i ], term, wrapperNode );
+		for ( let i = 0; i < node.childNodes.length; i++ ) {
+			walk( node.childNodes[ i ], term, wrapperNode );
 		}
 	} else if ( node.nodeName === '#text' ) {
 		debug( 'Parsing node with value:', node.nodeValue );

--- a/client/lib/highlight/index.js
+++ b/client/lib/highlight/index.js
@@ -69,10 +69,13 @@ function highlightNode( node, term, wrapperNode ) {
  * @private
  */
 function walk( node, term, wrapperNode ) {
+	let children;
 	debug( 'Node type', node.nodeName );
 	if ( node.childNodes.length ) {
-		for ( let i = 0; i < node.childNodes.length; i++ ) {
-			walk( node.childNodes[ i ], term, wrapperNode );
+		children = Array.from( node.childNodes );
+
+		for ( let i = 0; i < children.length; i++ ) {
+			walk( children[ i ], term, wrapperNode );
 		}
 	} else if ( node.nodeName === '#text' ) {
 		debug( 'Parsing node with value:', node.nodeValue );

--- a/client/lib/post-normalizer/rule-content-make-links-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-links-safe.js
@@ -1,14 +1,11 @@
 /**
- */
-
-/**
  * External dependencies
  */
-import { forEach, toArray } from 'lodash';
+import { forEach } from 'lodash';
 import { safeLinkRe } from './utils';
 
 export default function makeContentLinksSafe( post, dom ) {
-	const links = toArray( dom.querySelectorAll( 'a[href]' ) );
+	const links = Array.from( dom.querySelectorAll( 'a[href]' ) );
 	forEach( links, ( link ) => {
 		// only accept links that are to http or https sites
 		if ( ! safeLinkRe.test( link.href ) ) {

--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -3,7 +3,7 @@
  */
 
 import striptags from 'striptags';
-import { trim, toArray, forEach } from 'lodash';
+import { trim, forEach } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -70,12 +70,12 @@ export function formatExcerpt( content ) {
 	dom.id = '__better_excerpt__';
 
 	// strip any p's that are empty
-	toArray( dom.querySelectorAll( 'p' ) )
+	Array.from( dom.querySelectorAll( 'p' ) )
 		.filter( ( element ) => trim( element.textContent ).length === 0 )
 		.forEach( removeElement );
 
 	// remove styles for all p's that remain
-	toArray( dom.querySelectorAll( 'p' ) ).forEach( ( element ) => {
+	Array.from( dom.querySelectorAll( 'p' ) ).forEach( ( element ) => {
 		element.removeAttribute( 'style' );
 		element.removeAttribute( 'align' );
 	} );

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -9,7 +9,7 @@
  */
 import { expect } from 'chai';
 import { mount } from 'enzyme';
-import { defer, toArray } from 'lodash';
+import { defer } from 'lodash';
 import React from 'react';
 import moment from 'moment';
 
@@ -49,7 +49,7 @@ describe( 'MediaLibraryList item selection', () => {
 	function expectSelectedItems() {
 		defer( function () {
 			expect( mockSelectedItems ).to.have.members(
-				toArray( arguments ).map( function ( arg ) {
+				Array.from( arguments ).map( function ( arg ) {
 					return fixtures.media[ arg ];
 				} )
 			);

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -47,9 +47,9 @@ describe( 'MediaLibraryList item selection', () => {
 	}
 
 	function expectSelectedItems() {
-		defer( function ( ...args ) {
+		defer( function () {
 			expect( mockSelectedItems ).to.have.members(
-				args.map( function ( arg ) {
+				Array.from( arguments ).map( function ( arg ) {
 					return fixtures.media[ arg ];
 				} )
 			);

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -47,9 +47,9 @@ describe( 'MediaLibraryList item selection', () => {
 	}
 
 	function expectSelectedItems() {
-		defer( function () {
+		defer( function ( ...args ) {
 			expect( mockSelectedItems ).to.have.members(
-				Array.from( arguments ).map( function ( arg ) {
+				args.map( function ( arg ) {
 					return fixtures.media[ arg ];
 				} )
 			);

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -46,8 +46,8 @@ describe( 'MediaLibraryList item selection', () => {
 		mediaList.toggleItem( fixtures.media[ itemIndex ], shiftClick );
 	}
 
-	function expectSelectedItems() {
-		defer( function ( ...args ) {
+	function expectSelectedItems( ...args ) {
+		defer( function () {
 			expect( mockSelectedItems ).to.have.members(
 				args.map( function ( arg ) {
 					return fixtures.media[ arg ];

--- a/client/state/posts/utils/get-term-ids-from-edits.js
+++ b/client/state/posts/utils/get-term-ids-from-edits.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, isPlainObject, map, mapValues, reduce, toArray } from 'lodash';
+import { isEmpty, isPlainObject, map, mapValues, reduce } from 'lodash';
 
 /**
  * Takes existing term post edits and updates the `terms_by_id` attribute
@@ -20,7 +20,7 @@ export function getTermIdsFromEdits( post ) {
 		post.terms,
 		( prev, taxonomyTerms, taxonomyName ) => {
 			// Ensures we are working with an array
-			const termsArray = toArray( taxonomyTerms );
+			const termsArray = Object.values( taxonomyTerms );
 			if ( termsArray && termsArray.length && ! isPlainObject( termsArray[ 0 ] ) ) {
 				return prev;
 			}

--- a/client/state/posts/utils/is-terms-equal.js
+++ b/client/state/posts/utils/is-terms-equal.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isPlainObject, map, toArray, xor } from 'lodash';
+import { isPlainObject, map, xor } from 'lodash';
 
 /**
  * Returns truthy if local terms object is the same as the API response
@@ -12,7 +12,7 @@ import { isPlainObject, map, toArray, xor } from 'lodash';
  */
 export function isTermsEqual( localTermEdits, savedTerms ) {
 	return Object.entries( localTermEdits ).every( ( [ taxonomy, terms ] ) => {
-		const termsArray = toArray( terms );
+		const termsArray = Object.values( terms );
 		const isHierarchical = isPlainObject( termsArray[ 0 ] );
 		const normalizedEditedTerms = isHierarchical ? map( termsArray, 'ID' ) : termsArray;
 		const normalizedKey = isHierarchical ? 'ID' : 'name';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `toArray()` is used several times in the codebase, but it's pretty straightforward to replace it with either `Array.from` for iterables and `Object.values` for objects. This PR replaces all those instances. 

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all tests pass: `yarn run test-client`.
* Verify that when you access `/devdocs/docs/coding-guidelines.md?term=guidelines`, the "Guidelines" term is still highlighted.

#### Notes

ESLint errors are expected and pre-existing.