### PR TITLE
My Home: Fix spacing on "go mobile" task between action button and skip

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -98,7 +98,7 @@ const Task = ( {
 
 	const ActionButtonWithStats = ( { children } ) => {
 		return (
-			<div onClick={ startTask } role="presentation">
+			<div onClick={ startTask } role="presentation" className="task__action">
 				{ children }
 			</div>
 		);


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* `<AppsBadge>` component now accepts `className` prop that merges classes the usual way
* Update unit tests
* Ensure `<Task>` component adds the `task__action` to the action button

`<Task>` is responsible for adding the `task__action` class to action buttons that ensures there's a space between the action button and skip button.

The "go mobile" task is the only one that provides its own `actionButton` instead of allowing `<Task>` to render the action button itself. This change ensures that `actionButton`s will also get the `task__action` class applied.

We could also have added the class directly in the "go-mobile" component (so we add the `task__action` class to the component that gets passed to `actionButton`), but I felt it was better to keep responsibility for the `task__action` class within the `<Task>` component.

Before:
<img width="382" alt="Screenshot 2021-05-10 at 9 03 14 PM" src="https://user-images.githubusercontent.com/1500769/117634576-26acb280-b1d3-11eb-9f06-95b64128666f.png">

After:
<img width="382" alt="Screenshot 2021-05-10 at 9 02 52 PM" src="https://user-images.githubusercontent.com/1500769/117634610-30361a80-b1d3-11eb-8cd7-7480e015a123.png">



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to My Home on a site where the site setup checklist is complete
* Use dev tools to simulate mobile layout (the "go-mobile" task appears when the backend detects a mobile UA)
* Confirm the padding is fixed
* Try emulating Android and iOS devices to check the padding is correctly applied to App Store and Google Play buttons.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #49622
