### PR TITLE
Add eslint rule on maximum top level suites in a spec file.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,6 +79,7 @@ module.exports = {
 				'mocha/no-global-tests': 'error',
 				'mocha/no-async-describe': 'error',
 				'mocha/no-top-level-hooks': 'error',
+				'mocha/max-top-level-suites': [ 'warn', { limit: 1 } ],
 				'no-console': 'off',
 				// Disable all rules from "plugin:jest/recommended", as e2e tests use mocha
 				...Object.keys( require( 'eslint-plugin-jest' ).configs.recommended.rules ).reduce(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In conjunction with foundational changes proposed at #52658 and its preceding slack discussion at p1620373126069300-slack-C01QG4Y91RR, I think this eslint rule would serve us well.

Maximum number of top level suite is set to 1.
For the time being, this rule is set to only WARN, but I am open to having it set to ERROR to encourage anyone touching test files to also break it up.

#### Testing instructions

Pull the branch and in a file, introduce multiple top level `describe` blocks then run the linter.

Parent: #51209
Related to #52658

