### PR TITLE
Use account-specific titles for mailbox list

### DIFF
--- a/client/lib/emails/email-provider-constants.js
+++ b/client/lib/emails/email-provider-constants.js
@@ -1,2 +1,3 @@
+export const EMAIL_ACCOUNT_TYPE_FORWARD = 'email_forwarding';
 export const EMAIL_TYPE_FORWARD = 'email_forward';
 export const EMAIL_USER_ROLE_ADMIN = 'admin';

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -11,6 +11,7 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { EMAIL_ACCOUNT_TYPE_FORWARD } from 'calypso/lib/emails/email-provider-constants';
 import MaterialIcon from 'calypso/components/material-icon';
 import SectionHeader from 'calypso/components/section-header';
 import Badge from 'calypso/components/badge';
@@ -24,12 +25,22 @@ import Gridicon from 'calypso/components/gridicon';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { resendVerificationEmail } from 'calypso/state/email-forwarding/actions';
 
-const MailboxListHeader = ( { children } ) => {
+const getListHeaderTextForAccountType = ( accountType, translate ) => {
+	if ( accountType === EMAIL_ACCOUNT_TYPE_FORWARD ) {
+		return translate( 'Forwarded mailboxes' );
+	}
+	return translate( 'Mailboxes' );
+};
+
+const MailboxListHeader = ( { accountType = null, children, isPlaceholder = false } ) => {
 	const translate = useTranslate();
 
 	return (
 		<div className="email-plan-mailboxes-list__mailbox-list">
-			<SectionHeader label={ translate( 'Mailboxes' ) } />
+			<SectionHeader
+				isPlaceholder={ isPlaceholder }
+				label={ getListHeaderTextForAccountType( accountType, translate ) }
+			/>
 			{ children }
 		</div>
 	);
@@ -109,13 +120,13 @@ const getActionsForMailbox = ( mailbox, translate, dispatch ) => {
 	};
 };
 
-function EmailPlanMailboxesList( { mailboxes, isLoadingEmails } ) {
+function EmailPlanMailboxesList( { accountType, mailboxes, isLoadingEmails } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	if ( isLoadingEmails ) {
 		return (
-			<MailboxListHeader>
+			<MailboxListHeader isPlaceholder accountType={ accountType }>
 				<MailboxListItem isPlaceholder>
 					<MaterialIcon icon="email" />
 					<span />
@@ -126,7 +137,7 @@ function EmailPlanMailboxesList( { mailboxes, isLoadingEmails } ) {
 
 	if ( ! mailboxes || mailboxes.length < 1 ) {
 		return (
-			<MailboxListHeader>
+			<MailboxListHeader accountType={ accountType }>
 				<MailboxListItem hasNoEmails>
 					<span>{ translate( 'No mailboxes' ) }</span>
 				</MailboxListItem>
@@ -161,10 +172,11 @@ function EmailPlanMailboxesList( { mailboxes, isLoadingEmails } ) {
 		);
 	} );
 
-	return <MailboxListHeader>{ mailboxItems }</MailboxListHeader>;
+	return <MailboxListHeader accountType={ accountType }>{ mailboxItems }</MailboxListHeader>;
 }
 
 EmailPlanMailboxesList.propTypes = {
+	accountType: PropTypes.string,
 	mailboxes: PropTypes.array,
 	isLoadingEmails: PropTypes.bool,
 };

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -27,9 +27,14 @@ import { resendVerificationEmail } from 'calypso/state/email-forwarding/actions'
 
 const getListHeaderTextForAccountType = ( accountType, translate ) => {
 	if ( accountType === EMAIL_ACCOUNT_TYPE_FORWARD ) {
-		return translate( 'Forwarded mailboxes' );
+		return translate( 'Forwarded mailboxes', {
+			comment:
+				'This is a header for a list of email addresses that forward all emails to another email account',
+		} );
 	}
-	return translate( 'Mailboxes' );
+	return translate( 'Mailboxes', {
+		comment: 'This is a header for a list of email addresses the user owns',
+	} );
 };
 
 const MailboxListHeader = ( { accountType = null, children, isPlaceholder = false } ) => {

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -27,7 +27,7 @@ import { resendVerificationEmail } from 'calypso/state/email-forwarding/actions'
 
 const getListHeaderTextForAccountType = ( accountType, translate ) => {
 	if ( accountType === EMAIL_ACCOUNT_TYPE_FORWARD ) {
-		return translate( 'Forwarded mailboxes', {
+		return translate( 'Email forwards', {
 			comment:
 				'This is a header for a list of email addresses that forward all emails to another email account',
 		} );

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -106,10 +106,7 @@ class EmailPlan extends React.Component {
 	}
 
 	getAccountType() {
-		if ( this.state.emailAccounts[ 0 ] ) {
-			return this.state.emailAccounts[ 0 ].account_type ?? null;
-		}
-		return null;
+		return this.state?.emailAccounts[ 0 ]?.account_type ?? null;
 	}
 
 	getMailboxes() {

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -105,6 +105,13 @@ class EmailPlan extends React.Component {
 			);
 	}
 
+	getAccountType() {
+		if ( this.state.emailAccounts[ 0 ] ) {
+			return this.state.emailAccounts[ 0 ].account_type ?? null;
+		}
+		return null;
+	}
+
 	getMailboxes() {
 		if ( this.state.emailAccounts[ 0 ] ) {
 			return this.state.emailAccounts[ 0 ].emails;
@@ -266,6 +273,7 @@ class EmailPlan extends React.Component {
 				/>
 
 				<EmailPlanMailboxesList
+					accountType={ this.getAccountType() }
 					mailboxes={ this.getMailboxes() }
 					isLoadingEmails={ isLoadingEmailAccounts }
 				/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR stems from the discussion in #52750, where we were showing "Mailboxes" for all account types in the email plans page.

* The PR adds logic to display "Email forwards" when we're showing a list of email forwards
* The PR also adds placeholder content while we're waiting for the data that tells us which account type we have

#### Testing instructions

* Check out this branch and build it locally, or access the [live branch](https://calypso.live/?branch=add/account-type-to-email-plans).
* Navigate to `/email`, and pick a site that has domains with email services, including at least one with email forwarding configured.
* Click on the row for a domain with email forwarding.
* Verify that we show placeholder content in the section header for the list of mailboxes/forwards.
* Verify that we then show "Email forwards" for the section header.
* Click on "Back" to get back to your domain listing.
* Click on one or more domains with paid email services (e.g. G Suite, Google Workspace, or Professional Email)
* For each domain, verify that we show the placeholder for the mailbox list section header, and then show "Mailboxes" once the mailbox list is loaded.

#### Screenshots

##### Updated email forwarding header text
<img width="1073" alt="Screenshot 2021-05-13 at 21 41 31" src="https://user-images.githubusercontent.com/3376401/118178245-04659f80-b434-11eb-8541-970aa50d0aea.png">

##### Placeholder content in section header (the content in the mailbox list was already in place)
<img width="916" alt="Screenshot 2021-05-13 at 11 51 43" src="https://user-images.githubusercontent.com/3376401/118110734-1408c800-b3e3-11eb-887e-c566e538d680.png">
