### PR TITLE
Components: Add new top-level component to display list of links with icons and descriptions

### DIFF
--- a/client/components/vertical-nav/README.md
+++ b/client/components/vertical-nav/README.md
@@ -7,15 +7,15 @@ The following components can be used to display rows of links.
 ```js
 <VerticalNav>
 	<VerticalNavItem path="/stats">Stats</VerticalNavItem>
-	
+
 	<VerticalNavItem path="https://google.com" external>
 		Google
 	</VerticalNavItem>
-	
+
 	<VerticalNavItem path="/posts" onClick={ this.handleClickPosts }>
 		Posts
 	</VerticalNavItem>
-	
+
 	<VerticalNavItem isPlaceholder />
 
 	<VerticalNavItemEnhanced
@@ -46,4 +46,4 @@ instead on the following props:
 - **materialIcon** - String _optional_ - the identifier of the [Material Design icon](../../../packages/material-design-icons/README.md) to show in front of the text and description.
 - **onClick** - Function _optional_ - called when the item is clicked.
 - **path** - String _optional_ - the page the user is taken to when the item is clicked.
-- **text** - String _required_ - the main text of the navigation item.  
+- **text** - String _required_ - the main text of the navigation item.

--- a/client/components/vertical-nav/README.md
+++ b/client/components/vertical-nav/README.md
@@ -42,8 +42,8 @@ instead on the following props:
 
 - **description** - String _required_ - some longer copy displayed below the text.
 - **external** - Boolean _optional_ - determines whether or not the link is opened in a new window.
-- **gridicon** - String _optional_ - the identifier of the [Gridicon icon](../../../docs/icons.md) to show in front of the text and description.
-- **materialIcon** - String _optional_ - the identifier of the [Material Design icon](../../../packages/material-design-icons/README.md) to show in front of the text and description.
+- **gridicon** - String _optional_ - the identifier of the [Gridicon icon](../../../docs/icons.md) to show in front of the text and description (if `materialIcon` wasn't specified).
+- **materialIcon** - String _optional_ - the identifier of the [Material Design icon](../../../packages/material-design-icons/README.md) to show in front of the text and description (if `gridicon` wasn't specified).
 - **onClick** - Function _optional_ - called when the item is clicked.
 - **path** - String _optional_ - the page the user is taken to when the item is clicked.
 - **text** - String _required_ - the main text of the navigation item.

--- a/client/components/vertical-nav/README.md
+++ b/client/components/vertical-nav/README.md
@@ -1,28 +1,49 @@
 # VerticalNav
 
-These are two components to display rows of links.
+The following components can be used to display rows of links.
 
 ## Usage
 
 ```js
-// actual links items
 <VerticalNav>
 	<VerticalNavItem path="/stats">Stats</VerticalNavItem>
+	
 	<VerticalNavItem path="https://google.com" external>
 		Google
 	</VerticalNavItem>
+	
 	<VerticalNavItem path="/posts" onClick={ this.handleClickPosts }>
 		Posts
 	</VerticalNavItem>
+	
 	<VerticalNavItem isPlaceholder />
+
+	<VerticalNavItemEnhanced
+		description="https://wordpress.com"
+		gridicon="my-sites"
+		path="https://wordpress.com"
+		text="Create new site"
+	/>
 </VerticalNav>;
 ```
 
 ## Props
 
-`VerticalNavItem` is the only component thats behavior changes based on the given props.
+`VerticalNavItem` is usually used to display some text passed as `children`, and accepts the following props:
 
+- **className** - String _optional_ - additional class name to tag this component with.
 - **external** - Boolean _optional_ - determines whether or not the link is opened in a new window.
 - **isPlaceholder** - Boolean _optional_ - determines whether or not the placeholder styles are used.
 - **onClick** - Function _optional_ - called when the item is clicked.
-- **path** - String _required_ - the page the user is taken to when the item is clicked.
+- **path** - String _optional_ - the page the user is taken to when the item is clicked.
+
+`VerticalNavItemEnhanced` can also display a description as well as an icon. It no longer relies on `children` but
+instead on the following props:
+
+- **description** - String _required_ - some longer copy displayed below the text.
+- **external** - Boolean _optional_ - determines whether or not the link is opened in a new window.
+- **gridicon** - String _optional_ - the identifier of the [Gridicon icon](../../../docs/icons.md) to show in front of the text and description.
+- **materialIcon** - String _optional_ - the identifier of the [Material Design icon](../../../packages/material-design-icons/README.md) to show in front of the text and description.
+- **onClick** - Function _optional_ - called when the item is clicked.
+- **path** - String _optional_ - the page the user is taken to when the item is clicked.
+- **text** - String _required_ - the main text of the navigation item.  

--- a/client/components/vertical-nav/docs/example.jsx
+++ b/client/components/vertical-nav/docs/example.jsx
@@ -50,6 +50,7 @@ VerticalNavExample.defaultProps = {
 			<VerticalNavItemEnhanced
 				description="https://wordpress.com"
 				gridicon="my-sites"
+				key="5"
 				path="https://wordpress.com"
 				text="Create new site"
 			/>

--- a/client/components/vertical-nav/docs/example.jsx
+++ b/client/components/vertical-nav/docs/example.jsx
@@ -6,13 +6,15 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import VerticalNav from '../index';
-import VerticalNavItem from '../item/index';
+import VerticalNav from 'calypso/components/vertical-nav';
+import VerticalNavItem from 'calypso/components/vertical-nav/item';
+import VerticalNavItemEnhanced from 'calypso/components/vertical-nav/item/enhanced';
 
 const noop = () => {};
 
 VerticalNav.displayName = 'VerticalNav';
 VerticalNavItem.displayName = 'VerticalNavItem';
+VerticalNavItemEnhanced.displayName = 'VerticalNavItemEnhanced';
 VerticalNavExample.displayName = 'VerticalNav';
 
 function VerticalNavExample( props ) {
@@ -25,13 +27,32 @@ VerticalNavExample.defaultProps = {
 			<VerticalNavItem path="/stats" key="0">
 				Stats
 			</VerticalNavItem>
+
 			<VerticalNavItem path="https://google.com" external key="1">
 				Google
 			</VerticalNavItem>
+
 			<VerticalNavItem path="/posts" onClick={ noop } key="2">
 				Posts
 			</VerticalNavItem>
+
 			<VerticalNavItem isPlaceholder key="3" />
+
+			<VerticalNavItemEnhanced
+				description="Access your emails on the go with our Android and iOS apps"
+				external
+				key="4"
+				materialIcon="smartphone"
+				path="https://wp.com/app"
+				text="Get mobile app"
+			/>
+
+			<VerticalNavItemEnhanced
+				description="https://wordpress.com"
+				gridicon="my-sites"
+				path="https://wordpress.com"
+				text="Create new site"
+			/>
 		</VerticalNav>
 	),
 };

--- a/client/components/vertical-nav/item/enhanced.jsx
+++ b/client/components/vertical-nav/item/enhanced.jsx
@@ -16,18 +16,39 @@ import VerticalNavItem from 'calypso/components/vertical-nav/item';
  */
 import './style.scss';
 
-const VerticalNavItemEnhanced = ( { description, external, gridicon, materialIcon, path, onClick, text, } ) => {
+const VerticalNavItemEnhanced = ( {
+	description,
+	external,
+	gridicon,
+	materialIcon,
+	path,
+	onClick,
+	text,
+} ) => {
 	return (
 		<VerticalNavItem
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			className="vertical-nav-item-enhanced"
 			external={ external }
 			onClick={ onClick }
 			path={ path }
 		>
 			<>
-				{ gridicon && <Gridicon className="vertical-nav-item-enhanced__icon" icon={ gridicon } /> }
+				{ gridicon && (
+					<Gridicon
+						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+						className="vertical-nav-item-enhanced__icon"
+						icon={ gridicon }
+					/>
+				) }
 
-				{ ! gridicon && <MaterialIcon icon={ materialIcon } className="vertical-nav-item-enhanced__icon" /> }
+				{ ! gridicon && (
+					<MaterialIcon
+						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+						className="vertical-nav-item-enhanced__icon"
+						icon={ materialIcon }
+					/>
+				) }
 
 				<div>
 					<div>{ text }</div>

--- a/client/components/vertical-nav/item/enhanced.jsx
+++ b/client/components/vertical-nav/item/enhanced.jsx
@@ -16,6 +16,26 @@ import VerticalNavItem from 'calypso/components/vertical-nav/item';
  */
 import './style.scss';
 
+const Icon = ( { gridicon, materialIcon } ) => {
+	if ( gridicon ) {
+		return (
+			<Gridicon
+				// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+				className="vertical-nav-item-enhanced__icon"
+				icon={ gridicon }
+			/>
+		);
+	}
+
+	return (
+		<MaterialIcon
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+			className="vertical-nav-item-enhanced__icon"
+			icon={ materialIcon }
+		/>
+	);
+};
+
 const VerticalNavItemEnhanced = ( {
 	description,
 	external,
@@ -34,21 +54,7 @@ const VerticalNavItemEnhanced = ( {
 			path={ path }
 		>
 			<>
-				{ gridicon && (
-					<Gridicon
-						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-						className="vertical-nav-item-enhanced__icon"
-						icon={ gridicon }
-					/>
-				) }
-
-				{ ! gridicon && (
-					<MaterialIcon
-						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-						className="vertical-nav-item-enhanced__icon"
-						icon={ materialIcon }
-					/>
-				) }
+				<Icon gridicon={ gridicon } materialIcon={ materialIcon } />
 
 				<div>
 					<div>{ text }</div>

--- a/client/components/vertical-nav/item/enhanced.jsx
+++ b/client/components/vertical-nav/item/enhanced.jsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'calypso/components/gridicon';
+import MaterialIcon from 'calypso/components/material-icon';
+import VerticalNavItem from 'calypso/components/vertical-nav/item';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const VerticalNavItemEnhanced = ( { description, external, gridicon, materialIcon, path, onClick, text, } ) => {
+	return (
+		<VerticalNavItem
+			className="vertical-nav-item-enhanced"
+			external={ external }
+			onClick={ onClick }
+			path={ path }
+		>
+			<>
+				{ gridicon && <Gridicon className="vertical-nav-item-enhanced__icon" icon={ gridicon } /> }
+
+				{ ! gridicon && <MaterialIcon icon={ materialIcon } className="vertical-nav-item-enhanced__icon" /> }
+
+				<div>
+					<div>{ text }</div>
+
+					<small>{ description }</small>
+				</div>
+			</>
+		</VerticalNavItem>
+	);
+};
+
+VerticalNavItemEnhanced.propTypes = {
+	description: PropTypes.string.isRequired,
+	external: PropTypes.bool,
+	gridicon: PropTypes.string,
+	materialIcon: PropTypes.string,
+	onClick: PropTypes.func,
+	path: PropTypes.string,
+	text: PropTypes.string.isRequired,
+};
+
+export default VerticalNavItemEnhanced;

--- a/client/components/vertical-nav/item/index.jsx
+++ b/client/components/vertical-nav/item/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -21,6 +20,8 @@ const noop = () => {};
 
 class VerticalNavItem extends Component {
 	static propTypes = {
+		children: PropTypes.any,
+		className: PropTypes.string,
 		external: PropTypes.bool,
 		isPlaceholder: PropTypes.bool,
 		onClick: PropTypes.func,
@@ -33,11 +34,20 @@ class VerticalNavItem extends Component {
 		onClick: noop,
 	};
 
-	placeholder = () => {
+	getIcon = () => {
+		if ( this.props.external ) {
+			return <Gridicon icon="external" />;
+		}
+
+		return <Gridicon icon="chevron-right" />;
+	};
+
+	renderPlaceholder = () => {
 		const compactCardClassNames = classNames(
 			'vertical-nav-item is-placeholder',
 			this.props.className
 		);
+
 		return (
 			<CompactCard className={ compactCardClassNames }>
 				<span />
@@ -50,7 +60,7 @@ class VerticalNavItem extends Component {
 		const { isPlaceholder, external, onClick, path, className, children } = this.props;
 
 		if ( isPlaceholder ) {
-			return this.placeholder();
+			return this.renderPlaceholder();
 		}
 
 		const compactCardClassNames = classNames( 'vertical-nav-item', className );
@@ -61,19 +71,12 @@ class VerticalNavItem extends Component {
 			<a href={ path } onClick={ onClick } { ...linkProps }>
 				<CompactCard className={ compactCardClassNames }>
 					{ this.getIcon() }
+
 					<span>{ children }</span>
 				</CompactCard>
 			</a>
 		);
 	}
-
-	getIcon = () => {
-		if ( this.props.external ) {
-			return <Gridicon icon="external" />;
-		}
-
-		return <Gridicon icon="chevron-right" />;
-	};
 }
 
 export default VerticalNavItem;

--- a/client/components/vertical-nav/item/style.scss
+++ b/client/components/vertical-nav/item/style.scss
@@ -1,5 +1,5 @@
 .vertical-nav-item {
-	.gridicon {
+	> .gridicon {
 		box-sizing: border-box;
 		color: var( --color-neutral-20 );
 		display: block;
@@ -24,5 +24,32 @@
 			float: right;
 			width: 22px;
 		}
+	}
+}
+
+.vertical-nav-item-enhanced {
+	span {
+		display: flex;
+		align-items: center;
+
+		.vertical-nav-item-enhanced__icon {
+			fill: var( --color-neutral-60 );
+			width: 32px;
+			height: 32px;
+			margin-right: 16px;
+		}
+
+		div {
+			color: var( --color-neutral-90 );
+
+			small {
+				color: var( --color-neutral-50 );
+				font-size: $font-body-small;
+			}
+		}
+	}
+
+	a:hover & {
+		background: var( --color-neutral-0 );
 	}
 }

--- a/client/devdocs/design/playground-scope.js
+++ b/client/devdocs/design/playground-scope.js
@@ -121,4 +121,5 @@ export { default as Version } from 'calypso/components/version';
 export { default as VerticalMenu } from 'calypso/components/vertical-menu';
 export { default as VerticalNav } from 'calypso/components/vertical-nav';
 export { default as VerticalNavItem } from 'calypso/components/vertical-nav/item';
+export { default as VerticalNavItemEnhanced } from 'calypso/components/vertical-nav/item/enhanced';
 export { default as Wizard } from 'calypso/components/wizard';

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
@@ -47,42 +46,12 @@ import { getMaxTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
+import VerticalNavItemEnhanced from 'calypso/components/vertical-nav/item/enhanced';
 
+/**
+ * Style dependencies
+ */
 import './style.scss';
-
-const DomainManagementNavigationItemContents = function ( props ) {
-	const { gridicon, materialIcon, text, description } = props;
-	return (
-		<React.Fragment>
-			{ gridicon && <Gridicon className="navigation__icon" icon={ gridicon } /> }
-			{ ! gridicon && <MaterialIcon icon={ materialIcon } className="navigation__icon" /> }
-			<div>
-				<div>{ text }</div>
-				<small>{ description }</small>
-			</div>
-		</React.Fragment>
-	);
-};
-
-const DomainManagementNavigationItem = function ( props ) {
-	const { path, onClick, external, gridicon, materialIcon, text, description } = props;
-
-	return (
-		<VerticalNavItem
-			path={ path }
-			onClick={ onClick }
-			external={ external }
-			className="navigation__nav-item"
-		>
-			<DomainManagementNavigationItemContents
-				materialIcon={ materialIcon }
-				gridicon={ gridicon }
-				text={ text }
-				description={ description }
-			/>
-		</VerticalNavItem>
-	);
-};
 
 class DomainManagementNavigationEnhanced extends React.Component {
 	getEmail() {
@@ -144,7 +113,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		}
 
 		return (
-			<DomainManagementNavigationItem
+			<VerticalNavItemEnhanced
 				path={ emailManagement( selectedSite.slug, domain.name, currentRoute ) }
 				materialIcon="email"
 				text={ navigationText }
@@ -188,7 +157,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		const description = this.getDestinationText();
 
 		return (
-			<DomainManagementNavigationItem
+			<VerticalNavItemEnhanced
 				path={ domainManagementNameServers( selectedSite.slug, domain.name, currentRoute ) }
 				materialIcon="language"
 				text={ translate( 'Change your name servers & DNS records' ) }
@@ -203,7 +172,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		const description = this.getDestinationText();
 
 		return (
-			<DomainManagementNavigationItem
+			<VerticalNavItemEnhanced
 				path={ domainManagementDns( selectedSite.slug, domain.name, currentRoute ) }
 				materialIcon="language"
 				text={ translate( 'Update your DNS records' ) }
@@ -230,7 +199,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		}
 
 		return (
-			<DomainManagementNavigationItem
+			<VerticalNavItemEnhanced
 				path={ domainManagementContactsPrivacy( selectedSite.slug, domain.name, currentRoute ) }
 				materialIcon="chrome_reader_mode"
 				text={ translate( 'Update your contact information' ) }
@@ -263,10 +232,10 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		}
 
 		return (
-			<DomainManagementNavigationItem
+			<VerticalNavItemEnhanced
 				path={ domainManagementTransfer( selectedSite.slug, domain.name, currentRoute ) }
 				materialIcon="sync_alt"
-				text={ translate( 'Transfer domain' ) }
+				text={ translate( 'Transfer your domain' ) }
 				description={ description }
 			/>
 		);
@@ -280,7 +249,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		}
 
 		return (
-			<DomainManagementNavigationItem
+			<VerticalNavItemEnhanced
 				path={ domainManagementTransfer( selectedSite.slug, domain.name, currentRoute ) }
 				materialIcon="sync_alt"
 				text={ translate( 'Transfer mapping' ) }
@@ -298,7 +267,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		}
 
 		return (
-			<DomainManagementNavigationItem
+			<VerticalNavItemEnhanced
 				onClick={ this.handleTransferDomainClick }
 				path={ domainTransferIn( selectedSite.slug, domain.name, true ) }
 				materialIcon="sync_alt"
@@ -320,7 +289,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		const path = domainManagementDomainConnectMapping( selectedSite.slug, domain.name );
 
 		return (
-			<DomainManagementNavigationItem
+			<VerticalNavItemEnhanced
 				path={ path }
 				materialIcon="double_arrow"
 				text={ translate( 'Connect your domain' ) }
@@ -339,7 +308,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		const wpcomUrl = withoutHttp( getUnmappedUrl( selectedSite ) );
 
 		return (
-			<DomainManagementNavigationItem
+			<VerticalNavItemEnhanced
 				path={ `/home/${ selectedSite.slug }` }
 				gridicon="my-sites"
 				text={ translate( 'Manage your site' ) }
@@ -412,7 +381,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		const { selectedSite, translate } = this.props;
 
 		return (
-			<DomainManagementNavigationItem
+			<VerticalNavItemEnhanced
 				path={ domainAddNew( selectedSite.slug ) }
 				onClick={ this.handlePickCustomDomainClick }
 				materialIcon="search"
@@ -431,7 +400,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		}
 
 		return (
-			<DomainManagementNavigationItem
+			<VerticalNavItemEnhanced
 				path={ domainManagementChangeSiteAddress( selectedSite.slug, domain.name, currentRoute ) }
 				onClick={ this.handleChangeSiteAddressClick }
 				materialIcon="create"
@@ -463,7 +432,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		}
 
 		return (
-			<DomainManagementNavigationItem
+			<VerticalNavItemEnhanced
 				path={ path }
 				onClick={ this.handlePickCustomDomainClick }
 				materialIcon="search"
@@ -502,7 +471,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		}
 
 		return (
-			<DomainManagementNavigationItem
+			<VerticalNavItemEnhanced
 				path={ domainManagementSecurity( selectedSite.slug, domain.name, currentRoute ) }
 				onClick={ this.handleDomainSecurityClick }
 				materialIcon="security"
@@ -556,7 +525,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 			const link = cancelPurchase( selectedSite.slug, purchase.id );
 
 			return (
-				<DomainManagementNavigationItem
+				<VerticalNavItemEnhanced
 					path={ link }
 					onClick={ this.handleDomainDeleteClick }
 					materialIcon="delete"
@@ -572,12 +541,12 @@ class DomainManagementNavigationEnhanced extends React.Component {
 				site={ selectedSite }
 				purchase={ purchase }
 				useVerticalNavItem={ true }
-				className="navigation__nav-item is-clickable"
+				className="navigation-enhanced__delete-domain is-clickable"
 				onClickTracks={ this.handleDomainDeleteClick }
 			>
-				<span>
-					<DomainManagementNavigationItemContents materialIcon="delete" text={ title } />
-				</span>
+				<MaterialIcon icon="delete" />
+
+				<strong>{ title }</strong>
 			</RemovePurchase>
 		);
 	}
@@ -586,7 +555,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		const { domain, selectedSite, currentRoute, translate } = this.props;
 
 		return (
-			<DomainManagementNavigationItem
+			<VerticalNavItemEnhanced
 				path={ domainManagementRedirectSettings( selectedSite.slug, domain.name, currentRoute ) }
 				materialIcon="language"
 				text={ translate( 'Redirect settings' ) }

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -541,6 +541,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 				site={ selectedSite }
 				purchase={ purchase }
 				useVerticalNavItem={ true }
+				// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 				className="navigation-enhanced__delete-domain is-clickable"
 				onClickTracks={ this.handleDomainDeleteClick }
 			>

--- a/client/my-sites/domains/domain-management/edit/navigation/style.scss
+++ b/client/my-sites/domains/domain-management/edit/navigation/style.scss
@@ -1,23 +1,20 @@
-.navigation__nav-item {
+.navigation-enhanced__delete-domain {
+	.material-icon {
+		fill: var( --color-neutral-60 );
+		height: 32px;
+		margin-right: 16px;
+		width: 32px;
+	}
+
 	span {
-		display: flex;
 		align-items: center;
-		> .navigation__icon {
-			fill: var( --color-neutral-60 );
-			width: 32px;
-			height: 32px;
-			margin-right: 16px;
-		}
-		> .gridicons-my-sites {
-			position: static;
-		}
-		div {
-			color: var( --color-neutral-90 );
-			small {
-				color: var( --color-neutral-50 );
-				font-size: $font-body-small;
-			}
-		}
+		display: flex;
+		min-height: 48px;
+	}
+
+	strong {
+		color: var( --color-neutral-90 );
+		font-weight: normal;
 	}
 
 	a:hover & {


### PR DESCRIPTION
This pull request extracts the components responsible for displaying a list of navigation links with icons and descriptions from the domain management section:

![screenshot](https://user-images.githubusercontent.com/594356/117970380-e0696780-b328-11eb-8182-fb6ac346315c.png)

This refactoring introduces a new `VerticalNavItemEnhanced` component that will allow us to show such a list in any part of Calypso. Those changes were extracted from https://github.com/Automattic/wp-calypso/pull/52755.

#### Testing instructions

1. Run `git checkout add/vertical-nav-item-enhanced` and start your server, or open a [live branch](https://calypso.live/?branch=add/vertical-nav-item-enhanced)
2. Log into a WordPress.com with a domain
3. Open the [`Domains` page](http://calypso.localhost:3000/domains/manage)
4. Click on that domain
5. Assert that the `Domain Settings` page displays like before
6. Open the [documentation page](http://calypso.localhost:3000/devdocs/design/vertical-nav) of the `VerticalNav` component
7. Assert that the example now shows two new items with icons and descriptions