### PR TITLE
Update calypso-build's thread-loader ^2.1.3 -> ^3.0.4

### DIFF
--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## trunk
 
+- Updated dependencies
+  - thread-loader to ^3.0.4
+
 ## 8.0.0
 
 - Breaking: Drop option `postCssConfig` for Sass loader. The property `postCssOptions` will be passed as is

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -71,7 +71,7 @@
 		"sass-loader": "^8.0.0",
 		"semver": "^7.3.2",
 		"terser-webpack-plugin": "^5.1.1",
-		"thread-loader": "^2.1.3",
+		"thread-loader": "^3.0.4",
 		"typescript": "^4.2.4",
 		"webpack-cli": "^4.6.0"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -17427,7 +17427,7 @@ load-json-file@^6.2.0:
     strip-bom "^4.0.0"
     type-fest "^0.6.0"
 
-loader-runner@^2.3.1, loader-runner@^2.4.0:
+loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
@@ -26399,16 +26399,7 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-thread-loader@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/thread-loader/-/thread-loader-2.1.3.tgz#cbd2c139fc2b2de6e9d28f62286ab770c1acbdda"
-  integrity sha512-wNrVKH2Lcf8ZrWxDF/khdlLlsTMczdcwPA9VEK4c2exlEPynYWxi9op3nPTo5lAnDIkE0rQEB3VBP+4Zncc9Hg==
-  dependencies:
-    loader-runner "^2.3.1"
-    loader-utils "^1.1.0"
-    neo-async "^2.6.0"
-
-thread-loader@^3.0.1:
+thread-loader@^3.0.1, thread-loader@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/thread-loader/-/thread-loader-3.0.4.tgz#c392e4c0241fbc80430eb680e4886819b504a31b"
   integrity sha512-ByaL2TPb+m6yArpqQUZvP+5S1mZtXsEP7nWKKlAUTm7fCml8kB5s1uI3+eHRP2bk5mVYfRSBI7FFf+tWEyLZwA==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update calypso-build's thread-loader ^2.1.3 -> ^3.0.4

While looking closely at my `yarn` output I noticed this:

`warning "@automattic/calypso-build > thread-loader@2.1.3" has incorrect peer dependency "webpack@^2.0.0 || ^3.0.0 || ^4.0.0".`

This made me think that thread-loader hasn't been updated in a while, since it doesn't "support" webpack 5. I looked into it deeper and found calypso referencing two copies of threadloader: an older 2.1.3, and a newer 3.0.4 (which does "support" webpack 5).

3.0.4 comes from a sub-dependency of @wordpress/scripts in the main lockfile:
![2021-05-14_15-58](https://user-images.githubusercontent.com/937354/118330377-527ab180-b4cd-11eb-91b3-7d27ac3acbdb.png)

2.1.3 comes from packages/calypso-build/package.json: https://github.com/Automattic/wp-calypso/blob/6faf9c3ae0a747de85afc21717a4e553c4e8980d/packages/calypso-build/package.json#L74

So there end up being two resolutions in the main lockfile:
![2021-05-14_16-01](https://user-images.githubusercontent.com/937354/118330894-9ff71e80-b4cd-11eb-9bcb-fd00160a1f26.png)

Checking the releases, thread-loader 2 -> 3 only [has one breaking change](https://github.com/webpack-contrib/thread-loader/releases): `minimum supported Node.js version is 10.13`. Shouldn't be a problem?

I don't know if this upgrade is actually noticeable, or if removing that one version resolution actually affects bundle sizes in any way. I wanted to do this as a small cleanup and to potentially point out another issue.

Checking the history of `packages/calypso-build/package.json`, a bot is often updating the dependencies: 
![2021-05-14_16-03](https://user-images.githubusercontent.com/937354/118331313-0ed47780-b4ce-11eb-9c2b-5ec68138feab.png)
But `thread-loader` was getting left behind. Could this be a symptom of a wider problem of some packages not being noticed by the bot (or maybe we just don't have time to manually review/check the upgrades?)  For example, if I look for more webpack peer errors there are a few other loaders which are probably out of date:

```
warning "@automattic/calypso-build > cache-loader@4.1.0" has incorrect peer dependency "webpack@^4.0.0".
warning "@automattic/calypso-build > file-loader@4.3.0" has incorrect peer dependency "webpack@^4.0.0".
```

Could be some similar issues.



#### Testing instructions

* Use calypso?