### PR TITLE
Fix wrong href of Jetpack Free card button

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card/test/button.jsx
+++ b/client/components/jetpack/card/jetpack-free-card/test/button.jsx
@@ -52,7 +52,7 @@ describe( 'JetpackFreeCardButton', () => {
 			ui: { selectedSiteId: siteId },
 			sites: {
 				items: {
-					[ siteId ]: { options: { admin_url: adminUrl } },
+					[ siteId ]: { options: { admin_url: adminUrl }, jetpack: true },
 				},
 			},
 		};
@@ -60,6 +60,21 @@ describe( 'JetpackFreeCardButton', () => {
 		render( <JetpackFreeCardButton />, { initialState } );
 
 		expect( getHref() ).toEqual( jetpackAdminUrl );
+	} );
+
+	it( 'should link to the connect page if the site is not a Jetpack site', () => {
+		const initialState = {
+			ui: { selectedSiteId: siteId },
+			sites: {
+				items: {
+					[ siteId ]: { options: { admin_url: adminUrl }, jetpack: false },
+				},
+			},
+		};
+
+		render( <JetpackFreeCardButton />, { initialState } );
+
+		expect( getHref() ).toEqual( JPC_PATH_BASE );
 	} );
 
 	it( 'should link to the Jetpack section in the site admin, when site in context', () => {

--- a/client/state/selectors/get-jetpack-recommendations-url.ts
+++ b/client/state/selectors/get-jetpack-recommendations-url.ts
@@ -1,13 +1,27 @@
 /**
+ * External dependencies
+ */
+import { getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
+
+/**
  * Internal dependencies
  */
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
 
-export default function getJetpackRecommendationsUrl( state ) {
+/**
+ * Type dependencies
+ */
+import type { AppState } from 'calypso/types';
+
+export default function getJetpackRecommendationsUrl( state: AppState ): string | undefined {
 	const site = getSelectedSite( state );
 
+	if ( ! site?.jetpack ) {
+		return undefined;
+	}
+
 	const adminUrl = site?.options?.admin_url;
+
 	return adminUrl
 		? getUrlFromParts( {
 				...getUrlParts( adminUrl + 'admin.php' ),

--- a/client/state/ui/selectors/site-data.ts
+++ b/client/state/ui/selectors/site-data.ts
@@ -8,6 +8,7 @@ export interface SiteData {
 	domain: string;
 	locale: string;
 	options?: SiteDataOptions;
+	jetpack?: boolean;
 	// TODO: fill out the rest of this
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

When visiting the Jetpack connect section without any site in context, if your primary site is a simple site, the "Start for free" button directs you to a wrong URL. This PR fixes this.

Fixes 1164141197617539-as-1200286265849335

### Testing instructions

To reproduce the issue:
- Make sure your primary site is not a Jetpack site, and that you're authenticated in wordpress.com
- Visit `https://wordpress.com/jetpack/connect/store?source=jetpack-connect-plans&cta_id=masthead-install-page-9&cta_from=home`
- The URL of the "Start for free" link should be `https://:site/wp-admin/admin.php?page=jetpack#/recommendations`, even though the site is not a Jetpack site

To test the fix:
- Download the PR and run Calypso
- Make sure your primary site is not a Jetpack site, and that you're authenticated in wordpress.com
- Visit `https://wordpress.com/jetpack/connect/store?source=jetpack-connect-plans&cta_id=masthead-install-page-9&cta_from=home`
- The URL of the "Start for free" link should be `/jetpack/connect`

### Screenshots
<img width="884" alt="Screen Shot 2021-05-06 at 12 41 30 PM" src="https://user-images.githubusercontent.com/1620183/117334621-38efbf00-ae68-11eb-990c-b5b126d4ceff.png">