### PR TITLE
Sidebar: disable nav-unification functions for jetpack-cloud.

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -64,7 +64,7 @@ import './style.scss';
 
 function SidebarScrollSynchronizer( { enabled } ) {
 	const isNarrow = useBreakpoint( '<660px' );
-	const active = enabled && ! isNarrow;
+	const active = enabled && ! isNarrow && ! config.isEnabled( 'jetpack-cloud' ); // Jetpack cloud hasn't yet aligned with WPCOM.
 
 	React.useEffect( () => {
 		if ( active ) {
@@ -251,7 +251,8 @@ class Layout extends Component {
 			if ( this.props.isNewLaunchFlow || this.props.isCheckoutFromGutenboarding ) {
 				bodyClass.push( 'is-new-launch-flow' );
 			}
-			if ( this.props.isNavUnificationEnabled ) {
+			if ( this.props.isNavUnificationEnabled && ! config.isEnabled( 'jetpack-cloud' ) ) {
+				// Jetpack cloud hasn't yet aligned with WPCOM.
 				bodyClass.push( 'is-nav-unification' );
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
There was a report in slack (p1620248491337700-slack-C01APA37DDW) that some nav-unification styles were applied to https://cloud.jetpack.com. 

**Steps to Reproduce:**
- Go directly to https://cloud.jetpack.com/partner-portal (you will need test partner access)
- Resize the window
- The sidebar is lost

The problem was that while the traditional Jetpack Cloud loads a jetpack site https://github.com/Automattic/wp-calypso/blob/510b7fdd8f3f60bc0e3b6cfebf36df24becabadf/client/state/selectors/is-nav-unification-enabled.js#L18-L20 and thus nav-unification is disabled, the Partner Portal doesn't have a selected site and two things are happening: 

- nav-unification is enabled
- `SidebarScrollSynchronizer` is triggered. This function also depends to `nav-unification` sidebar styles which aren't loaded 
https://github.com/Automattic/wp-calypso/blob/d4742c19ae76f219e39f85905369b846e67210a5/client/my-sites/sidebar-unified/style.scss#L51


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1620248491337700-slack-C01APA37DDW