### PR TITLE
Extensions: Remove FormToggle in favor of ToggleControl in WP Super Cache

### DIFF
--- a/client/extensions/wp-super-cache/components/advanced/accepted-filenames.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/accepted-filenames.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { get, pick } from 'lodash';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -15,7 +15,6 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import FormLabel from 'calypso/components/forms/form-label';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import SectionHeader from 'calypso/components/section-header';
 import WrapSettingsForm from '../wrap-settings-form';
 
@@ -46,13 +45,12 @@ class AcceptedFilenames extends Component {
 		} = this.props;
 
 		return (
-			<FormToggle
+			<ToggleControl
 				checked={ get( pages, fieldName, false ) }
 				disabled={ isRequesting || isSaving || isReadOnly || ! get( pages, parent, true ) }
 				onChange={ this.handleToggle( fieldName ) }
-			>
-				<span>{ fieldLabel }</span>
-			</FormToggle>
+				label={ <span>{ fieldLabel }</span> }
+			/>
 		);
 	};
 

--- a/client/extensions/wp-super-cache/components/advanced/advanced.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/advanced.jsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { pick } from 'lodash';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -12,7 +12,6 @@ import { Card } from '@automattic/components';
 import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import SectionHeader from 'calypso/components/section-header';
 import WrapSettingsForm from '../wrap-settings-form';
 
@@ -45,152 +44,161 @@ const Advanced = ( {
 			<Card>
 				<form>
 					<FormFieldset>
-						<FormToggle
+						<ToggleControl
 							checked={ !! is_mfunc_enabled }
 							disabled={ isDisabled || !! cache_mod_rewrite }
 							onChange={ handleAutosavingToggle( 'is_mfunc_enabled' ) }
-						>
-							<span>
-								{ translate(
-									'Enable dynamic caching. Requires PHP or legacy caching. (See ' +
-										'{{faq}}FAQ{{/faq}} or wp-super-cache/plugins/dynamic-cache-test.php for example code.)',
-									{
-										components: {
-											faq: (
-												<ExternalLink
-													icon={ true }
-													target="_blank"
-													href="http://wordpress.org/plugins/wp-super-cache/faq/"
-												/>
-											),
-										},
-									}
-								) }
-							</span>
-						</FormToggle>
+							label={
+								<span>
+									{ translate(
+										'Enable dynamic caching. Requires PHP or legacy caching. (See ' +
+											'{{faq}}FAQ{{/faq}} or wp-super-cache/plugins/dynamic-cache-test.php for example code.)',
+										{
+											components: {
+												faq: (
+													<ExternalLink
+														icon={ true }
+														target="_blank"
+														href="http://wordpress.org/plugins/wp-super-cache/faq/"
+													/>
+												),
+											},
+										}
+									) }
+								</span>
+							}
+						/>
 
-						<FormToggle
+						<ToggleControl
 							checked={ !! is_mobile_enabled }
 							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'is_mobile_enabled' ) }
-						>
-							<span>
-								{ translate(
-									'Mobile device support. (External plugin or theme required. See the ' +
-										'{{faq}}FAQ{{/faq}} for further details.)',
-									{
-										components: {
-											faq: (
-												<ExternalLink
-													icon={ true }
-													target="_blank"
-													href="http://wordpress.org/plugins/wp-super-cache/faq/"
-												/>
-											),
-										},
-									}
-								) }
-							</span>
-							{ is_mobile_enabled && (
-								<FormSettingExplanation>
-									{ translate( '{{strong}}Mobile Browsers{{/strong}}{{br/}}', {
-										components: {
-											br: <br />,
-											strong: <strong />,
-										},
-									} ) }
-									{ cache_mobile_browsers || '' }
+							label={
+								<>
+									<span>
+										{ translate(
+											'Mobile device support. (External plugin or theme required. See the ' +
+												'{{faq}}FAQ{{/faq}} for further details.)',
+											{
+												components: {
+													faq: (
+														<ExternalLink
+															icon={ true }
+															target="_blank"
+															href="http://wordpress.org/plugins/wp-super-cache/faq/"
+														/>
+													),
+												},
+											}
+										) }
+									</span>
+									{ is_mobile_enabled && (
+										<FormSettingExplanation>
+											{ translate( '{{strong}}Mobile Browsers{{/strong}}{{br/}}', {
+												components: {
+													br: <br />,
+													strong: <strong />,
+												},
+											} ) }
+											{ cache_mobile_browsers || '' }
 
-									{ translate( '{{br/}}{{strong}}Mobile Prefixes{{/strong}}{{br/}}', {
-										components: {
-											br: <br />,
-											strong: <strong />,
-										},
-									} ) }
-									{ cache_mobile_prefixes || '' }
-								</FormSettingExplanation>
-							) }
-						</FormToggle>
+											{ translate( '{{br/}}{{strong}}Mobile Prefixes{{/strong}}{{br/}}', {
+												components: {
+													br: <br />,
+													strong: <strong />,
+												},
+											} ) }
+											{ cache_mobile_prefixes || '' }
+										</FormSettingExplanation>
+									) }
+								</>
+							}
+						/>
 
-						<FormToggle
+						<ToggleControl
 							checked={ !! disable_utf8 }
 							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'disable_utf8' ) }
-						>
-							<span>
-								{ translate(
-									'Remove UTF8/blog charset support from .htaccess file. Only necessary if you see ' +
-										'odd characters or punctuation looks incorrect. Requires rewrite rules update.'
-								) }
-							</span>
-						</FormToggle>
+							label={
+								<span>
+									{ translate(
+										'Remove UTF8/blog charset support from .htaccess file. Only necessary if you see ' +
+											'odd characters or punctuation looks incorrect. Requires rewrite rules update.'
+									) }
+								</span>
+							}
+						/>
 
-						<FormToggle
+						<ToggleControl
 							checked={ !! clear_cache_on_post_edit }
 							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'clear_cache_on_post_edit' ) }
-						>
-							<span>
-								{ translate(
-									'Clear all cache files when a post or page is published or updated.'
-								) }
-							</span>
-						</FormToggle>
+							label={
+								<span>
+									{ translate(
+										'Clear all cache files when a post or page is published or updated.'
+									) }
+								</span>
+							}
+						/>
 
-						<FormToggle
+						<ToggleControl
 							checked={ !! front_page_checks }
 							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'front_page_checks' ) }
-						>
-							<span>
-								{ translate(
-									'Extra homepage checks. (Very occasionally stops homepage caching) {{em}}(Recommended){{/em}}',
-									{
-										components: { em: <em /> },
-									}
-								) }
-							</span>
-						</FormToggle>
+							label={
+								<span>
+									{ translate(
+										'Extra homepage checks. (Very occasionally stops homepage caching) {{em}}(Recommended){{/em}}',
+										{
+											components: { em: <em /> },
+										}
+									) }
+								</span>
+							}
+						/>
 
-						<FormToggle
+						<ToggleControl
 							checked={ !! refresh_current_only_on_comments }
 							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'refresh_current_only_on_comments' ) }
-						>
-							<span>{ translate( 'Only refresh current page when comments made.' ) }</span>
-						</FormToggle>
+							label={
+								<span>{ translate( 'Only refresh current page when comments made.' ) }</span>
+							}
+						/>
 
-						<FormToggle
+						<ToggleControl
 							checked={ !! cache_list }
 							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'cache_list' ) }
-						>
-							<span>{ translate( 'List the newest cached pages on this page.' ) }</span>
-						</FormToggle>
+							label={ <span>{ translate( 'List the newest cached pages on this page.' ) }</span> }
+						/>
 
-						<FormToggle
+						<ToggleControl
 							checked={ ! cache_disable_locking }
 							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'cache_disable_locking' ) }
-						>
-							<span>
-								{ translate(
-									'Coarse file locking. You do not need this as it will slow down your website.'
-								) }
-							</span>
-						</FormToggle>
+							label={
+								<span>
+									{ translate(
+										'Coarse file locking. You do not need this as it will slow down your website.'
+									) }
+								</span>
+							}
+						/>
 
-						<FormToggle
+						<ToggleControl
 							checked={ !! cache_late_init }
 							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'cache_late_init' ) }
-						>
-							<span>
-								{ translate(
-									'Late init. Display cached files after WordPress has loaded. Most useful in legacy mode.'
-								) }
-							</span>
-						</FormToggle>
+							label={
+								<span>
+									{ translate(
+										'Late init. Display cached files after WordPress has loaded. Most useful in legacy mode.'
+									) }
+								</span>
+							}
+						/>
 					</FormFieldset>
 				</form>
 			</Card>

--- a/client/extensions/wp-super-cache/components/advanced/caching.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/caching.jsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { includes, pick } from 'lodash';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -14,7 +14,6 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import Notice from 'calypso/components/notice';
 import SectionHeader from 'calypso/components/section-header';
 import WrapSettingsForm from '../wrap-settings-form';
@@ -74,13 +73,12 @@ const Caching = ( {
 						/>
 					) }
 					<FormFieldset>
-						<FormToggle
+						<ToggleControl
 							checked={ !! is_cache_enabled }
 							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'is_cache_enabled' ) }
-						>
-							<span>{ translate( 'Enable Page Caching' ) }</span>
-						</FormToggle>
+							label={ <span>{ translate( 'Enable Page Caching' ) }</span> }
+						/>
 					</FormFieldset>
 
 					<FormFieldset className="wp-super-cache__cache-type-fieldset">

--- a/client/extensions/wp-super-cache/components/advanced/expiry-time.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/expiry-time.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { pick } from 'lodash';
 import moment from 'moment';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -16,7 +16,6 @@ import FormRadio from 'calypso/components/forms/form-radio';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import SectionHeader from 'calypso/components/section-header';
 import WrapSettingsForm from '../wrap-settings-form';
 
@@ -157,14 +156,13 @@ const ExpiryTime = ( {
 			<FormFieldset>
 				<FormLabel htmlFor="cache_gc_email_me">{ translate( 'Notification Emails' ) }</FormLabel>
 
-				<FormToggle
+				<ToggleControl
 					checked={ !! cache_gc_email_me }
 					disabled={ isDisabled }
 					id="cache_gc_email_me"
 					onChange={ handleAutosavingToggle( 'cache_gc_email_me' ) }
-				>
-					<span>{ translate( 'Email me when the garbage collection runs.' ) }</span>
-				</FormToggle>
+					label={ <span>{ translate( 'Email me when the garbage collection runs.' ) }</span> }
+				/>
 			</FormFieldset>
 		);
 	};

--- a/client/extensions/wp-super-cache/components/advanced/lock-down.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/lock-down.jsx
@@ -1,16 +1,15 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { pick } from 'lodash';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
 import SectionHeader from 'calypso/components/section-header';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import Gridicon from 'calypso/components/gridicon';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -37,17 +36,18 @@ const LockDown = ( {
 			<Card>
 				<form>
 					<FormFieldset>
-						<FormToggle
+						<ToggleControl
 							checked={ !! cache_lock_down }
 							disabled={ isRequesting || isSaving || isReadOnly }
 							onChange={ handleAutosavingToggle( 'cache_lock_down' ) }
-						>
-							<span>
-								{ translate(
-									'Enable lock down to prepare your server for an expected spike in traffic.'
-								) }
-							</span>
-						</FormToggle>
+							label={
+								<span>
+									{ translate(
+										'Enable lock down to prepare your server for an expected spike in traffic.'
+									) }
+								</span>
+							}
+						/>
 					</FormFieldset>
 
 					<div className="wp-super-cache__lock-down-container">

--- a/client/extensions/wp-super-cache/components/advanced/miscellaneous.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/miscellaneous.jsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { pick } from 'lodash';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -11,7 +11,6 @@ import { pick } from 'lodash';
 import { Card } from '@automattic/components';
 import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import SectionHeader from 'calypso/components/section-header';
 import Notice from 'calypso/components/notice';
 import WrapSettingsForm from '../wrap-settings-form';
@@ -58,20 +57,21 @@ const Miscellaneous = ( {
 					) }
 					<FormFieldset>
 						{ ! compressionDisabledMessage && (
-							<FormToggle
+							<ToggleControl
 								checked={ !! cache_compression }
 								disabled={ isDisabled }
 								onChange={ handleAutosavingToggle( 'cache_compression' ) }
-							>
-								<span>
-									{ translate(
-										'Compress pages so they’re served more quickly to visitors. {{em}}(Recommended{{/em}})',
-										{
-											components: { em: <em /> },
-										}
-									) }
-								</span>
-							</FormToggle>
+								label={
+									<span>
+										{ translate(
+											'Compress pages so they’re served more quickly to visitors. {{em}}(Recommended{{/em}})',
+											{
+												components: { em: <em /> },
+											}
+										) }
+									</span>
+								}
+							/>
 						) }
 						{ ! compressionDisabledMessage && (
 							<Notice
@@ -84,49 +84,52 @@ const Miscellaneous = ( {
 							/>
 						) }
 
-						<FormToggle
+						<ToggleControl
 							checked={ !! dont_cache_logged_in }
 							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'dont_cache_logged_in' ) }
-						>
-							<span>
-								{ translate( 'Don’t cache pages for known users. {{em}}(Recommended){{/em}}', {
-									components: { em: <em /> },
-								} ) }
-							</span>
-						</FormToggle>
+							label={
+								<span>
+									{ translate( 'Don’t cache pages for known users. {{em}}(Recommended){{/em}}', {
+										components: { em: <em /> },
+									} ) }
+								</span>
+							}
+						/>
 
-						<FormToggle
+						<ToggleControl
 							checked={ !! cache_rebuild }
 							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'cache_rebuild' ) }
-						>
-							<span>
-								{ translate(
-									'Cache rebuild. Serve a supercache file to anonymous users while a new ' +
-										'file is being generated. {{em}}(Recommended){{/em}}',
-									{
-										components: { em: <em /> },
-									}
-								) }
-							</span>
-						</FormToggle>
+							label={
+								<span>
+									{ translate(
+										'Cache rebuild. Serve a supercache file to anonymous users while a new ' +
+											'file is being generated. {{em}}(Recommended){{/em}}',
+										{
+											components: { em: <em /> },
+										}
+									) }
+								</span>
+							}
+						/>
 
-						<FormToggle
+						<ToggleControl
 							checked={ !! use_304_headers }
 							disabled={ isDisabled || !! cache_mod_rewrite }
 							onChange={ handleAutosavingToggle( 'use_304_headers' ) }
-						>
-							<span>
-								{ translate(
-									'304 Not Modified browser caching. Indicate when a page has not been ' +
-										'modified since it was last requested. {{em}}(Recommended){{/em}}',
-									{
-										components: { em: <em /> },
-									}
-								) }
-							</span>
-						</FormToggle>
+							label={
+								<span>
+									{ translate(
+										'304 Not Modified browser caching. Indicate when a page has not been ' +
+											'modified since it was last requested. {{em}}(Recommended){{/em}}',
+										{
+											components: { em: <em /> },
+										}
+									) }
+								</span>
+							}
+						/>
 
 						{ cache_mod_rewrite && (
 							<Notice
@@ -150,51 +153,56 @@ const Miscellaneous = ( {
 							/>
 						) }
 
-						<FormToggle
+						<ToggleControl
 							checked={ !! no_cache_for_get }
 							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'no_cache_for_get' ) }
-						>
-							<span>
-								{ translate( 'Don’t cache pages with GET parameters. (?x=y at the end of a url)' ) }
-							</span>
-						</FormToggle>
+							label={
+								<span>
+									{ translate(
+										'Don’t cache pages with GET parameters. (?x=y at the end of a url)'
+									) }
+								</span>
+							}
+						/>
 
-						<FormToggle
+						<ToggleControl
 							checked={ !! make_known_anon }
 							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'make_known_anon' ) }
-						>
-							<span>
-								{ translate(
-									'Make known users anonymous so they’re served supercached static files.'
-								) }
-							</span>
-						</FormToggle>
+							label={
+								<span>
+									{ translate(
+										'Make known users anonymous so they’re served supercached static files.'
+									) }
+								</span>
+							}
+						/>
 
-						<FormToggle
+						<ToggleControl
 							checked={ !! cache_hello_world }
 							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'cache_hello_world' ) }
-						>
-							<span>
-								{ translate(
-									'Proudly tell the world your server is {{fry}}Stephen Fry proof{{/fry}}! ' +
-										'(places a message in your blog’s footer)',
-									{
-										components: {
-											fry: (
-												<ExternalLink
-													icon={ true }
-													target="_blank"
-													href="https://twitter.com/#!/HibbsLupusTrust/statuses/136429993059291136"
-												/>
-											),
-										},
-									}
-								) }
-							</span>
-						</FormToggle>
+							label={
+								<span>
+									{ translate(
+										'Proudly tell the world your server is {{fry}}Stephen Fry proof{{/fry}}! ' +
+											'(places a message in your blog’s footer)',
+										{
+											components: {
+												fry: (
+													<ExternalLink
+														icon={ true }
+														target="_blank"
+														href="https://twitter.com/#!/HibbsLupusTrust/statuses/136429993059291136"
+													/>
+												),
+											},
+										}
+									) }
+								</span>
+							}
+						/>
 					</FormFieldset>
 				</form>
 			</Card>

--- a/client/extensions/wp-super-cache/components/cdn/index.jsx
+++ b/client/extensions/wp-super-cache/components/cdn/index.jsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { get, pick } from 'lodash';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -14,7 +14,6 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import SectionHeader from 'calypso/components/section-header';
 import WrapSettingsForm from '../wrap-settings-form';
 
@@ -47,13 +46,12 @@ const CdnTab = ( {
 			<Card>
 				<form>
 					<FormFieldset>
-						<FormToggle
+						<ToggleControl
 							checked={ !! ossdlcdn }
 							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'ossdlcdn' ) }
-						>
-							<span>{ translate( 'Enable CDN Support' ) }</span>
-						</FormToggle>
+							label={ <span>{ translate( 'Enable CDN Support' ) }</span> }
+						/>
 					</FormFieldset>
 
 					<div className="wp-super-cache__cdn-fieldsets">
@@ -171,13 +169,14 @@ const CdnTab = ( {
 						</FormFieldset>
 
 						<FormFieldset>
-							<FormToggle
+							<ToggleControl
 								checked={ !! ossdl_https }
 								disabled={ isRequesting || isSaving || ! ossdlcdn }
 								onChange={ handleAutosavingToggle( 'ossdl_https' ) }
-							>
-								<span>{ translate( 'Skip https URLs to avoid "mixed content" errors' ) }</span>
-							</FormToggle>
+								label={
+									<span>{ translate( 'Skip https URLs to avoid "mixed content" errors' ) }</span>
+								}
+							/>
 						</FormFieldset>
 					</div>
 				</form>

--- a/client/extensions/wp-super-cache/components/debug/index.jsx
+++ b/client/extensions/wp-super-cache/components/debug/index.jsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { pick } from 'lodash';
 import moment from 'moment';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -17,7 +17,6 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import SectionHeader from 'calypso/components/section-header';
 import WrapSettingsForm from '../wrap-settings-form';
 
@@ -70,13 +69,12 @@ class DebugTab extends Component {
 					</SectionHeader>
 					<Card>
 						<FormFieldset>
-							<FormToggle
+							<ToggleControl
 								checked={ !! wp_super_cache_debug }
 								disabled={ isRequesting || isSaving }
 								onChange={ handleAutosavingToggle( 'wp_super_cache_debug' ) }
-							>
-								{ translate( 'Enable Debugging' ) }
-							</FormToggle>
+								label={ translate( 'Enable Debugging' ) }
+							/>
 						</FormFieldset>
 						<div className="wp-super-cache__debug-fieldsets">
 							<FormFieldset>
@@ -123,13 +121,12 @@ class DebugTab extends Component {
 								</FormSettingExplanation>
 							</FormFieldset>
 							<FormFieldset>
-								<FormToggle
+								<ToggleControl
 									checked={ !! wp_super_cache_comments }
 									disabled={ isRequesting || isSaving || ! wp_super_cache_debug }
 									onChange={ handleAutosavingToggle( 'wp_super_cache_comments' ) }
-								>
-									{ translate( 'Cache Status Messages' ) }
-								</FormToggle>
+									label={ translate( 'Cache Status Messages' ) }
+								/>
 								<FormSettingExplanation isIndented>
 									{ translate( 'Display comments at the end of every page like this:' ) }
 									<span className="wp-super-cache__debug-cache-comment-snippet">
@@ -162,13 +159,12 @@ class DebugTab extends Component {
 					</SectionHeader>
 					<Card>
 						<FormFieldset>
-							<FormToggle
+							<ToggleControl
 								checked={ !! wp_super_cache_front_page_check }
 								disabled={ isRequesting || isSaving || ! wp_super_cache_debug }
 								onChange={ handleAutosavingToggle( 'wp_super_cache_front_page_check' ) }
-							>
-								{ translate( 'Check front page every 5 minutes.' ) }
-							</FormToggle>
+								label={ translate( 'Check front page every 5 minutes.' ) }
+							/>
 							<FormSettingExplanation isIndented>
 								{ translate( " If there are errors you'll receive an email." ) }
 							</FormSettingExplanation>
@@ -197,7 +193,7 @@ class DebugTab extends Component {
 								</FormSettingExplanation>
 							</FormFieldset>
 							<FormFieldset>
-								<FormToggle
+								<ToggleControl
 									checked={ !! wp_super_cache_front_page_clear }
 									disabled={
 										isRequesting ||
@@ -206,10 +202,9 @@ class DebugTab extends Component {
 										! wp_super_cache_front_page_check
 									}
 									onChange={ handleAutosavingToggle( 'wp_super_cache_front_page_clear' ) }
-								>
-									{ translate( 'Clear cache on error.' ) }
-								</FormToggle>
-								<FormToggle
+									label={ translate( 'Clear cache on error.' ) }
+								/>
+								<ToggleControl
 									checked={ !! wp_super_cache_front_page_notification }
 									disabled={
 										isRequesting ||
@@ -218,9 +213,10 @@ class DebugTab extends Component {
 										! wp_super_cache_front_page_check
 									}
 									onChange={ handleAutosavingToggle( 'wp_super_cache_front_page_notification' ) }
-								>
-									{ translate( 'Email the blog admin when checks are made. (useful for testing)' ) }
-								</FormToggle>
+									label={ translate(
+										'Email the blog admin when checks are made. (useful for testing)'
+									) }
+								/>
 							</FormFieldset>
 						</div>
 					</Card>

--- a/client/extensions/wp-super-cache/components/easy/index.jsx
+++ b/client/extensions/wp-super-cache/components/easy/index.jsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { flowRight, get, isEmpty, pick } from 'lodash';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -14,7 +14,6 @@ import { isHttps } from 'calypso/lib/url';
 import { Button, Card } from '@automattic/components';
 import Notice from 'calypso/components/notice';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import Gridicon from 'calypso/components/gridicon';
 import QueryStatus from '../data/query-status';
 import SectionHeader from 'calypso/components/section-header';
@@ -99,13 +98,12 @@ class EasyTab extends Component {
 				<SectionHeader label={ translate( 'Caching' ) } />
 				<Card>
 					<form>
-						<FormToggle
+						<ToggleControl
 							checked={ !! is_cache_enabled }
 							disabled={ isRequesting || isSaving || isReadOnly }
 							onChange={ handleAutosavingToggle( 'is_cache_enabled' ) }
-						>
-							<span>{ translate( 'Enable Page Caching' ) }</span>
-						</FormToggle>
+							label={ <span>{ translate( 'Enable Page Caching' ) }</span> }
+						/>
 					</form>
 				</Card>
 
@@ -130,14 +128,15 @@ class EasyTab extends Component {
 							{ isHttps( get( site, 'options.admin_url', '' ) ) && (
 								<form>
 									<FormFieldset>
-										<FormToggle
+										<ToggleControl
 											checked={ this.state.httpOnly }
 											onChange={ this.handleHttpOnlyChange }
-										>
-											<span>
-												{ translate( 'Send non-secure (non https) request for homepage' ) }
-											</span>
-										</FormToggle>
+											label={
+												<span>
+													{ translate( 'Send non-secure (non https) request for homepage' ) }
+												</span>
+											}
+										/>
 									</FormFieldset>
 								</form>
 							) }

--- a/client/extensions/wp-super-cache/components/plugins/index.jsx
+++ b/client/extensions/wp-super-cache/components/plugins/index.jsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { flowRight, map, mapValues, pick } from 'lodash';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -14,7 +14,6 @@ import { Card } from '@automattic/components';
 import ExternalLink from 'calypso/components/external-link';
 import SectionHeader from 'calypso/components/section-header';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import WrapSettingsForm from '../wrap-settings-form';
 import QueryPlugins from '../data/query-plugins';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -85,14 +84,13 @@ class PluginsTab extends Component {
 					{ map( plugins, ( { desc, enabled, key, title, toggling, url } ) => {
 						return (
 							<div key={ key }>
-								<FormToggle
+								<ToggleControl
 									checked={ !! enabled }
 									data-plugin={ key }
 									disabled={ isRequesting || toggling }
 									onChange={ this.togglePlugin( key, ! enabled ) }
-								>
-									<span>{ title }</span>
-								</FormToggle>
+									label={ <span>{ title }</span> }
+								/>
 								<FormSettingExplanation>
 									{ desc + ' ' }
 									{ url && (

--- a/client/extensions/wp-super-cache/components/preload/index.jsx
+++ b/client/extensions/wp-super-cache/components/preload/index.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { flowRight, get, pick } from 'lodash';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -16,7 +16,6 @@ import FormLegend from 'calypso/components/forms/form-legend';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import Notice from 'calypso/components/notice';
 import QueryStatus from '../data/query-status';
 import SectionHeader from 'calypso/components/section-header';
@@ -172,53 +171,60 @@ class PreloadTab extends Component {
 				<Card>
 					<form>
 						<FormFieldset>
-							<FormToggle
+							<ToggleControl
 								checked={ !! preload_on }
 								disabled={ isRequesting || isSaving }
 								onChange={ handleAutosavingToggle( 'preload_on' ) }
-							>
-								<span>
-									{ translate(
-										'Preload mode. (Garbage collection only on legacy cache files. Recommended.)'
-									) }
-								</span>
-							</FormToggle>
+								label={
+									<span>
+										{ translate(
+											'Preload mode. (Garbage collection only on legacy cache files. Recommended.)'
+										) }
+									</span>
+								}
+							/>
 
-							<FormToggle
+							<ToggleControl
 								checked={ this.state.preloadRefresh }
 								disabled={ isRequesting || isSaving }
 								onChange={ this.handlePreloadRefreshChange }
-							>
-								<span>
-									{ translate(
-										'Refresh preloaded cache files every {{number /}} minute ',
-										'Refresh preloaded cache files every {{number /}} minutes ',
-										{
-											count: preload_interval || 0,
-											components: {
-												number: CachePreloadInterval( {
-													handleChange,
-													isDisabled: isRequesting || isSaving || ! this.state.preloadRefresh,
-													preload_interval,
-												} ),
-											},
-										}
-									) }
+								label={
+									<span>
+										{ translate(
+											'Refresh preloaded cache files every {{number /}} minute ',
+											'Refresh preloaded cache files every {{number /}} minutes ',
+											{
+												count: preload_interval || 0,
+												components: {
+													number: CachePreloadInterval( {
+														handleChange,
+														isDisabled: isRequesting || isSaving || ! this.state.preloadRefresh,
+														preload_interval,
+													} ),
+												},
+											}
+										) }
 
-									{ translate( '(minimum %(minutes)d minute).', '(minimum %(minutes)d minutes).', {
-										args: { minutes: minimum_preload_interval || 0 },
-										count: minimum_preload_interval || 0,
-									} ) }
-								</span>
-							</FormToggle>
+										{ translate(
+											'(minimum %(minutes)d minute).',
+											'(minimum %(minutes)d minutes).',
+											{
+												args: { minutes: minimum_preload_interval || 0 },
+												count: minimum_preload_interval || 0,
+											}
+										) }
+									</span>
+								}
+							/>
 
-							<FormToggle
+							<ToggleControl
 								checked={ !! preload_taxonomies }
 								disabled={ isRequesting || isSaving }
 								onChange={ handleAutosavingToggle( 'preload_taxonomies' ) }
-							>
-								<span>{ translate( 'Preload tags, categories and other taxonomies.' ) }</span>
-							</FormToggle>
+								label={
+									<span>{ translate( 'Preload tags, categories and other taxonomies.' ) }</span>
+								}
+							/>
 						</FormFieldset>
 
 						{ post_count && post_count > 100 && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #52915 we removed the last real need for a `FormToggle` component in Calypso. With that merged, `FormToggle` became a simple proxy of the `ToggleControl` component, and the only real difference is the way that the label is provided - in `FormToggle` we provide those as `children`, while in `ToggleControl` that's being done with the `label` prop. So `FormToggle` can just be removed in favor of `ToggleControl`, there is no real need to maintain that abstraction anymore.

This PR updates all of the `FormToggle` instances in the WP Super Cache extension to use `ToggleControl`. While it may look like a big PR, this is 99% because **we're now passing the `children` as a `label` prop.**

This PR is split off #52917.

#### Testing instructions

* Verify all tests pass.
* Verify we correctly replace all `FormToggle` `children` props with `label` prop when using `ToggleControl`. 
* Verify all toggles work and look the same way as before in `/extensions/wp-super-cache/:site` where `:site` is a Jetpack site. Go through all the settings tabs of the extension.

#### Notes

We're also fixing a couple of minor spacing discrepancies in the meantime.