### PR TITLE
Framework: Refactor away from `_.each()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -410,6 +410,7 @@ module.exports = {
 		'you-dont-need-lodash-underscore/detect': 'error',
 		'you-dont-need-lodash-underscore/drop': 'error',
 		'you-dont-need-lodash-underscore/drop-right': 'error',
+		'you-dont-need-lodash-underscore/each': 'error',
 		'you-dont-need-lodash-underscore/ends-with': 'error',
 		'you-dont-need-lodash-underscore/entries': 'error',
 		'you-dont-need-lodash-underscore/every': 'error',

--- a/client/components/rating/test/index.js
+++ b/client/components/rating/test/index.js
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { each } from 'lodash';
 import React from 'react';
 
 /**
@@ -50,7 +49,7 @@ describe( '<Rating />', () => {
 		} );
 
 		test( 'should render rating clipping mask properly', () => {
-			each( [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ], function ( ratingValue ) {
+			[ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ].forEach( function ( ratingValue ) {
 				const size = 24; // use default size
 				const wrapper = shallow( <Rating rating={ ratingValue } size={ size } /> );
 

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { clone, difference, each, forEach, last, map, some, take } from 'lodash';
+import { clone, difference, forEach, last, map, some, take } from 'lodash';
 import classNames from 'classnames';
 import debugFactory from 'debug';
 
@@ -344,8 +344,7 @@ class TokenField extends PureComponent {
 		} else {
 			match = match.toLocaleLowerCase();
 
-			each(
-				suggestions,
+			suggestions.forEach(
 				function ( suggestion ) {
 					const index = suggestion.toLocaleLowerCase().indexOf( match );
 					if ( this.props.value.indexOf( suggestion ) === -1 ) {

--- a/client/lib/perfmon/index.js
+++ b/client/lib/perfmon/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { each, remove } from 'lodash';
+import { remove } from 'lodash';
 import page from 'page';
 
 /**
@@ -152,7 +152,7 @@ function recordPlaceholders( mutation ) {
 		return;
 	}
 
-	each( nodes, function ( node ) {
+	nodes.forEach( function ( node ) {
 		if ( isPlaceholder( node ) ) {
 			recordPlaceholderNode( node );
 		}
@@ -161,7 +161,7 @@ function recordPlaceholders( mutation ) {
 		// only fires for the top element of an added subtree
 		if ( node.querySelectorAll ) {
 			// funky syntax because NodeList walks like an array but doesn't quack like one
-			each( node.querySelectorAll( PLACEHOLDER_MATCHER ), recordPlaceholderNode );
+			Array.from( node.querySelectorAll( PLACEHOLDER_MATCHER ) ).forEach( recordPlaceholderNode );
 		}
 	} );
 }

--- a/client/lib/perfmon/index.js
+++ b/client/lib/perfmon/index.js
@@ -152,7 +152,7 @@ function recordPlaceholders( mutation ) {
 		return;
 	}
 
-	nodes.forEach( function ( node ) {
+	Array.from( nodes ).forEach( function ( node ) {
 		if ( isPlaceholder( node ) ) {
 			recordPlaceholderNode( node );
 		}

--- a/client/my-sites/activity/activity-log-tasklist/index.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { isEmpty, get, each, includes, find } from 'lodash';
+import { isEmpty, get, includes, find } from 'lodash';
 import page from 'page';
 
 /**
@@ -278,7 +278,7 @@ class ActivityLogTasklist extends Component {
 
 		const { showErrorNotice, showSuccessNotice, siteName, translate } = this.props;
 
-		each( itemsWithUpdate, ( item ) => {
+		itemsWithUpdate.forEach( ( item ) => {
 			const { slug, updateStatus, type, name } = item;
 			// Finds in prevProps.pluginWithUpdate, prevProps.themeWithUpdate or prevpros.coreWithUpdate
 			const prevItemWithUpdate = find( prevProps[ `${ type }WithUpdate` ], { slug } );

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
-import { each, get, includes, isEqual, map } from 'lodash';
+import { get, includes, isEqual, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -125,7 +125,7 @@ export class CommentNavigation extends Component {
 			unlike,
 		} = this.props;
 		this.props.removeNotice( 'comment-notice' );
-		each( selectedComments, ( { commentId, isLiked, postId, status } ) => {
+		selectedComments.forEach( ( { commentId, isLiked, postId, status } ) => {
 			if ( 'delete' === newStatus ) {
 				deletePermanently( postId, commentId );
 				return;

--- a/client/my-sites/comments/comment/comment-html-editor/index.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/index.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { delay, each, get, map, reduce, reject } from 'lodash';
+import { delay, get, map, reduce, reject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -61,7 +61,9 @@ export class CommentHtmlEditor extends Component {
 		}
 	) => {
 		const element = document.createElement( tag );
-		each( attributes, ( value, key ) => element.setAttribute( key, value ) );
+		Object.entries( attributes ).forEach( ( [ key, value ] ) =>
+			element.setAttribute( key, value )
+		);
 		element.innerHTML = '<!---->';
 		const fragments = element.outerHTML.split( '<!---->' );
 		const opener =

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import page from 'page';
-import { each, startsWith } from 'lodash';
+import { startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -135,7 +135,7 @@ export const clearCommentNotices = ( { store }, next ) => {
 	if ( ! startsWith( nextPath, '/comments' ) ) {
 		const { getState, dispatch } = store;
 		const notices = getNotices( getState() );
-		each( notices, ( { noticeId } ) => {
+		notices.forEach( ( { noticeId } ) => {
 			if ( startsWith( noticeId, 'comment-notice' ) ) {
 				dispatch( removeNotice( noticeId ) );
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `each()` is used several times in the codebase, but it's pretty straightforward to replace it with either `Object.entries().forEach()`, or just `Array.prototype.forEach()`, depending on the type of the value it's used on. This PR replaces all instances. 

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all tests pass: `yarn run test-client client/lib/post-normalizer`.
* Smoke test the following:
  * Comments area - `/comments/all/:site`
  * Activity log - `/activity-log/:site`
  * Rating component - `/devdocs/design/rating`
  * Token field component - `/devdocs/design/token-fields`

#### Notes

There is a pre-existing ESLint error that is expected to occur in one of the affected files.