### PR TITLE
Hide Cloudflare section from Jetpack sites

### DIFF
--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -40,6 +40,7 @@ const SiteSettingsTraffic = ( {
 	handleAutosavingRadio,
 	handleSubmitForm,
 	isAdmin,
+	isJetpack,
 	isJetpackAdmin,
 	isRequestingSettings,
 	isSavingSettings,
@@ -68,7 +69,9 @@ const SiteSettingsTraffic = ( {
 				fields={ fields }
 			/>
 		) }
-		{ isAdmin && config.isEnabled( 'cloudflare' ) && <CloudflareAnalyticsSettings /> }
+		{ ! isJetpack && isAdmin && config.isEnabled( 'cloudflare' ) && (
+			<CloudflareAnalyticsSettings />
+		) }
 
 		{ isJetpackAdmin && (
 			<JetpackSiteStats
@@ -109,6 +112,7 @@ const connectComponent = connect( ( state ) => {
 
 	return {
 		isAdmin,
+		isJetpack,
 		isJetpackAdmin,
 	};
 } );

--- a/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
+++ b/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
@@ -25,7 +25,7 @@ import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-secti
 import cloudflareIllustration from 'calypso/assets/images/illustrations/cloudflare-logo-small.svg';
 import {
 	findFirstSimilarPlanKey,
-	TYPE_PREMIUM,
+	TYPE_SECURITY_DAILY,
 	FEATURE_CLOUDFLARE_ANALYTICS,
 } from '@automattic/calypso-products';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -128,10 +128,10 @@ export function CloudflareAnalyticsSettings( {
 	const renderForm = () => {
 		const placeholderText = isRequestingSettings ? translate( 'Loading' ) : '';
 
-		const nudgeTitle = translate( 'Available with Premium plans or higher' );
+		const nudgeTitle = translate( 'Available with Security plans or higher' );
 
 		const plan = findFirstSimilarPlanKey( site.plan.product_slug, {
-			type: TYPE_PREMIUM,
+			type: TYPE_SECURITY_DAILY,
 		} );
 
 		const nudge = (

--- a/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
+++ b/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
@@ -25,7 +25,7 @@ import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-secti
 import cloudflareIllustration from 'calypso/assets/images/illustrations/cloudflare-logo-small.svg';
 import {
 	findFirstSimilarPlanKey,
-	TYPE_SECURITY_DAILY,
+	TYPE_PREMIUM,
 	FEATURE_CLOUDFLARE_ANALYTICS,
 } from '@automattic/calypso-products';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -128,10 +128,10 @@ export function CloudflareAnalyticsSettings( {
 	const renderForm = () => {
 		const placeholderText = isRequestingSettings ? translate( 'Loading' ) : '';
 
-		const nudgeTitle = translate( 'Available with Security plans or higher' );
+		const nudgeTitle = translate( 'Available with Premium plans or higher' );
 
 		const plan = findFirstSimilarPlanKey( site.plan.product_slug, {
-			type: TYPE_SECURITY_DAILY,
+			type: TYPE_PREMIUM,
 		} );
 
 		const nudge = (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide Cloudflare section (and upsell) from Jetpack sites. For more background, read pbAPfg-1he-p2#comment-3060.

#### Testing instructions

* Download this PR.
* Run Calypso with `yarn start`.
* Select a Jetpack site.
* Visit `http://calypso.localhost:3000/marketing/traffic/[site]`.
* Make sure there is _no_ Cloudflare section visible.
* Select a WordPress.com site without leaving the page.
* Make sure the Cloudflare section _is_ visible.

#### Demo

#### Jetpack site (no Cloudflare section)
![image](https://user-images.githubusercontent.com/3418513/118135027-89b76880-b3d0-11eb-8db6-37c1412692e7.png)


#### WordPress.com site with Personal plan (Cloudflare section is visible, upsell is shown)
![image](https://user-images.githubusercontent.com/3418513/118135067-950a9400-b3d0-11eb-89e1-435dfe8eab8c.png)

#### WordPress.com site with Personal plan (Cloudflare section is visible, no upsell is shown)
![image](https://user-images.githubusercontent.com/3418513/118135112-a358b000-b3d0-11eb-98ca-6c225833875b.png)