### PR TITLE
Themes: Remove blank menu item in popover menu for theme cards

### DIFF
--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -15,7 +15,6 @@ import {
 	tryAndCustomize as tryAndCustomizeAction,
 	confirmDelete,
 	showThemePreview as themePreview,
-	showAutoLoadingHomepageWarning as showAutoLoadingHomepageWarningAction,
 } from 'calypso/state/themes/actions';
 import {
 	getJetpackUpgradeUrlIfPremiumTheme,
@@ -145,10 +144,6 @@ function getAllThemeOptions() {
 		action: themePreview,
 	};
 
-	const showAutoLoadingHomepageWarning = {
-		action: showAutoLoadingHomepageWarningAction,
-	};
-
 	const signupLabel = translate( 'Pick this design', {
 		comment: 'when signing up for a WordPress.com account with a selected theme',
 	} );
@@ -197,7 +192,6 @@ function getAllThemeOptions() {
 		info,
 		support,
 		help,
-		showAutoLoadingHomepageWarning,
 	};
 }
 export const connectOptions = connect(


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/10274366/119681606-34d41300-be10-11eb-87a3-8772f41e819e.png) | ![image](https://user-images.githubusercontent.com/10274366/119680702-6d272180-be0f-11eb-963c-98e1fb6397dd.png) |

Removes this [blank menu item](https://d.pr/v/adaYsx).

The blank menu item dispatches the `showAutoLoadingHomepageWarning` action, but this is the same action that the ["activate" button dispatches](https://github.com/Automattic/wp-calypso/blob/3c990841748ed80ca1de8663b6cf0cebf2346a27/client/state/themes/actions/activate.js#L48). Since they're both part of the same menu, this leads me to believe that the blank menu item is a duplicate and can be removed.

While the blank menu item does create the "showAutoLoadingHomepage" modal, it looks like the "activate" button does this as well, so it seems like we don't need the blank menu item. Note that both buttons have [very similar functionality](https://user-images.githubusercontent.com/10274366/118847112-66daf780-b89b-11eb-929b-21d28c139ec3.png).

Related to #42052

retrofox has already reviewed/tested, but I'm just noting my thoughts here, now that I've done my due diligence, to show what I've tested as well.

### Testing Notes

The "theme-options" component is used in many places. I personally did a thorough review to determine that the only place which uses this showAutoLoadingHomepageWarning option from that theme-options component is the menu shown above. Admittedly, searching for usage of this option is a part of the QA process for this pull request, so you will either need to take my investigation for granted or repeat this large effort (which took me one whole day).

Assuming we take that investigation for granted, then all we need to do is look at the popover menu in each place that it is used.

### Testing Instructions

1. Check the theme showcase for:
- A simple site
- An atomic site
- A non-atomic site, connected via jetpack

Be sure to check the recommended and advanced theme sections separately.

Expected Behavior: All the previously existing menu options (aside from the blank one) should still exist, and should function like they did before.

2. When activating a theme on a simple site, check that the autoloading warning modal shows, both from the theme showcase and from the single theme page.


