### PR TITLE
[TeamCity] Add build and suite for gutenberg mobile tests

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -26,7 +26,7 @@ object WPComTests : Project({
 
 fun gutenbergBuildType(screenSize: String): BuildType {
 	return BuildType {
-		id("Gutenberg")
+		id("Gutenberg_$screenSize")
 		name = "Gutenberg tests ($screenSize)"
 		description = "Runs Gutenberg E2E tests using $screenSize screen resolution"
 

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -24,8 +24,8 @@ object WPComTests : Project({
 	buildType(gutenbergBuildType("mobile"));
 })
 
-fun gutenbergBuildType(screenSize: String) {
-	return BuildType({
+fun gutenbergBuildType(screenSize: String): BuildType {
+	return BuildType {
 		id("Gutenberg")
 		name = "Gutenberg tests ($screenSize)"
 		description = "Runs Gutenberg E2E tests using $screenSize screen resolution"
@@ -42,9 +42,29 @@ fun gutenbergBuildType(screenSize: String) {
 		}
 
 		params {
-			text(name="URL", value="https://wordpress.com", label = "Test URL", description = "URL to test against", allowEmpty = false)
-			checkbox(name="GUTENBERG_EDGE", value="false", label = "Use gutenberg-edge", description = "Use a blog with gutenberg-edge sticker", checked="true", unchecked = "false")
-			checkbox(name="COBLOCKS_EDGE", value="false", label = "Use coblocks-edge", description = "Use a blog with coblocks-edge sticker", checked="true", unchecked = "false")
+			text(
+				name = "URL",
+				value = "https://wordpress.com",
+				label = "Test URL",
+				description = "URL to test against",
+				allowEmpty = false
+			)
+			checkbox(
+				name = "GUTENBERG_EDGE",
+				value = "false",
+				label = "Use gutenberg-edge",
+				description = "Use a blog with gutenberg-edge sticker",
+				checked = "true",
+				unchecked = "false"
+			)
+			checkbox(
+				name = "COBLOCKS_EDGE",
+				value = "false",
+				label = "Use coblocks-edge",
+				description = "Use a blog with coblocks-edge sticker",
+				checked = "true",
+				unchecked = "false"
+			)
 		}
 
 		steps {
@@ -158,5 +178,5 @@ fun gutenbergBuildType(screenSize: String) {
 				withPendingChangesOnly = false
 			}
 		}
-	})
+	}
 }

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -20,141 +20,143 @@ object WPComTests : Project({
 		param("build.prefix", "1")
 	}
 
-	buildType(Gutenberg)
+	buildType(gutenbergBuildType("desktop"));
+	buildType(gutenbergBuildType("mobile"));
 })
 
-private object Gutenberg : BuildType({
-	id("Gutenberg")
-	name = "Gutenberg tests (desktop)"
-	description = "Runs Gutenberg E2E tests using desktop screen resolution"
+fun gutenbergBuildType(screenSize: String) {
+	return BuildType({
+		id("Gutenberg")
+		name = "Gutenberg tests ($screenSize)"
+		description = "Runs Gutenberg E2E tests using $screenSize screen resolution"
 
-	artifactRules = """
-		reports => reports
-		logs.tgz => logs.tgz
-		screenshots => screenshots
-	""".trimIndent()
+		artifactRules = """
+			reports => reports
+			logs.tgz => logs.tgz
+			screenshots => screenshots
+		""".trimIndent()
 
-	vcs {
-		root(Settings.WpCalypso)
-		cleanCheckout = true
-	}
-
-	params {
-		text(name="URL", value="https://wordpress.com", label = "Test URL", description = "URL to test against", allowEmpty = false)
-		checkbox(name="GUTENBERG_EDGE", value="false", label = "Use gutenberg-edge", description = "Use a blog with gutenberg-edge sticker", checked="true", unchecked = "false")
-		checkbox(name="COBLOCKS_EDGE", value="false", label = "Use coblocks-edge", description = "Use a blog with coblocks-edge sticker", checked="true", unchecked = "false")
-	}
-
-	steps {
-		bashNodeScript {
-			name = "Prepare environment"
-			scriptContent = """
-				export NODE_ENV="test"
-
-				# Install modules
-				${_self.yarn_install_cmd}
-			"""
+		vcs {
+			root(Settings.WpCalypso)
+			cleanCheckout = true
 		}
-		bashNodeScript {
-			name = "Run e2e tests (desktop)"
-			scriptContent = """
-				shopt -s globstar
-				set -x
 
-				cd test/e2e
-				mkdir temp
-
-				export LIVEBRANCHES=false
-				export NODE_CONFIG_ENV=test
-				export TEST_VIDEO=true
-				export HIGHLIGHT_ELEMENT=true
-				export GUTENBERG_EDGE=%GUTENBERG_EDGE%
-				export COBLOCKS_EDGE=%COBLOCKS_EDGE%
-				export URL=%URL%
-				export BROWSERSIZE=desktop
-				export BROWSERLOCALE=en
-				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL}\"}"
-
-				# Instructs Magellan to not hide the output from individual `mocha` processes. This is required for
-				# mocha-teamcity-reporter to work.
-				export MAGELLANDEBUG=true
-
-				# Decrypt config
-				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
-
-				# Run the test
-				yarn magellan --config=magellan-gutenberg.json --max_workers=%E2E_WORKERS% --suiteTag=parallel --local_browser=chrome --mocha_args="--reporter mocha-teamcity-reporter"
-			""".trimIndent()
-			dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"
+		params {
+			text(name="URL", value="https://wordpress.com", label = "Test URL", description = "URL to test against", allowEmpty = false)
+			checkbox(name="GUTENBERG_EDGE", value="false", label = "Use gutenberg-edge", description = "Use a blog with gutenberg-edge sticker", checked="true", unchecked = "false")
+			checkbox(name="COBLOCKS_EDGE", value="false", label = "Use coblocks-edge", description = "Use a blog with coblocks-edge sticker", checked="true", unchecked = "false")
 		}
-		bashNodeScript {
-			name = "Collect results"
-			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
-			scriptContent = """
-				set -x
 
-				mkdir -p screenshots
-				find test/e2e -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
+		steps {
+			bashNodeScript {
+				name = "Prepare environment"
+				scriptContent = """
+					export NODE_ENV="test"
 
-				mkdir -p logs
-				find test/e2e -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
-			""".trimIndent()
+					# Install modules
+					${_self.yarn_install_cmd}
+				"""
+			}
+			bashNodeScript {
+				name = "Run e2e tests ($screenSize)"
+				scriptContent = """
+					shopt -s globstar
+					set -x
+
+					cd test/e2e
+					mkdir temp
+
+					export LIVEBRANCHES=false
+					export NODE_CONFIG_ENV=test
+					export TEST_VIDEO=true
+					export HIGHLIGHT_ELEMENT=true
+					export GUTENBERG_EDGE=%GUTENBERG_EDGE%
+					export COBLOCKS_EDGE=%COBLOCKS_EDGE%
+					export URL=%URL%
+					export BROWSERSIZE=$screenSize
+					export BROWSERLOCALE=en
+					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL}\"}"
+
+					# Instructs Magellan to not hide the output from individual `mocha` processes. This is required for
+					# mocha-teamcity-reporter to work.
+					export MAGELLANDEBUG=true
+
+					# Decrypt config
+					openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
+
+					# Run the test
+					yarn magellan --config=magellan-gutenberg.json --max_workers=%E2E_WORKERS% --suiteTag=parallel --local_browser=chrome --mocha_args="--reporter mocha-teamcity-reporter"
+				""".trimIndent()
+				dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"
+			}
+			bashNodeScript {
+				name = "Collect results"
+				executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+				scriptContent = """
+					set -x
+
+					mkdir -p screenshots
+					find test/e2e -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
+
+					mkdir -p logs
+					find test/e2e -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
+				""".trimIndent()
+			}
 		}
-	}
 
-	features {
-		perfmon {
+		features {
+			perfmon {
+			}
+			notifications {
+				notifierSettings = slackNotifier {
+					connection = "PROJECT_EXT_11"
+					sendTo = "#gutenberg-e2e"
+					messageFormat = verboseMessageFormat {
+						addBranch = true
+						addStatusText = true
+						maximumNumberOfChanges = 10
+					}
+				}
+				branchFilter = "+:<default>"
+				buildFailed = true
+				buildFinishedSuccessfully = true
+			}
 		}
-		notifications {
-			notifierSettings = slackNotifier {
-				connection = "PROJECT_EXT_11"
-				sendTo = "#gutenberg-e2e"
-				messageFormat = verboseMessageFormat {
-					addBranch = true
-					addStatusText = true
-					maximumNumberOfChanges = 10
+
+		failureConditions {
+			executionTimeoutMin = 20
+			// TeamCity will mute a test if it fails and then succeeds within the same build. Otherwise TeamCity UI will not
+			// display a difference between real errors and retries, making it hard to understand what is actually failing.
+			supportTestRetry = true
+
+			// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have
+			// been muted previously.
+			nonZeroExitCode = false
+
+			// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner
+			// crashes and no tests are run.
+			failOnMetricChange {
+				metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
+				threshold = 50
+				units = BuildFailureOnMetric.MetricUnit.PERCENTS
+				comparison = BuildFailureOnMetric.MetricComparison.LESS
+				compareTo = build {
+					buildRule = lastSuccessful()
 				}
 			}
-			branchFilter = "+:<default>"
-			buildFailed = true
-			buildFinishedSuccessfully = true
 		}
-	}
 
-	failureConditions {
-		executionTimeoutMin = 20
-		// TeamCity will mute a test if it fails and then succeeds within the same build. Otherwise TeamCity UI will not
-		// display a difference between real errors and retries, making it hard to understand what is actually failing.
-		supportTestRetry = true
-
-		// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have
-		// been muted previously.
-		nonZeroExitCode = false
-
-		// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner
-		// crashes and no tests are run.
-		failOnMetricChange {
-			metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
-			threshold = 50
-			units = BuildFailureOnMetric.MetricUnit.PERCENTS
-			comparison = BuildFailureOnMetric.MetricComparison.LESS
-			compareTo = build {
-				buildRule = lastSuccessful()
+		triggers {
+			schedule {
+				schedulingPolicy = daily {
+					hour = 4
+				}
+				branchFilter = """
+					+:trunk
+				""".trimIndent()
+				triggerBuild = always()
+				withPendingChangesOnly = false
 			}
 		}
-	}
-
-	triggers {
-		schedule {
-			schedulingPolicy = daily {
-				hour = 4
-			}
-			branchFilter = """
-				+:trunk
-			""".trimIndent()
-			triggerBuild = always()
-			withPendingChangesOnly = false
-		}
-	}
-
-})
+	})
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Create a factory func to DRY the creation of Gutenberg build types for different screen sizes. The screen size piece of data changes, but everything else is the same;
* Add the buildType for the mobile screen size.

Standing on the shoulder of giants -- based on the work from @scinos here (thanks!): https://github.com/Automattic/wp-calypso/pull/51965.


#### Testing instructions

TBD
