### PR TITLE
ci(translate): Use a CJS adapter for mocha-debug-reporter

### DIFF
--- a/packages/mocha-debug-reporter/package.json
+++ b/packages/mocha-debug-reporter/package.json
@@ -2,7 +2,7 @@
 	"name": "@automattic/mocha-debug-reporter",
 	"version": "0.1.0",
 	"description": "Mocha reporter that dumps all info about the test execution",
-	"main": "dist/cjs/index.js",
+	"main": "dist/cjs/cjs.js",
 	"author": "Automattic Inc.",
 	"repository": {
 		"type": "git",

--- a/packages/mocha-debug-reporter/src/cjs.js
+++ b/packages/mocha-debug-reporter/src/cjs.js
@@ -1,0 +1,1 @@
+module.exports = require( './index' ).default;

--- a/packages/mocha-debug-reporter/src/index.ts
+++ b/packages/mocha-debug-reporter/src/index.ts
@@ -29,7 +29,7 @@ interface Event {
 	data?: Record< string, unknown >;
 }
 
-export = class DebugReporter extends Mocha.reporters.Base {
+export default class DebugReporter extends Mocha.reporters.Base {
 	events: Event[];
 	reporterOptions?: Record< string, unknown >;
 
@@ -91,4 +91,4 @@ export = class DebugReporter extends Mocha.reporters.Base {
 		};
 		this.events.push( event );
 	}
-};
+}

--- a/packages/mocha-debug-reporter/tsconfig.json
+++ b/packages/mocha-debug-reporter/tsconfig.json
@@ -4,7 +4,7 @@
 		"lib": [ "DOM", "es2020" ],
 		"baseUrl": ".",
 		"module": "commonjs",
-		"allowJs": false,
+		"allowJs": true,
 		"declaration": true,
 		"declarationDir": "dist/types",
 		"outDir": "dist/cjs",
@@ -28,5 +28,5 @@
 
 		"composite": true
 	},
-	"include": [ "src" ]
+	"include": [ "src", "src/cjs.js" ]
 }


### PR DESCRIPTION
### Background

In #52751 we introudced `mocha-debug-reportet`, a Mocha reporter used to dump debug info about the tests. This reporter is written in TypeScript, and uses the synxtax `export =` to produce a transpiled package that can be imported by node by just `require('mocha-debug-reporter')`.

The syntax `export =` is not supported by `@babel/plugin-transform-typescript`, used to generate a `.pot` file with the translations for our packages. 

This is currently breaking the `translate` job in CircleCI (https://app.circleci.com/pipelines/github/Automattic/wp-calypso/100278/workflows/3827f0c5-9b55-43ef-9ae2-c5d27204533b/jobs/1037417/parallel-runs/0/steps/0-104):

```
$ npx rimraf build/strings && wp-babel-makepot './{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base './' --dir './build/strings' --output './calypso-strings.pot'
/home/circleci/wp-calypso/packages/mocha-debug-reporter/src/index.ts SyntaxError: /home/circleci/wp-calypso/packages/mocha-debug-reporter/src/index.ts: `export =` is not supported by @babel/plugin-transform-typescript
Please consider using `export <value>;`.
  30 | }
  31 |
> 32 | export = class DebugReporter extends Mocha.reporters.Base {
     | ^
  33 | 	events: Event[];
  34 | 	reporterOptions?: Record< string, unknown >;
  35 |
    at File.buildCodeFrameError (/home/circleci/wp-calypso/node_modules/@babel/core/lib/transformation/file/file.js:244:12)
    at NodePath.buildCodeFrameError (/home/circleci/wp-calypso/node_modules/@babel/traverse/lib/path/index.js:133:21)
    at PluginPass.TSExportAssignment (/home/circleci/wp-calypso/node_modules/@babel/plugin-transform-typescript/lib/index.js:386:20)
    at newFn (/home/circleci/wp-calypso/node_modules/@babel/traverse/lib/visitors.js:171:21)
    at NodePath._call (/home/circleci/wp-calypso/node_modules/@babel/traverse/lib/path/context.js:53:20)
    at NodePath.call (/home/circleci/wp-calypso/node_modules/@babel/traverse/lib/path/context.js:40:17)
    at NodePath.visit (/home/circleci/wp-calypso/node_modules/@babel/traverse/lib/path/context.js:90:31)
    at TraversalContext.visitQueue (/home/circleci/wp-calypso/node_modules/@babel/traverse/lib/context.js:110:16)
    at TraversalContext.visitMultiple (/home/circleci/wp-calypso/node_modules/@babel/traverse/lib/context.js:74:17)
    at TraversalContext.visit (/home/circleci/wp-calypso/node_modules/@babel/traverse/lib/context.js:136:19) {
  code: 'BABEL_TRANSFORM_ERROR'
}
Done in 31.31s.
```


### Changes proposed in this Pull Request

Use the most common `export default` instead of `export =`. This will generate a module that has to be imported as `require('./index').default`.

Introduce a `cjs.js` file used as a CJS adapter, used to import `.default` and re-export it as just `module.exports`. This allows consumers of this package to continue using `require('mocha-debug-reporter')`.

### Testing instructions

N/A