### PR TITLE
Design picker: re-write and re-enable randomized designs unit tests

### DIFF
--- a/packages/design-picker/src/utils/__tests__/shuffle.test.ts
+++ b/packages/design-picker/src/utils/__tests__/shuffle.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Internal dependencies
+ */
+import { shuffleArray } from '../shuffle';
+
+const TEST_ARRAY_EMPTY = [];
+const TEST_ARRAY_SINGLE = [ 'foo' ];
+const TEST_ARRAY_MANY = [ 'baz', 1, { foo: 'bar' }, null, true ];
+
+describe( 'Design Picker shuffle utils', () => {
+	describe( 'shuffleArray', () => {
+		afterEach( () => {
+			jest.resetAllMocks();
+		} );
+
+		it( 'should shuffle an array correctly', () => {
+			const randomSpy = jest.spyOn( Math, 'random' ).mockImplementation( () => 0 );
+
+			// If Math.random() always returns `0`, then the array's first item should
+			// become the last item, while every other item stays in the same order.
+			expect( shuffleArray( TEST_ARRAY_MANY ) ).toEqual( [
+				...TEST_ARRAY_MANY.slice( 1, TEST_ARRAY_MANY.length ),
+				TEST_ARRAY_MANY[ 0 ],
+			] );
+			expect( randomSpy ).toHaveBeenCalledTimes( TEST_ARRAY_MANY.length - 1 );
+		} );
+
+		it( 'should create a new copy of the shuffled array', () => {
+			const shuffled = shuffleArray( TEST_ARRAY_SINGLE );
+
+			// Same array contents, but not referencing the same array value
+			expect( shuffled ).toEqual( TEST_ARRAY_SINGLE );
+			expect( shuffled ).not.toBe( TEST_ARRAY_SINGLE );
+		} );
+
+		it( 'should handle empty arrays', () => {
+			const randomSpy = jest.spyOn( Math, 'random' );
+
+			// if Math.random() always returns 0, then the array's first item should
+			// become the last item, while every other item stays in the same order.
+			expect( shuffleArray( TEST_ARRAY_EMPTY ) ).toEqual( TEST_ARRAY_EMPTY );
+			expect( randomSpy ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/packages/design-picker/src/utils/__tests__/shuffle.test.ts
+++ b/packages/design-picker/src/utils/__tests__/shuffle.test.ts
@@ -25,7 +25,7 @@ describe( 'Design Picker shuffle utils', () => {
 			expect( randomSpy ).toHaveBeenCalledTimes( TEST_ARRAY_MANY.length - 1 );
 		} );
 
-		it( 'should create a new copy of the shuffled array', () => {
+		it( 'should create a new copy of the input array', () => {
 			const shuffled = shuffleArray( TEST_ARRAY_SINGLE );
 
 			// Same array contents, but not referencing the same array value
@@ -36,8 +36,6 @@ describe( 'Design Picker shuffle utils', () => {
 		it( 'should handle empty arrays', () => {
 			const randomSpy = jest.spyOn( Math, 'random' );
 
-			// if Math.random() always returns 0, then the array's first item should
-			// become the last item, while every other item stays in the same order.
 			expect( shuffleArray( TEST_ARRAY_EMPTY ) ).toEqual( TEST_ARRAY_EMPTY );
 			expect( randomSpy ).not.toHaveBeenCalled();
 		} );

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -9,6 +9,7 @@ import { isEnabled } from '@automattic/calypso-config';
  */
 import { availableDesignsConfig } from './available-designs-config';
 import { DESIGN_IMAGE_FOLDER } from '../constants';
+import { shuffleArray } from './shuffle';
 import type { MShotsOptions } from '../components/mshots-image';
 import type { Design } from '../types';
 import type { AvailableDesigns } from './available-designs-config';
@@ -94,14 +95,7 @@ export function getAvailableDesigns( {
 	};
 
 	if ( randomize ) {
-		// Durstenfeld algorithm https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
-		for ( let i = designs.featured.length - 1; i > 0; i-- ) {
-			const j = Math.floor( Math.random() * ( i + 1 ) );
-			[ designs.featured[ i ], designs.featured[ j ] ] = [
-				designs.featured[ j ],
-				designs.featured[ i ],
-			];
-		}
+		designs.featured = shuffleArray( designs.featured );
 	}
 
 	// Force blank canvas design to always be first in the list

--- a/packages/design-picker/src/utils/shuffle.ts
+++ b/packages/design-picker/src/utils/shuffle.ts
@@ -1,0 +1,10 @@
+export function shuffleArray< T >( array: Array< T > ): Array< T > {
+	const arrayToShuffle = array.slice( 0 );
+	// Durstenfeld algorithm https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
+	for ( let i = arrayToShuffle.length - 1; i > 0; i-- ) {
+		const j = Math.floor( Math.random() * ( i + 1 ) );
+		[ arrayToShuffle[ i ], arrayToShuffle[ j ] ] = [ arrayToShuffle[ j ], arrayToShuffle[ i ] ];
+	}
+
+	return arrayToShuffle;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Extract shuffling logic from `getAvailableDesigns` into a separate `shuffleArray` function
* Unit test `shuffleArray` independently (by mocking `Math.random()`)
* Re-write unit tests for the randomization logic `getAvailableDesigns` so that the tests are predictable

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* check the code changes
* `yarn test-packages packages/design-picker`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #51743

Related to https://github.com/Automattic/wp-calypso/pull/51633#discussion_r626047488
Related to #52634
