### PR TITLE
Blocks: Remove FormToggle in favor of ToggleControl

### DIFF
--- a/client/blocks/post-share/connection.jsx
+++ b/client/blocks/post-share/connection.jsx
@@ -1,15 +1,14 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-import cssSafeUrl from 'calypso/lib/css-safe-url';
+import classNames from 'classnames';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import FormToggle from 'calypso/components/forms/form-toggle';
-import classNames from 'classnames';
+import cssSafeUrl from 'calypso/lib/css-safe-url';
 import SocialLogo from 'calypso/components/social-logo';
 
 const PostShareConnection = ( { connection, isActive, onToggle } ) => {
@@ -50,7 +49,7 @@ const PostShareConnection = ( { connection, isActive, onToggle } ) => {
 			<div className="post-share__service-account-name">
 				<span>{ external_display }</span>
 			</div>
-			<FormToggle checked={ isActive } />
+			<ToggleControl checked={ isActive } />
 		</div>
 	);
 };

--- a/client/blocks/post-share/docs/example.jsx
+++ b/client/blocks/post-share/docs/example.jsx
@@ -4,11 +4,11 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import FormToggle from 'calypso/components/forms/form-toggle';
 import Notice from 'calypso/components/notice';
 import PostShare from 'calypso/blocks/post-share';
 import QueryPosts from 'calypso/components/data/query-posts';
@@ -45,9 +45,11 @@ class PostShareExample extends Component {
 					</p>
 				) }
 
-				<FormToggle onChange={ this.toggleEnable } checked={ this.state.isEnabled }>
-					Live Sharing Enabled
-				</FormToggle>
+				<ToggleControl
+					onChange={ this.toggleEnable }
+					checked={ this.state.isEnabled }
+					label="Live Sharing Enabled"
+				/>
 
 				{ this.state.isEnabled && (
 					<Notice

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { find, get } from 'lodash';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -13,7 +14,6 @@ import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import ReaderPopover from 'calypso/reader/components/reader-popover';
 import SegmentedControl from 'calypso/components/segmented-control';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import {
 	subscribeToNewPostEmail,
@@ -154,13 +154,12 @@ class ReaderSiteNotificationSettings extends Component {
 					className="reader-site-notification-settings__popout"
 				>
 					<div className="reader-site-notification-settings__popout-toggle">
-						<FormToggle
+						<ToggleControl
 							onChange={ this.toggleNewPostNotification }
 							checked={ sendNewPostsByNotification }
 							id="reader-site-notification-settings__notifications"
-						>
-							{ translate( 'Notify me of new posts' ) }
-						</FormToggle>
+							label={ translate( 'Notify me of new posts' ) }
+						/>
 						<p className="reader-site-notification-settings__popout-hint">
 							{ translate( 'Receive web and mobile notifications for new posts from this site.' ) }
 						</p>
@@ -173,13 +172,12 @@ class ReaderSiteNotificationSettings extends Component {
 						}
 					>
 						{ ! isEmailBlocked && (
-							<FormToggle
+							<ToggleControl
 								onChange={ this.toggleNewPostEmail }
 								checked={ sendNewPostsByEmail }
 								id={ 'reader-site-notification-settings__email-posts' }
-							>
-								{ translate( 'Email me new posts' ) }
-							</FormToggle>
+								label={ translate( 'Email me new posts' ) }
+							/>
 						) }
 
 						{ isEmailBlocked && (
@@ -223,13 +221,12 @@ class ReaderSiteNotificationSettings extends Component {
 					) }
 					{ ! isEmailBlocked && (
 						<div className="reader-site-notification-settings__popout-toggle">
-							<FormToggle
+							<ToggleControl
 								onChange={ this.toggleNewCommentEmail }
 								checked={ sendNewCommentsByEmail }
 								id="reader-site-notification-settings__email-comments"
-							>
-								{ translate( 'Email me new comments' ) }
-							</FormToggle>
+								label={ translate( 'Email me new comments' ) }
+							/>
 						</div>
 					) }
 				</ReaderPopover>

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -7,6 +7,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get, find } from 'lodash';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -17,7 +18,6 @@ import FormInputValidation from 'calypso/components/forms/form-input-validation'
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import FormLegend from 'calypso/components/forms/form-legend';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -271,7 +271,7 @@ class TermFormDialog extends Component {
 
 		return (
 			<FormFieldset>
-				<FormToggle
+				<ToggleControl
 					checked={ isTopLevel }
 					onChange={ this.onTopLevelChange }
 					help={
@@ -285,13 +285,12 @@ class TermFormDialog extends Component {
 							</span>
 						)
 					}
-				>
-					{ translate( 'Top level %(term)s', {
+					label={ translate( 'Top level %(term)s', {
 						args: { term: labels.singular_name },
 						context: 'Terms: New term being created is top level',
 						comment: 'term is the singular_name label of a hierarchical taxonomy, e.g. "Category"',
 					} ) }
-				</FormToggle>
+				/>
 				{ ! isTopLevel && (
 					<div className="term-form-dialog__parent-tree-selector">
 						<FormLegend>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #52915 we removed the last real need for a `FormToggle` component in Calypso. With that merged, `FormToggle` became a simple proxy of the `ToggleControl` component, and the only real difference is the way that the label is provided - in `FormToggle` we provide those as `children`, while in `ToggleControl` that's being done with the `label` prop. So `FormToggle` can just be removed in favor of `ToggleControl`, there is no real need to maintain that abstraction anymore.

This PR updates all of the `FormToggle` instances in Calypso blocks to use `ToggleControl`. The changes are 99% coming from the fact that **we're now passing the `children` as a `label` prop.**

This PR is split off #52917.

#### Testing instructions

* Verify all tests pass.
* Verify we correctly replace all `FormToggle` `children` props with `label` prop when using `ToggleControl`. 
* Verify all toggles work and look the same way as before in:
  * `/devdocs/blocks/post-share`
  * `/following/manage` - click on the "Settings" of a blog you're following and observe the toggles in the popover.
  * `/settings/podcasting/:site` where `:site` is a WP.com site - observe the top category toggle when adding a new category.