### PR TITLE
Ensure verification button in email forward page is right-aligned

### DIFF
--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -224,6 +224,7 @@
 			flex: 0.75;
 			margin-top: 0;
 			margin-left: auto;
+			text-align: right;
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR ensures that the verification button in the email forward page is right-aligned when we're not using the mobile layout.

#### Testing instructions

* Open this branch locally or in the [live branch](https://calypso.live/?branch=fix/email-forwarding-mobile-button-alignment)
* Open the new email forwards page for a domain that has an unverified email forward (create a new one if you need to)
* Verify that in the desktop view the "Resend verification email" button is right-aligned
* Reduce the width of the view and verify that the button remains right-aligned and clearly visible until the layout changes to the mobile-friendly vertical layout.

Related to #52750