### PR TITLE
Stats: add share-stats pane in Simple sites.

### DIFF
--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -39,17 +39,6 @@ const StatsInsights = ( props ) => {
 	const { isJetpack, siteId, siteSlug, translate } = props;
 	const moduleStrings = statsStrings();
 
-	let tagsList;
-	if ( ! isJetpack ) {
-		tagsList = (
-			<StatsModule
-				path="tags-categories"
-				moduleStrings={ moduleStrings.tags }
-				statType="statsTags"
-			/>
-		);
-	}
-
 	// TODO: should be refactored into separate components
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -81,11 +70,17 @@ const StatsInsights = ( props ) => {
 						<div className="stats__module-column">
 							<LatestPostSummary />
 							<MostPopular />
-							{ tagsList }
+							{ ! isJetpack && (
+								<StatsModule
+									path="tags-categories"
+									moduleStrings={ moduleStrings.tags }
+									statType="statsTags"
+								/>
+							) }
 							<AnnualSiteStats isWidget />
 						</div>
 						<div className="stats__module-column">
-							<StatShares siteId={ siteId } />
+							{ ! isJetpack && <StatShares siteId={ siteId } /> }
 							<Reach />
 							<Followers path={ 'followers' } />
 						</div>

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -78,9 +78,9 @@ const StatsInsights = ( props ) => {
 								/>
 							) }
 							<AnnualSiteStats isWidget />
+							{ ! isJetpack && <StatShares siteId={ siteId } /> }
 						</div>
 						<div className="stats__module-column">
-							{ ! isJetpack && <StatShares siteId={ siteId } /> }
 							<Reach />
 							<Followers path={ 'followers' } />
 						</div>

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -28,6 +28,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import SectionHeader from 'calypso/components/section-header';
 import StatsViews from '../stats-views';
 import Followers from '../stats-followers';
+import StatShares from '../stats-shares';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -84,6 +85,7 @@ const StatsInsights = ( props ) => {
 							<AnnualSiteStats isWidget />
 						</div>
 						<div className="stats__module-column">
+							<StatShares siteId={ siteId } />
 							<Reach />
 							<Followers path={ 'followers' } />
 						</div>

--- a/client/my-sites/stats/stats-shares/index.jsx
+++ b/client/my-sites/stats/stats-shares/index.jsx
@@ -52,13 +52,7 @@ const StatShares = ( { siteId } ) => {
 							let count;
 							if ( ( count = siteStats.stats[ 'shares_' + service.ID ] ) ) {
 								return (
-									<StatsTab
-										gridicon={ service.genericon }
-										label={ service.name }
-										loading={ isLoading }
-										value={ count }
-										compact
-									/>
+									<StatsTab label={ service.name } loading={ isLoading } value={ count } compact />
 								);
 							}
 						} ) }

--- a/client/my-sites/stats/stats-shares/index.jsx
+++ b/client/my-sites/stats/stats-shares/index.jsx
@@ -1,0 +1,121 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { useSelector } from 'react-redux';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '@automattic/components';
+import StatsTabs from '../stats-tabs';
+import StatsTab from '../stats-tabs/tab';
+import SectionHeader from 'calypso/components/section-header';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData,
+	hasSiteStatsQueryFailed,
+} from 'calypso/state/stats/lists/selectors';
+import { useTranslate } from 'i18n-calypso';
+
+const StatShares = ( { siteId } ) => {
+	const translate = useTranslate();
+	const isLoading = useSelector( ( state ) =>
+		isRequestingSiteStatsForQuery( state, siteId, 'stats' )
+	);
+	const hasError = useSelector( ( state ) => hasSiteStatsQueryFailed( state, siteId, 'stats' ) );
+	const {
+		shares,
+		sharesFacebook,
+		sharesPressThis,
+		sharesTwitter,
+		sharesTumblr,
+		sharesLinkedin,
+		sharesEmail,
+	} = useSelector( ( state ) => getSiteStatsNormalizedData( state, siteId, 'stats' ) ) || {};
+
+	const classes = [
+		'stats-module',
+		{
+			'is-loading': isLoading,
+			'is-showing-error': hasError,
+		},
+	];
+
+	return (
+		<div>
+			{ siteId && <QuerySiteStats siteId={ siteId } statType="stats" /> }
+			<SectionHeader label={ translate( 'Shares' ) } />
+			<Card className={ classNames( ...classes ) }>
+				<StatsTabs borderless>
+					<StatsTab
+						gridicon="share"
+						label={ translate( 'Total' ) }
+						loading={ isLoading }
+						value={ shares }
+						compact
+					/>
+					{ !! sharesFacebook && (
+						<StatsTab
+							gridicon="facebook"
+							label={ translate( 'Facebook' ) }
+							loading={ isLoading }
+							value={ sharesFacebook }
+							compact
+						/>
+					) }
+					{ !! sharesTwitter && (
+						<StatsTab
+							gridicon="twitter"
+							label={ translate( 'Twitter' ) }
+							loading={ isLoading }
+							value={ sharesTwitter }
+							compact
+						/>
+					) }
+					{ !! sharesTumblr && (
+						<StatsTab
+							gridicon="tumblr"
+							label={ translate( 'Tumblr' ) }
+							loading={ isLoading }
+							value={ sharesTumblr }
+							compact
+						/>
+					) }
+					{ !! sharesLinkedin && (
+						<StatsTab
+							gridicon="linkedin"
+							label={ translate( 'LinkedIn' ) }
+							loading={ isLoading }
+							value={ sharesLinkedin }
+							compact
+						/>
+					) }
+					{ !! sharesEmail && (
+						<StatsTab
+							gridicon="email"
+							label={ translate( 'Email' ) }
+							loading={ isLoading }
+							value={ sharesEmail }
+							compact
+						/>
+					) }
+					{ !! sharesPressThis && (
+						<StatsTab
+							gridicon="pressthis"
+							label={ translate( 'Press This' ) }
+							loading={ isLoading }
+							value={ sharesPressThis }
+							compact
+						/>
+					) }
+				</StatsTabs>
+			</Card>
+		</div>
+	);
+};
+
+export default StatShares;

--- a/client/my-sites/stats/stats-shares/index.jsx
+++ b/client/my-sites/stats/stats-shares/index.jsx
@@ -14,9 +14,11 @@ import StatsTabs from '../stats-tabs';
 import StatsTab from '../stats-tabs/tab';
 import SectionHeader from 'calypso/components/section-header';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import QuerySharingButtons from 'calypso/components/data/query-sharing-buttons';
+import getSharingButtons from 'calypso/state/selectors/get-sharing-buttons';
 import {
 	isRequestingSiteStatsForQuery,
-	getSiteStatsNormalizedData,
+	getSiteStatsForQuery,
 	hasSiteStatsQueryFailed,
 } from 'calypso/state/stats/lists/selectors';
 import { useTranslate } from 'i18n-calypso';
@@ -26,17 +28,9 @@ const StatShares = ( { siteId } ) => {
 	const isLoading = useSelector( ( state ) =>
 		isRequestingSiteStatsForQuery( state, siteId, 'stats' )
 	);
+	const shareButtons = useSelector( ( state ) => getSharingButtons( state, siteId ) );
 	const hasError = useSelector( ( state ) => hasSiteStatsQueryFailed( state, siteId, 'stats' ) );
-	const {
-		shares,
-		sharesFacebook,
-		sharesPressThis,
-		sharesTwitter,
-		sharesTumblr,
-		sharesLinkedin,
-		sharesEmail,
-	} = useSelector( ( state ) => getSiteStatsNormalizedData( state, siteId, 'stats' ) ) || {};
-
+	const siteStats = useSelector( ( state ) => getSiteStatsForQuery( state, siteId, 'stats' ) );
 	const classes = [
 		'stats-module',
 		{
@@ -48,6 +42,7 @@ const StatShares = ( { siteId } ) => {
 	return (
 		<div>
 			{ siteId && <QuerySiteStats siteId={ siteId } statType="stats" /> }
+			{ siteId && <QuerySharingButtons siteId={ siteId } /> }
 			<SectionHeader label={ translate( 'Shares' ) } />
 			<Card className={ classNames( ...classes ) }>
 				<StatsTabs borderless>
@@ -55,63 +50,25 @@ const StatShares = ( { siteId } ) => {
 						gridicon="share"
 						label={ translate( 'Total' ) }
 						loading={ isLoading }
-						value={ shares }
+						value={ siteStats && siteStats?.stats?.shares }
 						compact
 					/>
-					{ !! sharesFacebook && (
-						<StatsTab
-							gridicon="facebook"
-							label={ translate( 'Facebook' ) }
-							loading={ isLoading }
-							value={ sharesFacebook }
-							compact
-						/>
-					) }
-					{ !! sharesTwitter && (
-						<StatsTab
-							gridicon="twitter"
-							label={ translate( 'Twitter' ) }
-							loading={ isLoading }
-							value={ sharesTwitter }
-							compact
-						/>
-					) }
-					{ !! sharesTumblr && (
-						<StatsTab
-							gridicon="tumblr"
-							label={ translate( 'Tumblr' ) }
-							loading={ isLoading }
-							value={ sharesTumblr }
-							compact
-						/>
-					) }
-					{ !! sharesLinkedin && (
-						<StatsTab
-							gridicon="linkedin"
-							label={ translate( 'LinkedIn' ) }
-							loading={ isLoading }
-							value={ sharesLinkedin }
-							compact
-						/>
-					) }
-					{ !! sharesEmail && (
-						<StatsTab
-							gridicon="email"
-							label={ translate( 'Email' ) }
-							loading={ isLoading }
-							value={ sharesEmail }
-							compact
-						/>
-					) }
-					{ !! sharesPressThis && (
-						<StatsTab
-							gridicon="pressthis"
-							label={ translate( 'Press This' ) }
-							loading={ isLoading }
-							value={ sharesPressThis }
-							compact
-						/>
-					) }
+					{ siteStats &&
+						shareButtons &&
+						shareButtons.map( ( service ) => {
+							let count;
+							if ( ( count = siteStats.stats[ 'shares_' + service.ID ] ) ) {
+								return (
+									<StatsTab
+										gridicon={ service.genericon }
+										label={ service.name }
+										loading={ isLoading }
+										value={ count }
+										compact
+									/>
+								);
+							}
+						} ) }
 				</StatsTabs>
 			</Card>
 		</div>

--- a/client/my-sites/stats/stats-shares/index.jsx
+++ b/client/my-sites/stats/stats-shares/index.jsx
@@ -46,13 +46,6 @@ const StatShares = ( { siteId } ) => {
 			<SectionHeader label={ translate( 'Shares' ) } />
 			<Card className={ classNames( ...classes ) }>
 				<StatsTabs borderless>
-					<StatsTab
-						gridicon="share"
-						label={ translate( 'Total' ) }
-						loading={ isLoading }
-						value={ siteStats && siteStats?.stats?.shares }
-						compact
-					/>
 					{ siteStats &&
 						shareButtons &&
 						shareButtons.map( ( service ) => {

--- a/client/my-sites/stats/stats-shares/index.jsx
+++ b/client/my-sites/stats/stats-shares/index.jsx
@@ -12,6 +12,7 @@ import classNames from 'classnames';
 import { Card } from '@automattic/components';
 import StatsTabs from '../stats-tabs';
 import StatsTab from '../stats-tabs/tab';
+import ErrorPanel from '../stats-error';
 import SectionHeader from 'calypso/components/section-header';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import QuerySharingButtons from 'calypso/components/data/query-sharing-buttons';
@@ -56,6 +57,9 @@ const StatShares = ( { siteId } ) => {
 								);
 							}
 						} ) }
+					{ ! isLoading && ! siteStats?.stats.shares && (
+						<ErrorPanel message={ translate( 'No shares recorded' ) } />
+					) }
 				</StatsTabs>
 			</Card>
 		</div>

--- a/client/my-sites/stats/stats-tabs/style.scss
+++ b/client/my-sites/stats/stats-tabs/style.scss
@@ -38,6 +38,10 @@
 				border-top: none;
 			}
 
+			&.no-icon {
+				padding-left: 24px;
+			}
+
 			a,
 			.no-link {
 				display: block;

--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -60,6 +60,7 @@ class StatsTabsTab extends React.Component {
 			'is-loading': loading,
 			'is-low': ! value,
 			'is-compact': compact,
+			'no-icon': ! gridicon,
 		} );
 
 		const tabIcon = gridicon ? <Gridicon icon={ gridicon } size={ 18 } /> : null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a Share Stats pane showing an overview of some social networks

#### Testing instructions

**Simple Sites**
- Spin up calypso live
- Go to `/stats/insights/automattic.com`
- Check the shares module
- Also, make sure that Tags & Categories still displays

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before | After
-------|------
![](https://cln.sh/QpLFBj+) | ![](https://cln.sh/pT4Ny7+)

WP Admin 
![](https://cln.sh/wKjmEP+)

**Atomic Sites**
Stats from atomic sites are not yet available.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/51095
