### PR TITLE
Show unused mailbox warnings for Titan on Email Plan page

### DIFF
--- a/client/lib/emails/email-provider-constants.js
+++ b/client/lib/emails/email-provider-constants.js
@@ -1,3 +1,5 @@
 export const EMAIL_ACCOUNT_TYPE_FORWARD = 'email_forwarding';
 export const EMAIL_TYPE_FORWARD = 'email_forward';
 export const EMAIL_USER_ROLE_ADMIN = 'admin';
+export const EMAIL_WARNING_SLUG_UNUSED_MAILBOXES = 'unused_mailboxes';
+export const EMAIL_WARNING_TYPE_ACTION_REQUIRED = 'action_required';

--- a/client/lib/emails/email-provider-constants.js
+++ b/client/lib/emails/email-provider-constants.js
@@ -1,4 +1,5 @@
 export const EMAIL_ACCOUNT_TYPE_FORWARD = 'email_forwarding';
+export const EMAIL_ACCOUNT_TYPE_TITAN_MAIL = 'titan';
 export const EMAIL_TYPE_FORWARD = 'email_forward';
 export const EMAIL_USER_ROLE_ADMIN = 'admin';
 export const EMAIL_WARNING_SLUG_UNUSED_MAILBOXES = 'unused_mailboxes';

--- a/client/my-sites/email/email-management/home/email-plan-header.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-header.jsx
@@ -10,12 +10,14 @@ import React from 'react';
  * Internal dependencies
  */
 import EmailPlanSubscription from 'calypso/my-sites/email/email-management/home/email-plan-subscription';
+import EmailPlanWarnings from 'calypso/my-sites/email/email-management/home/email-plan-warnings';
 import EmailTypeIcon from 'calypso/my-sites/email/email-management/home/email-type-icon';
 import MaterialIcon from 'calypso/components/material-icon';
 import { resolveEmailPlanStatus } from 'calypso/my-sites/email/email-management/home/utils';
 
 const EmailPlanHeader = ( {
 	domain,
+	emailAccounts,
 	hasEmailSubscription,
 	isLoadingPurchase,
 	purchase,
@@ -45,6 +47,10 @@ const EmailPlanHeader = ( {
 				</div>
 			</CompactCard>
 
+			{ hasEmailSubscription && emailAccounts?.warnings?.length && (
+				<EmailPlanWarnings warnings={ emailAccounts?.warnings } />
+			) }
+
 			{ hasEmailSubscription && (
 				<EmailPlanSubscription
 					purchase={ purchase }
@@ -59,6 +65,7 @@ const EmailPlanHeader = ( {
 
 EmailPlanHeader.propTypes = {
 	domain: PropTypes.object.isRequired,
+	emailAccounts: PropTypes.array.isRequired,
 	hasEmailSubscription: PropTypes.bool.isRequired,
 	isLoadingPurchase: PropTypes.bool.isRequired,
 	purchase: PropTypes.object,

--- a/client/my-sites/email/email-management/home/email-plan-header.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-header.jsx
@@ -50,9 +50,9 @@ const EmailPlanHeader = ( {
 						<MaterialIcon icon={ icon } /> { text }
 					</span>
 				</div>
-			</CompactCard>
 
-			{ hasEmailSubscription && <EmailPlanWarnings warnings={ emailAccount?.warnings } /> }
+				{ hasEmailSubscription && <EmailPlanWarnings warnings={ emailAccount?.warnings } /> }
+			</CompactCard>
 
 			{ hasEmailSubscription && (
 				<EmailPlanSubscription

--- a/client/my-sites/email/email-management/home/email-plan-header.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-header.jsx
@@ -17,8 +17,9 @@ import { resolveEmailPlanStatus } from 'calypso/my-sites/email/email-management/
 
 const EmailPlanHeader = ( {
 	domain,
-	emailAccounts,
+	emailAccount,
 	hasEmailSubscription,
+	isLoadingEmails,
 	isLoadingPurchase,
 	purchase,
 	selectedSite,
@@ -27,7 +28,11 @@ const EmailPlanHeader = ( {
 		return null;
 	}
 
-	const { statusClass, text, icon } = resolveEmailPlanStatus( domain );
+	const { statusClass, text, icon } = resolveEmailPlanStatus(
+		domain,
+		emailAccount,
+		isLoadingEmails
+	);
 
 	const cardClasses = classnames( 'email-plan-header', statusClass );
 
@@ -47,8 +52,8 @@ const EmailPlanHeader = ( {
 				</div>
 			</CompactCard>
 
-			{ hasEmailSubscription && emailAccounts?.warnings?.length && (
-				<EmailPlanWarnings warnings={ emailAccounts?.warnings } />
+			{ hasEmailSubscription && emailAccount?.warnings?.length && (
+				<EmailPlanWarnings warnings={ emailAccount?.warnings } />
 			) }
 
 			{ hasEmailSubscription && (
@@ -65,7 +70,8 @@ const EmailPlanHeader = ( {
 
 EmailPlanHeader.propTypes = {
 	domain: PropTypes.object.isRequired,
-	emailAccounts: PropTypes.array.isRequired,
+	emailAccount: PropTypes.object,
+	isLoadingEmails: PropTypes.bool.isRequired,
 	hasEmailSubscription: PropTypes.bool.isRequired,
 	isLoadingPurchase: PropTypes.bool.isRequired,
 	purchase: PropTypes.object,

--- a/client/my-sites/email/email-management/home/email-plan-header.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-header.jsx
@@ -52,9 +52,7 @@ const EmailPlanHeader = ( {
 				</div>
 			</CompactCard>
 
-			{ hasEmailSubscription && emailAccount?.warnings?.length && (
-				<EmailPlanWarnings warnings={ emailAccount?.warnings } />
-			) }
+			{ hasEmailSubscription && <EmailPlanWarnings warnings={ emailAccount?.warnings } /> }
 
 			{ hasEmailSubscription && (
 				<EmailPlanSubscription

--- a/client/my-sites/email/email-management/home/email-plan-header.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-header.jsx
@@ -51,7 +51,13 @@ const EmailPlanHeader = ( {
 					</span>
 				</div>
 
-				{ hasEmailSubscription && <EmailPlanWarnings warnings={ emailAccount?.warnings } /> }
+				{ hasEmailSubscription && emailAccount && (
+					<EmailPlanWarnings
+						domain={ domain }
+						warnings={ emailAccount.warnings }
+						emailAccountType={ emailAccount.account_type }
+					/>
+				) }
 			</CompactCard>
 
 			{ hasEmailSubscription && (

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { CompactCard } from '@automattic/components';
+
+const EmailPlanWarnings = ( { warnings } ) =>
+	warnings.map( ( warning, index ) => (
+		<CompactCard highlight="info" className="email-plan-warnings__warning" key={ index }>
+			<span>
+				<em>{ warning.message }</em>
+			</span>
+		</CompactCard>
+	) );
+
+EmailPlanWarnings.propTypes = {
+	warnings: PropTypes.array.isRequired,
+};
+
+export default EmailPlanWarnings;

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -3,31 +3,34 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import Notice from 'calypso/components/notice';
-import { EMAIL_WARNING_TYPE_ACTION_REQUIRED } from 'calypso/lib/emails/email-provider-constants';
-
-const getWarningStatus = ( warning ) => {
-	return EMAIL_WARNING_TYPE_ACTION_REQUIRED === warning.warning_type ? 'is-info' : 'is-warning';
-};
+import { Button } from '@automattic/components';
+import Gridicon from 'calypso/components/gridicon';
 
 const EmailPlanWarnings = ( { warnings } ) => {
+	const translate = useTranslate();
+
 	if ( ! warnings?.[ 0 ] ) {
 		return null;
 	}
 
-	return warnings.map( ( warning, index ) => (
-		<Notice
-			status={ getWarningStatus( warning ) }
-			text={ warning.message }
-			showDismiss={ false }
-			className="email-plan-warnings__warning"
-			key={ index }
-		/>
-	) );
+	return (
+		<div className="email-plan-warnings__container">
+			{ warnings.map( ( warning, index ) => (
+				<div className="email-plan-warnings__warning" key={ index }>
+					<span>{ warning.message }</span>
+					<Button compact primary href={ 'controlPanelUrl' }>
+						{ translate( 'Activate Mailboxes' ) }
+						<Gridicon icon="external" size={ 18 } />
+					</Button>
+				</div>
+			) ) }
+		</div>
+	);
 };
 
 EmailPlanWarnings.propTypes = {

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -7,15 +7,22 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { CompactCard } from '@automattic/components';
+import Notice from 'calypso/components/notice';
+import { EMAIL_WARNING_TYPE_ACTION_REQUIRED } from 'calypso/lib/emails/email-provider-constants';
+
+const getWarningStatus = ( warning ) => {
+	return EMAIL_WARNING_TYPE_ACTION_REQUIRED === warning.warning_type ? 'is-info' : 'is-warning';
+};
 
 const EmailPlanWarnings = ( { warnings } ) =>
 	warnings.map( ( warning, index ) => (
-		<CompactCard highlight="info" className="email-plan-warnings__warning" key={ index }>
-			<span>
-				<em>{ warning.message }</em>
-			</span>
-		</CompactCard>
+		<Notice
+			status={ getWarningStatus( warning ) }
+			text={ warning.message }
+			showDismiss={ false }
+			className="email-plan-warnings__warning"
+			key={ index }
+		/>
 	) );
 
 EmailPlanWarnings.propTypes = {

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -14,8 +14,12 @@ const getWarningStatus = ( warning ) => {
 	return EMAIL_WARNING_TYPE_ACTION_REQUIRED === warning.warning_type ? 'is-info' : 'is-warning';
 };
 
-const EmailPlanWarnings = ( { warnings } ) =>
-	warnings.map( ( warning, index ) => (
+const EmailPlanWarnings = ( { warnings } ) => {
+	if ( ! warnings?.[ 0 ] ) {
+		return null;
+	}
+
+	return warnings.map( ( warning, index ) => (
 		<Notice
 			status={ getWarningStatus( warning ) }
 			text={ warning.message }
@@ -24,9 +28,10 @@ const EmailPlanWarnings = ( { warnings } ) =>
 			key={ index }
 		/>
 	) );
+};
 
 EmailPlanWarnings.propTypes = {
-	warnings: PropTypes.array.isRequired,
+	warnings: PropTypes.array,
 };
 
 export default EmailPlanWarnings;

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -3,38 +3,100 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useTranslate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
 import Gridicon from 'calypso/components/gridicon';
+import { isEnabled } from '@automattic/calypso-config';
+import {
+	emailManagementManageTitanAccount,
+	emailManagementTitanControlPanelRedirect,
+} from 'calypso/my-sites/email/paths';
+import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/constants';
+import { connect } from 'react-redux';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import {
+	EMAIL_ACCOUNT_TYPE_TITAN_MAIL,
+	EMAIL_WARNING_SLUG_UNUSED_MAILBOXES,
+} from 'calypso/lib/emails/email-provider-constants';
 
-const EmailPlanWarnings = ( { warnings } ) => {
-	const translate = useTranslate();
+class EmailPlanWarnings extends React.Component {
+	renderWarningCTAForTitanUnusedMailboxes() {
+		const { selectedSiteSlug, domain, currentRoute, translate } = this.props;
 
-	if ( ! warnings?.[ 0 ] ) {
+		const showExternalControlPanelLink = ! isEnabled( 'titan/iframe-control-panel' );
+		const controlPanelUrl = showExternalControlPanelLink
+			? emailManagementTitanControlPanelRedirect( selectedSiteSlug, domain.name, currentRoute, {
+					context: TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL,
+			  } )
+			: emailManagementManageTitanAccount( selectedSiteSlug, domain.name, currentRoute, {
+					context: TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL,
+			  } );
+
+		return (
+			<Button
+				compact
+				primary
+				href={ controlPanelUrl }
+				target={ showExternalControlPanelLink ? '_blank' : null }
+			>
+				{ translate( 'Activate Mailboxes' ) }
+				{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+				{ showExternalControlPanelLink && <Gridicon icon="external" size={ 16 } /> }
+				{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
+			</Button>
+		);
+	}
+
+	renderWarningCTA( warning ) {
+		const warningSlug = warning.warning_slug;
+		if ( ! warningSlug ) {
+			return null;
+		}
+
+		if ( EMAIL_WARNING_SLUG_UNUSED_MAILBOXES === warningSlug ) {
+			if ( EMAIL_ACCOUNT_TYPE_TITAN_MAIL === this.props.emailAccountType ) {
+				return this.renderWarningCTAForTitanUnusedMailboxes();
+			}
+		}
+
 		return null;
 	}
 
-	return (
-		<div className="email-plan-warnings__container">
-			{ warnings.map( ( warning, index ) => (
-				<div className="email-plan-warnings__warning" key={ index }>
-					<span>{ warning.message }</span>
-					<Button compact primary href={ 'controlPanelUrl' }>
-						{ translate( 'Activate Mailboxes' ) }
-						<Gridicon icon="external" size={ 18 } />
-					</Button>
-				</div>
-			) ) }
-		</div>
-	);
-};
+	render() {
+		const warnings = this.props.warnings;
+		if ( ! warnings?.[ 0 ] ) {
+			return null;
+		}
+
+		return (
+			<div className="email-plan-warnings__container">
+				{ warnings.map( ( warning, index ) => (
+					<div className="email-plan-warnings__warning" key={ index }>
+						<div className="email-plan-warnings__message">
+							<span>{ warning.message }</span>
+						</div>
+						<div className="email-plan-warnings__cta">{ this.renderWarningCTA( warning ) }</div>
+					</div>
+				) ) }
+			</div>
+		);
+	}
+}
 
 EmailPlanWarnings.propTypes = {
+	domain: PropTypes.object.isRequired,
+	emailAccountType: PropTypes.string.isRequired,
 	warnings: PropTypes.array,
 };
 
-export default EmailPlanWarnings;
+export default connect( ( state ) => {
+	return {
+		currentRoute: getCurrentRoute( state ),
+		selectedSiteSlug: getSelectedSiteSlug( state ),
+	};
+} )( localize( EmailPlanWarnings ) );

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -1,22 +1,22 @@
 /**
  * External dependencies
  */
+import { connect } from 'react-redux';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import { Button } from '@automattic/components';
+import { isEnabled } from '@automattic/calypso-config';
 
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
 import Gridicon from 'calypso/components/gridicon';
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	emailManagementManageTitanAccount,
 	emailManagementTitanControlPanelRedirect,
 } from 'calypso/my-sites/email/paths';
 import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/constants';
-import { connect } from 'react-redux';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import {
@@ -25,6 +25,12 @@ import {
 } from 'calypso/lib/emails/email-provider-constants';
 
 class EmailPlanWarnings extends React.Component {
+	static propTypes = {
+		domain: PropTypes.object.isRequired,
+		emailAccountType: PropTypes.string.isRequired,
+		warnings: PropTypes.array,
+	};
+
 	renderWarningCTAForTitanUnusedMailboxes() {
 		const { selectedSiteSlug, domain, currentRoute, translate } = this.props;
 
@@ -87,12 +93,6 @@ class EmailPlanWarnings extends React.Component {
 		);
 	}
 }
-
-EmailPlanWarnings.propTypes = {
-	domain: PropTypes.object.isRequired,
-	emailAccountType: PropTypes.string.isRequired,
-	warnings: PropTypes.array,
-};
 
 export default connect( ( state ) => {
 	return {

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -1,28 +1,28 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
-import React from 'react';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
 import { Button } from '@automattic/components';
+import { connect } from 'react-redux';
 import { isEnabled } from '@automattic/calypso-config';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-import Gridicon from 'calypso/components/gridicon';
-import {
-	emailManagementManageTitanAccount,
-	emailManagementTitanControlPanelRedirect,
-} from 'calypso/my-sites/email/paths';
-import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/constants';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import {
 	EMAIL_ACCOUNT_TYPE_TITAN_MAIL,
 	EMAIL_WARNING_SLUG_UNUSED_MAILBOXES,
 } from 'calypso/lib/emails/email-provider-constants';
+import {
+	emailManagementManageTitanAccount,
+	emailManagementTitanControlPanelRedirect,
+} from 'calypso/my-sites/email/paths';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import Gridicon from 'calypso/components/gridicon';
+import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/constants';
 
 class EmailPlanWarnings extends React.Component {
 	static propTypes = {
@@ -51,9 +51,7 @@ class EmailPlanWarnings extends React.Component {
 				target={ showExternalControlPanelLink ? '_blank' : null }
 			>
 				{ translate( 'Activate Mailboxes' ) }
-				{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
-				{ showExternalControlPanelLink && <Gridicon icon="external" size={ 16 } /> }
-				{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
+				{ showExternalControlPanelLink || <Gridicon icon="external" /> }
 			</Button>
 		);
 	}

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -51,7 +51,7 @@ class EmailPlanWarnings extends React.Component {
 				target={ showExternalControlPanelLink ? '_blank' : null }
 			>
 				{ translate( 'Activate Mailboxes' ) }
-				{ showExternalControlPanelLink || <Gridicon icon="external" /> }
+				{ showExternalControlPanelLink && <Gridicon icon="external" /> }
 			</Button>
 		);
 	}

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -264,6 +264,7 @@ class EmailPlan extends React.Component {
 					isLoadingPurchase={ isLoadingPurchase }
 					purchase={ purchase }
 					selectedSite={ selectedSite }
+					emailAccounts={ this.state?.emailAccounts[ 0 ] }
 				/>
 
 				<EmailPlanMailboxesList

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -265,7 +265,7 @@ class EmailPlan extends React.Component {
 					isLoadingPurchase={ isLoadingPurchase }
 					purchase={ purchase }
 					selectedSite={ selectedSite }
-					emailAccount={ this.state?.emailAccounts[ 0 ] ?? null }
+					emailAccount={ this.state.emailAccounts?.[ 0 ] }
 				/>
 
 				<EmailPlanMailboxesList

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -261,10 +261,11 @@ class EmailPlan extends React.Component {
 				<EmailPlanHeader
 					domain={ domain }
 					hasEmailSubscription={ hasSubscription }
+					isLoadingEmails={ isLoadingEmailAccounts }
 					isLoadingPurchase={ isLoadingPurchase }
 					purchase={ purchase }
 					selectedSite={ selectedSite }
-					emailAccounts={ this.state?.emailAccounts[ 0 ] }
+					emailAccount={ this.state?.emailAccounts[ 0 ] ?? null }
 				/>
 
 				<EmailPlanMailboxesList

--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -13,6 +13,7 @@ import {
 	hasPendingGSuiteUsers,
 } from 'calypso/lib/gsuite';
 import {
+	getConfiguredTitanMailboxCount,
 	getMaxTitanMailboxCount,
 	getTitanExpiryDate,
 	getTitanSubscriptionId,
@@ -114,7 +115,7 @@ export function resolveEmailPlanStatus( domain, emailAccount, isLoadingEmails ) 
 	const defaultActiveStatus = {
 		statusClass: 'success',
 		icon: isLoadingEmails ? 'cached' : 'check_circle',
-		text: isLoadingEmails ? translate( 'Loading accounts' ) : translate( 'Active' ),
+		text: isLoadingEmails ? translate( 'Loading details' ) : translate( 'Active' ),
 	};
 
 	const defaultWarningStatus = {
@@ -143,7 +144,16 @@ export function resolveEmailPlanStatus( domain, emailAccount, isLoadingEmails ) 
 			}
 		}
 		// Check for unused mailboxes
-		if ( hasUnusedMailboxWarnings( emailAccount?.warnings ) ) {
+		if ( emailAccount && hasUnusedMailboxWarnings( emailAccount.warnings ) ) {
+			return defaultWarningStatus;
+		}
+
+		// Fallback logic if we don't have an emailAccount - this will initially be the case for the email home page.
+		if (
+			! isLoadingEmails &&
+			! emailAccount &&
+			getMaxTitanMailboxCount( domain ) > getConfiguredTitanMailboxCount( domain )
+		) {
 			return defaultWarningStatus;
 		}
 

--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -6,6 +6,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { EMAIL_WARNING_SLUG_UNUSED_MAILBOXES } from 'calypso/lib/emails/email-provider-constants';
 import {
 	getGSuiteMailboxCount,
 	getGSuiteSubscriptionId,
@@ -19,7 +20,6 @@ import {
 	getTitanSubscriptionId,
 	hasTitanMailWithUs,
 } from 'calypso/lib/titan';
-import { EMAIL_WARNING_SLUG_UNUSED_MAILBOXES } from 'calypso/lib/emails/email-provider-constants';
 import { getEmailForwardsCount, hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -413,4 +413,17 @@
 	flex-basis: 100%;
 	line-height: 30px;
 	margin-top: 24px;
+
+	.email-plan-warnings__warning {
+		display: flex;
+		align-items: center;
+
+		.email-plan-warnings__message {
+			flex: 1 1 auto;
+		}
+
+		.email-plan-warnings__cta {
+			margin-left: 15px;
+		}
+	}
 }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -406,3 +406,7 @@
 .email-plan-subscription__expired {
 	color: var( --color-error-50 );
 }
+
+.email-plan-warnings__warning.notice {
+	margin-bottom: 1px;
+}

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -426,9 +426,9 @@
 			margin-left: 15px;
 
 			.button .gridicon {
+				height: 16px;
 				margin-left: 8px;
 				width: 16px;
-				height: 16px;
 			}
 		}
 	}

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -173,6 +173,7 @@
 .email-plan-header {
 	display: flex;
 	align-items: center;
+	flex-wrap: wrap;
 
 	h2 {
 		font-size: $font-title-large;
@@ -407,6 +408,9 @@
 	color: var( --color-error-50 );
 }
 
-.email-plan-warnings__warning.notice {
-	margin-bottom: 1px;
+.email-plan-warnings__container {
+	width: 100%;
+	flex-basis: 100%;
+	line-height: 30px;
+	margin-top: 24px;
 }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -409,14 +409,14 @@
 }
 
 .email-plan-warnings__container {
-	width: 100%;
 	flex-basis: 100%;
 	line-height: 30px;
 	margin-top: 24px;
+	width: 100%;
 
 	.email-plan-warnings__warning {
-		display: flex;
 		align-items: center;
+		display: flex;
 
 		.email-plan-warnings__message {
 			flex: 1 1 auto;
@@ -427,6 +427,8 @@
 
 			.button .gridicon {
 				margin-left: 8px;
+				width: 16px;
+				height: 16px;
 			}
 		}
 	}

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -424,6 +424,10 @@
 
 		.email-plan-warnings__cta {
 			margin-left: 15px;
+
+			.button .gridicon {
+				margin-left: 8px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Summary

This PR seeks to show warnings at the account level for Professional Email accounts where there are unused mailboxes available. The warnings are derived from data fetched from the new Email Accounts API endpoint.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch in your sandbox, or try it out on [calypso live](https://calypso.live/?branch=add/show-unused-mailbox-warnings-for-titan)
- Navigate to a site i.e. `/email/:siteName:` where you have a Professional email plan with unused mailboxes
- Confirm that status of the plan is `Action Required`
- Confirm that warnings are shown just below the status 

<img width="1065" alt="Screenshot 2021-05-20 at 2 41 21 AM" src="https://user-images.githubusercontent.com/277661/118906194-3172f000-b915-11eb-8183-78ef79c51c30.png">
