### PR TITLE
e2e tests: Fix "Can launch a site" test so that it actually waits for the launch to complete

### DIFF
--- a/test/e2e/lib/flows/launch-site-flow.js
+++ b/test/e2e/lib/flows/launch-site-flow.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { By } from 'selenium-webdriver';
 
 /**
@@ -34,7 +33,7 @@ export default class LaunchSiteFlow {
 			dismissDomainUpsellLocator
 		);
 		if ( domainUpsellPresent ) {
-			return await driverHelper.clickWhenClickable( this.driver, dismissDomainUpsellLocator );
+			await driverHelper.clickWhenClickable( this.driver, dismissDomainUpsellLocator );
 		}
 
 		return await myHomePage.isSiteLaunched();

--- a/test/e2e/lib/flows/launch-site-flow.js
+++ b/test/e2e/lib/flows/launch-site-flow.js
@@ -36,6 +36,6 @@ export default class LaunchSiteFlow {
 			await driverHelper.clickWhenClickable( this.driver, dismissDomainUpsellLocator );
 		}
 
-		return await myHomePage.isSiteLaunched();
+		return await myHomePage.waitForSiteLaunchComplete();
 	}
 }

--- a/test/e2e/lib/pages/my-home-page.js
+++ b/test/e2e/lib/pages/my-home-page.js
@@ -27,6 +27,7 @@ export default class MyHomePage extends AsyncBaseContainer {
 		this.launchSiteTaskCompleteLocator = By.css(
 			'.customer-home__main [data-task="site_launched"] .nav-item__complete'
 		);
+		this.celebrateNoticeTitleLocator = By.css( '.celebrate-notice__title' );
 	}
 
 	async _postInit() {
@@ -58,9 +59,14 @@ export default class MyHomePage extends AsyncBaseContainer {
 		return assert( badgeText === 'Complete', 'Could not locate message that email is verified.' );
 	}
 
-	async isSiteLaunched() {
-		await this.closeCelebrateNotice();
-		return await driverHelper.isElementLocated( this.driver, this.launchSiteTaskCompleteLocator );
+	async waitForSiteLaunchComplete() {
+		await driverHelper.waitUntilElementLocated( this.driver, this.celebrateNoticeTitleLocator );
+		const notice = await this.driver.findElement( this.celebrateNoticeTitleLocator );
+		const noticeText = await notice.getText();
+		return assert(
+			noticeText === 'You launched your site!',
+			'Could not locate message that site was launched.'
+		);
 	}
 
 	async updateHomepageFromSiteSetup() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The "Can launch a site" e2e test has four bugs and might never have worked as intended. This PR fixes the test.

First, if the launch flow includes the domain upsell (which it always does in my attempts), the test returns immediately, not waiting for the launch to complete. 

The second bug is more subtle; the test calls `isSiteLaunched()` and returns the result, but just returning true or false from a test does not cause it to pass or fail. Even if `isSiteLaunched()` returned false, then the test would still complete successfully.

The third bug is that `isSiteLaunched()` doesn't actually wait for anything to happen; it only checks if the site launch has completed and returns. If the loading page is still visible, it will always return false.

The fourth bug is that the page element targeted by the selector used to determine if the site was launched appears to never be displayed, even if the site was launched successfully, meaning that `isSiteLaunched()` is never true.

#### Testing instructions

Make sure e2e tests pass.

If you care to, you can verify that this fails appropriately by running the updated test on this commit, where the launch flow was actually broken: f97d92c218eb8b6db473ae60ced2b617bd425c84