### PR TITLE
My Home: Promote the menu editing tutorial as the primary action in the "Edit the site menu" task

### DIFF
--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -33,6 +34,7 @@ class InlineSupportLink extends Component {
 	};
 
 	static propTypes = {
+		className: PropTypes.string,
 		supportPostId: PropTypes.number,
 		supportLink: PropTypes.string,
 		showText: PropTypes.bool,
@@ -59,6 +61,7 @@ class InlineSupportLink extends Component {
 
 	render() {
 		const {
+			className,
 			showText,
 			supportPostId,
 			supportLink,
@@ -101,7 +104,7 @@ class InlineSupportLink extends Component {
 
 		return (
 			<LinkComponent
-				className="inline-support-link"
+				className={ classnames( 'inline-support-link', className ) }
 				href={ url }
 				onClick={ openDialog }
 				onMouseEnter={

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
@@ -4,6 +4,8 @@
 import React from 'react';
 import { translate } from 'i18n-calypso';
 import { Button } from '@automattic/components';
+import classnames from 'classnames';
+
 /**
  * Internal dependencies
  */
@@ -37,8 +39,10 @@ const CurrentTaskItem = ( { currentTask, skipTask, startTask, useAccordionLayout
 				<div className="site-setup-list__task-actions task__actions">
 					{ currentTask.actionText && (
 						<Button
-							className="site-setup-list__task-action task__action"
-							primary
+							className={ classnames( 'site-setup-list__task-action', 'task__action', {
+								'is-link': currentTask.actionIsLink,
+							} ) }
+							primary={ ! currentTask.actionIsLink }
 							onClick={ () => startTask() }
 							disabled={
 								currentTask.isDisabled ||

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
@@ -37,6 +37,7 @@ const CurrentTaskItem = ( { currentTask, skipTask, startTask, useAccordionLayout
 					{ currentTask.description }
 				</p>
 				<div className="site-setup-list__task-actions task__actions">
+					{ currentTask.customFirstButton }
 					{ currentTask.actionText && (
 						<Button
 							className={ classnames( 'site-setup-list__task-action', 'task__action', {

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -184,27 +184,28 @@ export const getTask = (
 			taskData = {
 				timing: 10,
 				title: translate( 'Edit the site menu' ),
-				description: (
-					<>
-						{ translate(
-							"Building an effective navigation menu makes it easier for someone to find what they're looking for and improve search engine rankings."
-						) }{ ' ' }
-						<InlineSupportLink
-							supportPostId={ 59580 }
-							supportLink={ localizeUrl( 'https://wordpress.com/support/menus/' ) }
-							showIcon={ false }
-							tracksEvent="calypso_customer_home_menus_support_page_view"
-							statsGroup="calypso_customer_home"
-							statsName="menus_view_tutorial"
-						>
-							{ translate( 'View tutorial.' ) }
-						</InlineSupportLink>
-					</>
+				description: translate(
+					"Building an effective navigation menu makes it easier for someone to find what they're looking for and improve search engine rankings."
 				),
 				actionText: translate( 'Add a menu' ),
 				isSkippable: true,
 				actionUrl: menusUrl,
 				actionIsLink: true,
+				customFirstButton: (
+					<InlineSupportLink
+						// The following classes are globally shared
+						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+						className="button is-primary task__action"
+						supportPostId={ 59580 }
+						supportLink={ localizeUrl( 'https://wordpress.com/support/menus/' ) }
+						showIcon={ false }
+						tracksEvent="calypso_customer_home_menus_support_page_view"
+						statsGroup="calypso_customer_home"
+						statsName="menus_view_tutorial"
+					>
+						{ translate( 'View tutorial' ) }
+					</InlineSupportLink>
+				),
 			};
 			break;
 		case CHECKLIST_KNOWN_TASKS.SITE_THEME_SELECTED:

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -204,6 +204,7 @@ export const getTask = (
 				actionText: translate( 'Add a menu' ),
 				isSkippable: true,
 				actionUrl: menusUrl,
+				actionIsLink: true,
 			};
 			break;
 		case CHECKLIST_KNOWN_TASKS.SITE_THEME_SELECTED:

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -188,7 +188,6 @@ export const getTask = (
 					"Building an effective navigation menu makes it easier for someone to find what they're looking for and improve search engine rankings."
 				),
 				actionText: translate( 'Add a menu' ),
-				isSkippable: true,
 				actionUrl: menusUrl,
 				actionIsLink: true,
 				customFirstButton: (

--- a/client/state/selectors/is-site-checklist-complete.js
+++ b/client/state/selectors/is-site-checklist-complete.js
@@ -36,6 +36,7 @@ export default function isSiteChecklistComplete( state, siteId ) {
 	 *	Any other case leads to a pending task.
 	 *	C) the mobile_app_installed task, because it shouldn't affect the site setup status.
 	 *	D) the start_site_setup task, because it autocompletes on view as a way of starting the checklist.
+	 *	E) the site_menu_updated task, because it shouldn't affect the site setup status.
 	 *
 	 *		@param   {object}  task The task that we'll check to see if it's completed.
 	 *		@returns {boolean}      Whether the task is considered to be completed or not.
@@ -56,6 +57,13 @@ export default function isSiteChecklistComplete( state, siteId ) {
 
 		// Starting site setup autocompletes, so it shouldn't cause an incomplete checklist.
 		if ( CHECKLIST_KNOWN_TASKS.START_SITE_SETUP === task.id ) {
+			return true;
+		}
+
+		// The menu updating task isn't mandatory because not every site needs menu changes
+		// to be made. However the task also isn't skippable (#47334), so if a user chooses
+		// to leave the task undone it shouldn't count towards not completing setup.
+		if ( CHECKLIST_KNOWN_TASKS.SITE_MENU_UPDATED === task.id ) {
 			return true;
 		}
 


### PR DESCRIPTION
The site setup checklist on My Home includes a task to "edit your menu". Completing this task means taking users to the customiser, which can be confusing.

This change is discussed in greater detail in #47334, but in short this PR encourages users to view the tutorial for menus over actually making the menu change. It also replaces the explicit "skip" action with an implicit skippability. Now if the only task left incomplete is the menu task, then it will be counted as skipped. This depends on the change in D61706-code, and is a bit of a hack that tries to make up for the fact that the "edit your menu" task has lost its skip button.

#### Changes proposed in this Pull Request

* Allow inline support links to be custom styled
* Move the menu tutorial link from the task description to the primary action
* Render the "Add a menu" button as a secondary action
* Hide the skip button from the task
* Make the task not count towards setup completion

<img width="951" alt="Screenshot 2021-05-19 at 3 30 28 PM" src="https://user-images.githubusercontent.com/1500769/119066117-2ca45e00-ba33-11eb-9b8a-354e2d16e00e.png">

The secondary "Add a menu" button still fires the `calypso_checklist_task_start` track event.
The "View tutorial" button still fires the `calypso_customer_home_menus_support_page_view` track event and still opens in a modal.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test using calypso live and a site that has not completed setup yet
* Test buttons still work as expected
* Apply D61706-code
* Create a new unlaunched site
  * Complete every task except editing the menu and launching
  * Launch the site
  * When landing on the My Home page notice the site setup is complete
  * Reload page with `?disable-nav-unification` and see that the site setup progress bar isn't visible
* Create another new unlaunched site
  * Launch the site before completing any other tasks
  * After landing on My Home page get celebration that site was launched
  * Dismiss that celebration notice by saying you want to continue setup
  * See that the checklist is still there

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #47334