### PR TITLE
Add tracking event for pricing page visits

### DIFF
--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -56,6 +56,10 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
 
 	useEffect( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_pricing_page_visit', { site: siteSlug } ) );
+	}, [ dispatch, siteSlug ] );
+
+	useEffect( () => {
 		setDuration( defaultDuration );
 	}, [ defaultDuration ] );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds a tracking event that's triggered when a visit is made to the plans/pricing page. This will make data analysis easier.

Fixes 1196108640073826-as-1200353586548861

### Testing instructions

- Download the PR and run both Calypso and cloud
- Make sure you can see page view events in the console or network panel
- In cloud, visit `/pricing` and make sure the event `calypso_jetpack_pricing_page_visit` is triggered with an empty `site` property
- Then visit `/pricing/:site` and make sure the same event is triggered with the site slug as the `site` value
- In Calypso, visit `/plans/:site` and make sure the same event is triggered with the site slug as the `site` value
- Still in Calypso, select another site and check that the event is triggered again