### PR TITLE
Jetpack Cloud Pricing: Fix Jetpack Free button does not respect site protocol.

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card/test/button.jsx
+++ b/client/components/jetpack/card/jetpack-free-card/test/button.jsx
@@ -92,6 +92,15 @@ describe( 'JetpackFreeCardButton', () => {
 		expect( getHref() ).toEqual( jetpackAdminUrl.replace( siteUrl, subSiteUrl ) );
 	} );
 
+	it( 'should link to the "admin_url" query arg value, when "admin_url" query arg is present', () => {
+		const wpAdminQueryArg = `http://non-https-site.com/wp-admin/`;
+		const jetpackAdminUrlFromQueryArg = `${ wpAdminQueryArg }admin.php?page=jetpack#/recommendations`;
+
+		render( <JetpackFreeCardButton urlQueryArgs={ { admin_url: wpAdminQueryArg } } /> );
+
+		expect( getHref() ).toEqual( jetpackAdminUrlFromQueryArg );
+	} );
+
 	it( 'should link to the connect page, if site in context is invalid', () => {
 		render( <JetpackFreeCardButton urlQueryArgs={ { site: '%' } } /> );
 

--- a/client/components/jetpack/card/jetpack-free-card/use-jetpack-free-button-props.ts
+++ b/client/components/jetpack/card/jetpack-free-card/use-jetpack-free-button-props.ts
@@ -77,6 +77,13 @@ export default function useJetpackFreeButtonProps(
 	urlQueryArgs: QueryArgs = {}
 ): Props {
 	const recommendationsUrl = useSelector( getJetpackRecommendationsUrl );
+	const siteWpAdminUrl = urlQueryArgs?.admin_url
+		? getUrlFromParts( {
+				...getUrlParts( urlQueryArgs.admin_url + 'admin.php' ),
+				search: '?page=jetpack',
+				hash: '/recommendations',
+		  } ).href
+		: recommendationsUrl;
 	const trackCallback = useTrackCallback( undefined, 'calypso_product_jpfree_click', {
 		site_id: siteId || undefined,
 	} );
@@ -84,8 +91,8 @@ export default function useJetpackFreeButtonProps(
 		storePlan( PLAN_JETPACK_FREE );
 		trackCallback();
 	}, [ trackCallback ] );
-	const href = useMemo( () => buildHref( recommendationsUrl, siteId, urlQueryArgs ), [
-		recommendationsUrl,
+	const href = useMemo( () => buildHref( siteWpAdminUrl, siteId, urlQueryArgs ), [
+		siteWpAdminUrl,
 		siteId,
 		urlQueryArgs,
 	] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Added the site's `wp_admin` query arg to the Jetpack redirects coming from the plugin: D61244-code
- If the Pricing page is coming from Jetpack Redirect: source=`jetpack-connect-plans` or source=`jetpack-nav-site-only-plans`, this PR utilizes the 'wp_admin' query arg to build the "Jetpack Free" button url that points back to the site's /wp-admin page.

#### Testing instructions

1. First apply patch D61244-code and point `jetpack.com` to your sandbox IP.
2. Checkout this PR and run `yarn start-jetpack-cloud`.
3. Starting with a brand new self-hosted site, using **http://** (_not https://_)
    - (this is kinda the tricky part because jurassic ninja runs on https only, so we can't use a JN site for testing.  For me, I happen to already own an old site that utilizes http-only so I was able to do my testing with that. Otherwise I suppose you could use your Jetpack plugin docker environment with a jurassic-tube or ngrok tunnel to an non-https domain.  And I suppose there are other ways too, but I'm not sure what they are off hand.  If you know of a better way to quickly spin up a new http-only WordPress site, please let me know. :)
4. Install Jetpack and start the connection process.
    - *Bonus points for utilizing site-only connection.
5. Upon successful connection, you'll be redirected to `https://cloud.jetpack.com/pricing/...`
6. Verify that the query arg `wp_admin` exists in the `cloud.jetpack.com/pricing/...` url and that the query arg value is the site's non-https wp-admin url. For example: `...&admin_url=http%3A%2F%2Fyoursite.com%2Fwp-admin%2F`
7. In the url, change `https://cloud.jetpack.com/` to `https://jetpack.cloud.localhost:3000/`
8. At the bottom of the page, the "Jetpack Free" button should point to the site's non-https wp-admin recommendations url. ie.-  `http://yoursite.com/wp-admin/admin.php?page=jetpack#/recommendations`.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1164141197617539-as-1200255987445623

Fixes https://github.com/Automattic/wp-calypso/issues/52394