### PR TITLE
Temporarily enable reskin just for testing via calypso.live.

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -727,6 +727,7 @@ class Signup extends React.Component {
 					}
 
 					this.isReskinned = 'treatment' === experimentAssignment?.variationName;
+					this.isReskinned = true;
 					this.isReskinned
 						? document.body.classList.add( 'is-white-signup' )
 						: document.body.classList.remove( 'is-white-signup' );


### PR DESCRIPTION
This mod just enables the reskin for `/start` because the experiment ended on May 18 and we just need a place to see how the reskin looks like.

DO NOT MERGE.
