### PR TITLE
Domain suggestions are not displayed when moves back from checkout page

### DIFF
--- a/test/e2e/specs/specs-calypso/wp-signup-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-signup-spec.js
@@ -996,4 +996,67 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await new DeleteAccountFlow( this.driver ).deleteAccount( username );
 		} );
 	} );
+
+	describe( 'Sign up for a site on a paid plan w/ domain name then move back to domain step @signup', function () {
+		const siteName = dataHelper.getNewBlogName();
+		const expectedDomainName = `${ siteName }.live`;
+		const emailAddress = dataHelper.getEmailAddress( siteName, signupInboxId );
+		const testDomainRegistarDetails = dataHelper.getTestDomainRegistarDetails( emailAddress );
+
+		before( async function () {
+			return await driverManager.ensureNotLoggedIn( driver );
+		} );
+
+		it( 'Can visit the start page', async function () {
+			await StartPage.Visit( driver, StartPage.getStartURL() );
+		} );
+
+		it( 'Can see the account page and enter account details', async function () {
+			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+			return await createYourAccountPage.enterAccountDetailsAndSubmit(
+				emailAddress,
+				siteName,
+				passwordForTestAccounts
+			);
+		} );
+
+		it( 'Can then see the domains page, and can search for a blog name, can see and select a paid .live address in results ', async function () {
+			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			await findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
+			try {
+				return await findADomainComponent.selectDomainAddress( expectedDomainName );
+			} catch ( err ) {
+				if ( await NewUserRegistrationUnavailableComponent.Expect( driver ) ) {
+					await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ' );
+					return this.skip();
+				}
+			}
+		} );
+
+		it( 'Can then see the plans page and select the premium plan ', async function () {
+			const pickAPlanPage = await PickAPlanPage.Expect( driver );
+			const displayed = await pickAPlanPage.displayed();
+			assert.strictEqual( displayed, true, 'The pick a plan page is not displayed' );
+			return await pickAPlanPage.selectPremiumPlan();
+		} );
+
+		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
+			return await new SignUpStep( driver ).continueAlong( siteName, passwordForTestAccounts );
+		} );
+
+		it( 'Can see checkout page and enter registrar details', async function () {
+			const checkOutPage = await CheckOutPage.Expect( driver );
+			return await checkOutPage.enterRegistrarDetails( testDomainRegistarDetails );
+		} );
+
+		it( 'Can see the domain suggestions when moves back from the checkout page', async function () {
+			await driver.navigate().back();
+			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			return await findADomainComponent.selectFreeAddress();
+		} );
+
+		after( 'Can delete our newly created account', async function () {
+			return await new DeleteAccountFlow( driver ).deleteAccount( siteName );
+		} );
+	} );
 } );

--- a/test/e2e/specs/specs-calypso/wp-signup-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-signup-spec.js
@@ -1004,15 +1004,15 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		const testDomainRegistarDetails = dataHelper.getTestDomainRegistarDetails( emailAddress );
 
 		before( async function () {
-			await driverManager.ensureNotLoggedIn( driver );
+			await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'Can visit the start page', async function () {
-			await StartPage.Visit( driver, StartPage.getStartURL() );
+			await StartPage.Visit( this.driver, StartPage.getStartURL() );
 		} );
 
 		it( 'Can see the account page and enter account details', async function () {
-			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+			const createYourAccountPage = await CreateYourAccountPage.Expect( this.driver );
 			await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
 				siteName,
@@ -1021,12 +1021,12 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can then see the domains page, and can search for a blog name, can see and select a paid .live address in results ', async function () {
-			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			const findADomainComponent = await FindADomainComponent.Expect( this.driver );
 			await findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
 			try {
 				await findADomainComponent.selectDomainAddress( expectedDomainName );
 			} catch ( err ) {
-				if ( await NewUserRegistrationUnavailableComponent.Expect( driver ) ) {
+				if ( await NewUserRegistrationUnavailableComponent.Expect( this.driver ) ) {
 					await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ' );
 					return this.skip();
 				}
@@ -1034,29 +1034,29 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can then see the plans page and select the premium plan ', async function () {
-			const pickAPlanPage = await PickAPlanPage.Expect( driver );
+			const pickAPlanPage = await PickAPlanPage.Expect( this.driver );
 			const displayed = await pickAPlanPage.displayed();
 			assert.strictEqual( displayed, true, 'The pick a plan page is not displayed' );
 			await pickAPlanPage.selectPremiumPlan();
 		} );
 
 		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
-			return await new SignUpStep( driver ).continueAlong( siteName, passwordForTestAccounts );
+			return await new SignUpStep( this.driver ).continueAlong( siteName, passwordForTestAccounts );
 		} );
 
 		it( 'Can see checkout page and enter registrar details', async function () {
-			const checkOutPage = await CheckOutPage.Expect( driver );
+			const checkOutPage = await CheckOutPage.Expect( this.driver );
 			await checkOutPage.enterRegistrarDetails( testDomainRegistarDetails );
 		} );
 
 		it( 'Can see the domain suggestions when moves back from the checkout page', async function () {
-			await driver.navigate().back();
-			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			await this.driver.navigate().back();
+			const findADomainComponent = await FindADomainComponent.Expect( this.driver );
 			await findADomainComponent.selectFreeAddress();
 		} );
 
 		after( 'Can delete our newly created account', async function () {
-			await new DeleteAccountFlow( driver ).deleteAccount( siteName );
+			await new DeleteAccountFlow( this.driver ).deleteAccount( siteName );
 		} );
 	} );
 } );

--- a/test/e2e/specs/specs-calypso/wp-signup-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-signup-spec.js
@@ -1004,7 +1004,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		const testDomainRegistarDetails = dataHelper.getTestDomainRegistarDetails( emailAddress );
 
 		before( async function () {
-			return await driverManager.ensureNotLoggedIn( driver );
+			await driverManager.ensureNotLoggedIn( driver );
 		} );
 
 		it( 'Can visit the start page', async function () {
@@ -1013,7 +1013,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 		it( 'Can see the account page and enter account details', async function () {
 			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
-			return await createYourAccountPage.enterAccountDetailsAndSubmit(
+			await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
 				siteName,
 				passwordForTestAccounts
@@ -1024,7 +1024,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			const findADomainComponent = await FindADomainComponent.Expect( driver );
 			await findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
 			try {
-				return await findADomainComponent.selectDomainAddress( expectedDomainName );
+				await findADomainComponent.selectDomainAddress( expectedDomainName );
 			} catch ( err ) {
 				if ( await NewUserRegistrationUnavailableComponent.Expect( driver ) ) {
 					await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ' );
@@ -1037,7 +1037,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			const pickAPlanPage = await PickAPlanPage.Expect( driver );
 			const displayed = await pickAPlanPage.displayed();
 			assert.strictEqual( displayed, true, 'The pick a plan page is not displayed' );
-			return await pickAPlanPage.selectPremiumPlan();
+			await pickAPlanPage.selectPremiumPlan();
 		} );
 
 		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
@@ -1046,17 +1046,17 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 		it( 'Can see checkout page and enter registrar details', async function () {
 			const checkOutPage = await CheckOutPage.Expect( driver );
-			return await checkOutPage.enterRegistrarDetails( testDomainRegistarDetails );
+			await checkOutPage.enterRegistrarDetails( testDomainRegistarDetails );
 		} );
 
 		it( 'Can see the domain suggestions when moves back from the checkout page', async function () {
 			await driver.navigate().back();
 			const findADomainComponent = await FindADomainComponent.Expect( driver );
-			return await findADomainComponent.selectFreeAddress();
+			await findADomainComponent.selectFreeAddress();
 		} );
 
 		after( 'Can delete our newly created account', async function () {
-			return await new DeleteAccountFlow( driver ).deleteAccount( siteName );
+			await new DeleteAccountFlow( driver ).deleteAccount( siteName );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes the bug that domain suggestions are not displayed in the signup flow when you moves back from the checkout page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new website from https://wordpress.com/start/new . The bug happens for both new and existing users.
1. Select a paid plan and proceed to the checkout page.
1. Click on the browser back button.
1. The domains step should display the suggestions.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #52610 
