### PR TITLE
Jetpack Backup: fix progress bar initialization message

### DIFF
--- a/client/my-sites/backup/rewind-flow/download.tsx
+++ b/client/my-sites/backup/rewind-flow/download.tsx
@@ -141,7 +141,11 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 			<h3 className="rewind-flow__title">
 				{ translate( 'Currently creating a downloadable backup of your site' ) }
 			</h3>
-			<ProgressBar percent={ percent } />
+			<ProgressBar
+				isReady={ ! isDownloadURLNotReady }
+				percent={ percent }
+				initializationMessage={ translate( 'Initializing the download process' ) }
+			/>
 			<p className="rewind-flow__info">
 				{ translate(
 					"We're creating a downloadable backup of your site from {{strong}}%(backupDisplayDate)s{{/strong}}.",

--- a/client/my-sites/backup/rewind-flow/progress-bar.tsx
+++ b/client/my-sites/backup/rewind-flow/progress-bar.tsx
@@ -9,9 +9,15 @@ import React, { FunctionComponent } from 'react';
  */
 import { ProgressBar } from '@automattic/components';
 
+/**
+ * Type dependencies
+ */
+import type { TranslateResult } from 'i18n-calypso';
+
 interface Props {
 	isReady: boolean;
 	percent: number | null;
+	initializationMessage: TranslateResult;
 	message?: string;
 	entry?: string;
 }
@@ -19,6 +25,7 @@ interface Props {
 const RewindFlowProgressBar: FunctionComponent< Props > = ( {
 	isReady,
 	percent,
+	initializationMessage,
 	message,
 	entry,
 } ) => {
@@ -29,7 +36,7 @@ const RewindFlowProgressBar: FunctionComponent< Props > = ( {
 		<div className="rewind-flow__progress-bar">
 			<div className="rewind-flow__progress-bar-header">
 				<p className="rewind-flow__progress-bar-message">
-					{ isReady ? message : translate( 'Initializing the restore process' ) }
+					{ isReady ? message : initializationMessage }
 				</p>
 				<p className="rewind-flow__progress-bar-percent">
 					{ translate( '%(filteredPercent)d%% complete', { args: { filteredPercent } } ) }

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -117,6 +117,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			<h3 className="rewind-flow__title">{ translate( 'Currently restoring your site' ) }</h3>
 			<ProgressBar
 				isReady={ 'running' === status }
+				initializationMessage={ translate( 'Initializing the restore process' ) }
 				message={ message }
 				entry={ currentEntry }
 				percent={ percent }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* During a backup download, show `'Initializing the download process'` rather than `'Initializing the restore process'`.
* Add `initializationMessage` prop to let the parent component pass down the right message.

#### Testing instructions

Prerequisites:
* Jetpack site with Jetpack Backup (any flavor works).

* Download this PR.
* Start Calypso Green with `yarn start-jetpack-cloud`. 
* Visit `http://jetpack.cloud.localhost:3000/backup/[site]/`.
* Download the latest backup.
* Make sure that during the download process, you see the `'Initializing the download process'` right above the progress bar.
* Go back to `http://jetpack.cloud.localhost:3000/backup/[site]/`.
* Restore your site to your latest backup.
* Make sure that during the restore process, you see the `'Initializing the restore process'` right above the progress bar. 

#### Demo

##### Download process
https://user-images.githubusercontent.com/3418513/118877463-7ae32100-b8bc-11eb-8641-93a1eab7326a.mp4

![image](https://user-images.githubusercontent.com/3418513/119008037-c995c700-b95f-11eb-9f0d-90d52d0fd925.png)

##### Restore process
https://user-images.githubusercontent.com/3418513/118877476-7fa7d500-b8bc-11eb-9665-7e034a1291a8.mp4



Related to 1164141197617539-as-1200285990520787