### PR TITLE
Framework: Refactor away from `_.invoke()`

### DIFF
--- a/client/blocks/inline-help/inline-help-compact-result.jsx
+++ b/client/blocks/inline-help/inline-help-compact-result.jsx
@@ -20,7 +20,7 @@ class InlineHelpCompactResult extends Component {
 	};
 
 	onClick = ( event ) => {
-		this.props.onClick( event, this.props.helpLink );
+		this.props.onClick?.( event, this.props.helpLink );
 	};
 
 	render() {

--- a/client/blocks/inline-help/inline-help-compact-result.jsx
+++ b/client/blocks/inline-help/inline-help-compact-result.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { invoke } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,7 +20,7 @@ class InlineHelpCompactResult extends Component {
 	};
 
 	onClick = ( event ) => {
-		invoke( this.props, 'onClick', event, this.props.helpLink );
+		this.props.onClick( event, this.props.helpLink );
 	};
 
 	render() {

--- a/client/signup/steps/import-url-onboarding/index.jsx
+++ b/client/signup/steps/import-url-onboarding/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { get, includes, invoke, isEmpty } from 'lodash';
+import { get, includes, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -107,7 +107,7 @@ class ImportURLOnboardingStepComponent extends Component {
 
 	handleInputRef = ( el ) => ( this.inputRef = el );
 
-	focusInput = () => invoke( this.inputRef, 'focus' );
+	focusInput = () => this.inputRef.focus();
 
 	setUrlError = ( urlValidationMessage ) =>
 		this.setState( { urlValidationMessage }, this.focusInput );

--- a/client/signup/steps/import-url-onboarding/index.jsx
+++ b/client/signup/steps/import-url-onboarding/index.jsx
@@ -107,7 +107,7 @@ class ImportURLOnboardingStepComponent extends Component {
 
 	handleInputRef = ( el ) => ( this.inputRef = el );
 
-	focusInput = () => this.inputRef.focus();
+	focusInput = () => this.inputRef?.focus();
 
 	setUrlError = ( urlValidationMessage ) =>
 		this.setState( { urlValidationMessage }, this.focusInput );

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { get, includes, invoke } from 'lodash';
+import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -62,7 +62,7 @@ class ImportURLStepComponent extends Component {
 
 	handleInputRef = ( el ) => ( this.inputRef = el );
 
-	focusInput = () => invoke( this.inputRef, 'focus' );
+	focusInput = () => this.inputRef.focus();
 
 	setUrlError = ( urlValidationMessage ) =>
 		this.setState( { urlValidationMessage }, this.focusInput );

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -62,7 +62,7 @@ class ImportURLStepComponent extends Component {
 
 	handleInputRef = ( el ) => ( this.inputRef = el );
 
-	focusInput = () => this.inputRef.focus();
+	focusInput = () => this.inputRef?.focus();
 
 	setUrlError = ( urlValidationMessage ) =>
 		this.setState( { urlValidationMessage }, this.focusInput );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `invoke()` instances in Calypso are too few and can be replaced with a simple invocation of the function in question. That's what this PR is doing.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Manually verify invocation code changes make sense.