### PR TITLE
Themes: Track atomic users who click the 'Upload Theme' button.

### DIFF
--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -20,7 +20,7 @@ import {
 	getSelectedSite,
 } from 'calypso/state/ui/selectors';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
+import { isJetpackSiteMultiSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { Button } from '@automattic/components';
 import { isATEnabled } from 'calypso/lib/automated-transfer';
 
@@ -44,11 +44,13 @@ function getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) {
 const InstallThemeButton = connectOptions(
 	( {
 		isMultisite,
+		jetpackSite,
 		isLoggedIn,
 		siteSlug,
 		dispatchTracksEvent,
 		canUploadThemesOrPlugins,
 		ATEnabled,
+		allMySites,
 	} ) => {
 		if ( ! isLoggedIn || isMultisite ) {
 			return null;
@@ -58,7 +60,9 @@ const InstallThemeButton = connectOptions(
 			trackClick( 'upload theme' );
 			dispatchTracksEvent( {
 				tracksEventProps: {
+					is_all_my_sites: allMySites,
 					is_atomic: ATEnabled,
+					is_jetpack_connected: jetpackSite,
 				},
 			} );
 		};
@@ -79,11 +83,13 @@ const mapStateToProps = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const selectedSite = getSelectedSite( state );
 	return {
+		allMySites: ! selectedSite,
 		siteSlug: getSelectedSiteSlug( state ),
 		isLoggedIn: isUserLoggedIn( state ),
 		isMultisite: isJetpackSiteMultiSite( state, selectedSiteId ),
+		jetpackSite: Boolean( isJetpackSite( state, selectedSiteId ) ),
 		canUploadThemesOrPlugins: siteCanUploadThemesOrPlugins( state, selectedSiteId ),
-		ATEnabled: isATEnabled( selectedSite ),
+		ATEnabled: Boolean( isATEnabled( selectedSite ) ),
 	};
 };
 

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -22,7 +22,7 @@ import {
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isJetpackSiteMultiSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { Button } from '@automattic/components';
-import { isATEnabled } from 'calypso/lib/automated-transfer';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 
 /**
  * Style dependencies
@@ -49,7 +49,7 @@ const InstallThemeButton = connectOptions(
 		siteSlug,
 		dispatchTracksEvent,
 		canUploadThemesOrPlugins,
-		ATEnabled,
+		atomicSite,
 		allMySites,
 	} ) => {
 		if ( ! isLoggedIn || isMultisite ) {
@@ -61,7 +61,7 @@ const InstallThemeButton = connectOptions(
 			dispatchTracksEvent( {
 				tracksEventProps: {
 					is_all_my_sites: allMySites,
-					is_atomic: ATEnabled,
+					is_atomic: atomicSite,
 					is_jetpack_connected: jetpackSite,
 				},
 			} );
@@ -89,7 +89,7 @@ const mapStateToProps = ( state ) => {
 		isMultisite: isJetpackSiteMultiSite( state, selectedSiteId ),
 		jetpackSite: Boolean( isJetpackSite( state, selectedSiteId ) ),
 		canUploadThemesOrPlugins: siteCanUploadThemesOrPlugins( state, selectedSiteId ),
-		ATEnabled: Boolean( isATEnabled( selectedSite ) ),
+		atomicSite: Boolean( isAtomicSite( selectedSite ) ),
 	};
 };
 


### PR DESCRIPTION
When a user clicks the "Install Theme" button, we should track if they did so from an atomic site.

#### Testing instructions

There are 4 ways to see the "install theme" button.
1. From a simple site's /themes page
2. From an atomic site's /themes page
3. From a self-hosted jetpack-connected site's /themes page
4. From the "all my sites" /themes page

Navigate to each of these 4, and click the "Install Theme" button.

Observe the events in mc tracks

Observe the following 3 properties for these events:
- **is_all_my_sites**: Was the user on the "All My Sites" page?
- **is_atomic**: Was the user on an atomic site?
- **is_jetpack_connected**: Was the user on a jetpack-connected site?

These properties should be appropriately set based on the page from which you clicked the "Install Theme" button.

Related to #52927
