### PR TITLE
Jetpack Backup plugin skip the plans page on auth

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -228,7 +228,8 @@ export class JetpackAuthorize extends Component {
 			this.shouldRedirectJetpackStart() ||
 			getRoleFromScope( scope ) === 'subscriber' ||
 			this.isJetpackUpgradeFlow() ||
-			this.isFromJetpackConnectionManager()
+			this.isFromJetpackConnectionManager() ||
+			this.isFromJetpackBackupPlugin()
 		) {
 			debug(
 				'Going back to WP Admin.',
@@ -309,6 +310,11 @@ export class JetpackAuthorize extends Component {
 	isFromJetpackConnectionManager( props = this.props ) {
 		const { from } = props.authQuery;
 		return startsWith( from, 'connection-ui' );
+	}
+
+	isFromJetpackBackupPlugin( props = this.props ) {
+		const { from } = props.authQuery;
+		return startsWith( from, 'jetpack-backup' );
 	}
 
 	isWooRedirect = ( props = this.props ) => {

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -256,6 +256,30 @@ describe( 'JetpackAuthorize', () => {
 		} );
 	} );
 
+	describe( 'isFromJetpackBackupPlugin', () => {
+		const isFromJetpackBackupPlugin = new JetpackAuthorize().isFromJetpackBackupPlugin;
+
+		test( 'is from backup plugin', () => {
+			const props = {
+				authQuery: {
+					from: 'jetpack-backup',
+				},
+			};
+
+			expect( isFromJetpackBackupPlugin( props ) ).toBe( true );
+		} );
+
+		test( 'is not from backup plugin', () => {
+			const props = {
+				authQuery: {
+					from: 'not-jetpack-backup',
+				},
+			};
+
+			expect( isFromJetpackBackupPlugin( props ) ).toBe( false );
+		} );
+	} );
+
 	describe( 'isFromJetpackBoost', () => {
 		const isFromJetpackBoost = new JetpackAuthorize().isFromJetpackBoost;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Similar change to #48713 where we want to redirect back to wp-admin.

#### Testing instructions

* With these changes pulled down, make sure the Jetpack & Jetpack Backup ([PR](https://github.com/Automattic/jetpack/pull/19716)) plugins are active.
* Disconnect the Jetpack connection if connected.
* Add the following constants to your wp-config:

```
define( 'JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME', true );
define( 'CALYPSO_ENV', 'development' );
```

* Starting at `/wp-admin/admin.php?page=jetpack-backup` use the "Connect" button. You should be taken through the Calypso auth flow, and then redirected back to the same `page=jetpack-backup` wp-admin page you started from.
