### PR TITLE
Framework: Refactor away from `_.differenceWith()`

### DIFF
--- a/client/lib/analytics/cart.js
+++ b/client/lib/analytics/cart.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { differenceWith, isEqual, each, omit } from 'lodash';
+import { isEqual, each, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,12 +10,16 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { recordAddToCart } from 'calypso/lib/analytics/record-add-to-cart';
 import { getAllCartItems } from 'calypso/lib/cart-values/cart-items';
 
+function difference( items1, items2 ) {
+	return items1.filter( ( a ) => ! items2.some( ( b ) => isEqual( a, b ) ) );
+}
+
 export function recordEvents( previousCart, nextCart ) {
 	const previousItems = getAllCartItems( previousCart );
 	const nextItems = getAllCartItems( nextCart );
 
-	each( differenceWith( nextItems, previousItems, isEqual ), recordAddEvent );
-	each( differenceWith( previousItems, nextItems, isEqual ), recordRemoveEvent );
+	each( difference( nextItems, previousItems, isEqual ), recordAddEvent );
+	each( difference( previousItems, nextItems, isEqual ), recordRemoveEvent );
 }
 
 function removeNestedProperties( cartItem ) {

--- a/client/lib/analytics/cart.js
+++ b/client/lib/analytics/cart.js
@@ -18,8 +18,8 @@ export function recordEvents( previousCart, nextCart ) {
 	const previousItems = getAllCartItems( previousCart );
 	const nextItems = getAllCartItems( nextCart );
 
-	each( difference( nextItems, previousItems, isEqual ), recordAddEvent );
-	each( difference( previousItems, nextItems, isEqual ), recordRemoveEvent );
+	each( difference( nextItems, previousItems ), recordAddEvent );
+	each( difference( previousItems, nextItems ), recordRemoveEvent );
 }
 
 function removeNestedProperties( cartItem ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `differenceWith()` is used just once in the codebase, but it's pretty straightforward to replace it with a custom implementation using `Array.prototype.filter()` and `Array.prototype.some()`. 

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* The functionality is covered by tests, so just verify they pass: 
  * `yarn run test-client client/lib/analytics/test/cart.js`
