### PR TITLE
[TeamCity] Keep the previous Desktop screenSize builtType for its historical data

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -22,6 +22,8 @@ object WPComTests : Project({
 
 	buildType(gutenbergBuildType("desktop"));
 	buildType(gutenbergBuildType("mobile"));
+	// Keep the previous Desktop screenSize builtType for its historical data
+	buildType(GutenbergDesktopLegacy);
 })
 
 fun gutenbergBuildType(screenSize: String): BuildType {
@@ -180,3 +182,132 @@ fun gutenbergBuildType(screenSize: String): BuildType {
 		}
 	}
 }
+
+// Keep the previous Desktop screenSize builtType for its historical data
+private object GutenbergDesktopLegacy : BuildType({
+	id("Gutenberg")
+	name = "Gutenberg tests (desktop) legacy"
+	description = "Runs Gutenberg E2E tests using desktop screen resolution"
+
+	artifactRules = """
+		reports => reports
+		logs.tgz => logs.tgz
+		screenshots => screenshots
+	""".trimIndent()
+
+	vcs {
+		root(Settings.WpCalypso)
+		cleanCheckout = true
+	}
+
+	params {
+		text(name="URL", value="https://wordpress.com", label = "Test URL", description = "URL to test against", allowEmpty = false)
+		checkbox(name="GUTENBERG_EDGE", value="false", label = "Use gutenberg-edge", description = "Use a blog with gutenberg-edge sticker", checked="true", unchecked = "false")
+		checkbox(name="COBLOCKS_EDGE", value="false", label = "Use coblocks-edge", description = "Use a blog with coblocks-edge sticker", checked="true", unchecked = "false")
+	}
+
+	steps {
+		bashNodeScript {
+			name = "Prepare environment"
+			scriptContent = """
+				export NODE_ENV="test"
+				# Install modules
+				${_self.yarn_install_cmd}
+			"""
+		}
+		bashNodeScript {
+			name = "Run e2e tests (desktop)"
+			scriptContent = """
+				shopt -s globstar
+				set -x
+				cd test/e2e
+				mkdir temp
+				export LIVEBRANCHES=false
+				export NODE_CONFIG_ENV=test
+				export TEST_VIDEO=true
+				export HIGHLIGHT_ELEMENT=true
+				export GUTENBERG_EDGE=%GUTENBERG_EDGE%
+				export COBLOCKS_EDGE=%COBLOCKS_EDGE%
+				export URL=%URL%
+				export BROWSERSIZE=desktop
+				export BROWSERLOCALE=en
+				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL}\"}"
+				# Instructs Magellan to not hide the output from individual `mocha` processes. This is required for
+				# mocha-teamcity-reporter to work.
+				export MAGELLANDEBUG=true
+				# Decrypt config
+				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
+				# Run the test
+				yarn magellan --config=magellan-gutenberg.json --max_workers=%E2E_WORKERS% --suiteTag=parallel --local_browser=chrome --mocha_args="--reporter mocha-teamcity-reporter"
+			""".trimIndent()
+			dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"
+		}
+		bashNodeScript {
+			name = "Collect results"
+			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+			scriptContent = """
+				set -x
+				mkdir -p screenshots
+				find test/e2e -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
+				mkdir -p logs
+				find test/e2e -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
+			""".trimIndent()
+		}
+	}
+
+	features {
+		perfmon {
+		}
+		notifications {
+			notifierSettings = slackNotifier {
+				connection = "PROJECT_EXT_11"
+				sendTo = "#gutenberg-e2e"
+				messageFormat = verboseMessageFormat {
+					addBranch = true
+					addStatusText = true
+					maximumNumberOfChanges = 10
+				}
+			}
+			branchFilter = "+:<default>"
+			buildFailed = true
+			buildFinishedSuccessfully = true
+		}
+	}
+
+	failureConditions {
+		executionTimeoutMin = 20
+		// TeamCity will mute a test if it fails and then succeeds within the same build. Otherwise TeamCity UI will not
+		// display a difference between real errors and retries, making it hard to understand what is actually failing.
+		supportTestRetry = true
+
+		// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have
+		// been muted previously.
+		nonZeroExitCode = false
+
+		// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner
+		// crashes and no tests are run.
+		failOnMetricChange {
+			metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
+			threshold = 50
+			units = BuildFailureOnMetric.MetricUnit.PERCENTS
+			comparison = BuildFailureOnMetric.MetricComparison.LESS
+			compareTo = build {
+				buildRule = lastSuccessful()
+			}
+		}
+	}
+
+	triggers {
+		schedule {
+			schedulingPolicy = daily {
+				hour = 4
+			}
+			branchFilter = """
+				+:trunk
+			""".trimIndent()
+			triggerBuild = always()
+			withPendingChangesOnly = false
+		}
+	}
+
+})

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -19,16 +19,16 @@ object WPComTests : Project({
 		param("docker_image", "%docker_image_e2e%")
 		param("build.prefix", "1")
 	}
-
-	buildType(gutenbergBuildType("desktop"));
+	// Keep the previous ID in order to preserve the historical data
+	buildType(gutenbergBuildType("desktop", "Gutenberg"));
 	buildType(gutenbergBuildType("mobile"));
-	// Keep the previous Desktop screenSize builtType for its historical data
-	buildType(GutenbergDesktopLegacy);
 })
 
-fun gutenbergBuildType(screenSize: String): BuildType {
+fun gutenbergBuildType(screenSize: String, overrideId: String? = null): BuildType {
+	var theId = if (overrideId === null) "Gutenberg_$screenSize" else overrideId;
+
 	return BuildType {
-		id("Gutenberg_$screenSize")
+		id(theId as String)
 		name = "Gutenberg tests ($screenSize)"
 		description = "Runs Gutenberg E2E tests using $screenSize screen resolution"
 
@@ -182,132 +182,3 @@ fun gutenbergBuildType(screenSize: String): BuildType {
 		}
 	}
 }
-
-// Keep the previous Desktop screenSize builtType for its historical data
-private object GutenbergDesktopLegacy : BuildType({
-	id("Gutenberg")
-	name = "Gutenberg tests (desktop) legacy"
-	description = "Runs Gutenberg E2E tests using desktop screen resolution"
-
-	artifactRules = """
-		reports => reports
-		logs.tgz => logs.tgz
-		screenshots => screenshots
-	""".trimIndent()
-
-	vcs {
-		root(Settings.WpCalypso)
-		cleanCheckout = true
-	}
-
-	params {
-		text(name="URL", value="https://wordpress.com", label = "Test URL", description = "URL to test against", allowEmpty = false)
-		checkbox(name="GUTENBERG_EDGE", value="false", label = "Use gutenberg-edge", description = "Use a blog with gutenberg-edge sticker", checked="true", unchecked = "false")
-		checkbox(name="COBLOCKS_EDGE", value="false", label = "Use coblocks-edge", description = "Use a blog with coblocks-edge sticker", checked="true", unchecked = "false")
-	}
-
-	steps {
-		bashNodeScript {
-			name = "Prepare environment"
-			scriptContent = """
-				export NODE_ENV="test"
-				# Install modules
-				${_self.yarn_install_cmd}
-			"""
-		}
-		bashNodeScript {
-			name = "Run e2e tests (desktop)"
-			scriptContent = """
-				shopt -s globstar
-				set -x
-				cd test/e2e
-				mkdir temp
-				export LIVEBRANCHES=false
-				export NODE_CONFIG_ENV=test
-				export TEST_VIDEO=true
-				export HIGHLIGHT_ELEMENT=true
-				export GUTENBERG_EDGE=%GUTENBERG_EDGE%
-				export COBLOCKS_EDGE=%COBLOCKS_EDGE%
-				export URL=%URL%
-				export BROWSERSIZE=desktop
-				export BROWSERLOCALE=en
-				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL}\"}"
-				# Instructs Magellan to not hide the output from individual `mocha` processes. This is required for
-				# mocha-teamcity-reporter to work.
-				export MAGELLANDEBUG=true
-				# Decrypt config
-				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
-				# Run the test
-				yarn magellan --config=magellan-gutenberg.json --max_workers=%E2E_WORKERS% --suiteTag=parallel --local_browser=chrome --mocha_args="--reporter mocha-teamcity-reporter"
-			""".trimIndent()
-			dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"
-		}
-		bashNodeScript {
-			name = "Collect results"
-			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
-			scriptContent = """
-				set -x
-				mkdir -p screenshots
-				find test/e2e -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
-				mkdir -p logs
-				find test/e2e -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
-			""".trimIndent()
-		}
-	}
-
-	features {
-		perfmon {
-		}
-		notifications {
-			notifierSettings = slackNotifier {
-				connection = "PROJECT_EXT_11"
-				sendTo = "#gutenberg-e2e"
-				messageFormat = verboseMessageFormat {
-					addBranch = true
-					addStatusText = true
-					maximumNumberOfChanges = 10
-				}
-			}
-			branchFilter = "+:<default>"
-			buildFailed = true
-			buildFinishedSuccessfully = true
-		}
-	}
-
-	failureConditions {
-		executionTimeoutMin = 20
-		// TeamCity will mute a test if it fails and then succeeds within the same build. Otherwise TeamCity UI will not
-		// display a difference between real errors and retries, making it hard to understand what is actually failing.
-		supportTestRetry = true
-
-		// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have
-		// been muted previously.
-		nonZeroExitCode = false
-
-		// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner
-		// crashes and no tests are run.
-		failOnMetricChange {
-			metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
-			threshold = 50
-			units = BuildFailureOnMetric.MetricUnit.PERCENTS
-			comparison = BuildFailureOnMetric.MetricComparison.LESS
-			compareTo = build {
-				buildRule = lastSuccessful()
-			}
-		}
-	}
-
-	triggers {
-		schedule {
-			schedulingPolicy = daily {
-				hour = 4
-			}
-			branchFilter = """
-				+:trunk
-			""".trimIndent()
-			triggerBuild = always()
-			withPendingChangesOnly = false
-		}
-	}
-
-})


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When we merged the changes [here](https://github.com/Automattic/wp-calypso/pull/52680), we didn't realize that changing the ID of the buildType would mean TC would remove its record too 🤦🏻 . Now we have the two builds for each screenSize, but since the ID for the Desktop one changed, the old type record is gone.

This is an attempt to add it back, as the data it had might be useful. And a lesson to be learned, too! When changing ID of buildTypes, we need to have that in mind and ask ourselves if the data from the old record is still valuable. It'd be also interesting to explore if there are any ways to migrate or export this data.


#### Testing instructions

* A new entry named `Gutenberg tests (desktop) legacy` under `Projects->Calypso->WPCom Tests` should appear in TC, it should have the old data 🤞🏻 
