### PR TITLE
Add/cover pullquote block e2e tests

### DIFF
--- a/test/e2e/lib/components/post-preview-component.js
+++ b/test/e2e/lib/components/post-preview-component.js
@@ -50,6 +50,12 @@ export default class PostPreviewComponent extends AsyncBaseContainer {
 		return await this.viewPostPage.imageDisplayed( fileDetails );
 	}
 
+	async hasImageWithFileName( fileName ) {
+		await PostPreviewComponent.switchToIFrame( this.driver );
+		this.viewPostPage = await ViewPostPage.Expect( this.driver );
+		return await this.viewPostPage.hasImageWithFileName( fileName );
+	}
+
 	async edit() {
 		await this.driver.switchTo().defaultContent();
 		return await driverHelper.clickWhenClickable(

--- a/test/e2e/lib/gutenberg/blocks/cover-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/cover-block-component.js
@@ -74,7 +74,7 @@ export default class CoverBlockComponent extends GutenbergBlockComponent {
 			.perform();
 
 		// make sure it actually gets focus
-		await driverHelper.waitUntilLocatedAndVisible(
+		await driverHelper.waitUntilElementLocatedAndVisible(
 			this.driver,
 			By.css( `${ this.blockID }.block-editor-block-list__block.is-selected` )
 		);

--- a/test/e2e/lib/gutenberg/blocks/cover-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/cover-block-component.js
@@ -9,20 +9,74 @@ import { By } from 'selenium-webdriver';
 import * as driverHelper from '../../driver-helper';
 import GutenbergBlockComponent from './gutenberg-block-component';
 
+/**
+ * POM class to represent a Cover block. Contains methods unique to the Cover block. For other shared
+ * media actions, see shared-block-flows/media-block-flows.js
+ */
 export default class CoverBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Cover';
 
+	/**
+	 * Sets the provided text to the Cover title Paragraph block. Appends the text to whatever is already there.
+	 *
+	 * @param {string} text Text to type in the Cover title Paragraph block.
+	 */
 	async setTitleText( text ) {
 		const paragraphLocator = By.css( `${ this.blockID } p.block-editor-rich-text__editable` );
-		await driverHelper.waitUntilLocatedAndVisible( this.driver, paragraphLocator );
 		const paragraphElement = await this.driver.findElement( paragraphLocator );
 		await paragraphElement.sendKeys( text );
 	}
 
+	/**
+	 * Gets the src value for the image being used currently as the Cover background.
+	 *
+	 * @returns {string | null} The value of the src string on the background img element, or null if src is unset
+	 */
 	async getImageSrc() {
 		const imgElement = await this.driver.findElement(
 			By.css( `${ this.blockID } img.wp-block-cover__image-background` )
 		);
-		return ( await imgElement.getAttribute( 'src' ) ) || '';
+		return await imgElement.getAttribute( 'src' );
+	}
+
+	/**
+	 * In the starting Cover state, pick a background color the nth position of the color swatch button.
+	 * E.g., if you wanted to pick the second color, pass 2 for the nthPosition value.
+	 *
+	 * @param {number} nthPosition The nth position (index starting at 1) for the color to select.
+	 */
+	async selectInitialBackgroundColorByNthPosition( nthPosition ) {
+		const buttonLocator = By.css(
+			`${ this.blockID } .components-circular-option-picker__option-wrapper:nth-child(${ nthPosition }) button`
+		);
+		await driverHelper.clickWhenClickable( this.driver, buttonLocator );
+	}
+
+	/**
+	 * Focus the parent Cover block by clicking on its background.
+	 *
+	 * Focusing the parent block is surprisingly hard on a Cover because there's always some kind of text
+	 * in the middle of the block which will take focus when clicked. We can't use keyboard navigation because it
+	 * doesn't cause the block toolbar to appear. This method focuses the parent Cover by clicking on the background
+	 * between the middle and bottom of the block to avoid the middle text and any open toolbars.
+	 */
+	async focusBlock() {
+		const coverElement = await this.driver.findElement( this.expectedElementSelector );
+		const coverHeight = ( await coverElement.getRect() ).height;
+		// we're splitting the difference between the middle of the cover and the bottom
+		// we can move this even more aggressively toward 0.50 in the future if needed
+		const verticalOffsetBelowCenter = -parseInt( coverHeight * 0.25 );
+		const actions = this.driver.actions();
+		await actions
+			.move( { origin: coverElement, y: verticalOffsetBelowCenter } )
+			.press()
+			.release()
+			.perform();
+
+		// make sure it actually gets focus
+		await driverHelper.waitUntilLocatedAndVisible(
+			this.driver,
+			By.css( `${ this.blockID }.block-editor-block-list__block.is-selected` )
+		);
 	}
 }

--- a/test/e2e/lib/gutenberg/blocks/cover-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/cover-block-component.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import * as driverHelper from '../../driver-helper';
+import GutenbergBlockComponent from './gutenberg-block-component';
+
+export default class CoverBlockComponent extends GutenbergBlockComponent {
+	static blockTitle = 'Cover';
+
+	async setTitleText( text ) {
+		const paragraphLocator = By.css( `${ this.blockID } p.block-editor-rich-text__editable` );
+		await driverHelper.waitUntilLocatedAndVisible( this.driver, paragraphLocator );
+		const paragraphElement = await this.driver.findElement( paragraphLocator );
+		await paragraphElement.sendKeys( text );
+	}
+
+	async getImageSrc() {
+		const imgElement = await this.driver.findElement(
+			By.css( `${ this.blockID } img.wp-block-cover__image-background` )
+		);
+		return ( await imgElement.getAttribute( 'src' ) ) || '';
+	}
+}

--- a/test/e2e/lib/gutenberg/blocks/index.js
+++ b/test/e2e/lib/gutenberg/blocks/index.js
@@ -17,3 +17,5 @@ export { default as GutenbergBlockComponent } from './gutenberg-block-component'
 export { default as MarkdownBlockComponent } from './markdown-block-component';
 export { default as SimplePaymentBlockComponent } from './payment-block-component';
 export { PremiumContentBlockComponent } from './premium-content-block-component';
+export { default as CoverBlockComponent } from './cover-block-component';
+export { default as PullquoteBlockComponent } from './pullquote-block-component';

--- a/test/e2e/lib/gutenberg/blocks/pullquote-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/pullquote-block-component.js
@@ -6,27 +6,64 @@ import { By } from 'selenium-webdriver';
 /**
  * Internal dependencies
  */
-import * as driverHelper from '../../driver-helper';
 import GutenbergBlockComponent from './gutenberg-block-component';
 
+/**
+ * POM class to represent a Pullquote block.
+ */
 export default class PullquoteBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Pullquote';
 
-	async setTextInFauxTextbox( text, textboxLocator ) {
-		await driverHelper.waitUntilLocatedAndVisible( this.driver, textboxLocator );
+	_quoteLocator() {
+		return By.css( `${ this.blockID } [aria-label='Pullquote text']` );
+	}
+
+	_citationLocator() {
+		return By.css( `${ this.blockID } [aria-label='Pullquote citation text']` );
+	}
+
+	async _setTextInFakeTextbox( text, textboxLocator ) {
 		// These aren't real textboxes, so driverHelpers.setWhenSettable will NOT work
 		// So we have to get the element and send the keys directly
 		const fauxTextboxElement = await this.driver.findElement( textboxLocator );
 		await fauxTextboxElement.sendKeys( text );
 	}
 
+	/**
+	 * Set the text in the quote part of the Pullquote. Does not clear existing text.
+	 *
+	 * @param {string} quoteText Text to add
+	 */
 	async setQuote( quoteText ) {
-		const quoteLocator = By.css( `${ this.blockID } [aria-label='Pullquote text']` );
-		await this.setTextInFauxTextbox( quoteText, quoteLocator );
+		await this._setTextInFakeTextbox( quoteText, this._quoteLocator() );
 	}
 
+	/**
+	 * Set the text in the citation part of the Pullquote. Does not clear existing text.
+	 *
+	 * @param {string} citationText Text to add
+	 */
 	async setCitation( citationText ) {
-		const citationLocator = By.css( `${ this.blockID } [aria-label='Pullquote citation text']` );
-		await this.setTextInFauxTextbox( citationText, citationLocator );
+		await this._setTextInFakeTextbox( citationText, this._citationLocator() );
+	}
+
+	/**
+	 * Gets the text currently set in the quote part of the Pullquote.
+	 *
+	 * @returns {string} The current quote text
+	 */
+	async getQuoteText() {
+		const quoteWrapperElement = await this.driver.findElement( this._quoteLocator() );
+		return await quoteWrapperElement.getText();
+	}
+
+	/**
+	 * Gets the text currently set in the citation part of the Pullquote.
+	 *
+	 * @returns {string} The current citation text
+	 */
+	async getCitationText() {
+		const quoteWrapperElement = await this.driver.findElement( this._citationLocator() );
+		return await quoteWrapperElement.getText();
 	}
 }

--- a/test/e2e/lib/gutenberg/blocks/pullquote-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/pullquote-block-component.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import * as driverHelper from '../../driver-helper';
+import GutenbergBlockComponent from './gutenberg-block-component';
+
+export default class PullquoteBlockComponent extends GutenbergBlockComponent {
+	static blockTitle = 'Pullquote';
+
+	async setTextInFauxTextbox( text, textboxLocator ) {
+		await driverHelper.waitUntilLocatedAndVisible( this.driver, textboxLocator );
+		// These aren't real textboxes, so driverHelpers.setWhenSettable will NOT work
+		// So we have to get the element and send the keys directly
+		const fauxTextboxElement = await this.driver.findElement( textboxLocator );
+		await fauxTextboxElement.sendKeys( text );
+	}
+
+	async setQuote( quoteText ) {
+		const quoteLocator = By.css( `${ this.blockID } [aria-label='Pullquote text']` );
+		await this.setTextInFauxTextbox( quoteText, quoteLocator );
+	}
+
+	async setCitation( citationText ) {
+		const citationLocator = By.css( `${ this.blockID } [aria-label='Pullquote citation text']` );
+		await this.setTextInFauxTextbox( citationText, citationLocator );
+	}
+}

--- a/test/e2e/lib/gutenberg/blocks/shared-block-flows/media-block-flows.js
+++ b/test/e2e/lib/gutenberg/blocks/shared-block-flows/media-block-flows.js
@@ -25,7 +25,7 @@ export default class MediaBlockFlows {
 	 * @param {Object} fileDetails A MediaHelper file details object for the image file to upload
 	 */
 	async uploadImage( parentBlockSelector, fileDetails ) {
-		await driverHelper.waitUntilLocatedAndVisible(
+		await driverHelper.waitUntilElementLocatedAndVisible(
 			this.driver,
 			By.css( `${ parentBlockSelector } .components-form-file-upload` )
 		);
@@ -35,7 +35,7 @@ export default class MediaBlockFlows {
 		);
 		await filePathInput.sendKeys( fileDetails.file );
 
-		await driverHelper.waitTillNotPresent(
+		await driverHelper.waitUntilElementNotLocated(
 			this.driver,
 			By.css( `${ parentBlockSelector } .components-spinner` )
 		);
@@ -49,7 +49,7 @@ export default class MediaBlockFlows {
 	async waitForMediaLibraryDialog() {
 		// It's in top iframe, not the editor's!
 		await this.driver.switchTo().defaultContent();
-		await driverHelper.waitUntilLocatedAndVisible(
+		await driverHelper.waitUntilElementLocatedAndVisible(
 			this.driver,
 			By.css( '.dialog__content .media-library' )
 		);
@@ -67,7 +67,7 @@ export default class MediaBlockFlows {
 			By.css( '.media-library__upload-button-input' )
 		);
 		await filePathInput.sendKeys( fileDetails.file );
-		await driverHelper.waitTillNotPresent(
+		await driverHelper.waitUntilElementNotLocated(
 			this.driver,
 			By.css( '.media-library__list-item.is-selected.is-transient' )
 		);
@@ -76,7 +76,7 @@ export default class MediaBlockFlows {
 			this.driver,
 			By.css( 'button[data-e2e-button=confirm]' )
 		);
-		await driverHelper.waitTillNotPresent(
+		await driverHelper.waitUntilElementNotLocated(
 			this.driver,
 			By.css( '.dialog__content .media-library' )
 		);

--- a/test/e2e/lib/gutenberg/blocks/shared-block-flows/media-block-flows.js
+++ b/test/e2e/lib/gutenberg/blocks/shared-block-flows/media-block-flows.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import * as driverHelper from '../../../driver-helper';
+
+export default class MediaBlockFlows {
+	constructor( driver, blockComponent ) {
+		this.driver = driver;
+		this.blockComponent = blockComponent;
+	}
+
+	async uploadImage( fileDetails ) {
+		await driverHelper.waitUntilLocatedAndVisible(
+			this.driver,
+			By.css( `${ this.blockComponent.blockID } .components-form-file-upload` )
+		);
+		const filePathInput = await this.driver.findElement(
+			By.css( `${ this.blockComponent.blockID } .components-form-file-upload input[type="file"]` )
+		);
+		await filePathInput.sendKeys( fileDetails.file );
+		return await driverHelper.waitTillNotPresent(
+			this.driver,
+			By.css( `${ this.blockComponent.blockID } .components-spinner` )
+		);
+	}
+}

--- a/test/e2e/lib/gutenberg/blocks/shared-block-flows/media-block-flows.js
+++ b/test/e2e/lib/gutenberg/blocks/shared-block-flows/media-block-flows.js
@@ -7,25 +7,80 @@ import { By } from 'selenium-webdriver';
  * Internal dependencies
  */
 import * as driverHelper from '../../../driver-helper';
+import GutenbergEditorComponent from '../../../gutenberg/gutenberg-editor-component';
 
+/**
+ * A flow class for the shared set of actions among media-based blocks. For future growth, anything
+ * specific to a block should go in that block POM class, and anything shared can be added here to keep it DRY.
+ */
 export default class MediaBlockFlows {
-	constructor( driver, blockComponent ) {
+	constructor( driver ) {
 		this.driver = driver;
-		this.blockComponent = blockComponent;
 	}
 
-	async uploadImage( fileDetails ) {
+	/**
+	 * Flow for directly uploading an image to image-based blocks (e.g. Cover, Image) using the hidden input field.
+	 *
+	 * @param {string} parentBlockSelector A CSS selector that identifies the parent block element
+	 * @param {Object} fileDetails A MediaHelper file details object for the image file to upload
+	 */
+	async uploadImage( parentBlockSelector, fileDetails ) {
 		await driverHelper.waitUntilLocatedAndVisible(
 			this.driver,
-			By.css( `${ this.blockComponent.blockID } .components-form-file-upload` )
+			By.css( `${ parentBlockSelector } .components-form-file-upload` )
 		);
+
 		const filePathInput = await this.driver.findElement(
-			By.css( `${ this.blockComponent.blockID } .components-form-file-upload input[type="file"]` )
+			By.css( `${ parentBlockSelector } .components-form-file-upload input[type="file"]` )
 		);
 		await filePathInput.sendKeys( fileDetails.file );
-		return await driverHelper.waitTillNotPresent(
+
+		await driverHelper.waitTillNotPresent(
 			this.driver,
-			By.css( `${ this.blockComponent.blockID } .components-spinner` )
+			By.css( `${ parentBlockSelector } .components-spinner` )
 		);
+	}
+
+	/**
+	 * Wait for the Media Library dialog to open in the editor. The workflows to open the Media Library
+	 * dialog vary a lot between blocks, but become shared once the dialog is open, which is why the flows
+	 * start at that point.
+	 */
+	async waitForMediaLibraryDialog() {
+		// It's in top iframe, not the editor's!
+		await this.driver.switchTo().defaultContent();
+		await driverHelper.waitUntilLocatedAndVisible(
+			this.driver,
+			By.css( '.dialog__content .media-library' )
+		);
+	}
+
+	/**
+	 * Interact with an open Media Library dialog in the editor to upload and insert an image.
+	 *
+	 * @param {Object} fileDetails A MediaHelper file details object for the image file to upload
+	 */
+	async uploadAndSelectImageInMediaLibraryDialog( fileDetails ) {
+		await this.waitForMediaLibraryDialog();
+
+		const filePathInput = await this.driver.findElement(
+			By.css( '.media-library__upload-button-input' )
+		);
+		await filePathInput.sendKeys( fileDetails.file );
+		await driverHelper.waitTillNotPresent(
+			this.driver,
+			By.css( '.media-library__list-item.is-selected.is-transient' )
+		);
+
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( 'button[data-e2e-button=confirm]' )
+		);
+		await driverHelper.waitTillNotPresent(
+			this.driver,
+			By.css( '.dialog__content .media-library' )
+		);
+		// return back to iframe in the editor
+		await GutenbergEditorComponent.Expect( this.driver );
 	}
 }

--- a/test/e2e/lib/gutenberg/gutenberg-block-toolbar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-block-toolbar-component.js
@@ -1,0 +1,113 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import * as driverHelper from '../driver-helper';
+import * as driverManager from '../driver-manager';
+
+import AsyncBaseContainer from '../async-base-container';
+import GutenbergPopoverMenuComponent from './gutenberg-popover-menu-component';
+
+/**
+ * POM class for the block editing toolbar re-used throughout the Gutenberg editor
+ */
+export default class GutenbergBlockToolbarComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		// Must account for the mobile toolbar too!
+		let toolbarSelector;
+		if ( driverManager.currentScreenSize() === 'mobile' ) {
+			toolbarSelector = '.edit-post-header-toolbar__block-toolbar';
+		} else {
+			toolbarSelector = '.block-editor-block-contextual-toolbar';
+		}
+
+		super( driver, By.css( toolbarSelector ) );
+		this.toolbarSelector = toolbarSelector;
+	}
+
+	/**
+	 * Expect the block toolbar to be found in the DOM within the standard timeout window, returning
+	 * an instance of this class to interact with the toolbar.
+	 * NOTE: the caller must take the necessary steps to ensure the toolbar will appear before calling Expect.
+	 * The requirements to make the toolbar appear are too different among blocks to standardize here.
+	 *
+	 * @param {Object} driver Instance of Selenium WebDriver
+	 * @returns An instance of this class
+	 */
+	static async Expect( driver ) {
+		const page = new this( driver );
+		await page._expectInit();
+		return page;
+	}
+
+	/**
+	 * Click a button in the toolbar by the text of the button. E.g. "Add Media"
+	 *
+	 * @param {string} buttonText Button text to match
+	 */
+	async clickToolbarButtonByText( buttonText ) {
+		await driverHelper.selectElementByText(
+			this.driver,
+			By.css( `${ this.toolbarSelector } button.components-button` ),
+			buttonText
+		);
+	}
+
+	/**
+	 * Select an option from a popover menu opened from the toolbar by the CSS class of the popover menu item.
+	 * This pass-through method is added here for convenience so popover menu workflows can be completed all from
+	 * the toolbar component class.
+	 *
+	 * @param {string} cssClass Target CSS class of the popover menu item
+	 */
+	async selectDropdownOptionByCssClass( cssClass ) {
+		const popoverMenuComponent = await GutenbergPopoverMenuComponent.Expect( this.driver );
+		await popoverMenuComponent.selectOptionByCssClass( cssClass );
+	}
+
+	/**
+	 * Select an option from a popover menu opened from the toolbar by the text of the popover menu item.
+	 * This pass-through method is added here for convenience so popover menu workflows can be completed all from
+	 * the toolbar component class.
+	 *
+	 * @param {*} text Target text of the popover menu item
+	 */
+	async selectDropdownOptionByText( text ) {
+		const popoverMenuComponent = await GutenbergPopoverMenuComponent.Expect( this.driver );
+		await popoverMenuComponent.selectOptionByText( text );
+	}
+
+	/**
+	 * Click the toolbar button shared among blocks for transforming the block to a new type
+	 */
+	async openBlockTransformMenu() {
+		const openMenuButtonLocator = By.css(
+			` ${ this.toolbarSelector } .block-editor-block-switcher button`
+		);
+		await driverHelper.clickWhenClickable( this.driver, openMenuButtonLocator );
+		// make sure it opens!
+		await GutenbergPopoverMenuComponent.Expect( this.driver );
+	}
+
+	/**
+	 * Transform the current block for this toolbar to a new block type using the toolbar transform button.
+	 * The new block type is targeted from the class suffix of that option in the popover menu, which is usually
+	 * just the name of the new block type.
+	 *
+	 * @param {string} targetBlockButtonClassSuffix suffix of the target block type class in the popover menu (e.g. 'columns')
+	 */
+	async transformBlockToNewType( targetBlockButtonClassSuffix ) {
+		const targetButtonCssClass = `editor-block-list-item-${ targetBlockButtonClassSuffix }`;
+		await this.openBlockTransformMenu();
+		await this.selectDropdownOptionByCssClass( targetButtonCssClass );
+	}
+
+	// Future possible expansions:
+	// - add aria-label based toolbar button clicking
+	// - add methods for shared menu buttons, like the more options button
+	// - add even more handling for popover/dropdown menu based buttons
+}

--- a/test/e2e/lib/gutenberg/gutenberg-block-toolbar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-block-toolbar-component.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { By } from 'selenium-webdriver';
+import { By, WebDriver } from 'selenium-webdriver';
 
 /**
  * Internal dependencies
@@ -35,7 +35,7 @@ export default class GutenbergBlockToolbarComponent extends AsyncBaseContainer {
 	 * NOTE: the caller must take the necessary steps to ensure the toolbar will appear before calling Expect.
 	 * The requirements to make the toolbar appear are too different among blocks to standardize here.
 	 *
-	 * @param {Object} driver Instance of Selenium WebDriver
+	 * @param {WebDriver} driver Instance of Selenium WebDriver
 	 * @returns An instance of this class
 	 */
 	static async Expect( driver ) {
@@ -74,7 +74,7 @@ export default class GutenbergBlockToolbarComponent extends AsyncBaseContainer {
 	 * This pass-through method is added here for convenience so popover menu workflows can be completed all from
 	 * the toolbar component class.
 	 *
-	 * @param {*} text Target text of the popover menu item
+	 * @param {string} text Target text of the popover menu item
 	 */
 	async selectDropdownOptionByText( text ) {
 		const popoverMenuComponent = await GutenbergPopoverMenuComponent.Expect( this.driver );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -389,6 +389,12 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			case 'Premium Content':
 				blockSettings = { blockClass: 'premium-content-container' };
 				break;
+			case 'Pullquote':
+				blockSettings = { blockClass: 'pullquote' };
+				break;
+			case 'Cover':
+				blockSettings = { blockClass: 'cover' };
+				break;
 		}
 
 		return { ...defaultSettings, ...blockSettings };

--- a/test/e2e/lib/gutenberg/gutenberg-popover-menu-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-popover-menu-component.js
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import * as driverHelper from '../driver-helper';
+import AsyncBaseContainer from '../async-base-container';
+
+/**
+ * POM class for interacting with popover menus in the Gutenberg editor.
+ */
+export default class GutenbergPopoverMenuComponent extends AsyncBaseContainer {
+	constructor( driver, additionalMenuSelectors ) {
+		let menuSelector = '.components-popover div[role=menu]';
+		if ( additionalMenuSelectors && additionalMenuSelectors.ariaLabel ) {
+			menuSelector += `[aria-label='${ additionalMenuSelectors.ariaLabel }']`;
+		}
+
+		if ( additionalMenuSelectors && additionalMenuSelectors.class ) {
+			menuSelector += `.${ additionalMenuSelectors.class }`;
+		}
+
+		super( driver, By.css( menuSelector ) );
+		this.menuSelector = menuSelector;
+	}
+
+	/**
+	 * Expect the targeted popover menu to appear within the standard timeout time. All popover menus
+	 * have the same basic DOM structure. However, certain popover menus can have different aria-labels
+	 * and additional classes. So if you want to ensure a specific popover is open, use additionalMenuSelectors
+	 * to be more specific.
+	 *
+	 * @param {Object} driver Instance of the Selenium WebDriver
+	 * @param {{ariaLabel: string, class: string}} additionalMenuSelectors Optional object to specify more
+	 * specific selectors to ensure a specific popover menu is open.
+	 * @returns An instance of this class
+	 */
+	static async Expect( driver, additionalMenuSelectors ) {
+		const page = new this( driver, additionalMenuSelectors );
+		await page._expectInit();
+		return page;
+	}
+
+	/**
+	 * Select option from popover menu by text
+	 *
+	 * @param {string} text text to match in popover menu option
+	 */
+	async selectOptionByText( text ) {
+		await driverHelper.selectElementByText(
+			this.driver,
+			// using menuitem role over button because there are some nested buttons in style previews
+			// using partial match (*) to account for 'menuitemradio' role
+			By.css( `${ this.menuSelector } [role*=menuitem]` ),
+			text
+		);
+	}
+
+	/**
+	 * Select option from popover menu by the class attached to the menu item element
+	 *
+	 * @param {string} cssClass Class to match in popover menu item. No need to include period prefix.
+	 */
+	async selectOptionByCssClass( cssClass ) {
+		// worth being extra safe since it needs to go right into a selector
+		if ( ! cssClass.startsWith( '.' ) ) {
+			cssClass = `.${ cssClass }`;
+		}
+
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( `${ this.menuSelector } [role*=menuitem]${ cssClass }` )
+		);
+	}
+
+	/**
+	 * Wait until the popover menu is gone
+	 */
+	async waitUntilPopoverIsGone() {
+		await driverHelper.waitTillNotPresent( this.driver, By.css( this.menuSelector ) );
+	}
+}

--- a/test/e2e/lib/gutenberg/gutenberg-popover-menu-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-popover-menu-component.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { By } from 'selenium-webdriver';
+import { By, WebDriver } from 'selenium-webdriver';
 
 /**
  * Internal dependencies
@@ -33,8 +33,8 @@ export default class GutenbergPopoverMenuComponent extends AsyncBaseContainer {
 	 * and additional classes. So if you want to ensure a specific popover is open, use additionalMenuSelectors
 	 * to be more specific.
 	 *
-	 * @param {Object} driver Instance of the Selenium WebDriver
-	 * @param {{ariaLabel: string, class: string}} additionalMenuSelectors Optional object to specify more
+	 * @param {WebDriver} driver Instance of the Selenium WebDriver
+	 * @param {{ariaLabel?: string, class?: string}} [additionalMenuSelectors=undefined] Optional object to specify more
 	 * specific selectors to ensure a specific popover menu is open.
 	 * @returns An instance of this class
 	 */
@@ -80,6 +80,6 @@ export default class GutenbergPopoverMenuComponent extends AsyncBaseContainer {
 	 * Wait until the popover menu is gone
 	 */
 	async waitUntilPopoverIsGone() {
-		await driverHelper.waitTillNotPresent( this.driver, By.css( this.menuSelector ) );
+		await driverHelper.waitUntilElementNotLocated( this.driver, By.css( this.menuSelector ) );
 	}
 }

--- a/test/e2e/lib/pages/view-post-page.js
+++ b/test/e2e/lib/pages/view-post-page.js
@@ -90,6 +90,11 @@ export default class ViewPostPage extends AsyncBaseContainer {
 			} );
 	}
 
+	async hasImageWithFileName( fileName ) {
+		const imageElement = await this.driver.findElement( By.css( `img[src*='${ fileName }']` ) );
+		return await driverHelper.imageVisible( this.driver, imageElement );
+	}
+
 	async leaveAComment( comment ) {
 		const commentButtonSelector = By.css( '#comment-submit' );
 		const commentSubmittingSelector = By.css( '#comment-form-submitting' );

--- a/test/e2e/specs-gutenberg/blocks/wp-gutenberg-cover-block-spec.js
+++ b/test/e2e/specs-gutenberg/blocks/wp-gutenberg-cover-block-spec.js
@@ -1,0 +1,125 @@
+/**
+ * External dependencies
+ */
+import assert from 'assert';
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import LoginFlow from '../../lib/flows/login-flow.js';
+
+import GutenbergEditorComponent from '../../lib/gutenberg/gutenberg-editor-component';
+import PostPreviewComponent from '../../lib/components/post-preview-component';
+import ViewPostPage from '../../lib/pages/view-post-page.js';
+import MediaBlockFlows from '../../lib/gutenberg/blocks/shared-block-flows/media-block-flows';
+
+import * as driverManager from '../../lib/driver-manager';
+import * as dataHelper from '../../lib/data-helper';
+import * as mediaHelper from '../../lib/media-helper';
+import * as driverHelper from '../../lib/driver-helper';
+import CoverBlockComponent from '../../lib/gutenberg/blocks/cover-block-component.js';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+const host = dataHelper.getJetpackHost();
+const gutenbergUser =
+	process.env.GUTENBERG_EDGE === 'true' ? 'gutenbergSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
+
+describe( `[${ host }] Calypso Gutenberg Editor: Cover Block (${ screenSize })`, function () {
+	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
+
+	describe( 'Full workflow to preview and publish post with Cover @parallel', function () {
+		const coverTitleText = 'Witty Cover Text';
+		let imageFileDetails;
+		let coverBlockId;
+
+		before( async function () {
+			imageFileDetails = await mediaHelper.createFile();
+		} );
+
+		step( 'Can log in', async function () {
+			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			await this.loginFlow.loginAndStartNewPost( null, true );
+		} );
+
+		step( 'Can add Cover to post', async function () {
+			const editorComponent = await GutenbergEditorComponent.Expect( driver );
+			coverBlockId = await editorComponent.addBlock( CoverBlockComponent.blockTitle );
+		} );
+
+		step( 'Can upload an image to the Cover', async function () {
+			const coverComponent = await CoverBlockComponent.Expect( driver, coverBlockId );
+			const mediaBlockFlows = new MediaBlockFlows( driver, coverComponent );
+			await mediaBlockFlows.uploadImage( imageFileDetails );
+			const imageSrcInEditor = await coverComponent.getImageSrc();
+			assert(
+				imageSrcInEditor.includes( imageFileDetails.fileName ),
+				'The uploaded image did not have expected file name in src attribute'
+			);
+		} );
+
+		step( 'Can add title text to Cover image', async function () {
+			const editorComponent = await GutenbergEditorComponent.Expect( driver );
+			const coverComponent = await CoverBlockComponent.Expect( driver, coverBlockId );
+			await coverComponent.setTitleText( coverTitleText );
+			const editorContent = await editorComponent.getContent();
+			assert(
+				editorContent.includes( coverTitleText ),
+				'The typed Cover title text was not found in the editor'
+			);
+		} );
+
+		step( 'Can see image and title text in preview', async function () {
+			const editorComponent = await GutenbergEditorComponent.Expect( driver );
+			await editorComponent.ensureSaved();
+			await editorComponent.launchPreview();
+
+			const previewComponent = await PostPreviewComponent.Expect( driver );
+			const previewContent = await previewComponent.postContent();
+			assert(
+				previewContent.includes( coverTitleText ),
+				'The Cover title text was not found in the preview'
+			);
+			assert(
+				await previewComponent.hasImageWithFileName( imageFileDetails.fileName ),
+				'The Cover image was not found in the preview'
+			);
+		} );
+
+		step( 'Can close post preview', async function () {
+			const previewComponent = await PostPreviewComponent.Expect( driver );
+			await previewComponent.close();
+		} );
+
+		step( 'Can see image and title text in published post', async function () {
+			const editorComponent = await GutenbergEditorComponent.Expect( driver );
+			await editorComponent.publish( { visit: true } );
+
+			const viewPostPage = await ViewPostPage.Expect( driver );
+			const postContent = await viewPostPage.postContent();
+			assert(
+				postContent.includes( coverTitleText ),
+				'The Cover title text was not found in the published post'
+			);
+			assert(
+				viewPostPage.hasImageWithFileName( imageFileDetails.fileName ),
+				'The Cover image was not found in the published post'
+			);
+		} );
+
+		after( async function () {
+			if ( imageFileDetails ) {
+				await mediaHelper.deleteFile( imageFileDetails );
+			}
+			await driverHelper.acceptAlertIfPresent( driver );
+		} );
+	} );
+} );

--- a/test/e2e/specs-gutenberg/blocks/wp-gutenberg-cover-block-spec.js
+++ b/test/e2e/specs-gutenberg/blocks/wp-gutenberg-cover-block-spec.js
@@ -150,7 +150,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Cover Block (${ screenSize })`,
 			const primaryColorPosition = 1;
 			await coverComponent.selectInitialBackgroundColorByNthPosition( primaryColorPosition );
 			// Make sure it actually sets a background by waiting until block has updated class
-			await driverHelper.waitUntilLocatedAndVisible(
+			await driverHelper.waitUntilElementLocatedAndVisible(
 				driver,
 				By.css( `${ coverComponent.blockID }.has-primary-background-color` )
 			);

--- a/test/e2e/specs-gutenberg/blocks/wp-gutenberg-pullquote-block-spec.js
+++ b/test/e2e/specs-gutenberg/blocks/wp-gutenberg-pullquote-block-spec.js
@@ -144,7 +144,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pullquote Block (${ screenSize 
 
 			// we can't just look at block ID, because it actually stays the same between transforms!
 			// so specifically, we want to make sure a Paragraph block with that ID does not exist anymore
-			await driverHelper.waitTillNotPresent(
+			await driverHelper.waitUntilElementNotLocated(
 				driver,
 				By.css( `p#${ blockId }.wp-block-paragraph` )
 			);
@@ -177,7 +177,10 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pullquote Block (${ screenSize 
 
 			// once again, the block ID will persist!
 			// so we must be granular and look for a Pullquote specifically to disappear
-			await driverHelper.waitTillNotPresent( driver, By.css( `${ blockId }.wp-block-pullquote` ) );
+			await driverHelper.waitUntilElementNotLocated(
+				driver,
+				By.css( `${ blockId }.wp-block-pullquote` )
+			);
 		} );
 
 		step( 'Both the quote and citation text are kept across transform', async function () {

--- a/test/e2e/specs-gutenberg/blocks/wp-gutenberg-pullquote-block-spec.js
+++ b/test/e2e/specs-gutenberg/blocks/wp-gutenberg-pullquote-block-spec.js
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import assert from 'assert';
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import LoginFlow from '../../lib/flows/login-flow.js';
+
+import GutenbergEditorComponent from '../../lib/gutenberg/gutenberg-editor-component';
+import PullquoteBlockComponent from '../../lib/gutenberg/blocks/pullquote-block-component';
+import PostPreviewComponent from '../../lib/components/post-preview-component';
+import ViewPostPage from '../../lib/pages/view-post-page.js';
+
+import * as driverManager from '../../lib/driver-manager';
+import * as dataHelper from '../../lib/data-helper';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+const host = dataHelper.getJetpackHost();
+const gutenbergUser =
+	process.env.GUTENBERG_EDGE === 'true' ? 'gutenbergSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
+
+describe( `[${ host }] Calypso Gutenberg Editor: Pullquote Block (${ screenSize })`, function () {
+	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( 'Start browser', async function () {
+		this.timeout( startBrowserTimeoutMS );
+		driver = await driverManager.startBrowser();
+	} );
+
+	describe( 'Full workflow to preview and publish post with Pullquote @parallel', function () {
+		let pullquoteBlockId;
+
+		const quoteText =
+			'The problem with quotes on the Internet is that it is hard to verify their authenticity.';
+		const citationText = 'Abraham Lincoln';
+
+		step( 'Can log in', async function () {
+			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			await this.loginFlow.loginAndStartNewPost( null, true );
+		} );
+
+		step( 'Can add pullquote to post', async function () {
+			const editorComponent = await GutenbergEditorComponent.Expect( driver );
+			pullquoteBlockId = await editorComponent.addBlock( PullquoteBlockComponent.blockTitle );
+		} );
+
+		step( 'Can add quote text to pullquote', async function () {
+			const editorComponent = await GutenbergEditorComponent.Expect( driver );
+			const pullquoteComponent = await PullquoteBlockComponent.Expect( driver, pullquoteBlockId );
+			await pullquoteComponent.setQuote( quoteText );
+			const editorContent = await editorComponent.getContent();
+			assert(
+				editorContent.includes( quoteText ),
+				'The typed quote text was not found in the editor'
+			);
+		} );
+
+		step( 'Can add citation text to pullquote', async function () {
+			const editorComponent = await GutenbergEditorComponent.Expect( driver );
+			const pullquoteComponent = await PullquoteBlockComponent.Expect( driver, pullquoteBlockId );
+			await pullquoteComponent.setCitation( citationText );
+			const editorContent = await editorComponent.getContent();
+			assert(
+				editorContent.includes( citationText ),
+				'The typed citation text was not found in the editor'
+			);
+		} );
+
+		step( 'Can see quote and citation in preview', async function () {
+			const editorComponent = await GutenbergEditorComponent.Expect( driver );
+			await editorComponent.ensureSaved();
+			await editorComponent.launchPreview();
+
+			const previewComponent = await PostPreviewComponent.Expect( driver );
+			const previewContent = await previewComponent.postContent();
+			assert( previewContent.includes( quoteText ), 'The quote text was not found in the preview' );
+			assert(
+				previewContent.includes( citationText ),
+				'The citation text was not found in the preview'
+			);
+		} );
+
+		step( 'Can close post preview', async function () {
+			const previewComponent = await PostPreviewComponent.Expect( driver );
+			await previewComponent.close();
+		} );
+
+		step( 'Can see quote and citation in published post', async function () {
+			const editorComponent = await GutenbergEditorComponent.Expect( driver );
+			await editorComponent.publish( { visit: true } );
+
+			const viewPostPage = await ViewPostPage.Expect( driver );
+			const postContent = await viewPostPage.postContent();
+			assert(
+				postContent.includes( quoteText ),
+				'The quote text was not found in the published post'
+			);
+			assert(
+				postContent.includes( citationText ),
+				'The citation text was not found in the published post'
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds some E2E coverage for Pullquote and Cover blocks in the editor. Cases focus on taking the blocks through preview and publish, and various methods of data population and transformation.

New specs:
- `specs-gutenberg/blocks/wp-gutenberg-cover-block-spec.js`
- `specs-gutenberg/blocks/wp-gutenberg-pullquote-block-spec.js`

Sample output of the new scripts:

    [WPCOM] Calypso Gutenberg Editor: Pullquote Block (mobile)

    Full workflow to preview and publish post with Pullquote @parallel
    Logging in as e2eflowtestinggutenbergsimple
      ✓ Can log in (28547ms)
      ✓ Can add pullquote to post (4195ms)
      ✓ Can add quote text to pullquote (2661ms)
      ✓ Can add citation text to pullquote (606ms)
      ✓ Can see quote and citation in preview (5420ms)
      ✓ Can close post preview (2278ms)
      ✓ Can see quote and citation in published post (6275ms)

    Block transforms to and from Pullquote
    Logging in as e2eflowtestinggutenbergsimple
      ✓ Can log in (29206ms)
      ✓ Can add text to Paragraph (2623ms)
      ✓ Can transform Paragraph to Pullquote (3576ms)
      ✓ Transformed Pullquote has the text as its quote text (40ms)
      ✓ Can add citation to new transformed Pullquote (473ms)
      ✓ Can transform the Pullquote back into Paragraph block(s) (3644ms)
      ✓ Both the quote and citation text are kept across transform (77ms)

    14 passing (2m)


    [WPCOM] Calypso Gutenberg Editor: Cover Block (desktop)

    Full workflow to preview and publish post with Cover @parallel
    Logging in as e2eflowtestinggutenbergsimple
      ✓ Can log in (27390ms)
      ✓ Can add Cover to post (4429ms)
      ✓ Can upload an image to the Cover (4526ms)
      ✓ Can add title text to Cover image (752ms)
      ✓ Can see image and title text in preview (8232ms)
      ✓ Can close post preview (2306ms)
      ✓ Can see image and title text in published post (6740ms)

    Other ways to set Cover background @parallel
    Logging in as e2eflowtestinggutenbergsimple
      ✓ Can log in (29399ms)
      ✓ Can add Cover to post (4343ms)
      ✓ Can use initial swatches buttons to set a background color (611ms)
      ✓ Can use Add Media toolbar button to launch Media Library (1430ms)
      ✓ Can use Media Library to insert background image (6836ms)

    12 passing (2m)

#### Testing instructions

Run the specs:

- [ ] `BROWSERSIZE=desktop node_modules/.bin/mocha specs-gutenberg/blocks/wp-gutenberg-cover-block-spec.js`
- [ ] `BROWSERSIZE=desktop node_modules/.bin/mocha specs-gutenberg/blocks/wp-gutenberg-pullquote-block-spec.js`
- [ ] `BROWSERSIZE=mobile node_modules/.bin/mocha specs-gutenberg/blocks/wp-gutenberg-cover-block-spec.js`
- [ ] `BROWSERSIZE=mobile node_modules/.bin/mocha specs-gutenberg/blocks/wp-gutenberg-pullquote-block-spec.js`

##### Questions / Looking for feedback

To manage the scope of the PR, I tended towards being cautious towards refactoring other shared library code. Let me know if you think it would be worth going after those refactors a bit more aggressively in this PR. Namely, I'm 👀 at the existing `image-block-component.js`, which I pulled a lot of the shared functionality out into `media-block-flows.js`, but didn't cutover at the moment.  

Speaking of which, pulling out the shared media block behavior to a separate flows class seemed the best option because the inheritance tree was already getting pretty long on the block components, but I waffled back and forth a lot on what was the best way to do that. So let me know if the current implementation feels clunky or doesn't seem like it will grow well!
