### PR TITLE
Fix mobile display of the new email plans page

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan-subscription.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-subscription.jsx
@@ -106,7 +106,7 @@ class EmailPlanSubscription extends React.Component {
 				>
 					{ expiryText }
 				</div>
-				<div>{ this.renderRenewButton() }</div>
+				<div className="email-plan-subscription__renew">{ this.renderRenewButton() }</div>
 				<div className="email-plan-subscription__auto-renew">{ this.renderAutoRenewToggle() }</div>
 			</CompactCard>
 		);

--- a/client/my-sites/email/email-management/home/email-plan-subscription.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-subscription.jsx
@@ -107,7 +107,7 @@ class EmailPlanSubscription extends React.Component {
 					{ expiryText }
 				</div>
 				<div>{ this.renderRenewButton() }</div>
-				<div>{ this.renderAutoRenewToggle() }</div>
+				<div className="email-plan-subscription__auto-renew">{ this.renderAutoRenewToggle() }</div>
 			</CompactCard>
 		);
 	}

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -209,8 +209,8 @@
 }
 
 .email-plan-mailboxes-list__mailbox-action-menu {
-    position: absolute;
-    right: 16px;
+	position: absolute;
+	right: 16px;
 	top: 28px;
 
 	@include break-mobile {

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -327,8 +327,12 @@
 		margin-left: 15px;
 		flex: 1 1 auto;
 	}
-	> div:last-child {
+	.email-plan-subscription__auto-renew {
 		margin-left: 15px;
+		/* Ensure auto-renew text is using the standard font size */
+		label {
+			font-size: $font-body;
+		}
 		/* vertically aligns the auto-renew toggle - not sure if there's a better way... */
 		> div > div {
 			margin-top: auto;

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -271,9 +271,18 @@
 		vertical-align: middle;
 		word-break: break-all;
 	}
+
 	> .badge {
-		margin-left: 10px;
+		/* Hide admin badge in mobile layouts */
+		display: none;
+
+		@include break-xlarge {
+			align-self: center;
+			display: unset;
+			margin-left: 10px;
+		}
 	}
+
 	.email-plan-mailboxes-list__mailbox-list-item-warning {
 		border-top: 1px solid var( --color-neutral-5 );
 		color: var( --color-error );

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -320,15 +320,25 @@
 }
 
 .email-plan-subscription__card {
-	display: flex;
 	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
 
-	> div:nth-last-child( 2 ) {
-		margin-left: 15px;
-		flex: 1 1 auto;
+	@include break-small {
+		flex-wrap: initial;
 	}
+
+	.email-plan-subscription__renew {
+		margin-left: auto;
+		margin-right: 16px;
+
+		@include break-small {
+			flex: 1 1 auto;
+			margin-left: 16px;
+		}
+	}
+
 	.email-plan-subscription__auto-renew {
-		margin-left: 15px;
 		/* Ensure auto-renew text is using the standard font size */
 		label {
 			font-size: $font-body;

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -210,9 +210,16 @@
 
 .email-plan-mailboxes-list__mailbox-action-menu {
     position: absolute;
-    right: 24px;
-    top: 50%;
-	transform: translateY( -50% );
+    right: 16px;
+	top: 28px;
+
+	@include break-mobile {
+		right: 24px;
+	}
+
+	> .button.is-borderless {
+		padding: 0;
+	}
 }
 
 .popover__menu-item.email-plan-mailboxes-list__mailbox-action-menu-item {
@@ -238,16 +245,25 @@
 		flex-direction: row;
 	}
 
-	&.card.is-highlight {
-		padding-left: 13px;
-	}
-	&.card.is-error {
-		border-left-color: var( --color-error-50 );
+	&.card {
+		&.is-highlight {
+			padding-left: 13px;
+		}
+
+		&.is-error {
+			border-left-color: var( --color-error-50 );
+		}
 	}
 
 	.email-plan-mailboxes-list__mailbox-list-item-main {
 		display: flex;
 		flex-direction: column;
+		padding-right: 56px;
+
+		@include break-mobile {
+			padding-right: 72px;
+		}
+
 		> div:not( :first-child ) {
 			margin-top: 0.5em;
 		}

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -248,6 +248,10 @@
 	&.card {
 		&.is-highlight {
 			padding-left: 13px;
+
+			@include break-mobile {
+				padding-left: 21px;
+			}
 		}
 
 		&.is-error {

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -241,11 +241,17 @@
 	display: flex;
 	flex-direction: column;
 
-	@include break-xlarge {
-		flex-direction: row;
-	}
-
 	&.card {
+		&.is-compact {
+			@include break-xlarge {
+				flex-direction: row;
+				/* The padding jumps as we need the padding on this element instead
+				 * of mailbox-list-item-main when we shift to flex-direction: row
+				 */
+				padding-right: 72px;
+			}
+		}
+
 		&.is-highlight {
 			padding-left: 13px;
 
@@ -266,6 +272,11 @@
 
 		@include break-mobile {
 			padding-right: 48px;
+		}
+
+		@include break-xlarge {
+			/* Padding moves to parent mailbox-list-item when we shift to flex-direction: row */
+			padding-right: 0;
 		}
 
 		> div:not( :first-child ) {

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -262,10 +262,10 @@
 	.email-plan-mailboxes-list__mailbox-list-item-main {
 		display: flex;
 		flex-direction: column;
-		padding-right: 56px;
+		padding-right: 40px;
 
 		@include break-mobile {
-			padding-right: 72px;
+			padding-right: 48px;
 		}
 
 		> div:not( :first-child ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR includes the following improvements:
* We now hide the "Admin" badge when the user is on narrower screens (this was in the original designs)
* We now use the same font size for the "Expires" text and the auto-renew label
* When the screen gets narrower, we push the "Renew now" button to the right, and allow the auto-renew label to shift onto the next line if needed
* The mailbox-level ellipsis menu is now aligned with the top text, and spacing for it is responsive based on the top row of the mailbox card
* The left spacing for mailboxes with warnings has been fixed for wider screens -- it was too narrow and left mailboxes with warnings too far to the left

#### Testing instructions

* Open the UI locally or via the [live branch](https://calypso.live/?branch=fix/mobile-display-email-plans)
* Navigate to `/email/:siteSlug`
* Click on an email account that has one or more admin users (which should be most Google Workspace, G Suite, or Professional Email accounts) -- also ensure that the email plan for the subscription shows the auto-renew toggle (which is controlled by whether there is a payment method linked to the subscription)
* For various browser widths, but especially mobile widths (< 600px wide) and tablet widths (< ~1000px), verify the following:
  - We don't show the "Admin" badge across the card (see the screenshots below for a visual)
  - We show the "Auto-renew" text in the same size font as the "Expires" text (this should apply across all screen sizes, including desktop)
  - For narrower widths (especially under ~400px), the subscription management options below the plan header respond well, with the Auto-renew toggle shifting to the next line at narrower widths.
  - The ellipsis menu should be aligned with the top row of text in all cases
  - The mailbox name should not overlap with the ellipsis menu, especially as the screen gets really narrow
 * Navigate to the plan page for a domain with email forwarding and an unverified email address for a mailbox. (You can create a new forward if needed.)
 * Verify that on narrow screens, the warning content for the mailbox and the ellipsis menu don't interfere with each other. (You may need to test that using #52930, which is derived from this branch.)

#### Screenshots

##### Before
<img width="466" alt="Screenshot 2021-05-17 at 10 54 25" src="https://user-images.githubusercontent.com/3376401/118462342-dcf62780-b6fe-11eb-8f76-cc39632ea0eb.png">

##### After
<img width="466" alt="Screenshot 2021-05-17 at 10 55 47" src="https://user-images.githubusercontent.com/3376401/118462370-e54e6280-b6fe-11eb-9cfb-dff9bd380fb0.png">

##### Left spacing for warnings

| Before | After |
| -------| ----- |
|  <img width="681" alt="Screenshot 2021-05-18 at 10 01 37" src="https://user-images.githubusercontent.com/3376401/118614651-4722d100-b7c0-11eb-92f9-034f930bb8b7.png"> | <img width="681" alt="Screenshot 2021-05-18 at 10 01 56" src="https://user-images.githubusercontent.com/3376401/118614704-53a72980-b7c0-11eb-8557-6776e53a5b50.png"> |

##### Ellipsis menu alignment and overflow

| Before | After |
| -------| ----- |
| <img width="317" alt="Screenshot 2021-05-18 at 10 09 30" src="https://user-images.githubusercontent.com/3376401/118616719-3d01d200-b7c2-11eb-9a32-f339010b90c2.png"> | <img width="315" alt="Screenshot 2021-05-18 at 10 15 41" src="https://user-images.githubusercontent.com/3376401/118616756-4428e000-b7c2-11eb-98b9-01e366e4db06.png"> |

