### PR TITLE
Jetpack Plans: Hide yearly billing discount message when monthly billing is selected.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/plans-filter-bar/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-filter-bar/index.tsx
@@ -40,14 +40,14 @@ interface FilterBarProps {
 }
 
 type DiscountMessageProps = {
-	primary?: boolean;
+	toggleChecked?: boolean;
 };
 
 const CLOUD_MASTERBAR_STICKY = false;
 const CALYPSO_MASTERBAR_HEIGHT = 47;
 const CLOUD_MASTERBAR_HEIGHT = CLOUD_MASTERBAR_STICKY ? 94 : 0;
 
-const DiscountMessage: React.FC< DiscountMessageProps > = ( { primary } ) => {
+const DiscountMessage: React.FC< DiscountMessageProps > = ( { toggleChecked } ) => {
 	const translate = useTranslate();
 	const isMobile: boolean = useMobileBreakpoint();
 
@@ -64,10 +64,10 @@ const DiscountMessage: React.FC< DiscountMessageProps > = ( { primary } ) => {
 		return null;
 	}
 
-	return (
+	return toggleChecked ? (
 		<div
 			className={ classNames( 'plans-filter-bar__discount-message', {
-				primary,
+				toggleChecked,
 			} ) }
 		>
 			<div>
@@ -85,7 +85,7 @@ const DiscountMessage: React.FC< DiscountMessageProps > = ( { primary } ) => {
 				{ String.fromCodePoint( 0x1f389 ) } { /* Celebration emoji 🎉 */ }
 			</div>
 		</div>
-	);
+	) : null;
 };
 
 const PlansFilterBar: React.FC< FilterBarProps > = ( {
@@ -111,20 +111,24 @@ const PlansFilterBar: React.FC< FilterBarProps > = ( {
 
 	return (
 		<div ref={ barRef } className={ classNames( 'plans-filter-bar', { sticky: hasCrossed } ) }>
-			<div
-				className={ classNames( 'plans-filter-bar__duration-toggle', {
-					checked: durationChecked,
-				} ) }
-			>
-				<span className="plans-filter-bar__toggle-off-label">{ translate( 'Bill monthly' ) }</span>
-				<ToggleControl
-					className="plans-filter-bar__toggle-control"
-					checked={ durationChecked }
-					onChange={ () => setDurationChecked( ( prevState ) => ! prevState ) }
-				/>
-				<span className="plans-filter-bar__toggle-on-label">{ translate( 'Bill yearly' ) }</span>
+			<div className="plans-filter-bar__duration-toggle-wrapper">
+				<div
+					className={ classNames( 'plans-filter-bar__duration-toggle', {
+						checked: durationChecked,
+					} ) }
+				>
+					<span className="plans-filter-bar__toggle-off-label">
+						{ translate( 'Bill monthly' ) }
+					</span>
+					<ToggleControl
+						className="plans-filter-bar__toggle-control"
+						checked={ durationChecked }
+						onChange={ () => setDurationChecked( ( prevState ) => ! prevState ) }
+					/>
+					<span className="plans-filter-bar__toggle-on-label">{ translate( 'Bill yearly' ) }</span>
+				</div>
+				{ showDiscountMessage && <DiscountMessage toggleChecked={ durationChecked } /> }
 			</div>
-			{ showDiscountMessage && <DiscountMessage primary={ durationChecked } /> }
 		</div>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/plans-filter-bar/style.scss
+++ b/client/my-sites/plans/jetpack-plans/plans-filter-bar/style.scss
@@ -16,6 +16,10 @@
 		flex-direction: row;
 	}
 
+	.plans-filter-bar__duration-toggle-wrapper {
+		position: relative;
+	}
+
 	.plans-filter-bar__duration-toggle {
 		display: flex;
 		justify-content: center;
@@ -38,7 +42,6 @@
 
 		@include breakpoint-deprecated( '>480px' ) {
 			padding-bottom: 0;
-			margin-right: 20px;
 		}
 	}
 	.plans-filter-bar__toggle-control {
@@ -83,9 +86,14 @@
 	font-size: 0.8125rem;
 	font-weight: 600;
 	padding-top: 2px;
+	color: var( --color-primary );
+	white-space: nowrap;
+	text-align: center;
 
-	&.primary {
-		color: var( --color-primary );
+	@include breakpoint-deprecated( '>480px' ) {
+		position: absolute;
+		left: calc( 100% + 12px );
+		top: 3px;
 	}
 
 	.plans-filter-bar__discount-message-text {

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -164,8 +164,6 @@ export const getHighestAnnualDiscount = createSelector(
 			.map( ( yearlySlug ) => {
 				const yearly = getProductCost( state, yearlySlug );
 
-				console.log( yearly );
-
 				const monthlySlug = getMonthlySlugFromYearly( yearlySlug );
 				const monthly = monthlySlug && getProductCost( state, monthlySlug );
 

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -164,6 +164,8 @@ export const getHighestAnnualDiscount = createSelector(
 			.map( ( yearlySlug ) => {
 				const yearly = getProductCost( state, yearlySlug );
 
+				console.log( yearly );
+
 				const monthlySlug = getMonthlySlugFromYearly( yearlySlug );
 				const monthly = monthlySlug && getProductCost( state, monthlySlug );
 


### PR DESCRIPTION
On the Jetpack Plans page, When a user clicks on the billing duration toggle, they should only see "20% off" when they have selected yearly billing. Right now it shows for both yearly **and monthly**.

#### Changes proposed in this Pull Request

- This PR **shows** the "Save 20%" discount message when "Bill yearly" is selected, and **hides** the discount message when "Bill monthly" is selected.

#### Testing instructions

1. Run this PR in calypso green. (`yarn start-jetpack-cloud`)
2. Go to the pricing page at `http://jetpack.cloud.localhost:3000/pricing`
3. Toggle the Billing duration toggle switch back and forth from "Bill monthly" to "Bill yearly" and verify that the "Save 20%" discount message only appears when "Bill yearly" is selected.  
4. Verify that the appearance looks ok. (CSS styling)
5. Verify the duration toggle and discount message appearance looks good in mobile view too.

Related to 1164141197617539-as-1200311994324959

.
### Screenshots BEFORE:

**Bill Monthly**
<img width="410" alt="Screenshot on 2021-05-13 at 15-27-12" src="https://user-images.githubusercontent.com/11078128/118177060-3230f100-b400-11eb-99e7-7291bb24989d.png">

**Bill Yearly**
<img width="410" alt="Screenshot on 2021-05-13 at 15-26-34" src="https://user-images.githubusercontent.com/11078128/118177094-3a892c00-b400-11eb-87d1-86a6fc8b8484.png">


.
### Screenshots AFTER:

**Bill Monthly**
<img width="423" alt="Screenshot on 2021-05-13 at 15-28-53" src="https://user-images.githubusercontent.com/11078128/118177122-41b03a00-b400-11eb-9393-132069620cce.png">

**Bill Yearly**
<img width="427" alt="Screenshot on 2021-05-13 at 15-28-04" src="https://user-images.githubusercontent.com/11078128/118177136-470d8480-b400-11eb-96ed-ece3b923c291.png">
