### PR TITLE
Remove Jetpack related code in WPcom plans sections

### DIFF
--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -296,7 +296,6 @@ export class PlanFeaturesComparison extends Component {
 
 PlanFeaturesComparison.propTypes = {
 	basePlansPath: PropTypes.string,
-	displayJetpackPlans: PropTypes.bool,
 	isInSignup: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,
 	// either you specify the plans prop or isPlaceholder prop
@@ -311,7 +310,6 @@ PlanFeaturesComparison.propTypes = {
 
 PlanFeaturesComparison.defaultProps = {
 	basePlansPath: null,
-	displayJetpackPlans: false,
 	isInSignup: true,
 	siteId: null,
 	onUpgradeClick: noop,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -412,7 +412,6 @@ export class PlanFeatures extends Component {
 		const {
 			basePlansPath,
 			disableBloggerPlanWithNonBlogDomain,
-			displayJetpackPlans,
 			isInSignup,
 			isJetpack,
 			planProperties,
@@ -441,8 +440,8 @@ export class PlanFeatures extends Component {
 			} = properties;
 			let { discountPrice } = properties;
 			const classes = classNames( 'plan-features__table-item', 'has-border-top' );
+			const billingTimeFrame = planConstantObj.getBillingTimeFrame();
 			let audience = planConstantObj.getAudience();
-			let billingTimeFrame = planConstantObj.getBillingTimeFrame();
 
 			if ( disableBloggerPlanWithNonBlogDomain || this.props.nonDotBlogDomains.length > 0 ) {
 				if ( planMatches( planName, { type: TYPE_BLOGGER } ) ) {
@@ -450,7 +449,7 @@ export class PlanFeatures extends Component {
 				}
 			}
 
-			if ( isInSignup && ! displayJetpackPlans ) {
+			if ( isInSignup ) {
 				switch ( siteType ) {
 					case 'blog':
 						audience = planConstantObj.getBlogAudience();
@@ -464,10 +463,6 @@ export class PlanFeatures extends Component {
 					default:
 						audience = planConstantObj.getAudience();
 				}
-			}
-
-			if ( isInSignup && displayJetpackPlans ) {
-				billingTimeFrame = planConstantObj.getSignupBillingTimeFrame();
 			}
 
 			return (
@@ -538,7 +533,6 @@ export class PlanFeatures extends Component {
 			isInSignup,
 			onUpgradeClick: ownPropsOnUpgradeClick,
 			redirectTo,
-			displayJetpackPlans,
 			withDiscount,
 			selectedSiteSlug,
 			shoppingCartManager,
@@ -584,7 +578,7 @@ export class PlanFeatures extends Component {
 					),
 				] )
 				.then( () => {
-					if ( ! displayJetpackPlans && withDiscount && this.isMounted ) {
+					if ( withDiscount && this.isMounted ) {
 						return shoppingCartManager.applyCoupon( withDiscount );
 					}
 				} )
@@ -597,7 +591,7 @@ export class PlanFeatures extends Component {
 		const planPath = getPlanPath( planName ) || '';
 		const checkoutUrlArgs = {};
 		// Auto-apply the coupon code to the cart for WPCOM sites
-		if ( ! displayJetpackPlans && withDiscount ) {
+		if ( withDiscount ) {
 			checkoutUrlArgs.coupon = withDiscount;
 		}
 		if ( redirectTo ) {
@@ -864,7 +858,6 @@ PlanFeatures.propTypes = {
 	basePlansPath: PropTypes.string,
 	canPurchase: PropTypes.bool.isRequired,
 	disableBloggerPlanWithNonBlogDomain: PropTypes.bool,
-	displayJetpackPlans: PropTypes.bool,
 	isInSignup: PropTypes.bool,
 	isJetpack: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,
@@ -884,7 +877,6 @@ PlanFeatures.propTypes = {
 
 PlanFeatures.defaultProps = {
 	basePlansPath: null,
-	displayJetpackPlans: false,
 	isInSignup: false,
 	isJetpack: false,
 	selectedSiteSlug: '',
@@ -931,15 +923,13 @@ const ConnectedPlanFeatures = connect(
 			plans,
 			isLandingPage,
 			siteId,
-			displayJetpackPlans,
 			visiblePlans,
 			popularPlanSpec,
 			kindOfPlanTypeSelector,
 		} = ownProps;
 		const selectedSiteId = siteId;
 		const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
-		// If no site is selected, fall back to use the `displayJetpackPlans` prop's value
-		const isJetpack = selectedSiteId ? isJetpackSite( state, selectedSiteId ) : displayJetpackPlans;
+		const isJetpack = selectedSiteId ? isJetpackSite( state, selectedSiteId ) : false;
 		const isSiteAT = selectedSiteId ? isSiteAutomatedTransfer( state, selectedSiteId ) : false;
 		const siteIsPrivate = isPrivateSite( state, selectedSiteId );
 		const sitePlan = getSitePlan( state, selectedSiteId );
@@ -1014,9 +1004,6 @@ const ConnectedPlanFeatures = connect(
 					}
 				}
 
-				if ( displayJetpackPlans ) {
-					planFeatures = getPlanFeaturesObject( planConstantObj.getSignupFeatures( currentPlan ) );
-				}
 				const siteIsPrivateAndGoingAtomic = siteIsPrivate && isWpComEcommercePlan( plan );
 				const isMonthlyObj = { isMonthly: showMonthlyPrice };
 				const rawPrice = siteId

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -46,13 +46,6 @@ import {
 	PLAN_PERSONAL_MONTHLY,
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_2_YEARS,
-	PLAN_JETPACK_FREE,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
 	TYPE_BUSINESS,
 	TYPE_ECOMMERCE,
 	TYPE_FREE,
@@ -112,71 +105,6 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures()', () => {
 		} );
 		const plans = instance.getPlansForPlanFeatures();
 		expect( plans ).toEqual( [ PLAN_BUSINESS, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_ECOMMERCE ] );
-	} );
-	test( 'Should render <PlanFeatures /> with Jetpack monthly plans when called with jetpack props', () => {
-		const instance = new PlansFeaturesMain( {
-			...props,
-			displayJetpackPlans: true,
-			intervalType: 'monthly',
-		} );
-		const plans = instance.getPlansForPlanFeatures();
-		expect( plans ).toEqual( [
-			PLAN_JETPACK_FREE,
-			PLAN_JETPACK_PERSONAL_MONTHLY,
-			PLAN_JETPACK_PREMIUM_MONTHLY,
-			PLAN_JETPACK_BUSINESS_MONTHLY,
-		] );
-	} );
-
-	test( 'Should render <PlanFeatures /> with Jetpack monthly plans without free one when requested', () => {
-		const instance = new PlansFeaturesMain( {
-			...props,
-			displayJetpackPlans: true,
-			intervalType: 'monthly',
-			hideFreePlan: true,
-		} );
-		const plans = instance.getPlansForPlanFeatures();
-		expect( plans ).toEqual( [
-			PLAN_JETPACK_PERSONAL_MONTHLY,
-			PLAN_JETPACK_PREMIUM_MONTHLY,
-			PLAN_JETPACK_BUSINESS_MONTHLY,
-		] );
-	} );
-	test( 'Should render <PlanFeatures /> with Jetpack monthly data-e2e-plans when requested', () => {
-		const instance = new PlansFeaturesMain( { ...props, displayJetpackPlans: true } );
-		const comp = shallow( instance.getPlanFeatures() );
-		expect( comp.find( '[data-e2e-plans="jetpack"]' ).length ).toBe( 1 );
-	} );
-
-	test( 'Should render <PlanFeatures /> with Jetpack plans when called with jetpack props', () => {
-		const instance = new PlansFeaturesMain( { ...props, displayJetpackPlans: true } );
-		const plans = instance.getPlansForPlanFeatures();
-		expect( plans ).toEqual( [
-			PLAN_JETPACK_FREE,
-			PLAN_JETPACK_PERSONAL,
-			PLAN_JETPACK_PREMIUM,
-			PLAN_JETPACK_BUSINESS,
-		] );
-	} );
-
-	test( 'Should render <PlanFeatures /> with Jetpack plans without free one when requested', () => {
-		const instance = new PlansFeaturesMain( {
-			...props,
-			displayJetpackPlans: true,
-			hideFreePlan: true,
-		} );
-		const plans = instance.getPlansForPlanFeatures();
-		expect( plans ).toEqual( [
-			PLAN_JETPACK_PERSONAL,
-			PLAN_JETPACK_PREMIUM,
-			PLAN_JETPACK_BUSINESS,
-		] );
-	} );
-
-	test( 'Should render <PlanFeatures /> with Jetpack data-e2e-plans when requested', () => {
-		const instance = new PlansFeaturesMain( { ...props, displayJetpackPlans: true } );
-		const comp = shallow( instance.getPlanFeatures() );
-		expect( comp.find( '[data-e2e-plans="jetpack"]' ).length ).toBe( 1 );
 	} );
 
 	test( 'Should render <PlanFeatures /> with WP.com plans when requested', () => {

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -23,8 +23,6 @@ import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import FormattedHeader from 'calypso/components/formatted-header';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
-import isSiteAutomatedTransferSelector from 'calypso/state/selectors/is-site-automated-transfer';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import QueryContactDetailsCache from 'calypso/components/data/query-contact-details-cache';
 import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
@@ -44,7 +42,6 @@ class Plans extends React.Component {
 	static propTypes = {
 		context: PropTypes.object.isRequired,
 		redirectToAddDomainFlow: PropTypes.bool,
-		displayJetpackPlans: PropTypes.bool,
 		intervalType: PropTypes.string,
 		customerType: PropTypes.string,
 		selectedFeature: PropTypes.string,
@@ -53,7 +50,6 @@ class Plans extends React.Component {
 	};
 
 	static defaultProps = {
-		displayJetpackPlans: false,
 		intervalType: 'yearly',
 	};
 
@@ -71,18 +67,10 @@ class Plans extends React.Component {
 	}
 
 	isInvalidPlanInterval() {
-		const {
-			displayJetpackPlans,
-			isEligibleForWpComMonthlyPlan,
-			intervalType,
-			selectedSite,
-		} = this.props;
-		const isJetpack2Yearly = displayJetpackPlans && intervalType === '2yearly';
-		const isWpcomMonthly = ! displayJetpackPlans && intervalType === 'monthly';
+		const { isEligibleForWpComMonthlyPlan, intervalType, selectedSite } = this.props;
+		const isWpcomMonthly = intervalType === 'monthly';
 
-		return (
-			selectedSite && ( isJetpack2Yearly || ( isWpcomMonthly && ! isEligibleForWpComMonthlyPlan ) )
-		);
+		return selectedSite && isWpcomMonthly && ! isEligibleForWpComMonthlyPlan;
 	}
 
 	redirectIfInvalidPlanInterval() {
@@ -110,7 +98,6 @@ class Plans extends React.Component {
 		const {
 			selectedSite,
 			translate,
-			displayJetpackPlans,
 			canAccessPlans,
 			customerType,
 			isWPForTeamsSite,
@@ -159,7 +146,6 @@ class Plans extends React.Component {
 								) : (
 									<PlansFeaturesMain
 										redirectToAddDomainFlow={ this.props.redirectToAddDomainFlow }
-										displayJetpackPlans={ displayJetpackPlans }
 										hideFreePlan={ true }
 										customerType={ customerType }
 										intervalType={ this.props.intervalType }
@@ -186,8 +172,6 @@ class Plans extends React.Component {
 export default connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 
-	const jetpackSite = isJetpackSite( state, selectedSiteId );
-	const isSiteAutomatedTransfer = isSiteAutomatedTransferSelector( state, selectedSiteId );
 	const currentPlan = getCurrentPlan( state, selectedSiteId );
 	const currentPlanIntervalType = getIntervalTypeForTerm(
 		getPlan( currentPlan?.productSlug )?.term
@@ -197,7 +181,6 @@ export default connect( ( state ) => {
 		currentPlanIntervalType,
 		purchase: currentPlan ? getByPurchaseId( state, currentPlan.id ) : null,
 		selectedSite: getSelectedSite( state ),
-		displayJetpackPlans: ! isSiteAutomatedTransfer && jetpackSite,
 		canAccessPlans: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 		isWPForTeamsSite: isSiteWPForTeams( state, selectedSiteId ),
 		isEligibleForWpComMonthlyPlan:

--- a/client/signup/steps/plans-atomic-store/index.jsx
+++ b/client/signup/steps/plans-atomic-store/index.jsx
@@ -126,7 +126,6 @@ export class PlansAtomicStoreStep extends Component {
 					isInSignup={ true }
 					siteId={ siteId }
 					domainName={ this.getDomainName() }
-					displayJetpackPlans={ false }
 				/>
 			</div>
 		);

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -181,7 +181,6 @@ export class PlansStep extends Component {
 						intervalType={ this.getIntervalType() }
 						onUpgradeClick={ this.onSelectPlan }
 						showFAQ={ false }
-						displayJetpackPlans={ false }
 						domainName={ this.getDomainName() }
 						customerType={ this.getCustomerType() }
 						disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }


### PR DESCRIPTION
### Changes proposed in this Pull Request

Jetpack plans are displayed in their own section since the Jetpack offer reset. The plans components that now only display WPcom products still contain Jetpack related code. This PR removes it.

### Implementation notes

This PR consists in removing the `displayJetpackPlans` prop from the `PlanFeatures`, `PlanFeaturesComparison`, `PlansFeaturesMain`, and `Plans` components, which now always resolves to `false`.

#### `PlanFeatures`

- Instantiated in `client/signup/steps/plans-atomic-store/index.jsx` with `displayJetpackPlans={ false }`.
- Instantiated in `client/my-sites/plans/p2-plans-main.jsx ` with no `displayJetpackPlans` prop.
- Instantiated in `client/my-sites/plans-features-main/index.jsx` with `displayJetpackPlans={ displayJetpackPlans }`, where `displayJetpackPlans` is always false. See below.

_Note: the `isJetpack` prop in `PlanFeatures` will most likely always be false as well. For readability, this will be addressed in a separate PR._

#### `PlanFeaturesComparison`

- Instantiated in `client/my-sites/plans-features-main/index.jsx` with `displayJetpackPlans={ displayJetpackPlans }`, where `displayJetpackPlans` is always false. See below.

#### `PlansFeaturesMain`

- Instantiated in `client/signup/steps/plans/index.jsx` with `displayJetpackPlans={ false }`.
- Instantiated in `client/my-sites/plans/main.jsx` with `displayJetpackPlans={ displayJetpackPlans }`, where `displayJetpackPlans` is always false. See below. 

#### `Plans`

The `displayJetpackPlans` prop is computed as follow: `! isSiteAutomatedTransfer && jetpackSite`. `jetpackSite` is now always false, since `Plans` is instantiated in `client/my-sites/plans/controller.jsx::plans` after the Jetpack plans redirect.

### Testing instructions

- Review code carefully, following the _Implementation notes_ along
- Download the PR and run Calypso
- Visit the plans page with both a simple and Jetpack sites, and check that it looks and behaves as in production