### PR TITLE
Remove trailing whitespace below Google card in email comparison page

### DIFF
--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -171,6 +171,10 @@
 				margin-top: 0;
 			}
 
+			> .form-fieldset {
+				margin-bottom: 0;
+			}
+
 			.titan-new-mailbox-list__actions {
 				justify-content: space-between;
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes an unintended margin from the Google Workspace card in the email comparison page

#### Testing instructions

* Load Calypso for this branch via a local dev environment or via the [live branch](https://calypso.live/?branch=fix/trailing-space-in-email-comparison-page).
* Navigate to Upgrades -> Domains for a site that has domains without email.
* For one such domain, click on the "Add Email" button.
* Verify that there isn't a trailing space below the user/mailbox form for the Google card -- this is easier to see on narrower screen widths.

#### Screenshots

##### Before
<img width="611" alt="Screenshot 2021-05-07 at 11 39 01" src="https://user-images.githubusercontent.com/3376401/117431118-24273000-af29-11eb-8ff9-0a973add7b95.png">

##### After
<img width="611" alt="Screenshot 2021-05-07 at 11 38 37" src="https://user-images.githubusercontent.com/3376401/117431136-2ab5a780-af29-11eb-8d26-691747efc86c.png">
