### PR TITLE
`?shuffle` param on My Home will request shuffled views

### DIFF
--- a/client/components/data/query-home-layout/index.js
+++ b/client/components/data/query-home-layout/index.js
@@ -9,10 +9,10 @@ import { useDispatch } from 'react-redux';
  */
 import { requestHomeLayout } from 'calypso/state/home/actions';
 
-export default function QueryHomeLayout( { isDev, forcedView, siteId } ) {
+export default function QueryHomeLayout( { isDev, forcedView, siteId, shuffle } ) {
 	const dispatch = useDispatch();
 	React.useEffect( () => {
-		dispatch( requestHomeLayout( siteId, isDev, forcedView ) );
+		dispatch( requestHomeLayout( siteId, isDev, forcedView, shuffle ) );
 	}, [ dispatch, siteId ] );
 
 	return null;

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -18,6 +18,7 @@ export default async function ( context, next ) {
 	const isDev = context.query.dev === 'true';
 	const forcedView = context.query.view;
 	const noticeType = context.query.notice;
+	const shuffle = context.query.hasOwnProperty( 'shuffle' );
 
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {
@@ -30,6 +31,7 @@ export default async function ( context, next ) {
 			isDev={ isDev }
 			forcedView={ forcedView }
 			noticeType={ noticeType }
+			shuffleViews={ shuffle }
 		/>
 	);
 

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -45,6 +45,7 @@ const Home = ( {
 	siteId,
 	trackViewSiteAction,
 	noticeType,
+	shuffleViews,
 } ) => {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
@@ -97,7 +98,14 @@ const Home = ( {
 			<PageViewTracker path={ `/home/:site` } title={ translate( 'My Home' ) } />
 			<DocumentHead title={ translate( 'My Home' ) } />
 			{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
-			{ siteId && <QueryHomeLayout siteId={ siteId } isDev={ isDev } forcedView={ forcedView } /> }
+			{ siteId && (
+				<QueryHomeLayout
+					siteId={ siteId }
+					isDev={ isDev }
+					forcedView={ forcedView }
+					shuffle={ shuffleViews }
+				/>
+			) }
 			<SidebarNavigation />
 			{ header }
 			{ layout ? (
@@ -128,6 +136,7 @@ Home.propTypes = {
 	site: PropTypes.object.isRequired,
 	siteId: PropTypes.number.isRequired,
 	trackViewSiteAction: PropTypes.func.isRequired,
+	shuffleViews: PropTypes.bool,
 };
 
 const mapStateToProps = ( state ) => {

--- a/client/state/data-layer/wpcom/sites/home/layout/index.js
+++ b/client/state/data-layer/wpcom/sites/home/layout/index.js
@@ -10,6 +10,7 @@ import config from '@automattic/calypso-config';
 
 const requestLayout = ( action ) => {
 	const isDev = config.isEnabled( 'home/layout-dev' ) || action.isDev;
+
 	return http(
 		{
 			method: 'GET',
@@ -18,6 +19,7 @@ const requestLayout = ( action ) => {
 			query: {
 				...( isDev && { dev: true } ),
 				...( isDev && action.forcedView && { view: action.forcedView } ),
+				...( action.shuffle && { shuffle: true } ),
 			},
 		},
 		action

--- a/client/state/home/actions.js
+++ b/client/state/home/actions.js
@@ -12,11 +12,17 @@ import {
 import 'calypso/state/data-layer/wpcom/sites/home/layout';
 import 'calypso/state/home/init';
 
-export const requestHomeLayout = ( siteId, isDev = false, forcedView = null ) => ( {
+export const requestHomeLayout = (
+	siteId,
+	isDev = false,
+	forcedView = null,
+	shuffle = false
+) => ( {
 	type: HOME_LAYOUT_REQUEST,
 	siteId,
 	isDev,
 	forcedView,
+	shuffle,
 } );
 
 export const skipCurrentViewHomeLayout = ( siteId, reminder = null ) => ( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As described in pd2qGl-2J-p2, some promo cards on My Home "block" other cards until they're dismissed. D61325-code changes that. This front end change adds a `?shuffle` feature flag that can be used to try out the changed behaviour.

* Sends `?shuffle=true` param to `/home/layout` endpoint if calypso url has `?shuffle` param

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D61325-code
* Fire up this branch and navigate to My Home
* Add `?shuffle` to the calypso url and reload (so url bar will look like `/home/{{ test site }}?shuffle`)
   * If the site setup is incomplete then the checklist will still show
   * If the user has just launched, or site setup was just completed, then that view will still show
   * If site setup is done then each refresh of My Home will show a different view (i.e. you'll see a different promotional card)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pd2qGl-2J-p2
