### PR TITLE
E2E: Ignore notice when applying coupon

### DIFF
--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -11,7 +11,6 @@ import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 import { currentScreenSize } from '../driver-manager';
 import { getJetpackHost } from '../data-helper';
-import NoticesComponent from './notices-component';
 
 export default class SecurePaymentComponent extends AsyncBaseContainer {
 	constructor( driver ) {
@@ -335,8 +334,6 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 					'.checkout-steps__step-complete-content .coupon button'
 			)
 		);
-		const noticesComponent = await NoticesComponent.Expect( this.driver );
-		await noticesComponent.dismissNotice();
 		return this.waitForCouponToBeApplied();
 	}
 


### PR DESCRIPTION
Closes #52442 

#### Changes proposed in this Pull Request

Closing the success notice after applying the coupon is an unnecessary step. The notice [does seem to be flaky itself](https://github.com/Automattic/wp-calypso/issues/52442#issuecomment-832025174), but it's not what we're testing here and should not break the test.

#### Testing instructions

All `wp-plan-purchase-spec.js` tests should pass.