### PR TITLE
Emails: Extract header from Email Plan page to standalone component

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan-header.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-header.jsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { CompactCard } from '@automattic/components';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import EmailPlanSubscription from 'calypso/my-sites/email/email-management/home/email-plan-subscription';
+import EmailTypeIcon from 'calypso/my-sites/email/email-management/home/email-type-icon';
+import MaterialIcon from 'calypso/components/material-icon';
+import { resolveEmailPlanStatus } from 'calypso/my-sites/email/email-management/home/utils';
+
+const EmailPlanHeader = ( { domain, hasEmailSubscription, isLoadingPurchase, purchase, selectedSite } ) => {
+	if ( ! domain ) {
+		return null;
+	}
+
+	const { statusClass, text, icon } = resolveEmailPlanStatus( domain );
+
+	const cardClasses = classnames( 'email-plan__header', statusClass );
+
+	return (
+		<>
+			<CompactCard className={ cardClasses }>
+				<span className="email-plan__header-icon">
+					<EmailTypeIcon domain={ domain } />
+				</span>
+
+				<div>
+					<h2>{ domain.name }</h2>
+
+					<span className="email-plan__status">
+						<MaterialIcon icon={ icon } /> { text }
+					</span>
+				</div>
+			</CompactCard>
+
+			{ hasEmailSubscription && (
+				<EmailPlanSubscription
+					purchase={ purchase }
+					domain={ domain }
+					selectedSite={ selectedSite }
+					isLoadingPurchase={ isLoadingPurchase }
+				/>
+			) }
+		</>
+	);
+}
+
+EmailPlanHeader.propTypes = {
+	domain: PropTypes.object.isRequired,
+	hasEmailSubscription: PropTypes.bool.isRequired,
+	isLoadingPurchase: PropTypes.bool.isRequired,
+	purchase: PropTypes.object,
+	selectedSite: PropTypes.object.isRequired,
+};
+
+export default EmailPlanHeader;

--- a/client/my-sites/email/email-management/home/email-plan-header.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-header.jsx
@@ -14,26 +14,32 @@ import EmailTypeIcon from 'calypso/my-sites/email/email-management/home/email-ty
 import MaterialIcon from 'calypso/components/material-icon';
 import { resolveEmailPlanStatus } from 'calypso/my-sites/email/email-management/home/utils';
 
-const EmailPlanHeader = ( { domain, hasEmailSubscription, isLoadingPurchase, purchase, selectedSite } ) => {
+const EmailPlanHeader = ( {
+	domain,
+	hasEmailSubscription,
+	isLoadingPurchase,
+	purchase,
+	selectedSite,
+} ) => {
 	if ( ! domain ) {
 		return null;
 	}
 
 	const { statusClass, text, icon } = resolveEmailPlanStatus( domain );
 
-	const cardClasses = classnames( 'email-plan__header', statusClass );
+	const cardClasses = classnames( 'email-plan-header', statusClass );
 
 	return (
 		<>
 			<CompactCard className={ cardClasses }>
-				<span className="email-plan__header-icon">
+				<span className="email-plan-header__icon">
 					<EmailTypeIcon domain={ domain } />
 				</span>
 
 				<div>
 					<h2>{ domain.name }</h2>
 
-					<span className="email-plan__status">
+					<span className="email-plan-header__status">
 						<MaterialIcon icon={ icon } /> { text }
 					</span>
 				</div>
@@ -49,7 +55,7 @@ const EmailPlanHeader = ( { domain, hasEmailSubscription, isLoadingPurchase, pur
 			) }
 		</>
 	);
-}
+};
 
 EmailPlanHeader.propTypes = {
 	domain: PropTypes.object.isRequired,

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -19,7 +19,10 @@ import {
 	getProductType,
 	hasGSuiteWithUs,
 } from 'calypso/lib/gsuite';
-import { getEmailPurchaseByDomain, hasEmailSubscription } from 'calypso/my-sites/email/email-management/home/utils';
+import {
+	getEmailPurchaseByDomain,
+	hasEmailSubscription,
+} from 'calypso/my-sites/email/email-management/home/utils';
 import { getTitanSubscriptionId, hasTitanMailWithUs } from 'calypso/lib/titan';
 import HeaderCake from 'calypso/components/header-cake';
 import VerticalNav from 'calypso/components/vertical-nav';
@@ -49,7 +52,7 @@ class EmailPlan extends React.Component {
 
 		// Connected props
 		currentRoute: PropTypes.string,
-		hasEmailSubscription: PropTypes.bool,
+		hasSubscription: PropTypes.bool,
 		isLoadingPurchase: PropTypes.bool,
 		purchase: PropTypes.object,
 	};
@@ -162,9 +165,9 @@ class EmailPlan extends React.Component {
 	}
 
 	renderBillingNavItem() {
-		const { hasEmailSubscription, purchase, selectedSite, translate } = this.props;
+		const { hasSubscription, purchase, selectedSite, translate } = this.props;
 
-		if ( ! hasEmailSubscription ) {
+		if ( ! hasSubscription ) {
 			return null;
 		}
 
@@ -239,7 +242,7 @@ class EmailPlan extends React.Component {
 		const {
 			domain,
 			selectedSite,
-			hasEmailSubscription,
+			hasSubscription,
 			purchase,
 			isLoadingPurchase,
 			translate,
@@ -250,15 +253,13 @@ class EmailPlan extends React.Component {
 
 		return (
 			<>
-				{ selectedSite && hasEmailSubscription && (
-					<QuerySitePurchases siteId={ selectedSite.ID } />
-				) }
+				{ selectedSite && hasSubscription && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 
 				<HeaderCake onClick={ this.handleBack }>{ this.getHeaderText() }</HeaderCake>
 
 				<EmailPlanHeader
 					domain={ domain }
-					hasEmailSubscription={ hasEmailSubscription }
+					hasEmailSubscription={ hasSubscription }
 					isLoadingPurchase={ isLoadingPurchase }
 					purchase={ purchase }
 					selectedSite={ selectedSite }
@@ -289,6 +290,6 @@ export default connect( ( state, ownProps ) => {
 		isLoadingPurchase:
 			isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
 		purchase: getEmailPurchaseByDomain( state, ownProps.domain ),
-		hasEmailSubscription: hasEmailSubscription( ownProps.domain ),
+		hasSubscription: hasEmailSubscription( ownProps.domain ),
 	};
 } )( localize( EmailPlan ) );

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import classnames from 'classnames';
-import { CompactCard } from '@automattic/components';
 import { connect } from 'react-redux';
 import { isEnabled } from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
@@ -18,15 +16,14 @@ import {
 	getGoogleAdminUrl,
 	getGoogleMailServiceFamily,
 	getGSuiteProductSlug,
-	getGSuiteSubscriptionId,
 	getProductType,
 	hasGSuiteWithUs,
 } from 'calypso/lib/gsuite';
+import { getEmailPurchaseByDomain, hasEmailSubscription } from 'calypso/my-sites/email/email-management/home/utils';
 import { getTitanSubscriptionId, hasTitanMailWithUs } from 'calypso/lib/titan';
 import HeaderCake from 'calypso/components/header-cake';
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
-import EmailTypeIcon from 'calypso/my-sites/email/email-management/home/email-type-icon';
 import {
 	emailManagement,
 	emailManagementAddGSuiteUsers,
@@ -35,16 +32,13 @@ import {
 	emailManagementNewTitanAccount,
 	emailManagementTitanControlPanelRedirect,
 } from 'calypso/my-sites/email/paths';
+import EmailPlanHeader from 'calypso/my-sites/email/email-management/home/email-plan-header';
 import EmailPlanMailboxesList from 'calypso/my-sites/email/email-management/home/email-plan-mailboxes-list';
 import {
-	getByPurchaseId,
 	hasLoadedSitePurchasesFromServer,
 	isFetchingSitePurchases,
 } from 'calypso/state/purchases/selectors';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import EmailPlanSubscription from 'calypso/my-sites/email/email-management/home/email-plan-subscription';
-import MaterialIcon from 'calypso/components/material-icon';
-import { resolveEmailPlanStatus } from 'calypso/my-sites/email/email-management/home/utils';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
@@ -55,7 +49,7 @@ class EmailPlan extends React.Component {
 
 		// Connected props
 		currentRoute: PropTypes.string,
-		hasEmailPlanSubscription: PropTypes.bool,
+		hasEmailSubscription: PropTypes.bool,
 		isLoadingPurchase: PropTypes.bool,
 		purchase: PropTypes.object,
 	};
@@ -168,9 +162,9 @@ class EmailPlan extends React.Component {
 	}
 
 	renderBillingNavItem() {
-		const { hasEmailPlanSubscription, purchase, selectedSite, translate } = this.props;
+		const { hasEmailSubscription, purchase, selectedSite, translate } = this.props;
 
-		if ( ! hasEmailPlanSubscription ) {
+		if ( ! hasEmailSubscription ) {
 			return null;
 		}
 
@@ -245,44 +239,30 @@ class EmailPlan extends React.Component {
 		const {
 			domain,
 			selectedSite,
-			hasEmailPlanSubscription,
+			hasEmailSubscription,
 			purchase,
 			isLoadingPurchase,
 			translate,
 		} = this.props;
 
-		const { statusClass, text, icon } = resolveEmailPlanStatus( domain );
-
-		const cardClasses = classnames( 'email-plan__general', statusClass );
 		const addMailboxProps = this.getAddMailboxProps();
 		const { isLoadingEmailAccounts } = this.state;
 
 		return (
 			<>
-				{ selectedSite && hasEmailPlanSubscription && (
+				{ selectedSite && hasEmailSubscription && (
 					<QuerySitePurchases siteId={ selectedSite.ID } />
 				) }
-				<HeaderCake onClick={ this.handleBack }>{ this.getHeaderText() }</HeaderCake>
-				<CompactCard className={ cardClasses }>
-					<span className="email-plan__general-icon">
-						<EmailTypeIcon domain={ domain } />
-					</span>
-					<div>
-						<h2>{ domain.name }</h2>
-						<span className="email-plan__status">
-							<MaterialIcon icon={ icon } /> { text }
-						</span>
-					</div>
-				</CompactCard>
 
-				{ hasEmailPlanSubscription && (
-					<EmailPlanSubscription
-						purchase={ purchase }
-						domain={ domain }
-						selectedSite={ selectedSite }
-						isLoadingPurchase={ isLoadingPurchase }
-					/>
-				) }
+				<HeaderCake onClick={ this.handleBack }>{ this.getHeaderText() }</HeaderCake>
+
+				<EmailPlanHeader
+					domain={ domain }
+					hasEmailSubscription={ hasEmailSubscription }
+					isLoadingPurchase={ isLoadingPurchase }
+					purchase={ purchase }
+					selectedSite={ selectedSite }
+				/>
 
 				<EmailPlanMailboxesList
 					mailboxes={ this.getMailboxes() }
@@ -304,20 +284,11 @@ class EmailPlan extends React.Component {
 }
 
 export default connect( ( state, ownProps ) => {
-	let subscriptionId = null;
-	if ( hasGSuiteWithUs( ownProps.domain ) ) {
-		subscriptionId = getGSuiteSubscriptionId( ownProps.domain );
-	} else if ( hasTitanMailWithUs( ownProps.domain ) ) {
-		subscriptionId = getTitanSubscriptionId( ownProps.domain );
-	}
-
-	const purchase = subscriptionId ? getByPurchaseId( state, parseInt( subscriptionId, 10 ) ) : null;
-
 	return {
 		currentRoute: getCurrentRoute( state ),
 		isLoadingPurchase:
 			isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
-		purchase,
-		hasEmailPlanSubscription: !! subscriptionId,
+		purchase: getEmailPurchaseByDomain( state, ownProps.domain ),
+		hasEmailSubscription: hasEmailSubscription( ownProps.domain ),
 	};
 } )( localize( EmailPlan ) );

--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -6,9 +6,15 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { getGSuiteMailboxCount, hasGSuiteWithUs, hasPendingGSuiteUsers } from 'calypso/lib/gsuite';
-import { getMaxTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
+import {
+	getGSuiteMailboxCount,
+	getGSuiteSubscriptionId,
+	hasGSuiteWithUs,
+	hasPendingGSuiteUsers
+} from 'calypso/lib/gsuite';
+import { getMaxTitanMailboxCount, getTitanSubscriptionId, hasTitanMailWithUs } from 'calypso/lib/titan';
 import { getEmailForwardsCount, hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
+import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 
 export function getNumberOfMailboxesText( domain ) {
 	if ( hasGSuiteWithUs( domain ) ) {
@@ -41,6 +47,49 @@ export function getNumberOfMailboxesText( domain ) {
 		} );
 	}
 	return '';
+}
+
+/**
+ * Retrieves the email purchase associated to the specified domain.
+ *
+ * @param {object} state - global state
+ * @param {object} domain - domain object
+ * @returns {object|null} the corresponding email purchase, or null if not found
+ */
+export function getEmailPurchaseByDomain( state, domain ) {
+	const subscriptionId = getEmailSubscriptionIdByDomain( domain );
+
+	return subscriptionId ? getByPurchaseId( state, subscriptionId ) : null;
+}
+
+/**
+ * Retrieves the identifier of the email subscription for the specified domain.
+ *
+ * @param {object} domain - domain object
+ * @returns {number|null} the corresponding subscription id, or null if not found
+ */
+function getEmailSubscriptionIdByDomain( domain ) {
+	let subscriptionId = null;
+
+	if ( hasGSuiteWithUs( domain ) ) {
+		subscriptionId = getGSuiteSubscriptionId( domain );
+	} else if ( hasTitanMailWithUs( domain ) ) {
+		subscriptionId = getTitanSubscriptionId( domain );
+	}
+
+	return subscriptionId ? parseInt( subscriptionId, 10 ) : null;
+}
+
+/**
+ * Determines whether an email subscription exists for the specified domain.
+ *
+ * @param {object} domain - domain object
+ * @returns {boolean} true if an email subscription exists, false otherwise
+ */
+export function hasEmailSubscription( domain ) {
+	const subscriptionId = getEmailSubscriptionIdByDomain( domain );
+
+	return !! subscriptionId;
 }
 
 export function resolveEmailPlanStatus( domain ) {

--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -10,9 +10,13 @@ import {
 	getGSuiteMailboxCount,
 	getGSuiteSubscriptionId,
 	hasGSuiteWithUs,
-	hasPendingGSuiteUsers
+	hasPendingGSuiteUsers,
 } from 'calypso/lib/gsuite';
-import { getMaxTitanMailboxCount, getTitanSubscriptionId, hasTitanMailWithUs } from 'calypso/lib/titan';
+import {
+	getMaxTitanMailboxCount,
+	getTitanSubscriptionId,
+	hasTitanMailWithUs,
+} from 'calypso/lib/titan';
 import { getEmailForwardsCount, hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -82,10 +82,12 @@
 	}
 }
 
-@mixin email_status_color( $color ) {
+@mixin email_plan_header_status_color( $color ) {
 	border-top: 5px solid $color;
-	.email-plan__status {
+
+	.email-plan-header__status {
 		color: $color;
+
 		> svg {
 			fill: $color;
 		}
@@ -98,35 +100,37 @@
 	padding-top: 28px;
 }
 
-.email-plan__status {
+.email-plan-header__status {
 	display: flex;
 	align-items: center;
+
 	> svg {
 		margin-right: 5px;
 	}
 }
 
-.email-plan__header {
+.email-plan-header {
 	display: flex;
 	align-items: center;
+
 	h2 {
 		font-size: $font-title-large;
 	}
 
 	&.success {
-		@include email_status_color( var( --color-success ) );
+		@include email_plan_header_status_color( var( --color-success ) );
 	}
 
 	&.warning {
-		@include email_status_color( var( --color-warning ) );
+		@include email_plan_header_status_color( var( --color-warning ) );
 	}
 
 	&.error {
-		@include email_status_color( var( --color-error ) );
+		@include email_plan_header_status_color( var( --color-error ) );
 	}
 }
 
-.email-plan__header-icon {
+.email-plan-header__icon {
 	> img, svg {
 		height: 36px;
 		width: 36px;

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -106,7 +106,7 @@
 	}
 }
 
-.email-plan__general {
+.email-plan__header {
 	display: flex;
 	align-items: center;
 	h2 {
@@ -116,20 +116,23 @@
 	&.success {
 		@include email_status_color( var( --color-success ) );
 	}
+
 	&.warning {
 		@include email_status_color( var( --color-warning ) );
 	}
+
 	&.error {
 		@include email_status_color( var( --color-error ) );
 	}
 }
 
-.email-plan__general-icon {
+.email-plan__header-icon {
 	> img, svg {
 		height: 36px;
 		width: 36px;
 		margin-right: 20px;
 	}
+
 	> .gridicon.gridicons-my-sites {
 		fill: var( --color-wordpress-com );
 	}


### PR DESCRIPTION
This pull request extracts the header of the `Email Plan` page to a new component that can be reused on other pages:

![screenshot](https://user-images.githubusercontent.com/594356/117978786-87063600-b332-11eb-9abd-8f06f47b231b.png)

Those changes were extracted from https://github.com/Automattic/wp-calypso/pull/52755.

#### Testing instructions

1. Run `git checkout add/email-plan-header` and start your server, or open a [live branch](https://calypso.live/?branch=add/email-plan-header)
2. Log into a WordPress.com account with at least one email subscription
3. Open the [`Email` page](http://calypso.localhost:3000/email)
4. Click any domain with emails
5. Assert that the header displays like before
6. Reload that page
7. Assert that the header displays like before