### PR TITLE
QuerySiteSettings: refactor away from `UNSAFE_componentWillReceiveProps`

### DIFF
--- a/client/components/data/query-site-settings/index.js
+++ b/client/components/data/query-site-settings/index.js
@@ -2,9 +2,9 @@
  * External dependencies
  */
 
-import { Component } from 'react';
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -12,43 +12,24 @@ import { connect } from 'react-redux';
 import { isRequestingSiteSettings } from 'calypso/state/site-settings/selectors';
 import { requestSiteSettings } from 'calypso/state/site-settings/actions';
 
-class QuerySiteSettings extends Component {
-	UNSAFE_componentWillMount() {
-		this.requestSettings( this.props );
+const request = ( siteId ) => ( dispatch, getState ) => {
+	if ( ! isRequestingSiteSettings( getState(), siteId ) ) {
+		dispatch( requestSiteSettings( siteId ) );
 	}
+};
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		const { siteId } = this.props;
-		if ( ! nextProps.siteId || siteId === nextProps.siteId ) {
-			return;
-		}
+function QuerySiteSettings( { siteId } ) {
+	const dispatch = useDispatch();
 
-		this.requestSettings( nextProps );
-	}
+	useEffect( () => {
+		dispatch( request( siteId ) );
+	}, [ dispatch, siteId ] );
 
-	requestSettings( props ) {
-		const { requestingSiteSettings, siteId } = props;
-		if ( ! requestingSiteSettings && siteId ) {
-			props.requestSiteSettings( siteId );
-		}
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
 QuerySiteSettings.propTypes = {
-	siteId: PropTypes.number,
-	requestingSiteSettings: PropTypes.bool,
-	requestSiteSettings: PropTypes.func,
+	siteId: PropTypes.number.isRequired,
 };
 
-export default connect(
-	( state, { siteId } ) => {
-		return {
-			requestingSiteSettings: isRequestingSiteSettings( state, siteId ),
-		};
-	},
-	{ requestSiteSettings }
-)( QuerySiteSettings );
+export default QuerySiteSettings;

--- a/client/components/data/query-site-settings/index.js
+++ b/client/components/data/query-site-settings/index.js
@@ -22,7 +22,7 @@ function QuerySiteSettings( { siteId } ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		dispatch( request( siteId ) );
+		siteId && dispatch( request( siteId ) );
 	}, [ dispatch, siteId ] );
 
 	return null;

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -33,7 +33,7 @@ import { shallow } from 'enzyme';
 import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import React from 'react';
-import { createStore } from 'redux';
+import { applyMiddleware, createStore } from 'redux';
 import { Provider } from 'react-redux';
 import {
 	PLAN_FREE,
@@ -45,6 +45,7 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_2_YEARS,
 } from '@automattic/calypso-products';
+import thunkMiddleware from 'redux-thunk';
 
 /**
  * Internal dependencies
@@ -74,7 +75,11 @@ const initialReduxState = {
 };
 
 function renderWithRedux( ui ) {
-	const store = createStore( ( state ) => state, initialReduxState );
+	const store = createStore(
+		( state ) => state,
+		initialReduxState,
+		applyMiddleware( thunkMiddleware )
+	);
 	return render( <Provider store={ store }>{ ui }</Provider> );
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `<QuerySiteSettings />`: refactor away from `UNSAFE_componentWillReceiveProps`

#### Testing instructions

QuerySiteSettings is used in a bunch of different places, e.g. in `/settings/general/<site-slug>`.

- Go to e.g. `/settings/general/<site-slug>`
- Make sure you see a request to `/sites/<site-id>/settings`
- Switch your active site and make sure site settings are refetched with the new `siteId`
