### PR TITLE
Delete superfluous condition in Jetpack product card button `isDisabled` prop

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -295,7 +295,7 @@ const JetpackProductCard: React.FC< Props > = ( {
 						primary={ buttonPrimary }
 						className="jetpack-product-card__button"
 						onClick={ onButtonClick }
-						disabled={ isDisabled || isDeprecated }
+						disabled={ isDeprecated }
 					>
 						{ buttonLabel }
 					</Button>


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR removes a superfluous condition in setting the `isDisabled` prop of a Jetpack product card button.

### Testing instructions


- Download the PR and run Calypso
- Visit the plans page with a Jetpack site selected
- Select a `JetpackProductCard` in the React inspector (it should be the `Components` tab in the dev tools)
- Set the prop `isDeprecated` to true, and check that the card looks like the capture below
- Set the prop `isDisabled` to true, and check that the card looks like the capture below

### Screenshots


#### Normal
<img width="497" alt="Screen Shot 2021-05-07 at 2 03 25 PM" src="https://user-images.githubusercontent.com/1620183/117491004-9d308280-af3d-11eb-8551-e2b4031cc562.png">

#### Deprecated
<img width="498" alt="Screen Shot 2021-05-07 at 2 03 53 PM" src="https://user-images.githubusercontent.com/1620183/117490998-9ace2880-af3d-11eb-974f-7cdf1706876e.png">

#### Disabled
<img width="497" alt="Screen Shot 2021-05-07 at 2 03 14 PM" src="https://user-images.githubusercontent.com/1620183/117490993-986bce80-af3d-11eb-9da9-5a7088be95a4.png">
