### PR TITLE
Render new sidebar component on Jetpack sites

### DIFF
--- a/client/state/selectors/is-nav-unification-enabled.js
+++ b/client/state/selectors/is-nav-unification-enabled.js
@@ -2,8 +2,9 @@
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteOption, isJetpackSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import versionCompare from 'calypso/lib/version-compare';
 
 export default ( state ) => {
 	const hasDocument = 'undefined' !== typeof document;
@@ -13,10 +14,11 @@ export default ( state ) => {
 		return false;
 	}
 
-	// Disabled for Jetpack sites.
+	// Disabled for Jetpack sites below 9.8.
 	const siteId = getSelectedSiteId( state );
 	if ( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) {
-		return false;
+		const jetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
+		return jetpackVersion && versionCompare( jetpackVersion, '9.8-alpha', '>=' );
 	}
 
 	return true;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Enables nav unification on Jetpack sites on Calypso.

Technically the menu is still not unified, since WP Admin for Jetpack sites is still considered a separate area and therefore uses a different menu. So this PR is actually changing what React component is used for rendering the menu in order to avoid the current UI inconsistency when switching from a WP.com site to a Jetpack and vice versa. The menu items are virtually the same, just displayed differently.

Before | After
--- | ---
![May-14-2021 14-28-57](https://user-images.githubusercontent.com/1233880/118270790-c95d7d80-b4c0-11eb-8ac5-97ea9f0752dc.gif) | ![May-14-2021 14-29-12](https://user-images.githubusercontent.com/1233880/118270802-ccf10480-b4c0-11eb-8559-cc62cf226ac2.gif)


Note: These changes depends on https://github.com/Automattic/jetpack/pull/19852 (otherwise some menu items would be missing).

#### Testing instructions

- Switch to a Jetpack site running Jetpack 9.7 or below.
- Make sure the old sidebar gets rendered.
- Switch to a Jetpack site running Jetpack 9.8 or above (JP 9.8 has not been released yet, you'd need to install Jetpack Beta and activate `Bleeding Edge`).
- Make sure the new sidebar gets rendered.
