### PR TITLE
DismissibleCard: refactor to hooks, remove Lodash

### DIFF
--- a/client/blocks/dismissible-card/docs/example.jsx
+++ b/client/blocks/dismissible-card/docs/example.jsx
@@ -2,8 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
-import { partial } from 'lodash';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -12,7 +11,13 @@ import { Button } from '@automattic/components';
 import DismissibleCard from '../';
 import { savePreference } from 'calypso/state/preferences/actions';
 
-function DismissibleCardExample( { clearPreference } ) {
+function DismissibleCardExample() {
+	const dispatch = useDispatch();
+
+	function clearPreference() {
+		dispatch( savePreference( 'dismissible-card-example', null ) );
+	}
+
 	return (
 		<div className="docs__design-assets-group">
 			<h2>
@@ -29,10 +34,6 @@ function DismissibleCardExample( { clearPreference } ) {
 	);
 }
 
-const ConnectedDismissibleCardExample = connect( null, {
-	clearPreference: partial( savePreference, 'dismissible-card-example', null ),
-} )( DismissibleCardExample );
+DismissibleCardExample.displayName = 'DismissibleCard';
 
-ConnectedDismissibleCardExample.displayName = 'DismissibleCard';
-
-export default ConnectedDismissibleCardExample;
+export default DismissibleCardExample;

--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -3,10 +3,8 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import { flow } from 'lodash';
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -23,71 +21,37 @@ import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/prefe
 import './style.scss';
 
 const PREFERENCE_PREFIX = 'dismissible-card-';
-const noop = () => {};
 
-class DismissibleCard extends Component {
-	static propTypes = {
-		className: PropTypes.string,
-		dismissCard: PropTypes.func,
-		highlight: PropTypes.oneOf( [ 'error', 'info', 'success', 'warning' ] ),
-		isDismissed: PropTypes.bool,
-		temporary: PropTypes.bool,
-		onClick: PropTypes.func,
-		preferenceName: PropTypes.string.isRequired,
-	};
+function DismissibleCard( { className, highlight, temporary, onClick, preferenceName, children } ) {
+	const preference = `${ PREFERENCE_PREFIX }${ preferenceName }`;
+	const isDismissed = useSelector( ( state ) => getPreference( state, preference ) );
+	const hasReceivedPreferences = useSelector( hasReceivedRemotePreferences );
+	const dispatch = useDispatch();
 
-	static defaultProps = {
-		onClick: noop,
-	};
-
-	render() {
-		const {
-			className,
-			highlight,
-			isDismissed,
-			onClick,
-			dismissCard,
-			hasReceivedPreferences,
-		} = this.props;
-
-		if ( isDismissed || ! hasReceivedPreferences ) {
-			return null;
-		}
-
-		return (
-			<Card className={ className } highlight={ highlight }>
-				<QueryPreferences />
-				<Gridicon
-					icon="cross"
-					className="dismissible-card__close-icon"
-					onClick={ flow( onClick, dismissCard ) }
-				/>
-				{ this.props.children }
-			</Card>
-		);
+	if ( isDismissed || ! hasReceivedPreferences ) {
+		return null;
 	}
+
+	function handleClick( event ) {
+		onClick?.( event );
+		dispatch( ( temporary ? setPreference : savePreference )( preference, true ) );
+	}
+
+	return (
+		<Card className={ className } highlight={ highlight }>
+			<QueryPreferences />
+			<Gridicon icon="cross" className="dismissible-card__close-icon" onClick={ handleClick } />
+			{ children }
+		</Card>
+	);
 }
 
-export default connect(
-	( state, ownProps ) => {
-		const preference = `${ PREFERENCE_PREFIX }${ ownProps.preferenceName }`;
+DismissibleCard.propTypes = {
+	className: PropTypes.string,
+	highlight: PropTypes.oneOf( [ 'error', 'info', 'success', 'warning' ] ),
+	temporary: PropTypes.bool,
+	onClick: PropTypes.func,
+	preferenceName: PropTypes.string.isRequired,
+};
 
-		return {
-			isDismissed: getPreference( state, preference ),
-			hasReceivedPreferences: hasReceivedRemotePreferences( state ),
-		};
-	},
-	( dispatch, ownProps ) =>
-		bindActionCreators(
-			{
-				dismissCard: () => {
-					const preference = `${ PREFERENCE_PREFIX }${ ownProps.preferenceName }`;
-					if ( ownProps.temporary ) {
-						return setPreference( preference, true );
-					}
-					return savePreference( preference, true );
-				},
-			},
-			dispatch
-		)
-)( DismissibleCard );
+export default DismissibleCard;


### PR DESCRIPTION
Refactors `DismissibleCard` to a function component with hooks, removing usage of APIs and patterns we consider legacy:
- no more Lodash
- no more `noop` for default props
- removes `bindActionCreators` usage

**How to test:**
Play with the devdocs example and verify it works OK