### PR TITLE
Framework: Refactor away from `_.uniqueId()`

### DIFF
--- a/client/components/forms/range/index.jsx
+++ b/client/components/forms/range/index.jsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
-import { omit, uniqueId } from 'lodash';
+import { omit } from 'lodash';
 import classnames from 'classnames';
+import { v4 as uuid } from 'uuid';
 
 /**
  * Internal dependencies
@@ -37,7 +37,7 @@ export default class extends React.Component {
 	};
 
 	state = {
-		id: uniqueId( 'range' ),
+		id: 'range' + uuid(),
 	};
 
 	getMinContentElement = () => {

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -5,8 +5,9 @@ import { isMobile } from '@automattic/viewport';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { debounce, uniqueId } from 'lodash';
+import { debounce } from 'lodash';
 import i18n from 'i18n-calypso';
+import { v4 as uuid } from 'uuid';
 
 /**
  * Internal dependencies
@@ -99,7 +100,7 @@ class Search extends Component {
 	constructor( props ) {
 		super( props );
 
-		this.instanceId = uniqueId();
+		this.instanceId = uuid();
 
 		this.state = {
 			keyword: props.initialValue || '',

--- a/client/extensions/woocommerce/state/data-layer/request/actions.js
+++ b/client/extensions/woocommerce/state/data-layer/request/actions.js
@@ -11,7 +11,7 @@ import { WOOCOMMERCE_API_REQUEST } from 'woocommerce/state/action-types';
 function _createRequestAction( method, siteId, path, body, onSuccessAction, onFailureAction ) {
 	const action = {
 		type: WOOCOMMERCE_API_REQUEST,
-		requestId: 'request_' + uuid().replace( /-/g, '' ),
+		requestId: 'request_' + uuid(),
 		method,
 		siteId,
 		path,

--- a/client/extensions/woocommerce/state/data-layer/request/actions.js
+++ b/client/extensions/woocommerce/state/data-layer/request/actions.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-
-import { uniqueId } from 'lodash';
+import { v4 as uuid } from 'uuid';
 
 /**
  * Internal dependencies
@@ -12,7 +11,7 @@ import { WOOCOMMERCE_API_REQUEST } from 'woocommerce/state/action-types';
 function _createRequestAction( method, siteId, path, body, onSuccessAction, onFailureAction ) {
 	const action = {
 		type: WOOCOMMERCE_API_REQUEST,
-		requestId: uniqueId( 'request_' ),
+		requestId: 'request_' + uuid().replace( /-/g, '' ),
 		method,
 		siteId,
 		path,

--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -99,7 +99,7 @@ export const ExpandableSidebarMenu = ( {
 		setSubmenuHovered( false );
 	};
 
-	const menuId = 'menu' + uuid().replace( /-/g, '' );
+	const menuId = 'menu' + uuid();
 
 	useLayoutEffect( () => {
 		if ( submenuHovered && offScreen( submenu.current ) ) {

--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -3,7 +3,7 @@
  */
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, { useState, useRef, useLayoutEffect } from 'react';
+import React, { useMemo, useState, useRef, useLayoutEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { get } from 'lodash';
 import { v4 as uuid } from 'uuid';
@@ -99,7 +99,7 @@ export const ExpandableSidebarMenu = ( {
 		setSubmenuHovered( false );
 	};
 
-	const menuId = 'menu' + uuid();
+	const menuId = useMemo( () => 'menu' + uuid(), [] );
 
 	useLayoutEffect( () => {
 		if ( submenuHovered && offScreen( submenu.current ) ) {

--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -5,7 +5,8 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useState, useRef, useLayoutEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { get, uniqueId } from 'lodash';
+import { get } from 'lodash';
+import { v4 as uuid } from 'uuid';
 
 /**
  * Internal dependencies
@@ -98,7 +99,7 @@ export const ExpandableSidebarMenu = ( {
 		setSubmenuHovered( false );
 	};
 
-	const menuId = uniqueId( 'menu' );
+	const menuId = 'menu' + uuid().replace( /-/g, '' );
 
 	useLayoutEffect( () => {
 		if ( submenuHovered && offScreen( submenu.current ) ) {

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -12,9 +12,9 @@ import {
 	pickBy,
 	property,
 	some,
-	uniqueId,
 } from 'lodash';
 import update from 'immutability-helper';
+import { v4 as uuid } from 'uuid';
 
 function Controller( options ) {
 	if ( ! ( this instanceof Controller ) ) {
@@ -132,7 +132,7 @@ Controller.prototype.sanitize = function () {
 
 Controller.prototype.validate = function () {
 	const fieldValues = getAllFieldValues( this._currentState );
-	const id = uniqueId();
+	const id = uuid();
 
 	this._setState( setFieldsValidating( this._currentState ) );
 

--- a/client/state/terms/actions.js
+++ b/client/state/terms/actions.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { filter, get, uniqueId } from 'lodash';
+import { filter, get } from 'lodash';
+import { v4 as uuid } from 'uuid';
 
 /**
  * Internal dependencies
@@ -33,7 +34,7 @@ import 'calypso/state/terms/init';
  */
 export function addTerm( siteId, taxonomy, term ) {
 	return ( dispatch ) => {
-		const temporaryId = uniqueId( 'temporary' );
+		const temporaryId = 'temporary' + uuid().replace( /-/g, '' );
 
 		dispatch(
 			receiveTerm( siteId, taxonomy, {

--- a/client/state/terms/actions.js
+++ b/client/state/terms/actions.js
@@ -34,7 +34,7 @@ import 'calypso/state/terms/init';
  */
 export function addTerm( siteId, taxonomy, term ) {
 	return ( dispatch ) => {
-		const temporaryId = 'temporary' + uuid().replace( /-/g, '' );
+		const temporaryId = 'temporary' + uuid();
 
 		dispatch(
 			receiveTerm( siteId, taxonomy, {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `uniqueId()` can be replaced with the `uuid.v4()` function that we already use in a bunch of places in Calypso. While it's different (it produces an alphanumeric + dash sequence) from `_.uniqueId` (which produces a prefixable number), it does the job to create a unique ID arguably better than `uniqueId()` does. 

We removed the `uniqueId` instances where they were imported from `impure-lodash` in #52672, so this PR depends on it and needs to be rebased when it's merged.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all tests still pass.
* Verify `/devdocs/design/ranges` range component still works well.
* Verify `/devdocs/design/search` search components still work well.
* Pick a site and play with the sidebar menu and verify it still works well when expanded and collapsed in a menu section.
* Go to `/domains/manage/:domain/dns/:site` and verify that adding and deleting a DNS record still works well.
