### PR TITLE
Fix default worker count

### DIFF
--- a/client/webpack.common.js
+++ b/client/webpack.common.js
@@ -28,7 +28,7 @@ if ( process.env.CIRCLECI ) {
 } else {
 	workerCount = getEnvVarAsNaturalNumber(
 		'WORKERS',
-		Math.min( Math.max( cpus().length - 1, 2, 32 ) )
+		Math.min( Math.max( cpus().length - 1, 2 ), 32 )
 	);
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the default value of `WORKERS`
* When it was refactored away from `lodash.clamp()`, a bug was introduced

The current code is: `Math.min( Math.max( cpus().length - 1, 2, 32 ) )`. It intends to use the value `cpus().length - 1`, while keeping it inside of the range 2-32. However, it doesn't do that. It mostly returns 32, unless you have more than 32 cpus.

Notice:
 - Math.min() is only provided one scalar argument and as such, does nothing
 - Math.max is provided 3 scalar arguments: c-1, 2, and 32. But there's no reason to provide 2 since 32 will always "win". 

That let me deduce the intended meaning vs. the actual meaning.

#### Testing instructions

Add this patch
```diff
diff --git a/client/webpack.config.js b/client/webpack.config.js
index 5d7ff6fa75..dea38de24b 100644
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -34,6 +34,7 @@ const pkgDir = require( 'pkg-dir' );
 const cacheIdentifier = require( '../build-tools/babel/babel-loader-cache-identifier' );
 const config = require( './server/config' );
 const { workerCount } = require( './webpack.common' );
+console.log( { workerCount } );
 const getAliasesForExtensions = require( '../build-tools/webpack/extensions' );
 const RequireChunkCallbackPlugin = require( '../build-tools/webpack/require-chunk-callback-plugin' );
 const GenerateChunksMapPlugin = require( '../build-tools/webpack/generate-chunks-map-plugin' );
```

Examine the workerCount when running `yarn start` before and after changes.
On my 4 core, 8 thread laptop:
![2021-05-14_11-34](https://user-images.githubusercontent.com/937354/118301413-a1fab680-b4a8-11eb-9688-7ee60a905f0f.png)
![2021-05-14_11-34_1](https://user-images.githubusercontent.com/937354/118301425-a4f5a700-b4a8-11eb-8398-d3046530796f.png)
