### PR TITLE
Framework: Refactor away from `_.forOwn()`

### DIFF
--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -36,7 +36,7 @@ const SLIDESHOW_URLS = {
 };
 
 function processEmbeds( domNode ) {
-	Object.entries( embedsToLookFor ).map( ( [ embedSelector, fn ] ) => {
+	Object.entries( embedsToLookFor ).forEach( ( [ embedSelector, fn ] ) => {
 		const nodes = domNode.querySelectorAll( embedSelector );
 		forEach( filter( nodes, nodeNeedsProcessing ), fn );
 	} );

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -4,7 +4,7 @@
 
 import React, { PureComponent } from 'react';
 import ReactDom from 'react-dom';
-import { filter, forEach, forOwn } from 'lodash';
+import { filter, forEach } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -36,7 +36,7 @@ const SLIDESHOW_URLS = {
 };
 
 function processEmbeds( domNode ) {
-	forOwn( embedsToLookFor, ( fn, embedSelector ) => {
+	Object.entries( embedsToLookFor ).map( ( [ embedSelector, fn ] ) => {
 		const nodes = domNode.querySelectorAll( embedSelector );
 		forEach( filter( nodes, nodeNeedsProcessing ), fn );
 	} );

--- a/client/lib/post-normalizer/rule-decode-entities.js
+++ b/client/lib/post-normalizer/rule-decode-entities.js
@@ -31,7 +31,7 @@ export default function decodeEntities( post, fields = DEFAULT_FIELDS ) {
 
 	if ( post.tags ) {
 		// tags is an object
-		Object.values( post.tags ).map( function ( tag ) {
+		Object.values( post.tags ).forEach( function ( tag ) {
 			tag.name = decode( tag.name );
 		} );
 	}

--- a/client/lib/post-normalizer/rule-decode-entities.js
+++ b/client/lib/post-normalizer/rule-decode-entities.js
@@ -1,13 +1,6 @@
 /**
- * External dependencies
- */
-
-import { forOwn } from 'lodash';
-
-/**
  * Internal Dependencies
  */
-
 import { decodeEntities as decode } from 'calypso/lib/formatting';
 import safeImageURL from 'calypso/lib/safe-image-url';
 
@@ -38,7 +31,7 @@ export default function decodeEntities( post, fields = DEFAULT_FIELDS ) {
 
 	if ( post.tags ) {
 		// tags is an object
-		forOwn( post.tags, function ( tag ) {
+		Object.values( post.tags ).map( function ( tag ) {
 			tag.name = decode( tag.name );
 		} );
 	}

--- a/client/lib/post-normalizer/rule-safe-image-properties.js
+++ b/client/lib/post-normalizer/rule-safe-image-properties.js
@@ -22,7 +22,7 @@ export default function safeImagePropertiesForWidth( maxWidth ) {
 			makeImageURLSafe( post.canonical_image, 'uri', maxWidth, post.URL );
 		}
 		if ( post.attachments ) {
-			Object.values( post.attachments ).map( function ( attachment ) {
+			Object.values( post.attachments ).forEach( function ( attachment ) {
 				if ( startsWith( attachment.mime_type, 'image/' ) ) {
 					makeImageURLSafe( attachment, 'URL', maxWidth, post.URL );
 				}

--- a/client/lib/post-normalizer/rule-safe-image-properties.js
+++ b/client/lib/post-normalizer/rule-safe-image-properties.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forOwn, startsWith } from 'lodash';
+import { startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,7 +22,7 @@ export default function safeImagePropertiesForWidth( maxWidth ) {
 			makeImageURLSafe( post.canonical_image, 'uri', maxWidth, post.URL );
 		}
 		if ( post.attachments ) {
-			forOwn( post.attachments, function ( attachment ) {
+			Object.values( post.attachments ).map( function ( attachment ) {
 				if ( startsWith( attachment.mime_type, 'image/' ) ) {
 					makeImageURLSafe( attachment, 'URL', maxWidth, post.URL );
 				}

--- a/client/state/data-layer/wpcom/sites/activity-types/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity-types/from-api.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, forOwn } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,7 +17,7 @@ import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
  */
 export function transformer( apiResponse ) {
 	const groups = [];
-	forOwn( get( apiResponse, [ 'groups' ], {} ), ( group, slug ) => {
+	Object.entries( get( apiResponse, [ 'groups' ], {} ) ).map( ( [ slug, group ] ) => {
 		groups.push( {
 			key: slug,
 			name: group.name,

--- a/client/state/data-layer/wpcom/sites/activity-types/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity-types/from-api.js
@@ -17,7 +17,7 @@ import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
  */
 export function transformer( apiResponse ) {
 	const groups = [];
-	Object.entries( get( apiResponse, [ 'groups' ], {} ) ).map( ( [ slug, group ] ) => {
+	Object.entries( get( apiResponse, [ 'groups' ], {} ) ).forEach( ( [ slug, group ] ) => {
 		groups.push( {
 			key: slug,
 			name: group.name,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `forOwn()` is used several times in the codebase, but it's pretty straightforward to replace it with either `Object.entries()`, `Object.values()` or `Object.keys()`, depending on what it's used for. This PR replaces all instances. 

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all tests pass: `yarn run test-client client/lib/post-normalizer`.
* Go to `/media/:site`, click on the question mark on the bottom right, and click on "Add a Photo Gallery". Verify the modal appears and the video plays like before.
* Go to `/activity-log/:site` for a Jetpack or Atomic site. Verify the activity type dropdown and its content looks and works like before.