### PR TITLE
Fix Jetpack product grid translations

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -59,8 +59,13 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 	// is connected, and thus, we don't need to show the Jetpack Free card.
 	const isSiteInContext = !! siteId;
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const currentPlanSlug =
-		useSelector( ( state ) => getSitePlan( state, siteId ) )?.product_slug || null;
+	const currentPlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
+	const currentPlanSlug = currentPlan?.product_slug || null;
+	const currentPlanTranslatedName =
+		currentPlan && currentPlan.product_name_short
+			? // eslint-disable-next-line wpcalypso/i18n-no-variables
+			  translate( currentPlan.product_name_short )
+			: null;
 
 	const { availableProducts, purchasedProducts, includedInPlanProducts } = useGetPlansGridProducts(
 		siteId
@@ -73,7 +78,7 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 			sortBy( getPlansToDisplay( { duration, currentPlanSlug } ), ( item ) =>
 				getProductPosition( item.productSlug as JetpackPlanSlug )
 			),
-		[ duration, currentPlanSlug ]
+		[ duration, currentPlanSlug, currentPlanTranslatedName ]
 	);
 	const sortedProducts = useMemo(
 		() =>

--- a/packages/calypso-products/src/plans-list.js
+++ b/packages/calypso-products/src/plans-list.js
@@ -720,7 +720,10 @@ const getPlanJetpackSecurityRealtimeDetails = () => ( {
 const getPlanJetpackCompleteDetails = () => ( {
 	group: GROUP_JETPACK,
 	type: TYPE_ALL,
-	getTitle: () => translate( 'Complete' ),
+	getTitle: () =>
+		translate( 'Complete', {
+			context: 'Jetpack plan name',
+		} ),
 	getAudience: () => translate(),
 	availableFor: ( plan ) =>
 		[ PLAN_JETPACK_FREE, ...JETPACK_SECURITY_PLANS, ...JETPACK_LEGACY_PLANS ].includes( plan ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add context to the 'Complete' Jetpack plan name, so that it'd have a separate translation and not the standard translation for 'complete'.
* Fix the issue with caching of the Jetpack plans, by using the translated plan name to force an update once it becomes translated.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to a non-English user locale - non-Latin character set would show the issue more clearly.
* Have a linked Jetpack site and navigate to https://wordpress.com/plans/your-jetpack-site-url and confirm that 'Security Daily', 'Complete' and 'Security Real-Time' display English titles and descriptions.
* Switch to monthly or yearly payments and see that the translations are displayed now.
* Re-test on calypso.live or local instance and see that the translations are displayed without the need to switch the payment period toggle, but the 'Complete' plan title remains untranslated due to the added context.

Before:
<img width="800" alt="plans-before" src="https://user-images.githubusercontent.com/7847633/117220920-889e9e00-ae08-11eb-850a-488c575b9c4c.png">

After:
<img width="800" alt="plans-after" src="https://user-images.githubusercontent.com/7847633/117221487-aae4eb80-ae09-11eb-91a6-98ac76be32a1.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

