### PR TITLE
ci(e2e): Create hook for creating browser

### DIFF
--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -119,9 +119,6 @@ export async function startBrowser( {
 	resizeBrowserWindow = true,
 	disableThirdPartyCookies = false,
 } = {} ) {
-	if ( global.__BROWSER__ ) {
-		return global.__BROWSER__;
-	}
 	const screenSize = currentScreenSize();
 	const locale = currentLocale();
 	let driver;
@@ -170,7 +167,7 @@ export async function startBrowser( {
 		} );
 
 		global.browserName = caps.browserName;
-		global.__BROWSER__ = driver = builder.usingServer( sauceURL ).withCapabilities( caps ).build();
+		driver = builder.usingServer( sauceURL ).withCapabilities( caps ).build();
 
 		driver.setFileDetector( new remote.FileDetector() );
 
@@ -235,10 +232,7 @@ export async function startBrowser( {
 
 				builder = new webdriver.Builder();
 				builder.setChromeOptions( options );
-				global.__BROWSER__ = driver = builder
-					.forBrowser( 'chrome' )
-					.setLoggingPrefs( pref )
-					.build();
+				driver = builder.forBrowser( 'chrome' ).setLoggingPrefs( pref ).build();
 				global.browserName = 'chrome';
 				break;
 			case 'firefox':
@@ -262,10 +256,7 @@ export async function startBrowser( {
 				options.setProxy( getProxyType() );
 				builder = new webdriver.Builder();
 				builder.setFirefoxOptions( options );
-				global.__BROWSER__ = driver = builder
-					.forBrowser( 'firefox' )
-					.setLoggingPrefs( pref )
-					.build();
+				driver = builder.forBrowser( 'firefox' ).setLoggingPrefs( pref ).build();
 				global.browserName = 'firefox';
 				break;
 			default:
@@ -399,7 +390,6 @@ export async function acceptAllAlerts( driver ) {
 }
 
 export function quitBrowser( driver ) {
-	global.__BROWSER__ = null;
 	return driver.quit();
 }
 

--- a/test/e2e/lib/hooks/browser-logs.js
+++ b/test/e2e/lib/hooks/browser-logs.js
@@ -10,13 +10,11 @@ import { getBrowserLogs, getPerformanceLogs } from '../driver-helper';
 import { generatePath } from '../test-utils';
 
 export const saveBrowserLogs = async () => {
-	const driver = global.__BROWSER__;
-
 	try {
 		await Promise.allSettled(
 			[
-				[ () => getBrowserLogs( driver ), 'console.log' ],
-				[ () => getPerformanceLogs( driver ), 'performance.log' ],
+				[ () => getBrowserLogs( this.driver ), 'console.log' ],
+				[ () => getPerformanceLogs( this.driver ), 'performance.log' ],
 			].map( async ( [ logsPromise, file ] ) => {
 				const logs = await logsPromise();
 				return fs.writeFile( generatePath( file ), JSON.stringify( logs, null, 2 ) );

--- a/test/e2e/lib/hooks/browser.js
+++ b/test/e2e/lib/hooks/browser.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { quitBrowser } from '../driver-manager';
+import { quitBrowser, startBrowser, ensureNotLoggedIn } from '../driver-manager';
 
 export const closeBrowser = async () => {
 	if ( ! global.__BROWSER__ ) {
@@ -11,4 +11,10 @@ export const closeBrowser = async () => {
 
 	const driver = global.__BROWSER__;
 	await quitBrowser( driver );
+};
+
+export const createBrowser = async () => {
+	const driver = await startBrowser();
+	await ensureNotLoggedIn( driver );
+	global.__BROWSER__ = driver;
 };

--- a/test/e2e/lib/hooks/browser.js
+++ b/test/e2e/lib/hooks/browser.js
@@ -1,7 +1,14 @@
 /**
+ * External dependencies
+ */
+import config from 'config';
+
+/**
  * Internal dependencies
  */
 import { quitBrowser, startBrowser, ensureNotLoggedIn } from '../driver-manager';
+
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 
 export const closeBrowser = async () => {
 	if ( ! global.__BROWSER__ ) {
@@ -13,8 +20,9 @@ export const closeBrowser = async () => {
 	await quitBrowser( driver );
 };
 
-export const createBrowser = async () => {
+export async function createBrowser() {
+	this.timeout( startBrowserTimeoutMS );
 	const driver = await startBrowser();
 	await ensureNotLoggedIn( driver );
 	global.__BROWSER__ = driver;
-};
+}

--- a/test/e2e/lib/hooks/browser.js
+++ b/test/e2e/lib/hooks/browser.js
@@ -10,19 +10,12 @@ import { quitBrowser, startBrowser, ensureNotLoggedIn } from '../driver-manager'
 
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 
-export const closeBrowser = async () => {
-	if ( ! global.__BROWSER__ ) {
-		// Early return if there's no browser, i.e. when all specs were skipped.
-		return;
-	}
-
-	const driver = global.__BROWSER__;
-	await quitBrowser( driver );
+export const closeBrowser = async function () {
+	await quitBrowser( this.driver );
 };
 
 export async function createBrowser() {
 	this.timeout( startBrowserTimeoutMS );
-	const driver = await startBrowser();
-	await ensureNotLoggedIn( driver );
-	global.__BROWSER__ = driver;
+	this.driver = await startBrowser();
+	await ensureNotLoggedIn( this.driver );
 }

--- a/test/e2e/lib/hooks/framebuffer.js
+++ b/test/e2e/lib/hooks/framebuffer.js
@@ -60,7 +60,7 @@ export const buildHooks = ( displayNum ) => {
 			);
 			await mkdir( path.dirname( fileName ), { recursive: true } );
 
-			const driver = global.__BROWSER__;
+			const driver = this.driver;
 			const screenshotData = await driver.takeScreenshot();
 			await writeFile( fileName, screenshotData, { encoding: 'base64' } );
 		} catch ( err ) {

--- a/test/e2e/lib/hooks/index.js
+++ b/test/e2e/lib/hooks/index.js
@@ -9,6 +9,7 @@ import config from 'config';
 import { buildHooks as buildVideoHooks } from './video-recorder';
 import { buildHooks as buildFramebufferHooks, getFreeDisplay } from './framebuffer';
 import { saveBrowserLogs } from './browser-logs';
+import { createBrowser, closeBrowser } from './browser';
 
 const isVideoEnabled = () => {
 	const video = config.has( 'useTestVideo' )
@@ -20,7 +21,7 @@ const isVideoEnabled = () => {
 export const mochaHooks = async () => {
 	const hooks = {
 		afterAll: [ saveBrowserLogs ],
-		beforeAll: [],
+		beforeAll: [ createBrowser ],
 		afterEach: [],
 	};
 
@@ -42,6 +43,8 @@ export const mochaHooks = async () => {
 		hooks.afterEach = [ ...hooks.afterEach, takeScreenshot, saveVideoRecording ];
 		hooks.afterAll = [ ...hooks.afterAll, stopFramebuffer, stopVideoRecording ];
 	}
+
+	hooks.afterAll = [ ...hooks.afterAll, closeBrowser ];
 
 	return hooks;
 };

--- a/test/e2e/lib/hooks/index.js
+++ b/test/e2e/lib/hooks/index.js
@@ -20,8 +20,8 @@ const isVideoEnabled = () => {
 
 export const mochaHooks = async () => {
 	const hooks = {
-		afterAll: [ saveBrowserLogs ],
-		beforeAll: [ createBrowser ],
+		afterAll: [],
+		beforeAll: [],
 		afterEach: [],
 	};
 
@@ -44,7 +44,8 @@ export const mochaHooks = async () => {
 		hooks.afterAll = [ ...hooks.afterAll, stopFramebuffer, stopVideoRecording ];
 	}
 
-	hooks.afterAll = [ ...hooks.afterAll, closeBrowser ];
+	hooks.afterAll = [ ...hooks.afterAll, saveBrowserLogs, closeBrowser ];
+	hooks.beforeAll = [ ...hooks.beforeAll, createBrowser ];
 
 	return hooks;
 };

--- a/test/e2e/lib/mocha-hooks.js
+++ b/test/e2e/lib/mocha-hooks.js
@@ -22,47 +22,41 @@ before( function () {
 
 // Sauce Breakpoint
 afterEach( function () {
-	const driver = global.__BROWSER__;
-
 	if (
 		process.env.SAUCEDEBUG &&
 		this.currentTest.state === 'failed' &&
 		config.has( 'sauce' ) &&
 		config.get( 'sauce' )
 	) {
-		driver.executeScript( 'sauce: break' );
+		this.driver.executeScript( 'sauce: break' );
 	}
 } );
 
 // Dismiss any alerts for switching away
 afterEach( async function () {
-	await this.timeout( afterHookTimeoutMS );
-	const driver = global.__BROWSER__;
+	this.timeout( afterHookTimeoutMS );
 
 	if (
 		this.currentTest &&
 		this.currentTest.state === 'failed' &&
 		( config.get( 'closeBrowserOnComplete' ) === true || global.isHeadless === true )
 	) {
-		await driverManager.acceptAllAlerts( driver );
+		await driverManager.acceptAllAlerts( this.driver );
 	}
 } );
 
 // Update Sauce Job Status locally
 afterEach( function () {
-	const driver = global.__BROWSER__;
-
 	if ( config.has( 'sauce' ) && config.get( 'sauce' ) ) {
-		driver.allPassed = driver.allPassed && this.currentTest.state === 'passed';
+		this.driver.allPassed = this.driver.allPassed && this.currentTest.state === 'passed';
 	}
 } );
 
 // Push SauceLabs job status update (if applicable)
 after( async function () {
-	await this.timeout( afterHookTimeoutMS );
-	const driver = global.__BROWSER__;
+	this.timeout( afterHookTimeoutMS );
 
 	if ( config.has( 'sauce' ) && config.get( 'sauce' ) ) {
-		await driver.executeScript( 'sauce:job-result=' + driver.allPassed );
+		await this.driver.executeScript( 'sauce:job-result=' + this.driver.allPassed );
 	}
 } );

--- a/test/e2e/specs-i18n/logged-out-redirect-i18n-spec.js
+++ b/test/e2e/specs-i18n/logged-out-redirect-i18n-spec.js
@@ -19,11 +19,10 @@ const locale = driverManager.currentLocale();
 
 describe( `Logged out homepage redirect test @i18n (${ locale })`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
 
 	it( `should redirect to the correct url for wordpress.com (${ locale })`, async function () {
 		// No culture here implies 'en'
-		const wpHomePage = await WPHomePage.Visit( driver );
+		const wpHomePage = await WPHomePage.Visit( this.driver );
 		await wpHomePage.checkURL( locale );
 	} );
 } );

--- a/test/e2e/specs-i18n/logged-out-redirect-i18n-spec.js
+++ b/test/e2e/specs-i18n/logged-out-redirect-i18n-spec.js
@@ -13,19 +13,13 @@ import * as driverManager from '../lib/driver-manager.js';
 import WPHomePage from '../lib/pages/wp-home-page';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 
 // call run.sh with -I to feed in the mag16
 const locale = driverManager.currentLocale();
 
 describe( `Logged out homepage redirect test @i18n (${ locale })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( `should redirect to the correct url for wordpress.com (${ locale })`, async function () {
 		// No culture here implies 'en'

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -44,144 +44,146 @@ const siteName = dataHelper.getJetpackSiteName();
 
 describe( `Jetpack Connect: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
 
 	describe( 'Connect From wp-admin: @parallel @jetpack @canary', function () {
 		before( async function () {
-			return await driverManager.ensureNotLoggedIn( driver );
+			return await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'Can log in to WPCOM', async function () {
-			const loginFlow = new LoginFlow( driver, 'jetpackConnectUser' );
+			const loginFlow = new LoginFlow( this.driver, 'jetpackConnectUser' );
 			await loginFlow.login();
 		} );
 
 		it( 'Can create wporg site', async function () {
 			this.timeout( mochaTimeOut * 12 );
 
-			this.jnFlow = new JetpackConnectFlow( driver, null );
+			this.jnFlow = new JetpackConnectFlow( this.driver, null );
 			return await this.jnFlow.createJNSite();
 		} );
 
 		it( 'Can navigate to the Jetpack dashboard', async function () {
-			await WPAdminSidebar.refreshIfJNError( driver );
-			this.wpAdminSidebar = await WPAdminSidebar.Expect( driver );
+			await WPAdminSidebar.refreshIfJNError( this.driver );
+			this.wpAdminSidebar = await WPAdminSidebar.Expect( this.driver );
 			return await this.wpAdminSidebar.selectJetpack();
 		} );
 
 		it( 'Can click the Connect Jetpack button', async function () {
-			await driverHelper.refreshIfJNError( driver );
-			this.wpAdminJetpack = await WPAdminJetpackPage.Expect( driver );
+			await driverHelper.refreshIfJNError( this.driver );
+			this.wpAdminJetpack = await WPAdminJetpackPage.Expect( this.driver );
 			return await this.wpAdminJetpack.inPlaceConnect();
 		} );
 
 		it( 'Can Approve in-place connection', async function () {
-			const inPlaceApprovePage = await WPAdminInPlaceApprovePage.Expect( driver );
+			const inPlaceApprovePage = await WPAdminInPlaceApprovePage.Expect( this.driver );
 			await inPlaceApprovePage.approve();
 		} );
 
 		it( 'Can click the free plan button', async function () {
-			const pickAPlanPage = await PickAPlanPage.Expect( driver );
+			const pickAPlanPage = await PickAPlanPage.Expect( this.driver );
 			return await pickAPlanPage.selectFreePlanJetpack();
 		} );
 
 		it( 'Can assert we are on Jetpack Dashboard', async function () {
-			await WPAdminJetpackPage.Expect( driver );
+			await WPAdminJetpackPage.Expect( this.driver );
 		} );
 	} );
 
 	describe( 'Pre-connect from Jetpack.com using free plan: @parallel @jetpack', function () {
 		before( async function () {
-			return await driverManager.ensureNotLoggedIn( driver );
+			return await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'Can select Get Started', async function () {
-			const jetPackComPage = await JetpackComPage.Visit( driver );
+			const jetPackComPage = await JetpackComPage.Visit( this.driver );
 			return await jetPackComPage.selectGetStarted();
 		} );
 
 		it( 'Can select free plan', async function () {
-			const pickAPlanPage = await PickAPlanPage.Expect( driver );
+			const pickAPlanPage = await PickAPlanPage.Expect( this.driver );
 			return await pickAPlanPage.selectFreePlanJetpack();
 		} );
 
 		it( 'Can see Jetpack connect page', async function () {
-			return await JetpackConnectPage.Expect( driver );
+			return await JetpackConnectPage.Expect( this.driver );
 		} );
 	} );
 
 	describe( 'Connect via SSO: @parallel @jetpack', function () {
 		before( async function () {
-			return await driverManager.ensureNotLoggedIn( driver );
+			return await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'Can register new Subscriber user', async function () {
 			this.accountName = dataHelper.getNewBlogName();
 			this.emailAddress = dataHelper.getEmailAddress( this.accountName, signupInboxId );
 			this.password = config.get( 'passwordForNewTestSignUps' );
-			const signupFlow = new SignUpFlow( driver, {
+			const signupFlow = new SignUpFlow( this.driver, {
 				accountName: this.accountName,
 				emailAddress: this.emailAddress,
 				password: this.password,
 			} );
 			await signupFlow.signupFreeAccount();
 			await signupFlow.activateAccount();
-			return await driverManager.ensureNotLoggedIn( driver );
+			return await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'Can log into WordPress.com', async function () {
-			return await new LoginFlow( driver ).login();
+			return await new LoginFlow( this.driver ).login();
 		} );
 
 		it( 'Can log into site via Jetpack SSO', async function () {
-			const loginPage = await WPAdminLogonPage.Visit( driver, dataHelper.getJetpackSiteName() );
+			const loginPage = await WPAdminLogonPage.Visit(
+				this.driver,
+				dataHelper.getJetpackSiteName()
+			);
 			return await loginPage.logonSSO();
 		} );
 
 		it( 'Add new user as Subscriber in wp-admin', async function () {
-			await WPAdminSidebar.refreshIfJNError( driver );
-			const wpAdminSidebar = await WPAdminSidebar.Expect( driver );
+			await WPAdminSidebar.refreshIfJNError( this.driver );
+			const wpAdminSidebar = await WPAdminSidebar.Expect( this.driver );
 			await wpAdminSidebar.selectAddNewUser();
-			await WPAdminNewUserPage.refreshIfJNError( driver );
-			const wpAdminNewUserPage = await WPAdminNewUserPage.Expect( driver );
+			await WPAdminNewUserPage.refreshIfJNError( this.driver );
+			const wpAdminNewUserPage = await WPAdminNewUserPage.Expect( this.driver );
 			return await wpAdminNewUserPage.addUser( this.emailAddress );
 		} );
 
 		it( 'Log out from WP Admin', async function () {
-			await driverManager.ensureNotLoggedIn( driver );
-			await WPAdminDashboardPage.refreshIfJNError( driver );
+			await driverManager.ensureNotLoggedIn( this.driver );
+			await WPAdminDashboardPage.refreshIfJNError( this.driver );
 			const wPAdminDashboardPage = await WPAdminDashboardPage.Visit(
-				driver,
+				this.driver,
 				WPAdminDashboardPage.getUrl( siteName )
 			);
 			return await wPAdminDashboardPage.logout();
 		} );
 
 		it( 'Can log in as Subscriber', async function () {
-			const loginPage = await LoginPage.Visit( driver );
+			const loginPage = await LoginPage.Visit( this.driver );
 			return await loginPage.login( this.accountName, this.password );
 		} );
 
 		it( 'Can login via SSO into WP Admin', async function () {
-			const wpAdminLogonPage = await WPAdminLogonPage.Visit( driver, siteName );
+			const wpAdminLogonPage = await WPAdminLogonPage.Visit( this.driver, siteName );
 			await wpAdminLogonPage.logonSSO();
-			const jetpackAuthorizePage = await JetpackAuthorizePage.Expect( driver );
+			const jetpackAuthorizePage = await JetpackAuthorizePage.Expect( this.driver );
 			return await jetpackAuthorizePage.approveSSOConnection();
 		} );
 	} );
 
 	describe( 'Pre-connect from Jetpack.com using "Install Jetpack" button: @parallel @jetpack', function () {
 		before( async function () {
-			return await driverManager.ensureNotLoggedIn( driver );
+			return await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'Can select Install Jetpack on Design Page', async function () {
-			const jetpackComFeaturesDesignPage = await JetpackComFeaturesDesignPage.Visit( driver );
+			const jetpackComFeaturesDesignPage = await JetpackComFeaturesDesignPage.Visit( this.driver );
 			return await jetpackComFeaturesDesignPage.installJetpack();
 		} );
 
 		it( 'Can see Jetpack connect page', async function () {
-			return await JetpackConnectPage.Expect( driver );
+			return await JetpackConnectPage.Expect( this.driver );
 		} );
 	} );
 
@@ -189,11 +191,11 @@ describe( `Jetpack Connect: (${ screenSize })`, function () {
 		let jnFlow;
 
 		before( async function () {
-			return await driverManager.ensureNotLoggedIn( driver );
+			return await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'We can set the sandbox cookie for payments', async function () {
-			const wpHomePage = await WPHomePage.Visit( driver );
+			const wpHomePage = await WPHomePage.Visit( this.driver );
 			await wpHomePage.checkURL( locale );
 			return await wpHomePage.setSandboxModeForPayments( sandboxCookieValue );
 		} );
@@ -201,33 +203,33 @@ describe( `Jetpack Connect: (${ screenSize })`, function () {
 		it( 'Can create wporg site', async function () {
 			this.timeout( mochaTimeOut * 12 );
 
-			jnFlow = new JetpackConnectFlow( driver );
+			jnFlow = new JetpackConnectFlow( this.driver );
 			return await jnFlow.createJNSite();
 		} );
 
 		it( 'Can select buy Jetpack Security on Pricing Page', async function () {
-			const jetpackComPricingPage = await JetpackComPricingPage.Visit( driver );
+			const jetpackComPricingPage = await JetpackComPricingPage.Visit( this.driver );
 			return await jetpackComPricingPage.buyJetpackPlan( 'jetpack_security_daily' );
 		} );
 
 		it( 'Can start connection flow using JN site', async function () {
-			const jetPackConnectPage = await JetpackConnectPage.Expect( driver );
+			const jetPackConnectPage = await JetpackConnectPage.Expect( this.driver );
 			return await jetPackConnectPage.addSiteUrl( jnFlow.url );
 		} );
 
 		it( 'Can log into WP.com', async function () {
 			const user = dataHelper.getAccountConfig( 'jetpackConnectUser' );
-			const loginPage = await LoginPage.Expect( driver );
+			const loginPage = await LoginPage.Expect( this.driver );
 			return await loginPage.login( user[ 0 ], user[ 1 ] );
 		} );
 
 		it( 'Can wait for Jetpack get connected', async function () {
-			const jetpackAuthorizePage = await JetpackAuthorizePage.Expect( driver );
+			const jetpackAuthorizePage = await JetpackAuthorizePage.Expect( this.driver );
 			return await jetpackAuthorizePage.waitToDisappear();
 		} );
 
 		it( 'Can see the secure payment page and enter/submit test payment details', async function () {
-			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 			const securityPlanInCart = await securePaymentComponent.containsPlan(
 				'jetpack_security_daily'
 			);
@@ -238,10 +240,10 @@ describe( `Jetpack Connect: (${ screenSize })`, function () {
 		} );
 
 		it( 'Can see Jetpack Security plan', async function () {
-			const thankYouModal = await ThankYouModalComponent.Expect( driver );
+			const thankYouModal = await ThankYouModalComponent.Expect( this.driver );
 			await thankYouModal.continue();
 
-			const myPlanPage = await MyPlanPage.Expect( driver );
+			const myPlanPage = await MyPlanPage.Expect( this.driver );
 			const isSecurity = await myPlanPage.isSecurityPlan();
 			assert( isSecurity, 'Can not verify Security plan' );
 		} );

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -35,7 +35,6 @@ import MyPlanPage from '../lib/pages/my-plan-page';
 import WPAdminInPlaceApprovePage from '../lib/pages/wp-admin/wp-admin-in-place-approve-page';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const signupInboxId = config.get( 'signupInboxId' );
 const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
@@ -45,12 +44,7 @@ const siteName = dataHelper.getJetpackSiteName();
 
 describe( `Jetpack Connect: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	describe( 'Connect From wp-admin: @parallel @jetpack @canary', function () {
 		before( async function () {

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -26,18 +26,12 @@ import WPAdminSidebar from '../lib/pages/wp-admin/wp-admin-sidebar';
 import WPAdminLogonPage from '../lib/pages/wp-admin/wp-admin-logon-page';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Jetpack Plans: (${ screenSize }) @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	describe( 'Purchase Business Plan:', function () {
 		before( async function () {

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -31,52 +31,54 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Jetpack Plans: (${ screenSize }) @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
 
 	describe( 'Purchase Business Plan:', function () {
 		before( async function () {
-			return await driverManager.clearCookiesAndDeleteLocalStorage( driver );
+			return await driverManager.clearCookiesAndDeleteLocalStorage( this.driver );
 		} );
 
 		it( 'Can log into WordPress.com', async function () {
-			this.loginFlow = new LoginFlow( driver );
+			this.loginFlow = new LoginFlow( this.driver );
 			return await this.loginFlow.login();
 		} );
 
 		it( 'Can log into site via Jetpack SSO', async function () {
-			const loginPage = await WPAdminLogonPage.Visit( driver, dataHelper.getJetpackSiteName() );
+			const loginPage = await WPAdminLogonPage.Visit(
+				this.driver,
+				dataHelper.getJetpackSiteName()
+			);
 			return await loginPage.logonSSO();
 		} );
 
 		it( 'Can open Jetpack dashboard', async function () {
-			await WPAdminSidebar.refreshIfJNError( driver );
-			const wpAdminSidebar = await WPAdminSidebar.Expect( driver );
+			await WPAdminSidebar.refreshIfJNError( this.driver );
+			const wpAdminSidebar = await WPAdminSidebar.Expect( this.driver );
 			return await wpAdminSidebar.selectJetpack();
 		} );
 
 		it( 'Can find and click Upgrade nudge button', async function () {
-			await driverHelper.refreshIfJNError( driver );
-			const jetpackDashboard = await WPAdminJetpackPage.Expect( driver );
+			await driverHelper.refreshIfJNError( this.driver );
+			const jetpackDashboard = await WPAdminJetpackPage.Expect( this.driver );
 			return await jetpackDashboard.clickUpgradeNudge();
 		} );
 
 		it( 'Can then see secure payment component and Search in the cart', async function () {
-			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 			return await securePaymentComponent.containsPlan( 'jetpack_search' );
 		} );
 
 		// Remove all items from basket for clean up
 		after( async function () {
-			await ReaderPage.Visit( driver );
+			await ReaderPage.Visit( this.driver );
 
-			const navbarComponent = await NavBarComponent.Expect( driver );
+			const navbarComponent = await NavBarComponent.Expect( this.driver );
 			await navbarComponent.clickMySites();
 
-			const sidebarComponent = await SidebarComponent.Expect( driver );
+			const sidebarComponent = await SidebarComponent.Expect( this.driver );
 			await sidebarComponent.selectPlans();
 
-			await PlansPage.Expect( driver );
-			const shoppingCartWidgetComponent = await ShoppingCartWidgetComponent.Expect( driver );
+			await PlansPage.Expect( this.driver );
+			const shoppingCartWidgetComponent = await ShoppingCartWidgetComponent.Expect( this.driver );
 			await shoppingCartWidgetComponent.empty();
 		} );
 	} );

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-plugins-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-plugins-spec.js
@@ -18,41 +18,39 @@ import LoginFlow from '../lib/flows/login-flow';
 import NoticesComponent from '../lib/components/notices-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = getJetpackHost();
 
 describe( `[${ host }] Jetpack Plugins - Activating a plugin: (${ screenSize }) @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
 
 	it( 'Can login and select Manage Plugins', async function () {
-		await driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		await driverManager.clearCookiesAndDeleteLocalStorage( this.driver );
 
-		const loginFlow = new LoginFlow( driver );
+		const loginFlow = new LoginFlow( this.driver );
 		await loginFlow.loginAndSelectManagePluginsJetpack();
 	} );
 
 	it( 'Can ensure Hello Dolly is deactivated', async function () {
-		const pluginsPage = await PluginsPage.Expect( driver );
+		const pluginsPage = await PluginsPage.Expect( this.driver );
 		await pluginsPage.viewPlugin( 'hello' );
-		const pluginDetailsPage = await PluginDetailsPage.Expect( driver );
+		const pluginDetailsPage = await PluginDetailsPage.Expect( this.driver );
 		await pluginDetailsPage.waitForPlugin();
 		await pluginDetailsPage.ensureDeactivated();
 		return await pluginDetailsPage.goBack();
 	} );
 
 	it( 'Can view the plugin details to activate Hello Dolly', async function () {
-		const pluginsPage = await PluginsPage.Expect( driver );
+		const pluginsPage = await PluginsPage.Expect( this.driver );
 		await pluginsPage.viewPlugin( 'hello' );
-		const pluginDetailsPage = await PluginDetailsPage.Expect( driver );
+		const pluginDetailsPage = await PluginDetailsPage.Expect( this.driver );
 		await pluginDetailsPage.waitForPlugin();
 		return await pluginDetailsPage.clickActivateToggleForPlugin();
 	} );
 
 	it( 'Can see a success message contains Hello Dolly', async function () {
 		const expectedPartialText = 'Successfully activated Hello Dolly';
-		const noticesComponent = await NoticesComponent.Expect( driver );
+		const noticesComponent = await NoticesComponent.Expect( this.driver );
 		await noticesComponent.isSuccessNoticeDisplayed();
 		const successMessageText = await noticesComponent.getNoticeContent();
 		return assert.strictEqual(
@@ -65,19 +63,18 @@ describe( `[${ host }] Jetpack Plugins - Activating a plugin: (${ screenSize }) 
 
 describe( `[${ host }] Jetpack Plugins - Searching a plugin: (${ screenSize }) @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
 
 	it( 'Can login and select Plugins', async function () {
-		await driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		await driverManager.clearCookiesAndDeleteLocalStorage( this.driver );
 
-		const loginFlow = new LoginFlow( driver );
+		const loginFlow = new LoginFlow( this.driver );
 		await loginFlow.loginAndSelectPluginsJetpack();
 	} );
 
 	it( 'Can open the plugins browser and find WP Job Manager by searching for Automattic', async function () {
 		const pluginVendor = 'WP Job Manager';
 		const pluginTitle = 'WP Job Manager';
-		const pluginsBrowserPage = await PluginsBrowserPage.Expect( driver );
+		const pluginsBrowserPage = await PluginsBrowserPage.Expect( this.driver );
 		await pluginsBrowserPage.searchForPlugin( pluginVendor );
 		const pluginDisplayed = await pluginsBrowserPage.pluginTitledShown( pluginTitle, pluginVendor );
 		assert( pluginDisplayed, `The plugin titled ${ pluginTitle } was not displayed` );

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-plugins-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-plugins-spec.js
@@ -24,12 +24,7 @@ const host = getJetpackHost();
 
 describe( `[${ host }] Jetpack Plugins - Activating a plugin: (${ screenSize }) @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Can login and select Manage Plugins', async function () {
 		await driverManager.clearCookiesAndDeleteLocalStorage( driver );
@@ -70,12 +65,7 @@ describe( `[${ host }] Jetpack Plugins - Activating a plugin: (${ screenSize }) 
 
 describe( `[${ host }] Jetpack Plugins - Searching a plugin: (${ screenSize }) @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Can login and select Plugins', async function () {
 		await driverManager.clearCookiesAndDeleteLocalStorage( driver );

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-settings-writing-media-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-settings-writing-media-spec.js
@@ -15,18 +15,12 @@ import SettingsPage from '../lib/pages/settings-page';
 import LoginFlow from '../lib/flows/login-flow';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Jetpack Settings on Calypso: (${ screenSize }) @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	before( async function () {
 		await driverManager.clearCookiesAndDeleteLocalStorage( driver );

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-settings-writing-media-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-settings-writing-media-spec.js
@@ -20,16 +20,15 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Jetpack Settings on Calypso: (${ screenSize }) @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
 
 	before( async function () {
-		await driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		await driverManager.clearCookiesAndDeleteLocalStorage( this.driver );
 	} );
 
 	before( async function () {
-		const loginFlow = new LoginFlow( driver, 'jetpackUser' + host );
+		const loginFlow = new LoginFlow( this.driver, 'jetpackUser' + host );
 		await loginFlow.loginAndSelectSettings();
-		this.settingsPage = await SettingsPage.Expect( driver );
+		this.settingsPage = await SettingsPage.Expect( this.driver );
 		return await this.settingsPage.selectWriting();
 	} );
 

--- a/test/e2e/specs/specs-calypso/wp-calypso-seo-preview.js
+++ b/test/e2e/specs/specs-calypso/wp-calypso-seo-preview.js
@@ -20,19 +20,12 @@ import NavBarComponent from '../../lib/components/nav-bar-component.js';
 import SidebarComponent from '../../lib/components/sidebar-component.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] SEO Preview page: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-		await driverManager.clearCookiesAndDeleteLocalStorage( driver );
-	} );
+	const driver = global.__BROWSER__;
 
 	// Login as Business plan user and open the sidebar
 	it( 'Log In', async function () {

--- a/test/e2e/specs/specs-calypso/wp-calypso-seo-preview.js
+++ b/test/e2e/specs/specs-calypso/wp-calypso-seo-preview.js
@@ -25,7 +25,11 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] SEO Preview page: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	// Login as Business plan user and open the sidebar
 	it( 'Log In', async function () {

--- a/test/e2e/specs/specs-calypso/wp-calypso-seo-preview.js
+++ b/test/e2e/specs/specs-calypso/wp-calypso-seo-preview.js
@@ -25,40 +25,38 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] SEO Preview page: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	// Login as Business plan user and open the sidebar
 	it( 'Log In', async function () {
-		const loginFlow = new LoginFlow( driver, 'wooCommerceUser' );
+		const loginFlow = new LoginFlow( this.driver, 'wooCommerceUser' );
 		await loginFlow.login();
-		const navBarComponent = await NavBarComponent.Expect( driver );
+		const navBarComponent = await NavBarComponent.Expect( this.driver );
 		return await navBarComponent.clickMySites();
 	} );
 
 	it( 'Open the marketing page', async function () {
-		this.sidebarComponent = await SidebarComponent.Expect( driver );
+		this.sidebarComponent = await SidebarComponent.Expect( this.driver );
 		return await this.sidebarComponent.selectMarketing();
 	} );
 
 	it( 'Enter front page meta description and click preview button ', async function () {
-		const trafficPage = new TrafficPage( driver );
+		const trafficPage = new TrafficPage( this.driver );
 		await trafficPage.openTrafficTab();
 		await trafficPage.enterFrontPageMetaAndClickPreviewButton();
 	} );
 
 	it( 'Ensure site preview stays open for 10 seconds', async function () {
-		await driverHelper.waitUntilElementLocatedAndVisible( driver, By.css( '.web-preview.is-seo' ) );
+		await driverHelper.waitUntilElementLocatedAndVisible(
+			this.driver,
+			By.css( '.web-preview.is-seo' )
+		);
 		const wait = async ( interval ) => {
 			return new Promise( ( resolve ) => {
 				setTimeout( resolve, interval );
 			} );
 		};
 		await wait( 10000 );
-		const previewPane = await driver.findElement( By.css( '.web-preview.is-seo' ) );
+		const previewPane = await this.driver.findElement( By.css( '.web-preview.is-seo' ) );
 		assert( previewPane, 'The site preview component has been closed.' );
 	} );
 } );

--- a/test/e2e/specs/specs-calypso/wp-calypso-user-agent.js
+++ b/test/e2e/specs/specs-calypso/wp-calypso-user-agent.js
@@ -13,19 +13,12 @@ import * as dataHelper from '../../lib/data-helper';
 import WPHomePage from '../../lib/pages/wp-home-page';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] User Agent: (${ screenSize }) @parallel @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-		await driverManager.ensureNotLoggedIn( driver );
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Can see the correct user agent set', async function () {
 		await WPHomePage.Visit( driver );

--- a/test/e2e/specs/specs-calypso/wp-calypso-user-agent.js
+++ b/test/e2e/specs/specs-calypso/wp-calypso-user-agent.js
@@ -18,7 +18,11 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] User Agent: (${ screenSize }) @parallel @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	it( 'Can see the correct user agent set', async function () {
 		await WPHomePage.Visit( driver );

--- a/test/e2e/specs/specs-calypso/wp-calypso-user-agent.js
+++ b/test/e2e/specs/specs-calypso/wp-calypso-user-agent.js
@@ -18,15 +18,10 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] User Agent: (${ screenSize }) @parallel @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	it( 'Can see the correct user agent set', async function () {
-		await WPHomePage.Visit( driver );
-		const userAgent = await driver.executeScript( 'return navigator.userAgent;' );
+		await WPHomePage.Visit( this.driver );
+		const userAgent = await this.driver.executeScript( 'return navigator.userAgent;' );
 		assert(
 			userAgent.match( 'wp-e2e-tests' ),
 			`User Agent does not contain 'wp-e2e-tests'.  [${ userAgent }]`

--- a/test/e2e/specs/specs-calypso/wp-editor__edit-media-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-editor__edit-media-spec.js
@@ -14,18 +14,12 @@ import SideBarComponent from '../../lib/components/sidebar-component';
 import MediaPage from '../../lib/pages/media-page';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Media: Edit Media (${ screenSize }) @parallel @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	before( 'Can login and select my site', async function () {
 		const loginFlow = new LoginFlow( driver );

--- a/test/e2e/specs/specs-calypso/wp-editor__edit-media-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-editor__edit-media-spec.js
@@ -19,28 +19,27 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Media: Edit Media (${ screenSize }) @parallel @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
 
 	before( 'Can login and select my site', async function () {
-		const loginFlow = new LoginFlow( driver );
+		const loginFlow = new LoginFlow( this.driver );
 		await loginFlow.loginAndSelectMySite();
 	} );
 
 	it( "Select 'Media' option and see media content", async function () {
-		const sideBarComponent = await SideBarComponent.Expect( driver );
+		const sideBarComponent = await SideBarComponent.Expect( this.driver );
 		await sideBarComponent.selectMedia();
-		return await MediaPage.Expect( driver );
+		return await MediaPage.Expect( this.driver );
 	} );
 
 	it( 'Select a random media item and click edit', async function () {
-		const mediaPage = await MediaPage.Expect( driver );
+		const mediaPage = await MediaPage.Expect( this.driver );
 		await mediaPage.selectFirstImage();
 		await mediaPage.selectEditMedia();
 		return await mediaPage.mediaEditorShowing();
 	} );
 
 	it( 'Click Edit Image', async function () {
-		const mediaPage = await MediaPage.Expect( driver );
+		const mediaPage = await MediaPage.Expect( this.driver );
 		await mediaPage.clickEditImage();
 		return await mediaPage.imageShowingInEditor();
 	} );

--- a/test/e2e/specs/specs-calypso/wp-editor__media-upload-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-editor__media-upload-spec.js
@@ -15,7 +15,6 @@ import * as mediaHelper from '../../lib/media-helper.js';
 import * as dataHelper from '../../lib/data-helper';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
@@ -23,12 +22,7 @@ describe( `[${ host }] Editor: Media Upload (${ screenSize }) @parallel @jetpack
 	this.timeout( mochaTimeOut );
 	let gutenbergEditor;
 	let blockID;
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	before( async function () {
 		let editorType = 'iframe';

--- a/test/e2e/specs/specs-calypso/wp-editor__media-upload-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-editor__media-upload-spec.js
@@ -22,18 +22,17 @@ describe( `[${ host }] Editor: Media Upload (${ screenSize }) @parallel @jetpack
 	this.timeout( mochaTimeOut );
 	let gutenbergEditor;
 	let blockID;
-	const driver = global.__BROWSER__;
 
 	before( async function () {
 		let editorType = 'iframe';
-		const loginFlow = new LoginFlow( driver );
+		const loginFlow = new LoginFlow( this.driver );
 
 		if ( host !== 'WPCOM' ) {
 			editorType = 'wpadmin';
 		}
 		await loginFlow.loginAndStartNewPage( null, true, { editorType: editorType } );
 
-		gutenbergEditor = await GutenbergEditorComponent.Expect( driver, editorType );
+		gutenbergEditor = await GutenbergEditorComponent.Expect( this.driver, editorType );
 		await gutenbergEditor.displayed();
 	} );
 

--- a/test/e2e/specs/specs-calypso/wp-gutenboarding__create-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-gutenboarding__create-spec.js
@@ -24,20 +24,14 @@ import * as dataHelper from '../../lib/data-helper.js';
 import * as driverHelper from '../../lib/driver-helper.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 
 describe( `Gutenboarding - Create new site as existing user: (${ screenSize }) @parallel @canary`, function () {
 	this.timeout( mochaTimeOut );
 	const siteTitle = dataHelper.randomPhrase();
 	const domainQuery = dataHelper.randomPhrase();
-	let driver;
 	let newSiteDomain = '';
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Can log in as user', async function () {
 		await new LoginFlow( driver ).login();

--- a/test/e2e/specs/specs-calypso/wp-gutenboarding__create-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-gutenboarding__create-spec.js
@@ -31,26 +31,25 @@ describe( `Gutenboarding - Create new site as existing user: (${ screenSize }) @
 	const siteTitle = dataHelper.randomPhrase();
 	const domainQuery = dataHelper.randomPhrase();
 	let newSiteDomain = '';
-	const driver = global.__BROWSER__;
 
 	it( 'Can log in as user', async function () {
-		await new LoginFlow( driver ).login();
+		await new LoginFlow( this.driver ).login();
 	} );
 
 	it( 'Can visit Gutenboarding page and see Onboarding block', async function () {
-		const page = await NewPage.Visit( driver, NewPage.getGutenboardingURL() );
+		const page = await NewPage.Visit( this.driver, NewPage.getGutenboardingURL() );
 		const blockExists = await page.waitForBlock();
 		assert( blockExists, 'Onboarding block is not rendered' );
 	} );
 
 	it( 'Can see Acquire Intent and set site title', async function () {
-		const acquireIntentPage = await AcquireIntentPage.Expect( driver );
+		const acquireIntentPage = await AcquireIntentPage.Expect( this.driver );
 		await acquireIntentPage.enterSiteTitle( siteTitle );
 	} );
 
 	it( 'Can change language to Spanish and back to English', async function () {
-		const acquireIntentPage = await AcquireIntentPage.Expect( driver );
-		const languagePicker = await LanguagePickerComponent.Expect( driver );
+		const acquireIntentPage = await AcquireIntentPage.Expect( this.driver );
+		const languagePicker = await LanguagePickerComponent.Expect( this.driver );
 
 		await languagePicker.switchLanguage( 'es' );
 
@@ -58,7 +57,7 @@ describe( `Gutenboarding - Create new site as existing user: (${ screenSize }) @
 			acquireIntentPage.nextButtonLocator,
 			'Continuar'
 		);
-		await driverHelper.waitUntilElementLocatedAndVisible( driver, nextButtonLocatorES );
+		await driverHelper.waitUntilElementLocatedAndVisible( this.driver, nextButtonLocatorES );
 
 		await languagePicker.switchLanguage( 'en' );
 
@@ -66,13 +65,13 @@ describe( `Gutenboarding - Create new site as existing user: (${ screenSize }) @
 			acquireIntentPage.nextButtonLocator,
 			'Continue'
 		);
-		await driverHelper.waitUntilElementLocatedAndVisible( driver, nextButtonLocatorEN );
+		await driverHelper.waitUntilElementLocatedAndVisible( this.driver, nextButtonLocatorEN );
 
 		await acquireIntentPage.goToNextStep();
 	} );
 
 	it( 'Can see Domains Page, search for domains, pick a free domain, and continue', async function () {
-		const domainsPage = await DomainsPage.Expect( driver );
+		const domainsPage = await DomainsPage.Expect( this.driver );
 		await domainsPage.enterDomainQuery( domainQuery );
 		await domainsPage.waitForDomainSuggestionsToLoad();
 		newSiteDomain = await domainsPage.getFreeDomainName();
@@ -81,25 +80,25 @@ describe( `Gutenboarding - Create new site as existing user: (${ screenSize }) @
 	} );
 
 	it( 'Can see Design Locator and select a random free design', async function () {
-		const designLocatorPage = await DesignLocatorPage.Expect( driver );
+		const designLocatorPage = await DesignLocatorPage.Expect( this.driver );
 		await designLocatorPage.selectFreeDesign();
 	} );
 
 	it( 'Can see Style Preview, choose a random font pairing, and continue', async function () {
-		const stylePreviewPage = await StylePreviewPage.Expect( driver );
+		const stylePreviewPage = await StylePreviewPage.Expect( this.driver );
 		await stylePreviewPage.selectFontPairing();
 		await stylePreviewPage.continue();
 	} );
 
 	it( 'Can see Feature picker and choose a feature that requires a business plan', async function () {
-		const featuresPage = await FeaturesPage.Expect( driver );
+		const featuresPage = await FeaturesPage.Expect( this.driver );
 		await featuresPage.selectPluginsFeature();
 		await featuresPage.goToNextStep();
 	} );
 
 	it( 'Can see Plans Grid with business plan recommended and can choose free plan', async function () {
-		const plansPage = await PlansPage.Expect( driver );
-		const recommendedPlan = await plansPage.getRecommendedPlan( driver );
+		const plansPage = await PlansPage.Expect( this.driver );
+		const recommendedPlan = await plansPage.getRecommendedPlan( this.driver );
 		assert.strictEqual(
 			recommendedPlan,
 			'Business',
@@ -109,7 +108,7 @@ describe( `Gutenboarding - Create new site as existing user: (${ screenSize }) @
 		await plansPage.selectFreePlan();
 
 		// Redirect console messages that starts with "onboarding-debug" to E2E log.
-		await driver
+		await this.driver
 			.manage()
 			.logs()
 			.get( 'browser' )
@@ -123,11 +122,11 @@ describe( `Gutenboarding - Create new site as existing user: (${ screenSize }) @
 	} );
 
 	it( 'Can see the gutenberg page editor', async function () {
-		const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+		const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 		await gEditorComponent.initEditor();
 	} );
 
 	after( 'Can delete site', async function () {
-		await new DeleteSiteFlow( driver ).deleteSite( newSiteDomain );
+		await new DeleteSiteFlow( this.driver ).deleteSite( newSiteDomain );
 	} );
 } );

--- a/test/e2e/specs/specs-calypso/wp-gutenboarding__visit-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-gutenboarding__visit-spec.js
@@ -16,17 +16,12 @@ const screenSize = driverManager.currentScreenSize();
 
 describe( `Gutenboarding - Visit Gutenboarding page as a logged in user: (${ screenSize }) @parallel @canary`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	it( 'Can log in as user', async function () {
-		await new LoginFlow( driver ).login();
+		await new LoginFlow( this.driver ).login();
 	} );
 
 	it( 'Can visit Gutenboarding', async function () {
-		await NewPage.Visit( driver );
+		await NewPage.Visit( this.driver );
 	} );
 } );

--- a/test/e2e/specs/specs-calypso/wp-gutenboarding__visit-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-gutenboarding__visit-spec.js
@@ -16,7 +16,11 @@ const screenSize = driverManager.currentScreenSize();
 
 describe( `Gutenboarding - Visit Gutenboarding page as a logged in user: (${ screenSize }) @parallel @canary`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	it( 'Can log in as user', async function () {
 		await new LoginFlow( driver ).login();

--- a/test/e2e/specs/specs-calypso/wp-gutenboarding__visit-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-gutenboarding__visit-spec.js
@@ -12,17 +12,11 @@ import NewPage from '../../lib/pages/gutenboarding/new-page.js';
 import * as driverManager from '../../lib/driver-manager.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 
 describe( `Gutenboarding - Visit Gutenboarding page as a logged in user: (${ screenSize }) @parallel @canary`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Can log in as user', async function () {
 		await new LoginFlow( driver ).login();

--- a/test/e2e/specs/specs-calypso/wp-import-site-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-import-site-spec.js
@@ -17,17 +17,11 @@ import ImporterPage from '../../lib/pages/importer-page';
 import * as driverManager from '../../lib/driver-manager.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 
 describe( 'Verify Import Option: (' + screenSize + ') @parallel', function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Can log in as default user', async function () {
 		const loginFlow = new LoginFlow( driver );

--- a/test/e2e/specs/specs-calypso/wp-import-site-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-import-site-spec.js
@@ -21,7 +21,11 @@ const screenSize = driverManager.currentScreenSize();
 
 describe( 'Verify Import Option: (' + screenSize + ') @parallel', function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	it( 'Can log in as default user', async function () {
 		const loginFlow = new LoginFlow( driver );

--- a/test/e2e/specs/specs-calypso/wp-import-site-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-import-site-spec.js
@@ -21,40 +21,35 @@ const screenSize = driverManager.currentScreenSize();
 
 describe( 'Verify Import Option: (' + screenSize + ') @parallel', function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	it( 'Can log in as default user', async function () {
-		const loginFlow = new LoginFlow( driver );
+		const loginFlow = new LoginFlow( this.driver );
 		return await loginFlow.login();
 	} );
 
 	it( 'Can open the sidebar', async function () {
-		const navBarComponent = await NavBarComponent.Expect( driver );
+		const navBarComponent = await NavBarComponent.Expect( this.driver );
 		await navBarComponent.clickMySites();
 	} );
 
 	it( "Following 'Import' menu option opens the Import page", async function () {
-		const sideBarComponent = await SideBarComponent.Expect( driver );
+		const sideBarComponent = await SideBarComponent.Expect( this.driver );
 		await sideBarComponent.selectImport();
-		await ImporterPage.Expect( driver );
+		await ImporterPage.Expect( this.driver );
 	} );
 
 	it( 'Can see the WordPress importer', async function () {
-		const importerPage = await ImporterPage.Expect( driver );
+		const importerPage = await ImporterPage.Expect( this.driver );
 		assert( await importerPage.importerIsDisplayed( 'wordpress' ) );
 	} );
 
 	it( 'Can see the Medium importer', async function () {
-		const importerPage = await ImporterPage.Expect( driver );
+		const importerPage = await ImporterPage.Expect( this.driver );
 		assert( await importerPage.importerIsDisplayed( 'medium-logo' ) );
 	} );
 
 	it( 'Can see the Blogger importer', async function () {
-		const importerPage = await ImporterPage.Expect( driver );
+		const importerPage = await ImporterPage.Expect( this.driver );
 		assert( await importerPage.importerIsDisplayed( 'blogger-alt' ) );
 	} );
 } );

--- a/test/e2e/specs/specs-calypso/wp-inline-help-support-search-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-inline-help-support-search-spec.js
@@ -16,7 +16,6 @@ import SupportSearchComponent from '../../lib/components/support-search-componen
 import SidebarComponent from '../../lib/components/sidebar-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
@@ -25,12 +24,7 @@ let inlineHelpPopoverComponent;
 
 describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Login and select a page that is not the My Home page', async function () {
 		const loginFlow = new LoginFlow( driver );

--- a/test/e2e/specs/specs-calypso/wp-inline-help-support-search-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-inline-help-support-search-spec.js
@@ -24,7 +24,11 @@ let inlineHelpPopoverComponent;
 
 describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	it( 'Login and select a page that is not the My Home page', async function () {
 		const loginFlow = new LoginFlow( driver );

--- a/test/e2e/specs/specs-calypso/wp-inline-help-support-search-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-inline-help-support-search-spec.js
@@ -24,26 +24,21 @@ let inlineHelpPopoverComponent;
 
 describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	it( 'Login and select a page that is not the My Home page', async function () {
-		const loginFlow = new LoginFlow( driver );
+		const loginFlow = new LoginFlow( this.driver );
 
 		// The "/home" route is the only one where the "FAB" inline help
 		// is not shown.
 		await loginFlow.loginAndSelectSettings();
 
 		// Initialize the helper component
-		inlineHelpPopoverComponent = await InlineHelpPopoverComponent.Expect( driver );
+		inlineHelpPopoverComponent = await InlineHelpPopoverComponent.Expect( this.driver );
 	} );
 
 	describe( 'Popover UI visibility', function () {
 		it( 'Check help toggle is not visible on My Home page', async function () {
-			const sidebarComponent = await SidebarComponent.Expect( driver );
+			const sidebarComponent = await SidebarComponent.Expect( this.driver );
 			await sidebarComponent.selectMyHome();
 
 			// The toggle only hides once the "Get help" card is rendered so
@@ -52,7 +47,7 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, function () {
 		} );
 
 		it( 'Check help toggle is visible on Settings page', async function () {
-			const sidebarComponent = await SidebarComponent.Expect( driver );
+			const sidebarComponent = await SidebarComponent.Expect( this.driver );
 
 			// The "inline help" FAB should not appear on the My Home
 			// because there is already a support search "Card" on that
@@ -74,7 +69,7 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, function () {
 	describe( 'Performing searches', function () {
 		it( 'Open Inline Help popover', async function () {
 			await inlineHelpPopoverComponent.toggleOpen();
-			supportSearchComponent = await SupportSearchComponent.Expect( driver );
+			supportSearchComponent = await SupportSearchComponent.Expect( this.driver );
 		} );
 
 		it( 'Displays contextual search results by default', async function () {

--- a/test/e2e/specs/specs-calypso/wp-invite-users__editor-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__editor-spec.js
@@ -40,27 +40,26 @@ describe( `[${ host }] Invites - New user as Editor: (${ screenSize }) @parallel
 	let acceptInviteURL = '';
 	let inviteCreated = false;
 	let inviteAccepted = false;
-	const driver = global.__BROWSER__;
 
 	it( 'Can log in and navigate to Invite People page', async function () {
-		await new LoginFlow( driver ).loginAndSelectPeople();
-		const peoplePage = await PeoplePage.Expect( driver );
+		await new LoginFlow( this.driver ).loginAndSelectPeople();
+		const peoplePage = await PeoplePage.Expect( this.driver );
 		return await peoplePage.inviteUser();
 	} );
 
 	it( 'Can invite a new user as an editor and see its pending', async function () {
-		const invitePeoplePage = await InvitePeoplePage.Expect( driver );
+		const invitePeoplePage = await InvitePeoplePage.Expect( this.driver );
 		await invitePeoplePage.inviteNewUser(
 			newInviteEmailAddress,
 			'editor',
 			'Automated e2e testing'
 		);
-		const noticesComponent = await NoticesComponent.Expect( driver );
+		const noticesComponent = await NoticesComponent.Expect( this.driver );
 		await noticesComponent.isSuccessNoticeDisplayed();
 		inviteCreated = true;
 		await invitePeoplePage.backToPeopleMenu();
 
-		const peoplePage = await PeoplePage.Expect( driver );
+		const peoplePage = await PeoplePage.Expect( this.driver );
 		await peoplePage.selectInvites();
 		return await peoplePage.waitForPendingInviteDisplayedFor( newInviteEmailAddress );
 	} );
@@ -78,10 +77,10 @@ describe( `[${ host }] Invites - New user as Editor: (${ screenSize }) @parallel
 	} );
 
 	it( 'Can sign up as new user for the blog via invite link', async function () {
-		await driverManager.ensureNotLoggedIn( driver );
+		await driverManager.ensureNotLoggedIn( this.driver );
 
-		await driver.get( acceptInviteURL );
-		const acceptInvitePage = await AcceptInvitePage.Expect( driver );
+		await this.driver.get( acceptInviteURL );
+		const acceptInvitePage = await AcceptInvitePage.Expect( this.driver );
 
 		const actualEmailAddress = await acceptInvitePage.getEmailPreFilled();
 		const headerInviteText = await acceptInvitePage.getHeaderInviteText();
@@ -93,10 +92,10 @@ describe( `[${ host }] Invites - New user as Editor: (${ screenSize }) @parallel
 	} );
 
 	it( 'User has been added as Editor', async function () {
-		await PostsPage.Expect( driver );
+		await PostsPage.Expect( this.driver );
 
 		inviteAccepted = true;
-		const noticesComponent = await NoticesComponent.Expect( driver );
+		const noticesComponent = await NoticesComponent.Expect( this.driver );
 		const invitesMessageTitleDisplayed = await noticesComponent.getNoticeContent();
 		return assert(
 			invitesMessageTitleDisplayed.includes( 'Editor' ),
@@ -105,9 +104,9 @@ describe( `[${ host }] Invites - New user as Editor: (${ screenSize }) @parallel
 	} );
 
 	it( 'As the original user can see and remove new user', async function () {
-		await new LoginFlow( driver ).loginAndSelectPeople();
+		await new LoginFlow( this.driver ).loginAndSelectPeople();
 
-		const peoplePage = await PeoplePage.Expect( driver );
+		const peoplePage = await PeoplePage.Expect( this.driver );
 		await peoplePage.selectTeam();
 		await peoplePage.searchForUser( newUserName );
 		const numberPeopleShown = await peoplePage.numberSearchResults();
@@ -118,9 +117,9 @@ describe( `[${ host }] Invites - New user as Editor: (${ screenSize }) @parallel
 		);
 
 		await peoplePage.selectOnlyPersonDisplayed();
-		const editTeamMemberPage = await EditTeamMemberPage.Expect( driver );
+		const editTeamMemberPage = await EditTeamMemberPage.Expect( this.driver );
 		await editTeamMemberPage.removeUserAndDeleteContent();
-		const noticesComponent = await NoticesComponent.Expect( driver );
+		const noticesComponent = await NoticesComponent.Expect( this.driver );
 		const displayed = await noticesComponent.isSuccessNoticeDisplayed();
 		return assert.strictEqual(
 			displayed,
@@ -131,20 +130,20 @@ describe( `[${ host }] Invites - New user as Editor: (${ screenSize }) @parallel
 
 	it( 'As the invited user, I am no longer an editor on the site', async function () {
 		if ( 'WPCOM' !== dataHelper.getJetpackHost() ) return this.skip();
-		const loginPage = await LoginPage.Visit( driver );
+		const loginPage = await LoginPage.Visit( this.driver );
 		await loginPage.login( newUserName, password );
-		await ReaderPage.Expect( driver );
+		await ReaderPage.Expect( this.driver );
 
-		const navBarComponent = await NavBarComponent.Expect( driver );
+		const navBarComponent = await NavBarComponent.Expect( this.driver );
 		await navBarComponent.clickMySites();
-		return await NoSitesComponent.Expect( driver );
+		return await NoSitesComponent.Expect( this.driver );
 	} );
 
 	after( async function () {
 		if ( inviteCreated ) {
 			try {
-				await new LoginFlow( driver ).loginAndSelectPeople();
-				const peoplePage = await PeoplePage.Expect( driver );
+				await new LoginFlow( this.driver ).loginAndSelectPeople();
+				const peoplePage = await PeoplePage.Expect( this.driver );
 				await peoplePage.selectInvites();
 
 				// Sometimes, the 'accept invite' step fails. In these cases, we perform cleanup
@@ -155,7 +154,7 @@ describe( `[${ host }] Invites - New user as Editor: (${ screenSize }) @parallel
 					await peoplePage.goToRevokeInvitePage( newInviteEmailAddress );
 				}
 
-				const clearOrRevokeInvitePage = await RevokePage.Expect( driver );
+				const clearOrRevokeInvitePage = await RevokePage.Expect( this.driver );
 				await clearOrRevokeInvitePage.revokeUser();
 			} catch {
 				console.log( 'Invites cleanup failed for (Inviting new user as an Editor)' );

--- a/test/e2e/specs/specs-calypso/wp-invite-users__editor-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__editor-spec.js
@@ -27,7 +27,6 @@ import * as driverManager from '../../lib/driver-manager.js';
 import EmailClient from '../../lib/email-client.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const inviteInboxId = config.get( 'inviteInboxId' );
 const password = config.get( 'passwordForNewTestSignUps' );
 const screenSize = driverManager.currentScreenSize();
@@ -41,12 +40,7 @@ describe( `[${ host }] Invites - New user as Editor: (${ screenSize }) @parallel
 	let acceptInviteURL = '';
 	let inviteCreated = false;
 	let inviteAccepted = false;
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Can log in and navigate to Invite People page', async function () {
 		await new LoginFlow( driver ).loginAndSelectPeople();

--- a/test/e2e/specs/specs-calypso/wp-invite-users__revoke-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__revoke-spec.js
@@ -21,7 +21,6 @@ import * as driverManager from '../../lib/driver-manager.js';
 import EmailClient from '../../lib/email-client.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const inviteInboxId = config.get( 'inviteInboxId' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
@@ -32,12 +31,7 @@ describe( `[${ host }] Invites - New user as Editor and revoke: (${ screenSize }
 	const newUserName = 'e2eflowtestingeditorb' + new Date().getTime().toString();
 	const newInviteEmailAddress = dataHelper.getEmailAddress( newUserName, inviteInboxId );
 	let acceptInviteURL = '';
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Can log in and navigate to Invite People page', async function () {
 		await new LoginFlow( driver ).loginAndSelectPeople();

--- a/test/e2e/specs/specs-calypso/wp-invite-users__revoke-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__revoke-spec.js
@@ -31,32 +31,31 @@ describe( `[${ host }] Invites - New user as Editor and revoke: (${ screenSize }
 	const newUserName = 'e2eflowtestingeditorb' + new Date().getTime().toString();
 	const newInviteEmailAddress = dataHelper.getEmailAddress( newUserName, inviteInboxId );
 	let acceptInviteURL = '';
-	const driver = global.__BROWSER__;
 
 	it( 'Can log in and navigate to Invite People page', async function () {
-		await new LoginFlow( driver ).loginAndSelectPeople();
-		const peoplePage = await PeoplePage.Expect( driver );
+		await new LoginFlow( this.driver ).loginAndSelectPeople();
+		const peoplePage = await PeoplePage.Expect( this.driver );
 		return await peoplePage.inviteUser();
 	} );
 
 	it( 'Can Invite a New User as an Editor, then revoke the invite', async function () {
-		const invitePeoplePage = await InvitePeoplePage.Expect( driver );
+		const invitePeoplePage = await InvitePeoplePage.Expect( this.driver );
 		await invitePeoplePage.inviteNewUser(
 			newInviteEmailAddress,
 			'editor',
 			'Automated e2e testing'
 		);
-		const noticesComponent = await NoticesComponent.Expect( driver );
+		const noticesComponent = await NoticesComponent.Expect( this.driver );
 		await noticesComponent.isSuccessNoticeDisplayed();
 		await invitePeoplePage.backToPeopleMenu();
 
-		const peoplePage = await PeoplePage.Expect( driver );
+		const peoplePage = await PeoplePage.Expect( this.driver );
 		await peoplePage.selectInvites();
 		await peoplePage.waitForPendingInviteDisplayedFor( newInviteEmailAddress );
 
 		await peoplePage.goToRevokeInvitePage( newInviteEmailAddress );
 
-		const revokePage = await RevokePage.Expect( driver );
+		const revokePage = await RevokePage.Expect( this.driver );
 		await revokePage.revokeUser();
 		const sent = await noticesComponent.isSuccessNoticeDisplayed();
 		return assert( sent, 'The sent confirmation message was not displayed' );
@@ -75,12 +74,12 @@ describe( `[${ host }] Invites - New user as Editor and revoke: (${ screenSize }
 	} );
 
 	it( 'Can open the invite page and see it has been revoked', async function () {
-		await driverManager.ensureNotLoggedIn( driver );
+		await driverManager.ensureNotLoggedIn( this.driver );
 
-		await driver.get( acceptInviteURL );
-		await AcceptInvitePage.Expect( driver );
+		await this.driver.get( acceptInviteURL );
+		await AcceptInvitePage.Expect( this.driver );
 
-		const inviteErrorPage = await InviteErrorPage.Expect( driver );
+		const inviteErrorPage = await InviteErrorPage.Expect( this.driver );
 		const displayed = await inviteErrorPage.inviteErrorTitleDisplayed();
 		return assert( displayed, 'The invite was not successfully revoked' );
 	} );

--- a/test/e2e/specs/specs-calypso/wp-invite-users__viewer-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__viewer-spec.js
@@ -40,31 +40,30 @@ describe( `[${ host }] Invites - New user as Viewer: (${ screenSize }) @parallel
 	let acceptInviteURL = '';
 	let inviteCreated = false;
 	let inviteAccepted = false;
-	const driver = global.__BROWSER__;
 
 	it( 'As an anonymous user I can not see a private site', async function () {
-		return await PrivateSiteLoginPage.Visit( driver, siteUrl );
+		return await PrivateSiteLoginPage.Visit( this.driver, siteUrl );
 	} );
 
 	it( 'Can log in and navigate to Invite People page', async function () {
-		await new LoginFlow( driver, 'privateSiteUser' ).loginAndSelectPeople();
-		const peoplePage = await PeoplePage.Expect( driver );
+		await new LoginFlow( this.driver, 'privateSiteUser' ).loginAndSelectPeople();
+		const peoplePage = await PeoplePage.Expect( this.driver );
 		return await peoplePage.inviteUser();
 	} );
 
 	it( 'Can invite a new user as a viewer and see its pending', async function () {
-		const invitePeoplePage = await InvitePeoplePage.Expect( driver );
+		const invitePeoplePage = await InvitePeoplePage.Expect( this.driver );
 		await invitePeoplePage.inviteNewUser(
 			newInviteEmailAddress,
 			'viewer',
 			'Automated e2e testing'
 		);
-		const noticesComponent = await NoticesComponent.Expect( driver );
+		const noticesComponent = await NoticesComponent.Expect( this.driver );
 		await noticesComponent.isSuccessNoticeDisplayed();
 		inviteCreated = true;
 		await invitePeoplePage.backToPeopleMenu();
 
-		const peoplePage = await PeoplePage.Expect( driver );
+		const peoplePage = await PeoplePage.Expect( this.driver );
 		await peoplePage.selectInvites();
 		return await peoplePage.waitForPendingInviteDisplayedFor( newInviteEmailAddress );
 	} );
@@ -82,10 +81,10 @@ describe( `[${ host }] Invites - New user as Viewer: (${ screenSize }) @parallel
 	} );
 
 	it( 'Can sign up as new user for the blog via invite link', async function () {
-		await driverManager.ensureNotLoggedIn( driver );
+		await driverManager.ensureNotLoggedIn( this.driver );
 
-		await driver.get( acceptInviteURL );
-		const acceptInvitePage = await AcceptInvitePage.Expect( driver );
+		await this.driver.get( acceptInviteURL );
+		const acceptInvitePage = await AcceptInvitePage.Expect( this.driver );
 
 		const actualEmailAddress = await acceptInvitePage.getEmailPreFilled();
 		const headerInviteText = await acceptInvitePage.getHeaderInviteText();
@@ -99,7 +98,7 @@ describe( `[${ host }] Invites - New user as Viewer: (${ screenSize }) @parallel
 
 	it( 'Can see user has been added as a Viewer', async function () {
 		inviteAccepted = true;
-		const noticesComponent = await NoticesComponent.Expect( driver );
+		const noticesComponent = await NoticesComponent.Expect( this.driver );
 		const followMessageDisplayed = await noticesComponent.getNoticeContent();
 		assert.strictEqual(
 			true,
@@ -107,14 +106,14 @@ describe( `[${ host }] Invites - New user as Viewer: (${ screenSize }) @parallel
 			`The follow message '${ followMessageDisplayed }' does not include 'viewer'`
 		);
 
-		await ReaderPage.Expect( driver );
-		return await ViewBlogPage.Visit( driver, siteUrl );
+		await ReaderPage.Expect( this.driver );
+		return await ViewBlogPage.Visit( this.driver, siteUrl );
 	} );
 
 	it( 'Can see new user added and can be removed', async function () {
-		await new LoginFlow( driver, 'privateSiteUser' ).loginAndSelectPeople();
+		await new LoginFlow( this.driver, 'privateSiteUser' ).loginAndSelectPeople();
 
-		const peoplePage = await PeoplePage.Expect( driver );
+		const peoplePage = await PeoplePage.Expect( this.driver );
 		await peoplePage.selectViewers();
 		let displayed = await peoplePage.viewerDisplayed( newUserName );
 		assert( displayed, `The username of '${ newUserName }' was not displayed as a site viewer` );
@@ -133,18 +132,18 @@ describe( `[${ host }] Invites - New user as Viewer: (${ screenSize }) @parallel
 	} );
 
 	it( 'Can not see the site - see the private site log in page', async function () {
-		const loginPage = await LoginPage.Visit( driver );
+		const loginPage = await LoginPage.Visit( this.driver );
 		await loginPage.login( newUserName, password );
 
-		await ReaderPage.Expect( driver );
-		return await PrivateSiteLoginPage.Visit( driver, siteUrl );
+		await ReaderPage.Expect( this.driver );
+		return await PrivateSiteLoginPage.Visit( this.driver, siteUrl );
 	} );
 
 	after( async function () {
 		if ( inviteCreated ) {
 			try {
-				await new LoginFlow( driver, 'privateSiteUser' ).loginAndSelectPeople();
-				const peoplePageCleanup = await PeoplePage.Expect( driver );
+				await new LoginFlow( this.driver, 'privateSiteUser' ).loginAndSelectPeople();
+				const peoplePageCleanup = await PeoplePage.Expect( this.driver );
 				await peoplePageCleanup.selectInvites();
 
 				// Sometimes, the 'accept invite' step fails. In these cases, we perform cleanup
@@ -155,7 +154,7 @@ describe( `[${ host }] Invites - New user as Viewer: (${ screenSize }) @parallel
 					await peoplePageCleanup.goToRevokeInvitePage( newInviteEmailAddress );
 				}
 
-				const clearOrRevokeInvitePage = await RevokePage.Expect( driver );
+				const clearOrRevokeInvitePage = await RevokePage.Expect( this.driver );
 				await clearOrRevokeInvitePage.revokeUser();
 			} catch {
 				console.log(
@@ -166,8 +165,8 @@ describe( `[${ host }] Invites - New user as Viewer: (${ screenSize }) @parallel
 		}
 
 		if ( ! removedViewerFlag ) {
-			await new LoginFlow( driver, 'privateSiteUser' ).loginAndSelectPeople();
-			const peoplePage = await PeoplePage.Expect( driver );
+			await new LoginFlow( this.driver, 'privateSiteUser' ).loginAndSelectPeople();
+			const peoplePage = await PeoplePage.Expect( this.driver );
 
 			await peoplePage.selectViewers();
 			const displayed = await peoplePage.viewerDisplayed( newUserName );

--- a/test/e2e/specs/specs-calypso/wp-invite-users__viewer-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__viewer-spec.js
@@ -24,7 +24,6 @@ import * as driverManager from '../../lib/driver-manager.js';
 import EmailClient from '../../lib/email-client.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const inviteInboxId = config.get( 'inviteInboxId' );
 const password = config.get( 'passwordForNewTestSignUps' );
 const screenSize = driverManager.currentScreenSize();
@@ -41,12 +40,7 @@ describe( `[${ host }] Invites - New user as Viewer: (${ screenSize }) @parallel
 	let acceptInviteURL = '';
 	let inviteCreated = false;
 	let inviteAccepted = false;
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'As an anonymous user I can not see a private site', async function () {
 		return await PrivateSiteLoginPage.Visit( driver, siteUrl );

--- a/test/e2e/specs/specs-calypso/wp-launch-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-launch-spec.js
@@ -21,7 +21,6 @@ import MyHomePage from '../../lib/pages/my-home-page.js';
 
 const host = dataHelper.getJetpackHost();
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const signupInboxId = config.get( 'signupInboxId' );
 
@@ -40,12 +39,7 @@ const createAndActivateAccount = async function ( driver, accountName ) {
 
 describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	describe( 'Launch a free site', function () {
 		const siteName = dataHelper.getNewBlogName();

--- a/test/e2e/specs/specs-calypso/wp-launch-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-launch-spec.js
@@ -39,7 +39,11 @@ const createAndActivateAccount = async function ( driver, accountName ) {
 
 describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	describe( 'Launch a free site', function () {
 		const siteName = dataHelper.getNewBlogName();

--- a/test/e2e/specs/specs-calypso/wp-launch-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-launch-spec.js
@@ -39,30 +39,25 @@ const createAndActivateAccount = async function ( driver, accountName ) {
 
 describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	describe( 'Launch a free site', function () {
 		const siteName = dataHelper.getNewBlogName();
 
 		before( 'Can log in', async function () {
-			const loginFlow = new LoginFlow( driver );
+			const loginFlow = new LoginFlow( this.driver );
 			await loginFlow.login();
 		} );
 
 		it( 'Can create a free site', async function () {
-			return await new CreateSiteFlow( driver, siteName ).createFreeSite();
+			return await new CreateSiteFlow( this.driver, siteName ).createFreeSite();
 		} );
 
 		it( 'Can launch a site', async function () {
-			return await new LaunchSiteFlow( driver ).launchFreeSite();
+			return await new LaunchSiteFlow( this.driver ).launchFreeSite();
 		} );
 
 		after( 'Delete the newly created site', async function () {
-			const deleteSite = new DeleteSiteFlow( driver );
+			const deleteSite = new DeleteSiteFlow( this.driver );
 			return await deleteSite.deleteSite( siteName + '.wordpress.com' );
 		} );
 	} );
@@ -77,34 +72,34 @@ describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () 
 		const secondSiteName = dataHelper.getNewBlogName();
 
 		before( 'Create 2 free sites as a new user', async function () {
-			await createAndActivateAccount( driver, accountName );
-			await new CreateSiteFlow( driver, firstSiteName ).createFreeSite();
-			await new CreateSiteFlow( driver, secondSiteName ).createFreeSite();
+			await createAndActivateAccount( this.driver, accountName );
+			await new CreateSiteFlow( this.driver, firstSiteName ).createFreeSite();
+			await new CreateSiteFlow( this.driver, secondSiteName ).createFreeSite();
 		} );
 
 		it( 'Can start launch flow and abandon', async function () {
-			const myHomePage = await MyHomePage.Expect( driver );
+			const myHomePage = await MyHomePage.Expect( this.driver );
 			await myHomePage.launchSiteFromSiteSetup();
-			await FindADomainComponent.Expect( driver );
+			await FindADomainComponent.Expect( this.driver );
 			// force reloading the page from the server to simulate an expired cache
-			await driver.executeScript( 'window.location.reload(true);' );
-			await FindADomainComponent.Expect( driver );
-			return await driver.navigate().back();
+			await this.driver.executeScript( 'window.location.reload(true);' );
+			await FindADomainComponent.Expect( this.driver );
+			return await this.driver.navigate().back();
 		} );
 
 		it( 'Can switch sites and launch the first site', async function () {
-			const sideBarComponent = await SidebarComponent.Expect( driver );
+			const sideBarComponent = await SidebarComponent.Expect( this.driver );
 			await sideBarComponent.selectSiteSwitcher();
 			await sideBarComponent.searchForSite( firstSiteName );
 			if ( driverManager.currentScreenSize() === 'mobile' ) {
 				await sideBarComponent.ensureSidebarMenuVisible();
 				await sideBarComponent.selectMyHome();
 			}
-			return await new LaunchSiteFlow( driver ).launchFreeSite();
+			return await new LaunchSiteFlow( this.driver ).launchFreeSite();
 		} );
 
 		after( 'Delete the newly created account', async function () {
-			return await new DeleteAccountFlow( driver ).deleteAccount( accountName );
+			return await new DeleteAccountFlow( this.driver ).deleteAccount( accountName );
 		} );
 	} );
 } );

--- a/test/e2e/specs/specs-calypso/wp-likes-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-likes-spec.js
@@ -16,7 +16,6 @@ import CommentLikesComponent from '../../lib/pages/frontend/comment-likes-compon
 
 const host = dataHelper.getJetpackHost();
 const screenSize = driverManager.currentScreenSize();
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const mochaTimeoutMS = config.get( 'mochaTimeoutMS' );
 const blogPostTitle = dataHelper.randomPhrase();
 const blogPostQuote =
@@ -27,16 +26,11 @@ const blogPostQuote =
  * for both loggedin and logged out users.
  */
 describe( `[${ host }] Likes: (${ screenSize }) @parallel`, function () {
-	let driver;
 	let postUrl;
 	this.timeout( mochaTimeoutMS );
 	const comment = dataHelper.randomPhrase();
 	const accountKey = 'gutenbergSimpleSiteUser';
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Login, create a new post and view it', async function () {
 		const loginFlow = new LoginFlow( driver, accountKey );

--- a/test/e2e/specs/specs-calypso/wp-likes-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-likes-spec.js
@@ -30,36 +30,31 @@ describe( `[${ host }] Likes: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeoutMS );
 	const comment = dataHelper.randomPhrase();
 	const accountKey = 'gutenbergSimpleSiteUser';
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	it( 'Login, create a new post and view it', async function () {
-		const loginFlow = new LoginFlow( driver, accountKey );
+		const loginFlow = new LoginFlow( this.driver, accountKey );
 		await loginFlow.loginAndStartNewPost( null, true );
 
-		const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+		const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 		await gEditorComponent.enterTitle( blogPostTitle );
 		await gEditorComponent.enterText( blogPostQuote );
 		postUrl = await gEditorComponent.publish( { visit: true } );
 	} );
 
 	it( 'Like post', async function () {
-		const postLikes = await PostLikesComponent.Expect( driver );
+		const postLikes = await PostLikesComponent.Expect( this.driver );
 		await postLikes.clickLike();
 		await postLikes.expectLiked();
 	} );
 
 	it( 'Unlike post', async function () {
-		const postLikes = await PostLikesComponent.Expect( driver );
+		const postLikes = await PostLikesComponent.Expect( this.driver );
 		await postLikes.clickUnlike();
 		await postLikes.expectNotLiked();
 	} );
 
 	it( 'Post comment', async function () {
-		const commentArea = await CommentsAreaComponent.Expect( driver );
+		const commentArea = await CommentsAreaComponent.Expect( this.driver );
 
 		// commentArea.reply fails to find .comment-reply-link at times,
 		// as we're not concerned with the assertion just call postComment directly
@@ -67,24 +62,24 @@ describe( `[${ host }] Likes: (${ screenSize }) @parallel`, function () {
 	} );
 
 	it( 'Like comment', async function () {
-		const commentLikes = await CommentLikesComponent.Expect( driver, comment );
+		const commentLikes = await CommentLikesComponent.Expect( this.driver, comment );
 		await commentLikes.likeComment();
 		await commentLikes.expectLiked();
 	} );
 
 	it( 'Unlike comment', async function () {
-		const commentLikes = await CommentLikesComponent.Expect( driver, comment );
+		const commentLikes = await CommentLikesComponent.Expect( this.driver, comment );
 		await commentLikes.unlikeComment();
 		await commentLikes.expectNotLiked();
 	} );
 
 	it( 'Like post as logged out user', async function () {
-		await driverManager.ensureNotLoggedIntoSite( driver, postUrl );
+		await driverManager.ensureNotLoggedIntoSite( this.driver, postUrl );
 
-		const postLikes = await PostLikesComponent.Visit( driver, postUrl );
+		const postLikes = await PostLikesComponent.Visit( this.driver, postUrl );
 		await postLikes.clickLike();
 
-		const loginFlow = new LoginFlow( driver, accountKey );
+		const loginFlow = new LoginFlow( this.driver, accountKey );
 		await loginFlow.loginUsingPopup();
 
 		await postLikes.expectLiked();

--- a/test/e2e/specs/specs-calypso/wp-likes-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-likes-spec.js
@@ -30,7 +30,11 @@ describe( `[${ host }] Likes: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeoutMS );
 	const comment = dataHelper.randomPhrase();
 	const accountKey = 'gutenbergSimpleSiteUser';
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	it( 'Login, create a new post and view it', async function () {
 		const loginFlow = new LoginFlow( driver, accountKey );

--- a/test/e2e/specs/specs-calypso/wp-log-in-out-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-log-in-out-spec.js
@@ -21,19 +21,12 @@ import LoginPage from '../../lib/pages/login-page';
 import WPAdminLogonPage from '../../lib/pages/wp-admin/wp-admin-logon-page.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Auth Screen Canary: (${ screenSize }) @parallel @safaricanary`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-		return await driverManager.ensureNotLoggedIn( driver );
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Can see the log in screen', async function () {
 		await LoginPage.Visit( driver, LoginPage.getLoginURL() );
@@ -42,12 +35,7 @@ describe( `[${ host }] Auth Screen Canary: (${ screenSize }) @parallel @safarica
 
 describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	describe( 'Logging In and Out: @jetpack', function () {
 		before( async function () {

--- a/test/e2e/specs/specs-calypso/wp-log-in-out-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-log-in-out-spec.js
@@ -26,38 +26,28 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Auth Screen Canary: (${ screenSize }) @parallel @safaricanary`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	it( 'Can see the log in screen', async function () {
-		await LoginPage.Visit( driver, LoginPage.getLoginURL() );
+		await LoginPage.Visit( this.driver, LoginPage.getLoginURL() );
 	} );
 } );
 
 describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	describe( 'Logging In and Out: @jetpack', function () {
 		before( async function () {
-			return await driverManager.ensureNotLoggedIn( driver );
+			return await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		describe( 'Can Log In', function () {
 			it( 'Can log in', async function () {
-				const loginFlow = new LoginFlow( driver );
+				const loginFlow = new LoginFlow( this.driver );
 				await loginFlow.login( { useFreshLogin: true } );
 			} );
 
 			it( 'Can see Stats Page after logging in', async function () {
-				return await StatsPage.Expect( driver );
+				return await StatsPage.Expect( this.driver );
 			} );
 		} );
 
@@ -65,29 +55,32 @@ describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 		if ( host !== 'WPCOM' ) {
 			describe( 'Can Log via Jetpack SSO', function () {
 				it( 'Can log into site via Jetpack SSO', async function () {
-					const loginPage = await WPAdminLogonPage.Visit( driver, dataHelper.getJetpackSiteName() );
+					const loginPage = await WPAdminLogonPage.Visit(
+						this.driver,
+						dataHelper.getJetpackSiteName()
+					);
 					return await loginPage.logonSSO();
 				} );
 
 				it( 'Can return to Reader', async function () {
-					return await ReaderPage.Visit( driver );
+					return await ReaderPage.Visit( this.driver );
 				} );
 			} );
 		}
 
 		describe( 'Can Log Out', function () {
 			it( 'Can view profile to log out', async function () {
-				const navbarComponent = await NavBarComponent.Expect( driver );
+				const navbarComponent = await NavBarComponent.Expect( this.driver );
 				await navbarComponent.clickProfileLink();
 			} );
 
 			it( 'Can logout from profile page', async function () {
-				const profilePage = await ProfilePage.Expect( driver );
+				const profilePage = await ProfilePage.Expect( this.driver );
 				await profilePage.clickSignOut();
 			} );
 
 			it( 'Can see wordpress.com home when after logging out', async function () {
-				return await LoggedOutMasterbarComponent.Expect( driver );
+				return await LoggedOutMasterbarComponent.Expect( this.driver );
 			} );
 		} );
 	} );

--- a/test/e2e/specs/specs-calypso/wp-log-in-out-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-log-in-out-spec.js
@@ -26,7 +26,11 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Auth Screen Canary: (${ screenSize }) @parallel @safaricanary`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	it( 'Can see the log in screen', async function () {
 		await LoginPage.Visit( driver, LoginPage.getLoginURL() );
@@ -35,7 +39,11 @@ describe( `[${ host }] Auth Screen Canary: (${ screenSize }) @parallel @safarica
 
 describe( `[${ host }] Authentication: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	describe( 'Logging In and Out: @jetpack', function () {
 		before( async function () {

--- a/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
@@ -29,19 +29,13 @@ import LoginFlow from '../../lib/flows/login-flow.js';
 import * as SlackNotifier from '../../lib/slack-notifier';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const domainsInboxId = config.get( 'domainsInboxId' );
 const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	describe( 'Adding a domain to an existing site', function () {
 		const blogName = dataHelper.getNewBlogName();

--- a/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
@@ -35,7 +35,11 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	describe( 'Adding a domain to an existing site', function () {
 		const blogName = dataHelper.getNewBlogName();

--- a/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
@@ -35,11 +35,6 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	describe( 'Adding a domain to an existing site', function () {
 		const blogName = dataHelper.getNewBlogName();
@@ -58,11 +53,11 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 		} );
 
 		it( 'Log In and Select Domains', async function () {
-			return await new LoginFlow( driver, 'gutenbergSimpleSiteUser' ).loginAndSelectDomains();
+			return await new LoginFlow( this.driver, 'gutenbergSimpleSiteUser' ).loginAndSelectDomains();
 		} );
 
 		it( 'Can see the Domains page and choose add a domain', async function () {
-			const domainsPage = await DomainsPage.Expect( driver );
+			const domainsPage = await DomainsPage.Expect( this.driver );
 			await domainsPage.setABTestControlGroupsInLocalStorage();
 			await domainsPage.clickAddDomain();
 			await domainsPage.popOverMenuDisplayed();
@@ -72,9 +67,9 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 		it( 'Can see the domain search component', async function () {
 			let findADomainComponent;
 			try {
-				findADomainComponent = await FindADomainComponent.Expect( driver );
+				findADomainComponent = await FindADomainComponent.Expect( this.driver );
 			} catch ( err ) {
-				if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
+				if ( await RegistrationUnavailableComponent.Expect( this.driver ) ) {
 					await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
 						suppressDuplicateMessages: true,
 					} );
@@ -85,36 +80,36 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 		} );
 
 		it( 'Can search for a blog name', async function () {
-			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			const findADomainComponent = await FindADomainComponent.Expect( this.driver );
 			// Search for the full blog name including the .com, as the default TLD suggestion is not always .com.
 			return await findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
 		} );
 
 		it( 'Can select the .com search result and decline Google Apps for email', async function () {
-			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			const findADomainComponent = await FindADomainComponent.Expect( this.driver );
 			await findADomainComponent.selectDomainAddress( expectedDomainName );
 			return await findADomainComponent.declineGoogleApps();
 		} );
 
 		it( 'Can see checkout page and enter registrar details', async function () {
-			const checkOutPage = await CheckOutPage.Expect( driver );
+			const checkOutPage = await CheckOutPage.Expect( this.driver );
 			await checkOutPage.enterRegistrarDetails( testDomainRegistarDetails );
 			return await checkOutPage.submitForm();
 		} );
 
 		it( 'Can then see secure payment component', async function () {
-			return await SecurePaymentComponent.Expect( driver );
+			return await SecurePaymentComponent.Expect( this.driver );
 		} );
 
 		it( 'Empty the cart', async function () {
-			await ReaderPage.Visit( driver );
-			const navBarComponent = await NavBarComponent.Expect( driver );
+			await ReaderPage.Visit( this.driver );
+			const navBarComponent = await NavBarComponent.Expect( this.driver );
 			await navBarComponent.clickMySites();
-			const sidebarComponent = await SidebarComponent.Expect( driver );
+			const sidebarComponent = await SidebarComponent.Expect( this.driver );
 			await sidebarComponent.selectDomains();
-			await DomainsPage.Expect( driver );
+			await DomainsPage.Expect( this.driver );
 			try {
-				const shoppingCartWidgetComponent = await ShoppingCartWidgetComponent.Expect( driver );
+				const shoppingCartWidgetComponent = await ShoppingCartWidgetComponent.Expect( this.driver );
 				await shoppingCartWidgetComponent.removeDomainRegistraion( expectedDomainName );
 			} catch {
 				console.log( `Can't clean up domain registration for ${ expectedDomainName } from cart` );
@@ -136,11 +131,11 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 		} );
 
 		it( 'Log In and Select Domains', async function () {
-			return await new LoginFlow( driver, 'gutenbergSimpleSiteUser' ).loginAndSelectDomains();
+			return await new LoginFlow( this.driver, 'gutenbergSimpleSiteUser' ).loginAndSelectDomains();
 		} );
 
 		it( 'Can see the Domains page and choose add a domain', async function () {
-			const domainsPage = await DomainsPage.Expect( driver );
+			const domainsPage = await DomainsPage.Expect( this.driver );
 			await domainsPage.setABTestControlGroupsInLocalStorage();
 			await domainsPage.clickAddDomain();
 			await domainsPage.popOverMenuDisplayed();
@@ -150,9 +145,9 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 		it( 'Can see the domain search component', async function () {
 			let findADomainComponent;
 			try {
-				findADomainComponent = await FindADomainComponent.Expect( driver );
+				findADomainComponent = await FindADomainComponent.Expect( this.driver );
 			} catch ( err ) {
-				if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
+				if ( await RegistrationUnavailableComponent.Expect( this.driver ) ) {
 					await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
 						suppressDuplicateMessages: true,
 					} );
@@ -163,46 +158,46 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 		} );
 
 		it( 'Can select to use an existing domain', async function () {
-			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			const findADomainComponent = await FindADomainComponent.Expect( this.driver );
 			return await findADomainComponent.selectUseOwnDomain();
 		} );
 
 		it( 'Can see use my own domain page', async function () {
-			return await MyOwnDomainPage.Expect( driver );
+			return await MyOwnDomainPage.Expect( this.driver );
 		} );
 
 		it( 'Can select to buy domain mapping', async function () {
-			const myOwnDomainPage = await MyOwnDomainPage.Expect( driver );
+			const myOwnDomainPage = await MyOwnDomainPage.Expect( this.driver );
 			return await myOwnDomainPage.selectBuyDomainMapping();
 		} );
 
 		it( 'Can see enter a domain component', async function () {
-			return await MapADomainPage.Expect( driver );
+			return await MapADomainPage.Expect( this.driver );
 		} );
 
 		it( 'Can enter the domain name', async function () {
-			const enterADomainComponent = await EnterADomainComponent.Expect( driver );
+			const enterADomainComponent = await EnterADomainComponent.Expect( this.driver );
 			return await enterADomainComponent.enterADomain( blogName );
 		} );
 
 		it.skip( 'Can add domain to the cart', async function () {
-			const enterADomainComponent = await EnterADomainComponent.Expect( driver );
+			const enterADomainComponent = await EnterADomainComponent.Expect( this.driver );
 			return await enterADomainComponent.clickonAddButtonToAddDomainToTheCart();
 		} );
 
 		it.skip( 'Can see checkout page', async function () {
-			return await MapADomainCheckoutPage.Expect( driver );
+			return await MapADomainCheckoutPage.Expect( this.driver );
 		} );
 
 		it.skip( 'Empty the cart', async function () {
-			await ReaderPage.Visit( driver );
-			const navBarComponent = await NavBarComponent.Expect( driver );
+			await ReaderPage.Visit( this.driver );
+			const navBarComponent = await NavBarComponent.Expect( this.driver );
 			await navBarComponent.clickMySites();
-			const sideBarComponent = await SidebarComponent.Expect( driver );
+			const sideBarComponent = await SidebarComponent.Expect( this.driver );
 			await sideBarComponent.selectDomains();
-			await DomainsPage.Expect( driver );
+			await DomainsPage.Expect( this.driver );
 			try {
-				const shoppingCartWidgetComponent = await ShoppingCartWidgetComponent.Expect( driver );
+				const shoppingCartWidgetComponent = await ShoppingCartWidgetComponent.Expect( this.driver );
 				await shoppingCartWidgetComponent.removeDomainMapping( blogName );
 			} catch {
 				console.log( 'Cart already empty' );

--- a/test/e2e/specs/specs-calypso/wp-my-home-support-search-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-my-home-support-search-spec.js
@@ -26,7 +26,11 @@ const helpCardLocator = By.css( '.help-search' );
 
 describe( `[${ host }] My Home "Get help" support search card: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	it( 'Login and select the My Home page', async function () {
 		const loginFlow = new LoginFlow( driver );

--- a/test/e2e/specs/specs-calypso/wp-my-home-support-search-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-my-home-support-search-spec.js
@@ -17,7 +17,6 @@ import SupportSearchComponent from '../../lib/components/support-search-componen
 import SidebarComponent from '../../lib/components/sidebar-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
@@ -27,12 +26,7 @@ const helpCardLocator = By.css( '.help-search' );
 
 describe( `[${ host }] My Home "Get help" support search card: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Login and select the My Home page', async function () {
 		const loginFlow = new LoginFlow( driver );

--- a/test/e2e/specs/specs-calypso/wp-my-home-support-search-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-my-home-support-search-spec.js
@@ -26,32 +26,30 @@ const helpCardLocator = By.css( '.help-search' );
 
 describe( `[${ host }] My Home "Get help" support search card: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	it( 'Login and select the My Home page', async function () {
-		const loginFlow = new LoginFlow( driver );
+		const loginFlow = new LoginFlow( this.driver );
 
 		await loginFlow.loginAndSelectMySite();
 
 		// The "/home" route is the only one this support search
 		// "Card" will show on
-		const sidebarComponent = await SidebarComponent.Expect( driver );
+		const sidebarComponent = await SidebarComponent.Expect( this.driver );
 		await sidebarComponent.selectMyHome();
 	} );
 
 	it( 'Verify "Get help" support card is displayed', async function () {
 		// Card can take a little while to display, so let's wait...
-		await driverHelper.waitUntilElementLocatedAndVisible( driver, helpCardLocator );
+		await driverHelper.waitUntilElementLocatedAndVisible( this.driver, helpCardLocator );
 
 		// For safety also scroll into viewport - also helps when visually verify test runs.
-		await driverHelper.scrollIntoView( driver, helpCardLocator );
+		await driverHelper.scrollIntoView( this.driver, helpCardLocator );
 
 		// Verify it is there.
-		const isGetHelpCardPresent = await driverHelper.isElementLocated( driver, helpCardLocator );
+		const isGetHelpCardPresent = await driverHelper.isElementLocated(
+			this.driver,
+			helpCardLocator
+		);
 		assert.equal(
 			isGetHelpCardPresent,
 			true,
@@ -60,7 +58,7 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 	} );
 
 	it( 'Displays Default Results initially', async function () {
-		supportSearchComponent = await SupportSearchComponent.Expect( driver );
+		supportSearchComponent = await SupportSearchComponent.Expect( this.driver );
 		const resultsCount = await supportSearchComponent.getDefaultResultsCount();
 		assert.equal( resultsCount, 6, 'There are not 6 Default Results displayed.' );
 	} );

--- a/test/e2e/specs/specs-calypso/wp-notifications-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-notifications-spec.js
@@ -20,7 +20,6 @@ import NavBarComponent from '../../lib/components/nav-bar-component.js';
 import NotificationsComponent from '../../lib/components/notifications-component.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
@@ -29,12 +28,7 @@ describe( `[${ host }] Notifications: (${ screenSize }) @parallel`, function () 
 	const commentingUser = dataHelper.getAccountConfig( 'commentingUser' )[ 0 ];
 	const comment = dataHelper.randomPhrase() + ' TBD';
 	let commentedPostTitle;
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Can log in as commenting user', async function () {
 		const loginFlow = new LoginFlow( driver, 'commentingUser' );

--- a/test/e2e/specs/specs-calypso/wp-notifications-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-notifications-spec.js
@@ -25,18 +25,13 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Notifications: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	const commentingUser = dataHelper.getAccountConfig( 'commentingUser' )[ 0 ];
 	const comment = dataHelper.randomPhrase() + ' TBD';
 	let commentedPostTitle;
 
 	it( 'Can log in as commenting user', async function () {
-		const loginFlow = new LoginFlow( driver, 'commentingUser' );
+		const loginFlow = new LoginFlow( this.driver, 'commentingUser' );
 		return await loginFlow.login();
 	} );
 
@@ -44,22 +39,22 @@ describe( `[${ host }] Notifications: (${ screenSize }) @parallel`, function () 
 		const testSiteForInvitationsURL = `https://${ dataHelper.configGet(
 			'testSiteForNotifications'
 		) }`;
-		const viewBlogPage = await ViewSitePage.Visit( driver, testSiteForInvitationsURL );
+		const viewBlogPage = await ViewSitePage.Visit( this.driver, testSiteForInvitationsURL );
 		return await viewBlogPage.viewFirstPost();
 	} );
 
 	it( 'Can see the first post page and capture the title', async function () {
-		const viewPostPage = await ViewPostPage.Expect( driver );
+		const viewPostPage = await ViewPostPage.Expect( this.driver );
 		commentedPostTitle = await viewPostPage.postTitle();
 	} );
 
 	it( 'Can leave a comment', async function () {
-		const viewPostPage = await ViewPostPage.Expect( driver );
+		const viewPostPage = await ViewPostPage.Expect( this.driver );
 		return await viewPostPage.leaveAComment( comment );
 	} );
 
 	it( 'Can see the comment', async function () {
-		const viewPostPage = await ViewPostPage.Expect( driver );
+		const viewPostPage = await ViewPostPage.Expect( this.driver );
 		const shown = await viewPostPage.commentEventuallyShown( comment );
 		if ( shown === false ) {
 			return slackNotifier.warn(
@@ -69,12 +64,12 @@ describe( `[${ host }] Notifications: (${ screenSize }) @parallel`, function () 
 	} );
 
 	it( 'Can log in as notifications user', async function () {
-		const loginFlow = new LoginFlow( driver, 'notificationsUser' );
+		const loginFlow = new LoginFlow( this.driver, 'notificationsUser' );
 		return await loginFlow.login();
 	} );
 
 	it( 'Can open notifications tab with keyboard shortcut', async function () {
-		const navBarComponent = await NavBarComponent.Expect( driver );
+		const navBarComponent = await NavBarComponent.Expect( this.driver );
 		await navBarComponent.openNotificationsShortcut();
 		const present = await navBarComponent.confirmNotificationsOpen();
 		return assert( present, 'Notifications tab is not open' );
@@ -82,9 +77,9 @@ describe( `[${ host }] Notifications: (${ screenSize }) @parallel`, function () 
 
 	it( 'Can see the notification of the comment', async function () {
 		const expectedContent = `${ commentingUser } commented on ${ commentedPostTitle }\n${ comment }`;
-		const navBarComponent = await NavBarComponent.Expect( driver );
+		const navBarComponent = await NavBarComponent.Expect( this.driver );
 		await navBarComponent.openNotifications();
-		const notificationsComponent = await NotificationsComponent.Expect( driver );
+		const notificationsComponent = await NotificationsComponent.Expect( this.driver );
 		await notificationsComponent.selectComments();
 		const content = await notificationsComponent.allCommentsContent();
 		return assert.strictEqual(
@@ -95,7 +90,7 @@ describe( `[${ host }] Notifications: (${ screenSize }) @parallel`, function () 
 	} );
 
 	it( 'Can delete the comment (and wait for UNDO grace period so it is actually deleted)', async function () {
-		const notificationsComponent = await NotificationsComponent.Expect( driver );
+		const notificationsComponent = await NotificationsComponent.Expect( this.driver );
 		await notificationsComponent.selectCommentByText( comment );
 		await notificationsComponent.trashComment();
 		await notificationsComponent.waitForUndoMessage();

--- a/test/e2e/specs/specs-calypso/wp-notifications-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-notifications-spec.js
@@ -25,10 +25,15 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Notifications: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
+
 	const commentingUser = dataHelper.getAccountConfig( 'commentingUser' )[ 0 ];
 	const comment = dataHelper.randomPhrase() + ' TBD';
 	let commentedPostTitle;
-	const driver = global.__BROWSER__;
 
 	it( 'Can log in as commenting user', async function () {
 		const loginFlow = new LoginFlow( driver, 'commentingUser' );

--- a/test/e2e/specs/specs-calypso/wp-plan-purchase__comparing-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-plan-purchase__comparing-spec.js
@@ -20,20 +20,19 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Plans - Comparing plans: (${ screenSize }) @parallel @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
 
 	it( 'Login and Select My Site', async function () {
-		const loginFlow = new LoginFlow( driver );
+		const loginFlow = new LoginFlow( this.driver );
 		return await loginFlow.loginAndSelectMySite();
 	} );
 
 	it( 'Can Select Plans', async function () {
-		const sideBarComponent = await SidebarComponent.Expect( driver );
+		const sideBarComponent = await SidebarComponent.Expect( this.driver );
 		return await sideBarComponent.selectPlans();
 	} );
 
 	it( 'Can Compare Plans', async function () {
-		const plansPage = await PlansPage.Expect( driver );
+		const plansPage = await PlansPage.Expect( this.driver );
 		await plansPage.openPlansTab();
 		return await plansPage.waitForComparison();
 	} );
@@ -41,13 +40,13 @@ describe( `[${ host }] Plans - Comparing plans: (${ screenSize }) @parallel @jet
 	if ( host === 'WPCOM' ) {
 		it( 'Can Verify Current Plan', async function () {
 			const planName = 'premium';
-			const plansPage = await PlansPage.Expect( driver );
+			const plansPage = await PlansPage.Expect( this.driver );
 			const present = await plansPage.confirmCurrentPlan( planName );
 			return assert( present, `Failed to detect correct plan (${ planName })` );
 		} );
 
 		it( 'Can See Exactly One Primary CTA Button', async function () {
-			const plansPage = await PlansPage.Expect( driver );
+			const plansPage = await PlansPage.Expect( this.driver );
 			return assert(
 				await plansPage.onePrimaryButtonShown(),
 				'Incorrect number of primary buttons'
@@ -56,7 +55,7 @@ describe( `[${ host }] Plans - Comparing plans: (${ screenSize }) @parallel @jet
 	} else {
 		it( 'Can Verify Current Plan', async function () {
 			// Jetpack
-			const plansPage = await PlansPage.Expect( driver );
+			const plansPage = await PlansPage.Expect( this.driver );
 			const displayed = await plansPage.planTypesShown( 'jetpack' );
 			return assert( displayed, 'The Jetpack plans are NOT displayed' );
 		} );

--- a/test/e2e/specs/specs-calypso/wp-plan-purchase__comparing-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-plan-purchase__comparing-spec.js
@@ -15,18 +15,12 @@ import PlansPage from '../../lib/pages/plans-page.js';
 import SidebarComponent from '../../lib/components/sidebar-component.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Plans - Comparing plans: (${ screenSize }) @parallel @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Login and Select My Site', async function () {
 		const loginFlow = new LoginFlow( driver );

--- a/test/e2e/specs/specs-calypso/wp-plan-purchase__renew-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-plan-purchase__renew-spec.js
@@ -23,31 +23,30 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Plans - Renew: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
 
 	before( async function () {
-		return await driverManager.ensureNotLoggedIn( driver );
+		return await driverManager.ensureNotLoggedIn( this.driver );
 	} );
 
 	it( 'Can log into WordPress.com', async function () {
-		const loginFlow = new LoginFlow( driver );
+		const loginFlow = new LoginFlow( this.driver );
 		return await loginFlow.login();
 	} );
 
 	it( 'Can navigate to purchases', async function () {
-		const navBarComponent = await NavBarComponent.Expect( driver );
+		const navBarComponent = await NavBarComponent.Expect( this.driver );
 		await navBarComponent.clickProfileLink();
-		const profilePage = await ProfilePage.Expect( driver );
+		const profilePage = await ProfilePage.Expect( this.driver );
 		await profilePage.chooseManagePurchases();
-		const purchasesPage = await PurchasesPage.Expect( driver );
+		const purchasesPage = await PurchasesPage.Expect( this.driver );
 		await purchasesPage.dismissGuidedTour();
 		return await purchasesPage.selectPremiumPlanOnConnectedSite();
 	} );
 
 	it( '"Renew Now" link takes user to Payment Details form', async function () {
-		const managePurchasePage = await ManagePurchasePage.Expect( driver );
+		const managePurchasePage = await ManagePurchasePage.Expect( this.driver );
 		await managePurchasePage.chooseRenewNow();
-		const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+		const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 		const premiumPlanInCart = await securePaymentComponent.containsPremiumPlan();
 		return assert.strictEqual(
 			premiumPlanInCart,

--- a/test/e2e/specs/specs-calypso/wp-plan-purchase__renew-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-plan-purchase__renew-spec.js
@@ -18,18 +18,12 @@ import PurchasesPage from '../../lib/pages/purchases-page';
 import ManagePurchasePage from '../../lib/pages/manage-purchase-page';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Plans - Renew: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	before( async function () {
 		return await driverManager.ensureNotLoggedIn( driver );

--- a/test/e2e/specs/specs-calypso/wp-plan-purchase__upgrade-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-plan-purchase__upgrade-spec.js
@@ -21,27 +21,26 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Plans - Upgrade: (${ screenSize }) @parallel @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
 
 	before( async function () {
-		return await driverManager.ensureNotLoggedIn( driver );
+		return await driverManager.ensureNotLoggedIn( this.driver );
 	} );
 
 	it( 'Can log into WordPress.com', async function () {
-		const loginFlow = new LoginFlow( driver );
+		const loginFlow = new LoginFlow( this.driver );
 		return await loginFlow.loginAndSelectMySite();
 	} );
 
 	it( 'Can navigate to plans page and select business plan', async function () {
-		const sidebarComponent = await SidebarComponent.Expect( driver );
+		const sidebarComponent = await SidebarComponent.Expect( this.driver );
 		await sidebarComponent.selectPlans();
-		const plansPage = await PlansPage.Expect( driver );
+		const plansPage = await PlansPage.Expect( this.driver );
 		await plansPage.openPlansTab();
 		return await plansPage.selectPaidPlan();
 	} );
 
 	it( 'User is taken to be Payment Details form', async function () {
-		const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+		const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 		const businessPlanInCart = await securePaymentComponent.containsBusinessPlan();
 		return assert.strictEqual(
 			businessPlanInCart,

--- a/test/e2e/specs/specs-calypso/wp-plan-purchase__upgrade-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-plan-purchase__upgrade-spec.js
@@ -16,18 +16,12 @@ import SidebarComponent from '../../lib/components/sidebar-component.js';
 import SecurePaymentComponent from '../../lib/components/secure-payment-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Plans - Upgrade: (${ screenSize }) @parallel @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	before( async function () {
 		return await driverManager.ensureNotLoggedIn( driver );

--- a/test/e2e/specs/specs-calypso/wp-plan-purchase__viewing-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-plan-purchase__viewing-spec.js
@@ -23,24 +23,23 @@ describe( `[${ host }] Plans - Viewing: (${ screenSize }) @parallel @jetpack`, f
 	this.timeout( mochaTimeOut );
 	let originalCartAmount;
 	let loginFlow;
-	const driver = global.__BROWSER__;
 
 	before( async function () {
-		return await driverManager.ensureNotLoggedIn( driver );
+		return await driverManager.ensureNotLoggedIn( this.driver );
 	} );
 
 	it( 'Login and Select My Site', async function () {
-		loginFlow = new LoginFlow( driver );
+		loginFlow = new LoginFlow( this.driver );
 		return await loginFlow.loginAndSelectMySite();
 	} );
 
 	it( 'Can Select Plans', async function () {
-		const sideBarComponent = await SidebarComponent.Expect( driver );
+		const sideBarComponent = await SidebarComponent.Expect( this.driver );
 		return await sideBarComponent.selectPlans();
 	} );
 
 	it( 'Can Compare Plans', async function () {
-		const plansPage = await PlansPage.Expect( driver );
+		const plansPage = await PlansPage.Expect( this.driver );
 		await plansPage.openPlansTab();
 		if ( host === 'WPCOM' ) {
 			await plansPage.openAdvancedPlansSegment();
@@ -49,12 +48,12 @@ describe( `[${ host }] Plans - Viewing: (${ screenSize }) @parallel @jetpack`, f
 	} );
 
 	it( 'Select Business Plan', async function () {
-		const plansPage = await PlansPage.Expect( driver );
+		const plansPage = await PlansPage.Expect( this.driver );
 		return await plansPage.selectPaidPlan();
 	} );
 
 	it( 'Remove any existing coupon', async function () {
-		const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+		const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 
 		if ( await securePaymentComponent.hasCouponApplied() ) {
 			await securePaymentComponent.removeCoupon();
@@ -62,7 +61,7 @@ describe( `[${ host }] Plans - Viewing: (${ screenSize }) @parallel @jetpack`, f
 	} );
 
 	it( 'Can Correctly Apply Coupon', async function () {
-		const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+		const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 
 		await securePaymentComponent.toggleCartSummary();
 		originalCartAmount = await securePaymentComponent.cartTotalAmount();
@@ -77,7 +76,7 @@ describe( `[${ host }] Plans - Viewing: (${ screenSize }) @parallel @jetpack`, f
 	} );
 
 	it( 'Can Remove Coupon', async function () {
-		const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+		const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 
 		await securePaymentComponent.removeCoupon();
 
@@ -86,7 +85,7 @@ describe( `[${ host }] Plans - Viewing: (${ screenSize }) @parallel @jetpack`, f
 	} );
 
 	it( 'Remove from cart', async function () {
-		const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+		const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 
 		return await securePaymentComponent.removeBusinessPlan();
 	} );

--- a/test/e2e/specs/specs-calypso/wp-plan-purchase__viewing-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-plan-purchase__viewing-spec.js
@@ -16,20 +16,14 @@ import SidebarComponent from '../../lib/components/sidebar-component.js';
 import SecurePaymentComponent from '../../lib/components/secure-payment-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Plans - Viewing: (${ screenSize }) @parallel @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
 	let originalCartAmount;
 	let loginFlow;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	before( async function () {
 		return await driverManager.ensureNotLoggedIn( driver );

--- a/test/e2e/specs/specs-calypso/wp-reader-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-reader-spec.js
@@ -22,7 +22,11 @@ const screenSize = driverManager.currentScreenSize();
 
 describe( 'Reader: (' + screenSize + ') @parallel', function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	it( 'Can log in as commenting user', async function () {
 		this.loginFlow = new LoginFlow( driver, 'commentingUser' );

--- a/test/e2e/specs/specs-calypso/wp-reader-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-reader-spec.js
@@ -22,24 +22,19 @@ const screenSize = driverManager.currentScreenSize();
 
 describe( 'Reader: (' + screenSize + ') @parallel', function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	it( 'Can log in as commenting user', async function () {
-		this.loginFlow = new LoginFlow( driver, 'commentingUser' );
+		this.loginFlow = new LoginFlow( this.driver, 'commentingUser' );
 		return await this.loginFlow.login( { useFreshLogin: true } );
 	} );
 
 	it( 'Can see the Reader stream', async function () {
-		await ReaderPage.Expect( driver );
+		await ReaderPage.Expect( this.driver );
 	} );
 
 	it( 'The latest post is on the expected test site', async function () {
 		const testSiteForNotifications = dataHelper.configGet( 'testSiteForNotifications' );
-		const readerPage = await ReaderPage.Expect( driver );
+		const readerPage = await ReaderPage.Expect( this.driver );
 		const siteOfLatestPost = await readerPage.siteOfLatestPost();
 		return assert.strictEqual(
 			siteOfLatestPost,
@@ -50,20 +45,20 @@ describe( 'Reader: (' + screenSize + ') @parallel', function () {
 
 	it( 'Can comment on the latest post and see the comment appear', async function () {
 		this.comment = dataHelper.randomPhrase();
-		const readerPage = await ReaderPage.Expect( driver );
+		const readerPage = await ReaderPage.Expect( this.driver );
 		await readerPage.commentOnLatestPost( this.comment );
 		await readerPage.waitForCommentToAppear( this.comment );
 	} );
 
 	it( 'Can log in as test site owner', async function () {
-		this.loginFlow = new LoginFlow( driver, 'notificationsUser' );
+		this.loginFlow = new LoginFlow( this.driver, 'notificationsUser' );
 		return await this.loginFlow.login();
 	} );
 
 	it( 'Can delete the new comment (and wait for UNDO grace period so step is actually deleted)', async function () {
-		this.navBarComponent = await NavBarComponent.Expect( driver );
+		this.navBarComponent = await NavBarComponent.Expect( this.driver );
 		await this.navBarComponent.openNotifications();
-		this.notificationsComponent = await NotificationsComponent.Expect( driver );
+		this.notificationsComponent = await NotificationsComponent.Expect( this.driver );
 		await this.notificationsComponent.selectCommentByText( this.comment );
 		await this.notificationsComponent.trashComment();
 		await this.notificationsComponent.waitForUndoMessage();

--- a/test/e2e/specs/specs-calypso/wp-reader-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-reader-spec.js
@@ -18,17 +18,11 @@ import * as driverManager from '../../lib/driver-manager.js';
 import * as dataHelper from '../../lib/data-helper.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 
 describe( 'Reader: (' + screenSize + ') @parallel', function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Can log in as commenting user', async function () {
 		this.loginFlow = new LoginFlow( driver, 'commentingUser' );

--- a/test/e2e/specs/specs-calypso/wp-signup-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-signup-spec.js
@@ -66,7 +66,11 @@ const sandboxCookieValue = config.get( 'storeSandboxCookieValue' );
 
 describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	describe( 'Sign up for a free WordPress.com site from the Jetpack new site page, and log in via a magic link @signup @email', function () {
 		const blogName = dataHelper.getNewBlogName();

--- a/test/e2e/specs/specs-calypso/wp-signup-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-signup-spec.js
@@ -57,7 +57,6 @@ import MyHomePage from '../../lib/pages/my-home-page';
 import GutenbergEditorComponent from '../../lib/gutenberg/gutenberg-editor-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const signupInboxId = config.get( 'signupInboxId' );
 const host = dataHelper.getJetpackHost();
@@ -67,12 +66,7 @@ const sandboxCookieValue = config.get( 'storeSandboxCookieValue' );
 
 describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		this.driver = driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	describe( 'Sign up for a free WordPress.com site from the Jetpack new site page, and log in via a magic link @signup @email', function () {
 		const blogName = dataHelper.getNewBlogName();

--- a/test/e2e/specs/specs-calypso/wp-signup-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-signup-spec.js
@@ -66,11 +66,6 @@ const sandboxCookieValue = config.get( 'storeSandboxCookieValue' );
 
 describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	describe( 'Sign up for a free WordPress.com site from the Jetpack new site page, and log in via a magic link @signup @email', function () {
 		const blogName = dataHelper.getNewBlogName();
@@ -79,15 +74,15 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		let magicLoginLink;
 
 		before( async function () {
-			return await driverManager.ensureNotLoggedIn( driver );
+			return await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'Can create a new WordPress site', async function () {
-			await StartPage.Visit( driver, StartPage.getStartURL() );
+			await StartPage.Visit( this.driver, StartPage.getStartURL() );
 		} );
 
 		it( 'Can see the account page and enter account details', async function () {
-			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+			const createYourAccountPage = await CreateYourAccountPage.Expect( this.driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
 				blogName,
@@ -96,7 +91,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results', async function () {
-			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			const findADomainComponent = await FindADomainComponent.Expect( this.driver );
 			await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
 			// See https://github.com/Automattic/wp-calypso/pull/38641/
 			// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
@@ -112,12 +107,12 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can see the plans page and pick the free plan', async function () {
-			const pickAPlanPage = await PickAPlanPage.Expect( driver );
+			const pickAPlanPage = await PickAPlanPage.Expect( this.driver );
 			return await pickAPlanPage.selectFreePlan();
 		} );
 
 		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
-			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+			return await new SignUpStep( this.driver ).continueAlong( blogName, passwordForTestAccounts );
 		} );
 
 		sharedSteps.canSeeTheOnboardingChecklist();
@@ -126,8 +121,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			if ( process.env.HORIZON_TESTS === 'true' ) {
 				return this.skip();
 			}
-			await driverManager.ensureNotLoggedIn( driver );
-			const loginPage = await LoginPage.Visit( driver );
+			await driverManager.ensureNotLoggedIn( this.driver );
+			const loginPage = await LoginPage.Visit( this.driver );
 			return await loginPage.requestMagicLink( emailAddress );
 		} );
 
@@ -159,18 +154,18 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			if ( process.env.HORIZON_TESTS === 'true' ) {
 				return this.skip();
 			}
-			await driver.get( magicLoginLink );
-			const magicLoginPage = await MagicLoginPage.Expect( driver );
+			await this.driver.get( magicLoginLink );
+			const magicLoginPage = await MagicLoginPage.Expect( this.driver );
 			await magicLoginPage.finishLogin();
 			try {
-				await CustomerHomePage.Expect( driver );
+				await CustomerHomePage.Expect( this.driver );
 			} catch ( e ) {
-				await ReaderPage.Expect( driver );
+				await ReaderPage.Expect( this.driver );
 			}
 		} );
 
 		after( 'Can delete our newly created account', async function () {
-			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+			return await new DeleteAccountFlow( this.driver ).deleteAccount( blogName );
 		} );
 	} );
 
@@ -180,15 +175,15 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 
 		before( async function () {
-			return await driverManager.ensureNotLoggedIn( driver );
+			return await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'Can visit the start page', async function () {
-			await StartPage.Visit( driver, StartPage.getStartURL( { culture: locale } ) );
+			await StartPage.Visit( this.driver, StartPage.getStartURL( { culture: locale } ) );
 		} );
 
 		it( 'Can see the account page and enter account details', async function () {
-			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+			const createYourAccountPage = await CreateYourAccountPage.Expect( this.driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
 				blogName,
@@ -197,7 +192,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results', async function () {
-			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			const findADomainComponent = await FindADomainComponent.Expect( this.driver );
 			await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
 			// See https://github.com/Automattic/wp-calypso/pull/38641/
 			// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
@@ -213,18 +208,18 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can see the plans page and pick the free plan', async function () {
-			const pickAPlanPage = await PickAPlanPage.Expect( driver );
+			const pickAPlanPage = await PickAPlanPage.Expect( this.driver );
 			return await pickAPlanPage.selectFreePlan();
 		} );
 
 		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
-			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+			return await new SignUpStep( this.driver ).continueAlong( blogName, passwordForTestAccounts );
 		} );
 
 		sharedSteps.canSeeTheOnboardingChecklist();
 
 		after( 'Can delete our newly created account', async function () {
-			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+			return await new DeleteAccountFlow( this.driver ).deleteAccount( blogName );
 		} );
 	} );
 
@@ -235,15 +230,18 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		let originalCartAmount;
 
 		before( async function () {
-			return await driverManager.ensureNotLoggedIn( driver );
+			return await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'Can visit the start page', async function () {
-			await StartPage.Visit( driver, StartPage.getStartURL( { flow: 'main', culture: locale } ) );
+			await StartPage.Visit(
+				this.driver,
+				StartPage.getStartURL( { flow: 'main', culture: locale } )
+			);
 		} );
 
 		it( 'Can see the account page and enter account details', async function () {
-			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+			const createYourAccountPage = await CreateYourAccountPage.Expect( this.driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
 				blogName,
@@ -252,43 +250,43 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can see the "About" page, and enter some site information', async function () {
-			const aboutPage = await AboutPage.Expect( driver );
+			const aboutPage = await AboutPage.Expect( this.driver );
 			return await aboutPage.enterSiteDetails( blogName, '', {
 				showcase: true,
 			} );
 		} );
 
 		it( 'Can accept defaults for about page', async function () {
-			const aboutPage = await AboutPage.Expect( driver );
+			const aboutPage = await AboutPage.Expect( this.driver );
 			await aboutPage.submitForm();
 		} );
 
 		it( 'Can then see the domains page ', async function () {
-			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			const findADomainComponent = await FindADomainComponent.Expect( this.driver );
 			const displayed = await findADomainComponent.displayed();
 			return assert.strictEqual( displayed, true, 'The choose a domain page is not displayed' );
 		} );
 
 		it( 'Can search for a blog name, can see and select a free WordPress.com blog address in results', async function () {
-			return await new SignUpStep( driver ).selectFreeWordPressDotComAddresss(
+			return await new SignUpStep( this.driver ).selectFreeWordPressDotComAddresss(
 				blogName,
 				expectedBlogAddresses
 			);
 		} );
 
 		it( 'Can then see the plans page and select the premium plan ', async function () {
-			const pickAPlanPage = await PickAPlanPage.Expect( driver );
+			const pickAPlanPage = await PickAPlanPage.Expect( this.driver );
 			const displayed = await pickAPlanPage.displayed();
 			assert.strictEqual( displayed, true, 'The pick a plan page is not displayed' );
 			return await pickAPlanPage.selectPremiumPlan();
 		} );
 
 		it( 'Can then see the sign up processing page which will automatically move along', async function () {
-			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+			return await new SignUpStep( this.driver ).continueAlong( blogName, passwordForTestAccounts );
 		} );
 
 		it( 'Can then see the secure payment page with the premium plan in the cart', async function () {
-			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 			const premiumPlanInCart = await securePaymentComponent.containsPremiumPlan();
 			assert.strictEqual( premiumPlanInCart, true, "The cart doesn't contain the premium plan" );
 			const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
@@ -300,7 +298,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can Correctly Apply Coupon discount', async function () {
-			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 			await securePaymentComponent.toggleCartSummary();
 			originalCartAmount = await securePaymentComponent.cartTotalAmount();
 
@@ -320,7 +318,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can Remove Coupon', async function () {
-			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 
 			await securePaymentComponent.removeCoupon();
 
@@ -329,7 +327,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		after( 'Can delete our newly created account', async function () {
-			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+			return await new DeleteAccountFlow( this.driver ).deleteAccount( blogName );
 		} );
 	} );
 
@@ -341,11 +339,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		const expectedCurrencySymbol = '£';
 
 		before( async function () {
-			return await driverManager.ensureNotLoggedIn( driver );
+			return await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'We can set the sandbox cookie for payments', async function () {
-			const wPHomePage = await WPHomePage.Visit( driver );
+			const wPHomePage = await WPHomePage.Visit( this.driver );
 			await wPHomePage.checkURL( locale );
 			await wPHomePage.setSandboxModeForPayments( sandboxCookieValue );
 			return await wPHomePage.setCurrencyForPayments( currencyValue );
@@ -353,13 +351,13 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 		it( 'Can visit the start page', async function () {
 			await StartPage.Visit(
-				driver,
+				this.driver,
 				StartPage.getStartURL( { culture: locale, flow: 'personal' } )
 			);
 		} );
 
 		it( 'Can see the account details page and enter account details', async function () {
-			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+			const createYourAccountPage = await CreateYourAccountPage.Expect( this.driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
 				blogName,
@@ -368,18 +366,18 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can then see the domains page and can search for a blog name, can see and select a free WordPress.com blog address in results', async function () {
-			return await new SignUpStep( driver ).selectFreeWordPressDotComAddresss(
+			return await new SignUpStep( this.driver ).selectFreeWordPressDotComAddresss(
 				blogName,
 				expectedBlogAddresses
 			);
 		} );
 
 		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
-			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+			return await new SignUpStep( this.driver ).continueAlong( blogName, passwordForTestAccounts );
 		} );
 
 		it( 'Can then see the secure payment page with the expected currency in the cart', async function () {
-			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 			if ( driverManager.currentScreenSize() === 'desktop' ) {
 				const totalShown = await securePaymentComponent.cartTotalDisplayed();
 				assert.strictEqual(
@@ -396,7 +394,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can then see the secure payment page with the expected products in the cart', async function () {
-			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 			const personalPlanInCart = await securePaymentComponent.containsPersonalPlan();
 			assert.strictEqual( personalPlanInCart, true, "The cart doesn't contain the personal plan" );
 			const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
@@ -409,7 +407,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 		it( 'Can submit test payment details', async function () {
 			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
-			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 			await securePaymentComponent.completeTaxDetailsInContactSection( testCreditCardDetails );
 			await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
 			await securePaymentComponent.submitPaymentDetails();
@@ -419,11 +417,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		sharedSteps.canSeeTheOnboardingChecklist();
 
 		it( 'Can delete the plan', async function () {
-			return await new DeletePlanFlow( driver ).deletePlan( 'personal' );
+			return await new DeletePlanFlow( this.driver ).deletePlan( 'personal' );
 		} );
 
 		after( 'Can delete our newly created account', async function () {
-			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+			return await new DeleteAccountFlow( this.driver ).deleteAccount( blogName );
 		} );
 	} );
 
@@ -446,11 +444,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		before( async function () {
-			return await driverManager.ensureNotLoggedIn( driver );
+			return await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'We can visit set the sandbox cookie for payments', async function () {
-			const wPHomePage = await WPHomePage.Visit( driver );
+			const wPHomePage = await WPHomePage.Visit( this.driver );
 			await wPHomePage.checkURL( locale );
 			await wPHomePage.setSandboxModeForPayments( sandboxCookieValue );
 			return await wPHomePage.setCurrencyForPayments( currencyValue );
@@ -458,7 +456,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 		it( 'Can visit the domains start page', async function () {
 			await StartPage.Visit(
-				driver,
+				this.driver,
 				StartPage.getStartURL( {
 					culture: locale,
 					flow: 'domain-first',
@@ -468,12 +466,12 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can select domain only from the domain first choice page', async function () {
-			const domainFirstPage = await DomainFirstPage.Expect( driver );
+			const domainFirstPage = await DomainFirstPage.Expect( this.driver );
 			return await domainFirstPage.chooseJustBuyTheDomain();
 		} );
 
 		it( 'Can then enter account details', async function () {
-			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+			const createYourAccountPage = await CreateYourAccountPage.Expect( this.driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
 				siteName,
@@ -482,17 +480,20 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
-			return await new SignUpStep( driver ).continueAlong( siteName, passwordForTestAccounts );
+			return await new SignUpStep( this.driver ).continueAlong( siteName, passwordForTestAccounts );
 		} );
 
 		it( 'Can see checkout page and enter registrar details', async function () {
 			let checkOutPage;
 			try {
-				checkOutPage = await CheckOutPage.Expect( driver );
+				checkOutPage = await CheckOutPage.Expect( this.driver );
 			} catch ( err ) {
 				//TODO: Check this code once more when domain registration is not available
 				if (
-					driverHelper.isElementEventuallyLocatedAndVisible( driver, By.css( '.empty-content' ) )
+					driverHelper.isElementEventuallyLocatedAndVisible(
+						this.driver,
+						By.css( '.empty-content' )
+					)
 				) {
 					await SlackNotifier.warn(
 						"OOPS! Something went wrong, you don't have a site! Check if domains registrations is available."
@@ -505,7 +506,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can then see the secure payment page with the correct products in the cart', async function () {
-			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 			const domainInCart = await securePaymentComponent.containsDotLiveDomain();
 			assert.strictEqual( domainInCart, true, "The cart doesn't contain the .live domain product" );
 			const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
@@ -517,7 +518,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can then see the secure payment page with the expected currency in the cart', async function () {
-			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 			if ( driverManager.currentScreenSize() === 'desktop' ) {
 				const totalShown = await securePaymentComponent.cartTotalDisplayed();
 				assert.strictEqual(
@@ -535,7 +536,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 		it( 'Can enter/submit test payment details', async function () {
 			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
-			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 			// No need to fill out contact details here as they already have been completed
 			await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
 			await securePaymentComponent.submitPaymentDetails();
@@ -544,12 +545,12 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can open the sidebar', async function () {
-			const navBarComponent = await NavBarComponent.Expect( driver );
+			const navBarComponent = await NavBarComponent.Expect( this.driver );
 			await navBarComponent.clickMySites();
 		} );
 
 		it( 'We should only see one option - the settings option', async function () {
-			const sidebarComponent = await SidebarComponent.Expect( driver );
+			const sidebarComponent = await SidebarComponent.Expect( this.driver );
 			const numberMenuItems = await sidebarComponent.numberOfMenuItems();
 			assert.strictEqual(
 				numberMenuItems,
@@ -562,22 +563,22 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 		after( 'We can cancel the domain and delete newly created account', async function () {
 			return await ( async () => {
-				await ReaderPage.Visit( driver );
-				const navBarComponent = await NavBarComponent.Expect( driver );
+				await ReaderPage.Visit( this.driver );
+				const navBarComponent = await NavBarComponent.Expect( this.driver );
 				await navBarComponent.clickMySites();
-				const sidebarComponent = await SidebarComponent.Expect( driver );
+				const sidebarComponent = await SidebarComponent.Expect( this.driver );
 				await sidebarComponent.settingsOptionExists( true );
-				const domainOnlySettingsPage = await DomainOnlySettingsPage.Expect( driver );
+				const domainOnlySettingsPage = await DomainOnlySettingsPage.Expect( this.driver );
 				await domainOnlySettingsPage.manageDomain();
-				const domainDetailsPage = await DomainDetailsPage.Expect( driver );
+				const domainDetailsPage = await DomainDetailsPage.Expect( this.driver );
 				await domainDetailsPage.cancelDomain();
 
-				const cancelPurchasePage = await CancelPurchasePage.Expect( driver );
+				const cancelPurchasePage = await CancelPurchasePage.Expect( this.driver );
 				await cancelPurchasePage.clickCancelPurchase();
 
-				const cancelDomainPage = await CancelDomainPage.Expect( driver );
+				const cancelDomainPage = await CancelDomainPage.Expect( this.driver );
 				await cancelDomainPage.completeSurveyAndConfirm();
-				return await new DeleteAccountFlow( driver ).deleteAccount( siteName );
+				return await new DeleteAccountFlow( this.driver ).deleteAccount( siteName );
 			} )().catch( ( err ) => {
 				SlackNotifier.warn(
 					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
@@ -606,11 +607,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		before( async function () {
-			return await driverManager.ensureNotLoggedIn( driver );
+			return await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'We can set the sandbox cookie for payments', async function () {
-			const wPHomePage = await WPHomePage.Visit( driver );
+			const wPHomePage = await WPHomePage.Visit( this.driver );
 			await wPHomePage.checkURL( locale );
 			await wPHomePage.setSandboxModeForPayments( sandboxCookieValue );
 			return await wPHomePage.setCurrencyForPayments( currencyValue );
@@ -618,13 +619,13 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 		it( 'Can visit the start page', async function () {
 			await StartPage.Visit(
-				driver,
+				this.driver,
 				StartPage.getStartURL( { culture: locale, flow: 'business' } )
 			);
 		} );
 
 		it( 'Can then enter account details and continue', async function () {
-			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+			const createYourAccountPage = await CreateYourAccountPage.Expect( this.driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
 				siteName,
@@ -633,12 +634,12 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can then see the domains page, and can search for a blog name, can see and select a paid .live address in results ', async function () {
-			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			const findADomainComponent = await FindADomainComponent.Expect( this.driver );
 			await findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
 			try {
 				return await findADomainComponent.selectDomainAddress( expectedDomainName );
 			} catch ( err ) {
-				if ( await NewUserRegistrationUnavailableComponent.Expect( driver ) ) {
+				if ( await NewUserRegistrationUnavailableComponent.Expect( this.driver ) ) {
 					await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ' );
 					return this.skip();
 				}
@@ -646,17 +647,17 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
-			return await new SignUpStep( driver ).continueAlong( siteName, passwordForTestAccounts );
+			return await new SignUpStep( this.driver ).continueAlong( siteName, passwordForTestAccounts );
 		} );
 
 		it( 'Can see checkout page and enter registrar details', async function () {
-			const checkOutPage = await CheckOutPage.Expect( driver );
+			const checkOutPage = await CheckOutPage.Expect( this.driver );
 			await checkOutPage.enterRegistrarDetails( testDomainRegistarDetails );
 			return await checkOutPage.submitForm();
 		} );
 
 		it( 'Can then see the secure payment page with the correct products in the cart', async function () {
-			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 			const domainInCart = await securePaymentComponent.containsDotLiveDomain();
 			assert.strictEqual( domainInCart, true, "The cart doesn't contain the .live domain product" );
 			const businessPlanInCart = await securePaymentComponent.containsBusinessPlan();
@@ -675,7 +676,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can then see the secure payment page with the expected currency in the cart', async function () {
-			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 			if ( driverManager.currentScreenSize() === 'desktop' ) {
 				const totalShown = await securePaymentComponent.cartTotalDisplayed();
 				assert.strictEqual(
@@ -693,7 +694,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 		it( 'Can enter/submit test payment details', async function () {
 			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
-			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 			// No need to fill out contact details here as they already have been completed
 			await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
 			await securePaymentComponent.submitPaymentDetails();
@@ -704,13 +705,13 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		sharedSteps.canSeeTheOnboardingChecklist();
 
 		it( 'Can delete the plan', async function () {
-			return await new DeletePlanFlow( driver ).deletePlan( 'business', {
+			return await new DeletePlanFlow( this.driver ).deletePlan( 'business', {
 				deleteDomainAlso: true,
 			} );
 		} );
 
 		after( 'Can delete our newly created account', async function () {
-			return await new DeleteAccountFlow( driver ).deleteAccount( siteName );
+			return await new DeleteAccountFlow( this.driver ).deleteAccount( siteName );
 		} );
 	} );
 
@@ -718,16 +719,16 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		const blogName = dataHelper.getNewBlogName();
 
 		before( async function () {
-			return await driverManager.ensureNotLoggedIn( driver );
+			return await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'Can visit the start page', async function () {
-			await StartPage.Visit( driver, StartPage.getStartURL( { culture: locale } ) );
+			await StartPage.Visit( this.driver, StartPage.getStartURL( { culture: locale } ) );
 		} );
 
 		it( 'Can then enter account details and continue', async function () {
 			const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
-			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+			const createYourAccountPage = await CreateYourAccountPage.Expect( this.driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
 				blogName,
@@ -737,7 +738,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 		it( 'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results', async function () {
 			// const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
-			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			const findADomainComponent = await FindADomainComponent.Expect( this.driver );
 			await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
 			// See https://github.com/Automattic/wp-calypso/pull/38641/
 			// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
@@ -753,12 +754,12 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can then see the plans page and pick the free plan', async function () {
-			const pickAPlanPage = await PickAPlanPage.Expect( driver );
+			const pickAPlanPage = await PickAPlanPage.Expect( this.driver );
 			return await pickAPlanPage.selectFreePlan();
 		} );
 
 		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
-			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+			return await new SignUpStep( this.driver ).continueAlong( blogName, passwordForTestAccounts );
 		} );
 
 		sharedSteps.canSeeTheOnboardingChecklist();
@@ -769,9 +770,9 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			if ( dataHelper.getTargetType() === 'IE11' ) {
 				return this.skip();
 			}
-			const myHomePage = await MyHomePage.Expect( driver );
+			const myHomePage = await MyHomePage.Expect( this.driver );
 			await myHomePage.updateHomepageFromSiteSetup();
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.initEditor();
 
 			const hasInvalidBlocks = await gEditorComponent.hasInvalidBlocks();
@@ -784,7 +785,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		after( 'Can delete our newly created account', async function () {
-			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+			return await new DeleteAccountFlow( this.driver ).deleteAccount( blogName );
 		} );
 	} );
 
@@ -803,12 +804,12 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		before( async function () {
-			await driverManager.ensureNotLoggedIn( driver );
+			await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'Can enter the onboarding flow with vertical set', async function () {
 			await StartPage.Visit(
-				driver,
+				this.driver,
 				StartPage.getStartURL( {
 					culture: locale,
 					flow: 'onboarding-with-preview',
@@ -819,7 +820,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 		it( 'Can then enter account details and continue', async function () {
 			const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
-			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+			const createYourAccountPage = await CreateYourAccountPage.Expect( this.driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
 				blogName,
@@ -828,18 +829,18 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can see the "Site Type" page, and enter some site information', async function () {
-			const siteTypePage = await SiteTypePage.Expect( driver );
+			const siteTypePage = await SiteTypePage.Expect( this.driver );
 			return await siteTypePage.selectBlogType();
 		} );
 
 		it( 'Can see the "Site title" page, and enter the site title', async function () {
-			const siteTitlePage = await SiteTitlePage.Expect( driver );
+			const siteTitlePage = await SiteTitlePage.Expect( this.driver );
 			await siteTitlePage.enterSiteTitle( blogName );
 			return await siteTitlePage.submitForm();
 		} );
 
 		it( 'Can then see the domains page, and Can search for a blog name, can see and select a free .art.blog address in the results', async function () {
-			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			const findADomainComponent = await FindADomainComponent.Expect( this.driver );
 			await findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
 			// More details: https://github.com/Automattic/wp-calypso/pull/35347
 			// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
@@ -855,25 +856,25 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can then see the plans page and pick the free plan', async function () {
-			const pickAPlanPage = await PickAPlanPage.Expect( driver );
+			const pickAPlanPage = await PickAPlanPage.Expect( this.driver );
 			return await pickAPlanPage.selectFreePlan();
 		} );
 
 		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
-			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+			return await new SignUpStep( this.driver ).continueAlong( blogName, passwordForTestAccounts );
 		} );
 
 		sharedSteps.canSeeTheOnboardingChecklist();
 
 		it( 'Can delete site', async function () {
-			const sidebarComponent = await SidebarComponent.Expect( driver );
+			const sidebarComponent = await SidebarComponent.Expect( this.driver );
 			await sidebarComponent.selectSettings();
-			const settingsPage = await SettingsPage.Expect( driver );
+			const settingsPage = await SettingsPage.Expect( this.driver );
 			return await settingsPage.deleteSite( expectedDomainName );
 		} );
 
 		after( 'Can delete our newly created account', async function () {
-			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+			return await new DeleteAccountFlow( this.driver ).deleteAccount( blogName );
 		} );
 	} );
 
@@ -882,23 +883,23 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		const blogName = dataHelper.getNewBlogName();
 
 		before( async function () {
-			await driverManager.ensureNotLoggedIn( driver );
+			await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'Can enter the account flow and see the account details page', async function () {
 			await StartPage.Visit(
-				driver,
+				this.driver,
 				StartPage.getStartURL( {
 					culture: locale,
 					flow: 'account',
 				} )
 			);
-			await CreateYourAccountPage.Expect( driver );
+			await CreateYourAccountPage.Expect( this.driver );
 		} );
 
 		it( 'Can then enter account details and continue', async function () {
 			const emailAddress = dataHelper.getEmailAddress( userName, signupInboxId );
-			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+			const createYourAccountPage = await CreateYourAccountPage.Expect( this.driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
 				userName,
@@ -907,23 +908,23 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
-			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+			return await new SignUpStep( this.driver ).continueAlong( blogName, passwordForTestAccounts );
 		} );
 
 		it( 'We are then on the Reader page and have no sites - we click Create Site', async function () {
-			await ReaderPage.Expect( driver );
-			const navBarComponent = await NavBarComponent.Expect( driver );
+			await ReaderPage.Expect( this.driver );
+			const navBarComponent = await NavBarComponent.Expect( this.driver );
 			await navBarComponent.clickMySites();
-			const noSitesComponent = await NoSitesComponent.Expect( driver );
+			const noSitesComponent = await NoSitesComponent.Expect( this.driver );
 			return await noSitesComponent.createSite();
 		} );
 
 		it( 'We are creating the site using the New Onboarding (Gutenboarding)', async function () {
-			return await new GutenboardingFlow( driver ).createFreeSite();
+			return await new GutenboardingFlow( this.driver ).createFreeSite();
 		} );
 
 		after( 'Can delete our newly created account', async function () {
-			return await new DeleteAccountFlow( driver ).deleteAccount( userName );
+			return await new DeleteAccountFlow( this.driver ).deleteAccount( userName );
 		} );
 	} );
 
@@ -931,28 +932,28 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		const userName = dataHelper.getNewBlogName();
 
 		before( async function () {
-			await driverManager.ensureNotLoggedIn( driver );
+			await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'Can enter the reader flow and see the Reader landing page', async function () {
 			await StartPage.Visit(
-				driver,
+				this.driver,
 				StartPage.getStartURL( {
 					culture: locale,
 					flow: 'reader',
 				} )
 			);
-			return await ReaderLandingPage.Expect( driver );
+			return await ReaderLandingPage.Expect( this.driver );
 		} );
 
 		it( 'Can choose Start Using The Reader', async function () {
-			const readerLandingPage = await ReaderLandingPage.Expect( driver );
+			const readerLandingPage = await ReaderLandingPage.Expect( this.driver );
 			return await readerLandingPage.clickStartUsingTheReader();
 		} );
 
 		it( 'Can see the account details page and enter account details and continue', async function () {
 			const emailAddress = dataHelper.getEmailAddress( userName, signupInboxId );
-			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+			const createYourAccountPage = await CreateYourAccountPage.Expect( this.driver );
 			return await createYourAccountPage.enterAccountDetailsAndSubmit(
 				emailAddress,
 				userName,
@@ -961,15 +962,15 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 
 		it( 'Can then see the sign up processing page which will finish automatically move along', async function () {
-			return await new SignUpStep( driver ).continueAlong( userName, passwordForTestAccounts );
+			return await new SignUpStep( this.driver ).continueAlong( userName, passwordForTestAccounts );
 		} );
 
 		it( 'We are then on the Reader page', async function () {
-			return await ReaderPage.Expect( driver );
+			return await ReaderPage.Expect( this.driver );
 		} );
 
 		after( 'Can delete our newly created account', async function () {
-			return await new DeleteAccountFlow( driver ).deleteAccount( userName );
+			return await new DeleteAccountFlow( this.driver ).deleteAccount( userName );
 		} );
 	} );
 
@@ -977,22 +978,22 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		const emailAddress = dataHelper.getEmailAddress( dataHelper.getNewBlogName(), signupInboxId );
 
 		before( async function () {
-			await driverManager.ensureNotLoggedIn( driver );
+			await driverManager.ensureNotLoggedIn( this.driver );
 		} );
 
 		it( 'Signup and create site using default options', async function () {
-			await NewPage.Visit( driver );
+			await NewPage.Visit( this.driver );
 
-			await new GutenboardingFlow( driver ).signupAndCreateFreeSite( { emailAddress } );
+			await new GutenboardingFlow( this.driver ).signupAndCreateFreeSite( { emailAddress } );
 		} );
 
 		after( 'Can delete our newly created account', async function () {
 			// Gutenboarding creates users with auto-generated usernames so we need
 			// to find the username before we can delete it.
-			const accountSettingsPage = await AccountSettingsPage.Visit( driver );
+			const accountSettingsPage = await AccountSettingsPage.Visit( this.driver );
 			const username = await accountSettingsPage.getUsername();
 
-			return await new DeleteAccountFlow( driver ).deleteAccount( username );
+			return await new DeleteAccountFlow( this.driver ).deleteAccount( username );
 		} );
 	} );
 } );

--- a/test/e2e/specs/specs-calypso/wp-ssr-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-ssr-spec.js
@@ -22,7 +22,11 @@ async function ssrWorksForPage( driver, url ) {
 
 describe( 'Server-side rendering: @canary @parallel', function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	it( '/log-in renders on the server', async function () {
 		await ssrWorksForPage( driver, LoginPage.getLoginURL() );

--- a/test/e2e/specs/specs-calypso/wp-ssr-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-ssr-spec.js
@@ -11,10 +11,8 @@ import assert from 'assert';
 import LoginPage from '../../lib/pages/login-page';
 import ThemesPage from '../../lib/pages/themes-page';
 import * as dataHelper from '../../lib/data-helper';
-import * as driverManager from '../../lib/driver-manager';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 
 async function ssrWorksForPage( driver, url ) {
 	await driver.get( url );
@@ -24,13 +22,7 @@ async function ssrWorksForPage( driver, url ) {
 
 describe( 'Server-side rendering: @canary @parallel', function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-		await driverManager.ensureNotLoggedIn( driver );
-	} );
+	const driver = global.__BROWSER__;
 
 	it( '/log-in renders on the server', async function () {
 		await ssrWorksForPage( driver, LoginPage.getLoginURL() );

--- a/test/e2e/specs/specs-calypso/wp-ssr-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-ssr-spec.js
@@ -22,21 +22,16 @@ async function ssrWorksForPage( driver, url ) {
 
 describe( 'Server-side rendering: @canary @parallel', function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	it( '/log-in renders on the server', async function () {
-		await ssrWorksForPage( driver, LoginPage.getLoginURL() );
+		await ssrWorksForPage( this.driver, LoginPage.getLoginURL() );
 	} );
 
 	it( '/themes renders on the server', async function () {
-		await ssrWorksForPage( driver, ThemesPage.getStartURL() );
+		await ssrWorksForPage( this.driver, ThemesPage.getStartURL() );
 	} );
 
 	it( '/theme/twentytwenty renders on the server', async function () {
-		await ssrWorksForPage( driver, dataHelper.getCalypsoURL( 'theme/twentytwenty' ) );
+		await ssrWorksForPage( this.driver, dataHelper.getCalypsoURL( 'theme/twentytwenty' ) );
 	} );
 } );

--- a/test/e2e/specs/specs-calypso/wp-stats-insights-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-stats-insights-spec.js
@@ -21,7 +21,11 @@ const screenSize = driverManager.currentScreenSize();
 describe( 'Stats: (' + screenSize + ') @parallel', function () {
 	this.timeout( mochaTimeOut );
 	let statsPage;
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	it( 'Can log in as user', async function () {
 		this.loginFlow = new LoginFlow( driver );

--- a/test/e2e/specs/specs-calypso/wp-stats-insights-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-stats-insights-spec.js
@@ -16,18 +16,12 @@ import StatsPage from '../../lib/pages/stats-page.js';
 import * as driverManager from '../../lib/driver-manager.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 
 describe( 'Stats: (' + screenSize + ') @parallel', function () {
 	this.timeout( mochaTimeOut );
 	let statsPage;
-	let driver;
-
-	before( async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Can log in as user', async function () {
 		this.loginFlow = new LoginFlow( driver );

--- a/test/e2e/specs/specs-calypso/wp-stats-insights-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-stats-insights-spec.js
@@ -21,26 +21,21 @@ const screenSize = driverManager.currentScreenSize();
 describe( 'Stats: (' + screenSize + ') @parallel', function () {
 	this.timeout( mochaTimeOut );
 	let statsPage;
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	it( 'Can log in as user', async function () {
-		this.loginFlow = new LoginFlow( driver );
+		this.loginFlow = new LoginFlow( this.driver );
 		return await this.loginFlow.login();
 	} );
 
 	it( 'Can open the sidebar', async function () {
-		const navBarComponent = await NavBarComponent.Expect( driver );
+		const navBarComponent = await NavBarComponent.Expect( this.driver );
 		await navBarComponent.clickMySites();
 	} );
 
 	it( 'Can open the stats page', async function () {
-		const sidebarComponent = await SidebarComponent.Expect( driver );
+		const sidebarComponent = await SidebarComponent.Expect( this.driver );
 		await sidebarComponent.selectStats();
-		statsPage = await StatsPage.Expect( driver );
+		statsPage = await StatsPage.Expect( this.driver );
 	} );
 
 	it( 'Can open the stats insights page', async function () {

--- a/test/e2e/specs/specs-calypso/wp-theme__multisite-activate-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-theme__multisite-activate-spec.js
@@ -20,21 +20,20 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Themes: Activate a theme, all sites (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
 
 	it( 'Login and select themes', async function () {
 		this.themeSearchName = 'twenty';
 		this.expectedTheme = 'Twenty F';
 
-		this.loginFlow = new LoginFlow( driver, 'multiSiteUser' );
+		this.loginFlow = new LoginFlow( this.driver, 'multiSiteUser' );
 		await this.loginFlow.loginAndSelectAllSites();
 
-		this.sidebarComponent = await SidebarComponent.Expect( driver );
+		this.sidebarComponent = await SidebarComponent.Expect( this.driver );
 		await this.sidebarComponent.selectAllSitesThemes();
 	} );
 
 	it( 'can search for free themes', async function () {
-		this.themesPage = await ThemesPage.Expect( driver );
+		this.themesPage = await ThemesPage.Expect( this.driver );
 		await this.themesPage.waitUntilThemesLoaded();
 		await this.themesPage.showOnlyFreeThemes();
 		await this.themesPage.searchFor( this.themeSearchName );
@@ -54,7 +53,7 @@ describe( `[${ host }] Themes: Activate a theme, all sites (${ screenSize }) @pa
 
 	it( 'can click activate', async function () {
 		await this.themesPage.clickPopoverItem( 'Activate' );
-		return ( this.siteSelector = await SiteSelectorComponent.Expect( driver ) );
+		return ( this.siteSelector = await SiteSelectorComponent.Expect( this.driver ) );
 	} );
 
 	it( 'shows the site selector', async function () {

--- a/test/e2e/specs/specs-calypso/wp-theme__multisite-activate-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-theme__multisite-activate-spec.js
@@ -15,19 +15,12 @@ import SiteSelectorComponent from '../../lib/components/site-selector-component'
 import LoginFlow from '../../lib/flows/login-flow.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Themes: Activate a theme, all sites (${ screenSize }) @parallel`, function () {
-	let driver;
-
-	before( async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
-
 	this.timeout( mochaTimeOut );
+	const driver = global.__BROWSER__;
 
 	it( 'Login and select themes', async function () {
 		this.themeSearchName = 'twenty';

--- a/test/e2e/specs/specs-calypso/wp-theme__multisite-preview-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-theme__multisite-preview-spec.js
@@ -20,21 +20,20 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Themes: Preview a theme, all sites (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
 
 	it( 'Login and select themes', async function () {
 		this.themeSearchName = 'twenty';
 		this.expectedTheme = 'Twenty F';
 
-		this.loginFlow = new LoginFlow( driver, 'multiSiteUser' );
+		this.loginFlow = new LoginFlow( this.driver, 'multiSiteUser' );
 		await this.loginFlow.loginAndSelectAllSites();
 
-		this.sidebarComponent = await SidebarComponent.Expect( driver );
+		this.sidebarComponent = await SidebarComponent.Expect( this.driver );
 		await this.sidebarComponent.selectAllSitesThemes();
 	} );
 
 	it( 'can search for free themes', async function () {
-		this.themesPage = await ThemesPage.Expect( driver );
+		this.themesPage = await ThemesPage.Expect( this.driver );
 		await this.themesPage.waitUntilThemesLoaded();
 		await this.themesPage.showOnlyFreeThemes();
 		await this.themesPage.searchFor( this.themeSearchName );

--- a/test/e2e/specs/specs-calypso/wp-theme__multisite-preview-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-theme__multisite-preview-spec.js
@@ -15,18 +15,12 @@ import SidebarComponent from '../../lib/components/sidebar-component';
 import LoginFlow from '../../lib/flows/login-flow.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Themes: Preview a theme, all sites (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Login and select themes', async function () {
 		this.themeSearchName = 'twenty';

--- a/test/e2e/specs/specs-calypso/wp-theme__switch-activate-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-theme__switch-activate-spec.js
@@ -26,20 +26,19 @@ const host = dataHelper.getJetpackHost();
 // NOTE: test in jetpack env is failing due to some strange issue, when switching to new tab. It fails only in CI
 describe( `[${ host }] Activating Themes: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
 
 	it( 'Login', async function () {
-		const loginFlow = new LoginFlow( driver );
+		const loginFlow = new LoginFlow( this.driver );
 		return await loginFlow.loginAndSelectMySite( null, { useFreshLogin: true } );
 	} );
 
 	it( 'Can open Themes menu', async function () {
-		const sidebarComponent = await SidebarComponent.Expect( driver );
+		const sidebarComponent = await SidebarComponent.Expect( this.driver );
 		return await sidebarComponent.selectThemes();
 	} );
 
 	it( 'Can activate a different free theme', async function () {
-		const themesPage = await ThemesPage.Expect( driver );
+		const themesPage = await ThemesPage.Expect( this.driver );
 		await themesPage.waitUntilThemesLoaded();
 		await themesPage.showOnlyFreeThemes();
 		await themesPage.searchFor( 'Twenty F' );
@@ -51,23 +50,23 @@ describe( `[${ host }] Activating Themes: (${ screenSize }) @parallel`, function
 	} );
 
 	it( 'Can see the theme thanks dialog', async function () {
-		const themeDialogComponent = await ThemeDialogComponent.Expect( driver );
+		const themeDialogComponent = await ThemeDialogComponent.Expect( this.driver );
 		await themeDialogComponent.customizeSite();
 	} );
 
 	if ( host === 'WPCOM' ) {
 		it( 'Can customize the site from the theme thanks dialog', async function () {
-			return await CustomizerPage.Expect( driver );
+			return await CustomizerPage.Expect( this.driver );
 		} );
 	} else {
 		it( 'Can log in via Jetpack SSO', async function () {
-			const wpAdminLogonPage = await WPAdminLogonPage.Expect( driver );
+			const wpAdminLogonPage = await WPAdminLogonPage.Expect( this.driver );
 			return await wpAdminLogonPage.logonSSO();
 		} );
 
 		it( 'Can customize the site from the theme thanks dialog', async function () {
-			await WPAdminCustomizerPage.refreshIfJNError( driver );
-			return await WPAdminCustomizerPage.Expect( driver );
+			await WPAdminCustomizerPage.refreshIfJNError( this.driver );
+			return await WPAdminCustomizerPage.Expect( this.driver );
 		} );
 	}
 } );

--- a/test/e2e/specs/specs-calypso/wp-theme__switch-activate-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-theme__switch-activate-spec.js
@@ -20,19 +20,13 @@ import WPAdminLogonPage from '../../lib/pages/wp-admin/wp-admin-logon-page.js';
 import * as dataHelper from '../../lib/data-helper';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 // NOTE: test in jetpack env is failing due to some strange issue, when switching to new tab. It fails only in CI
 describe( `[${ host }] Activating Themes: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Login', async function () {
 		const loginFlow = new LoginFlow( driver );

--- a/test/e2e/specs/specs-calypso/wp-theme__switch-preview-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-theme__switch-preview-spec.js
@@ -16,18 +16,12 @@ import ThemeDetailPage from '../../lib/pages/theme-detail-page.js';
 import * as dataHelper from '../../lib/data-helper';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Previewing Themes: (${ screenSize }) @parallel @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Can login and select themes', async function () {
 		const loginFlow = new LoginFlow( driver );

--- a/test/e2e/specs/specs-calypso/wp-theme__switch-preview-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-theme__switch-preview-spec.js
@@ -21,15 +21,14 @@ const host = dataHelper.getJetpackHost();
 
 describe( `[${ host }] Previewing Themes: (${ screenSize }) @parallel @jetpack`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
 
 	it( 'Can login and select themes', async function () {
-		const loginFlow = new LoginFlow( driver );
+		const loginFlow = new LoginFlow( this.driver );
 		await loginFlow.loginAndSelectThemes();
 	} );
 
 	it( 'Can select a different free theme', async function () {
-		this.themesPage = await ThemesPage.Expect( driver );
+		this.themesPage = await ThemesPage.Expect( this.driver );
 		await this.themesPage.waitUntilThemesLoaded();
 		await this.themesPage.showOnlyFreeThemes();
 		await this.themesPage.searchFor( 'Twenty S' );
@@ -38,12 +37,12 @@ describe( `[${ host }] Previewing Themes: (${ screenSize }) @parallel @jetpack`,
 	} );
 
 	it( 'Can see theme details page and open the live demo', async function () {
-		this.themeDetailPage = await ThemeDetailPage.Expect( driver );
+		this.themeDetailPage = await ThemeDetailPage.Expect( this.driver );
 		return await this.themeDetailPage.openLiveDemo();
 	} );
 
 	it( 'Activate button appears on the theme preview page', async function () {
-		this.themePreviewPage = await ThemePreviewPage.Expect( driver );
+		this.themePreviewPage = await ThemePreviewPage.Expect( this.driver );
 		await this.themePreviewPage.activateButtonVisible();
 	} );
 } );

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-blocks-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-blocks-spec.js
@@ -15,7 +15,6 @@ import * as driverManager from '../../lib/driver-manager';
 import * as dataHelper from '../../lib/data-helper';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 const gutenbergUser =
@@ -23,12 +22,7 @@ const gutenbergUser =
 
 describe( `[${ host }] Calypso Gutenberg Editor: Blocks (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	describe( 'Can see monetization blocks in block inserter @canary @parallel', function () {
 		it( 'Can log in', async function () {

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-blocks-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-blocks-spec.js
@@ -22,7 +22,11 @@ const gutenbergUser =
 
 describe( `[${ host }] Calypso Gutenberg Editor: Blocks (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	describe( 'Can see monetization blocks in block inserter @canary @parallel', function () {
 		it( 'Can log in', async function () {

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-blocks-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-blocks-spec.js
@@ -22,20 +22,15 @@ const gutenbergUser =
 
 describe( `[${ host }] Calypso Gutenberg Editor: Blocks (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	describe( 'Can see monetization blocks in block inserter @canary @parallel', function () {
 		it( 'Can log in', async function () {
-			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		it( 'Can see the Earn blocks', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.openBlockInserterAndSearch( 'earn' );
 			const shownItems = await gEditorComponent.getShownBlockInserterItems();
 
@@ -56,7 +51,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Blocks (${ screenSize })`, func
 		} );
 
 		it( 'Can see the Grow blocks', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.openBlockInserterAndSearch( 'grow' );
 			const shownItems = await gEditorComponent.getShownBlockInserterItems();
 

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-coblocks-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-coblocks-spec.js
@@ -17,7 +17,6 @@ import * as dataHelper from '../../lib/data-helper';
 import * as mediaHelper from '../../lib/media-helper';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 const gutenbergUser =
@@ -25,12 +24,7 @@ const gutenbergUser =
 
 describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	describe( 'Insert a Click to Tweet block: @parallel', function () {
 		it( 'Can log in', async function () {

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-coblocks-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-coblocks-spec.js
@@ -24,7 +24,11 @@ const gutenbergUser =
 
 describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	describe( 'Insert a Click to Tweet block: @parallel', function () {
 		it( 'Can log in', async function () {

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-coblocks-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-coblocks-spec.js
@@ -24,31 +24,26 @@ const gutenbergUser =
 
 describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	describe( 'Insert a Click to Tweet block: @parallel', function () {
 		it( 'Can log in', async function () {
-			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		it( 'Can insert the Click to Tweet block', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.addBlock( 'Click to Tweet' );
 			return await driverHelper.waitUntilElementLocatedAndVisible(
-				driver,
+				this.driver,
 				By.css( '.wp-block-coblocks-click-to-tweet' )
 			);
 		} );
 
 		it( 'Can enter text to tweet', async function () {
 			const textLocator = By.css( '.wp-block-coblocks-click-to-tweet__text' );
-			await driverHelper.waitUntilElementLocatedAndVisible( driver, textLocator );
-			return await driver
+			await driverHelper.waitUntilElementLocatedAndVisible( this.driver, textLocator );
+			return await this.driver
 				.findElement( textLocator )
 				.sendKeys(
 					'The foolish man seeks happiness in the distance. The wise grows it under his feet. — James Oppenheim'
@@ -56,7 +51,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 		} );
 
 		it( 'Can publish and view content', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			// We need to save the post to get a stable post slug for the block's `url` attribute.
 			// See https://github.com/godaddy-wordpress/coblocks/issues/1663.
 			await gEditorComponent.ensureSaved();
@@ -65,7 +60,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 
 		it( 'Can see the Click to Tweet block in our published post', async function () {
 			return await driverHelper.waitUntilElementLocatedAndVisible(
-				driver,
+				this.driver,
 				By.css( '.entry-content .wp-block-coblocks-click-to-tweet' )
 			);
 		} );
@@ -73,27 +68,27 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 
 	describe( 'Insert a Dynamic HR block: @parallel', function () {
 		it( 'Can log in', async function () {
-			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		it( 'Can insert the Dynamic HR block', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.addBlock( 'Dynamic HR' );
 			return await driverHelper.waitUntilElementLocatedAndVisible(
-				driver,
+				this.driver,
 				By.css( '.wp-block-coblocks-dynamic-separator' )
 			);
 		} );
 
 		it( 'Can publish and view content', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			return await gEditorComponent.publish( { visit: true } );
 		} );
 
 		it( 'Can see the Dynamic HR block in our published post', async function () {
 			return await driverHelper.waitUntilElementLocatedAndVisible(
-				driver,
+				this.driver,
 				By.css( '.entry-content .wp-block-coblocks-dynamic-separator' )
 			);
 		} );
@@ -101,27 +96,27 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 
 	describe( 'Insert a Hero block: @parallel', function () {
 		it( 'Can log in', async function () {
-			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		it( 'Can insert the Hero block', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.addBlock( 'Hero' );
 			return await driverHelper.waitUntilElementLocatedAndVisible(
-				driver,
+				this.driver,
 				By.css( '.wp-block-coblocks-hero' )
 			);
 		} );
 
 		it( 'Can publish and view content', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			return await gEditorComponent.publish( { visit: true } );
 		} );
 
 		it( 'Can see the Hero block in our published post', async function () {
 			return await driverHelper.waitUntilElementLocatedAndVisible(
-				driver,
+				this.driver,
 				By.css( '.entry-content .wp-block-coblocks-hero' )
 			);
 		} );
@@ -137,46 +132,46 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 		} );
 
 		it( 'Can log in', async function () {
-			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		it( 'Can insert the Logos block', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.addBlock( 'Logos' );
 			return await driverHelper.waitUntilElementLocatedAndVisible(
-				driver,
+				this.driver,
 				By.css( '.wp-block-coblocks-logos' )
 			);
 		} );
 
 		it( 'Can select an image as a logo', async function () {
 			await driverHelper.waitUntilElementLocatedAndVisible(
-				driver,
+				this.driver,
 				By.css( '.block-editor-media-placeholder' )
 			);
 			await driverHelper.waitUntilElementLocatedAndVisible(
-				driver,
+				this.driver,
 				By.css( '.components-form-file-upload ' )
 			);
-			const filePathInput = await driver.findElement(
+			const filePathInput = await this.driver.findElement(
 				By.css( '.components-form-file-upload input[type="file"]' )
 			);
 			await filePathInput.sendKeys( fileDetails.file );
 			return await driverHelper.waitUntilElementNotLocated(
-				driver,
+				this.driver,
 				By.css( '.wp-block-image .components-spinner' )
 			);
 		} );
 
 		it( 'Can publish and view content', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			return await gEditorComponent.publish( { visit: true } );
 		} );
 
 		it( 'Can see the Logos block in our published post', async function () {
 			return await driverHelper.waitUntilElementLocatedAndVisible(
-				driver,
+				this.driver,
 				By.css( '.entry-content .wp-block-coblocks-logos' )
 			);
 		} );
@@ -184,27 +179,27 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 
 	describe( 'Insert a Pricing Table block: @parallel', function () {
 		it( 'Can log in', async function () {
-			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		it( 'Can insert the Pricing Table block', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.addBlock( 'Pricing Table' );
 			return await driverHelper.waitUntilElementLocatedAndVisible(
-				driver,
+				this.driver,
 				By.css( '.wp-block-coblocks-pricing-table' )
 			);
 		} );
 
 		it( 'Can publish and view content', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			return await gEditorComponent.publish( { visit: true } );
 		} );
 
 		it( 'Can see the Pricing Table block in our published post', async function () {
 			return await driverHelper.waitUntilElementLocatedAndVisible(
-				driver,
+				this.driver,
 				By.css( '.entry-content .wp-block-coblocks-pricing-table' )
 			);
 		} );
@@ -216,7 +211,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 		);
 
 		async function setGutter( buttonText ) {
-			const controlsEl = await driver.findElement( gutterControlsLocator );
+			const controlsEl = await this.driver.findElement( gutterControlsLocator );
 			const buttonEl = await controlsEl.findElement(
 				By.xpath( `//button[text()='${ buttonText }']` )
 			);
@@ -224,25 +219,25 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 
 			await buttonEl.click();
 			await driverHelper.waitUntilElementLocatedAndVisible(
-				driver,
+				this.driver,
 				By.css( `.wp-block-coblocks-pricing-table__inner.has-${ name }-gutter` )
 			);
 		}
 
 		it( 'Can log in', async function () {
-			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		it( 'Can see gutter controls for supporting block', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.addBlock( 'Pricing Table' );
 			await driverHelper.waitUntilElementLocatedAndVisible(
-				driver,
+				this.driver,
 				By.css( '.wp-block-coblocks-pricing-table' )
 			);
 			await gEditorComponent.openSidebar();
-			await driverHelper.waitUntilElementLocatedAndVisible( driver, gutterControlsLocator );
+			await driverHelper.waitUntilElementLocatedAndVisible( this.driver, gutterControlsLocator );
 		} );
 
 		it( 'Can set the "None" gutter value', async function () {

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -16,7 +16,6 @@ import * as driverManager from '../../lib/driver-manager.js';
 import * as dataHelper from '../../lib/data-helper.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
@@ -41,12 +40,7 @@ function getTotalEventsFiredForBlock( eventsStack, event, block ) {
 
 describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	describe( 'Tracking: @parallel', function () {
 		it( 'Can log in to WPAdmin and create new Post', async function () {

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -40,7 +40,11 @@ function getTotalEventsFiredForBlock( eventsStack, event, block ) {
 
 describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	describe( 'Tracking: @parallel', function () {
 		it( 'Can log in to WPAdmin and create new Post', async function () {

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -40,35 +40,30 @@ function getTotalEventsFiredForBlock( eventsStack, event, block ) {
 
 describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	describe( 'Tracking: @parallel', function () {
 		it( 'Can log in to WPAdmin and create new Post', async function () {
-			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 
 			if ( host !== 'WPCOM' ) {
-				this.loginFlow = new LoginFlow( driver );
+				this.loginFlow = new LoginFlow( this.driver );
 			}
 
 			await this.loginFlow.loginAndSelectWPAdmin();
 
-			const wpadminSidebarComponent = await WPAdminSidebar.Expect( driver );
+			const wpadminSidebarComponent = await WPAdminSidebar.Expect( this.driver );
 			await wpadminSidebarComponent.selectNewPost();
 		} );
 
 		it( 'Check for presence of e2e specific tracking events stack on global', async function () {
-			await GutenbergEditorComponent.Expect( driver, 'wp-admin' );
-			const eventsStack = await driver.executeScript( `return window._e2eEventsStack;` );
+			await GutenbergEditorComponent.Expect( this.driver, 'wp-admin' );
+			const eventsStack = await this.driver.executeScript( `return window._e2eEventsStack;` );
 			// Check evaluates to truthy
 			assert( eventsStack, 'Tracking events stack missing from window._e2eEventsStack' );
 		} );
 
 		it( 'Tracks "wpcom_block_inserted" event', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver, 'wp-admin' );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver, 'wp-admin' );
 
 			// Insert some Blocks
 			await gEditorComponent.addBlock( 'Heading' );
@@ -77,7 +72,7 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 
 			// Grab the events stack (only present on e2e test envs).
 			// see: https://github.com/Automattic/wp-calypso/pull/41329
-			const eventsStack = await driver.executeScript( `return window._e2eEventsStack;` );
+			const eventsStack = await this.driver.executeScript( `return window._e2eEventsStack;` );
 
 			// Assert that all block insertion events were tracked correctly
 			assert.strictEqual(
@@ -96,7 +91,7 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 		afterEach( async function () {
 			// Reset e2e tests events stack after each step in order
 			// that we have a test specific stack to assert against.
-			await driver.executeScript( `window._e2eEventsStack = [];` );
+			await this.driver.executeScript( `window._e2eEventsStack = [];` );
 		} );
 	} );
 } );

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-focused-launch-spec.js
@@ -23,8 +23,12 @@ const screenSize = driverManager.currentScreenSize();
 
 describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
+	let driver;
 	let selectedSubdomain;
-	const driver = global.__BROWSER__;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	describe( 'Launch a free site', function () {
 		const siteName = dataHelper.getNewBlogName();

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-focused-launch-spec.js
@@ -17,20 +17,14 @@ import GutenboardingFlow from '../../lib/flows/gutenboarding-flow.js';
 import GutenbergEditorComponent from '../../lib/gutenberg/gutenberg-editor-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 
 const host = dataHelper.getJetpackHost();
 const screenSize = driverManager.currentScreenSize();
 
 describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
 	let selectedSubdomain;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	describe( 'Launch a free site', function () {
 		const siteName = dataHelper.getNewBlogName();

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-focused-launch-spec.js
@@ -23,25 +23,20 @@ const screenSize = driverManager.currentScreenSize();
 
 describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
 	let selectedSubdomain;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	describe( 'Launch a free site', function () {
 		const siteName = dataHelper.getNewBlogName();
 
 		before( 'Can log in', async function () {
-			const loginFlow = new LoginFlow( driver );
+			const loginFlow = new LoginFlow( this.driver );
 			await loginFlow.login();
 		} );
 
 		it( 'Can create a free site', async function () {
 			const gutenboardingUrl = dataHelper.getCalypsoURL( '/new' );
-			await driver.get( gutenboardingUrl );
-			await new GutenboardingFlow( driver ).createFreeSite( siteName );
+			await this.driver.get( gutenboardingUrl );
+			await new GutenboardingFlow( this.driver ).createFreeSite( siteName );
 		} );
 
 		it( 'Can open focused launch modal', async function () {
@@ -49,11 +44,11 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 				By.css( '.editor-gutenberg-launch__launch-button' ),
 				'Launch'
 			);
-			await driverHelper.clickWhenClickable( driver, launchButtonLocator );
+			await driverHelper.clickWhenClickable( this.driver, launchButtonLocator );
 
 			const focusedLaunchModalLocator = By.css( '.launch__focused-modal' );
 			const isFocusedLaunchModalPresent = await driverHelper.isElementLocated(
-				driver,
+				this.driver,
 				focusedLaunchModalLocator
 			);
 
@@ -69,7 +64,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			// If the site title input is not rendered, skip this step.
 			// Note: This is currently parked here but unused as we are using the `/start` flow.
 			const isSiteTitleInputPresent = await driverHelper.isElementLocated(
-				driver,
+				this.driver,
 				siteTitleInputLocator
 			);
 
@@ -79,13 +74,13 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 
 			// Set a site title
 			const siteTitle = dataHelper.randomPhrase();
-			await driverHelper.setWhenSettable( driver, siteTitleInputLocator, siteTitle, {
+			await driverHelper.setWhenSettable( this.driver, siteTitleInputLocator, siteTitle, {
 				pauseBetweenKeysMS: 10,
 			} );
 
 			// Wait for domain suggestions to reload.
 			// Prevent the driver from picking up the previously displayed suggestion.
-			await driver.sleep( 2000 );
+			await this.driver.sleep( 2000 );
 
 			// Wait for the new suggestion items to be rendered,
 			// and get the first domain suggestion item.
@@ -93,7 +88,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 				'.domain-picker__suggestion-item:first-child'
 			);
 			await driverHelper.waitUntilElementLocatedAndVisible(
-				driver,
+				this.driver,
 				firstDomainSuggestionItemLocator
 			);
 
@@ -108,7 +103,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 
 			const domainSuggestionsContainUserEnteredSiteTitle = await driverHelper.isElementLocated(
-				driver,
+				this.driver,
 				domainSuggestionsContainUserEnteredSiteTitleLocator
 			);
 
@@ -122,7 +117,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			// Click on the free domain suggestion item
 			const freeDomainButtonLocator = By.css( '.domain-picker__suggestion-item.is-free' );
 
-			await driverHelper.clickWhenClickable( driver, freeDomainButtonLocator );
+			await driverHelper.clickWhenClickable( this.driver, freeDomainButtonLocator );
 
 			// Check if the free domain suggestion item is now selected
 			const selectedFreeDomainSuggestionItemLocator = By.css(
@@ -130,7 +125,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 
 			const isSelectedFreeDomainSuggestionItemPresent = await driverHelper.isElementLocated(
-				driver,
+				this.driver,
 				selectedFreeDomainSuggestionItemLocator
 			);
 
@@ -140,7 +135,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 				'.domain-picker__suggestion-item.is-free.is-selected .domain-picker__suggestion-item-name'
 			);
 
-			const selectedFreeDomainSuggestionItemName = await driver.findElement(
+			const selectedFreeDomainSuggestionItemName = await this.driver.findElement(
 				selectedFreeDomainSuggestionItemNameLocator
 			);
 
@@ -160,13 +155,13 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 				'View all plans'
 			);
 
-			await driverHelper.clickWhenClickable( driver, viewAllPlansButtonLocator );
+			await driverHelper.clickWhenClickable( this.driver, viewAllPlansButtonLocator );
 
 			// Check if detailed plans grid is displayed
 			const plansGridInDetailedViewLocator = By.css( '.focused-launch-details__body .plans-grid' );
 
 			const isPlansGridInDetailedViewPresent = await driverHelper.isElementLocated(
-				driver,
+				this.driver,
 				plansGridInDetailedViewLocator
 			);
 
@@ -183,7 +178,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 				'Monthly'
 			);
 
-			await driverHelper.clickWhenClickable( driver, monthlyButtonLocator );
+			await driverHelper.clickWhenClickable( this.driver, monthlyButtonLocator );
 
 			// Check if plans grid is really switched over to monthly view
 			// by checking if the price note "per month, billed monthly" exists.
@@ -193,7 +188,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 
 			const isPerMonthBilledMonthlyPricePresent = await driverHelper.isElementLocated(
-				driver,
+				this.driver,
 				perMonthBilledMonthlyPriceNoteLocator
 			);
 
@@ -210,7 +205,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 				'Select Personal'
 			);
 
-			await driverHelper.clickWhenClickable( driver, selectPersonalPlanButtonLocator );
+			await driverHelper.clickWhenClickable( this.driver, selectPersonalPlanButtonLocator );
 
 			// When the detailed plans grid is closed and user returns to the summary view,
 			// check if the selected monthly plan item is "Personal Plan".
@@ -220,7 +215,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 
 			const selectedPlanIsPersonalMonthlyPlan = await driverHelper.isElementLocated(
-				driver,
+				this.driver,
 				selectedPlanIsPersonalMonthlyPlanLocator
 			);
 
@@ -229,12 +224,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 
 		it( 'Can reload block editor and reopen focused launch', async function () {
 			// Reload block editor
-			await driver.navigate().refresh();
+			await this.driver.navigate().refresh();
 
 			// Press "Reload" on confirmation dialog when block editor asks if user really wants to navigate away.
 			try {
-				await driver.wait( until.alertIsPresent(), 4000 );
-				const alert = await driver.switchTo().alert();
+				await this.driver.wait( until.alertIsPresent(), 4000 );
+				const alert = await this.driver.switchTo().alert();
 				await alert.accept();
 			} catch ( e ) {
 				// This doesn't happen when autosave hasn't kicked in so
@@ -243,19 +238,19 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			}
 
 			// Wait for block editor to load and switch frame context to block editor
-			await GutenbergEditorComponent.Expect( driver );
+			await GutenbergEditorComponent.Expect( this.driver );
 
 			// Click on the launch button
 			const launchButtonLocator = driverHelper.createTextLocator(
 				By.css( '.editor-gutenberg-launch__launch-button' ),
 				'Launch'
 			);
-			await driverHelper.clickWhenClickable( driver, launchButtonLocator );
+			await driverHelper.clickWhenClickable( this.driver, launchButtonLocator );
 
 			// See if focused launch modal can be reopened
 			const focusedLaunchModalLocator = By.css( '.launch__focused-modal' );
 			const isFocusedLaunchModalPresent = await driverHelper.isElementLocated(
-				driver,
+				this.driver,
 				focusedLaunchModalLocator
 			);
 
@@ -269,7 +264,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 
 			const selectedDomainSuggestionIsPreviouslySelectedSubdomain = await driverHelper.isElementLocated(
-				driver,
+				this.driver,
 				selectedDomainSuggestionContainingPreviouslySelectedSubdomainLocator
 			);
 
@@ -287,7 +282,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 
 			const selectedPlanIsPersonalMonthlyPlan = await driverHelper.isElementLocated(
-				driver,
+				this.driver,
 				selectedPlanIsPersonalMonthlyPlanLocator
 			);
 
@@ -304,7 +299,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 				/Free Plan/
 			);
 
-			await driverHelper.clickWhenClickable( driver, freePlanLocator );
+			await driverHelper.clickWhenClickable( this.driver, freePlanLocator );
 
 			// When the detailed plans grid is closed and user returns to the summary view,
 			// check if the selected monthly plan item is "Free Plan".
@@ -314,7 +309,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 			);
 
 			const selectedPlanIsFreePlan = await driverHelper.isElementLocated(
-				driver,
+				this.driver,
 				selectedPlanIsFreePlanLocator
 			);
 
@@ -324,13 +319,13 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 		it( 'Can launch site with Free plan.', async function () {
 			// Click on the launch button
 			const siteLaunchButtonLocator = By.css( '.focused-launch-summary__launch-button' );
-			await driverHelper.clickWhenClickable( driver, siteLaunchButtonLocator );
+			await driverHelper.clickWhenClickable( this.driver, siteLaunchButtonLocator );
 
 			// Wait for the focused launch success view to show up
 			const focusedLaunchSuccessViewLocator = By.css( '.focused-launch-success__wrapper' );
 
 			const isFocusedLaunchSuccessViewPresent = await driverHelper.isElementLocated(
-				driver,
+				this.driver,
 				focusedLaunchSuccessViewLocator
 			);
 
@@ -338,7 +333,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Focused launch on (${ screenSiz
 		} );
 
 		after( 'Delete the newly created site', async function () {
-			const deleteSite = new DeleteSiteFlow( driver );
+			const deleteSite = new DeleteSiteFlow( this.driver );
 			await deleteSite.deleteSite( siteName + '.wordpress.com' );
 		} );
 	} );

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-spec.js
@@ -31,7 +31,11 @@ const gutenbergUser =
 
 describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	describe( 'Public Pages: @parallel', function () {
 		let fileDetails;

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-spec.js
@@ -24,7 +24,6 @@ import * as dataHelper from '../../lib/data-helper.js';
 import * as driverHelper from '../../lib/driver-helper';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 const gutenbergUser =
@@ -32,12 +31,7 @@ const gutenbergUser =
 
 describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	describe( 'Public Pages: @parallel', function () {
 		let fileDetails;

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-spec.js
@@ -31,11 +31,6 @@ const gutenbergUser =
 
 describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	describe( 'Public Pages: @parallel', function () {
 		let fileDetails;
@@ -50,21 +45,21 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		it( 'Can log in', async function () {
-			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 			if ( host !== 'WPCOM' ) {
-				this.loginFlow = new LoginFlow( driver );
+				this.loginFlow = new LoginFlow( this.driver );
 			}
 			return await this.loginFlow.loginAndStartNewPage( null, true );
 		} );
 
 		it( 'Can enter page title, content and image', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.enterTitle( pageTitle );
 			await gEditorComponent.enterText( pageQuote );
 			await gEditorComponent.addImage( fileDetails );
 
 			await gEditorComponent.openSidebar();
-			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( this.driver );
 			await gEditorSidebarComponent.enterImageAltText( fileDetails );
 			await gEditorComponent.closeSidebar();
 		} );
@@ -79,13 +74,13 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );*/
 
 		it( 'Can launch page preview', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.ensureSaved();
 			await gEditorComponent.launchPreview();
 		} );
 
 		it( 'Can see correct page title in preview', async function () {
-			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			const pagePreviewComponent = await PagePreviewComponent.Expect( this.driver );
 			const actualPageTitle = await pagePreviewComponent.pageTitle();
 			assert.strictEqual(
 				actualPageTitle.toUpperCase(),
@@ -95,7 +90,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		it( 'Can see correct page content in preview', async function () {
-			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			const pagePreviewComponent = await PagePreviewComponent.Expect( this.driver );
 			const content = await pagePreviewComponent.pageContent();
 			assert.strictEqual(
 				content.indexOf( pageQuote ) > -1,
@@ -109,7 +104,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		it( 'Can see the image uploaded in the preview', async function () {
-			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			const pagePreviewComponent = await PagePreviewComponent.Expect( this.driver );
 			const imageDisplayed = await pagePreviewComponent.imageDisplayed( fileDetails );
 			return assert.strictEqual(
 				imageDisplayed,
@@ -119,17 +114,17 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		it( 'Can close page preview', async function () {
-			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			const pagePreviewComponent = await PagePreviewComponent.Expect( this.driver );
 			await pagePreviewComponent.close();
 		} );
 
 		it( 'Can publish and preview published content', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.publish( { visit: true } );
 		} );
 
 		it( 'Can see correct page title', async function () {
-			const viewPagePage = await ViewPagePage.Expect( driver );
+			const viewPagePage = await ViewPagePage.Expect( this.driver );
 			const actualPageTitle = await viewPagePage.pageTitle();
 			assert.strictEqual(
 				actualPageTitle.toUpperCase(),
@@ -139,7 +134,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		it( 'Can see correct page content', async function () {
-			const viewPagePage = await ViewPagePage.Expect( driver );
+			const viewPagePage = await ViewPagePage.Expect( this.driver );
 			const content = await viewPagePage.pageContent();
 			assert.strictEqual(
 				content.indexOf( pageQuote ) > -1,
@@ -164,7 +159,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} ); */
 
 		it( 'Can see the image uploaded displayed', async function () {
-			const viewPagePage = await ViewPagePage.Expect( driver );
+			const viewPagePage = await ViewPagePage.Expect( this.driver );
 			const imageDisplayed = await viewPagePage.imageDisplayed( fileDetails );
 			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the published page' );
 		} );
@@ -182,31 +177,31 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			'Few people know how to take a walk. The qualifications are endurance, plain clothes, old shoes, an eye for nature, good humor, vast curiosity, good speech, good silence and nothing too much.\n— Ralph Waldo Emerson';
 
 		it( 'Can log in', async function () {
-			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPage( null, true );
 		} );
 
 		it( 'Can enter page title and content', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.enterTitle( pageTitle );
 			await gEditorComponent.enterText( pageQuote );
 			return await gEditorComponent.ensureSaved();
 		} );
 
 		it( 'Can set visibility to private which immediately publishes it', async function () {
-			const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( this.driver );
 			await gSidebarComponent.chooseDocumentSettings();
 			await gSidebarComponent.setVisibilityToPrivate();
 			return await gSidebarComponent.hideComponentIfNecessary();
 		} );
 
 		it( 'Can view content', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.viewPublishedPostOrPage();
 		} );
 
 		it( 'Can view page title as logged in user', async function () {
-			const viewPagePage = await ViewPagePage.Expect( driver );
+			const viewPagePage = await ViewPagePage.Expect( this.driver );
 			const actualPageTitle = await viewPagePage.pageTitle();
 			assert.strictEqual(
 				actualPageTitle.toUpperCase(),
@@ -216,7 +211,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		it( 'Can view page content as logged in user', async function () {
-			const viewPagePage = await ViewPagePage.Expect( driver );
+			const viewPagePage = await ViewPagePage.Expect( this.driver );
 			const content = await viewPagePage.pageContent();
 			assert.strictEqual(
 				content.indexOf( pageQuote ) > -1,
@@ -230,10 +225,10 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		it( "Can't view page title or content as non-logged in user", async function () {
-			await driver.manage().deleteAllCookies();
-			await driver.navigate().refresh();
+			await this.driver.manage().deleteAllCookies();
+			await this.driver.navigate().refresh();
 
-			const notFoundPage = await NotFoundPage.Expect( driver );
+			const notFoundPage = await NotFoundPage.Expect( this.driver );
 			const displayed = await notFoundPage.displayed();
 			assert.strictEqual(
 				displayed,
@@ -251,30 +246,30 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 
 		describe( 'Publish a Password Protected Page', function () {
 			it( 'Can log in', async function () {
-				this.loginFlow = new LoginFlow( driver, gutenbergUser );
+				this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 				return await this.loginFlow.loginAndStartNewPage( null, true );
 			} );
 
 			it( 'Can enter page title and content and set to password protected', async function () {
-				let gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
+				let gHeaderComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gHeaderComponent.enterTitle( pageTitle );
 
-				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( this.driver );
 				await gSidebarComponent.chooseDocumentSettings();
 				await gSidebarComponent.setVisibilityToPasswordProtected( postPassword );
 				await gSidebarComponent.hideComponentIfNecessary();
 
-				gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
+				gHeaderComponent = await GutenbergEditorComponent.Expect( this.driver );
 				return await gHeaderComponent.enterText( pageQuote );
 			} );
 
 			it( 'Can publish and view content', async function () {
-				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
+				const gHeaderComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gHeaderComponent.publish( { visit: true } );
 			} );
 
 			it( 'As a logged in user, With no password entered, Can view page title', async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const actualPageTitle = await viewPagePage.pageTitle();
 				assert.strictEqual(
 					actualPageTitle.toUpperCase(),
@@ -283,7 +278,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( 'Can see password field', async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const isPasswordProtected = await viewPagePage.isPasswordProtected();
 				assert.strictEqual(
 					isPasswordProtected,
@@ -293,7 +288,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( "Can't see content when no password is entered", async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const content = await viewPagePage.pageContent();
 				assert.strictEqual(
 					content.indexOf( pageQuote ) === -1,
@@ -307,12 +302,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( 'With incorrect password entered, Enter incorrect password', async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				await viewPagePage.enterPassword( 'password' );
 			} );
 
 			it( 'Can view page title', async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const actualPageTitle = await viewPagePage.pageTitle();
 				assert.strictEqual(
 					actualPageTitle.toUpperCase(),
@@ -321,7 +316,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( 'Can see password field', async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const isPasswordProtected = await viewPagePage.isPasswordProtected();
 				assert.strictEqual(
 					isPasswordProtected,
@@ -331,7 +326,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( "Can't see content when incorrect password is entered", async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const content = await viewPagePage.pageContent();
 				assert.strictEqual(
 					content.indexOf( pageQuote ) === -1,
@@ -345,12 +340,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( 'With correct password entered, Enter correct password', async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				await viewPagePage.enterPassword( postPassword );
 			} );
 
 			it( 'Can view page title', async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const actualPageTitle = await viewPagePage.pageTitle();
 				assert.strictEqual(
 					actualPageTitle.toUpperCase(),
@@ -359,7 +354,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( "Can't see password field", async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const isPasswordProtected = await viewPagePage.isPasswordProtected();
 				assert.strictEqual(
 					isPasswordProtected,
@@ -369,7 +364,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( 'Can see page content', async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const content = await viewPagePage.pageContent();
 				assert.strictEqual(
 					content.indexOf( pageQuote ) > -1,
@@ -383,12 +378,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( 'As a non-logged in user, Clear cookies (log out)', async function () {
-				await driver.manage().deleteAllCookies();
-				await driver.navigate().refresh();
+				await this.driver.manage().deleteAllCookies();
+				await this.driver.navigate().refresh();
 			} );
 
 			it( 'With no password entered, Can view page title', async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const actualPageTitle = await viewPagePage.pageTitle();
 				assert.strictEqual(
 					actualPageTitle.toUpperCase(),
@@ -397,7 +392,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( 'Can see password field', async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const isPasswordProtected = await viewPagePage.isPasswordProtected();
 				assert.strictEqual(
 					isPasswordProtected,
@@ -407,7 +402,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( "Can't see content when no password is entered", async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const content = await viewPagePage.pageContent();
 				assert.strictEqual(
 					content.indexOf( pageQuote ) === -1,
@@ -421,12 +416,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( 'With incorrect password entered, Enter incorrect password', async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				await viewPagePage.enterPassword( 'password' );
 			} );
 
 			it( 'Can view page title', async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const actualPageTitle = await viewPagePage.pageTitle();
 				assert.strictEqual(
 					actualPageTitle.toUpperCase(),
@@ -435,7 +430,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( 'Can see password field', async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const isPasswordProtected = await viewPagePage.isPasswordProtected();
 				assert.strictEqual(
 					isPasswordProtected,
@@ -445,7 +440,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( "Can't see content when incorrect password is entered", async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const content = await viewPagePage.pageContent();
 				assert.strictEqual(
 					content.indexOf( pageQuote ) === -1,
@@ -459,12 +454,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( 'With correct password entered, Enter correct password', async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				await viewPagePage.enterPassword( postPassword );
 			} );
 
 			it( 'Can view page title', async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const actualPageTitle = await viewPagePage.pageTitle();
 				assert.strictEqual(
 					actualPageTitle.toUpperCase(),
@@ -473,7 +468,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( "Can't see password field", async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const isPasswordProtected = await viewPagePage.isPasswordProtected();
 				assert.strictEqual(
 					isPasswordProtected,
@@ -483,7 +478,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			} );
 
 			it( 'Can see page content', async function () {
-				const viewPagePage = await ViewPagePage.Expect( driver );
+				const viewPagePage = await ViewPagePage.Expect( this.driver );
 				const content = await viewPagePage.pageContent();
 				assert.strictEqual(
 					content.indexOf( pageQuote ) > -1,
@@ -510,16 +505,16 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		};
 
 		it( 'Can log in', async function () {
-			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPage( null, true );
 		} );
 
 		it( 'Can insert the payment button', async function () {
 			const pageTitle = 'Payment Button Page: ' + dataHelper.randomPhrase();
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			const blockId = await gEditorComponent.addBlock( 'Pay with PayPal' );
 
-			const gPaymentComponent = await SimplePaymentsBlockComponent.Expect( driver, blockId );
+			const gPaymentComponent = await SimplePaymentsBlockComponent.Expect( this.driver, blockId );
 			await gPaymentComponent.insertPaymentButtonDetails( paymentButtonDetails );
 
 			await gEditorComponent.enterTitle( pageTitle );
@@ -528,7 +523,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		it( 'Can publish and view content', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			try {
 				await gEditorComponent.publish( { visit: true } );
 			} catch {
@@ -546,7 +541,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		it( 'Can see the payment button in our published page', async function () {
-			const viewPagePage = await ViewPagePage.Expect( driver );
+			const viewPagePage = await ViewPagePage.Expect( this.driver );
 			const displayed = await viewPagePage.paymentButtonDisplayed();
 			return assert.strictEqual(
 				displayed,
@@ -556,17 +551,17 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		it( 'The payment button in our published page opens a new Paypal window for payment', async function () {
-			const numberOfOpenBrowserWindows = await driverHelper.numberOfOpenWindows( driver );
+			const numberOfOpenBrowserWindows = await driverHelper.numberOfOpenWindows( this.driver );
 			assert.strictEqual(
 				numberOfOpenBrowserWindows,
 				1,
 				'There is more than one open browser window before clicking payment button'
 			);
-			const viewPagePage = await ViewPagePage.Expect( driver );
+			const viewPagePage = await ViewPagePage.Expect( this.driver );
 			await viewPagePage.clickPaymentButton();
 			// Skip some lines and checks until Chrome can handle multiple windows in app mode
 			// await driverHelper.waitUntilAbleToSwitchToWindow( driver, 1 );
-			await PaypalCheckoutPage.Expect( driver );
+			await PaypalCheckoutPage.Expect( this.driver );
 			// const amountDisplayed = await paypalCheckoutPage.priceDisplayed();
 			// assert.strictEqual(
 			// 	amountDisplayed,
@@ -582,7 +577,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		after( async function () {
-			await driverHelper.closeAllPopupWindows( driver );
+			await driverHelper.closeAllPopupWindows( this.driver );
 		} );
 	} );
 } );

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-post-editor-spec.js
@@ -33,7 +33,6 @@ import * as SlackNotifier from '../../lib/slack-notifier';
 import EmbedsBlockComponent from '../../lib/gutenberg/blocks/embeds-block-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 const gutenbergUser =
@@ -41,12 +40,7 @@ const gutenbergUser =
 
 describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function () {
 		let fileDetails;

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-post-editor-spec.js
@@ -40,11 +40,6 @@ const gutenbergUser =
 
 describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function () {
 		let fileDetails;
@@ -61,26 +56,26 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		it( 'Can log in', async function () {
-			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		it( 'Can enter post title, content and image', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.enterTitle( blogPostTitle );
 			await gEditorComponent.enterText( blogPostQuote );
 			await gEditorComponent.addImage( fileDetails );
 
 			await gEditorComponent.openSidebar();
-			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( this.driver );
 			await gEditorSidebarComponent.enterImageAltText( fileDetails );
 			await gEditorComponent.closeSidebar();
 		} );
 
 		it( 'Expand Categories and Tags', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.openSidebar();
-			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( this.driver );
 			await gEditorSidebarComponent.selectDocumentTab();
 			await gEditorSidebarComponent.collapseStatusAndVisibility(); // Status and visibility starts opened
 			await gEditorSidebarComponent.expandCategories();
@@ -88,12 +83,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		it( 'Can add a new category', async function () {
-			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( this.driver );
 			await gEditorSidebarComponent.addNewCategory( newCategoryName );
 		} );
 
 		it( 'Can add a new tag', async function () {
-			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( this.driver );
 			await gEditorSidebarComponent.addNewTag( newTagName );
 			const tagDisplayed = await gEditorSidebarComponent.tagEventuallyDisplayed( newTagName );
 			assert.strictEqual(
@@ -104,8 +99,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		it( 'Close categories and tags', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( this.driver );
 			await gEditorSidebarComponent.selectDocumentTab();
 			await gEditorSidebarComponent.collapseCategories();
 			await gEditorSidebarComponent.collapseTags();
@@ -113,13 +108,13 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		it( 'Can launch post preview', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.ensureSaved();
 			await gEditorComponent.launchPreview();
 		} );
 
 		it( 'Can see correct post title in preview', async function () {
-			this.postPreviewComponent = await PostPreviewComponent.Expect( driver );
+			this.postPreviewComponent = await PostPreviewComponent.Expect( this.driver );
 
 			const postTitle = await this.postPreviewComponent.postTitle();
 			assert.strictEqual(
@@ -171,12 +166,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		it( 'Can publish and view content', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.publish( { visit: true } );
 		} );
 
 		it( 'Can see correct post title', async function () {
-			const viewPostPage = await ViewPostPage.Expect( driver );
+			const viewPostPage = await ViewPostPage.Expect( this.driver );
 			const postTitle = await viewPostPage.postTitle();
 			assert.strictEqual(
 				postTitle.toLowerCase(),
@@ -186,7 +181,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		it( 'Can see correct post content', async function () {
-			const viewPostPage = await ViewPostPage.Expect( driver );
+			const viewPostPage = await ViewPostPage.Expect( this.driver );
 			const content = await viewPostPage.postContent();
 			assert.strictEqual(
 				content.indexOf( blogPostQuote ) > -1,
@@ -200,7 +195,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		it( 'Can see correct post category', async function () {
-			const viewPostPage = await ViewPostPage.Expect( driver );
+			const viewPostPage = await ViewPostPage.Expect( this.driver );
 			const categoryDisplayed = await viewPostPage.categoryDisplayed();
 			assert.strictEqual(
 				categoryDisplayed.toUpperCase(),
@@ -210,7 +205,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		it( 'Can see the image published', async function () {
-			const viewPostPage = await ViewPostPage.Expect( driver );
+			const viewPostPage = await ViewPostPage.Expect( this.driver );
 			const imageDisplayed = await viewPostPage.imageDisplayed( fileDetails );
 			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the published post' );
 		} );
@@ -230,7 +225,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			if ( fileDetails ) {
 				await mediaHelper.deleteFile( fileDetails );
 			}
-			await driverHelper.acceptAlertIfPresent( driver );
+			await driverHelper.acceptAlertIfPresent( this.driver );
 		} );
 	} );
 
@@ -241,33 +236,33 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				'“Whenever you find yourself on the side of the majority, it is time to pause and reflect.”\n- Mark Twain';
 
 			it( 'Can log in', async function () {
-				this.loginFlow = new LoginFlow( driver, gutenbergUser );
+				this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 				return await this.loginFlow.login( { useFreshLogin: true } );
 			} );
 
 			it( 'Start new post', async function () {
-				const navBarComponent = await NavBarComponent.Expect( driver );
+				const navBarComponent = await NavBarComponent.Expect( this.driver );
 				await navBarComponent.clickMySites();
-				const sidebarComponent = await SidebarComponent.Expect( driver );
+				const sidebarComponent = await SidebarComponent.Expect( this.driver );
 				await sidebarComponent.selectPosts();
-				const postsPage = await PostsPage.Expect( driver );
+				const postsPage = await PostsPage.Expect( this.driver );
 				return await postsPage.addNewPost();
 			} );
 
 			it( 'Can enter post title and text content', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gEditorComponent.initEditor();
 				await gEditorComponent.enterTitle( blogPostTitle );
 				await gEditorComponent.enterText( blogPostQuote );
 			} );
 
 			it( 'Can publish and view content', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gEditorComponent.publish( { visit: true } );
 			} );
 
 			it( 'Can see correct post title', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const postTitle = await viewPostPage.postTitle();
 				assert.strictEqual(
 					postTitle.toLowerCase(),
@@ -284,36 +279,36 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const blogPostQuote = '“Worries shared are worries halved.”\n- Unknown';
 
 			it( 'Can log in', async function () {
-				this.loginFlow = new LoginFlow( driver, gutenbergUser );
+				this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 				return await this.loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			it( 'Can enter post title and content', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gEditorComponent.enterTitle( blogPostTitle );
 				await gEditorComponent.enterText( blogPostQuote );
 			} );
 
 			it( 'Can schedule content for a future date and see correct publish date', async function () {
-				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( this.driver );
 				await gSidebarComponent.displayComponentIfNecessary();
 				await gSidebarComponent.chooseDocumentSettings();
 				const publishDate = await gSidebarComponent.scheduleFuturePost();
 
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				return await gEditorComponent.schedulePost( publishDate );
 			} );
 
 			it( 'Remove scheduled post', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gEditorComponent.closeScheduledPanel();
-				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( this.driver );
 				await gSidebarComponent.selectDocumentTab();
 				await gSidebarComponent.trashPost();
 			} );
 
 			it( 'Can then see the Posts page with a confirmation message', async function () {
-				const noticesComponent = await NoticesComponent.Expect( driver );
+				const noticesComponent = await NoticesComponent.Expect( this.driver );
 				const displayed = await noticesComponent.isSuccessNoticeDisplayed();
 				return assert.strictEqual(
 					displayed,
@@ -323,7 +318,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			after( async function () {
-				await driverHelper.acceptAlertIfPresent( driver );
+				await driverHelper.acceptAlertIfPresent( this.driver );
 			} );
 		} );
 	} );
@@ -335,12 +330,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				'If you’re not prepared to be wrong; you’ll never come up with anything original.\n— Sir Ken Robinson';
 
 			it( 'Can log in', async function () {
-				this.loginFlow = new LoginFlow( driver, gutenbergUser );
+				this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 				return await this.loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			it( 'Can enter post title and content', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gEditorComponent.enterTitle( blogPostTitle );
 				return await gEditorComponent.enterText( blogPostQuote );
 				// Temporarily disable ensureSaved() to prevent error:
@@ -359,9 +354,9 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'Can allow comments', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gEditorComponent.openSidebar();
-				const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+				const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( this.driver );
 				await gEditorSidebarComponent.selectDocumentTab();
 				await gEditorSidebarComponent.collapseStatusAndVisibility(); // Status and visibility starts opened
 				await gEditorSidebarComponent.expandDiscussion();
@@ -369,7 +364,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'Set to private which publishes it - Can set visibility to private which immediately publishes it', async function () {
-				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( this.driver );
 				await gSidebarComponent.chooseDocumentSettings();
 				await gSidebarComponent.expandStatusAndVisibility();
 				await gSidebarComponent.setVisibilityToPrivate();
@@ -377,12 +372,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'Can view content', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				return await gEditorComponent.viewPublishedPostOrPage();
 			} );
 
 			it( 'As a logged in user - Can see correct post title', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const postTitle = await viewPostPage.postTitle();
 				assert.strictEqual(
 					postTitle.toLowerCase(),
@@ -392,7 +387,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'Can see correct post content', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const content = await viewPostPage.postContent();
 				assert.strictEqual(
 					content.indexOf( blogPostQuote ) > -1,
@@ -406,7 +401,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'Can see comments enabled', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const visible = await viewPostPage.commentsVisible();
 				assert.strictEqual(
 					visible,
@@ -416,7 +411,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( "Can't see sharing buttons", async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const visible = await viewPostPage.sharingButtonsVisible();
 				assert.strictEqual(
 					visible,
@@ -426,12 +421,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'Ensure we are not logggd in', async function () {
-				await driverManager.clearCookiesAndDeleteLocalStorage( driver );
-				await driver.navigate().refresh();
+				await driverManager.clearCookiesAndDeleteLocalStorage( this.driver );
+				await this.driver.navigate().refresh();
 			} );
 
 			it( "As a non-logged in user - Can't see post at all", async function () {
-				const notFoundPage = await NotFoundPage.Expect( driver );
+				const notFoundPage = await NotFoundPage.Expect( this.driver );
 				const displayed = await notFoundPage.displayed();
 				assert.strictEqual(
 					displayed,
@@ -441,7 +436,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			after( async function () {
-				await driverHelper.acceptAlertIfPresent( driver );
+				await driverHelper.acceptAlertIfPresent( this.driver );
 			} );
 		} );
 	} );
@@ -454,29 +449,29 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const postPassword = 'e2e' + new Date().getTime().toString();
 
 			it( 'Can log in', async function () {
-				const loginFlow = new LoginFlow( driver, gutenbergUser );
+				const loginFlow = new LoginFlow( this.driver, gutenbergUser );
 				await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			it( 'Can enter post title and content and set to password protected', async function () {
-				let gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				let gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gEditorComponent.enterTitle( blogPostTitle );
 
-				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( this.driver );
 				await gSidebarComponent.chooseDocumentSettings();
 				await gSidebarComponent.setVisibilityToPasswordProtected( postPassword );
 				await gSidebarComponent.hideComponentIfNecessary();
 
-				gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				return await gEditorComponent.enterText( blogPostQuote );
 			} );
 
 			it( 'Can publish and view content', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gEditorComponent.publish( { visit: true } );
 			} );
 			it( 'As a logged in user, With no password entered, Can view page title', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const actualPostTitle = await viewPostPage.postTitle();
 				assert.strictEqual(
 					actualPostTitle.toUpperCase(),
@@ -485,7 +480,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'Can see password field', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const isPasswordProtected = await viewPostPage.isPasswordProtected();
 				assert.strictEqual(
 					isPasswordProtected,
@@ -495,7 +490,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( "Can't see content when no password is entered", async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const content = await viewPostPage.postContent();
 				assert.strictEqual(
 					content.indexOf( blogPostQuote ) === -1,
@@ -509,12 +504,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'With incorrect password entered, Enter incorrect password', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				await viewPostPage.enterPassword( 'password' );
 			} );
 
 			it( 'Can view post title', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const actualPostTitle = await viewPostPage.postTitle();
 				assert.strictEqual(
 					actualPostTitle.toUpperCase(),
@@ -523,7 +518,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'Can see password field', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const isPasswordProtected = await viewPostPage.isPasswordProtected();
 				assert.strictEqual(
 					isPasswordProtected,
@@ -533,7 +528,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( "Can't see content when incorrect password is entered", async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const content = await viewPostPage.postContent();
 				assert.strictEqual(
 					content.indexOf( blogPostQuote ) === -1,
@@ -547,12 +542,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'With correct password entered, Enter correct password', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				await viewPostPage.enterPassword( postPassword );
 			} );
 
 			it( 'Can view post title', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const actualPostTitle = await viewPostPage.postTitle();
 				assert.strictEqual(
 					actualPostTitle.toUpperCase(),
@@ -561,7 +556,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( "Can't see password field", async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const isPasswordProtected = await viewPostPage.isPasswordProtected();
 				assert.strictEqual(
 					isPasswordProtected,
@@ -571,7 +566,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'Can see post content', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const content = await viewPostPage.postContent();
 				assert.strictEqual(
 					content.indexOf( blogPostQuote ) > -1,
@@ -585,12 +580,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'As a non-logged in user, Clear cookies (log out)', async function () {
-				await driver.manage().deleteAllCookies();
-				await driver.navigate().refresh();
+				await this.driver.manage().deleteAllCookies();
+				await this.driver.navigate().refresh();
 			} );
 
 			it( 'With no password entered, Can view page title', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const actualPostTitle = await viewPostPage.postTitle();
 				assert.strictEqual(
 					actualPostTitle.toUpperCase(),
@@ -599,7 +594,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'Can see password field', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const isPasswordProtected = await viewPostPage.isPasswordProtected();
 				assert.strictEqual(
 					isPasswordProtected,
@@ -609,7 +604,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( "Can't see content when no password is entered", async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const content = await viewPostPage.postContent();
 				assert.strictEqual(
 					content.indexOf( blogPostQuote ) === -1,
@@ -623,12 +618,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'With incorrect password entered, Enter incorrect password', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				await viewPostPage.enterPassword( 'password' );
 			} );
 
 			it( 'Can view post title', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const actualPostTitle = await viewPostPage.postTitle();
 				assert.strictEqual(
 					actualPostTitle.toUpperCase(),
@@ -637,7 +632,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'Can see password field', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const isPasswordProtected = await viewPostPage.isPasswordProtected();
 				assert.strictEqual(
 					isPasswordProtected,
@@ -647,7 +642,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( "Can't see content when incorrect password is entered", async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const content = await viewPostPage.postContent();
 				assert.strictEqual(
 					content.indexOf( blogPostQuote ) === -1,
@@ -661,12 +656,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'With correct password entered, Enter correct password', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				await viewPostPage.enterPassword( postPassword );
 			} );
 
 			it( 'Can view post title', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const actualPostTitle = await viewPostPage.postTitle();
 				assert.strictEqual(
 					actualPostTitle.toUpperCase(),
@@ -675,7 +670,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( "Can't see password field", async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const isPasswordProtected = await viewPostPage.isPasswordProtected();
 				assert.strictEqual(
 					isPasswordProtected,
@@ -685,7 +680,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'Can see page content', async function () {
-				const viewPostPage = await ViewPostPage.Expect( driver );
+				const viewPostPage = await ViewPostPage.Expect( this.driver );
 				const content = await viewPostPage.postContent();
 				assert.strictEqual(
 					content.indexOf( blogPostQuote ) > -1,
@@ -699,7 +694,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			after( async function () {
-				await driverHelper.acceptAlertIfPresent( driver );
+				await driverHelper.acceptAlertIfPresent( this.driver );
 			} );
 		} );
 	} );
@@ -711,25 +706,25 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				'The only victory that counts is the victory over yourself.\n— Jesse Owens\n';
 
 			it( 'Can log in', async function () {
-				const loginFlow = new LoginFlow( driver, gutenbergUser );
+				const loginFlow = new LoginFlow( this.driver, gutenbergUser );
 				return await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			it( 'Can enter post title and content', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gEditorComponent.enterTitle( blogPostTitle );
 				await gEditorComponent.enterText( blogPostQuote );
 				return gEditorComponent.ensureSaved();
 			} );
 
 			it( 'Can trash the new post', async function () {
-				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( this.driver );
 				await gSidebarComponent.chooseDocumentSettings();
 				return await gSidebarComponent.trashPost();
 			} );
 
 			it( 'Can then see the Posts page with a confirmation message', async function () {
-				const noticesComponent = await NoticesComponent.Expect( driver );
+				const noticesComponent = await NoticesComponent.Expect( this.driver );
 				const displayed = await noticesComponent.isSuccessNoticeDisplayed();
 				return assert.strictEqual(
 					displayed,
@@ -739,7 +734,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			after( async function () {
-				await driverHelper.acceptAlertIfPresent( driver );
+				await driverHelper.acceptAlertIfPresent( this.driver );
 			} );
 		} );
 	} );
@@ -752,37 +747,37 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				'Science is organised knowledge. Wisdom is organised life..\n~ Immanuel Kant';
 
 			it( 'Can log in', async function () {
-				const loginFlow = new LoginFlow( driver, gutenbergUser );
+				const loginFlow = new LoginFlow( this.driver, gutenbergUser );
 				return await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			it( 'Can enter post title and content', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gEditorComponent.enterTitle( originalBlogPostTitle );
 				await gEditorComponent.enterText( blogPostQuote );
 			} );
 
 			it( 'Can publish the post', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gEditorComponent.publish( { visit: true } );
 			} );
 
 			describe( 'Edit the post via posts', function () {
 				it( 'Can view the posts list', async function () {
-					await ReaderPage.Visit( driver );
-					const navbarComponent = await NavBarComponent.Expect( driver );
+					await ReaderPage.Visit( this.driver );
+					const navbarComponent = await NavBarComponent.Expect( this.driver );
 					await navbarComponent.clickMySites();
 					const jetpackSiteName = dataHelper.getJetpackSiteName();
-					const sidebarComponent = await SidebarComponent.Expect( driver );
+					const sidebarComponent = await SidebarComponent.Expect( this.driver );
 					if ( host !== 'WPCOM' ) {
 						await sidebarComponent.selectSite( jetpackSiteName );
 					}
 					await sidebarComponent.selectPosts();
-					return await PostsPage.Expect( driver );
+					return await PostsPage.Expect( this.driver );
 				} );
 
 				it( 'Can see and edit our new post', async function () {
-					const postsPage = await PostsPage.Expect( driver );
+					const postsPage = await PostsPage.Expect( this.driver );
 					await postsPage.waitForPostTitled( originalBlogPostTitle );
 					const displayed = await postsPage.isPostDisplayed( originalBlogPostTitle );
 					assert.strictEqual(
@@ -791,11 +786,11 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 						`The blog post titled '${ originalBlogPostTitle }' is not displayed in the list of posts`
 					);
 					await postsPage.editPostWithTitle( originalBlogPostTitle );
-					return await GutenbergEditorComponent.Expect( driver );
+					return await GutenbergEditorComponent.Expect( this.driver );
 				} );
 
 				it( 'Can see the post title', async function () {
-					const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+					const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 					const titleShown = await gEditorComponent.titleShown();
 					assert.strictEqual(
 						titleShown,
@@ -805,14 +800,14 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				} );
 
 				it( 'Can see the Line Height setting for the paragraph', async function () {
-					const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+					const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( this.driver );
 
 					if ( driverManager.currentScreenSize() === 'mobile' )
 						await gSidebarComponent.hideComponentIfNecessary();
 
 					// Give focus to the first paragraph block found
 					await driverHelper.clickWhenClickable(
-						driver,
+						this.driver,
 						By.css( 'p.block-editor-rich-text__editable:first-of-type' )
 					);
 
@@ -820,7 +815,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 					await gSidebarComponent.chooseBlockSettings();
 
 					const lineHeighSettingPresent = await driverHelper.isElementLocated(
-						driver,
+						this.driver,
 						By.css( '.block-editor-line-height-control' )
 					);
 
@@ -831,7 +826,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				} );
 
 				it( 'Can set the new title and update it, and link to the updated post', async function () {
-					const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+					const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 					await gEditorComponent.enterTitle( updatedBlogPostTitle );
 
 					return await gEditorComponent.update( { visit: true } );
@@ -839,11 +834,11 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 				describe( 'Can view the post with the new title', function () {
 					it( 'Can view the post', async function () {
-						return await ViewPostPage.Expect( driver );
+						return await ViewPostPage.Expect( this.driver );
 					} );
 
 					it( 'Can see correct post title', async function () {
-						const viewPostPage = await ViewPostPage.Expect( driver );
+						const viewPostPage = await ViewPostPage.Expect( this.driver );
 						const postTitle = await viewPostPage.postTitle();
 						return assert.strictEqual(
 							postTitle.toLowerCase(),
@@ -856,7 +851,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		after( async function () {
-			await driverHelper.acceptAlertIfPresent( driver );
+			await driverHelper.acceptAlertIfPresent( this.driver );
 		} );
 	} );
 
@@ -867,12 +862,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const subject = "Let's work together";
 
 			it( 'Can log in', async function () {
-				const loginFlow = new LoginFlow( driver, gutenbergUser );
+				const loginFlow = new LoginFlow( this.driver, gutenbergUser );
 				return await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			it( 'Can insert the contact form', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gEditorComponent.enterTitle( originalBlogPostTitle );
 				await gEditorComponent.insertContactForm( contactEmail, subject );
 				await gEditorComponent.ensureSaved();
@@ -886,12 +881,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			it( 'Can publish and view content', async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gEditorComponent.publish( { visit: true } );
 			} );
 
 			it( 'Can see the contact form in our published post', async function () {
-				this.viewPostPage = await ViewPostPage.Expect( driver );
+				this.viewPostPage = await ViewPostPage.Expect( this.driver );
 				const displayed = await this.viewPostPage.contactFormDisplayed();
 				assert.strictEqual(
 					displayed,
@@ -901,7 +896,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			after( async function () {
-				await driverHelper.acceptAlertIfPresent( driver );
+				await driverHelper.acceptAlertIfPresent( this.driver );
 			} );
 		} );
 	} );
@@ -918,16 +913,16 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		};
 
 		it( 'Can log in', async function () {
-			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		it( 'Can insert the payment button', async function () {
 			const blogPostTitle = 'Payment Button: ' + dataHelper.randomPhrase();
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			const blockId = await gEditorComponent.addBlock( 'Pay with PayPal' );
 
-			const gPaymentComponent = await SimplePaymentsBlockComponent.Expect( driver, blockId );
+			const gPaymentComponent = await SimplePaymentsBlockComponent.Expect( this.driver, blockId );
 			await gPaymentComponent.insertPaymentButtonDetails( paymentButtonDetails );
 
 			await gEditorComponent.enterTitle( blogPostTitle );
@@ -936,7 +931,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		it( 'Can publish and view content', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			try {
 				await gEditorComponent.publish( { visit: true } );
 			} catch {
@@ -954,7 +949,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		it( 'Can see the payment button in our published post', async function () {
-			const viewPostPage = await ViewPostPage.Expect( driver );
+			const viewPostPage = await ViewPostPage.Expect( this.driver );
 			const displayed = await viewPostPage.paymentButtonDisplayed();
 			return assert.strictEqual(
 				displayed,
@@ -964,17 +959,17 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		it( 'The payment button in our published post opens a new Paypal window for payment', async function () {
-			const numberOfOpenBrowserWindows = await driverHelper.numberOfOpenWindows( driver );
+			const numberOfOpenBrowserWindows = await driverHelper.numberOfOpenWindows( this.driver );
 			assert.strictEqual(
 				numberOfOpenBrowserWindows,
 				1,
 				'There is more than one open browser window before clicking payment button'
 			);
-			const viewPostPage = await ViewPostPage.Expect( driver );
+			const viewPostPage = await ViewPostPage.Expect( this.driver );
 			await viewPostPage.clickPaymentButton();
 			// Skip some lines and checks until Chrome can handle multiple windows in app mode
 			// await driverHelper.waitUntilAbleToSwitchToWindow( driver, 1 );
-			await PaypalCheckoutPage.Expect( driver );
+			await PaypalCheckoutPage.Expect( this.driver );
 			// const amountDisplayed = await paypalCheckoutPage.priceDisplayed();
 			// assert.strictEqual(
 			// 	amountDisplayed,
@@ -990,8 +985,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		after( async function () {
-			await driverHelper.acceptAlertIfPresent( driver );
-			await driverHelper.closeAllPopupWindows( driver );
+			await driverHelper.acceptAlertIfPresent( this.driver );
+			await driverHelper.closeAllPopupWindows( this.driver );
 		} );
 	} );
 
@@ -1005,12 +1000,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		it( 'Can log in', async function () {
-			const loginFlow = new LoginFlow( driver, gutenbergUser );
+			const loginFlow = new LoginFlow( this.driver, gutenbergUser );
 			return await loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		it( 'Can insert an image in an Image block with the Media Modal', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			return await gEditorComponent.addImageFromMediaModal( fileDetails );
 		} );
 	} );
@@ -1022,44 +1017,44 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				'To really be of help to others we need to be guided by compassion.\n— Dalai Lama';
 
 			it( 'Can log in', async function () {
-				const loginFlow = new LoginFlow( driver, gutenbergUser );
+				const loginFlow = new LoginFlow( this.driver, gutenbergUser );
 				return await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			it( 'Can enter post title and content', async function () {
-				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
+				const gHeaderComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gHeaderComponent.enterTitle( originalBlogPostTitle );
 				await gHeaderComponent.enterText( blogPostQuote );
 			} );
 
 			it( 'Can publish the post', async function () {
-				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
+				const gHeaderComponent = await GutenbergEditorComponent.Expect( this.driver );
 				return await gHeaderComponent.publish();
 			} );
 		} );
 
 		describe( 'Revert the post to draft', function () {
 			it( 'Can revert the post to draft', async function () {
-				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
+				const gHeaderComponent = await GutenbergEditorComponent.Expect( this.driver );
 				await gHeaderComponent.dismissSuccessNotice();
 				await gHeaderComponent.revertToDraft();
 			} );
 		} );
 
 		after( async function () {
-			await driverHelper.acceptAlertIfPresent( driver );
+			await driverHelper.acceptAlertIfPresent( this.driver );
 		} );
 	} );
 
 	describe( 'Insert embeds: @parallel', function () {
 		it( 'Can log in', async function () {
-			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		it( 'Can start post', async function () {
 			const blogPostTitle = 'Embeds: ' + dataHelper.randomPhrase();
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.enterTitle( blogPostTitle );
 			const title = await gEditorComponent.titleShown();
 			assert.strictEqual( title, blogPostTitle );
@@ -1083,21 +1078,21 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			},
 		].forEach( ( Block ) => {
 			it( `Can insert ${ Block.name } block`, async function () {
-				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 				const embedBlock = await gEditorComponent.addBlock( Block.name );
-				const gEmbedsComponent = await EmbedsBlockComponent.Expect( driver, embedBlock );
+				const gEmbedsComponent = await EmbedsBlockComponent.Expect( this.driver, embedBlock );
 				await gEmbedsComponent.embedUrl( Block.url );
 				await gEmbedsComponent.isEmbeddedInEditor( Block.selector );
 			} );
 		} );
 
 		it( 'Can publish and view content', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			return await gEditorComponent.publish( { visit: true } );
 		} );
 
 		it( 'Can see embedded content in our published post', async function () {
-			const viewPostPage = await ViewPostPage.Expect( driver );
+			const viewPostPage = await ViewPostPage.Expect( this.driver );
 			this.youtubePostLocator = '.youtube-player';
 			await viewPostPage.embedContentDisplayed( this.youtubePostLocator ); // check YouTube content
 			this.instagramPostLocator = '.instagram-media-rendered';
@@ -1107,19 +1102,19 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		after( async function () {
-			await driverHelper.acceptAlertIfPresent( driver );
+			await driverHelper.acceptAlertIfPresent( this.driver );
 		} );
 	} );
 
 	describe( 'Can Share Posts From Reader (PressThis)! @parallel', function () {
 		it( 'Can log in', async function () {
-			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 			await this.loginFlow.login();
 			return await this.loginFlow.checkForDevDocsAndRedirectToReader();
 		} );
 
 		it( 'Find a post to share (press this)', async function () {
-			const readerPage = await ReaderPage.Expect( driver );
+			const readerPage = await ReaderPage.Expect( this.driver );
 			const sharePostError = await readerPage.shareLatestPost();
 			if ( sharePostError instanceof Error ) {
 				throw sharePostError;
@@ -1127,17 +1122,17 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		it( 'Block Editor loads with shared content', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			return await gEditorComponent.initEditor();
 		} );
 
 		it( 'Can publish and view content', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			return await gEditorComponent.publish( { visit: true } );
 		} );
 
 		it( 'Can see a post title and post content', async function () {
-			const viewPostPage = await ViewPostPage.Expect( driver );
+			const viewPostPage = await ViewPostPage.Expect( this.driver );
 			const postTitle = await viewPostPage.postTitle();
 			const postContent = await viewPostPage.postContent();
 			assert( postTitle.length > 0, 'Press This did not copy a post title!' );
@@ -1153,37 +1148,37 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			'Your most unhappy customers are your greatest source of learning. ~ Bill Gates';
 
 		it( 'Can log in', async function () {
-			const loginFlow = new LoginFlow( driver, gutenbergUser );
+			const loginFlow = new LoginFlow( this.driver, gutenbergUser );
 			await loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		it( 'Can enter post title and text content', async function () {
-			const editor = await GutenbergEditorComponent.Expect( driver );
+			const editor = await GutenbergEditorComponent.Expect( this.driver );
 			await editor.enterTitle( originalTitle );
 			await editor.enterText( originalContent );
 			await editor.ensureSaved();
 		} );
 
 		it( 'Can update post title and text content', async function () {
-			const editor = await GutenbergEditorComponent.Expect( driver );
+			const editor = await GutenbergEditorComponent.Expect( this.driver );
 			await editor.enterTitle( updatedTitle );
 			await editor.replaceTextOnLastParagraph( updatedContent );
 			await editor.ensureSaved();
 		} );
 
 		it( 'Can open the revisions modal', async function () {
-			const editor = await GutenbergEditorComponent.Expect( driver );
+			const editor = await GutenbergEditorComponent.Expect( this.driver );
 			await editor.openSidebar();
-			const sidebar = await GutenbergEditorSidebarComponent.Expect( driver );
+			const sidebar = await GutenbergEditorSidebarComponent.Expect( this.driver );
 			await sidebar.selectDocumentTab();
 			await sidebar.openRevisionsDialog();
 		} );
 
 		it( 'Can restore the previous revision', async function () {
-			const revisions = await RevisionsModalComponent.Expect( driver );
+			const revisions = await RevisionsModalComponent.Expect( this.driver );
 			await revisions.loadFirstRevision();
 
-			const editor = await GutenbergEditorComponent.Expect( driver );
+			const editor = await GutenbergEditorComponent.Expect( this.driver );
 			await editor.closeSidebar();
 			await editor.ensureSaved();
 			const title = await editor.getTitle();

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-post-editor-spec.js
@@ -40,7 +40,11 @@ const gutenbergUser =
 
 describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function () {
 		let fileDetails;

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-upgrade-spec.js
@@ -35,7 +35,7 @@ const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-const driver = global.__BROWSER__;
+let driver;
 let editor;
 let sampleImages;
 
@@ -165,6 +165,9 @@ describe( `[${ host }, ${ screenSize }] Test Gutenberg upgrade against most popu
 		}
 	} );
 
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 	after( async function () {
 		if ( sampleImages && sampleImages.length ) {
 			await Promise.all(

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-upgrade-spec.js
@@ -32,11 +32,10 @@ import {
 } from '../../lib/gutenberg/blocks';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
+const driver = global.__BROWSER__;
 let editor;
 let sampleImages;
 
@@ -164,11 +163,6 @@ describe( `[${ host }, ${ screenSize }] Test Gutenberg upgrade against most popu
 		} else {
 			this.skip();
 		}
-	} );
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = global.__BROWSER__ = await driverManager.startBrowser();
 	} );
 
 	after( async function () {

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-upgrade-spec.js
@@ -35,7 +35,6 @@ const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let driver;
 let editor;
 let sampleImages;
 
@@ -99,10 +98,11 @@ async function insertBlock( Block ) {
 /**
  * Starts a new post in the editor. User must be logged-in.
  *
+ * @param {object} driver Instance of WebDriver
  * @param {object} loginFlow Instance of the LoginFlow helper.
  * @returns {object} Instance of the GutenbergEditorComponent.
  */
-async function startNewPost( loginFlow ) {
+async function startNewPost( driver, loginFlow ) {
 	await ReaderPage.Visit( driver );
 	await NavBarComponent.Expect( driver );
 
@@ -135,9 +135,10 @@ function verifyBlockInEditor( Block ) {
 /**
  * Re-usable collection of steps for verifying blocks in the frontend/published page.
  *
+ * @param {object} driver Instance of WebDriver
  * @param {Function} Block A block class.
  */
-function verifyBlockInPublishedPage( Block ) {
+function verifyBlockInPublishedPage( driver, Block ) {
 	it( 'Publish page', async function () {
 		await editor.publish( { visit: true } );
 	} );
@@ -165,9 +166,6 @@ describe( `[${ host }, ${ screenSize }] Test Gutenberg upgrade against most popu
 		}
 	} );
 
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 	after( async function () {
 		if ( sampleImages && sampleImages.length ) {
 			await Promise.all(
@@ -197,10 +195,10 @@ describe( `[${ host }, ${ screenSize }] Test Gutenberg upgrade against most popu
 
 			describe( `Test the block on a non-edge site`, function () {
 				it( `Log in and start a new post`, async function () {
-					const loginFlow = new LoginFlow( driver, 'gutenbergUpgradeUser' );
+					const loginFlow = new LoginFlow( this.driver, 'gutenbergUpgradeUser' );
 
 					await loginFlow.login();
-					editor = await startNewPost( loginFlow );
+					editor = await startNewPost( this.driver, loginFlow );
 				} );
 
 				it( `Insert and configure the block`, async function () {
@@ -213,14 +211,14 @@ describe( `[${ host }, ${ screenSize }] Test Gutenberg upgrade against most popu
 					currentGutenbergBlocksCode = await editor.getBlocksCode();
 				} );
 
-				verifyBlockInPublishedPage( Block );
+				verifyBlockInPublishedPage( this.driver, Block );
 
 				describe( `Test the same block on a corresponding edge site`, function () {
 					it( `Start a new post`, async function () {
-						const loginFlow = new LoginFlow( driver, 'gutenbergUpgradeEdgeUser' );
+						const loginFlow = new LoginFlow( this.driver, 'gutenbergUpgradeEdgeUser' );
 
 						// No need to log in again as the edge site is owned by the same user.
-						editor = await startNewPost( loginFlow );
+						editor = await startNewPost( this.driver, loginFlow );
 					} );
 
 					it( 'Load the block via markup copied from the non-edge site', async function () {

--- a/test/e2e/specs/specs-wpcom/wp-comments-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-comments-spec.js
@@ -22,8 +22,12 @@ const blogPostQuote =
 
 describe( `[${ host }] Comments: (${ screenSize })`, function () {
 	let fileDetails;
+	let driver;
 	this.timeout( mochaTimeoutMS );
-	const driver = global.__BROWSER__;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	// Create image file for upload
 	before( async function () {

--- a/test/e2e/specs/specs-wpcom/wp-comments-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-comments-spec.js
@@ -15,7 +15,6 @@ import GutenbergEditorComponent from '../../lib/gutenberg/gutenberg-editor-compo
 
 const host = dataHelper.getJetpackHost();
 const screenSize = driverManager.currentScreenSize();
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const mochaTimeoutMS = config.get( 'mochaTimeoutMS' );
 const blogPostTitle = dataHelper.randomPhrase();
 const blogPostQuote =
@@ -23,13 +22,8 @@ const blogPostQuote =
 
 describe( `[${ host }] Comments: (${ screenSize })`, function () {
 	let fileDetails;
-	let driver;
 	this.timeout( mochaTimeoutMS );
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	// Create image file for upload
 	before( async function () {

--- a/test/e2e/specs/specs-wpcom/wp-comments-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-comments-spec.js
@@ -22,12 +22,7 @@ const blogPostQuote =
 
 describe( `[${ host }] Comments: (${ screenSize })`, function () {
 	let fileDetails;
-	let driver;
 	this.timeout( mochaTimeoutMS );
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	// Create image file for upload
 	before( async function () {
@@ -37,20 +32,20 @@ describe( `[${ host }] Comments: (${ screenSize })`, function () {
 
 	describe( 'Commenting and replying to newly created post in Gutenberg Editor: @parallel', function () {
 		it( 'Can login and create a new post', async function () {
-			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
+			this.loginFlow = new LoginFlow( this.driver, 'gutenbergSimpleSiteUser' );
 			await this.loginFlow.loginAndStartNewPost( null, true );
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.enterTitle( blogPostTitle );
 			await gEditorComponent.enterText( blogPostQuote );
 		} );
 
 		it( 'Can publish and visit site', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 			await gEditorComponent.publish( { visit: true } );
 		} );
 
 		it( 'Can post a comment', async function () {
-			const commentArea = await CommentsAreaComponent.Expect( driver );
+			const commentArea = await CommentsAreaComponent.Expect( this.driver );
 			const comment = dataHelper.randomPhrase();
 
 			await commentArea._postComment( comment );
@@ -59,7 +54,7 @@ describe( `[${ host }] Comments: (${ screenSize })`, function () {
 		} );
 
 		it( 'Can post a reply', async function () {
-			const commentArea = await CommentsAreaComponent.Expect( driver );
+			const commentArea = await CommentsAreaComponent.Expect( this.driver );
 			const comment = dataHelper.randomPhrase();
 
 			await commentArea.reply( comment );

--- a/test/e2e/specs/specs-wpcom/wp-gutenberg-experimental-features-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-gutenberg-experimental-features-spec.js
@@ -43,7 +43,11 @@ function camelCaseDash( string ) {
 
 describe( `[${ host }] Experimental features we depend on are available (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	it( 'Can log in', async function () {
 		this.loginFlow = new LoginFlow( driver, gutenbergUser );

--- a/test/e2e/specs/specs-wpcom/wp-gutenberg-experimental-features-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-gutenberg-experimental-features-spec.js
@@ -12,7 +12,6 @@ import * as driverManager from '../../lib/driver-manager';
 import * as dataHelper from '../../lib/data-helper';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 const gutenbergUser =
@@ -44,12 +43,7 @@ function camelCaseDash( string ) {
 
 describe( `[${ host }] Experimental features we depend on are available (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Can log in', async function () {
 		this.loginFlow = new LoginFlow( driver, gutenbergUser );

--- a/test/e2e/specs/specs-wpcom/wp-gutenberg-experimental-features-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-gutenberg-experimental-features-spec.js
@@ -43,14 +43,9 @@ function camelCaseDash( string ) {
 
 describe( `[${ host }] Experimental features we depend on are available (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	it( 'Can log in', async function () {
-		this.loginFlow = new LoginFlow( driver, gutenbergUser );
+		this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 		return await this.loginFlow.loginAndStartNewPost( null, true );
 	} );
 
@@ -61,7 +56,7 @@ describe( `[${ host }] Experimental features we depend on are available (${ scre
 			const wpGlobalName = camelCaseDash( packageName.substr( '@wordpress/'.length ) );
 
 			it( `"${ wpGlobalName }" package should be available in the global window object`, async function () {
-				const typeofPackage = await driver.executeScript(
+				const typeofPackage = await this.driver.executeScript(
 					`return typeof window.wp['${ wpGlobalName }']`
 				);
 				assert.notStrictEqual(
@@ -73,7 +68,7 @@ describe( `[${ host }] Experimental features we depend on are available (${ scre
 
 			for ( const feature of features ) {
 				it( `${ feature } should be available in ${ packageName }`, async function () {
-					const typeofExperimentalFeature = await driver.executeScript(
+					const typeofExperimentalFeature = await this.driver.executeScript(
 						`return typeof window.wp['${ wpGlobalName }']['${ feature }']`
 					);
 					assert.notStrictEqual(
@@ -88,7 +83,7 @@ describe( `[${ host }] Experimental features we depend on are available (${ scre
 
 	describe( 'Experimental data we depend on is available', function () {
 		it( `is iterable: wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns`, async function () {
-			const __experimentalBlockPatternsAreIterable = await driver.executeScript(
+			const __experimentalBlockPatternsAreIterable = await this.driver.executeScript(
 				`return Array.isArray( window.wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns )`
 			);
 			assert(
@@ -107,7 +102,7 @@ describe( `[${ host }] Experimental features we depend on are available (${ scre
 		// change in the number to the lower end, then something is probably wrong.
 		it( `number of block patterns loaded should be greater than the default`, async function () {
 			const expectedExperimentalBlockPatternsLength = 50;
-			const __experimentalBlockPatternsLength = await driver.executeScript(
+			const __experimentalBlockPatternsLength = await this.driver.executeScript(
 				`return window.wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns.length`
 			);
 			assert(
@@ -118,6 +113,6 @@ describe( `[${ host }] Experimental features we depend on are available (${ scre
 	} );
 
 	after( async () => {
-		return await driver.switchTo().defaultContent();
+		return await this.driver.switchTo().defaultContent();
 	} );
 } );

--- a/test/e2e/specs/specs-wpcom/wp-site-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-site-editor-spec.js
@@ -14,19 +14,13 @@ import SiteEditorPage from '../../lib/pages/site-editor-page.js';
 import SiteEditorComponent from '../../lib/components/site-editor-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 const gutenbergUser = 'siteEditorSimpleSiteUser';
 
 describe( `[${ host }] Site Editor (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( 'Start browser', async function () {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-	} );
+	const driver = global.__BROWSER__;
 
 	it( 'Can log in', async function () {
 		this.loginFlow = new LoginFlow( driver, gutenbergUser );

--- a/test/e2e/specs/specs-wpcom/wp-site-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-site-editor-spec.js
@@ -20,7 +20,11 @@ const gutenbergUser = 'siteEditorSimpleSiteUser';
 
 describe( `[${ host }] Site Editor (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	const driver = global.__BROWSER__;
+	let driver;
+
+	before( () => {
+		driver = global.__BROWSER__;
+	} );
 
 	it( 'Can log in', async function () {
 		this.loginFlow = new LoginFlow( driver, gutenbergUser );

--- a/test/e2e/specs/specs-wpcom/wp-site-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-site-editor-spec.js
@@ -20,37 +20,32 @@ const gutenbergUser = 'siteEditorSimpleSiteUser';
 
 describe( `[${ host }] Site Editor (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
-	let driver;
-
-	before( () => {
-		driver = global.__BROWSER__;
-	} );
 
 	it( 'Can log in', async function () {
-		this.loginFlow = new LoginFlow( driver, gutenbergUser );
+		this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
 		return await this.loginFlow.loginAndSelectMySite();
 	} );
 
 	it( 'Can open site editor', async function () {
-		const sidebarComponent = await SidebarComponent.Expect( driver );
+		const sidebarComponent = await SidebarComponent.Expect( this.driver );
 		return await sidebarComponent.selectSiteEditor();
 	} );
 
 	it( 'Site editor opens', async function () {
-		return await SiteEditorPage.Expect( driver );
+		return await SiteEditorPage.Expect( this.driver );
 	} );
 
 	it( 'Template loads', async function () {
-		const editor = await SiteEditorComponent.Expect( driver );
+		const editor = await SiteEditorComponent.Expect( this.driver );
 		return await editor.waitForTemplateToLoad();
 	} );
 
 	it( 'Template parts load', async function () {
-		const editor = await SiteEditorComponent.Expect( driver );
+		const editor = await SiteEditorComponent.Expect( this.driver );
 		return await editor.waitForTemplatePartsToLoad();
 	} );
 
 	after( async () => {
-		return await driver.switchTo().defaultContent();
+		return await this.driver.switchTo().defaultContent();
 	} );
 } );


### PR DESCRIPTION
#### Background

Virtually every e2e test implements the same `before` hook to create a new browser instance, with minor variations regarding cleaning cookies and local storage. 

#### Changes proposed in this Pull Request

This PR eliminates some repetition by creating a Root Hook for browser creation

While working on this PR I found that the hook `closeBrowser` was never called 🤷🏼 , so I added it back.

#### Testing instructions

Verify e2e tests still pass.