### PR TITLE
Allow redirecting to /checkout/jetpack when feature flag is active

### DIFF
--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -615,6 +615,25 @@ export function checkout(
 	const productsArray = Array.isArray( products ) ? products : [ products ];
 	const productsString = productsArray.join( ',' );
 
+	if ( config.isEnabled( 'jetpack/userless-checkout' ) ) {
+		const { unlinked, purchasetoken, purchaseNonce, site } = urlQueryArgs;
+		const canDoUnlinkedCheckout = unlinked && !! site && ( !! purchasetoken || purchaseNonce );
+
+		// Enter userless checkout if unlinked, purchasetoken or purchaseNonce, and site are all set
+		if ( isJetpackCloud() && canDoUnlinkedCheckout ) {
+			const host =
+				'development' === urlQueryArgs.calypso_env
+					? 'http://calypso.localhost:3000'
+					: 'https://wordpress.com';
+
+			window.location.href = addQueryArgs(
+				urlQueryArgs,
+				host + `/checkout/jetpack/${ siteSlug }/${ productsString }`
+			);
+			return;
+		}
+	}
+
 	// If there is not siteSlug, we need to redirect the user to the site selection
 	// step of the flow. Since purchases of multiple products are allowed, we need
 	// to pass all products separated by comma in the URL.

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -41,6 +41,7 @@
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/redirect-legacy-plans": true,
+		"jetpack/userless-checkout": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds support on the pricing page for purchase buttons to link to the `/checkout/jetpack` flow. They should only be active in development environments and when linked to during an unlinked connection flow (by supplying a purchase nonce).

#### Testing instructions

* Connect a new site (not userlessly), and ensure that the product card links still go to the normal checkout.
* Connect a new site (userlessly), and ensure that the product card links go to `wpcom/checkout/jetpack` (This route is not active in this PR, so it will probably redirect elsewhere for now. This is okay.)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
