### PR TITLE
Jetpack Search: instant search toggle should change with Jetpack Search toggle

### DIFF
--- a/client/my-sites/site-settings/jetpack-module-toggle.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle.jsx
@@ -42,6 +42,7 @@ class JetpackModuleToggle extends Component {
 	};
 
 	handleChange = () => {
+		this.props.onChange( ! this.props.checked );
 		if ( ! this.props.checked ) {
 			this.recordTracksEvent( 'calypso_jetpack_module_toggle', 'on' );
 			this.props.activateModule( this.props.siteId, this.props.moduleSlug );

--- a/client/my-sites/site-settings/jetpack-module-toggle.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle.jsx
@@ -39,6 +39,7 @@ class JetpackModuleToggle extends Component {
 		activateModule: PropTypes.func,
 		deactivateModule: PropTypes.func,
 		path: PropTypes.string,
+		onChange: PropTypes.func,
 	};
 
 	handleChange = () => {

--- a/client/my-sites/site-settings/jetpack-module-toggle.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle.jsx
@@ -43,7 +43,7 @@ class JetpackModuleToggle extends Component {
 	};
 
 	handleChange = () => {
-		this.props.onChange( ! this.props.checked );
+		this.props?.onChange && this.props.onChange( ! this.props.checked );
 		if ( ! this.props.checked ) {
 			this.recordTracksEvent( 'calypso_jetpack_module_toggle', 'on' );
 			this.props.activateModule( this.props.siteId, this.props.moduleSlug );

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -141,24 +141,6 @@ class Search extends Component {
 		);
 	}
 
-	/**
-	 * Change Instant toggle with Jetpack Toggle.
-	 *
-	 * Note: Even if it's a Jetpack site, we need to set jetpack_search_enabled,
-	 *       as it controls the availability of the Instant Search toggle.
-	 *
-	 * @param {boolean} jetpackSearchEnabled Whether Jetpack Search is enabled after toggling
-	 */
-	handleJetpackSearchToggleChange = ( jetpackSearchEnabled ) => {
-		this.props.trackEvent( `Toggled instant_search_enabled` );
-		// Change instant toggle status with Jetpack Search toggle
-		this.props.updateFields( { instant_search_enabled: jetpackSearchEnabled }, () => {
-			// Set Jetpack Search status and submit form
-			this.props.trackEvent( `Toggled jetpack_search_enabled` );
-			this.props.setFieldValue( 'jetpack_search_enabled', jetpackSearchEnabled, true );
-		} );
-	};
-
 	renderSettingsCard() {
 		const {
 			activatingSearchModule,

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -162,7 +162,37 @@ class Search extends Component {
 			isSearchModuleActive,
 			siteId,
 			translate,
+			saveJetpackSettings,
+			submitForm,
+			updateFields,
+			trackEvent,
 		} = this.props;
+
+		/**
+		 * Call WPCOM endpionts to update remote Jetpack sites' settings
+		 *
+		 * @param {boolean} jetpackSearchEnabled Whether Jetpack Search is enabled
+		 */
+		const handleInstantSearchToggleForJetpackSites = ( jetpackSearchEnabled ) =>
+			saveJetpackSettings( siteId, {
+				instant_search_enabled: jetpackSearchEnabled,
+			} );
+
+		/**
+		 * Change instant toggle status with Jetpack Search toggle and then save settings
+		 *
+		 * @param {boolean} jetpackSearchEnabled Whether Jetpack Search is enabled
+		 */
+		const handleJetpackSearchToggleForSimpleSites = ( jetpackSearchEnabled ) => {
+			trackEvent( `Toggled instant_search_enabled` );
+			updateFields(
+				{
+					instant_search_enabled: jetpackSearchEnabled,
+					jetpack_search_enabled: jetpackSearchEnabled,
+				},
+				submitForm
+			);
+		};
 
 		return (
 			<Fragment>
@@ -175,13 +205,13 @@ class Search extends Component {
 								moduleSlug="search"
 								label={ translate( 'Enable Jetpack Search' ) }
 								disabled={ isRequestingSettings || isSavingSettings }
-								onChange={ this.handleJetpackSearchToggleChange }
+								onChange={ handleInstantSearchToggleForJetpackSites }
 							/>
 						) : (
 							<FormToggle
 								checked={ !! fields.jetpack_search_enabled }
 								disabled={ isRequestingSettings || isSavingSettings }
-								onChange={ this.handleJetpackSearchToggleChange }
+								onChange={ handleJetpackSearchToggleForSimpleSites }
 							>
 								{ translate( 'Enable Jetpack Search' ) }
 							</FormToggle>
@@ -196,7 +226,11 @@ class Search extends Component {
 									! ( isSearchModuleActive || fields.jetpack_search_enabled ) ||
 									! this.props.hasSearchProduct
 								}
-								onChange={ handleAutosavingToggle( 'instant_search_enabled' ) }
+								onChange={
+									! this.props.siteIsJetpack
+										? handleAutosavingToggle( 'instant_search_enabled' )
+										: handleInstantSearchToggleForJetpackSites
+								}
 							>
 								{ translate( 'Enable instant search experience (recommended)' ) }
 							</FormToggle>

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -57,6 +57,14 @@ class Search extends Component {
 		isRequestingSettings: PropTypes.bool,
 		fields: PropTypes.object,
 		trackEvent: PropTypes.func.isRequired,
+		activatingSearchModule: PropTypes.func.isRequired,
+		isLoading: PropTypes.bool,
+		isSearchModuleActive: PropTypes.bool,
+		siteId: PropTypes.number,
+		translate: PropTypes.func.isRequired,
+		saveJetpackSettings: PropTypes.func.isRequired,
+		submitForm: PropTypes.func.isRequired,
+		updateFields: PropTypes.func.isRequired,
 	};
 
 	renderInfoLink( link ) {

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -174,7 +174,7 @@ class Search extends Component {
 		 * @param {boolean} jetpackSearchEnabled Whether Jetpack Search is enabled
 		 */
 		const handleJetpackSearchToggleForSimpleSites = ( jetpackSearchEnabled ) => {
-			trackEvent( `Toggled instant_search_enabled` );
+			trackEvent( 'Toggled instant_search_enabled' );
 			updateFields(
 				{
 					instant_search_enabled: jetpackSearchEnabled,

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -217,9 +217,9 @@ class Search extends Component {
 									! this.props.hasSearchProduct
 								}
 								onChange={
-									! this.props.siteIsJetpack
-										? handleAutosavingToggle( 'instant_search_enabled' )
-										: handleInstantSearchToggleForJetpackSites
+									this.props.siteIsJetpack
+										? handleInstantSearchToggleForJetpackSites
+										: handleAutosavingToggle( 'instant_search_enabled' )
 								}
 							>
 								{ translate( 'Enable instant search experience (recommended)' ) }

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -94,14 +94,10 @@ class Search extends Component {
 					{ this.props.translate(
 						'Allow your visitors to get search results as soon as they start typing.'
 					) }{ ' ' }
-					{ this.props.hasSearchProduct
-						? this.props.translate(
-								'If deactivated, Jetpack Search will still optimize your search results but visitors will have to submit a search query before seeing any results.'
-						  )
-						: // The following notice is only shown for Business/Pro plan holders.
-						  this.props.translate(
-								'Instant search is only available with a Jetpack Search subscription.'
-						  ) }
+					{ ! this.props.hasSearchProduct && // The following notice is only shown for Business/Pro plan holders.
+						this.props.translate(
+							'Instant search is only available with a Jetpack Search subscription.'
+						) }
 				</FormSettingExplanation>
 			</div>
 		);

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -159,7 +159,7 @@ class Search extends Component {
 		} = this.props;
 
 		/**
-		 * Call WPCOM endpionts to update remote Jetpack sites' settings
+		 * Call WPCOM endpoints to update remote Jetpack sites' settings
 		 *
 		 * @param {boolean} jetpackSearchEnabled Whether Jetpack Search is enabled
 		 */

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -132,8 +132,19 @@ class Search extends Component {
 		);
 	}
 
+	/**
+	 * Change Instant toggle with Jetpack Toggle.
+	 *
+	 * Note: Even if it's a Jetpack site, we need to set jetpack_search_enabled,
+	 *       as it controls the availability of the Instant Search toggle.
+	 *
+	 * @param {boolean} jetpack_search_enabled Whether Jetpack Search is enabled after toggling
+	 * @returns void
+	 */
 	handleJetpackSearchToggleChange = ( jetpack_search_enabled ) =>
+		// Change instant toggle status with Jetpack Search toggle
 		this.props.updateFields( { instant_search_enabled: jetpack_search_enabled }, () =>
+			// Set Jetpack Search status and submit form
 			this.props.setFieldValue( 'jetpack_search_enabled', jetpack_search_enabled, true )
 		);
 

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -132,6 +132,11 @@ class Search extends Component {
 		);
 	}
 
+	handleJetpackSearchToggleChange = ( jetpack_search_enabled ) =>
+		this.props.updateFields( { instant_search_enabled: jetpack_search_enabled }, () =>
+			this.props.setFieldValue( 'jetpack_search_enabled', jetpack_search_enabled, true )
+		);
+
 	renderSettingsCard() {
 		const {
 			activatingSearchModule,
@@ -143,7 +148,6 @@ class Search extends Component {
 			isSearchModuleActive,
 			siteId,
 			translate,
-			updateFields,
 		} = this.props;
 
 		return (
@@ -157,17 +161,13 @@ class Search extends Component {
 								moduleSlug="search"
 								label={ translate( 'Enable Jetpack Search' ) }
 								disabled={ isRequestingSettings || isSavingSettings }
+								onChange={ this.handleJetpackSearchToggleChange }
 							/>
 						) : (
 							<FormToggle
 								checked={ !! fields.jetpack_search_enabled }
 								disabled={ isRequestingSettings || isSavingSettings }
-								onChange={ () =>
-									updateFields(
-										{ instant_search_enabled: ! fields.jetpack_search_enabled },
-										handleAutosavingToggle( 'jetpack_search_enabled' )
-									)
-								}
+								onChange={ this.handleJetpackSearchToggleChange }
 							>
 								{ translate( 'Enable Jetpack Search' ) }
 							</FormToggle>

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -155,7 +155,7 @@ class Search extends Component {
 							<JetpackModuleToggle
 								siteId={ siteId }
 								moduleSlug="search"
-								label={ translate( 'Improve built-in WordPress search performance.' ) }
+								label={ translate( 'Enable Jetpack Search' ) }
 								disabled={ isRequestingSettings || isSavingSettings }
 							/>
 						) : (
@@ -169,7 +169,7 @@ class Search extends Component {
 									)
 								}
 							>
-								{ translate( 'Improve built-in WordPress search performance.' ) }
+								{ translate( 'Enable Jetpack Search' ) }
 							</FormToggle>
 						) }
 

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -138,14 +138,14 @@ class Search extends Component {
 	 * Note: Even if it's a Jetpack site, we need to set jetpack_search_enabled,
 	 *       as it controls the availability of the Instant Search toggle.
 	 *
-	 * @param {boolean} jetpack_search_enabled Whether Jetpack Search is enabled after toggling
+	 * @param {boolean} jetpackSearchEnabled Whether Jetpack Search is enabled after toggling
 	 * @returns void
 	 */
-	handleJetpackSearchToggleChange = ( jetpack_search_enabled ) =>
+	handleJetpackSearchToggleChange = ( jetpackSearchEnabled ) =>
 		// Change instant toggle status with Jetpack Search toggle
-		this.props.updateFields( { instant_search_enabled: jetpack_search_enabled }, () =>
+		this.props.updateFields( { instant_search_enabled: jetpackSearchEnabled }, () =>
 			// Set Jetpack Search status and submit form
-			this.props.setFieldValue( 'jetpack_search_enabled', jetpack_search_enabled, true )
+			this.props.setFieldValue( 'jetpack_search_enabled', jetpackSearchEnabled, true )
 		);
 
 	renderSettingsCard() {

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -143,6 +143,7 @@ class Search extends Component {
 			isSearchModuleActive,
 			siteId,
 			translate,
+			updateFields,
 		} = this.props;
 
 		return (
@@ -161,7 +162,12 @@ class Search extends Component {
 							<FormToggle
 								checked={ !! fields.jetpack_search_enabled }
 								disabled={ isRequestingSettings || isSavingSettings }
-								onChange={ handleAutosavingToggle( 'jetpack_search_enabled' ) }
+								onChange={ () =>
+									updateFields(
+										{ instant_search_enabled: ! fields.jetpack_search_enabled },
+										handleAutosavingToggle( 'jetpack_search_enabled' )
+									)
+								}
 							>
 								{ translate( 'Improve built-in WordPress search performance.' ) }
 							</FormToggle>

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -56,6 +56,7 @@ class Search extends Component {
 		isSavingSettings: PropTypes.bool,
 		isRequestingSettings: PropTypes.bool,
 		fields: PropTypes.object,
+		trackEvent: PropTypes.func.isRequired,
 	};
 
 	renderInfoLink( link ) {
@@ -139,14 +140,16 @@ class Search extends Component {
 	 *       as it controls the availability of the Instant Search toggle.
 	 *
 	 * @param {boolean} jetpackSearchEnabled Whether Jetpack Search is enabled after toggling
-	 * @returns void
 	 */
-	handleJetpackSearchToggleChange = ( jetpackSearchEnabled ) =>
+	handleJetpackSearchToggleChange = ( jetpackSearchEnabled ) => {
+		this.props.trackEvent( `Toggled instant_search_enabled` );
 		// Change instant toggle status with Jetpack Search toggle
-		this.props.updateFields( { instant_search_enabled: jetpackSearchEnabled }, () =>
+		this.props.updateFields( { instant_search_enabled: jetpackSearchEnabled }, () => {
 			// Set Jetpack Search status and submit form
-			this.props.setFieldValue( 'jetpack_search_enabled', jetpackSearchEnabled, true )
-		);
+			this.props.trackEvent( `Toggled jetpack_search_enabled` );
+			this.props.setFieldValue( 'jetpack_search_enabled', jetpackSearchEnabled, true );
+		} );
+	};
 
 	renderSettingsCard() {
 		const {

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -53,7 +53,7 @@ class SiteSettingsPerformance extends Component {
 			translate,
 			trackEvent,
 			updateFields,
-			setFieldValue,
+			saveJetpackSettings,
 		} = this.props;
 		const siteIsJetpackNonAtomic = siteIsJetpack && ! siteIsAtomic;
 
@@ -76,7 +76,8 @@ class SiteSettingsPerformance extends Component {
 				<Search
 					handleAutosavingToggle={ handleAutosavingToggle }
 					updateFields={ updateFields }
-					setFieldValue={ setFieldValue }
+					submitForm={ submitForm }
+					saveJetpackSettings={ saveJetpackSettings }
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -80,6 +80,7 @@ class SiteSettingsPerformance extends Component {
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }
+					trackEvent={ trackEvent }
 				/>
 
 				{ siteIsJetpack && (

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -53,6 +53,7 @@ class SiteSettingsPerformance extends Component {
 			translate,
 			trackEvent,
 			updateFields,
+			setFieldValue,
 		} = this.props;
 		const siteIsJetpackNonAtomic = siteIsJetpack && ! siteIsAtomic;
 
@@ -75,6 +76,7 @@ class SiteSettingsPerformance extends Component {
 				<Search
 					handleAutosavingToggle={ handleAutosavingToggle }
 					updateFields={ updateFields }
+					setFieldValue={ setFieldValue }
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -74,6 +74,7 @@ class SiteSettingsPerformance extends Component {
 
 				<Search
 					handleAutosavingToggle={ handleAutosavingToggle }
+					updateFields={ updateFields }
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }


### PR DESCRIPTION
Fixes: #52404

#### Changes proposed in this Pull Request
- When disabling Jetpack Search, instant search would also be disabled which is a child option under Jetpack Search, which also aligns with Jetpack plugin settings page.
- And, because we recommend instant search, when Jetpack is re-enabled, instant search would be re-enabled too.
- Changed label to be clearer - 'Enable Jetpack Search'
- Separate the setting saving of jetpack sites (including Atomic) from simple sites to avoid a random error discussed in P2.

#### Discussion
pcNPJE-8a-p2

#### Testing instructions
- Open Settings->General->Performance of a site with Jetpack Search plan (Atomic/Simple/Jetpack sites) in Clypso
- Ensure when Jetpack Search  is toggled disabled, instant search is disabled as well.
- Ensure when Jetpack Search is toggled enabled, instant search is set to enabled.
- Ensure Instant search toggle could change and save without affecting Jetpack Search toggle.
- Ensure it works for Atomic / Simple / Jetpack site.

![image](https://user-images.githubusercontent.com/1425433/117230494-52493900-ae71-11eb-875f-8ca230779670.png)


Gif: https://d.pr/i/dl2HRh
