### PR TITLE
Rename isSwitched to isRelatedContentEnabled in toggle button

### DIFF
--- a/client/my-sites/email/email-provider-features/toggle-button.js
+++ b/client/my-sites/email/email-provider-features/toggle-button.js
@@ -11,21 +11,21 @@ import { useTranslate } from 'i18n-calypso';
  */
 import { Button } from '@automattic/components';
 
-function EmailProviderFeaturesToggleButton( { handleClick, isSwitched } ) {
+function EmailProviderFeaturesToggleButton( { handleClick, isRelatedContentExpanded } ) {
 	const translate = useTranslate();
 
 	return (
 		<Button className="email-provider-features__toggle-button" onClick={ handleClick }>
 			<span>{ translate( 'Learn more' ) }</span>
 
-			<Gridicon icon={ isSwitched ? 'chevron-up' : 'chevron-down' } />
+			<Gridicon icon={ isRelatedContentExpanded ? 'chevron-up' : 'chevron-down' } />
 		</Button>
 	);
 }
 
 EmailProviderFeaturesToggleButton.propTypes = {
 	handleClick: PropTypes.func.isRequired,
-	isSwitched: PropTypes.bool.isRequired,
+	isRelatedContentExpanded: PropTypes.bool.isRequired,
 };
 
 export default EmailProviderFeaturesToggleButton;

--- a/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
@@ -87,7 +87,7 @@ function EmailProviderCard( {
 				{ showFeaturesToggleButton && (
 					<EmailProviderFeaturesToggleButton
 						handleClick={ () => setFeaturesExpanded( ! areFeaturesExpanded ) }
-						isSwitched={ areFeaturesExpanded }
+						isRelatedContentExpanded={ areFeaturesExpanded }
 					/>
 				) }
 			</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR changes the name of the `isSwitched` prop to `isRelatedContentEnabled` as per the discussion in #52621

#### Testing instructions

* Run the code for this branch using a local development environment or the [live branch](https://calypso.live/?branch=update/email-toggle-button-prop-name)
* Navigate to Upgrades -> Domains  and click on "Add Email" for a domain that doesn't have email yet
* Reduce the width of your browser window to ensure that the "Learn more" button appears instead of the feature list.
* Verify that clicking on the button expands and contracts the related content appropriately

Related to #52621 
