### PR TITLE
Replace bind( this ) pattern with arrow functions

### DIFF
--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -57,12 +57,9 @@ function main() {
 		} else if ( this.subscribeTry === this.subscribeTries ) {
 			const sub_retry_ms = 120000;
 			debug( 'main: polling until next subscribe attempt', 'sub_retry_ms =', sub_retry_ms );
-			setTimeout(
-				function () {
-					this.subscribeTry = 0;
-				}.bind( this ),
-				sub_retry_ms
-			);
+			setTimeout( () => {
+				this.subscribeTry = 0;
+			}, sub_retry_ms );
 		}
 		this.subscribeTry++;
 	}

--- a/client/components/bulk-select/docs/example.jsx
+++ b/client/components/bulk-select/docs/example.jsx
@@ -43,10 +43,10 @@ export default class extends React.Component {
 
 	renderElements = () => {
 		return this.state.elements.map( ( element, index ) => {
-			const onClick = function () {
+			const onClick = () => {
 				element.selected = ! element.selected;
 				this.forceUpdate();
-			}.bind( this );
+			};
 			return (
 				<FormLabel key={ index }>
 					<FormInputCheckbox onClick={ onClick } checked={ element.selected } readOnly />

--- a/client/components/section-nav/docs/example.jsx
+++ b/client/components/section-nav/docs/example.jsx
@@ -74,25 +74,22 @@ class SectionNavigation extends PureComponent {
 	render() {
 		const demoSections = {};
 
-		forEach(
-			omit( this.props, 'isolated', 'uniqueInstance', 'readmeFilePath' ),
-			function ( prop, key ) {
-				demoSections[ key ] = [];
+		forEach( omit( this.props, 'isolated', 'uniqueInstance', 'readmeFilePath' ), ( prop, key ) => {
+			demoSections[ key ] = [];
 
-				prop.forEach( function ( item, index ) {
-					demoSections[ key ].push(
-						<NavItem
-							key={ key + '-' + index }
-							count={ item.count }
-							selected={ this.state[ key + 'SelectedIndex' ] === index }
-							onClick={ this.handleNavItemClick( key, index ) }
-						>
-							{ 'object' === typeof item ? item.name : item }
-						</NavItem>
-					);
-				}, this );
-			}.bind( this )
-		);
+			prop.forEach( ( item, index ) => {
+				demoSections[ key ].push(
+					<NavItem
+						key={ key + '-' + index }
+						count={ item.count }
+						selected={ this.state[ key + 'SelectedIndex' ] === index }
+						onClick={ this.handleNavItemClick( key, index ) }
+					>
+						{ 'object' === typeof item ? item.name : item }
+					</NavItem>
+				);
+			} );
+		} );
 
 		return (
 			<div>
@@ -158,14 +155,11 @@ class SectionNavigation extends PureComponent {
 		);
 	};
 
-	handleNavItemClick = ( section, index ) => {
-		return function () {
-			const stateUpdate = {};
-
-			stateUpdate[ section + 'SelectedIndex' ] = index;
-			this.setState( stateUpdate );
-		}.bind( this );
-	};
+	handleNavItemClick( section, index ) {
+		return () => {
+			this.setState( { [ section + 'SelectedIndex' ]: index } );
+		};
+	}
 
 	demoSearch = ( keywords ) => {
 		console.log( 'Section Nav Search (keywords):', keywords );

--- a/client/components/segmented-control/README.md
+++ b/client/components/segmented-control/README.md
@@ -61,14 +61,14 @@ export default class extends React.Component {
 	}
 
 	handleFilterClick( value ) {
-		return function () {
+		return () => {
 			// ... (track analytics, add to state, etc.)
 
 			this.setState( {
 				selected: value,
 				// ...
 			} );
-		}.bind( this );
+		};
 	}
 }
 ```

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -344,18 +344,16 @@ class TokenField extends PureComponent {
 		} else {
 			match = match.toLocaleLowerCase();
 
-			suggestions.forEach(
-				function ( suggestion ) {
-					const index = suggestion.toLocaleLowerCase().indexOf( match );
-					if ( this.props.value.indexOf( suggestion ) === -1 ) {
-						if ( index === 0 ) {
-							startsWithMatch.push( suggestion );
-						} else if ( index > 0 ) {
-							containsMatch.push( suggestion );
-						}
+			suggestions.forEach( ( suggestion ) => {
+				const index = suggestion.toLocaleLowerCase().indexOf( match );
+				if ( this.props.value.indexOf( suggestion ) === -1 ) {
+					if ( index === 0 ) {
+						startsWithMatch.push( suggestion );
+					} else if ( index > 0 ) {
+						containsMatch.push( suggestion );
 					}
-				}.bind( this )
-			);
+				}
+			} );
 
 			suggestions = startsWithMatch.concat( containsMatch );
 		}

--- a/client/components/token-field/suggestions-list.jsx
+++ b/client/components/token-field/suggestions-list.jsx
@@ -47,12 +47,9 @@ class SuggestionsList extends React.PureComponent {
 				} );
 			}
 
-			setTimeout(
-				function () {
-					this._scrollingIntoView = false;
-				}.bind( this ),
-				100
-			);
+			setTimeout( () => {
+				this._scrollingIntoView = false;
+			}, 100 );
 		}
 	}
 
@@ -90,51 +87,48 @@ class SuggestionsList extends React.PureComponent {
 	}
 
 	_renderSuggestions = () => {
-		return map(
-			this.props.suggestions,
-			function ( suggestion, index ) {
-				const match = this._computeSuggestionMatch( suggestion );
-				const classes = classNames( 'token-field__suggestion', {
-					'is-selected': index === this.props.selectedIndex,
-				} );
+		return map( this.props.suggestions, ( suggestion, index ) => {
+			const match = this._computeSuggestionMatch( suggestion );
+			const classes = classNames( 'token-field__suggestion', {
+				'is-selected': index === this.props.selectedIndex,
+			} );
 
-				return (
-					// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions
-					<li
-						className={ classes }
-						key={ suggestion }
-						onMouseDown={ this._handleMouseDown }
-						onClick={ this._handleClick( suggestion ) }
-						onMouseEnter={ this._handleHover( suggestion ) }
-					>
-						{ match ? (
-							<span>
-								{ match.suggestionBeforeMatch }
-								<strong className="token-field__suggestion-match">{ match.suggestionMatch }</strong>
-								{ match.suggestionAfterMatch }
-							</span>
-						) : (
-							this.props.displayTransform( suggestion )
-						) }
-					</li>
-				);
-			}.bind( this )
-		);
+			return (
+				// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions
+				<li
+					className={ classes }
+					key={ suggestion }
+					onMouseDown={ this._handleMouseDown }
+					onClick={ this._handleClick( suggestion ) }
+					onMouseEnter={ this._handleHover( suggestion ) }
+				>
+					{ match ? (
+						<span>
+							{ match.suggestionBeforeMatch }
+							<strong className="token-field__suggestion-match">{ match.suggestionMatch }</strong>
+							{ match.suggestionAfterMatch }
+						</span>
+					) : (
+						this.props.displayTransform( suggestion )
+					) }
+				</li>
+			);
+		} );
 	};
 
-	_handleHover = ( suggestion ) => {
-		return function () {
+	_handleHover( suggestion ) {
+		return () => {
 			if ( ! this._scrollingIntoView ) {
 				this.props.onHover( suggestion );
 			}
-		}.bind( this );
-	};
+		};
+	}
 
-	_handleClick = ( suggestion ) => {
-		return function () {
+	_handleClick( suggestion ) {
+		return () => {
 			this.props.onSelect( suggestion );
-		}.bind( this );
-	};
+		};
+	}
 
 	_handleMouseDown = ( e ) => {
 		// By preventing default here, we will not lose focus of <input> when clicking a suggestion

--- a/client/devdocs/doc.jsx
+++ b/client/devdocs/doc.jsx
@@ -52,15 +52,9 @@ export default class extends React.Component {
 			error: null,
 		} );
 		this.delayLoadingMessage();
-		DocService.fetch(
-			this.props.path,
-			function ( error, body ) {
-				this.setState( {
-					body,
-					error,
-				} );
-			}.bind( this )
-		);
+		DocService.fetch( this.props.path, ( error, body ) => {
+			this.setState( { body, error } );
+		} );
 	};
 
 	setBodyScrollPosition = () => {
@@ -75,16 +69,13 @@ export default class extends React.Component {
 
 	delayLoadingMessage = () => {
 		this.clearLoadingMessage();
-		this.timeoutID = setTimeout(
-			function () {
-				if ( ! this.state.body ) {
-					this.setState( {
-						body: 'Loading…',
-					} );
-				}
-			}.bind( this ),
-			1000
-		);
+		this.timeoutID = setTimeout( () => {
+			if ( ! this.state.body ) {
+				this.setState( {
+					body: 'Loading…',
+				} );
+			}
+		}, 1000 );
 	};
 
 	clearLoadingMessage = () => {

--- a/client/devdocs/main.jsx
+++ b/client/devdocs/main.jsx
@@ -66,16 +66,13 @@ export default class Devdocs extends React.Component {
 			return;
 		}
 
-		DocService.list(
-			DEFAULT_FILES,
-			function ( err, results ) {
-				if ( ! err ) {
-					this.setState( {
-						defaultResults: results,
-					} );
-				}
-			}.bind( this )
-		);
+		DocService.list( DEFAULT_FILES, ( err, results ) => {
+			if ( ! err ) {
+				this.setState( {
+					defaultResults: results,
+				} );
+			}
+		} );
 	};
 
 	componentDidMount() {
@@ -115,19 +112,16 @@ export default class Devdocs extends React.Component {
 		if ( ! term ) {
 			return;
 		}
-		DocService.search(
-			term,
-			function ( err, results ) {
-				if ( err ) {
-					log( 'search error: %o', err );
-				}
+		DocService.search( term, ( err, results ) => {
+			if ( err ) {
+				log( 'search error: %o', err );
+			}
 
-				this.setState( {
-					results: results,
-					searching: false,
-				} );
-			}.bind( this )
-		);
+			this.setState( {
+				results,
+				searching: false,
+			} );
+		} );
 	};
 
 	results = () => {

--- a/client/extensions/woocommerce/components/action-header/actions.js
+++ b/client/extensions/woocommerce/components/action-header/actions.js
@@ -69,24 +69,21 @@ class ActionButtons extends Component {
 	getButtonWidths = () => {
 		let totalWidth = 0;
 
-		React.Children.forEach(
-			this.props.children,
-			function ( child, index ) {
-				if ( ! child ) {
-					return;
-				}
-				/* eslint-disable react/no-string-refs */
-				const node = ReactDom.findDOMNode( this.refs[ 'button-' + index ] );
-				/* eslint-enable react/no-string-refs */
+		React.Children.forEach( this.props.children, ( child, index ) => {
+			if ( ! child ) {
+				return;
+			}
+			/* eslint-disable react/no-string-refs */
+			const node = ReactDom.findDOMNode( this.refs[ 'button-' + index ] );
+			/* eslint-enable react/no-string-refs */
 
-				if ( ! node ) {
-					return;
-				}
+			if ( ! node ) {
+				return;
+			}
 
-				const buttonWidth = node.offsetWidth;
-				totalWidth += buttonWidth;
-			}.bind( this )
-		);
+			const buttonWidth = node.offsetWidth;
+			totalWidth += buttonWidth;
+		} );
 
 		this.buttonsWidth = Math.max( totalWidth, this.buttonsWidth || 0 );
 	};

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -296,16 +296,13 @@ ABTest.prototype.hasBeenInPreviousSeriesTest = function () {
 	const previousExperimentIds = keys( getSavedVariations() );
 	let previousName;
 
-	return some(
-		previousExperimentIds,
-		function ( previousExperimentId ) {
-			previousName = previousExperimentId.substring(
-				0,
-				previousExperimentId.length - '_YYYYMMDD'.length
-			);
-			return previousExperimentId !== this.experimentId && previousName === this.name;
-		}.bind( this )
-	);
+	return some( previousExperimentIds, ( previousExperimentId ) => {
+		previousName = previousExperimentId.substring(
+			0,
+			previousExperimentId.length - '_YYYYMMDD'.length
+		);
+		return previousExperimentId !== this.experimentId && previousName === this.name;
+	} );
 };
 
 ABTest.prototype.hasRegisteredBeforeTestBegan = function () {
@@ -365,17 +362,13 @@ ABTest.prototype.saveVariation = function ( variation ) {
 };
 
 ABTest.prototype.saveVariationOnBackend = function ( variation ) {
-	wpcom.undocumented().saveABTestData(
-		this.experimentId,
-		variation,
-		function ( error ) {
-			if ( error ) {
-				debug( '%s: Error saving variation %s: %s', this.experimentId, variation, error );
-			} else {
-				debug( '%s: Variation saved successfully: %s.', this.experimentId, variation );
-			}
-		}.bind( this )
-	);
+	wpcom.undocumented().saveABTestData( this.experimentId, variation, ( error ) => {
+		if ( error ) {
+			debug( '%s: Error saving variation %s: %s', this.experimentId, variation, error );
+		} else {
+			debug( '%s: Variation saved successfully: %s.', this.experimentId, variation );
+		}
+	} );
 };
 
 ABTest.prototype.saveVariationInLocalStorage = function ( variation ) {

--- a/client/lib/data-poller/poller.js
+++ b/client/lib/data-poller/poller.js
@@ -43,10 +43,10 @@ function Poller( dataStore, fetcher, options ) {
 }
 
 Poller.prototype.start = function () {
-	const fetch = function () {
+	const fetch = () => {
 		debug( 'Calling fetcher for %o', { fetcher: this.fetcher, store: this.dataStore } );
 		this.fetch();
-	}.bind( this );
+	};
 
 	if ( ! this.timer ) {
 		debug( 'Starting poller for %o', this.dataStore );

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -60,16 +60,14 @@ Controller.prototype.getInitialState = function () {
 };
 
 Controller.prototype._loadFieldValues = function () {
-	this._loadFunction(
-		function ( error, fieldValues ) {
-			if ( error ) {
-				this._onError( error );
-				return;
-			}
+	this._loadFunction( ( error, fieldValues ) => {
+		if ( error ) {
+			this._onError( error );
+			return;
+		}
 
-			this._setState( initializeFields( this._currentState, fieldValues ) );
-		}.bind( this )
-	);
+		this._setState( initializeFields( this._currentState, fieldValues ) );
+	} );
 };
 
 Controller.prototype.handleFieldChange = function ( change ) {
@@ -99,10 +97,10 @@ Controller.prototype.handleSubmit = function ( onComplete ) {
 		return;
 	}
 
-	this._onValidationComplete = function () {
+	this._onValidationComplete = () => {
 		this._setState( showAllErrors( this._currentState ) );
 		onComplete( hasErrors( this._currentState ) );
-	}.bind( this );
+	};
 
 	if ( ! this._pendingValidation ) {
 		this.sanitize();
@@ -122,12 +120,9 @@ Controller.prototype.sanitize = function () {
 		return;
 	}
 
-	this._sanitizerFunction(
-		fieldValues,
-		function ( newFieldValues ) {
-			this._setState( changeFieldValues( this._currentState, newFieldValues ) );
-		}.bind( this )
-	);
+	this._sanitizerFunction( fieldValues, ( newFieldValues ) => {
+		this._setState( changeFieldValues( this._currentState, newFieldValues ) );
+	} );
 };
 
 Controller.prototype.validate = function () {
@@ -138,29 +133,26 @@ Controller.prototype.validate = function () {
 
 	this._pendingValidation = id;
 
-	this._validatorFunction(
-		fieldValues,
-		function ( error, fieldErrors ) {
-			if ( id !== this._pendingValidation ) {
-				return;
-			}
+	this._validatorFunction( fieldValues, ( error, fieldErrors ) => {
+		if ( id !== this._pendingValidation ) {
+			return;
+		}
 
-			if ( error ) {
-				this._onError( error );
-				return;
-			}
+		if ( error ) {
+			this._onError( error );
+			return;
+		}
 
-			this._pendingValidation = null;
-			this._setState(
-				setFieldErrors( this._currentState, fieldErrors, this._hideFieldErrorsOnChange )
-			);
+		this._pendingValidation = null;
+		this._setState(
+			setFieldErrors( this._currentState, fieldErrors, this._hideFieldErrorsOnChange )
+		);
 
-			if ( this._onValidationComplete ) {
-				this._onValidationComplete();
-				this._onValidationComplete = null;
-			}
-		}.bind( this )
-	);
+		if ( this._onValidationComplete ) {
+			this._onValidationComplete();
+			this._onValidationComplete = null;
+		}
+	} );
 };
 
 Controller.prototype.resetFields = function ( fieldValues ) {

--- a/client/lib/network-connection/index.js
+++ b/client/lib/network-connection/index.js
@@ -75,13 +75,10 @@ const NetworkConnectionApp = {
 
 		this.on( 'change', changeCallback );
 
-		window.addEventListener(
-			'beforeunload',
-			function () {
-				debug( 'Removing listener.' );
-				this.off( 'change', changeCallback );
-			}.bind( this )
-		);
+		window.addEventListener( 'beforeunload', () => {
+			debug( 'Removing listener.' );
+			this.off( 'change', changeCallback );
+		} );
 	},
 
 	/**

--- a/client/lib/products-list/index.js
+++ b/client/lib/products-list/index.js
@@ -73,38 +73,35 @@ ProductsList.prototype.fetch = function () {
 
 	this.isFetching = true;
 
-	wpcom.req.get(
-		'/products',
-		function ( error, data ) {
-			if ( error ) {
-				debug( 'error fetching ProductsList from api', error );
+	wpcom.req.get( '/products', ( error, data ) => {
+		if ( error ) {
+			debug( 'error fetching ProductsList from api', error );
 
-				return;
+			return;
+		}
+
+		const productsList = data;
+
+		debug( 'ProductsList fetched from api:', productsList );
+
+		if ( ! this.initialized ) {
+			this.initialize( productsList );
+		} else {
+			this.data = productsList;
+		}
+
+		this.isFetching = false;
+
+		this.emit( 'change' );
+
+		if ( typeof localStorage !== 'undefined' ) {
+			try {
+				localStorage.setItem( 'ProductsList', JSON.stringify( productsList ) );
+			} catch ( e ) {
+				// ignore problems storing the list into local storage
 			}
-
-			const productsList = data;
-
-			debug( 'ProductsList fetched from api:', productsList );
-
-			if ( ! this.initialized ) {
-				this.initialize( productsList );
-			} else {
-				this.data = productsList;
-			}
-
-			this.isFetching = false;
-
-			this.emit( 'change' );
-
-			if ( typeof localStorage !== 'undefined' ) {
-				try {
-					localStorage.setItem( 'ProductsList', JSON.stringify( productsList ) );
-				} catch ( e ) {
-					// ignore problems storing the list into local storage
-				}
-			}
-		}.bind( this )
-	);
+		}
+	} );
 };
 
 /**

--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -47,24 +47,22 @@ function TwoStepAuthorization() {
  * fetch data about users two step configuration from /me/two-step
  */
 TwoStepAuthorization.prototype.fetch = function ( callback ) {
-	wpcom.me().getTwoStep(
-		function ( error, data ) {
-			if ( ! error ) {
-				this.data = data;
+	wpcom.me().getTwoStep( ( error, data ) => {
+		if ( ! error ) {
+			this.data = data;
 
-				if ( this.isReauthRequired() && ! this.initialized ) {
-					this.bumpMCStat( 'reauth-required' );
-				}
-
-				this.initialized = true;
-				this.emit( 'change' );
+			if ( this.isReauthRequired() && ! this.initialized ) {
+				this.bumpMCStat( 'reauth-required' );
 			}
 
-			if ( callback ) {
-				callback( error, data );
-			}
-		}.bind( this )
-	);
+			this.initialized = true;
+			this.emit( 'change' );
+		}
+
+		if ( callback ) {
+			callback( error, data );
+		}
+	} );
 };
 
 TwoStepAuthorization.prototype.postLoginRequest = function ( endpoint, data ) {
@@ -147,7 +145,7 @@ TwoStepAuthorization.prototype.validateCode = function ( args, callback ) {
 			...args,
 			code: args.code.replace( /\s/g, '' ),
 		},
-		function ( error, data ) {
+		( error, data ) => {
 			if ( ! error && data.success ) {
 				if ( args.action ) {
 					this.bumpMCStat(
@@ -176,7 +174,7 @@ TwoStepAuthorization.prototype.validateCode = function ( args, callback ) {
 			if ( callback ) {
 				callback( error, data );
 			}
-		}.bind( this )
+		}
 	);
 };
 
@@ -185,47 +183,43 @@ TwoStepAuthorization.prototype.validateCode = function ( args, callback ) {
  * /me/two-step/sms/new
  */
 TwoStepAuthorization.prototype.sendSMSCode = function ( callback ) {
-	wpcom.me().sendSMSValidationCode(
-		function ( error, data ) {
-			if ( error ) {
-				debug( 'Sending SMS code failed: ' + JSON.stringify( error ) );
+	wpcom.me().sendSMSValidationCode( ( error, data ) => {
+		if ( error ) {
+			debug( 'Sending SMS code failed: ' + JSON.stringify( error ) );
 
-				if ( error.error && 'rate_limited' === error.error ) {
-					debug( 'SMS resend throttled.' );
-					this.bumpMCStat( 'sms-code-send-throttled' );
-					this.smsResendThrottled = true;
-				}
-			} else {
-				this.smsResendThrottled = false;
-				this.bumpMCStat( 'sms-code-send-success' );
+			if ( error.error && 'rate_limited' === error.error ) {
+				debug( 'SMS resend throttled.' );
+				this.bumpMCStat( 'sms-code-send-throttled' );
+				this.smsResendThrottled = true;
 			}
+		} else {
+			this.smsResendThrottled = false;
+			this.bumpMCStat( 'sms-code-send-success' );
+		}
 
-			this.emit( 'change' );
+		this.emit( 'change' );
 
-			if ( callback ) {
-				callback( error, data );
-			}
-		}.bind( this )
-	);
+		if ( callback ) {
+			callback( error, data );
+		}
+	} );
 };
 
 /*
  * Fetches a new set of backup codes by calling /me/two-step/backup-codes/new
  */
 TwoStepAuthorization.prototype.backupCodes = function ( callback ) {
-	wpcom.me().backupCodes(
-		function ( error, data ) {
-			if ( error ) {
-				debug( 'Fetching Backup Codes failed: ' + JSON.stringify( error ) );
-			} else {
-				this.bumpMCStat( 'new-backup-codes-success' );
-			}
+	wpcom.me().backupCodes( ( error, data ) => {
+		if ( error ) {
+			debug( 'Fetching Backup Codes failed: ' + JSON.stringify( error ) );
+		} else {
+			this.bumpMCStat( 'new-backup-codes-success' );
+		}
 
-			if ( callback ) {
-				callback( error, data );
-			}
-		}.bind( this )
-	);
+		if ( callback ) {
+			callback( error, data );
+		}
+	} );
 };
 
 /*
@@ -239,24 +233,21 @@ TwoStepAuthorization.prototype.validateBackupCode = function ( code, callback ) 
 		action: 'create-backup-receipt',
 	};
 
-	wpcom.me().validateTwoStepCode(
-		args,
-		function ( error, data ) {
-			if ( error ) {
-				debug( 'Validating Two Step Code failed: ' + JSON.stringify( error ) );
-			}
+	wpcom.me().validateTwoStepCode( args, ( error, data ) => {
+		if ( error ) {
+			debug( 'Validating Two Step Code failed: ' + JSON.stringify( error ) );
+		}
 
-			if ( data ) {
-				this.bumpMCStat(
-					data.success ? 'backup-code-validate-success' : 'backup-code-validate-failure'
-				);
-			}
+		if ( data ) {
+			this.bumpMCStat(
+				data.success ? 'backup-code-validate-success' : 'backup-code-validate-failure'
+			);
+		}
 
-			if ( callback ) {
-				callback( error, data );
-			}
-		}.bind( this )
-	);
+		if ( callback ) {
+			callback( error, data );
+		}
+	} );
 };
 
 /*

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -239,10 +239,10 @@ class Security2faCodePrompt extends React.Component {
 							className="security-2fa-code-prompt__send-code"
 							disabled={ ! this.state.codeRequestsAllowed }
 							isPrimary={ false }
-							onClick={ function ( event ) {
+							onClick={ ( event ) => {
 								gaRecordEvent( 'Me', 'Clicked On 2fa Code Prompt Send Code Via SMS Button' );
 								this.onRequestCode( event );
-							}.bind( this ) }
+							} }
 						>
 							{ this.state.codeRequestPerformed
 								? this.props.translate( 'Resend Code' )
@@ -254,10 +254,10 @@ class Security2faCodePrompt extends React.Component {
 						<FormButton
 							className="security-2fa-code-prompt__cancel"
 							isPrimary={ false }
-							onClick={ function ( event ) {
+							onClick={ ( event ) => {
 								gaRecordEvent( 'Me', 'Clicked On Disable 2fa Cancel Button' );
 								this.onCancel( event );
-							}.bind( this ) }
+							} }
 						>
 							{ this.props.translate( 'Cancel' ) }
 						</FormButton>

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -177,7 +177,7 @@ class Security2faEnable extends React.Component {
 		return (
 			<button
 				className="security-2fa-enable__toggle"
-				onClick={ function ( event ) {
+				onClick={ ( event ) => {
 					this.toggleMethod( event );
 					gaRecordEvent(
 						'Me',
@@ -185,7 +185,7 @@ class Security2faEnable extends React.Component {
 						'current-method',
 						this.state.method
 					);
-				}.bind( this ) }
+				} }
 			/>
 		);
 	};
@@ -360,9 +360,9 @@ class Security2faEnable extends React.Component {
 				<FormButton
 					className="security-2fa-enable__verify"
 					disabled={ this.getFormDisabled() }
-					onClick={ function () {
+					onClick={ () => {
 						gaRecordEvent( 'Me', 'Clicked On Enable 2fa Button', 'method', this.state.method );
-					}.bind( this ) }
+					} }
 				>
 					{ this.state.submittingCode
 						? this.props.translate( 'Enabling…', {
@@ -377,10 +377,10 @@ class Security2faEnable extends React.Component {
 					<FormButton
 						disabled={ ! this.state.smsRequestsAllowed }
 						isPrimary={ false }
-						onClick={ function ( event ) {
+						onClick={ ( event ) => {
 							gaRecordEvent( 'Me', 'Clicked On Resend SMS Button' );
 							this.onResendCode( event );
-						}.bind( this ) }
+						} }
 					>
 						{ this.props.translate( 'Resend Code', {
 							context: 'A button label to let a user get the SMS code sent again.',
@@ -389,10 +389,10 @@ class Security2faEnable extends React.Component {
 				) : (
 					<FormButton
 						isPrimary={ false }
-						onClick={ function ( event ) {
+						onClick={ ( event ) => {
 							gaRecordEvent( 'Me', 'Clicked On Enable SMS Use SMS Button' );
 							this.onVerifyBySMS( event );
-						}.bind( this ) }
+						} }
 					>
 						{ this.props.translate( 'Use SMS', {
 							context: 'A button label to let a user switch to enabling Two-Step by SMS.',
@@ -403,7 +403,7 @@ class Security2faEnable extends React.Component {
 				<FormButton
 					className="security-2fa-enable__cancel"
 					isPrimary={ false }
-					onClick={ function ( event ) {
+					onClick={ ( event ) => {
 						gaRecordEvent(
 							'Me',
 							'Clicked On Step 2 Cancel 2fa Button',
@@ -411,7 +411,7 @@ class Security2faEnable extends React.Component {
 							this.state.method
 						);
 						this.props.onCancel( event );
-					}.bind( this ) }
+					} }
 				>
 					{ this.props.translate( 'Cancel' ) }
 				</FormButton>

--- a/client/me/security-2fa-initial-setup/index.jsx
+++ b/client/me/security-2fa-initial-setup/index.jsx
@@ -42,10 +42,10 @@ class Security2faInitialSetup extends React.Component {
 				</p>
 
 				<FormButton
-					onClick={ function ( event ) {
+					onClick={ ( event ) => {
 						gaRecordEvent( 'Me', 'Clicked On 2fa Get Started Button' );
 						this.props.onSuccess( event );
-					}.bind( this ) }
+					} }
 				>
 					{ this.props.translate( 'Get Started' ) }
 				</FormButton>

--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -121,19 +121,15 @@ class SiteRedirectStep extends React.Component {
 			return;
 		}
 
-		canRedirect(
-			this.props.selectedSite.ID,
-			domain,
-			function ( error ) {
-				if ( error ) {
-					this.props.errorNotice( this.getValidationErrorMessage( domain, error ) );
-					this.setState( { isSubmitting: false } );
-					return;
-				}
+		canRedirect( this.props.selectedSite.ID, domain, ( error ) => {
+			if ( error ) {
+				this.props.errorNotice( this.getValidationErrorMessage( domain, error ) );
+				this.setState( { isSubmitting: false } );
+				return;
+			}
 
-				this.addSiteRedirectToCart( domain );
-			}.bind( this )
-		);
+			this.addSiteRedirectToCart( domain );
+		} );
 	};
 
 	addSiteRedirectToCart = ( domain ) => {

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -225,11 +225,11 @@ export class MediaLibraryList extends React.Component {
 			} );
 		}
 
-		const onFetchNextPage = function () {
+		const onFetchNextPage = () => {
 			// InfiniteList passes its own parameter which would interfere
 			// with the optional parameters expected by mediaOnFetchNextPage
 			this.props.mediaOnFetchNextPage();
-		}.bind( this );
+		};
 
 		// some sources aren't grouped beyond anything but the source, so set the
 		// getItemGroup function to return the source, and no label.

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -161,11 +161,11 @@ class AboutStep extends Component {
 	}
 
 	handleSegmentClick( value ) {
-		return function () {
+		return () => {
 			this.setState( {
 				userExperience: value,
 			} );
-		}.bind( this );
+		};
 	}
 
 	handleSubmit = ( event ) => {

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -148,32 +148,30 @@ class Site extends React.Component {
 
 		this.setState( { submitting: true } );
 
-		this.formStateController.handleSubmit(
-			function ( hasErrors ) {
-				const site = formState.getFieldValue( this.state.form, 'site' );
+		this.formStateController.handleSubmit( ( hasErrors ) => {
+			const site = formState.getFieldValue( this.state.form, 'site' );
 
-				this.setState( { submitting: false } );
+			this.setState( { submitting: false } );
 
-				if ( hasErrors ) {
-					return;
-				}
+			if ( hasErrors ) {
+				return;
+			}
 
-				recordTracksEvent( 'calypso_signup_site_step_submit', {
-					unique_site_urls_searched: siteUrlsSearched.length,
-					times_validation_failed: timesValidationFailed,
-				} );
+			recordTracksEvent( 'calypso_signup_site_step_submit', {
+				unique_site_urls_searched: siteUrlsSearched.length,
+				times_validation_failed: timesValidationFailed,
+			} );
 
-				this.resetAnalyticsData();
+			this.resetAnalyticsData();
 
-				this.props.submitSignupStep( {
-					stepName: this.props.stepName,
-					form: this.state.form,
-					site,
-				} );
+			this.props.submitSignupStep( {
+				stepName: this.props.stepName,
+				form: this.state.form,
+				site,
+			} );
 
-				this.props.goToNextStep();
-			}.bind( this )
-		);
+			this.props.goToNextStep();
+		} );
 	};
 
 	handleBlur = () => {
@@ -213,30 +211,27 @@ class Site extends React.Component {
 			return;
 		}
 
-		return map(
-			messages,
-			function ( message, error_code ) {
-				if ( error_code === 'blog_name_reserved' ) {
-					return (
-						<span>
-							<p>
-								{ message }
-								&nbsp;
-								{ this.props.translate(
-									'Is this your username? {{a}}Log in now to claim this site address{{/a}}.',
-									{
-										components: {
-											a: <a href={ link } />,
-										},
-									}
-								) }
-							</p>
-						</span>
-					);
-				}
-				return message;
-			}.bind( this )
-		);
+		return map( messages, ( message, error_code ) => {
+			if ( error_code === 'blog_name_reserved' ) {
+				return (
+					<span>
+						<p>
+							{ message }
+							&nbsp;
+							{ this.props.translate(
+								'Is this your username? {{a}}Log in now to claim this site address{{/a}}.',
+								{
+									components: {
+										a: <a href={ link } />,
+									},
+								}
+							) }
+						</p>
+					</span>
+				);
+			}
+			return message;
+		} );
 	};
 
 	formFields = () => {


### PR DESCRIPTION
Replaces inline functions with `.bind( this )`:
```js
function ( x ) {
  this.setState( { x } );
}.bind( this );
```
with arrow functions. They have this `this` binding from the start.

Arrow functions have been natively supported in all our environments for a very long time. The modified code comes from the pre-ES5 era.