### PR TITLE
Emails: Add button to toggle list of features in Email Comparison page on mobile

### DIFF
--- a/client/components/gsuite/gsuite-new-user-list/style.scss
+++ b/client/components/gsuite/gsuite-new-user-list/style.scss
@@ -28,6 +28,14 @@
 	@include breakpoint-deprecated( '>480px' ) {
 		width: auto;
 	}
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-bottom: 20px;
+	}
+
+	@include breakpoint-deprecated( '>800px' ) {
+		margin-bottom: 0;
+	}
 }
 
 .gsuite-new-user-list__domain-select {

--- a/client/lib/titan/new-mailbox.js
+++ b/client/lib/titan/new-mailbox.js
@@ -35,7 +35,7 @@ const getMailboxRequiredBooleanValue = () =>
 const getMailboxOptionalStringValueWithTranslatedError = () =>
 	PropTypes.shape( {
 		value: PropTypes.string.isRequired,
-		error: PropTypes.oneOfType( PropTypes.string, PropTypes.array ),
+		error: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
 	} );
 
 const getMailboxRequiredStringValue = () =>
@@ -47,7 +47,7 @@ const getMailboxRequiredStringValue = () =>
 const getMailboxRequiredStringValueWithTranslatedError = () =>
 	PropTypes.shape( {
 		value: PropTypes.string.isRequired,
-		error: PropTypes.oneOfType( PropTypes.string, PropTypes.array ),
+		error: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
 	} ).isRequired;
 
 const getMailboxPropTypeShape = () =>

--- a/client/my-sites/email/email-provider-features/button.js
+++ b/client/my-sites/email/email-provider-features/button.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import Gridicon from 'calypso/components/gridicon';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+
+function EmailProviderFeaturesButton( { handleClick, isToggled } ) {
+	const translate = useTranslate();
+
+	return (
+		<Button className="email-provider-features__button" onClick={ handleClick }>
+			<span>{ translate( 'Learn more' ) }</span>
+
+			<Gridicon icon={ isToggled ? 'chevron-up' : 'chevron-down' } />
+		</Button>
+	);
+}
+
+EmailProviderFeaturesButton.propTypes = {
+	handleClick: PropTypes.func.isRequired,
+	isToggled: PropTypes.bool.isRequired,
+};
+
+export default EmailProviderFeaturesButton;

--- a/client/my-sites/email/email-provider-features/index.js
+++ b/client/my-sites/email/email-provider-features/index.js
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import Gridicon from 'calypso/components/gridicon';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -14,12 +15,36 @@ import { preventWidows } from 'calypso/lib/formatting';
  */
 import './style.scss';
 
-export default ( { title } ) => {
+function EmailProviderFeature( { title } ) {
 	return (
-		<span className="email-provider-features">
+		<div className="email-provider-features">
 			<Gridicon icon="checkmark" size="18" />
 
 			{ preventWidows( title ) }
-		</span>
+		</div>
 	);
+}
+
+EmailProviderFeature.propTypes = {
+	title: PropTypes.string.isRequired,
 };
+
+function EmailProviderFeatures( { features } ) {
+	if ( ! features ) {
+		return null;
+	}
+
+	return (
+		<div className="email-providers-comparison__provider-features">
+			{ features.map( ( feature, index ) => (
+				<EmailProviderFeature key={ index } title={ feature } />
+			) ) }
+		</div>
+	);
+}
+
+EmailProviderFeatures.propTypes = {
+	features: PropTypes.arrayOf( PropTypes.string ),
+};
+
+export default EmailProviderFeatures;

--- a/client/my-sites/email/email-provider-features/index.js
+++ b/client/my-sites/email/email-provider-features/index.js
@@ -17,7 +17,7 @@ import './style.scss';
 
 function EmailProviderFeature( { title } ) {
 	return (
-		<div className="email-provider-feature">
+		<div className="email-provider-features__feature">
 			<Gridicon icon="checkmark" size="18" />
 
 			{ preventWidows( title ) }

--- a/client/my-sites/email/email-provider-features/index.js
+++ b/client/my-sites/email/email-provider-features/index.js
@@ -17,7 +17,7 @@ import './style.scss';
 
 function EmailProviderFeature( { title } ) {
 	return (
-		<div className="email-provider-features">
+		<div className="email-provider-feature">
 			<Gridicon icon="checkmark" size="18" />
 
 			{ preventWidows( title ) }
@@ -35,7 +35,7 @@ function EmailProviderFeatures( { features } ) {
 	}
 
 	return (
-		<div className="email-providers-comparison__provider-features">
+		<div className="email-provider-features">
 			{ features.map( ( feature, index ) => (
 				<EmailProviderFeature key={ index } title={ feature } />
 			) ) }

--- a/client/my-sites/email/email-provider-features/style.scss
+++ b/client/my-sites/email/email-provider-features/style.scss
@@ -1,4 +1,4 @@
-.email-provider-feature {
+.email-provider-features__feature {
 	margin-left: 28px;
 	margin-top: 8px;
 
@@ -23,5 +23,14 @@
 		margin-left: -28px;
 		margin-top: 2px;
 		position: absolute;
+	}
+}
+
+.email-provider-features__button {
+	overflow: visible;
+	white-space: nowrap;
+
+	.gridicon {
+		margin-left: 5px;
 	}
 }

--- a/client/my-sites/email/email-provider-features/style.scss
+++ b/client/my-sites/email/email-provider-features/style.scss
@@ -1,3 +1,24 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
+.email-providers-comparison__provider-features {
+	margin-bottom: 1em;
+
+	@include break-mobile {
+		margin-bottom: 0;
+		padding-left: 3.5em;
+	}
+
+	.email-provider-features:first-child {
+		margin-top: 0;
+	}
+
+	.email-provider-features:first-child::before {
+		border-bottom: none;
+		margin-bottom: 0;
+	}
+}
+
 .email-provider-features {
 	margin: 8px 0;
 	display: block;

--- a/client/my-sites/email/email-provider-features/style.scss
+++ b/client/my-sites/email/email-provider-features/style.scss
@@ -1,43 +1,27 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+.email-provider-feature {
+	margin-left: 28px;
+	margin-top: 8px;
 
-.email-providers-comparison__provider-features {
-	margin-bottom: 1em;
-
-	@include break-mobile {
-		margin-bottom: 0;
-		padding-left: 3.5em;
-	}
-
-	.email-provider-features:first-child {
+	&:first-child {
 		margin-top: 0;
 	}
 
-	.email-provider-features:first-child::before {
-		border-bottom: none;
-		margin-bottom: 0;
-	}
-}
-
-.email-provider-features {
-	margin: 8px 0;
-	display: block;
-
-	.gridicon {
-		position: absolute;
-		margin: 1px 0 0 -28px;
-		fill: var( --studio-green-40 );
-	}
-
 	&::before {
+		border-bottom: 1px solid var( --color-neutral-5 );
 		content: '';
 		display: block;
 		height: 1px;
-		border-bottom: 1px solid var( --color-neutral-5 );
 		margin-bottom: 8px;
 	}
 
-	@include breakpoint-deprecated( '<480px' ) {
-		margin-left: 28px;
+	&:first-child::before {
+		display: none;
+	}
+
+	.gridicon {
+		fill: var( --studio-green-40 );
+		margin-left: -28px;
+		margin-top: 2px;
+		position: absolute;
 	}
 }

--- a/client/my-sites/email/email-provider-features/style.scss
+++ b/client/my-sites/email/email-provider-features/style.scss
@@ -26,7 +26,7 @@
 	}
 }
 
-.email-provider-features__button {
+.email-provider-features__toggle-button {
 	overflow: visible;
 	white-space: nowrap;
 

--- a/client/my-sites/email/email-provider-features/toggle-button.js
+++ b/client/my-sites/email/email-provider-features/toggle-button.js
@@ -11,21 +11,21 @@ import { useTranslate } from 'i18n-calypso';
  */
 import { Button } from '@automattic/components';
 
-function EmailProviderFeaturesButton( { handleClick, isToggled } ) {
+function EmailProviderFeaturesToggleButton( { handleClick, isSwitched } ) {
 	const translate = useTranslate();
 
 	return (
-		<Button className="email-provider-features__button" onClick={ handleClick }>
+		<Button className="email-provider-features__toggle-button" onClick={ handleClick }>
 			<span>{ translate( 'Learn more' ) }</span>
 
-			<Gridicon icon={ isToggled ? 'chevron-up' : 'chevron-down' } />
+			<Gridicon icon={ isSwitched ? 'chevron-up' : 'chevron-down' } />
 		</Button>
 	);
 }
 
-EmailProviderFeaturesButton.propTypes = {
+EmailProviderFeaturesToggleButton.propTypes = {
 	handleClick: PropTypes.func.isRequired,
-	isToggled: PropTypes.bool.isRequired,
+	isSwitched: PropTypes.bool.isRequired,
 };
 
-export default EmailProviderFeaturesButton;
+export default EmailProviderFeaturesToggleButton;

--- a/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
@@ -1,17 +1,19 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import { Button } from '@automattic/components';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { useBreakpoint } from '@automattic/viewport-react';
 
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import PromoCardPrice from 'calypso/components/promo-section/promo-card/price';
 import EmailProviderFeatures from 'calypso/my-sites/email/email-provider-features';
+import EmailProviderFeaturesButton from 'calypso/my-sites/email/email-provider-features/button';
 
 const noop = () => {};
 
@@ -34,8 +36,13 @@ function EmailProviderCard( {
 	expandButtonLabel,
 	features,
 } ) {
+	const [ areFeaturesToggled, toggleFeatures ] = useState( false );
+
+	const showFeaturesToggleButton = useBreakpoint( '<1040px' ) && detailsExpanded;
+
 	const toggleVisibility = ( event ) => {
 		event.preventDefault();
+
 		onExpandedChange( providerKey, ! detailsExpanded );
 	};
 
@@ -64,13 +71,24 @@ function EmailProviderCard( {
 				) }
 			</div>
 
-			<PromoCardPrice formattedPrice={ formattedPrice } discount={ discount } />
+			<div className="email-providers-comparison__provider-price-and-button">
+				<div>
+					<PromoCardPrice formattedPrice={ formattedPrice } discount={ discount } />
 
-			{ additionalPriceInformation && (
-				<span className="email-providers-comparison__provider-additional-price-information">
-					{ additionalPriceInformation }
-				</span>
-			) }
+					{ additionalPriceInformation && (
+						<div className="email-providers-comparison__provider-additional-price-information">
+							{ additionalPriceInformation }
+						</div>
+					) }
+				</div>
+
+				{ showFeaturesToggleButton && (
+					<EmailProviderFeaturesButton
+						handleClick={ () => toggleFeatures( ! areFeaturesToggled ) }
+						isToggled={ areFeaturesToggled }
+					/>
+				) }
+			</div>
 
 			<div className="email-providers-comparison__provider-form-and-features">
 				<div className="email-providers-comparison__provider-form">
@@ -83,7 +101,9 @@ function EmailProviderCard( {
 					) }
 				</div>
 
-				<EmailProviderFeatures features={ features } />
+				{ ( ! showFeaturesToggleButton || areFeaturesToggled ) && (
+					<EmailProviderFeatures features={ features } />
+				) }
 			</div>
 
 			{ children }

--- a/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
@@ -13,7 +13,7 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import PromoCardPrice from 'calypso/components/promo-section/promo-card/price';
 import EmailProviderFeatures from 'calypso/my-sites/email/email-provider-features';
-import EmailProviderFeaturesButton from 'calypso/my-sites/email/email-provider-features/button';
+import EmailProviderFeaturesToggleButton from 'calypso/my-sites/email/email-provider-features/toggle-button';
 
 const noop = () => {};
 
@@ -36,9 +36,11 @@ function EmailProviderCard( {
 	expandButtonLabel,
 	features,
 } ) {
-	const [ areFeaturesToggled, toggleFeatures ] = useState( false );
+	const [ areFeaturesExpanded, setFeaturesExpanded ] = useState( false );
 
-	const showFeaturesToggleButton = useBreakpoint( '<1040px' ) && detailsExpanded;
+	const isViewportSizeLowerThan1040px = useBreakpoint( '<1040px' );
+
+	const showFeaturesToggleButton = detailsExpanded && isViewportSizeLowerThan1040px;
 
 	const toggleVisibility = ( event ) => {
 		event.preventDefault();
@@ -83,9 +85,9 @@ function EmailProviderCard( {
 				</div>
 
 				{ showFeaturesToggleButton && (
-					<EmailProviderFeaturesButton
-						handleClick={ () => toggleFeatures( ! areFeaturesToggled ) }
-						isToggled={ areFeaturesToggled }
+					<EmailProviderFeaturesToggleButton
+						handleClick={ () => setFeaturesExpanded( ! areFeaturesExpanded ) }
+						isSwitched={ areFeaturesExpanded }
 					/>
 				) }
 			</div>
@@ -101,7 +103,7 @@ function EmailProviderCard( {
 					) }
 				</div>
 
-				{ ( ! showFeaturesToggleButton || areFeaturesToggled ) && (
+				{ ( ! showFeaturesToggleButton || areFeaturesExpanded ) && (
 					<EmailProviderFeatures features={ features } />
 				) }
 			</div>

--- a/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
@@ -11,7 +11,7 @@ import classnames from 'classnames';
 import { Button } from '@automattic/components';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import PromoCardPrice from 'calypso/components/promo-section/promo-card/price';
-import EmailProviderFeature from 'calypso/my-sites/email/email-provider-features';
+import EmailProviderFeatures from 'calypso/my-sites/email/email-provider-features';
 
 const noop = () => {};
 
@@ -34,16 +34,11 @@ function EmailProviderCard( {
 	expandButtonLabel,
 	features,
 } ) {
-	const renderFeatures = ( providerSlug, featureList ) => {
-		return featureList.map( ( feature, index ) => (
-			<EmailProviderFeature key={ `feature-${ providerSlug }-${ index }` } title={ feature } />
-		) );
-	};
-
 	const toggleVisibility = ( event ) => {
 		event.preventDefault();
 		onExpandedChange( providerKey, ! detailsExpanded );
 	};
+
 	const labelForExpandButton = expandButtonLabel ? expandButtonLabel : buttonLabel;
 
 	return (
@@ -57,6 +52,7 @@ function EmailProviderCard( {
 		>
 			<div className="email-providers-comparison__provider-card-main-details">
 				<p>{ description }</p>
+
 				{ showExpandButton && (
 					<Button
 						primary={ false }
@@ -67,25 +63,29 @@ function EmailProviderCard( {
 					</Button>
 				) }
 			</div>
+
 			<PromoCardPrice formattedPrice={ formattedPrice } discount={ discount } />
+
 			{ additionalPriceInformation && (
 				<span className="email-providers-comparison__provider-additional-price-information">
 					{ additionalPriceInformation }
 				</span>
 			) }
+
 			<div className="email-providers-comparison__provider-form-and-features">
 				<div className="email-providers-comparison__provider-form">
 					{ formFields }
+
 					{ buttonLabel && (
 						<Button primary onClick={ onButtonClick }>
 							{ buttonLabel }
 						</Button>
 					) }
 				</div>
-				<div className="email-providers-comparison__provider-features">
-					{ features && renderFeatures( providerKey, features ) }
-				</div>
+
+				<EmailProviderFeatures features={ features } />
 			</div>
+
 			{ children }
 		</PromoCard>
 	);

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -84,13 +84,13 @@
 	}
 
 	.email-providers-comparison__provider-card-main-details {
-		align-items: center;
 		display: flex;
 		flex-direction: column;
 		justify-content: space-between;
 		margin-bottom: 1em;
 
 		@include break-mobile {
+			align-items: center;
 			flex-direction: row;
 		}
 
@@ -99,10 +99,22 @@
 		}
 	}
 
+	.email-providers-comparison__provider-price-and-button {
+		align-items: center;
+		display: flex;
+		justify-content: space-between;
+		margin-bottom: 1em;
+	}
+
 	.email-providers-comparison__provider-expand-cta {
-		margin-left: 2em;
+		margin-top: 1em;
 		overflow: visible;
 		white-space: nowrap;
+
+		@include break-mobile {
+			margin-left: 2em;
+			margin-top: 0;
+		}
 	}
 
 	.promo-card__price {
@@ -126,7 +138,6 @@
 
 	.email-providers-comparison__provider-additional-price-information {
 		color: var( --color-text-subtle );
-		display: inline-block;
 		font-size: $font-body-extra-small;
 		font-style: normal;
 		margin-top: 3px;
@@ -148,16 +159,15 @@
 			display: flex;
 			flex-direction: column-reverse;
 
-			@include break-xlarge {
+			@include breakpoint-deprecated( '>1040px' ) {
 				flex-direction: row;
 			}
 		}
 
 		.email-providers-comparison__provider-form {
 			flex-grow: 1;
-			margin-top: 2.5em;
 
-			@include break-xlarge {
+			@include breakpoint-deprecated( '>1040px' ) {
 				margin-top: 0;
 			}
 
@@ -175,9 +185,10 @@
 		}
 
 		.email-provider-features {
-			margin-top: 1em;
+			margin-bottom: 2.5em;
 
-			@include break-xlarge {
+			@include breakpoint-deprecated( '>1040px' ) {
+				margin-bottom: 0;
 				margin-left: 2em;
 				margin-top: 0;
 			}

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -60,19 +60,12 @@
 }
 
 .email-providers-comparison__provider-card.promo-card {
-
 	.action-panel__figure {
 		margin-bottom: 0.5em;
 		margin-top: 0;
 
 		img {
 			max-width: 24px;
-		}
-	}
-
-	@include break-mobile {
-		.action-panel__title {
-			margin-bottom: 0;
 		}
 	}
 
@@ -91,27 +84,25 @@
 	}
 
 	.email-providers-comparison__provider-card-main-details {
+		align-items: center;
 		display: flex;
 		flex-direction: column;
+		justify-content: space-between;
 		margin-bottom: 1em;
 
 		@include break-mobile {
 			flex-direction: row;
-			margin-bottom: 0;
 		}
 
 		p {
-			margin-bottom: 1em;
+			margin-bottom: 0;
+		}
+	}
 
-			@include break-xlarge {
-				flex-grow: 7;
-				line-height: 40px;
-				margin-bottom: 0;
-			}
-		}
-		.email-providers-comparison__provider-expand-cta {
-			flex-grow: 1;
-		}
+	.email-providers-comparison__provider-expand-cta {
+		margin-left: 2em;
+		overflow: visible;
+		white-space: nowrap;
 	}
 
 	.promo-card__price {
@@ -142,29 +133,10 @@
 	}
 
 	.email-providers-comparison__provider-form-and-features {
+		display: none;
 		justify-content: space-between;
 		margin-top: 1em;
 		line-height: 1.5;
-
-		.email-providers-comparison__provider-form {
-			flex-grow: 1;
-
-			.titan-new-mailbox-list__actions {
-				justify-content: space-between;
-			}
-
-			.email-providers-comparison__gsuite-user-list-action-continue {
-				margin-top: 1em;
-				@include break-mobile {
-					margin-top: 0;
-				}
-			}
-		}
-	}
-
-	/* Handle expanded vs contracted state */
-	.email-providers-comparison__provider-form-and-features {
-		display: none;
 	}
 
 	&.is-expanded {
@@ -176,8 +148,38 @@
 			display: flex;
 			flex-direction: column-reverse;
 
-			@include break-mobile {
+			@include break-xlarge {
 				flex-direction: row;
+			}
+		}
+
+		.email-providers-comparison__provider-form {
+			flex-grow: 1;
+			margin-top: 2.5em;
+
+			@include break-xlarge {
+				margin-top: 0;
+			}
+
+			.titan-new-mailbox-list__actions {
+				justify-content: space-between;
+			}
+
+			.email-providers-comparison__gsuite-user-list-action-continue {
+				margin-top: 1em;
+
+				@include break-mobile {
+					margin-top: 0;
+				}
+			}
+		}
+
+		.email-provider-features {
+			margin-top: 1em;
+
+			@include break-xlarge {
+				margin-left: 2em;
+				margin-top: 0;
 			}
 		}
 	}

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -160,22 +160,6 @@
 				}
 			}
 		}
-
-		.email-providers-comparison__provider-features {
-			margin-bottom: 1em;
-			@include break-mobile {
-				margin-bottom: 0;
-				padding-left: 3.5em;
-			}
-
-			.email-provider-features:first-child {
-				margin-top: 0;
-			}
-			.email-provider-features:first-child::before {
-				border-bottom: none;
-				margin-bottom: 0;
-			}
-		}
 	}
 
 	/* Handle expanded vs contracted state */

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -145,9 +145,6 @@
 
 	.email-providers-comparison__provider-form-and-features {
 		display: none;
-		justify-content: space-between;
-		margin-top: 1em;
-		line-height: 1.5;
 	}
 
 	&.is-expanded {
@@ -158,6 +155,9 @@
 		.email-providers-comparison__provider-form-and-features {
 			display: flex;
 			flex-direction: column-reverse;
+			justify-content: space-between;
+			margin-top: 1em;
+			line-height: 1.5;
 
 			@include breakpoint-deprecated( '>1040px' ) {
 				flex-direction: row;


### PR DESCRIPTION
This pull request seeks to improve the display of the `Email Comparison` page on devices with a small viewport. In addition to tweaking breakpoints/spacing and fixing misalignments, it introduces a new button that can be used to show/hide the list of features of a given email product:

##### Large viewports

Before | After
------ | -----
![before](https://user-images.githubusercontent.com/594356/117176208-eb277800-adcf-11eb-8304-082fdced58fb.png) <br/><br/> | ![after](https://user-images.githubusercontent.com/594356/117176219-eebaff00-adcf-11eb-8db1-bb35b0f06794.png)

##### Medium viewports

Before | After | After (Features Expanded)
------ | ----- | -----
![before](https://user-images.githubusercontent.com/594356/117176592-540ef000-add0-11eb-994a-7bd5489a1cd6.png)<br/><br/><br/><br/><br/><br/><br/> | ![after](https://user-images.githubusercontent.com/594356/117176614-583b0d80-add0-11eb-9999-2fe07bef5151.png)<br/><br/><br/><br/><br/><br/> | ![after](https://user-images.githubusercontent.com/594356/117176760-86205200-add0-11eb-93b0-4a8391ff8881.png)

##### Small viewports

Before | After | After (Features Expanded)
------ | ----- | -----
![before](https://user-images.githubusercontent.com/594356/117180320-5b37fd00-add4-11eb-984b-3259be48065d.png) <br/><br/><br/><br/> | ![after](https://user-images.githubusercontent.com/594356/117180685-ba960d00-add4-11eb-9d1f-d8e4c88b67e2.png) <br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/> | ![after](https://user-images.githubusercontent.com/594356/117180616-a5b97980-add4-11eb-9660-69834a2da746.png)


Note the following are out of scope:

1. Showing form fields on separate lines
2. Removing deprecated breakpoints

The first item will be addressed in another pull request. We have no plans yet for the second item, as this would require updating the [`@automattic/viewport`](https://github.com/Automattic/wp-calypso/tree/bd262f39a92e04d391bcfd0665e7dc8176f66516/packages/viewport) and [`@automattic/viewport-react`](https://github.com/Automattic/wp-calypso/tree/bd262f39a92e04d391bcfd0665e7dc8176f66516/packages/viewport-react) packages in order to support [Gutenberg breakpoints](https://github.com/WordPress/gutenberg/blob/d1764758b42353fce76dbf7d355d99538d58642d/packages/base-styles/_breakpoints.scss) since [that's what is recommended](https://github.com/Automattic/wp-calypso/blob/20ad6e03c1051210cc8ca9a6fe93378eddd4223a/docs/coding-guidelines/css.md#media-queries).

#### Testing instructions

1. Run `git checkout add/toggle-email-features` and start your server, or open a [live branch](https://calypso.live/?branch=add/toggle-email-features)
2. Log into a WordPress.com account that has a domain without email
3. Open the [`Domains` page](http://calypso.localhost:3000/domains/manage)
4. Click the `Add` button for that domain
5. Assert that the `Email Comparison` page looks fine whatever the width of your browser is
6. Assert that the `Learn more` button behaves correctly