### PR TITLE
Remove deprecated code related to types in pricing page

### DIFF
--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -67,14 +67,6 @@ Object.defineProperties( MORE_FEATURES_LINK, {
 	},
 } );
 
-/**
- * Plans and products that have options and can't be purchased themselves.
- */
-export const OPTIONS_JETPACK_SECURITY = 'jetpack_security';
-export const OPTIONS_JETPACK_SECURITY_MONTHLY = 'jetpack_security_monthly';
-export const OPTIONS_JETPACK_BACKUP = 'jetpack_backup';
-export const OPTIONS_JETPACK_BACKUP_MONTHLY = 'jetpack_backup_monthly';
-
 // Types of items. This determines the card UI.
 export const ITEM_TYPE_PLAN = 'item-type-plan';
 export const ITEM_TYPE_BUNDLE = 'item-type-bundle';

--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -43,11 +43,7 @@ import { buildCardFeaturesFromItem } from './utils';
 import type { SelectorProduct } from './types';
 import type { JetpackPlanSlug } from '@automattic/calypso-products';
 
-export const ALL = 'all';
-export const PERFORMANCE = 'performance';
-export const SECURITY = 'security';
 export const PLAN_COMPARISON_PAGE = 'https://jetpack.com/features/comparison/';
-
 export const INTRO_PRICING_DISCOUNT_PERCENTAGE = 40;
 
 /**
@@ -69,7 +65,6 @@ Object.defineProperties( MORE_FEATURES_LINK, {
 
 // Types of items. This determines the card UI.
 export const ITEM_TYPE_PLAN = 'item-type-plan';
-export const ITEM_TYPE_BUNDLE = 'item-type-bundle';
 export const ITEM_TYPE_PRODUCT = 'item-type-product';
 
 // Jetpack CRM
@@ -83,7 +78,6 @@ export const EXTERNAL_PRODUCT_CRM_FREE: ( variation: Iterations ) => SelectorPro
 	productSlug: PRODUCT_JETPACK_CRM_FREE,
 	term: TERM_ANNUALLY,
 	type: ITEM_TYPE_PRODUCT,
-	subtypes: [],
 	isFree: true,
 	costProductSlug: PRODUCT_JETPACK_CRM_FREE,
 	monthlyProductSlug: PRODUCT_JETPACK_CRM_FREE_MONTHLY,
@@ -134,7 +128,6 @@ export const EXTERNAL_PRODUCT_CRM: ( variation: Iterations ) => SelectorProduct 
 	productSlug: PRODUCT_JETPACK_CRM,
 	term: TERM_ANNUALLY,
 	type: ITEM_TYPE_PRODUCT,
-	subtypes: [],
 	costProductSlug: PRODUCT_JETPACK_CRM,
 	monthlyProductSlug: PRODUCT_JETPACK_CRM,
 	iconSlug: 'jetpack_crm',
@@ -173,7 +166,6 @@ export const EXTERNAL_PRODUCT_CRM_MONTHLY: ( variation: Iterations ) => Selector
 	productSlug: PRODUCT_JETPACK_CRM_MONTHLY,
 	term: TERM_MONTHLY,
 	displayTerm: TERM_ANNUALLY,
-	subtypes: [],
 	costProductSlug: PRODUCT_JETPACK_CRM_MONTHLY,
 } );
 
@@ -230,23 +222,6 @@ export const PRODUCT_UPSELLS_BY_FEATURE: Record< string, JetpackPlanSlug > = {
 	[ FEATURE_ADVANCED_SEO ]: PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 	[ FEATURE_ACTIVITY_LOG ]: PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 };
-
-/*
- * Constants that contain products that have real-time and daily options.
- */
-export const DAILY_PRODUCTS = [
-	PRODUCT_JETPACK_BACKUP_DAILY,
-	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
-	PLAN_JETPACK_SECURITY_DAILY,
-	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
-];
-
-export const REALTIME_PRODUCTS = [
-	PRODUCT_JETPACK_BACKUP_REALTIME,
-	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
-	PLAN_JETPACK_SECURITY_REALTIME,
-	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
-];
 
 /**
  * Matrix of available dowgradable plans for each plan.

--- a/client/my-sites/plans/jetpack-plans/plans-filter-bar/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-filter-bar/index.tsx
@@ -25,7 +25,7 @@ import { getHighestAnnualDiscount } from '../utils';
 /**
  * Type dependencies
  */
-import type { Duration, DurationChangeCallback, ProductType } from '../types';
+import type { Duration, DurationChangeCallback } from '../types';
 
 /**
  * Style dependencies
@@ -37,7 +37,6 @@ interface FilterBarProps {
 	showDurations?: boolean;
 	duration?: Duration;
 	onDurationChange?: DurationChangeCallback;
-	onProductTypeChange?: ( arg0: ProductType ) => void;
 }
 
 type DiscountMessageProps = {

--- a/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
@@ -7,7 +7,7 @@ import {
 	getYearlyPlanByMonthly,
 } from '@automattic/calypso-products';
 import { SELECTOR_PLANS } from '../constants';
-import { getJetpackDescriptionWithOptions, slugToSelectorProduct } from '../utils';
+import { slugToSelectorProduct } from '../utils';
 
 /**
  * Type dependencies
@@ -34,12 +34,7 @@ export const getPlansToDisplay = ( {
 				product.term === duration &&
 				// Don't include a plan the user already owns, regardless of the term
 				! currentPlanTerms.includes( product.productSlug )
-		)
-		.map( ( product: SelectorProduct ) => ( {
-			...product,
-			description: getJetpackDescriptionWithOptions( product ),
-		} ) );
-
+		);
 	if ( currentPlanSlug && JETPACK_RESET_PLANS.includes( currentPlanSlug ) ) {
 		const currentPlanSelectorProduct = slugToSelectorProduct( currentPlanSlug );
 		if ( currentPlanSelectorProduct ) {
@@ -86,10 +81,6 @@ export const getProductsToDisplay = ( {
 		[ ...purchasedProducts, ...filteredProducts ]
 			// Make sure we don't allow any null or invalid products
 			.filter( ( product ): product is SelectorProduct => !! product )
-			.map( ( product ) => ( {
-				...product,
-				description: getJetpackDescriptionWithOptions( product as SelectorProduct ),
-			} ) )
 	);
 };
 

--- a/client/my-sites/plans/jetpack-plans/types.ts
+++ b/client/my-sites/plans/jetpack-plans/types.ts
@@ -6,20 +6,12 @@ import type { TranslateResult } from 'i18n-calypso';
 import type { ReactNode, ReactElement } from 'react';
 import type { TERM_ANNUALLY, TERM_MONTHLY } from '@automattic/calypso-products';
 import type { Purchase } from 'calypso/lib/purchases/types';
-import type {
-	ALL,
-	PERFORMANCE,
-	SECURITY,
-	ITEM_TYPE_PLAN,
-	ITEM_TYPE_BUNDLE,
-	ITEM_TYPE_PRODUCT,
-} from './constants';
+import type { ITEM_TYPE_PLAN, ITEM_TYPE_PRODUCT } from './constants';
 import type { PlanRecommendation } from './plan-upgrade/types';
 
 export type Duration = typeof TERM_ANNUALLY | typeof TERM_MONTHLY;
 export type DurationString = 'annual' | 'monthly';
-export type ProductType = typeof ALL | typeof PERFORMANCE | typeof SECURITY;
-export type ItemType = typeof ITEM_TYPE_PLAN | typeof ITEM_TYPE_BUNDLE | typeof ITEM_TYPE_PRODUCT;
+export type ItemType = typeof ITEM_TYPE_PLAN | typeof ITEM_TYPE_PRODUCT;
 
 export interface QueryArgs {
 	[ key: string ]: string;
@@ -113,7 +105,6 @@ export interface SelectorProduct extends SelectorProductCost {
 	term: Duration;
 	buttonLabel?: TranslateResult;
 	features: SelectorProductFeatures;
-	subtypes: string[];
 	infoText?: TranslateResult | ReactNode;
 	legacy?: boolean;
 	hidePrice?: boolean;

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -4,7 +4,7 @@
 import { translate, TranslateResult, numberFormat } from 'i18n-calypso';
 import { compact } from 'lodash';
 import page from 'page';
-import React, { createElement, Fragment } from 'react';
+import { createElement, Fragment } from 'react';
 import { createSelector } from '@automattic/state-utils';
 
 /**
@@ -12,13 +12,10 @@ import { createSelector } from '@automattic/state-utils';
  */
 import { getFeatureByKey, getFeatureCategoryByKey } from 'calypso/lib/plans/features-list';
 import {
-	DAILY_PRODUCTS,
 	EXTERNAL_PRODUCTS_LIST,
 	EXTERNAL_PRODUCTS_SLUG_MAP,
 	ITEM_TYPE_PRODUCT,
-	ITEM_TYPE_BUNDLE,
 	ITEM_TYPE_PLAN,
-	REALTIME_PRODUCTS,
 } from './constants';
 import RecordsDetails from './records-details';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -28,7 +25,6 @@ import {
 	TERM_BIENNIALLY,
 	JETPACK_LEGACY_PLANS,
 	JETPACK_RESET_PLANS,
-	JETPACK_SECURITY_PLANS,
 	JETPACK_PLANS_BY_TERM,
 	JETPACK_SEARCH_PRODUCTS,
 	JETPACK_PRODUCT_PRICE_MATRIX,
@@ -436,7 +432,6 @@ export function itemToSelectorProduct(
 			iconSlug,
 			displayName: getJetpackProductDisplayName( item ),
 			type: ITEM_TYPE_PRODUCT,
-			subtypes: [],
 			shortName: getJetpackProductShortName( item ) || '',
 			tagline: getJetpackProductTagline( item ),
 			description: getJetpackProductDescription( item ),
@@ -472,15 +467,13 @@ export function itemToSelectorProduct(
 		}
 		const isResetPlan = JETPACK_RESET_PLANS.includes( productSlug );
 		const iconAppend = isResetPlan ? '_v2' : '';
-		const type = JETPACK_SECURITY_PLANS.includes( productSlug ) ? ITEM_TYPE_BUNDLE : ITEM_TYPE_PLAN;
 		return {
 			productSlug,
 			// Using the same slug for any duration helps prevent unnecessary DOM updates
 			iconSlug: ( yearlyProductSlug || productSlug ) + iconAppend,
 			displayName: getForCurrentCROIteration( item.getTitle ),
 			buttonLabel: getForCurrentCROIteration( item.getButtonLabel ),
-			type,
-			subtypes: [],
+			type: ITEM_TYPE_PLAN,
 			shortName: getForCurrentCROIteration( item.getTitle ),
 			tagline: getForCurrentCROIteration( item.getTagline ) || '',
 			description: getForCurrentCROIteration( item.getDescription ),
@@ -681,33 +674,6 @@ export function manageSitePurchase( siteSlug: string, purchaseId: number ): void
 		page( relativePath );
 	}
 }
-
-/**
- * Append "Available Options: Real-time and Daily" to the product description.
- *
- * @param product SelectorProduct
- *
- * @returns ReactNode | TranslateResult
- */
-export const getJetpackDescriptionWithOptions = (
-	product: SelectorProduct
-): React.ReactNode | TranslateResult => {
-	const em = React.createElement( 'em', null, null );
-
-	// If the product has 'subtypes' (containing daily and real-time product slugs).
-	// then append "Available options: Real-time or Daily" to the product description.
-	return product.subtypes.some( ( subtype ) => DAILY_PRODUCTS.includes( subtype ) ) &&
-		product.subtypes.some( ( subtype ) => REALTIME_PRODUCTS.includes( subtype ) )
-		? translate( '%(productDescription)s {{em}}Available options: Real-time or Daily.{{/em}}', {
-				args: {
-					productDescription: product.description,
-				},
-				components: {
-					em,
-				},
-		  } )
-		: product.description;
-};
 
 /**
  * Return the slug of a highlighted product if the given slug is Jetpack product

--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -5,6 +5,10 @@ import React, { useEffect } from 'react';
 import { find } from 'lodash';
 
 import { CompactCard } from '@automattic/components';
+import {
+	FEATURE_GOOGLE_ANALYTICS,
+	PLAN_JETPACK_SECURITY_DAILY,
+} from '@automattic/calypso-products';
 import ExternalLink from 'calypso/components/external-link';
 import SupportInfo from 'calypso/components/support-info';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -18,14 +22,10 @@ import FormAnalyticsStores from '../form-analytics-stores';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import googleIllustration from 'calypso/assets/images/illustrations/google-analytics-logo.svg';
-import { FEATURE_GOOGLE_ANALYTICS } from '@automattic/calypso-products';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
-import {
-	OPTIONS_JETPACK_SECURITY,
-	PRODUCT_UPSELLS_BY_FEATURE,
-} from 'calypso/my-sites/plans/jetpack-plans/constants';
+import { PRODUCT_UPSELLS_BY_FEATURE } from 'calypso/my-sites/plans/jetpack-plans/constants';
 
 /**
  * Style dependencies
@@ -81,21 +81,6 @@ const GoogleAnalyticsJetpackForm = ( {
 	};
 
 	const renderForm = () => {
-		const plan = OPTIONS_JETPACK_SECURITY;
-
-		const nudge = (
-			<UpsellNudge
-				description={ translate(
-					"Monitor your site's views, clicks, and other important metrics"
-				) }
-				event={ 'google_analytics_settings' }
-				feature={ FEATURE_GOOGLE_ANALYTICS }
-				plan={ plan }
-				href={ upsellHref }
-				showIcon={ true }
-				title={ nudgeTitle }
-			/>
-		);
 		return (
 			<form id="analytics" onSubmit={ handleSubmitForm }>
 				<QueryJetpackModules siteId={ siteId } />
@@ -225,7 +210,17 @@ const GoogleAnalyticsJetpackForm = ( {
 					) }
 				</CompactCard>
 				{ showUpgradeNudge && site && site.plan ? (
-					nudge
+					<UpsellNudge
+						description={ translate(
+							"Monitor your site's views, clicks, and other important metrics"
+						) }
+						event={ 'google_analytics_settings' }
+						feature={ FEATURE_GOOGLE_ANALYTICS }
+						plan={ PLAN_JETPACK_SECURITY_DAILY }
+						href={ upsellHref }
+						showIcon={ true }
+						title={ nudgeTitle }
+					/>
 				) : (
 					<CompactCard>
 						<div className="analytics site-settings__analytics">

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -21,8 +21,8 @@ import {
 	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_SECURITY_DAILY,
 } from '@automattic/calypso-products';
-import { OPTIONS_JETPACK_SECURITY } from 'calypso/my-sites/plans/jetpack-plans/constants';
 
 /**
  * Internal dependencies
@@ -198,7 +198,7 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 					/>
 				);
 				expect( comp.find( 'UpsellNudge' ) ).toHaveLength( 1 );
-				expect( comp.find( 'UpsellNudge' ).props().href ).toContain( OPTIONS_JETPACK_SECURITY );
+				expect( comp.find( 'UpsellNudge' ).props().href ).toContain( PLAN_JETPACK_SECURITY_DAILY );
 			} );
 		}
 	);

--- a/client/my-sites/site-settings/test/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-google-analytics.jsx
@@ -22,8 +22,8 @@ import {
 	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_SECURITY_DAILY,
 } from '@automattic/calypso-products';
-import { OPTIONS_JETPACK_SECURITY } from 'calypso/my-sites/plans/jetpack-plans/constants';
 
 /**
  * Internal dependencies
@@ -100,7 +100,7 @@ describe( 'UpsellNudge should get appropriate plan constant for both forms', () 
 				);
 				expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
 				expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ).props().plan ).toBe(
-					OPTIONS_JETPACK_SECURITY
+					PLAN_JETPACK_SECURITY_DAILY
 				);
 			} );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

The first versions of the pricing page allowed to filter the list of products by type. This is not the case anymore and this PR removes the unused code.

### Implementation notes

- Removed values for type filter
- Removed bundle type
- Removed subtypes and associated logic

### Testing instructions

- Review code
- Check that all checks pass
- Download the PR and run Calypso
- Check that the product descriptions match what's in production