### PR TITLE
Use uuid for gutenberg e2e tests

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -20,15 +20,14 @@ object WPComTests : Project({
 		param("build.prefix", "1")
 	}
 	// Keep the previous ID in order to preserve the historical data
-	buildType(gutenbergBuildType("desktop", "Gutenberg"));
-	buildType(gutenbergBuildType("mobile"));
+	buildType(gutenbergBuildType("desktop", "aee94c18-ee11-4c80-b6aa-245b967a97db"));
+	buildType(gutenbergBuildType("mobile","2af2eaed-87d5-41f4-ab1d-4ed589d5ae82"));
 })
 
-fun gutenbergBuildType(screenSize: String, overrideId: String? = null): BuildType {
-	var theId = if (overrideId === null) "Gutenberg_$screenSize" else overrideId;
-
+fun gutenbergBuildType(screenSize: String, buildUuid: String): BuildType {
 	return BuildType {
-		id(theId as String)
+		uuid = buildUuid
+		id("WPComTests_gutenberg_$screenSize")
 		name = "Gutenberg tests ($screenSize)"
 		description = "Runs Gutenberg E2E tests using $screenSize screen resolution"
 


### PR DESCRIPTION
### Background

"Gutenberg e2e" tests in `trunk` are failing with:

![image](https://user-images.githubusercontent.com/975703/117620784-195edc00-b171-11eb-83d9-ce3473670357.png)

I believe this is caused by the `id` field, mostly because I've found [working with ids is quite tricky.](https://github.com/Automattic/wp-calypso/pull/51132#issuecomment-800994743).

#### Changes proposed in this Pull Request

* Specify an `uuid` (generated using TeamCity UI) instead of an `id`.

#### Testing instructions

Run Gutenberg e2e tests for this branch, and check TeamCity doesn't complain about loading the configuration
