### PR TITLE
clientRouter: Replace hydrate with render in dev

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -25,7 +25,7 @@ import {
 	getImmediateLoginLocale,
 } from 'calypso/state/immediate-login/selectors';
 import { getSiteFragment } from 'calypso/lib/route';
-import { hydrate } from './web-util.js';
+import { render } from './web-util.js';
 
 /**
  * Re-export
@@ -87,7 +87,7 @@ export const makeLayout = makeLayoutMiddleware( ProviderWrappedLayout );
  * divs.
  */
 export function clientRouter( route, ...middlewares ) {
-	page( route, ...middlewares, hydrate );
+	page( route, ...middlewares, render );
 }
 
 export function redirectLoggedOut( context, next ) {

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -25,7 +25,7 @@ import {
 	getImmediateLoginLocale,
 } from 'calypso/state/immediate-login/selectors';
 import { getSiteFragment } from 'calypso/lib/route';
-import { render } from './web-util.js';
+import { hydrate } from './web-util.js';
 
 /**
  * Re-export
@@ -87,7 +87,7 @@ export const makeLayout = makeLayoutMiddleware( ProviderWrappedLayout );
  * divs.
  */
 export function clientRouter( route, ...middlewares ) {
-	page( route, ...middlewares, render );
+	page( route, ...middlewares, hydrate );
 }
 
 export function redirectLoggedOut( context, next ) {

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -25,7 +25,7 @@ import {
 	getImmediateLoginLocale,
 } from 'calypso/state/immediate-login/selectors';
 import { getSiteFragment } from 'calypso/lib/route';
-import { hydrate } from './web-util.js';
+import { render, hydrate } from './web-util.js';
 
 /**
  * Re-export
@@ -73,6 +73,22 @@ export const ProviderWrappedLayout = ( {
 export const makeLayout = makeLayoutMiddleware( ProviderWrappedLayout );
 
 /**
+ * For logged in users with bootstrap (production), ReactDOM.hydrate().
+ * Otherwise (development), ReactDOM.render().
+ * See: https://wp.me/pd2qbF-P#comment-20
+ *
+ * @param context - Middleware context
+ */
+function smartHydrate( context ) {
+	const doHydrate =
+		! config.isEnabled( 'wpcom-user-bootstrap' ) && isUserLoggedIn( context.store.getState() )
+			? render
+			: hydrate;
+
+	doHydrate( context );
+}
+
+/**
  * Isomorphic routing helper, client side
  *
  * @param { string } route - A route path
@@ -87,7 +103,7 @@ export const makeLayout = makeLayoutMiddleware( ProviderWrappedLayout );
  * divs.
  */
 export function clientRouter( route, ...middlewares ) {
-	page( route, ...middlewares, hydrate );
+	page( route, ...middlewares, smartHydrate );
 }
 
 export function redirectLoggedOut( context, next ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `clientRouter()` now uses `ReactDOM.render()` instead of `ReactDOM.hydrate()` to transition between SSR -> Client Side Rendering
  * Current code does not guarantee the contract to `.hydrate()`: `React expects that the rendered content is identical between the server and the client.` (https://reactjs.org/docs/react-dom.html#hydrate), since it may start with a logged out SSR view and attempt to hydrate it with a logged in client side view, which are different. This leads to bugs.
  * The SSR -> Client Side Render transition seems to only happen on dev, not prod
* **Detailed post here: pd2qbF-P-p2**

#### Testing instructions

* Visit `http://calypso.localhost:3000/themes` while logged in before and after this PR
* Before, see lots of white space before content (left side)
![2021-05-07_13-58](https://user-images.githubusercontent.com/937354/117728946-bf313b80-b1af-11eb-8b4f-fe58ac6815ae.png)

* After, see intended layout:
![2021-05-10_16-50](https://user-images.githubusercontent.com/937354/117728977-ca846700-b1af-11eb-8c21-ce3e3e85d84a.png)

* Also test `http://calypso.localhost:3000/themes` while logged out
* General/basic testing of other pages
