### PR TITLE
Nav Unification: Fix dashboard appearance check when loading the editor

### DIFF
--- a/client/state/preferences/constants.js
+++ b/client/state/preferences/constants.js
@@ -8,4 +8,5 @@ export const DEFAULT_PREFERENCE_VALUES = {
 	mediaScale: 0.157,
 	editorConfirmationDisabledSites: [],
 	colorScheme: 'default',
+	linkDestination: false,
 };

--- a/client/state/preferences/reducer.js
+++ b/client/state/preferences/reducer.js
@@ -9,11 +9,13 @@ import { omit } from 'lodash';
 import { withStorageKey } from '@automattic/state-utils';
 import {
 	PREFERENCES_SET,
+	PREFERENCES_SAVE,
 	PREFERENCES_RECEIVE,
 	PREFERENCES_FETCH,
 	PREFERENCES_FETCH_SUCCESS,
 	PREFERENCES_FETCH_FAILURE,
 	PREFERENCES_SAVE_SUCCESS,
+	PREFERENCES_SAVE_FAILURE,
 } from 'calypso/state/action-types';
 import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import { remoteValuesSchema } from './schema';
@@ -80,6 +82,20 @@ export const fetching = ( state = false, action ) => {
 	return state;
 };
 
+export const failed = ( state = false, action ) => {
+	switch ( action.type ) {
+		case PREFERENCES_SAVE:
+		case PREFERENCES_FETCH:
+		case PREFERENCES_SAVE_SUCCESS:
+		case PREFERENCES_FETCH_SUCCESS:
+			return false;
+		case PREFERENCES_SAVE_FAILURE:
+		case PREFERENCES_FETCH_FAILURE:
+			return true;
+	}
+	return state;
+};
+
 const lastFetchedTimestamp = ( state = false, action ) => {
 	switch ( action.type ) {
 		case PREFERENCES_FETCH_SUCCESS:
@@ -93,6 +109,7 @@ const combinedReducer = combineReducers( {
 	localValues,
 	remoteValues,
 	fetching,
+	failed,
 	lastFetchedTimestamp,
 } );
 const preferencesReducer = withStorageKey( 'preferences', combinedReducer );

--- a/client/state/preferences/selectors.js
+++ b/client/state/preferences/selectors.js
@@ -56,3 +56,10 @@ export const preferencesLastFetchedTimestamp = ( state ) => state.preferences.la
 export function hasReceivedRemotePreferences( state ) {
 	return !! state.preferences.remoteValues;
 }
+
+/*
+ * Returns whether the previous request to save or retrieve the preferences, failed.
+ *
+ * @param {state} state State object
+ */
+export const hasPreferencesRequestFailed = ( state ) => state.preferences.failed;

--- a/client/state/preferences/selectors.js
+++ b/client/state/preferences/selectors.js
@@ -24,7 +24,11 @@ export const isFetchingPreferences = ( state ) => !! state.preferences.fetching;
 export function getPreference( state, key ) {
 	return get(
 		find(
-			[ state.preferences.localValues, state.preferences.remoteValues, DEFAULT_PREFERENCE_VALUES ],
+			[
+				state.preferences?.localValues,
+				state.preferences?.remoteValues,
+				DEFAULT_PREFERENCE_VALUES,
+			],
 			( source ) => has( source, key )
 		),
 		key,

--- a/client/state/preferences/test/reducer.js
+++ b/client/state/preferences/test/reducer.js
@@ -22,6 +22,7 @@ describe( 'reducer', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
 			'localValues',
 			'remoteValues',
+			'failed',
 			'fetching',
 			'lastFetchedTimestamp',
 		] );

--- a/client/state/selectors/should-load-gutenframe.js
+++ b/client/state/selectors/should-load-gutenframe.js
@@ -3,13 +3,12 @@
  */
 import { isEligibleForGutenframe } from 'calypso/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
-import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import { getPreference } from 'calypso/state/preferences/selectors';
 
 export const shouldLoadGutenframe = ( state, siteId ) => {
 	return (
 		isEligibleForGutenframe( state, siteId ) &&
-		( ! isNavUnificationEnabled( state ) ||
-			! getUserSettings( state )?.calypso_preferences?.linkDestination )
+		( ! isNavUnificationEnabled( state ) || ! getPreference( state, 'linkDestination' ) )
 	);
 };
 export default shouldLoadGutenframe;


### PR DESCRIPTION
In #51108 we introduced a check to determine if the dashboard appearance
option was on, and if so, redirect to `wp-admin` rather than load the
Gutenframe. This also affected any links to the editor.

Unfortunately, there was a misinterpretation of user settings. Where we
can technically read the `calypso_preferences` from user settings, we
should be using the alternative `/me/preferences` endpoint. One of the
reasons for this is that the user token to access settings can become
stale, requiring people with 2FA active to input an auth code. That in
turn means that the request to access user settings fails and when
loading the editor, we wait for a timeout before continuing.

This creates an unacceptable delay when loading the editor as noted
in #52651 which this fixes by swapping to using the 'preferences' part
of the store, rather than user settings.

#### Testing instructions

As noted in #52561, it's possible to get into a state where hard refreshing the editor will result in a blank screen for around 10 seconds, as the call to user settings fails and we wait for the timeout. This might only be for people with 2FA where the access token has expired.

Whether the bug can be replicated or not, we need to ensure that with this change there is not a long delay with a blank screen as the editor loads. 

* Load the editor, on a site.
* Hard refresh by holding shift while refreshing the browser
* You can also try clearing the `calypso` local storage and refreshing again.
* You may find that there is a long delay with a blank screen as the editor loads.
* Switch to this branch, and go through the same procedure.
* Observe that everything functions the same, but any delay in loading the editor is gone
* Go to /me/account and turn an the Dashboard Appearance setting
* Now all links to the editor should default to `wp-admin`

Related to #52651
