### PR TITLE
Design Picker: skip flakey unit test

### DIFF
--- a/packages/design-picker/src/utils/__tests__/available-designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/available-designs.test.ts
@@ -197,7 +197,10 @@ describe( 'Design Picker design utils', () => {
 			);
 		} );
 
-		it( 'should randomize the results order when the randomize flag is specified', () => {
+		// The next test is temporarily disabled because of its flakeyness.
+		// Tracked in https://github.com/Automattic/wp-calypso/issues/51743
+		// eslint-disable-next-line jest/no-disabled-tests
+		it.skip( 'should randomize the results order when the randomize flag is specified', () => {
 			// Randomization is checked by comparing randomized and non-randomized
 			// return values, and checking that these values are normally different,
 			// but that they are equal after being sorted.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Skip the `should randomize the results order when the randomize flag is specified` unit test, since it's flakey (see https://github.com/Automattic/wp-calypso/pull/51633#discussion_r626047488)
* Improving and re-enabling the test tracked in https://github.com/Automattic/wp-calypso/issues/51743 

#### Testing instructions

Run `cd packages/design-picker && yarn jest --verbose` and make sure that the `should randomize the results order when the randomize flag is specified` unit test is skipped

Related to #51633
