### PR TITLE
Fix mobile display for new email forward page

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -64,6 +64,16 @@ const MailboxListItemWarning = ( { warningText } ) => {
 	);
 };
 
+const MailboxListItemAction = ( { buttonText, onClick } ) => {
+	return (
+		<div className="email-plan-mailboxes-list__mailbox-list-item-action">
+			<Button compact onClick={ onClick }>
+				{ buttonText }
+			</Button>
+		</div>
+	);
+};
+
 const resendEmailForwardVerification = ( mailbox, dispatch ) => {
 	const destination = getEmailForwardAddress( mailbox );
 	dispatch(
@@ -95,9 +105,10 @@ const getActionsForMailbox = ( mailbox, translate, dispatch ) => {
 	if ( isEmailForward( mailbox ) && ! isEmailForwardVerified( mailbox ) ) {
 		return {
 			action: (
-				<Button compact onClick={ () => resendEmailForwardVerification( mailbox, dispatch ) }>
-					{ translate( 'Resend verification email' ) }
-				</Button>
+				<MailboxListItemAction
+					buttonText={ translate( 'Resend verification email' ) }
+					onClick={ () => resendEmailForwardVerification( mailbox, dispatch ) }
+				/>
 			),
 			warning: <MailboxListItemWarning warningText={ translate( 'Verification required' ) } />,
 		};

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -187,14 +187,12 @@
 		line-height: 24px;
 		margin-top: 18px;
 		padding-top: 18px;
-		text-align: center;
 
 		@include break-small {
 			border-top: none;
 			margin-left: 16px;
 			margin-top: 0;
 			padding-top: 0;
-			text-align: left;
 		}
 
 		> svg {

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .email-management {
 	.empty-content__illustration {
 		width: 250px;
@@ -141,6 +144,12 @@
 
 .email-plan-mailboxes-list__mailbox-list-item {
 	display: flex;
+	flex-direction: column;
+
+	@include break-mobile {
+		flex-direction: row;
+	}
+
 	.email-plan-mailboxes-list__mailbox-list-item-main {
 		display: flex;
 		flex-direction: column;
@@ -165,15 +174,28 @@
 	}
 	.email-plan-mailboxes-list__mailbox-list-item-main span {
 		vertical-align: middle;
+		word-break: break-all;
 	}
 	> .badge {
 		margin-left: 10px;
 	}
 	.email-plan-mailboxes-list__mailbox-list-item-warning {
+		border-top: 1px solid var( --color-neutral-5 );
 		color: var( --color-error );
 		font-size: $font-body-small;
 		line-height: 24px;
-		margin-left: 16px;
+		margin-top: 24px;
+		padding-top: 24px;
+		text-align: center;
+
+		@include break-mobile {
+			border-top: none;
+			margin-left: 16px;
+			margin-top: 0;
+			padding-top: 0;
+			text-align: left;
+		}
+
 		> svg {
 			margin-right: 6px;
 			vertical-align: middle;
@@ -184,8 +206,13 @@
 	}
 
 	.button {
-		margin-left: auto;
+		margin-top: 18px;
 		max-height: 2rem;
+
+		@include break-mobile {
+			margin-top: 0;
+			margin-left: auto;
+		}
 	}
 }
 

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -151,6 +151,12 @@
 		flex-direction: row;
 	}
 
+	&.card.is-highlight {
+		padding-left: 13px;
+	}
+	&.card.is-error {
+		border-left-color: var( --color-error-50 );
+	}
 	.email-plan-mailboxes-list__mailbox-list-item-main {
 		display: flex;
 		flex-direction: column;

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -147,7 +147,7 @@
 	display: flex;
 	flex-direction: column;
 
-	@include break-small {
+	@include break-xlarge {
 		flex-direction: row;
 	}
 
@@ -194,9 +194,10 @@
 		margin-top: 18px;
 		padding-top: 18px;
 
-		@include break-small {
+		@include break-xlarge {
 			border-top: none;
 			margin-left: 16px;
+			margin-right: 16px;
 			margin-top: 0;
 			padding-top: 0;
 		}
@@ -210,13 +211,12 @@
 		}
 	}
 
-	.button {
+	.email-plan-mailboxes-list__mailbox-list-item-action {
 		margin-top: 12px;
-
-		@include break-small {
+		@include break-xlarge {
+			flex: 0.75;
 			margin-top: 0;
 			margin-left: auto;
-			max-height: 2rem;
 		}
 	}
 }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -148,44 +148,54 @@
 	flex-direction: column;
 
 	@include break-xlarge {
+		align-items: center;
 		flex-direction: row;
 	}
 
 	&.card.is-highlight {
 		padding-left: 13px;
 	}
+
 	&.card.is-error {
 		border-left-color: var( --color-error-50 );
 	}
+
 	.email-plan-mailboxes-list__mailbox-list-item-main {
 		display: flex;
 		flex-direction: column;
+
 		> div:not( :first-child ) {
 			margin-top: 0.5em;
 		}
 	}
+
 	&.is-placeholder > span,
 	&.is-placeholder .email-plan-mailboxes-list__mailbox-list-item-main {
 		@include placeholder( --color-neutral-5 );
 		width: 50%;
 	}
+
 	&.no-emails > span {
 		color: var( --color-text-subtle );
 		font-style: italic;
 	}
+
 	> svg,
 	.email-plan-mailboxes-list__mailbox-list-item-main svg {
 		fill: var( --studio-gray-40 );
 		margin-right: 10px;
 		vertical-align: middle;
 	}
+
 	.email-plan-mailboxes-list__mailbox-list-item-main span {
 		vertical-align: middle;
 		word-break: break-all;
 	}
+
 	> .badge {
 		margin-left: 10px;
 	}
+
 	.email-plan-mailboxes-list__mailbox-list-item-warning {
 		border-top: 1px solid var( --color-neutral-5 );
 		color: var( --color-error );
@@ -196,6 +206,7 @@
 
 		@include break-xlarge {
 			border-top: none;
+			flex-grow: 1;
 			margin-left: 16px;
 			margin-right: 16px;
 			margin-top: 0;
@@ -206,6 +217,7 @@
 			margin-right: 6px;
 			vertical-align: middle;
 		}
+
 		> span {
 			vertical-align: middle;
 		}
@@ -213,10 +225,9 @@
 
 	.email-plan-mailboxes-list__mailbox-list-item-action {
 		margin-top: 12px;
+
 		@include break-xlarge {
-			flex: 0.75;
 			margin-top: 0;
-			margin-left: auto;
 		}
 	}
 }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -148,54 +148,44 @@
 	flex-direction: column;
 
 	@include break-xlarge {
-		align-items: center;
 		flex-direction: row;
 	}
 
 	&.card.is-highlight {
 		padding-left: 13px;
 	}
-
 	&.card.is-error {
 		border-left-color: var( --color-error-50 );
 	}
-
 	.email-plan-mailboxes-list__mailbox-list-item-main {
 		display: flex;
 		flex-direction: column;
-
 		> div:not( :first-child ) {
 			margin-top: 0.5em;
 		}
 	}
-
 	&.is-placeholder > span,
 	&.is-placeholder .email-plan-mailboxes-list__mailbox-list-item-main {
 		@include placeholder( --color-neutral-5 );
 		width: 50%;
 	}
-
 	&.no-emails > span {
 		color: var( --color-text-subtle );
 		font-style: italic;
 	}
-
 	> svg,
 	.email-plan-mailboxes-list__mailbox-list-item-main svg {
 		fill: var( --studio-gray-40 );
 		margin-right: 10px;
 		vertical-align: middle;
 	}
-
 	.email-plan-mailboxes-list__mailbox-list-item-main span {
 		vertical-align: middle;
 		word-break: break-all;
 	}
-
 	> .badge {
 		margin-left: 10px;
 	}
-
 	.email-plan-mailboxes-list__mailbox-list-item-warning {
 		border-top: 1px solid var( --color-neutral-5 );
 		color: var( --color-error );
@@ -206,7 +196,6 @@
 
 		@include break-xlarge {
 			border-top: none;
-			flex-grow: 1;
 			margin-left: 16px;
 			margin-right: 16px;
 			margin-top: 0;
@@ -217,7 +206,6 @@
 			margin-right: 6px;
 			vertical-align: middle;
 		}
-
 		> span {
 			vertical-align: middle;
 		}
@@ -225,9 +213,10 @@
 
 	.email-plan-mailboxes-list__mailbox-list-item-action {
 		margin-top: 12px;
-
 		@include break-xlarge {
+			flex: 0.75;
 			margin-top: 0;
+			margin-left: auto;
 		}
 	}
 }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -114,6 +114,7 @@
 	align-items: center;
 	h2 {
 		font-size: $font-title-large;
+		word-break: break-all;
 	}
 
 	&.success {
@@ -146,7 +147,7 @@
 	display: flex;
 	flex-direction: column;
 
-	@include break-mobile {
+	@include break-small {
 		flex-direction: row;
 	}
 
@@ -182,13 +183,13 @@
 	.email-plan-mailboxes-list__mailbox-list-item-warning {
 		border-top: 1px solid var( --color-neutral-5 );
 		color: var( --color-error );
-		font-size: $font-body-small;
+		font-size: $font-body-extra-small;
 		line-height: 24px;
-		margin-top: 24px;
-		padding-top: 24px;
+		margin-top: 18px;
+		padding-top: 18px;
 		text-align: center;
 
-		@include break-mobile {
+		@include break-small {
 			border-top: none;
 			margin-left: 16px;
 			margin-top: 0;
@@ -206,12 +207,12 @@
 	}
 
 	.button {
-		margin-top: 18px;
-		max-height: 2rem;
+		margin-top: 12px;
 
-		@include break-mobile {
+		@include break-small {
 			margin-top: 0;
 			margin-left: auto;
+			max-height: 2rem;
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR ensures that the new email forward page is mobile-friendly
* It is worth noting that the implementation here shows the warning and button vertically instead of horizontally as per the design, as some translated strings would not work well horizontally.

#### Testing instructions

* Ensure that you have a domain with active email forwards, including at least one where the email address still needs to be verified.
* Open a local version of Calypso running this branch, or the live version.
* Navigate to `/email/:yourSiteSlug?flags=email/centralized-home` to bring up the new email management home page.
* Click through to your domain with email forwards
* Adjust the size of the display to test various mobile, tablet, and larger screen sizes.
* Verify that all the text, the verification warning, and the resend email verification button are always visible and clickable.
* Either switch languages to Russian/German (or some language of your choice), or manually make the text in the resend verification very long, and verify that the text is visible at various sizes. (The longest text for the button is for Russian: `Повторно отправить письмо для подтверждения`.)

#### Screenshot

<img width="383" alt="Screenshot 2021-05-12 at 15 44 39" src="https://user-images.githubusercontent.com/3376401/117985500-0b5bb780-b339-11eb-906b-9ccd8c459847.png">


Related to #52169, where this was originally introduced.
