### PR TITLE
Onboarding: Add FSE support

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -5,13 +5,18 @@ import i18n from 'i18n-calypso';
 import { find, get } from 'lodash';
 
 /**
+ * Internal Dependencies
+ */
+import config from '@automattic/calypso-config';
+
+/**
  * Internal dependencies
  */
 
 const getSiteTypePropertyDefaults = ( propertyKey ) =>
 	get(
 		{
-			theme: 'pub/hever',
+			theme: config.isEnabled( 'gutenboarding/site-editor' ) ? 'pub/seedlet-blocks' : 'pub/hever',
 			// General copy
 			siteMockupHelpTipCopy: i18n.translate(
 				"Scroll down to see how your site will look. You can customize it with your own text and photos when we're done with the setup basics."

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -16,7 +16,7 @@ import config from '@automattic/calypso-config';
 const getSiteTypePropertyDefaults = ( propertyKey ) =>
 	get(
 		{
-			theme: config.isEnabled( 'signup/core-site-editor' ) ? 'pub/seedlet-blocks' : 'pub/hever',
+			theme: config.isEnabled( 'signup/core-site-editor' ) ? 'pub/blockbase' : 'pub/hever',
 			// General copy
 			siteMockupHelpTipCopy: i18n.translate(
 				"Scroll down to see how your site will look. You can customize it with your own text and photos when we're done with the setup basics."

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -3,16 +3,18 @@
  */
 import i18n from 'i18n-calypso';
 import { find, get } from 'lodash';
-
-/**
- * Internal Dependencies
- */
 import config from '@automattic/calypso-config';
 
 /**
  * Internal dependencies
  */
 
+/**
+ * Return default value for given `propertyKey`.
+ *
+ * @param {string} propertyKey property to retrieve
+ * @returns default value for the specified property
+ */
 const getSiteTypePropertyDefaults = ( propertyKey ) =>
 	get(
 		{

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -16,7 +16,7 @@ import config from '@automattic/calypso-config';
 const getSiteTypePropertyDefaults = ( propertyKey ) =>
 	get(
 		{
-			theme: config.isEnabled( 'gutenboarding/site-editor' ) ? 'pub/seedlet-blocks' : 'pub/hever',
+			theme: config.isEnabled( 'signup/core-site-editor' ) ? 'pub/seedlet-blocks' : 'pub/hever',
 			// General copy
 			siteMockupHelpTipCopy: i18n.translate(
 				"Scroll down to see how your site will look. You can customize it with your own text and photos when we're done with the setup basics."

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -164,6 +164,8 @@ function getNewSiteParams( {
 	const shouldUseDefaultAnnotationAsFallback = true;
 
 	let shouldEnableFse = selectedDesign?.is_fse;
+	// If the user didn't select any design, then we make sure
+	// the default theme is used to determine the `shouldEnableFse`'s value.
 	if ( ! selectedDesign ) {
 		const designs = getAvailableDesigns();
 		const themeSlug = theme.replace( 'pub/', '' );

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -54,6 +54,7 @@ import flows from 'calypso/signup/config/flows';
 import steps, { isDomainStepSkippable } from 'calypso/signup/config/steps';
 import { fetchSitesAndUser } from 'calypso/lib/signup/step-actions/fetch-sites-and-user';
 import { getAvailableDesigns, isBlankCanvasDesign } from '@automattic/design-picker';
+import config from '@automattic/calypso-config';
 
 /**
  * Constants
@@ -166,7 +167,11 @@ function getNewSiteParams( {
 	// to lookup the theme object based on the theme slug.
 	let selectedDesign = get( signupDependencies, 'selectedDesign', false );
 	if ( ! selectedDesign ) {
-		const designs = getAvailableDesigns();
+		const designs = getAvailableDesigns( {
+			includeAlphaDesigns: false,
+			useFseDesigns: config.isEnabled( 'signup/core-site-editor' ),
+			randomize: false,
+		} );
 		const themeSlug = theme.replace( 'pub/', '' ).replace( 'premium/', '' );
 		selectedDesign = designs.featured.find( ( { slug } ) => slug === themeSlug );
 	}

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -168,7 +168,7 @@ function getNewSiteParams( {
 	// the default theme is used to determine the `shouldEnableFse`'s value.
 	if ( ! selectedDesign ) {
 		const designs = getAvailableDesigns();
-		const themeSlug = theme.replace( 'pub/', '' );
+		const themeSlug = theme.replace( 'pub/', '' ).replace( 'premium/', '' );
 		const design = designs.featured.find( ( { slug } ) => slug === themeSlug );
 		shouldEnableFse = design?.is_fse;
 	}

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -53,7 +53,7 @@ import SignupCart from 'calypso/lib/signup/cart';
 import flows from 'calypso/signup/config/flows';
 import steps, { isDomainStepSkippable } from 'calypso/signup/config/steps';
 import { fetchSitesAndUser } from 'calypso/lib/signup/step-actions/fetch-sites-and-user';
-import { isBlankCanvasDesign } from '@automattic/design-picker';
+import { getAvailableDesigns, isBlankCanvasDesign } from '@automattic/design-picker';
 
 /**
  * Constants
@@ -163,6 +163,14 @@ function getNewSiteParams( {
 	// when segment and vertical values are not sent. Check pbAok1-p2#comment-834.
 	const shouldUseDefaultAnnotationAsFallback = true;
 
+	let shouldEnableFse = selectedDesign?.is_fse;
+	if ( ! selectedDesign ) {
+		const designs = getAvailableDesigns();
+		const themeSlug = theme.replace( 'pub/', '' );
+		const design = designs.featured.find( ( { slug } ) => slug === themeSlug );
+		shouldEnableFse = design?.is_fse;
+	}
+
 	const newSiteParams = {
 		blog_title: siteTitle,
 		public: Visibility.PublicNotIndexed,
@@ -182,6 +190,7 @@ function getNewSiteParams( {
 			site_creation_flow: flowToCheck,
 			timezone_string: guessTimezone(),
 			wpcom_public_coming_soon: 1,
+			enable_fse: shouldEnableFse,
 		},
 		validate: false,
 	};

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -143,7 +143,6 @@ function getNewSiteParams( {
 	const siteStyle = getSiteStyle( state ).trim();
 	const siteSegment = getSiteTypePropertyValue( 'slug', siteType, 'id' );
 	const siteTypeTheme = getSiteTypePropertyValue( 'slug', siteType, 'theme' );
-	const selectedDesign = get( signupDependencies, 'selectedDesign', false );
 
 	const shouldSkipDomainStep = ! siteUrl && isDomainStepSkippable( flowToCheck );
 	const shouldHideFreePlan = get( getSignupDependencyStore( state ), 'shouldHideFreePlan', false );
@@ -163,16 +162,16 @@ function getNewSiteParams( {
 	// when segment and vertical values are not sent. Check pbAok1-p2#comment-834.
 	const shouldUseDefaultAnnotationAsFallback = true;
 
-	let shouldEnableFse = selectedDesign?.is_fse;
-	// If the user didn't select any design, then we make sure
-	// the default theme is used to determine the `shouldEnableFse`'s value.
+	// If the user didn't select any design, then we try
+	// to lookup the theme object based on the theme slug.
+	let selectedDesign = get( signupDependencies, 'selectedDesign', false );
 	if ( ! selectedDesign ) {
 		const designs = getAvailableDesigns();
 		const themeSlug = theme.replace( 'pub/', '' ).replace( 'premium/', '' );
-		const design = designs.featured.find( ( { slug } ) => slug === themeSlug );
-		shouldEnableFse = design?.is_fse;
+		selectedDesign = designs.featured.find( ( { slug } ) => slug === themeSlug );
 	}
 
+	const shouldEnableFse = selectedDesign?.is_fse;
 	const newSiteParams = {
 		blog_title: siteTitle,
 		public: Visibility.PublicNotIndexed,
@@ -224,7 +223,6 @@ function getNewSiteParams( {
 	}
 
 	if ( selectedDesign ) {
-		// If there's a selected design, it means that the current flow contains the "design" step.
 		newSiteParams.options.theme = `pub/${ selectedDesign.theme }`;
 		newSiteParams.options.template = selectedDesign.template;
 		newSiteParams.options.use_patterns = true;

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -3,6 +3,10 @@
  */
 import debugFactory from 'debug';
 import { defer, difference, get, includes, isEmpty, pick, startsWith } from 'lodash';
+import { getUrlParts } from '@automattic/calypso-url';
+import { Site } from '@automattic/data-stores';
+import { getAvailableDesigns, isBlankCanvasDesign } from '@automattic/design-picker';
+import config from '@automattic/calypso-config';
 
 /**
  * Internal dependencies
@@ -18,7 +22,6 @@ import {
 	supportsPrivacyProtectionPurchase,
 	planItem as getCartItemForPlan,
 } from 'calypso/lib/cart-values/cart-items';
-import { getUrlParts } from '@automattic/calypso-url';
 
 // State actions and selectors
 import { getCurrentUserName, isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -40,26 +43,22 @@ import {
 	getNuxUrlInputValue,
 } from 'calypso/state/importer-nux/temp-selectors';
 import { getSiteId } from 'calypso/state/sites/selectors';
-import { Site } from '@automattic/data-stores';
-const Visibility = Site.Visibility;
 
 // Current directory dependencies
 import { isValidLandingPageVertical } from 'calypso/lib/signup/verticals';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
-
 import SignupCart from 'calypso/lib/signup/cart';
 
 // Others
 import flows from 'calypso/signup/config/flows';
 import steps, { isDomainStepSkippable } from 'calypso/signup/config/steps';
 import { fetchSitesAndUser } from 'calypso/lib/signup/step-actions/fetch-sites-and-user';
-import { getAvailableDesigns, isBlankCanvasDesign } from '@automattic/design-picker';
-import config from '@automattic/calypso-config';
 
 /**
  * Constants
  */
 const debug = debugFactory( 'calypso:signup:step-actions' );
+const Visibility = Site.Visibility;
 
 export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 	const { siteId, siteSlug } = data;

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -5,7 +5,8 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import DesignPicker from '@automattic/design-picker';
+import DesignPicker, { getAvailableDesigns } from '@automattic/design-picker';
+import config from '@automattic/calypso-config';
 
 /**
  * Internal dependencies
@@ -51,8 +52,24 @@ class DesignPickerStep extends Component {
 	};
 
 	renderDesignPicker() {
+		const designs = getAvailableDesigns( {
+			includeAlphaDesigns: false,
+			useFseDesigns: config.isEnabled( 'signup/core-site-editor' ),
+			randomize: false,
+		} ).featured.filter(
+			// By default, exclude anchorfm-specific designs
+			( design ) => design.features.findIndex( ( f ) => f === 'anchorfm' ) < 0
+		);
+
 		// props.locale obtained via `localize` HoC
-		return <DesignPicker theme="dark" locale={ this.props.locale } onSelect={ this.pickDesign } />;
+		return (
+			<DesignPicker
+				theme="dark"
+				locale={ this.props.locale }
+				onSelect={ this.pickDesign }
+				designs={ designs }
+			/>
+		);
 	}
 
 	headerText() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Set the `enable_fse` flag for the create site request based on the selected theme
* Change the default theme to `blockbase` when `signup/core-site-editor` flag is set.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test default theme**

1. Start dev Calypso
2. Open "http://calypso.localhost:3000/start/with-design-picker?flags=signup/core-site-editor"
3. Choose a domain, choose a plan
4. At the theme select step, click on "Skip for now"
5. Your site should be created now. Make sure your site's theme is `blockbase`
6. Make sure `core-site-editor-enabled` and `gutenberg-edge` block stickers are applied

**Test with a selected design**

1. Start dev Calypso
2. Open "http://calypso.localhost:3000/start/with-design-picker?flags=signup/core-site-editor"
3. Choose a domain, choose a plan
4. At the theme select step, choose any theme other than `blockbase`
5. Your site should be created now. Make sure your site's theme is correctly set to the theme you selected.
6. Make sure `core-site-editor-enabled` and `gutenberg-edge` block stickers are applied

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/52744
