### PR TITLE
Standardize page view tracks events for pricing page

### DIFF
--- a/client/my-sites/plans/jetpack-plans/get-view-tracker-path.ts
+++ b/client/my-sites/plans/jetpack-plans/get-view-tracker-path.ts
@@ -1,0 +1,14 @@
+const sitePattern = /\/:site\??/;
+const siteSegment = '/:site';
+
+export default function getViewTrackerPath( path: string, siteId?: number | null ): string {
+	if ( siteId ) {
+		if ( ! path.match( sitePattern ) ) {
+			return path + siteSegment;
+		}
+
+		return path.replace( sitePattern, siteSegment );
+	}
+
+	return path.replace( sitePattern, '' );
+}

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -22,6 +22,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySites from 'calypso/components/data/query-sites';
 import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import getViewTrackerPath from './get-view-tracker-path';
 import ProductGrid from './product-grid';
 
 /**
@@ -143,7 +144,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 		setDuration( selectedDuration );
 	};
 
-	const viewTrackerPath = siteId ? `${ rootUrl }/:site` : rootUrl;
+	const viewTrackerPath = getViewTrackerPath( rootUrl, siteId );
 	const viewTrackerProps = siteId ? { site: siteSlug } : {};
 
 	return (

--- a/client/my-sites/plans/jetpack-plans/test/get-view-tracker-path.js
+++ b/client/my-sites/plans/jetpack-plans/test/get-view-tracker-path.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import getViewTrackerPath from '../get-view-tracker-path';
+
+const path = '/pricing';
+const siteSegment = ':site';
+const siteId = 1;
+
+describe( 'getViewTrackerPath', () => {
+	it( 'should return the path with the site segment if the site id is passed', () => {
+		expect( getViewTrackerPath( path, siteId ) ).toEqual( `${ path }/${ siteSegment }` );
+	} );
+
+	it( 'should return the path if it has the site segment and the site id is passed', () => {
+		expect( getViewTrackerPath( `${ path }/${ siteSegment }`, siteId ) ).toEqual(
+			`${ path }/${ siteSegment }`
+		);
+		expect( getViewTrackerPath( `${ path }/${ siteSegment }?`, siteId ) ).toEqual(
+			`${ path }/${ siteSegment }`
+		);
+	} );
+
+	it( 'should return the path without the site segment if no site id is passed', () => {
+		expect( getViewTrackerPath( path ) ).toEqual( path );
+		expect( getViewTrackerPath( `${ path }/${ siteSegment }` ) ).toEqual( path );
+		expect( getViewTrackerPath( `${ path }/${ siteSegment }?` ) ).toEqual( path );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request

A look at the analytics data is showing that the pricing page is triggering a page view event with a different `path` property depending on how it is accessed:
- Logged out user > `/pricing`
- Logged in user with no site in context > `/pricing/:site?`
- Logged in user with site in context > `/pricing/:site?/:site`

People not aware of this would get an inaccurate page view number.

This PR fixes it by sending the actual path along, i.e:
- Visiting `/pricing`, logged in or not > `/pricing`
- Visiting `/pricing/mysite.com` > `/pricing/:site`

Fixes 1164141197617539-as-1200355207187617

### Testing instructions

- Download the PR and run both Calypso and cloud
- Make sure you can see page view events in the console or network panel
- In cloud, visit `/pricing` and make sure the page view event is triggered with the value `path: "/pricing"`
- Then visit `/pricing/anysite.com` and make sure the page view event is triggered with the value `path: "/pricing/:site"`
- In Calypso, visit `/plans/anysite.com` and make sure the page view event is triggered with the value `path: "/plans/:site"`