### PR TITLE
Cancel Purchase Upsell: remove live chat reference

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
@@ -50,8 +50,7 @@ export class DowngradeStep extends Component {
 			refundReason = (
 				<p>
 					{ translate(
-						'WordPress.com Personal still gives you access to email and chat support, ' +
-							'removal of ads, and more — and for 50% of the cost of your current plan.'
+						'WordPress.com Personal still gives you access to email support, removal of ads, and more — and for 50% of the cost of your current plan.'
 					) }
 				</p>
 			);


### PR DESCRIPTION
Live chat is not available for personal plans. This removes it from the cancel purchase downgrade upsell.

Fixes: 343-gh-Automattic/payments-shilling

**To test:**
Visual would probably suffice, but:

- Purchase a Premium plan
- Cancel the purchase
- Verify that the Personal plan nudge doesn't mention live chat.