### PR TITLE
Domain picker recommended badge: adjust padding according to screensize

### DIFF
--- a/packages/domain-picker/src/components/style.scss
+++ b/packages/domain-picker/src/components/style.scss
@@ -314,7 +314,8 @@ $accent-blue: #117ac9;
 .domain-picker__badge {
 	display: inline-flex;
 	border-radius: 2px;
-	padding: 0 10px;
+	padding: 0 2%; // adjust according padding to screen size
+	white-space: nowrap;
 	line-height: 20px;
 	height: 20px;
 	align-items: center;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

1. It adjusts the horizontal padding to 2% instead of solid 10px. This helps things on mobile and doesn't change things much on desktop. Media queries may be a better solution, but I like the simplicity of this one more. So I'll ask @ollierozdarz for his OK on this fluid padding. 
2. Bans word-breaking for the badge.

### How to test
1. Go to [/new](https://calypso.live/new?branch=fix/recommended-badge-on-mobile).
2. Reach the domain picker
3. Simulate smaller screen using DevTools. Things should look good from 300px wide and above.

Fixes https://github.com/Automattic/wp-calypso/issues/50578
