### PR TITLE
Nav sidebar: Remove hieght override

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
@@ -3,8 +3,6 @@
 @import '../nav-sidebar/style.scss';
 
 .wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button {
-	height: $header-height !important;
-
 	// Match this animation with the nav-sidebar, so that the button is not hidden
 	// before the sidebar menu finishes sliding out.
 	transition: visibility $sidebar-transition-period linear;
@@ -12,6 +10,5 @@
 
 	&.is-hidden {
 		visibility: hidden;
-
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Gutenberg [recently made a change](https://github.com/WordPress/gutenberg/pull/31044) which modified the height of the W-button in the toolbar. This caused whitespace on wpcom, because we manually set the height ourselves (visible in gutenberg edge):

(Note the white line at the top of the button):

<img width="429" alt="Screen Shot 2021-05-13 at 11 28 24 AM" src="https://user-images.githubusercontent.com/6265975/118170177-a65a9d00-b3de-11eb-8f94-d6a399e70681.png">

I'm not sure why we added the height override, but it doesn't seem to be important anymore -- I don't notice a difference after removing it, other than the glitch being fixed on gutenberg edge:

<img width="253" alt="Screen Shot 2021-05-13 at 11 26 39 AM" src="https://user-images.githubusercontent.com/6265975/118170375-dace5900-b3de-11eb-836d-754215fcaace.png">

#### Testing instructions
1. Run `install-plugin.sh etk fix/w-button-whitespace` on your sandbox
2. Sandbox and load a gutenberg edge editor. There should be no whitespace above the w-button.
3. Sandbox and load a non-gutenberg edge editor. The w-button should look the same as before.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
