### PR TITLE
Me: Remove FormToggle in favor of ToggleControl

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -9,6 +9,7 @@ import debugFactory from 'debug';
 import emailValidator from 'email-validator';
 import { debounce, flowRight as compose, get, has, map, size } from 'lodash';
 import { connect } from 'react-redux';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -59,7 +60,6 @@ import {
 import FormattedHeader from 'calypso/components/formatted-header';
 import wpcom from 'calypso/lib/wp';
 import user from 'calypso/lib/user';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
 import {
 	cancelPendingEmailChange,
@@ -1070,27 +1070,30 @@ class Account extends React.Component {
 								<FormLabel id="account__link_destination" htmlFor="link_destination">
 									{ translate( 'Dashboard appearance' ) }
 								</FormLabel>
-								<FormToggle
+								<ToggleControl
 									checked={ !! this.getUserSetting( linkDestinationKey ) }
 									onChange={ this.toggleLinkDestination }
 									disabled={ this.getDisabledState( INTERFACE_FORM_NAME ) }
-								>
-									{ translate(
-										'{{spanlead}}Show wp-admin pages if available{{/spanlead}} {{spanextra}}Replace your dashboard pages with more advanced wp-admin equivalents.{{/spanextra}}',
-										{
-											components: {
-												spanlead: <strong className="account__link-destination-label-lead" />,
-												spanextra: <span className="account__link-destination-label-extra" />,
-											},
-										}
-									) }
-									<InlineSupportLink
-										supportPostId={ 80368 }
-										supportLink={ localizeUrl(
-											'https://wordpress.com/support/account-settings/#dashboard-appearance'
-										) }
-									/>
-								</FormToggle>
+									label={
+										<>
+											{ translate(
+												'{{spanlead}}Show wp-admin pages if available{{/spanlead}} {{spanextra}}Replace your dashboard pages with more advanced wp-admin equivalents.{{/spanextra}}',
+												{
+													components: {
+														spanlead: <strong className="account__link-destination-label-lead" />,
+														spanextra: <span className="account__link-destination-label-extra" />,
+													},
+												}
+											) }
+											<InlineSupportLink
+												supportPostId={ 80368 }
+												supportLink={ localizeUrl(
+													'https://wordpress.com/support/account-settings/#dashboard-appearance'
+												) }
+											/>
+										</>
+									}
+								/>
 							</FormFieldset>
 						) }
 

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -6,6 +6,7 @@ import { flowRight as compose } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import { withLocalizeUrl } from '@automattic/i18n-utils';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -15,7 +16,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import ExternalLink from 'calypso/components/external-link';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import Main from 'calypso/components/main';
 import { protectForm } from 'calypso/lib/protect-form';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
@@ -134,12 +134,11 @@ class Privacy extends React.Component {
 								) }
 							</p>
 							<hr />
-							<FormToggle
+							<ToggleControl
 								id="tracks_opt_out"
 								checked={ ! this.props.tracksOptOut }
 								onChange={ this.updateTracksOptOut }
-							>
-								{ translate(
+								label={ translate(
 									'Share information with our analytics tool about your use of services while ' +
 										'logged in to your WordPress.com account. {{cookiePolicyLink}}Learn more' +
 										'{{/cookiePolicyLink}}.',
@@ -149,7 +148,7 @@ class Privacy extends React.Component {
 										},
 									}
 								) }
-							</FormToggle>
+							/>
 						</FormFieldset>
 
 						<FormButton isSubmitting={ isUpdatingUserSettings } disabled={ isSubmitButtonDisabled }>

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { flowRight as compose } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -17,7 +18,6 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import Main from 'calypso/components/main';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import ProfileLinks from 'calypso/me/profile-links';
@@ -117,11 +117,10 @@ class Profile extends React.Component {
 						</FormFieldset>
 
 						<FormFieldset>
-							<FormToggle
+							<ToggleControl
 								checked={ this.props.getSetting( 'gravatar_profile_hidden' ) }
 								onChange={ this.toggleGravatarHidden }
-							>
-								{ this.props.translate(
+								label={ this.props.translate(
 									'{{spanLead}}Hide my Gravatar profile.{{/spanLead}} {{spanExtra}}This will prevent your {{profileLink}}Gravatar profile{{/profileLink}} and photo from appearing on any site. It may take some time for the changes to take effect. Gravatar profiles can be deleted at {{deleteLink}}Gravatar.com{{/deleteLink}}.{{/spanExtra}}',
 									{
 										components: {
@@ -140,7 +139,7 @@ class Profile extends React.Component {
 										},
 									}
 								) }
-							</FormToggle>
+							/>
 						</FormFieldset>
 
 						<p className="profile__submit-button-wrapper">

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -20,7 +21,6 @@ import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
 import { createNotice } from 'calypso/state/notices/actions';
 import AutoRenewDisablingDialog from './auto-renew-disabling-dialog';
 import AutoRenewPaymentMethodDialog from './auto-renew-payment-method-dialog';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import { isExpired, isOneTimePurchase, isRechargeable } from '../../../../lib/purchases';
 import { getChangePaymentMethodPath } from '../../utils';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -220,13 +220,12 @@ class AutoRenewToggle extends Component {
 
 		return (
 			<>
-				<FormToggle
+				<ToggleControl
 					checked={ this.getToggleUiStatus() }
 					disabled={ this.isUpdatingAutoRenew() }
 					onChange={ this.onToggleAutoRenew }
-				>
-					{ withTextStatus && this.renderTextStatus() }
-				</FormToggle>
+					label={ withTextStatus && this.renderTextStatus() }
+				/>
 				<AutoRenewDisablingDialog
 					isVisible={ this.state.showAutoRenewDisablingDialog }
 					planName={ planName }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #52915 we removed the last real need for a `FormToggle` component in Calypso. With that merged, `FormToggle` became a simple proxy of the `ToggleControl` component, and the only real difference is the way that the label is provided - in `FormToggle` we provide those as `children`, while in `ToggleControl` that's being done with the `label` prop. So `FormToggle` can just be removed in favor of `ToggleControl`, there is no real need to maintain that abstraction anymore.

This PR updates all of the `FormToggle` instances in the "Me" area (including Purchases) to use `ToggleControl`. The changes are 99% coming from the fact that **we're now passing the `children` as a `label` prop.**

This PR is split off #52917.

#### Testing instructions

* Verify all tests pass.
* Verify we correctly replace all `FormToggle` `children` props with `label` prop when using `ToggleControl`. 
* Verify all toggles work and look the same way as before in:
  * `/me`
  * `/me/account` - you need to have selected a different language for a toggle to appear
  * `/me/privacy`
  * `/me/purchases` - click on a Purchase, and observe the auto-renew toggle