### PR TITLE
Jetpack: Remove some more old version checks

### DIFF
--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -364,9 +364,6 @@ describe( 'MediaUtils', () => {
 				{ extension: 'exe' },
 				{
 					jetpack: true,
-					options: {
-						jetpack_version: '3.8.0',
-					},
 				}
 			);
 
@@ -398,7 +395,6 @@ describe( 'MediaUtils', () => {
 		const jetpackSite = {
 			jetpack: true,
 			options: {
-				jetpack_version: '4.5',
 				max_upload_size: 1024,
 				active_modules: [ 'videopress' ],
 			},
@@ -434,22 +430,6 @@ describe( 'MediaUtils', () => {
 			).to.be.null;
 		} );
 
-		test( 'should not return null if a video is being uploaded for a pre-4.5 Jetpack site with VideoPress enabled', () => {
-			const isAcceptableSize = MediaUtils.isExceedingSiteMaxUploadSize(
-				{ size: 1024, mime_type: 'video/mp4' },
-				{
-					jetpack: true,
-					options: {
-						jetpack_version: '3.8.1',
-						max_upload_size: 1024,
-						active_modules: [ 'videopress' ],
-					},
-				}
-			);
-
-			expect( isAcceptableSize ).to.not.be.null;
-		} );
-
 		test( 'should not return null if an image is being uploaded for a Jetpack site with VideoPress enabled', () => {
 			expect(
 				MediaUtils.isExceedingSiteMaxUploadSize(
@@ -465,7 +445,6 @@ describe( 'MediaUtils', () => {
 				{
 					jetpack: true,
 					options: {
-						jetpack_version: '4.5',
 						max_upload_size: 1024,
 					},
 				}

--- a/client/lib/media/utils/is-exceeding-site-max-upload-size.js
+++ b/client/lib/media/utils/is-exceeding-site-max-upload-size.js
@@ -6,7 +6,6 @@ import { includes, startsWith, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import versionCompare from 'calypso/lib/version-compare';
 import { getMimeType } from 'calypso/lib/media/utils/get-mime-type';
 
 /**
@@ -33,7 +32,6 @@ export function isExceedingSiteMaxUploadSize( item, site ) {
 	if (
 		site.jetpack &&
 		includes( get( site, 'options.active_modules' ), 'videopress' ) &&
-		versionCompare( get( site, 'options.jetpack_version' ), '4.5', '>=' ) &&
 		startsWith( getMimeType( item ), 'video/' )
 	) {
 		return null;

--- a/client/my-sites/marketing/controller.js
+++ b/client/my-sites/marketing/controller.js
@@ -16,18 +16,12 @@ import SharingConnections from './connections/connections';
 import Traffic from './traffic/';
 import UltimateTrafficGuide from './ultimate-traffic-guide';
 import { requestSite } from 'calypso/state/sites/actions';
-import {
-	getSiteSlug,
-	isJetpackSite,
-	isJetpackModuleActive,
-	getSiteOption,
-} from 'calypso/state/sites/selectors';
+import { getSiteSlug, isJetpackSite, isJetpackModuleActive } from 'calypso/state/sites/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { fetchPreferences } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
-import versionCompare from 'calypso/lib/version-compare';
 import { setExpandedService } from 'calypso/state/sharing/actions';
 
 export const redirectConnections = ( context ) => {
@@ -120,13 +114,10 @@ export const sharingButtons = ( context, next ) => {
 		);
 	}
 
-	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
-
 	if (
 		siteId &&
 		isJetpackSite( state, siteId ) &&
-		( ! isJetpackModuleActive( state, siteId, 'sharedaddy' ) ||
-			versionCompare( siteJetpackVersion, '3.4-dev', '<' ) )
+		! isJetpackModuleActive( state, siteId, 'sharedaddy' )
 	) {
 		store.dispatch(
 			errorNotice(

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -31,7 +31,6 @@ import { userCan } from 'calypso/lib/site/utils';
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import FeatureExample from 'calypso/components/feature-example';
-import versionCompare from 'calypso/lib/version-compare';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
@@ -39,7 +38,6 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
 import isActivatingJetpackModule from 'calypso/state/selectors/is-activating-jetpack-module';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
@@ -74,8 +72,7 @@ class InvitePeople extends React.Component {
 			this.props.siteId !== nextProps.siteId ||
 			this.props.needsVerification !== nextProps.needsVerification ||
 			this.props.showSSONotice !== nextProps.showSSONotice ||
-			this.props.isJetpack !== nextProps.isJetpack ||
-			this.props.isSiteAutomatedTransfer !== nextProps.isSiteAutomatedTransfer
+			this.props.isJetpack !== nextProps.isJetpack
 		) {
 			this.setState( this.resetState( nextProps ) );
 		}
@@ -476,23 +473,7 @@ class InvitePeople extends React.Component {
 			return inviteForm;
 		}
 
-		const jetpackVersion = get( site, 'options.jetpack_version', 0 );
-		if ( ! this.props.isSiteAutomatedTransfer && versionCompare( jetpackVersion, '5.0', '<' ) ) {
-			return (
-				<div className="invite-people__action-required">
-					<Notice
-						status="is-warning"
-						showDismiss={ false }
-						text={ translate( 'Inviting users requires Jetpack 5.0 or higher' ) }
-					>
-						<NoticeAction href={ `/plugins/jetpack/${ site.slug }` }>
-							{ translate( 'Update' ) }
-						</NoticeAction>
-					</Notice>
-					<FeatureExample>{ inviteForm }</FeatureExample>
-				</div>
-			);
-		} else if ( showSSONotice ) {
+		if ( showSSONotice ) {
 			return (
 				<div className="invite-people__action-required">
 					<Notice
@@ -758,7 +739,6 @@ const mapStateToProps = ( state ) => {
 		needsVerification: ! isCurrentUserEmailVerified( state ),
 		showSSONotice: ! ( activating || active ),
 		isJetpack: isJetpackSite( state, siteId ),
-		isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
 		isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
 		inviteLinks: getInviteLinksForSite( state, siteId ),
 		siteRoles: getSiteRoles( state, siteId ),

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -31,7 +31,6 @@ import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import SupportInfo from 'calypso/components/support-info';
-import versionCompare from 'calypso/lib/version-compare';
 
 class ThemeEnhancements extends Component {
 	static defaultProps = {
@@ -180,7 +179,6 @@ class ThemeEnhancements extends Component {
 	renderMinilevenSettings() {
 		const { minilevenModuleActive, selectedSiteId, site, translate } = this.props;
 		const formPending = this.isFormPending();
-		const jetpackVersion = get( site, 'options.jetpack_version', 0 );
 		const minilevenSupportUrl = 'https://jetpack.com/support/mobile-theme/';
 		const googleMobileCheckUrl = `https://search.google.com/test/mobile-friendly?url=${ encodeURIComponent(
 			`${ site.URL }?jetpack-preview=responsivetheme`
@@ -198,9 +196,7 @@ class ThemeEnhancements extends Component {
 					status="is-info"
 					showDismiss={ false }
 					text={
-						minilevenModuleActive &&
-						jetpackVersion &&
-						versionCompare( jetpackVersion, '8.1-alpha', '>=' )
+						minilevenModuleActive
 							? translate(
 									'{{b}}Action needed:{{/b}} The Jetpack mobile theme is not supported ' +
 										'anymore. It will be removed when you update to the most recent ' +

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-
-import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
@@ -20,15 +18,8 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormToggle from 'calypso/components/forms/form-toggle';
-import {
-	getCustomizerUrl,
-	isJetpackSite,
-	isJetpackMinimumVersion,
-} from 'calypso/state/sites/selectors';
+import { getCustomizerUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
-import Notice from 'calypso/components/notice';
-import NoticeAction from 'calypso/components/notice/notice-action';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import SupportInfo from 'calypso/components/support-info';
 
@@ -176,112 +167,8 @@ class ThemeEnhancements extends Component {
 		);
 	}
 
-	renderMinilevenSettings() {
-		const { minilevenModuleActive, selectedSiteId, site, translate } = this.props;
-		const formPending = this.isFormPending();
-		const minilevenSupportUrl = 'https://jetpack.com/support/mobile-theme/';
-		const googleMobileCheckUrl = `https://search.google.com/test/mobile-friendly?url=${ encodeURIComponent(
-			`${ site.URL }?jetpack-preview=responsivetheme`
-		) }`;
-
-		return (
-			<FormFieldset
-				className={ classnames(
-					'minileven',
-					`${ minilevenModuleActive ? `active` : `inactive` }`
-				) }
-			>
-				<FormLegend>{ translate( 'Mobile Theme' ) }</FormLegend>
-				<Notice
-					status="is-info"
-					showDismiss={ false }
-					text={
-						minilevenModuleActive
-							? translate(
-									'{{b}}Action needed:{{/b}} The Jetpack mobile theme is not supported ' +
-										'anymore. It will be removed when you update to the most recent ' +
-										'version of the plugin. Please ensure your current theme ' +
-										'is mobile-ready {{link}}using this tool{{/link}}. ' +
-										'If it is not, consider replacing it.',
-									{
-										components: {
-											b: <strong />,
-											link: (
-												<a
-													href={ googleMobileCheckUrl }
-													target="_blank"
-													rel="noopener noreferrer"
-												/>
-											),
-										},
-									}
-							  )
-							: translate(
-									'{{b}}Note:{{/b}} The Jetpack mobile theme is not supported ' +
-										'anymore. It will be removed when you update ' +
-										'to the most recent version of the plugin.',
-									{
-										components: {
-											b: <strong />,
-										},
-									}
-							  )
-					}
-				>
-					<NoticeAction href={ minilevenSupportUrl } external>
-						{ translate( 'Learn more' ) }
-					</NoticeAction>
-				</Notice>
-				<SupportInfo
-					text={ translate(
-						'Enables a lightweight, mobile-friendly theme ' +
-							'that will be displayed to visitors on mobile devices.'
-					) }
-					link={ minilevenSupportUrl }
-				/>
-				<p>
-					{ translate(
-						'Give your site a fast-loading, streamlined look for mobile devices. Visitors will ' +
-							'still see your regular theme on other screen sizes.'
-					) }
-				</p>
-				<JetpackModuleToggle
-					siteId={ selectedSiteId }
-					moduleSlug="minileven"
-					label={ translate( 'Enable the Jetpack Mobile theme' ) }
-					disabled={ formPending || ! minilevenModuleActive }
-				/>
-
-				<div className="theme-enhancements__module-settings site-settings__child-settings">
-					{ this.renderToggle(
-						'wp_mobile_excerpt',
-						! minilevenModuleActive,
-						translate( 'Use excerpts instead of full posts on front page and archive pages' )
-					) }
-					{ this.renderToggle(
-						'wp_mobile_featured_images',
-						! minilevenModuleActive,
-						translate( 'Show featured images' )
-					) }
-					{ this.renderToggle(
-						'wp_mobile_app_promos',
-						! minilevenModuleActive,
-						translate(
-							'Show an ad for the {{link}}WordPress mobile apps{{/link}} in the footer of the mobile theme',
-							{
-								components: {
-									link: <a href="https://apps.wordpress.com/" />,
-								},
-							}
-						)
-					) }
-				</div>
-			</FormFieldset>
-		);
-	}
-
 	render() {
-		const { siteIsJetpack, siteHasMinileven, translate } = this.props;
+		const { siteIsJetpack, translate } = this.props;
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
@@ -293,12 +180,6 @@ class ThemeEnhancements extends Component {
 						<Fragment>
 							{ this.renderJetpackInfiniteScrollSettings() }
 							<hr />
-							{ siteHasMinileven && (
-								<Fragment>
-									{ this.renderMinilevenSettings() }
-									<hr />
-								</Fragment>
-							) }
 							{ this.renderCustomCSSSettings() }
 						</Fragment>
 					) : (
@@ -319,13 +200,6 @@ export default connect( ( state ) => {
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
 		selectedSiteId,
 		siteIsJetpack: isJetpackSite( state, selectedSiteId ),
-		infiniteScrollModuleActive: !! isJetpackModuleActive(
-			state,
-			selectedSiteId,
-			'infinite-scroll'
-		),
-		minilevenModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'minileven' ),
 		site,
-		siteHasMinileven: false === isJetpackMinimumVersion( state, selectedSiteId, '8.3-alpha' ),
 	};
 } )( localize( ThemeEnhancements ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Jetpack's support policy is the current version - 1. With regards to that, every once in a while we've been removing obsolete version checks for older, no longer supported versions of Jetpack. This PR addresses that for some remaining older version checks. #46067 was a similar PR a while ago.

#### Testing instructions

* Pick a Jetpack site.
* Smoke test the media area for a site, try uploading a huge file.
* Smoke test `/marketing/:site`
* Smoke test `/people/new/:site`
* Smoke test `/settings/writing/:site`, particularly the **Theme Enhancements** card.
* Verify all tests pass.