### PR TITLE
FullStory Analytics: adding tracking restrictions

### DIFF
--- a/client/lib/analytics/fullstory.js
+++ b/client/lib/analytics/fullstory.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import cookie from 'cookie';
 import debug from 'debug';
 
 /**
@@ -62,11 +61,6 @@ function maybeAddFullStoryScript() {
 		if ( ! fullStoryScriptLoaded ) {
 			fullStoryDebug( 'maybeAddFullStoryScript:', false );
 		}
-		return;
-	}
-
-	// Only record session for US-based users.
-	if ( 'US' !== cookie.parse( document.cookie ).country_code ) {
 		return;
 	}
 

--- a/client/lib/analytics/fullstory.js
+++ b/client/lib/analytics/fullstory.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import cookie from 'cookie';
 import debug from 'debug';
 
 /**
@@ -42,6 +43,14 @@ export function recordFullStoryEvent( name, _props ) {
 }
 
 function maybeAddFullStoryScript() {
+	// Don't record user activity on Checkout pages
+	if ( document.location.href.indexOf( 'checkout' ) !== -1 ) {
+		if ( window.FS ) {
+			window.FS.shutdown();
+		}
+		return;
+	}
+
 	if (
 		fullStoryScriptLoaded ||
 		! config.isEnabled( 'fullstory' ) ||
@@ -53,6 +62,11 @@ function maybeAddFullStoryScript() {
 		if ( ! fullStoryScriptLoaded ) {
 			fullStoryDebug( 'maybeAddFullStoryScript:', false );
 		}
+		return;
+	}
+
+	// Only record session for US-based users.
+	if ( 'US' !== cookie.parse( document.cookie ).country_code ) {
 		return;
 	}
 


### PR DESCRIPTION
The PR is a followup to #52768 which added FullStory analytics (enabled only on dev environments). This PR adds restrictions to limit FullStory to US-based users only, and to exclude it from VIP users as well as Checkout page activity.

TODO
* Add the VIP exclusion.

#### Testing instructions
* See #52768 for test instructions.
* Navigate to Checkout and confirm that no data is sent to FullStory.
* Navigate away from Checkout and confirm that FullStory tracking restarts

Related to #52768 
