### PR TITLE
QueryCountryStates: refactor away from `UNSAFE_` lifecycle methods

### DIFF
--- a/client/components/data/query-country-states/index.jsx
+++ b/client/components/data/query-country-states/index.jsx
@@ -3,8 +3,8 @@
  */
 
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -12,37 +12,24 @@ import { connect } from 'react-redux';
 import { isCountryStatesFetching } from 'calypso/state/country-states/selectors';
 import { requestCountryStates } from 'calypso/state/country-states/actions';
 
-class QueryCountryStates extends Component {
-	componentDidMount() {
-		this.request();
+const request = ( countryCode ) => ( dispatch, getState ) => {
+	if ( ! isCountryStatesFetching( getState(), countryCode ) ) {
+		dispatch( requestCountryStates( countryCode ) );
 	}
+};
 
-	componentDidUpdate( prevProps ) {
-		if ( this.props.countryCode !== prevProps.countryCode ) {
-			this.request();
-		}
-	}
+function QueryCountryStates( { countryCode } ) {
+	const dispatch = useDispatch();
 
-	request() {
-		if ( ! this.props.isRequesting ) {
-			this.props.requestCountryStates( this.props.countryCode );
-		}
-	}
+	useEffect( () => {
+		dispatch( request( countryCode ) );
+	}, [ dispatch, countryCode ] );
 
-	render() {
-		return null;
-	}
+	return null;
 }
 
 QueryCountryStates.propTypes = {
 	countryCode: PropTypes.string.isRequired,
-	isRequesting: PropTypes.bool,
-	requestCountryStates: PropTypes.func,
 };
 
-export default connect(
-	( state, { countryCode } ) => ( {
-		isRequesting: isCountryStatesFetching( state, countryCode ),
-	} ),
-	{ requestCountryStates }
-)( QueryCountryStates );
+export default QueryCountryStates;

--- a/client/components/data/query-country-states/index.jsx
+++ b/client/components/data/query-country-states/index.jsx
@@ -13,19 +13,19 @@ import { isCountryStatesFetching } from 'calypso/state/country-states/selectors'
 import { requestCountryStates } from 'calypso/state/country-states/actions';
 
 class QueryCountryStates extends Component {
-	UNSAFE_componentWillMount() {
-		this.request( this.props );
+	componentDidMount() {
+		this.request();
 	}
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.countryCode !== nextProps.countryCode ) {
-			this.request( nextProps );
+	componentDidUpdate( prevProps ) {
+		if ( this.props.countryCode !== prevProps.countryCode ) {
+			this.request();
 		}
 	}
 
-	request( props ) {
-		if ( ! props.isRequesting ) {
-			props.requestCountryStates( props.countryCode );
+	request() {
+		if ( ! this.props.isRequesting ) {
+			this.props.requestCountryStates( this.props.countryCode );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `<QueryCountryStates />`: Refactor away from `UNSAFE_` lifecycle methods

#### Testing instructions

* Go to `/domains/manage/<site-slug>/edit-contact-info/<domain-slug>` (edit contact info form for a domain you own)
* For `Country` select `United States`, a `State` field should appear under `City`
* Make sure states are fetched properly (see screenshot)
* Now change `Country` to Canada and make sure states are properly refetched¹

<img width="334" alt="Screenshot 2021-05-12 at 12 55 17" src="https://user-images.githubusercontent.com/9202899/117964499-f9bae580-b321-11eb-9f40-abf679725166.png">

¹ For Canada it says `Province` but it's still the same field
