### PR TITLE
Post-Checkout Upsell: Scroll to the top of the page when component mounts

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -98,6 +98,10 @@ export class UpsellNudge extends React.Component {
 		showPurchaseModal: false,
 	};
 
+	componentDidMount() {
+		window.scrollTo( 0, 0 );
+	}
+
 	render() {
 		const { selectedSiteId, isLoading, hasProductsList, hasSitePlans, upsellType } = this.props;
 


### PR DESCRIPTION
When the cart make-up, contact details, or stored payment method list in Checkout cause the user's scroll position to be far down the page, the post-Checkout upsell will load mid-page. This forces the window to scroll to the top for the upsell.

Fixes: #49473

**To Test:**
- buy a premium plan and a domain
- make sure your browser is scrolled all the way to the bottom of the page
- complete checkout
- the business plan upsell should load
- verify that the upsell renders with the browser scrolled to the top