### PR TITLE
Lead users to Jetpack branded login form when coming from Jetpack's Pricing

### DIFF
--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -658,10 +658,18 @@ export function checkout(
 		? `/checkout/${ siteSlug }/${ productsString }`
 		: `/jetpack/connect/${ productsString }`;
 
+	// Unauthenticated users will be presented with a Jetpack branded version of the login form
+	// if the URL has the query parameter `source=jetpack-plans`. We only want to do this if the
+	// user is in Jetpack Cloud.
+	const urlQueryArgsWithSource =
+		isJetpackCloud() && ! urlQueryArgs.source
+			? { ...urlQueryArgs, source: 'jetpack-plans' }
+			: urlQueryArgs;
+
 	if ( isJetpackCloud() && ! config.isEnabled( 'jetpack-cloud/connect' ) ) {
-		window.location.href = addQueryArgs( urlQueryArgs, `https://wordpress.com${ path }` );
+		window.location.href = addQueryArgs( urlQueryArgsWithSource, `https://wordpress.com${ path }` );
 	} else {
-		page( addQueryArgs( urlQueryArgs, path ) );
+		page( addQueryArgs( urlQueryArgsWithSource, path ) );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `source=jetpack-plans` query parameter to the URL for any user visiting checkout from Jetpack's Pricing page. Unauthenticated users will see a Jetpack branded login form rather than the default WordPress.com one.

#### Testing instructions

**Prerequisites**
* Being authenticated in WordPress.com.
* A self-hosted Jetpack site.

**Instructions**
* Download this PR.
* Start Calypso Green with `yarn start-jetpack-cloud`.
* Visit `http://jetpack.cloud.localhost:3000/pricing/[site]?site=[site]`. Replace `[site]` with a valid Jetpack site slug.
* Click on any paid product.
* Make sure you are redirected to the checkout and that the URL contains `source=jetpack-plans` query parameter.
* Copy the whole URL.
* Open an incognito window and paste the URL.
* Make sure you are redirected to a Jetpack branded login form.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1164141197617539-as-1200291140514287

#### Demo
![image](https://user-images.githubusercontent.com/3418513/117194587-421e5480-adb2-11eb-967e-72d3eb396296.png)