### PR TITLE
i18n: Use `defaultI18n` from `@wordpress/i18n` for `I18nProvider`

### DIFF
--- a/client/components/calypso-i18n-provider/index.tsx
+++ b/client/components/calypso-i18n-provider/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import * as React from 'react';
-import { createI18n, setLocaleData as setWpI18nLocaleData } from '@wordpress/i18n';
+import { defaultI18n } from '@wordpress/i18n';
 import { I18nProvider } from '@wordpress/react-i18n';
 import i18n from 'i18n-calypso';
 import { LocaleProvider, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
@@ -10,15 +10,9 @@ import { LocaleProvider, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
 const CalypsoI18nProvider: React.FunctionComponent = ( { children } ) => {
 	const [ localeSlug, setLocaleSlug ] = React.useState( i18n.getLocaleSlug() );
 
-	// Create a new @wordpress/i18n instance when the locale changes,
-	// as `setLocaleData` doesn't replace the entire locale data, but rather merges it with the existing one,
-	// which may lead to residue translations from previous locales to remain causing displaying mixed up translations.
-	const wpI18n = React.useMemo( () => createI18n( i18n.getLocale() ), [ localeSlug ] );
-
 	React.useEffect( () => {
 		const onChange = () => {
-			setWpI18nLocaleData( i18n.getLocale() );
-			wpI18n.setLocaleData( i18n.getLocale() );
+			defaultI18n.setLocaleData( i18n.getLocale() );
 			setLocaleSlug( i18n.getLocaleSlug() );
 		};
 
@@ -27,11 +21,15 @@ const CalypsoI18nProvider: React.FunctionComponent = ( { children } ) => {
 		return () => {
 			i18n.off( 'change', onChange );
 		};
-	}, [ wpI18n ] );
+	}, [] );
+
+	React.useEffect( () => {
+		defaultI18n.resetLocaleData( i18n.getLocale() );
+	}, [ localeSlug ] );
 
 	return (
 		<LocaleProvider localeSlug={ localeSlug || i18nDefaultLocaleSlug }>
-			<I18nProvider i18n={ wpI18n }>{ children }</I18nProvider>
+			<I18nProvider i18n={ defaultI18n }>{ children }</I18nProvider>
 		</LocaleProvider>
 	);
 };

--- a/client/landing/gutenboarding/components/locale-context/index.tsx
+++ b/client/landing/gutenboarding/components/locale-context/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import * as React from 'react';
-import { createI18n, setLocaleData, LocaleData } from '@wordpress/i18n';
+import { defaultI18n, LocaleData } from '@wordpress/i18n';
 import { subscribe, select } from '@wordpress/data';
 import { I18nProvider } from '@wordpress/react-i18n';
 import {
@@ -53,16 +53,8 @@ export const LocaleContext: React.FunctionComponent = ( { children } ) => {
 	const [ localeDataLoaded, setLocaleDataLoaded ] = React.useState( false );
 	const localeSlug = contextLocaleData?.[ '' ]?.localeSlug ?? DEFAULT_LOCALE_SLUG;
 
-	// Create a new @wordpress/i18n instance when the locale changes,
-	// as `setLocaleData` doesn't replace the entire locale data, but rather merges it with the existing one,
-	// which may lead to residue translations from previous locales to remain causing displaying mixed up translations.
-	const wpI18n = React.useMemo( () => createI18n( contextLocaleData ), [ localeSlug ] );
-
 	const setLocale = ( newLocaleData: LocaleData | undefined ) => {
-		// Translations done within react are made using the `@wordpress/i18n` instance passed to the <I18nProvider/>.
-		// We must also set the locale for translations done outside of a react rendering cycle using setLocaleData.
-		setLocaleData( newLocaleData );
-		wpI18n.setLocaleData( newLocaleData );
+		defaultI18n.resetLocaleData( newLocaleData );
 		setContextLocaleData( newLocaleData );
 		setLocaleDataLoaded( true );
 	};
@@ -99,7 +91,7 @@ export const LocaleContext: React.FunctionComponent = ( { children } ) => {
 	return (
 		<ChangeLocaleContext.Provider value={ changeLocale }>
 			<LocaleProvider localeSlug={ localeSlug }>
-				<I18nProvider i18n={ wpI18n }>{ localeDataLoaded ? children : null }</I18nProvider>
+				<I18nProvider i18n={ defaultI18n }>{ localeDataLoaded ? children : null }</I18nProvider>
 			</LocaleProvider>
 		</ChangeLocaleContext.Provider>
 	);


### PR DESCRIPTION
With `resetLocaleData` method being added to `@wordpress/i18n@3.20.0` it's no longer needed to use private i18n instances for `I18nProvider`, since the said method can be used to reset the translation state when switching between locales.

#### Changes proposed in this Pull Request

* Remove private `@wordpress/i18n` instance and use `defaultI18n` in **CalypsoI18nProvider** component.
* Remove private `@wordpress/i18n` instance and use `defaultI18n` in Gutenboarding's **LocaleContext** component.

#### Testing instructions

* Open `calypso.live` and switch to a Mag-16 locale.
  * Browse through Calypso and confirm sections and components that are using `@wordpress/react-i18n` are translated as expected (e.g. Language picker in **Interface settings**, **Composite checkout**, etc.)
* Confirm translations are being loaded on Gutenboarding:
  * Open `calypso.live/new/{locale}`.
  * Switch to English and confirm the original strings are shown.
  * Optionally, switch to another language and confirm the strings are translated as expected.
* Review code changes.

Related to https://github.com/Automattic/wp-calypso/pull/51406#discussion_r604877352
