### PR TITLE
webpack config: Restore `RequireChunkCallbackPlugin`

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -35,6 +35,7 @@ const cacheIdentifier = require( '../build-tools/babel/babel-loader-cache-identi
 const config = require( './server/config' );
 const { workerCount } = require( './webpack.common' );
 const getAliasesForExtensions = require( '../build-tools/webpack/extensions' );
+const RequireChunkCallbackPlugin = require( '../build-tools/webpack/require-chunk-callback-plugin' );
 const GenerateChunksMapPlugin = require( '../build-tools/webpack/generate-chunks-map-plugin' );
 const AssetsWriter = require( '../build-tools/webpack/assets-writer-plugin.js' );
 
@@ -327,6 +328,7 @@ const webpackConfig = {
 			new GenerateChunksMapPlugin( {
 				output: path.resolve( '.', `chunks-map.${ extraPath }.json` ),
 			} ),
+		new RequireChunkCallbackPlugin(),
 		/*
 		 * ExPlat: Don't import the server logger when we are in the browser
 		 */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Restore `RequireChunkCallbackPlugin` (which is mandatory for loading translation chunks asynchronously) that has been removed in https://github.com/Automattic/wp-calypso/pull/49614

#### Testing instructions

* Boot Calypso locally with `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks,wpcom-user-bootstrap yarn start`
* Change UI to a Mag-16 language.
* Confirm async translations are being loaded correctly, i.e. go to `http://calypso.localhost:3000/me` and navigate through the settings screens from the sidebar.
* Confirm `window.__requireChunkCallback__` is present.

Related to #52857
