### PR TITLE
Add Iponweb trackers.

### DIFF
--- a/client/lib/analytics/ad-tracking/ad-track-registration.js
+++ b/client/lib/analytics/ad-tracking/ad-track-registration.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { isAdTrackingAllowed, refreshCountryCodeCookieGdpr } from 'calypso/lib/analytics/utils';
+import { getCurrentUser } from '@automattic/calypso-analytics';
 
 import {
 	debug,
@@ -10,6 +11,7 @@ import {
 	isWpcomGoogleAdsGtagEnabled,
 	isFloodlightEnabled,
 	isPinterestEnabled,
+	isIponwebEnabled,
 	TRACKING_IDS,
 } from './constants';
 import { loadTrackingScripts } from './load-tracking-scripts';
@@ -27,6 +29,7 @@ export async function adTrackRegistration() {
 	}
 
 	await loadTrackingScripts();
+	const currentUser = getCurrentUser();
 
 	// Google Ads Gtag
 
@@ -75,6 +78,19 @@ export async function adTrackRegistration() {
 		const params = [ 'track', 'lead' ];
 		debug( 'adTrackRegistration: [Pinterest]', params );
 		window.pintrk( ...params );
+	}
+
+	// Iponweb
+
+	if ( isIponwebEnabled ) {
+		debug( 'adTrackRegistration: [Iponweb]' );
+		window.smartPixel( 'sendEvent', {
+			id: 'registration',
+			data: {
+				is_new_user: 0,
+				user_id: currentUser ? currentUser.hashedPii.ID : '',
+			},
+		} );
 	}
 
 	debug( 'adTrackRegistration: dataLayer:', JSON.stringify( window.dataLayer, null, 2 ) );

--- a/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
+++ b/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
@@ -23,6 +23,7 @@ import {
 	isTwitterEnabled,
 	isPinterestEnabled,
 	isIconMediaEnabled,
+	isIponwebEnabled,
 	TRACKING_IDS,
 	ICON_MEDIA_SIGNUP_PIXEL_URL,
 } from './constants';
@@ -190,6 +191,19 @@ export async function adTrackSignupComplete( { isNewUserSite } ) {
 		const params = [ 'track', 'Signup', {} ];
 		debug( 'recordSignup: [Twitter]', params );
 		window.twq( ...params );
+	}
+
+	// Iponweb
+
+	if ( isIponwebEnabled ) {
+		debug( 'recordSignup: [Iponweb]' );
+		window.smartPixel( 'sendEvent', {
+			id: 'signup',
+			data: {
+				is_new_user: 0,
+				user_id: currentUser ? currentUser.hashedPii.ID : '',
+			},
+		} );
 	}
 
 	debug( 'recordSignup: dataLayer:', JSON.stringify( window.dataLayer, null, 2 ) );

--- a/client/lib/analytics/ad-tracking/ad-track-signup-start.js
+++ b/client/lib/analytics/ad-tracking/ad-track-signup-start.js
@@ -4,7 +4,13 @@
 import { isAdTrackingAllowed, refreshCountryCodeCookieGdpr } from 'calypso/lib/analytics/utils';
 
 import { getCurrentUser } from '@automattic/calypso-analytics';
-import { debug, isWpcomGoogleAdsGtagEnabled, isFloodlightEnabled, TRACKING_IDS } from './constants';
+import {
+	debug,
+	isWpcomGoogleAdsGtagEnabled,
+	isFloodlightEnabled,
+	isIponwebEnabled,
+	TRACKING_IDS,
+} from './constants';
 import { loadTrackingScripts } from './load-tracking-scripts';
 import { recordParamsInFloodlightGtag } from './floodlight';
 
@@ -49,5 +55,18 @@ export async function adTrackSignupStart( flow ) {
 		];
 		debug( 'adTrackSignupStart: [Google Ads Gtag]', params );
 		window.gtag( ...params );
+	}
+
+	// Iponweb
+
+	if ( isIponwebEnabled && ! currentUser && 'onboarding' === flow ) {
+		debug( 'adTrackSignupStart: [Iponweb]' );
+		window.smartPixel( 'sendEvent', {
+			id: 'signup_start',
+			data: {
+				is_new_user: 0,
+				user_id: currentUser ? currentUser.hashedPii.ID : '',
+			},
+		} );
 	}
 }

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -28,6 +28,7 @@ export const isCriteoEnabled = false;
 export const isPandoraEnabled = false;
 export const isQuoraEnabled = false;
 export const isAdRollEnabled = false;
+export const isIponwebEnabled = true;
 
 /**
  * Module variables
@@ -65,6 +66,7 @@ export const LINKED_IN_SCRIPT_URL = 'https://snap.licdn.com/li.lms-analytics/ins
 export const QUORA_SCRIPT_URL = 'https://a.quora.com/qevents.js';
 export const OUTBRAIN_SCRIPT_URL = 'https://amplify.outbrain.com/cp/obtp.js';
 export const PINTEREST_SCRIPT_URL = 'https://s.pinimg.com/ct/core.js';
+export const IPONWEB_SCRIPT_URL = 'https://s.pubmine.com/loader.js';
 export const TRACKING_IDS = {
 	bingInit: '4074038',
 	facebookInit: '823166884443641',

--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -22,6 +22,7 @@ import {
 	isOutbrainEnabled,
 	isPinterestEnabled,
 	isGoogleAnalyticsEnabled,
+	isIponwebEnabled,
 	TRACKING_IDS,
 	FACEBOOK_TRACKING_SCRIPT_URL,
 	GOOGLE_GTAG_SCRIPT_URL,
@@ -32,6 +33,7 @@ import {
 	QUORA_SCRIPT_URL,
 	OUTBRAIN_SCRIPT_URL,
 	PINTEREST_SCRIPT_URL,
+	IPONWEB_SCRIPT_URL,
 } from './constants';
 
 // Ensure setup has run.
@@ -114,6 +116,10 @@ function getTrackingScriptsToLoad() {
 		scripts.push( PINTEREST_SCRIPT_URL );
 	}
 
+	if ( isIponwebEnabled ) {
+		scripts.push( IPONWEB_SCRIPT_URL );
+	}
+
 	return scripts;
 }
 
@@ -151,6 +157,14 @@ function initLoadedTrackingScripts() {
 		const currentUser = getCurrentUser();
 		const params = currentUser ? { em: currentUser.hashedPii.email } : {};
 		window.pintrk( 'load', TRACKING_IDS.pinterestInit, params );
+	}
+
+	// init Iponweb
+	if ( isIponwebEnabled ) {
+		window.smartPixel = ( command, data ) => {
+			window.smartPixel.cmd = window.smartPixel.cmd || [];
+			window.smartPixel.cmd.push( [ command, data ] );
+		};
 	}
 
 	debug( 'loadTrackingScripts: init done' );

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -25,6 +25,7 @@ import {
 	isAdRollEnabled,
 	isGoogleAnalyticsEnabled,
 	isGoogleAnalyticsEnhancedEcommerceEnabled,
+	isIponwebEnabled,
 	TRACKING_IDS,
 	EXPERIAN_CONVERSION_PIXEL_URL,
 	YAHOO_GEMINI_CONVERSION_PIXEL_URL,
@@ -57,6 +58,7 @@ export async function recordOrder( cart, orderId ) {
 	}
 
 	await loadTrackingScripts();
+	const currentUser = getCurrentUser();
 
 	if ( cart.is_signup ) {
 		return;
@@ -162,6 +164,30 @@ export async function recordOrder( cart, orderId ) {
 	if ( isAdRollEnabled ) {
 		debug( 'recordOrder: [AdRoll]' );
 		window.adRoll.trackPurchase();
+	}
+
+	// Iponweb
+
+	if ( isIponwebEnabled ) {
+		debug( 'recordOrder: [Iponweb]', cart );
+		window.smartPixel( 'sendEvent', {
+			id: 'purchase',
+			data: {
+				is_new_user: 0,
+				user_id: currentUser ? currentUser.hashedPii.ID : '',
+
+				order_id: orderId,
+				cur: cart.currency,
+				value: cart.total_cost,
+
+				line_items: cart.products.map( ( product ) => ( {
+					product_name: product.product_name,
+					product_id: product.product_id,
+					product_price: product.product_cost,
+					product_quantity: product.quantity || 1,
+				} ) ),
+			},
+		} );
 	}
 
 	// Uses JSON.stringify() to print the expanded object because during localhost or .live testing after firing this

--- a/client/lib/analytics/ad-tracking/retarget.js
+++ b/client/lib/analytics/ad-tracking/retarget.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { isAdTrackingAllowed, refreshCountryCodeCookieGdpr } from 'calypso/lib/analytics/utils';
+import { getCurrentUser } from '@automattic/calypso-analytics';
 
 import {
 	debug,
@@ -16,6 +17,7 @@ import {
 	isAdRollEnabled,
 	isIconMediaEnabled,
 	isGeminiEnabled,
+	isIponwebEnabled,
 	TRACKING_IDS,
 	ICON_MEDIA_RETARGETING_PIXEL_URL,
 	YAHOO_GEMINI_AUDIENCE_BUILDING_PIXEL_URL,
@@ -51,6 +53,9 @@ export async function retarget( urlPath ) {
 	await loadTrackingScripts();
 
 	debug( 'retarget:', urlPath );
+
+	// Current user.
+	const currentUser = getCurrentUser();
 
 	// Non rate limited retargeting (main trackers)
 
@@ -97,6 +102,18 @@ export async function retarget( urlPath ) {
 	if ( isAdRollEnabled ) {
 		debug( 'retarget: [AdRoll]' );
 		window.adRoll.trackPageview();
+	}
+
+	// Iponweb
+	if ( isIponwebEnabled ) {
+		debug( 'retarget: [Iponweb]' );
+		window.smartPixel( 'sendEvent', {
+			id: 'pageview',
+			data: {
+				is_new_user: 0,
+				user_id: currentUser ? currentUser.hashedPii.ID : '',
+			},
+		} );
 	}
 
 	// Rate limited retargeting (secondary trackers)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**See:** p5UegX-FQ-p2 ... This adds the Iponweb trackers for `pageview`, `signup_start`, `signup`, and `purchase` events.

#### Testing instructions

Visit: https://calypso.live/start?branch=add/pubmine-trackers

Run the following in DevTools console and then reload the page. Note: Replace `[secret]` with the `store_sandbox` secret -- search MC secret store for "Store Sandbox Cookie Secret".

```
var doc = document, cD = doc.location.hostname.split( '.' ).slice( -2 ).join( '.' );
doc.cookie = 'store_sandbox=[secret]; path=/; domain=.' + cD + '; samesite=none; secure';
doc.cookie = 'flags=a8c-analytics.on,gdpr-banner,google-analytics,ad-tracking; path=/; domain=.' + cD;
doc.cookie = 'sensitive_pixel_option=yes; path=/; domain=.' + cD;
localStorage.setItem( 'debug', 'calypso:*' );
```

- Filter Console tab in DevTools by `Iponweb`
- Set Preserve Log on for Network and Console tabs in DevTools.
- Register, create site, and complete checkout using store sandbox test card `4242 4242 4242 4242`
- Confirm the following events fired:

![Screen Shot on 2021-05-10 at 23:34:00](https://user-images.githubusercontent.com/1563559/117754388-426e8380-b1e8-11eb-91f5-b9f9112fd2bc.png)
