### PR TITLE
Shopping Cart: Remove 'invalid' coupon type

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/coupon.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/coupon.tsx
@@ -2,19 +2,34 @@
  * External dependencies
  */
 import React from 'react';
-import styled from '@emotion/styled';
 import { keyframes } from '@emotion/core';
 import PropTypes from 'prop-types';
 import { useTranslate } from 'i18n-calypso';
 import { Button } from '@automattic/composite-checkout';
-import { Field } from '@automattic/wpcom-checkout';
+import { Field, styled } from '@automattic/wpcom-checkout';
+import type { CouponStatus } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
  */
 import joinClasses from './join-classes';
+import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
 
-export default function Coupon( { id, className, disabled, couponStatus, couponFieldStateProps } ) {
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
+export default function Coupon( {
+	id,
+	className,
+	disabled,
+	couponStatus,
+	couponFieldStateProps,
+}: {
+	id: string;
+	className?: string;
+	disabled?: boolean;
+	couponStatus: CouponStatus;
+	couponFieldStateProps: CouponFieldStateProps;
+} ): JSX.Element {
 	const translate = useTranslate();
 	const {
 		couponFieldValue,
@@ -25,7 +40,7 @@ export default function Coupon( { id, className, disabled, couponStatus, couponF
 		handleCouponSubmit,
 	} = couponFieldStateProps;
 
-	const hasCouponError = couponStatus === 'invalid' || couponStatus === 'rejected';
+	const hasCouponError = couponStatus === 'rejected';
 	const isPending = couponStatus === 'pending';
 
 	const errorMessage = getCouponErrorMessageFromStatus( translate, couponStatus, isFreshOrEdited );
@@ -44,7 +59,7 @@ export default function Coupon( { id, className, disabled, couponStatus, couponF
 				inputClassName="coupon-code"
 				value={ couponFieldValue }
 				disabled={ disabled || isPending }
-				placeholder={ translate( 'Enter your coupon code' ) }
+				placeholder={ String( translate( 'Enter your coupon code' ) ) }
 				isError={ hasCouponError && ! isFreshOrEdited }
 				errorMessage={ errorMessage }
 				onChange={ ( input ) => {
@@ -93,7 +108,7 @@ const animateInRTL = keyframes`
 `;
 
 const CouponWrapper = styled.form`
-	margin: ${ ( props ) => props.marginTop } 0 0;
+	margin: 0;
 	padding-top: 0;
 	position: relative;
 `;
@@ -114,14 +129,15 @@ const ApplyButton = styled( Button )`
 	}
 `;
 
-function getCouponErrorMessageFromStatus( translate, status, isFreshOrEdited ) {
-	if ( status === 'invalid' && ! isFreshOrEdited ) {
-		return translate(
-			"We couldn't find your coupon. Please check your coupon code and try again."
+function getCouponErrorMessageFromStatus(
+	translate: ReturnType< typeof useTranslate >,
+	status: CouponStatus,
+	isFreshOrEdited: boolean
+): string | undefined {
+	if ( status === 'rejected' && ! isFreshOrEdited ) {
+		return String(
+			translate( "We couldn't find your coupon. Please check your coupon code and try again." )
 		);
 	}
-	if ( status === 'rejected' ) {
-		return translate( 'This coupon does not apply to any items in the cart.' );
-	}
-	return null;
+	return undefined;
 }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -659,7 +659,6 @@ export default function CompositeCheckout( {
 					isLoggedOutCart={ !! isLoggedOutCart }
 					createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 					infoMessage={ infoMessage }
-					isJetpackCheckout={ isJetpackCheckout }
 				/>
 			</CheckoutProvider>
 		</React.Fragment>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -621,7 +621,7 @@ export default function CompositeCheckout( {
 		);
 	}
 
-	const updatedSiteId = isJetpackCheckout ? parseInt( responseCart.blog_id ) : siteId;
+	const updatedSiteId = isJetpackCheckout ? parseInt( String( responseCart.blog_id ), 10 ) : siteId;
 
 	return (
 		<React.Fragment>

--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -25,7 +25,7 @@ This is a React hook that can be used in any child component under [ShoppingCart
 - `isPendingUpdate: boolean`. True if the cart is loading in any way, either during its initial load, when a `cartKey` changes, or when a modification request is pending.
 - `loadingError: string | null | undefined`. If fetching or updating the cart causes an error, this will be a string that contains the error message.
 - `loadingErrorType: ShoppingCartError | undefined`. If fetching or updating the cart causes an error, this will contain a string that explains what type of error.
-- `couponStatus: 'fresh' | 'pending' | 'applied' | 'invalid' | 'rejected' | 'error'`. A string that can be used to determine if a coupon is applied.
+- `couponStatus: 'fresh' | 'pending' | 'applied' | 'rejected'. A string that can be used to determine if a coupon is applied.
 
 The following actions are also properties. Each one returns a Promise that resolves when the cart is next valid (this may be after several queued actions are complete).
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -77,10 +77,9 @@ export type CacheStatus = 'fresh' | 'fresh-pending' | 'valid' | 'invalid' | 'pen
  *   - 'fresh': User has not (yet) attempted to apply a coupon.
  *   - 'pending': Coupon request has been sent, awaiting response.
  *   - 'applied': Coupon has been applied to the cart.
- *   - 'invalid': Coupon code is not recognized.
- *   - 'rejected': Valid code, but does not apply to the cart items.
+ *   - 'rejected': Coupon code did not apply. The reason should be in the cart errors.
  */
-export type CouponStatus = 'fresh' | 'pending' | 'applied' | 'invalid' | 'rejected' | 'error';
+export type CouponStatus = 'fresh' | 'pending' | 'applied' | 'rejected' | 'error';
 
 export type ShoppingCartAction =
 	| { type: 'CLEAR_QUEUED_ACTIONS' }

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -79,7 +79,7 @@ export type CacheStatus = 'fresh' | 'fresh-pending' | 'valid' | 'invalid' | 'pen
  *   - 'applied': Coupon has been applied to the cart.
  *   - 'rejected': Coupon code did not apply. The reason should be in the cart errors.
  */
-export type CouponStatus = 'fresh' | 'pending' | 'applied' | 'rejected' | 'error';
+export type CouponStatus = 'fresh' | 'pending' | 'applied' | 'rejected';
 
 export type ShoppingCartAction =
 	| { type: 'CLEAR_QUEUED_ACTIONS' }

--- a/packages/shopping-cart/src/use-shopping-cart-reducer.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-reducer.ts
@@ -268,15 +268,11 @@ function getUpdatedCouponStatus(
 	responseCart: ResponseCart
 ): CouponStatus {
 	const isCouponApplied = responseCart.is_coupon_applied;
-	const couponDiscounts = responseCart.coupon_discounts_integer.length;
 
 	if ( isCouponApplied ) {
 		return 'applied';
 	}
-	if ( currentCouponStatus === 'pending' && couponDiscounts <= 0 ) {
-		return 'invalid';
-	}
-	if ( currentCouponStatus === 'pending' && couponDiscounts > 0 ) {
+	if ( currentCouponStatus === 'pending' ) {
 		return 'rejected';
 	}
 	return 'fresh';

--- a/packages/wpcom-checkout/src/field.tsx
+++ b/packages/wpcom-checkout/src/field.tsx
@@ -38,7 +38,7 @@ export default function Field( {
 	inputClassName?: string;
 	isError?: boolean;
 	onChange: ( value: string ) => void;
-	label: string;
+	label?: string;
 	value: string;
 	icon?: React.ReactNode;
 	iconAction?: () => void;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If a coupon code is sent to the shopping-cart endpoint, it either works (represented by the `applied` value of the `CouponStatus` type), or it doesn't (represented by the `rejected` value). The `CouponStatus` type in the shopping-cart package includes two additional types, `invalid`, and `error`, but neither of these ever will occur. This PR removes the unused strings from the type.

Originally, `invalid` and `rejected` were meant to differentiate different types of coupon failure states, but in practice only one ever occurs. The cause for a failed coupon will be returned by the `messages.errors` property of the cart (and will be improved once D61506-code is merged).

As a side-effect, this PR also converts the `Coupon` component in checkout to TypeScript.

#### Testing instructions

- Visit checkout with a product in your cart.
- Add an invalid coupon code and press "Apply".
- Verify that you get two errors that the code did not apply: one as a global notice, and one as the subtext for the coupon field.
- Add a valid coupon code and press "Apply".
- Verify that the coupon is applied correctly and that there is a global notice to this effect.