### PR TITLE
Playwright: Refactor framework interaction with config values and environment variables.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -777,8 +777,8 @@ object RunCalypsoPlaywrightE2eTests : BuildType({
 				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
 
 				# Run the test
-				export BROWSERSIZE="mobile"
-				export BROWSERLOCALE="en"
+				export DISPLAYSIZE="mobile"
+				export TARGETLOCALE="en"
 				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 
 				xvfb-run yarn magellan --config=magellan-playwright.json --max_workers=%E2E_WORKERS% --local_browser=chrome --mocha_args="--reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter.json"

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -777,8 +777,8 @@ object RunCalypsoPlaywrightE2eTests : BuildType({
 				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
 
 				# Run the test
-				export DISPLAYSIZE="mobile"
-				export TARGETLOCALE="en"
+				export VIEWPORT_SIZE="mobile"
+				export LOCALE="en"
 				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 
 				xvfb-run yarn magellan --config=magellan-playwright.json --max_workers=%E2E_WORKERS% --local_browser=chrome --mocha_args="--reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter.json"

--- a/packages/calypso-e2e/src/browser-helper.ts
+++ b/packages/calypso-e2e/src/browser-helper.ts
@@ -1,55 +1,61 @@
 /**
+ * External dependencies
+ */
+import config from 'config';
+
+/**
  * Internal dependencies
  */
-import type { screenSize, localeCode } from './types';
+import type { displaySize, localeCode, displayDimensions } from './types';
 
 /**
  * Returns the target screen size for tests to run against.
  *
- * By default, this function will return 'desktop' as the target.
- * To specify another screen size, set the BROWSERSIZE environment variable.
+ * If the environment variable BROWSERSIZE is set, this will override all configuration
+ * values. Otherwise, the default path contained in the configuration file is returned.
  *
- * @returns {screenSize} Target screen size.
+ * @returns {displaySize} Target screen size.
  */
-export function getTargetScreenSize(): screenSize {
-	return ! process.env.BROWSERSIZE
-		? 'desktop'
-		: ( process.env.BROWSERSIZE.toLowerCase() as screenSize );
+export function getTargetDisplaySize(): displaySize {
+	return ! process.env.DISPLAYSIZE
+		? config.get( 'displaySize' )
+		: ( process.env.DISPLAYSIZE.toLowerCase() as displaySize );
 }
 
 /**
  * Returns the locale under test.
  *
- * By default, this function will return 'en' as the locale.
- * To set the locale, set the BROWSERLOCALE environment variable.
+ * If the environment variable BROWSERLOCALE is set, this will override all configuration
+ * values. Otherwise, the default path contained in the configuration file is returned.
  *
  * @returns {localeCode} Target locale code.
  */
 export function getTargetLocale(): localeCode {
-	return ! process.env.BROWSERLOCALE ? 'en' : process.env.BROWSERLOCALE.toLowerCase();
+	return ! process.env.TARGETLOCALE
+		? config.get( 'locale' )
+		: process.env.TARGETLOCALE.toLowerCase();
 }
 
 /**
  * Returns a set of screen dimensions in numbers.
  *
- * This function takes the output of `getTargetScreenSize` and returns an
+ * This function takes the output of `getTargetDisplaySize` and returns an
  * object key/value mapping of the screen diemensions represented by
  * the output.
  *
- * @returns {number, number} Object with key/value mapping of screen dimensions.
+ * @param {displaySize} [target] Target display size to use, overriding defaults.
+ * @returns {displayDimensions} Object with key/value mapping of screen dimensions.
  * @throws {Error} If target screen size was not set.
  */
-export function getScreenDimension(): { width: number; height: number } {
-	switch ( getTargetScreenSize() ) {
-		case 'mobile':
-			return { width: 400, height: 1000 };
-		case 'tablet':
-			return { width: 1024, height: 1000 };
-		case 'desktop':
-			return { width: 1440, height: 1000 };
-		case 'laptop':
-			return { width: 1400, height: 790 };
-		default:
-			throw new Error( 'Unsupported screen size specified.' );
+export function getDisplayResolution( target?: displaySize ): displayDimensions {
+	if ( ! target ) {
+		target = getTargetDisplaySize();
+	}
+
+	try {
+		const resolutions: { [ key: string ]: displayDimensions } = config.get( 'displayResolutions' );
+		return resolutions[ target ];
+	} catch ( err ) {
+		throw new Error( 'Unsupported screen size specified.' );
 	}
 }

--- a/packages/calypso-e2e/src/browser-helper.ts
+++ b/packages/calypso-e2e/src/browser-helper.ts
@@ -6,7 +6,7 @@ import config from 'config';
 /**
  * Internal dependencies
  */
-import type { displaySize, localeCode, displayDimensions } from './types';
+import type { viewportName, localeCode, viewportSize } from './types';
 
 /**
  * Returns the target screen size for tests to run against.
@@ -14,12 +14,12 @@ import type { displaySize, localeCode, displayDimensions } from './types';
  * If the environment variable BROWSERSIZE is set, this will override all configuration
  * values. Otherwise, the default path contained in the configuration file is returned.
  *
- * @returns {displaySize} Target screen size.
+ * @returns {viewportName} Target screen size.
  */
-export function getTargetDisplaySize(): displaySize {
-	return ! process.env.DISPLAYSIZE
-		? config.get( 'displaySize' )
-		: ( process.env.DISPLAYSIZE.toLowerCase() as displaySize );
+export function getViewportName(): viewportName {
+	return ! process.env.VIEWPORT_NAME
+		? config.get( 'viewportName' )
+		: ( process.env.VIEWPORT_NAME.toLowerCase() as viewportName );
 }
 
 /**
@@ -30,30 +30,28 @@ export function getTargetDisplaySize(): displaySize {
  *
  * @returns {localeCode} Target locale code.
  */
-export function getTargetLocale(): localeCode {
-	return ! process.env.TARGETLOCALE
-		? config.get( 'locale' )
-		: process.env.TARGETLOCALE.toLowerCase();
+export function getLocale(): localeCode {
+	return ! process.env.LOCALE ? config.get( 'locale' ) : process.env.LOCALE.toLowerCase();
 }
 
 /**
  * Returns a set of screen dimensions in numbers.
  *
- * This function takes the output of `getTargetDisplaySize` and returns an
+ * This function takes the output of `getViewportName` and returns an
  * object key/value mapping of the screen diemensions represented by
  * the output.
  *
- * @param {displaySize} [target] Target display size to use, overriding defaults.
- * @returns {displayDimensions} Object with key/value mapping of screen dimensions.
+ * @param {viewportName} [target] Target display size to use, overriding defaults.
+ * @returns {viewportSize} Object with key/value mapping of screen dimensions.
  * @throws {Error} If target screen size was not set.
  */
-export function getDisplayResolution( target?: displaySize ): displayDimensions {
+export function getViewportSize( target?: viewportName ): viewportSize {
 	if ( ! target ) {
-		target = getTargetDisplaySize();
+		target = getViewportName();
 	}
 
 	try {
-		const resolutions: { [ key: string ]: displayDimensions } = config.get( 'displayResolutions' );
+		const resolutions: { [ key: string ]: viewportSize } = config.get( 'viewportSize' );
 		return resolutions[ target ];
 	} catch ( err ) {
 		throw new Error( 'Unsupported screen size specified.' );

--- a/packages/calypso-e2e/src/browser-helper.ts
+++ b/packages/calypso-e2e/src/browser-helper.ts
@@ -17,9 +17,9 @@ import type { viewportName, localeCode, viewportSize } from './types';
  * @returns {viewportName} Target screen size.
  */
 export function getViewportName(): viewportName {
-	return ! process.env.VIEWPORT_NAME
-		? config.get( 'viewportName' )
-		: ( process.env.VIEWPORT_NAME.toLowerCase() as viewportName );
+	return (
+		process.env.VIEWPORT_NAME || config.get( 'viewportName' )!
+	).toLowerCase() as viewportName;
 }
 
 /**
@@ -31,7 +31,7 @@ export function getViewportName(): viewportName {
  * @returns {localeCode} Target locale code.
  */
 export function getLocale(): localeCode {
-	return ! process.env.LOCALE ? config.get( 'locale' ) : process.env.LOCALE.toLowerCase();
+	return ( process.env.LOCALE || config.get( 'locale' )! ).toLowerCase() as localeCode;
 }
 
 /**
@@ -50,10 +50,9 @@ export function getViewportSize( target?: viewportName ): viewportSize {
 		target = getViewportName();
 	}
 
-	try {
-		const resolutions: { [ key: string ]: viewportSize } = config.get( 'viewportSize' );
-		return resolutions[ target ];
-	} catch ( err ) {
-		throw new Error( 'Unsupported screen size specified.' );
+	const sizes: { [ key: string ]: viewportSize } = config.get( 'viewportSize' );
+	if ( ! Object.keys( sizes ).includes( target ) ) {
+		throw new Error( `Unsupported viewport: ${ target }` );
 	}
+	return sizes[ target ];
 }

--- a/packages/calypso-e2e/src/browser-manager.ts
+++ b/packages/calypso-e2e/src/browser-manager.ts
@@ -15,12 +15,12 @@ import type { Browser, BrowserContext, Page } from 'playwright';
  * Internal dependencies
  */
 import { getVideoDir, getDateString, getAssetDir } from './media-helper';
-import { getDisplayResolution } from './browser-helper';
+import { getViewportSize } from './browser-helper';
 
 /**
  * Type dependencies
  */
-import { displayDimensions } from './types';
+import { viewportSize } from './types';
 
 /**
  * Constants
@@ -71,7 +71,7 @@ export async function launchBrowserContext(): Promise< BrowserContext > {
 
 	// By default, record video for each browser context.
 	const videoDir = getVideoDir();
-	const dimension: displayDimensions = getDisplayResolution();
+	const dimension: viewportSize = getViewportSize();
 	const timestamp = getDateString();
 	const userAgent = `user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${ await browser.version() } Safari/537.36`;
 
@@ -100,7 +100,7 @@ export async function launchBrowserContext(): Promise< BrowserContext > {
 export async function launchBrowser(): Promise< Browser > {
 	const isHeadless = process.env.HEADLESS === 'true' || config.has( 'headless' );
 
-	const dimension = getDisplayResolution();
+	const dimension: viewportSize = getViewportSize();
 
 	return await chromium.launch( {
 		headless: isHeadless,

--- a/packages/calypso-e2e/src/browser-manager.ts
+++ b/packages/calypso-e2e/src/browser-manager.ts
@@ -15,7 +15,12 @@ import type { Browser, BrowserContext, Page } from 'playwright';
  * Internal dependencies
  */
 import { getVideoDir, getDateString, getAssetDir } from './media-helper';
-import { getScreenDimension } from './browser-helper';
+import { getDisplayResolution } from './browser-helper';
+
+/**
+ * Type dependencies
+ */
+import { displayDimensions } from './types';
 
 /**
  * Constants
@@ -66,7 +71,7 @@ export async function launchBrowserContext(): Promise< BrowserContext > {
 
 	// By default, record video for each browser context.
 	const videoDir = getVideoDir();
-	const dimension = getScreenDimension();
+	const dimension: displayDimensions = getDisplayResolution();
 	const timestamp = getDateString();
 	const userAgent = `user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${ await browser.version() } Safari/537.36`;
 
@@ -95,7 +100,7 @@ export async function launchBrowserContext(): Promise< BrowserContext > {
 export async function launchBrowser(): Promise< Browser > {
 	const isHeadless = process.env.HEADLESS === 'true' || config.has( 'headless' );
 
-	const dimension = getScreenDimension();
+	const dimension = getDisplayResolution();
 
 	return await chromium.launch( {
 		headless: isHeadless,

--- a/packages/calypso-e2e/src/media-helper.ts
+++ b/packages/calypso-e2e/src/media-helper.ts
@@ -2,37 +2,50 @@
  * External dependencies
  */
 import path from 'path';
+import config from 'config';
 
 /**
  * Internal dependencies
  */
-import { getTargetLocale, getTargetScreenSize } from './browser-helper';
+import { getTargetLocale, getTargetDisplaySize } from './browser-helper';
+
+const artifacts: { [ key: string ]: string } = config.get( 'artifacts' );
 
 /**
  * Returns the base asset directory.
  *
+ * If the environment variable TEMP_ASSET_PATH is set, this will return a path
+ * to the directory. Otherwise, the parent directory of this current file.
+ *
  * @returns {string} Absolute path to the directory.
  */
 export function getAssetDir(): string {
+	console.log( __dirname );
 	return path.resolve( process.env.TEMP_ASSET_PATH || path.join( __dirname, '..' ) );
 }
 
 /**
  * Returns the screenshot save directory.
  *
+ * If the environment variable SCREENSHOTDIR is set, this will override all configuration
+ * values. Otherwise, the default path contained in the configuration file is returned.
+ *
  * @returns {string} Absolute path to the directory.
  */
 export function getScreenshotDir(): string {
-	return path.resolve( getAssetDir(), process.env.SCREENSHOTDIR || 'screenshots' );
+	return path.resolve( getAssetDir(), process.env.SCREENSHOTDIR || artifacts.screenshot );
 }
 
 /**
  * Returns the video save directory.
  *
+ * If the environment variable VIDEODIR is set, this will override all configuration
+ * values. Otherwise, the default path contained in the configuration file is returned.
+ *
  * @returns {string} Absolute path to the directory.
  */
 export function getVideoDir(): string {
-	return path.resolve( getAssetDir(), process.env.VIDEODIR || 'screenshots/videos' );
+	return path.resolve( getAssetDir(), process.env.VIDEODIR || artifacts.video );
 }
 
 /**
@@ -43,7 +56,7 @@ export function getVideoDir(): string {
  */
 export function getScreenshotName( name: string ): string {
 	const shortTestFileName = name.replace( /[^a-z0-9]/gi, '-' ).toLowerCase();
-	const screenSize = getTargetScreenSize().toUpperCase();
+	const screenSize = getTargetDisplaySize().toUpperCase();
 	const locale = getTargetLocale().toUpperCase();
 	const date = getDateString();
 	const fileName = `FAILED-${ locale }-${ screenSize }-${ shortTestFileName }-${ date }`;
@@ -60,7 +73,7 @@ export function getScreenshotName( name: string ): string {
 export function getVideoName( name: string ): string {
 	const suiteName = name.replace( /[^a-z0-9]/gi, '-' ).toLowerCase();
 	const locale = getTargetLocale().toUpperCase();
-	const screenSize = getTargetScreenSize().toUpperCase();
+	const screenSize = getTargetDisplaySize().toUpperCase();
 	const date = getDateString();
 	const fileName = `FAILED-${ locale }-${ screenSize }-${ suiteName }-${ date }`;
 	const videoDir = getVideoDir();

--- a/packages/calypso-e2e/src/media-helper.ts
+++ b/packages/calypso-e2e/src/media-helper.ts
@@ -20,7 +20,6 @@ const artifacts: { [ key: string ]: string } = config.get( 'artifacts' );
  * @returns {string} Absolute path to the directory.
  */
 export function getAssetDir(): string {
-	console.log( __dirname );
 	return path.resolve( process.env.TEMP_ASSET_PATH || path.join( __dirname, '..' ) );
 }
 

--- a/packages/calypso-e2e/src/media-helper.ts
+++ b/packages/calypso-e2e/src/media-helper.ts
@@ -7,7 +7,7 @@ import config from 'config';
 /**
  * Internal dependencies
  */
-import { getTargetLocale, getTargetDisplaySize } from './browser-helper';
+import { getLocale, getViewportName } from './browser-helper';
 
 const artifacts: { [ key: string ]: string } = config.get( 'artifacts' );
 
@@ -55,8 +55,8 @@ export function getVideoDir(): string {
  */
 export function getScreenshotName( name: string ): string {
 	const shortTestFileName = name.replace( /[^a-z0-9]/gi, '-' ).toLowerCase();
-	const screenSize = getTargetDisplaySize().toUpperCase();
-	const locale = getTargetLocale().toUpperCase();
+	const screenSize = getViewportName().toUpperCase();
+	const locale = getLocale().toUpperCase();
 	const date = getDateString();
 	const fileName = `FAILED-${ locale }-${ screenSize }-${ shortTestFileName }-${ date }`;
 	const screenshotDir = getScreenshotDir();
@@ -71,8 +71,8 @@ export function getScreenshotName( name: string ): string {
  */
 export function getVideoName( name: string ): string {
 	const suiteName = name.replace( /[^a-z0-9]/gi, '-' ).toLowerCase();
-	const locale = getTargetLocale().toUpperCase();
-	const screenSize = getTargetDisplaySize().toUpperCase();
+	const locale = getLocale().toUpperCase();
+	const screenSize = getViewportName().toUpperCase();
 	const date = getDateString();
 	const fileName = `FAILED-${ locale }-${ screenSize }-${ suiteName }-${ date }`;
 	const videoDir = getVideoDir();

--- a/packages/calypso-e2e/src/types.d.ts
+++ b/packages/calypso-e2e/src/types.d.ts
@@ -1,8 +1,8 @@
 // Browser Manager
-export type displaySize = 'desktop' | 'mobile' | 'laptop' | 'tablet';
+export type viewportName = 'desktop' | 'mobile' | 'laptop' | 'tablet';
 export type localeCode = string;
 
-export type displayDimensions = {
+export type viewportSize = {
 	width: number;
 	height: number;
 };

--- a/packages/calypso-e2e/src/types.d.ts
+++ b/packages/calypso-e2e/src/types.d.ts
@@ -1,3 +1,8 @@
 // Browser Manager
-export type screenSize = 'desktop' | 'mobile' | 'laptop' | 'tablet';
+export type displaySize = 'desktop' | 'mobile' | 'laptop' | 'tablet';
 export type localeCode = string;
+
+export type displayDimensions = {
+	width: number;
+	height: number;
+};

--- a/test/e2e/config/default.json
+++ b/test/e2e/config/default.json
@@ -24,8 +24,8 @@
 		"video": "screenshots/videos",
 		"log": "."
 	},
-	"displaySize": "desktop",
-	"displayResolutions": {
+	"viewportName": "desktop",
+	"viewportSize": {
 		"mobile": {
 			"width": 400,
 			"height": 1000

--- a/test/e2e/config/default.json
+++ b/test/e2e/config/default.json
@@ -19,6 +19,31 @@
 	"reportWarningsToSlack": false,
 	"closeBrowserOnComplete": true,
 	"highlightElements": false,
+	"artifacts": {
+		"screenshot": "screenshots",
+		"video": "screenshots/videos",
+		"log": "."
+	},
+	"displaySize": "desktop",
+	"displayResolutions": {
+		"mobile": {
+			"width": 400,
+			"height": 1000
+		},
+		"tablet": {
+			"width": 1024,
+			"height": 1000
+		},
+		"desktop": {
+			"width": 1440,
+			"height": 1000
+		},
+		"laptop": {
+			"width": 1440,
+			"height": 790
+		}
+	},
+	"locale": "en",
 	"sauceConfigurations": {
 		"osx-chrome": {
 			"browserName": "chrome",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to refactor environment variable names, config values and how the Playwright framework interacts with these values.

- rename two environment variables: `BROWSERSIZE`→`DISPLAYSIZE`, `BROWSERLOCALE`→`TARGETLOCALE`
- rename functions in MediaHelper and BrowserHelper to align with the changes above.
- add new TypeScript types.
- add new config values in `default.json` that are read by the framework to set up the environment before executing tests.

#### Testing instructions

Ensure that TeamCity is able to run the test suite.
Ensure that artifacts produced are appropriately sized display resolution wise.

Related: #51082
Parent: #52843
Child: #53031