### PR TITLE
Redux Middleware: Include query params when opening links outside calypso

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -102,7 +102,7 @@ const setupContextMiddleware = ( reduxStore ) => {
 		// Some paths live outside of Calypso and should be opened separately
 		// Examples: /support, /forums
 		if ( isOutsideCalypso( context.pathname ) ) {
-			window.location.href = context.pathname;
+			window.location.href = context.path;
 			return;
 		}
 


### PR DESCRIPTION
This PR updates our redux context middleware to include query parameters when opening links outside a calypso context.

The goal is to resolve the first issue reported in https://github.com/Automattic/wp-calypso/issues/52705 where the "Edit homepage" button in the My Home Site setup checklist goes to the wrong URL:

![My_Home_‹_JulesausTestMigration_—_WordPress_com](https://user-images.githubusercontent.com/5952255/118774543-4b86e100-b8c9-11eb-9b86-2aa374c9d14b.jpg)

#### Testing instructions

First, confirm that this PR fulfils its intended purpose:
1. sandbox `public-api.wordpress.com` to enable the checklist on atomic sites
2. Check that this does fix the "Edit homepage" link on a test atomic site that has not yet completed the onboarding checklist

This PR will change the behaviour of any external link passed to `page()` or `page.show()` so we also want to check that we don't break other external links.

The changed code was introduced in #40461 to support links to support and forums, and the query params seems like an oversite rather than a design choice, so I think we'll be ok, but we should still check a few links.

On the other hand, it seems like this would be fouling up a lot of atomic links.