### PR TITLE
Add webpack filesystem cache

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -156,6 +156,7 @@ const fileLoader = FileConfig.loader(
 
 const webpackConfig = {
 	bail: ! isDevelopment,
+	cache: { type: 'filesystem' },
 	context: __dirname,
 	entry: filterEntrypoints( {
 		'entry-main': [ path.join( __dirname, 'boot', 'app' ) ],
@@ -269,6 +270,9 @@ const webpackConfig = {
 				extensionsDirectory: path.resolve( __dirname, 'extensions' ),
 			} )
 		),
+		fallback: {
+			fs: false,
+		},
 	},
 	node: false,
 	plugins: [

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -270,9 +270,6 @@ const webpackConfig = {
 				extensionsDirectory: path.resolve( __dirname, 'extensions' ),
 			} )
 		),
-		fallback: {
-			fs: false,
-		},
 	},
 	node: false,
 	plugins: [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable [webpack 5 persistent caching](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#persistent-caching)
* I initially included `resolve.fallback.fs: false` to solve an error I was seeing about not being able to resolve the fs package in the terminal, but I removed it and I can't seem to get the error again. So I did remove it from this branch: 635f34510ae92. But it might be needed? That solution was based off the [webpack 4 -> 5 migration guide](https://webpack.js.org/migrate/5/) ("If you are using something like `node.fs: 'empty'` replace it with `resolve.fallback.fs: false.`").
* Benchmarks


I benchmarked by running `yarn && yarn start`, then attempting to visit http://calypso.localhost:3000. This changeset showed a noticeable improvement in overall time on my laptop (~1m50s -> ~1m00s).
Benchmark results:
```
  no cache - try 1
  00m:00s Start
  00m:30s See Emoji Screen
  02m:00s See home screen loaded in browser
  
  no cache - try 2
  00m:00s Start
  00m:30s See Emoji Screen
  01m:42s See home screen loaded in browser
  
  cache - try 1
  00m:00s Start
  00m:30s See Emoji Screen
  01m:04s See home screen loaded in browser
  
  cache - try 2 
  00m:00s Start
  00m:30s See Emoji Screen
  00m:57s see home screen loaded in browser
```

#### Testing instructions

* Benchmark as above
* Also needs testing in other environments+contexts, like CI