### PR TITLE
ci(e2e): Do not install custom chrome version

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -54,15 +54,6 @@ object RunCalypsoE2eDesktopTests : BuildType({
 				shopt -s globstar
 				set -x
 
-				# Chrome upgrade start
-				wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_90.0.4430.93-1_amd64.deb
-				sudo apt-get install -y ./google-chrome-stable_90.0.4430.93-1_amd64.deb
-				rm ./google-chrome-stable_90.0.4430.93-1_amd64.deb
-				cd test/e2e
-				npm install chromedriver --chromedriver-force-download --detect_chromedriver_version
-				cd ../..
-				# Chrome upgrade end
-
 				cd test/e2e
 				mkdir temp
 
@@ -228,15 +219,6 @@ object RunCalypsoE2eMobileTests : BuildType({
 			scriptContent = """
 				shopt -s globstar
 				set -x
-
-				# Chrome upgrade start
-				wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_90.0.4430.93-1_amd64.deb
-				sudo apt-get install -y ./google-chrome-stable_90.0.4430.93-1_amd64.deb
-				rm ./google-chrome-stable_90.0.4430.93-1_amd64.deb
-				cd test/e2e
-				npm install chromedriver --chromedriver-force-download --detect_chromedriver_version
-				cd ../..
-				# Chrome upgrade end
 
 				cd test/e2e
 				mkdir temp


### PR DESCRIPTION
### Background

Docker images used to run e2e tests contain the latest Chrome version since #52448.

Base image `1.0.334` includes a newer Chrome version, `90.0.4430.212-1`. This causes problems when the build is trying to downgrade Chrome:

![image](https://user-images.githubusercontent.com/975703/117755400-6a77da00-b21c-11eb-8ada-2a90b1055403.png)



### Changes proposed in this Pull Request

Drop logic to install a specific Chrome version at build time.


### Testing instructions

Verify e2e tests pass