### PR TITLE
Reader: Update Reader CSS for Story block

### DIFF
--- a/client/blocks/reader-full-post/story.scss
+++ b/client/blocks/reader-full-post/story.scss
@@ -1,6 +1,7 @@
 $wp-story-background-color: #0e1112;
 
 .wp-story-container {
+	display: block;
 	height: 320px;
 	width: 180px;
 	margin-left: auto;
@@ -15,6 +16,8 @@ $wp-story-background-color: #0e1112;
 	-webkit-tap-highlight-color: transparent;
 	box-shadow: 0 2px 12px rgba( 0, 0, 0, 0.25 );
 	transition: box-shadow 0.3s ease-in-out, transform 0.3s cubic-bezier( 0.18, 0.14, 0.25, 1 );
+	break-inside: avoid;
+	page-break-inside: avoid;
 
 	figure {
 		transition: transform 0.3s cubic-bezier( 0.18, 0.14, 0.25, 1 );
@@ -22,9 +25,9 @@ $wp-story-background-color: #0e1112;
 
 	&:hover {
 		box-shadow: 0 4px 12px rgba( 0, 0, 0, 0.3 );
-		transform: scale( 1.03, 1.03 );
+		transform: scale3d( 1.03, 1.03, 1 );
 		figure {
-			transform: scale( 1.07, 1.07 );
+			transform: scale3d( 1.07, 1.07, 1 );
 		}
 	}
 
@@ -39,7 +42,7 @@ $wp-story-background-color: #0e1112;
 	.wp-story-wrapper {
 		display: block;
 		position: absolute;
-		height: auto;
+		height: 100%;
 		bottom: 0;
 		top: 0;
 		left: 0;

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -204,7 +204,8 @@ function embedSlideshow( domNode ) {
 function embedStory( domNode ) {
 	debug( 'processing story for ', domNode );
 
-	const storyLink = domNode.querySelector( 'a.wp-story-container' );
+	// wp-story-overlay is here for backwards compatiblity with Stories on Jetpack 9.7 and below.
+	const storyLink = domNode.querySelector( 'a.wp-story-container, a.wp-story-overlay' );
 
 	// Open story in a new tab
 	if ( storyLink ) {

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -204,7 +204,7 @@ function embedSlideshow( domNode ) {
 function embedStory( domNode ) {
 	debug( 'processing story for ', domNode );
 
-	const storyLink = domNode.querySelector( 'a.wp-story-overlay' );
+	const storyLink = domNode.querySelector( 'a.wp-story-container' );
 
 	// Open story in a new tab
 	if ( storyLink ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes the broken CSS when rendering a Story block in the Reader detail view, by bringing in the relevant changes from https://github.com/Automattic/jetpack/pull/19746, https://github.com/Automattic/jetpack/pull/19788, and https://github.com/Automattic/jetpack/pull/19631.

![calypso-story-css-fix](https://user-images.githubusercontent.com/9613966/118344604-f5810900-b569-11eb-88b6-abb1296ae728.png)

Also updates the link selector so that Story links continue to open in a new tab as they did before.

(CSS originally added to Calypso in https://github.com/Automattic/wp-calypso/pull/45397.)

#### Testing instructions

##### WordPress.com
* Open the Reader at http://calypso.localhost:3000/.
* Subscribe to a WordPress.com site that has stories.
* Open a story in full page, confirm the CSS is applied and the preview looks normal.
* Click on the embed, a new tab should open and the story should load in fullscreen.

##### Jetpack (backwards compatibility)
* Open the Reader.
* Select a story from a Jetpack site running 9.7 or earlier (i.e. before the fixes mentioned above).
* Open a story in full page, confirm the CSS is applied and the preview looks normal.
* Click on the embed, a new tab should open and the story should load in fullscreen.
