### PR TITLE
Partner Portal: Add the full blog url in the license details card

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -15,7 +15,7 @@ import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/r
 interface Props {
 	licenseKey: string;
 	product: string;
-	domain: string;
+	siteUrl: string | null;
 	attachedAt: string | null;
 	revokedAt: string | null;
 }
@@ -23,7 +23,7 @@ interface Props {
 export default function LicenseDetailsActions( {
 	licenseKey,
 	product,
-	domain,
+	siteUrl,
 	attachedAt,
 	revokedAt,
 }: Props ): ReactElement {
@@ -51,7 +51,7 @@ export default function LicenseDetailsActions( {
 				<RevokeLicenseDialog
 					licenseKey={ licenseKey }
 					product={ product }
-					domain={ domain }
+					siteUrl={ siteUrl }
 					onClose={ closeRevokeDialog }
 				/>
 			) }

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -23,7 +23,7 @@ import './style.scss';
 interface Props {
 	licenseKey: string;
 	product: string;
-	domain: string;
+	siteUrl: string | null;
 	username: string | null;
 	blogId: number | null;
 	issuedAt: string;
@@ -37,7 +37,7 @@ const DETAILS_DATE_FORMAT = 'YYYY-MM-DD h:mm:ss A';
 export default function LicenseDetails( {
 	licenseKey,
 	product,
-	domain,
+	siteUrl,
 	username,
 	blogId,
 	issuedAt,
@@ -67,6 +67,17 @@ export default function LicenseDetails( {
 							<Gridicon icon="clipboard" />
 						</ClipboardButton>
 					</div>
+				</li>
+
+				<li className="license-details__list-item license-details__list-item--wide">
+					<h4 className="license-details__label">{ translate( 'Blog URL' ) }</h4>
+					{ siteUrl ? (
+						<a href={ siteUrl } target="_blank" rel="noopener noreferrer">
+							{ siteUrl }
+						</a>
+					) : (
+						<Gridicon icon="minus" />
+					) }
 				</li>
 
 				<li className="license-details__list-item">
@@ -109,7 +120,7 @@ export default function LicenseDetails( {
 			<LicenseDetailsActions
 				licenseKey={ licenseKey }
 				product={ product }
-				domain={ domain }
+				siteUrl={ siteUrl }
 				attachedAt={ attachedAt }
 				revokedAt={ revokedAt }
 			/>

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -180,7 +180,7 @@ export default function LicensePreview( {
 				<LicenseDetails
 					licenseKey={ licenseKey }
 					product={ product }
-					domain={ domain }
+					siteUrl={ siteUrl }
 					username={ username }
 					blogId={ blogId }
 					issuedAt={ issuedAt }

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -24,14 +24,14 @@ import './style.scss';
 interface Props {
 	licenseKey: string;
 	product: string;
-	domain: string;
+	siteUrl: string | null;
 	onClose: ( action?: string ) => void;
 }
 
 export default function RevokeLicenseDialog( {
 	licenseKey,
 	product,
-	domain,
+	siteUrl,
 	onClose,
 	...rest
 }: Props ): ReactElement {
@@ -100,9 +100,9 @@ export default function RevokeLicenseDialog( {
 			</p>
 
 			<ul>
-				{ domain && (
+				{ siteUrl && (
 					<li>
-						<strong>{ translate( 'Site:' ) }</strong> { domain }
+						<strong>{ translate( 'Site:' ) }</strong> { siteUrl }
 					</li>
 				) }
 				<li>


### PR DESCRIPTION
Context: pbtFPC-103-p2#comment-3459

#### Changes proposed in this Pull Request

* Partner Portal: Add the full blog url in the license details card

#### Testing instructions

1. If you do not have a partner key, please contact Infinity for one or you will be unable to view test this PR.
2. Check out this PR locally, then run `yarn && yarn start-jetpack-cloud`.
3. Assign 2 licenses to 2 different sites on the same domain but in different subdirectories. A multisite setup on JN works very well for this.
4. Expand the 2 assigned licenses' details cards to confirm their full URL is visible.