### PR TITLE
Add domain credit check and tweak wording for no domains view

### DIFF
--- a/client/my-sites/email/email-management/home/email-no-domain.jsx
+++ b/client/my-sites/email/email-management/home/email-no-domain.jsx
@@ -5,14 +5,20 @@ import { isFreePlan } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import EmptyContent from 'calypso/components/empty-content';
+import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
 import Illustration from 'calypso/assets/images/customer-home/illustration--task-find-domain.svg';
 
 const EmailNoDomain = ( { selectedSite, translate } ) => {
+	const hasAvailableDomainCredit = useSelector( ( state ) =>
+		hasDomainCredit( state, selectedSite.ID )
+	);
+
 	if ( isFreePlan( selectedSite.plan.product_slug ) ) {
 		return (
 			<EmptyContent
@@ -20,9 +26,23 @@ const EmailNoDomain = ( { selectedSite, translate } ) => {
 				actionURL={ `/plans/${ selectedSite.slug }` }
 				illustration={ Illustration }
 				line={ translate(
-					'Upgrade now, claim your domain and pick from one of our flexible options to connect your domain with email and start getting emails today.'
+					'Upgrade now, set up your domain and pick from one of our flexible options to connect your domain with email and start getting emails today.'
 				) }
 				title={ translate( 'Get your own domain for a custom email address' ) }
+			/>
+		);
+	}
+
+	if ( hasAvailableDomainCredit ) {
+		return (
+			<EmptyContent
+				action={ translate( 'Add a Domain' ) }
+				actionURL={ `/domains/add/${ selectedSite.slug }` }
+				illustration={ Illustration }
+				line={ translate(
+					'Claim your domain, pick from one of our flexible options to connect your domain with email and start getting emails today.'
+				) }
+				title={ translate( 'Claim your free domain to use with a custom email address' ) }
 			/>
 		);
 	}
@@ -33,9 +53,9 @@ const EmailNoDomain = ( { selectedSite, translate } ) => {
 			actionURL={ `/domains/add/${ selectedSite.slug }` }
 			illustration={ Illustration }
 			line={ translate(
-				'Claim your domain, pick from one of our flexible options to connect your domain with email and start getting emails today.'
+				'Set up or buy your domain, pick from one of our flexible email options, and start getting emails today.'
 			) }
-			title={ translate( 'Claim your free domain to use with a custom email address' ) }
+			title={ translate( 'Set up a domain to use with a custom email address' ) }
 		/>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR implements the copy and logic changes proposed in [this comment](https://github.com/Automattic/wp-calypso/pull/52815/files#r632514326) on #52815, which boil down to the following:
  - When the user has a paid plan but has used their domain credit, change the copy to refer to "Buy or set up a domain"
  - When the user has a paid plan and hasn't used their domain credit, keep the existing copy
  - When the user has a free site, use "set up" instead of "claim" as monthly plans don't include a domain

#### Testing instructions

* Run this branch locally or via the [live branch](https://calypso.live/?branch=update/no-domains-cta-email-home)
* For a free site that doesn't have a domain, navigate to `/email/:siteSlug`
* Verify that you see the "Free site" copy in the first screenshot below
* For a site that has a paid plan and has an unused domain credit, navigate to `/email/:siteSlug`
* Verify that you see the "claim"-style copy as per the second screenshot below
* For a site that has a paid plan and doesn't have a domain credit, navigate to `/email/:siteSlug`
* Verify that you see the "set up or buy" copy as per the final screenshot below

#### Screenshots

_Note that all cases below have no domains on the site._

##### Free site
<img width="1146" alt="Screenshot 2021-05-14 at 16 13 04" src="https://user-images.githubusercontent.com/3376401/118283126-527bb100-b4cf-11eb-9c36-f12e9cd3d9f2.png">

##### Site with a paid plan and an available domain credit
<img width="1146" alt="Screenshot 2021-05-14 at 16 09 25" src="https://user-images.githubusercontent.com/3376401/118283025-34ae4c00-b4cf-11eb-9a48-a73c25a3f8ae.png">

##### Site with a paid plan and no available domain credit
<img width="1146" alt="Screenshot 2021-05-14 at 16 09 11" src="https://user-images.githubusercontent.com/3376401/118283011-2e1fd480-b4cf-11eb-850f-66713c38bd68.png">

Related to #52815
