### PR TITLE
Dont bail on filteredProgressedSteps array when it's unempty

### DIFF
--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -13,7 +13,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import { getPreviousStepName, getStepUrl, isFirstStepInFlow } from 'calypso/signup/utils';
+import { getStepUrl, isFirstStepInFlow } from 'calypso/signup/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
@@ -47,7 +47,7 @@ export class NavigationLink extends Component {
 	};
 
 	getPreviousStep( flowName, signupProgress, currentStepName ) {
-		let previousStep = { stepName: null };
+		const previousStep = { stepName: null };
 
 		if ( isFirstStepInFlow( flowName, currentStepName ) ) {
 			return previousStep;
@@ -62,24 +62,12 @@ export class NavigationLink extends Component {
 			return previousStep;
 		}
 
-		//Get the previous step according to the step definition
-		const previousStepName = getPreviousStepName( flowName, currentStepName );
-
 		//Find previous step in current relevant filtered progress
-		const previousStepFromProgress = filteredProgressedSteps.find(
-			( step ) => step.stepName === previousStepName
+		const currentStepIndexInProgress = filteredProgressedSteps.findIndex(
+			( step ) => step.stepName === currentStepName
 		);
-		if ( previousStepFromProgress ) {
-			previousStep = previousStepFromProgress;
-		} else {
-			//If no previous step found in progress, go to the last step of the progress that belongs to the current flow
-			const [ lastKnownStepInFlow ] = filteredProgressedSteps
-				.filter( ( step ) => step.stepName !== currentStepName )
-				.slice( -1 );
-			previousStep = lastKnownStepInFlow;
-		}
 
-		return previousStep;
+		return filteredProgressedSteps[ currentStepIndexInProgress - 1 ] || previousStep;
 	}
 
 	getBackUrl() {

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -67,6 +67,11 @@ export class NavigationLink extends Component {
 			( step ) => step.stepName === currentStepName
 		);
 
+		// Current step isn't finished, so isn't part of the progress array yet, go to the top of the progress array.
+		if ( currentStepIndexInProgress === -1 ) {
+			return filteredProgressedSteps.pop();
+		}
+
 		return filteredProgressedSteps[ currentStepIndexInProgress - 1 ] || previousStep;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the following lines:
https://github.com/Automattic/wp-calypso/blob/trunk/client/signup/navigation-link/index.jsx#L65-L71

We use the stateless flow configuration as the source of truth for steps order. This assumes flow linearity. But the flow isn't always linear as some steps can alter the following steps such as this one:

![image](https://user-images.githubusercontent.com/17054134/118135885-ce102c00-b403-11eb-9859-d69b5031cc7a.png)

This means that hard-coded flow steps can have steps that no longer belong to the flow after the user makes a choice. And when figuring the previous step, one of these [automatically skipped](https://github.com/Automattic/wp-calypso/blob/fix/use-progress-for-nav/client/signup/steps/site-or-domain/index.jsx#L152) steps can be returned by `getPreviousStep` helper. And we're looking for that returned step in the progress array, we naturally won't find it. 

This PR relies completely on `signupProgress` to determine the previous step, and when nothing is found there (eg: when the user accesses an advanced URL directly), we return a `null` step.

My doubt about this fix is that if we persist the progress on local storage, and the user lands in a different flow somehow, the back button would be broken again. But I'd like your feedback on this first. 


### Testing steps
Please follow the reproduction steps in the issue (#52608).

Fixes #52608