### PR TITLE
Framework: Refactor away from `_.unionBy()`

### DIFF
--- a/client/my-sites/activity/activity-log-tasklist/to-update.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/to-update.jsx
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { get, unionBy } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +14,11 @@ import { isJetpackSiteSecondaryNetworkSite } from 'calypso/state/sites/selectors
 import { requestSiteAlerts } from 'calypso/state/data-getters';
 
 const emptyList = [];
+
+const unionBySlug = ( a = [], b = [] ) => [
+	...a,
+	...b.filter( ( { slug: bSlug } ) => ! a.some( ( { slug: aSlug } ) => aSlug === bSlug ) ),
+];
 
 export default ( WrappedComponent ) => {
 	class ToUpdate extends Component {
@@ -36,7 +41,7 @@ export default ( WrappedComponent ) => {
 			return {
 				plugins:
 					nextProps.siteId === prevState.siteId
-						? unionBy( nextProps.plugins, prevState.plugins, 'slug' )
+						? unionBySlug( nextProps.plugins, prevState.plugins )
 						: emptyList,
 				siteId: nextProps.siteId,
 			};

--- a/client/my-sites/activity/activity-log-tasklist/to-update.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/to-update.jsx
@@ -17,7 +17,7 @@ const emptyList = [];
 
 const unionBySlug = ( a = [], b = [] ) => [
 	...a,
-	...b.filter( ( { slug: bSlug } ) => ! a.some( ( { slug: aSlug } ) => aSlug === bSlug ) ),
+	...b.filter( ( be ) => ! a.some( ( ae ) => ae.slug === be.slug ) ),
 ];
 
 export default ( WrappedComponent ) => {

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -6,7 +6,6 @@ import {
 	orderBy,
 	has,
 	map,
-	unionBy,
 	reject,
 	isEqual,
 	get,
@@ -46,6 +45,11 @@ import {
 import trees from './trees/reducer';
 import ui from './ui/reducer';
 import { getStateKey, getErrorKey, commentHasLink, getCommentDate } from './utils';
+
+const unionById = ( a = [], b = [] ) => [
+	...a,
+	...b.filter( ( { ID: bId } ) => ! a.some( ( { ID: aId } ) => aId === bId ) ),
+];
 
 const isCommentManagementEdit = ( newProperties ) =>
 	has( newProperties, 'commentContent' ) &&
@@ -122,7 +126,7 @@ export function items( state = {}, action ) {
 				contiguous: ! action.commentById,
 				has_link: commentHasLink( _comment.content, _comment.has_link ),
 			} ) );
-			const allComments = unionBy( state[ stateKey ], comments, 'ID' );
+			const allComments = unionById( state[ stateKey ], comments );
 			return {
 				...state,
 				[ stateKey ]: ! skipSort ? orderBy( allComments, getCommentDate, [ 'desc' ] ) : allComments,
@@ -193,7 +197,7 @@ export function pendingItems( state = {}, action ) {
 				contiguous: ! action.commentById,
 				has_link: commentHasLink( _comment.content, _comment.has_link ),
 			} ) );
-			const allComments = unionBy( state[ stateKey ], comments, 'ID' );
+			const allComments = unionById( state[ stateKey ], comments );
 			return {
 				...state,
 				[ stateKey ]: orderBy( allComments, getCommentDate, [ 'desc' ] ),

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -48,7 +48,7 @@ import { getStateKey, getErrorKey, commentHasLink, getCommentDate } from './util
 
 const unionById = ( a = [], b = [] ) => [
 	...a,
-	...b.filter( ( { ID: bId } ) => ! a.some( ( { ID: aId } ) => aId === bId ) ),
+	...b.filter( ( bc ) => ! a.some( ( ac ) => ac.ID === bc.ID ) ),
 ];
 
 const isCommentManagementEdit = ( newProperties ) =>

--- a/client/state/comments/trees/reducer.js
+++ b/client/state/comments/trees/reducer.js
@@ -16,7 +16,7 @@ import { keyedReducer } from 'calypso/state/utils';
 
 const unionByCommentId = ( a = [], b = [] ) => [
 	...a,
-	...b.filter( ( { commentId: bId } ) => ! a.some( ( { commentId: aId } ) => aId === bId ) ),
+	...b.filter( ( bc ) => ! a.some( ( ac ) => ac.commentId === bc.commentId ) ),
 ];
 
 const convertToTree = ( comments ) =>

--- a/client/state/comments/trees/reducer.js
+++ b/client/state/comments/trees/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, map, reject, unionBy } from 'lodash';
+import { get, map, reject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,6 +13,11 @@ import {
 	COMMENTS_TREE_SITE_ADD,
 } from 'calypso/state/action-types';
 import { keyedReducer } from 'calypso/state/utils';
+
+const unionByCommentId = ( a = [], b = [] ) => [
+	...a,
+	...b.filter( ( { commentId: bId } ) => ! a.some( ( { commentId: aId } ) => aId === bId ) ),
+];
 
 const convertToTree = ( comments ) =>
 	map(
@@ -44,10 +49,10 @@ const siteTree = ( state = [], action ) => {
 			return reject( state, { commentId: action.commentId } );
 		case COMMENTS_RECEIVE:
 			// Add the new comments to the state
-			return unionBy( convertToTree( action.comments ), state, 'commentId' );
+			return unionByCommentId( convertToTree( action.comments ), state );
 		case COMMENTS_TREE_SITE_ADD:
 			// Replace the comments of a given status with the comments freshly fetched from the server
-			return unionBy( action.tree, reject( state, { status: action.status } ), 'commentId' );
+			return unionByCommentId( action.tree, reject( state, { status: action.status } ) );
 	}
 	return state;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `unionBy()` is used just three times in the codebase, but it's pretty straightforward to replace it with custom implementations with a simple array spread concatenation with extra filtering. This PR replaces all instances. 

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify all tests pass: `yarn run test-client client/state/comments`.
* Smoke test the activity log on a site that has one or more plugins with outdated versions.
