### PR TITLE
Signup  launch-site flow: dont pass the click event to handleSkip

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1222,7 +1222,7 @@ class RegisterDomainStep extends React.Component {
 			domainSkipPurchase = (
 				<DomainSkipSuggestion
 					selectedSiteSlug={ this.props.selectedSite.slug }
-					onButtonClick={ this.props.onSkip }
+					onButtonClick={ () => this.props.onSkip() }
 				/>
 			);
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

It’s this line, we’re passing `handleSkip` to `onSkip`. Then inside the component, we’re doing this:

https://github.com/Automattic/wp-calypso/blob/3ad54614a4022826034ef4312e82b1df2d014c06/client/components/domains/register-domain-step/index.jsx#L1225

This calls `onSkip` with the click event, `onSkip` forwards the call to `handleSkip`, `handleSkip’s` first param is `googleAppsCartItem`, so the click event is added as a Google app cart item.

Changing the line from

```jsx
onButtonClick={ this.props.onSkip }
```
To

```jsx
onButtonClick={ () => this.props.onSkip() }
```
Fixes the issue on the surface. But it might just be covering a deeper problem.

#### Testing instructions

1. Go to production /start.
2. Create a site. Note down its URL.
3. Go to https://hash-f9d2e934baaadd49c6e1c433b15a426d7557353e.calypso.live/start/launch-site/domains-launch?siteSlug=YOUR_SITE.wordpress.com.
4. If newest Chrome, enable 3rd party cookies by clicking the 👁️ in the URL bar and refresh the page.
5. Pick a free domain and launch your site. It should launch successfuly.
