### PR TITLE
Web Preview: Update "Edit header" button copy and move to the right

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -94,10 +94,6 @@
 	color: var( --color-primary );
 	border-radius: 0;
 
-	@include break-small {
-		border-left: 1px solid var( --color-neutral-5 );
-	}
-
 	@include break-large {
 		padding: 6px 32px;
 	}

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -149,18 +149,6 @@ class PreviewToolbar extends Component {
 						) ) }
 					</SelectDropdown>
 				) }
-				{ showEditHeaderLink && canUserEditThemeOptions && (
-					<Button
-						borderless
-						aria-label={ translate( 'Edit header' ) }
-						className="web-preview__edit-header-link"
-						href={ customizeUrl }
-						onClick={ this.handleEditorWebPreviewEditHeader }
-					>
-						{ translate( 'Edit header' ) }
-					</Button>
-				) }
-
 				{ showUrl && (
 					<ClipboardButtonInput
 						className="web-preview__url-clipboard-input"
@@ -176,6 +164,17 @@ class PreviewToolbar extends Component {
 							onClick={ this.handleEditorWebPreviewEdit }
 						>
 							{ translate( 'Edit' ) }
+						</Button>
+					) }
+					{ showEditHeaderLink && canUserEditThemeOptions && (
+						<Button
+							borderless
+							aria-label={ translate( 'Customize' ) }
+							className="web-preview__edit-header-link"
+							href={ customizeUrl }
+							onClick={ this.handleEditorWebPreviewEditHeader }
+						>
+							{ translate( 'Customize' ) }
 						</Button>
 					) }
 					{ showExternal && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change "Edit header" to "Customize" to follow existing language for site customization
* Move the button from the left of the toolbar to the right for better discoverability.

It's very likely we'll want to move this button to a more discoverable place entirely, but for now, this might help alleviate a teensy bit of confusion.

**Before**

<img width="1657" alt="Screen Shot 2021-05-07 at 1 37 15 PM" src="https://user-images.githubusercontent.com/2124984/117495399-90169200-af43-11eb-9305-1ac2fb3618cd.png">

**After**

<img width="1652" alt="Screen Shot 2021-05-07 at 1 36 33 PM" src="https://user-images.githubusercontent.com/2124984/117495447-a3296200-af43-11eb-8b32-6494b6ef8e45.png">

See #52641 

#### Testing instructions

* Switch to this PR
* Navigate to a post or page
* Preview the post or page
* The preview window should have a "customize" button in the toolbar, as seen above, rather than an "Edit Header" button
* The button should still function as before :)