### PR TITLE
Add warning to email plan header for expired email subscription

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan-subscription.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-subscription.jsx
@@ -14,7 +14,7 @@ import AutoRenewToggle from 'calypso/me/purchases/manage-purchase/auto-renew-tog
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 
 class EmailPlanSubscription extends React.Component {
-	isSubscriptionExpired() {
+	hasSubscriptionExpired() {
 		const { isLoadingPurchase, purchase } = this.props;
 
 		if ( isLoadingPurchase || ! purchase ) {
@@ -42,7 +42,7 @@ class EmailPlanSubscription extends React.Component {
 			<RenewButton
 				compact={ true }
 				purchase={ purchase }
-				primary={ this.isSubscriptionExpired() }
+				primary={ this.hasSubscriptionExpired() }
 				selectedSite={ selectedSite }
 				subscriptionId={ parseInt( purchase.id, 10 ) }
 				tracksProps={ { source: 'email-plan-view' } }
@@ -86,14 +86,14 @@ class EmailPlanSubscription extends React.Component {
 			return null;
 		}
 
-		const isSubscriptionExpired = this.isSubscriptionExpired();
+		const hasSubscriptionExpired = this.hasSubscriptionExpired();
 		const translateArgs = {
 			args: {
 				expiryDate: moment.utc( purchase.expiryDate ).format( 'LL' ),
 			},
 			comment: 'Shows the expiry date of the email subscription',
 		};
-		const expiryText = isSubscriptionExpired
+		const expiryText = hasSubscriptionExpired
 			? translate( 'Expired: %(expiryDate)s', translateArgs )
 			: translate( 'Expires: %(expiryDate)s', translateArgs );
 
@@ -101,7 +101,7 @@ class EmailPlanSubscription extends React.Component {
 			<CompactCard className="email-plan-subscription__card">
 				<div
 					className={ classNames( {
-						'email-plan-subscription__expired': isSubscriptionExpired,
+						'email-plan-subscription__expired': hasSubscriptionExpired,
 					} ) }
 				>
 					{ expiryText }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -255,3 +255,7 @@
 		height: 28px;
 	}
 }
+
+.email-plan-subscription__expired {
+	color: var( --color-error-50 );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds logic to the email plan header to display "Expired: [expiryDate]" in red when the subscription has already expired (instead of "Expires: [expiryDate]"), and switches the "Renew now" button to be primary for expired subscriptions

This behaviour is closely related to #52863, where we are flagging expired Professional Email subscriptions, but not showing a relevant warning/CTA on the email plan page.

#### Testing instructions

* Run this branch locally or via the [live branch](https://calypso.live/?branch=add/expiry-warnings-to-email-plan-page)
* Navigate to `/email` and then pick a site that has an expired email subscription (ideally you'd have multiple subscription types)
* Click on the site with the expired email subscription, and then click on the row for the expired subscription
* Verify that the header shows "Expired: [expiryDate]" in red font the second row and the "Renew now" button is shown as a primary CTA
* Go back to your list of emails and visit the Email Plan page for a non-expired, paid email subscription
* Verify that the header shows "Expires: [expiryDate]" in a normal colour and the "Renew now" button is not primary
* Go back to the email list and pick a domain with email forwarding
* Verify that the renewal/subscription section doesn't show at all (this is the existing behaviour)

#### Screenshot
<img width="714" alt="Screenshot 2021-05-14 at 13 25 22" src="https://user-images.githubusercontent.com/3376401/118264438-fa858000-b4b7-11eb-9469-455e81d6f99e.png">
