### PR TITLE
E2E: Try 'wait' proxy for better error stack

### DIFF
--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -47,19 +47,18 @@ const until = {
 
 		return new WebElementCondition(
 			`for element to be clickable ${ locatorStr }`,
-			async function () {
-				return null;
-				// try {
-				// 	const element = await waitUntilElementStopsMoving( driver, locator );
-				// 	const isEnabled = await element.isEnabled();
-				// 	const isAriaEnabled = await element
-				// 		.getAttribute( 'aria-disabled' )
-				// 		.then( ( v ) => v !== 'true' );
+			async function ( driver ) {
+				try {
+					const element = await waitUntilElementStopsMoving( driver, locator );
+					const isEnabled = await element.isEnabled();
+					const isAriaEnabled = await element
+						.getAttribute( 'aria-disabled' )
+						.then( ( v ) => v !== 'true' );
 
-				// 	return isEnabled && isAriaEnabled ? element : null;
-				// } catch {
-				// 	return null;
-				// }
+					return isEnabled && isAriaEnabled ? element : null;
+				} catch {
+					return null;
+				}
 			}
 		);
 	},
@@ -75,7 +74,7 @@ const until = {
  * @returns {Promise<WebElement>} A promise that will be resolved with
  * the clicked element
  */
-export async function clickWhenClickable( driver, locator, timeout = 1 ) {
+export async function clickWhenClickable( driver, locator, timeout = explicitWaitMS ) {
 	const element = await driver.wait( until.elementIsClickable( locator ), timeout );
 
 	try {

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -47,18 +47,19 @@ const until = {
 
 		return new WebElementCondition(
 			`for element to be clickable ${ locatorStr }`,
-			async function ( driver ) {
-				try {
-					const element = await waitUntilElementStopsMoving( driver, locator );
-					const isEnabled = await element.isEnabled();
-					const isAriaEnabled = await element
-						.getAttribute( 'aria-disabled' )
-						.then( ( v ) => v !== 'true' );
+			async function () {
+				return null;
+				// try {
+				// 	const element = await waitUntilElementStopsMoving( driver, locator );
+				// 	const isEnabled = await element.isEnabled();
+				// 	const isAriaEnabled = await element
+				// 		.getAttribute( 'aria-disabled' )
+				// 		.then( ( v ) => v !== 'true' );
 
-					return isEnabled && isAriaEnabled ? element : null;
-				} catch {
-					return null;
-				}
+				// 	return isEnabled && isAriaEnabled ? element : null;
+				// } catch {
+				// 	return null;
+				// }
 			}
 		);
 	},
@@ -74,7 +75,7 @@ const until = {
  * @returns {Promise<WebElement>} A promise that will be resolved with
  * the clicked element
  */
-export async function clickWhenClickable( driver, locator, timeout = explicitWaitMS ) {
+export async function clickWhenClickable( driver, locator, timeout = 1 ) {
 	const element = await driver.wait( until.elementIsClickable( locator ), timeout );
 
 	try {

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -47,18 +47,19 @@ const until = {
 
 		return new WebElementCondition(
 			`for element to be clickable ${ locatorStr }`,
-			async function ( driver ) {
-				try {
-					const element = await waitUntilElementStopsMoving( driver, locator );
-					const isEnabled = await element.isEnabled();
-					const isAriaEnabled = await element
-						.getAttribute( 'aria-disabled' )
-						.then( ( v ) => v !== 'true' );
+			async function () {
+				return null;
+				// try {
+				// 	const element = await waitUntilElementStopsMoving( driver, locator );
+				// 	const isEnabled = await element.isEnabled();
+				// 	const isAriaEnabled = await element
+				// 		.getAttribute( 'aria-disabled' )
+				// 		.then( ( v ) => v !== 'true' );
 
-					return isEnabled && isAriaEnabled ? element : null;
-				} catch {
-					return null;
-				}
+				// 	return isEnabled && isAriaEnabled ? element : null;
+				// } catch {
+				// 	return null;
+				// }
 			}
 		);
 	},

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -47,19 +47,18 @@ const until = {
 
 		return new WebElementCondition(
 			`for element to be clickable ${ locatorStr }`,
-			async function () {
-				return null;
-				// try {
-				// 	const element = await waitUntilElementStopsMoving( driver, locator );
-				// 	const isEnabled = await element.isEnabled();
-				// 	const isAriaEnabled = await element
-				// 		.getAttribute( 'aria-disabled' )
-				// 		.then( ( v ) => v !== 'true' );
+			async function ( driver ) {
+				try {
+					const element = await waitUntilElementStopsMoving( driver, locator );
+					const isEnabled = await element.isEnabled();
+					const isAriaEnabled = await element
+						.getAttribute( 'aria-disabled' )
+						.then( ( v ) => v !== 'true' );
 
-				// 	return isEnabled && isAriaEnabled ? element : null;
-				// } catch {
-				// 	return null;
-				// }
+					return isEnabled && isAriaEnabled ? element : null;
+				} catch {
+					return null;
+				}
 			}
 		);
 	},

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -281,8 +281,8 @@ export async function startBrowser( {
 		await resizeBrowser( driver, screenSize );
 	}
 
-	// return driver;
-	return createDriverProxy( driver );
+	return driver;
+	// return createDriverProxy( driver );
 }
 
 export async function resizeBrowser( driver, screenSize ) {

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -281,7 +281,6 @@ export async function startBrowser( {
 		await resizeBrowser( driver, screenSize );
 	}
 
-	// return driver;
 	return createDriverProxy( driver );
 }
 

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -281,8 +281,8 @@ export async function startBrowser( {
 		await resizeBrowser( driver, screenSize );
 	}
 
-	return driver;
-	// return createDriverProxy( driver );
+	// return driver;
+	return createDriverProxy( driver );
 }
 
 export async function resizeBrowser( driver, screenSize ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

One of the most common errors is the `TimeoutError` thrown by the `driver.wait()` call. When the `wait` call is not wrapped with the `try/catch & re-throw` block, the error has a very poor stack, which makes it difficult to debug:
```
TimeoutError: Waiting for element to be clickable By(css selector, header.masterbar a.masterbar__item)
Wait timed out after 20136ms
    at /Automattic/wp-calypso/node_modules/selenium-webdriver/lib/webdriver.js:842:17
    # (yes, that's it)
```
(See [this example build](https://teamcity.a8c.com/viewLog.html?buildId=6178402&buildTypeId=calypso_RunCalypsoE2eDesktopTests) where that error is thrown)

We could address this issue by wrapping all the `wait` calls with try/catch and re-throwing the error, but that didn't sound to me like an optimal solution because it would require us to remember doing that every time we call `wait`, and a lot of the current `wait`s to refactor. Instead, I created a driver proxy that hooks up to the `wait` which produces basically the same stack, only now we don't need to do any extra wrapping. Here's the same error re-thrown via the proxied call:

```
Error: TimeoutError: Waiting for element to be clickable By(css selector, a.masterbar__item-new)
Wait timed out after 20189ms
      at Proxy.<anonymous> (lib/driver-manager.js:104:14)
      at async Proxy.clickWhenClickable (lib/driver-helper.js:79:18)
      at async NavBarComponent.clickCreateNewPost (lib/components/nav-bar-component.js:19:3)
      at async LoginFlow.loginAndStartNewPost (lib/flows/login-flow.js:132:3)
      at async Context.<anonymous> (specs/wp-likes-spec.js:44:4)
```
(See [this example build](https://teamcity.a8c.com/viewLog.html?buildId=6178617&buildTypeId=calypso_RunCalypsoE2eDesktopTests) where that error is thrown)


#### Testing instructions

All specs should pass.