### PR TITLE
E2E: Fix NoSuchWindow flaky error when using popup login

### DIFF
--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -262,19 +262,12 @@ export default class LoginFlow {
 		await driverHelper.waitUntilAbleToSwitchToWindow( this.driver, 1 );
 		const loginPage = await LoginPage.Expect( this.driver );
 
-		try {
-			await loginPage.login(
-				this.account.email || this.account.username,
-				this.account.password,
-				false,
-				{ retry: false }
-			);
-		} catch ( error ) {
-			// Popup login window closes itself so let's handle WebDriver complaints
-			if ( 'NoSuchWindowError' !== error.name ) {
-				throw error;
-			}
-		}
+		await loginPage.login(
+			this.account.email || this.account.username,
+			this.account.password,
+			false,
+			{ isPopup: true }
+		);
 
 		// Make sure we've switched back to the post window
 		await driverHelper.waitUntilAbleToSwitchToWindow( this.driver, 0 );

--- a/test/e2e/lib/pages/login-page.js
+++ b/test/e2e/lib/pages/login-page.js
@@ -20,7 +20,7 @@ export default class LoginPage extends AsyncBaseContainer {
 		super( driver, By.css( '.wp-login__container' ), LoginPage.getLoginURL() );
 	}
 
-	async login( username, password, emailSSO = false, { retry = true } = {} ) {
+	async login( username, password, emailSSO = false, { retry = true, isPopup = false } = {} ) {
 		const driver = this.driver;
 		const userNameLocator = By.css( '#usernameOrEmail' );
 		const passwordLocator = By.css( '#password' );
@@ -48,6 +48,10 @@ export default class LoginPage extends AsyncBaseContainer {
 			await driver.findElement( passwordLocator ).sendKeys( Key.ENTER );
 		}
 
+		if ( isPopup ) {
+			return;
+		}
+
 		await this.driver.sleep( 1000 );
 
 		if ( retry === true ) {
@@ -65,7 +69,7 @@ export default class LoginPage extends AsyncBaseContainer {
 				return await this.login( username, password, { retry: false } );
 			}
 		}
-		return await driverHelper.waitUntilElementNotLocated( driver, userNameLocator );
+		await driverHelper.waitUntilElementNotLocated( driver, userNameLocator );
 	}
 
 	use2FAMethod( twoFAMethod ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes the [flaky `NoSuchWindow` error](https://teamcity.a8c.com/viewLog.html?buildId=6173643&buildTypeId=calypso_RunCalypsoE2eMobileTests) when using the popup login flow.

#### Testing instructions

All specs should pass.