### PR TITLE
Remove sass tilde imports

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/hide-plugin-buttons-mobile.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/hide-plugin-buttons-mobile.scss
@@ -1,6 +1,6 @@
-@import '~@wordpress/base-styles/mixins';
-@import '~@wordpress/base-styles/variables';
-@import '~@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/breakpoints';
 
 .interface-pinned-items > button:not( :first-child ) {
 	@media ( max-width: $break-medium ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/styles.scss
@@ -1,4 +1,4 @@
-@import '~@automattic/onboarding/styles/mixins';
+@import '@automattic/onboarding/styles/mixins';
 
 .nux-launch-menu {
 	h4 {

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/styles.scss
@@ -1,10 +1,10 @@
-@import '~@wordpress/base-styles/mixins';
-@import '~@wordpress/base-styles/variables';
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/z-index';
-@import '~@automattic/typography/styles/variables';
-@import '~@automattic/onboarding/styles/variables';
-@import '~@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/z-index';
+@import '@automattic/typography/styles/variables';
+@import '@automattic/onboarding/styles/variables';
+@import '@automattic/onboarding/styles/mixins';
 
 body.has-nux-launch-modal {
 	overflow: hidden;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/styles.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@automattic/onboarding/styles/mixins';
 
 .nux-launch-sidebar {
 	@include onboarding-block-margin;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-step/styles.scss
@@ -1,7 +1,7 @@
-@import '~@wordpress/base-styles/variables';
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@automattic/typography/styles/fonts';
-@import '~@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@automattic/typography/styles/fonts';
+@import '@automattic/onboarding/styles/mixins';
 
 .nux-launch-step__header {
 	@include onboarding-heading-padding;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/styles.scss
@@ -1,5 +1,5 @@
-@import '~@automattic/typography/styles/variables';
-@import '~@automattic/onboarding/styles/mixins';
+@import '@automattic/typography/styles/variables';
+@import '@automattic/onboarding/styles/mixins';
 
 // TODO: This is former dark-gray-500 from @wordpress/base-styles.
 // Replace with a color from the standard palette.

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/styles.scss
@@ -1,4 +1,4 @@
-@import '~@automattic/onboarding/styles/variables';
+@import '@automattic/onboarding/styles/variables';
 
 .nux-launch-step__input {
 	position: relative;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/styles.scss
@@ -1,5 +1,5 @@
-@import '~@automattic/onboarding/styles/mixins';
-@import '~@automattic/plans-grid/src/variables';
+@import '@automattic/onboarding/styles/mixins';
+@import '@automattic/plans-grid/src/variables';
 
 .nux-launch-modal.step-plan {
 	// Remove extraneous whitespace after plans details.

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.scss
@@ -1,4 +1,4 @@
-@import '~@automattic/page-pattern-modal/src/styles/page-pattern-modal';
+@import '@automattic/page-pattern-modal/src/styles/page-pattern-modal';
 
 .sidebar-modal-opener {
 	display: flex;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/style.scss
@@ -1,4 +1,4 @@
-@import '~@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/colors';
 
 // TODO: This is former light-gray-900 from @wordpress/base-styles.
 // Replace with a color from the standard palette.

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/colors';
-@import '~@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/variables';
 
 // TODO: These colors used to be in @wordpress/base-styles.
 // Replace them with colors from the updated standard palette.

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -1,7 +1,7 @@
-@import '~@wordpress/base-styles/colors';
-@import '~@wordpress/base-styles/mixins';
-@import '~@wordpress/base-styles/variables';
-@import '~@wordpress/base-styles/z-index';
+@import '@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/z-index';
 
 $sidebar-width: 272px;
 $sidebar-transition-period: 100ms;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/variables';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/mixins';
 @import '../nav-sidebar/style.scss';
 
 .wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-modal/style.scss
@@ -1,8 +1,8 @@
 // @TODO: remove the ignore rule and replace font sizes accordingly
 /* stylelint-disable scales/font-size */
 
-@import '~@automattic/typography/styles/fonts';
-@import '~@automattic/onboarding/styles/mixins';
+@import '@automattic/typography/styles/fonts';
+@import '@automattic/onboarding/styles/mixins';
 
 $wpcom-modal-breakpoint: 660px;
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -1,7 +1,7 @@
-@import '~@wordpress/base-styles/colors';
-@import '~@wordpress/base-styles/mixins';
-@import '~@wordpress/base-styles/variables';
-@import '~@wordpress/base-styles/z-index';
+@import '@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/z-index';
 
 $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: replace with standard color
 

--- a/apps/o2-blocks/src/todo/editor.scss
+++ b/apps/o2-blocks/src/todo/editor.scss
@@ -1,4 +1,4 @@
-@import '~@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/colors';
 
 $color-accent-green: #31843f;
 $color-move-button-icon: #555d66; // dark-gray-500

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.scss
@@ -1,4 +1,4 @@
-@import '~@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/variables';
 
 @media ( max-width: 600px ) {
 	// stylelint-disable-next-line selector-max-id

--- a/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.scss
+++ b/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.scss
@@ -1,4 +1,4 @@
-@import '~@automattic/typography/styles/fonts';
+@import '@automattic/typography/styles/fonts';
 
 .use-classic-block-guide__heading {
 	font-family: $brand-serif;

--- a/client/assets/stylesheets/gutenberg-base-styles.scss
+++ b/client/assets/stylesheets/gutenberg-base-styles.scss
@@ -1,6 +1,6 @@
-@import '~@wordpress/base-styles/z-index';
-@import '~@wordpress/base-styles/colors';
-@import '~@wordpress/base-styles/variables';
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
-@import '~@wordpress/base-styles/animations';
+@import '@wordpress/base-styles/z-index';
+@import '@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/animations';

--- a/client/assets/stylesheets/gutenboarding.scss
+++ b/client/assets/stylesheets/gutenboarding.scss
@@ -1,6 +1,6 @@
 // Color Schemes
 // Currently used only by Calypso dev badge shown in development mode
-@import '~@automattic/calypso-color-schemes/src/calypso-color-schemes';
+@import '@automattic/calypso-color-schemes/src/calypso-color-schemes';
 
 // Shared
 @import 'shared/reset'; // css reset before the rest of the styles are defined

--- a/client/assets/stylesheets/shared/_typography.scss
+++ b/client/assets/stylesheets/shared/_typography.scss
@@ -1,5 +1,5 @@
-@import '~@automattic/typography/styles/fonts';
-@import '~@automattic/typography/styles/variables';
+@import '@automattic/typography/styles/fonts';
+@import '@automattic/typography/styles/variables';
 @import './mixins/breakpoints';
 
 $signup-sans: 'Noto Sans', $sans;

--- a/client/assets/stylesheets/style.scss
+++ b/client/assets/stylesheets/style.scss
@@ -2,7 +2,7 @@
 @import 'vendor';
 
 // Color Schemes
-@import '~@automattic/calypso-color-schemes/src/calypso-color-schemes';
+@import '@automattic/calypso-color-schemes/src/calypso-color-schemes';
 
 // Shared
 @import 'shared/reset'; // css reset before the rest of the styles are defined
@@ -19,7 +19,7 @@
 @import './_nav-unification';
 
 // @wordpress/components stylesheet
-@import '~@wordpress/components/build-style/style.css';
+@import '@wordpress/components/build-style/style.css';
 
 // Overrides for @wordpress/components
 @import './_wp-components-overrides.scss';

--- a/client/assets/stylesheets/style.scss
+++ b/client/assets/stylesheets/style.scss
@@ -19,7 +19,7 @@
 @import './_nav-unification';
 
 // @wordpress/components stylesheet
-@import '@wordpress/components/build-style/style.css';
+@import '@wordpress/components/build-style/style';
 
 // Overrides for @wordpress/components
 @import './_wp-components-overrides.scss';

--- a/client/blocks/editor-checkout-modal/style.scss
+++ b/client/blocks/editor-checkout-modal/style.scss
@@ -1,6 +1,6 @@
-@import '~@automattic/typography/styles/variables';
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .editor-checkout-modal {
 	z-index: z-index( 'root', '.main.calypsoify.is-iframe' );

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .layout:not( .is-jetpack-woocommerce-flow ):not( .is-jetpack-woo-dna-flow ):not( .is-wccom-oauth-flow ) {
 	.login.is-jetpack {

--- a/client/blocks/nav-unification-modal/style.scss
+++ b/client/blocks/nav-unification-modal/style.scss
@@ -1,9 +1,9 @@
 // @TODO: remove the ignore rule and replace font sizes accordingly
 /* stylelint-disable scales/font-size */
 
-@import '~@automattic/typography/styles/fonts';
-@import '~@automattic/onboarding/styles/mixins';
-@import '~@wordpress/base-styles/breakpoints';
+@import '@automattic/typography/styles/fonts';
+@import '@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
 
 $modal-breakpoint: 600px;
 $modal-padding-v: 40px;

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -1,6 +1,6 @@
 @import 'woocommerce/components/text-control/style.scss';
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .signup-form .signup-form__input.form-text-input {
 	margin-bottom: 20px;

--- a/client/components/domains/domain-search-results/style.scss
+++ b/client/components/domains/domain-search-results/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .domain-search-results__transfer-card {
 	display: flex;

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .domain-suggestion {
 	&.is-clickable {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .featured-domain-suggestions {
 	display: flex;

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .free-domain-explainer {
 	.banner__description {

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .register-domain-step__search {
 	padding-bottom: 12px;

--- a/client/components/domains/reskin-side-explainer/style.scss
+++ b/client/components/domains/reskin-side-explainer/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .reskin-side-explainer {
     width: 100%;

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .search-filters__dropdown-filters {
 	align-items: center;

--- a/client/components/foldable-faq/style.scss
+++ b/client/components/foldable-faq/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .foldable-faq {
 	padding: 0 15px;

--- a/client/components/jetpack/backup-card/style.scss
+++ b/client/components/jetpack/backup-card/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 /* Header */
 

--- a/client/components/jetpack/card/jetpack-free-card/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .jetpack-free-card {
 	padding: 24px 32px;

--- a/client/components/promo-section/promo-card/style.scss
+++ b/client/components/promo-section/promo-card/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .promo-card {
 	display: flex;

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .web-preview {
 	position: fixed;

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -1,4 +1,4 @@
-@import '~@wordpress/edit-post/build-style/style';
+@import '@wordpress/edit-post/build-style/style';
 
 .is-group-gutenberg.layout {
 	background-color: var( --color-surface );

--- a/client/jetpack-cloud/sections/partner-portal/billing-details/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/_breakpoints.scss';
-@import '~@wordpress/base-styles/_mixins.scss';
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
 
 .billing-details {
 	&__row {

--- a/client/jetpack-cloud/sections/partner-portal/billing-summary/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/billing-summary/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/_breakpoints.scss';
-@import '~@wordpress/base-styles/_mixins.scss';
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
 
 .billing-summary {
 	display: flex;

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/style.scss
@@ -1,4 +1,4 @@
-@import '~@wordpress/base-styles/_mixins.scss';
+@import '@wordpress/base-styles/_mixins.scss';
 
 .issue-license-form {
 	p {

--- a/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/_breakpoints.scss';
-@import '~@wordpress/base-styles/_mixins.scss';
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
 
 .license-details {
 	margin: 0;

--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/_breakpoints.scss';
-@import '~@wordpress/base-styles/_mixins.scss';
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
 
 $column-domain: 1;
 $column-actions: 4;

--- a/client/jetpack-cloud/sections/partner-portal/license-list/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/_breakpoints.scss';
-@import '~@wordpress/base-styles/_mixins.scss';
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
 
 .license-list {
 	&__header {

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -1,6 +1,6 @@
-@import '~@wordpress/base-styles/_breakpoints.scss';
-@import '~@wordpress/base-styles/_mixins.scss';
-@import '~@wordpress/base-styles/_mixins.scss';
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+@import '@wordpress/base-styles/_mixins.scss';
 
 .license-preview {
 	margin: 0;

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/_breakpoints.scss';
-@import '~@wordpress/base-styles/_mixins.scss';
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
 
 .revoke-license-dialog {
 	.dialog__content {

--- a/client/jetpack-cloud/sections/partner-portal/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/style.scss
@@ -1,6 +1,6 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
-@import '~@automattic/typography/styles/fonts';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@automattic/typography/styles/fonts';
 
 .layout__content--partner-portal-issue-license {
 	// Make sure the layout container is high enough so select dropdowns do not get cut off.

--- a/client/jetpack-cloud/sections/partner-portal/text-placeholder/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/text-placeholder/style.scss
@@ -1,4 +1,4 @@
-@import '~@wordpress/base-styles/_mixins.scss';
+@import '@wordpress/base-styles/_mixins.scss';
 
 .partner-portal-text-placeholder {
 	@include placeholder( --color-neutral-10 );

--- a/client/jetpack-cloud/sections/pricing/header/style.scss
+++ b/client/jetpack-cloud/sections/pricing/header/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .header {
 	text-align: center;

--- a/client/jetpack-cloud/sections/pricing/jpcom-footer/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-footer/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .jpcom-footer {
 	display: flex;

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .jpcom-masterbar {
 	background-color: var( --color-surface );

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -1,6 +1,6 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
-@import '~@automattic/typography/styles/fonts';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@automattic/typography/styles/fonts';
 
 .is-group-jetpack-cloud.is-section-jetpack-cloud-pricing {
 	--color-accent: var( --studio-jetpack-green-40 );

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/host-selection/style.scss
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/host-selection/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .host-selection__notice {
 	padding: 21px 24px 24px 27px;

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/style.scss
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .advanced-credentials.main {
 	.step-progress {

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -1,6 +1,6 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../variables.scss';
-@import '~@automattic/onboarding/styles/z-index';
+@import '@automattic/onboarding/styles/z-index';
 
 $margin--gutenboarding__header-section-item: 13px; // matches design
 $padding--gutenboarding__header: $grid-unit-10;

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -1,5 +1,5 @@
 @import '../../variables.scss';
-@import '~@automattic/calypso-color-schemes/src/calypso-color-schemes';
+@import '@automattic/calypso-color-schemes/src/calypso-color-schemes';
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../mixins';
 

--- a/client/landing/gutenboarding/mixins.scss
+++ b/client/landing/gutenboarding/mixins.scss
@@ -1,1 +1,1 @@
-@import '~@automattic/onboarding/styles/mixins';
+@import '@automattic/onboarding/styles/mixins';

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -1,7 +1,7 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../../variables.scss';
 @import '../../../mixins';
-@import '~@automattic/onboarding/styles/z-index';
+@import '@automattic/onboarding/styles/z-index';
 
 // Restyle `<Suggestion />` component
 .vertical-select {

--- a/client/landing/gutenboarding/onboarding-block/anchor-error/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/anchor-error/style.scss
@@ -1,5 +1,5 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
-@import '~@automattic/calypso-color-schemes/src/calypso-color-schemes';
+@import '@automattic/calypso-color-schemes/src/calypso-color-schemes';
 @import '../../mixins';
 
 .anchor-error__flex-container {

--- a/client/landing/gutenboarding/onboarding-block/designs/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/designs/style.scss
@@ -1,5 +1,5 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
-@import '~@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/colors';
 @import '../../mixins';
 @import '../../variables.scss';
 

--- a/client/landing/gutenboarding/onboarding-block/features/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/features/style.scss
@@ -1,5 +1,5 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
-@import '~@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/colors';
 @import '../../mixins';
 @import '../../variables.scss';
 

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -1,7 +1,7 @@
 // @TODO: Remove this line and restore the import in `./gutenboard.tsx` when a release after @wordpress/components@8.5.0 is published.
 // See https://github.com/WordPress/gutenberg/pull/19535
-@import '~@wordpress/components/build-style/style';
-@import '~@automattic/typography/styles/fonts';
+@import '@wordpress/components/build-style/style';
+@import '@automattic/typography/styles/fonts';
 @import 'assets/stylesheets/gutenberg-base-styles';
 
 // Override core variables: we don't have wp-admin header and sidebar in Calypso
@@ -13,9 +13,9 @@ $admin-sidebar-width-big: 0;
 $admin-sidebar-width-collapsed: 0;
 
 // Gutenberg styles
-@import '~@wordpress/edit-post/src/style.scss';
-@import '~@wordpress/block-editor/src/style.scss';
-@import '~@wordpress/format-library/src/style.scss';
+@import '@wordpress/edit-post/src/style.scss';
+@import '@wordpress/block-editor/src/style.scss';
+@import '@wordpress/format-library/src/style.scss';
 
 // Own/Gutenboarding styles
 @import './variables.scss';

--- a/client/landing/gutenboarding/variables.scss
+++ b/client/landing/gutenboarding/variables.scss
@@ -1,4 +1,4 @@
-@import '~@automattic/onboarding/styles/variables';
+@import '@automattic/onboarding/styles/variables';
 
 $acquire-intent-transition-duration: 200ms;
 $acquire-intent-transition-algorithm: ease-in-out;

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -1,6 +1,6 @@
-@import '~@automattic/onboarding/styles/mixins';
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 @media ( max-height: 450px ) {
 	.magic-login__handle-link,

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -1,9 +1,9 @@
 @import 'jetpack-connect/colors.scss';
 @import 'woocommerce/components/text-control/style.scss';
-@import '~@automattic/onboarding/styles/mixins';
-@import '~@automattic/typography/styles/fonts';
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@automattic/onboarding/styles/mixins';
+@import '@automattic/typography/styles/fonts';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 $image-height: 47px;
 

--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .help-results {
 	margin-bottom: 16px;

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .help__heading {
 	display: flex;

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -1,6 +1,6 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
-@import '~@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
 
 .checkout-thank-you {
 	box-sizing: border-box;

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 $search_results_top_spacing: 24px;
 $card_padding_small: 16px;
 $card_padding_large: 24px;

--- a/client/my-sites/domains/components/mapping-instructions/style.scss
+++ b/client/my-sites/domains/components/mapping-instructions/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .mapping-instructions__placeholder {
 	padding: 16px;

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .memberships__module-header {
 	background: var( --color-surface );

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .earn .promo-section__promos img {
 	width: 48px;

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .email-management {
 	.empty-content__illustration {

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .email-providers-comparison__providers {
 	display: flex;

--- a/client/my-sites/email/titan-mail-add-mailboxes/style.scss
+++ b/client/my-sites/email/titan-mail-add-mailboxes/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .titan-mail-add-mailboxes__new-mailbox .form-label .form-text-input-with-affixes__suffix {
 	font-weight: normal;

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 // Content group
 .plans-features-main__group {

--- a/client/my-sites/plans/jetpack-plans/faq/style.scss
+++ b/client/my-sites/plans/jetpack-plans/faq/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .jetpack-faq {
 	max-width: 750px;

--- a/client/my-sites/plans/jetpack-plans/more-info-box/style.scss
+++ b/client/my-sites/plans/jetpack-plans/more-info-box/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .more-info-box__more-container {
 	background-color: var( --color-surface );

--- a/client/my-sites/plans/jetpack-plans/plan-upgrade/style.scss
+++ b/client/my-sites/plans/jetpack-plans/plan-upgrade/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/mixins';
-@import '~@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
 
 .plan-upgrade__product {
 	border-bottom: solid 2px var( --color-primary );

--- a/client/my-sites/plans/jetpack-plans/plans-filter-bar/style.scss
+++ b/client/my-sites/plans/jetpack-plans/plans-filter-bar/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .plans-filter-bar {
 	display: flex;

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .product-grid__section {
 	margin-bottom: 70px;

--- a/client/signup/p2-processing-screen/style.scss
+++ b/client/signup/p2-processing-screen/style.scss
@@ -1,6 +1,6 @@
 @import url( 'https://fonts.googleapis.com/css2?family=Inter:wght@400;900&display=swap' );
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .p2-processing-screen {
 	box-sizing: border-box;

--- a/client/signup/p2-step-wrapper/style.scss
+++ b/client/signup/p2-step-wrapper/style.scss
@@ -1,6 +1,6 @@
 @import url( 'https://fonts.googleapis.com/css2?family=Inter:wght@400;900&display=swap' );
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .p2-step-wrapper {
 	box-sizing: border-box;

--- a/client/signup/reskinned-processing-screen/style.scss
+++ b/client/signup/reskinned-processing-screen/style.scss
@@ -1,4 +1,4 @@
-@import '~@automattic/onboarding/styles/mixins';
+@import '@automattic/onboarding/styles/mixins';
 
 $progress-duration: 800ms;
 

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/_breakpoints.scss';
-@import '~@wordpress/base-styles/_mixins.scss';
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
 
 .signup__step.is-design {
 	.step-wrapper {

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .domains__step-section-wrapper {
 	margin: 0 auto;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -1,6 +1,6 @@
-@import '~@automattic/onboarding/styles/mixins';
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 
 body.is-section-signup {

--- a/docs/coding-guidelines/css.md
+++ b/docs/coding-guidelines/css.md
@@ -20,11 +20,11 @@ Take a component called `site/index.jsx` that renders a site item on the picker.
 
 ```scss
 .site__title {
-    color: #333;
+	color: #333;
 
-    &.is-jetpack {
-        color: #444;
-    }
+	&.is-jetpack {
+		color: #444;
+	}
 }
 ```
 
@@ -32,13 +32,13 @@ Take a component called `site/index.jsx` that renders a site item on the picker.
 
 ```scss
 .site {
-    .title {
-        color: #333;
+	.title {
+		color: #333;
 
-        .jetpack {
-            color: #444;
-        }
-    }
+		.jetpack {
+			color: #444;
+		}
+	}
 }
 ```
 
@@ -47,7 +47,7 @@ The modifier classes are always attached to a base element (the wrapper of a com
 ```scss
 // Modify 'site__title' for in CurrentSite component's display
 .current-site .site__title {
-    color: #444;
+	color: #444;
 }
 ```
 
@@ -101,17 +101,17 @@ Under the hood, we are using webpack and its `sass-loader`, for compiling the st
 To avoid code bloat and have a more consistent experience we use the same breakpoints in all SCSS files whenever possible. DO NOT define your own media queries. We should use the `break-*` mixins from [Gutenberg](https://github.com/WordPress/gutenberg/blob/0f1f5e75408705f0ec014f5d2ea3d9fcc8a97817/packages/base-styles/_mixins.scss). For example:
 
 ```scss
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .class-name {
-    margin-bottom: 8px;
-    padding: 12px;
+	margin-bottom: 8px;
+	padding: 12px;
 
-    @include break-mobile {
-        margin-bottom: 16px;
-        padding: 24px;
-    }
+	@include break-mobile {
+		margin-bottom: 16px;
+		padding: 24px;
+	}
 }
 ```
 
@@ -142,14 +142,14 @@ Example of the above:
 
 ```scss
 .parent {
-    @extend %awesomeness;
-    border: 1px solid;
-    font-size: 2em;
-    @include moar-awesome( true );
+	@extend %awesomeness;
+	border: 1px solid;
+	font-size: 2em;
+	@include moar-awesome( true );
 
-    &::before {
-        // and so on
-    }
+	&::before {
+		// and so on
+	}
 }
 ```
 
@@ -186,13 +186,13 @@ We're using [RTLCSS](https://github.com/MohammadYounes/rtlcss) to convert `publi
 ```scss
 /*rtl:ignore*/
 div.alignright {
-  float: right;
-  clear: right;
-  margin: 0.5em 0 0.8em 1.4em;
+	float: right;
+	clear: right;
+	margin: 0.5em 0 0.8em 1.4em;
 }
 /*rtl:ignore*/
 input.email {
-    direction:ltr
+	direction: ltr;
 }
 ```
 
@@ -201,7 +201,7 @@ If you need custom RTL css code, add it to your stylesheet with a .rtl class pre
 ```scss
 /*rtl:ignore*/
 .rtl div.onlyinrtl {
-    font-family:Tahoma;
+	font-family: Tahoma;
 }
 ```
 
@@ -209,18 +209,18 @@ Note for either of the above that because of the SCSS build process, if you're n
 
 ```scss
 .rtl {
-  .onlyinrtl {
-    margin-right: 5px #{"/*rtl:ignore*/"};;
-  }
+	.onlyinrtl {
+		margin-right: 5px #{'/*rtl:ignore*/'};
+	}
 }
 ```
 
 You can also define specific values for RTL like so:
 
 ```scss
-  .class {
-    margin-right: 5px #{"/*rtl:2px*/"};;
-  }
+.class {
+	margin-right: 5px #{'/*rtl:2px*/'};
+}
 ```
 
 You can find more details in the [RTLCSS documentation](https://github.com/MohammadYounes/rtlcss/blob/HEAD/README.md).
@@ -231,9 +231,9 @@ When defining positioning properties, indent the top/right/bottom/left one level
 
 ```css
 selector {
-  position: absolute;
-    left: 0;
-    top: 20px;
+	position: absolute;
+	left: 0;
+	top: 20px;
 }
 ```
 
@@ -243,9 +243,9 @@ selector {
 - DO use a single space before an opening brace
 
 ```scss
-@include breakpoint-deprecated( ">480px" ) {
-  color: rgb( 0, 0, 0 );
-  transform: translate( -50%, -50% ) scale( 1 );
+@include breakpoint-deprecated( '>480px' ) {
+	color: rgb( 0, 0, 0 );
+	transform: translate( -50%, -50% ) scale( 1 );
 }
 ```
 
@@ -290,9 +290,9 @@ As a simple example, imagine that we have a page with the following markup:
 ```html
 <div class="masterbar"></div>
 <div class="modal">
-  <div class="modal__icon"></div>
-  <div class="modal__content"></div>
-  <div class="modal__header"></div>
+	<div class="modal__icon"></div>
+	<div class="modal__content"></div>
+	<div class="modal__header"></div>
 </div>
 ```
 
@@ -300,22 +300,22 @@ With CSS of:
 
 ```css
 div {
-    position: relative;
+	position: relative;
 }
 .masterbar {
-    z-index: 2;
+	z-index: 2;
 }
 .modal {
-    z-index: 1;
+	z-index: 1;
 }
 .modal__icon {
-    z-index: 100;
+	z-index: 100;
 }
 .modal__content {
-   z-index: 300;
+	z-index: 300;
 }
 .modal__header {
-   z-index: 200;
+	z-index: 200;
 }
 ```
 
@@ -339,21 +339,21 @@ values sorted from lowest to highest within a stacking context:
 
 ```scss
 $z-layers: (
-    'root': (
-        '.modal': 1,
-        '.masterbar': 2
-    ),
-    '.modal': (
-        '.modal__icon': 100,
-        '.modal__header': 200,
-        '.modal__content': 300
-    )
+	'root': (
+		'.modal': 1,
+		'.masterbar': 2,
+	),
+	'.modal': (
+		'.modal__icon': 100,
+		'.modal__header': 200,
+		'.modal__content': 300,
+	),
 );
 ```
 
 ```scss
 .modal__icon {
-    z-index: z-index( '.modal', '.modal__icon' ); // returns 100
+	z-index: z-index( '.modal', '.modal__icon' ); // returns 100
 }
 ```
 

--- a/packages/components/src/card/style.scss
+++ b/packages/components/src/card/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 @import '../styles/clear-fix';
 
 .card {

--- a/packages/components/src/dialog/style.scss
+++ b/packages/components/src/dialog/style.scss
@@ -1,5 +1,5 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .dialog__backdrop,
 .dialog__backdrop.card {

--- a/packages/design-picker/src/components/mshots-image/style.scss
+++ b/packages/design-picker/src/components/mshots-image/style.scss
@@ -1,4 +1,4 @@
-@import '~@automattic/onboarding/styles/mixins';
+@import '@automattic/onboarding/styles/mixins';
 
 .mshots-image__loader {
 	@include onboarding-placeholder();

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -1,5 +1,5 @@
-@import '~@automattic/onboarding/styles/mixins';
-@import '~@automattic/onboarding/styles/variables';
+@import '@automattic/onboarding/styles/mixins';
+@import '@automattic/onboarding/styles/variables';
 
 .design-picker {
 	.design-picker__header {

--- a/packages/domain-picker/src/components/domain-categories/style.scss
+++ b/packages/domain-picker/src/components/domain-categories/style.scss
@@ -1,4 +1,4 @@
-@import '~@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/breakpoints';
 
 .domain-categories {
 	@media ( max-width: $break-mobile ) {

--- a/packages/domain-picker/src/components/info-tooltip/style.scss
+++ b/packages/domain-picker/src/components/info-tooltip/style.scss
@@ -1,4 +1,4 @@
-@import '~@automattic/onboarding/styles/variables';
+@import '@automattic/onboarding/styles/variables';
 
 .info-tooltip {
     &.components-button.has-icon.has-text svg {

--- a/packages/domain-picker/src/components/style.scss
+++ b/packages/domain-picker/src/components/style.scss
@@ -1,6 +1,6 @@
-@import '~@automattic/calypso-color-schemes';
-@import '~@automattic/onboarding/styles/mixins';
-@import '~@automattic/typography/styles/fonts';
+@import '@automattic/calypso-color-schemes';
+@import '@automattic/onboarding/styles/mixins';
+@import '@automattic/typography/styles/fonts';
 
 $accent-blue: #117ac9;
 

--- a/packages/language-picker/src/style.scss
+++ b/packages/language-picker/src/style.scss
@@ -1,6 +1,6 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
-@import '~@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
 
 .language-picker-component {
 	flex-direction: column;

--- a/packages/launch/src/focused-launch/style.scss
+++ b/packages/launch/src/focused-launch/style.scss
@@ -1,8 +1,8 @@
-@import '~@wordpress/base-styles/mixins';
-@import '~@wordpress/base-styles/variables';
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/z-index';
-@import '~@automattic/onboarding/styles/variables';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/z-index';
+@import '@automattic/onboarding/styles/variables';
 
 body.is-focused-launch-complete .editor-gutenberg-launch__launch-button {
 	display: none;

--- a/packages/launch/src/focused-launch/success/style.scss
+++ b/packages/launch/src/focused-launch/success/style.scss
@@ -1,5 +1,5 @@
-@import '~@automattic/onboarding/styles/variables';
-@import '~@automattic/onboarding/styles/mixins';
+@import '@automattic/onboarding/styles/variables';
+@import '@automattic/onboarding/styles/mixins';
 @import '../../variables';
 
 // Override some of the .focused-launch-container styles,

--- a/packages/launch/src/focused-launch/summary/focused-launch-summary-item/style.scss
+++ b/packages/launch/src/focused-launch/summary/focused-launch-summary-item/style.scss
@@ -1,5 +1,5 @@
-@import '~@automattic/typography/styles/variables';
-@import '~@automattic/onboarding/styles/variables';
+@import '@automattic/typography/styles/variables';
+@import '@automattic/onboarding/styles/variables';
 @import '../../../variables';
 
 .focused-launch-summary__item {

--- a/packages/launch/src/focused-launch/summary/style.scss
+++ b/packages/launch/src/focused-launch/summary/style.scss
@@ -1,10 +1,10 @@
-@import '~@wordpress/base-styles/mixins';
-@import '~@wordpress/base-styles/variables';
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/z-index';
-@import '~@automattic/typography/styles/variables';
-@import '~@automattic/onboarding/styles/variables';
-@import '~@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/z-index';
+@import '@automattic/typography/styles/variables';
+@import '@automattic/onboarding/styles/variables';
+@import '@automattic/onboarding/styles/mixins';
 
 $commentary-column-width-medium: 280px;
 $commentary-column-width-large: 320px;

--- a/packages/launch/src/launch/styles.scss
+++ b/packages/launch/src/launch/styles.scss
@@ -1,10 +1,10 @@
-@import '~@wordpress/base-styles/mixins';
-@import '~@wordpress/base-styles/variables';
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/z-index';
-@import '~@automattic/typography/styles/variables';
-@import '~@automattic/onboarding/styles/variables';
-@import '~@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/z-index';
+@import '@automattic/typography/styles/variables';
+@import '@automattic/onboarding/styles/variables';
+@import '@automattic/onboarding/styles/mixins';
 @import '../variables';
 
 // =============================================================================

--- a/packages/onboarding/README.md
+++ b/packages/onboarding/README.md
@@ -12,8 +12,8 @@ yarn add @automattic/onboarding
 
 Import the variables or mixins that you need.
 
-`@import '~@automattic/onboarding/styles/variables'`
-`@import '~@automattic/onboarding/styles/mixins'`
+`@import '@automattic/onboarding/styles/variables'`
+`@import '@automattic/onboarding/styles/mixins'`
 
 Import the components that you need.
 

--- a/packages/onboarding/styles/base-styles.scss
+++ b/packages/onboarding/styles/base-styles.scss
@@ -1,7 +1,7 @@
-@import '~@wordpress/base-styles/z-index';
-@import '~@wordpress/base-styles/colors';
-@import '~@wordpress/base-styles/variables';
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
-@import '~@wordpress/base-styles/animations';
-@import '~@automattic/typography/styles/fonts';
+@import '@wordpress/base-styles/z-index';
+@import '@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/animations';
+@import '@automattic/typography/styles/fonts';

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -1,7 +1,7 @@
-@import '~@automattic/color-studio/dist/color-variables';
-@import '~@automattic/typography/styles/fonts';
-@import '~@automattic/typography/styles/variables';
-@import '~@wordpress/base-styles/variables';
+@import '@automattic/color-studio/dist/color-variables';
+@import '@automattic/typography/styles/fonts';
+@import '@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/variables';
 
 @mixin screen-reader-text() {
 	border: 0;

--- a/packages/plans-grid/src/plans-accordion-item/style.scss
+++ b/packages/plans-grid/src/plans-accordion-item/style.scss
@@ -1,6 +1,6 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@automattic/onboarding/styles/mixins';
-@import '~@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@automattic/onboarding/styles/mixins';
+@import '@automattic/typography/styles/variables';
 @import '../variables.scss';
 
 $plans-accordion-item-border-radius: 5px; /* stylelint-disable-line scales/radii */

--- a/packages/plans-grid/src/plans-accordion/style.scss
+++ b/packages/plans-grid/src/plans-accordion/style.scss
@@ -1,6 +1,6 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@automattic/onboarding/styles/mixins';
-@import '~@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@automattic/onboarding/styles/mixins';
+@import '@automattic/typography/styles/variables';
 @import '../variables.scss';
 
 .plans-accordion__actions {

--- a/packages/plans-grid/src/plans-details/style.scss
+++ b/packages/plans-grid/src/plans-details/style.scss
@@ -1,7 +1,7 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
-@import '~@automattic/onboarding/styles/mixins';
-@import '~@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@automattic/onboarding/styles/mixins';
+@import '@automattic/typography/styles/variables';
 @import '../variables';
 
 // Used to "counter" the negative margin set on the container, while allowing the

--- a/packages/plans-grid/src/plans-feature-list/style.scss
+++ b/packages/plans-grid/src/plans-feature-list/style.scss
@@ -1,4 +1,4 @@
-@import '~@automattic/onboarding/styles/mixins';
+@import '@automattic/onboarding/styles/mixins';
 @import '../variables.scss';
 
 .plans-feature-list {

--- a/packages/plans-grid/src/plans-grid/style.scss
+++ b/packages/plans-grid/src/plans-grid/style.scss
@@ -1,7 +1,7 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
-@import '~@automattic/onboarding/styles/variables';
-@import '~@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@automattic/onboarding/styles/variables';
+@import '@automattic/onboarding/styles/mixins';
 @import '../variables.scss';
 
 .plans-grid {

--- a/packages/plans-grid/src/plans-interval-toggle/style.scss
+++ b/packages/plans-grid/src/plans-interval-toggle/style.scss
@@ -1,4 +1,4 @@
-@import '~@automattic/typography/styles/variables';
+@import '@automattic/typography/styles/variables';
 @import '../variables';
 
 .plans-interval-toggle {

--- a/packages/plans-grid/src/plans-table/style.scss
+++ b/packages/plans-grid/src/plans-table/style.scss
@@ -1,7 +1,7 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@automattic/onboarding/styles/variables';
-@import '~@automattic/onboarding/styles/mixins';
-@import '~@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@automattic/onboarding/styles/variables';
+@import '@automattic/onboarding/styles/mixins';
+@import '@automattic/typography/styles/variables';
 @import '../variables.scss';
 
 /* stylelint-disable scales/font-size */

--- a/packages/plans-grid/src/segmented-control/style.scss
+++ b/packages/plans-grid/src/segmented-control/style.scss
@@ -1,4 +1,4 @@
-@import '~@automattic/typography/styles/variables';
+@import '@automattic/typography/styles/variables';
 
 /**
  * Segmented Control

--- a/packages/plans-grid/src/variables.scss
+++ b/packages/plans-grid/src/variables.scss
@@ -1,4 +1,4 @@
-@import '~@automattic/onboarding/styles/variables';
+@import '@automattic/onboarding/styles/variables';
 @import './functions.scss';
 
 // Plans Table

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -2,9 +2,9 @@
 * @component Search
 */
 
-@import '~@automattic/typography/styles/variables';
-@import '~@wordpress/base-styles/variables';
-@import '~@wordpress/base-styles/mixins';
+@import '@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/mixins';
 
 $input-z-index: 20;
 

--- a/packages/typography/README.md
+++ b/packages/typography/README.md
@@ -18,7 +18,7 @@ Note that this package contains two sass files and there are use cases for `@imp
 
 ### Import the `variables.scss` file
 
-`@import '~@automattic/typography/styles/variables';`
+`@import '@automattic/typography/styles/variables';`
 
 Apply font variables as needed:
 
@@ -30,7 +30,7 @@ Apply font variables as needed:
 
 ### Import the `fonts.sccc` file
 
-`@import '~@automattic/typography/styles/fonts';`
+`@import '@automattic/typography/styles/fonts';`
 
 Extend the .wp-brand-font selector in your SCSS:
 

--- a/packages/whats-new/src/style.scss
+++ b/packages/whats-new/src/style.scss
@@ -1,9 +1,9 @@
 // @TODO: remove the ignore rule and replace font sizes accordingly
 /* stylelint-disable scales/font-size */
 
-@import '~@automattic/typography/styles/fonts';
-@import '~@automattic/onboarding/styles/mixins';
-@import '~@automattic/calypso-color-schemes';
+@import '@automattic/typography/styles/fonts';
+@import '@automattic/onboarding/styles/mixins';
+@import '@automattic/calypso-color-schemes';
 
 $wpcom-modal-breakpoint: 660px;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Relies on #52729 (won't work till that is merged)

According to the [sass documentation](https://github.com/webpack-contrib/sass-loader#resolving-import-at-rules), using tilde (`~`) to resolve `node_modules` imports is no longer needed. Since these types of imports are causing some problems with the smarter builds project, I've removed the tilde by replacing all instances of `@import '~` with `@import '`.

#### Testing instructions
- [x] CSS should compile for all builds
- [x] Styles should be correct on the front end
