### PR TITLE
Enable Jetpack checkout in staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -67,7 +67,7 @@
 		"jetpack/happychat": true,
 		"jetpack/personal-plan": false,
 		"jetpack/magic-link-signup": true,
-		"jetpack/userless-checkout": false,
+		"jetpack/userless-checkout": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jitms": true,
 		"lasagna": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR simply enabled the `jetpack/userless-checkout` feature flag in staging. This will allow A12s to test Jetpack checkout without running a Calypso development environment.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
