### PR TITLE
Theme Showcase: Removed old nessie illustration from themes search

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -126,7 +126,6 @@ export class ThemesList extends React.Component {
 		return (
 			this.props.emptyContent || (
 				<EmptyContent
-					illustration="/calypso/images/illustrations/no-themes-drake.svg"
 					title={ this.props.translate( 'Sorry, no themes found.' ) }
 					line={ this.props.translate( 'Try a different search or more filters?' ) }
 				/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  Removed old nessie illustration from themes search

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/themes/[YOUR WP SITE]`
* Scroll down and press the Show All Themes button
* Search for a theme that doesn't exists
* You should not see an image of nessie.

##### Before
![image](https://user-images.githubusercontent.com/375980/118857210-2afd5d80-b8ae-11eb-8160-49e1274bdd7e.png)

##### After
![image](https://user-images.githubusercontent.com/375980/118857076-05705400-b8ae-11eb-8c86-c07b5d57e523.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #51290 
