### PR TITLE
chore(eslint): Add exceptions for jest/no-conditional-expect

### DIFF
--- a/client/extensions/woocommerce/state/sites/test/request.js
+++ b/client/extensions/woocommerce/state/sites/test/request.js
@@ -33,6 +33,7 @@ describe( 'request', () => {
 			return request( siteId )
 				.get( 'bad_placeholder_endpoint' )
 				.catch( ( error ) => {
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( error.statusCode ).to.equal( 404 );
 				} );
 		} );
@@ -65,6 +66,7 @@ describe( 'request', () => {
 			return request( siteId )
 				.post( 'bad_placeholder_endpoint' )
 				.catch( ( error ) => {
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( error.statusCode ).to.equal( 404 );
 				} );
 		} );
@@ -97,6 +99,7 @@ describe( 'request', () => {
 			return request( siteId )
 				.put( 'bad_placeholder_endpoint' )
 				.catch( ( error ) => {
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( error.statusCode ).to.equal( 404 );
 				} );
 		} );
@@ -127,6 +130,7 @@ describe( 'request', () => {
 			return request( siteId )
 				.del( 'bad_placeholder_endpoint' )
 				.catch( ( error ) => {
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( error.statusCode ).to.equal( 404 );
 				} );
 		} );

--- a/client/lib/directly/test/index.js
+++ b/client/lib/directly/test/index.js
@@ -91,7 +91,9 @@ describe( 'index', () => {
 					directly
 						.initialize()
 						.catch( ( e ) => {
+							// eslint-disable-next-line jest/no-conditional-expect
 							expect( e ).to.be.an.instanceof( Error );
+							// eslint-disable-next-line jest/no-conditional-expect
 							expect( e.message ).to.contain( error.src );
 						} )
 						.then( () => done() );
@@ -150,10 +152,12 @@ describe( 'index', () => {
 					directly
 						.initialize()
 						.catch( ( e ) => {
+							/* eslint-disable jest/no-conditional-expect */
 							expect( e ).to.be.an.instanceof( Error );
 							expect( e.message ).to.equal(
 								'Directly Real-Time Messaging is not available at this time.'
 							);
+							/* eslint-enable jest/no-conditional-expect */
 						} )
 						.then( () => done() );
 				} );
@@ -164,6 +168,7 @@ describe( 'index', () => {
 					directly
 						.initialize()
 						.catch( () => {
+							// eslint-disable-next-line jest/no-conditional-expect
 							expect( loadScript.loadScript ).not.to.have.been.called;
 						} )
 						.then( () => done() );

--- a/client/lib/geocoding/test/index.js
+++ b/client/lib/geocoding/test/index.js
@@ -29,6 +29,7 @@ describe( 'geocoding', () => {
 				return new Promise( ( done ) => {
 					geocode( TEST_ADDRESS )
 						.then( ( results ) => {
+							// eslint-disable-next-line jest/no-conditional-expect
 							expect( results ).to.eql( [ 1, 2, 3 ] );
 							done();
 						} )
@@ -48,6 +49,7 @@ describe( 'geocoding', () => {
 				return new Promise( ( done ) => {
 					reverseGeocode( TEST_LATITUDE, TEST_LONGITUDE )
 						.then( ( results ) => {
+							// eslint-disable-next-line jest/no-conditional-expect
 							expect( results ).to.eql( [ 1, 2, 3 ] );
 							done();
 						} )

--- a/client/lib/happychat/test/index.js
+++ b/client/lib/happychat/test/index.js
@@ -80,15 +80,18 @@ describe( 'connection', () => {
 			} );
 
 			test( 'unauthorized event', () => {
+				expect.hasAssertions();
 				socket.close = jest.fn();
 				expect.assertions( 3 );
 				socket.emit( 'unauthorized' );
 				return openSocket.catch( () => {
+					/* eslint-disable jest/no-conditional-expect */
 					expect( dispatch ).toHaveBeenCalledTimes( 1 );
 					expect( dispatch ).toHaveBeenCalledWith(
 						receiveUnauthorized( 'User is not authorized' )
 					);
 					expect( socket.close ).toHaveBeenCalled();
+					/* eslint-enable jest/no-conditional-expect */
 				} );
 			} );
 
@@ -263,16 +266,19 @@ describe( 'connection', () => {
 
 		describe( 'connection.request should emit a SocketIO event', () => {
 			test( 'and dispatch callbackTimeout if request ran out of time', () => {
+				expect.hasAssertions();
 				socket.emit( 'init' ); // resolve internal openSocket promise
 
 				const action = requestTranscript( null );
 				socket.emit = jest.fn();
 				return connection.request( action, 100 ).catch( ( error ) => {
+					/* eslint-disable jest/no-conditional-expect */
 					expect( socket.emit ).toHaveBeenCalled();
 					expect( socket.emit.mock.calls[ 0 ][ 0 ] ).toBe( action.event );
 					expect( socket.emit.mock.calls[ 0 ][ 1 ] ).toBe( action.payload );
 					expect( dispatch ).toHaveBeenCalledWith( receiveTranscriptTimeout() );
 					expect( error.message ).toBe( 'timeout' );
+					/* eslint-enable jest/no-conditional-expect */
 				} );
 			} );
 
@@ -300,10 +306,13 @@ describe( 'connection', () => {
 					callback( 'no data', null ); // fake server responded with error
 				} );
 				return connection.request( action, 100 ).catch( ( error ) => {
+					expect.hasAssertions();
+					/* eslint-disable jest/no-conditional-expect */
 					expect( error.message ).toBe( 'no data' );
 					expect( dispatch ).toHaveBeenCalledWith(
 						receiveError( action.event + ' request failed: ' + error.message )
 					);
+					/* eslint-enable jest/no-conditional-expect */
 				} );
 			} );
 		} );
@@ -323,9 +332,11 @@ describe( 'connection', () => {
 		} );
 
 		test( 'connection.send should dispatch receiveError action', () => {
+			expect.hasAssertions();
 			socket.emit = jest.fn();
 			const action = sendTyping( 'content' );
 			return connection.send( action ).catch( ( e ) => {
+				// eslint-disable-next-line jest/no-conditional-expect
 				expect( dispatch ).toHaveBeenCalledWith(
 					receiveError( 'failed to send ' + action.event + ': ' + e )
 				);
@@ -333,9 +344,11 @@ describe( 'connection', () => {
 		} );
 
 		test( 'connection.request should dispatch receiveError action', () => {
+			expect.hasAssertions();
 			socket.emit = jest.fn();
 			const action = requestTranscript( null );
 			return connection.request( action, 100 ).catch( ( e ) => {
+				// eslint-disable-next-line jest/no-conditional-expect
 				expect( dispatch ).toHaveBeenCalledWith(
 					receiveError( 'failed to send ' + action.event + ': ' + e )
 				);

--- a/client/state/exporter/test/actions.js
+++ b/client/state/exporter/test/actions.js
@@ -93,6 +93,7 @@ describe( 'actions', () => {
 			return new Promise( ( done ) => {
 				advancedSettingsFetch( 100658273 )( spy, getState )
 					.then( () => {
+						// eslint-disable-next-line jest/no-conditional-expect
 						expect( spy ).to.have.been.calledWithMatch( {
 							type: EXPORT_ADVANCED_SETTINGS_RECEIVE,
 							siteId: 100658273,
@@ -109,6 +110,7 @@ describe( 'actions', () => {
 			return new Promise( ( done ) => {
 				advancedSettingsFetch( 0 )( spy, getState )
 					.then( () => {
+						// eslint-disable-next-line jest/no-conditional-expect
 						expect( spy ).to.have.been.calledWithMatch( {
 							type: EXPORT_ADVANCED_SETTINGS_FETCH_FAIL,
 							siteId: 0,
@@ -161,6 +163,7 @@ describe( 'actions', () => {
 			return new Promise( ( done ) => {
 				startExport( 2916284, false )( spy, getStateCustomSettings )
 					.then( () => {
+						// eslint-disable-next-line jest/no-conditional-expect
 						expect( spy ).to.have.been.calledWith( {
 							type: EXPORT_STARTED,
 							siteId: 2916284,
@@ -176,11 +179,13 @@ describe( 'actions', () => {
 			return new Promise( ( done ) => {
 				startExport( 2916284 )( spy, getState )
 					.then( () => {
+						/* eslint-disable jest/no-conditional-expect */
 						expect( spy ).to.have.been.calledTwice;
 						expect( spy ).to.have.been.calledWith( {
 							type: EXPORT_STARTED,
 							siteId: 2916284,
 						} );
+						/* eslint-enable jest/no-conditional-expect */
 
 						done();
 					} )
@@ -192,11 +197,13 @@ describe( 'actions', () => {
 			return new Promise( ( done ) => {
 				startExport( 77203074 )( spy, getState )
 					.then( () => {
+						/* eslint-disable jest/no-conditional-expect */
 						expect( spy ).to.have.been.calledTwice;
 						expect( spy ).to.have.been.calledWithMatch( {
 							type: EXPORT_FAILURE,
 							siteId: 77203074,
 						} );
+						/* eslint-enable jest/no-conditional-expect */
 
 						done();
 					} )

--- a/client/state/plugins/installed/test/actions.js
+++ b/client/state/plugins/installed/test/actions.js
@@ -343,6 +343,7 @@ describe( 'actions', () => {
 			);
 			// updatePlugin returns a rejected promise here
 			return response.catch( () => {
+				// eslint-disable-next-line jest/no-conditional-expect
 				expect( spy.callCount ).to.eql( 0 );
 			} );
 		} );
@@ -569,6 +570,7 @@ describe( 'actions', () => {
 		test( 'should dispatch fail action when request fails', () => {
 			const response = installPlugin( site.ID, { slug: 'fake', id: 'fake/fake' } )( spy, getState );
 			return response.catch( () => {
+				// eslint-disable-next-line jest/no-conditional-expect
 				expect( spy ).to.have.been.calledWith( {
 					type: PLUGIN_INSTALL_REQUEST_FAILURE,
 					action: INSTALL_PLUGIN,
@@ -640,6 +642,7 @@ describe( 'actions', () => {
 		test( 'should dispatch fail action when request fails', () => {
 			const response = removePlugin( site.ID, { slug: 'fake', id: 'fake/fake' } )( spy, getState );
 			return response.catch( () => {
+				// eslint-disable-next-line jest/no-conditional-expect
 				expect( spy ).to.have.been.calledWith( {
 					type: PLUGIN_REMOVE_REQUEST_FAILURE,
 					action: REMOVE_PLUGIN,

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -416,8 +416,10 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch failure action when saving new post fails', () => {
+			expect.hasAssertions();
 			return new Promise( ( done ) => {
 				savePost( 77203074, null, { title: 'Hello World' } )( dispatch ).catch( () => {
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( dispatch ).toHaveBeenCalledWith( {
 						type: POST_SAVE_FAILURE,
 						siteId: 77203074,
@@ -430,8 +432,10 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch failure action when saving existing post fails', () => {
+			expect.hasAssertions();
 			return new Promise( ( done ) => {
 				savePost( 77203074, 102, { title: 'Hello World' } )( dispatch ).catch( () => {
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( dispatch ).toHaveBeenCalledWith( {
 						type: POST_SAVE_FAILURE,
 						siteId: 77203074,
@@ -496,8 +500,10 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch failure action when deleting post fails', () => {
+			expect.hasAssertions();
 			return new Promise( ( done ) => {
 				deletePost( 77203074, 102 )( dispatch, getState ).catch( () => {
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( dispatch ).toHaveBeenCalledWith( {
 						type: POST_DELETE_FAILURE,
 						siteId: 77203074,
@@ -556,8 +562,10 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch failure action when restoring post fails', () => {
+			expect.hasAssertions();
 			return new Promise( ( done ) => {
 				restorePost( 77203074, 102 )( dispatch, getState ).catch( () => {
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( dispatch ).toHaveBeenCalledWith( {
 						type: POST_RESTORE_FAILURE,
 						siteId: 77203074,

--- a/client/state/reader/related-posts/test/actions.js
+++ b/client/state/reader/related-posts/test/actions.js
@@ -117,6 +117,7 @@ describe( 'actions', () => {
 
 		test( 'should have dispatched receive with an empty array', () => {
 			return requestPromise.catch( () => {
+				// eslint-disable-next-line jest/no-conditional-expect
 				expect( fakeDispatch ).to.have.been.calledWith( {
 					type: READER_RELATED_POSTS_RECEIVE,
 					payload: {
@@ -131,6 +132,7 @@ describe( 'actions', () => {
 
 		test( 'should fail the promise and dispatch failure', () => {
 			return requestPromise.catch( () => {
+				// eslint-disable-next-line jest/no-conditional-expect
 				expect( fakeDispatch ).to.have.been.calledWith( {
 					type: READER_RELATED_POSTS_REQUEST_FAILURE,
 					payload: {

--- a/client/state/reader/tags/images/test/actions.js
+++ b/client/state/reader/tags/images/test/actions.js
@@ -57,12 +57,14 @@ describe( 'actions', () => {
 
 			return request
 				.then( () => {
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( dispatchSpy ).to.have.been.calledWith( {
 						type: READER_TAG_IMAGES_REQUEST_SUCCESS,
 						data: sampleSuccessResponse,
 						tag: 'banana',
 					} );
 
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( dispatchSpy ).to.have.been.calledWith( {
 						type: READER_TAG_IMAGES_RECEIVE,
 						images: sampleSuccessResponse.images,

--- a/client/state/reader/thumbnails/test/actions.js
+++ b/client/state/reader/thumbnails/test/actions.js
@@ -69,17 +69,20 @@ describe( 'actions', () => {
 
 			return request
 				.then( () => {
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( dispatchSpy ).to.have.been.calledWith( {
 						type: READER_THUMBNAIL_REQUEST_SUCCESS,
 						embedUrl: successfulEmbedUrl,
 					} );
 
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( dispatchSpy ).to.have.been.calledWith( {
 						type: READER_THUMBNAIL_RECEIVE,
 						embedUrl: successfulEmbedUrl,
 						thumbnailUrl,
 					} );
 
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( dispatchSpy ).to.have.been.calledThrice;
 				} )
 				.catch( ( err ) => {
@@ -110,11 +113,13 @@ describe( 'actions', () => {
 
 			return request
 				.then( () => {
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( dispatchSpy ).to.have.been.calledWithMatch( {
 						type: READER_THUMBNAIL_REQUEST_FAILURE,
 						embedUrl: failureEmbedUrl,
 					} );
 
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( dispatchSpy ).to.have.been.calledTwice;
 				} )
 				.catch( ( err ) => {

--- a/client/state/terms/test/actions.js
+++ b/client/state/terms/test/actions.js
@@ -612,8 +612,10 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should not dispatch any action on Failure', () => {
+			expect.hasAssertions();
 			const spy = jest.fn();
 			return updateTerm( siteId, taxonomyName, 10, 'toto', { name: 'ribs' } )( spy ).catch( () => {
+				// eslint-disable-next-line jest/no-conditional-expect
 				expect( spy ).not.toHaveBeenCalled();
 			} );
 		} );

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -893,6 +893,7 @@ describe( 'actions', () => {
 
 		test( 'should dispatch failure on error', () => {
 			return initiateThemeTransfer( siteId )( spy ).catch( () => {
+				/* eslint-disable jest/no-conditional-expect */
 				expect( spy ).to.have.been.calledOnce;
 
 				expect( spy ).to.have.been.calledWithMatch( {
@@ -900,6 +901,7 @@ describe( 'actions', () => {
 					siteId,
 				} );
 				expect( spy ).to.have.been.calledWith( sinon.match.has( 'error', sinon.match.truthy ) );
+				/* eslint-enable jest/no-conditional-expect */
 			} );
 		} );
 	} );

--- a/client/state/user-suggestions/test/actions.js
+++ b/client/state/user-suggestions/test/actions.js
@@ -57,6 +57,7 @@ describe( 'actions', () => {
 
 			return request
 				.then( () => {
+					/* eslint-disable jest/no-conditional-expect */
 					expect( dispatchSpy ).to.have.been.calledWith( {
 						type: USER_SUGGESTIONS_REQUEST_SUCCESS,
 						data: sampleSuccessResponse,
@@ -68,6 +69,7 @@ describe( 'actions', () => {
 						suggestions: sampleSuccessResponse.suggestions,
 						siteId,
 					} );
+					/* eslint-enable jest/no-conditional-expect */
 				} )
 				.catch( ( err ) => {
 					assert.fail( err, undefined, 'errback should not have been called' );


### PR DESCRIPTION
#### Background

With the update of `eslint-plugin-jest` in #52549, it started to detecdt conditional expects inside `.catch()` blocks. This raised the number of eslint errors in `trunk`.

#### Changes proposed in this Pull Request

* Add exceptions for that rule when the expect is in a `catch` block.
* When possible (i.e. when not ussing `chai`) add `expect.hasAssertions();` check to ensure the test fails if those `catch` are not executed.

#### Testing instructions

* Verify unit tests pass