### PR TITLE
Fix the reset button to reset the TLD filter

### DIFF
--- a/client/components/domains/search-filters/dropdown-filters.jsx
+++ b/client/components/domains/search-filters/dropdown-filters.jsx
@@ -120,7 +120,7 @@ export class DropdownFilters extends Component {
 	handleFiltersReset = () => {
 		this.setState( { showOverallValidationError: false }, () => {
 			this.togglePopover( { discardChanges: false } );
-			this.props.onReset( 'includeDashes', 'maxCharacters', 'exactSldMatchesOnly' );
+			this.props.onReset( 'tlds', 'includeDashes', 'maxCharacters', 'exactSldMatchesOnly' );
 		} );
 	};
 	handleFiltersSubmit = () => {


### PR DESCRIPTION
Recently I deployed #52874 but didn't notice that the Reset button is not resetting the Extensions filter. Here's a fix for that

#### Changes proposed in this Pull Request

* Fix the Reset button action to reset the `tlds` filter too

<img width="1081" alt="Screenshot 2021-05-19 at 18 52 18" src="https://user-images.githubusercontent.com/1355045/118844268-80983100-b8d3-11eb-8601-f87245d989f0.png">

#### Testing instructions

* Without this PR if you apply some Extensions filter and click on the Reset button it won't reset the TLD filter. With this PR the Reset button should reset the TLD filter too.
