### PR TITLE
Layout: Adds a full width layout option and uses it in Themes page.

### DIFF
--- a/client/components/main/index.jsx
+++ b/client/components/main/index.jsx
@@ -9,9 +9,15 @@ import classNames from 'classnames';
  */
 import './style.scss';
 
-export default function Main( { className, children, wideLayout = false } ) {
+export default function Main( {
+	className,
+	children,
+	wideLayout = false,
+	fullWidthLayout = false,
+} ) {
 	const classes = classNames( className, 'main', {
 		'is-wide-layout': wideLayout,
+		'is-full-width-layout': fullWidthLayout,
 	} );
 
 	return (

--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -3,8 +3,7 @@
 	max-width: 720px;
 	z-index: z-index( 'root', '.main' );
 
-	// Themes is a great example of using all this new space ;)
-	&.themes {
+	&.is-full-width-layout {
 		max-width: 100%;
 	}
 

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -87,7 +87,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 	const isPartnerPlan = purchase && isPartnerPurchase( purchase );
 
 	return (
-		<Main wideLayout className="themes">
+		<Main fullWidthLayout className="themes">
 			<SidebarNavigation />
 			<FormattedHeader
 				brandFont

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -70,7 +70,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 		}
 	}
 	return (
-		<Main wideLayout className="themes">
+		<Main fullWidthLayout className="themes">
 			<SidebarNavigation />
 			<FormattedHeader
 				brandFont


### PR DESCRIPTION
#### Changes proposed in this Pull Request
After reverting https://github.com/Automattic/wp-calypso/pull/52715, we should also apply 100% to Themes page:

* Adds a full width layout option and uses it in Themes page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/themes/your.site.domain`
* Inspect that the layout is full width

Before | After
-------|------
![](https://cln.sh/QYoc7i+) | ![](https://cln.sh/1yfiry+)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/52715
