### PR TITLE
Remove code for deprecated Security and Backup options

### DIFF
--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -67,14 +67,6 @@ Object.defineProperties( MORE_FEATURES_LINK, {
 	},
 } );
 
-/**
- * Plans and products that have options and can't be purchased themselves.
- */
-export const OPTIONS_JETPACK_SECURITY = 'jetpack_security';
-export const OPTIONS_JETPACK_SECURITY_MONTHLY = 'jetpack_security_monthly';
-export const OPTIONS_JETPACK_BACKUP = 'jetpack_backup';
-export const OPTIONS_JETPACK_BACKUP_MONTHLY = 'jetpack_backup_monthly';
-
 // Types of items. This determines the card UI.
 export const ITEM_TYPE_PLAN = 'item-type-plan';
 export const ITEM_TYPE_BUNDLE = 'item-type-bundle';

--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -5,6 +5,10 @@ import React, { useEffect } from 'react';
 import { find } from 'lodash';
 
 import { CompactCard } from '@automattic/components';
+import {
+	FEATURE_GOOGLE_ANALYTICS,
+	PLAN_JETPACK_SECURITY_DAILY,
+} from '@automattic/calypso-products';
 import ExternalLink from 'calypso/components/external-link';
 import SupportInfo from 'calypso/components/support-info';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -18,14 +22,10 @@ import FormAnalyticsStores from '../form-analytics-stores';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import googleIllustration from 'calypso/assets/images/illustrations/google-analytics-logo.svg';
-import { FEATURE_GOOGLE_ANALYTICS } from '@automattic/calypso-products';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
-import {
-	OPTIONS_JETPACK_SECURITY,
-	PRODUCT_UPSELLS_BY_FEATURE,
-} from 'calypso/my-sites/plans/jetpack-plans/constants';
+import { PRODUCT_UPSELLS_BY_FEATURE } from 'calypso/my-sites/plans/jetpack-plans/constants';
 
 /**
  * Style dependencies
@@ -81,21 +81,6 @@ const GoogleAnalyticsJetpackForm = ( {
 	};
 
 	const renderForm = () => {
-		const plan = OPTIONS_JETPACK_SECURITY;
-
-		const nudge = (
-			<UpsellNudge
-				description={ translate(
-					"Monitor your site's views, clicks, and other important metrics"
-				) }
-				event={ 'google_analytics_settings' }
-				feature={ FEATURE_GOOGLE_ANALYTICS }
-				plan={ plan }
-				href={ upsellHref }
-				showIcon={ true }
-				title={ nudgeTitle }
-			/>
-		);
 		return (
 			<form id="analytics" onSubmit={ handleSubmitForm }>
 				<QueryJetpackModules siteId={ siteId } />
@@ -225,7 +210,17 @@ const GoogleAnalyticsJetpackForm = ( {
 					) }
 				</CompactCard>
 				{ showUpgradeNudge && site && site.plan ? (
-					nudge
+					<UpsellNudge
+						description={ translate(
+							"Monitor your site's views, clicks, and other important metrics"
+						) }
+						event={ 'google_analytics_settings' }
+						feature={ FEATURE_GOOGLE_ANALYTICS }
+						plan={ PLAN_JETPACK_SECURITY_DAILY }
+						href={ upsellHref }
+						showIcon={ true }
+						title={ nudgeTitle }
+					/>
 				) : (
 					<CompactCard>
 						<div className="analytics site-settings__analytics">

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -21,8 +21,8 @@ import {
 	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_SECURITY_DAILY,
 } from '@automattic/calypso-products';
-import { OPTIONS_JETPACK_SECURITY } from 'calypso/my-sites/plans/jetpack-plans/constants';
 
 /**
  * Internal dependencies
@@ -198,7 +198,7 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 					/>
 				);
 				expect( comp.find( 'UpsellNudge' ) ).toHaveLength( 1 );
-				expect( comp.find( 'UpsellNudge' ).props().href ).toContain( OPTIONS_JETPACK_SECURITY );
+				expect( comp.find( 'UpsellNudge' ).props().href ).toContain( PLAN_JETPACK_SECURITY_DAILY );
 			} );
 		}
 	);

--- a/client/my-sites/site-settings/test/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-google-analytics.jsx
@@ -22,8 +22,8 @@ import {
 	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_SECURITY_DAILY,
 } from '@automattic/calypso-products';
-import { OPTIONS_JETPACK_SECURITY } from 'calypso/my-sites/plans/jetpack-plans/constants';
 
 /**
  * Internal dependencies
@@ -100,7 +100,7 @@ describe( 'UpsellNudge should get appropriate plan constant for both forms', () 
 				);
 				expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
 				expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ).props().plan ).toBe(
-					OPTIONS_JETPACK_SECURITY
+					PLAN_JETPACK_SECURITY_DAILY
 				);
 			} );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR removes code related to Backup and Security options, that were introduced at the start of the offer reset, but where discarded since.

### Testing instructions

- Check that all tests pass in this PR (or run `yarn test-client:watch client/my-sites/site-settings/test/form-google-analytics.jsx` and `yarn test-client:watch client/my-sites/site-settings/seo-settings/test/form.jsx`)
- Download the PR and run Calypso
- Visit `/marketing/traffic/:site`, and click on the nudge in the Google section (see capture below)
- Check that you're redirected to the checkout page with Security Daily monthly in cart

### Screenshots

_Nudge_
<img width="1060" alt="Screen Shot 2021-05-05 at 9 06 34 AM" src="https://user-images.githubusercontent.com/1620183/117145610-55fd9280-ad81-11eb-8d6f-1ff1c6efb99c.png">


_Checkout_
<img width="585" alt="Screen Shot 2021-05-05 at 9 06 19 AM" src="https://user-images.githubusercontent.com/1620183/117145627-5ac24680-ad81-11eb-9ccf-f405beb09bce.png">
