### PR TITLE
My Home: Update message in stats card when new site has had no visitors

### DIFF
--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { useEffect } from 'react';
 import { connect, useDispatch } from 'react-redux';
-import { numberFormat, useTranslate } from 'i18n-calypso';
+import i18nCalypso, { numberFormat, useTranslate } from 'i18n-calypso';
 import { Card } from '@automattic/components';
 import { times } from 'lodash';
 import moment from 'moment';
@@ -70,11 +70,21 @@ export const StatsV2 = ( {
 		}
 	}, [ isSiteUnlaunched ] );
 
+	const newSiteCopy =
+		[ 'en', 'en-gb' ].includes( i18nCalypso.getLocaleSlug() ) ||
+		i18nCalypso.hasTranslation(
+			'No stats to display yet. Publish or share a post to get some traffic to your site.'
+		)
+			? translate(
+					'No stats to display yet. Publish or share a post to get some traffic to your site.'
+			  )
+			: translate( "No traffic yet, but you'll get there!" );
+
 	const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
 	const siteOlderThanAWeek = Date.now() - new Date( siteCreatedAt ).getTime() > WEEK_IN_MS;
 	const statsPlaceholderMessage = siteOlderThanAWeek
 		? translate( "No traffic this week, but don't give up!" )
-		: translate( "No traffic yet, but you'll get there!" );
+		: newSiteCopy;
 
 	return (
 		<div className="stats">

--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -75,8 +75,11 @@ export const StatsV2 = ( {
 		i18nCalypso.hasTranslation(
 			'No stats to display yet. Publish or share a post to get some traffic to your site.'
 		)
-			? translate(
-					'No stats to display yet. Publish or share a post to get some traffic to your site.'
+			? preventWidows(
+					translate(
+						'No stats to display yet. Publish or share a post to get some traffic to your site.'
+					),
+					4
 			  )
 			: translate( "No traffic yet, but you'll get there!" );
 

--- a/client/my-sites/customer-home/cards/features/stats/style.scss
+++ b/client/my-sites/customer-home/cards/features/stats/style.scss
@@ -29,6 +29,10 @@
 		.chart__bar {
 			height: 150px;
 		}
+
+		.chart__empty {
+			text-align: center;
+		}
 	}
 }
 


### PR DESCRIPTION
The stats currently shows this placeholder message when a new site has had no visits:
<img width="947" alt="Screenshot 2021-05-10 at 5 31 50 PM" src="https://user-images.githubusercontent.com/1500769/117611289-4fbf4a00-b1b7-11eb-8fff-3d5b88e0073c.png">

"but you'll get there" doesn't seem right for brand new sites. Updated to the suggestion in #44918, now the card looks like this:
<img width="995" alt="Screenshot 2021-05-11 at 10 51 48 AM" src="https://user-images.githubusercontent.com/1500769/117734135-edae2580-b246-11eb-8a96-a026f27a56ef.png">

#### Changes proposed in this Pull Request

* update placeholder message for new sites (younger than one week) to `No stats to display yet. Publish or share a post to get some traffic to your site.`
* show the existing message if the copy hasn't been translated yet
* ensure longer message is wrapped and centred nicely

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* Set user language to `English` or `English (UK)`
* Check the stats card on My Home displays the new message
* Set user language to something non-English
* Check the stats card on My Home displays the old message (Google Translate might come in handy)
* Check the message on the stats card is unchanged for one of your old testing sites that doesn't get any traffic

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #44918
