### PR TITLE
ci(e2e): Use test name for assets path

### DIFF
--- a/packages/magellan-mocha-plugin/lib/test_run.js
+++ b/packages/magellan-mocha-plugin/lib/test_run.js
@@ -5,11 +5,23 @@
 
 const _ = require( 'lodash' );
 const mochaSettings = require( './settings' );
+const path = require( 'path' );
+const fs = require( 'fs' );
+
+const testCounter = {};
 
 const MochaTestRun = function ( options ) {
 	// Share assets directory with mocha tests
-	process.env.TEMP_ASSET_PATH = options.tempAssetPath;
-
+	const testName = options.locator.name;
+	const sanitizedName = testName
+		.replace( /[^a-z0-9]/gi, '-' )
+		.replace( /-+/g, '-' )
+		.replace( /^-|-$/, '' )
+		.toLowerCase();
+	testCounter[ options.locator.name ] = ( testCounter[ options.locator.name ] ?? 0 ) + 1;
+	const assetsDir = sanitizedName + '-' + testCounter[ options.locator.name ];
+	process.env.TEMP_ASSET_PATH = path.join( options.tempAssetPath, '..', assetsDir );
+	fs.mkdirSync( process.env.TEMP_ASSET_PATH, { recursive: true } );
 	_.extend( this, options );
 };
 

--- a/packages/magellan-mocha-plugin/lib/test_run.js
+++ b/packages/magellan-mocha-plugin/lib/test_run.js
@@ -32,7 +32,7 @@ const MochaTestRun = function ( options ) {
 		}
 	} )( {
 		basePath: path.join( options.tempAssetPath, '..', sanitizedName ),
-		counter: 1,
+		counter: 0,
 	} );
 
 	process.env.TEMP_ASSET_PATH = pathWithCounter;

--- a/packages/magellan-mocha-plugin/package.json
+++ b/packages/magellan-mocha-plugin/package.json
@@ -24,6 +24,7 @@
 	},
 	"devDependencies": {
 		"coffee-script": "^1.12.7",
-		"mocha": "^8.1.3"
+		"mocha": "^8.1.3",
+		"mock-fs": "^4.11.0"
 	}
 }

--- a/packages/magellan-mocha-plugin/test/test_run.spec.js
+++ b/packages/magellan-mocha-plugin/test/test_run.spec.js
@@ -1,8 +1,18 @@
 const testFramework = require( '../index' );
 const TestRun = testFramework.TestRun;
+const mockFs = require( 'mock-fs' );
 
 describe( 'TestRun class', function () {
 	let run;
+
+	beforeAll( () => {
+		mockFs( {
+			'/tmp': {},
+		} );
+	} );
+	afterAll( () => {
+		mockFs.restore();
+	} );
 
 	beforeEach( function () {
 		run = new TestRun( {
@@ -10,6 +20,7 @@ describe( 'TestRun class', function () {
 				name: 'The full name of the test to run',
 			},
 			mockingPort: 10,
+			tempAssetPath: '/tmp',
 		} );
 	} );
 
@@ -44,6 +55,7 @@ describe( 'TestRun class', function () {
 				name: 'The full name of the test to run',
 			},
 			mockingPort: 10,
+			tempAssetPath: '/tmp',
 		} );
 
 		const args = localRun.getArguments();


### PR DESCRIPTION
#### Background

When Magellan is about to spin up a new Mocha process, it creates a temporary directory for the test to store its artifacts (eg: logs, screenshots). This temp directory is provided via an environment variable named `TEMP_ASSETS_PATH`. This temp directory is composed of a bunch of random strings.

Due those random strings, when collecting those assets it is quite hard to determine which assets belong to which test.

#### Changes proposed in this Pull Request

* Change the name of the temporary assets path to use the test name.

#### Testing instructions

* Open one of the e2e tests that has failures or muted tests, and verify the assets are stored in path with sensible names.