### PR TITLE
Partner Portal: Add tracks events

### DIFF
--- a/client/components/jetpack/portal-nav/index.tsx
+++ b/client/components/jetpack/portal-nav/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { ReactElement } from 'react';
 import classnames from 'classnames';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -15,6 +15,7 @@ import {
 	hasFetchedPartner,
 } from 'calypso/state/partner-portal/partner/selectors';
 import { isPartnerPortal } from 'calypso/state/partner-portal/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
 import SectionNav from 'calypso/components/section-nav';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -30,6 +31,7 @@ interface Props {
 }
 
 export default function PortalNav( { className = '' }: Props ): ReactElement | null {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const partnerFetched = useSelector( hasFetchedPartner );
 	const partner = useSelector( getCurrentPartner );
@@ -43,6 +45,14 @@ export default function PortalNav( { className = '' }: Props ): ReactElement | n
 		return null;
 	}
 
+	const onNavItemClick = ( menuItem: string ) => {
+		dispatch(
+			recordTracksEvent( 'calypso_partner_portal_jetpack_portal_nav_menu_click', {
+				menu_item: menuItem,
+			} )
+		);
+	};
+
 	return (
 		<>
 			<QueryJetpackPartnerPortalPartner />
@@ -53,10 +63,18 @@ export default function PortalNav( { className = '' }: Props ): ReactElement | n
 					className={ classnames( 'portal-nav', className ) }
 				>
 					<NavTabs label={ translate( 'Portal' ) }>
-						<NavItem path="/" selected={ isManagingSites }>
+						<NavItem
+							path="/"
+							selected={ isManagingSites }
+							onClick={ () => onNavItemClick( 'Manage Sites' ) }
+						>
 							{ translate( 'Manage Sites' ) }
 						</NavItem>
-						<NavItem path="/partner-portal" selected={ ! isManagingSites }>
+						<NavItem
+							path="/partner-portal"
+							selected={ ! isManagingSites }
+							onClick={ () => onNavItemClick( 'Partner Portal' ) }
+						>
 							{ translate( 'Partner Portal' ) }
 						</NavItem>
 					</NavTabs>

--- a/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
@@ -3,6 +3,7 @@
  */
 import React, { ReactElement, useCallback, useRef, useState } from 'react';
 import { numberFormat, useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
 import formatCurrency from '@automattic/format-currency';
 
 /**
@@ -13,6 +14,7 @@ import Tooltip from 'calypso/components/tooltip';
 import Gridicon from 'calypso/components/gridicon';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import useBillingDashboardQuery from 'calypso/state/partner-portal/licenses/hooks/use-billing-dashboard-query';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 
 /**
@@ -22,11 +24,19 @@ import './style.scss';
 
 function CostTooltip(): ReactElement {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const tooltip = useRef< SVGSVGElement >( null );
 	const [ isOpen, setIsOpen ] = useState( false );
 
-	const open = useCallback( () => setIsOpen( true ), [ setIsOpen ] );
-	const close = useCallback( () => setIsOpen( false ), [ setIsOpen ] );
+	const open = useCallback( () => {
+		setIsOpen( true );
+		dispatch( recordTracksEvent( 'calypso_partner_portal_billing_summary_cost_tooltip_open' ) );
+	}, [ dispatch, setIsOpen ] );
+
+	const close = useCallback( () => {
+		setIsOpen( false );
+		dispatch( recordTracksEvent( 'calypso_partner_portal_billing_summary_cost_tooltip_close' ) );
+	}, [ dispatch, setIsOpen ] );
 
 	return (
 		<>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -16,6 +16,7 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import useIssueLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-issue-license-mutation';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies
@@ -54,11 +55,22 @@ export default function IssueLicenseForm(): ReactElement {
 	} );
 	const [ product, setProduct ] = useState( '' );
 
-	const onSelectProduct = useCallback( ( option ) => setProduct( option.value ), [ setProduct ] );
+	const onSelectProduct = useCallback(
+		( option ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_partner_portal_issue_license_product_select', {
+					product: option.value,
+				} )
+			);
+			setProduct( option.value );
+		},
+		[ setProduct ]
+	);
 
 	const onIssueLicense = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_partner_portal_issue_license_submit', { product } ) );
 		issueLicense.mutate( { product } );
-	}, [ product, issueLicense.mutate ] );
+	}, [ dispatch, product, issueLicense.mutate ] );
 
 	useEffect( () => {
 		// Make sure we keep product in sync with the query results.
@@ -72,6 +84,10 @@ export default function IssueLicenseForm(): ReactElement {
 			setProduct( products.data[ 0 ].value );
 		}
 	}, [ product, products.data, setProduct ] );
+
+	const onGoBack = () => {
+		dispatch( recordTracksEvent( 'calypso_partner_portal_issue_license_back' ) );
+	};
 
 	return (
 		<Card className="issue-license-form">
@@ -88,7 +104,11 @@ export default function IssueLicenseForm(): ReactElement {
 			) }
 
 			<div className="issue-license-form__actions">
-				<Button href="/partner-portal/licenses" disabled={ issueLicense.isLoading }>
+				<Button
+					href="/partner-portal/licenses"
+					disabled={ issueLicense.isLoading }
+					onClick={ onGoBack }
+				>
 					{ translate( 'Go back' ) }
 				</Button>
 

--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { ReactElement, useCallback, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -11,6 +12,7 @@ import { Button } from '@automattic/components';
 import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/revoke-license-dialog';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 interface Props {
 	licenseKey: string;
@@ -27,17 +29,20 @@ export default function LicenseDetailsActions( {
 	attachedAt,
 	revokedAt,
 }: Props ): ReactElement {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const [ revokeDialog, setRevokeDialog ] = useState( false );
 
 	const openRevokeDialog = useCallback( () => {
 		setRevokeDialog( true );
-	}, [ setRevokeDialog ] );
+		dispatch( recordTracksEvent( 'calypso_partner_portal_license_details_revoke_dialog_open' ) );
+	}, [ dispatch, setRevokeDialog ] );
 
 	const closeRevokeDialog = useCallback( () => {
 		setRevokeDialog( false );
-	}, [ setRevokeDialog ] );
+		dispatch( recordTracksEvent( 'calypso_partner_portal_license_details_revoke_dialog_close' ) );
+	}, [ dispatch, setRevokeDialog ] );
 
 	return (
 		<div className="license-details__actions">

--- a/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
@@ -3,13 +3,14 @@
  */
 import React, { ReactElement } from 'react';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
 import { getLicenseCounts } from 'calypso/state/partner-portal/licenses/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 
 /**
@@ -22,6 +23,7 @@ interface Props {
 }
 
 export default function LicenseListEmpty( { filter }: Props ): ReactElement {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const counts = useSelector( getLicenseCounts );
 	const hasAssignedLicenses = counts[ LicenseFilter.Attached ] > 0;
@@ -35,13 +37,21 @@ export default function LicenseListEmpty( { filter }: Props ): ReactElement {
 
 	const licenseFilterStatusTitle = licenseFilterStatusTitleMap[ filter ] as string;
 
+	const onIssueNewLicense = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_partner_portal_license_list_empty_issue_license_click' )
+		);
+	};
+
 	return (
 		<div className="license-list__empty-list">
 			<h2>{ licenseFilterStatusTitle }</h2>
 			{ filter === LicenseFilter.Detached && hasAssignedLicenses && (
 				<p>{ translate( 'Every license you own is currently attached to a site.' ) }</p>
 			) }
-			<Button href="/partner-portal/issue-license">{ translate( 'Issue New License' ) }</Button>
+			<Button href="/partner-portal/issue-license" onClick={ onIssueNewLicense }>
+				{ translate( 'Issue New License' ) }
+			</Button>
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-list/header.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/header.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropsWithChildren, ReactElement, useCallback, useContext } from 'react';
+import { useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import classnames from 'classnames';
@@ -19,6 +20,7 @@ import Gridicon from 'calypso/components/gridicon';
 import { addQueryArgs } from 'calypso/lib/route';
 import { internalToPublicLicenseSortField } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies
@@ -58,9 +60,17 @@ function SortButton( {
 	currentSortDirection,
 	children,
 }: PropsWithChildren< SortButtonProps > ) {
+	const dispatch = useDispatch();
 	const sort = useCallback( () => {
 		setSortingConfig( sortField, currentSortField, currentSortDirection );
-	}, [ sortField, currentSortField, currentSortDirection ] );
+		dispatch(
+			recordTracksEvent( 'calypso_partner_portal_license_list_sort_button_click', {
+				sort_field: sortField,
+				current_sort_field: currentSortField,
+				current_sort_direction: currentSortDirection,
+			} )
+		);
+	}, [ dispatch, sortField, currentSortField, currentSortDirection ] );
 
 	return (
 		<h2 className={ classnames( { 'is-selected': sortField === currentSortField } ) }>

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropsWithChildren, ReactElement, useContext } from 'react';
-import { useSelector } from 'react-redux';
+import React, { PropsWithChildren, ReactElement, useContext, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import page from 'page';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
 import CSSTransition from 'react-transition-group/CSSTransition';
@@ -11,6 +11,7 @@ import CSSTransition from 'react-transition-group/CSSTransition';
  * Internal dependencies
  */
 import { LICENSES_PER_PAGE } from 'calypso/state/partner-portal/licenses/constants';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { addQueryArgs } from 'calypso/lib/route';
 import { License, PaginatedItems } from 'calypso/state/partner-portal/types';
 import {
@@ -49,6 +50,7 @@ const LicenseTransition = ( props: PropsWithChildren< LicenseTransitionProps > )
 );
 
 export default function LicenseList(): ReactElement {
+	const dispatch = useDispatch();
 	const { filter, search, sortField, sortDirection, currentPage } = useContext(
 		LicenseListContext
 	);
@@ -58,6 +60,18 @@ export default function LicenseList(): ReactElement {
 	const showLicenses = hasFetched && ! isFetching && !! licenses;
 	const showPagination = showLicenses && licenses.totalPages > 1;
 	const showNoResults = hasFetched && ! isFetching && licenses && licenses.items.length === 0;
+
+	const onPageClick = useCallback(
+		( pageNumber: number ) => {
+			setPage( pageNumber );
+			dispatch(
+				recordTracksEvent( 'calypso_partner_portal_license_list_pagination_page_click', {
+					page: pageNumber,
+				} )
+			);
+		},
+		[ dispatch ]
+	);
 
 	return (
 		<div className="license-list">
@@ -106,7 +120,7 @@ export default function LicenseList(): ReactElement {
 							page={ currentPage }
 							perPage={ LICENSES_PER_PAGE }
 							total={ licenses.totalItems }
-							pageClick={ setPage }
+							pageClick={ onPageClick }
 						/>
 					</LicenseTransition>
 				) }

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -12,6 +12,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getUrlParts } from '@automattic/calypso-url';
 import { infoNotice } from 'calypso/state/notices/actions';
 import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
@@ -64,10 +65,12 @@ export default function LicensePreview( {
 
 	const open = useCallback( () => {
 		setOpen( ! isOpen );
-	}, [ isOpen ] );
+		dispatch( recordTracksEvent( 'calypso_partner_portal_license_list_preview_toggle' ) );
+	}, [ dispatch, isOpen ] );
 
 	const onCopyLicense = useCallback( () => {
 		dispatch( infoNotice( translate( 'License copied!' ), { duration: 2000 } ) );
+		dispatch( recordTracksEvent( 'calypso_partner_portal_license_list_copy_license_click' ) );
 	}, [ dispatch, translate ] );
 
 	useEffect( () => {

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { ReactElement } from 'react';
+import { useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -21,6 +22,7 @@ import {
 import LicenseStateFilter from 'calypso/jetpack-cloud/sections/partner-portal/license-state-filter';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
 import SelectPartnerKeyDropdown from 'calypso/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies
@@ -42,6 +44,7 @@ export default function Licenses( {
 	sortDirection,
 	sortField,
 }: Props ): ReactElement {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	const context = {
@@ -50,6 +53,10 @@ export default function Licenses( {
 		currentPage,
 		sortDirection,
 		sortField,
+	};
+
+	const onIssueNewLicenseClick = () => {
+		dispatch( recordTracksEvent( 'calypso_partner_portal_license_list_issue_license_click' ) );
 	};
 
 	return (
@@ -62,7 +69,12 @@ export default function Licenses( {
 
 				<SelectPartnerKeyDropdown />
 
-				<Button href="/partner-portal/issue-license" primary style={ { marginLeft: 'auto' } }>
+				<Button
+					href="/partner-portal/issue-license"
+					onClick={ onIssueNewLicenseClick }
+					primary
+					style={ { marginLeft: 'auto' } }
+				>
 					{ translate( 'Issue New License' ) }
 				</Button>
 			</div>

--- a/client/jetpack-cloud/sections/partner-portal/primary/partner-access/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/partner-access/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { ReactElement } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 
@@ -15,6 +15,7 @@ import {
 	getCurrentPartner,
 	hasFetchedPartner,
 } from 'calypso/state/partner-portal/partner/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
 import Main from 'calypso/components/main';
 import CardHeading from 'calypso/components/card-heading';
@@ -22,6 +23,7 @@ import Spinner from 'calypso/components/spinner';
 import { useReturnUrl } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 
 export default function PartnerAccess(): ReactElement | null {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const hasFetched = useSelector( hasFetchedPartner );
 	const isFetching = useSelector( isFetchingPartner );
@@ -29,6 +31,12 @@ export default function PartnerAccess(): ReactElement | null {
 	const keys = ( partner?.keys || [] ) as PartnerKey[];
 	const hasPartner = hasFetched && ! isFetching && keys.length > 0;
 	const showError = hasFetched && ! isFetching && keys.length === 0;
+
+	const onManageSitesClick = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_partner_portal_partner_access_error_manage_sites_click' )
+		);
+	};
 
 	useReturnUrl( hasPartner );
 
@@ -44,7 +52,7 @@ export default function PartnerAccess(): ReactElement | null {
 				<div className="partner-access__error">
 					<p>{ translate( 'Your account is not registered as a partner account.' ) }</p>
 
-					<Button href="/" primary>
+					<Button href="/" onClick={ onManageSitesClick } primary>
 						{ translate( 'Manage Sites' ) }
 					</Button>
 				</div>

--- a/client/jetpack-cloud/sections/partner-portal/primary/select-partner-key/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/select-partner-key/index.tsx
@@ -17,6 +17,7 @@ import {
 	hasActivePartnerKey,
 	hasFetchedPartner,
 } from 'calypso/state/partner-portal/partner/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
 import Main from 'calypso/components/main';
 import CardHeading from 'calypso/components/card-heading';
@@ -38,6 +39,11 @@ export default function SelectPartnerKey(): ReactElement | null {
 	const keys = ( partner?.keys || [] ) as PartnerKey[];
 	const showKeys = hasFetched && ! isFetching && keys.length > 0;
 
+	const onSelectPartnerKey = ( keyId: number ) => {
+		dispatch( setActivePartnerKey( keyId ) );
+		dispatch( recordTracksEvent( 'calypso_partner_portal_select_partner_key_click' ) );
+	};
+
 	useReturnUrl( hasKey );
 
 	return (
@@ -55,7 +61,7 @@ export default function SelectPartnerKey(): ReactElement | null {
 					{ keys.map( ( key ) => (
 						<Card key={ key.id } className="select-partner-key__card" compact>
 							<div className="select-partner-key__key-name">{ key.name }</div>
-							<Button primary onClick={ () => dispatch( setActivePartnerKey( key.id ) ) }>
+							<Button primary onClick={ () => onSelectPartnerKey( key.id ) }>
 								{ translate( 'Select' ) }
 							</Button>
 						</Card>

--- a/client/jetpack-cloud/sections/partner-portal/primary/terms-of-service-consent/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/terms-of-service-consent/index.tsx
@@ -15,6 +15,7 @@ import {
 } from 'calypso/state/partner-portal/partner/selectors';
 import { receivePartner } from 'calypso/state/partner-portal/partner/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { formatApiPartner } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
 import Main from 'calypso/components/main';
@@ -38,11 +39,13 @@ export default function TermsOfServiceConsent(): ReactElement | null {
 	const consent = useTOSConsentMutation( {
 		onSuccess: ( partner ) => {
 			dispatch( receivePartner( formatApiPartner( partner ) ) );
+			dispatch( recordTracksEvent( 'calypso_partner_portal_tos_agree_success' ) );
 		},
 		onError: () => {
 			dispatch(
 				errorNotice( translate( 'We were unable to update your partner account details.' ) )
 			);
+			dispatch( recordTracksEvent( 'calypso_partner_portal_tos_agree_error' ) );
 		},
 	} );
 	const partner = useSelector( getCurrentPartner );
@@ -53,11 +56,17 @@ export default function TermsOfServiceConsent(): ReactElement | null {
 	const checkTOS = useCallback(
 		( event ) => {
 			setCheckedTOS( event.target.checked );
+			dispatch(
+				recordTracksEvent( 'calypso_partner_portal_tos_toggle', {
+					checked: event.target.checked,
+				} )
+			);
 		},
 		[ setCheckedTOS ]
 	);
 
 	const agreeToTOS = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_partner_portal_tos_agree_click' ) );
 		consent.mutate();
 	}, [] );
 

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -15,6 +15,7 @@ import { noop } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
 import useRefreshLicenseList from 'calypso/state/partner-portal/licenses/hooks/use-refresh-license-list';
 import useRevokeLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-revoke-license-mutation';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies
@@ -56,6 +57,7 @@ export default function RevokeLicenseDialog( {
 	}, [ onClose, mutation.isLoading ] );
 
 	const revoke = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_partner_portal_license_list_revoke_dialog_revoke' ) );
 		mutation.mutate( { licenseKey } );
 	}, [ licenseKey, mutation.mutate ] );
 

--- a/client/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown/index.tsx
@@ -13,6 +13,7 @@ import {
 	getCurrentPartner,
 } from 'calypso/state/partner-portal/partner/selectors';
 import { setActivePartnerKey } from 'calypso/state/partner-portal/partner/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import SelectDropdown from 'calypso/components/select-dropdown';
 
 /**
@@ -28,6 +29,9 @@ export default function SelectPartnerKeyDropdown(): ReactElement | null {
 	const onKeySelect = useCallback(
 		( option ) => {
 			dispatch( setActivePartnerKey( parseInt( option.value ) ) );
+			dispatch(
+				recordTracksEvent( 'calypso_partner_portal_select_partner_key_dropdown_option_select' )
+			);
 		},
 		[ dispatch ]
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Tracks events to the Partner Portal where the users interact with the interface.
* The following events were added:

- Jetpack Cloud
    - `calypso_partner_portal_jetpack_portal_nav_menu_click` { menu_item }
- Billing Summary
    - `calypso_partner_portal_billing_summary_cost_tooltip_open`
    - `calypso_partner_portal_billing_summary_cost_tooltip_close`
- Issue License
    - `calypso_partner_portal_issue_license_product_select` { product }
    - `calypso_partner_portal_issue_license_submit` { product }
    - `calypso_partner_portal_issue_license_back`
- License Details
    - `calypso_partner_portal_license_details_revoke_dialog_open`
    - `calypso_partner_portal_license_details_revoke_dialog_close`
- License List
    - `calypso_partner_portal_license_list_empty_issue_license_click`
    - `calypso_partner_portal_license_list_sort_button_click` { sort_field, current_sort_field, current_sort_direction }
    - `calypso_partner_portal_license_list_pagination_page_click` { page }
    - `calypso_partner_portal_license_list_copy_license_click`
    - `calypso_partner_portal_license_list_preview_toggle`
    - `calypso_partner_portal_license_list_search` { query }
    - `calypso_partner_portal_license_list_state_filter_click`
    - `calypso_partner_portal_license_list_revoke_dialog_revoke`
    - `calypso_partner_portal_license_list_issue_license_click`
- `calypso_partner_portal_select_partner_key_dropdown_option_select`
- `calypso_partner_portal_partner_access_error_manage_sites_click`
- `calypso_partner_portal_select_partner_key_click`
- Partner Portal TOS
    - `calypso_partner_portal_tos_toggle` { checked }
    - `calypso_partner_portal_tos_agree_click`
    - `calypso_partner_portal_tos_agree_success`
    - `calypso_partner_portal_tos_agree_error`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run yarn && yarn start-jetpack-cloud.
* Visit http://jetpack.cloud.localhost:3000/partner-portal
* Since I've added a reasonable number of events, open the Dev Tools, check the Network tab, and filter by `calypso_partner_portal` (this is the prefix of the events I've added)
* Click on links, buttons, dropdowns, and check that they are being tracked
