### PR TITLE
Try bail instead of mocha-steps

### DIFF
--- a/packages/magellan-mocha-plugin/lib/test_run.js
+++ b/packages/magellan-mocha-plugin/lib/test_run.js
@@ -31,7 +31,7 @@ MochaTestRun.prototype.getArguments = function () {
 		grepString = grepString.split( ch ).join( '\\' + ch );
 	} );
 
-	let args = [ '--mocking_port=' + this.mockingPort, '--worker=1', '-g', grepString ];
+	let args = [ '--bail', '--mocking_port=' + this.mockingPort, '--worker=1', '-g', grepString ];
 
 	if ( mochaSettings.mochaConfig ) {
 		args.push( '--config', mochaSettings.mochaConfig );

--- a/packages/magellan-mocha-plugin/lib/test_run.js
+++ b/packages/magellan-mocha-plugin/lib/test_run.js
@@ -31,7 +31,7 @@ MochaTestRun.prototype.getArguments = function () {
 		grepString = grepString.split( ch ).join( '\\' + ch );
 	} );
 
-	let args = [ '--bail', '--mocking_port=' + this.mockingPort, '--worker=1', '-g', grepString ];
+	let args = [ '--mocking_port=' + this.mockingPort, '--worker=1', '-g', grepString ];
 
 	if ( mochaSettings.mochaConfig ) {
 		args.push( '--config', mochaSettings.mochaConfig );

--- a/packages/magellan-mocha-plugin/test/test_run.spec.js
+++ b/packages/magellan-mocha-plugin/test/test_run.spec.js
@@ -48,7 +48,6 @@ describe( 'TestRun class', function () {
 
 		const args = localRun.getArguments();
 		expect( args ).toEqual( [
-			'--bail',
 			'--mocking_port=10',
 			'--worker=1',
 			'-g',

--- a/packages/magellan-mocha-plugin/test/test_run.spec.js
+++ b/packages/magellan-mocha-plugin/test/test_run.spec.js
@@ -48,6 +48,7 @@ describe( 'TestRun class', function () {
 
 		const args = localRun.getArguments();
 		expect( args ).toEqual( [
+			'--bail',
 			'--mocking_port=10',
 			'--worker=1',
 			'-g',

--- a/test/e2e/.mocharc.yml
+++ b/test/e2e/.mocharc.yml
@@ -1,3 +1,4 @@
+bail: true
 require:
   - 'esm'
   - 'test/mocha.env.js'

--- a/test/e2e/.mocharc.yml
+++ b/test/e2e/.mocharc.yml
@@ -1,7 +1,6 @@
 require:
   - 'esm'
   - 'test/mocha.env.js'
-  - 'mocha-steps'
   - 'lib/hooks'
 file:
   - 'lib/before.js'

--- a/test/e2e/lib/shared-steps/wp-signup-spec.js
+++ b/test/e2e/lib/shared-steps/wp-signup-spec.js
@@ -12,7 +12,7 @@ import InlineHelpChecklistComponent from '../components/inline-help-checklist-co
 import SitePreviewComponent from '../components/site-preview-component.js';
 
 export const canSeeTheSitePreview = () => {
-	step( 'Can then see the site preview', async function () {
+	it( 'Can then see the site preview', async function () {
 		const sitePreviewComponent = await SitePreviewComponent.Expect( this.driver );
 
 		const toolbar = await sitePreviewComponent.sitePreviewToolbar();
@@ -31,7 +31,7 @@ export const canSeeTheSitePreview = () => {
 };
 
 export const canSeeTheInlineHelpCongratulations = () => {
-	step( 'Can then see the inlineHelp congratulations', async function () {
+	it( 'Can then see the inlineHelp congratulations', async function () {
 		const inlineHelpChecklistComponent = await InlineHelpChecklistComponent.Expect( this.driver );
 
 		const congratulations = await inlineHelpChecklistComponent.congratulationsExists();
@@ -43,7 +43,7 @@ export const canSeeTheInlineHelpCongratulations = () => {
 };
 
 export const canSeeTheOnboardingChecklist = () => {
-	step( 'Can then see the site setup list', async function () {
+	it( 'Can then see the site setup list', async function () {
 		// dismiss upsell page if displayed
 		try {
 			const upsellPage = await UpsellPage.Expect( this.driver );

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -51,7 +51,6 @@
 		"mailosaur": "^4.0.0",
 		"mocha": "^8.1.3",
 		"mocha-junit-reporter": "^2.0.0",
-		"mocha-steps": "^1.3.0",
 		"mocha-teamcity-reporter": "^3.0.0",
 		"node-slack-upload": "^1.2.1",
 		"png-itxt": "^1.3.0",

--- a/test/e2e/scripts/jetpack/wp-jetpack-activate.js
+++ b/test/e2e/scripts/jetpack/wp-jetpack-activate.js
@@ -36,36 +36,36 @@ describe( `[${ host }] Jetpack Connection: (${ screenSize }) @jetpack`, function
 			return await driverManager.clearCookiesAndDeleteLocalStorage( driver );
 		} );
 
-		step( 'Can log into WordPress.com', async function () {
+		it( 'Can log into WordPress.com', async function () {
 			this.loginFlow = new LoginFlow( driver, 'jetpackUserCI' );
 			return await this.loginFlow.login();
 		} );
 
-		step( 'Can log into site via wp-login.php', async function () {
+		it( 'Can log into site via wp-login.php', async function () {
 			const user = dataHelper.getAccountConfig( 'jetpackUserCI' );
 			const loginPage = await WPAdminLogonPage.Visit( driver, dataHelper.getJetpackSiteName() );
 			await loginPage.login( user[ 0 ], user[ 1 ] );
 		} );
 
-		step( 'Can open Plugins page', async function () {
+		it( 'Can open Plugins page', async function () {
 			await WPAdminSidebar.refreshIfJNError( driver );
 			this.wpAdminSidebar = await WPAdminSidebar.Expect( driver );
 			return await this.wpAdminSidebar.selectPlugins();
 		} );
 
-		step( 'Can activate Jetpack', async function () {
+		it( 'Can activate Jetpack', async function () {
 			await driverHelper.refreshIfJNError( driver );
 			this.wpAdminPlugins = await WPAdminPluginsPage.Expect( driver );
 			return await this.wpAdminPlugins.activateJetpack();
 		} );
 
-		step( 'Can connect Jetpack', async function () {
+		it( 'Can connect Jetpack', async function () {
 			this.wpAdminPlugins.connectJetpackAfterActivation();
 			this.jetpackAuthorizePage = await JetpackAuthorizePage.Expect( driver );
 			await this.jetpackAuthorizePage.approveConnection();
 		} );
 
-		step( 'Can select Free plan', async function () {
+		it( 'Can select Free plan', async function () {
 			const pickAPlanPage = await PickAPlanPage.Expect( driver );
 			return await pickAPlanPage.selectFreePlan();
 		} );

--- a/test/e2e/scripts/jetpack/wp-jetpack-deactivate.js
+++ b/test/e2e/scripts/jetpack/wp-jetpack-deactivate.js
@@ -33,22 +33,22 @@ describe( `[${ host }] Jetpack Connection Removal: (${ screenSize }) @jetpack`, 
 			return await driverManager.clearCookiesAndDeleteLocalStorage( driver );
 		} );
 
-		step( 'Can log into WordPress.com and open My Sites', async function () {
+		it( 'Can log into WordPress.com and open My Sites', async function () {
 			this.loginFlow = new LoginFlow( driver, 'jetpackUserCI' );
 			return await this.loginFlow.loginAndSelectMySite();
 		} );
 
-		step( 'Can open site Settings', async function () {
+		it( 'Can open site Settings', async function () {
 			this.sidebarComponent = await SidebarComponent.Expect( driver );
 			return await this.sidebarComponent.selectSettings();
 		} );
 
-		step( 'Can manage connection', async function () {
+		it( 'Can manage connection', async function () {
 			this.settingsPage = await SettingsPage.Expect( driver );
 			return await this.settingsPage.manageConnection();
 		} );
 
-		step( 'Can disconnect site', async function () {
+		it( 'Can disconnect site', async function () {
 			return await this.settingsPage.disconnectSite();
 		} );
 	} );

--- a/test/e2e/scripts/jetpack/wp-jetpack-jn-activate.js
+++ b/test/e2e/scripts/jetpack/wp-jetpack-jn-activate.js
@@ -45,12 +45,12 @@ describe( `[${ host }] Jurassic Ninja Connection: (${ screenSize }) @jetpack`, f
 		return driverManager.clearCookiesAndDeleteLocalStorage( driver );
 	} );
 
-	step( 'Can connect from WP Admin', async function () {
+	it( 'Can connect from WP Admin', async function () {
 		this.jnFlow = new JetpackConnectFlow( driver, 'jetpackUserJN' );
 		return await this.jnFlow.connectFromWPAdmin();
 	} );
 
-	step( 'Can logout from WP admin', async function () {
+	it( 'Can logout from WP admin', async function () {
 		const wpDashboard = await WPAdminDashboardPage.Visit(
 			driver,
 			WPAdminDashboardPage.getUrl( this.jnFlow.url )
@@ -58,7 +58,7 @@ describe( `[${ host }] Jurassic Ninja Connection: (${ screenSize }) @jetpack`, f
 		return wpDashboard.logout();
 	} );
 
-	step( 'Can save JN credentials to file', async function () {
+	it( 'Can save JN credentials to file', async function () {
 		await writeJNCredentials( this.jnFlow.url, 'demo', this.jnFlow.password );
 	} );
 } );

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-blocks-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-blocks-spec.js
@@ -31,12 +31,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Blocks (${ screenSize })`, func
 	} );
 
 	describe( 'Can see monetization blocks in block inserter @canary @parallel', function () {
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
-		step( 'Can see the Earn blocks', async function () {
+		it( 'Can see the Earn blocks', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.openBlockInserterAndSearch( 'earn' );
 			const shownItems = await gEditorComponent.getShownBlockInserterItems();
@@ -57,7 +57,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Blocks (${ screenSize })`, func
 			await gEditorComponent.closeBlockInserter();
 		} );
 
-		step( 'Can see the Grow blocks', async function () {
+		it( 'Can see the Grow blocks', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.openBlockInserterAndSearch( 'grow' );
 			const shownItems = await gEditorComponent.getShownBlockInserterItems();

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-checkout-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-checkout-spec.js
@@ -39,13 +39,13 @@ describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize
 	} );
 
 	describe( 'Can trigger the checkout modal via post editor', function () {
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			this.timeout( mochaTimeOut * 12 );
 			const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteFreePlanUser' );
 			return await loginFlow.loginAndStartNewPost( null, true );
 		} );
 
-		step( 'We can set the sandbox cookie for payments', async function () {
+		it( 'We can set the sandbox cookie for payments', async function () {
 			const wPHomePage = await WPHomePage.Visit( driver );
 			await wPHomePage.checkURL( locale );
 			await wPHomePage.setSandboxModeForPayments( sandboxCookieValue );
@@ -53,7 +53,7 @@ describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize
 			return await driver.navigate().back();
 		} );
 
-		step( 'Can insert the premium block', async function () {
+		it( 'Can insert the premium block', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.addBlock( 'Simple Payments' );
 			return await driverHelper.waitUntilElementLocatedAndVisible(
@@ -62,14 +62,14 @@ describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize
 			);
 		} );
 
-		step( 'Can click Upgrade button on premium block', async function () {
+		it( 'Can click Upgrade button on premium block', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.ensureSaved();
 			await gEditorComponent.clickUpgradeOnPremiumBlock();
 			return await driver.switchTo().defaultContent();
 		} );
 
-		step( 'Can view checkout modal', async function () {
+		it( 'Can view checkout modal', async function () {
 			editorUrl = await driver.executeScript( 'return window.location.href' );
 			const compositeCheckoutIsPresent = await driverHelper.isElementEventuallyLocatedAndVisible(
 				driver,
@@ -84,7 +84,7 @@ describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize
 	} );
 
 	describe( 'Has correct plan details', function () {
-		step( 'Contains Premium Plan', async function () {
+		it( 'Contains Premium Plan', async function () {
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 			const checkoutContainsPremiumPlan = await securePaymentComponent.containsPremiumPlan();
 			assert.strictEqual(
@@ -94,7 +94,7 @@ describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize
 			);
 		} );
 
-		step( 'Can change plan length', async function () {
+		it( 'Can change plan length', async function () {
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 			const originalCartAmount = await securePaymentComponent.cartTotalAmount();
 			await driverHelper.waitUntilElementLocatedAndVisible(
@@ -129,7 +129,7 @@ describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize
 	} );
 
 	describe( 'Can add/remove coupons', function () {
-		step( 'Can Enter Coupon Code', async function () {
+		it( 'Can Enter Coupon Code', async function () {
 			const enterCouponCodeButton = await driverHelper.isElementLocated(
 				driver,
 				By.css( '.wp-checkout-order-review__show-coupon-field-button' )
@@ -156,7 +156,7 @@ describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize
 			}
 		} );
 
-		step( 'Can Remove Coupon', async function () {
+		it( 'Can Remove Coupon', async function () {
 			await driver.switchTo().defaultContent();
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 			const originalCartAmount = await securePaymentComponent.cartTotalAmount();
@@ -169,7 +169,7 @@ describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize
 			);
 		} );
 
-		step( 'Can Save Order And Continue', async function () {
+		it( 'Can Save Order And Continue', async function () {
 			return await driverHelper.clickWhenClickable(
 				driver,
 				By.css(
@@ -182,14 +182,14 @@ describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize
 	describe( 'Can make payment', function () {
 		const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
 
-		step( 'Can fill out billing information', async function () {
+		it( 'Can fill out billing information', async function () {
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 			return await securePaymentComponent.completeTaxDetailsInContactSection(
 				testCreditCardDetails
 			);
 		} );
 
-		step( 'Can select and fill out credit card payment method', async function () {
+		it( 'Can select and fill out credit card payment method', async function () {
 			const existingCardIsPresent = await driverHelper.isElementLocated(
 				driver,
 				By.css( '[id*="existingCard-"]:checked' )
@@ -203,7 +203,7 @@ describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize
 			return true;
 		} );
 
-		step( 'Can process the payment', async function () {
+		it( 'Can process the payment', async function () {
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 			await securePaymentComponent.submitPaymentDetails();
 			await securePaymentComponent.waitForCreditCardPaymentProcessing();
@@ -219,12 +219,12 @@ describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		step( 'Can decline upgrade offer', async function () {
+		it( 'Can decline upgrade offer', async function () {
 			const upsellPage = await UpsellPage.Expect( driver );
 			return await upsellPage.declineOffer();
 		} );
 
-		step( 'Can return to editor', async function () {
+		it( 'Can return to editor', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.initEditor();
 			await driver.switchTo().defaultContent();
@@ -238,12 +238,12 @@ describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize
 	} );
 
 	describe( 'Can delete the premium plan', function () {
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteFreePlanUser' );
 			return await loginFlow.login();
 		} );
 
-		step( 'We can set the sandbox cookie for payments', async function () {
+		it( 'We can set the sandbox cookie for payments', async function () {
 			const wPHomePage = await WPHomePage.Visit( driver );
 			await wPHomePage.checkURL( locale );
 			await wPHomePage.setSandboxModeForPayments( sandboxCookieValue );
@@ -251,7 +251,7 @@ describe.skip( `[${ host }] Calypso Gutenberg Editor: Checkout on (${ screenSize
 			return await driver.navigate().back();
 		} );
 
-		step( 'Can delete the premium plan', async function () {
+		it( 'Can delete the premium plan', async function () {
 			return await new DeletePlanFlow( driver ).deletePlan( 'premium' );
 		} );
 	} );

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-coblocks-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-coblocks-spec.js
@@ -33,12 +33,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 	} );
 
 	describe( 'Insert a Click to Tweet block: @parallel', function () {
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
-		step( 'Can insert the Click to Tweet block', async function () {
+		it( 'Can insert the Click to Tweet block', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.addBlock( 'Click to Tweet' );
 			return await driverHelper.waitUntilElementLocatedAndVisible(
@@ -47,7 +47,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 			);
 		} );
 
-		step( 'Can enter text to tweet', async function () {
+		it( 'Can enter text to tweet', async function () {
 			const textLocator = By.css( '.wp-block-coblocks-click-to-tweet__text' );
 			await driverHelper.waitUntilElementLocatedAndVisible( driver, textLocator );
 			return await driver
@@ -57,7 +57,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 				);
 		} );
 
-		step( 'Can publish and view content', async function () {
+		it( 'Can publish and view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			// We need to save the post to get a stable post slug for the block's `url` attribute.
 			// See https://github.com/godaddy-wordpress/coblocks/issues/1663.
@@ -65,7 +65,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 			return await gEditorComponent.publish( { visit: true } );
 		} );
 
-		step( 'Can see the Click to Tweet block in our published post', async function () {
+		it( 'Can see the Click to Tweet block in our published post', async function () {
 			return await driverHelper.waitUntilElementLocatedAndVisible(
 				driver,
 				By.css( '.entry-content .wp-block-coblocks-click-to-tweet' )
@@ -74,12 +74,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 	} );
 
 	describe( 'Insert a Dynamic HR block: @parallel', function () {
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
-		step( 'Can insert the Dynamic HR block', async function () {
+		it( 'Can insert the Dynamic HR block', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.addBlock( 'Dynamic HR' );
 			return await driverHelper.waitUntilElementLocatedAndVisible(
@@ -88,12 +88,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 			);
 		} );
 
-		step( 'Can publish and view content', async function () {
+		it( 'Can publish and view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			return await gEditorComponent.publish( { visit: true } );
 		} );
 
-		step( 'Can see the Dynamic HR block in our published post', async function () {
+		it( 'Can see the Dynamic HR block in our published post', async function () {
 			return await driverHelper.waitUntilElementLocatedAndVisible(
 				driver,
 				By.css( '.entry-content .wp-block-coblocks-dynamic-separator' )
@@ -102,12 +102,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 	} );
 
 	describe( 'Insert a Hero block: @parallel', function () {
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
-		step( 'Can insert the Hero block', async function () {
+		it( 'Can insert the Hero block', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.addBlock( 'Hero' );
 			return await driverHelper.waitUntilElementLocatedAndVisible(
@@ -116,12 +116,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 			);
 		} );
 
-		step( 'Can publish and view content', async function () {
+		it( 'Can publish and view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			return await gEditorComponent.publish( { visit: true } );
 		} );
 
-		step( 'Can see the Hero block in our published post', async function () {
+		it( 'Can see the Hero block in our published post', async function () {
 			return await driverHelper.waitUntilElementLocatedAndVisible(
 				driver,
 				By.css( '.entry-content .wp-block-coblocks-hero' )
@@ -138,12 +138,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 			return fileDetails;
 		} );
 
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
-		step( 'Can insert the Logos block', async function () {
+		it( 'Can insert the Logos block', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.addBlock( 'Logos' );
 			return await driverHelper.waitUntilElementLocatedAndVisible(
@@ -152,7 +152,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 			);
 		} );
 
-		step( 'Can select an image as a logo', async function () {
+		it( 'Can select an image as a logo', async function () {
 			await driverHelper.waitUntilElementLocatedAndVisible(
 				driver,
 				By.css( '.block-editor-media-placeholder' )
@@ -171,12 +171,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 			);
 		} );
 
-		step( 'Can publish and view content', async function () {
+		it( 'Can publish and view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			return await gEditorComponent.publish( { visit: true } );
 		} );
 
-		step( 'Can see the Logos block in our published post', async function () {
+		it( 'Can see the Logos block in our published post', async function () {
 			return await driverHelper.waitUntilElementLocatedAndVisible(
 				driver,
 				By.css( '.entry-content .wp-block-coblocks-logos' )
@@ -185,12 +185,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 	} );
 
 	describe( 'Insert a Pricing Table block: @parallel', function () {
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
-		step( 'Can insert the Pricing Table block', async function () {
+		it( 'Can insert the Pricing Table block', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.addBlock( 'Pricing Table' );
 			return await driverHelper.waitUntilElementLocatedAndVisible(
@@ -199,12 +199,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 			);
 		} );
 
-		step( 'Can publish and view content', async function () {
+		it( 'Can publish and view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			return await gEditorComponent.publish( { visit: true } );
 		} );
 
-		step( 'Can see the Pricing Table block in our published post', async function () {
+		it( 'Can see the Pricing Table block in our published post', async function () {
 			return await driverHelper.waitUntilElementLocatedAndVisible(
 				driver,
 				By.css( '.entry-content .wp-block-coblocks-pricing-table' )
@@ -231,12 +231,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 			);
 		}
 
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
-		step( 'Can see gutter controls for supporting block', async function () {
+		it( 'Can see gutter controls for supporting block', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.addBlock( 'Pricing Table' );
 			await driverHelper.waitUntilElementLocatedAndVisible(
@@ -247,23 +247,23 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 			await driverHelper.waitUntilElementLocatedAndVisible( driver, gutterControlsLocator );
 		} );
 
-		step( 'Can set the "None" gutter value', async function () {
+		it( 'Can set the "None" gutter value', async function () {
 			await setGutter( 'None' );
 		} );
 
-		step( 'Can set the "S" gutter value', async function () {
+		it( 'Can set the "S" gutter value', async function () {
 			await setGutter( 'S' );
 		} );
 
-		step( 'Can set the "M" gutter value', async function () {
+		it( 'Can set the "M" gutter value', async function () {
 			await setGutter( 'M' );
 		} );
 
-		step( 'Can set the "L" gutter value', async function () {
+		it( 'Can set the "L" gutter value', async function () {
 			await setGutter( 'L' );
 		} );
 
-		step( 'Can set the "XL" gutter value', async function () {
+		it( 'Can set the "XL" gutter value', async function () {
 			await setGutter( 'XL' );
 		} );
 	} );

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -49,7 +49,7 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 	} );
 
 	describe( 'Tracking: @parallel', function () {
-		step( 'Can log in to WPAdmin and create new Post', async function () {
+		it( 'Can log in to WPAdmin and create new Post', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 
 			if ( host !== 'WPCOM' ) {
@@ -62,14 +62,14 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 			await wpadminSidebarComponent.selectNewPost();
 		} );
 
-		step( 'Check for presence of e2e specific tracking events stack on global', async function () {
+		it( 'Check for presence of e2e specific tracking events stack on global', async function () {
 			await GutenbergEditorComponent.Expect( driver, 'wp-admin' );
 			const eventsStack = await driver.executeScript( `return window._e2eEventsStack;` );
 			// Check evaluates to truthy
 			assert( eventsStack, 'Tracking events stack missing from window._e2eEventsStack' );
 		} );
 
-		step( 'Tracks "wpcom_block_inserted" event', async function () {
+		it( 'Tracks "wpcom_block_inserted" event', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver, 'wp-admin' );
 
 			// Insert some Blocks

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-focused-launch-spec.js
@@ -4,7 +4,6 @@
 import assert from 'assert';
 import config from 'config';
 import { By, until } from 'selenium-webdriver';
-import { step } from 'mocha-steps';
 
 /**
  * Internal dependencies
@@ -41,13 +40,13 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			await loginFlow.login();
 		} );
 
-		step( 'Can create a free site', async function () {
+		it( 'Can create a free site', async function () {
 			const gutenboardingUrl = dataHelper.getCalypsoURL( '/new' );
 			await driver.get( gutenboardingUrl );
 			await new GutenboardingFlow( driver ).createFreeSite( siteName );
 		} );
 
-		step( 'Can open focused launch modal', async function () {
+		it( 'Can open focused launch modal', async function () {
 			const launchButtonLocator = await driverHelper.getElementByText(
 				driver,
 				By.css( '.editor-gutenberg-launch__launch-button' ),
@@ -64,7 +63,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			assert( isFocusedLaunchModalPresent, 'Focused launch modal did not open.' );
 		} );
 
-		step( 'Can see updated list of domains when changing site title', async function () {
+		it( 'Can see updated list of domains when changing site title', async function () {
 			// Get the site title input
 			const siteTitleInputLocator = By.css( '.focused-launch-summary__input input[type=text]' );
 
@@ -123,7 +122,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 		} );
 
-		step( 'Can select free domain suggestion item', async function () {
+		it( 'Can select free domain suggestion item', async function () {
 			// Click on the free domain suggestion item
 			const freeDomainButtonLocator = By.css( '.domain-picker__suggestion-item.is-free' );
 
@@ -158,7 +157,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 		} );
 
-		step( 'Can open detailed plans grid', async function () {
+		it( 'Can open detailed plans grid', async function () {
 			// Click on "View All Plans" button
 			const viewAllPlansButtonLocator = driverHelper.getElementByText(
 				driver,
@@ -182,7 +181,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 		} );
 
-		step( 'Can switch to monthly plans view', async function () {
+		it( 'Can switch to monthly plans view', async function () {
 			// Click "Monthly" toggle button
 			const monthlyButtonLocator = driverHelper.getElementByText(
 				driver,
@@ -211,7 +210,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 		} );
 
-		step( 'Can select Personal monthly plan', async function () {
+		it( 'Can select Personal monthly plan', async function () {
 			// Click "Select Personal" button
 			const selectPersonalPlanButtonLocator = driverHelper.getElementByText(
 				driver,
@@ -237,7 +236,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			assert( selectedPlanIsPersonalMonthlyPlan, 'The personal monthly plan was not selected.' );
 		} );
 
-		step( 'Can reload block editor and reopen focused launch', async function () {
+		it( 'Can reload block editor and reopen focused launch', async function () {
 			// Reload block editor
 			await driver.navigate().refresh();
 
@@ -273,7 +272,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			assert( isFocusedLaunchModalPresent, 'Focused launch modal did not open.' );
 		} );
 
-		step( 'Can persist previously selected domain in focused launch', async function () {
+		it( 'Can persist previously selected domain in focused launch', async function () {
 			const selectedDomainSuggestionContainingPreviouslySelectedSubdomainLocator = await driverHelper.getElementByText(
 				driver,
 				By.css( '.domain-picker__suggestion-item.is-selected' ),
@@ -291,7 +290,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 		} );
 
-		step( 'Can persist previously selected plan in focused launch', async function () {
+		it( 'Can persist previously selected plan in focused launch', async function () {
 			// Check if the selected monthly plan item is "Personal Plan".
 			const selectedPlanIsPersonalMonthlyPlanLocator = driverHelper.getElementByText(
 				driver,
@@ -310,7 +309,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 		} );
 
-		step( 'Can select Free plan', async function () {
+		it( 'Can select Free plan', async function () {
 			// Click "Free Plan" button
 			const freePlanLocator = driverHelper.getElementByText(
 				driver,
@@ -336,7 +335,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			assert( selectedPlanIsFreePlan, 'The free plan was not selected.' );
 		} );
 
-		step( 'Can launch site with Free plan.', async function () {
+		it( 'Can launch site with Free plan.', async function () {
 			// Click on the launch button
 			const siteLaunchButtonLocator = By.css( '.focused-launch-summary__launch-button' );
 			await driverHelper.clickWhenClickable( driver, siteLaunchButtonLocator );

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-page-editor-spec.js
@@ -51,7 +51,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			return fileDetails;
 		} );
 
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			if ( host !== 'WPCOM' ) {
 				this.loginFlow = new LoginFlow( driver );
@@ -59,7 +59,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			return await this.loginFlow.loginAndStartNewPage( null, true );
 		} );
 
-		step( 'Can enter page title, content and image', async function () {
+		it( 'Can enter page title, content and image', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.enterTitle( pageTitle );
 			await gEditorComponent.enterText( pageQuote );
@@ -72,7 +72,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		/* Skip until sharing is added in Gutenberg editor
-		step( 'Can disable sharing buttons', async function() {
+		it( 'Can disable sharing buttons', async function() {
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.selectDocumentTab();
 			await gEditorSidebarComponent.expandSharingSection();
@@ -80,13 +80,13 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			await gEditorSidebarComponent.closeSharingSection();
 		} );*/
 
-		step( 'Can launch page preview', async function () {
+		it( 'Can launch page preview', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.ensureSaved();
 			await gEditorComponent.launchPreview();
 		} );
 
-		step( 'Can see correct page title in preview', async function () {
+		it( 'Can see correct page title in preview', async function () {
 			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
 			const actualPageTitle = await pagePreviewComponent.pageTitle();
 			assert.strictEqual(
@@ -96,7 +96,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			);
 		} );
 
-		step( 'Can see correct page content in preview', async function () {
+		it( 'Can see correct page content in preview', async function () {
 			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
 			const content = await pagePreviewComponent.pageContent();
 			assert.strictEqual(
@@ -110,7 +110,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			);
 		} );
 
-		step( 'Can see the image uploaded in the preview', async function () {
+		it( 'Can see the image uploaded in the preview', async function () {
 			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
 			const imageDisplayed = await pagePreviewComponent.imageDisplayed( fileDetails );
 			return assert.strictEqual(
@@ -120,17 +120,17 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			);
 		} );
 
-		step( 'Can close page preview', async function () {
+		it( 'Can close page preview', async function () {
 			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
 			await pagePreviewComponent.close();
 		} );
 
-		step( 'Can publish and preview published content', async function () {
+		it( 'Can publish and preview published content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.publish( { visit: true } );
 		} );
 
-		step( 'Can see correct page title', async function () {
+		it( 'Can see correct page title', async function () {
 			const viewPagePage = await ViewPagePage.Expect( driver );
 			const actualPageTitle = await viewPagePage.pageTitle();
 			assert.strictEqual(
@@ -140,7 +140,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			);
 		} );
 
-		step( 'Can see correct page content', async function () {
+		it( 'Can see correct page content', async function () {
 			const viewPagePage = await ViewPagePage.Expect( driver );
 			const content = await viewPagePage.pageContent();
 			assert.strictEqual(
@@ -155,7 +155,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		/* Skip until sharing is added in Gutenberg editor
-		step( "Can't see sharing buttons", async function() {
+		it( "Can't see sharing buttons", async function() {
 			const viewPagePage = await ViewPagePage.Expect( driver );
 			let visible = await viewPagePage.sharingButtonsVisible();
 			assert.strictEqual(
@@ -165,7 +165,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			);
 		} ); */
 
-		step( 'Can see the image uploaded displayed', async function () {
+		it( 'Can see the image uploaded displayed', async function () {
 			const viewPagePage = await ViewPagePage.Expect( driver );
 			const imageDisplayed = await viewPagePage.imageDisplayed( fileDetails );
 			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the published page' );
@@ -183,31 +183,31 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		const pageQuote =
 			'Few people know how to take a walk. The qualifications are endurance, plain clothes, old shoes, an eye for nature, good humor, vast curiosity, good speech, good silence and nothing too much.\n— Ralph Waldo Emerson';
 
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPage( null, true );
 		} );
 
-		step( 'Can enter page title and content', async function () {
+		it( 'Can enter page title and content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.enterTitle( pageTitle );
 			await gEditorComponent.enterText( pageQuote );
 			return await gEditorComponent.ensureSaved();
 		} );
 
-		step( 'Can set visibility to private which immediately publishes it', async function () {
+		it( 'Can set visibility to private which immediately publishes it', async function () {
 			const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gSidebarComponent.chooseDocumentSettings();
 			await gSidebarComponent.setVisibilityToPrivate();
 			return await gSidebarComponent.hideComponentIfNecessary();
 		} );
 
-		step( 'Can view content', async function () {
+		it( 'Can view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.viewPublishedPostOrPage();
 		} );
 
-		step( 'Can view page title as logged in user', async function () {
+		it( 'Can view page title as logged in user', async function () {
 			const viewPagePage = await ViewPagePage.Expect( driver );
 			const actualPageTitle = await viewPagePage.pageTitle();
 			assert.strictEqual(
@@ -217,7 +217,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			);
 		} );
 
-		step( 'Can view page content as logged in user', async function () {
+		it( 'Can view page content as logged in user', async function () {
 			const viewPagePage = await ViewPagePage.Expect( driver );
 			const content = await viewPagePage.pageContent();
 			assert.strictEqual(
@@ -231,7 +231,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			);
 		} );
 
-		step( "Can't view page title or content as non-logged in user", async function () {
+		it( "Can't view page title or content as non-logged in user", async function () {
 			await driver.manage().deleteAllCookies();
 			await driver.navigate().refresh();
 
@@ -252,12 +252,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		const postPassword = 'e2e' + new Date().getTime().toString();
 
 		describe( 'Publish a Password Protected Page', function () {
-			step( 'Can log in', async function () {
+			it( 'Can log in', async function () {
 				this.loginFlow = new LoginFlow( driver, gutenbergUser );
 				return await this.loginFlow.loginAndStartNewPage( null, true );
 			} );
 
-			step( 'Can enter page title and content and set to password protected', async function () {
+			it( 'Can enter page title and content and set to password protected', async function () {
 				let gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
 				await gHeaderComponent.enterTitle( pageTitle );
 
@@ -270,24 +270,21 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				return await gHeaderComponent.enterText( pageQuote );
 			} );
 
-			step( 'Can publish and view content', async function () {
+			it( 'Can publish and view content', async function () {
 				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
 				await gHeaderComponent.publish( { visit: true } );
 			} );
 
-			step(
-				'As a logged in user, With no password entered, Can view page title',
-				async function () {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const actualPageTitle = await viewPagePage.pageTitle();
-					assert.strictEqual(
-						actualPageTitle.toUpperCase(),
-						( 'Protected: ' + pageTitle ).toUpperCase()
-					);
-				}
-			);
+			it( 'As a logged in user, With no password entered, Can view page title', async function () {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const actualPageTitle = await viewPagePage.pageTitle();
+				assert.strictEqual(
+					actualPageTitle.toUpperCase(),
+					( 'Protected: ' + pageTitle ).toUpperCase()
+				);
+			} );
 
-			step( 'Can see password field', async function () {
+			it( 'Can see password field', async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const isPasswordProtected = await viewPagePage.isPasswordProtected();
 				assert.strictEqual(
@@ -297,7 +294,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				);
 			} );
 
-			step( "Can't see content when no password is entered", async function () {
+			it( "Can't see content when no password is entered", async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const content = await viewPagePage.pageContent();
 				assert.strictEqual(
@@ -311,12 +308,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'With incorrect password entered, Enter incorrect password', async function () {
+			it( 'With incorrect password entered, Enter incorrect password', async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				await viewPagePage.enterPassword( 'password' );
 			} );
 
-			step( 'Can view page title', async function () {
+			it( 'Can view page title', async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const actualPageTitle = await viewPagePage.pageTitle();
 				assert.strictEqual(
@@ -325,7 +322,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'Can see password field', async function () {
+			it( 'Can see password field', async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const isPasswordProtected = await viewPagePage.isPasswordProtected();
 				assert.strictEqual(
@@ -335,7 +332,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				);
 			} );
 
-			step( "Can't see content when incorrect password is entered", async function () {
+			it( "Can't see content when incorrect password is entered", async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const content = await viewPagePage.pageContent();
 				assert.strictEqual(
@@ -349,12 +346,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'With correct password entered, Enter correct password', async function () {
+			it( 'With correct password entered, Enter correct password', async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				await viewPagePage.enterPassword( postPassword );
 			} );
 
-			step( 'Can view page title', async function () {
+			it( 'Can view page title', async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const actualPageTitle = await viewPagePage.pageTitle();
 				assert.strictEqual(
@@ -363,7 +360,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				);
 			} );
 
-			step( "Can't see password field", async function () {
+			it( "Can't see password field", async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const isPasswordProtected = await viewPagePage.isPasswordProtected();
 				assert.strictEqual(
@@ -373,7 +370,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'Can see page content', async function () {
+			it( 'Can see page content', async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const content = await viewPagePage.pageContent();
 				assert.strictEqual(
@@ -387,12 +384,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'As a non-logged in user, Clear cookies (log out)', async function () {
+			it( 'As a non-logged in user, Clear cookies (log out)', async function () {
 				await driver.manage().deleteAllCookies();
 				await driver.navigate().refresh();
 			} );
 
-			step( 'With no password entered, Can view page title', async function () {
+			it( 'With no password entered, Can view page title', async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const actualPageTitle = await viewPagePage.pageTitle();
 				assert.strictEqual(
@@ -401,7 +398,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'Can see password field', async function () {
+			it( 'Can see password field', async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const isPasswordProtected = await viewPagePage.isPasswordProtected();
 				assert.strictEqual(
@@ -411,7 +408,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				);
 			} );
 
-			step( "Can't see content when no password is entered", async function () {
+			it( "Can't see content when no password is entered", async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const content = await viewPagePage.pageContent();
 				assert.strictEqual(
@@ -425,12 +422,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'With incorrect password entered, Enter incorrect password', async function () {
+			it( 'With incorrect password entered, Enter incorrect password', async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				await viewPagePage.enterPassword( 'password' );
 			} );
 
-			step( 'Can view page title', async function () {
+			it( 'Can view page title', async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const actualPageTitle = await viewPagePage.pageTitle();
 				assert.strictEqual(
@@ -439,7 +436,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'Can see password field', async function () {
+			it( 'Can see password field', async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const isPasswordProtected = await viewPagePage.isPasswordProtected();
 				assert.strictEqual(
@@ -449,7 +446,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				);
 			} );
 
-			step( "Can't see content when incorrect password is entered", async function () {
+			it( "Can't see content when incorrect password is entered", async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const content = await viewPagePage.pageContent();
 				assert.strictEqual(
@@ -463,12 +460,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'With correct password entered, Enter correct password', async function () {
+			it( 'With correct password entered, Enter correct password', async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				await viewPagePage.enterPassword( postPassword );
 			} );
 
-			step( 'Can view page title', async function () {
+			it( 'Can view page title', async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const actualPageTitle = await viewPagePage.pageTitle();
 				assert.strictEqual(
@@ -477,7 +474,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				);
 			} );
 
-			step( "Can't see password field", async function () {
+			it( "Can't see password field", async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const isPasswordProtected = await viewPagePage.isPasswordProtected();
 				assert.strictEqual(
@@ -487,7 +484,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'Can see page content', async function () {
+			it( 'Can see page content', async function () {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const content = await viewPagePage.pageContent();
 				assert.strictEqual(
@@ -514,12 +511,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			email: 'test@wordpress.com',
 		};
 
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPage( null, true );
 		} );
 
-		step( 'Can insert the payment button', async function () {
+		it( 'Can insert the payment button', async function () {
 			const pageTitle = 'Payment Button Page: ' + dataHelper.randomPhrase();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			const blockId = await gEditorComponent.addBlock( 'Pay with PayPal' );
@@ -532,7 +529,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			return await gPaymentComponent.ensurePaymentButtonDisplayedInEditor();
 		} );
 
-		step( 'Can publish and view content', async function () {
+		it( 'Can publish and view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			try {
 				await gEditorComponent.publish( { visit: true } );
@@ -550,7 +547,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			}
 		} );
 
-		step( 'Can see the payment button in our published page', async function () {
+		it( 'Can see the payment button in our published page', async function () {
 			const viewPagePage = await ViewPagePage.Expect( driver );
 			const displayed = await viewPagePage.paymentButtonDisplayed();
 			return assert.strictEqual(
@@ -560,35 +557,32 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			);
 		} );
 
-		step(
-			'The payment button in our published page opens a new Paypal window for payment',
-			async function () {
-				const numberOfOpenBrowserWindows = await driverHelper.numberOfOpenWindows( driver );
-				assert.strictEqual(
-					numberOfOpenBrowserWindows,
-					1,
-					'There is more than one open browser window before clicking payment button'
-				);
-				const viewPagePage = await ViewPagePage.Expect( driver );
-				await viewPagePage.clickPaymentButton();
-				// Skip some lines and checks until Chrome can handle multiple windows in app mode
-				// await driverHelper.waitForNumberOfWindows( driver, 2 );
-				// await driverHelper.switchToWindowByIndex( driver, 1 );
-				await PaypalCheckoutPage.Expect( driver );
-				// const amountDisplayed = await paypalCheckoutPage.priceDisplayed();
-				// assert.strictEqual(
-				// 	amountDisplayed,
-				// 	`${ paymentButtonDetails.symbol }${ paymentButtonDetails.price } ${
-				// 		paymentButtonDetails.currency
-				// 	}`,
-				// 	"The amount displayed on Paypal isn't correct"
-				// );
-				// await driverHelper.closeCurrentWindow( driver );
-				// await driverHelper.switchToWindowByIndex( driver, 0 );
-				// viewPagePage = await ViewPagePage.Expect( driver );
-				// assert( await viewPagePage.displayed(), 'view page page is not displayed' );
-			}
-		);
+		it( 'The payment button in our published page opens a new Paypal window for payment', async function () {
+			const numberOfOpenBrowserWindows = await driverHelper.numberOfOpenWindows( driver );
+			assert.strictEqual(
+				numberOfOpenBrowserWindows,
+				1,
+				'There is more than one open browser window before clicking payment button'
+			);
+			const viewPagePage = await ViewPagePage.Expect( driver );
+			await viewPagePage.clickPaymentButton();
+			// Skip some lines and checks until Chrome can handle multiple windows in app mode
+			// await driverHelper.waitForNumberOfWindows( driver, 2 );
+			// await driverHelper.switchToWindowByIndex( driver, 1 );
+			await PaypalCheckoutPage.Expect( driver );
+			// const amountDisplayed = await paypalCheckoutPage.priceDisplayed();
+			// assert.strictEqual(
+			// 	amountDisplayed,
+			// 	`${ paymentButtonDetails.symbol }${ paymentButtonDetails.price } ${
+			// 		paymentButtonDetails.currency
+			// 	}`,
+			// 	"The amount displayed on Paypal isn't correct"
+			// );
+			// await driverHelper.closeCurrentWindow( driver );
+			// await driverHelper.switchToWindowByIndex( driver, 0 );
+			// viewPagePage = await ViewPagePage.Expect( driver );
+			// assert( await viewPagePage.displayed(), 'view page page is not displayed' );
+		} );
 
 		after( async function () {
 			await driverHelper.ensurePopupsClosed( driver );

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-post-editor-spec.js
@@ -63,12 +63,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			return fileDetails;
 		} );
 
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
-		step( 'Can enter post title, content and image', async function () {
+		it( 'Can enter post title, content and image', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.enterTitle( blogPostTitle );
 			await gEditorComponent.enterText( blogPostQuote );
@@ -80,7 +80,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			await gEditorComponent.closeSidebar();
 		} );
 
-		step( 'Expand Categories and Tags', async function () {
+		it( 'Expand Categories and Tags', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.openSidebar();
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
@@ -90,12 +90,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			await gEditorSidebarComponent.expandTags();
 		} );
 
-		step( 'Can add a new category', async function () {
+		it( 'Can add a new category', async function () {
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.addNewCategory( newCategoryName );
 		} );
 
-		step( 'Can add a new tag', async function () {
+		it( 'Can add a new tag', async function () {
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.addNewTag( newTagName );
 			const tagDisplayed = await gEditorSidebarComponent.tagEventuallyDisplayed( newTagName );
@@ -106,7 +106,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			);
 		} );
 
-		step( 'Close categories and tags', async function () {
+		it( 'Close categories and tags', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.selectDocumentTab();
@@ -115,13 +115,13 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			await gEditorComponent.closeSidebar();
 		} );
 
-		step( 'Can launch post preview', async function () {
+		it( 'Can launch post preview', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.ensureSaved();
 			await gEditorComponent.launchPreview();
 		} );
 
-		step( 'Can see correct post title in preview', async function () {
+		it( 'Can see correct post title in preview', async function () {
 			this.postPreviewComponent = await PostPreviewComponent.Expect( driver );
 
 			const postTitle = await this.postPreviewComponent.postTitle();
@@ -132,7 +132,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			);
 		} );
 
-		step( 'Can see correct post content in preview', async function () {
+		it( 'Can see correct post content in preview', async function () {
 			const content = await this.postPreviewComponent.postContent();
 			assert.strictEqual(
 				content.indexOf( blogPostQuote ) > -1,
@@ -145,7 +145,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			);
 		} );
 
-		step( 'Can see the post category in preview', async function () {
+		it( 'Can see the post category in preview', async function () {
 			const categoryDisplayed = await this.postPreviewComponent.categoryDisplayed();
 			assert.strictEqual(
 				categoryDisplayed.toUpperCase(),
@@ -155,7 +155,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		// Disable this step until https://github.com/Automattic/wp-calypso/issues/28974 is solved
-		// step( 'Can see the post tag in preview', async function() {
+		// it( 'Can see the post tag in preview', async function() {
 		// 	let tagDisplayed = await this.postPreviewComponent.tagDisplayed();
 		// 	assert.strictEqual(
 		// 		tagDisplayed.toUpperCase(),
@@ -164,21 +164,21 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		// 	);
 		// } );
 
-		step( 'Can see the image in preview', async function () {
+		it( 'Can see the image in preview', async function () {
 			const imageDisplayed = await this.postPreviewComponent.imageDisplayed( fileDetails );
 			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the web preview' );
 		} );
 
-		step( 'Can close post preview', async function () {
+		it( 'Can close post preview', async function () {
 			await this.postPreviewComponent.close();
 		} );
 
-		step( 'Can publish and view content', async function () {
+		it( 'Can publish and view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.publish( { visit: true } );
 		} );
 
-		step( 'Can see correct post title', async function () {
+		it( 'Can see correct post title', async function () {
 			const viewPostPage = await ViewPostPage.Expect( driver );
 			const postTitle = await viewPostPage.postTitle();
 			assert.strictEqual(
@@ -188,7 +188,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			);
 		} );
 
-		step( 'Can see correct post content', async function () {
+		it( 'Can see correct post content', async function () {
 			const viewPostPage = await ViewPostPage.Expect( driver );
 			const content = await viewPostPage.postContent();
 			assert.strictEqual(
@@ -202,7 +202,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			);
 		} );
 
-		step( 'Can see correct post category', async function () {
+		it( 'Can see correct post category', async function () {
 			const viewPostPage = await ViewPostPage.Expect( driver );
 			const categoryDisplayed = await viewPostPage.categoryDisplayed();
 			assert.strictEqual(
@@ -212,14 +212,14 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			);
 		} );
 
-		step( 'Can see the image published', async function () {
+		it( 'Can see the image published', async function () {
 			const viewPostPage = await ViewPostPage.Expect( driver );
 			const imageDisplayed = await viewPostPage.imageDisplayed( fileDetails );
 			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the published post' );
 		} );
 
 		// Disable this step until https://github.com/Automattic/wp-calypso/issues/28974 is solved
-		// step( 'Can see correct post tag', async function() {
+		// it( 'Can see correct post tag', async function() {
 		// 	const viewPostPage = await ViewPostPage.Expect( driver );
 		// 	let tagDisplayed = await viewPostPage.tagDisplayed();
 		// 	assert.strictEqual(
@@ -243,12 +243,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const blogPostQuote =
 				'“Whenever you find yourself on the side of the majority, it is time to pause and reflect.”\n- Mark Twain';
 
-			step( 'Can log in', async function () {
+			it( 'Can log in', async function () {
 				this.loginFlow = new LoginFlow( driver, gutenbergUser );
 				return await this.loginFlow.login( { useFreshLogin: true } );
 			} );
 
-			step( 'Start new post', async function () {
+			it( 'Start new post', async function () {
 				const navBarComponent = await NavBarComponent.Expect( driver );
 				await navBarComponent.clickMySites();
 				const sidebarComponent = await SidebarComponent.Expect( driver );
@@ -257,19 +257,19 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				return await postsPage.addNewPost();
 			} );
 
-			step( 'Can enter post title and text content', async function () {
+			it( 'Can enter post title and text content', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.initEditor();
 				await gEditorComponent.enterTitle( blogPostTitle );
 				await gEditorComponent.enterText( blogPostQuote );
 			} );
 
-			step( 'Can publish and view content', async function () {
+			it( 'Can publish and view content', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.publish( { visit: true } );
 			} );
 
-			step( 'Can see correct post title', async function () {
+			it( 'Can see correct post title', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const postTitle = await viewPostPage.postTitle();
 				assert.strictEqual(
@@ -286,23 +286,23 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		const blogPostQuote =
 			'“We are what we pretend to be, so we must be careful about what we pretend to be”\n- Kurt Vonnegut';
 
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			const loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await loginFlow.loginAndStartNewPost( null, true );
 		} );
 
-		step( 'Can enter post title and content', async function () {
+		it( 'Can enter post title and content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.enterTitle( blogPostTitle );
 			await gEditorComponent.enterText( blogPostQuote );
 		} );
 
-		step( 'Can publish and view content', async function () {
+		it( 'Can publish and view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.publish( { visit: true } );
 		} );
 
-		step( 'Can see the post in the Activity log', async function () {
+		it( 'Can see the post in the Activity log', async function () {
 			await ReaderPage.Visit( driver );
 			const navBarComponent = await NavBarComponent.Expect( driver );
 			await navBarComponent.clickMySites();
@@ -332,31 +332,28 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote = '“Worries shared are worries halved.”\n- Unknown';
 
-			step( 'Can log in', async function () {
+			it( 'Can log in', async function () {
 				this.loginFlow = new LoginFlow( driver, gutenbergUser );
 				return await this.loginFlow.loginAndStartNewPost( null, true );
 			} );
 
-			step( 'Can enter post title and content', async function () {
+			it( 'Can enter post title and content', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.enterTitle( blogPostTitle );
 				await gEditorComponent.enterText( blogPostQuote );
 			} );
 
-			step(
-				'Can schedule content for a future date and see correct publish date',
-				async function () {
-					const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
-					await gSidebarComponent.displayComponentIfNecessary();
-					await gSidebarComponent.chooseDocumentSettings();
-					const publishDate = await gSidebarComponent.scheduleFuturePost();
+			it( 'Can schedule content for a future date and see correct publish date', async function () {
+				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+				await gSidebarComponent.displayComponentIfNecessary();
+				await gSidebarComponent.chooseDocumentSettings();
+				const publishDate = await gSidebarComponent.scheduleFuturePost();
 
-					const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-					return await gEditorComponent.schedulePost( publishDate );
-				}
-			);
+				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				return await gEditorComponent.schedulePost( publishDate );
+			} );
 
-			step( 'Remove scheduled post', async function () {
+			it( 'Remove scheduled post', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.closeScheduledPanel();
 				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
@@ -364,7 +361,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				await gSidebarComponent.trashPost();
 			} );
 
-			step( 'Can then see the Posts page with a confirmation message', async function () {
+			it( 'Can then see the Posts page with a confirmation message', async function () {
 				const noticesComponent = await NoticesComponent.Expect( driver );
 				const displayed = await noticesComponent.isSuccessNoticeDisplayed();
 				return assert.strictEqual(
@@ -386,12 +383,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const blogPostQuote =
 				'If you’re not prepared to be wrong; you’ll never come up with anything original.\n— Sir Ken Robinson';
 
-			step( 'Can log in', async function () {
+			it( 'Can log in', async function () {
 				this.loginFlow = new LoginFlow( driver, gutenbergUser );
 				return await this.loginFlow.loginAndStartNewPost( null, true );
 			} );
 
-			step( 'Can enter post title and content', async function () {
+			it( 'Can enter post title and content', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.enterTitle( blogPostTitle );
 				return await gEditorComponent.enterText( blogPostQuote );
@@ -400,7 +397,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				// return await gEditorComponent.ensureSaved();
 			} );
 
-			step( 'Can disable sharing buttons', async function () {
+			it( 'Can disable sharing buttons', async function () {
 				return await SlackNotifier.warn(
 					'Sharing buttons not currently available for Gutenberg in Calypso'
 				);
@@ -410,7 +407,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				//await postEditorSidebarComponent.closeSharingSection();
 			} );
 
-			step( 'Can allow comments', async function () {
+			it( 'Can allow comments', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.openSidebar();
 				const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
@@ -420,23 +417,20 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				return await gEditorSidebarComponent.setCommentsPreference( { allow: true } );
 			} );
 
-			step(
-				'Set to private which publishes it - Can set visibility to private which immediately publishes it',
-				async function () {
-					const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
-					await gSidebarComponent.chooseDocumentSettings();
-					await gSidebarComponent.expandStatusAndVisibility();
-					await gSidebarComponent.setVisibilityToPrivate();
-					return await gSidebarComponent.hideComponentIfNecessary();
-				}
-			);
+			it( 'Set to private which publishes it - Can set visibility to private which immediately publishes it', async function () {
+				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+				await gSidebarComponent.chooseDocumentSettings();
+				await gSidebarComponent.expandStatusAndVisibility();
+				await gSidebarComponent.setVisibilityToPrivate();
+				return await gSidebarComponent.hideComponentIfNecessary();
+			} );
 
-			step( 'Can view content', async function () {
+			it( 'Can view content', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				return await gEditorComponent.viewPublishedPostOrPage();
 			} );
 
-			step( 'As a logged in user - Can see correct post title', async function () {
+			it( 'As a logged in user - Can see correct post title', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const postTitle = await viewPostPage.postTitle();
 				assert.strictEqual(
@@ -446,7 +440,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'Can see correct post content', async function () {
+			it( 'Can see correct post content', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const content = await viewPostPage.postContent();
 				assert.strictEqual(
@@ -460,7 +454,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'Can see comments enabled', async function () {
+			it( 'Can see comments enabled', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const visible = await viewPostPage.commentsVisible();
 				assert.strictEqual(
@@ -470,7 +464,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( "Can't see sharing buttons", async function () {
+			it( "Can't see sharing buttons", async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const visible = await viewPostPage.sharingButtonsVisible();
 				assert.strictEqual(
@@ -480,12 +474,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'Ensure we are not logggd in', async function () {
+			it( 'Ensure we are not logggd in', async function () {
 				await driverManager.clearCookiesAndDeleteLocalStorage( driver );
 				await driver.navigate().refresh();
 			} );
 
-			step( "As a non-logged in user - Can't see post at all", async function () {
+			it( "As a non-logged in user - Can't see post at all", async function () {
 				const notFoundPage = await NotFoundPage.Expect( driver );
 				const displayed = await notFoundPage.displayed();
 				assert.strictEqual(
@@ -508,12 +502,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				'The best thing about the future is that it comes only one day at a time.\n— Abraham Lincoln';
 			const postPassword = 'e2e' + new Date().getTime().toString();
 
-			step( 'Can log in', async function () {
+			it( 'Can log in', async function () {
 				const loginFlow = new LoginFlow( driver, gutenbergUser );
 				await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
-			step( 'Can enter post title and content and set to password protected', async function () {
+			it( 'Can enter post title and content and set to password protected', async function () {
 				let gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.enterTitle( blogPostTitle );
 
@@ -526,23 +520,20 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				return await gEditorComponent.enterText( blogPostQuote );
 			} );
 
-			step( 'Can publish and view content', async function () {
+			it( 'Can publish and view content', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.publish( { visit: true } );
 			} );
-			step(
-				'As a logged in user, With no password entered, Can view page title',
-				async function () {
-					const viewPostPage = await ViewPostPage.Expect( driver );
-					const actualPostTitle = await viewPostPage.postTitle();
-					assert.strictEqual(
-						actualPostTitle.toUpperCase(),
-						( 'Protected: ' + blogPostTitle ).toUpperCase()
-					);
-				}
-			);
+			it( 'As a logged in user, With no password entered, Can view page title', async function () {
+				const viewPostPage = await ViewPostPage.Expect( driver );
+				const actualPostTitle = await viewPostPage.postTitle();
+				assert.strictEqual(
+					actualPostTitle.toUpperCase(),
+					( 'Protected: ' + blogPostTitle ).toUpperCase()
+				);
+			} );
 
-			step( 'Can see password field', async function () {
+			it( 'Can see password field', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const isPasswordProtected = await viewPostPage.isPasswordProtected();
 				assert.strictEqual(
@@ -552,7 +543,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( "Can't see content when no password is entered", async function () {
+			it( "Can't see content when no password is entered", async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const content = await viewPostPage.postContent();
 				assert.strictEqual(
@@ -566,12 +557,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'With incorrect password entered, Enter incorrect password', async function () {
+			it( 'With incorrect password entered, Enter incorrect password', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				await viewPostPage.enterPassword( 'password' );
 			} );
 
-			step( 'Can view post title', async function () {
+			it( 'Can view post title', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const actualPostTitle = await viewPostPage.postTitle();
 				assert.strictEqual(
@@ -580,7 +571,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'Can see password field', async function () {
+			it( 'Can see password field', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const isPasswordProtected = await viewPostPage.isPasswordProtected();
 				assert.strictEqual(
@@ -590,7 +581,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( "Can't see content when incorrect password is entered", async function () {
+			it( "Can't see content when incorrect password is entered", async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const content = await viewPostPage.postContent();
 				assert.strictEqual(
@@ -604,12 +595,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'With correct password entered, Enter correct password', async function () {
+			it( 'With correct password entered, Enter correct password', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				await viewPostPage.enterPassword( postPassword );
 			} );
 
-			step( 'Can view post title', async function () {
+			it( 'Can view post title', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const actualPostTitle = await viewPostPage.postTitle();
 				assert.strictEqual(
@@ -618,7 +609,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( "Can't see password field", async function () {
+			it( "Can't see password field", async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const isPasswordProtected = await viewPostPage.isPasswordProtected();
 				assert.strictEqual(
@@ -628,7 +619,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'Can see post content', async function () {
+			it( 'Can see post content', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const content = await viewPostPage.postContent();
 				assert.strictEqual(
@@ -642,12 +633,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'As a non-logged in user, Clear cookies (log out)', async function () {
+			it( 'As a non-logged in user, Clear cookies (log out)', async function () {
 				await driver.manage().deleteAllCookies();
 				await driver.navigate().refresh();
 			} );
 
-			step( 'With no password entered, Can view page title', async function () {
+			it( 'With no password entered, Can view page title', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const actualPostTitle = await viewPostPage.postTitle();
 				assert.strictEqual(
@@ -656,7 +647,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'Can see password field', async function () {
+			it( 'Can see password field', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const isPasswordProtected = await viewPostPage.isPasswordProtected();
 				assert.strictEqual(
@@ -666,7 +657,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( "Can't see content when no password is entered", async function () {
+			it( "Can't see content when no password is entered", async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const content = await viewPostPage.postContent();
 				assert.strictEqual(
@@ -680,12 +671,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'With incorrect password entered, Enter incorrect password', async function () {
+			it( 'With incorrect password entered, Enter incorrect password', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				await viewPostPage.enterPassword( 'password' );
 			} );
 
-			step( 'Can view post title', async function () {
+			it( 'Can view post title', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const actualPostTitle = await viewPostPage.postTitle();
 				assert.strictEqual(
@@ -694,7 +685,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'Can see password field', async function () {
+			it( 'Can see password field', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const isPasswordProtected = await viewPostPage.isPasswordProtected();
 				assert.strictEqual(
@@ -704,7 +695,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( "Can't see content when incorrect password is entered", async function () {
+			it( "Can't see content when incorrect password is entered", async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const content = await viewPostPage.postContent();
 				assert.strictEqual(
@@ -718,12 +709,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'With correct password entered, Enter correct password', async function () {
+			it( 'With correct password entered, Enter correct password', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				await viewPostPage.enterPassword( postPassword );
 			} );
 
-			step( 'Can view post title', async function () {
+			it( 'Can view post title', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const actualPostTitle = await viewPostPage.postTitle();
 				assert.strictEqual(
@@ -732,7 +723,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( "Can't see password field", async function () {
+			it( "Can't see password field", async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const isPasswordProtected = await viewPostPage.isPasswordProtected();
 				assert.strictEqual(
@@ -742,7 +733,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'Can see page content', async function () {
+			it( 'Can see page content', async function () {
 				const viewPostPage = await ViewPostPage.Expect( driver );
 				const content = await viewPostPage.postContent();
 				assert.strictEqual(
@@ -768,25 +759,25 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const blogPostQuote =
 				'The only victory that counts is the victory over yourself.\n— Jesse Owens\n';
 
-			step( 'Can log in', async function () {
+			it( 'Can log in', async function () {
 				const loginFlow = new LoginFlow( driver, gutenbergUser );
 				return await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
-			step( 'Can enter post title and content', async function () {
+			it( 'Can enter post title and content', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.enterTitle( blogPostTitle );
 				await gEditorComponent.enterText( blogPostQuote );
 				return gEditorComponent.ensureSaved();
 			} );
 
-			step( 'Can trash the new post', async function () {
+			it( 'Can trash the new post', async function () {
 				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 				await gSidebarComponent.chooseDocumentSettings();
 				return await gSidebarComponent.trashPost();
 			} );
 
-			step( 'Can then see the Posts page with a confirmation message', async function () {
+			it( 'Can then see the Posts page with a confirmation message', async function () {
 				const noticesComponent = await NoticesComponent.Expect( driver );
 				const displayed = await noticesComponent.isSuccessNoticeDisplayed();
 				return assert.strictEqual(
@@ -809,24 +800,24 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const blogPostQuote =
 				'Science is organised knowledge. Wisdom is organised life..\n~ Immanuel Kant';
 
-			step( 'Can log in', async function () {
+			it( 'Can log in', async function () {
 				const loginFlow = new LoginFlow( driver, gutenbergUser );
 				return await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
-			step( 'Can enter post title and content', async function () {
+			it( 'Can enter post title and content', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.enterTitle( originalBlogPostTitle );
 				await gEditorComponent.enterText( blogPostQuote );
 			} );
 
-			step( 'Can publish the post', async function () {
+			it( 'Can publish the post', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.publish( { visit: true } );
 			} );
 
 			describe( 'Edit the post via posts', function () {
-				step( 'Can view the posts list', async function () {
+				it( 'Can view the posts list', async function () {
 					await ReaderPage.Visit( driver );
 					const navbarComponent = await NavBarComponent.Expect( driver );
 					await navbarComponent.clickMySites();
@@ -839,7 +830,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 					return await PostsPage.Expect( driver );
 				} );
 
-				step( 'Can see and edit our new post', async function () {
+				it( 'Can see and edit our new post', async function () {
 					const postsPage = await PostsPage.Expect( driver );
 					await postsPage.waitForPostTitled( originalBlogPostTitle );
 					const displayed = await postsPage.isPostDisplayed( originalBlogPostTitle );
@@ -852,7 +843,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 					return await GutenbergEditorComponent.Expect( driver );
 				} );
 
-				step( 'Can see the post title', async function () {
+				it( 'Can see the post title', async function () {
 					const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 					const titleShown = await gEditorComponent.titleShown();
 					assert.strictEqual(
@@ -862,7 +853,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 					);
 				} );
 
-				step( 'Can see the Line Height setting for the paragraph', async function () {
+				it( 'Can see the Line Height setting for the paragraph', async function () {
 					const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 
 					if ( driverManager.currentScreenSize() === 'mobile' )
@@ -888,22 +879,19 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 					assert.ok( lineHeighSettingPresent, 'Line height setting not found' );
 				} );
 
-				step(
-					'Can set the new title and update it, and link to the updated post',
-					async function () {
-						const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-						await gEditorComponent.enterTitle( updatedBlogPostTitle );
+				it( 'Can set the new title and update it, and link to the updated post', async function () {
+					const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+					await gEditorComponent.enterTitle( updatedBlogPostTitle );
 
-						return await gEditorComponent.update( { visit: true } );
-					}
-				);
+					return await gEditorComponent.update( { visit: true } );
+				} );
 
 				describe( 'Can view the post with the new title', function () {
-					step( 'Can view the post', async function () {
+					it( 'Can view the post', async function () {
 						return await ViewPostPage.Expect( driver );
 					} );
 
-					step( 'Can see correct post title', async function () {
+					it( 'Can see correct post title', async function () {
 						const viewPostPage = await ViewPostPage.Expect( driver );
 						const postTitle = await viewPostPage.postTitle();
 						return assert.strictEqual(
@@ -927,12 +915,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const contactEmail = 'testing@automattic.com';
 			const subject = "Let's work together";
 
-			step( 'Can log in', async function () {
+			it( 'Can log in', async function () {
 				const loginFlow = new LoginFlow( driver, gutenbergUser );
 				return await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
-			step( 'Can insert the contact form', async function () {
+			it( 'Can insert the contact form', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.enterTitle( originalBlogPostTitle );
 				await gEditorComponent.insertContactForm( contactEmail, subject );
@@ -946,12 +934,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			step( 'Can publish and view content', async function () {
+			it( 'Can publish and view content', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.publish( { visit: true } );
 			} );
 
-			step( 'Can see the contact form in our published post', async function () {
+			it( 'Can see the contact form in our published post', async function () {
 				this.viewPostPage = await ViewPostPage.Expect( driver );
 				const displayed = await this.viewPostPage.contactFormDisplayed();
 				assert.strictEqual(
@@ -978,12 +966,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			email: 'test@wordpress.com',
 		};
 
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
-		step( 'Can insert the payment button', async function () {
+		it( 'Can insert the payment button', async function () {
 			const blogPostTitle = 'Payment Button: ' + dataHelper.randomPhrase();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			const blockId = await gEditorComponent.addBlock( 'Pay with PayPal' );
@@ -996,7 +984,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			return await gPaymentComponent.ensurePaymentButtonDisplayedInEditor();
 		} );
 
-		step( 'Can publish and view content', async function () {
+		it( 'Can publish and view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			try {
 				await gEditorComponent.publish( { visit: true } );
@@ -1014,7 +1002,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			}
 		} );
 
-		step( 'Can see the payment button in our published post', async function () {
+		it( 'Can see the payment button in our published post', async function () {
 			const viewPostPage = await ViewPostPage.Expect( driver );
 			const displayed = await viewPostPage.paymentButtonDisplayed();
 			return assert.strictEqual(
@@ -1024,35 +1012,32 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			);
 		} );
 
-		step(
-			'The payment button in our published post opens a new Paypal window for payment',
-			async function () {
-				const numberOfOpenBrowserWindows = await driverHelper.numberOfOpenWindows( driver );
-				assert.strictEqual(
-					numberOfOpenBrowserWindows,
-					1,
-					'There is more than one open browser window before clicking payment button'
-				);
-				const viewPostPage = await ViewPostPage.Expect( driver );
-				await viewPostPage.clickPaymentButton();
-				// Skip some lines and checks until Chrome can handle multiple windows in app mode
-				// await driverHelper.waitForNumberOfWindows( driver, 2 );
-				// await driverHelper.switchToWindowByIndex( driver, 1 );
-				await PaypalCheckoutPage.Expect( driver );
-				// const amountDisplayed = await paypalCheckoutPage.priceDisplayed();
-				// assert.strictEqual(
-				// 	amountDisplayed,
-				// 	`${ paymentButtonDetails.symbol }${ paymentButtonDetails.price } ${
-				// 		paymentButtonDetails.currency
-				// 	}`,
-				// 	"The amount displayed on Paypal isn't correct"
-				// );
-				// await driverHelper.closeCurrentWindow( driver );
-				// await driverHelper.switchToWindowByIndex( driver, 0 );
-				// viewPostPage = await ViewPostPage.Expect( driver );
-				// assert( await viewPostPage.displayed(), 'view post page is not displayed' );
-			}
-		);
+		it( 'The payment button in our published post opens a new Paypal window for payment', async function () {
+			const numberOfOpenBrowserWindows = await driverHelper.numberOfOpenWindows( driver );
+			assert.strictEqual(
+				numberOfOpenBrowserWindows,
+				1,
+				'There is more than one open browser window before clicking payment button'
+			);
+			const viewPostPage = await ViewPostPage.Expect( driver );
+			await viewPostPage.clickPaymentButton();
+			// Skip some lines and checks until Chrome can handle multiple windows in app mode
+			// await driverHelper.waitForNumberOfWindows( driver, 2 );
+			// await driverHelper.switchToWindowByIndex( driver, 1 );
+			await PaypalCheckoutPage.Expect( driver );
+			// const amountDisplayed = await paypalCheckoutPage.priceDisplayed();
+			// assert.strictEqual(
+			// 	amountDisplayed,
+			// 	`${ paymentButtonDetails.symbol }${ paymentButtonDetails.price } ${
+			// 		paymentButtonDetails.currency
+			// 	}`,
+			// 	"The amount displayed on Paypal isn't correct"
+			// );
+			// await driverHelper.closeCurrentWindow( driver );
+			// await driverHelper.switchToWindowByIndex( driver, 0 );
+			// viewPostPage = await ViewPostPage.Expect( driver );
+			// assert( await viewPostPage.displayed(), 'view post page is not displayed' );
+		} );
 
 		after( async function () {
 			await driverHelper.acceptAlertIfPresent( driver );
@@ -1069,12 +1054,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			return fileDetails;
 		} );
 
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			const loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await loginFlow.loginAndStartNewPost( null, true );
 		} );
 
-		step( 'Can insert an image in an Image block with the Media Modal', async function () {
+		it( 'Can insert an image in an Image block with the Media Modal', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			return await gEditorComponent.addImageFromMediaModal( fileDetails );
 		} );
@@ -1086,25 +1071,25 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const blogPostQuote =
 				'To really be of help to others we need to be guided by compassion.\n— Dalai Lama';
 
-			step( 'Can log in', async function () {
+			it( 'Can log in', async function () {
 				const loginFlow = new LoginFlow( driver, gutenbergUser );
 				return await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
-			step( 'Can enter post title and content', async function () {
+			it( 'Can enter post title and content', async function () {
 				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
 				await gHeaderComponent.enterTitle( originalBlogPostTitle );
 				await gHeaderComponent.enterText( blogPostQuote );
 			} );
 
-			step( 'Can publish the post', async function () {
+			it( 'Can publish the post', async function () {
 				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
 				return await gHeaderComponent.publish();
 			} );
 		} );
 
 		describe( 'Revert the post to draft', function () {
-			step( 'Can revert the post to draft', async function () {
+			it( 'Can revert the post to draft', async function () {
 				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
 				await gHeaderComponent.dismissSuccessNotice();
 				await gHeaderComponent.revertToDraft();
@@ -1117,12 +1102,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 	} );
 
 	describe( 'Insert embeds: @parallel', function () {
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
-		step( 'Can start post', async function () {
+		it( 'Can start post', async function () {
 			const blogPostTitle = 'Embeds: ' + dataHelper.randomPhrase();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.enterTitle( blogPostTitle );
@@ -1147,7 +1132,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				selector: '.wp-block-embed iframe[title="Embedded content from youtube.com"]',
 			},
 		].forEach( ( Block ) => {
-			step( `Can insert ${ Block.name } block`, async function () {
+			it( `Can insert ${ Block.name } block`, async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				const embedBlock = await gEditorComponent.addBlock( Block.name );
 				const gEmbedsComponent = await EmbedsBlockComponent.Expect( driver, embedBlock );
@@ -1156,12 +1141,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 		} );
 
-		step( 'Can publish and view content', async function () {
+		it( 'Can publish and view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			return await gEditorComponent.publish( { visit: true } );
 		} );
 
-		step( 'Can see embedded content in our published post', async function () {
+		it( 'Can see embedded content in our published post', async function () {
 			const viewPostPage = await ViewPostPage.Expect( driver );
 			this.youtubePostLocator = '.youtube-player';
 			await viewPostPage.embedContentDisplayed( this.youtubePostLocator ); // check YouTube content
@@ -1177,13 +1162,13 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 	} );
 
 	describe( 'Can Share Posts From Reader (PressThis)! @parallel', function () {
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			await this.loginFlow.login();
 			return await this.loginFlow.checkForDevDocsAndRedirectToReader();
 		} );
 
-		step( 'Find a post to share (press this)', async function () {
+		it( 'Find a post to share (press this)', async function () {
 			const readerPage = await ReaderPage.Expect( driver );
 			const sharePostError = await readerPage.shareLatestPost();
 			if ( sharePostError instanceof Error ) {
@@ -1191,17 +1176,17 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			}
 		} );
 
-		step( 'Block Editor loads with shared content', async function () {
+		it( 'Block Editor loads with shared content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			return await gEditorComponent.initEditor();
 		} );
 
-		step( 'Can publish and view content', async function () {
+		it( 'Can publish and view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			return await gEditorComponent.publish( { visit: true } );
 		} );
 
-		step( 'Can see a post title and post content', async function () {
+		it( 'Can see a post title and post content', async function () {
 			const viewPostPage = await ViewPostPage.Expect( driver );
 			const postTitle = await viewPostPage.postTitle();
 			const postContent = await viewPostPage.postContent();
@@ -1217,26 +1202,26 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		const updatedContent =
 			'Your most unhappy customers are your greatest source of learning. ~ Bill Gates';
 
-		step( 'Can log in', async function () {
+		it( 'Can log in', async function () {
 			const loginFlow = new LoginFlow( driver, gutenbergUser );
 			await loginFlow.loginAndStartNewPost( null, true );
 		} );
 
-		step( 'Can enter post title and text content', async function () {
+		it( 'Can enter post title and text content', async function () {
 			const editor = await GutenbergEditorComponent.Expect( driver );
 			await editor.enterTitle( originalTitle );
 			await editor.enterText( originalContent );
 			await editor.ensureSaved();
 		} );
 
-		step( 'Can update post title and text content', async function () {
+		it( 'Can update post title and text content', async function () {
 			const editor = await GutenbergEditorComponent.Expect( driver );
 			await editor.enterTitle( updatedTitle );
 			await editor.replaceTextOnLastParagraph( updatedContent );
 			await editor.ensureSaved();
 		} );
 
-		step( 'Can open the revisions modal', async function () {
+		it( 'Can open the revisions modal', async function () {
 			const editor = await GutenbergEditorComponent.Expect( driver );
 			await editor.openSidebar();
 			const sidebar = await GutenbergEditorSidebarComponent.Expect( driver );
@@ -1244,7 +1229,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			await sidebar.openRevisionsDialog();
 		} );
 
-		step( 'Can restore the previous revision', async function () {
+		it( 'Can restore the previous revision', async function () {
 			const revisions = await RevisionsModalComponent.Expect( driver );
 			await revisions.loadFirstRevision();
 

--- a/test/e2e/specs-gutenberg/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs-gutenberg/wp-calypso-gutenberg-upgrade-spec.js
@@ -122,12 +122,12 @@ async function startNewPost( loginFlow ) {
  * @param {Function} Block A block class.
  */
 function verifyBlockInEditor( Block ) {
-	step( 'Block is displayed in the editor', async function () {
+	it( 'Block is displayed in the editor', async function () {
 		const blockDisplayed = await editor.blockDisplayedInEditor( Block.blockName );
 		assert( blockDisplayed, `The block "${ Block.blockName }" was not found in the editor.` );
 	} );
 
-	step( 'Block does not invalidate', async function () {
+	it( 'Block does not invalidate', async function () {
 		const hasInvalidBlocks = await editor.hasInvalidBlocks();
 		assert( ! hasInvalidBlocks, `The block "${ Block.blockName }" is invalid.` );
 	} );
@@ -139,7 +139,7 @@ function verifyBlockInEditor( Block ) {
  * @param {Function} Block A block class.
  */
 function verifyBlockInPublishedPage( Block ) {
-	step( 'Publish page', async function () {
+	it( 'Publish page', async function () {
 		await editor.publish( { visit: true } );
 	} );
 
@@ -151,7 +151,7 @@ function verifyBlockInPublishedPage( Block ) {
 	 * removed.
 	 */
 	if ( ! [ YoutubeBlockComponent, SlideshowBlockComponent ].includes( Block ) ) {
-		step( 'Block is displayed in the published page', async function () {
+		it( 'Block is displayed in the published page', async function () {
 			await driverHelper.waitUntilElementLocatedAndVisible( driver, Block.blockFrontendLocator );
 		} );
 	}
@@ -199,34 +199,34 @@ describe( `[${ host }, ${ screenSize }] Test Gutenberg upgrade against most popu
 			let currentGutenbergBlocksCode;
 
 			describe( `Test the block on a non-edge site`, function () {
-				step( `Log in and start a new post`, async function () {
+				it( `Log in and start a new post`, async function () {
 					const loginFlow = new LoginFlow( driver, 'gutenbergUpgradeUser' );
 
 					await loginFlow.login();
 					editor = await startNewPost( loginFlow );
 				} );
 
-				step( `Insert and configure the block`, async function () {
+				it( `Insert and configure the block`, async function () {
 					await insertBlock( Block );
 				} );
 
 				verifyBlockInEditor( Block );
 
-				step( 'Copy the markup for the block', async function () {
+				it( 'Copy the markup for the block', async function () {
 					currentGutenbergBlocksCode = await editor.getBlocksCode();
 				} );
 
 				verifyBlockInPublishedPage( Block );
 
 				describe( `Test the same block on a corresponding edge site`, function () {
-					step( `Start a new post`, async function () {
+					it( `Start a new post`, async function () {
 						const loginFlow = new LoginFlow( driver, 'gutenbergUpgradeEdgeUser' );
 
 						// No need to log in again as the edge site is owned by the same user.
 						editor = await startNewPost( loginFlow );
 					} );
 
-					step( 'Load the block via markup copied from the non-edge site', async function () {
+					it( 'Load the block via markup copied from the non-edge site', async function () {
 						await editor.setBlocksCode( currentGutenbergBlocksCode );
 					} );
 

--- a/test/e2e/specs-gutenberg/wp-comments-spec.js
+++ b/test/e2e/specs-gutenberg/wp-comments-spec.js
@@ -38,7 +38,7 @@ describe( `[${ host }] Comments: (${ screenSize })`, function () {
 	} );
 
 	describe( 'Commenting and replying to newly created post in Gutenberg Editor: @parallel', function () {
-		step( 'Can login and create a new post', async function () {
+		it( 'Can login and create a new post', async function () {
 			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
 			await this.loginFlow.loginAndStartNewPost( null, true );
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
@@ -46,12 +46,12 @@ describe( `[${ host }] Comments: (${ screenSize })`, function () {
 			await gEditorComponent.enterText( blogPostQuote );
 		} );
 
-		step( 'Can publish and visit site', async function () {
+		it( 'Can publish and visit site', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.publish( { visit: true } );
 		} );
 
-		step( 'Can post a comment', async function () {
+		it( 'Can post a comment', async function () {
 			const commentArea = await CommentsAreaComponent.Expect( driver );
 			const comment = dataHelper.randomPhrase();
 
@@ -60,7 +60,7 @@ describe( `[${ host }] Comments: (${ screenSize })`, function () {
 			await commentArea.verifyCommentIsVisible( comment );
 		} );
 
-		step( 'Can post a reply', async function () {
+		it( 'Can post a reply', async function () {
 			const commentArea = await CommentsAreaComponent.Expect( driver );
 			const comment = dataHelper.randomPhrase();
 

--- a/test/e2e/specs-gutenberg/wp-gutenberg-experimental-features-spec.js
+++ b/test/e2e/specs-gutenberg/wp-gutenberg-experimental-features-spec.js
@@ -51,7 +51,7 @@ describe( `[${ host }] Experimental features we depend on are available (${ scre
 		driver = await driverManager.startBrowser();
 	} );
 
-	step( 'Can log in', async function () {
+	it( 'Can log in', async function () {
 		this.loginFlow = new LoginFlow( driver, gutenbergUser );
 		return await this.loginFlow.loginAndStartNewPost( null, true );
 	} );
@@ -62,22 +62,19 @@ describe( `[${ host }] Experimental features we depend on are available (${ scre
 			// The algorithm WP uses to convert package names to variable names is here: https://github.com/WordPress/gutenberg/blob/a03ea51e11a36d0abeecb4ce4e4cea5ffebdffc5/packages/dependency-extraction-webpack-plugin/lib/util.js#L40-L45
 			const wpGlobalName = camelCaseDash( packageName.substr( '@wordpress/'.length ) );
 
-			step(
-				`"${ wpGlobalName }" package should be available in the global window object`,
-				async function () {
-					const typeofPackage = await driver.executeScript(
-						`return typeof window.wp['${ wpGlobalName }']`
-					);
-					assert.notStrictEqual(
-						typeofPackage,
-						'undefined',
-						`${ wpGlobalName } is ${ typeofPackage }`
-					);
-				}
-			);
+			it( `"${ wpGlobalName }" package should be available in the global window object`, async function () {
+				const typeofPackage = await driver.executeScript(
+					`return typeof window.wp['${ wpGlobalName }']`
+				);
+				assert.notStrictEqual(
+					typeofPackage,
+					'undefined',
+					`${ wpGlobalName } is ${ typeofPackage }`
+				);
+			} );
 
 			for ( const feature of features ) {
-				step( `${ feature } should be available in ${ packageName }`, async function () {
+				it( `${ feature } should be available in ${ packageName }`, async function () {
 					const typeofExperimentalFeature = await driver.executeScript(
 						`return typeof window.wp['${ wpGlobalName }']['${ feature }']`
 					);
@@ -92,18 +89,15 @@ describe( `[${ host }] Experimental features we depend on are available (${ scre
 	} );
 
 	describe( 'Experimental data we depend on is available', function () {
-		step(
-			`is iterable: wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns`,
-			async function () {
-				const __experimentalBlockPatternsAreIterable = await driver.executeScript(
-					`return Array.isArray( window.wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns )`
-				);
-				assert(
-					__experimentalBlockPatternsAreIterable,
-					'__experimentalBlockPatterns was not iterable, please contact #team-ganon to update premium pattern highlighting'
-				);
-			}
-		);
+		it( `is iterable: wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns`, async function () {
+			const __experimentalBlockPatternsAreIterable = await driver.executeScript(
+				`return Array.isArray( window.wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns )`
+			);
+			assert(
+				__experimentalBlockPatternsAreIterable,
+				'__experimentalBlockPatterns was not iterable, please contact #team-ganon to update premium pattern highlighting'
+			);
+		} );
 
 		// Regression test for https://github.com/Automattic/wp-calypso/pull/48940.
 		// At the time I write this, the default block patterns in the test site /
@@ -113,7 +107,7 @@ describe( `[${ host }] Experimental features we depend on are available (${ scre
 		// also to avoid potential false-negatives. I assume it's more likely that more
 		// patterns will be added than removed. This also means if we see a dramatic
 		// change in the number to the lower end, then something is probably wrong.
-		step( `number of block patterns loaded should be greater than the default`, async function () {
+		it( `number of block patterns loaded should be greater than the default`, async function () {
 			const expectedExperimentalBlockPatternsLength = 50;
 			const __experimentalBlockPatternsLength = await driver.executeScript(
 				`return window.wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns.length`

--- a/test/e2e/specs-i18n/logged-out-redirect-i18n-spec.js
+++ b/test/e2e/specs-i18n/logged-out-redirect-i18n-spec.js
@@ -27,7 +27,7 @@ describe( `Logged out homepage redirect test @i18n (${ locale })`, function () {
 		driver = await driverManager.startBrowser();
 	} );
 
-	step( `should redirect to the correct url for wordpress.com (${ locale })`, async function () {
+	it( `should redirect to the correct url for wordpress.com (${ locale })`, async function () {
 		// No culture here implies 'en'
 		const wpHomePage = await WPHomePage.Visit( driver );
 		await wpHomePage.checkURL( locale );

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -57,41 +57,41 @@ describe( `Jetpack Connect: (${ screenSize })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can log in to WPCOM', async function () {
+		it( 'Can log in to WPCOM', async function () {
 			const loginFlow = new LoginFlow( driver, 'jetpackConnectUser' );
 			await loginFlow.login();
 		} );
 
-		step( 'Can create wporg site', async function () {
+		it( 'Can create wporg site', async function () {
 			this.timeout( mochaTimeOut * 12 );
 
 			this.jnFlow = new JetpackConnectFlow( driver, null );
 			return await this.jnFlow.createJNSite();
 		} );
 
-		step( 'Can navigate to the Jetpack dashboard', async function () {
+		it( 'Can navigate to the Jetpack dashboard', async function () {
 			await WPAdminSidebar.refreshIfJNError( driver );
 			this.wpAdminSidebar = await WPAdminSidebar.Expect( driver );
 			return await this.wpAdminSidebar.selectJetpack();
 		} );
 
-		step( 'Can click the Connect Jetpack button', async function () {
+		it( 'Can click the Connect Jetpack button', async function () {
 			await driverHelper.refreshIfJNError( driver );
 			this.wpAdminJetpack = await WPAdminJetpackPage.Expect( driver );
 			return await this.wpAdminJetpack.inPlaceConnect();
 		} );
 
-		step( 'Can Approve in-place connection', async function () {
+		it( 'Can Approve in-place connection', async function () {
 			const inPlaceApprovePage = await WPAdminInPlaceApprovePage.Expect( driver );
 			await inPlaceApprovePage.approve();
 		} );
 
-		step( 'Can click the free plan button', async function () {
+		it( 'Can click the free plan button', async function () {
 			const pickAPlanPage = await PickAPlanPage.Expect( driver );
 			return await pickAPlanPage.selectFreePlanJetpack();
 		} );
 
-		step( 'Can assert we are on Jetpack Dashboard', async function () {
+		it( 'Can assert we are on Jetpack Dashboard', async function () {
 			await WPAdminJetpackPage.Expect( driver );
 		} );
 	} );
@@ -101,17 +101,17 @@ describe( `Jetpack Connect: (${ screenSize })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can select Get Started', async function () {
+		it( 'Can select Get Started', async function () {
 			const jetPackComPage = await JetpackComPage.Visit( driver );
 			return await jetPackComPage.selectGetStarted();
 		} );
 
-		step( 'Can select free plan', async function () {
+		it( 'Can select free plan', async function () {
 			const pickAPlanPage = await PickAPlanPage.Expect( driver );
 			return await pickAPlanPage.selectFreePlanJetpack();
 		} );
 
-		step( 'Can see Jetpack connect page', async function () {
+		it( 'Can see Jetpack connect page', async function () {
 			return await JetpackConnectPage.Expect( driver );
 		} );
 	} );
@@ -121,7 +121,7 @@ describe( `Jetpack Connect: (${ screenSize })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can register new Subscriber user', async function () {
+		it( 'Can register new Subscriber user', async function () {
 			this.accountName = dataHelper.getNewBlogName();
 			this.emailAddress = dataHelper.getEmailAddress( this.accountName, signupInboxId );
 			this.password = config.get( 'passwordForNewTestSignUps' );
@@ -135,16 +135,16 @@ describe( `Jetpack Connect: (${ screenSize })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can log into WordPress.com', async function () {
+		it( 'Can log into WordPress.com', async function () {
 			return await new LoginFlow( driver ).login();
 		} );
 
-		step( 'Can log into site via Jetpack SSO', async function () {
+		it( 'Can log into site via Jetpack SSO', async function () {
 			const loginPage = await WPAdminLogonPage.Visit( driver, dataHelper.getJetpackSiteName() );
 			return await loginPage.logonSSO();
 		} );
 
-		step( 'Add new user as Subscriber in wp-admin', async function () {
+		it( 'Add new user as Subscriber in wp-admin', async function () {
 			await WPAdminSidebar.refreshIfJNError( driver );
 			const wpAdminSidebar = await WPAdminSidebar.Expect( driver );
 			await wpAdminSidebar.selectAddNewUser();
@@ -153,7 +153,7 @@ describe( `Jetpack Connect: (${ screenSize })`, function () {
 			return await wpAdminNewUserPage.addUser( this.emailAddress );
 		} );
 
-		step( 'Log out from WP Admin', async function () {
+		it( 'Log out from WP Admin', async function () {
 			await driverManager.ensureNotLoggedIn( driver );
 			await WPAdminDashboardPage.refreshIfJNError( driver );
 			const wPAdminDashboardPage = await WPAdminDashboardPage.Visit(
@@ -163,12 +163,12 @@ describe( `Jetpack Connect: (${ screenSize })`, function () {
 			return await wPAdminDashboardPage.logout();
 		} );
 
-		step( 'Can log in as Subscriber', async function () {
+		it( 'Can log in as Subscriber', async function () {
 			const loginPage = await LoginPage.Visit( driver );
 			return await loginPage.login( this.accountName, this.password );
 		} );
 
-		step( 'Can login via SSO into WP Admin', async function () {
+		it( 'Can login via SSO into WP Admin', async function () {
 			const wpAdminLogonPage = await WPAdminLogonPage.Visit( driver, siteName );
 			await wpAdminLogonPage.logonSSO();
 			const jetpackAuthorizePage = await JetpackAuthorizePage.Expect( driver );
@@ -181,12 +181,12 @@ describe( `Jetpack Connect: (${ screenSize })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can select Install Jetpack on Design Page', async function () {
+		it( 'Can select Install Jetpack on Design Page', async function () {
 			const jetpackComFeaturesDesignPage = await JetpackComFeaturesDesignPage.Visit( driver );
 			return await jetpackComFeaturesDesignPage.installJetpack();
 		} );
 
-		step( 'Can see Jetpack connect page', async function () {
+		it( 'Can see Jetpack connect page', async function () {
 			return await JetpackConnectPage.Expect( driver );
 		} );
 	} );
@@ -198,59 +198,52 @@ describe( `Jetpack Connect: (${ screenSize })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'We can set the sandbox cookie for payments', async function () {
+		it( 'We can set the sandbox cookie for payments', async function () {
 			const wpHomePage = await WPHomePage.Visit( driver );
 			await wpHomePage.checkURL( locale );
 			return await wpHomePage.setSandboxModeForPayments( sandboxCookieValue );
 		} );
 
-		step( 'Can create wporg site', async function () {
+		it( 'Can create wporg site', async function () {
 			this.timeout( mochaTimeOut * 12 );
 
 			jnFlow = new JetpackConnectFlow( driver );
 			return await jnFlow.createJNSite();
 		} );
 
-		step( 'Can select buy Jetpack Security on Pricing Page', async function () {
+		it( 'Can select buy Jetpack Security on Pricing Page', async function () {
 			const jetpackComPricingPage = await JetpackComPricingPage.Visit( driver );
 			return await jetpackComPricingPage.buyJetpackPlan( 'jetpack_security_daily' );
 		} );
 
-		step( 'Can start connection flow using JN site', async function () {
+		it( 'Can start connection flow using JN site', async function () {
 			const jetPackConnectPage = await JetpackConnectPage.Expect( driver );
 			return await jetPackConnectPage.addSiteUrl( jnFlow.url );
 		} );
 
-		step( 'Can log into WP.com', async function () {
+		it( 'Can log into WP.com', async function () {
 			const user = dataHelper.getAccountConfig( 'jetpackConnectUser' );
 			const loginPage = await LoginPage.Expect( driver );
 			return await loginPage.login( user[ 0 ], user[ 1 ] );
 		} );
 
-		step( 'Can wait for Jetpack get connected', async function () {
+		it( 'Can wait for Jetpack get connected', async function () {
 			const jetpackAuthorizePage = await JetpackAuthorizePage.Expect( driver );
 			return await jetpackAuthorizePage.waitToDisappear();
 		} );
 
-		step(
-			'Can see the secure payment page and enter/submit test payment details',
-			async function () {
-				const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
-				const securityPlanInCart = await securePaymentComponent.containsPlan(
-					'jetpack_security_daily'
-				);
-				assert.strictEqual(
-					securityPlanInCart,
-					true,
-					"The cart doesn't contain the security plan"
-				);
-				await securePaymentComponent.payWithStoredCardIfPossible( testCreditCardDetails );
-				await securePaymentComponent.waitForCreditCardPaymentProcessing();
-				return await securePaymentComponent.waitForPageToDisappear();
-			}
-		);
+		it( 'Can see the secure payment page and enter/submit test payment details', async function () {
+			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const securityPlanInCart = await securePaymentComponent.containsPlan(
+				'jetpack_security_daily'
+			);
+			assert.strictEqual( securityPlanInCart, true, "The cart doesn't contain the security plan" );
+			await securePaymentComponent.payWithStoredCardIfPossible( testCreditCardDetails );
+			await securePaymentComponent.waitForCreditCardPaymentProcessing();
+			return await securePaymentComponent.waitForPageToDisappear();
+		} );
 
-		step( 'Can see Jetpack Security plan', async function () {
+		it( 'Can see Jetpack Security plan', async function () {
 			const thankYouModal = await ThankYouModalComponent.Expect( driver );
 			await thankYouModal.continue();
 

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -44,29 +44,29 @@ describe( `[${ host }] Jetpack Plans: (${ screenSize }) @jetpack`, function () {
 			return await driverManager.clearCookiesAndDeleteLocalStorage( driver );
 		} );
 
-		step( 'Can log into WordPress.com', async function () {
+		it( 'Can log into WordPress.com', async function () {
 			this.loginFlow = new LoginFlow( driver );
 			return await this.loginFlow.login();
 		} );
 
-		step( 'Can log into site via Jetpack SSO', async function () {
+		it( 'Can log into site via Jetpack SSO', async function () {
 			const loginPage = await WPAdminLogonPage.Visit( driver, dataHelper.getJetpackSiteName() );
 			return await loginPage.logonSSO();
 		} );
 
-		step( 'Can open Jetpack dashboard', async function () {
+		it( 'Can open Jetpack dashboard', async function () {
 			await WPAdminSidebar.refreshIfJNError( driver );
 			const wpAdminSidebar = await WPAdminSidebar.Expect( driver );
 			return await wpAdminSidebar.selectJetpack();
 		} );
 
-		step( 'Can find and click Upgrade nudge button', async function () {
+		it( 'Can find and click Upgrade nudge button', async function () {
 			await driverHelper.refreshIfJNError( driver );
 			const jetpackDashboard = await WPAdminJetpackPage.Expect( driver );
 			return await jetpackDashboard.clickUpgradeNudge();
 		} );
 
-		step( 'Can then see secure payment component and Search in the cart', async function () {
+		it( 'Can then see secure payment component and Search in the cart', async function () {
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 			return await securePaymentComponent.containsPlan( 'jetpack_search' );
 		} );

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-plugins-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-plugins-spec.js
@@ -31,14 +31,14 @@ describe( `[${ host }] Jetpack Plugins - Activating a plugin: (${ screenSize }) 
 		driver = await driverManager.startBrowser();
 	} );
 
-	step( 'Can login and select Manage Plugins', async function () {
+	it( 'Can login and select Manage Plugins', async function () {
 		await driverManager.clearCookiesAndDeleteLocalStorage( driver );
 
 		const loginFlow = new LoginFlow( driver );
 		await loginFlow.loginAndSelectManagePluginsJetpack();
 	} );
 
-	step( 'Can ensure Hello Dolly is deactivated', async function () {
+	it( 'Can ensure Hello Dolly is deactivated', async function () {
 		const pluginsPage = await PluginsPage.Expect( driver );
 		await pluginsPage.viewPlugin( 'hello' );
 		const pluginDetailsPage = await PluginDetailsPage.Expect( driver );
@@ -47,7 +47,7 @@ describe( `[${ host }] Jetpack Plugins - Activating a plugin: (${ screenSize }) 
 		return await pluginDetailsPage.goBack();
 	} );
 
-	step( 'Can view the plugin details to activate Hello Dolly', async function () {
+	it( 'Can view the plugin details to activate Hello Dolly', async function () {
 		const pluginsPage = await PluginsPage.Expect( driver );
 		await pluginsPage.viewPlugin( 'hello' );
 		const pluginDetailsPage = await PluginDetailsPage.Expect( driver );
@@ -55,7 +55,7 @@ describe( `[${ host }] Jetpack Plugins - Activating a plugin: (${ screenSize }) 
 		return await pluginDetailsPage.clickActivateToggleForPlugin();
 	} );
 
-	step( 'Can see a success message contains Hello Dolly', async function () {
+	it( 'Can see a success message contains Hello Dolly', async function () {
 		const expectedPartialText = 'Successfully activated Hello Dolly';
 		const noticesComponent = await NoticesComponent.Expect( driver );
 		await noticesComponent.isSuccessNoticeDisplayed();
@@ -77,25 +77,19 @@ describe( `[${ host }] Jetpack Plugins - Searching a plugin: (${ screenSize }) @
 		driver = await driverManager.startBrowser();
 	} );
 
-	step( 'Can login and select Plugins', async function () {
+	it( 'Can login and select Plugins', async function () {
 		await driverManager.clearCookiesAndDeleteLocalStorage( driver );
 
 		const loginFlow = new LoginFlow( driver );
 		await loginFlow.loginAndSelectPluginsJetpack();
 	} );
 
-	step(
-		'Can open the plugins browser and find WP Job Manager by searching for Automattic',
-		async function () {
-			const pluginVendor = 'WP Job Manager';
-			const pluginTitle = 'WP Job Manager';
-			const pluginsBrowserPage = await PluginsBrowserPage.Expect( driver );
-			await pluginsBrowserPage.searchForPlugin( pluginVendor );
-			const pluginDisplayed = await pluginsBrowserPage.pluginTitledShown(
-				pluginTitle,
-				pluginVendor
-			);
-			assert( pluginDisplayed, `The plugin titled ${ pluginTitle } was not displayed` );
-		}
-	);
+	it( 'Can open the plugins browser and find WP Job Manager by searching for Automattic', async function () {
+		const pluginVendor = 'WP Job Manager';
+		const pluginTitle = 'WP Job Manager';
+		const pluginsBrowserPage = await PluginsBrowserPage.Expect( driver );
+		await pluginsBrowserPage.searchForPlugin( pluginVendor );
+		const pluginDisplayed = await pluginsBrowserPage.pluginTitledShown( pluginTitle, pluginVendor );
+		assert( pluginDisplayed, `The plugin titled ${ pluginTitle } was not displayed` );
+	} );
 } );

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-settings-writing-media-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-settings-writing-media-spec.js
@@ -40,17 +40,17 @@ describe( `[${ host }] Jetpack Settings on Calypso: (${ screenSize }) @jetpack`,
 	} );
 
 	describe( 'Can see Media Settings', function () {
-		step( 'Can see media settings section', async function () {
+		it( 'Can see media settings section', async function () {
 			const shown = await this.settingsPage.mediaSettingsSectionDisplayed();
 			assert( shown, "Can't see the media settings section under the Writing settings" );
 		} );
 
-		step( 'Can see the Carousel toggle switch', async function () {
+		it( 'Can see the Carousel toggle switch', async function () {
 			const shown = await this.settingsPage.carouselToggleDisplayed();
 			assert( shown, "Can't see the carousel setting toggle under the Writing settings" );
 		} );
 
-		step( 'Can see the Carousel background color drop down', async function () {
+		it( 'Can see the Carousel background color drop down', async function () {
 			const shown = await this.settingsPage.carouseBackgroundColorDisplayed();
 			assert(
 				shown,
@@ -58,7 +58,7 @@ describe( `[${ host }] Jetpack Settings on Calypso: (${ screenSize }) @jetpack`,
 			);
 		} );
 
-		step( 'Can see the Photon toggle switch', async function () {
+		it( 'Can see the Photon toggle switch', async function () {
 			await this.settingsPage.selectPerformance();
 			const shown = await this.settingsPage.photonToggleDisplayed();
 			assert( shown, "Can't see the Photon setting toggle under the Writing settings" );

--- a/test/e2e/specs-jetpack-calypso/wp-pressable-nux-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-pressable-nux-spec.js
@@ -41,50 +41,50 @@ describe.skip( `[${ host }] Pressable NUX: (${ screenSize })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can log into WordPress.com', async function () {
+		it( 'Can log into WordPress.com', async function () {
 			return await new LoginFlow( driver, 'jetpackUser' + host ).login();
 		} );
 
-		step( 'Can log into Pressable', async function () {
+		it( 'Can log into Pressable', async function () {
 			const pressableLogonPage = await PressableLogonPage.Visit( driver );
 			return await pressableLogonPage.loginWithWP();
 		} );
 
-		step( 'Can approve login with WordPress', async function () {
+		it( 'Can approve login with WordPress', async function () {
 			const pressableApprovePage = await PressableApprovePage.Expect( driver );
 			return await pressableApprovePage.approve();
 		} );
 
-		step( 'Can create new site', async function () {
+		it( 'Can create new site', async function () {
 			this.siteName = dataHelper.getNewBlogName();
 			this.pressableSitesPage = await PressableSitesPage.Expect( driver );
 			return await this.pressableSitesPage.addNewSite( this.siteName );
 		} );
 
-		step( 'Can go to site settings', async function () {
+		it( 'Can go to site settings', async function () {
 			return await this.pressableSitesPage.gotoSettings( this.siteName );
 		} );
 
-		step( 'Can proceed to Jetpack activation', async function () {
+		it( 'Can proceed to Jetpack activation', async function () {
 			const siteSettings = await PressableSiteSettingsPage.Expect( driver );
 			await siteSettings.waitForJetpackPremium();
 			return await siteSettings.activateJetpackPremium();
 		} );
 
-		step( 'Can approve connection on the authorization page', async function () {
+		it( 'Can approve connection on the authorization page', async function () {
 			const jetpackAuthorizePage = await JetpackAuthorizePage.Expect( driver );
 			return await jetpackAuthorizePage.approveConnection();
 		} );
 
-		step( 'Can wait for 30 sec until Jetpack Rewind will be ready for configuration', function () {
+		it( 'Can wait for 30 sec until Jetpack Rewind will be ready for configuration', function () {
 			return driver.sleep( 30000 );
 		} );
 
-		step( 'Can proceed with Pressable NUX flow', async function () {
+		it( 'Can proceed with Pressable NUX flow', async function () {
 			return await new PressableNUXFlow( driver ).addSiteCredentials();
 		} );
 
-		step( 'Can open Rewind activity page', async function () {
+		it( 'Can open Rewind activity page', async function () {
 			await ReaderPage.Visit( driver );
 			const navBarComponent = await NavBarComponent.Expect( driver );
 			await navBarComponent.clickMySites();
@@ -95,7 +95,7 @@ describe.skip( `[${ host }] Pressable NUX: (${ screenSize })`, function () {
 		} );
 
 		// Disabled due to to longer time is required to make a backup.
-		// step( 'Can wait until Rewind backup is completed', function() {
+		// it( 'Can wait until Rewind backup is completed', function() {
 		// 	const activityPage = new ActivityPage( driver );
 		// 	return activityPage.waitUntilBackupCompleted();
 		// } );

--- a/test/e2e/specs-playwright/wp-log-in-out-spec.js
+++ b/test/e2e/specs-playwright/wp-log-in-out-spec.js
@@ -22,14 +22,14 @@ describe( `Main Suite 1 @parallel`, function () {
 	} );
 
 	describe( 'Subsuite 1-1', function () {
-		step( 'Can see the log in page', async function () {
+		it( 'Can see the log in page', async function () {
 			const url = LoginPage.getLoginURL();
 			return await this.page.goto( url, { waitUntill: 'networkidle' } );
 		} );
 	} );
 
 	describe( 'Subsuite 1-2', function () {
-		step( 'Should also pass', async function () {
+		it( 'Should also pass', async function () {
 			return await this.page.goto( 'https://google.com', { waitUntill: 'networkidle' } );
 		} );
 	} );
@@ -43,11 +43,11 @@ describe( `Main Suite 2 @parallel`, function () {
 	} );
 
 	describe( 'Subsuite 2-1', function () {
-		step( 'Should fail', async function () {
+		it( 'Should fail', async function () {
 			await this.page.click( 'non-existing-selector' );
 		} );
 
-		step( 'Should be aborted', async function () {
+		it( 'Should be aborted', async function () {
 			const url = LoginPage.getLoginURL();
 			/*
 			Waits for network activity to cease.
@@ -59,13 +59,13 @@ describe( `Main Suite 2 @parallel`, function () {
 	} );
 
 	describe( 'Subsuite 2-2', function () {
-		step( 'Should pass', async function () {
+		it( 'Should pass', async function () {
 			return await this.page.goto( 'https://wordpress.com/support/', {
 				waitUntill: 'networkidle',
 			} );
 		} );
 
-		step( 'Also should pass', async function () {
+		it( 'Also should pass', async function () {
 			return await this.page.goto( 'https://wordpress.com/support/start', {
 				waitUntill: 'networkidle',
 			} );

--- a/test/e2e/specs/wp-calypso-seo-preview.js
+++ b/test/e2e/specs/wp-calypso-seo-preview.js
@@ -34,39 +34,34 @@ describe( `[${ host }] SEO Preview page: (${ screenSize }) @parallel`, function 
 		await driverManager.clearCookiesAndDeleteLocalStorage( driver );
 	} );
 
-	describe( 'SEO Preview page:', function () {
-		// Login as Business plan user and open the sidebar
-		step( 'Log In', async function () {
-			const loginFlow = new LoginFlow( driver, 'wooCommerceUser' );
-			await loginFlow.login();
-			const navBarComponent = await NavBarComponent.Expect( driver );
-			return await navBarComponent.clickMySites();
-		} );
+	// Login as Business plan user and open the sidebar
+	it( 'Log In', async function () {
+		const loginFlow = new LoginFlow( driver, 'wooCommerceUser' );
+		await loginFlow.login();
+		const navBarComponent = await NavBarComponent.Expect( driver );
+		return await navBarComponent.clickMySites();
+	} );
 
-		step( 'Open the marketing page', async function () {
-			this.sidebarComponent = await SidebarComponent.Expect( driver );
-			return await this.sidebarComponent.selectMarketing();
-		} );
+	it( 'Open the marketing page', async function () {
+		this.sidebarComponent = await SidebarComponent.Expect( driver );
+		return await this.sidebarComponent.selectMarketing();
+	} );
 
-		step( 'Enter front page meta description and click preview button ', async function () {
-			const trafficPage = new TrafficPage( driver );
-			await trafficPage.openTrafficTab();
-			await trafficPage.enterFrontPageMetaAndClickPreviewButton();
-		} );
+	it( 'Enter front page meta description and click preview button ', async function () {
+		const trafficPage = new TrafficPage( driver );
+		await trafficPage.openTrafficTab();
+		await trafficPage.enterFrontPageMetaAndClickPreviewButton();
+	} );
 
-		step( 'Ensure site preview stays open for 10 seconds', async function () {
-			await driverHelper.waitUntilElementLocatedAndVisible(
-				driver,
-				By.css( '.web-preview.is-seo' )
-			);
-			const wait = async ( interval ) => {
-				return new Promise( ( resolve ) => {
-					setTimeout( resolve, interval );
-				} );
-			};
-			await wait( 10000 );
-			const previewPane = await driver.findElement( By.css( '.web-preview.is-seo' ) );
-			assert( previewPane, 'The site preview component has been closed.' );
-		} );
+	it( 'Ensure site preview stays open for 10 seconds', async function () {
+		await driverHelper.waitUntilElementLocatedAndVisible( driver, By.css( '.web-preview.is-seo' ) );
+		const wait = async ( interval ) => {
+			return new Promise( ( resolve ) => {
+				setTimeout( resolve, interval );
+			} );
+		};
+		await wait( 10000 );
+		const previewPane = await driver.findElement( By.css( '.web-preview.is-seo' ) );
+		assert( previewPane, 'The site preview component has been closed.' );
 	} );
 } );

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -41,22 +41,22 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 		const domainQuery = dataHelper.randomPhrase();
 		let newSiteDomain = '';
 
-		step( 'Can log in as user', async function () {
+		it( 'Can log in as user', async function () {
 			await new LoginFlow( driver ).login();
 		} );
 
-		step( 'Can visit Gutenboarding page and see Onboarding block', async function () {
+		it( 'Can visit Gutenboarding page and see Onboarding block', async function () {
 			const page = await NewPage.Visit( driver, NewPage.getGutenboardingURL() );
 			const blockExists = await page.waitForBlock();
 			assert( blockExists, 'Onboarding block is not rendered' );
 		} );
 
-		step( 'Can see Acquire Intent and set site title', async function () {
+		it( 'Can see Acquire Intent and set site title', async function () {
 			const acquireIntentPage = await AcquireIntentPage.Expect( driver );
 			await acquireIntentPage.enterSiteTitle( siteTitle );
 		} );
 
-		step( 'Can change language to Spanish and back to English', async function () {
+		it( 'Can change language to Spanish and back to English', async function () {
 			const acquireIntentPage = await AcquireIntentPage.Expect( driver );
 			const languagePicker = await LanguagePickerComponent.Expect( driver );
 
@@ -79,67 +79,58 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 			await acquireIntentPage.goToNextStep();
 		} );
 
-		step(
-			'Can see Domains Page, search for domains, pick a free domain, and continue',
-			async function () {
-				const domainsPage = await DomainsPage.Expect( driver );
-				await domainsPage.enterDomainQuery( domainQuery );
-				await domainsPage.waitForDomainSuggestionsToLoad();
-				newSiteDomain = await domainsPage.getFreeDomainName();
-				await domainsPage.selectFreeDomain();
-				await domainsPage.continueToNextStep();
-			}
-		);
+		it( 'Can see Domains Page, search for domains, pick a free domain, and continue', async function () {
+			const domainsPage = await DomainsPage.Expect( driver );
+			await domainsPage.enterDomainQuery( domainQuery );
+			await domainsPage.waitForDomainSuggestionsToLoad();
+			newSiteDomain = await domainsPage.getFreeDomainName();
+			await domainsPage.selectFreeDomain();
+			await domainsPage.continueToNextStep();
+		} );
 
-		step( 'Can see Design Locator and select a random free design', async function () {
+		it( 'Can see Design Locator and select a random free design', async function () {
 			const designLocatorPage = await DesignLocatorPage.Expect( driver );
 			await designLocatorPage.selectFreeDesign();
 		} );
 
-		step( 'Can see Style Preview, choose a random font pairing, and continue', async function () {
+		it( 'Can see Style Preview, choose a random font pairing, and continue', async function () {
 			const stylePreviewPage = await StylePreviewPage.Expect( driver );
 			await stylePreviewPage.selectFontPairing();
 			await stylePreviewPage.continue();
 		} );
 
-		step(
-			'Can see Feature picker and choose a feature that requires a business plan',
-			async function () {
-				const featuresPage = await FeaturesPage.Expect( driver );
-				await featuresPage.selectPluginsFeature();
-				await featuresPage.goToNextStep();
-			}
-		);
+		it( 'Can see Feature picker and choose a feature that requires a business plan', async function () {
+			const featuresPage = await FeaturesPage.Expect( driver );
+			await featuresPage.selectPluginsFeature();
+			await featuresPage.goToNextStep();
+		} );
 
-		step(
-			'Can see Plans Grid with business plan recommended and can choose free plan',
-			async function () {
-				const plansPage = await PlansPage.Expect( driver );
-				const recommendedPlan = await plansPage.getRecommendedPlan( driver );
-				assert.strictEqual(
-					recommendedPlan,
-					'Business',
-					'The Business plan should be recommended because the plugins feature was selected in the previous step'
-				);
-				await plansPage.expandAllPlans();
-				await plansPage.selectFreePlan();
+		it( 'Can see Plans Grid with business plan recommended and can choose free plan', async function () {
+			const plansPage = await PlansPage.Expect( driver );
+			const recommendedPlan = await plansPage.getRecommendedPlan( driver );
+			assert.strictEqual(
+				recommendedPlan,
+				'Business',
+				'The Business plan should be recommended because the plugins feature was selected in the previous step'
+			);
+			await plansPage.expandAllPlans();
+			await plansPage.selectFreePlan();
 
-				// Redirect console messages that starts with "onboarding-debug" to E2E log.
-				await driver
-					.manage()
-					.logs()
-					.get( 'browser' )
-					.then( function ( logs ) {
-						logs.forEach( ( log ) => {
-							if ( log.message.indexOf( 'onboarding-debug' ) > -1 ) {
-								console.log( log.message );
-							}
-						} );
+			// Redirect console messages that starts with "onboarding-debug" to E2E log.
+			await driver
+				.manage()
+				.logs()
+				.get( 'browser' )
+				.then( function ( logs ) {
+					logs.forEach( ( log ) => {
+						if ( log.message.indexOf( 'onboarding-debug' ) > -1 ) {
+							console.log( log.message );
+						}
 					} );
-			}
-		);
+				} );
+		} );
 
-		step( 'Can see the gutenberg page editor', async function () {
+		it( 'Can see the gutenberg page editor', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.initEditor();
 		} );
@@ -150,11 +141,11 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 	} );
 
 	describe( 'Visit Gutenboarding page as a logged in user @parallel', function () {
-		step( 'Can log in as user', async function () {
+		it( 'Can log in as user', async function () {
 			await new LoginFlow( driver ).login();
 		} );
 
-		step( 'Can visit Gutenboarding', async function () {
+		it( 'Can visit Gutenboarding', async function () {
 			await NewPage.Visit( driver );
 		} );
 	} );

--- a/test/e2e/specs/wp-import-site-spec.js
+++ b/test/e2e/specs/wp-import-site-spec.js
@@ -29,33 +29,33 @@ describe( 'Verify Import Option: (' + screenSize + ') @parallel', function () {
 		driver = await driverManager.startBrowser();
 	} );
 
-	step( 'Can log in as default user', async function () {
+	it( 'Can log in as default user', async function () {
 		const loginFlow = new LoginFlow( driver );
 		return await loginFlow.login();
 	} );
 
-	step( 'Can open the sidebar', async function () {
+	it( 'Can open the sidebar', async function () {
 		const navBarComponent = await NavBarComponent.Expect( driver );
 		await navBarComponent.clickMySites();
 	} );
 
-	step( "Following 'Import' menu option opens the Import page", async function () {
+	it( "Following 'Import' menu option opens the Import page", async function () {
 		const sideBarComponent = await SideBarComponent.Expect( driver );
 		await sideBarComponent.selectImport();
 		await ImporterPage.Expect( driver );
 	} );
 
-	step( 'Can see the WordPress importer', async function () {
+	it( 'Can see the WordPress importer', async function () {
 		const importerPage = await ImporterPage.Expect( driver );
 		assert( await importerPage.importerIsDisplayed( 'wordpress' ) );
 	} );
 
-	step( 'Can see the Medium importer', async function () {
+	it( 'Can see the Medium importer', async function () {
 		const importerPage = await ImporterPage.Expect( driver );
 		assert( await importerPage.importerIsDisplayed( 'medium-logo' ) );
 	} );
 
-	step( 'Can see the Blogger importer', async function () {
+	it( 'Can see the Blogger importer', async function () {
 		const importerPage = await ImporterPage.Expect( driver );
 		assert( await importerPage.importerIsDisplayed( 'blogger-alt' ) );
 	} );

--- a/test/e2e/specs/wp-inline-help-support-search-spec.js
+++ b/test/e2e/specs/wp-inline-help-support-search-spec.js
@@ -32,7 +32,7 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, function () {
 		driver = await driverManager.startBrowser();
 	} );
 
-	step( 'Login and select a page that is not the My Home page', async function () {
+	it( 'Login and select a page that is not the My Home page', async function () {
 		const loginFlow = new LoginFlow( driver );
 
 		// The "/home" route is the only one where the "FAB" inline help
@@ -44,7 +44,7 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, function () {
 	} );
 
 	describe( 'Popover UI visibility', function () {
-		step( 'Check help toggle is not visible on My Home page', async function () {
+		it( 'Check help toggle is not visible on My Home page', async function () {
 			const sidebarComponent = await SidebarComponent.Expect( driver );
 			await sidebarComponent.selectMyHome();
 
@@ -53,7 +53,7 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, function () {
 			await inlineHelpPopoverComponent.waitForToggleNotToBePresent();
 		} );
 
-		step( 'Check help toggle is visible on Settings page', async function () {
+		it( 'Check help toggle is visible on Settings page', async function () {
 			const sidebarComponent = await SidebarComponent.Expect( driver );
 
 			// The "inline help" FAB should not appear on the My Home
@@ -74,17 +74,17 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, function () {
 	} );
 
 	describe( 'Performing searches', function () {
-		step( 'Open Inline Help popover', async function () {
+		it( 'Open Inline Help popover', async function () {
 			await inlineHelpPopoverComponent.toggleOpen();
 			supportSearchComponent = await SupportSearchComponent.Expect( driver );
 		} );
 
-		step( 'Displays contextual search results by default', async function () {
+		it( 'Displays contextual search results by default', async function () {
 			const resultsCount = await supportSearchComponent.getDefaultResultsCount();
 			assert.equal( resultsCount, 6, 'There are no 6 contextual results displayed' );
 		} );
 
-		step( 'Returns search results for valid search query', async function () {
+		it( 'Returns search results for valid search query', async function () {
 			await supportSearchComponent.searchFor( 'Podcast' );
 			const resultsCount = await supportSearchComponent.getSearchResultsCount();
 
@@ -100,7 +100,7 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, function () {
 			);
 		} );
 
-		step( 'Resets search UI to default state when search input is cleared ', async function () {
+		it( 'Resets search UI to default state when search input is cleared ', async function () {
 			await supportSearchComponent.clearSearchField();
 
 			const resultsCount = await supportSearchComponent.getDefaultResultsCount();
@@ -108,23 +108,20 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, function () {
 			assert.equal( resultsCount, 6, 'There are no contextual results displayed' );
 		} );
 
-		step(
-			'Shows "No results" indicator and re-displays contextual results for search queries which return no results',
-			async function () {
-				const invalidSearchQueryReturningNoResults = ';;;ppp;;;';
+		it( 'Shows "No results" indicator and re-displays contextual results for search queries which return no results', async function () {
+			const invalidSearchQueryReturningNoResults = ';;;ppp;;;';
 
-				await supportSearchComponent.searchFor( invalidSearchQueryReturningNoResults );
-				const resultsCount = await supportSearchComponent.getErrorResultsCount();
+			await supportSearchComponent.searchFor( invalidSearchQueryReturningNoResults );
+			const resultsCount = await supportSearchComponent.getErrorResultsCount();
 
-				const hasNoResultsMessage = await supportSearchComponent.hasNoResultsMessage();
+			const hasNoResultsMessage = await supportSearchComponent.hasNoResultsMessage();
 
-				assert.equal( hasNoResultsMessage, true, 'The "No results" message was not displayed.' );
+			assert.equal( hasNoResultsMessage, true, 'The "No results" message was not displayed.' );
 
-				assert.equal( resultsCount, 6, 'There are no contextual results displayed.' );
-			}
-		);
+			assert.equal( resultsCount, 6, 'There are no contextual results displayed.' );
+		} );
 
-		step( 'Does not request search results for empty search queries', async function () {
+		it( 'Does not request search results for empty search queries', async function () {
 			await supportSearchComponent.clearSearchField();
 
 			const emptyWhitespaceQuery = '         ';
@@ -140,7 +137,7 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, function () {
 			);
 		} );
 
-		step( 'Close Inline Help popover', async function () {
+		it( 'Close Inline Help popover', async function () {
 			await inlineHelpPopoverComponent.toggleClosed();
 			const isPopoverVisible = await inlineHelpPopoverComponent.isPopoverVisible();
 			assert.equal( isPopoverVisible, false, 'Popover was not closed correctly.' );

--- a/test/e2e/specs/wp-invite-users-spec.js
+++ b/test/e2e/specs/wp-invite-users-spec.js
@@ -53,13 +53,13 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 		let inviteCreated = false;
 		let inviteAccepted = false;
 
-		step( 'Can log in and navigate to Invite People page', async function () {
+		it( 'Can log in and navigate to Invite People page', async function () {
 			await new LoginFlow( driver ).loginAndSelectPeople();
 			const peoplePage = await PeoplePage.Expect( driver );
 			return await peoplePage.inviteUser();
 		} );
 
-		step( 'Can invite a new user as an editor and see its pending', async function () {
+		it( 'Can invite a new user as an editor and see its pending', async function () {
 			const invitePeoplePage = await InvitePeoplePage.Expect( driver );
 			await invitePeoplePage.inviteNewUser(
 				newInviteEmailAddress,
@@ -76,7 +76,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 			return await peoplePage.waitForPendingInviteDisplayedFor( newInviteEmailAddress );
 		} );
 
-		step( 'Can see an invitation email received for the invite', async function () {
+		it( 'Can see an invitation email received for the invite', async function () {
 			const emails = await emailClient.pollEmailsByRecipient( newInviteEmailAddress );
 			const links = emails[ 0 ].html.links;
 			const link = links.find( ( l ) => l.href.includes( 'accept-invite' ) );
@@ -88,7 +88,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 			);
 		} );
 
-		step( 'Can sign up as new user for the blog via invite link', async function () {
+		it( 'Can sign up as new user for the blog via invite link', async function () {
 			await driverManager.ensureNotLoggedIn( driver );
 
 			await driver.get( acceptInviteURL );
@@ -103,7 +103,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 			return await acceptInvitePage.waitUntilNotVisible();
 		} );
 
-		step( 'User has been added as Editor', async function () {
+		it( 'User has been added as Editor', async function () {
 			await PostsPage.Expect( driver );
 
 			inviteAccepted = true;
@@ -115,7 +115,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 			);
 		} );
 
-		step( 'As the original user can see and remove new user', async function () {
+		it( 'As the original user can see and remove new user', async function () {
 			await new LoginFlow( driver ).loginAndSelectPeople();
 
 			const peoplePage = await PeoplePage.Expect( driver );
@@ -140,7 +140,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 			);
 		} );
 
-		step( 'As the invited user, I am no longer an editor on the site', async function () {
+		it( 'As the invited user, I am no longer an editor on the site', async function () {
 			if ( 'WPCOM' !== dataHelper.getJetpackHost() ) return this.skip();
 			const loginPage = await LoginPage.Visit( driver );
 			await loginPage.login( newUserName, password );
@@ -181,13 +181,13 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 		const newInviteEmailAddress = dataHelper.getEmailAddress( newUserName, inviteInboxId );
 		let acceptInviteURL = '';
 
-		step( 'Can log in and navigate to Invite People page', async function () {
+		it( 'Can log in and navigate to Invite People page', async function () {
 			await new LoginFlow( driver ).loginAndSelectPeople();
 			const peoplePage = await PeoplePage.Expect( driver );
 			return await peoplePage.inviteUser();
 		} );
 
-		step( 'Can Invite a New User as an Editor, then revoke the invite', async function () {
+		it( 'Can Invite a New User as an Editor, then revoke the invite', async function () {
 			const invitePeoplePage = await InvitePeoplePage.Expect( driver );
 			await invitePeoplePage.inviteNewUser(
 				newInviteEmailAddress,
@@ -210,7 +210,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 			return assert( sent, 'The sent confirmation message was not displayed' );
 		} );
 
-		step( 'Can see an invitation email received for the invite', async function () {
+		it( 'Can see an invitation email received for the invite', async function () {
 			const emails = await emailClient.pollEmailsByRecipient( newInviteEmailAddress );
 			const links = emails[ 0 ].html.links;
 			const link = links.find( ( l ) => l.href.includes( 'accept-invite' ) );
@@ -222,7 +222,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 			);
 		} );
 
-		step( 'Can open the invite page and see it has been revoked', async function () {
+		it( 'Can open the invite page and see it has been revoked', async function () {
 			await driverManager.ensureNotLoggedIn( driver );
 
 			await driver.get( acceptInviteURL );
@@ -244,17 +244,17 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 		let inviteCreated = false;
 		let inviteAccepted = false;
 
-		step( 'As an anonymous user I can not see a private site', async function () {
+		it( 'As an anonymous user I can not see a private site', async function () {
 			return await PrivateSiteLoginPage.Visit( driver, siteUrl );
 		} );
 
-		step( 'Can log in and navigate to Invite People page', async function () {
+		it( 'Can log in and navigate to Invite People page', async function () {
 			await new LoginFlow( driver, 'privateSiteUser' ).loginAndSelectPeople();
 			const peoplePage = await PeoplePage.Expect( driver );
 			return await peoplePage.inviteUser();
 		} );
 
-		step( 'Can invite a new user as a viewer and see its pending', async function () {
+		it( 'Can invite a new user as a viewer and see its pending', async function () {
 			const invitePeoplePage = await InvitePeoplePage.Expect( driver );
 			await invitePeoplePage.inviteNewUser(
 				newInviteEmailAddress,
@@ -271,7 +271,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 			return await peoplePage.waitForPendingInviteDisplayedFor( newInviteEmailAddress );
 		} );
 
-		step( 'Can see an invitation email received for the invite', async function () {
+		it( 'Can see an invitation email received for the invite', async function () {
 			const emails = await emailClient.pollEmailsByRecipient( newInviteEmailAddress );
 			const links = emails[ 0 ].html.links;
 			const link = links.find( ( l ) => l.href.includes( 'accept-invite' ) );
@@ -283,7 +283,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 			);
 		} );
 
-		step( 'Can sign up as new user for the blog via invite link', async function () {
+		it( 'Can sign up as new user for the blog via invite link', async function () {
 			await driverManager.ensureNotLoggedIn( driver );
 
 			await driver.get( acceptInviteURL );
@@ -299,7 +299,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 			return await acceptInvitePage.waitUntilNotVisible();
 		} );
 
-		step( 'Can see user has been added as a Viewer', async function () {
+		it( 'Can see user has been added as a Viewer', async function () {
 			inviteAccepted = true;
 			const noticesComponent = await NoticesComponent.Expect( driver );
 			const followMessageDisplayed = await noticesComponent.getNoticeContent();
@@ -313,7 +313,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 			return await ViewBlogPage.Visit( driver, siteUrl );
 		} );
 
-		step( 'Can see new user added and can be removed', async function () {
+		it( 'Can see new user added and can be removed', async function () {
 			await new LoginFlow( driver, 'privateSiteUser' ).loginAndSelectPeople();
 
 			const peoplePage = await PeoplePage.Expect( driver );
@@ -334,7 +334,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 			);
 		} );
 
-		step( 'Can not see the site - see the private site log in page', async function () {
+		it( 'Can not see the site - see the private site log in page', async function () {
 			const loginPage = await LoginPage.Visit( driver );
 			await loginPage.login( newUserName, password );
 

--- a/test/e2e/specs/wp-launch-spec.js
+++ b/test/e2e/specs/wp-launch-spec.js
@@ -55,11 +55,11 @@ describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () 
 			await loginFlow.login();
 		} );
 
-		step( 'Can create a free site', async function () {
+		it( 'Can create a free site', async function () {
 			return await new CreateSiteFlow( driver, siteName ).createFreeSite();
 		} );
 
-		step( 'Can launch a site', async function () {
+		it( 'Can launch a site', async function () {
 			return await new LaunchSiteFlow( driver ).launchFreeSite();
 		} );
 
@@ -84,7 +84,7 @@ describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () 
 			await new CreateSiteFlow( driver, secondSiteName ).createFreeSite();
 		} );
 
-		step( 'Can start launch flow and abandon', async function () {
+		it( 'Can start launch flow and abandon', async function () {
 			const myHomePage = await MyHomePage.Expect( driver );
 			await myHomePage.launchSiteFromSiteSetup();
 			await FindADomainComponent.Expect( driver );
@@ -94,7 +94,7 @@ describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () 
 			return await driver.navigate().back();
 		} );
 
-		step( 'Can switch sites and launch the first site', async function () {
+		it( 'Can switch sites and launch the first site', async function () {
 			const sideBarComponent = await SidebarComponent.Expect( driver );
 			await sideBarComponent.selectSiteSwitcher();
 			await sideBarComponent.searchForSite( firstSiteName );

--- a/test/e2e/specs/wp-likes-spec.js
+++ b/test/e2e/specs/wp-likes-spec.js
@@ -39,7 +39,7 @@ describe( `[${ host }] Likes: (${ screenSize })`, function () {
 	} );
 
 	describe( 'Like posts and comments @parallel', function () {
-		step( 'Login, create a new post and view it', async function () {
+		it( 'Login, create a new post and view it', async function () {
 			const loginFlow = new LoginFlow( driver, accountKey );
 			await loginFlow.loginAndStartNewPost( null, true );
 
@@ -49,19 +49,19 @@ describe( `[${ host }] Likes: (${ screenSize })`, function () {
 			postUrl = await gEditorComponent.publish( { visit: true } );
 		} );
 
-		step( 'Like post', async function () {
+		it( 'Like post', async function () {
 			const postLikes = await PostLikesComponent.Expect( driver );
 			await postLikes.clickLike();
 			await postLikes.expectLiked();
 		} );
 
-		step( 'Unlike post', async function () {
+		it( 'Unlike post', async function () {
 			const postLikes = await PostLikesComponent.Expect( driver );
 			await postLikes.clickUnlike();
 			await postLikes.expectNotLiked();
 		} );
 
-		step( 'Post comment', async function () {
+		it( 'Post comment', async function () {
 			const commentArea = await CommentsAreaComponent.Expect( driver );
 
 			// commentArea.reply fails to find .comment-reply-link at times,
@@ -69,19 +69,19 @@ describe( `[${ host }] Likes: (${ screenSize })`, function () {
 			await commentArea._postComment( comment );
 		} );
 
-		step( 'Like comment', async function () {
+		it( 'Like comment', async function () {
 			const commentLikes = await CommentLikesComponent.Expect( driver, comment );
 			await commentLikes.likeComment();
 			await commentLikes.expectLiked();
 		} );
 
-		step( 'Unlike comment', async function () {
+		it( 'Unlike comment', async function () {
 			const commentLikes = await CommentLikesComponent.Expect( driver, comment );
 			await commentLikes.unlikeComment();
 			await commentLikes.expectNotLiked();
 		} );
 
-		step( 'Like post as logged out user', async function () {
+		it( 'Like post as logged out user', async function () {
 			await driverManager.ensureNotLoggedIntoSite( driver, postUrl );
 
 			const postLikes = await PostLikesComponent.Visit( driver, postUrl );

--- a/test/e2e/specs/wp-log-in-out-spec.js
+++ b/test/e2e/specs/wp-log-in-out-spec.js
@@ -44,7 +44,7 @@ describe( `[${ host }] Auth Screen Canary: (${ screenSize }) @parallel @safarica
 	} );
 
 	describe( 'Loading the log-in screen', function () {
-		step( 'Can see the log in screen', async function () {
+		it( 'Can see the log in screen', async function () {
 			await LoginPage.Visit( driver, LoginPage.getLoginURL() );
 		} );
 	} );
@@ -65,12 +65,12 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 		} );
 
 		describe( 'Can Log In', function () {
-			step( 'Can log in', async function () {
+			it( 'Can log in', async function () {
 				const loginFlow = new LoginFlow( driver );
 				await loginFlow.login( { useFreshLogin: true } );
 			} );
 
-			step( 'Can see Stats Page after logging in', async function () {
+			it( 'Can see Stats Page after logging in', async function () {
 				return await StatsPage.Expect( driver );
 			} );
 		} );
@@ -78,29 +78,29 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 		// Test Jetpack SSO
 		if ( host !== 'WPCOM' ) {
 			describe( 'Can Log via Jetpack SSO', function () {
-				step( 'Can log into site via Jetpack SSO', async function () {
+				it( 'Can log into site via Jetpack SSO', async function () {
 					const loginPage = await WPAdminLogonPage.Visit( driver, dataHelper.getJetpackSiteName() );
 					return await loginPage.logonSSO();
 				} );
 
-				step( 'Can return to Reader', async function () {
+				it( 'Can return to Reader', async function () {
 					return await ReaderPage.Visit( driver );
 				} );
 			} );
 		}
 
 		describe( 'Can Log Out', function () {
-			step( 'Can view profile to log out', async function () {
+			it( 'Can view profile to log out', async function () {
 				const navbarComponent = await NavBarComponent.Expect( driver );
 				await navbarComponent.clickProfileLink();
 			} );
 
-			step( 'Can logout from profile page', async function () {
+			it( 'Can logout from profile page', async function () {
 				const profilePage = await ProfilePage.Expect( driver );
 				await profilePage.clickSignOut();
 			} );
 
-			step( 'Can see wordpress.com home when after logging out', async function () {
+			it( 'Can see wordpress.com home when after logging out', async function () {
 				return await LoggedOutMasterbarComponent.Expect( driver );
 			} );
 		} );
@@ -142,7 +142,7 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 				} );
 			} );
 
-			step( 'Should be on the /log-in/sms page', async function () {
+			it( 'Should be on the /log-in/sms page', async function () {
 				await twoFALoginPage.displayed();
 				const urlDisplayed = await driver.getCurrentUrl();
 
@@ -152,7 +152,7 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 				);
 			} );
 
-			step( "Enter the 2fa code and we're logged in", async function () {
+			it( "Enter the 2fa code and we're logged in", async function () {
 				return await twoFALoginPage.enter2FACode( twoFACode );
 			} );
 		} );
@@ -173,7 +173,7 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 				twoFALoginPage = new LoginPage( driver );
 			} );
 
-			step( 'Should be on the /log-in/push page', async function () {
+			it( 'Should be on the /log-in/push page', async function () {
 				await twoFALoginPage.displayed();
 				const urlDisplayed = await driver.getCurrentUrl();
 				assert(
@@ -182,7 +182,7 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 				);
 			} );
 
-			step( "Approve push 2fa token and we're logged in", async function () {
+			it( "Approve push 2fa token and we're logged in", async function () {
 				await subscribeToPush( loginFlow.account.pushConfig, async ( pushToken ) => {
 					await approvePushToken( pushToken, loginFlow.account.bearerToken );
 					const readerPage = new ReaderPage( driver );
@@ -209,7 +209,7 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 				return twoFALoginPage.use2FAMethod( 'otp' );
 			} );
 
-			step( 'Should be on the /log-in/authenticator page', async function () {
+			it( 'Should be on the /log-in/authenticator page', async function () {
 				await twoFALoginPage.displayed();
 				const urlDisplayed = await driver.getCurrentUrl();
 				assert(
@@ -218,7 +218,7 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 				);
 			} );
 
-			step( "Enter the 2fa code and we're logged in", async function () {
+			it( "Enter the 2fa code and we're logged in", async function () {
 				const twoFACode = speakeasy.totp( {
 					secret: loginFlow.account[ '2faOTPsecret' ],
 					encoding: 'base32',
@@ -248,7 +248,7 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 					return await loginFlow.login( { emailSSO: true, useFreshLogin: true } );
 				} );
 
-				step( 'Can find the magic link in the email received', async function () {
+				it( 'Can find the magic link in the email received', async function () {
 					const emails = await emailClient.pollEmailsByRecipient( loginFlow.account.email );
 					magicLinkEmail = emails.find(
 						( email ) => email.subject.indexOf( 'WordPress.com' ) > -1
@@ -263,7 +263,7 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 
 				describe( 'Can use the magic link to log in', function () {
 					let magicLoginPage;
-					step( "Visit the magic link and we're logged in", async function () {
+					it( "Visit the magic link and we're logged in", async function () {
 						driver.get( magicLoginLink );
 						magicLoginPage = new MagicLoginPage( driver );
 						await magicLoginPage.finishLogin();
@@ -309,7 +309,7 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 					return await loginFlow.login( { emailSSO: true } );
 				} );
 
-				step( 'Can find the magic link in the email received', async function () {
+				it( 'Can find the magic link in the email received', async function () {
 					const emails = await emailClient.pollEmailsByRecipient( loginFlow.account.email );
 					magicLinkEmail = emails.find(
 						( email ) => email.subject.indexOf( 'WordPress.com' ) > -1
@@ -352,7 +352,7 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 						} );
 					} );
 
-					step( 'Should be on the /log-in/sms page', async function () {
+					it( 'Should be on the /log-in/sms page', async function () {
 						await twoFALoginPage.displayed();
 						const urlDisplayed = await driver.getCurrentUrl();
 
@@ -362,7 +362,7 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 						);
 					} );
 
-					step( "Enter the 2fa code and we're logged in", async function () {
+					it( "Enter the 2fa code and we're logged in", async function () {
 						return await twoFALoginPage.enter2FACode( twoFACode );
 					} );
 
@@ -403,7 +403,7 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 					return await loginFlow.login( { emailSSO: true } );
 				} );
 
-				step( 'Can find the magic link in the email received', async function () {
+				it( 'Can find the magic link in the email received', async function () {
 					const emails = await emailClient.pollEmailsByRecipient( loginFlow.account.email );
 					magicLinkEmail = emails.find(
 						( email ) => email.subject.indexOf( 'WordPress.com' ) > -1
@@ -427,7 +427,7 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 						return await twoFALoginPage.use2FAMethod( 'otp' );
 					} );
 
-					step( 'Should be on the /log-in/authenticator page', async function () {
+					it( 'Should be on the /log-in/authenticator page', async function () {
 						await twoFALoginPage.displayed();
 						const urlDisplayed = await driver.getCurrentUrl();
 						assert(
@@ -436,7 +436,7 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 						);
 					} );
 
-					step( "Enter the 2fa code and we're logged in", async function () {
+					it( "Enter the 2fa code and we're logged in", async function () {
 						const twoFACode = speakeasy.totp( {
 							secret: loginFlow.account[ '2faOTPsecret' ],
 							encoding: 'base32',
@@ -472,7 +472,7 @@ describe( `[${ host }] User Agent: (${ screenSize }) @parallel @jetpack`, functi
 		await driverManager.ensureNotLoggedIn( driver );
 	} );
 
-	step( 'Can see the correct user agent set', async function () {
+	it( 'Can see the correct user agent set', async function () {
 		await WPHomePage.Visit( driver );
 		const userAgent = await driver.executeScript( 'return navigator.userAgent;' );
 		assert(

--- a/test/e2e/specs/wp-manage-domains-spec.js
+++ b/test/e2e/specs/wp-manage-domains-spec.js
@@ -59,11 +59,11 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 			}
 		} );
 
-		step( 'Log In and Select Domains', async function () {
+		it( 'Log In and Select Domains', async function () {
 			return await new LoginFlow( driver, 'gutenbergSimpleSiteUser' ).loginAndSelectDomains();
 		} );
 
-		step( 'Can see the Domains page and choose add a domain', async function () {
+		it( 'Can see the Domains page and choose add a domain', async function () {
 			const domainsPage = await DomainsPage.Expect( driver );
 			await domainsPage.setABTestControlGroupsInLocalStorage();
 			await domainsPage.clickAddDomain();
@@ -71,7 +71,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 			return await domainsPage.clickPopoverItem( 'to this site' );
 		} );
 
-		step( 'Can see the domain search component', async function () {
+		it( 'Can see the domain search component', async function () {
 			let findADomainComponent;
 			try {
 				findADomainComponent = await FindADomainComponent.Expect( driver );
@@ -86,29 +86,29 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 			return await findADomainComponent.waitForResults();
 		} );
 
-		step( 'Can search for a blog name', async function () {
+		it( 'Can search for a blog name', async function () {
 			const findADomainComponent = await FindADomainComponent.Expect( driver );
 			// Search for the full blog name including the .com, as the default TLD suggestion is not always .com.
 			return await findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
 		} );
 
-		step( 'Can select the .com search result and decline Google Apps for email', async function () {
+		it( 'Can select the .com search result and decline Google Apps for email', async function () {
 			const findADomainComponent = await FindADomainComponent.Expect( driver );
 			await findADomainComponent.selectDomainAddress( expectedDomainName );
 			return await findADomainComponent.declineGoogleApps();
 		} );
 
-		step( 'Can see checkout page and enter registrar details', async function () {
+		it( 'Can see checkout page and enter registrar details', async function () {
 			const checkOutPage = await CheckOutPage.Expect( driver );
 			await checkOutPage.enterRegistrarDetails( testDomainRegistarDetails );
 			return await checkOutPage.submitForm();
 		} );
 
-		step( 'Can then see secure payment component', async function () {
+		it( 'Can then see secure payment component', async function () {
 			return await SecurePaymentComponent.Expect( driver );
 		} );
 
-		step( 'Empty the cart', async function () {
+		it( 'Empty the cart', async function () {
 			await ReaderPage.Visit( driver );
 			const navBarComponent = await NavBarComponent.Expect( driver );
 			await navBarComponent.clickMySites();
@@ -137,11 +137,11 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 			}
 		} );
 
-		step( 'Log In and Select Domains', async function () {
+		it( 'Log In and Select Domains', async function () {
 			return await new LoginFlow( driver, 'gutenbergSimpleSiteUser' ).loginAndSelectDomains();
 		} );
 
-		step( 'Can see the Domains page and choose add a domain', async function () {
+		it( 'Can see the Domains page and choose add a domain', async function () {
 			const domainsPage = await DomainsPage.Expect( driver );
 			await domainsPage.setABTestControlGroupsInLocalStorage();
 			await domainsPage.clickAddDomain();
@@ -149,7 +149,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 			return await domainsPage.clickPopoverItem( 'to this site' );
 		} );
 
-		step( 'Can see the domain search component', async function () {
+		it( 'Can see the domain search component', async function () {
 			let findADomainComponent;
 			try {
 				findADomainComponent = await FindADomainComponent.Expect( driver );
@@ -164,39 +164,39 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 			return await findADomainComponent.waitForResults();
 		} );
 
-		step( 'Can select to use an existing domain', async function () {
+		it( 'Can select to use an existing domain', async function () {
 			const findADomainComponent = await FindADomainComponent.Expect( driver );
 			return await findADomainComponent.selectUseOwnDomain();
 		} );
 
-		step( 'Can see use my own domain page', async function () {
+		it( 'Can see use my own domain page', async function () {
 			return await MyOwnDomainPage.Expect( driver );
 		} );
 
-		step( 'Can select to buy domain mapping', async function () {
+		it( 'Can select to buy domain mapping', async function () {
 			const myOwnDomainPage = await MyOwnDomainPage.Expect( driver );
 			return await myOwnDomainPage.selectBuyDomainMapping();
 		} );
 
-		step( 'Can see enter a domain component', async function () {
+		it( 'Can see enter a domain component', async function () {
 			return await MapADomainPage.Expect( driver );
 		} );
 
-		step( 'Can enter the domain name', async function () {
+		it( 'Can enter the domain name', async function () {
 			const enterADomainComponent = await EnterADomainComponent.Expect( driver );
 			return await enterADomainComponent.enterADomain( blogName );
 		} );
 
-		step( 'Can add domain to the cart', async function () {
+		it( 'Can add domain to the cart', async function () {
 			const enterADomainComponent = await EnterADomainComponent.Expect( driver );
 			return await enterADomainComponent.clickonAddButtonToAddDomainToTheCart();
 		} );
 
-		step( 'Can see checkout page', async function () {
+		it( 'Can see checkout page', async function () {
 			return await MapADomainCheckoutPage.Expect( driver );
 		} );
 
-		step( 'Empty the cart', async function () {
+		it( 'Empty the cart', async function () {
 			await ReaderPage.Visit( driver );
 			const navBarComponent = await NavBarComponent.Expect( driver );
 			await navBarComponent.clickMySites();

--- a/test/e2e/specs/wp-media-editor-spec.js
+++ b/test/e2e/specs/wp-media-editor-spec.js
@@ -33,20 +33,20 @@ describe( `[${ host }] Media: Edit Media (${ screenSize }) @parallel @jetpack`, 
 			await loginFlow.loginAndSelectMySite();
 		} );
 
-		step( "Select 'Media' option and see media content", async function () {
+		it( "Select 'Media' option and see media content", async function () {
 			const sideBarComponent = await SideBarComponent.Expect( driver );
 			await sideBarComponent.selectMedia();
 			return await MediaPage.Expect( driver );
 		} );
 
-		step( 'Select a random media item and click edit', async function () {
+		it( 'Select a random media item and click edit', async function () {
 			const mediaPage = await MediaPage.Expect( driver );
 			await mediaPage.selectFirstImage();
 			await mediaPage.selectEditMedia();
 			return await mediaPage.mediaEditorShowing();
 		} );
 
-		step( 'Click Edit Image', async function () {
+		it( 'Click Edit Image', async function () {
 			const mediaPage = await MediaPage.Expect( driver );
 			await mediaPage.clickEditImage();
 			return await mediaPage.imageShowingInEditor();

--- a/test/e2e/specs/wp-media-upload-spec.js
+++ b/test/e2e/specs/wp-media-upload-spec.js
@@ -49,19 +49,19 @@ describe( `[${ host }] Editor: Media Upload (${ screenSize }) @parallel @jetpack
 			describe( 'Can upload a normal image', function () {
 				let fileDetails;
 
-				step( 'Navigate to Editor page and create image file for upload', async function () {
+				it( 'Navigate to Editor page and create image file for upload', async function () {
 					fileDetails = await mediaHelper.createFileWithFilename( 'normal.jpg' );
 				} );
 
-				step( 'Can upload an image', async function () {
+				it( 'Can upload an image', async function () {
 					blockID = await gutenbergEditor.addImage( fileDetails );
 				} );
 
-				step( 'Can delete image', async function () {
+				it( 'Can delete image', async function () {
 					await gutenbergEditor.removeBlock( blockID );
 				} );
 
-				step( 'Clean up', async function () {
+				it( 'Clean up', async function () {
 					if ( fileDetails ) {
 						await mediaHelper.deleteFile( fileDetails );
 					}
@@ -71,22 +71,22 @@ describe( `[${ host }] Editor: Media Upload (${ screenSize }) @parallel @jetpack
 			describe( 'Can upload an image with reserved url chars in the filename', function () {
 				let fileDetails;
 
-				step( 'Create image file for upload', async function () {
+				it( 'Create image file for upload', async function () {
 					fileDetails = await mediaHelper.createFileWithFilename(
 						'filewith#?#?reservedurlchars.jpg',
 						true
 					);
 				} );
 
-				step( 'Can upload an image', async function () {
+				it( 'Can upload an image', async function () {
 					blockID = await gutenbergEditor.addImage( fileDetails );
 				} );
 
-				step( 'Can delete image', async function () {
+				it( 'Can delete image', async function () {
 					await gutenbergEditor.removeBlock( blockID );
 				} );
 
-				step( 'Clean up', async function () {
+				it( 'Clean up', async function () {
 					if ( fileDetails ) {
 						await mediaHelper.deleteFile( fileDetails );
 					}
@@ -96,19 +96,19 @@ describe( `[${ host }] Editor: Media Upload (${ screenSize }) @parallel @jetpack
 			describe( 'Can upload an mp3', function () {
 				let fileDetails;
 
-				step( 'Create mp3 for upload', async function () {
+				it( 'Create mp3 for upload', async function () {
 					fileDetails = await mediaHelper.getMP3FileWithFilename( 'new.mp3' );
 				} );
 
-				step( 'Can upload an mp3', async function () {
+				it( 'Can upload an mp3', async function () {
 					blockID = await gutenbergEditor.addFile( fileDetails );
 				} );
 
-				step( 'Can delete mp3', async function () {
+				it( 'Can delete mp3', async function () {
 					await gutenbergEditor.removeBlock( blockID );
 				} );
 
-				step( 'Clean up', async function () {
+				it( 'Clean up', async function () {
 					if ( fileDetails ) {
 						await mediaHelper.deleteFile( fileDetails );
 					}

--- a/test/e2e/specs/wp-my-home-support-search-spec.js
+++ b/test/e2e/specs/wp-my-home-support-search-spec.js
@@ -34,7 +34,7 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 		driver = await driverManager.startBrowser();
 	} );
 
-	step( 'Login and select the My Home page', async function () {
+	it( 'Login and select the My Home page', async function () {
 		const loginFlow = new LoginFlow( driver );
 
 		await loginFlow.loginAndSelectMySite();
@@ -45,7 +45,7 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 		await sidebarComponent.selectMyHome();
 	} );
 
-	step( 'Verify "Get help" support card is displayed', async function () {
+	it( 'Verify "Get help" support card is displayed', async function () {
 		// Card can take a little while to display, so let's wait...
 		await driverHelper.waitUntilElementLocatedAndVisible( driver, helpCardLocator );
 
@@ -61,13 +61,13 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 		);
 	} );
 
-	step( 'Displays Default Results initially', async function () {
+	it( 'Displays Default Results initially', async function () {
 		supportSearchComponent = await SupportSearchComponent.Expect( driver );
 		const resultsCount = await supportSearchComponent.getDefaultResultsCount();
 		assert.equal( resultsCount, 6, 'There are not 6 Default Results displayed.' );
 	} );
 
-	step( 'Returns API Search Results for valid search query', async function () {
+	it( 'Returns API Search Results for valid search query', async function () {
 		await supportSearchComponent.searchFor( 'Domain' );
 
 		const searchResultsCount = await supportSearchComponent.getSearchResultsCount();
@@ -104,7 +104,7 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 		);
 	} );
 
-	step( 'Resets search UI to default state when search input is cleared', async function () {
+	it( 'Resets search UI to default state when search input is cleared', async function () {
 		await supportSearchComponent.clearSearchField();
 
 		const searchResults = await supportSearchComponent.waitForSearchResultsNotToBePresent();
@@ -120,28 +120,25 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 		assert.equal( defaultResultsCount, 6, 'The 6 Default Results are not displayed.' );
 	} );
 
-	step(
-		'Shows "No results" indicator and re-displays contextual results for search queries which return no results',
-		async function () {
-			const invalidSearchQueryReturningNoResults = ';;;ppp;;;';
+	it( 'Shows "No results" indicator and re-displays contextual results for search queries which return no results', async function () {
+		const invalidSearchQueryReturningNoResults = ';;;ppp;;;';
 
-			await supportSearchComponent.searchFor( invalidSearchQueryReturningNoResults );
+		await supportSearchComponent.searchFor( invalidSearchQueryReturningNoResults );
 
-			const searchResults = await supportSearchComponent.waitForSearchResultsNotToBePresent();
+		const searchResults = await supportSearchComponent.waitForSearchResultsNotToBePresent();
 
-			const resultsCount = await supportSearchComponent.getErrorResultsCount();
+		const resultsCount = await supportSearchComponent.getErrorResultsCount();
 
-			const hasNoResultsMessage = await supportSearchComponent.hasNoResultsMessage();
+		const hasNoResultsMessage = await supportSearchComponent.hasNoResultsMessage();
 
-			assert.equal( searchResults, true, 'The API Search Results are not displayed.' );
+		assert.equal( searchResults, true, 'The API Search Results are not displayed.' );
 
-			assert.equal( hasNoResultsMessage, true, 'The "No results" message was not displayed.' );
+		assert.equal( hasNoResultsMessage, true, 'The "No results" message was not displayed.' );
 
-			assert.equal( resultsCount, 6, 'The 6 default Error Results are not displayed.' );
-		}
-	);
+		assert.equal( resultsCount, 6, 'The 6 default Error Results are not displayed.' );
+	} );
 
-	step( 'Clearing search resets to default state', async function () {
+	it( 'Clearing search resets to default state', async function () {
 		await supportSearchComponent.clearSearchField();
 
 		const errorResults = await supportSearchComponent.waitForErrorResultsNotToBePresent();
@@ -153,7 +150,7 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 		assert.equal( resultsCount, 6, 'The 6 Default Results are not displayed.' );
 	} );
 
-	step( 'Does not request API Search Results for empty search queries', async function () {
+	it( 'Does not request API Search Results for empty search queries', async function () {
 		const emptyWhitespaceQuery = '         ';
 
 		await supportSearchComponent.searchFor( emptyWhitespaceQuery );

--- a/test/e2e/specs/wp-notifications-spec.js
+++ b/test/e2e/specs/wp-notifications-spec.js
@@ -37,12 +37,12 @@ describe( `[${ host }] Notifications: (${ screenSize }) @parallel`, function () 
 	const comment = dataHelper.randomPhrase() + ' TBD';
 	let commentedPostTitle;
 
-	step( 'Can log in as commenting user', async function () {
+	it( 'Can log in as commenting user', async function () {
 		const loginFlow = new LoginFlow( driver, 'commentingUser' );
 		return await loginFlow.login();
 	} );
 
-	step( 'Can view the first post', async function () {
+	it( 'Can view the first post', async function () {
 		const testSiteForInvitationsURL = `https://${ dataHelper.configGet(
 			'testSiteForNotifications'
 		) }`;
@@ -50,17 +50,17 @@ describe( `[${ host }] Notifications: (${ screenSize }) @parallel`, function () 
 		return await viewBlogPage.viewFirstPost();
 	} );
 
-	step( 'Can see the first post page and capture the title', async function () {
+	it( 'Can see the first post page and capture the title', async function () {
 		const viewPostPage = await ViewPostPage.Expect( driver );
 		commentedPostTitle = await viewPostPage.postTitle();
 	} );
 
-	step( 'Can leave a comment', async function () {
+	it( 'Can leave a comment', async function () {
 		const viewPostPage = await ViewPostPage.Expect( driver );
 		return await viewPostPage.leaveAComment( comment );
 	} );
 
-	step( 'Can see the comment', async function () {
+	it( 'Can see the comment', async function () {
 		const viewPostPage = await ViewPostPage.Expect( driver );
 		const shown = await viewPostPage.commentEventuallyShown( comment );
 		if ( shown === false ) {
@@ -70,19 +70,19 @@ describe( `[${ host }] Notifications: (${ screenSize }) @parallel`, function () 
 		}
 	} );
 
-	step( 'Can log in as notifications user', async function () {
+	it( 'Can log in as notifications user', async function () {
 		const loginFlow = new LoginFlow( driver, 'notificationsUser' );
 		return await loginFlow.login();
 	} );
 
-	step( 'Can open notifications tab with keyboard shortcut', async function () {
+	it( 'Can open notifications tab with keyboard shortcut', async function () {
 		const navBarComponent = await NavBarComponent.Expect( driver );
 		await navBarComponent.openNotificationsShortcut();
 		const present = await navBarComponent.confirmNotificationsOpen();
 		return assert( present, 'Notifications tab is not open' );
 	} );
 
-	step( 'Can see the notification of the comment', async function () {
+	it( 'Can see the notification of the comment', async function () {
 		const expectedContent = `${ commentingUser } commented on ${ commentedPostTitle }\n${ comment }`;
 		const navBarComponent = await NavBarComponent.Expect( driver );
 		await navBarComponent.openNotifications();
@@ -96,14 +96,11 @@ describe( `[${ host }] Notifications: (${ screenSize }) @parallel`, function () 
 		);
 	} );
 
-	step(
-		'Can delete the comment (and wait for UNDO grace period so it is actually deleted)',
-		async function () {
-			const notificationsComponent = await NotificationsComponent.Expect( driver );
-			await notificationsComponent.selectCommentByText( comment );
-			await notificationsComponent.trashComment();
-			await notificationsComponent.waitForUndoMessage();
-			return await notificationsComponent.waitForUndoMessageToDisappear();
-		}
-	);
+	it( 'Can delete the comment (and wait for UNDO grace period so it is actually deleted)', async function () {
+		const notificationsComponent = await NotificationsComponent.Expect( driver );
+		await notificationsComponent.selectCommentByText( comment );
+		await notificationsComponent.trashComment();
+		await notificationsComponent.waitForUndoMessage();
+		return await notificationsComponent.waitForUndoMessageToDisappear();
+	} );
 } );

--- a/test/e2e/specs/wp-plan-purchase-spec.js
+++ b/test/e2e/specs/wp-plan-purchase-spec.js
@@ -34,31 +34,31 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 	} );
 
 	describe( 'Comparing Plans:  @parallel @jetpack', function () {
-		step( 'Login and Select My Site', async function () {
+		it( 'Login and Select My Site', async function () {
 			const loginFlow = new LoginFlow( driver );
 			return await loginFlow.loginAndSelectMySite();
 		} );
 
-		step( 'Can Select Plans', async function () {
+		it( 'Can Select Plans', async function () {
 			const sideBarComponent = await SidebarComponent.Expect( driver );
 			return await sideBarComponent.selectPlans();
 		} );
 
-		step( 'Can Compare Plans', async function () {
+		it( 'Can Compare Plans', async function () {
 			const plansPage = await PlansPage.Expect( driver );
 			await plansPage.openPlansTab();
 			return await plansPage.waitForComparison();
 		} );
 
 		if ( host === 'WPCOM' ) {
-			step( 'Can Verify Current Plan', async function () {
+			it( 'Can Verify Current Plan', async function () {
 				const planName = 'premium';
 				const plansPage = await PlansPage.Expect( driver );
 				const present = await plansPage.confirmCurrentPlan( planName );
 				return assert( present, `Failed to detect correct plan (${ planName })` );
 			} );
 
-			step( 'Can See Exactly One Primary CTA Button', async function () {
+			it( 'Can See Exactly One Primary CTA Button', async function () {
 				const plansPage = await PlansPage.Expect( driver );
 				return assert(
 					await plansPage.onePrimaryButtonShown(),
@@ -66,7 +66,7 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 				);
 			} );
 		} else {
-			step( 'Can Verify Current Plan', async function () {
+			it( 'Can Verify Current Plan', async function () {
 				// Jetpack
 				const plansPage = await PlansPage.Expect( driver );
 				const displayed = await plansPage.planTypesShown( 'jetpack' );
@@ -83,17 +83,17 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Login and Select My Site', async function () {
+		it( 'Login and Select My Site', async function () {
 			loginFlow = new LoginFlow( driver );
 			return await loginFlow.loginAndSelectMySite();
 		} );
 
-		step( 'Can Select Plans', async function () {
+		it( 'Can Select Plans', async function () {
 			const sideBarComponent = await SidebarComponent.Expect( driver );
 			return await sideBarComponent.selectPlans();
 		} );
 
-		step( 'Can Compare Plans', async function () {
+		it( 'Can Compare Plans', async function () {
 			const plansPage = await PlansPage.Expect( driver );
 			await plansPage.openPlansTab();
 			if ( host === 'WPCOM' ) {
@@ -102,12 +102,12 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 			return await plansPage.waitForComparison();
 		} );
 
-		step( 'Select Business Plan', async function () {
+		it( 'Select Business Plan', async function () {
 			const plansPage = await PlansPage.Expect( driver );
 			return await plansPage.selectPaidPlan();
 		} );
 
-		step( 'Remove any existing coupon', async function () {
+		it( 'Remove any existing coupon', async function () {
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 
 			if ( await securePaymentComponent.hasCouponApplied() ) {
@@ -115,7 +115,7 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 			}
 		} );
 
-		step( 'Can Correctly Apply Coupon', async function () {
+		it( 'Can Correctly Apply Coupon', async function () {
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 
 			await securePaymentComponent.toggleCartSummary();
@@ -130,7 +130,7 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 			assert.strictEqual( newCartAmount, expectedCartAmount, 'Coupon not applied properly' );
 		} );
 
-		step( 'Can Remove Coupon', async function () {
+		it( 'Can Remove Coupon', async function () {
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 
 			await securePaymentComponent.removeCoupon();
@@ -139,7 +139,7 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 			assert.strictEqual( removedCouponAmount, originalCartAmount, 'Coupon not removed properly' );
 		} );
 
-		step( 'Remove from cart', async function () {
+		it( 'Remove from cart', async function () {
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 
 			return await securePaymentComponent.removeBusinessPlan();
@@ -151,12 +151,12 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can log into WordPress.com', async function () {
+		it( 'Can log into WordPress.com', async function () {
 			const loginFlow = new LoginFlow( driver );
 			return await loginFlow.login();
 		} );
 
-		step( 'Can navigate to purchases', async function () {
+		it( 'Can navigate to purchases', async function () {
 			const navBarComponent = await NavBarComponent.Expect( driver );
 			await navBarComponent.clickProfileLink();
 			const profilePage = await ProfilePage.Expect( driver );
@@ -166,7 +166,7 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 			return await purchasesPage.selectPremiumPlanOnConnectedSite();
 		} );
 
-		step( '"Renew Now" link takes user to Payment Details form', async function () {
+		it( '"Renew Now" link takes user to Payment Details form', async function () {
 			const managePurchasePage = await ManagePurchasePage.Expect( driver );
 			await managePurchasePage.chooseRenewNow();
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
@@ -184,12 +184,12 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can log into WordPress.com', async function () {
+		it( 'Can log into WordPress.com', async function () {
 			const loginFlow = new LoginFlow( driver );
 			return await loginFlow.loginAndSelectMySite();
 		} );
 
-		step( 'Can navigate to plans page and select business plan', async function () {
+		it( 'Can navigate to plans page and select business plan', async function () {
 			const sidebarComponent = await SidebarComponent.Expect( driver );
 			await sidebarComponent.selectPlans();
 			const plansPage = await PlansPage.Expect( driver );
@@ -197,7 +197,7 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 			return await plansPage.selectPaidPlan();
 		} );
 
-		step( 'User is taken to be Payment Details form', async function () {
+		it( 'User is taken to be Payment Details form', async function () {
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 			const businessPlanInCart = await securePaymentComponent.containsBusinessPlan();
 			return assert.strictEqual(

--- a/test/e2e/specs/wp-reader-spec.js
+++ b/test/e2e/specs/wp-reader-spec.js
@@ -31,17 +31,17 @@ describe( 'Reader: (' + screenSize + ') @parallel', function () {
 	} );
 
 	describe( 'Log in as commenting user', function () {
-		step( 'Can log in as commenting user', async function () {
+		it( 'Can log in as commenting user', async function () {
 			this.loginFlow = new LoginFlow( driver, 'commentingUser' );
 			return await this.loginFlow.login( { useFreshLogin: true } );
 		} );
 
 		describe( 'Leave a comment on the latest post in the Reader', function () {
-			step( 'Can see the Reader stream', async function () {
+			it( 'Can see the Reader stream', async function () {
 				await ReaderPage.Expect( driver );
 			} );
 
-			step( 'The latest post is on the expected test site', async function () {
+			it( 'The latest post is on the expected test site', async function () {
 				const testSiteForNotifications = dataHelper.configGet( 'testSiteForNotifications' );
 				const readerPage = await ReaderPage.Expect( driver );
 				const siteOfLatestPost = await readerPage.siteOfLatestPost();
@@ -52,7 +52,7 @@ describe( 'Reader: (' + screenSize + ') @parallel', function () {
 				);
 			} );
 
-			step( 'Can comment on the latest post and see the comment appear', async function () {
+			it( 'Can comment on the latest post and see the comment appear', async function () {
 				this.comment = dataHelper.randomPhrase();
 				const readerPage = await ReaderPage.Expect( driver );
 				await readerPage.commentOnLatestPost( this.comment );
@@ -60,23 +60,20 @@ describe( 'Reader: (' + screenSize + ') @parallel', function () {
 			} );
 
 			describe( 'Delete the new comment', function () {
-				step( 'Can log in as test site owner', async function () {
+				it( 'Can log in as test site owner', async function () {
 					this.loginFlow = new LoginFlow( driver, 'notificationsUser' );
 					return await this.loginFlow.login();
 				} );
 
-				step(
-					'Can delete the new comment (and wait for UNDO grace period so step is actually deleted)',
-					async function () {
-						this.navBarComponent = await NavBarComponent.Expect( driver );
-						await this.navBarComponent.openNotifications();
-						this.notificationsComponent = await NotificationsComponent.Expect( driver );
-						await this.notificationsComponent.selectCommentByText( this.comment );
-						await this.notificationsComponent.trashComment();
-						await this.notificationsComponent.waitForUndoMessage();
-						return await this.notificationsComponent.waitForUndoMessageToDisappear();
-					}
-				);
+				it( 'Can delete the new comment (and wait for UNDO grace period so step is actually deleted)', async function () {
+					this.navBarComponent = await NavBarComponent.Expect( driver );
+					await this.navBarComponent.openNotifications();
+					this.notificationsComponent = await NotificationsComponent.Expect( driver );
+					await this.notificationsComponent.selectCommentByText( this.comment );
+					await this.notificationsComponent.trashComment();
+					await this.notificationsComponent.waitForUndoMessage();
+					return await this.notificationsComponent.waitForUndoMessageToDisappear();
+				} );
 			} );
 		} );
 	} );

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -84,11 +84,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can create a new WordPress site', async function () {
+		it( 'Can create a new WordPress site', async function () {
 			await StartPage.Visit( driver, StartPage.getStartURL() );
 		} );
 
-		step( 'Can see the account page and enter account details', async function () {
+		it( 'Can see the account page and enter account details', async function () {
 			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
@@ -97,40 +97,34 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			);
 		} );
 
-		step(
-			'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
-			async function () {
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
-				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
-				// See https://github.com/Automattic/wp-calypso/pull/38641/
-				// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
-				// 	expectedBlogAddresses,
-				// 	blogName
-				// );
-				// const actualAddress = await findADomainComponent.freeBlogAddress();
-				// assert(
-				// 	expectedBlogAddresses.indexOf( actualAddress ) > -1,
-				// 	`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
-				// );
-				return await findADomainComponent.selectFreeAddress();
-			}
-		);
+		it( 'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results', async function () {
+			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
+			// See https://github.com/Automattic/wp-calypso/pull/38641/
+			// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
+			// 	expectedBlogAddresses,
+			// 	blogName
+			// );
+			// const actualAddress = await findADomainComponent.freeBlogAddress();
+			// assert(
+			// 	expectedBlogAddresses.indexOf( actualAddress ) > -1,
+			// 	`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
+			// );
+			return await findADomainComponent.selectFreeAddress();
+		} );
 
-		step( 'Can see the plans page and pick the free plan', async function () {
+		it( 'Can see the plans page and pick the free plan', async function () {
 			const pickAPlanPage = await PickAPlanPage.Expect( driver );
 			return await pickAPlanPage.selectFreePlan();
 		} );
 
-		step(
-			'Can then see the sign up processing page which will finish automatically move along',
-			async function () {
-				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
-			}
-		);
+		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
+			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+		} );
 
 		sharedSteps.canSeeTheOnboardingChecklist();
 
-		step( 'Can log out and request a magic link', async function () {
+		it( 'Can log out and request a magic link', async function () {
 			if ( process.env.HORIZON_TESTS === 'true' ) {
 				return this.skip();
 			}
@@ -139,7 +133,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await loginPage.requestMagicLink( emailAddress );
 		} );
 
-		step( 'Can see email containing magic link', async function () {
+		it( 'Can see email containing magic link', async function () {
 			if ( process.env.HORIZON_TESTS === 'true' ) {
 				return this.skip();
 			}
@@ -163,7 +157,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			);
 		} );
 
-		step( 'Can visit the magic link and we should be logged in', async function () {
+		it( 'Can visit the magic link and we should be logged in', async function () {
 			if ( process.env.HORIZON_TESTS === 'true' ) {
 				return this.skip();
 			}
@@ -191,11 +185,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can visit the start page', async function () {
+		it( 'Can visit the start page', async function () {
 			await StartPage.Visit( driver, StartPage.getStartURL( { culture: locale } ) );
 		} );
 
-		step( 'Can see the account page and enter account details', async function () {
+		it( 'Can see the account page and enter account details', async function () {
 			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
@@ -204,36 +198,30 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			);
 		} );
 
-		step(
-			'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
-			async function () {
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
-				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
-				// See https://github.com/Automattic/wp-calypso/pull/38641/
-				// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
-				// 	expectedBlogAddresses,
-				// 	blogName
-				// );
-				// const actualAddress = await findADomainComponent.freeBlogAddress();
-				// assert(
-				// 	expectedBlogAddresses.indexOf( actualAddress ) > -1,
-				// 	`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
-				// );
-				return await findADomainComponent.selectFreeAddress();
-			}
-		);
+		it( 'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results', async function () {
+			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
+			// See https://github.com/Automattic/wp-calypso/pull/38641/
+			// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
+			// 	expectedBlogAddresses,
+			// 	blogName
+			// );
+			// const actualAddress = await findADomainComponent.freeBlogAddress();
+			// assert(
+			// 	expectedBlogAddresses.indexOf( actualAddress ) > -1,
+			// 	`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
+			// );
+			return await findADomainComponent.selectFreeAddress();
+		} );
 
-		step( 'Can see the plans page and pick the free plan', async function () {
+		it( 'Can see the plans page and pick the free plan', async function () {
 			const pickAPlanPage = await PickAPlanPage.Expect( driver );
 			return await pickAPlanPage.selectFreePlan();
 		} );
 
-		step(
-			'Can then see the sign up processing page which will finish automatically move along',
-			async function () {
-				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
-			}
-		);
+		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
+			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+		} );
 
 		sharedSteps.canSeeTheOnboardingChecklist();
 
@@ -252,11 +240,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can visit the start page', async function () {
+		it( 'Can visit the start page', async function () {
 			await StartPage.Visit( driver, StartPage.getStartURL( { flow: 'main', culture: locale } ) );
 		} );
 
-		step( 'Can see the account page and enter account details', async function () {
+		it( 'Can see the account page and enter account details', async function () {
 			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
@@ -265,64 +253,55 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			);
 		} );
 
-		step( 'Can see the "About" page, and enter some site information', async function () {
+		it( 'Can see the "About" page, and enter some site information', async function () {
 			const aboutPage = await AboutPage.Expect( driver );
 			return await aboutPage.enterSiteDetails( blogName, '', {
 				showcase: true,
 			} );
 		} );
 
-		step( 'Can accept defaults for about page', async function () {
+		it( 'Can accept defaults for about page', async function () {
 			const aboutPage = await AboutPage.Expect( driver );
 			await aboutPage.submitForm();
 		} );
 
-		step( 'Can then see the domains page ', async function () {
+		it( 'Can then see the domains page ', async function () {
 			const findADomainComponent = await FindADomainComponent.Expect( driver );
 			const displayed = await findADomainComponent.displayed();
 			return assert.strictEqual( displayed, true, 'The choose a domain page is not displayed' );
 		} );
 
-		step(
-			'Can search for a blog name, can see and select a free WordPress.com blog address in results',
-			async function () {
-				return await new SignUpStep( driver ).selectFreeWordPressDotComAddresss(
-					blogName,
-					expectedBlogAddresses
-				);
-			}
-		);
+		it( 'Can search for a blog name, can see and select a free WordPress.com blog address in results', async function () {
+			return await new SignUpStep( driver ).selectFreeWordPressDotComAddresss(
+				blogName,
+				expectedBlogAddresses
+			);
+		} );
 
-		step( 'Can then see the plans page and select the premium plan ', async function () {
+		it( 'Can then see the plans page and select the premium plan ', async function () {
 			const pickAPlanPage = await PickAPlanPage.Expect( driver );
 			const displayed = await pickAPlanPage.displayed();
 			assert.strictEqual( displayed, true, 'The pick a plan page is not displayed' );
 			return await pickAPlanPage.selectPremiumPlan();
 		} );
 
-		step(
-			'Can then see the sign up processing page which will automatically move along',
-			async function () {
-				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
-			}
-		);
+		it( 'Can then see the sign up processing page which will automatically move along', async function () {
+			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+		} );
 
-		step(
-			'Can then see the secure payment page with the premium plan in the cart',
-			async function () {
-				const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
-				const premiumPlanInCart = await securePaymentComponent.containsPremiumPlan();
-				assert.strictEqual( premiumPlanInCart, true, "The cart doesn't contain the premium plan" );
-				const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
-				return assert.strictEqual(
-					numberOfProductsInCart,
-					1,
-					"The cart doesn't contain the expected number of products"
-				);
-			}
-		);
+		it( 'Can then see the secure payment page with the premium plan in the cart', async function () {
+			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const premiumPlanInCart = await securePaymentComponent.containsPremiumPlan();
+			assert.strictEqual( premiumPlanInCart, true, "The cart doesn't contain the premium plan" );
+			const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
+			return assert.strictEqual(
+				numberOfProductsInCart,
+				1,
+				"The cart doesn't contain the expected number of products"
+			);
+		} );
 
-		step( 'Can Correctly Apply Coupon discount', async function () {
+		it( 'Can Correctly Apply Coupon discount', async function () {
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 			await securePaymentComponent.toggleCartSummary();
 			originalCartAmount = await securePaymentComponent.cartTotalAmount();
@@ -342,7 +321,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			);
 		} );
 
-		step( 'Can Remove Coupon', async function () {
+		it( 'Can Remove Coupon', async function () {
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 
 			await securePaymentComponent.removeCoupon();
@@ -367,21 +346,21 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'We can set the sandbox cookie for payments', async function () {
+		it( 'We can set the sandbox cookie for payments', async function () {
 			const wPHomePage = await WPHomePage.Visit( driver );
 			await wPHomePage.checkURL( locale );
 			await wPHomePage.setSandboxModeForPayments( sandboxCookieValue );
 			return await wPHomePage.setCurrencyForPayments( currencyValue );
 		} );
 
-		step( 'Can visit the start page', async function () {
+		it( 'Can visit the start page', async function () {
 			await StartPage.Visit(
 				driver,
 				StartPage.getStartURL( { culture: locale, flow: 'personal' } )
 			);
 		} );
 
-		step( 'Can see the account details page and enter account details', async function () {
+		it( 'Can see the account details page and enter account details', async function () {
 			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
@@ -390,63 +369,47 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			);
 		} );
 
-		step(
-			'Can then see the domains page and can search for a blog name, can see and select a free WordPress.com blog address in results',
-			async function () {
-				return await new SignUpStep( driver ).selectFreeWordPressDotComAddresss(
-					blogName,
-					expectedBlogAddresses
-				);
-			}
-		);
+		it( 'Can then see the domains page and can search for a blog name, can see and select a free WordPress.com blog address in results', async function () {
+			return await new SignUpStep( driver ).selectFreeWordPressDotComAddresss(
+				blogName,
+				expectedBlogAddresses
+			);
+		} );
 
-		step(
-			'Can then see the sign up processing page which will finish automatically move along',
-			async function () {
-				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
-			}
-		);
+		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
+			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+		} );
 
-		step(
-			'Can then see the secure payment page with the expected currency in the cart',
-			async function () {
-				const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
-				if ( driverManager.currentScreenSize() === 'desktop' ) {
-					const totalShown = await securePaymentComponent.cartTotalDisplayed();
-					assert.strictEqual(
-						totalShown.indexOf( expectedCurrencySymbol ),
-						0,
-						`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
-					);
-				}
-				const paymentButtonText = await securePaymentComponent.paymentButtonText();
-				return assert(
-					paymentButtonText.includes( expectedCurrencySymbol ),
-					`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
-				);
-			}
-		);
-
-		step(
-			'Can then see the secure payment page with the expected products in the cart',
-			async function () {
-				const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
-				const personalPlanInCart = await securePaymentComponent.containsPersonalPlan();
+		it( 'Can then see the secure payment page with the expected currency in the cart', async function () {
+			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			if ( driverManager.currentScreenSize() === 'desktop' ) {
+				const totalShown = await securePaymentComponent.cartTotalDisplayed();
 				assert.strictEqual(
-					personalPlanInCart,
-					true,
-					"The cart doesn't contain the personal plan"
-				);
-				const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
-				return assert.strictEqual(
-					numberOfProductsInCart,
-					1,
-					"The cart doesn't contain the expected number of products"
+					totalShown.indexOf( expectedCurrencySymbol ),
+					0,
+					`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
 				);
 			}
-		);
+			const paymentButtonText = await securePaymentComponent.paymentButtonText();
+			return assert(
+				paymentButtonText.includes( expectedCurrencySymbol ),
+				`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
+			);
+		} );
 
-		step( 'Can submit test payment details', async function () {
+		it( 'Can then see the secure payment page with the expected products in the cart', async function () {
+			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const personalPlanInCart = await securePaymentComponent.containsPersonalPlan();
+			assert.strictEqual( personalPlanInCart, true, "The cart doesn't contain the personal plan" );
+			const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
+			return assert.strictEqual(
+				numberOfProductsInCart,
+				1,
+				"The cart doesn't contain the expected number of products"
+			);
+		} );
+
+		it( 'Can submit test payment details', async function () {
 			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 			await securePaymentComponent.completeTaxDetailsInContactSection( testCreditCardDetails );
@@ -457,7 +420,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 		sharedSteps.canSeeTheOnboardingChecklist();
 
-		step( 'Can delete the plan', async function () {
+		it( 'Can delete the plan', async function () {
 			return await new DeletePlanFlow( driver ).deletePlan( 'personal' );
 		} );
 
@@ -488,14 +451,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'We can visit set the sandbox cookie for payments', async function () {
+		it( 'We can visit set the sandbox cookie for payments', async function () {
 			const wPHomePage = await WPHomePage.Visit( driver );
 			await wPHomePage.checkURL( locale );
 			await wPHomePage.setSandboxModeForPayments( sandboxCookieValue );
 			return await wPHomePage.setCurrencyForPayments( currencyValue );
 		} );
 
-		step( 'Can visit the domains start page', async function () {
+		it( 'Can visit the domains start page', async function () {
 			await StartPage.Visit(
 				driver,
 				StartPage.getStartURL( {
@@ -506,12 +469,12 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			);
 		} );
 
-		step( 'Can select domain only from the domain first choice page', async function () {
+		it( 'Can select domain only from the domain first choice page', async function () {
 			const domainFirstPage = await DomainFirstPage.Expect( driver );
 			return await domainFirstPage.chooseJustBuyTheDomain();
 		} );
 
-		step( 'Can then enter account details', async function () {
+		it( 'Can then enter account details', async function () {
 			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
@@ -520,14 +483,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			);
 		} );
 
-		step(
-			'Can then see the sign up processing page which will finish automatically move along',
-			async function () {
-				return await new SignUpStep( driver ).continueAlong( siteName, passwordForTestAccounts );
-			}
-		);
+		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
+			return await new SignUpStep( driver ).continueAlong( siteName, passwordForTestAccounts );
+		} );
 
-		step( 'Can see checkout page and enter registrar details', async function () {
+		it( 'Can see checkout page and enter registrar details', async function () {
 			let checkOutPage;
 			try {
 				checkOutPage = await CheckOutPage.Expect( driver );
@@ -546,46 +506,36 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await checkOutPage.submitForm();
 		} );
 
-		step(
-			'Can then see the secure payment page with the correct products in the cart',
-			async function () {
-				const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
-				const domainInCart = await securePaymentComponent.containsDotLiveDomain();
+		it( 'Can then see the secure payment page with the correct products in the cart', async function () {
+			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const domainInCart = await securePaymentComponent.containsDotLiveDomain();
+			assert.strictEqual( domainInCart, true, "The cart doesn't contain the .live domain product" );
+			const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
+			return assert.strictEqual(
+				numberOfProductsInCart,
+				1,
+				"The cart doesn't contain the expected number of products"
+			);
+		} );
+
+		it( 'Can then see the secure payment page with the expected currency in the cart', async function () {
+			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			if ( driverManager.currentScreenSize() === 'desktop' ) {
+				const totalShown = await securePaymentComponent.cartTotalDisplayed();
 				assert.strictEqual(
-					domainInCart,
-					true,
-					"The cart doesn't contain the .live domain product"
-				);
-				const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
-				return assert.strictEqual(
-					numberOfProductsInCart,
-					1,
-					"The cart doesn't contain the expected number of products"
+					totalShown.indexOf( expectedCurrencySymbol ),
+					0,
+					`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
 				);
 			}
-		);
+			const paymentButtonText = await securePaymentComponent.paymentButtonText();
+			return assert(
+				paymentButtonText.includes( expectedCurrencySymbol ),
+				`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
+			);
+		} );
 
-		step(
-			'Can then see the secure payment page with the expected currency in the cart',
-			async function () {
-				const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
-				if ( driverManager.currentScreenSize() === 'desktop' ) {
-					const totalShown = await securePaymentComponent.cartTotalDisplayed();
-					assert.strictEqual(
-						totalShown.indexOf( expectedCurrencySymbol ),
-						0,
-						`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
-					);
-				}
-				const paymentButtonText = await securePaymentComponent.paymentButtonText();
-				return assert(
-					paymentButtonText.includes( expectedCurrencySymbol ),
-					`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
-				);
-			}
-		);
-
-		step( 'Can enter/submit test payment details', async function () {
+		it( 'Can enter/submit test payment details', async function () {
 			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 			// No need to fill out contact details here as they already have been completed
@@ -595,12 +545,12 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		step( 'Can open the sidebar', async function () {
+		it( 'Can open the sidebar', async function () {
 			const navBarComponent = await NavBarComponent.Expect( driver );
 			await navBarComponent.clickMySites();
 		} );
 
-		step( 'We should only see one option - the settings option', async function () {
+		it( 'We should only see one option - the settings option', async function () {
 			const sidebarComponent = await SidebarComponent.Expect( driver );
 			const numberMenuItems = await sidebarComponent.numberOfMenuItems();
 			assert.strictEqual(
@@ -661,21 +611,21 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'We can set the sandbox cookie for payments', async function () {
+		it( 'We can set the sandbox cookie for payments', async function () {
 			const wPHomePage = await WPHomePage.Visit( driver );
 			await wPHomePage.checkURL( locale );
 			await wPHomePage.setSandboxModeForPayments( sandboxCookieValue );
 			return await wPHomePage.setCurrencyForPayments( currencyValue );
 		} );
 
-		step( 'Can visit the start page', async function () {
+		it( 'Can visit the start page', async function () {
 			await StartPage.Visit(
 				driver,
 				StartPage.getStartURL( { culture: locale, flow: 'business' } )
 			);
 		} );
 
-		step( 'Can then enter account details and continue', async function () {
+		it( 'Can then enter account details and continue', async function () {
 			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
@@ -684,82 +634,66 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			);
 		} );
 
-		step(
-			'Can then see the domains page, and can search for a blog name, can see and select a paid .live address in results ',
-			async function () {
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
-				await findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
-				try {
-					return await findADomainComponent.selectDomainAddress( expectedDomainName );
-				} catch ( err ) {
-					if ( await NewUserRegistrationUnavailableComponent.Expect( driver ) ) {
-						await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ' );
-						return this.skip();
-					}
+		it( 'Can then see the domains page, and can search for a blog name, can see and select a paid .live address in results ', async function () {
+			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			await findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
+			try {
+				return await findADomainComponent.selectDomainAddress( expectedDomainName );
+			} catch ( err ) {
+				if ( await NewUserRegistrationUnavailableComponent.Expect( driver ) ) {
+					await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ' );
+					return this.skip();
 				}
 			}
-		);
+		} );
 
-		step(
-			'Can then see the sign up processing page which will finish automatically move along',
-			async function () {
-				return await new SignUpStep( driver ).continueAlong( siteName, passwordForTestAccounts );
-			}
-		);
+		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
+			return await new SignUpStep( driver ).continueAlong( siteName, passwordForTestAccounts );
+		} );
 
-		step( 'Can see checkout page and enter registrar details', async function () {
+		it( 'Can see checkout page and enter registrar details', async function () {
 			const checkOutPage = await CheckOutPage.Expect( driver );
 			await checkOutPage.enterRegistrarDetails( testDomainRegistarDetails );
 			return await checkOutPage.submitForm();
 		} );
 
-		step(
-			'Can then see the secure payment page with the correct products in the cart',
-			async function () {
-				const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
-				const domainInCart = await securePaymentComponent.containsDotLiveDomain();
-				assert.strictEqual(
-					domainInCart,
-					true,
-					"The cart doesn't contain the .live domain product"
-				);
-				const businessPlanInCart = await securePaymentComponent.containsBusinessPlan();
-				assert.strictEqual(
-					businessPlanInCart,
-					true,
-					"The cart doesn't contain the business plan product"
-				);
-				// Removing product number assertion due to https://github.com/Automattic/wp-calypso/issues/24579
-				// const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
-				// return assert.strictEqual(
-				// 	numberOfProductsInCart,
-				// 	3,
-				// 	"The cart doesn't contain the expected number of products"
-				// );
-			}
-		);
+		it( 'Can then see the secure payment page with the correct products in the cart', async function () {
+			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const domainInCart = await securePaymentComponent.containsDotLiveDomain();
+			assert.strictEqual( domainInCart, true, "The cart doesn't contain the .live domain product" );
+			const businessPlanInCart = await securePaymentComponent.containsBusinessPlan();
+			assert.strictEqual(
+				businessPlanInCart,
+				true,
+				"The cart doesn't contain the business plan product"
+			);
+			// Removing product number assertion due to https://github.com/Automattic/wp-calypso/issues/24579
+			// const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
+			// return assert.strictEqual(
+			// 	numberOfProductsInCart,
+			// 	3,
+			// 	"The cart doesn't contain the expected number of products"
+			// );
+		} );
 
-		step(
-			'Can then see the secure payment page with the expected currency in the cart',
-			async function () {
-				const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
-				if ( driverManager.currentScreenSize() === 'desktop' ) {
-					const totalShown = await securePaymentComponent.cartTotalDisplayed();
-					assert.strictEqual(
-						totalShown.indexOf( expectedCurrencySymbol ),
-						0,
-						`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
-					);
-				}
-				const paymentButtonText = await securePaymentComponent.paymentButtonText();
-				return assert(
-					paymentButtonText.includes( expectedCurrencySymbol ),
-					`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
+		it( 'Can then see the secure payment page with the expected currency in the cart', async function () {
+			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			if ( driverManager.currentScreenSize() === 'desktop' ) {
+				const totalShown = await securePaymentComponent.cartTotalDisplayed();
+				assert.strictEqual(
+					totalShown.indexOf( expectedCurrencySymbol ),
+					0,
+					`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
 				);
 			}
-		);
+			const paymentButtonText = await securePaymentComponent.paymentButtonText();
+			return assert(
+				paymentButtonText.includes( expectedCurrencySymbol ),
+				`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
+			);
+		} );
 
-		step( 'Can enter/submit test payment details', async function () {
+		it( 'Can enter/submit test payment details', async function () {
 			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 			// No need to fill out contact details here as they already have been completed
@@ -771,7 +705,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 		sharedSteps.canSeeTheOnboardingChecklist();
 
-		step( 'Can delete the plan', async function () {
+		it( 'Can delete the plan', async function () {
 			return await new DeletePlanFlow( driver ).deletePlan( 'business', {
 				deleteDomainAlso: true,
 			} );
@@ -789,11 +723,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can visit the start page', async function () {
+		it( 'Can visit the start page', async function () {
 			await StartPage.Visit( driver, StartPage.getStartURL( { culture: locale } ) );
 		} );
 
-		step( 'Can then enter account details and continue', async function () {
+		it( 'Can then enter account details and continue', async function () {
 			const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
@@ -803,41 +737,35 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			);
 		} );
 
-		step(
-			'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
-			async function () {
-				// const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
-				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
-				// See https://github.com/Automattic/wp-calypso/pull/38641/
-				// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
-				// 	expectedBlogAddresses,
-				// 	blogName
-				// );
-				// const actualAddress = await findADomainComponent.freeBlogAddress();
-				// assert(
-				// 	expectedBlogAddresses.indexOf( actualAddress ) > -1,
-				// 	`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
-				// );
-				return await findADomainComponent.selectFreeAddress();
-			}
-		);
+		it( 'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results', async function () {
+			// const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
+			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
+			// See https://github.com/Automattic/wp-calypso/pull/38641/
+			// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
+			// 	expectedBlogAddresses,
+			// 	blogName
+			// );
+			// const actualAddress = await findADomainComponent.freeBlogAddress();
+			// assert(
+			// 	expectedBlogAddresses.indexOf( actualAddress ) > -1,
+			// 	`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
+			// );
+			return await findADomainComponent.selectFreeAddress();
+		} );
 
-		step( 'Can then see the plans page and pick the free plan', async function () {
+		it( 'Can then see the plans page and pick the free plan', async function () {
 			const pickAPlanPage = await PickAPlanPage.Expect( driver );
 			return await pickAPlanPage.selectFreePlan();
 		} );
 
-		step(
-			'Can then see the sign up processing page which will finish automatically move along',
-			async function () {
-				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
-			}
-		);
+		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
+			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+		} );
 
 		sharedSteps.canSeeTheOnboardingChecklist();
 
-		step( 'Can update the homepage', async function () {
+		it( 'Can update the homepage', async function () {
 			// Skipping if IE11 due to JS errors caused by missing DOMRect polyfill.
 			// See https://github.com/Automattic/wp-calypso/issues/40502
 			if ( dataHelper.getTargetType() === 'IE11' ) {
@@ -880,7 +808,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can enter the onboarding flow with vertical set', async function () {
+		it( 'Can enter the onboarding flow with vertical set', async function () {
 			await StartPage.Visit(
 				driver,
 				StartPage.getStartURL( {
@@ -891,7 +819,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			);
 		} );
 
-		step( 'Can then enter account details and continue', async function () {
+		it( 'Can then enter account details and continue', async function () {
 			const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
@@ -901,51 +829,45 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			);
 		} );
 
-		step( 'Can see the "Site Type" page, and enter some site information', async function () {
+		it( 'Can see the "Site Type" page, and enter some site information', async function () {
 			const siteTypePage = await SiteTypePage.Expect( driver );
 			return await siteTypePage.selectBlogType();
 		} );
 
-		step( 'Can see the "Site title" page, and enter the site title', async function () {
+		it( 'Can see the "Site title" page, and enter the site title', async function () {
 			const siteTitlePage = await SiteTitlePage.Expect( driver );
 			await siteTitlePage.enterSiteTitle( blogName );
 			return await siteTitlePage.submitForm();
 		} );
 
-		step(
-			'Can then see the domains page, and Can search for a blog name, can see and select a free .art.blog address in the results',
-			async function () {
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
-				await findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
-				// More details: https://github.com/Automattic/wp-calypso/pull/35347
-				// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
-				// 	expectedDomainName,
-				// 	blogName
-				// );
-				const actualAddress = await findADomainComponent.freeBlogAddress();
-				assert(
-					expectedDomainName.indexOf( actualAddress ) > -1,
-					`The displayed blog address: '${ actualAddress }' was not the expected addresses: '${ expectedDomainName }'`
-				);
-				return await findADomainComponent.selectFreeAddress();
-			}
-		);
+		it( 'Can then see the domains page, and Can search for a blog name, can see and select a free .art.blog address in the results', async function () {
+			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			await findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
+			// More details: https://github.com/Automattic/wp-calypso/pull/35347
+			// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
+			// 	expectedDomainName,
+			// 	blogName
+			// );
+			const actualAddress = await findADomainComponent.freeBlogAddress();
+			assert(
+				expectedDomainName.indexOf( actualAddress ) > -1,
+				`The displayed blog address: '${ actualAddress }' was not the expected addresses: '${ expectedDomainName }'`
+			);
+			return await findADomainComponent.selectFreeAddress();
+		} );
 
-		step( 'Can then see the plans page and pick the free plan', async function () {
+		it( 'Can then see the plans page and pick the free plan', async function () {
 			const pickAPlanPage = await PickAPlanPage.Expect( driver );
 			return await pickAPlanPage.selectFreePlan();
 		} );
 
-		step(
-			'Can then see the sign up processing page which will finish automatically move along',
-			async function () {
-				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
-			}
-		);
+		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
+			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+		} );
 
 		sharedSteps.canSeeTheOnboardingChecklist();
 
-		step( 'Can delete site', async function () {
+		it( 'Can delete site', async function () {
 			const sidebarComponent = await SidebarComponent.Expect( driver );
 			await sidebarComponent.selectSettings();
 			const settingsPage = await SettingsPage.Expect( driver );
@@ -965,7 +887,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can enter the account flow and see the account details page', async function () {
+		it( 'Can enter the account flow and see the account details page', async function () {
 			await StartPage.Visit(
 				driver,
 				StartPage.getStartURL( {
@@ -976,7 +898,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			await CreateYourAccountPage.Expect( driver );
 		} );
 
-		step( 'Can then enter account details and continue', async function () {
+		it( 'Can then enter account details and continue', async function () {
 			const emailAddress = dataHelper.getEmailAddress( userName, signupInboxId );
 			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
@@ -986,25 +908,19 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			);
 		} );
 
-		step(
-			'Can then see the sign up processing page which will finish automatically move along',
-			async function () {
-				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
-			}
-		);
+		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
+			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+		} );
 
-		step(
-			'We are then on the Reader page and have no sites - we click Create Site',
-			async function () {
-				await ReaderPage.Expect( driver );
-				const navBarComponent = await NavBarComponent.Expect( driver );
-				await navBarComponent.clickMySites();
-				const noSitesComponent = await NoSitesComponent.Expect( driver );
-				return await noSitesComponent.createSite();
-			}
-		);
+		it( 'We are then on the Reader page and have no sites - we click Create Site', async function () {
+			await ReaderPage.Expect( driver );
+			const navBarComponent = await NavBarComponent.Expect( driver );
+			await navBarComponent.clickMySites();
+			const noSitesComponent = await NoSitesComponent.Expect( driver );
+			return await noSitesComponent.createSite();
+		} );
 
-		step( 'We are creating the site using the New Onboarding (Gutenboarding)', async function () {
+		it( 'We are creating the site using the New Onboarding (Gutenboarding)', async function () {
 			return await new GutenboardingFlow( driver ).createFreeSite();
 		} );
 
@@ -1020,7 +936,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can enter the reader flow and see the Reader landing page', async function () {
+		it( 'Can enter the reader flow and see the Reader landing page', async function () {
 			await StartPage.Visit(
 				driver,
 				StartPage.getStartURL( {
@@ -1031,32 +947,26 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await ReaderLandingPage.Expect( driver );
 		} );
 
-		step( 'Can choose Start Using The Reader', async function () {
+		it( 'Can choose Start Using The Reader', async function () {
 			const readerLandingPage = await ReaderLandingPage.Expect( driver );
 			return await readerLandingPage.clickStartUsingTheReader();
 		} );
 
-		step(
-			'Can see the account details page and enter account details and continue',
-			async function () {
-				const emailAddress = dataHelper.getEmailAddress( userName, signupInboxId );
-				const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
-				return await createYourAccountPage.enterAccountDetailsAndSubmit(
-					emailAddress,
-					userName,
-					passwordForTestAccounts
-				);
-			}
-		);
+		it( 'Can see the account details page and enter account details and continue', async function () {
+			const emailAddress = dataHelper.getEmailAddress( userName, signupInboxId );
+			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+			return await createYourAccountPage.enterAccountDetailsAndSubmit(
+				emailAddress,
+				userName,
+				passwordForTestAccounts
+			);
+		} );
 
-		step(
-			'Can then see the sign up processing page which will finish automatically move along',
-			async function () {
-				return await new SignUpStep( driver ).continueAlong( userName, passwordForTestAccounts );
-			}
-		);
+		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
+			return await new SignUpStep( driver ).continueAlong( userName, passwordForTestAccounts );
+		} );
 
-		step( 'We are then on the Reader page', async function () {
+		it( 'We are then on the Reader page', async function () {
 			return await ReaderPage.Expect( driver );
 		} );
 
@@ -1072,7 +982,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Signup and create site using default options', async function () {
+		it( 'Signup and create site using default options', async function () {
 			await NewPage.Visit( driver );
 
 			await new GutenboardingFlow( driver ).signupAndCreateFreeSite( { emailAddress } );

--- a/test/e2e/specs/wp-site-editor-spec.js
+++ b/test/e2e/specs/wp-site-editor-spec.js
@@ -28,26 +28,26 @@ describe( `[${ host }] Site Editor (${ screenSize }) @parallel`, function () {
 		driver = await driverManager.startBrowser();
 	} );
 
-	step( 'Can log in', async function () {
+	it( 'Can log in', async function () {
 		this.loginFlow = new LoginFlow( driver, gutenbergUser );
 		return await this.loginFlow.loginAndSelectMySite();
 	} );
 
-	step( 'Can open site editor', async function () {
+	it( 'Can open site editor', async function () {
 		const sidebarComponent = await SidebarComponent.Expect( driver );
 		return await sidebarComponent.selectSiteEditor();
 	} );
 
-	step( 'Site editor opens', async function () {
+	it( 'Site editor opens', async function () {
 		return await SiteEditorPage.Expect( driver );
 	} );
 
-	step( 'Template loads', async function () {
+	it( 'Template loads', async function () {
 		const editor = await SiteEditorComponent.Expect( driver );
 		return await editor.waitForTemplateToLoad();
 	} );
 
-	step( 'Template parts load', async function () {
+	it( 'Template parts load', async function () {
 		const editor = await SiteEditorComponent.Expect( driver );
 		return await editor.waitForTemplatePartsToLoad();
 	} );

--- a/test/e2e/specs/wp-ssr-spec.js
+++ b/test/e2e/specs/wp-ssr-spec.js
@@ -32,15 +32,15 @@ describe( 'Server-side rendering: @canary @parallel', function () {
 		await driverManager.ensureNotLoggedIn( driver );
 	} );
 
-	step( '/log-in renders on the server', async function () {
+	it( '/log-in renders on the server', async function () {
 		await ssrWorksForPage( driver, LoginPage.getLoginURL() );
 	} );
 
-	step( '/themes renders on the server', async function () {
+	it( '/themes renders on the server', async function () {
 		await ssrWorksForPage( driver, ThemesPage.getStartURL() );
 	} );
 
-	step( '/theme/twentytwenty renders on the server', async function () {
+	it( '/theme/twentytwenty renders on the server', async function () {
 		await ssrWorksForPage( driver, dataHelper.getCalypsoURL( 'theme/twentytwenty' ) );
 	} );
 } );

--- a/test/e2e/specs/wp-stats-insights-spec.js
+++ b/test/e2e/specs/wp-stats-insights-spec.js
@@ -29,12 +29,12 @@ describe( 'Stats: (' + screenSize + ') @parallel', function () {
 	} );
 
 	describe( 'Log in as user', function () {
-		step( 'Can log in as user', async function () {
+		it( 'Can log in as user', async function () {
 			this.loginFlow = new LoginFlow( driver );
 			return await this.loginFlow.login();
 		} );
 
-		step( 'Can open the sidebar', async function () {
+		it( 'Can open the sidebar', async function () {
 			const navBarComponent = await NavBarComponent.Expect( driver );
 			await navBarComponent.clickMySites();
 		} );
@@ -42,13 +42,13 @@ describe( 'Stats: (' + screenSize + ') @parallel', function () {
 		describe( 'Can navigate to the stats insights page', function () {
 			let statsPage;
 
-			step( 'Can open the stats page', async function () {
+			it( 'Can open the stats page', async function () {
 				const sidebarComponent = await SidebarComponent.Expect( driver );
 				await sidebarComponent.selectStats();
 				statsPage = await StatsPage.Expect( driver );
 			} );
 
-			step( 'Can open the stats insights page', async function () {
+			it( 'Can open the stats insights page', async function () {
 				await statsPage.openInsights();
 			} );
 		} );

--- a/test/e2e/specs/wp-theme-multisite-spec.js
+++ b/test/e2e/specs/wp-theme-multisite-spec.js
@@ -37,7 +37,7 @@ describe( `[${ host }] Themes: All sites (${ screenSize })`, function () {
 	describe( 'Preview a theme @parallel', function () {
 		this.timeout( mochaTimeOut );
 
-		step( 'Login and select themes', async function () {
+		it( 'Login and select themes', async function () {
 			this.themeSearchName = 'twenty';
 			this.expectedTheme = 'Twenty F';
 
@@ -48,7 +48,7 @@ describe( `[${ host }] Themes: All sites (${ screenSize })`, function () {
 			await this.sidebarComponent.selectAllSitesThemes();
 		} );
 
-		step( 'can search for free themes', async function () {
+		it( 'can search for free themes', async function () {
 			this.themesPage = await ThemesPage.Expect( driver );
 			await this.themesPage.waitUntilThemesLoaded();
 			await this.themesPage.showOnlyFreeThemes();
@@ -58,33 +58,33 @@ describe( `[${ host }] Themes: All sites (${ screenSize })`, function () {
 		} );
 
 		describe( 'when a theme more button is clicked', function () {
-			step( 'click theme more button', async function () {
+			it( 'click theme more button', async function () {
 				await this.themesPage.clickNewThemeMoreButton();
 			} );
 
-			step( 'should show a menu', async function () {
+			it( 'should show a menu', async function () {
 				const displayed = await this.themesPage.popOverMenuDisplayed();
 				assert( displayed, 'Popover menu not displayed' );
 			} );
 
 			describe.skip( 'when "Try & Customize" is clicked', function () {
-				step( 'click try and customize popover', async function () {
+				it( 'click try and customize popover', async function () {
 					await this.themesPage.clickPopoverItem( 'Try & Customize' );
 					this.siteSelector = await SiteSelectorComponent.Expect( driver );
 				} );
 
-				step( 'should show the site selector', async function () {
+				it( 'should show the site selector', async function () {
 					const siteSelectorShown = await this.siteSelector.displayed();
 					return assert( siteSelectorShown, 'The site selector was not shown' );
 				} );
 
 				describe( 'when a site is selected, and Customize is clicked', function () {
-					step( 'select first site', async function () {
+					it( 'select first site', async function () {
 						await this.siteSelector.selectFirstSite();
 						await this.siteSelector.ok();
 					} );
 
-					step( 'should open the customizer with the selected site and theme', async function () {
+					it( 'should open the customizer with the selected site and theme', async function () {
 						this.customizerPage = await CustomizerPage.Expect( driver );
 						const url = await driver.getCurrentUrl();
 						assert( url.indexOf( this.siteSelector.selectedSiteDomain ) > -1, 'Wrong site domain' );
@@ -102,7 +102,7 @@ describe( `[${ host }] Themes: All sites (${ screenSize })`, function () {
 	describe( 'Activate a theme @parallel', function () {
 		this.timeout( mochaTimeOut );
 
-		step( 'Login and select themes', async function () {
+		it( 'Login and select themes', async function () {
 			this.themeSearchName = 'twenty';
 			this.expectedTheme = 'Twenty F';
 
@@ -113,7 +113,7 @@ describe( `[${ host }] Themes: All sites (${ screenSize })`, function () {
 			await this.sidebarComponent.selectAllSitesThemes();
 		} );
 
-		step( 'can search for free themes', async function () {
+		it( 'can search for free themes', async function () {
 			this.themesPage = await ThemesPage.Expect( driver );
 			await this.themesPage.waitUntilThemesLoaded();
 			await this.themesPage.showOnlyFreeThemes();
@@ -124,39 +124,39 @@ describe( `[${ host }] Themes: All sites (${ screenSize })`, function () {
 		} );
 
 		describe( 'when a theme more button is clicked', function () {
-			step( 'click new theme more button', async function () {
+			it( 'click new theme more button', async function () {
 				await this.themesPage.clickNewThemeMoreButton();
 			} );
 
-			step( 'should show a menu', async function () {
+			it( 'should show a menu', async function () {
 				const displayed = await this.themesPage.popOverMenuDisplayed();
 				assert( displayed, 'Popover menu not displayed' );
 			} );
 
 			describe( 'when Activate is clicked', function () {
-				step( 'can click activate', async function () {
+				it( 'can click activate', async function () {
 					await this.themesPage.clickPopoverItem( 'Activate' );
 					return ( this.siteSelector = await SiteSelectorComponent.Expect( driver ) );
 				} );
 
-				step( 'shows the site selector', async function () {
+				it( 'shows the site selector', async function () {
 					const siteSelectorShown = await this.siteSelector.displayed();
 					return assert( siteSelectorShown, 'The site selector was not shown' );
 				} );
 
-				step( 'can select the first site sites', async function () {
+				it( 'can select the first site sites', async function () {
 					await this.siteSelector.selectFirstSite();
 					return await this.siteSelector.ok();
 				} );
 
 				// Skip reason: https://github.com/Automattic/wp-calypso/issues/50130
 				describe.skip( 'Successful activation dialog', function () {
-					step( 'should show the successful activation dialog', async function () {
+					it( 'should show the successful activation dialog', async function () {
 						const themeDialogComponent = await ThemeDialogComponent.Expect( driver );
 						return await themeDialogComponent.goToThemeDetail();
 					} );
 
-					step( 'should show the correct theme in the current theme bar', async function () {
+					it( 'should show the correct theme in the current theme bar', async function () {
 						this.themeDetailPage = await ThemeDetailPage.Expect( driver );
 						await this.themeDetailPage.goBackToAllThemes();
 						this.currentThemeComponent = await CurrentThemeComponent.Expect( driver );
@@ -164,7 +164,7 @@ describe( `[${ host }] Themes: All sites (${ screenSize })`, function () {
 						return assert.strictEqual( name, this.currentThemeName );
 					} );
 
-					step( 'should highlight the current theme as active', async function () {
+					it( 'should highlight the current theme as active', async function () {
 						await this.themesPage.clearSearch();
 						await this.themesPage.searchFor( this.themeSearchName );
 						const name = await this.themesPage.getActiveThemeName();

--- a/test/e2e/specs/wp-theme-switch-spec.js
+++ b/test/e2e/specs/wp-theme-switch-spec.js
@@ -36,13 +36,13 @@ describe( `[${ host }] Previewing Themes: (${ screenSize })`, function () {
 	} );
 
 	describe( 'Previewing Themes @parallel @jetpack', function () {
-		step( 'Can login and select themes', async function () {
+		it( 'Can login and select themes', async function () {
 			const loginFlow = new LoginFlow( driver );
 			await loginFlow.loginAndSelectThemes();
 		} );
 
 		describe( 'Can preview free themes', function () {
-			step( 'Can select a different free theme', async function () {
+			it( 'Can select a different free theme', async function () {
 				this.themesPage = await ThemesPage.Expect( driver );
 				await this.themesPage.waitUntilThemesLoaded();
 				await this.themesPage.showOnlyFreeThemes();
@@ -51,12 +51,12 @@ describe( `[${ host }] Previewing Themes: (${ screenSize })`, function () {
 				return await this.themesPage.selectNewThemeStartingWith( 'Twenty S' );
 			} );
 
-			step( 'Can see theme details page and open the live demo', async function () {
+			it( 'Can see theme details page and open the live demo', async function () {
 				this.themeDetailPage = await ThemeDetailPage.Expect( driver );
 				return await this.themeDetailPage.openLiveDemo();
 			} );
 
-			step( 'Activate button appears on the theme preview page', async function () {
+			it( 'Activate button appears on the theme preview page', async function () {
 				this.themePreviewPage = await ThemePreviewPage.Expect( driver );
 				await this.themePreviewPage.activateButtonVisible();
 			} );
@@ -75,18 +75,18 @@ describe( `[${ host }] Activating Themes: (${ screenSize }) @parallel`, function
 	} );
 
 	describe( 'Activating Themes:', function () {
-		step( 'Login', async function () {
+		it( 'Login', async function () {
 			const loginFlow = new LoginFlow( driver );
 			return await loginFlow.loginAndSelectMySite( null, { useFreshLogin: true } );
 		} );
 
-		step( 'Can open Themes menu', async function () {
+		it( 'Can open Themes menu', async function () {
 			const sidebarComponent = await SidebarComponent.Expect( driver );
 			return await sidebarComponent.selectThemes();
 		} );
 
 		describe( 'Can switch free themes', function () {
-			step( 'Can activate a different free theme', async function () {
+			it( 'Can activate a different free theme', async function () {
 				const themesPage = await ThemesPage.Expect( driver );
 				await themesPage.waitUntilThemesLoaded();
 				await themesPage.showOnlyFreeThemes();
@@ -98,22 +98,22 @@ describe( `[${ host }] Activating Themes: (${ screenSize }) @parallel`, function
 				return await themesPage.clickPopoverItem( 'Activate' );
 			} );
 
-			step( 'Can see the theme thanks dialog', async function () {
+			it( 'Can see the theme thanks dialog', async function () {
 				const themeDialogComponent = await ThemeDialogComponent.Expect( driver );
 				await themeDialogComponent.customizeSite();
 			} );
 
 			if ( host === 'WPCOM' ) {
-				step( 'Can customize the site from the theme thanks dialog', async function () {
+				it( 'Can customize the site from the theme thanks dialog', async function () {
 					return await CustomizerPage.Expect( driver );
 				} );
 			} else {
-				step( 'Can log in via Jetpack SSO', async function () {
+				it( 'Can log in via Jetpack SSO', async function () {
 					const wpAdminLogonPage = await WPAdminLogonPage.Expect( driver );
 					return await wpAdminLogonPage.logonSSO();
 				} );
 
-				step( 'Can customize the site from the theme thanks dialog', async function () {
+				it( 'Can customize the site from the theme thanks dialog', async function () {
 					await WPAdminCustomizerPage.refreshIfJNError( driver );
 					return await WPAdminCustomizerPage.Expect( driver );
 				} );

--- a/yarn.lock
+++ b/yarn.lock
@@ -18467,11 +18467,6 @@ mocha-junit-reporter@^2.0.0:
     strip-ansi "^4.0.0"
     xml "^1.0.0"
 
-mocha-steps@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/mocha-steps/-/mocha-steps-1.3.0.tgz#2449231ec45ec56810f65502cb22e2571862957f"
-  integrity sha512-KZvpMJTqzLZw3mOb+EEuYi4YZS41C9iTnb7skVFRxHjUd1OYbl64tCMSmpdIRM9LnwIrSOaRfPtNpF5msgv6Eg==
-
 mocha-teamcity-reporter@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/mocha-teamcity-reporter/-/mocha-teamcity-reporter-3.0.0.tgz#2c4776288f23dac61aa0fee5930571cc2a51df1a"


### PR DESCRIPTION
#### Background

To understand the goal of this PR it is good to have some background on how Magellan and Mocha work:

* When Magellan starts it will run find all `describe` blocks tagged with `@parallel`. Then, it wil send each `@parallel` block to a separate Mocha process. This means that form Mocha's point of view, there is one and only one suite being run.

* `mocha-steps` implements `step` as a replacement for `it`. The main benefit is that when a `step` fails, it will skip the rest of `step` tests in the same `describe` block.

* By default, whenan `it` block fails, other `it` blocks in the same `describe` block will continue running. This behaviour can be changed with the `--bail` flag, so when an `it` fails, the whole test is aborted.

With that in mind, I think `mocha-steps` is redundant for us: as Mocha is running only one suite tagged with `@parallel`, aborting it when a test fails (i.e. use `--bail`) is virtually the same than using `step`.

There is a caveat to consider: nested describe blocks. Imagine there is a `@parallel` block that has two `describe` blocks inside. When using `it`+`--bail`, it will not run the second `describe` block if the first one fails. When using `step` it will still run the second `describe` block. 

With the current behaviour both `describe` blocks may fail. In general, there may be more than one failing tests per Mocha run. This makes capturing screenshots, video recordings and logs from tests more complicated, as now you need to make sure you don't overwrite files from previous tests in the same Mocha process. 

#### Changes proposed in this Pull Request

* Drop `mocha-steps` and use `it` + `--bail` instead.

#### Testing instructions

* Check e2e tests still pass.