### PR TITLE
Block patterns: Remove the block that filters out core blocks from the patterns inserter

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -62,15 +62,6 @@ class Block_Patterns_From_API {
 	 * @return array Results of pattern registration.
 	 */
 	public function register_patterns() {
-		if ( class_exists( 'WP_Block_Patterns_Registry' ) ) {
-			// Remove core patterns.
-			foreach ( \WP_Block_Patterns_Registry::get_instance()->get_all_registered() as $pattern ) {
-				if ( 'core/' === substr( $pattern['name'], 0, 5 ) ) {
-					unregister_block_pattern( $pattern['name'] );
-				}
-			}
-		}
-
 		// Used to track which patterns we successfully register.
 		$results = array();
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -251,14 +251,19 @@ class Block_Patterns_From_API {
 			foreach ( \WP_Block_Patterns_Registry::get_instance()->get_all_registered() as $pattern ) {
 				// Gutenberg registers patterns with varying prefixes, but categorizes them using `core/*` in a blockTypes array.
 				// This will ensure we remove `query/*` blocks for example.
+				// TODO: We need to revisit our usage or $pattern['blockTypes']: they are currently an experimental feature and not guaranteed to reference `core/*` blocks.
 				$pattern_block_type_or_name = ! empty( $pattern['blockTypes'][0] ) ? $pattern['blockTypes'][0] : $pattern['name'];
 				if ( 'core/' === substr( $pattern_block_type_or_name, 0, 5 ) ) {
 					unregister_block_pattern( $pattern['name'] );
 				}
 			}
 			if ( function_exists( '_register_core_block_patterns_and_categories' ) ) {
-				switch_to_locale( $this->utils->get_block_patterns_locale() );
+				$did_switch_locale = switch_to_locale( $this->utils->get_block_patterns_locale() );
 				_register_core_block_patterns_and_categories();
+				// The site locale might be the same as the current locale so switching could have failed in such instances.
+				if ( $did_switch_locale !== false ) {
+					restore_previous_locale();
+				}
 			}
 		}
 	}
@@ -280,7 +285,7 @@ class Block_Patterns_From_API {
 					unset( $pattern_properties['name'] );
 					register_block_pattern(
 						$pattern['name'],
-						$pattern_properties,
+						$pattern_properties
 					);
 				}
 			}

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -60,11 +60,10 @@ class Block_Patterns_From_API {
 	 * @param Block_Patterns_Utils $utils            A class dependency containing utils methods.
 	 */
 	public function __construct( $patterns_sources, Block_Patterns_Utils $utils = null ) {
-		$patterns_sources                          = empty( $patterns_sources ) ? array( 'block_patterns' ) : $patterns_sources;
-		$this->patterns_sources                    = empty( array_diff( $patterns_sources, $this->valid_patterns_sources ) ) ? $patterns_sources : array( 'block_patterns' );
-		$this->utils                               = empty( $utils ) ? new \A8C\FSE\Block_Patterns_Utils() : $utils;
-		// Add categories to this array using the core pattern name as the key
-		// for core patterns we wish to "recategorize"
+		$patterns_sources       = empty( $patterns_sources ) ? array( 'block_patterns' ) : $patterns_sources;
+		$this->patterns_sources = empty( array_diff( $patterns_sources, $this->valid_patterns_sources ) ) ? $patterns_sources : array( 'block_patterns' );
+		$this->utils            = empty( $utils ) ? new \A8C\FSE\Block_Patterns_Utils() : $utils;
+		// Add categories to this array using the core pattern name as the key for core patterns we wish to "recategorize".
 		$this->core_to_wpcom_categories_dictionary = array(
 			'core/quote' => array(
 				'quotes' => __( 'Quotes', 'full-site-editing' ),
@@ -243,7 +242,7 @@ class Block_Patterns_From_API {
 	}
 
 	/**
-	 * Unregister all core patterns, then reregister core patterns in core Wordpress only,
+	 * Unregister all core patterns, then reregister core patterns in core WordPress only,
 	 * that is those in wp-includes/block-patterns.php
 	 * Gutenberg adds new and overrides existing core patterns. We don't want these for now.
 	 */
@@ -256,7 +255,6 @@ class Block_Patterns_From_API {
 				if ( 'core/' === substr( $pattern_block_type_or_name, 0, 5 ) ) {
 					unregister_block_pattern( $pattern['name'] );
 				}
-
 			}
 			if ( function_exists( '_register_core_block_patterns_and_categories' ) ) {
 				switch_to_locale( $this->utils->get_block_patterns_locale() );
@@ -264,7 +262,7 @@ class Block_Patterns_From_API {
 			}
 		}
 	}
-	//
+
 	/**
 	 * Update categories for core patterns if a records exists in $this->core_to_wpcom_categories_dictionary
 	 * and reregister them.
@@ -275,13 +273,14 @@ class Block_Patterns_From_API {
 				$wpcom_categories = $this->core_to_wpcom_categories_dictionary[ $pattern['name'] ];
 				if ( isset( $wpcom_categories ) ) {
 					unregister_block_pattern( $pattern['name'] );
-					$pattern_properties = array_merge( $pattern, array( 'categories' => array_keys(
-						$wpcom_categories
-					) ) );
+					$pattern_properties = array_merge(
+						$pattern,
+						array( 'categories' => array_keys( $wpcom_categories ) )
+					);
 					unset( $pattern_properties['name'] );
 					register_block_pattern(
 						$pattern['name'],
-						$pattern_properties
+						$pattern_properties,
 					);
 				}
 			}

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -45,15 +45,32 @@ class Block_Patterns_From_API {
 	private $utils;
 
 	/**
+	 * A dictionary to map existing WPCOM pattern categories to core patterns.
+	 * These should match the categories in $patterns_sources,
+	 * which are registered in $this->register_patterns()
+	 *
+	 * @var array
+	 */
+	private $core_to_wpcom_categories_dictionary;
+
+	/**
 	 * Block_Patterns constructor.
 	 *
 	 * @param array                $patterns_sources A array of strings, each of which matches a valid source for retrieving patterns.
 	 * @param Block_Patterns_Utils $utils            A class dependency containing utils methods.
 	 */
 	public function __construct( $patterns_sources, Block_Patterns_Utils $utils = null ) {
-		$patterns_sources       = empty( $patterns_sources ) ? array( 'block_patterns' ) : $patterns_sources;
-		$this->patterns_sources = empty( array_diff( $patterns_sources, $this->valid_patterns_sources ) ) ? $patterns_sources : array( 'block_patterns' );
-		$this->utils            = empty( $utils ) ? new \A8C\FSE\Block_Patterns_Utils() : $utils;
+		$patterns_sources                          = empty( $patterns_sources ) ? array( 'block_patterns' ) : $patterns_sources;
+		$this->patterns_sources                    = empty( array_diff( $patterns_sources, $this->valid_patterns_sources ) ) ? $patterns_sources : array( 'block_patterns' );
+		$this->utils                               = empty( $utils ) ? new \A8C\FSE\Block_Patterns_Utils() : $utils;
+		// Add categories to this array using the core pattern name as the key
+		// for core patterns we wish to "recategorize"
+		$this->core_to_wpcom_categories_dictionary = array(
+			'core/quote' => array(
+				'quotes' => __( 'Quotes', 'full-site-editing' ),
+				'text'   => __( 'Text', 'full-site-editing' ),
+			),
+		);
 	}
 
 	/**
@@ -62,6 +79,8 @@ class Block_Patterns_From_API {
 	 * @return array Results of pattern registration.
 	 */
 	public function register_patterns() {
+		$this->reregister_core_patterns();
+
 		// Used to track which patterns we successfully register.
 		$results = array();
 
@@ -132,6 +151,9 @@ class Block_Patterns_From_API {
 				}
 			}
 		}
+
+		$this->update_core_patterns_with_wpcom_categories();
+
 		return $results;
 	}
 
@@ -179,19 +201,11 @@ class Block_Patterns_From_API {
 			);
 
 			$block_patterns = $this->utils->remote_get( $request_url );
+
 			$this->utils->cache_add( $patterns_cache_key, $block_patterns, 'ptk_patterns', DAY_IN_SECONDS );
 		}
 
 		return $block_patterns;
-	}
-
-	/**
-	 * Get the locale to be used for fetching block patterns
-	 */
-	private function get_block_patterns_locale() {
-		// Make sure to get blog locale, not user locale.
-		$language = function_exists( 'get_blog_lang_code' ) ? get_blog_lang_code() : get_locale();
-		return \A8C\FSE\Common\get_iso_639_locale( $language );
 	}
 
 	/**
@@ -226,6 +240,52 @@ class Block_Patterns_From_API {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Unregister all core patterns, then reregister core patterns in core Wordpress only,
+	 * that is those in wp-includes/block-patterns.php
+	 * Gutenberg adds new and overrides existing core patterns. We don't want these for now.
+	 */
+	private function reregister_core_patterns() {
+		if ( class_exists( 'WP_Block_Patterns_Registry' ) ) {
+			foreach ( \WP_Block_Patterns_Registry::get_instance()->get_all_registered() as $pattern ) {
+				// Gutenberg registers patterns with varying prefixes, but categorizes them using `core/*` in a blockTypes array.
+				// This will ensure we remove `query/*` blocks for example.
+				$pattern_block_type_or_name = ! empty( $pattern['blockTypes'][0] ) ? $pattern['blockTypes'][0] : $pattern['name'];
+				if ( 'core/' === substr( $pattern_block_type_or_name, 0, 5 ) ) {
+					unregister_block_pattern( $pattern['name'] );
+				}
+
+			}
+			if ( function_exists( '_register_core_block_patterns_and_categories' ) ) {
+				switch_to_locale( $this->utils->get_block_patterns_locale() );
+				_register_core_block_patterns_and_categories();
+			}
+		}
+	}
+	//
+	/**
+	 * Update categories for core patterns if a records exists in $this->core_to_wpcom_categories_dictionary
+	 * and reregister them.
+	 */
+	private function update_core_patterns_with_wpcom_categories() {
+		if ( class_exists( 'WP_Block_Patterns_Registry' ) ) {
+			foreach ( \WP_Block_Patterns_Registry::get_instance()->get_all_registered() as $pattern ) {
+				$wpcom_categories = $this->core_to_wpcom_categories_dictionary[ $pattern['name'] ];
+				if ( isset( $wpcom_categories ) ) {
+					unregister_block_pattern( $pattern['name'] );
+					$pattern_properties = array_merge( $pattern, array( 'categories' => array_keys(
+						$wpcom_categories
+					) ) );
+					unset( $pattern_properties['name'] );
+					register_block_pattern(
+						$pattern['name'],
+						$pattern_properties
+					);
+				}
+			}
+		}
 	}
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -261,7 +261,7 @@ class Block_Patterns_From_API {
 				$did_switch_locale = switch_to_locale( $this->utils->get_block_patterns_locale() );
 				_register_core_block_patterns_and_categories();
 				// The site locale might be the same as the current locale so switching could have failed in such instances.
-				if ( $did_switch_locale !== false ) {
+				if ( false !== $did_switch_locale ) {
 					restore_previous_locale();
 				}
 			}


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR tests out unleashing core patterns in WPCOM. By "core" we mean patterns shipped with WordPress and not those added or overwritten by Gutenberg (See https://github.com/WordPress/gutenberg/blob/trunk/lib/block-patterns.php#L11)

<img width="1522" alt="Screen Shot 2021-05-10 at 1 54 10 pm" src="https://user-images.githubusercontent.com/6458278/117603781-3e664580-b197-11eb-94b9-c160fb435588.png">

## Testing instructions

Apply this ETK patch to your sandbox 

`install-plugin.sh etk add/core-patterns-to-inserter`

and open up the editor in a sandboxed site. 

Check the patterns inserter for [core block patterns](https://github.com/WordPress/gutenberg/tree/trunk/lib/block-patterns).

You can verify that core blocks exist in the inserter by looking at the core block files, e.g., https://github.com/WordPress/gutenberg/blob/trunk/lib/block-patterns/two-buttons.php and then finding the corresponding pattern/category in your editor. 

Here are the core buttons:

<img width="360" alt="Screen Shot 2021-05-17 at 12 00 55 pm" src="https://user-images.githubusercontent.com/6458278/118423082-9bb64580-b707-11eb-8942-37e30a6ddda9.png">

Switch you site language to Swedish and see if some of the core patterns are translated. 🇸🇪
Think of meatballs and cranberry sauce!

Check that Gutenberg patterns, e.g., `query/*` patterns are not present.

<img width="537" alt="Screen Shot 2021-05-17 at 12 00 13 pm" src="https://user-images.githubusercontent.com/6458278/118423000-775a6900-b707-11eb-8899-3bc8c77b862f.png">



Related to https://github.com/Automattic/view-design/issues/267
