### PR TITLE
Framework: Refactor away from `_.head()`

### DIFF
--- a/client/blocks/image-selector/dropzone.jsx
+++ b/client/blocks/image-selector/dropzone.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { head } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -33,7 +32,7 @@ class ImageSelectorDropZone extends Component {
 		 *
 		 * At the moment we ignore all the other images that were dragged onto the DropZone
 		 */
-		const droppedImage = head( filterItemsByMimePrefix( files, 'image' ) );
+		const droppedImage = filterItemsByMimePrefix( files, 'image' )[ 0 ];
 
 		if ( ! droppedImage ) {
 			return false;

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -9,7 +9,6 @@ import {
 	filter,
 	forEach,
 	get,
-	head,
 	includes,
 	keys,
 	map,
@@ -288,7 +287,7 @@ class SignupForm extends Component {
 
 				if ( field === 'username' && ! includes( usernamesSearched, fields.username ) ) {
 					recordTracksEvent( 'calypso_signup_username_validation_failed', {
-						error: head( keys( fieldError ) ),
+						error: keys( fieldError )[ 0 ],
 						username: fields.username,
 					} );
 
@@ -297,7 +296,7 @@ class SignupForm extends Component {
 
 				if ( field === 'password' ) {
 					recordTracksEvent( 'calypso_signup_password_validation_failed', {
-						error: head( keys( fieldError ) ),
+						error: keys( fieldError )[ 0 ],
 					} );
 
 					timesPasswordValidationFailed++;

--- a/client/blocks/user-mentions/add.jsx
+++ b/client/blocks/user-mentions/add.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Fragment } from 'react';
 import getCaretCoordinates from 'textarea-caret';
-import { escapeRegExp, findIndex, get, head, includes, throttle, pick } from 'lodash';
+import { escapeRegExp, findIndex, get, includes, throttle, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -288,7 +288,7 @@ export default ( WrappedComponent ) =>
 
 			this.matchingSuggestions = this.getMatchingSuggestions( suggestions, query );
 			const selectedSuggestionId =
-				this.state.selectedSuggestionId || get( head( this.matchingSuggestions ), 'ID' );
+				this.state.selectedSuggestionId || get( this.matchingSuggestions[ 0 ], 'ID' );
 
 			const popoverPosition = pick( this.state.popoverPosition, [ 'top', 'left' ] );
 

--- a/client/components/community-translator/utils.js
+++ b/client/components/community-translator/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { head, find, get } from 'lodash';
+import { find, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -39,7 +39,7 @@ export function getSingleTranslationData(
 	];
 
 	return post( glotPressUrl, postFormData.join( '' ) ).then( ( glotPressDataEntries ) =>
-		normalizeDetailsFromTranslationData( head( glotPressDataEntries ) )
+		normalizeDetailsFromTranslationData( glotPressDataEntries[ 0 ] )
 	);
 }
 

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { Component, createElement } from 'react';
 import { connect } from 'react-redux';
-import { get, deburr, kebabCase, pick, head, includes, isEqual, isEmpty, camelCase } from 'lodash';
+import { get, deburr, kebabCase, pick, includes, isEqual, isEmpty, camelCase } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -244,7 +244,7 @@ export class ContactDetailsFormFields extends Component {
 	}
 
 	focusFirstError() {
-		const firstErrorName = kebabCase( head( formState.getInvalidFields( this.state.form ) ).name );
+		const firstErrorName = kebabCase( formState.getInvalidFields( this.state.form )[ 0 ].name );
 		const firstErrorRef = this.inputRefs[ firstErrorName ];
 
 		try {

--- a/client/gutenberg/editor/media-utils.js
+++ b/client/gutenberg/editor/media-utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, head, includes, reduce } from 'lodash';
+import { get, includes, reduce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -41,7 +41,7 @@ export const mediaCalypsoToGutenberg = ( media ) => {
 			),
 		},
 		title: get( media, 'title' ),
-		type: head( get( media, 'mime_type', '' ).split( '/' ) ),
+		type: get( media, 'mime_type', '' ).split( '/' )[ 0 ],
 		width: get( media, 'width' ),
 	};
 };

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { head, includes, isEmpty } from 'lodash';
+import { includes, isEmpty } from 'lodash';
 import page from 'page';
 
 /**
@@ -107,7 +107,7 @@ export function getRoleFromScope( scope ) {
 	if ( ! includes( scope, ':' ) ) {
 		return null;
 	}
-	const role = head( scope.split( ':', 1 ) );
+	const role = scope.split( ':', 1 )[ 0 ];
 	if ( ! isEmpty( role ) ) {
 		return role;
 	}

--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { translate } from 'i18n-calypso';
-import { filter, head, orderBy, values } from 'lodash';
+import { filter, orderBy, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -230,7 +230,7 @@ export function getFileImporters( params = {} ) {
 }
 
 export function getImporterByKey( key, params = {} ) {
-	return head( filter( getImporters( params ), ( importer ) => importer.key === key ) );
+	return filter( getImporters( params ), ( importer ) => importer.key === key )[ 0 ];
 }
 
 export default getConfig;

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -3,7 +3,7 @@
  */
 
 import { localize } from 'i18n-calypso';
-import { debounce, flowRight as compose, head, isEmpty } from 'lodash';
+import { debounce, flowRight as compose, isEmpty } from 'lodash';
 import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
@@ -122,7 +122,7 @@ class AccountPassword extends React.Component {
 
 	renderValidationNotices = () => {
 		const { translate } = this.props;
-		const failure = head( this.state.validation?.test_results.failed );
+		const failure = this.state.validation?.test_results.failed?.[ 0 ];
 
 		if ( this.state.validation?.passed ) {
 			return (

--- a/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -1,12 +1,10 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { head } from 'lodash';
 
 /**
  * Internal dependencies
@@ -113,6 +111,6 @@ export default connect( ( state ) => {
 		hasNonPrimaryDomainsFlag: getCurrentUser( state )
 			? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
 			: false,
-		registeredDomain: head( registeredDomains ),
+		registeredDomain: registeredDomains[ 0 ],
 	};
 } )( localize( CustomDomainPurchaseDetail ) );

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { groupBy, head, isEmpty, map, size, values } from 'lodash';
+import { groupBy, isEmpty, map, size, values } from 'lodash';
 import PropTypes from 'prop-types';
 import page from 'page';
 import classnames from 'classnames';
@@ -46,6 +46,7 @@ import { localizeUrl } from 'calypso/lib/i18n-utils';
 import './content.scss';
 
 const noop = () => {};
+const first = ( arr ) => arr[ 0 ];
 
 export class MediaLibraryContent extends React.Component {
 	static propTypes = {
@@ -461,7 +462,7 @@ export class MediaLibraryContent extends React.Component {
 export default connect(
 	( state, ownProps ) => {
 		const guidedTourState = getGuidedTourState( state );
-		const mediaValidationErrorTypes = values( ownProps.mediaValidationErrors ).map( head );
+		const mediaValidationErrorTypes = values( ownProps.mediaValidationErrors ).map( first );
 		const shouldPauseGuidedTour =
 			! isEmpty( guidedTourState.tour ) && 0 < size( mediaValidationErrorTypes );
 		const googleConnection = getKeyringConnectionsByName( state, 'google_photos' );

--- a/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
+++ b/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { head, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -121,7 +121,7 @@ class PodcastCoverImageSetting extends PureComponent {
 		}
 
 		const { selectedItems } = this.props;
-		const selectedItem = head( selectedItems );
+		const selectedItem = selectedItems[ 0 ];
 		if ( ! selectedItem ) {
 			return;
 		}

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { head, isEqual, flow, compact, includes } from 'lodash';
+import { isEqual, flow, compact, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -104,7 +104,7 @@ class SiteIconSetting extends Component {
 		}
 
 		const { siteId, selectedItems } = this.props;
-		const selectedItem = head( selectedItems );
+		const selectedItem = selectedItems[ 0 ];
 		if ( ! selectedItem ) {
 			return;
 		}

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -9,7 +9,6 @@ import classNames from 'classnames';
 import config from '@automattic/calypso-config';
 import titlecase from 'to-title-case';
 import Gridicon from 'calypso/components/gridicon';
-import { head } from 'lodash';
 import photon from 'photon';
 import page from 'page';
 
@@ -209,7 +208,7 @@ class ThemeSheet extends React.Component {
 		if ( this.isLoaded() ) {
 			// Results are being returned with photon params like `?w=…`. This makes the photon
 			// module abort and return null. Strip query string.
-			return head( head( this.props.screenshots ).split( '?', 1 ) );
+			return this.props.screenshots[ 0 ]?.replace( /\?.*/, '' );
 		}
 		return null;
 	}

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -6,7 +6,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { get, head, isEmpty, last, map } from 'lodash';
+import { get, isEmpty, last, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -186,7 +186,7 @@ class EditorRevisionsList extends PureComponent {
 export default connect(
 	( state, { comparisons, revisions, selectedRevisionId } ) => {
 		const { nextRevisionId, prevRevisionId } = get( comparisons, [ selectedRevisionId ], {} );
-		const latestRevisionId = get( head( revisions ), 'id' );
+		const latestRevisionId = get( revisions[ 0 ], 'id' );
 		const latestRevisionIsSelected = latestRevisionId === selectedRevisionId;
 		const earliestRevisionIsSelected =
 			! latestRevisionIsSelected && get( last( revisions ), 'id' ) === selectedRevisionId;

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { flow, get, head, isEmpty, includes, partial, some, values } from 'lodash';
+import { flow, get, isEmpty, includes, partial, some, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -382,7 +382,7 @@ export class EditorMediaModal extends Component {
 
 	getFirstEnabledFilter() {
 		if ( this.props.enabledFilters ) {
-			return head( this.props.enabledFilters );
+			return this.props.enabledFilters[ 0 ];
 		}
 	}
 

--- a/client/signup/validation-fieldset/index.jsx
+++ b/client/signup/validation-fieldset/index.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import { head, values } from 'lodash';
+import { values } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:validate-fieldset' );
 
@@ -25,7 +24,7 @@ export default class ValidationFieldset extends Component {
 			<FormInputValidation
 				isError={ true }
 				isValid={ false }
-				text={ head( values( this.props.errorMessages ) ) }
+				text={ values( this.props.errorMessages )[ 0 ] }
 			/>
 		);
 

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-
-import { compact, get, head, isEqual, sortBy } from 'lodash';
+import { compact, get, isEqual, sortBy } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:data-layer:remove-duplicate-gets' );
 
@@ -64,7 +63,12 @@ const unionWith = ( a = [], b = [] ) => [
  * @returns {string} unique key up to duplicate request descriptions
  */
 export const buildKey = ( { path, apiNamespace, apiVersion, query = {} } ) =>
-	JSON.stringify( [ path, apiNamespace, apiVersion, sortBy( Object.entries( query ), head ) ] );
+	JSON.stringify( [
+		path,
+		apiNamespace,
+		apiVersion,
+		sortBy( Object.entries( query ), ( q ) => q[ 0 ] ),
+	] );
 
 /**
  * Joins a responder action into a unique list of responder actions


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `head()` is only several times the Calypso codebase, and the usage is pretty simple, so this PR replaces it with `[ 0 ]` and optional chaining where necessary. This PR is similar to #52067, just does the work for `head()`, which is essentially a synonym of the same Lodash method.

I'm consciously not refactoring other neighboring or related instances that can be touched (like `last()`) - these will be addressed separately, as I'm trying to keep changes small, contained, and easier to test.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify Calypso builds and all tests pass.