### PR TITLE
Sidebar My Sites: Simplifies expanded logic and expands only when a child is selected on desktop.

### DIFF
--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -18,16 +18,12 @@ import PropTypes from 'prop-types';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import MySitesSidebarUnifiedStatsSparkline from './sparkline';
-import {
-	collapseAllMySitesSidebarSections,
-	expandMySitesSidebarSection,
-} from 'calypso/state/my-sites/sidebar/actions';
+import { collapseAllMySitesSidebarSections } from 'calypso/state/my-sites/sidebar/actions';
 
 export const MySitesSidebarUnifiedItem = ( {
 	count,
 	icon,
 	isSubItem = false,
-	sectionId,
 	selected = false,
 	slug,
 	title,
@@ -40,7 +36,6 @@ export const MySitesSidebarUnifiedItem = ( {
 
 	const onNavigate = () => {
 		reduxDispatch( collapseAllMySitesSidebarSections() );
-		reduxDispatch( expandMySitesSidebarSection( sectionId ) );
 		window.scrollTo( 0, 0 );
 	};
 

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -17,11 +17,9 @@ import { isWithinBreakpoint } from '@automattic/viewport';
 /**
  * Internal dependencies
  */
+
 import { isSidebarSectionOpen } from 'calypso/state/my-sites/sidebar/selectors';
-import {
-	toggleMySitesSidebarSection as toggleSection,
-	collapseAllMySitesSidebarSections,
-} from 'calypso/state/my-sites/sidebar/actions';
+import { toggleMySitesSidebarSection as toggleSection } from 'calypso/state/my-sites/sidebar/actions';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import MySitesSidebarUnifiedItem from './item';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
@@ -52,7 +50,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 		children.find( ( menuItem ) => menuItem?.url && itemLinkMatches( menuItem.url, path ) );
 	const childIsSelected = !! selectedMenuItem;
 	const showAsExpanded =
-		( ! isWithinBreakpoint( '>782px' ) && isExpanded ) || // For mobile breakpoints, we dont' care whether a child is secleted or the sidebar collapsed status.
+		( ! isWithinBreakpoint( '>782px' ) && ( childIsSelected || isExpanded ) ) || // For mobile breakpoints, we dont' care about the sidebar collapsed status.
 		( isWithinBreakpoint( '>782px' ) && childIsSelected && ! sidebarCollapsed ); // For desktop breakpoints, a child should be selected and the sidebar being expanded.
 
 	const onClick = () => {
@@ -70,11 +68,6 @@ export const MySitesSidebarUnifiedMenu = ( {
 
 				// Only open the page if menu is NOT full-width, otherwise just open / close the section instead of directly redirecting to the section.
 				page( link );
-			}
-
-			if ( ! sidebarCollapsed ) {
-				// Keep only current submenu open.
-				reduxDispatch( collapseAllMySitesSidebarSections() );
 			}
 		}
 
@@ -102,7 +95,6 @@ export const MySitesSidebarUnifiedMenu = ( {
 							key={ item.title }
 							{ ...item }
 							selected={ isSelected }
-							sectionId={ sectionId }
 							isSubItem={ true }
 							isHappychatSessionActive={ isHappychatSessionActive }
 							isJetpackNonAtomicSite={ isJetpackNonAtomicSite }

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -8,7 +8,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import page from 'page';
@@ -20,7 +20,6 @@ import { isWithinBreakpoint } from '@automattic/viewport';
 import { isSidebarSectionOpen } from 'calypso/state/my-sites/sidebar/selectors';
 import {
 	toggleMySitesSidebarSection as toggleSection,
-	expandMySitesSidebarSection as expandSection,
 	collapseAllMySitesSidebarSections,
 } from 'calypso/state/my-sites/sidebar/actions';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
@@ -45,28 +44,16 @@ export const MySitesSidebarUnifiedMenu = ( {
 	continueInCalypso,
 	...props
 } ) => {
-	const hasAutoExpanded = useRef( false );
 	const reduxDispatch = useDispatch();
 	const sectionId = 'SIDEBAR_SECTION_' + slug;
 	const isExpanded = useSelector( ( state ) => isSidebarSectionOpen( state, sectionId ) );
-	const allowExpansion =
-		( isWithinBreakpoint( '>782px' ) && ! sidebarCollapsed ) || ! isWithinBreakpoint( '>782px' ); // Do not allow expansion on Desktop with sidebar collapsed.
-
 	const selectedMenuItem =
 		Array.isArray( children ) &&
 		children.find( ( menuItem ) => menuItem?.url && itemLinkMatches( menuItem.url, path ) );
 	const childIsSelected = !! selectedMenuItem;
-
-	/**
-	 * One time only, auto-expand the currently active section, or the section
-	 * which contains the current active item.
-	 */
-	useEffect( () => {
-		if ( ! hasAutoExpanded.current && ( selected || childIsSelected ) && ! sidebarCollapsed ) {
-			reduxDispatch( expandSection( sectionId ) );
-			hasAutoExpanded.current = true;
-		}
-	}, [ selected, childIsSelected, reduxDispatch, sectionId, sidebarCollapsed ] );
+	const showAsExpanded =
+		( ! isWithinBreakpoint( '>782px' ) && isExpanded ) || // For mobile breakpoints, we dont' care whether a child is secleted or the sidebar collapsed status.
+		( isWithinBreakpoint( '>782px' ) && childIsSelected && ! sidebarCollapsed ); // For desktop breakpoints, a child should be selected and the sidebar being expanded.
 
 	const onClick = () => {
 		if ( isWithinBreakpoint( '>782px' ) ) {
@@ -99,7 +86,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 		<li>
 			<ExpandableSidebarMenu
 				onClick={ () => onClick() }
-				expanded={ isExpanded && allowExpansion }
+				expanded={ showAsExpanded }
 				title={ title }
 				customIcon={ <SidebarCustomIcon icon={ icon } /> }
 				className={ ( selected || childIsSelected ) && 'sidebar__menu--selected' }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Simplifies expanded logic by consolidating the code to 1 variable.
* Relies on `childIsSelected` for desktop breakpoints

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Desktop**
- Select a Jetpack site and expand "Upgrades" & "Jetpack".
- Now select a WPCOM site.
- Only one (the last) menu should display as expanded.

**Mobile**
- Select a Jetpack site and expand "Upgrades" & "Jetpack".
- Now select a WPCOM site.
- Both sections should be displayed as expanded.
- Clicking an other (Calypso) menu should just expand and not redirect.
- Clicking a submenu item should redirect and collapse the rest of the menus.

Before | After
-------|------
![](https://cln.sh/ZDUJgh+) | ![](https://cln.sh/snAvJ3+)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #52727
