### PR TITLE
Misc: Remove FormToggle in favor of ToggleControl

### DIFF
--- a/client/my-sites/earn/ads/form-settings.jsx
+++ b/client/my-sites/earn/ads/form-settings.jsx
@@ -1,19 +1,18 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
 import StateSelector from 'calypso/components/forms/us-state-selector';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import isSavingWordadsSettings from 'calypso/state/selectors/is-saving-wordads-settings';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -228,58 +227,51 @@ class AdsFormSettings extends Component {
 			<div>
 				<FormFieldset className="ads__settings-display-toggles">
 					<FormLegend>{ translate( 'Display ads below posts on' ) }</FormLegend>
-					<FormToggle
+					<ToggleControl
 						checked={ !! this.state.display_options?.display_front_page }
 						disabled={ this.props.isLoading }
 						onChange={ this.handleDisplayToggle( 'display_front_page' ) }
-					>
-						{ translate( 'Front page' ) }
-					</FormToggle>
-					<FormToggle
+						label={ translate( 'Front page' ) }
+					/>
+					<ToggleControl
 						checked={ !! this.state.display_options?.display_post }
 						disabled={ this.props.isLoading }
 						onChange={ this.handleDisplayToggle( 'display_post' ) }
-					>
-						{ translate( 'Posts' ) }
-					</FormToggle>
-					<FormToggle
+						label={ translate( 'Posts' ) }
+					/>
+					<ToggleControl
 						checked={ !! this.state.display_options?.display_page }
 						disabled={ this.props.isLoading }
 						onChange={ this.handleDisplayToggle( 'display_page' ) }
-					>
-						{ translate( 'Pages' ) }
-					</FormToggle>
-					<FormToggle
+						label={ translate( 'Pages' ) }
+					/>
+					<ToggleControl
 						checked={ !! this.state.display_options?.display_archive }
 						disabled={ this.props.isLoading }
 						onChange={ this.handleDisplayToggle( 'display_archive' ) }
-					>
-						{ translate( 'Archives' ) }
-					</FormToggle>
+						label={ translate( 'Archives' ) }
+					/>
 				</FormFieldset>
 				<FormFieldset className="ads__settings-display-toggles">
 					<FormLegend>{ translate( 'Additional ad placements' ) }</FormLegend>
-					<FormToggle
+					<ToggleControl
 						checked={ !! this.state.display_options?.enable_header_ad }
 						disabled={ this.props.isLoading }
 						onChange={ this.handleDisplayToggle( 'enable_header_ad' ) }
-					>
-						{ translate( 'Top of each page' ) }
-					</FormToggle>
-					<FormToggle
+						label={ translate( 'Top of each page' ) }
+					/>
+					<ToggleControl
 						checked={ !! this.state.display_options?.second_belowpost }
 						disabled={ this.props.isLoading }
 						onChange={ this.handleDisplayToggle( 'second_belowpost' ) }
-					>
-						{ translate( 'Second ad below post' ) }
-					</FormToggle>
-					<FormToggle
+						label={ translate( 'Second ad below post' ) }
+					/>
+					<ToggleControl
 						checked={ !! this.state.display_options?.sidebar }
 						disabled={ this.props.isLoading }
 						onChange={ this.handleDisplayToggle( 'sidebar' ) }
-					>
-						{ translate( 'Sidebar' ) }
-					</FormToggle>
+						label={ translate( 'Sidebar' ) }
+					/>
 				</FormFieldset>
 			</div>
 		);
@@ -483,13 +475,12 @@ class AdsFormSettings extends Component {
 						) }
 						link="https://wordpress.com/support/your-wordpress-com-site-and-the-ccpa/"
 					/>
-					<FormToggle
+					<ToggleControl
 						checked={ !! this.state.ccpa_enabled }
 						disabled={ this.props.isLoading }
 						onChange={ this.handleCompactToggle( 'ccpa_enabled' ) }
-					>
-						{ translate( 'Enable targeted advertising to California site visitors (CCPA)' ) }
-					</FormToggle>
+						label={ translate( 'Enable targeted advertising to California site visitors (CCPA)' ) }
+					/>
 
 					<div className="ads__child-settings">
 						<FormSettingExplanation>

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
 import classnames from 'classnames';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -20,7 +20,6 @@ import FormSelect from 'calypso/components/forms/form-select';
 import FormCurrencyInput from 'calypso/components/forms/form-currency-input';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import {
@@ -281,16 +280,22 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					) }
 				</FormFieldset>
 				<FormFieldset>
-					<FormToggle onChange={ handlePayWhatYouWant } checked={ editedPayWhatYouWant }>
-						{ translate( 'Enable customers to pick their own amount ("Pay what you want").' ) }
-					</FormToggle>
+					<ToggleControl
+						onChange={ handlePayWhatYouWant }
+						checked={ editedPayWhatYouWant }
+						label={ translate(
+							'Enable customers to pick their own amount ("Pay what you want").'
+						) }
+					/>
 				</FormFieldset>
 				<FormFieldset>
-					<FormToggle onChange={ handleMultiplePerUser } checked={ editedMultiplePerUser }>
-						{ translate(
+					<ToggleControl
+						onChange={ handleMultiplePerUser }
+						checked={ editedMultiplePerUser }
+						label={ translate(
 							'Allow the same customer to purchase or sign up to this plan multiple times.'
 						) }
-					</FormToggle>
+					/>
 				</FormFieldset>
 			</>
 		);
@@ -313,12 +318,11 @@ const RecurringPaymentsPlanAddEditModal = ( {
 							{ translate( 'Learn more.' ) }
 						</InlineSupportLink>
 					</p>
-					<FormToggle
+					<ToggleControl
 						onChange={ ( newValue ) => setEditedPostsEmail( newValue ) }
 						checked={ editedPostsEmail }
-					>
-						{ translate( 'Email newly published posts to your customers.' ) }
-					</FormToggle>
+						label={ translate( 'Email newly published posts to your customers.' ) }
+					/>
 				</FormFieldset>
 				<FormFieldset>
 					<h6 className="memberships__dialog-form-header">

--- a/client/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox.jsx
+++ b/client/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox.jsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslate } from 'i18n-calypso';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -16,7 +17,6 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import Gridicon from 'calypso/components/gridicon';
 import { getMailboxPropTypeShape } from 'calypso/lib/titan/new-mailbox';
 
@@ -148,15 +148,14 @@ const TitanNewMailbox = ( {
 				<div className="titan-mail-add-mailboxes__new-mailbox-password-and-is-admin">
 					{ showIsAdminToggle && (
 						<FormFieldset>
-							<FormToggle
+							<ToggleControl
 								checked={ isAdmin }
 								onChange={ ( newValue ) => {
 									onMailboxValueChange( 'isAdmin', newValue );
 								} }
 								help={ translate( 'Should this user have control panel access?' ) }
-							>
-								{ translate( 'Is admin?' ) }
-							</FormToggle>
+								label={ translate( 'Is admin?' ) }
+							/>
 						</FormFieldset>
 					) }
 				</div>

--- a/client/my-sites/plugins/plugin-action/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-action/plugin-action.jsx
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import classNames from 'classnames';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import FormToggle from 'calypso/components/forms/form-toggle';
 import InfoPopover from 'calypso/components/info-popover';
 
 /**
@@ -71,14 +70,13 @@ class PluginAction extends React.Component {
 
 	renderToggle() {
 		return (
-			<FormToggle
+			<ToggleControl
 				onChange={ this.props.action }
 				checked={ this.props.status }
 				disabled={ this.props.inProgress || this.props.disabled || !! this.props.disabledInfo }
 				id={ this.props.htmlFor }
-			>
-				{ this.renderLabel() }
-			</FormToggle>
+				label={ this.renderLabel() }
+			/>
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #52915 we removed the last real need for a `FormToggle` component in Calypso. With that merged, `FormToggle` became a simple proxy of the `ToggleControl` component, and the only real difference is the way that the label is provided - in `FormToggle` we provide those as `children`, while in `ToggleControl` that's being done with the `label` prop. So `FormToggle` can just be removed in favor of `ToggleControl`, there is no real need to maintain that abstraction anymore.

This PR updates all of the `FormToggle` remaining instances to use `ToggleControl`. The changes are 99% coming from the fact that **we're now passing the `children` as a `label` prop.**

This PR is split off #52917.

#### Testing instructions

* Verify all tests pass.
* Verify we correctly replace all `FormToggle` `children` props with `label` prop when using `ToggleControl`. 
* Verify all toggles work and look the same way as before in:
  * `/earn/ads-settings/:site` where `:site` is a WP.com site that has ads (wordads) enabled.
  * `/earn/payments/:site` - connect to Stripe and go to `/earn/payments-plans/:site`, then click "Add a new payment plan" and observe the modal toggles.
  * `/plugins/:plugin/:site` where `:plugin` is an installed plugin on the `:site` site - observe the activation and autoupdate toggles.
