### PR TITLE
Checkout: Move PayPal payment method from composite-checkout to wpcom-checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -3,7 +3,6 @@
  */
 import { useMemo } from 'react';
 import {
-	createPayPalMethod,
 	createAlipayMethod,
 	createAlipayPaymentMethodStore,
 	createGiropayMethod,
@@ -21,6 +20,7 @@ import {
 	createApplePayMethod,
 	createBancontactMethod,
 	createBancontactPaymentMethodStore,
+	createPayPalMethod,
 } from '@automattic/wpcom-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import type { StripeConfiguration, Stripe, StripeLoadingError } from '@automattic/calypso-stripe';

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -28,7 +28,6 @@ It's also possible to build an entirely custom form using the other components e
 Most components of this package require being inside a [CheckoutProvider](#checkoutprovider). That component requires an array of [Payment Method objects](#payment-methods) which define the available payment methods (stripe credit cards, apple pay, paypal, credits, etc.) that will be displayed in the form. While you can create these objects manually, the package provides many pre-defined payment method objects that can be created by using the following functions:
 
 - [createExistingCardMethod](#createExistingCardMethod)
-- [createPayPalMethod](#createpaypalmethod)
 - [createStripeMethod](#createStripeMethod)
 
 Any component which is a child of `CheckoutProvider` gets access to the following custom hooks:
@@ -368,16 +367,6 @@ An [@emotion/styled](https://emotion.sh/docs/styled) theme object that can be me
 ### createRegistry
 
 Creates a [data store](#data-stores) registry to be passed (optionally) to [CheckoutProvider](#checkoutprovider). See the `@wordpress/data` [docs for this function](https://developer.wordpress.org/block-editor/packages/packages-data/#createRegistry).
-
-### createPayPalMethod
-
-Creates a [Payment Method](#payment-methods) object. Requires passing an object with the following properties:
-
-- `registerStore: object => object`. The `registerStore` function from the return value of [createRegistry](#createRegistry).
-
-The object returned by this function **must have** the following property added to it:
-
-- `submitTransaction: async object => string`. An async function that sends the request to the endpoint to get the redirect url.
 
 ### createStripeMethod
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -11,7 +11,6 @@ import {
 	CheckoutSteps,
 	CheckoutSummaryArea,
 	CheckoutProvider,
-	createPayPalMethod,
 	createStripeMethod,
 	createStripePaymentMethodStore,
 	defaultRegistry,
@@ -78,13 +77,6 @@ async function stripeCardProcessor( data ) {
 	// This simulates the transaction and provisioning time
 	await asyncTimeout( 2000 );
 	return makeSuccessResponse( { success: true } );
-}
-
-async function makePayPalExpressRequest( data ) {
-	window.console.log( 'Processing paypal transaction with data', data );
-	// This simulates the transaction and provisioning time
-	await asyncTimeout( 2000 );
-	return window.location.href;
 }
 
 const { registerStore } = defaultRegistry;
@@ -242,18 +234,7 @@ function MyCheckout() {
 		} );
 	}, [ stripeStore, stripe, stripeConfiguration, isStripeLoading, stripeLoadingError ] );
 
-	const paypalMethod = useMemo(
-		() =>
-			createPayPalMethod( {
-				registerStore,
-				getSuccessUrl: () => '#',
-				getCancelUrl: () => '#',
-			} ),
-		[]
-	);
-	paypalMethod.submitTransaction = makePayPalExpressRequest;
-
-	const paymentMethods = [ stripeMethod, paypalMethod ].filter( Boolean );
+	const paymentMethods = [ stripeMethod ].filter( Boolean );
 
 	return (
 		<CheckoutProvider

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -54,7 +54,6 @@ import {
 	createStripeMethod,
 	createStripePaymentMethodStore,
 } from './lib/payment-methods/stripe-credit-card-fields';
-import { createPayPalMethod } from './lib/payment-methods/paypal';
 import { createExistingCardMethod } from './lib/payment-methods/existing-credit-card';
 import CheckoutOrderSummaryStep, {
 	CheckoutOrderSummary,
@@ -125,7 +124,6 @@ export {
 	createIdealPaymentMethodStore,
 	createP24Method,
 	createP24PaymentMethodStore,
-	createPayPalMethod,
 	createRegistry,
 	createSofortMethod,
 	createSofortPaymentMethodStore,

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -7,6 +7,7 @@ export * from './transformations';
 export * from './types';
 export * from './product-url-encoding';
 export { useDisplayCartMessages };
+export { createPayPalMethod } from './payment-methods/paypal';
 export { createApplePayMethod } from './payment-methods/apple-pay';
 export * from './postal-code';
 export { default as Field } from './field';

--- a/packages/wpcom-checkout/src/payment-methods/paypal.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/paypal.tsx
@@ -5,23 +5,31 @@ import React from 'react';
 import styled from '@emotion/styled';
 import debugFactory from 'debug';
 import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
-import Button from '../../components/button';
 import {
 	FormStatus,
 	TransactionStatus,
 	useTransactionStatus,
 	useLineItems,
-} from '../../public-api';
-import { useFormStatus } from '../form-status';
-import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
+	useFormStatus,
+	Button,
+} from '@automattic/composite-checkout';
+import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 
-const debug = debugFactory( 'composite-checkout:paypal' );
+/**
+ * Internal dependencies
+ */
+import { PaymentMethodLogos } from '../payment-method-logos';
 
-export function createPayPalMethod( { labelText = null } ) {
+const debug = debugFactory( 'wpcom-checkout:paypal' );
+
+// Disabling this rule to make migrating this easier with fewer changes
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
+export function createPayPalMethod( {
+	labelText = null,
+}: {
+	labelText?: string | null;
+} ): PaymentMethod {
 	debug( 'creating new paypal payment method' );
 	return {
 		id: 'paypal',
@@ -32,7 +40,7 @@ export function createPayPalMethod( { labelText = null } ) {
 	};
 }
 
-export function PaypalLabel( { labelText = null } ) {
+export function PaypalLabel( { labelText = null }: { labelText?: string | null } ): JSX.Element {
 	const { __ } = useI18n();
 
 	return (
@@ -45,12 +53,23 @@ export function PaypalLabel( { labelText = null } ) {
 	);
 }
 
-export function PaypalSubmitButton( { disabled, onClick } ) {
+export function PaypalSubmitButton( {
+	disabled,
+	onClick,
+}: {
+	disabled?: boolean;
+	onClick?: ProcessPayment;
+} ): JSX.Element {
 	const { formStatus } = useFormStatus();
 	const { transactionStatus } = useTransactionStatus();
 	const [ items ] = useLineItems();
 
 	const handleButtonPress = () => {
+		if ( ! onClick ) {
+			throw new Error(
+				'Missing onClick prop; PaypalSubmitButton must be used as a payment button in CheckoutSubmitButton'
+			);
+		}
 		onClick( 'paypal', {
 			items,
 		} );
@@ -68,7 +87,13 @@ export function PaypalSubmitButton( { disabled, onClick } ) {
 	);
 }
 
-function PayPalButtonContents( { formStatus, transactionStatus } ) {
+function PayPalButtonContents( {
+	formStatus,
+	transactionStatus,
+}: {
+	formStatus: FormStatus;
+	transactionStatus: TransactionStatus;
+} ): JSX.Element {
 	const { __ } = useI18n();
 	if ( transactionStatus === TransactionStatus.REDIRECTING ) {
 		return <span>{ __( 'Redirecting to PayPal…' ) }</span>;
@@ -86,12 +111,12 @@ const ButtonPayPalIcon = styled( PaypalLogo )`
 	transform: translateY( 2px );
 `;
 
-function PaypalSummary() {
+function PaypalSummary(): JSX.Element {
 	const { __ } = useI18n();
-	return __( 'PayPal' );
+	return <>{ __( 'PayPal' ) }</>;
 }
 
-function PaypalLogo( { className } ) {
+function PaypalLogo( { className }: { className?: string } ): JSX.Element {
 	return (
 		<svg
 			className={ className }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the PayPal payment method from the `@automattic/composite-checkout` package into the `@automattic/wpcom-checkout` package.

The `composite-checkout` package is intended to be a fairly generic checkout-building toolkit. As part of this we originally envisioned it containing various payment methods, but that quickly became a problem as it became clear that the payment methods we use on WordPress.com are pretty specific to our platform. To reduce leaky abstractions, we moved many of our payment methods over to calypso, but some have remained because the cost of moving them seemed too high for the benefit.

As we prepare to publish version 1.0.0 of the `@automattic/composite-checkout` package on npm, I think it's a good time to clean up extraneous parts of the package. The payment methods are the only part of the package that are not fully TypeScript and are also still pretty specific to our WordPress.com infrastructure. Eventually it would be nice to convert them all to TypeScript and put them in a package like `@automattic/wpcom-checkout` (which is intended to be WordPress.com specific). This PR converts one such payment method and moves it there.

#### Testing instructions

- Enter checkout with a product in the cart.
- Select PayPal as the payment method.
- Verify that you are redirected to the PayPal test page and that the total is correct. (No need to complete the payment.)
