### PR TITLE
Fix Jetpack plans URL duration parameter

### DIFF
--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -25,7 +25,7 @@ export default function (): void {
 			jetpackPlans( `/plans`, jetpackPricingContext );
 		}
 	} else {
-		jetpackPlans( `/pricing/:site?`, siteSelection, jetpackPricingContext );
+		jetpackPlans( `/pricing`, siteSelection, jetpackPricingContext );
 
 		if ( config.isEnabled( 'jetpack-cloud/connect' ) ) {
 			jetpackPlans( `/plans/:site?`, siteSelection, jetpackPricingContext );

--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -13,7 +13,7 @@ import SelectorPage from './selector';
 import getCurrentPlanTerm from 'calypso/state/selectors/get-current-plan-term';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { TERM_ANNUALLY } from '@automattic/calypso-products';
-import { getHighlightedProduct } from './utils';
+import { getHighlightedProduct, stringToDuration } from './utils';
 
 /**
  * Type dependencies
@@ -24,11 +24,9 @@ export const productSelect = ( rootUrl: string ): PageJS.Callback => ( context, 
 	// Get the selected site's current plan term, and set it as default duration
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
-	const duration: Duration =
-		( siteId && ( getCurrentPlanTerm( state, siteId ) as Duration ) ) ||
-		( TERM_ANNUALLY as Duration );
 	const urlQueryArgs: QueryArgs = context.query;
-	const { site } = getParamsFromContext( context );
+	const { site: siteParam, duration: durationParam } = getParamsFromContext( context );
+	const duration = siteId && ( getCurrentPlanTerm( state, siteId ) as Duration );
 	const planRecommendation = isEnabled( 'jetpack/redirect-legacy-plans' )
 		? getPlanRecommendationFromContext( context )
 		: undefined;
@@ -36,9 +34,9 @@ export const productSelect = ( rootUrl: string ): PageJS.Callback => ( context, 
 
 	context.primary = (
 		<SelectorPage
-			defaultDuration={ duration }
+			defaultDuration={ stringToDuration( durationParam ) || duration || TERM_ANNUALLY }
 			rootUrl={ rootUrl }
-			siteSlug={ site || context.query.site }
+			siteSlug={ siteParam || context.query.site }
 			urlQueryArgs={ urlQueryArgs }
 			highlightedProducts={ highlightedProducts }
 			header={ context.header }

--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -7,6 +7,7 @@ import { isEnabled } from '@automattic/calypso-config';
 /**
  * Internal dependencies
  */
+import getParamsFromContext from './get-params-from-context';
 import { getPlanRecommendationFromContext } from './plan-upgrade/utils';
 import SelectorPage from './selector';
 import getCurrentPlanTerm from 'calypso/state/selectors/get-current-plan-term';
@@ -27,17 +28,17 @@ export const productSelect = ( rootUrl: string ): PageJS.Callback => ( context, 
 		( siteId && ( getCurrentPlanTerm( state, siteId ) as Duration ) ) ||
 		( TERM_ANNUALLY as Duration );
 	const urlQueryArgs: QueryArgs = context.query;
+	const { site } = getParamsFromContext( context );
 	const planRecommendation = isEnabled( 'jetpack/redirect-legacy-plans' )
 		? getPlanRecommendationFromContext( context )
 		: undefined;
-
 	const highlightedProducts = getHighlightedProduct( urlQueryArgs.plan ) || undefined;
 
 	context.primary = (
 		<SelectorPage
 			defaultDuration={ duration }
 			rootUrl={ rootUrl }
-			siteSlug={ context.params.site || context.query.site }
+			siteSlug={ site || context.query.site }
 			urlQueryArgs={ urlQueryArgs }
 			highlightedProducts={ highlightedProducts }
 			header={ context.header }

--- a/client/my-sites/plans/jetpack-plans/get-params-from-context.ts
+++ b/client/my-sites/plans/jetpack-plans/get-params-from-context.ts
@@ -1,0 +1,41 @@
+/* eslint-disable jsdoc/no-undefined-types */
+
+/**
+ * Internal dependencies
+ */
+
+/**
+ * Type dependencies
+ */
+import { Duration } from './types';
+
+type Params = {
+	duration: Duration | undefined;
+	site: string | undefined;
+};
+
+/**
+ * Retrieves the values of the `duration` and `site` parameters passed in the
+ * URL, in the context of the Jetpack plans/pricing page.
+ *
+ * @example
+ * /pricing                    > { duration: undefined, site: undefined }
+ * /pricing/annual             > { duration: 'annual', site: undefined }
+ * /pricing/monthly            > { duration: 'monthly', site: undefined }
+ * /pricing/example.com        > { duration: undefined, site: 'example.com' }
+ * /pricing/annual/example.com > { duration: 'annual', site: 'example.com' }
+ * /pricing/weekly/example.com > { duration: undefined, site: 'example.com' }
+ *
+ * @param {PageJS.Context} context Page context
+ * @returns {Params} Parameters
+ */
+export default function getParamsFromContext( { params }: PageJS.Context ): Params {
+	const { duration: rawDuration, site: rawSite } = params;
+	const duration = [ 'annual', 'monthly' ].includes( rawDuration ) ? rawDuration : undefined;
+	const site = ( rawSite || ( duration ? undefined : rawDuration ) ) ?? undefined;
+
+	return {
+		duration,
+		site,
+	};
+}

--- a/client/my-sites/plans/jetpack-plans/test/get-params-from-context.js
+++ b/client/my-sites/plans/jetpack-plans/test/get-params-from-context.js
@@ -1,0 +1,80 @@
+/**
+ * Internal dependencies
+ */
+import getParamsFromContext from '../get-params-from-context';
+
+const annualDuration = 'annual';
+const monthlyDuration = 'monthly';
+const site = 'example.com';
+
+describe( 'getParamsFromContext', () => {
+	it( 'should return undefined values if no parameter is set', () => {
+		const context = {
+			params: {},
+		};
+
+		expect( getParamsFromContext( context ) ).toEqual( {
+			duration: undefined,
+			site: undefined,
+		} );
+	} );
+
+	it( 'should return the duration if the parameter is valid', () => {
+		const context = {
+			params: {
+				duration: annualDuration,
+			},
+		};
+
+		expect( getParamsFromContext( context ) ).toHaveProperty( 'duration', annualDuration );
+
+		context.params.duration = monthlyDuration;
+
+		expect( getParamsFromContext( context ) ).toHaveProperty( 'duration', monthlyDuration );
+	} );
+
+	it( 'should return an undefined duration if the parameter is invalid', () => {
+		const context = {
+			params: {
+				duration: 'abc',
+			},
+		};
+
+		expect( getParamsFromContext( context ) ).toHaveProperty( 'duration', undefined );
+	} );
+
+	it( 'should return an undefined site if the parameter is not set', () => {
+		const context = {
+			params: {
+				duration: annualDuration,
+			},
+		};
+
+		expect( getParamsFromContext( context ) ).toHaveProperty( 'site', undefined );
+	} );
+
+	it( 'should return the site if the parameter is set', () => {
+		const context = {
+			params: {
+				duration: annualDuration,
+				site,
+			},
+		};
+
+		expect( getParamsFromContext( context ) ).toHaveProperty( 'site', site );
+
+		context.params.duration = 'abc';
+
+		expect( getParamsFromContext( context ) ).toHaveProperty( 'site', site );
+	} );
+
+	it( 'should return the site if the parameter is not set but the duration parameter is invalid', () => {
+		const context = {
+			params: {
+				duration: site,
+			},
+		};
+
+		expect( getParamsFromContext( context ) ).toHaveProperty( 'site', site );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR removes a redundant `:site` parameter when defining the route for the pricing page, which makes the code more predictable and easier to update.

It also takes advantage of this to make the duration parameter actually change the displayed term in the cloud pricing page, and the Jetpack connect page.

### Implementation notes

It used to call the function `jetpackPlans` with the argument `/pricing/:site`, while the `duration` and `site` parameters were already defined in the function body.

`jetpackPlans` is now called with `/pricing` as its first argument. To make sure `duration` and `site` are assigned the proper values, we've introduced the `getParamsFromContext` function.

### Testing instructions

#### Prerequisites

- Download this PR and run Calypso and cloud
- Make sure you have a Jetpack site with a plan on a monthly term
- Make sure you're authenticated to wordpress.com

#### Cloud

- Visit `/pricing`, and check that the yearly prices are shown
- Visit `/pricing/monthly`, and check that the monthly prices are shown
- Visit `/pricing/:site`, check that the monthly prices are shown, and your product is selected
- Visit `/pricing/annual/:site`, check that the yearly prices are shown, and your product is selected
- Visit `/pricing/monthly/:site`, check that the monthly prices are shown, and your product is selected

#### Calypso (plans)

- Visit `/plans/:site`, check that the monthly prices are shown, and your product is selected

#### Calypso (Jetpack connect)

- Visit `/jetpack/connect/store`, check that the monthly prices are shown, and your product is selected
- Visit `/jetpack/connect/store/annual`, check that the yearly prices are shown, and your product is selected
- Visit `/jetpack/connect/store/:site`, check that the monthly prices are shown, and your product is selected
- Visit `/jetpack/connect/store/annual/:site`, check that the yearly prices are shown, and your product is selected
- Visit `/jetpack/connect/store/weekly/:site`, check that the monthly prices are shown, and your product is selected
