### PR TITLE
Error Reporting for GB/WP-Admin: Add crossorigin to other relevant script els and add return early in case of sanitized error

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
@@ -11,6 +11,14 @@ const headErrors = window._jsErr || [];
 const headErrorHandler = window._headJsErrorHandler;
 
 const reportError = ( { error } ) => {
+	// Sanitized error event objects do not include a nested error attribute. In
+	// that case, we return early to prevent a needless TypeError when defining
+	// `data`, below. Also, sanitized errors don't include any useful information,
+	// so the sensible thing to do is to completely ignore them.
+	if ( ! error ) {
+		return;
+	}
+
 	const data = {
 		message: error.message,
 		trace: error.stack,

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -16,9 +16,8 @@ namespace A8C\FSE\ErrorReporting;
 function head_error_handler() {
 	?><script type="text/javascript">
 		window._headJsErrorHandler = function( errEvent ) {
-			console.log(errEvent);
 			window._jsErr = window._jsErr || [];
-			window._jsErr.push(errEvent);
+			window._jsErr.push( errEvent );
 		}
 		window.addEventListener( 'error', window._headJsErrorHandler );
 	</script>
@@ -35,7 +34,7 @@ function head_error_handler() {
  */
 function add_crossorigin_to_script_els( $tag ) {
 	// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
-	if ( preg_match( '/<script\s.*src=.*s0\.wp\.com.*>/', $tag ) ) {
+	if ( preg_match( '/<script\s.*src=.*(s0\.wp\.com|stats\.wp\.com|widgets\.wp\.com).*>/', $tag ) ) {
 		return str_replace( ' src', " crossorigin='anonymous' src", $tag );
 	};
 	return $tag;


### PR DESCRIPTION
Project: p4TIVU-9DI-p2

#### Changes proposed in this Pull Request

* Add the `crossorigin=anonymous` to other relevant domains, see: pMz3w-cCq-p2#comment-86959
* Add a guard in the `reportError` function that will return early if the error is sanitized (just in case) which means the object passed doesn't have all necessary attributes and would end up causing an error (see inline comment);
* Minor formatting improvements;
* Keep segment of users to 10% for now. Once this is deployed and tested for a while, I'll then increase to 25% (or maybe a bit more).
* The next step after this is to figure out how to get this to work on :atom: :)


#### Testing instructions

1. Sandbox `public-api.wordpress.com` and `s0.wp.com`;
2. [Enable](https://gist.github.com/fullofcaffeine/b9c5546ac1646bbf497ed0c87bae5bac) jsconcat in your sandbox;
3. Sync this custom ETK build to your sandbox;
4. Load a new post, paste this [snippet](https://gist.github.com/fullofcaffeine/93644095d605391d73d5893f3da537c1) to make sure reporting still works (see details instructions on how to check Kibana in the CfT: p4TIVU-9Cm-p2);
5. Make sure to set the iframe context to wp-admin (`<wpcom-url>/wp-admin/post-new.php`) in the inspector!;
6. Inspect the DOM (either manually in the inspector), find all script elements that refer to `s0.wp.com`*[0], `stats.wp.com` and `widgets.wp.com`. They all should have a `crossorigin="anonymous"` attribute*[1];
7. All responses from stats.wp.com and widgets.wp.com should have the `Access-Control-Allow-Origin: *` header (this is not part of this changeset, and was added by systems a while ago, but would still be nice to sanity-check).


*[0]`s0.wp.com` that don't have `_static` as part of its URL (as those are handled by jsconcat directly and are not affected by this changeset), i.e `https://s0.wp.com/wp-content/mu-plugins/geo-location/geo-location-admin.js?`

*[1] **UPDATE**: Use the following snippet to get a list of relevant script els from the page and check that they have the `crossOrigin` attribute set to `anonymoys`, make sure you have the right iframe context first (see step 5 above):

```js
Array.from(document.querySelectorAll('script')).filter((el) => el.src.match(/s0\.wp\.com|stats\.wp\.com|widgets\.wp\.com/)).map((el) => [el.src, el.crossOrigin]);
```

I should note that there's some weirdness going on with the `stats.wp.com/w.js` script. The one that goes through the `script_loader_tag` filter/pipeline is `<script src='//stats.wp.com/w.js?ver=202118' id='jp-tracks-js'></script>` and it correctly gets the `crossorigin=anonymous` as you may see by running the snippet above. 

However, there are four other instances of the same script on the page (also verify yourself by running the snippet above):

```
21: <script src="//stats.wp.com/w.js?63" type="text/javascript" async="">​
22: <script src="//stats.wp.com/w.js?63" type="text/javascript" async="">​
23: <script src="//stats.wp.com/w.js?63" type="text/javascript" async="">​
24: <script src="https://stats.wp.com/w.js?61" defer="">
```

That seem to be added in another way that doesn't go through `script_loader_tag`, hence they don't get the `crossorigin` attr added. I have no idea how yet and why they're there. I don't think this is a blocker for accepting this PR, but it'd be nice to get someone to clarify that. 