### PR TITLE
[WIP] Nav Unification: Add quick Calypso/WP Admin switcher

### DIFF
--- a/client/blocks/quick-calypso-wp-admin-switcher/index.js
+++ b/client/blocks/quick-calypso-wp-admin-switcher/index.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import SegmentedControl from 'calypso/components/segmented-control';
+import SelectDropdown from 'calypso/components/select-dropdown';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSiteAdminUrl, isJetpackSite } from 'calypso/state/sites/selectors';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
+
+const QuickCalypsoWpAdminSwitcher = ( { wpAdminPath } ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
+	const fullWpAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId, wpAdminPath ) );
+	const isMobile = useMobileBreakpoint();
+
+	// Only visible on single-site screens of WordPress.com Simple and Atomic sites.
+	if ( ! wpAdminPath || ! fullWpAdminUrl || ! siteId || ( isJetpack && ! isAtomic ) ) {
+		return null;
+	}
+
+	const Component = isMobile ? SelectDropdown : SegmentedControl;
+
+	return (
+		<Component
+			className="quick-calypso-wp-admin-switcher"
+			compact
+			primary
+			selectedText={ translate( 'Default' ) }
+		>
+			<Component.Item
+				selected
+				title={ translate( 'See the default WordPress.com version of this screen' ) }
+			>
+				{ translate( 'Default' ) }
+			</Component.Item>
+			<Component.Item path={ fullWpAdminUrl } title={ translate( 'See this screen on WP Admin' ) }>
+				{ translate( 'WP Admin' ) }
+			</Component.Item>
+		</Component>
+	);
+};
+
+export default QuickCalypsoWpAdminSwitcher;

--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -10,6 +10,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { preventWidows } from 'calypso/lib/formatting';
+import QuickCalypsoWpAdminSwitcher from 'calypso/blocks/quick-calypso-wp-admin-switcher';
 
 /**
  * Style dependencies
@@ -25,6 +26,7 @@ function FormattedHeader( {
 	compactOnMobile,
 	align,
 	isSecondary,
+	wpAdminPath,
 } ) {
 	const classes = classNames( 'formatted-header', className, {
 		'is-without-subhead': ! subHeaderText,
@@ -37,11 +39,14 @@ function FormattedHeader( {
 
 	return (
 		<header id={ id } className={ classes }>
-			{ ! isSecondary && <h1 className={ headerClasses }>{ preventWidows( headerText, 2 ) }</h1> }
-			{ isSecondary && <h2 className={ headerClasses }>{ preventWidows( headerText, 2 ) }</h2> }
-			{ subHeaderText && (
-				<p className="formatted-header__subtitle">{ preventWidows( subHeaderText, 2 ) }</p>
-			) }
+			<div className="formatted-header__text">
+				{ ! isSecondary && <h1 className={ headerClasses }>{ preventWidows( headerText, 2 ) }</h1> }
+				{ isSecondary && <h2 className={ headerClasses }>{ preventWidows( headerText, 2 ) }</h2> }
+				{ subHeaderText && (
+					<p className="formatted-header__subtitle">{ preventWidows( subHeaderText, 2 ) }</p>
+				) }
+			</div>
+			{ wpAdminPath && <QuickCalypsoWpAdminSwitcher wpAdminPath={ wpAdminPath } /> }
 		</header>
 	);
 }
@@ -55,6 +60,7 @@ FormattedHeader.propTypes = {
 	compactOnMobile: PropTypes.bool,
 	isSecondary: PropTypes.bool,
 	align: PropTypes.oneOf( [ 'center', 'left', 'right' ] ),
+	wpAdminPath: PropTypes.string,
 };
 
 FormattedHeader.defaultProps = {

--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -1,4 +1,5 @@
 .formatted-header {
+	display: flex;
 	margin: 16px 0 24px;
 	text-align: center;
 
@@ -25,6 +26,15 @@
 
 	&.is-right-align {
 		text-align: right;
+	}
+
+	.formatted--header__text:not( :only-child ) {
+		margin-left: 12px;
+	}
+
+	.quick-calypso-wp-admin-switcher {
+		margin-left: auto;
+		align-self: start;
 	}
 }
 
@@ -68,6 +78,7 @@
 		text-align: left;
 
 		.formatted-header__title {
+			/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 			font-size: 17px;
 			font-weight: 600;
 			padding: 0 24px;

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -82,6 +82,7 @@ export class CommentsManagement extends Component {
 							'View, reply to, and manage all the comments across your site.'
 						) }
 						align="left"
+						wpAdminPath="edit-comments.php"
 					/>
 				) }
 				{ showPermissionError && (

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -38,7 +38,6 @@ const Home = ( {
 	isDev,
 	forcedView,
 	layout,
-	site,
 	siteId,
 	noticeType,
 	shuffleViews,
@@ -93,6 +92,7 @@ const Home = ( {
 				headerText={ translate( 'My Home' ) }
 				subHeaderText={ translate( 'Your hub for posting, editing, and growing your site.' ) }
 				align="left"
+				wpAdminPath="index.php"
 			/>
 			{ layout ? (
 				<>

--- a/client/my-sites/exporter/section-export.jsx
+++ b/client/my-sites/exporter/section-export.jsx
@@ -57,6 +57,7 @@ const SectionExport = ( { isJetpack, canUserExport, site, translate } ) => {
 					headerText={ translate( 'Export Content' ) }
 					subHeaderText={ translate( 'Back up or move your content to another site or platform.' ) }
 					align="left"
+					wpAdminPath="export.php"
 				/>
 				<ExporterContainer />
 			</Fragment>

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -296,6 +296,7 @@ class SectionImport extends Component {
 					headerText={ translate( 'Import Content' ) }
 					subHeaderText={ translate( 'Import content from another website or platform.' ) }
 					align="left"
+					wpAdminPath="import.php"
 				/>
 				<EmailVerificationGate allowUnlaunched>
 					{ isJetpack && ! isAtomic ? <JetpackImporter /> : this.renderImportersList() }

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -357,6 +357,7 @@ class Media extends Component {
 						'Manage all the media on your site, including images, video, and more.'
 					) }
 					align="left"
+					wpAdminPath="upload.php"
 				/>
 				{ this.showDialog() && (
 					<EditorMediaModalDialog

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -104,6 +104,7 @@ class PagesMain extends React.Component {
 							: translate( 'Create, edit, and manage the pages on your sites.' )
 					}
 					align="left"
+					wpAdminPath="/edit.php?post_type=page"
 				/>
 				<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ status } />
 				<PageList siteId={ siteId } status={ status } search={ search } query={ query } />

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -99,6 +99,7 @@ class People extends React.Component {
 					headerText={ translate( 'People' ) }
 					subHeaderText={ this.renderSubheaderText() }
 					align="left"
+					wpAdminPath="users.php"
 				/>
 				<div>
 					{

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -88,6 +88,7 @@ class PostsMain extends React.Component {
 							: translate( 'Create, edit, and manage the posts on your sites.' )
 					}
 					align="left"
+					wpAdminPath="edit.php"
 				/>
 				<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ statusSlug } />
 				<PostTypeList

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -43,6 +43,7 @@ const SiteSettingsComponent = ( { siteId, translate } ) => {
 					'Manage your site settings, including language, time zone, site visibility, and more.'
 				) }
 				align="left"
+				wpAdminPath="options-general.php"
 			/>
 			<SiteSettingsNavigation section={ 'general' } />
 			<GeneralSettings />

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -78,6 +78,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 				headerText={ translate( 'Themes' ) }
 				subHeaderText={ translate( 'Select or update the visual design for your site.' ) }
 				align="left"
+				wpAdminPath="themes.php"
 			/>
 			<CurrentTheme siteId={ siteId } />
 			{ bannerLocationBelowSearch ? null : upsellBanner }

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -53,6 +53,7 @@ function Types( {
 				headerText={ get( postType, 'label', '' ) }
 				subHeaderText={ subHeaderText }
 				align="left"
+				wpAdminPath={ `/edit.php?post_type=${ query.type }` }
 			/>
 			{ userCanEdit &&
 				postTypeSupported && [


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/51568
Fixes https://github.com/Automattic/wp-calypso/issues/51457
Fixes https://github.com/Automattic/wp-calypso/issues/51441
Fixes https://github.com/Automattic/wp-calypso/issues/50945
Fixes https://github.com/Automattic/wp-calypso/issues/51435
Fixes https://github.com/Automattic/wp-calypso/issues/51357

#### Changes proposed in this Pull Request

Adds a in-page toggle to every Calypso screen that has a WP Admin equivalent page, so users can quickly switch to them without needing to permanently change the "show wp-admin pages" toggle in their account settings.

Desktop | Mobile
--- | ---
<img width="1280" alt="Screen Shot 2021-05-18 at 15 07 58" src="https://user-images.githubusercontent.com/1233880/118657179-89add300-b7eb-11eb-81ab-5efed19a9529.png"> | <img width="444" alt="Screen Shot 2021-05-18 at 15 08 20" src="https://user-images.githubusercontent.com/1233880/118657191-8ca8c380-b7eb-11eb-9dd5-36cc45564365.png">

The quick switcher is only visible when a single Simple/Atomic site is selected. That means the switcher is not visible under the following scenarios:
- "All sites" screens (there is no WP Admin equivalent page).
- Jetpack sites (menu is not unified with WP Admin).

The "Default / WP Admin" terminology is deliberate, since I think that's less confusing than "Simple / Advanced" ("Advanced" denotes that the screen augments the "Simple" version while that's not always true).

#### Testing instructions

- Use the Calypso live link below.
- Switch to a Simple or Atomic site.
- Make sure the quick switcher shows up in the top-right corner of the following screens:
  - My Home
  - Posts > All posts
  - Media
  - Pages > All pages
  - Testimonials > All testimonials
  - Portfolio > All projects
  - Comments
  - Appearance > Themes
  - Users > All users
  - Tools > Import
  - Tools > Export
  - Settings > General
- Make sure they all link to the equivalent WP Admin page.
- Make sure the quick switcher looks good on mobile.
- Make sure the quick switcher looks good on RTL languages.
- Switch to a Jetpack site.
- Make sure the quick switcher doesn't show up.