### PR TITLE
Updating link to wpcourses.com

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -161,7 +161,11 @@ class Help extends React.PureComponent {
 						</p>
 					</div>
 				</CompactCard>
-				<CompactCard className="help__support-link" href="https://wpcourses.com" target="__blank">
+				<CompactCard
+					className="help__support-link"
+					href="https://wpcourses.com/?ref=wpcom-help-more-resources"
+					target="__blank"
+				>
 					<Gridicon icon="mail" size={ 36 } />
 					<div className="help__support-link-section">
 						<h2 className="help__support-link-title">{ this.props.translate( 'Courses' ) }</h2>

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -161,11 +161,7 @@ class Help extends React.PureComponent {
 						</p>
 					</div>
 				</CompactCard>
-				<CompactCard
-					className="help__support-link"
-					href="https://dailypost.wordpress.com/blogging-university/"
-					target="__blank"
-				>
+				<CompactCard className="help__support-link" href="https://wpcourses.com" target="__blank">
 					<Gridicon icon="mail" size={ 36 } />
 					<div className="help__support-link-section">
 						<h2 className="help__support-link-title">

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -164,12 +164,10 @@ class Help extends React.PureComponent {
 				<CompactCard className="help__support-link" href="https://wpcourses.com" target="__blank">
 					<Gridicon icon="mail" size={ 36 } />
 					<div className="help__support-link-section">
-						<h2 className="help__support-link-title">
-							{ this.props.translate( 'Email courses' ) }
-						</h2>
+						<h2 className="help__support-link-title">{ this.props.translate( 'Courses' ) }</h2>
 						<p className="help__support-link-content">
 							{ this.props.translate(
-								'Pick from our ever-growing list of free email courses to improve your knowledge.'
+								'Enroll in a course taught by WordPress experts, and become a part of its community.'
 							) }
 						</p>
 					</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

See: pcTixB-15-p2

#### Testing instructions

Open https://calypso.live/help?branch=update/bloggingu-link and confirm the following:

![Screen Shot on 2021-05-05 at 15:57:49](https://user-images.githubusercontent.com/1563559/117201491-afce7e80-adba-11eb-8110-f76eaef7c2e4.png)

Also confirm that it links to: https://wpcourses.com/