### PR TITLE
Checkout: Show custom disabled button for Google Pay when disabled

### DIFF
--- a/packages/wpcom-checkout/src/payment-request-button.tsx
+++ b/packages/wpcom-checkout/src/payment-request-button.tsx
@@ -59,7 +59,15 @@ export default function PaymentRequestButton( {
 		return <ApplePayButton disabled={ disabled } onClick={ onClick } />;
 	}
 	if ( paymentType === 'google-pay' ) {
-		return <GooglePayButton disabled={ disabled } onClick={ onClick } />;
+		// Google Pay branding does not have a disabled state so we will render a different button
+		if ( disabled ) {
+			return (
+				<Button disabled fullWidth>
+					{ __( 'Select a payment card' ) }
+				</Button>
+			);
+		}
+		return <GooglePayButton onClick={ onClick } />;
 	}
 	return (
 		<Button disabled={ disabled } onClick={ onClick } fullWidth>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the the checkout payment button is displayed, but the final payment step is not active, the button is displayed in a disabled state. When the Google Pay payment method was added in #52311, we neglected to include a disabled state (the button is disabled, but still _looks_ enabled). However, the [Google Pay branding guidelines](https://developers.google.com/pay/api/web/guides/brand-guidelines) say not to modify the button's appearance, so making it greyed-out is probably not an option. Instead, this PR replaces the branded button with a custom disabled button when it's disabled.

Before:

<img width="579" alt="Screen Shot 2021-05-14 at 6 46 52 PM" src="https://user-images.githubusercontent.com/2036909/118338689-c4aac080-b4e4-11eb-90f4-f842ee983c17.png">


After:

<img width="583" alt="Screen Shot 2021-05-14 at 6 43 12 PM" src="https://user-images.githubusercontent.com/2036909/118338665-b6f53b00-b4e4-11eb-90e9-e5a01fd3bcdc.png">


#### Testing instructions

- Enter checkout with a product in your cart.
- Make sure that you can see the Google Pay payment method. You'll need at least one card active in your Google Pay wallet and you'll need to be viewing the page over https. See #52311 if you need help with this.
- At the last step of checkout, select Google Pay as the payment method.
- Verify that the pay button appears enabled and has Google Branding.
- Click the "Edit" button on the first step of checkout (the order review), which will disable the rest of the form.
- Verify that the pay button appears disabled.