### PR TITLE
Importer: fix author mapping validation

### DIFF
--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -135,7 +135,7 @@ class AuthorMappingPane extends React.PureComponent {
 			site,
 			totalUsers,
 		} = this.props;
-		const canStartImport = hasSingleAuthor || sourceAuthors.some( ( author ) => author.mappedTo );
+		const canStartImport = hasSingleAuthor || sourceAuthors.every( ( author ) => author.mappedTo );
 		const mappingDescription = this.getMappingDescription(
 			sourceAuthors.length,
 			totalUsers,


### PR DESCRIPTION
The "Start import" button will be disabled until the user maps each author in the list.

#### Changes proposed in this Pull Request

* Updated author mapping validation.
* Fixed the error ↓
```
Uncaught (in promise) BadAuthorsError: Author mapping missing or incomplete.
```

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Prerequisites**

1. The source blog needs to have more than one user
2. The target blog needs to have more than one user

**Steps**﻿

1. Go to Tools/Import/WordPress
2. Click on 'upload it to import content'
3. Upload your XML WP export file
4. In the following screen, do not assign all users (leave at least one as "Choose an Author")
5. Click on "Start Import"

<img width="738" alt="Screenshot 2021-05-06 at 16 58 10" src="https://user-images.githubusercontent.com/1241413/117320229-50d93a00-ae8c-11eb-8e95-cfa6c98b2a0c.png">

<img width="737" alt="Screenshot 2021-05-06 at 16 58 22" src="https://user-images.githubusercontent.com/1241413/117320256-56cf1b00-ae8c-11eb-8035-6626a7de0f95.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #49503
