### PR TITLE
Change the ESLint rule on max top level describes to be an error.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,7 +79,7 @@ module.exports = {
 				'mocha/no-global-tests': 'error',
 				'mocha/no-async-describe': 'error',
 				'mocha/no-top-level-hooks': 'error',
-				'mocha/max-top-level-suites': [ 'warn', { limit: 1 } ],
+				'mocha/max-top-level-suites': [ 'error', { limit: 1 } ],
 				'no-console': 'off',
 				// Disable all rules from "plugin:jest/recommended", as e2e tests use mocha
 				...Object.keys( require( 'eslint-plugin-jest' ).configs.recommended.rules ).reduce(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR begins to enforce the `max-top-level-suites` mocha rule (until we move to Jest, at least) for tests whenever they are modified.

#### Testing instructions

Locally, modify a test file that has more than 1 top level describe suites, then add to the commit. An error should prevent further progress.

Related to #52916, #51082
