### PR TITLE
Revert "Layout: makes wide layout full width."

### DIFF
--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -3,8 +3,13 @@
 	max-width: 720px;
 	z-index: z-index( 'root', '.main' );
 
-	&.is-wide-layout {
+	// Themes is a great example of using all this new space ;)
+	&.themes {
 		max-width: 100%;
+	}
+
+	&.is-wide-layout {
+		max-width: 1040px;
 	}
 }
 

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -16,7 +16,7 @@ function Dashboard( className ) {
 	const translate = useTranslate();
 
 	return (
-		<Main className={ classNames( 'dashboard', className ) } wideLayout>
+		<Main className={ classNames( 'dashboard', className ) } wideLayout={ true }>
 			<ActionHeader breadcrumbs={ translate( 'Store' ) } />
 			<StoreMoveNoticeView />
 		</Main>

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -56,7 +56,7 @@ class StoreStats extends Component {
 		const widgetPath = getWidgetPath( unit, slug, queryParams );
 
 		return (
-			<Main className="store-stats woocommerce" wideLayout>
+			<Main className="store-stats woocommerce" wideLayout={ true }>
 				<PageViewTracker
 					path={ `/store/stats/orders/${ unit }/:site` }
 					title={ `Store > Stats > Orders > ${ titlecase( unit ) }` }

--- a/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
@@ -24,7 +24,7 @@ export default function BillingDashboard(): ReactElement {
 	const translate = useTranslate();
 
 	return (
-		<Main wideLayout className="billing-dashboard">
+		<Main wideLayout={ true } className="billing-dashboard">
 			<DocumentHead title={ translate( 'Billing' ) } />
 			<SidebarNavigation />
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -53,7 +53,7 @@ export default function Licenses( {
 	};
 
 	return (
-		<Main wideLayout className="licenses">
+		<Main wideLayout={ true } className="licenses">
 			<DocumentHead title={ translate( 'Licenses' ) } />
 			<SidebarNavigation />
 

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -990,7 +990,7 @@ class Account extends React.Component {
 		const renderUsernameForm = this.hasUnsavedUserSetting( 'user_login' );
 
 		return (
-			<Main wideLayout className="account">
+			<Main className="account is-wide-layout">
 				<QueryUserSettings />
 				<PageViewTracker path="/me/account" title="Me > Account Settings" />
 				<MeSidebarNavigation />

--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -110,7 +110,7 @@ class ConnectedApplications extends PureComponent {
 		const { translate } = this.props;
 
 		return (
-			<Main wideLayout className="security connected-applications">
+			<Main className="security connected-applications is-wide-layout">
 				<QueryConnectedApplications />
 
 				<PageViewTracker

--- a/client/me/memberships/main.jsx
+++ b/client/me/memberships/main.jsx
@@ -112,7 +112,7 @@ const MembershipsHistory = ( { translate, subscriptions, moment } ) => {
 	}
 
 	return (
-		<Main wideLayout className="memberships">
+		<Main className="memberships is-wide-layout">
 			<DocumentHead title={ translate( 'Other Sites' ) } />
 			<PageViewTracker path="/me/purchases/other" title="Me > Other Sites" />
 			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -40,7 +40,7 @@ class Subscription extends React.Component {
 		const { translate, subscription, moment, stoppingStatus } = this.props;
 
 		return (
-			<Main wideLayout className="memberships__subscription">
+			<Main className="memberships__subscription is-wide-layout">
 				<DocumentHead title={ translate( 'Subscription Details' ) } />
 				<MeSidebarNavigation />
 				<QueryMembershipsSubscriptions />

--- a/client/me/notification-settings/comment-settings/index.jsx
+++ b/client/me/notification-settings/comment-settings/index.jsx
@@ -56,7 +56,7 @@ class NotificationCommentsSettings extends Component {
 		const { path, translate } = this.props;
 
 		return (
-			<Main wideLayout className="comment-settings__main">
+			<Main className="comment-settings__main is-wide-layout">
 				<PageViewTracker
 					path="/me/notifications/comments"
 					title="Me > Notifications > Comments on other sites"

--- a/client/me/notification-settings/main.jsx
+++ b/client/me/notification-settings/main.jsx
@@ -59,7 +59,7 @@ class NotificationSettings extends Component {
 			this.props.saveSettings( 'blogs', findSettingsForBlog( blogId ), true );
 
 		return (
-			<Main wideLayout className="notification-settings">
+			<Main className="notification-settings is-wide-layout">
 				<PageViewTracker path="/me/notifications" title="Me > Notifications" />
 				<QueryUserDevices />
 				<MeSidebarNavigation />

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -64,7 +64,7 @@ class NotificationSubscriptions extends React.Component {
 
 	render() {
 		return (
-			<Main wideLayout className="reader-subscriptions__notifications-settings">
+			<Main className="reader-subscriptions__notifications-settings is-wide-layout">
 				<PageViewTracker
 					path="/me/notifications/subscriptions"
 					title="Me > Notifications > Subscriptions Delivery"

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -195,7 +195,7 @@ class WPCOMNotifications extends React.Component {
 
 	render() {
 		return (
-			<Main wideLayout className="wpcom-settings__main">
+			<Main className="wpcom-settings__main is-wide-layout">
 				<PageViewTracker
 					path="/me/notifications/updates"
 					title="Me > Notifications > Updates from WordPress.com"

--- a/client/me/pending-payments/index.jsx
+++ b/client/me/pending-payments/index.jsx
@@ -111,7 +111,7 @@ export class PendingPayments extends Component {
 		}
 
 		return (
-			<Main wideLayout className="pending-payments">
+			<Main className="pending-payments is-wide-layout">
 				<PageViewTracker path="/me/purchases/pending" title="Pending Payments" />
 				<MeSidebarNavigation />
 				<PurchasesNavigation section="pendingPayments" />

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -96,7 +96,7 @@ class Privacy extends React.Component {
 		);
 
 		return (
-			<Main wideLayout className="privacy">
+			<Main className="privacy is-wide-layout">
 				<QueryUserSettings />
 				<PageViewTracker path="/me/privacy" title="Me > Privacy" />
 				<DocumentHead title={ translate( 'Privacy Settings' ) } />

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -23,6 +23,7 @@ import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import ProfileLinks from 'calypso/me/profile-links';
 import ReauthRequired from 'calypso/me/reauth-required';
 import SectionHeader from 'calypso/components/section-header';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import { protectForm } from 'calypso/lib/protect-form';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
@@ -51,7 +52,7 @@ class Profile extends React.Component {
 		const gravatarProfileLink = 'https://gravatar.com/' + this.props.getSetting( 'user_login' );
 
 		return (
-			<Main className="profile">
+			<Main className="profile is-wide-layout">
 				<PageViewTracker path="/me" title="Me > My Profile" />
 				<MeSidebarNavigation />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />

--- a/client/me/purchases/add-new-payment-method/index.jsx
+++ b/client/me/purchases/add-new-payment-method/index.jsx
@@ -56,7 +56,7 @@ function AddNewPaymentMethod() {
 	}
 
 	return (
-		<Main wideLayout className="add-new-payment-method">
+		<Main className="add-new-payment-method is-wide-layout">
 			<PageViewTracker
 				path="/me/purchases/add-payment-method"
 				title={ concatTitle( titles.activeUpgrades, addPaymentMethodTitle ) }

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -40,7 +40,7 @@ export function BillingHistoryContent( {
 
 function BillingHistory(): JSX.Element {
 	return (
-		<Main wideLayout className="billing-history">
+		<Main className="billing-history is-wide-layout">
 			<DocumentHead title={ titles.billingHistory } />
 			<PageViewTracker path="/me/purchases/billing" title="Me > Billing History" />
 			<MeSidebarNavigation />

--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -69,7 +69,7 @@ class BillingReceipt extends React.Component {
 		const { transaction, transactionId, translate } = this.props;
 
 		return (
-			<Main wideLayout className="receipt">
+			<Main className="receipt is-wide-layout">
 				<DocumentHead title={ translate( 'Billing History' ) } />
 				<PageViewTracker
 					path="/me/purchases/billing/:receipt"

--- a/client/me/purchases/components/loading-placeholder/index.jsx
+++ b/client/me/purchases/components/loading-placeholder/index.jsx
@@ -5,6 +5,7 @@
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -29,8 +30,12 @@ class LoadingPlaceholder extends React.Component {
 	};
 
 	render() {
+		const classes = classnames( 'loading-placeholder', {
+			'is-wide-layout': this.props.isFullWidth,
+		} );
+
 		return (
-			<Main wideLayout={ this.props.isFullWidth } className="loading-placeholder">
+			<Main className={ classes }>
 				<HeaderCake className="loading-placeholder__header" onClick={ this.goBack }>
 					{ this.props.title }
 				</HeaderCake>

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -39,7 +39,7 @@ function noSites( context, analyticsPath ) {
 	const NoSitesWrapper = localize( () => {
 		return (
 			<PurchasesWrapper>
-				<Main wideLayout className="purchases__no-site">
+				<Main className="purchases__no-site is-wide-layout">
 					<PageViewTracker path={ analyticsPath } title="Purchases > No Sites" />
 					<PurchasesNavigation section="activeUpgrades" />
 					<NoSitesMessage />
@@ -62,7 +62,7 @@ export function cancelPurchase( context, next ) {
 	const CancelPurchaseWrapper = localize( () => {
 		return (
 			<PurchasesWrapper title={ titles.cancelPurchase }>
-				<Main wideLayout className="purchases__cancel">
+				<Main className="purchases__cancel is-wide-layout">
 					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 					<CancelPurchase
 						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
@@ -87,7 +87,7 @@ export function confirmCancelDomain( context, next ) {
 	const ConfirmCancelDomainWrapper = localize( () => {
 		return (
 			<PurchasesWrapper title={ titles.confirmCancelDomain }>
-				<Main wideLayout className="purchases__cancel-domain confirm-cancel-domain">
+				<Main className="purchases__cancel-domain confirm-cancel-domain is-wide-layout">
 					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 					<ConfirmCancelDomain
 						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
@@ -117,11 +117,11 @@ export function list( context, next ) {
 
 export function managePurchase( context, next ) {
 	const ManagePurchasesWrapper = localize( () => {
-		const classes = 'manage-purchase';
+		const classes = 'manage-purchase is-wide-layout';
 
 		return (
 			<PurchasesWrapper title={ titles.managePurchase }>
-				<Main wideLayout className={ classes }>
+				<Main className={ classes }>
 					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 					<PageViewTracker
 						path="/me/purchases/:site/:purchaseId"
@@ -155,7 +155,7 @@ export function changePaymentMethod( context, next ) {
 	const ChangePaymentMethodWrapper = localize( () => {
 		return (
 			<PurchasesWrapper title={ titles.changePaymentMethod }>
-				<Main wideLayout className="purchases__edit-payment-method">
+				<Main className="purchases__edit-payment-method is-wide-layout">
 					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 					<ChangePaymentMethod
 						purchaseId={ parseInt( context.params.purchaseId, 10 ) }

--- a/client/me/purchases/payment-methods/main.tsx
+++ b/client/me/purchases/payment-methods/main.tsx
@@ -24,7 +24,7 @@ import './style.scss';
 
 function PaymentMethods(): JSX.Element {
 	return (
-		<Main wideLayout className="payment-methods__main">
+		<Main className="payment-methods__main is-wide-layout">
 			<DocumentHead title={ titles.paymentMethods } />
 			<PageViewTracker path="/me/purchases/payment-methods" title="Me > Payment Methods" />
 			<MeSidebarNavigation />

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -142,7 +142,7 @@ class PurchasesList extends Component {
 		) {
 			if ( ! sites.length ) {
 				return (
-					<Main wideLayout className="purchases-list">
+					<Main className="purchases-list is-wide-layout">
 						<PageViewTracker path="/me/purchases" title="Purchases > No Sites" />
 						<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 						<PurchasesNavigation section="activeUpgrades" />
@@ -171,7 +171,7 @@ class PurchasesList extends Component {
 		}
 
 		return (
-			<Main wideLayout className="purchases-list">
+			<Main className="purchases-list is-wide-layout">
 				<QueryUserPurchases userId={ userId } />
 				<QueryMembershipsSubscriptions />
 				<PageViewTracker path="/me/purchases" title="Purchases" />

--- a/client/me/security-account-recovery/index.jsx
+++ b/client/me/security-account-recovery/index.jsx
@@ -55,7 +55,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import './style.scss';
 
 const SecurityAccountRecovery = ( props ) => (
-	<Main wideLayout className="security security-account-recovery">
+	<Main className="security security-account-recovery is-wide-layout">
 		<PageViewTracker path="/me/security/account-recovery" title="Me > Account Recovery" />
 		<QueryAccountRecoverySettings />
 

--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -41,7 +41,7 @@ class SecurityCheckupComponent extends React.Component {
 		const { path, translate } = this.props;
 
 		return (
-			<Main wideLayout className="security security-checkup">
+			<Main className="security security-checkup is-wide-layout">
 				<PageViewTracker path={ path } title="Me > Security Checkup" />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 				<MeSidebarNavigation />

--- a/client/me/security/main.jsx
+++ b/client/me/security/main.jsx
@@ -50,7 +50,7 @@ class Security extends React.Component {
 		const useCheckupMenu = config.isEnabled( 'security/security-checkup' );
 
 		return (
-			<Main wideLayout className="security">
+			<Main className="security is-wide-layout">
 				<PageViewTracker path={ path } title="Me > Password" />
 				<DocumentHead title={ translate( 'Password' ) } />
 				<MeSidebarNavigation />

--- a/client/me/site-blocks/main.jsx
+++ b/client/me/site-blocks/main.jsx
@@ -63,7 +63,7 @@ class SiteBlockList extends Component {
 		const hasNoBlocks = blockedSites.length === 0 && currentPage === lastPage;
 
 		return (
-			<Main wideLayout className="site-blocks">
+			<Main className="site-blocks is-wide-layout">
 				<QuerySiteBlocks />
 				<PageViewTracker path="/me/site-blocks" title="Me > Blocked Sites" />
 				<DocumentHead title={ translate( 'Blocked Sites' ) } />

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -84,7 +84,7 @@ class SocialLogin extends Component {
 		const title = useCheckupMenu ? translate( 'Social Logins' ) : translate( 'Social Login' );
 
 		return (
-			<Main wideLayout className="security social-login">
+			<Main className="security social-login is-wide-layout">
 				<PageViewTracker path="/me/security/social-login" title="Me > Social Login" />
 				<DocumentHead title={ title } />
 				<MeSidebarNavigation />

--- a/client/me/two-step/index.jsx
+++ b/client/me/two-step/index.jsx
@@ -106,7 +106,7 @@ class TwoStep extends Component {
 		const useCheckupMenu = config.isEnabled( 'security/security-checkup' );
 
 		return (
-			<Main wideLayout className="security two-step">
+			<Main className="security two-step is-wide-layout">
 				<QueryUserSettings />
 				<PageViewTracker path="/me/security/two-step" title="Me > Two-Step Authentication" />
 				<MeSidebarNavigation />

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -93,7 +93,7 @@ const Home = ( {
 	);
 
 	return (
-		<Main wideLayout className="customer-home__main">
+		<Main className="customer-home__main is-wide-layout">
 			<PageViewTracker path={ `/home/:site` } title={ translate( 'My Home' ) } />
 			<DocumentHead title={ translate( 'My Home' ) } />
 			{ siteId && <QuerySiteChecklist siteId={ siteId } /> }

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -191,7 +191,7 @@ class EarningsMain extends Component {
 		};
 
 		return (
-			<Main wideLayout={ true } className="earn">
+			<Main className="earn is-wide-layout">
 				<PageViewTracker
 					path={ section ? `/earn/${ section }/:site` : `/earn/:site` }
 					title={ `${ adsProgramName } ${ capitalize( section ) }` }

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -180,7 +180,7 @@ class Hosting extends Component {
 		};
 
 		return (
-			<Main wideLayout className="hosting">
+			<Main className="hosting is-wide-layout">
 				<PageViewTracker path="/hosting-config/:site" title="Hosting Configuration" />
 				<DocumentHead title={ translate( 'Hosting Configuration' ) } />
 				<SidebarNavigation />

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -97,7 +97,7 @@ class Plans extends React.Component {
 		return (
 			<div>
 				<DocumentHead title={ this.props.translate( 'Plans', { textOnly: true } ) } />
-				<Main wideLayout>
+				<Main wideLayout={ true }>
 					<SidebarNavigation />
 
 					<div id="plans" className="plans plans__has-sidebar" />
@@ -128,7 +128,7 @@ class Plans extends React.Component {
 				<PageViewTracker path="/plans/:site" title="Plans" />
 				<QueryContactDetailsCache />
 				<TrackComponentView eventName="calypso_plans_view" />
-				<Main wideLayout>
+				<Main wideLayout={ true }>
 					<SidebarNavigation />
 					{ ! canAccessPlans && (
 						<EmptyContent

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -67,7 +67,7 @@ export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
 		getReceiptUrlFor( siteSlug, targetReceiptId );
 
 	return (
-		<Main wideLayout className="purchases billing-history">
+		<Main className="purchases billing-history is-wide-layout">
 			<MySitesSidebarNavigation />
 			<DocumentHead title={ titles.billingHistory } />
 			<PageViewTracker path="/purchases/billing-history" title="Billing History" />
@@ -122,7 +122,7 @@ export function ReceiptView( {
 	};
 
 	return (
-		<Main wideLayout className="purchases billing-history">
+		<Main className="purchases billing-history is-wide-layout">
 			<DocumentHead title={ titles.billingHistory } />
 			<PageViewTracker
 				path="/purchases/billing-history/:site/:receipt"

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -61,7 +61,7 @@ export function Purchases(): JSX.Element {
 	const logPurchasesError = useLogPurchasesError( 'site level purchases load error' );
 
 	return (
-		<Main wideLayout className="purchases">
+		<Main className="purchases is-wide-layout">
 			<MySitesSidebarNavigation />
 			<DocumentHead title={ titles.sectionTitle } />
 			<FormattedHeader
@@ -96,7 +96,7 @@ export function PurchaseDetails( {
 	const logPurchasesError = useLogPurchasesError( 'site level purchase details load error' );
 
 	return (
-		<Main wideLayout className="purchases">
+		<Main className="purchases is-wide-layout">
 			<DocumentHead title={ titles.managePurchase } />
 			<FormattedHeader
 				brandFont
@@ -141,7 +141,7 @@ export function PurchaseCancel( {
 	const logPurchasesError = useLogPurchasesError( 'site level purchase cancel load error' );
 
 	return (
-		<Main wideLayout className="purchases">
+		<Main className="purchases is-wide-layout">
 			<DocumentHead title={ titles.cancelPurchase } />
 			<FormattedHeader
 				brandFont
@@ -181,7 +181,7 @@ export function PurchaseChangePaymentMethod( {
 	);
 
 	return (
-		<Main wideLayout className="purchases">
+		<Main className="purchases is-wide-layout">
 			<DocumentHead title={ titles.changePaymentMethod } />
 			<FormattedHeader
 				brandFont
@@ -218,7 +218,7 @@ export function PurchaseCancelDomain( {
 	const logPurchasesError = useLogPurchasesError( 'site level purchase cancel domain load error' );
 
 	return (
-		<Main wideLayout className="purchases">
+		<Main className="purchases is-wide-layout">
 			<DocumentHead title={ titles.confirmCancelDomain } />
 			<FormattedHeader
 				brandFont

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -64,7 +64,7 @@ export function PaymentMethods( { siteSlug }: { siteSlug: string } ): JSX.Elemen
 	);
 
 	return (
-		<Main wideLayout className="purchases">
+		<Main className="purchases is-wide-layout">
 			<MySitesSidebarNavigation />
 			<DocumentHead title={ titles.paymentMethods } />
 			<PageViewTracker path="/purchases/payment-methods" title="Payment Methods" />
@@ -118,7 +118,7 @@ function SiteLevelAddNewPaymentMethodForm( { siteSlug }: { siteSlug: string } ):
 	}
 
 	return (
-		<Main wideLayout className="purchases">
+		<Main className="purchases is-wide-layout">
 			<MySitesSidebarNavigation />
 			<PageViewTracker path={ '/purchases/add-payment-method' } title={ titles.addPaymentMethod } />
 			<DocumentHead title={ titles.addPaymentMethod } />

--- a/client/my-sites/purchases/subscriptions/index.tsx
+++ b/client/my-sites/purchases/subscriptions/index.tsx
@@ -18,7 +18,7 @@ export default function Subscriptions() {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 
 	return (
-		<Main wideLayout className="subscriptions">
+		<Main className="subscriptions is-wide-layout">
 			<QuerySitePurchases siteId={ selectedSiteId } />
 			<PageViewTracker path="/purchases/subscriptions" title="Subscriptions" />
 			<SubscriptionsContent />

--- a/client/my-sites/stats/comment-follows/index.jsx
+++ b/client/my-sites/stats/comment-follows/index.jsx
@@ -50,13 +50,13 @@ class StatsCommentFollows extends Component {
 		const { perPage, translate } = this.props;
 
 		return (
-			<Main wideLayout>
+			<Main wideLayout={ true }>
 				<PageViewTracker
 					path="/stats/follows/comment/:site_id"
 					title="Stats > Followers > Comment"
 				/>
 
-				<div id="my-stats-content">
+				<div id="my-stats-content" className="follows-detail follows-detail-comment">
 					<HeaderCake onClick={ this.goBack }>{ translate( 'Comments Followers' ) }</HeaderCake>
 					<Followers
 						path="comment-follow-summary"

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -352,7 +352,7 @@ class StatsSite extends Component {
 		const { period } = this.props.period;
 
 		return (
-			<Main wideLayout>
+			<Main wideLayout={ true }>
 				<QueryKeyringConnections />
 				{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }
 				{ siteId && <QuerySiteKeyrings siteId={ siteId } /> }

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -223,7 +223,7 @@ class StatsSummary extends Component {
 		const { module } = this.props.context.params;
 
 		return (
-			<Main wideLayout>
+			<Main wideLayout={ true }>
 				<PageViewTracker
 					path={ `/stats/${ period }/${ module }/:site` }
 					title={ `Stats > ${ titlecase( period ) } > ${ titlecase( module ) }` }

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -141,7 +141,7 @@ class WordAds extends Component {
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<Main wideLayout>
+			<Main wideLayout={ true }>
 				<DocumentHead title={ translate( 'WordAds Stats' ) } />
 				<PageViewTracker
 					path={ `/stats/ads/${ period }/:site` }

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -87,7 +87,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 	const isPartnerPlan = purchase && isPartnerPurchase( purchase );
 
 	return (
-		<Main wideLayout className="themes">
+		<Main className="themes">
 			<SidebarNavigation />
 			<FormattedHeader
 				brandFont

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -70,7 +70,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 		}
 	}
 	return (
-		<Main wideLayout className="themes">
+		<Main className="themes">
 			<SidebarNavigation />
 			<FormattedHeader
 				brandFont


### PR DESCRIPTION
Reverts Automattic/wp-calypso#52715.

Apparently this PR caused some layout issues on cloud.jetpack.com/pricing, as you can see in this (zoomed out, 2200px-wide) screenshot 🙁 I think we may still need a `max-width` for some layouts.

<img width="1362" alt="image" src="https://user-images.githubusercontent.com/670067/117813469-baf53480-b228-11eb-83c2-709a98b325cc.png">
