### PR TITLE
Increase the segment of users that get error reporting to 25%

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -88,7 +88,7 @@ function activate_error_reporting() {
  * @return bool
  */
 function user_in_test_segment( $user_id ) {
-	$current_segment = 10; // segment of existing users that will get this feature.
+	$current_segment = 25; // segment of existing users that will get this feature in %.
 	$user_segment    = $user_id % 100;
 
 	// We get the last two digits of the user id and that will be used to decide in what


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Project: p4TIVU-9DI-p2. 

Follow up to: https://github.com/Automattic/wp-calypso/pull/49485.

* Increases the segment of users who get the WP-Admin/Gutenberg error reporting to 25%. Error reporting is activated by default to all a12s.

#### Testing instructions

This has been tested before and the increase in percentage doesn't really change the logic to justify another round of tests, but if you want to test, you can:

1. Put a `l('Error Reporting Activated!')` call [here](https://github.com/Automattic/wp-calypso/pull/52805);
2. Sync this ETK custom build to your sandbox;
3. Tail `/tmp/php-errors` in your sandbox;
4. Reload the the editor page;
5. Verify that you get a `Error Reporting Activated!` in the logs;
6. Now remove the `user_is_automattician( $user_id ) ||` part of the condition [here](https://github.com/Automattic/wp-calypso/blob/d36c2d0f4b5cad8b1edfbca5664fb83943106d05/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php#L129);
7. Replace the `$user_id` var [here](https://github.com/Automattic/wp-calypso/blob/d36c2d0f4b5cad8b1edfbca5664fb83943106d05/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php#L92) with a number that when % by 100, returns < than 25;
8. Verify that you get the log like before and error reporting will be activated;
9. Now replace `$user_id` with a number that when % by 100 returns >= 25. You should not get the log and error reporting will not be activated.