### PR TITLE
Theme Showcase: Add tracking events to the auto-loading homepage modal

### DIFF
--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -78,8 +78,8 @@ class AutoLoadingHomepageModal extends Component {
 		this.setState( { homepageAction: event.currentTarget.value } );
 	};
 
-	closeModalHandler = ( activate = false ) => () => {
-		if ( activate ) {
+	closeModalHandler = ( activate = 'dismiss' ) => () => {
+		if ( 'activeTheme' === activate ) {
 			const { installingThemeId, siteId, source } = this.props;
 			this.props.acceptAutoLoadingHomepageWarning( installingThemeId );
 			const keepCurrentHomepage = this.state.homepageAction === 'keep_current_homepage';
@@ -94,6 +94,9 @@ class AutoLoadingHomepageModal extends Component {
 				false,
 				keepCurrentHomepage
 			);
+		} else if ( 'keepCurrentTheme' === activate ) {
+			recordTracksEvent( 'calypso_theme_autoloading_modal_keep_theme_click' );
+			return this.props.hideAutoLoadingHomepageWarning();
 		}
 		recordTracksEvent( 'calypso_theme_autoloading_modal_dismiss' );
 		this.props.hideAutoLoadingHomepageWarning();
@@ -139,16 +142,16 @@ class AutoLoadingHomepageModal extends Component {
 						action: 'keepCurrentTheme',
 						label: translate( 'Keep my current theme' ),
 						isPrimary: false,
-						onClick: this.closeModalHandler( false ),
+						onClick: this.closeModalHandler( 'keepCurrentTheme' ),
 					},
 					{
 						action: 'activeTheme',
 						label: translate( 'Activate %(themeName)s', { args: { themeName } } ),
 						isPrimary: true,
-						onClick: this.closeModalHandler( true ),
+						onClick: this.closeModalHandler( 'activeTheme' ),
 					},
 				] }
-				onClose={ this.closeModalHandler( false ) }
+				onClose={ this.closeModalHandler( 'dismiss' ) }
 			>
 				<div>
 					<h1>

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -96,10 +96,10 @@ class AutoLoadingHomepageModal extends Component {
 				keepCurrentHomepage
 			);
 		} else if ( 'keepCurrentTheme' === action ) {
-			recordTracksEvent( 'calypso_theme_autoloading_modal_keep_theme_click' );
+			recordTracksEvent( 'calypso_theme_autoloading_modal_dismiss', { action: 'button' } );
 			return this.props.hideAutoLoadingHomepageWarning();
 		} else if ( 'dismiss' === action ) {
-			recordTracksEvent( 'calypso_theme_autoloading_modal_dismiss' );
+			recordTracksEvent( 'calypso_theme_autoloading_modal_dismiss', { action: 'escape' } );
 			return this.props.hideAutoLoadingHomepageWarning();
 		}
 	};

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -11,6 +11,7 @@ import { translate } from 'i18n-calypso';
  */
 import { Dialog } from '@automattic/components';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import {
@@ -78,8 +79,8 @@ class AutoLoadingHomepageModal extends Component {
 		this.setState( { homepageAction: event.currentTarget.value } );
 	};
 
-	closeModalHandler = ( activate = 'dismiss' ) => () => {
-		if ( 'activeTheme' === activate ) {
+	closeModalHandler = ( action = 'dismiss' ) => () => {
+		if ( 'activeTheme' === action ) {
 			const { installingThemeId, siteId, source } = this.props;
 			this.props.acceptAutoLoadingHomepageWarning( installingThemeId );
 			const keepCurrentHomepage = this.state.homepageAction === 'keep_current_homepage';
@@ -94,12 +95,13 @@ class AutoLoadingHomepageModal extends Component {
 				false,
 				keepCurrentHomepage
 			);
-		} else if ( 'keepCurrentTheme' === activate ) {
+		} else if ( 'keepCurrentTheme' === action ) {
 			recordTracksEvent( 'calypso_theme_autoloading_modal_keep_theme_click' );
 			return this.props.hideAutoLoadingHomepageWarning();
+		} else if ( 'dismiss' === action ) {
+			recordTracksEvent( 'calypso_theme_autoloading_modal_dismiss' );
+			return this.props.hideAutoLoadingHomepageWarning();
 		}
-		recordTracksEvent( 'calypso_theme_autoloading_modal_dismiss' );
-		this.props.hideAutoLoadingHomepageWarning();
 	};
 
 	render() {
@@ -153,6 +155,7 @@ class AutoLoadingHomepageModal extends Component {
 				] }
 				onClose={ this.closeModalHandler( 'dismiss' ) }
 			>
+				<TrackComponentView eventName={ 'calypso_theme_autoloading_modal_view' } />
 				<div>
 					<h1>
 						{ translate( 'How would you like to use %(themeName)s on your site?', {

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -80,11 +80,11 @@ class AutoLoadingHomepageModal extends Component {
 	};
 
 	closeModalHandler = ( action = 'dismiss' ) => () => {
+		const { installingThemeId, siteId, source } = this.props;
 		if ( 'activeTheme' === action ) {
-			const { installingThemeId, siteId, source } = this.props;
 			this.props.acceptAutoLoadingHomepageWarning( installingThemeId );
 			const keepCurrentHomepage = this.state.homepageAction === 'keep_current_homepage';
-			recordTracksEvent( 'calypso_theme_autoloading_modal_activate_click', {
+			recordTracksEvent( 'calypso_theme_autoloading_homepage_modal_activate_click', {
 				theme: installingThemeId,
 				keep_current_homepage: keepCurrentHomepage,
 			} );
@@ -96,10 +96,16 @@ class AutoLoadingHomepageModal extends Component {
 				keepCurrentHomepage
 			);
 		} else if ( 'keepCurrentTheme' === action ) {
-			recordTracksEvent( 'calypso_theme_autoloading_modal_dismiss', { action: 'button' } );
+			recordTracksEvent( 'calypso_theme_autoloading_homepage_modal_dismiss', {
+				action: 'button',
+				theme: installingThemeId,
+			} );
 			return this.props.hideAutoLoadingHomepageWarning();
 		} else if ( 'dismiss' === action ) {
-			recordTracksEvent( 'calypso_theme_autoloading_modal_dismiss', { action: 'escape' } );
+			recordTracksEvent( 'calypso_theme_autoloading_homepage_modal_dismiss', {
+				action: 'escape',
+				theme: installingThemeId,
+			} );
 			return this.props.hideAutoLoadingHomepageWarning();
 		}
 	};
@@ -133,7 +139,7 @@ class AutoLoadingHomepageModal extends Component {
 			return null;
 		}
 
-		const { name: themeName } = this.props.theme;
+		const { name: themeName, id: themeId } = this.props.theme;
 
 		return (
 			<Dialog
@@ -155,7 +161,10 @@ class AutoLoadingHomepageModal extends Component {
 				] }
 				onClose={ this.closeModalHandler( 'dismiss' ) }
 			>
-				<TrackComponentView eventName={ 'calypso_theme_autoloading_modal_view' } />
+				<TrackComponentView
+					eventName={ 'calypso_theme_autoloading_homepage_modal_view' }
+					eventProperties={ { theme: themeId } }
+				/>
 				<div>
 					<h1>
 						{ translate( 'How would you like to use %(themeName)s on your site?', {

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -83,7 +83,7 @@ class AutoLoadingHomepageModal extends Component {
 			const { installingThemeId, siteId, source } = this.props;
 			this.props.acceptAutoLoadingHomepageWarning( installingThemeId );
 			const keepCurrentHomepage = this.state.homepageAction === 'keep_current_homepage';
-			recordTracksEvent( 'calypso_theme_activate_new_click', {
+			recordTracksEvent( 'calypso_theme_autoloading_modal_activate_click', {
 				theme: installingThemeId,
 				keep_current_homepage: keepCurrentHomepage,
 			} );
@@ -95,7 +95,7 @@ class AutoLoadingHomepageModal extends Component {
 				keepCurrentHomepage
 			);
 		}
-		recordTracksEvent( 'calypso_theme_keep_current_theme_click' );
+		recordTracksEvent( 'calypso_theme_autoloading_modal_dismiss' );
 		this.props.hideAutoLoadingHomepageWarning();
 	};
 

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -10,6 +10,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Dialog } from '@automattic/components';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import {
@@ -82,6 +83,10 @@ class AutoLoadingHomepageModal extends Component {
 			const { installingThemeId, siteId, source } = this.props;
 			this.props.acceptAutoLoadingHomepageWarning( installingThemeId );
 			const keepCurrentHomepage = this.state.homepageAction === 'keep_current_homepage';
+			recordTracksEvent( 'calypso_theme_activate_new_click', {
+				theme: installingThemeId,
+				keep_current_homepage: keepCurrentHomepage,
+			} );
 			return this.props.activateTheme(
 				installingThemeId,
 				siteId,
@@ -90,6 +95,7 @@ class AutoLoadingHomepageModal extends Component {
 				keepCurrentHomepage
 			);
 		}
+		recordTracksEvent( 'calypso_theme_keep_current_theme_click' );
 		this.props.hideAutoLoadingHomepageWarning();
 	};
 
@@ -199,5 +205,6 @@ export default connect(
 		acceptAutoLoadingHomepageWarning,
 		hideAutoLoadingHomepageWarning,
 		activateTheme,
+		recordTracksEvent,
 	}
 )( AutoLoadingHomepageModal );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Tracks events to the actions on the Theme Showcase's auto-loading homepage modal. It looks like this:

<img width="591" alt="Screen Shot 2021-05-18 at 11 59 47 AM" src="https://user-images.githubusercontent.com/2124984/118684834-8ce79580-b7d0-11eb-9b64-93d7c6a97921.png">

**Example Tracks event logs**

Dismiss
<img width="1275" alt="Screen Shot 2021-05-19 at 1 52 41 PM" src="https://user-images.githubusercontent.com/2124984/118860942-f2f41b80-b8a9-11eb-9ca7-cb74f3a3ee55.png">

Activate
<img width="1340" alt="Screen Shot 2021-05-19 at 1 52 58 PM" src="https://user-images.githubusercontent.com/2124984/118860965-fa1b2980-b8a9-11eb-8042-0be7284fe0a5.png">

View
<img width="1176" alt="Screen Shot 2021-05-19 at 1 52 28 PM" src="https://user-images.githubusercontent.com/2124984/118860980-fedfdd80-b8a9-11eb-89c0-714dd39c57eb.png">


#### Testing instructions

* Switch to this PR and navigate to `/themes/[site]` on a simple site
* Click on a Recommended theme and "Activate"
* Check the Tracks events in MC (there will be several minutes' lag); alternatively, log them to your browser console with `localStorage.debug="calypso:analytics*"`
* You should see a Tracks event fire upon opening the modal - `calypso_theme_autoloading_homepage_modal_view` with prop theme id `theme: theme-name`
* You should see a Tracks event fire when you dismiss the modal (click outside it) - `calypso_theme_autoloading_homepage_modal_dismiss` with prop `action: 'escape'` and theme id `theme: theme-name`
* You should see a Tracks event fire when clicking "Keep current theme" - `calypso_theme_autoloading_homepage_modal_dismiss` with prop `action: 'button'` and theme id `theme: theme-name`
* You should also see a Tracks event fire when you choose to activate the theme, with props for the theme switched to and whether you chose to keep the current homepage or not - `calypso_theme_autoloading_homepage_modal_activate_click` with props `theme: 'theme-name'` and `keep_current_homepage: true/false`

Related to #52926
