### PR TITLE
Rebrand "Email" to "Professional Email"

### DIFF
--- a/client/lib/titan/get-titan-product-name.js
+++ b/client/lib/titan/get-titan-product-name.js
@@ -1,18 +1,8 @@
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { isEnabled } from '@automattic/calypso-config';
+import { translate } from 'i18n-calypso';
 
 export function getTitanProductName() {
-	if ( isEnabled( 'titan/phase-2' ) ) {
-		return i18n.translate( 'Email', {
-			comment: 'Email is the name of a WordPress.com product, not just a capitalization of "email"',
-		} );
-	}
-	return i18n.translate( 'Titan Mail' );
+	return translate( 'Professional Email' );
 }

--- a/client/lib/titan/get-titan-product-name.js
+++ b/client/lib/titan/get-titan-product-name.js
@@ -4,5 +4,7 @@
 import { translate } from 'i18n-calypso';
 
 export function getTitanProductName() {
-	return translate( 'Professional Email' );
+	return translate( 'Professional Email', {
+		comment: 'This is the name of our Professional Email product',
+	} );
 }

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -62,7 +62,7 @@ class RemoveDomainDialog extends Component {
 									productName: getTitanProductName(),
 								},
 								comment:
-									'%(productName) is the name of the product, which is either Email or Titan Mail',
+									'%(productName) is the name of the product, which should be Professional Email',
 							}
 						) }
 			</p>

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -62,7 +62,7 @@ class RemoveDomainDialog extends Component {
 									productName: getTitanProductName(),
 								},
 								comment:
-									'%(productName) is the name of the product, which should be Professional Email',
+									'%(productName) is the name of the product, which should be "Professional Email" translated',
 							}
 						) }
 			</p>

--- a/client/my-sites/checkout/composite-checkout/components/titan-terms-of-service.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/titan-terms-of-service.jsx
@@ -18,7 +18,7 @@ function TitanTermsOfService( { cart, translate } ) {
 	}
 
 	const titanTerms = translate(
-		"You understand that your Email service will be powered by Titan and is subject to Titan's {{titanCustomerTos}}Customer Terms of Service{{/titanCustomerTos}}, {{titanAup}}Acceptable Use Policy{{/titanAup}}, and {{titanPrivacy}}Privacy Policy{{/titanPrivacy}}.",
+		"You understand that your Professional Email service will be powered by Titan and is subject to Titan's {{titanCustomerTos}}Customer Terms of Service{{/titanCustomerTos}}, {{titanAup}}Acceptable Use Policy{{/titanAup}}, and {{titanPrivacy}}Privacy Policy{{/titanPrivacy}}.",
 		{
 			components: {
 				titanCustomerTos: (

--- a/client/my-sites/checkout/composite-checkout/components/titan-terms-of-service.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/titan-terms-of-service.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
  */
 import { hasTitanMail } from 'calypso/lib/cart-values/cart-items';
 import Gridicon from 'calypso/components/gridicon';
+import { getTitanProductName } from 'calypso/lib/titan';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -18,8 +19,13 @@ function TitanTermsOfService( { cart, translate } ) {
 	}
 
 	const titanTerms = translate(
-		"You understand that your Professional Email service will be powered by Titan and is subject to Titan's {{titanCustomerTos}}Customer Terms of Service{{/titanCustomerTos}}, {{titanAup}}Acceptable Use Policy{{/titanAup}}, and {{titanPrivacy}}Privacy Policy{{/titanPrivacy}}.",
+		"You understand that your %(productName)s service will be powered by Titan and is subject to Titan's {{titanCustomerTos}}Customer Terms of Service{{/titanCustomerTos}}, {{titanAup}}Acceptable Use Policy{{/titanAup}}, and {{titanPrivacy}}Privacy Policy{{/titanPrivacy}}.",
 		{
+			args: {
+				productName: getTitanProductName(),
+			},
+			comment:
+				'%(productName) is the name of the product, which should be "Professional Email" translated',
 			components: {
 				titanCustomerTos: (
 					<a

--- a/client/my-sites/domains/domain-management/list/list-header.jsx
+++ b/client/my-sites/domains/domain-management/list/list-header.jsx
@@ -73,7 +73,7 @@ class ListHeader extends React.PureComponent {
 									titanMailService: getTitanProductName(),
 								},
 								comment:
-									'%(googleMailService)s can be either "G Suite" or "Google Workspace"; %(titanMailService)s can be either "Email" or "Titan Mail"',
+									'%(googleMailService)s can be either "G Suite" or "Google Workspace"; %(titanMailService)s will be "Professional Email"',
 							}
 						) }
 					</InfoPopover>

--- a/client/my-sites/domains/domain-management/list/list-header.jsx
+++ b/client/my-sites/domains/domain-management/list/list-header.jsx
@@ -73,7 +73,7 @@ class ListHeader extends React.PureComponent {
 									titanMailService: getTitanProductName(),
 								},
 								comment:
-									'%(googleMailService)s can be either "G Suite" or "Google Workspace"; %(titanMailService)s will be "Professional Email"',
+									'%(googleMailService)s can be either "G Suite" or "Google Workspace"; %(titanMailService)s will be "Professional Email" translated',
 							}
 						) }
 					</InfoPopover>

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -23,7 +23,7 @@ import {
 	getEmailPurchaseByDomain,
 	hasEmailSubscription,
 } from 'calypso/my-sites/email/email-management/home/utils';
-import { getTitanSubscriptionId, hasTitanMailWithUs } from 'calypso/lib/titan';
+import { getTitanProductName, getTitanSubscriptionId, hasTitanMailWithUs } from 'calypso/lib/titan';
 import HeaderCake from 'calypso/components/header-cake';
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
@@ -158,7 +158,13 @@ class EmailPlan extends React.Component {
 		}
 
 		if ( hasTitanMailWithUs( domain ) ) {
-			return translate( 'Professional Email settings' );
+			return translate( '%(titanProductName)s settings', {
+				args: {
+					titanProductName: getTitanProductName(),
+				},
+				comment:
+					'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
+			} );
 		}
 
 		return translate( 'Email forwarding settings' );

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -158,7 +158,7 @@ class EmailPlan extends React.Component {
 		}
 
 		if ( hasTitanMailWithUs( domain ) ) {
-			return translate( 'Email settings' );
+			return translate( 'Professional Email settings' );
 		}
 
 		return translate( 'Email forwarding settings' );

--- a/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
@@ -85,7 +85,11 @@ class TitanControlPanelLoginCard extends React.Component {
 				'%(domainName)s is a domain name, e.g. example.com; %(productName)s is the product name, which should be Professional Email',
 		};
 		const sectionHeaderLabel = translate( '%(productName)s: %(domainName)s', translateArgs );
-		const buttonCtaText = translate( 'Log in to your Professional Email control panel' );
+		const buttonCtaText = translate( 'Log in to your %(productName)s control panel', {
+			args: { productName: getTitanProductName() },
+			comment:
+				'%(productName)s is the product name, which will be the translated version of "Professional Email"',
+		} );
 		const cardText = translate(
 			'Go to the %(productName)s control panel to manage email for %(domainName)s.',
 			translateArgs
@@ -126,7 +130,13 @@ class TitanControlPanelLoginCard extends React.Component {
 				<CompactCard>
 					{ this.state.iframeURL ? (
 						<iframe
-							title={ translate( 'Professional Email Control Panel' ) }
+							title={ translate( '%(titanProductName)s Control Panel', {
+								args: {
+									titanProductName: getTitanProductName(),
+								},
+								comment:
+									'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
+							} ) }
 							src={ this.state.iframeURL }
 							width="100%"
 							height="1200px"

--- a/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
@@ -82,7 +82,7 @@ class TitanControlPanelLoginCard extends React.Component {
 				productName: getTitanProductName(),
 			},
 			comment:
-				'%(domainName)s is a domain name, e.g. example.com; %(productName)s is the product name, which should be Professional Email',
+				'%(domainName)s is a domain name, e.g. example.com; %(productName)s is the product name, which should be "Professional Email" translated',
 		};
 		const sectionHeaderLabel = translate( '%(productName)s: %(domainName)s', translateArgs );
 		const buttonCtaText = translate( 'Log in to your %(productName)s control panel', {
@@ -120,7 +120,7 @@ class TitanControlPanelLoginCard extends React.Component {
 				productName: getTitanProductName(),
 			},
 			comment:
-				'%(domainName)s is a domain name, e.g. example.com; %(productName)s is the product name, which should be Professional Email',
+				'%(domainName)s is a domain name, e.g. example.com; %(productName)s is the product name, which should be "Professional Email" translated',
 		};
 		const sectionHeaderLabel = translate( '%(productName)s: %(domainName)s', translateArgs );
 

--- a/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
@@ -82,12 +82,10 @@ class TitanControlPanelLoginCard extends React.Component {
 				productName: getTitanProductName(),
 			},
 			comment:
-				'%(domainName)s is a domain name, e.g. example.com; %(productName)s is the product name, either Email or Titan Mail',
+				'%(domainName)s is a domain name, e.g. example.com; %(productName)s is the product name, which should be Professional Email',
 		};
 		const sectionHeaderLabel = translate( '%(productName)s: %(domainName)s', translateArgs );
-		const buttonCtaText = isEnabled( 'titan/phase-2' )
-			? translate( 'Log in to the Email control panel' )
-			: translate( "Log in to Titan's control panel" );
+		const buttonCtaText = translate( 'Log in to your Professional Email control panel' );
 		const cardText = translate(
 			'Go to the %(productName)s control panel to manage email for %(domainName)s.',
 			translateArgs
@@ -118,7 +116,7 @@ class TitanControlPanelLoginCard extends React.Component {
 				productName: getTitanProductName(),
 			},
 			comment:
-				'%(domainName)s is a domain name, e.g. example.com; %(productName)s is the product name, either Email or Titan Mail',
+				'%(domainName)s is a domain name, e.g. example.com; %(productName)s is the product name, which should be Professional Email',
 		};
 		const sectionHeaderLabel = translate( '%(productName)s: %(domainName)s', translateArgs );
 
@@ -128,7 +126,7 @@ class TitanControlPanelLoginCard extends React.Component {
 				<CompactCard>
 					{ this.state.iframeURL ? (
 						<iframe
-							title={ translate( 'Email Control Panel' ) }
+							title={ translate( 'Professional Email Control Panel' ) }
 							src={ this.state.iframeURL }
 							width="100%"
 							height="1200px"

--- a/client/my-sites/email/email-management/titan-control-panel-redirect/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-redirect/index.jsx
@@ -90,7 +90,7 @@ class TitanControlPanelRedirect extends React.Component {
 				<EmptyContent illustration="" title="">
 					<Card>
 						<Spinner size={ 40 } />
-						<h1>{ translate( 'Redirecting you to your Email Control Panel' ) }</h1>
+						<h1>{ translate( 'Redirecting you to your Professional Email Control Panel' ) }</h1>
 						<hr />
 						<img src={ poweredByTitanLogo } alt={ translate( 'Powered by Titan' ) } />
 					</Card>

--- a/client/my-sites/email/email-management/titan-control-panel-redirect/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-redirect/index.jsx
@@ -13,7 +13,7 @@ import { Card } from '@automattic/components';
 import EmptyContent from 'calypso/components/empty-content';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { fetchTitanAutoLoginURL } from 'calypso/my-sites/email/email-management/titan-functions';
-import { getTitanMailOrderId, hasTitanMailWithUs } from 'calypso/lib/titan';
+import { getTitanMailOrderId, getTitanProductName, hasTitanMailWithUs } from 'calypso/lib/titan';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import getSiteBySlug from 'calypso/state/sites/selectors/get-site-by-slug';
@@ -90,7 +90,15 @@ class TitanControlPanelRedirect extends React.Component {
 				<EmptyContent illustration="" title="">
 					<Card>
 						<Spinner size={ 40 } />
-						<h1>{ translate( 'Redirecting you to your Professional Email Control Panel' ) }</h1>
+						<h1>
+							{ translate( 'Redirecting you to your %(titanProductName)s Control Panel', {
+								args: {
+									titanProductName: getTitanProductName(),
+								},
+								comment:
+									'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
+							} ) }
+						</h1>
 						<hr />
 						<img src={ poweredByTitanLogo } alt={ translate( 'Powered by Titan' ) } />
 					</Card>

--- a/client/my-sites/email/email-management/titan-management-iframe/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-iframe/index.jsx
@@ -16,6 +16,7 @@ import EmptyContent from 'calypso/components/empty-content';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getTitanProductName } from 'calypso/lib/titan';
 import Header from 'calypso/my-sites/domains/domain-management/components/header';
 import { isEnabled } from '@automattic/calypso-config';
 import Main from 'calypso/components/main';
@@ -77,11 +78,25 @@ class TitanManagementIframe extends React.Component {
 					<QueryEmailAccounts siteId={ selectedSiteId } />
 				) }
 				<QuerySiteDomains siteId={ selectedSiteId } />
-				<DocumentHead title={ translate( 'Professional Email Management' ) } />
+				<DocumentHead
+					title={ translate( '%(titanProductName)s Management', {
+						args: {
+							titanProductName: getTitanProductName(),
+						},
+						comment:
+							'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
+					} ) }
+				/>
 				<SidebarNavigation />
 
 				<Header backHref={ emailManagementPath } selectedDomainName={ domainName }>
-					{ translate( 'Professional Email Settings' ) }
+					{ translate( '%(titanProductName)s settings', {
+						args: {
+							titanProductName: getTitanProductName(),
+						},
+						comment:
+							'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
+					} ) }
 				</Header>
 				{ this.renderManagementSection() }
 			</Main>

--- a/client/my-sites/email/email-management/titan-management-iframe/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-iframe/index.jsx
@@ -71,6 +71,13 @@ class TitanManagementIframe extends React.Component {
 			);
 		}
 		const emailManagementPath = emailManagement( selectedSiteSlug, domainName, currentRoute );
+		const pageTitle = translate( '%(titanProductName)s settings', {
+			args: {
+				titanProductName: getTitanProductName(),
+			},
+			comment:
+				'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
+		} );
 
 		return (
 			<Main className="titan-management-iframe" wideLayout>
@@ -78,25 +85,11 @@ class TitanManagementIframe extends React.Component {
 					<QueryEmailAccounts siteId={ selectedSiteId } />
 				) }
 				<QuerySiteDomains siteId={ selectedSiteId } />
-				<DocumentHead
-					title={ translate( '%(titanProductName)s Management', {
-						args: {
-							titanProductName: getTitanProductName(),
-						},
-						comment:
-							'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
-					} ) }
-				/>
+				<DocumentHead title={ pageTitle } />
 				<SidebarNavigation />
 
 				<Header backHref={ emailManagementPath } selectedDomainName={ domainName }>
-					{ translate( '%(titanProductName)s settings', {
-						args: {
-							titanProductName: getTitanProductName(),
-						},
-						comment:
-							'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
-					} ) }
+					{ pageTitle }
 				</Header>
 				{ this.renderManagementSection() }
 			</Main>

--- a/client/my-sites/email/email-management/titan-management-iframe/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-iframe/index.jsx
@@ -77,11 +77,11 @@ class TitanManagementIframe extends React.Component {
 					<QueryEmailAccounts siteId={ selectedSiteId } />
 				) }
 				<QuerySiteDomains siteId={ selectedSiteId } />
-				<DocumentHead title={ translate( 'Email Management' ) } />
+				<DocumentHead title={ translate( 'Professional Email Management' ) } />
 				<SidebarNavigation />
 
 				<Header backHref={ emailManagementPath } selectedDomainName={ domainName }>
-					{ translate( 'Email Settings' ) }
+					{ translate( 'Professional Email Settings' ) }
 				</Header>
 				{ this.renderManagementSection() }
 			</Main>

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -401,7 +401,7 @@ class EmailProvidersComparison extends React.Component {
 			<EmailProviderCard
 				providerKey="titan"
 				logo={ logo }
-				title={ translate( 'Email' ) }
+				title={ translate( 'Professional Email' ) }
 				badge={ poweredByTitan }
 				description={ translate(
 					'Easy-to-use email with incredibly powerful features. Manage your email and more on any device.'

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -39,6 +39,7 @@ import { getAnnualPrice, getGoogleMailServiceFamily, getMonthlyPrice } from 'cal
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getTitanProductName } from 'calypso/lib/titan';
 import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
 import { emailManagementForwarding } from 'calypso/my-sites/email/paths';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -392,7 +393,13 @@ class EmailProvidersComparison extends React.Component {
 					busy={ this.state.addingToCart }
 					onClick={ this.onTitanConfirmNewMailboxes }
 				>
-					{ translate( 'Add Email' ) }
+					{ translate( 'Add %(titanProductName)s', {
+						args: {
+							titanProductName: getTitanProductName(),
+						},
+						comment:
+							'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
+					} ) }
 				</Button>
 			</TitanNewMailboxList>
 		);
@@ -401,7 +408,7 @@ class EmailProvidersComparison extends React.Component {
 			<EmailProviderCard
 				providerKey="titan"
 				logo={ logo }
-				title={ translate( 'Professional Email' ) }
+				title={ getTitanProductName() }
 				badge={ poweredByTitan }
 				description={ translate(
 					'Easy-to-use email with incredibly powerful features. Manage your email and more on any device.'
@@ -412,7 +419,13 @@ class EmailProvidersComparison extends React.Component {
 				discount={ discount }
 				formFields={ formFields }
 				showExpandButton={ this.isDomainEligibleForEmail( domain ) }
-				expandButtonLabel={ translate( 'Add Email' ) }
+				expandButtonLabel={ translate( 'Add %(titanProductName)s', {
+					args: {
+						titanProductName: getTitanProductName(),
+					},
+					comment:
+						'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
+				} ) }
 				features={ getTitanFeatures() }
 			/>
 		);

--- a/client/my-sites/email/titan-redirector/index.jsx
+++ b/client/my-sites/email/titan-redirector/index.jsx
@@ -115,7 +115,7 @@ class TitanRedirector extends Component {
 				<EmptyContent
 					title={ translate( "We couldn't locate your account details" ) }
 					line={ translate(
-						'Please check that you purchased the Email subscription, as only the original purchaser can manage billing and add more accounts'
+						'Please check that you purchased the Professional Email subscription, as only the original purchaser can manage billing and add more accounts'
 					) }
 					action={ translate( 'Contact support' ) }
 					actionURL={ SUPPORT_ROOT }

--- a/client/my-sites/email/titan-redirector/index.jsx
+++ b/client/my-sites/email/titan-redirector/index.jsx
@@ -21,6 +21,7 @@ import { addQueryArgs } from 'calypso/lib/route';
 import { login } from 'calypso/lib/paths';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getTitanProductName } from 'calypso/lib/titan';
 import QuerySites from 'calypso/components/data/query-sites';
 
 class TitanRedirector extends Component {
@@ -115,7 +116,14 @@ class TitanRedirector extends Component {
 				<EmptyContent
 					title={ translate( "We couldn't locate your account details" ) }
 					line={ translate(
-						'Please check that you purchased the Professional Email subscription, as only the original purchaser can manage billing and add more accounts'
+						'Please check that you purchased the %(titanProductName)s subscription, as only the original purchaser can manage billing and add more accounts',
+						{
+							args: {
+								titanProductName: getTitanProductName(),
+							},
+							comment:
+								'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
+						}
 					) }
 					action={ translate( 'Contact support' ) }
 					actionURL={ SUPPORT_ROOT }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates all client-side uses of "Email" referring to our Email product to be "Professional Email", which includes a number of changes to use our common product name function and string substitution, mostly so we have consistent translations for "Professional Email"
* Note that we still have server-defined strings that will appear in the UI, so this doesn't address all cases where "Email" may appear instead of "Professional Email".

#### Testing instructions

There are a number of locations where we need to check that the new brand is displayed:
* The card header in the email comparison page (shown when adding email to an existing domain).
* The terms of service displayed in checkout when buying a new Professional Email subscription or adding Professional Email mailboxes to an existing subscription.
* When opening up the external link to manage your Professional Email settings via the Titan Control Panel, ensure that the redirect page uses "Professional Email" before redirecting.
* The card header for the new email plan management page should be "Professional Email settings"
* The card header and section header for the iframed control panel should include "Professional Email" -- this can be enabled by adding `?flags=titan/iframe-control-panel` to your URL

#### Screenshots

##### New email plan page
<img width="1073" alt="Screenshot 2021-05-11 at 12 45 17" src="https://user-images.githubusercontent.com/3376401/117804530-273b5c80-b258-11eb-9bc2-5ef92d3ed1e9.png">

##### Control panel redirect page
<img width="1058" alt="Screenshot 2021-05-11 at 12 48 55" src="https://user-images.githubusercontent.com/3376401/117804544-2a364d00-b258-11eb-908c-a630388da4a8.png">

##### Terms of service in checkout
<img width="599" alt="Screenshot 2021-05-11 at 12 47 35" src="https://user-images.githubusercontent.com/3376401/117804546-2acee380-b258-11eb-9797-1d3da1e4aa43.png">

##### Page header and section header for iframed control panel
<img width="1074" alt="Screenshot 2021-05-11 at 12 56 48" src="https://user-images.githubusercontent.com/3376401/117804880-99ac3c80-b258-11eb-99bb-8171efbd8ee0.png">
