### PR TITLE
Jetpack Search: Make instructions clearer for Business plan Instant Search toggle

### DIFF
--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -195,22 +195,24 @@ class Search extends Component {
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleJetpackSearchToggle }
 				/>
-
-				<div className="site-settings__jetpack-instant-search-toggle">
-					<ToggleControl
-						checked={
-							isSearchModuleActive &&
-							this.props.hasSearchProduct &&
-							!! fields.instant_search_enabled
-						}
-						disabled={ ! hasSearchProduct || isRequestingSettings || isSavingSettings }
-						onChange={ handleInstantSearchToggle }
-						label={ translate( 'Enable instant search experience (recommended)' ) }
-					/>
-					{ isLoading || activatingSearchModule || isSavingSettings
-						? this.renderSettingsUpdating()
-						: this.renderInstantSearchExplanation() }
-				</div>
+				{ this.props.hasSearchProduct && (
+					<div className="site-settings__jetpack-instant-search-toggle">
+						<ToggleControl
+							checked={
+								isSearchModuleActive &&
+								this.props.hasSearchProduct &&
+								!! fields.instant_search_enabled
+							}
+							disabled={ ! hasSearchProduct || isRequestingSettings || isSavingSettings }
+							onChange={ handleInstantSearchToggle }
+						>
+							{ translate( 'Enable instant search experience (recommended)' ) }
+						</ToggleControl>
+						{ isLoading || activatingSearchModule || isSavingSettings
+							? this.renderSettingsUpdating()
+							: this.renderInstantSearchExplanation() }
+					</div>
+				) }
 			</Fragment>
 		);
 	}
@@ -265,21 +267,24 @@ class Search extends Component {
 					checked={ !! fields.jetpack_search_enabled }
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleJetpackSearchToggle }
-					label={ translate( 'Enable Jetpack Search' ) }
-				/>
-
-				<div className="site-settings__jetpack-instant-search-toggle">
-					<ToggleControl
-						checked={ !! fields.jetpack_search_enabled && !! fields.instant_search_enabled }
-						disabled={ isRequestingSettings || isSavingSettings || ! hasSearchProduct }
-						onChange={ handleInstantSearchToggle }
-					>
-						{ translate( 'Enable instant search experience (recommended)' ) }
-					</ToggleControl>
-					{ isLoading || activatingSearchModule || isSavingSettings
-						? this.renderSettingsUpdating()
-						: this.renderInstantSearchExplanation() }
-				</div>
+				>
+					{ translate( 'Enable Jetpack Search' ) }
+				</ToggleControl>
+				{ /** Business plan could be simple sites too, unless user triggers certain actions  */ }
+				{ this.props.hasSearchProduct && (
+					<div className="site-settings__jetpack-instant-search-toggle">
+						<ToggleControl
+							checked={ !! fields.jetpack_search_enabled && !! fields.instant_search_enabled }
+							disabled={ isRequestingSettings || isSavingSettings || ! hasSearchProduct }
+							onChange={ handleInstantSearchToggle }
+						>
+							{ translate( 'Enable instant search experience (recommended)' ) }
+						</ToggleControl>
+						{ isLoading || activatingSearchModule || isSavingSettings
+							? this.renderSettingsUpdating()
+							: this.renderInstantSearchExplanation() }
+					</div>
+				) }
 			</Fragment>
 		);
 	}

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -126,7 +126,7 @@ class Search extends Component {
 		return (
 			<Fragment>
 				<UpsellNudge
-					title={ translate( 'Keep people reading and buying' ) }
+					title={ translate( 'Upgrade your Jetpack Search and get the instant search experience' ) }
 					description={ translate(
 						'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.'
 					) }

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -94,13 +94,6 @@ class Search extends Component {
 					{ this.props.translate(
 						'Allow your visitors to get search results as soon as they start typing.'
 					) }{ ' ' }
-					{ ! this.props.hasSearchProduct && // The following notice is only shown for Business/Pro plan holders.
-						this.props.translate(
-							'To enable Instant search experience, simply {{b}}follow the link below{{/b}} to upgrade to a Jetpack Search subscription.',
-							{
-								components: { b: <b /> },
-							}
-						) }
 				</FormSettingExplanation>
 			</div>
 		);

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -271,7 +271,7 @@ class Search extends Component {
 				<div className="site-settings__jetpack-instant-search-toggle">
 					<ToggleControl
 						checked={ !! fields.jetpack_search_enabled && !! fields.instant_search_enabled }
-						disabled={ isRequestingSettings || isSavingSettings || ! this.props.hasSearchProduct }
+						disabled={ isRequestingSettings || isSavingSettings || ! hasSearchProduct }
 						onChange={ handleInstantSearchToggle }
 					>
 						{ translate( 'Enable instant search experience (recommended)' ) }

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -198,9 +198,8 @@ class Search extends Component {
 							}
 							disabled={ ! hasSearchProduct || isRequestingSettings || isSavingSettings }
 							onChange={ handleInstantSearchToggle }
-						>
-							{ translate( 'Enable instant search experience (recommended)' ) }
-						</ToggleControl>
+							label={ translate( 'Enable instant search experience (recommended)' ) }
+						></ToggleControl>
 						{ isLoading || activatingSearchModule || isSavingSettings
 							? this.renderSettingsUpdating()
 							: this.renderInstantSearchExplanation() }
@@ -260,9 +259,8 @@ class Search extends Component {
 					checked={ !! fields.jetpack_search_enabled }
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleJetpackSearchToggle }
-				>
-					{ translate( 'Enable Jetpack Search' ) }
-				</ToggleControl>
+					label={ translate( 'Enable Jetpack Search' ) }
+				></ToggleControl>
 				{ /** Business plan could be simple sites too, unless user triggers certain actions  */ }
 				{ this.props.hasSearchProduct && (
 					<div className="site-settings__jetpack-instant-search-toggle">
@@ -270,9 +268,8 @@ class Search extends Component {
 							checked={ !! fields.jetpack_search_enabled && !! fields.instant_search_enabled }
 							disabled={ isRequestingSettings || isSavingSettings || ! hasSearchProduct }
 							onChange={ handleInstantSearchToggle }
-						>
-							{ translate( 'Enable instant search experience (recommended)' ) }
-						</ToggleControl>
+							label={ translate( 'Enable instant search experience (recommended)' ) }
+						></ToggleControl>
 						{ isLoading || activatingSearchModule || isSavingSettings
 							? this.renderSettingsUpdating()
 							: this.renderInstantSearchExplanation() }

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -284,7 +284,7 @@ class Search extends Component {
 	}
 
 	renderSettingsCard() {
-		const { fields, translate, siteIsJetpack } = this.props;
+		const { fields, translate, siteIsJetpack, hasSearchProduct } = this.props;
 
 		return (
 			<Fragment>
@@ -296,7 +296,7 @@ class Search extends Component {
 							: this.renderSearchTogglesForSimpleSites() }
 					</FormFieldset>
 				</CompactCard>
-				{ fields.instant_search_enabled && (
+				{ hasSearchProduct && fields.instant_search_enabled && (
 					<CompactCard
 						href={ this.props.customizerUrl }
 						target={ siteIsJetpack ? 'external' : null }

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -110,7 +110,7 @@ class Search extends Component {
 	}
 
 	renderUpgradeNotice() {
-		const { siteIsJetpack, siteSlug, translate } = this.props;
+		const { siteIsJetpack, siteSlug, translate, isOldJetpackSearchIncluded } = this.props;
 
 		const href = siteIsJetpack
 			? `/checkout/${ siteSlug }/${ PRODUCT_JETPACK_SEARCH_MONTHLY }`
@@ -119,7 +119,11 @@ class Search extends Component {
 		return (
 			<Fragment>
 				<UpsellNudge
-					title={ translate( 'Upgrade your Jetpack Search and get the instant search experience' ) }
+					title={
+						isOldJetpackSearchIncluded
+							? translate( 'Upgrade your Jetpack Search and get the instant search experience' )
+							: translate( 'Upgrade to Jetpack Search and get the instant search experience' )
+					}
 					description={ translate(
 						'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.'
 					) }
@@ -333,9 +337,9 @@ export default connect( ( state, { isRequestingSettings } ) => {
 	const hasSearchProduct =
 		getSitePurchases( state, siteId ).find( checkForSearchProduct ) ||
 		planHasJetpackSearch( site.plan?.product_slug );
-	const isSearchEligible =
-		( site && site.plan && ( hasBusinessPlan( site.plan ) || isVipPlan( site.plan ) ) ) ||
-		!! hasSearchProduct;
+	const isOldJetpackSearchIncluded =
+		site && site.plan && ( hasBusinessPlan( site.plan ) || isVipPlan( site.plan ) );
+	const isSearchEligible = isOldJetpackSearchIncluded || !! hasSearchProduct;
 	const upgradeLink =
 		'/checkout/' +
 		getSelectedSiteSlug( state ) +
@@ -358,5 +362,6 @@ export default connect( ( state, { isRequestingSettings } ) => {
 		upgradeLink,
 		isSearchModuleActive:
 			( isSearchModuleActive && ! deactivating ) || ( ! isSearchModuleActive && activating ),
+		isOldJetpackSearchIncluded,
 	};
 } )( localize( Search ) );

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { overSome } from 'lodash';
 import { ToggleControl } from '@wordpress/components';
 
 /**
@@ -31,17 +30,13 @@ import { getSitePurchases, isFetchingSitePurchases } from 'calypso/state/purchas
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import { isJetpackSite, getCustomizerUrl } from 'calypso/state/sites/selectors';
 import {
-	isBusiness,
-	isEnterprise,
-	isVipPlan,
-	isJetpackBusiness,
-	isEcommerce,
 	isJetpackSearch,
 	isP2Plus,
 	planHasJetpackSearch,
 	FEATURE_SEARCH,
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
 	PRODUCT_WPCOM_SEARCH_MONTHLY,
+	planHasJetpackClassicSearch,
 } from '@automattic/calypso-products';
 
 class Search extends Component {
@@ -110,7 +105,7 @@ class Search extends Component {
 	}
 
 	renderUpgradeNotice() {
-		const { siteIsJetpack, siteSlug, translate, isOldJetpackSearchIncluded } = this.props;
+		const { siteIsJetpack, siteSlug, translate, isJetpackClassicSearchIncluded } = this.props;
 
 		const href = siteIsJetpack
 			? `/checkout/${ siteSlug }/${ PRODUCT_JETPACK_SEARCH_MONTHLY }`
@@ -120,7 +115,7 @@ class Search extends Component {
 			<Fragment>
 				<UpsellNudge
 					title={
-						isOldJetpackSearchIncluded
+						isJetpackClassicSearchIncluded
 							? translate( 'Upgrade your Jetpack Search and get the instant search experience' )
 							: translate( 'Upgrade to Jetpack Search and get the instant search experience' )
 					}
@@ -328,7 +323,6 @@ class Search extends Component {
 	}
 }
 
-const hasBusinessPlan = overSome( isJetpackBusiness, isBusiness, isEnterprise, isEcommerce );
 const checkForSearchProduct = ( purchase ) =>
 	purchase.active && ( isJetpackSearch( purchase ) || isP2Plus( purchase ) );
 export default connect( ( state, { isRequestingSettings } ) => {
@@ -337,9 +331,8 @@ export default connect( ( state, { isRequestingSettings } ) => {
 	const hasSearchProduct =
 		getSitePurchases( state, siteId ).find( checkForSearchProduct ) ||
 		planHasJetpackSearch( site.plan?.product_slug );
-	const isOldJetpackSearchIncluded =
-		site && site.plan && ( hasBusinessPlan( site.plan ) || isVipPlan( site.plan ) );
-	const isSearchEligible = isOldJetpackSearchIncluded || !! hasSearchProduct;
+	const isJetpackClassicSearchIncluded = planHasJetpackClassicSearch( site?.plan );
+	const isSearchEligible = isJetpackClassicSearchIncluded || !! hasSearchProduct;
 	const upgradeLink =
 		'/checkout/' +
 		getSelectedSiteSlug( state ) +
@@ -362,6 +355,6 @@ export default connect( ( state, { isRequestingSettings } ) => {
 		upgradeLink,
 		isSearchModuleActive:
 			( isSearchModuleActive && ! deactivating ) || ( ! isSearchModuleActive && activating ),
-		isOldJetpackSearchIncluded,
+		isJetpackClassicSearchIncluded,
 	};
 } )( localize( Search ) );

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -54,6 +54,7 @@ class SiteSettingsPerformance extends Component {
 			trackEvent,
 			updateFields,
 			saveJetpackSettings,
+			activateModule,
 		} = this.props;
 		const siteIsJetpackNonAtomic = siteIsJetpack && ! siteIsAtomic;
 
@@ -80,6 +81,7 @@ class SiteSettingsPerformance extends Component {
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }
 					trackEvent={ trackEvent }
+					activateModule={ activateModule }
 				/>
 
 				{ showCloudflare && ! siteIsJetpackNonAtomic && <Cloudflare /> }

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -35,6 +35,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import QueryJetpackSettings from 'calypso/components/data/query-jetpack-settings';
 import getRequest from 'calypso/state/selectors/get-request';
+import { activateModule } from 'calypso/state/jetpack/modules/actions';
 
 const debug = debugFactory( 'calypso:site-settings' );
 
@@ -352,6 +353,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 					saveSiteSettings,
 					successNotice,
 					saveJetpackSettings,
+					activateModule,
 				},
 				dispatch
 			);

--- a/packages/calypso-products/src/main.js
+++ b/packages/calypso-products/src/main.js
@@ -28,6 +28,7 @@ import {
 	TYPE_P2_PLUS,
 } from './constants';
 import { PLANS_LIST } from './plans-list';
+import { isJetpackBusiness, isBusiness, isEnterprise, isEcommerce, isVipPlan } from '.';
 
 export function getPlans() {
 	return PLANS_LIST;
@@ -552,3 +553,20 @@ export const chooseDefaultCustomerType = ( { currentCustomerType, selectedPlan, 
 export const planHasJetpackSearch = ( planSlug ) =>
 	planHasFeature( planSlug, FEATURE_JETPACK_SEARCH ) ||
 	planHasFeature( planSlug, FEATURE_JETPACK_SEARCH_MONTHLY );
+
+/**
+ * Determines if a plan includes Jetpack Search Classic by checking available plans.
+ *
+ * @param   {object}  plan  Plan object.
+ * @returns {boolean}           Whether the specified plan includes Jetpack Search Classic.
+ */
+export function planHasJetpackClassicSearch( plan ) {
+	return (
+		plan &&
+		( isJetpackBusiness( plan ) ||
+			isBusiness( plan ) ||
+			isEnterprise( plan ) ||
+			isEcommerce( plan ) ||
+			isVipPlan( plan ) )
+	);
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/52736
Addresses the suggestion https://github.com/Automattic/wp-calypso/pull/52631#issuecomment-840786817 

#### Changes proposed in this Pull Request
- Changed instant search instructions for Business plan more clear - direct user to upgrade to a Jetpack Search subscription
- If site has Jetpack Search subscription, we enable Instant Search toggle 
- And if Instant Search toggle changes from unchecked to checked, Jetpack Search changes to checked

#### Testing instructions
Go to a site with Business plan but no Jetpack Search subscription, open General -> Settings -> Performance
- Ensure Business plan site has clearer information as shown in the screenshot
- Ensure Instant Search toggle is hidden

Go to a site with an active Jetpack Search subscription
- Ensure Instant search toggle is not disabled even if Jetpack Search is unchecked 
- Ensure When toggle Instant Search from unchecked to checked when Jetpack Search is unchecked, Jetpack Search changes to checked, as shown in the gif.

![image](https://user-images.githubusercontent.com/1425433/118415458-8f79ba80-b6fe-11eb-8775-a64273cff9c2.png)

![Screen Capture on 2021-05-14 at 15-48-15](https://user-images.githubusercontent.com/1425433/118218588-da5fbc00-b4cb-11eb-903d-0a4b60ac510a.gif)

