### PR TITLE
Components: Fix children propType of Tooltip

### DIFF
--- a/client/components/tooltip/index.jsx
+++ b/client/components/tooltip/index.jsx
@@ -54,7 +54,7 @@ Tooltip.propTypes = {
 	status: PropTypes.string,
 	showDelay: PropTypes.number,
 	showOnMobile: PropTypes.bool,
-	children: PropTypes.element,
+	children: PropTypes.node,
 	context: PropTypes.any,
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the `propType` of the `children` prop of `ToolTip` as it was unnecessarily forcing a single element, thus causing this error when opening `/devdocs/design/date-picker`:

![](https://cldup.com/KT_j6tt78p.png)

We're simply altering `element` to `node` here, as it's obvious by the example that multiple children are supported and work perfectly well.

#### Testing instructions

* Go to `/devdocs/design/date-picker`
* Verify you no longer see the error in the console.
* Verify that the tooltip on the current day still works and looks the same way as it did before.

#### Context

Found while working on #52917 and #52915.