### PR TITLE
Jetpack: add external link to Customizer sidebar item

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -500,7 +500,7 @@ export class MySitesSidebar extends Component {
 						link={ this.props.customizeUrl }
 						onNavigate={ this.trackCustomizeClick }
 						preloadSectionName="customize"
-						forceInternalLink
+						forceInternalLink={ ! this.props.isJetpack || this.props.isAtomicSite }
 						expandSection={ this.expandDesignSection }
 					/>
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add external link to Customizer sidebar item.

Right now, customers managing Jetpack non-Atomic sites will have a hard time with the experience associated with customizing a site:

* Their flow starts on WordPress.com, clicking the `Customize` item under `Design`.
* They're redirected to `SITE_URL/wp-admin/customize.php?return=CALYPSO_RETURN_URL`.
* When closing the Customizer they're dropped on their site / `SITE_URL`.

So they go through 3 different interfaces and end up on a different one than what they started with. This addition should help with setting a more precise expectation of what happens with the Customizer menu item.

Thanks @mmtr for the help in finding the exact place where this is happening!

#### Testing instructions

1. Fire up this PR.
1. Open http://calypso.localhost:3000/ and select a Jetpack site.
1. Ensure the external icon _**is visible**_.
1. Repeat step 2-3 with a Simple and an Atomic site, appending `?disable-nav-unification` to the URLs and ensuring the icon is **_not_** displayed in these scenarios.


#### Screenshots - Jetpack

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/117444646-a4ea2a00-af31-11eb-8e9d-929126031e20.png) | ![image](https://user-images.githubusercontent.com/390760/117444668-addafb80-af31-11eb-9dff-35073fb569d3.png)

#### Screenshots - Simple

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/117445036-22159f00-af32-11eb-8a66-afe7649b9d70.png) | ![image](https://user-images.githubusercontent.com/390760/117445101-378ac900-af32-11eb-90d1-6838f4b1fa38.png)

#### Screenshots - Atomic

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/117445282-6bfe8500-af32-11eb-9f73-ef6b9cd86f7e.png) | ![image](https://user-images.githubusercontent.com/390760/117445336-7a4ca100-af32-11eb-9e79-b3c8fb46bb2c.png)
