### PR TITLE
Domains: Remove FormToggle in favor of ToggleControl

### DIFF
--- a/client/components/gsuite/docs/new-user-list.tsx
+++ b/client/components/gsuite/docs/new-user-list.tsx
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import React, { useState } from 'react';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import FormLabel from 'calypso/components/forms/form-label';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import { CompactCard as Card } from '@automattic/components';
 import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
 import {
@@ -85,17 +85,18 @@ const GSuiteNewUserListExample = (): React.FunctionComponent => {
 			</GSuiteNewUserList>
 			<hr />
 			<FormLabel key="mulitple-domains">
-				<FormToggle checked={ useMultipleDomains } onChange={ toggleUseMultipleDomains }>
-					Use multiple domains
-				</FormToggle>
+				<ToggleControl
+					checked={ useMultipleDomains }
+					onChange={ toggleUseMultipleDomains }
+					label="Use multiple domains"
+				/>
 			</FormLabel>
 			<FormLabel key="extra-validation">
-				<FormToggle
+				<ToggleControl
 					checked={ useExtraValidation }
 					onChange={ () => setUseExtraValidation( ! useExtraValidation ) }
-				>
-					Use extra validation ( no a's in name )
-				</FormToggle>
+					label="Use extra validation ( no a's in name )"
+				/>
 			</FormLabel>
 		</Card>
 	);

--- a/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -12,7 +13,6 @@ import { connect } from 'react-redux';
 import { Card } from '@automattic/components';
 import ContactDisplay from './contact-display';
 import { PUBLIC_VS_PRIVATE } from 'calypso/lib/url/support';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import Gridicon from 'calypso/components/gridicon';
 import {
 	enableDomainPrivacy,
@@ -70,13 +70,12 @@ class ContactsPrivacyCard extends React.Component {
 		return (
 			<React.Fragment>
 				<div className="contacts-privacy__settings">
-					<FormToggle
+					<ToggleControl
 						checked={ privateDomain }
 						disabled={ isUpdatingPrivacy || ! privacyAvailable }
 						onChange={ this.togglePrivacy }
-					>
-						{ translate( 'Privacy Protection' ) }
-					</FormToggle>
+						label={ translate( 'Privacy Protection' ) }
+					/>
 				</div>
 				{ privacyProtectionNote }
 			</React.Fragment>
@@ -112,13 +111,12 @@ class ContactsPrivacyCard extends React.Component {
 		return (
 			<React.Fragment>
 				<div className="contacts-privacy__settings">
-					<FormToggle
+					<ToggleControl
 						checked={ contactInfoDisclosed }
 						disabled={ isUpdatingPrivacy || isPendingIcannVerification }
 						onChange={ this.toggleContactInfo }
-					>
-						{ translate( 'Display my contact information in public WHOIS' ) }
-					</FormToggle>
+						label={ translate( 'Display my contact information in public WHOIS' ) }
+					/>
 				</div>
 				{ contactVerificationNotice }
 			</React.Fragment>

--- a/client/my-sites/domains/domain-management/dns/domain-connect-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/domain-connect-record.jsx
@@ -5,13 +5,13 @@ import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { addDns, deleteDns } from 'calypso/state/domains/dns/actions';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import { domainConnect } from 'calypso/lib/domains/constants';
 import { getNormalizedData } from 'calypso/state/domains/dns/utils';
 import DnsRecordsList from '../dns-records/list';
@@ -117,7 +117,7 @@ class DomainConnectRecord extends React.Component {
 						content={ translate( 'Handled by WordPress.com' ) }
 						action={
 							<form className="dns__domain-connect-toggle">
-								<FormToggle
+								<ToggleControl
 									id="domain-connect-record"
 									name="domain-connect-record"
 									onChange={ this.handleToggle }

--- a/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
@@ -5,12 +5,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import { CHANGE_NAME_SERVERS } from 'calypso/lib/url/support';
 import {
 	composeAnalytics,
@@ -32,7 +32,7 @@ class NameserversToggle extends React.PureComponent {
 				</span>
 
 				<form className="name-servers__toggle">
-					<FormToggle
+					<ToggleControl
 						id="wp-nameservers"
 						name="wp-nameservers"
 						onChange={ this.handleToggle }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #52915 we removed the last real need for a `FormToggle` component in Calypso. With that merged, `FormToggle` became a simple proxy of the `ToggleControl` component, and the only real difference is the way that the label is provided - in `FormToggle` we provide those as `children`, while in `ToggleControl` that's being done with the `label` prop. So `FormToggle` can just be removed in favor of `ToggleControl`, there is no real need to maintain that abstraction anymore.

This PR updates all of the `FormToggle` instances in the domains area to use `ToggleControl`. The changes are 99% coming from the fact that **we're now passing the `children` as a `label` prop.**

This PR is split off #52917.

#### Testing instructions

* Verify all tests pass.
* Verify we correctly replace all `FormToggle` `children` props with `label` prop when using `ToggleControl`. 
* Verify all toggles work and look the same way as before in:
  * `/devdocs/design/g-suite`
  * `/domains/manage/:domain/contacts-privacy/:site`
  * `/domains/manage/:domain/edit/:site`
  * `/domains/manage/:domain/name-servers/:site`
  * `/domains/manage/:domain/dns/:site`
