### PR TITLE
Jetpack Connection: track the "skip user connection" events

### DIFF
--- a/client/blocks/jetpack-connect-skip-user/index.js
+++ b/client/blocks/jetpack-connect-skip-user/index.js
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
  */
 import { addQueryArgs } from 'calypso/lib/route';
 import { urlToSlug } from 'calypso/lib/url';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 /**
  * Style dependencies
@@ -30,6 +31,14 @@ class JetpackConnectSkipUser extends Component {
 		);
 	}
 
+	onSkip() {
+		recordTracksEvent( 'calypso_jpc_iframe_skip_user_connection' );
+	}
+
+	onFeatures() {
+		recordTracksEvent( 'calypso_jpc_iframe_view_all_features' );
+	}
+
 	render() {
 		const { translate } = this.props;
 
@@ -48,6 +57,7 @@ class JetpackConnectSkipUser extends Component {
 										target="_blank"
 										href="https://jetpack.com/support/why-the-wordpress-com-connection-is-important-for-jetpack/"
 										rel="noreferrer"
+										onClick={ this.onFeatures }
 									/>
 								),
 							},
@@ -55,7 +65,11 @@ class JetpackConnectSkipUser extends Component {
 					) }
 				</p>
 
-				<a className="jetpack-connect-skip-user__continue-link" href={ this.getPlansURL() }>
+				<a
+					className="jetpack-connect-skip-user__continue-link"
+					href={ this.getPlansURL() }
+					onClick={ this.onSkip }
+				>
 					{ translate( 'Continue without user account' ) }
 				</a>
 			</div>

--- a/client/blocks/jetpack-connect-skip-user/index.js
+++ b/client/blocks/jetpack-connect-skip-user/index.js
@@ -3,6 +3,7 @@
  */
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -17,6 +18,12 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import './style.scss';
 
 class JetpackConnectSkipUser extends Component {
+	static propTypes = {
+		homeUrl: PropTypes.string.isRequired,
+		redirectAfterAuth: PropTypes.string.isRequired,
+		source: PropTypes.string,
+	};
+
 	getPlansURL() {
 		const { homeUrl, redirectAfterAuth } = this.props;
 		const slug = urlToSlug( homeUrl );
@@ -31,12 +38,17 @@ class JetpackConnectSkipUser extends Component {
 		);
 	}
 
+	getTracksProps() {
+		const { source } = this.props;
+		return { source };
+	}
+
 	onSkip() {
-		recordTracksEvent( 'calypso_jpc_iframe_skip_user_connection' );
+		recordTracksEvent( 'calypso_jpc_iframe_skip_user_connection', this.getTracksProps() );
 	}
 
 	onFeatures() {
-		recordTracksEvent( 'calypso_jpc_iframe_view_all_features' );
+		recordTracksEvent( 'calypso_jpc_iframe_view_all_features', this.getTracksProps() );
 	}
 
 	render() {
@@ -57,7 +69,7 @@ class JetpackConnectSkipUser extends Component {
 										target="_blank"
 										href="https://jetpack.com/support/why-the-wordpress-com-connection-is-important-for-jetpack/"
 										rel="noreferrer"
-										onClick={ this.onFeatures }
+										onClick={ () => this.onFeatures() }
 									/>
 								),
 							},
@@ -68,7 +80,7 @@ class JetpackConnectSkipUser extends Component {
 				<a
 					className="jetpack-connect-skip-user__continue-link"
 					href={ this.getPlansURL() }
-					onClick={ this.onSkip }
+					onClick={ () => this.onSkip() }
 				>
 					{ translate( 'Continue without user account' ) }
 				</a>

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -672,6 +672,7 @@ export class LoginForm extends Component {
 					<JetpackConnectSkipUser
 						homeUrl={ currentQuery?.site }
 						redirectAfterAuth={ currentQuery?.redirect_after_auth }
+						source="login"
 					/>
 				) }
 			</form>

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -283,6 +283,7 @@ export class JetpackSignup extends Component {
 					<JetpackConnectSkipUser
 						homeUrl={ authQuery.homeUrl }
 						redirectAfterAuth={ authQuery.redirectAfterAuth }
+						source="signup"
 					/>
 				) }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Tracking the following events:
- `calypso_jpc_iframe_skip_user_connection` when users click on the "Continue without user account" button
- `calypso_jpc_iframe_view_all_features` when users click on the "Some features will not be available" link

#### Testing instructions

Please set the constant `define( 'JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME', true );` to skip the In-Place flow and go straight to Calypso.

##### Login page
1. Create a WordPress user with your WP.com email, but log out from WP.com
2. Disconnect Jetpack.
3. Initiate the connection process. You should get redirected to the Calypso login page.
4. Replace the `https://wordpress.com/` in the URL with the branch URL `https://hash-e08ed42484b80d5fd618fc65b90a53c7128ab285.calypso.live/`.
5. Click on the "Some features" link in the bottom of the page. The "Features" page should load in a new tab.
6. Click on the "Continue without user account" link in the bottom of the page. 6. You should get redirected to Jetpack Cloud plans page. Start with the free plan.
7. Open "Live Tracks" and confirm that events `calypso_jpc_iframe_skip_user_connection` and `calypso_jpc_iframe_view_all_features` were captured. Confirm that both events have the property `source: login`.


##### Registration page
1. Log out of WP.com and disconnect Jetpack.
2. Change your WordPress (not WP.com) email to something random.
3. Go to Jetpack and initiate the connection flow. You should get redirected to the registration form.
4. Replace `https://wordpress.com/` in the URL with the branch URL: `https://hash-e08ed42484b80d5fd618fc65b90a53c7128ab285.calypso.live/`
5. Click on the "Some features" link in the bottom of the page. The "Features" page should load in a new tab.
6. Click on the "Continue without user account" link in the bottom of the page. 6. You should get redirected to Jetpack Cloud plans page. Start with the free plan.
7. Open "Live Tracks" and confirm that events `calypso_jpc_iframe_skip_user_connection` and `calypso_jpc_iframe_view_all_features` were captured. Confirm that both events have the property `source: signup`.

Related to #52303
