### PR TITLE
Improve README and examples for SectionHeader component

### DIFF
--- a/client/components/section-header/README.md
+++ b/client/components/section-header/README.md
@@ -36,6 +36,9 @@ This is the base component and acts as a wrapper for a section's (a list of card
 ### Props
 
 - `className` - _optional_ (string|object) Classes to be added to the rendered component.
+- `count` - _optional_ (number) If supplied, this shows a badge containing the number.
+- `href` - _optional_ (string) A URL or path to navigate to when the header is clicked. (This makes the entire header clickable.)
+- `isPlaceholder` - _optional_ (bool) Show placeholder content.
 - `label` - _optional_ (string) The text to be displayed in the header.
 - `popoverText` - _optional_ (string) If entered, a support popover will appear to the right with this text.
 

--- a/client/components/section-header/docs/example.jsx
+++ b/client/components/section-header/docs/example.jsx
@@ -42,6 +42,12 @@ class SectionHeaderExample extends PureComponent {
 
 				<h3>{ translate( 'Empty SectionHeader' ) }</h3>
 				<SectionHeader />
+
+				<h3>{ translate( 'Placeholder SectionHeader' ) }</h3>
+				<SectionHeader isPlaceholder />
+
+				<h3>{ translate( 'SectionHeader with popover text' ) }</h3>
+				<SectionHeader label={ translate( 'Team' ) } popoverText={ translate( 'More details' ) } />
 			</div>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR improves the README and examples for the `SectionHeader` component to add some previously undocumented props.
* Note that this PR does _not_ add propTypes to the class, as that might cause broader issues for the _many_ existing uses of the component.

#### Testing instructions

* Navigate to the `SectionHeader` documentation in the live branch
* Verify that the additional options are documented, and work well when you interact with them