### PR TITLE
ExPlat: Add message to logStash properties

### DIFF
--- a/client/lib/explat/internals/log-error.ts
+++ b/client/lib/explat/internals/log-error.ts
@@ -31,6 +31,7 @@ export const logError = ( error: Record< string, string > & { message: string } 
 				...properties,
 				context: 'explat',
 				explat_client: 'calypso',
+				message,
 			},
 		};
 

--- a/client/lib/explat/internals/test/log-error.ts
+++ b/client/lib/explat/internals/test/log-error.ts
@@ -48,6 +48,7 @@ describe( 'logError', () => {
 		        "context": "explat",
 		        "explat_client": "calypso",
 		        "foo": "bar",
+		        "message": "asdf",
 		      },
 		    },
 		  ],
@@ -62,7 +63,7 @@ describe( 'logError', () => {
 		    "https://public-api.wordpress.com/rest/v1.1/js-error",
 		    Object {
 		      "body": FormData {
-		        "error": "{\\"message\\":\\"asdf\\",\\"properties\\":{\\"foo\\":\\"bar\\",\\"context\\":\\"explat\\",\\"explat_client\\":\\"calypso\\"}}",
+		        "error": "{\\"message\\":\\"asdf\\",\\"properties\\":{\\"foo\\":\\"bar\\",\\"context\\":\\"explat\\",\\"explat_client\\":\\"calypso\\",\\"message\\":\\"asdf\\"}}",
 		      },
 		      "method": "POST",
 		    },


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `message` to logStash `properties`

To fix type problems occurring in Grafana. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Updated AT

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
