### PR TITLE
E2E: gitignore all *.log files

### DIFF
--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -6,12 +6,10 @@
 /screenshots-i18n/
 /temp/
 /temp-cookies/
+*.log
 
 # config overrides
 /config/local-*
-
-# chromedriver logs
-chrome*.log
 
 # typescript output
 dist/


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Ignore all *.log files created when running E2E suites locally. At this moment this will ignore:
- `/test/e2e/chromedriver.log`
- `/test/e2e/console.log`
- `/test/e2e/performance.log`