### PR TITLE
Redirect cloud visitors back to cloud when clicking the back button in checkout page

### DIFF
--- a/client/layout/masterbar/checkout.jsx
+++ b/client/layout/masterbar/checkout.jsx
@@ -11,15 +11,27 @@ import { localize } from 'i18n-calypso';
 import Masterbar from './masterbar';
 import Item from './item';
 import WordPressWordmark from 'calypso/components/wordpress-wordmark';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 
 class CheckoutMasterbar extends React.Component {
 	clickClose = () => {
-		const { previousPath, siteSlug } = this.props;
+		const {
+			previousPath,
+			siteSlug,
+			visitingFromJetpackCloud,
+			recordTracksEvent: recordEvent,
+		} = this.props;
 		let closeUrl = siteSlug ? '/plans/' + siteSlug : '/start';
-		this.props.recordTracksEvent( 'calypso_masterbar_close_clicked' );
+
+		recordEvent( 'calypso_masterbar_close_clicked' );
+
+		if ( visitingFromJetpackCloud ) {
+			window.location = `https://cloud.jetpack.com/pricing/${ siteSlug }`;
+			return;
+		}
 
 		if (
 			previousPath &&
@@ -72,4 +84,9 @@ class CheckoutMasterbar extends React.Component {
 	}
 }
 
-export default connect( null, { recordTracksEvent } )( localize( CheckoutMasterbar ) );
+export default connect(
+	( state ) => ( {
+		visitingFromJetpackCloud: getInitialQueryArguments( state ).source === 'jetpack-plans',
+	} ),
+	{ recordTracksEvent }
+)( localize( CheckoutMasterbar ) );

--- a/client/layout/masterbar/checkout.jsx
+++ b/client/layout/masterbar/checkout.jsx
@@ -18,18 +18,13 @@ import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-
 
 class CheckoutMasterbar extends React.Component {
 	clickClose = () => {
-		const {
-			previousPath,
-			siteSlug,
-			visitingFromJetpackCloud,
-			recordTracksEvent: recordEvent,
-		} = this.props;
+		const { previousPath, siteSlug, checkoutBackUrl, recordTracksEvent: recordEvent } = this.props;
 		let closeUrl = siteSlug ? '/plans/' + siteSlug : '/start';
 
 		recordEvent( 'calypso_masterbar_close_clicked' );
 
-		if ( visitingFromJetpackCloud ) {
-			window.location = `https://cloud.jetpack.com/pricing/${ siteSlug }`;
+		if ( checkoutBackUrl ) {
+			window.location = checkoutBackUrl;
 			return;
 		}
 
@@ -86,7 +81,7 @@ class CheckoutMasterbar extends React.Component {
 
 export default connect(
 	( state ) => ( {
-		visitingFromJetpackCloud: getInitialQueryArguments( state ).source === 'jetpack-plans',
+		checkoutBackUrl: getInitialQueryArguments( state ).checkoutBackUrl,
 	} ),
 	{ recordTracksEvent }
 )( localize( CheckoutMasterbar ) );

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -631,18 +631,25 @@ export function checkout(
 		? `/checkout/${ siteSlug }/${ productsString }`
 		: `/jetpack/connect/${ productsString }`;
 
-	// Unauthenticated users will be presented with a Jetpack branded version of the login form
-	// if the URL has the query parameter `source=jetpack-plans`. We only want to do this if the
-	// user is in Jetpack Cloud.
-	const urlQueryArgsWithSource =
-		isJetpackCloud() && ! urlQueryArgs.source
-			? { ...urlQueryArgs, source: 'jetpack-plans' }
-			: urlQueryArgs;
+	if ( isJetpackCloud() ) {
+		// Unauthenticated users will be presented with a Jetpack branded version of the login form
+		// if the URL has the query parameter `source=jetpack-plans`. We only want to do this if the
+		// user is in Jetpack Cloud.
+		if ( ! urlQueryArgs.source ) {
+			urlQueryArgs.source = 'jetpack-plans';
+		}
+
+		// This URL is used when clicking the back button in the checkout screen to redirect users
+		// back to cloud instead of wordpress.com
+		if ( ! urlQueryArgs.checkoutBackUrl ) {
+			urlQueryArgs.checkoutBackUrl = window.location.href;
+		}
+	}
 
 	if ( isJetpackCloud() && ! config.isEnabled( 'jetpack-cloud/connect' ) ) {
-		window.location.href = addQueryArgs( urlQueryArgsWithSource, `https://wordpress.com${ path }` );
+		window.location.href = addQueryArgs( urlQueryArgs, `https://wordpress.com${ path }` );
 	} else {
-		page( addQueryArgs( urlQueryArgsWithSource, path ) );
+		page( addQueryArgs( urlQueryArgs, path ) );
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

In this PR, we make sure that users coming from Jetpack cloud to the checkout page can go back to the pricing page in cloud, when they hit the close button.

### Implementation notes

When selecting a product in the pricing page in cloud, the `source` query parameter is added with the value `jetpack-plans`. Using this to detect if a user comes from cloud seems to make sense.

If need be, a more elaborate solution could be to add the "back" URL along the `source` parameter.

*Update*: the latter solution was implemented

### Testing instructions

- Download the PR and run both Calypso and cloud concurrently
- Make sure you have a Jetpack site available
- Visit `/pricing` in cloud, and select a product
- Then copy the URL query parameters, and make sure it contains `checkoutBackUrl`
- Next, in Calypso, visit `/checkout/:site/jetpack_complete`
- In the checkout screen, click the close button (see capture below)
- Make sure you're redirected to the plans page in Calypso
- Then, visit `/checkout/:site/jetpack_complete` with the arguments you've just copied
- Repeat the operation and check that you're redirected to the pricing page in cloud

### Screenshots

<img width="893" alt="Screen Shot 2021-05-17 at 5 10 20 PM" src="https://user-images.githubusercontent.com/1620183/118557153-ca95e100-b732-11eb-8524-441c45bb96c9.png">
