### PR TITLE
Plugins: Fix install button missing from plugins page

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -585,7 +585,7 @@ export class PluginMeta extends Component {
 								{ this.renderAuthorUrl() } { this.renderSupportedFlag() }
 							</div>
 						</div>
-						{ ! this.props.calypsoify && this.renderActions() }
+						{ this.renderActions() }
 					</div>
 				</Card>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the Calypsoify check for `this.renderActions()`. It's not working correctly since Calypsoify has been removed.
* This will make the install button available on free Atomic, but we're separately changing that flow.
* There are other Calypsoify references in the component we may want to look into.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a new site with a business plan (an old Atomic site might work too), add a plugin (ex: WooCommerce)
* Wait until it's done
* Navigate to a new plugin page
* Verify that there is an Install button and that it works:

<img width="727" alt="Screen Shot 2021-05-12 at 8 06 04 PM" src="https://user-images.githubusercontent.com/1689238/118059015-7e772500-b35d-11eb-8990-293de9304b89.png">

* Navigate to a plugin page for an installed plugin. Verify that it shows Active, Autoupdates, and Remove actions:

<img width="730" alt="Screen Shot 2021-05-12 at 8 03 53 PM" src="https://user-images.githubusercontent.com/1689238/118058867-2fc98b00-b35d-11eb-8e8d-ec49e373b06d.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #17686
