### PR TITLE
Emails: Add new No Domain page

### DIFF
--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -2,42 +2,42 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import Main from 'calypso/components/main';
-import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
-import FormattedHeader from 'calypso/components/formatted-header';
-import { hasGSuiteSupportedDomain, hasGSuiteWithUs } from 'calypso/lib/gsuite';
-import getGSuiteUsers from 'calypso/state/selectors/get-gsuite-users';
-import hasLoadedGSuiteUsers from 'calypso/state/selectors/has-loaded-gsuite-users';
+import { Card } from '@automattic/components';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import DocumentHead from 'calypso/components/data/document-head';
+import EmailListActive from 'calypso/my-sites/email/email-management/home/email-list-active';
+import EmailListInactive from 'calypso/my-sites/email/email-management/home/email-list-inactive';
+import EmailPlan from 'calypso/my-sites/email/email-management/home/email-plan';
+import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
+import EmptyContent from 'calypso/components/empty-content';
+import FormattedHeader from 'calypso/components/formatted-header';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
+import getGSuiteUsers from 'calypso/state/selectors/get-gsuite-users';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
-import EmptyContent from 'calypso/components/empty-content';
-import DocumentHead from 'calypso/components/data/document-head';
+import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
+import hasLoadedGSuiteUsers from 'calypso/state/selectors/has-loaded-gsuite-users';
+import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
+import { hasGSuiteSupportedDomain, hasGSuiteWithUs } from 'calypso/lib/gsuite';
+import { hasTitanMailWithUs } from 'calypso/lib/titan';
+import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
+import Main from 'calypso/components/main';
 import QueryGSuiteUsers from 'calypso/components/data/query-gsuite-users';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
-import EmailProvidersComparison from '../email-providers-comparison';
-import { hasTitanMailWithUs } from 'calypso/lib/titan';
-import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
-import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
-import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
 import SectionHeader from 'calypso/components/section-header';
-import { Card } from '@automattic/components';
-import EmailListActive from 'calypso/my-sites/email/email-management/home/email-list-active';
-import EmailListInactive from 'calypso/my-sites/email/email-management/home/email-list-inactive';
-import EmailPlan from 'calypso/my-sites/email/email-management/home/email-plan';
+import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 
 /**
  * Style dependencies

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -14,6 +14,7 @@ import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmailListActive from 'calypso/my-sites/email/email-management/home/email-list-active';
 import EmailListInactive from 'calypso/my-sites/email/email-management/home/email-list-inactive';
+import EmailNoDomain from 'calypso/my-sites/email/email-management/home/email-no-domain';
 import EmailPlan from 'calypso/my-sites/email/email-management/home/email-plan';
 import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
 import EmptyContent from 'calypso/components/empty-content';
@@ -99,7 +100,7 @@ class EmailManagementHome extends React.Component {
 		const nonWpcomDomains = domains.filter( ( domain ) => ! domain.isWPCOMDomain );
 
 		if ( nonWpcomDomains.length < 1 ) {
-			return this.renderContentWithHeader( <div>no domains</div> );
+			return this.renderContentWithHeader( <EmailNoDomain selectedSite={ selectedSite } /> );
 		}
 
 		const domainsWithEmail = nonWpcomDomains.filter( domainHasEmail );

--- a/client/my-sites/email/email-management/home/email-no-domain.jsx
+++ b/client/my-sites/email/email-management/home/email-no-domain.jsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { isFreePlan } from '@automattic/calypso-products';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import EmptyContent from 'calypso/components/empty-content';
+import Illustration from 'calypso/assets/images/customer-home/illustration--task-find-domain.svg';
+
+const EmailNoDomain = ( { selectedSite, translate } ) => {
+	if ( isFreePlan( selectedSite.plan.product_slug ) ) {
+		return (
+			<EmptyContent
+				action={ translate( 'Upgrade', { context: 'verb' } ) }
+				actionURL={ `/plans/${ selectedSite.slug }` }
+				illustration={ Illustration }
+				line={ translate(
+					'Upgrade now, claim your domain and pick from one of our flexible options to connect your domain with email and start getting emails today.'
+				) }
+				title={ translate( 'Get your own domain for a custom email address' ) }
+			/>
+		);
+	}
+
+	return (
+		<EmptyContent
+			action={ translate( 'Add a Domain' ) }
+			actionURL={ `/domains/add/${ selectedSite.slug }` }
+			illustration={ Illustration }
+			line={ translate(
+				'Claim your domain, pick from one of our flexible options to connect your domain with email and start getting emails today.'
+			) }
+			title={ translate( 'Claim your free domain to use with a custom email address' ) }
+		/>
+	);
+};
+
+EmailNoDomain.propTypes = {
+	// Props passed to this component
+	selectedSite: PropTypes.object.isRequired,
+
+	// Props injected via localize()
+	translate: PropTypes.func.isRequired,
+};
+
+export default localize( EmailNoDomain );

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -59,7 +59,6 @@ class EmailPlan extends React.Component {
 
 	state = {
 		isLoadingEmailAccounts: false,
-		errorLoadingEmailAccounts: false,
 		hasLoadedEmailAccounts: false,
 		emailAccounts: [],
 	};
@@ -89,7 +88,6 @@ class EmailPlan extends React.Component {
 				( data ) => {
 					this.setState( {
 						isLoadingEmailAccounts: false,
-						errorLoadingEmailAccounts: false,
 						hasLoadedEmailAccounts: true,
 						emailAccounts: data?.accounts || [],
 					} );
@@ -97,7 +95,6 @@ class EmailPlan extends React.Component {
 				() => {
 					this.setState( {
 						isLoadingEmailAccounts: false,
-						errorLoadingEmailAccounts: true,
 						hasLoadedEmailAccounts: true,
 						emailAccounts: [],
 					} );


### PR DESCRIPTION
This pull request adds the `No Domain` page to the email management section, which will be displayed when no domain has been purchased yet for the current site. There are two variations depending on whether the plan attached to that site is free or not:

Free Plan| Paid Plan
------ | -----
![screenshot](https://user-images.githubusercontent.com/594356/118108463-5250b800-b3e0-11eb-9754-d1422bdabc27.png) | ![screenshot](https://user-images.githubusercontent.com/594356/118108565-701e1d00-b3e0-11eb-82ab-969e6d9d4390.png)


#### Testing instructions

1. Run `git checkout add/email-no-domain-page` and start your server, or open a [live branch](https://calypso.live/?branch=add/email-no-domain-page)
2. Log into a WordPress.com account with a site without plan nor domain
3. Open the [`Email` page](http://calypso.localhost:3000/email)
4. Assert that the page matches the first screenshot above
5. Click the `Upgrade` button
6. Assert that you are presented with the `Plans` page
7. Switch to a site with a paid plan but no domain
8. Navigate back to the `Email` page
9. Assert that the page matches the second screenshot above
10. Click the `Add a Domain` button
11. Assert that you are presented with the `Domain Search` page

