### PR TITLE
Add domain level warnings to new email home page

### DIFF
--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -21,7 +21,6 @@ import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
-import getGSuiteUsers from 'calypso/state/selectors/get-gsuite-users';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import {
 	getSelectedSite,
@@ -29,13 +28,11 @@ import {
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
-import hasLoadedGSuiteUsers from 'calypso/state/selectors/has-loaded-gsuite-users';
-import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 import { hasGSuiteSupportedDomain, hasGSuiteWithUs } from 'calypso/lib/gsuite';
+import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
 import Main from 'calypso/components/main';
-import QueryGSuiteUsers from 'calypso/components/data/query-gsuite-users';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import SectionHeader from 'calypso/components/section-header';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
@@ -49,8 +46,6 @@ class EmailManagementHome extends React.Component {
 	static propTypes = {
 		canManageSite: PropTypes.bool.isRequired,
 		domains: PropTypes.array.isRequired,
-		gsuiteUsers: PropTypes.array,
-		hasGSuiteUsersLoaded: PropTypes.bool.isRequired,
 		hasSiteDomainsLoaded: PropTypes.bool.isRequired,
 		selectedDomainName: PropTypes.string,
 		selectedSiteId: PropTypes.number.isRequired,
@@ -159,7 +154,6 @@ class EmailManagementHome extends React.Component {
 
 		return (
 			<Main wideLayout>
-				{ selectedSiteId && <QueryGSuiteUsers siteId={ selectedSiteId } /> }
 				{ selectedSiteId && <QuerySiteDomains siteId={ selectedSiteId } /> }
 				<DocumentHead title={ translate( 'Emails' ) } />
 				<SidebarNavigation />
@@ -191,8 +185,6 @@ export default connect( ( state ) => {
 		canManageSite: canCurrentUser( state, selectedSiteId, 'manage_options' ),
 		currentRoute: getCurrentRoute( state ),
 		domains: getDomainsBySiteId( state, selectedSiteId ),
-		gsuiteUsers: getGSuiteUsers( state, selectedSiteId ),
-		hasGSuiteUsersLoaded: hasLoadedGSuiteUsers( state, selectedSiteId ),
 		hasSiteDomainsLoaded: hasLoadedSiteDomains( state, selectedSiteId ),
 		hasSitesLoaded: hasLoadedSites( state ),
 		previousRoute: getPreviousRoute( state ),

--- a/client/my-sites/email/email-management/home/email-list-active.jsx
+++ b/client/my-sites/email/email-management/home/email-list-active.jsx
@@ -11,7 +11,11 @@ import { CompactCard } from '@automattic/components';
 import SectionHeader from 'calypso/components/section-header';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import EmailTypeIcon from 'calypso/my-sites/email/email-management/home/email-type-icon';
-import { getNumberOfMailboxesText } from 'calypso/my-sites/email/email-management/home/utils';
+import {
+	getNumberOfMailboxesText,
+	resolveEmailPlanStatus,
+} from 'calypso/my-sites/email/email-management/home/utils';
+import MaterialIcon from 'calypso/components/material-icon';
 
 class EmailListActive extends React.Component {
 	render() {
@@ -22,6 +26,9 @@ class EmailListActive extends React.Component {
 		}
 
 		const emailListItems = domains.map( ( domain ) => {
+			const { statusClass, text: warningText } = resolveEmailPlanStatus( domain );
+			const showWarning = statusClass !== 'success';
+
 			return (
 				<CompactCard
 					href={ emailManagement( selectedSiteSlug, domain.name, currentRoute ) }
@@ -34,6 +41,12 @@ class EmailListActive extends React.Component {
 						<h2>{ domain.name }</h2>
 						<span>{ getNumberOfMailboxesText( domain ) }</span>
 					</div>
+					{ showWarning && (
+						<div className="email-list-active__warning">
+							<MaterialIcon icon="info" />
+							<span>{ warningText }</span>
+						</div>
+					) }
 				</CompactCard>
 			);
 		} );

--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -99,6 +99,12 @@ export function hasEmailSubscription( domain ) {
 }
 
 export function resolveEmailPlanStatus( domain ) {
+	const defaultActive = {
+		statusClass: 'success',
+		icon: 'check_circle',
+		text: translate( 'Active' ),
+	};
+
 	const defaultWarning = {
 		statusClass: 'warning',
 		icon: 'info',
@@ -106,10 +112,11 @@ export function resolveEmailPlanStatus( domain ) {
 	};
 
 	if ( hasGSuiteWithUs( domain ) ) {
-		// This is structured this way to fold in ToS acceptance at the account level.
 		if ( hasPendingGSuiteUsers( domain ) ) {
 			return defaultWarning;
 		}
+
+		return defaultActive;
 	}
 
 	if ( hasTitanMailWithUs( domain ) ) {
@@ -120,21 +127,16 @@ export function resolveEmailPlanStatus( domain ) {
 			const startOfToday = new Date();
 			startOfToday.setUTCHours( 0, 0, 0, 0 );
 			if ( titanExpiryDate < startOfToday ) {
-				return {
-					additionalText: translate( 'Your subscription has expired' ),
-					...defaultWarning,
-				};
+				return defaultWarning;
 			}
 		}
 
 		if ( getMaxTitanMailboxCount( domain ) > getConfiguredTitanMailboxCount( domain ) ) {
 			return defaultWarning;
 		}
+
+		return defaultActive;
 	}
 
-	return {
-		statusClass: 'success',
-		icon: 'check_circle',
-		text: translate( 'Active' ),
-	};
+	return defaultActive;
 }

--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -99,13 +99,13 @@ export function hasEmailSubscription( domain ) {
 }
 
 export function resolveEmailPlanStatus( domain ) {
-	const defaultActive = {
+	const defaultActiveStatus = {
 		statusClass: 'success',
 		icon: 'check_circle',
 		text: translate( 'Active' ),
 	};
 
-	const defaultWarning = {
+	const defaultWarningStatus = {
 		statusClass: 'warning',
 		icon: 'info',
 		text: translate( 'Action required' ),
@@ -113,10 +113,10 @@ export function resolveEmailPlanStatus( domain ) {
 
 	if ( hasGSuiteWithUs( domain ) ) {
 		if ( hasPendingGSuiteUsers( domain ) ) {
-			return defaultWarning;
+			return defaultWarningStatus;
 		}
 
-		return defaultActive;
+		return defaultActiveStatus;
 	}
 
 	if ( hasTitanMailWithUs( domain ) ) {
@@ -127,16 +127,16 @@ export function resolveEmailPlanStatus( domain ) {
 			const startOfToday = new Date();
 			startOfToday.setUTCHours( 0, 0, 0, 0 );
 			if ( titanExpiryDate < startOfToday ) {
-				return defaultWarning;
+				return defaultWarningStatus;
 			}
 		}
 
 		if ( getMaxTitanMailboxCount( domain ) > getConfiguredTitanMailboxCount( domain ) ) {
-			return defaultWarning;
+			return defaultWarningStatus;
 		}
 
-		return defaultActive;
+		return defaultActiveStatus;
 	}
 
-	return defaultActive;
+	return defaultActiveStatus;
 }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -49,6 +49,10 @@
 		color: var( --color-text );
 		display: flex;
 
+		> div > h2 {
+			word-break: break-all;
+		}
+
 		> div > span {
 			font-size: $font-body-small;
 			color: var( --color-text-subtle );
@@ -60,15 +64,42 @@
 
 			> span {
 				color: var( --color-error-50 );
+				display: none;
 				vertical-align: middle;
+
+				@include break-small {
+					display: unset;
+				}
+
+				@include break-medium {
+					display: none;
+				}
+
+				@include break-large {
+					display: unset;
+				}
 			}
 
 			> svg {
 				fill: var( --color-error-50 );
 				height: 18px;
 				margin-right: 6px;
+				/* Push the icon down when there is no warning text */
+				margin-top: 3px;
 				vertical-align: middle;
 				width: 18px;
+
+				@include break-small {
+					margin-top: 0;
+				}
+
+				@include break-medium {
+					margin-top: 3px;
+				}
+
+				@include break-large {
+					margin-top: 0;
+				}
 			}
 		}
 	}
@@ -83,8 +114,14 @@
 
 	> img, svg {
 		height: 36px;
+		margin-right: 16px;
+		min-height: 36px;
+		min-width: 36px;
 		width: 36px;
-		margin-right: 24px;
+
+		@include break-large {
+			margin-right: 24px;
+		}
 	}
 	> .gridicon.gridicons-my-sites {
 		fill: var( --color-wordpress-com );

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -46,24 +46,45 @@
 
 .email-list-active {
 	> .card {
-		display: flex;
-		align-items: center;
 		color: var( --color-text );
+		display: flex;
+
 		> div > span {
 			font-size: $font-body-small;
 			color: var( --color-text-subtle );
 		}
+
+		.email-list-active__warning {
+			font-size: $font-body-extra-small;
+			margin-left: 14px;
+
+			> span {
+				color: var( --color-error-50 );
+				vertical-align: middle;
+			}
+
+			> svg {
+				fill: var( --color-error-50 );
+				height: 18px;
+				margin-right: 6px;
+				vertical-align: middle;
+				width: 18px;
+			}
+		}
 	}
+
 	> .card.is-card-link:hover {
 		background-color: var( --color-neutral-0 );
 	}
 }
 
 .email-list-active__item-icon {
+	align-self: center;
+
 	> img, svg {
 		height: 36px;
 		width: 36px;
-		margin-right: 20px;
+		margin-right: 24px;
 	}
 	> .gridicon.gridicons-my-sites {
 		fill: var( --color-wordpress-com );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds in the UI to display warnings on the new email home page
* The PR also expands some of the checks used for identifying warnings (which also apply on the email plan page)
* The PR also removes some unused G Suite data that was fetched for the page

It is worth noting that the responsive  behaviour for the new warnings is affected by the breakpoints where the left menu is visible. The key impact is that we show the warning icon and the text when the screen is wider than mobile, but too narrow to show the left nav, but we then hide the warning text when the screen is slightly wider than the breakpoint where the left nav appears. At full width we show the warning text again.

#### Testing instructions

* Run this branch locally or via the [live branch](https://calypso.live/?branch=add/domain-level-warnings-to-email-home)
* Navigate to `/email` and select a site that has one or more domains with email subscriptions that have issues.
* Verify that we show the warning icon and (depending on screen width) the "Action required" warning text for domains that have the following issues:
   - A G Suite subscription where one or more users need to accept the user-level terms of service.
   - A Professional Email subscription where there are one or more unused mailboxes.
   - An expired Professional Email subscription (we don't have the data for the Google subscriptions yet)
* Ensure that the screen displays well at various widths from mobile up
* For each of the warnings, click through to the email plans page and verify that the header section shows an "Action Required" warning in each case

#### Screenshots

##### Desktop display
<img width="885" alt="Screenshot 2021-05-14 at 12 20 44" src="https://user-images.githubusercontent.com/3376401/118257516-0456b580-b4af-11eb-8443-41daa092b381.png">

##### Mobile display
<img width="515" alt="Screenshot 2021-05-14 at 12 21 17" src="https://user-images.githubusercontent.com/3376401/118257547-0b7dc380-b4af-11eb-8ef7-ccd68fba9a95.png">