### PR TITLE
E2E: Remove unused waitForInfiniteListLoad helper

### DIFF
--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -312,17 +312,21 @@ export function unsetCheckbox( driver, locator ) {
 }
 
 /**
- * Check whether an image is actually visible - that is rendered to the screen - not just having a reference in the DOM
+ * Check whether an image element is actually visible - that is rendered to the
+ * screen - not just having a reference in the DOM.
  *
- * @param {object} driver - Browser context in which to search
- * @param {object} webElement - Element to search for
- * @returns {Promise} - Resolved when the script is done executing
+ * @param {WebDriver} driver The parent WebDriver instance
+ * @param {WebElement} element The image element
+ * @returns {Promise<boolean>} A promise that will resolve with whether the
+ * image is visible or not
  */
-export function imageVisible( driver, webElement ) {
-	return driver.executeScript(
-		'return (typeof arguments[0].naturalWidth!="undefined" && arguments[0].naturalWidth>0)',
-		webElement
-	);
+export async function isImageVisible( driver, element ) {
+	const tagName = await element.getTagName();
+	if ( tagName !== 'IMG' ) {
+		throw new Error( `Element is not an image: ${ tagName }` );
+	}
+
+	return driver.executeScript( 'return arguments[ 0 ].naturalWidth > 0', element );
 }
 
 export function checkForConsoleErrors( driver ) {

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -365,14 +365,6 @@ export function getPerformanceLogs( driver ) {
 	return driver.manage().logs().get( logging.Type.PERFORMANCE );
 }
 
-export function waitForInfiniteListLoad( driver, elementLocator, { numElements = 10 } = {} ) {
-	return driver.wait( function () {
-		return driver.findElements( elementLocator ).then( ( elements ) => {
-			return elements.length >= numElements;
-		} );
-	} );
-}
-
 export async function switchToWindowByIndex( driver, index ) {
 	const currentScreenSize = driverManager.currentScreenSize();
 	const handles = await driver.getAllWindowHandles();

--- a/test/e2e/lib/pages/view-page-page.js
+++ b/test/e2e/lib/pages/view-page-page.js
@@ -60,7 +60,7 @@ export default class ViewPagePage extends AsyncBaseContainer {
 		const imageElement = await this.driver.findElement(
 			By.css( `img[alt='${ fileDetails.imageName }']` )
 		);
-		return await driverHelper.imageVisible( this.driver, imageElement );
+		return await driverHelper.isImageVisible( this.driver, imageElement );
 	}
 
 	async paymentButtonDisplayed( retries = 3 ) {

--- a/test/e2e/lib/pages/view-post-page.js
+++ b/test/e2e/lib/pages/view-post-page.js
@@ -86,7 +86,7 @@ export default class ViewPostPage extends AsyncBaseContainer {
 		return await this.driver
 			.findElement( By.css( `img[alt='${ fileDetails.imageName }']` ) )
 			.then( ( imageElement ) => {
-				return driverHelper.imageVisible( this.driver, imageElement );
+				return driverHelper.isImageVisible( this.driver, imageElement );
 			} );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove unused `waitForInfiniteListLoad` helper
* Clean up and rename `imageVisible` to `isImageVisible` helper

#### Testing instructions

All tests should pass.