### PR TITLE
Partner Portal: Fix billing dashboard header flex wrap

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/style.scss
@@ -1,6 +1,7 @@
 .billing-dashboard {
 	&__header {
 		display: flex;
+		flex-wrap: wrap;
 		align-items: center;
 
 		@include breakpoint-deprecated( '>960px' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Minor adjustment to the Billing Dashboard header

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run yarn && yarn start-jetpack-cloud.
* Visit http://jetpack.cloud.localhost:3000/partner-portal, and select a partner key if you are prompted
* Check the header across different breakpoints and make sure it looks like the screenshot below

* Before:
![image](https://user-images.githubusercontent.com/5714212/117518128-0384c780-af75-11eb-98b2-e4f0b4bcf895.png)

* After:
![image](https://user-images.githubusercontent.com/5714212/117518116-f7006f00-af74-11eb-8f46-c3ba2aeb9f2a.png)

