### PR TITLE
Adding FBSAVE25 Coupon to Whitelist

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -274,6 +274,7 @@ function getRememberedCoupon() {
 	const ALLOWED_COUPON_CODE_LIST = [
 		'ALT',
 		'FBSAVE15',
+		'FBSAVE25',
 		'FIVERR',
 		'FLASHFB20OFF',
 		'FLASHFB50OFF',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* See pau2Xa-305-p2 (request 2)

#### Testing instructions

* Open: https://calypso.live/?branch=update/coupon-query-whitelist&coupon=FBSAVE25
* Add an annual plan to cart.
* Confirm coupon is auto-applied at checkout; i.e., that you didn't have to enter coupon for the discount.
