### PR TITLE
ci(e2e): Remove the domain registration from the cart

### DIFF
--- a/test/e2e/lib/components/shopping-cart-widget-component.js
+++ b/test/e2e/lib/components/shopping-cart-widget-component.js
@@ -43,4 +43,27 @@ export default class ShoppingCartWidgetComponent extends AsyncBaseContainer {
 			}
 		}
 	}
+
+	async removeDomainRegistraion( domain ) {
+		return this.remove( 'domain_reg', domain );
+	}
+
+	async remove( type, name ) {
+		const cartBadgeLocator = by.css( '.cart__count-badge' );
+
+		const present = await driverHelper.isElementLocated( this.driver, cartBadgeLocator );
+		if ( present ) {
+			await this.open();
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				by.xpath(
+					// Find an element X with class=.cart-item
+					//    that contains an element with data-e2e-product-slug=`type`
+					//    and a sibling with class="product-domain" and text=`name`
+					// and then select an element inside X that matches class=cart__remove-item
+					`//*[@class="cart-item"][.//*[@data-e2e-product-slug="${ type }"]/following-sibling::*[@class="product-domain"][text()="${ name }"]]//*[@class="cart__remove-item"]`
+				)
+			);
+		}
+	}
 }

--- a/test/e2e/lib/components/shopping-cart-widget-component.js
+++ b/test/e2e/lib/components/shopping-cart-widget-component.js
@@ -48,6 +48,10 @@ export default class ShoppingCartWidgetComponent extends AsyncBaseContainer {
 		return this.remove( 'domain_reg', domain );
 	}
 
+	async removeDomainMapping( domain ) {
+		return this.remove( 'domain_map', domain );
+	}
+
 	async remove( type, name ) {
 		const cartBadgeLocator = by.css( '.cart__count-badge' );
 

--- a/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
@@ -205,7 +205,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 			await DomainsPage.Expect( driver );
 			try {
 				const shoppingCartWidgetComponent = await ShoppingCartWidgetComponent.Expect( driver );
-				await shoppingCartWidgetComponent.empty();
+				await shoppingCartWidgetComponent.removeDomainMapping( blogName );
 			} catch {
 				console.log( 'Cart already empty' );
 			}

--- a/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
@@ -117,9 +117,9 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 			await DomainsPage.Expect( driver );
 			try {
 				const shoppingCartWidgetComponent = await ShoppingCartWidgetComponent.Expect( driver );
-				await shoppingCartWidgetComponent.empty();
+				await shoppingCartWidgetComponent.removeDomainRegistraion( expectedDomainName );
 			} catch {
-				console.log( 'Cart already empty' );
+				console.log( `Can't clean up domain registration for ${ expectedDomainName } from cart` );
 			}
 		} );
 	} );


### PR DESCRIPTION
#### Background

The e2e for Manage Domain was failing with

```
TimeoutError: Waiting for element to be clickable By(css selector, .gsuite-upsell-card__skip-button)
Wait timed out after 21299ms
Error: TimeoutError: Waiting for element to be clickable By(css selector, .gsuite-upsell-card__skip-button)
Wait timed out after 21299ms
at Proxy.<anonymous> (lib/driver-manager.js:104:14)
at processTicksAndRejections (internal/process/task_queues.js:93:5)
at async Proxy.clickWhenClickable (lib/driver-helper.js:78:18)
at async FindADomainComponent.declineGoogleApps (lib/components/find-a-domain-component.js:115:3)
at async Context.<anonymous> (specs/specs-calypso/wp-manage-domains-spec.js:98:11)
```

Looking at the code and screenshots, that screen should appear when the user enters a new `.com` domain. However, in some cases, we get this error:

![image](https://user-images.githubusercontent.com/975703/118465093-d74e1100-b701-11eb-9064-643730a284f7.png)

I manage to reproduce it using this flow:

- Start a browser, add a random `.com` domain to my cart
- In a new browser, clean up the shopping cart
- Continue to the Gmail screen.

Coincidentally, the only file that cleans the shopping cart is `test/e2e/specs/specs-calypso/wp-manage-domains-spec.js`, the same file that contains the flakey test.

#### Changes proposed in this Pull Request

* Implement methods in the Shopping Cart widget helper to selectively remove specific items, instead of a blanket `empty()` that empties all.
* Refactor `test/e2e/specs/specs-calypso/wp-manage-domains-spec.js` to just remove the item that was created specifically for the test.

#### Testing instructions

Verify e2e tests pass, and `test/e2e/specs/specs-calypso/wp-manage-domains-spec.js` doesn't need to be retried as often.