### PR TITLE
Make inline help button compact

### DIFF
--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -128,6 +128,7 @@ class InlineHelp extends Component {
 		const inlineHelpButtonClasses = {
 			'inline-help__button': true,
 			'is-active': isPopoverVisible,
+			'is-compact': true,
 		};
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This makes the inline help button compact, so it's not affected by these styles:

https://github.com/Automattic/wp-calypso/blob/fix/make-inline-help-compact/client/signup/style.scss#L141-L143

#### Testing instructions

1. Go to to /start
2. Make your viewport < 660px wide.
3. Inline help should look perfect. Not like [this](https://user-images.githubusercontent.com/87168/117783805-8f377600-b24b-11eb-84fb-4ed92737830d.png).

Fixes: https://github.com/Automattic/wp-calypso/issues/52860