### PR TITLE
Desktop: Disable social login and magic links

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -608,28 +608,26 @@ export class LoginForm extends Component {
 						</div>
 					</div>
 
-					{ config.isEnabled( 'signup/social' ) && (
-						<p className="login__form-terms">
-							{ preventWidows(
-								this.props.translate(
-									// To make any changes to this copy please speak to the legal team
-									'By continuing, ' + 'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
-									{
-										components: {
-											tosLink: (
-												<a
-													href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-													target="_blank"
-													rel="noopener noreferrer"
-												/>
-											),
-										},
-									}
-								),
-								5
-							) }
-						</p>
-					) }
+					<p className="login__form-terms">
+						{ preventWidows(
+							this.props.translate(
+								// To make any changes to this copy please speak to the legal team
+								'By continuing, ' + 'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
+								{
+									components: {
+										tosLink: (
+											<a
+												href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									},
+								}
+							),
+							5
+						) }
+					</p>
 
 					<div className="login__form-action">
 						<FormsButton primary disabled={ isFormDisabled }>

--- a/packages/calypso-config/src/desktop.ts
+++ b/packages/calypso-config/src/desktop.ts
@@ -16,7 +16,9 @@ const config = {
 const features = {
 	desktop: true,
 	'desktop-promo': false,
-	'sign-in-with-apple': 'false',
+	'sign-in-with-apple': false,
+	'signup/social': false,
+	'login/magic-login': false,
 };
 
 export default ( data: ConfigData ): ConfigData => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes social login on Desktop
* Remove magic linking on Desktop
* Show ToS even when social links are disabled

#### Testing instructions

* Login to the app

Related to https://github.com/Automattic/wp-calypso/pull/49614
