### PR TITLE
Fix tour on atomic sites due to get_blog_details check

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -83,9 +83,11 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 			$variant = 'tour';
 		}
 
-		$blog_age = time() - strtotime( get_blog_details()->registered );
+		if ( function_exists( 'get_blog_details' ) ) {
+			$blog_age = time() - strtotime( get_blog_details()->registered );
+		}
 
-		if ( $blog_age < self::NEW_SITE_AGE_SECONDS ) {
+		if ( isset( $blog_age ) && $blog_age < self::NEW_SITE_AGE_SECONDS ) {
 			$nux_status = 'enabled';
 		} elseif ( has_filter( 'wpcom_block_editor_nux_get_status' ) ) {
 			$nux_status = apply_filters( 'wpcom_block_editor_nux_get_status', false );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`get_blog_details` is a multi site function and is not available on atomic sites. https://developer.wordpress.org/reference/functions/get_blog_details/ and calling it has been resulting in errors on the `block-editor/nux` endpoint which is causing php errors and would cause the tour not to show on atomic sites by default

detailed description: https://github.com/Automattic/wp-calypso/issues/52599

fixes https://github.com/Automattic/wp-calypso/issues/52599
#### Testing instructions

Install to sandbox 
```
install-plugin.sh etk fix/error-getting-nux-status-on-atomic
```
Test that new sites for an existing user still show the tour

Install to an atomic site
* checkout the branch
* build with `cd apps/editing-toolkit && yarn build && zip -r plugin.zip editing-toolkit-plugin`
* install the plugin on atomic site

go to an editor in the atomic site, clear the local storage and reload the page
<img width="862" alt="Screen Shot 2021-05-07 at 3 01 35 PM" src="https://user-images.githubusercontent.com/22446385/117400082-4333bb00-af45-11eb-8c9b-39e81165342e.png">
reload the page, and the `block-editor/nux` endpoint should be called and return successfully


