### PR TITLE
Direct users to WP Admin theme install if their site is on Business o…

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -158,8 +158,10 @@ export const HardBlockingNotice = ( {
 	);
 
 	/*
-		This accounts for Atomic sites that are on a plan below Business so we can prompt them to upgrade
-		instead of showing them an "Upload in progress" notice.
+		For Atomic sites on plans below Business it will return the holds TRANSFER_ALREADY_EXISTS and NO_BUSINESS_PLAN.
+		Because TRANSFER_ALREADY_EXISTS is present and 'blocking' it will show an "Upload in progress" notice even when there isn't one.
+		In this scenario we need to check if it's an Atomic ste (TRANSFER_ALREADY_EXISTS) on a plan below Business (NO_BUSINESS_PLAN)
+		so we can stop the render of "Upload in progress" and prompt them to upgrade instead.
 	*/
 	if ( ! blockingHold || isAtomicSiteWithoutBusinessPlan( holds ) ) {
 		return null;

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -33,6 +33,7 @@ import { launchSite } from 'calypso/state/sites/launch/actions';
 import { isSavingSiteSettings } from 'calypso/state/site-settings/selectors';
 import { saveSiteSettings } from 'calypso/state/site-settings/actions';
 import getRequest from 'calypso/state/selectors/get-request';
+import { isAtomicSiteWithoutBusinessPlan } from './utils';
 
 /**
  * Style dependencies
@@ -189,7 +190,11 @@ function getProceedButtonText( holds: string[], translate: LocalizeProps[ 'trans
 function isProceedButtonDisabled( isEligible: boolean, holds: string[] ) {
 	const resolvableHolds = [ 'NO_BUSINESS_PLAN', 'SITE_UNLAUNCHED', 'SITE_NOT_PUBLIC' ];
 	const canHandleHoldsAutomatically = holds.every( ( h ) => resolvableHolds.includes( h ) );
-	return ! canHandleHoldsAutomatically && ! isEligible;
+
+	// If it's not eligible for Atomic transfer lets also make sure it's not already Atomic with a plan below business.
+	return (
+		! canHandleHoldsAutomatically && ! isEligible && ! isAtomicSiteWithoutBusinessPlan( holds )
+	);
 }
 
 function siteRequiresUpgrade( holds: string[] ) {

--- a/client/blocks/eligibility-warnings/utils.ts
+++ b/client/blocks/eligibility-warnings/utils.ts
@@ -1,0 +1,3 @@
+export function isAtomicSiteWithoutBusinessPlan( holds: string[] ): boolean {
+	return holds.includes( 'TRANSFER_ALREADY_EXISTS' ) && holds.includes( 'NO_BUSINESS_PLAN' );
+}

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -444,21 +444,19 @@ class ThemeShowcase extends React.Component {
 	}
 }
 
-const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => {
-	return {
-		currentThemeId: getActiveTheme( state, siteId ),
-		isLoggedIn: !! getCurrentUserId( state ),
-		siteSlug: getSiteSlug( state, siteId ),
-		description: getThemeShowcaseDescription( state, { filter, tier, vertical } ),
-		title: getThemeShowcaseTitle( state, { filter, tier, vertical } ),
-		subjects: getThemeFilterTerms( state, 'subject' ) || {},
-		filterString: prependThemeFilterKeys( state, filter ),
-		filterToTermTable: getThemeFilterToTermTable( state ),
-		hasShowcaseOpened: hasShowcaseOpenedSelector( state ),
-		themesBookmark: getThemesBookmark( state ),
-		hasBusinessOrEcommercePlan: siteHasBusinessOrEcommercePlan( state, siteId ),
-	};
-};
+const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
+	currentThemeId: getActiveTheme( state, siteId ),
+	isLoggedIn: !! getCurrentUserId( state ),
+	siteSlug: getSiteSlug( state, siteId ),
+	description: getThemeShowcaseDescription( state, { filter, tier, vertical } ),
+	title: getThemeShowcaseTitle( state, { filter, tier, vertical } ),
+	subjects: getThemeFilterTerms( state, 'subject' ) || {},
+	filterString: prependThemeFilterKeys( state, filter ),
+	filterToTermTable: getThemeFilterToTermTable( state ),
+	hasShowcaseOpened: hasShowcaseOpenedSelector( state ),
+	themesBookmark: getThemesBookmark( state ),
+	hasBusinessOrEcommercePlan: siteHasBusinessOrEcommercePlan( state, siteId ),
+} );
 
 const mapDispatchToProps = {
 	trackUploadClick: () => recordTracksEvent( 'calypso_click_theme_upload' ),

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -20,6 +20,7 @@ import { addTracking, trackClick } from './helpers';
 import DocumentHead from 'calypso/components/data/document-head';
 import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import siteHasBusinessOrEcommercePlan from 'calypso/state/sites/selectors/has-business-or-ecommerce-plan';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import ThemePreview from './theme-preview';
 import config from '@automattic/calypso-config';
@@ -46,6 +47,18 @@ import RecommendedThemes from './recommended-themes';
  * Style dependencies
  */
 import './theme-showcase.scss';
+
+function getInstallThemeSlug( siteSlug, hasBusinessOrEcommercePlan ) {
+	if ( siteSlug && hasBusinessOrEcommercePlan ) {
+		return `https://${ siteSlug }/wp-admin/theme-install.php`;
+	}
+
+	if ( siteSlug ) {
+		return `/themes/upload/${ siteSlug }`;
+	}
+
+	return '/themes/upload';
+}
 
 const subjectsMeta = {
 	photo: { icon: 'camera', order: 1 },
@@ -234,6 +247,7 @@ class ThemeShowcase extends React.Component {
 			title,
 			filterString,
 			isMultisite,
+			hasBusinessOrEcommercePlan,
 		} = this.props;
 		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
 
@@ -295,7 +309,7 @@ class ThemeShowcase extends React.Component {
 							className="themes__upload-button"
 							compact
 							onClick={ this.onUploadClick }
-							href={ siteSlug ? `/themes/upload/${ siteSlug }` : '/themes/upload' }
+							href={ getInstallThemeSlug( siteSlug, hasBusinessOrEcommercePlan ) }
 						>
 							<Gridicon icon="cloud-upload" />
 							{ translate( 'Install theme' ) }
@@ -430,18 +444,21 @@ class ThemeShowcase extends React.Component {
 	}
 }
 
-const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
-	currentThemeId: getActiveTheme( state, siteId ),
-	isLoggedIn: !! getCurrentUserId( state ),
-	siteSlug: getSiteSlug( state, siteId ),
-	description: getThemeShowcaseDescription( state, { filter, tier, vertical } ),
-	title: getThemeShowcaseTitle( state, { filter, tier, vertical } ),
-	subjects: getThemeFilterTerms( state, 'subject' ) || {},
-	filterString: prependThemeFilterKeys( state, filter ),
-	filterToTermTable: getThemeFilterToTermTable( state ),
-	hasShowcaseOpened: hasShowcaseOpenedSelector( state ),
-	themesBookmark: getThemesBookmark( state ),
-} );
+const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => {
+	return {
+		currentThemeId: getActiveTheme( state, siteId ),
+		isLoggedIn: !! getCurrentUserId( state ),
+		siteSlug: getSiteSlug( state, siteId ),
+		description: getThemeShowcaseDescription( state, { filter, tier, vertical } ),
+		title: getThemeShowcaseTitle( state, { filter, tier, vertical } ),
+		subjects: getThemeFilterTerms( state, 'subject' ) || {},
+		filterString: prependThemeFilterKeys( state, filter ),
+		filterToTermTable: getThemeFilterToTermTable( state ),
+		hasShowcaseOpened: hasShowcaseOpenedSelector( state ),
+		themesBookmark: getThemesBookmark( state ),
+		hasBusinessOrEcommercePlan: siteHasBusinessOrEcommercePlan( state, siteId ),
+	};
+};
 
 const mapDispatchToProps = {
 	trackUploadClick: () => recordTracksEvent( 'calypso_click_theme_upload' ),

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -49,15 +49,14 @@ import RecommendedThemes from './recommended-themes';
 import './theme-showcase.scss';
 
 function getInstallThemeSlug( siteSlug, hasBusinessOrEcommercePlan ) {
-	if ( siteSlug && hasBusinessOrEcommercePlan ) {
+	if ( ! siteSlug ) {
+		return '/themes/upload';
+	}
+	if ( hasBusinessOrEcommercePlan ) {
 		return `https://${ siteSlug }/wp-admin/theme-install.php`;
 	}
 
-	if ( siteSlug ) {
-		return `/themes/upload/${ siteSlug }`;
-	}
-
-	return '/themes/upload';
+	return `/themes/upload/${ siteSlug }`;
 }
 
 const subjectsMeta = {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -52,6 +52,7 @@ function getInstallThemeSlug( siteSlug, hasBusinessOrEcommercePlan ) {
 	if ( ! siteSlug ) {
 		return '/themes/upload';
 	}
+
 	if ( hasBusinessOrEcommercePlan ) {
 		return `https://${ siteSlug }/wp-admin/theme-install.php`;
 	}

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -20,7 +20,7 @@ import { addTracking, trackClick } from './helpers';
 import DocumentHead from 'calypso/components/data/document-head';
 import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
-import siteHasBusinessOrEcommercePlan from 'calypso/state/sites/selectors/has-business-or-ecommerce-plan';
+import siteCanUploadThemesOrPlugins from 'calypso/state/sites/selectors/can-upload-themes-or-plugins';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import ThemePreview from './theme-preview';
 import config from '@automattic/calypso-config';
@@ -48,12 +48,12 @@ import RecommendedThemes from './recommended-themes';
  */
 import './theme-showcase.scss';
 
-function getInstallThemeSlug( siteSlug, hasBusinessOrEcommercePlan ) {
+function getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) {
 	if ( ! siteSlug ) {
 		return '/themes/upload';
 	}
 
-	if ( hasBusinessOrEcommercePlan ) {
+	if ( canUploadThemesOrPlugins ) {
 		return `https://${ siteSlug }/wp-admin/theme-install.php`;
 	}
 
@@ -247,7 +247,7 @@ class ThemeShowcase extends React.Component {
 			title,
 			filterString,
 			isMultisite,
-			hasBusinessOrEcommercePlan,
+			canUploadThemesOrPlugins,
 		} = this.props;
 		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
 
@@ -309,7 +309,7 @@ class ThemeShowcase extends React.Component {
 							className="themes__upload-button"
 							compact
 							onClick={ this.onUploadClick }
-							href={ getInstallThemeSlug( siteSlug, hasBusinessOrEcommercePlan ) }
+							href={ getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) }
 						>
 							<Gridicon icon="cloud-upload" />
 							{ translate( 'Install theme' ) }
@@ -455,7 +455,7 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
 	filterToTermTable: getThemeFilterToTermTable( state ),
 	hasShowcaseOpened: hasShowcaseOpenedSelector( state ),
 	themesBookmark: getThemesBookmark( state ),
-	hasBusinessOrEcommercePlan: siteHasBusinessOrEcommercePlan( state, siteId ),
+	canUploadThemesOrPlugins: siteCanUploadThemesOrPlugins( state, siteId ),
 } );
 
 const mapDispatchToProps = {

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -46,6 +46,7 @@ import {
 	getUploadProgressLoaded,
 	isInstallInProgress,
 } from 'calypso/state/themes/upload-theme/selectors';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteCanUploadThemesOrPlugins from 'calypso/state/sites/selectors/can-upload-themes-or-plugins';
 import { getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { connectOptions } from 'calypso/my-sites/themes/theme-options';
@@ -302,6 +303,7 @@ const mapStateToProps = ( state ) => {
 		isEmpty( eligibilityHolds ) && isEmpty( eligibilityWarnings )
 	);
 	const canUploadThemesOrPlugins = siteCanUploadThemesOrPlugins( state, siteId );
+	const isAtomic = isSiteWpcomAtomic( state, siteId );
 
 	return {
 		siteId,
@@ -321,7 +323,8 @@ const mapStateToProps = ( state ) => {
 		installing: isInstallInProgress( state, siteId ),
 		backPath: getBackPath( state ),
 		showEligibility:
-			( ! isJetpack && ( hasEligibilityMessages || ! isEligible ) ) || ! canUploadThemesOrPlugins,
+			( ( isJetpack && isAtomic ) || ( ! isJetpack && ! isAtomic ) ) &&
+			( hasEligibilityMessages || ! isEligible || ! canUploadThemesOrPlugins ),
 		isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		canUploadThemesOrPlugins,

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -323,7 +323,7 @@ const mapStateToProps = ( state ) => {
 		installing: isInstallInProgress( state, siteId ),
 		backPath: getBackPath( state ),
 		showEligibility:
-			( ( isJetpack && isAtomic ) || ( ! isJetpack && ! isAtomic ) ) &&
+			( isAtomic || ! isJetpack ) &&
 			( hasEligibilityMessages || ! isEligible || ! canUploadThemesOrPlugins ),
 		isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { includes, find, isEmpty, flowRight } from 'lodash';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -45,6 +46,7 @@ import {
 	getUploadProgressLoaded,
 	isInstallInProgress,
 } from 'calypso/state/themes/upload-theme/selectors';
+import siteCanUploadThemesOrPlugins from 'calypso/state/sites/selectors/can-upload-themes-or-plugins';
 import { getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { connectOptions } from 'calypso/my-sites/themes/theme-options';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
@@ -91,6 +93,9 @@ class Upload extends React.Component {
 	componentDidMount() {
 		const { siteId, inProgress } = this.props;
 		! inProgress && this.props.clearThemeUpload( siteId );
+		if ( this.props.canUploadThemesOrPlugins ) {
+			this.redirectToWpAdmin();
+		}
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
@@ -109,11 +114,18 @@ class Upload extends React.Component {
 	};
 
 	componentDidUpdate( prevProps ) {
+		if ( this.props.canUploadThemesOrPlugins ) {
+			this.redirectToWpAdmin();
+		}
 		if ( this.props.complete && ! prevProps.complete ) {
 			this.successMessage();
 		} else if ( this.props.failed && ! prevProps.failed ) {
 			this.failureMessage();
 		}
+	}
+
+	redirectToWpAdmin() {
+		page( `https://${ this.props.siteSlug }/wp-admin/theme-install.php` );
 	}
 
 	successMessage() {
@@ -289,6 +301,7 @@ const mapStateToProps = ( state ) => {
 	const hasEligibilityMessages = ! (
 		isEmpty( eligibilityHolds ) && isEmpty( eligibilityWarnings )
 	);
+	const canUploadThemesOrPlugins = siteCanUploadThemesOrPlugins( state, siteId );
 
 	return {
 		siteId,
@@ -307,9 +320,11 @@ const mapStateToProps = ( state ) => {
 		progressLoaded: getUploadProgressLoaded( state, siteId ),
 		installing: isInstallInProgress( state, siteId ),
 		backPath: getBackPath( state ),
-		showEligibility: ! isJetpack && ( hasEligibilityMessages || ! isEligible ),
+		showEligibility:
+			( ! isJetpack && ( hasEligibilityMessages || ! isEligible ) ) || ! canUploadThemesOrPlugins,
 		isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
+		canUploadThemesOrPlugins,
 	};
 };
 

--- a/client/state/sites/selectors/can-upload-themes-or-plugins.js
+++ b/client/state/sites/selectors/can-upload-themes-or-plugins.js
@@ -1,15 +1,10 @@
 /**
  * Internal dependencies
  */
-import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
-import { isBusinessPlan, isEcommercePlan } from '@automattic/calypso-products';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import isSiteOnAtomicPlan from 'calypso/state/selectors/is-site-on-atomic-plan';
 
-// Only sites with plans Business and Ecommerce can install third-party themes and/or plugins.
+// Only Atomic sites with plans Business and above can install third-party themes and/or plugins.
 export default function siteCanUploadThemesOrPlugins( state, siteId ) {
-	const planSlug = getSitePlanSlug( state, siteId );
-	return (
-		( isBusinessPlan( planSlug ) || isEcommercePlan( planSlug ) ) &&
-		isSiteWpcomAtomic( state, siteId )
-	);
+	return isSiteOnAtomicPlan( state, siteId ) && isSiteWpcomAtomic( state, siteId );
 }

--- a/client/state/sites/selectors/can-upload-themes-or-plugins.js
+++ b/client/state/sites/selectors/can-upload-themes-or-plugins.js
@@ -3,9 +3,13 @@
  */
 import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
 import { isBusinessPlan, isEcommercePlan } from '@automattic/calypso-products';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 
 // Only sites with plans Business and Ecommerce can install third-party themes and/or plugins.
 export default function siteCanUploadThemesOrPlugins( state, siteId ) {
 	const planSlug = getSitePlanSlug( state, siteId );
-	return isBusinessPlan( planSlug ) || isEcommercePlan( planSlug );
+	return (
+		( isBusinessPlan( planSlug ) || isEcommercePlan( planSlug ) ) &&
+		isSiteWpcomAtomic( state, siteId )
+	);
 }

--- a/client/state/sites/selectors/can-upload-themes-or-plugins.js
+++ b/client/state/sites/selectors/can-upload-themes-or-plugins.js
@@ -4,7 +4,8 @@
 import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
 import { isBusinessPlan, isEcommercePlan } from '@automattic/calypso-products';
 
-export default function siteHasBusinessOrEcommercePlan( state, siteId ) {
+// Only sites with plans Business and Ecommerce can install third-party themes and/or plugins.
+export default function siteCanUploadThemesOrPlugins( state, siteId ) {
 	const planSlug = getSitePlanSlug( state, siteId );
 	return isBusinessPlan( planSlug ) || isEcommercePlan( planSlug );
 }

--- a/client/state/sites/selectors/has-business-or-ecommerce-plan.js
+++ b/client/state/sites/selectors/has-business-or-ecommerce-plan.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getSitesItems from 'calypso/state/selectors/get-sites-items';
+import { isBusinessPlan, isEcommercePlan } from '@automattic/calypso-products';
+
+export default function siteHasBusinessOrEcommercePlan( state, siteId ) {
+	const currentSite = getSitesItems( state )[ siteId ];
+	const planSlug = get( currentSite, 'plan.product_slug' );
+	return isBusinessPlan( planSlug ) || isEcommercePlan( planSlug );
+}

--- a/client/state/sites/selectors/has-business-or-ecommerce-plan.js
+++ b/client/state/sites/selectors/has-business-or-ecommerce-plan.js
@@ -1,16 +1,10 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
-import getSitesItems from 'calypso/state/selectors/get-sites-items';
+import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
 import { isBusinessPlan, isEcommercePlan } from '@automattic/calypso-products';
 
 export default function siteHasBusinessOrEcommercePlan( state, siteId ) {
-	const currentSite = getSitesItems( state )[ siteId ];
-	const planSlug = get( currentSite, 'plan.product_slug' );
+	const planSlug = getSitePlanSlug( state, siteId );
 	return isBusinessPlan( planSlug ) || isEcommercePlan( planSlug );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If a user is on a Business/Ecom plan then direct them to the WP Admin "Theme Install" screen instead of Calypso because users cannot update their Theme manually in Calypso but they are able to via WP Admin since WP 5.5

#### Testing instructions

* Open Calypso.live generated URL
* Go to `/themes/your-site.wordpress.com` on a site with a plan _below Business_ and click "Install theme" button to the right to manually upload a theme
* You should get sent to a Calypso screen which presents an upgrade nudge
* Go to `/themes/your-site.wordpress.com` on a site with a plan _Business or above_ and click "Install theme" button to the right to manually upload a theme
* You should get taken to `/wp-admin/theme-install.php`

Fixes https://github.com/Automattic/wp-calypso/issues/52710
