### PR TITLE
Calypsoify: Fix observer error

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -782,9 +782,12 @@ async function openLinksInParentFrame( calypsoPort ) {
 	// In the Post editor the `.interface-interface-skeleton__sidebar` element
 	// is always present. We can scope down our observer to the sidebar element in this case.
 	// Block settings sidebar, post editor
-	sidebarsObserver.observe( document.querySelector( '.interface-interface-skeleton__sidebar' ), {
-		childList: true,
-	} );
+	const sidebar = document.querySelector( '.interface-interface-skeleton__sidebar' );
+	if ( sidebar ) {
+		sidebarsObserver.observe( sidebar, {
+			childList: true,
+		} );
+	}
 
 	// Manage reusable blocks link in the 3 dots more menu, post and site editors
 	if ( manageReusableBlocksUrl ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a bug introduced by https://github.com/Automattic/wp-calypso/pull/52122: Manage Reusable Blocks URL is not replaced in the Site Editor when the editor is opened with the sidebar closed.

#### Testing instructions

1. Follow instructions in PCYsg-l4k-p2 to apply the changes proposed in this PR on your sandbox
2. Open Site Editor
3. Make sure sidebar is closed. If you had it open, then close it and refresh.
4. Click on 3 dots menu in the top-right corner
5. Make sure the "Manage reusable blocks" link is pointing to: wordpress.com/types/.......

