### PR TITLE
Themes controller: move logged-in handlers to a new module not imported by SSR

### DIFF
--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -5,7 +5,6 @@
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import debugFactory from 'debug';
-import { startsWith } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -53,7 +52,7 @@ export function fetchThemeDetailsData( context, next ) {
 
 export function details( context, next ) {
 	const { slug, section } = context.params;
-	if ( startsWith( context.prevPath, '/themes' ) ) {
+	if ( context.prevPath && context.prevPath.startsWith( '/themes' ) ) {
 		context.store.dispatch( setBackPath( context.prevPath ) );
 	}
 

--- a/client/my-sites/themes/controller-logged-in.jsx
+++ b/client/my-sites/themes/controller-logged-in.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import page from 'page';
-import { startsWith } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -38,8 +37,9 @@ export function loggedIn( context, next ) {
 export function upload( context, next ) {
 	// Store previous path to return to only if it was main showcase page
 	if (
-		startsWith( context.prevPath, '/themes' ) &&
-		! startsWith( context.prevPath, '/themes/upload' )
+		context.prevPath &&
+		context.prevPath.startsWith( '/themes' ) &&
+		! context.prevPath.startsWith( '/themes/upload' )
 	) {
 		context.store.dispatch( setBackPath( context.prevPath ) );
 	}

--- a/client/my-sites/themes/controller-logged-in.jsx
+++ b/client/my-sites/themes/controller-logged-in.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import page from 'page';
+import { startsWith } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { setBackPath } from 'calypso/state/themes/actions';
+import { getProps } from './controller';
+import SingleSiteComponent from './single-site';
+import MultiSiteComponent from './multi-site';
+import Upload from './theme-upload';
+
+export function loggedIn( context, next ) {
+	// Block direct access for P2 sites
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	if ( isSiteWPForTeams( state, siteId ) ) {
+		return page.redirect( `/home/${ context.params.site_id }` );
+	}
+
+	// Scroll to the top
+	if ( typeof window !== 'undefined' ) {
+		window.scrollTo( 0, 0 );
+	}
+
+	const Component = context.params.site_id ? SingleSiteComponent : MultiSiteComponent;
+	context.primary = <Component { ...getProps( context ) } />;
+
+	next();
+}
+
+export function upload( context, next ) {
+	// Store previous path to return to only if it was main showcase page
+	if (
+		startsWith( context.prevPath, '/themes' ) &&
+		! startsWith( context.prevPath, '/themes/upload' )
+	) {
+		context.store.dispatch( setBackPath( context.prevPath ) );
+	}
+
+	context.primary = <Upload />;
+	next();
+}

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { compact, includes, isEmpty } from 'lodash';
 import debugFactory from 'debug';
 import React from 'react';
 
@@ -39,7 +38,7 @@ export function getProps( context ) {
 }
 
 export function loggedOut( context, next ) {
-	if ( context.isServerSide && ! isEmpty( context.query ) ) {
+	if ( context.isServerSide && Object.keys( context.query ).length > 0 ) {
 		// Don't server-render URLs with query params
 		return next();
 	}
@@ -59,7 +58,7 @@ export function fetchThemeData( context, next ) {
 	const query = {
 		search: context.query.s,
 		tier: context.params.tier,
-		filter: compact( [ context.params.filter, context.params.vertical ] ).join( ',' ),
+		filter: [ context.params.filter, context.params.vertical ].filter( Boolean ).join( ',' ),
 		page: 1,
 		number: DEFAULT_THEME_QUERY.number,
 	};
@@ -76,13 +75,13 @@ export function fetchThemeData( context, next ) {
 export function fetchThemeFilters( context, next ) {
 	const { store } = context;
 
-	if ( ! isEmpty( getThemeFilters( store.getState() ) ) ) {
+	if ( Object.keys( getThemeFilters( store.getState() ) ).length > 0 ) {
 		debug( 'found theme filters in cache' );
 		return next();
 	}
 
 	const unsubscribe = store.subscribe( () => {
-		if ( ! isEmpty( getThemeFilters( store.getState() ) ) ) {
+		if ( Object.keys( getThemeFilters( store.getState() ) ).length > 0 ) {
 			unsubscribe();
 			return next();
 		}
@@ -93,7 +92,7 @@ export function fetchThemeFilters( context, next ) {
 // Legacy (Atlas-based Theme Showcase v4) route redirects
 
 export function redirectSearchAndType( { res, params: { site, search, tier } } ) {
-	const target = '/themes/' + compact( [ tier, site ] ).join( '/' ); // tier before site!
+	const target = '/themes/' + [ tier, site ].filter( Boolean ).join( '/' ); // tier before site!
 	if ( search ) {
 		res.redirect( `${ target }?s=${ search }` );
 	} else {
@@ -108,17 +107,17 @@ export function redirectFilterAndType( { res, params: { site, filter, tier } } )
 	} else {
 		parts = [ tier, site ];
 	}
-	res.redirect( '/themes/' + compact( parts ).join( '/' ) );
+	res.redirect( '/themes/' + parts.filter( Boolean ).join( '/' ) );
 }
 
 export function redirectToThemeDetails( { res, params: { site, theme, section } }, next ) {
 	// Make sure we aren't matching a site -- e.g. /themes/example.wordpress.com or /themes/1234567
-	if ( includes( theme, '.' ) || isFinite( theme ) ) {
+	if ( theme.includes( '.' ) || isFinite( theme ) ) {
 		return next();
 	}
 	let redirectedSection;
 	if ( section === 'support' ) {
 		redirectedSection = 'setup';
 	}
-	res.redirect( '/theme/' + compact( [ theme, redirectedSection, site ] ).join( '/' ) );
+	res.redirect( '/theme/' + [ theme, redirectedSection, site ].filter( Boolean ).join( '/' ) );
 }

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -112,7 +112,7 @@ export function redirectFilterAndType( { res, params: { site, filter, tier } } )
 
 export function redirectToThemeDetails( { res, params: { site, theme, section } }, next ) {
 	// Make sure we aren't matching a site -- e.g. /themes/example.wordpress.com or /themes/1234567
-	if ( theme.includes( '.' ) || isFinite( theme ) ) {
+	if ( theme.includes( '.' ) || Number.isInteger( parseInt( theme, 10 ) ) ) {
 		return next();
 	}
 	let redirectedSection;

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -1,29 +1,23 @@
 /**
  * External dependencies
  */
-import { compact, includes, isEmpty, startsWith } from 'lodash';
+import { compact, includes, isEmpty } from 'lodash';
 import debugFactory from 'debug';
 import React from 'react';
-import page from 'page';
 
 /**
  * Internal Dependencies
  */
-import SingleSiteComponent from 'calypso/my-sites/themes/single-site';
-import MultiSiteComponent from 'calypso/my-sites/themes/multi-site';
 import LoggedOutComponent from './logged-out';
-import Upload from 'calypso/my-sites/themes/theme-upload';
 import trackScrollPage from 'calypso/lib/track-scroll-page';
 import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
-import { requestThemes, requestThemeFilters, setBackPath } from 'calypso/state/themes/actions';
+import { requestThemes, requestThemeFilters } from 'calypso/state/themes/actions';
 import { getThemeFilters, getThemesForQuery } from 'calypso/state/themes/selectors';
 import { getAnalyticsData } from './helpers';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 
 const debug = debugFactory( 'calypso:themes' );
 
-function getProps( context ) {
+export function getProps( context ) {
 	const { tier, filter, vertical } = context.params;
 
 	const { analyticsPath, analyticsPageTitle } = getAnalyticsData( context.path, context.params );
@@ -42,38 +36,6 @@ function getProps( context ) {
 		pathName: context.pathname,
 		trackScrollPage: boundTrackScrollPage,
 	};
-}
-
-export function upload( context, next ) {
-	// Store previous path to return to only if it was main showcase page
-	if (
-		startsWith( context.prevPath, '/themes' ) &&
-		! startsWith( context.prevPath, '/themes/upload' )
-	) {
-		context.store.dispatch( setBackPath( context.prevPath ) );
-	}
-
-	context.primary = <Upload />;
-	next();
-}
-
-export function loggedIn( context, next ) {
-	// Block direct access for P2 sites
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
-	if ( isSiteWPForTeams( state, siteId ) ) {
-		return page.redirect( `/home/${ context.params.site_id }` );
-	}
-
-	// Scroll to the top
-	if ( typeof window !== 'undefined' ) {
-		window.scrollTo( 0, 0 );
-	}
-
-	const Component = context.params.site_id ? SingleSiteComponent : MultiSiteComponent;
-	context.primary = <Component { ...getProps( context ) } />;
-
-	next();
 }
 
 export function loggedOut( context, next ) {

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -4,7 +4,8 @@
 import userFactory from 'calypso/lib/user';
 import { makeLayout, redirectLoggedOut } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
-import { loggedIn, loggedOut, upload, fetchThemeFilters } from './controller';
+import { loggedOut, fetchThemeFilters } from './controller';
+import { loggedIn, upload } from './controller-logged-in';
 import { validateFilters, validateVertical } from './validate-filters';
 
 function redirectToLoginIfSiteRequested( context, next ) {

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -165,10 +165,6 @@ const webpackConfig = {
 			COMMIT_SHA: JSON.stringify( commitSha ),
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
 		} ),
-		new webpack.NormalModuleReplacementPlugin(
-			/^calypso[/\\]my-sites[/\\]themes[/\\]theme-upload$/,
-			'calypso/components/empty-component'
-		), // Depends on BOM
 		new webpack.IgnorePlugin( { resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ } ),
 		! isDevelopment && new ExternalModulesWriter(),
 	].filter( Boolean ),


### PR DESCRIPTION
This should help solve issues with importing `sites` controller in #52686. Handlers and imports that are specific to logged-in state are moved to a new `controller-logged-in` module. The Node.js server that does SSR doesn't need to import anything from that module and doesn't need to worry about SSR-safety of that code.

This removes 5% of my local server bundle (`build/server.js`, from 2.99 MB to 2.82 MB) and also removes the need to alias the `theme-upload` module in the server webpack config.