### PR TITLE
Fix: Bulk media editor does not save captions reliably

### DIFF
--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -207,7 +207,7 @@ class Media extends Component {
 
 	updateItem = ( itemId, detail ) => {
 		const { selectedItems } = this.state;
-		const index = findIndex( selectedItems, ( item ) => item.ID === itemId );
+		const index = selectedItems.findIndex( ( item ) => item.ID === itemId );
 
 		if ( index === -1 ) {
 			return;

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -7,6 +7,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
 import { localize } from 'i18n-calypso';
+import { findIndex } from 'lodash';
 
 /**
  * Internal dependencies
@@ -204,6 +205,25 @@ class Media extends Component {
 		this.maybeRedirectToAll();
 	};
 
+	updateItem = ( itemId, detail ) => {
+		const { selectedItems } = this.state;
+		const index = findIndex( selectedItems, ( item ) => item.ID === itemId );
+
+		if ( index === -1 ) {
+			return;
+		}
+
+		selectedItems.splice( index, 1, {
+			...selectedItems[ index ],
+			...detail,
+		} );
+
+		this.setState( {
+			...this.state,
+			selectedItems,
+		} );
+	};
+
 	setDetailSelectedIndex = ( index ) => {
 		this.setState( { currentDetail: index } );
 	};
@@ -377,6 +397,7 @@ class Media extends Component {
 								onEditImageItem={ this.editImage }
 								onEditVideoItem={ this.editVideo }
 								onRestoreItem={ this.restoreOriginalMedia }
+								onUpdateItem={ this.updateItem }
 								onSelectedIndexChange={ this.setDetailSelectedIndex }
 							/>
 						) }

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -7,7 +7,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
 import { localize } from 'i18n-calypso';
-import { findIndex } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -34,14 +34,19 @@ class EditorMediaModalDetailFields extends Component {
 
 	constructor() {
 		super( ...arguments );
-		this.persistChange = debounce( this.persistChange, 1000, { leading: true } );
+		this.persistChange = debounce( this._persistChange, 1000 );
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.item && nextProps.item && nextProps.item.ID !== this.props.item.ID ) {
-			this.setState( { modifiedItem: null } );
+		if ( nextProps.item && nextProps.item.ID !== this.props.item?.ID ) {
 			this.persistChange.cancel();
+			this._persistChange();
+			this.setState( { modifiedItem: null } );
 		}
+	}
+
+	componentWillUnmount() {
+		this._persistChange();
 	}
 
 	bumpTitleStat = () => {
@@ -68,8 +73,8 @@ class EditorMediaModalDetailFields extends Component {
 		return getMimePrefix( this.props.item ) === prefix;
 	}
 
-	persistChange() {
-		if ( ! this.props.site || ! this.state.modifiedItem ) {
+	_persistChange() {
+		if ( ! this.props.site || ! this.state?.modifiedItem ) {
 			return;
 		}
 

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -4,7 +4,7 @@
 import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { debounce, get } from 'lodash';
+import { debounce, get, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -25,11 +25,16 @@ class EditorMediaModalDetailFields extends Component {
 	static propTypes = {
 		site: PropTypes.object,
 		item: PropTypes.object,
+		onUpdate: PropTypes.func,
+	};
+
+	static defaultProps = {
+		onUpdate: noop,
 	};
 
 	constructor() {
 		super( ...arguments );
-		this.persistChange = debounce( this.persistChange, 1000 );
+		this.persistChange = debounce( this.persistChange, 1000, { leading: true } );
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
@@ -69,6 +74,7 @@ class EditorMediaModalDetailFields extends Component {
 		}
 
 		this.props.updateMedia( this.props.site.ID, this.state.modifiedItem );
+		this.props.onUpdate( this.props.item.ID, this.state.modifiedItem );
 	}
 
 	setFieldValue = ( { target } ) => {
@@ -78,8 +84,7 @@ class EditorMediaModalDetailFields extends Component {
 			{ [ target.name ]: target.value }
 		);
 
-		this.setState( { modifiedItem } );
-		this.persistChange();
+		this.setState( { modifiedItem }, this.persistChange );
 	};
 
 	getItemValue( attribute ) {

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 /**
  * External dependencies
  */
@@ -8,7 +9,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { flowRight, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
-import url from 'url';
+import { getUrlParts } from '@automattic/calypso-url';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -42,6 +43,7 @@ export class EditorMediaModalDetailItem extends Component {
 		onShowNextItem: PropTypes.func,
 		onEdit: PropTypes.func,
 		onRestore: PropTypes.func,
+		onUpdate: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -51,6 +53,7 @@ export class EditorMediaModalDetailItem extends Component {
 		onShowNextItem: noop,
 		onEdit: noop,
 		onRestore: noop,
+		onUpdate: noop,
 	};
 
 	/**
@@ -139,8 +142,8 @@ export class EditorMediaModalDetailItem extends Component {
 		const { item, translate } = this.props;
 
 		//do a simple guid vs url check
-		const guidParts = url.parse( item.guid );
-		const URLParts = url.parse( item.URL );
+		const guidParts = getUrlParts( item.guid );
+		const URLParts = getUrlParts( item.URL );
 
 		if ( guidParts.pathname === URLParts.pathname ) {
 			return false;
@@ -204,7 +207,9 @@ export class EditorMediaModalDetailItem extends Component {
 			return null;
 		}
 
-		return <EditorMediaModalDetailFields site={ site } item={ item } />;
+		return (
+			<EditorMediaModalDetailFields site={ site } item={ item } onUpdate={ this.props.onUpdate } />
+		);
 	}
 
 	renderPreviousItemButton() {

--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -32,12 +32,14 @@ class EditorMediaModalDetailBase extends React.Component {
 		onSelectedIndexChange: PropTypes.func,
 		onReturnToList: PropTypes.func,
 		onEdit: PropTypes.func,
-		onRestore: PropTypes.func,
+		onRestoreItem: PropTypes.func,
+		onUpdateItem: PropTypes.func,
 	};
 
 	static defaultProps = {
 		selectedIndex: 0,
 		onSelectedIndexChange: noop,
+		onUpdateItem: noop,
 	};
 
 	componentDidMount() {
@@ -71,6 +73,7 @@ class EditorMediaModalDetailBase extends React.Component {
 			onEditImageItem,
 			onEditVideoItem,
 			onRestoreItem,
+			onUpdateItem,
 			onReturnToList,
 			translate,
 		} = this.props;
@@ -78,6 +81,7 @@ class EditorMediaModalDetailBase extends React.Component {
 		const item = items[ selectedIndex ];
 		const mimePrefix = getMimePrefix( item );
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div className="editor-media-modal-detail">
 				<HeaderCake
@@ -93,9 +97,11 @@ class EditorMediaModalDetailBase extends React.Component {
 					onShowNextItem={ this.incrementIndex.bind( this, 1 ) }
 					onRestore={ onRestoreItem }
 					onEdit={ 'video' === mimePrefix ? onEditVideoItem : onEditImageItem }
+					onUpdate={ onUpdateItem }
 				/>
 			</div>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes the following two bugs of the bulk media editor:
  * The caption or description is not saved when move to the next/prev image within one second after changing the field.
     ![ML BULK EDITING](https://user-images.githubusercontent.com/4452464/116207660-6a69db80-a740-11eb-9fa8-6d8816720095.gif)
  * The caption or description is not updated when you move to the next/prev image then back after chaning the field. It will be updated close and reopen the dialog.
    ![bulk-media-editor-bug](https://user-images.githubusercontent.com/212034/118496956-92f15e00-b75f-11eb-962d-da2c093044fb.gif)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Case 1**
1. Select two images or more in the Media page.
2. Update caption or description then move to the next/prev image within one second after the change.
3. Click the Done button.
4. Reopen the media detail modal.
5. Make sure the value of the field is the same with your latest input.

**Case 2**
1. Select two images or more in the Media page.
2. Update caption or description.
3. Wait more than one second.
4. Move to the next/prev image then back. (do not close the dialog)
5. Make sure the value of the field is the same with your latest input.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #52041