### PR TITLE
WIP: Add cookie fallback fo tk_amp linker parameter

### DIFF
--- a/client/lib/analytics/utils/url-parse-amp-compatible.js
+++ b/client/lib/analytics/utils/url-parse-amp-compatible.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import cookie from 'cookie';
+
+/**
  * Internal dependencies
  */
 import debug from './debug';
@@ -57,8 +62,11 @@ export default function urlParseAmpCompatible( url ) {
 
 		debug( 'urlParseAmpCompatible: original query:', parsedUrl.search );
 
-		if ( parsedUrl.searchParams.has( 'tk_amp' ) ) {
-			const tk_amp = parseAmpEncodedParams( parsedUrl.searchParams.get( 'tk_amp' ) );
+		const cookies = cookie.parse( document.cookie );
+		const tkAmpEncoded = parsedUrl.searchParams.get( 'tk_amp' ) || cookies.tk_amp;
+
+		if ( tkAmpEncoded ) {
+			const tk_amp = parseAmpEncodedParams( tkAmpEncoded );
 			debug( 'urlParseAmpCompatible: tk_amp:', tk_amp );
 			for ( const key of Object.keys( tk_amp ) ) {
 				if ( ! parsedUrl.searchParams.has( key ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After [a change](https://github.com/ampproject/amphtml/pull/32100) in the AMP framework, linker params no longer being added to the URL when navigation between same origin pages.
As a solution to this, we're saving the `tk_amp` URL parameter (D61194-code) and then use it as a fallback in `urlSafeBase64DecodeString`.

#### Testing instructions

* D61194-code should be deployed beforehand
* Go to https://wordpress-com.cdn.ampproject.org/c/s/wordpress.com/create/
* Click on `Plans & Pricing`
* A `tk_amp` cookie should have been added
* Click on any `Start` CTA 
TBD

