### PR TITLE
Theme Showcase: Move "Install theme" button into header area to be more similar to "Install plugin" button from plugins page.

### DIFF
--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -25,7 +25,6 @@ import Gridicon from 'calypso/components/gridicon';
 import './install-theme-button.scss';
 
 const InstallThemeButton = connectOptions( ( { isMultisite, isLoggedIn, siteSlug } ) => {
-	// I'm not sure if this below code is needed, or if we can enforce these conditions by only including this component in the appropriate pages.
 	if ( ! isLoggedIn || isMultisite ) {
 		return null;
 	}

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 
+import siteCanUploadThemesOrPlugins from 'calypso/state/sites/selectors/can-upload-themes-or-plugins';
 import { connectOptions } from './theme-options';
 import { translate } from 'i18n-calypso';
 import { trackClick } from './helpers';
@@ -23,8 +24,20 @@ import { Button } from '@automattic/components';
  */
 import './install-theme-button.scss';
 
+function getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) {
+	if ( ! siteSlug ) {
+		return '/themes/upload';
+	}
+
+	if ( canUploadThemesOrPlugins ) {
+		return `https://${ siteSlug }/wp-admin/theme-install.php`;
+	}
+
+	return `/themes/upload/${ siteSlug }`;
+}
+
 const InstallThemeButton = connectOptions(
-	( { isMultisite, isLoggedIn, siteSlug, dispatchTracksEvent } ) => {
+	( { isMultisite, isLoggedIn, siteSlug, dispatchTracksEvent, canUploadThemesOrPlugins } ) => {
 		if ( ! isLoggedIn || isMultisite ) {
 			return null;
 		}
@@ -38,7 +51,7 @@ const InstallThemeButton = connectOptions(
 			<Button
 				className="themes__upload-button"
 				onClick={ clickHandler }
-				href={ siteSlug ? `/themes/upload/${ siteSlug }` : '/themes/upload' }
+				href={ getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) }
 			>
 				{ translate( 'Install theme' ) }
 			</Button>
@@ -52,6 +65,7 @@ const mapStateToProps = ( state ) => {
 		siteSlug: getSelectedSiteSlug( state ),
 		isLoggedIn: isUserLoggedIn( state ),
 		isMultisite: isJetpackSiteMultiSite( state, selectedSiteId ),
+		canUploadThemesOrPlugins: siteCanUploadThemesOrPlugins( state, selectedSiteId ),
 	};
 };
 

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+
+import { connectOptions } from './theme-options';
+import { translate } from 'i18n-calypso';
+import { trackClick } from './helpers';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+	getSelectedSiteSlug,
+} from 'calypso/state/ui/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
+import { isATEnabled } from 'calypso/lib/automated-transfer';
+import { Button } from '@automattic/components';
+import Gridicon from 'calypso/components/gridicon';
+
+/**
+ * Style dependencies
+ */
+import './install-theme-button.scss';
+
+const InstallThemeButton = connectOptions( ( { isMultisite, isLoggedIn, ATEnabled, siteSlug } ) => {
+	// I'm not sure if this below code is needed, or if we can enforce these conditions by only including this component in the appropriate pages.
+	if ( ! isLoggedIn || isMultisite ) {
+		return null;
+	}
+
+	const clickHandler = () => {
+		trackClick( 'upload theme' );
+		recordTracksEvent( 'calypso_click_theme_upload' );
+		if ( ATEnabled ) {
+			recordTracksEvent( 'calypso_automated_transfer_click_theme_upload' );
+		}
+	};
+
+	return (
+		<Button
+			className="themes__upload-button"
+			onClick={ clickHandler }
+			href={ siteSlug ? `/themes/upload/${ siteSlug }` : '/themes/upload' }
+		>
+			<Gridicon icon="cloud-upload" className="themes__upload-button-gridicon" />
+			{ translate( 'Install theme' ) }
+		</Button>
+	);
+} );
+
+const mapStateToProps = ( state ) => {
+	const selectedSiteId = getSelectedSiteId( state );
+	const selectedSite = getSelectedSite( state );
+	return {
+		siteSlug: getSelectedSiteSlug( state ),
+		isLoggedIn: isUserLoggedIn( state ),
+		isMultisite: isJetpackSiteMultiSite( state, selectedSiteId ),
+		ATEnabled: isATEnabled( selectedSite ),
+	};
+};
+
+export default connect( mapStateToProps )( InstallThemeButton );

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -13,14 +13,9 @@ import { connectOptions } from './theme-options';
 import { translate } from 'i18n-calypso';
 import { trackClick } from './helpers';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import {
-	getSelectedSite,
-	getSelectedSiteId,
-	getSelectedSiteSlug,
-} from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
-import { isATEnabled } from 'calypso/lib/automated-transfer';
 import { Button } from '@automattic/components';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -29,7 +24,7 @@ import Gridicon from 'calypso/components/gridicon';
  */
 import './install-theme-button.scss';
 
-const InstallThemeButton = connectOptions( ( { isMultisite, isLoggedIn, ATEnabled, siteSlug } ) => {
+const InstallThemeButton = connectOptions( ( { isMultisite, isLoggedIn, siteSlug } ) => {
 	// I'm not sure if this below code is needed, or if we can enforce these conditions by only including this component in the appropriate pages.
 	if ( ! isLoggedIn || isMultisite ) {
 		return null;
@@ -38,9 +33,6 @@ const InstallThemeButton = connectOptions( ( { isMultisite, isLoggedIn, ATEnable
 	const clickHandler = () => {
 		trackClick( 'upload theme' );
 		recordTracksEvent( 'calypso_click_theme_upload' );
-		if ( ATEnabled ) {
-			recordTracksEvent( 'calypso_automated_transfer_click_theme_upload' );
-		}
 	};
 
 	return (
@@ -57,12 +49,10 @@ const InstallThemeButton = connectOptions( ( { isMultisite, isLoggedIn, ATEnable
 
 const mapStateToProps = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
-	const selectedSite = getSelectedSite( state );
 	return {
 		siteSlug: getSelectedSiteSlug( state ),
 		isLoggedIn: isUserLoggedIn( state ),
 		isMultisite: isJetpackSiteMultiSite( state, selectedSiteId ),
-		ATEnabled: isATEnabled( selectedSite ),
 	};
 };
 

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -17,7 +17,6 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import { Button } from '@automattic/components';
-import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Style dependencies
@@ -40,7 +39,6 @@ const InstallThemeButton = connectOptions( ( { isMultisite, isLoggedIn, siteSlug
 			onClick={ clickHandler }
 			href={ siteSlug ? `/themes/upload/${ siteSlug }` : '/themes/upload' }
 		>
-			<Gridicon icon="cloud-upload" className="themes__upload-button-gridicon" />
 			{ translate( 'Install theme' ) }
 		</Button>
 	);

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -23,26 +23,28 @@ import { Button } from '@automattic/components';
  */
 import './install-theme-button.scss';
 
-const InstallThemeButton = connectOptions( ( { isMultisite, isLoggedIn, siteSlug } ) => {
-	if ( ! isLoggedIn || isMultisite ) {
-		return null;
+const InstallThemeButton = connectOptions(
+	( { isMultisite, isLoggedIn, siteSlug, dispatchTracksEvent } ) => {
+		if ( ! isLoggedIn || isMultisite ) {
+			return null;
+		}
+
+		const clickHandler = () => {
+			trackClick( 'upload theme' );
+			dispatchTracksEvent();
+		};
+
+		return (
+			<Button
+				className="themes__upload-button"
+				onClick={ clickHandler }
+				href={ siteSlug ? `/themes/upload/${ siteSlug }` : '/themes/upload' }
+			>
+				{ translate( 'Install theme' ) }
+			</Button>
+		);
 	}
-
-	const clickHandler = () => {
-		trackClick( 'upload theme' );
-		recordTracksEvent( 'calypso_click_theme_upload' );
-	};
-
-	return (
-		<Button
-			className="themes__upload-button"
-			onClick={ clickHandler }
-			href={ siteSlug ? `/themes/upload/${ siteSlug }` : '/themes/upload' }
-		>
-			{ translate( 'Install theme' ) }
-		</Button>
-	);
-} );
+);
 
 const mapStateToProps = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
@@ -53,4 +55,8 @@ const mapStateToProps = ( state ) => {
 	};
 };
 
-export default connect( mapStateToProps )( InstallThemeButton );
+const mapDispatchToProps = ( dispatch ) => ( {
+	dispatchTracksEvent: () => dispatch( recordTracksEvent( 'calypso_click_theme_upload' ) ),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( InstallThemeButton );

--- a/client/my-sites/themes/install-theme-button.scss
+++ b/client/my-sites/themes/install-theme-button.scss
@@ -1,7 +1,3 @@
-.themes__upload-button-gridicon {
-    margin-right: 3px;
-}
-
 .has-no-sidebar .themes__upload-button {
     margin-right: 32px;
 }

--- a/client/my-sites/themes/install-theme-button.scss
+++ b/client/my-sites/themes/install-theme-button.scss
@@ -1,0 +1,3 @@
+.themes__upload-button-gridicon {
+    margin-right: 3px;
+}

--- a/client/my-sites/themes/install-theme-button.scss
+++ b/client/my-sites/themes/install-theme-button.scss
@@ -1,3 +1,7 @@
 .themes__upload-button-gridicon {
     margin-right: 3px;
 }
+
+.has-no-sidebar .themes__upload-button {
+    margin-right: 32px;
+}

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -12,10 +12,12 @@ import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
 import { connectOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
+import InstallThemeButton from './install-theme-button';
 
 const MultiSiteThemeShowcase = connectOptions( ( props ) => (
 	<Main fullWidthLayout className="themes">
 		<SidebarNavigation />
+		<InstallThemeButton />
 		<ThemesSiteSelectorModal { ...props }>
 			<ThemeShowcase source="showcase" showUploadButton={ false } />
 		</ThemesSiteSelectorModal>

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -12,7 +12,6 @@ import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
 import CurrentTheme from 'calypso/my-sites/themes/current-theme';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
-import FormattedHeader from 'calypso/components/formatted-header';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
 import config from '@automattic/calypso-config';
@@ -38,6 +37,7 @@ import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { getLastThemeQuery, getThemesFoundForQuery } from 'calypso/state/themes/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
+import ThemesHeader from './themes-header';
 
 const ConnectedThemesSelection = connectOptions( ( props ) => {
 	return (
@@ -89,13 +89,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 	return (
 		<Main fullWidthLayout className="themes">
 			<SidebarNavigation />
-			<FormattedHeader
-				brandFont
-				className="themes__page-heading"
-				headerText={ translate( 'Themes' ) }
-				subHeaderText={ translate( 'Select or update the visual design for your site.' ) }
-				align="left"
-			/>
+			<ThemesHeader />
 			<CurrentTheme siteId={ siteId } />
 			{ ! requestingSitePlans && currentPlan && ! hasUnlimitedPremiumThemes && ! isPartnerPlan && (
 				<UpsellNudge

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -11,7 +11,6 @@ import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
 import CurrentTheme from 'calypso/my-sites/themes/current-theme';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
-import FormattedHeader from 'calypso/components/formatted-header';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
 import { connectOptions } from './theme-options';
@@ -21,6 +20,7 @@ import { hasFeature, isRequestingSitePlans } from 'calypso/state/sites/plans/sel
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
+import ThemesHeader from './themes-header';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 
@@ -72,13 +72,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 	return (
 		<Main fullWidthLayout className="themes">
 			<SidebarNavigation />
-			<FormattedHeader
-				brandFont
-				className="themes__page-heading"
-				headerText={ translate( 'Themes' ) }
-				subHeaderText={ translate( 'Select or update the visual design for your site.' ) }
-				align="left"
-			/>
+			<ThemesHeader />
 			<CurrentTheme siteId={ siteId } />
 			{ bannerLocationBelowSearch ? null : upsellBanner }
 

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import { compact, pickBy } from 'lodash';
-import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
@@ -111,8 +110,6 @@ class ThemeShowcase extends React.Component {
 		getScreenshotOption: PropTypes.func,
 		siteSlug: PropTypes.string,
 		upsellBanner: PropTypes.any,
-		trackUploadClick: PropTypes.func,
-		trackATUploadClick: PropTypes.func,
 		trackMoreThemesClick: PropTypes.func,
 		loggedOutComponent: PropTypes.bool,
 	};
@@ -218,20 +215,6 @@ class ThemeShowcase extends React.Component {
 		this.scrollToSearchInput();
 	};
 
-	onUploadClick = () => {
-		trackClick( 'upload theme' );
-		this.props.trackUploadClick();
-		if ( this.props.atEnabled ) {
-			this.props.trackATUploadClick();
-		}
-	};
-
-	showUploadButton = () => {
-		const { isMultisite, isLoggedIn } = this.props;
-
-		return isLoggedIn && ! isMultisite;
-	};
-
 	render() {
 		const {
 			currentThemeId,
@@ -241,7 +224,6 @@ class ThemeShowcase extends React.Component {
 			search,
 			filter,
 			translate,
-			siteSlug,
 			isLoggedIn,
 			pathName,
 			title,
@@ -304,17 +286,6 @@ class ThemeShowcase extends React.Component {
 					/>
 				) }
 				<div className="themes__content">
-					{ this.showUploadButton() && (
-						<Button
-							className="themes__upload-button"
-							compact
-							onClick={ this.onUploadClick }
-							href={ getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) }
-						>
-							<Gridicon icon="cloud-upload" />
-							{ translate( 'Install theme' ) }
-						</Button>
-					) }
 					{ ! this.props.loggedOutComponent && ! isQueried && (
 						<>
 							<RecommendedThemes
@@ -459,8 +430,6 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
 } );
 
 const mapDispatchToProps = {
-	trackUploadClick: () => recordTracksEvent( 'calypso_click_theme_upload' ),
-	trackATUploadClick: () => recordTracksEvent( 'calypso_automated_transfer_click_theme_upload' ),
 	trackMoreThemesClick: () => recordTracksEvent( 'calypso_themeshowcase_more_themes_clicked' ),
 	openThemesShowcase: () => openThemesShowcase(),
 };

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -19,7 +19,6 @@ import { addTracking, trackClick } from './helpers';
 import DocumentHead from 'calypso/components/data/document-head';
 import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
-import siteCanUploadThemesOrPlugins from 'calypso/state/sites/selectors/can-upload-themes-or-plugins';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import ThemePreview from './theme-preview';
 import config from '@automattic/calypso-config';
@@ -46,18 +45,6 @@ import RecommendedThemes from './recommended-themes';
  * Style dependencies
  */
 import './theme-showcase.scss';
-
-function getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) {
-	if ( ! siteSlug ) {
-		return '/themes/upload';
-	}
-
-	if ( canUploadThemesOrPlugins ) {
-		return `https://${ siteSlug }/wp-admin/theme-install.php`;
-	}
-
-	return `/themes/upload/${ siteSlug }`;
-}
 
 const subjectsMeta = {
 	photo: { icon: 'camera', order: 1 },
@@ -229,7 +216,6 @@ class ThemeShowcase extends React.Component {
 			title,
 			filterString,
 			isMultisite,
-			canUploadThemesOrPlugins,
 		} = this.props;
 		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
 
@@ -426,7 +412,6 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
 	filterToTermTable: getThemeFilterToTermTable( state ),
 	hasShowcaseOpened: hasShowcaseOpenedSelector( state ),
 	themesBookmark: getThemesBookmark( state ),
-	canUploadThemesOrPlugins: siteCanUploadThemesOrPlugins( state, siteId ),
 } );
 
 const mapDispatchToProps = {

--- a/client/my-sites/themes/themes-header.jsx
+++ b/client/my-sites/themes/themes-header.jsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+
+import FormattedHeader from 'calypso/components/formatted-header';
+import { translate } from 'i18n-calypso';
+import InstallThemeButton from './install-theme-button';
+
+/**
+ * Style dependencies
+ */
+import './themes-header.scss';
+
+const ThemesHeader = () => {
+	return (
+		<div className="themes__header">
+			<FormattedHeader
+				brandFont
+				className="themes__page-heading"
+				headerText={ translate( 'Themes' ) }
+				subHeaderText={ translate( 'Select or update the visual design for your site.' ) }
+				align="left"
+			/>
+			<div className="themes__install-theme-button-container">
+				<InstallThemeButton />
+			</div>
+		</div>
+	);
+};
+
+export default ThemesHeader;

--- a/client/my-sites/themes/themes-header.scss
+++ b/client/my-sites/themes/themes-header.scss
@@ -1,8 +1,6 @@
 .themes__header {
     display: flex;
     flex: 1 1 auto;
-    justify-content: flex-start;
-    align-items: center;
 
 	.themes__page-heading {
 		width: 100%;
@@ -10,31 +8,16 @@
 }
 
 .themes__install-theme-button-container {
-	display: flex;
-	flex-direction: column;
-	justify-content: flex-end;
-	align-items: stretch;
 	margin: auto;
 	margin-right: 15px;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		flex-direction: row;
-		align-items: flex-end;
 		margin-right: 0;
 		margin-bottom: 17px;
 	}
 
 	.themes__upload-button {
 		white-space: nowrap;
-
-		&:not( :last-child ) {
-			margin-bottom: 8px;
-
-			@include breakpoint-deprecated( '>480px' ) {
-				margin-bottom: 0;
-				margin-right: 10px;
-			}
-		}
 	}
 }
 

--- a/client/my-sites/themes/themes-header.scss
+++ b/client/my-sites/themes/themes-header.scss
@@ -1,0 +1,43 @@
+.themes__header {
+    display: flex;
+    flex: 1 1 auto;
+    justify-content: flex-start;
+    align-items: center;
+
+	.themes__page-heading {
+		width: 100%;
+	}
+}
+
+.themes__install-theme-button-container {
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+	align-items: stretch;
+	margin: auto;
+	margin-right: 15px;
+
+	@include breakpoint-deprecated( '>480px' ) {
+		flex-direction: row;
+		align-items: flex-end;
+		margin-right: 0;
+		margin-bottom: 17px;
+	}
+
+	.themes__upload-button {
+		white-space: nowrap;
+
+		&:not( :last-child ) {
+			margin-bottom: 8px;
+
+			@include breakpoint-deprecated( '>480px' ) {
+				margin-bottom: 0;
+				margin-right: 10px;
+			}
+		}
+	}
+}
+
+.themes__page-heading .formatted-header__subtitle {
+    margin: 0;
+}

--- a/client/my-sites/themes/themes-header.scss
+++ b/client/my-sites/themes/themes-header.scss
@@ -1,6 +1,5 @@
 .themes__header {
     display: flex;
-    flex: 1 1 auto;
 
 	.themes__page-heading {
 		width: 100%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the 'Install theme' button above the 'Current Theme' section so that the layout of the page is more analogous to the 'Install plugin' button

[Before Desktop](https://user-images.githubusercontent.com/10274366/118141364-48768700-b3d7-11eb-8862-b2e4cc703669.png)

[Before Mobile](https://user-images.githubusercontent.com/10274366/118141291-3268c680-b3d7-11eb-92ea-aa6d78a3afdb.png)

[After Desktop](https://user-images.githubusercontent.com/10274366/118141057-fa618380-b3d6-11eb-8423-24283cddd999.png)

[After Mobile](https://user-images.githubusercontent.com/10274366/118141128-106f4400-b3d7-11eb-9d69-66b83da6bf54.png)

[Plugins Page For Reference](https://user-images.githubusercontent.com/10274366/117474846-5b95dc80-af29-11eb-9791-058a2cdb9e8f.png)

#### Testing instructions

Previously existing behavior from trunk for install theme button should be maintained, for example:
- For any view which used to have an install theme button on trunk, it should still be there on my branch.
- For any view which did NOT used to have an install theme button on trunk, it should NOT be there on my branch.
- Just as it works on trunk, when a site is selected, install theme button should link to: /themes/upload/SITE_SLUG
- Just as it works on trunk, when a site is NOT selected, install theme button should link to: /themes/upload. Clicking it will prompt you to select a site.
- Clicking the install theme button should record an `upload theme` Google analytics event
- Clicking the install theme button should record a `calypso_click_theme_upload` tracks event
- The "Install theme" text on the button should translate to other languages
- Test different browsers, screen sizes and devices at your own discretion

Views to consider:
- /themes/SITE_SLUG page for a simple site
- /themes/SITE_SLUG page for an atomic site
- /themes/SITE_SLUG page for a self-hosted multisite install connected via jetpack
- /themes page rendered via Server-side rendering
- /themes page while logged out
- /themes page while logged in (/themes page for "All my sites")

Related to #52521