### PR TITLE
Fixup style syntax incompatible with dart-sass

### DIFF
--- a/client/blocks/login/two-factor-authentication/push-notification-illustration.scss
+++ b/client/blocks/login/two-factor-authentication/push-notification-illustration.scss
@@ -47,7 +47,7 @@
 }
 
 @keyframes two-factor-authentication__illustration-slide {
-	0 {
+	0% {
 		transform: translate3d( 0, 0, 0 );
 	}
 

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -1,5 +1,5 @@
 @keyframes notice-loading-pulse {
-	0, 100% {
+	0%, 100% {
 		opacity: 0.75;
 	}
 	50% {

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -77,7 +77,7 @@
 }
 
 @include breakpoint-deprecated( '<800px' ) {
-	&.migrate__plan-upsell {
+	.migrate__plan-upsell {
 		flex-wrap: wrap;
 		margin: 16px 0;
 		padding: 16px 0;
@@ -86,14 +86,14 @@
 		border-bottom: none;
 	}
 
-	&.migrate__plan-upsell-container,
-	&.migrate__plan-upsell-themes,
-	&.migrate__plan-upsell-plugins {
+	.migrate__plan-upsell-container,
+	.migrate__plan-upsell-themes,
+	.migrate__plan-upsell-plugins {
 		display: flex;
 		flex-wrap: wrap;
 	}
 
-	&.migrate__plan-upsell-container {
+	.migrate__plan-upsell-container {
 		display: flex;
 		border-top: 1px solid var( --color-neutral-10 );
 

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -1,4 +1,4 @@
-client/my-sites/stats/post-trends/style.scss .post-trends {
+.post-trends {
 	display: inline-block;
 	user-select: none;
 	position: relative;


### PR DESCRIPTION
Preparation for `node-sass` to `dart-sass` migration in #52729, where we discovered that `dart-sass` is more strict about the SCSS syntax. Fixing the following errors:

Missing `%` sign when specifying keyframes:
```
SassError: expected "%".
  ╷
3 │     0, 100%{
```
Selectors inside media query should not use `&` -- they are top-level selectors.
```
SassError: Top-level selectors may not contain the parent selector "&".
```

Regression (accidental paste?) introduced a year ago in #40579
```
SassError: expected selector.
  ╷
2 │ client/my-sites/stats/post-trends/style.scss .post-trends{
```

**How to test:**
Apply on top of #52729 and verify `yarn build-client-evergreen` doesn't fail when building CSS.