### PR TITLE
My Home: Replace "More Help" with "Contact Support"

### DIFF
--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -95,11 +95,11 @@ const HelpSearch = ( { searchQuery, openDialog, track } ) => {
 					</div>
 				</div>
 				<div className="help-search__footer">
-					<a className="help-search__cta" href="/help">
+					<a className="help-search__cta" href="/help/contact">
 						<span className="help-search__help-icon">
 							<Gridicon icon="help" size={ 36 } />
 						</span>
-						{ translate( 'More help' ) }
+						{ translate( 'Contact Support' ) }
 						<Gridicon className="help-search__go-icon" icon="chevron-right" size={ 24 } />
 					</a>
 				</div>

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -99,7 +99,7 @@ const HelpSearch = ( { searchQuery, openDialog, track } ) => {
 						<span className="help-search__help-icon">
 							<Gridicon icon="help" size={ 36 } />
 						</span>
-						{ translate( 'Contact Support' ) }
+						{ translate( 'Contact support' ) }
 						<Gridicon className="help-search__go-icon" icon="chevron-right" size={ 24 } />
 					</a>
 				</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replaces "More help" with a link to directly contact Support. 

#### Testing instructions

Verify the "More help" part has been replaced with "Contact Support" and links to `/help/contact`.

_Sidenote:_ "Contact us" is the string usually used for this purpose, and there may be i18n advantages to re-using this - should that be used instead of "Contact Support"? (cc @jordesign, @jeffgolenski)

<img width="370" alt="Screenshot 2021-05-13 at 17 09 46" src="https://user-images.githubusercontent.com/43215253/118153776-2cdaa300-b40e-11eb-8ff0-7c00c1a60300.png">

Fixes #52762
