### PR TITLE
Settings: Remove FormToggle in favor of ToggleControl

### DIFF
--- a/client/my-sites/site-settings/amp/wpcom.jsx
+++ b/client/my-sites/site-settings/amp/wpcom.jsx
@@ -1,18 +1,17 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import page from 'page';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { CompactCard } from '@automattic/components';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -78,13 +77,12 @@ class AmpWpcom extends Component {
 				<SettingsSectionHeader title={ translate( 'Accelerated Mobile Pages (AMP)' ) } />
 
 				<CompactCard className="amp__explanation site-settings__amp-explanation">
-					<FormToggle
+					<ToggleControl
 						checked={ !! ampIsEnabled }
 						disabled={ isDisabled }
 						onChange={ this.handleToggle }
-					>
-						{ translate( 'Improve the loading speed of your site on phones and tablets' ) }
-					</FormToggle>
+						label={ translate( 'Improve the loading speed of your site on phones and tablets' ) }
+					/>
 					<FormSettingExplanation isIndented>
 						{ translate(
 							'Your WordPress.com site supports the use of {{a}}Accelerated Mobile Pages{{/a}}, ' +

--- a/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
+++ b/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
@@ -4,6 +4,7 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { flowRight, partialRight, pick } from 'lodash';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -16,7 +17,6 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextValidation from 'calypso/components/forms/form-input-validation';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
@@ -219,13 +219,12 @@ export function CloudflareAnalyticsSettings( {
 				) : (
 					<CompactCard>
 						<div className="analytics site-settings__analytics">
-							<FormToggle
+							<ToggleControl
 								checked={ isCloudflareEnabled }
 								disabled={ isRequestingSettings || isSavingSettings || ! enableForm }
 								onChange={ () => handleFormToggle( ! isCloudflareEnabled ) }
-							>
-								{ translate( 'Add Cloudflare' ) }
-							</FormToggle>
+								label={ translate( 'Add Cloudflare' ) }
+							/>
 						</div>
 					</CompactCard>
 				) }

--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -3,16 +3,19 @@
  */
 import React, { useEffect } from 'react';
 import { find } from 'lodash';
-
 import { CompactCard } from '@automattic/components';
 import {
 	FEATURE_GOOGLE_ANALYTICS,
 	PLAN_JETPACK_SECURITY_DAILY,
 } from '@automattic/calypso-products';
+import { ToggleControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
 import ExternalLink from 'calypso/components/external-link';
 import SupportInfo from 'calypso/components/support-info';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
@@ -152,13 +155,12 @@ const GoogleAnalyticsJetpackForm = ( {
 								</ExternalLink>
 							</FormFieldset>
 							<FormFieldset>
-								<FormToggle
+								<ToggleControl
 									checked={ fields.wga ? Boolean( fields.wga.anonymize_ip ) : false }
 									disabled={ isRequestingSettings || ! enableForm }
 									onChange={ handleAnonymizeChange }
-								>
-									{ translate( 'Anonymize IP addresses' ) }
-								</FormToggle>
+									label={ translate( 'Anonymize IP addresses' ) }
+								/>
 								<FormSettingExplanation>
 									{ translate(
 										'Enabling this option is mandatory in certain countries due to national ' +

--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -2,21 +2,24 @@
  * External dependencies
  */
 import React, { useEffect } from 'react';
-
 import { CompactCard } from '@automattic/components';
-import ExternalLink from 'calypso/components/external-link';
-import UpsellNudge from 'calypso/blocks/upsell-nudge';
-import FormToggle from 'calypso/components/forms/form-toggle';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormLabel from 'calypso/components/forms/form-label';
-import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormTextValidation from 'calypso/components/forms/form-input-validation';
-import googleIllustration from 'calypso/assets/images/illustrations/google-analytics-logo.svg';
 import {
 	findFirstSimilarPlanKey,
 	FEATURE_GOOGLE_ANALYTICS,
 	TYPE_PREMIUM,
 } from '@automattic/calypso-products';
+import { ToggleControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import ExternalLink from 'calypso/components/external-link';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextValidation from 'calypso/components/forms/form-input-validation';
+import googleIllustration from 'calypso/assets/images/illustrations/google-analytics-logo.svg';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 
@@ -191,13 +194,12 @@ const GoogleAnalyticsSimpleForm = ( {
 				) : (
 					<CompactCard>
 						<div className="analytics site-settings__analytics">
-							<FormToggle
+							<ToggleControl
 								checked={ displayForm }
 								disabled={ isRequestingSettings || isSavingSettings }
 								onChange={ () => handleFormToggle( ! displayForm ) }
-							>
-								{ translate( 'Add Google' ) }
-							</FormToggle>
+								label={ translate( 'Add Google' ) }
+							/>
 						</div>
 					</CompactCard>
 				) }

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -13,7 +14,6 @@ import classnames from 'classnames';
 import { Card } from '@automattic/components';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import isActivatingJetpackModule from 'calypso/state/selectors/is-activating-jetpack-module';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
@@ -79,13 +79,12 @@ class CustomContentTypes extends Component {
 		return (
 			<div className="custom-content-types__module-settings">
 				{ hasToggle ? (
-					<FormToggle
+					<ToggleControl
 						checked={ !! fields[ name ] }
 						disabled={ this.isFormPending() || activatingCustomContentTypesModule }
 						onChange={ handleAutosavingToggle( name ) }
-					>
-						<span className="custom-content-types__label">{ label }</span>
-					</FormToggle>
+						label={ <span className="custom-content-types__label">{ label }</span> }
+					/>
 				) : (
 					<div
 						id={ numberFieldIdentifier }

--- a/client/my-sites/site-settings/feed-settings/index.jsx
+++ b/client/my-sites/site-settings/feed-settings/index.jsx
@@ -1,16 +1,15 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { CompactCard } from '@automattic/components';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -80,13 +79,12 @@ class FeedSettings extends Component {
 							) }
 						</FormSettingExplanation>
 					</FormFieldset>
-					<FormToggle
+					<ToggleControl
 						checked={ !! fields.rss_use_excerpt }
 						disabled={ isDisabled }
 						onChange={ handleToggle( 'rss_use_excerpt' ) }
-					>
-						{ translate( 'Limit feed to excerpt only' ) }
-					</FormToggle>
+						label={ translate( 'Limit feed to excerpt only' ) }
+					/>
 					<FormSettingExplanation isIndented className="feed-settings__excerpt-explanation">
 						{ translate(
 							'Enable this to include only an excerpt of your content. ' +

--- a/client/my-sites/site-settings/form-analytics-stores.jsx
+++ b/client/my-sites/site-settings/form-analytics-stores.jsx
@@ -1,15 +1,14 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import FormToggle from 'calypso/components/forms/form-toggle';
 import ExternalLink from 'calypso/components/external-link';
 import FormLegend from 'calypso/components/forms/form-legend';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
@@ -48,13 +47,12 @@ class FormAnalyticsStores extends Component {
 					const checked = fields.wga ? Boolean( fields.wga[ setting.key ] ) : false;
 					return (
 						<div key={ setting.key }>
-							<FormToggle
+							<ToggleControl
 								checked={ checked }
 								disabled={ disableAll }
 								onChange={ this.handleToggleChange( setting.key ) }
-							>
-								{ setting.label }
-							</FormToggle>
+								label={ setting.label }
+							/>
 							{ setting.explanation && this.renderExplanation( setting ) }
 							{ setting.children &&
 								this.renderSettings( setting.children, disableAll || ! checked, true ) }

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { flowRight, pick } from 'lodash';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -19,7 +19,6 @@ import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import Subscriptions from './subscriptions';
@@ -52,27 +51,26 @@ class SiteSettingsFormDiscussion extends Component {
 		} = this.props;
 		return (
 			<FormFieldset>
-				<FormToggle
+				<ToggleControl
 					checked={ !! fields.default_pingback_flag }
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleAutosavingToggle( 'default_pingback_flag' ) }
-				>
-					{ translate( 'Attempt to notify any blogs linked to from the article' ) }
-				</FormToggle>
-				<FormToggle
+					label={ translate( 'Attempt to notify any blogs linked to from the article' ) }
+				/>
+				<ToggleControl
 					checked={ !! fields.default_ping_status }
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleAutosavingToggle( 'default_ping_status' ) }
-				>
-					{ translate( 'Allow link notifications from other blogs (pingbacks and trackbacks)' ) }
-				</FormToggle>
-				<FormToggle
+					label={ translate(
+						'Allow link notifications from other blogs (pingbacks and trackbacks)'
+					) }
+				/>
+				<ToggleControl
 					checked={ !! fields.default_comment_status }
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleAutosavingToggle( 'default_comment_status' ) }
-				>
-					{ translate( 'Allow people to post comments on new articles' ) }
-				</FormToggle>
+					label={ translate( 'Allow people to post comments on new articles' ) }
+				/>
 				<FormSettingExplanation>
 					{ translate( 'These settings may be overridden for individual articles.' ) }
 				</FormSettingExplanation>
@@ -117,26 +115,23 @@ class SiteSettingsFormDiscussion extends Component {
 		} = this.props;
 		return (
 			<FormFieldset className="site-settings__other-comment-settings">
-				<FormToggle
+				<ToggleControl
 					checked={ !! fields.require_name_email }
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleAutosavingToggle( 'require_name_email' ) }
-				>
-					{ translate( 'Comment author must fill out name and e-mail' ) }
-				</FormToggle>
-				<FormToggle
+					label={ translate( 'Comment author must fill out name and e-mail' ) }
+				/>
+				<ToggleControl
 					checked={ !! fields.comment_registration }
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleAutosavingToggle( 'comment_registration' ) }
-				>
-					{ translate( 'Users must be registered and logged in to comment' ) }
-				</FormToggle>
-				<FormToggle
+					label={ translate( 'Users must be registered and logged in to comment' ) }
+				/>
+				<ToggleControl
 					checked={ !! fields.close_comments_for_old_posts }
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleAutosavingToggle( 'close_comments_for_old_posts' ) }
-				>
-					{ translate(
+					label={ translate(
 						'Automatically close comments on articles older than {{numberOfDays /}} day',
 						'Automatically close comments on articles older than {{numberOfDays /}} days',
 						{
@@ -146,24 +141,22 @@ class SiteSettingsFormDiscussion extends Component {
 							},
 						}
 					) }
-				</FormToggle>
-				<FormToggle
+				/>
+				<ToggleControl
 					checked={ !! fields.thread_comments }
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleAutosavingToggle( 'thread_comments' ) }
-				>
-					{ translate( 'Enable threaded (nested) comments up to {{number /}} levels deep', {
+					label={ translate( 'Enable threaded (nested) comments up to {{number /}} levels deep', {
 						components: {
 							number: this.renderInputThreadDepth(),
 						},
 					} ) }
-				</FormToggle>
-				<FormToggle
+				/>
+				<ToggleControl
 					checked={ !! fields.page_comments }
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleAutosavingToggle( 'page_comments' ) }
-				>
-					{ translate(
+					label={ translate(
 						'Break comments into pages with {{numComments /}} top level comments per page and the ' +
 							'{{firstOrLast /}} page displayed by default',
 						{
@@ -173,16 +166,15 @@ class SiteSettingsFormDiscussion extends Component {
 							},
 						}
 					) }
-				</FormToggle>
-				<FormToggle
+				/>
+				<ToggleControl
 					checked={ 'asc' === fields.comment_order }
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ this.handleCommentOrder }
-				>
-					{ translate(
+					label={ translate(
 						'Comments should be displayed with the older comments at the top of each page'
 					) }
-				</FormToggle>
+				/>
 
 				{ this.props.isJetpack && (
 					<SupportInfo
@@ -341,20 +333,18 @@ class SiteSettingsFormDiscussion extends Component {
 		return (
 			<FormFieldset>
 				<FormLegend>{ translate( 'E-mail me whenever' ) }</FormLegend>
-				<FormToggle
+				<ToggleControl
 					checked={ !! fields.comments_notify }
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleAutosavingToggle( 'comments_notify' ) }
-				>
-					{ translate( 'Anyone posts a comment' ) }
-				</FormToggle>
-				<FormToggle
+					label={ translate( 'Anyone posts a comment' ) }
+				/>
+				<ToggleControl
 					checked={ !! fields.moderation_notify }
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleAutosavingToggle( 'moderation_notify' ) }
-				>
-					{ translate( 'A comment is held for moderation' ) }
-				</FormToggle>
+					label={ translate( 'A comment is held for moderation' ) }
+				/>
 				{ this.emailMeLikes() }
 				{ this.emailMeReblogs() }
 				{ this.emailMeFollows() }
@@ -378,13 +368,12 @@ class SiteSettingsFormDiscussion extends Component {
 		}
 
 		return (
-			<FormToggle
+			<ToggleControl
 				checked={ !! fields.social_notifications_like }
 				disabled={ isRequestingSettings || isSavingSettings }
 				onChange={ handleAutosavingToggle( 'social_notifications_like' ) }
-			>
-				{ translate( 'Someone likes one of my posts' ) }
-			</FormToggle>
+				label={ translate( 'Someone likes one of my posts' ) }
+			/>
 		);
 	}
 
@@ -403,13 +392,12 @@ class SiteSettingsFormDiscussion extends Component {
 		}
 
 		return (
-			<FormToggle
+			<ToggleControl
 				checked={ !! fields.social_notifications_reblog }
 				disabled={ isRequestingSettings || isSavingSettings }
 				onChange={ handleAutosavingToggle( 'social_notifications_reblog' ) }
-			>
-				{ translate( 'Someone reblogs one of my posts' ) }
-			</FormToggle>
+				label={ translate( 'Someone reblogs one of my posts' ) }
+			/>
 		);
 	}
 
@@ -423,13 +411,12 @@ class SiteSettingsFormDiscussion extends Component {
 		} = this.props;
 
 		return (
-			<FormToggle
+			<ToggleControl
 				checked={ !! fields.social_notifications_subscribe }
 				disabled={ isRequestingSettings || isSavingSettings }
 				onChange={ handleAutosavingToggle( 'social_notifications_subscribe' ) }
-			>
-				{ translate( 'Someone follows my blog' ) }
-			</FormToggle>
+				label={ translate( 'Someone follows my blog' ) }
+			/>
 		);
 	}
 
@@ -444,20 +431,18 @@ class SiteSettingsFormDiscussion extends Component {
 		return (
 			<FormFieldset>
 				<FormLegend>{ translate( 'Before a comment appears' ) }</FormLegend>
-				<FormToggle
+				<ToggleControl
 					checked={ !! fields.comment_moderation }
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleAutosavingToggle( 'comment_moderation' ) }
-				>
-					{ translate( 'Comment must be manually approved' ) }
-				</FormToggle>
-				<FormToggle
+					label={ translate( 'Comment must be manually approved' ) }
+				/>
+				<ToggleControl
 					checked={ !! fields.comment_previously_approved }
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleAutosavingToggle( 'comment_previously_approved' ) }
-				>
-					{ translate( 'Comment author must have a previously approved comment' ) }
-				</FormToggle>
+					label={ translate( 'Comment author must have a previously approved comment' ) }
+				/>
 			</FormFieldset>
 		);
 	}

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -1,18 +1,17 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { isEmpty, partial } from 'lodash';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import SupportInfo from 'calypso/components/support-info';
@@ -65,12 +64,11 @@ class SiteSettingsFormJetpackMonitor extends Component {
 		const { monitorActive, translate } = this.props;
 
 		return (
-			<FormToggle
+			<ToggleControl
 				disabled={ this.disableForm() || ! monitorActive }
 				onChange={ this.handleToggle( 'email_notifications' ) }
 				checked={ !! this.state.email_notifications }
-			>
-				{ translate( 'Send notifications to your {{a}}WordPress.com email address{{/a}}', {
+				label={ translate( 'Send notifications to your {{a}}WordPress.com email address{{/a}}', {
 					components: {
 						a: (
 							<a
@@ -82,20 +80,19 @@ class SiteSettingsFormJetpackMonitor extends Component {
 						),
 					},
 				} ) }
-			</FormToggle>
+			/>
 		);
 	}
 
 	settingsMonitorWpNoteCheckbox() {
 		const { monitorActive, translate } = this.props;
 		return (
-			<FormToggle
+			<ToggleControl
 				disabled={ this.disableForm() || ! monitorActive }
 				onChange={ this.handleToggle( 'wp_note_notifications' ) }
 				checked={ !! this.state.wp_note_notifications }
-			>
-				{ translate( 'Send notifications via WordPress.com notification' ) }
-			</FormToggle>
+				label={ translate( 'Send notifications via WordPress.com notification' ) }
+			/>
 		);
 	}
 

--- a/client/my-sites/site-settings/jetpack-module-toggle.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle.jsx
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { ToggleControl } from '@wordpress/components';
+
 /**
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { activateModule, deactivateModule } from 'calypso/state/jetpack/modules/actions';
@@ -71,14 +71,13 @@ class JetpackModuleToggle extends Component {
 		return (
 			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			<span className="jetpack-module-toggle">
-				<FormToggle
+				<ToggleControl
 					id={ `${ this.props.siteId }-${ this.props.moduleSlug }-toggle` }
 					checked={ this.props.checked || false }
 					onChange={ this.handleChange }
 					disabled={ this.props.disabled || this.props.toggleDisabled || this.props.toggling }
-				>
-					{ this.props.label }
-				</FormToggle>
+					label={ this.props.label }
+				/>
 				{ this.props.description && (
 					<FormSettingExplanation isIndented>{ this.props.description }</FormSettingExplanation>
 				) }

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -6,12 +6,12 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { CompactCard } from '@automattic/components';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import FoldableCard from 'calypso/components/foldable-card';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLegend from 'calypso/components/forms/form-legend';
@@ -96,16 +96,15 @@ class JetpackSiteStats extends Component {
 		}
 
 		return (
-			<FormToggle
+			<ToggleControl
 				checked={ checked }
 				disabled={
 					isRequestingSettings || isSavingSettings || moduleUnavailable || ! statsModuleActive
 				}
 				onChange={ onChange }
 				key={ name }
-			>
-				{ label }
-			</FormToggle>
+				label={ label }
+			/>
 		);
 	}
 

--- a/client/my-sites/site-settings/manage-connection/api-cache.jsx
+++ b/client/my-sites/site-settings/manage-connection/api-cache.jsx
@@ -1,17 +1,16 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { connect } from 'react-redux';
 import { flowRight, pick } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { CompactCard } from '@automattic/components';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import config from '@automattic/calypso-config';
 import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -31,14 +30,17 @@ const ApiCache = ( {
 
 	return (
 		<CompactCard>
-			<FormToggle
+			<ToggleControl
 				checked={ !! fields.api_cache }
 				disabled={ isRequestingSettings || isSavingSettings }
 				onChange={ handleAutosavingToggle( 'api_cache' ) }
-			>
-				{ translate( 'Use synchronized data to boost performance' ) } (a8c-only experimental
-				feature)
-			</FormToggle>
+				label={
+					<>
+						{ translate( 'Use synchronized data to boost performance' ) }{ ' ' }
+						<span>(a8c-only experimental feature)</span>
+					</>
+				}
+			/>
 		</CompactCard>
 	);
 };

--- a/client/my-sites/site-settings/media-settings-writing.jsx
+++ b/client/my-sites/site-settings/media-settings-writing.jsx
@@ -5,12 +5,12 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
@@ -70,13 +70,12 @@ class MediaSettingsWriting extends Component {
 							disabled={ isRequestingOrSaving }
 						/>
 						<div className="site-settings__child-settings">
-							<FormToggle
+							<ToggleControl
 								checked={ fields.carousel_display_exif || false }
 								disabled={ isRequestingOrSaving || ! carouselActive }
 								onChange={ handleAutosavingToggle( 'carousel_display_exif' ) }
-							>
-								{ translate( 'Show photo metadata in carousel, when available' ) }
-							</FormToggle>
+								label={ translate( 'Show photo metadata in carousel, when available' ) }
+							/>
 							<FormLabel className={ labelClassName } htmlFor="carousel_background_color">
 								{ translate( 'Background Color' ) }
 							</FormLabel>

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -12,7 +12,6 @@ import { localize } from 'i18n-calypso';
 import { Card } from '@automattic/components';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import SupportInfo from 'calypso/components/support-info';
 import RelatedContentPreview from './related-content-preview';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
@@ -42,34 +41,31 @@ const RelatedPosts = ( {
 						link="https://jetpack.com/support/related-posts/"
 					/>
 
-					<FormToggle
+					<ToggleControl
 						checked={ !! fields.jetpack_relatedposts_enabled }
 						disabled={ isRequestingSettings || isSavingSettings }
 						onChange={ handleAutosavingToggle( 'jetpack_relatedposts_enabled' ) }
-					>
-						{ translate( 'Show related content after posts' ) }
-					</FormToggle>
+						label={ translate( 'Show related content after posts' ) }
+					/>
 
 					<div className="related-posts__module-settings site-settings__child-settings">
-						<FormToggle
+						<ToggleControl
 							checked={ !! fields.jetpack_relatedposts_show_headline }
 							disabled={
 								isRequestingSettings || isSavingSettings || ! fields.jetpack_relatedposts_enabled
 							}
 							onChange={ handleAutosavingToggle( 'jetpack_relatedposts_show_headline' ) }
-						>
-							{ translate( 'Highlight related content with a heading' ) }
-						</FormToggle>
+							label={ translate( 'Highlight related content with a heading' ) }
+						/>
 
-						<FormToggle
+						<ToggleControl
 							checked={ !! fields.jetpack_relatedposts_show_thumbnails }
 							disabled={
 								isRequestingSettings || isSavingSettings || ! fields.jetpack_relatedposts_enabled
 							}
 							onChange={ handleAutosavingToggle( 'jetpack_relatedposts_show_thumbnails' ) }
-						>
-							{ translate( 'Show a thumbnail image where available' ) }
-						</FormToggle>
+							label={ translate( 'Show a thumbnail image where available' ) }
+						/>
 					</div>
 
 					<FormSettingExplanation>

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -6,6 +6,7 @@ import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { overSome } from 'lodash';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -15,7 +16,6 @@ import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import SupportInfo from 'calypso/components/support-info';
@@ -174,7 +174,7 @@ class Search extends Component {
 				/>
 
 				<div className="site-settings__jetpack-instant-search-toggle">
-					<FormToggle
+					<ToggleControl
 						checked={ isSearchModuleActive && !! fields.instant_search_enabled }
 						disabled={
 							isRequestingSettings ||
@@ -183,9 +183,8 @@ class Search extends Component {
 							! this.props.hasSearchProduct
 						}
 						onChange={ handleInstantSearchToggle }
-					>
-						{ translate( 'Enable instant search experience (recommended)' ) }
-					</FormToggle>
+						label={ translate( 'Enable instant search experience (recommended)' ) }
+					/>
 					{ isLoading || activatingSearchModule || isSavingSettings
 						? this.renderSettingsUpdating()
 						: this.renderInstantSearchExplanation() }
@@ -227,16 +226,15 @@ class Search extends Component {
 
 		return (
 			<Fragment>
-				<FormToggle
+				<ToggleControl
 					checked={ !! fields.jetpack_search_enabled }
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleJetpackSearchToggle }
-				>
-					{ translate( 'Enable Jetpack Search' ) }
-				</FormToggle>
+					label={ translate( 'Enable Jetpack Search' ) }
+				/>
 
 				<div className="site-settings__jetpack-instant-search-toggle">
-					<FormToggle
+					<ToggleControl
 						checked={ !! fields.instant_search_enabled }
 						disabled={
 							isRequestingSettings ||
@@ -245,9 +243,8 @@ class Search extends Component {
 							! this.props.hasSearchProduct
 						}
 						onChange={ handleAutosavingToggle( 'instant_search_enabled' ) }
-					>
-						{ translate( 'Enable instant search experience (recommended)' ) }
-					</FormToggle>
+						label={ translate( 'Enable instant search experience (recommended)' ) }
+					/>
 					{ isLoading || activatingSearchModule || isSavingSettings
 						? this.renderSettingsUpdating()
 						: this.renderInstantSearchExplanation() }

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -5,12 +5,12 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -78,13 +78,12 @@ class SpeedUpSiteSettings extends Component {
 									'and static files (like CSS and JavaScript) from our global network of servers.'
 							) }
 						</FormSettingExplanation>
-						<FormToggle
+						<ToggleControl
 							checked={ siteAcceleratorStatus }
 							disabled={ isRequestingOrSaving || photonModuleUnavailable }
 							onChange={ this.handleCdnChange }
-						>
-							{ translate( 'Enable site accelerator' ) }
-						</FormToggle>
+							label={ translate( 'Enable site accelerator' ) }
+						/>
 						<div className="site-settings__child-settings">
 							<JetpackModuleToggle
 								siteId={ selectedSiteId }

--- a/client/my-sites/site-settings/sso.jsx
+++ b/client/my-sites/site-settings/sso.jsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -13,7 +13,6 @@ import { connect } from 'react-redux';
 import { Card } from '@automattic/components';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors/is-jetpack-module-unavailable-in-development-mode';
@@ -53,7 +52,7 @@ const Sso = ( {
 					/>
 
 					<div className="sso__module-settings site-settings__child-settings">
-						<FormToggle
+						<ToggleControl
 							checked={ !! fields.jetpack_sso_match_by_email }
 							disabled={
 								isRequestingSettings ||
@@ -62,11 +61,10 @@ const Sso = ( {
 								ssoModuleUnavailable
 							}
 							onChange={ handleAutosavingToggle( 'jetpack_sso_match_by_email' ) }
-						>
-							{ translate( 'Match accounts using email addresses' ) }
-						</FormToggle>
+							label={ translate( 'Match accounts using email addresses' ) }
+						/>
 
-						<FormToggle
+						<ToggleControl
 							checked={ !! fields.jetpack_sso_require_two_step }
 							disabled={
 								isRequestingSettings ||
@@ -75,9 +73,8 @@ const Sso = ( {
 								ssoModuleUnavailable
 							}
 							onChange={ handleAutosavingToggle( 'jetpack_sso_require_two_step' ) }
-						>
-							{ translate( 'Require two-step authentication' ) }
-						</FormToggle>
+							label={ translate( 'Require two-step authentication' ) }
+						/>
 					</div>
 				</FormFieldset>
 			</Card>

--- a/client/my-sites/site-settings/subscriptions.jsx
+++ b/client/my-sites/site-settings/subscriptions.jsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -13,7 +13,6 @@ import { connect } from 'react-redux';
 import { CompactCard } from '@automattic/components';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors/is-jetpack-module-unavailable-in-development-mode';
@@ -54,7 +53,7 @@ const Subscriptions = ( {
 					/>
 
 					<div className="subscriptions__module-settings site-settings__child-settings">
-						<FormToggle
+						<ToggleControl
 							checked={ !! fields.stb_enabled }
 							disabled={
 								isRequestingSettings ||
@@ -63,11 +62,10 @@ const Subscriptions = ( {
 								moduleUnavailable
 							}
 							onChange={ handleAutosavingToggle( 'stb_enabled' ) }
-						>
-							{ translate( 'Enable the "subscribe to site" option on your comment form' ) }
-						</FormToggle>
+							label={ translate( 'Enable the "subscribe to site" option on your comment form' ) }
+						/>
 
-						<FormToggle
+						<ToggleControl
 							checked={ !! fields.stc_enabled }
 							disabled={
 								isRequestingSettings ||
@@ -76,9 +74,10 @@ const Subscriptions = ( {
 								moduleUnavailable
 							}
 							onChange={ handleAutosavingToggle( 'stc_enabled' ) }
-						>
-							{ translate( 'Enable the "subscribe to comments" option on your comment form' ) }
-						</FormToggle>
+							label={ translate(
+								'Enable the "subscribe to comments" option on your comment form'
+							) }
+						/>
 					</div>
 				</FormFieldset>
 			</CompactCard>

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -6,6 +6,7 @@ import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import { connect } from 'react-redux';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -17,7 +18,6 @@ import FormLegend from 'calypso/components/forms/form-legend';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import { getCustomizerUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
@@ -49,13 +49,12 @@ class ThemeEnhancements extends Component {
 	renderToggle( name, isDisabled, label ) {
 		const { fields, handleAutosavingToggle } = this.props;
 		return (
-			<FormToggle
+			<ToggleControl
 				checked={ !! fields[ name ] }
 				disabled={ this.isFormPending() || isDisabled }
 				onChange={ handleAutosavingToggle( name ) }
-			>
-				{ label }
-			</FormToggle>
+				label={ label }
+			/>
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #52915 we removed the last real need for a `FormToggle` component in Calypso. With that merged, `FormToggle` became a simple proxy of the `ToggleControl` component, and the only real difference is the way that the label is provided - in `FormToggle` we provide those as `children`, while in `ToggleControl` that's being done with the `label` prop. So `FormToggle` can just be removed in favor of `ToggleControl`, there is no real need to maintain that abstraction anymore.

This PR updates all of the `FormToggle` instances in the site settings to use `ToggleControl`. While it may look like a big PR, this is 99% because **we're now passing the `children` as a `label` prop.**

This PR is split off #52917.

#### Testing instructions

* Verify all tests pass.
* Verify we correctly replace all `FormToggle` `children` props with `label` prop when using `ToggleControl`. 
* Going through all settings tabs in /settings/general/:site, verify all toggles work and look the same way as before, where `:site` is a:
  * Jetpack site
  * Atomic site
  * WP.com simple site

#### Notes

We're also fixing a couple of minor spacing discrepancies in the meantime.