### PR TITLE
Themes: use fullWidthLayout in logged-out and multi-site views

### DIFF
--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -14,7 +14,7 @@ import { connectOptions } from './theme-options';
 const ConnectedThemeShowcase = connectOptions( ThemeShowcase );
 
 export default ( props ) => (
-	<Main className="themes">
+	<Main fullWidthLayout className="themes">
 		<ConnectedThemeShowcase
 			{ ...props }
 			origin="wpcom"

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -14,7 +14,7 @@ import { connectOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
 
 const MultiSiteThemeShowcase = connectOptions( ( props ) => (
-	<Main className="themes">
+	<Main fullWidthLayout className="themes">
 		<SidebarNavigation />
 		<ThemesSiteSelectorModal { ...props }>
 			<ThemeShowcase source="showcase" showUploadButton={ false } />

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -23,7 +23,7 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 	// this component is still being rendered with site unset, so we need to guard
 	// against that case.
 	if ( ! siteId ) {
-		return <Main className="themes" />;
+		return <Main fullWidthLayout className="themes" />;
 	}
 
 	if ( isJetpack ) {


### PR DESCRIPTION
Fixup for #52753 which left some Themes pages without the full width layout.

You'll need to apply the fix in #52731 to see these pages correctly in development mode, without SSR-related bugs.

**Logged out view (`/themes`)**
Broken:
<img width="1043" alt="Screenshot 2021-05-12 at 10 12 02" src="https://user-images.githubusercontent.com/664258/117946031-33cebc00-b30f-11eb-91e5-df2e158f8921.png">

Fixed:
<img width="1426" alt="Screenshot 2021-05-12 at 10 46 52" src="https://user-images.githubusercontent.com/664258/117946230-6678b480-b30f-11eb-9aeb-050ad3310e6e.png">

**Multi-site view (`/themes` without a site slug, logged-in)**
Broken:
<img width="1500" alt="Screenshot 2021-05-12 at 10 14 51" src="https://user-images.githubusercontent.com/664258/117946486-a475d880-b30f-11eb-9ee8-4b734125dffb.png">

Fixed:
<img width="1500" alt="Screenshot 2021-05-12 at 10 15 12" src="https://user-images.githubusercontent.com/664258/117946601-be172000-b30f-11eb-86f5-4b6b42c0469a.png">
