### PR TITLE
Added initial static setup/loading page

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -197,7 +197,11 @@ class Layout extends Component {
 
 		const exemptedSections = [ 'jetpack-connect', 'happychat', 'devdocs', 'help', 'home' ];
 		const exemptedRoutes = [ '/log-in/jetpack' ];
-		const exemptedRoutesStartingWith = [ '/start/p2', '/plugins/domain' ];
+		const exemptedRoutesStartingWith = [
+			'/start/p2',
+			'/plugins/domain',
+			'/plugins/marketplace/setup',
+		];
 
 		return (
 			! exemptedSections.includes( this.props.sectionName ) &&

--- a/client/layout/masterbar/masterbar.jsx
+++ b/client/layout/masterbar/masterbar.jsx
@@ -17,7 +17,7 @@ const Masterbar = ( { children, className } ) => (
 );
 
 Masterbar.propTypes = {
-	children: PropTypes.node.isRequired,
+	children: PropTypes.node,
 	className: PropTypes.string,
 };
 

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -212,3 +212,10 @@ export function renderDomainsPage( context, next ) {
 	);
 	next();
 }
+
+export function renderPluginsSetupStatusPage( context, next ) {
+	context.primary = (
+		<AsyncLoad require="calypso/my-sites/plugins/marketplace/marketplace-plugin-setup-status" />
+	);
+	next();
+}

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -15,6 +15,7 @@ import {
 	jetpackCanUpdate,
 	plugins,
 	renderDomainsPage,
+	renderPluginsSetupStatusPage,
 	resetHistory,
 	scrollTopIfNoHash,
 	setupPlugins,
@@ -105,6 +106,13 @@ export default function () {
 
 		if ( config.isEnabled( 'marketplace-yoast' ) ) {
 			page( '/plugins/domain/:site', siteSelection, renderDomainsPage, makeLayout, clientRender );
+			page(
+				'/plugins/marketplace/setup/:site',
+				siteSelection,
+				renderPluginsSetupStatusPage,
+				makeLayout,
+				clientRender
+			);
 		}
 		page(
 			'/plugins/:pluginFilter(active|inactive|updates)/:site_id?',

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-setup-status/index.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-setup-status/index.tsx
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { ThemeProvider } from 'emotion-theming';
+import { ProgressBar } from '@automattic/components';
+import styled from '@emotion/styled';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import theme from 'calypso/my-sites/plugins/marketplace/theme';
+import Masterbar from 'calypso/layout/masterbar/masterbar';
+import { getStatusForPlugin } from 'calypso/state/plugins/installed/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
+
+/**
+ * Style dependencies
+ */
+import 'calypso/my-sites/plugins/marketplace/marketplace-plugin-setup-status/style.scss';
+
+const StyledProgressBar = styled( ProgressBar )`
+	margin: 20px 0px;
+`;
+
+function WrappedMarketplacePluginSetup( {
+	pluginSlug = 'wordpress-seo',
+}: {
+	pluginSlug?: string;
+} ): JSX.Element {
+	const selectedSite = useSelector( getSelectedSite );
+
+	//Plugin status can be extracted with this selector once installation is triggered
+	const pluginStatus = useSelector( ( state ) => {
+		return selectedSite ? getStatusForPlugin( state, selectedSite?.ID, pluginSlug ) : 'UNKNOWN';
+	} );
+
+	return (
+		<>
+			{ selectedSite?.ID ? <QueryJetpackPlugins siteIds={ [ selectedSite.ID ] } /> : '' }
+			<Masterbar></Masterbar>
+			<div className="marketplace-plugin-setup-status__root">
+				<div>
+					<h1 className="marketplace-plugin-setup-status__title wp-brand-font">
+						Installing Plugin { pluginStatus }
+					</h1>
+					<StyledProgressBar value={ 25 } color={ '#C9356E' } compact />
+					<div>Step 1 of 3</div>
+				</div>
+			</div>
+		</>
+	);
+}
+
+export default function MarketplacePluginSetup(): JSX.Element {
+	return (
+		<ThemeProvider theme={ theme }>
+			<WrappedMarketplacePluginSetup />
+		</ThemeProvider>
+	);
+}

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-setup-status/style.scss
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-setup-status/style.scss
@@ -1,0 +1,31 @@
+.is-section-plugins.has-no-sidebar {
+	.layout__content {
+		background-color: var( --studio-white );
+		height: 100vh;
+		@media ( max-width: 782px ) {
+			padding: 0;
+			background-color: var( --studio-white );
+			height: 100vh;
+			.layout__primary {
+				height: 100vh;
+				.marketplace-domain-upsell__root {
+					height: calc( 100vh - 50px );
+				}
+			}
+		}
+	}
+}
+
+.marketplace-plugin-setup-status__root {
+	margin-top: 350px;
+	display: flex;
+	justify-content: center;
+	h1 {
+		font-size: 2rem;
+	}
+	> div {
+		width: 90%;
+		text-align: center;
+		max-width: 509px;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The marketplace requires a loading page to show progress of provisioning. this is the initial static page as well as the route setup to show this page.
![image](https://user-images.githubusercontent.com/3422709/118751844-a85da980-b87f-11eb-973e-646181b13a3c.png)


#### Testing instructions
Go to route /plugins/marketplace/setup/{siteUrl}??flags=marketplace-yoast
e.g. : http://calypso.localhost:3000/plugins/domain/awesome.com?flags=marketplace-yoast
The above static page should be displayed


Related to #
