### PR TITLE
Signup: show Skip button above DesignPicker

### DIFF
--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/_breakpoints.scss';
+@import '~@wordpress/base-styles/_mixins.scss';
+
 .step-wrapper__skip-hr {
 	background: var( --color-primary-light );
 	max-width: 270px;
@@ -22,33 +25,7 @@
 }
 
 .step-wrapper__buttons.is-top-buttons {
-	text-align: center;
-	padding: 5px 0;
-	margin-bottom: 32px;
-}
-
-.step-wrapper__buttons.is-top-buttons .step-wrapper__skip-wrapper {
-	display: inline-block;
-	background: var( --color-surface );
-	border-radius: 2px;
-	padding: 2px 12px;
-	@include elevation ( 2dp );
-}
-
-.step-wrapper__buttons.is-top-buttons .step-wrapper__skip-heading {
-	display: inline;
-	color: var( --color-text );
-}
-
-.step-wrapper__buttons.is-top-buttons .navigation-link {
-	color: var( --color-accent );
-	text-decoration: underline;
-	transform: none;
-	vertical-align: baseline;
-	margin-left: 0.5em;
-	padding: 7px 0 9px !important;
-}
-
-.step-wrapper__buttons.is-top-buttons .navigation-link svg {
-	display: none;
+	@include break-mobile {
+		margin-top: 20px;
+	}
 }

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -77,6 +77,7 @@ class DesignPickerStep extends Component {
 				fallbackSubHeaderText={ subHeaderText }
 				subHeaderText={ subHeaderText }
 				stepContent={ this.renderDesignPicker() }
+				isTopButtons
 				{ ...this.props }
 			/>
 		);

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -29,10 +29,6 @@
 		@include break-mobile {
 			margin-top: 32px;
 		}
-
-		@include break-medium {
-			margin-top: 48px;
-		}
 	}
 
 	// Ugly, but necessary to cancel out some signup styles

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -6,6 +6,34 @@
 	max-width: 720px;
 }
 
+// Custom styles for the Skip button in the context of Domains step
+// They are applied only when redering <StepWrapper /> with prop hideSkip={false}
+.signup__step.is-domains .step-wrapper__buttons .step-wrapper__skip-wrapper {
+	display: inline-block;
+	background: var( --color-surface );
+	border-radius: 2px;
+	padding: 2px 12px;
+	@include elevation ( 2dp );
+
+	.navigation-link {
+		color: var( --color-accent );
+		text-decoration: underline;
+		transform: none;
+		vertical-align: baseline;
+		margin-left: 0.5em;
+		padding: 7px 0 9px !important;
+	}
+
+	.navigation-link svg {
+		display: none;
+	}
+
+	.step-wrapper__skip-heading {
+		display: inline;
+		color: var( --color-text );
+	}
+}
+
 .is-section-signup .domains__step-content {
 	margin-bottom: 50px;
 


### PR DESCRIPTION
Blocked until we integrate Design step after checkout or only in the Free flow. See pd2I8q-4K-p2

### Changes proposed in this Pull Request

* Make Skip button move visible by displaying it above the design options

<img width="1024" alt="Screenshot 2021-05-07 at 15 29 12" src="https://user-images.githubusercontent.com/14192054/117456375-cad2f700-af50-11eb-993b-2890e466d51a.png">

#### Technical changes
* Fix signup top Skip button to be re-used in other steps.
  * Update Domains step to add custom CSS when rendered with a Skip button
  * Cleanup custom CSS from step-wrapper so 'is-top-buttons' is not changing colours, padding and other styles.

### Testing instructions

* Go to `/start/with-design-picker/design`
* Skip button should be displayed at the top of the page as illustrated above

**Regression testing**

* Manually set `hideSkip={ false }` when rendering `<StepWrapper />` in [client/signup/steps/domains](https://github.com/Automattic/wp-calypso/blob/update/signup-step-wrapper-skip/client/signup/steps/domains/index.jsx#L809)
* Go to `/start/domains`

<img width="600" alt="Screenshot 2021-05-07 at 15 28 53" src="https://user-images.githubusercontent.com/14192054/117456497-ed651000-af50-11eb-8ae5-dee0a8bc59c6.png">

* Manually set `isTopButtons={true}` when rendering `<StepWrapper />` in [client/signup/steps/domains](https://github.com/Automattic/wp-calypso/blob/update/signup-step-wrapper-skip/client/signup/steps/domains/index.jsx#L810)
* Go to `/start/domains`

<img width="600" alt="Screenshot 2021-05-07 at 15 37 39" src="https://user-images.githubusercontent.com/14192054/117456589-0b327500-af51-11eb-8287-5e36589ddf65.png">

Fixes https://github.com/Automattic/wp-calypso/issues/52633