### PR TITLE
Design Picker: give Blank Canvas designs thumbs a title

### DIFF
--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -84,7 +84,11 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 					{ 'design-picker__image-frame-blank': isBlankCanvas }
 				) }
 			>
-				{ ! isBlankCanvas && (
+				{ isBlankCanvas ? (
+					<div className="design-picker__image-frame-blank-canvas__title">
+						{ __( 'Blank Canvas' ) }
+					</div>
+				) : (
 					<div className="design-picker__image-frame-inside">
 						<DesignPreviewImage design={ design } locale={ locale } />
 					</div>

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -122,6 +122,16 @@
 
 	.design-picker__image-frame-blank {
 		background: var( --studio-white );
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding-top: 32.5%; // 65% Aspect ratio for the picker divided by two
+		padding-bottom: 32.5%; // 65% Aspect ratio for the picker divided by two
+	}
+
+	.design-picker__image-frame-blank-canvas__title {
+		color: var( --studio-gray-40 );
+		font-weight: 600;
 	}
 
 	.design-picker__image-frame-inside {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The title says it all.

<img width="494" alt="image" src="https://user-images.githubusercontent.com/87168/118472712-cf966880-b711-11eb-90f4-4dc508921a2f.png">


#### Testing
1. Visit https://hash-11c8f4ca3d96acfdacf02439dd6506006be45df2.calypso.live/new/?flags=gutenboarding/alpha-templates
2. Advance to the design step.
3. Blank canvas should be first and should have a title in the middle of the thumbnail.