### PR TITLE
Reverts wide layout to 1040px.

### DIFF
--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -4,7 +4,7 @@
 	z-index: z-index( 'root', '.main' );
 
 	&.is-wide-layout {
-		max-width: 100%;
+		max-width: 1040px;
 	}
 }
 

--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -3,6 +3,11 @@
 	max-width: 720px;
 	z-index: z-index( 'root', '.main' );
 
+	// Themes is a great example of using all this new space ;)
+	&.themes {
+		max-width: 100%;
+	}
+
 	&.is-wide-layout {
 		max-width: 1040px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reverts the wide layout to `1040px` rather than 100%.


Related convo p1620734140151200-slack-C0D96691V

Related PR https://github.com/Automattic/wp-calypso/pull/52715