### PR TITLE
Add Google mailbox warnings to email plan page

### DIFF
--- a/client/lib/emails/email-provider-constants.js
+++ b/client/lib/emails/email-provider-constants.js
@@ -1,9 +1,12 @@
 export const EMAIL_ACCOUNT_TYPE_FORWARD = 'email_forwarding';
+export const EMAIL_ACCOUNT_TYPE_GOOGLE_WORKSPACE = 'google_workspace';
+export const EMAIL_ACCOUNT_TYPE_GSUITE = 'google_gsuite';
 export const EMAIL_ACCOUNT_TYPE_TITAN_MAIL = 'titan';
 export const EMAIL_ACCOUNT_TYPE_TITAN_MAIL_EXTERNAL = 'titan_external';
 export const EMAIL_TYPE_FORWARD = 'email_forward';
 export const EMAIL_USER_ROLE_ADMIN = 'admin';
 export const EMAIL_WARNING_SLUG_GOOGLE_ACCOUNT_TOS = 'google_pending_tos_acceptance';
+export const EMAIL_WARNING_SLUG_GOOGLE_MAILBOX_TOS = 'google_user_not_agreed_to_terms';
 export const EMAIL_WARNING_SLUG_UNUSED_MAILBOXES = 'unused_mailboxes';
 export const EMAIL_WARNING_SLUG_UNVERIFIED_FORWARDS = 'unverified_forwards';
 export const EMAIL_WARNING_TYPE_ACTION_REQUIRED = 'action_required';

--- a/client/lib/emails/index.js
+++ b/client/lib/emails/index.js
@@ -3,6 +3,8 @@ export { hasGoogleAccountTOSWarning } from './has-google-account-t-o-s-warning';
 export { hasUnusedMailboxWarning } from './has-unused-mailbox-warning';
 export { hasUnverifiedEmailForward } from './has-unverified-email-forward';
 export { isEmailForward } from './is-email-forward';
+export { isEmailForwardAccount } from './is-email-forward-account';
 export { isEmailForwardVerified } from './is-email-forward-verified';
 export { isEmailUserAdmin } from './is-email-user-admin';
+export { isGoogleEmailAccount } from './is-google-email-account';
 export { isTitanMailAccount } from './is-titan-mail-account';

--- a/client/lib/emails/is-email-forward-account.js
+++ b/client/lib/emails/is-email-forward-account.js
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { EMAIL_ACCOUNT_TYPE_FORWARD } from './email-provider-constants';
+
+export function isEmailForwardAccount( emailAccount ) {
+	return emailAccount?.account_type === EMAIL_ACCOUNT_TYPE_FORWARD;
+}

--- a/client/lib/emails/is-google-email-account.js
+++ b/client/lib/emails/is-google-email-account.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import {
+	EMAIL_ACCOUNT_TYPE_GOOGLE_WORKSPACE,
+	EMAIL_ACCOUNT_TYPE_GSUITE,
+} from './email-provider-constants';
+
+export function isGoogleEmailAccount( emailAccount ) {
+	return [ EMAIL_ACCOUNT_TYPE_GOOGLE_WORKSPACE, EMAIL_ACCOUNT_TYPE_GSUITE ].includes(
+		emailAccount?.account_type
+	);
+}

--- a/client/lib/gsuite/get-services-urls.js
+++ b/client/lib/gsuite/get-services-urls.js
@@ -47,6 +47,21 @@ export function getGoogleAdminUrl( emailOrDomain ) {
 }
 
 /**
+ * Generates an url pointing to Google Admin and its Reseller ToS page for the specified user.
+ *
+ * @param {string} email - email address
+ * @param {string} domainName - domain name
+ * @returns {string} - the corresponding url
+ */
+export function getGoogleAdminWithTosUrl( email, domainName ) {
+	return getAccountChooserUrl(
+		email,
+		'CPanel',
+		`https://admin.google.com/${ domainName }/AcceptTermsOfService`
+	);
+}
+
+/**
  * Generates an url pointing to Google Calendar.
  *
  * @param {string} emailOrDomain - email or domain name

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -5,6 +5,7 @@ export { getEligibleGSuiteDomain } from './get-eligible-gsuite-domain';
 export {
 	getGmailUrl,
 	getGoogleAdminUrl,
+	getGoogleAdminWithTosUrl,
 	getGoogleCalendarUrl,
 	getGoogleDocsUrl,
 	getGoogleDriveUrl,

--- a/client/my-sites/email/email-management/home/email-mailbox-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-warnings.jsx
@@ -26,11 +26,11 @@ import { isEmailForwardAccount } from 'calypso/lib/emails/is-email-forward-accou
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { resendVerificationEmail } from 'calypso/state/email-forwarding/actions';
 
-const MailboxListItemWarning = ( { warningText } ) => {
+const EmailMailboxWarningText = ( { text } ) => {
 	return (
 		<div className="email-mailbox-warnings__warning">
 			<Gridicon icon="info-outline" size={ 18 } />
-			<span>{ warningText }</span>
+			<span>{ text }</span>
 		</div>
 	);
 };
@@ -114,15 +114,11 @@ const getDetailsForWarning = ( { account, dispatch, mailbox, translate, warning 
 	return null;
 };
 
-const EmailMailboxWarning = ( { warningActionProps, warningText } ) => {
-	if ( ! warningActionProps ) {
-		return <MailboxListItemWarning warningText={ warningText } />;
-	}
-
+const EmailMailboxWarning = ( { actionProps, text } ) => {
 	return (
 		<>
-			<MailboxListItemWarning warningText={ warningText } />
-			{ warningActionProps && <MailboxListItemAction { ...warningActionProps } /> }
+			<EmailMailboxWarningText text={ text } />
+			{ actionProps && <EmailMailboxWarningAction { ...actionProps } /> }
 		</>
 	);
 };
@@ -150,8 +146,8 @@ const EmailMailboxWarnings = ( { account, mailbox } ) => {
 				return (
 					<EmailMailboxWarning
 						key={ warningKey }
-						warningActionProps={ warningDetails?.actionProps }
-						warningText={ warningDetails?.warningText }
+						actionProps={ warningDetails?.actionProps }
+						text={ warningDetails?.warningText }
 					/>
 				);
 			} ) }

--- a/client/my-sites/email/email-management/home/email-mailbox-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-warnings.jsx
@@ -17,10 +17,9 @@ import {
 import {
 	getEmailForwardAddress,
 	hasGoogleAccountTOSWarning,
-	isEmailUserAdmin,
 	isGoogleEmailAccount,
 } from 'calypso/lib/emails';
-import { getGmailUrl, getGoogleAdminWithTosUrl } from 'calypso/lib/gsuite';
+import { getGmailUrl } from 'calypso/lib/gsuite';
 import Gridicon from 'calypso/components/gridicon';
 import { isEmailForwardAccount } from 'calypso/lib/emails/is-email-forward-account';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -65,31 +64,17 @@ const getDetailsForWarning = ( { account, dispatch, mailbox, translate, warning 
 	const warningSlug = warning.warning_slug;
 
 	if ( isGoogleEmailAccount( account ) ) {
+		// If we need the account-level ToS agreed to, just show a pending message and no CTA.
+		if ( hasGoogleAccountTOSWarning( account ) ) {
+			return {
+				warningText: translate( 'Pending' ),
+			};
+		}
+
 		if ( warningSlug === EMAIL_WARNING_SLUG_GOOGLE_MAILBOX_TOS ) {
 			const emailAddress = `${ mailbox.mailbox }@${ mailbox.domain }`;
 
-			// If the the account-level Terms of Service need to be accepted, only admins can fix that
-			// issue, so ensure that we show the correct link for those users.
-			// For non-admins, not much can be done until the account-level Terms have been accepted.
-			if ( hasGoogleAccountTOSWarning( account ) ) {
-				if ( ! isEmailUserAdmin( mailbox ) ) {
-					return {
-						warningText: translate( 'Action required' ),
-					};
-				}
-
-				return {
-					actionProps: {
-						buttonText: translate( 'Finish setup' ),
-						isExternal: true,
-						href: getGoogleAdminWithTosUrl( emailAddress, mailbox.domain ),
-						target: '_blank',
-					},
-					warningText: translate( 'Action required' ),
-				};
-			}
-
-			// If the account-level Terms of Service have been accepted, link to Gmail for the user.
+			// The account-level Terms of Service have been accepted, so link to Gmail for the user.
 			return {
 				actionProps: {
 					buttonText: translate( 'Finish setup' ),

--- a/client/my-sites/email/email-management/home/email-mailbox-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-warnings.jsx
@@ -1,17 +1,19 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { Button } from '@automattic/components';
 import PropTypes from 'prop-types';
+import React from 'react';
 import { useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import Gridicon from 'calypso/components/gridicon';
-import { resendVerificationEmail } from 'calypso/state/email-forwarding/actions';
+import {
+	EMAIL_WARNING_SLUG_GOOGLE_MAILBOX_TOS,
+	EMAIL_WARNING_SLUG_UNVERIFIED_FORWARD,
+} from 'calypso/lib/emails/email-provider-constants';
 import {
 	getEmailForwardAddress,
 	hasGoogleAccountTOSWarning,
@@ -19,12 +21,10 @@ import {
 	isGoogleEmailAccount,
 } from 'calypso/lib/emails';
 import { getGoogleAdminUrl } from 'calypso/lib/gsuite';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import {
-	EMAIL_WARNING_SLUG_GOOGLE_MAILBOX_TOS,
-	EMAIL_WARNING_SLUG_UNVERIFIED_FORWARD,
-} from 'calypso/lib/emails/email-provider-constants';
+import Gridicon from 'calypso/components/gridicon';
 import { isEmailForwardAccount } from 'calypso/lib/emails/is-email-forward-account';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { resendVerificationEmail } from 'calypso/state/email-forwarding/actions';
 
 const MailboxListItemWarning = ( { warningText } ) => {
 	return (

--- a/client/my-sites/email/email-management/home/email-mailbox-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-warnings.jsx
@@ -1,0 +1,167 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Button } from '@automattic/components';
+import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'calypso/components/gridicon';
+import { resendVerificationEmail } from 'calypso/state/email-forwarding/actions';
+import {
+	getEmailForwardAddress,
+	hasGoogleAccountTOSWarning,
+	isEmailUserAdmin,
+	isGoogleEmailAccount,
+} from 'calypso/lib/emails';
+import { getGoogleAdminUrl } from 'calypso/lib/gsuite';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import {
+	EMAIL_WARNING_SLUG_GOOGLE_MAILBOX_TOS,
+	EMAIL_WARNING_SLUG_UNVERIFIED_FORWARD,
+} from 'calypso/lib/emails/email-provider-constants';
+import { isEmailForwardAccount } from 'calypso/lib/emails/is-email-forward-account';
+
+const MailboxListItemWarning = ( { warningText } ) => {
+	return (
+		<div className="email-mailbox-warnings__warning">
+			<Gridicon icon="info-outline" size={ 18 } />
+			<span>{ warningText }</span>
+		</div>
+	);
+};
+
+const MailboxListItemAction = ( { buttonText, external, ...otherProps } ) => {
+	return (
+		<div className="email-mailbox-warnings__action">
+			<Button compact { ...otherProps }>
+				<span>{ buttonText }</span>
+				{ external && <Gridicon icon="external" /> }
+			</Button>
+		</div>
+	);
+};
+
+const resendEmailForwardVerification = ( mailbox, dispatch ) => {
+	const destination = getEmailForwardAddress( mailbox );
+	dispatch(
+		recordTracksEvent(
+			'calypso_email_management_email_forwarding_resend_verification_email_click',
+			{
+				destination,
+				domain_name: mailbox.domain,
+				mailbox: mailbox.mailbox,
+			}
+		)
+	);
+	dispatch( resendVerificationEmail( mailbox.domain, mailbox.mailbox, destination ) );
+};
+
+const getDetailsForWarning = ( { account, dispatch, mailbox, translate, warning } ) => {
+	const warningSlug = warning.warning_slug;
+
+	if ( isGoogleEmailAccount( account ) ) {
+		if ( warningSlug === EMAIL_WARNING_SLUG_GOOGLE_MAILBOX_TOS ) {
+			const finishSetupForGoogle = {
+				actionProps: {
+					buttonText: translate( 'Finish setup' ),
+					external: true,
+					href: getGoogleAdminUrl( mailbox.domain ),
+					target: '_blank',
+				},
+				warningText: translate( 'Action required' ),
+			};
+
+			if ( isEmailUserAdmin( mailbox ) ) {
+				return finishSetupForGoogle;
+			}
+
+			// For non-admin users we disable the button if the account has been suspended
+			// due to not accepting the account ToS.
+			const googleAccountSuspendedDueToTOS = hasGoogleAccountTOSWarning( account );
+
+			return {
+				actionProps: {
+					...finishSetupForGoogle.actionProps,
+					disabled: googleAccountSuspendedDueToTOS,
+					href: googleAccountSuspendedDueToTOS ? null : finishSetupForGoogle.actionProps.href,
+				},
+				warningText: finishSetupForGoogle.warningText,
+			};
+		}
+
+		return null;
+	}
+
+	if ( isEmailForwardAccount( account ) ) {
+		if ( warningSlug === EMAIL_WARNING_SLUG_UNVERIFIED_FORWARD ) {
+			return {
+				actionProps: {
+					buttonText: translate( 'Resend verification email' ),
+					onClick: () => resendEmailForwardVerification( mailbox, dispatch ),
+				},
+				warningText: translate( 'Verification required' ),
+			};
+		}
+
+		return null;
+	}
+
+	return null;
+};
+
+const EmailMailboxWarning = ( { warningActionProps, warningText } ) => {
+	if ( ! warningActionProps ) {
+		return <MailboxListItemWarning warningText={ warningText } />;
+	}
+
+	return (
+		<>
+			<MailboxListItemWarning warningText={ warningText } />
+			{ warningActionProps && <MailboxListItemAction { ...warningActionProps } /> }
+		</>
+	);
+};
+
+const EmailMailboxWarnings = ( { account, mailbox } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	if ( ! mailbox?.warnings?.length ) {
+		return null;
+	}
+
+	return (
+		<>
+			{ mailbox.warnings.map( ( warning, index ) => {
+				const warningKey = `${ mailbox.mailbox }@${ mailbox.domain }-${ warning.warning_slug }-${ index }`;
+				const warningDetails = getDetailsForWarning( {
+					account,
+					dispatch,
+					mailbox,
+					translate,
+					warning,
+				} );
+
+				return (
+					<EmailMailboxWarning
+						key={ warningKey }
+						warningActionProps={ warningDetails?.actionProps }
+						warningText={ warningDetails?.warningText }
+					/>
+				);
+			} ) }
+		</>
+	);
+};
+
+EmailMailboxWarnings.propTypes = {
+	account: PropTypes.object.isRequired,
+	mailbox: PropTypes.object.isRequired,
+};
+
+export default EmailMailboxWarnings;

--- a/client/my-sites/email/email-management/home/email-mailbox-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-warnings.jsx
@@ -35,12 +35,12 @@ const MailboxListItemWarning = ( { warningText } ) => {
 	);
 };
 
-const MailboxListItemAction = ( { buttonText, external, ...otherProps } ) => {
+const EmailMailboxWarningAction = ( { buttonText, isExternal, ...otherProps } ) => {
 	return (
 		<div className="email-mailbox-warnings__action">
 			<Button compact { ...otherProps }>
 				<span>{ buttonText }</span>
-				{ external && <Gridicon icon="external" /> }
+				{ isExternal && <Gridicon icon="external" /> }
 			</Button>
 		</div>
 	);
@@ -69,7 +69,7 @@ const getDetailsForWarning = ( { account, dispatch, mailbox, translate, warning 
 			const finishSetupForGoogle = {
 				actionProps: {
 					buttonText: translate( 'Finish setup' ),
-					external: true,
+					isExternal: true,
 					href: getGoogleAdminUrl( mailbox.domain ),
 					target: '_blank',
 				},

--- a/client/my-sites/email/email-management/home/email-mailbox-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-warnings.jsx
@@ -12,7 +12,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import {
 	EMAIL_WARNING_SLUG_GOOGLE_MAILBOX_TOS,
-	EMAIL_WARNING_SLUG_UNVERIFIED_FORWARD,
+	EMAIL_WARNING_SLUG_UNVERIFIED_FORWARDS,
 } from 'calypso/lib/emails/email-provider-constants';
 import {
 	getEmailForwardAddress,
@@ -90,7 +90,7 @@ const getDetailsForWarning = ( { account, dispatch, mailbox, translate, warning 
 	}
 
 	if ( isEmailForwardAccount( account ) ) {
-		if ( warningSlug === EMAIL_WARNING_SLUG_UNVERIFIED_FORWARD ) {
+		if ( warningSlug === EMAIL_WARNING_SLUG_UNVERIFIED_FORWARDS ) {
 			return {
 				actionProps: {
 					buttonText: translate( 'Resend verification email' ),

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -281,10 +281,10 @@ function EmailPlanMailboxesList( { account, domain, isLoadingEmails, mailboxes, 
 	}
 
 	const mailboxItems = mailboxes.map( ( mailbox ) => {
-		const mailboxHasWarnings = ( mailbox?.warnings?.length ?? 0 ) > 0;
+		const mailboxHasWarnings = Boolean( mailbox?.warnings?.length );
 
 		return (
-			<MailboxListItem key={ mailbox.mailbox } isError={ !! mailboxHasWarnings }>
+			<MailboxListItem key={ mailbox.mailbox } isError={ mailboxHasWarnings }>
 				<div className="email-plan-mailboxes-list__mailbox-list-item-main">
 					<div>
 						<MaterialIcon icon="email" />

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -255,15 +255,9 @@ const ActionMenu = ( { domain, mailbox, selectedSite } ) => {
 	);
 };
 
-function EmailPlanMailboxesList( {
-	account,
-	accountType,
-	domain,
-	isLoadingEmails,
-	mailboxes,
-	selectedSite,
-} ) {
+function EmailPlanMailboxesList( { account, domain, isLoadingEmails, mailboxes, selectedSite } ) {
 	const translate = useTranslate();
+	const accountType = account?.account_type;
 
 	if ( isLoadingEmails ) {
 		return (
@@ -318,7 +312,6 @@ function EmailPlanMailboxesList( {
 
 EmailPlanMailboxesList.propTypes = {
 	account: PropTypes.object,
-	accountType: PropTypes.string,
 	domain: PropTypes.object,
 	isLoadingEmails: PropTypes.bool,
 	mailboxes: PropTypes.array,

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -17,7 +17,12 @@ import EmailMailboxWarnings from 'calypso/my-sites/email/email-management/home/e
 import { EMAIL_ACCOUNT_TYPE_FORWARD } from 'calypso/lib/emails/email-provider-constants';
 import { emailManagementForwarding } from 'calypso/my-sites/email/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { getEmailForwardAddress, isEmailForward, isEmailUserAdmin } from 'calypso/lib/emails';
+import {
+	getEmailForwardAddress,
+	hasGoogleAccountTOSWarning,
+	isEmailForward,
+	isEmailUserAdmin,
+} from 'calypso/lib/emails';
 import {
 	getGmailUrl,
 	getGoogleAdminUrl,
@@ -144,7 +149,11 @@ const getTitanMenuItems = ( email, translate ) => {
 	];
 };
 
-const getGSuiteMenuItems = ( email, mailbox, translate ) => {
+const getGSuiteMenuItems = ( { account, email, mailbox, translate } ) => {
+	if ( hasGoogleAccountTOSWarning( account ) ) {
+		return null;
+	}
+
 	return [
 		{
 			href: getGmailUrl( email ),
@@ -208,13 +217,16 @@ const getEmailForwardMenuItems = ( { currentRoute, domain, selectedSite, transla
 	];
 };
 
-const getMenuItems = ( { currentRoute, domain, email, mailbox, selectedSite }, translate ) => {
+const getMenuItems = (
+	{ account, currentRoute, domain, email, mailbox, selectedSite },
+	translate
+) => {
 	if ( hasTitanMailWithUs( domain ) ) {
 		return getTitanMenuItems( email, translate );
 	}
 
 	if ( hasGSuiteWithUs( domain ) ) {
-		return getGSuiteMenuItems( email, mailbox, translate );
+		return getGSuiteMenuItems( { account, email, mailbox, translate } );
 	}
 
 	if ( hasEmailForwards( domain ) ) {
@@ -224,12 +236,12 @@ const getMenuItems = ( { currentRoute, domain, email, mailbox, selectedSite }, t
 	return null;
 };
 
-const ActionMenu = ( { domain, mailbox, selectedSite } ) => {
+const ActionMenu = ( { account, domain, mailbox, selectedSite } ) => {
 	const currentRoute = useSelector( getCurrentRoute );
 	const translate = useTranslate();
 	const email = `${ mailbox.mailbox }@${ mailbox.domain }`;
 	const menuItems = getMenuItems(
-		{ currentRoute, domain, email, mailbox, selectedSite },
+		{ account, currentRoute, domain, email, mailbox, selectedSite },
 		translate
 	);
 	if ( ! menuItems ) {
@@ -302,7 +314,12 @@ function EmailPlanMailboxesList( { account, domain, isLoadingEmails, mailboxes, 
 					</Badge>
 				) }
 				<EmailMailboxWarnings account={ account } mailbox={ mailbox } />
-				<ActionMenu domain={ domain } mailbox={ mailbox } selectedSite={ selectedSite } />
+				<ActionMenu
+					account={ account }
+					domain={ domain }
+					mailbox={ mailbox }
+					selectedSite={ selectedSite }
+				/>
 			</MailboxListItem>
 		);
 	} );

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -102,15 +102,13 @@ class EmailPlan extends React.Component {
 			);
 	}
 
-	getAccountType() {
-		return this.state?.emailAccounts[ 0 ]?.account_type ?? null;
+	getAccount() {
+		return this.state?.emailAccounts[ 0 ];
 	}
 
 	getMailboxes() {
-		if ( this.state.emailAccounts[ 0 ] ) {
-			return this.state.emailAccounts[ 0 ].emails;
-		}
-		return [];
+		const account = this.getAccount();
+		return account?.emails ?? [];
 	}
 
 	handleBack = () => {
@@ -270,7 +268,7 @@ class EmailPlan extends React.Component {
 				/>
 
 				<EmailPlanMailboxesList
-					accountType={ this.getAccountType() }
+					account={ this.getAccount() }
 					domain={ domain }
 					mailboxes={ this.getMailboxes() }
 					isLoadingEmails={ isLoadingEmailAccounts }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -299,7 +299,7 @@
 	.email-mailbox-warnings__warning {
 		border-top: 1px solid var( --color-neutral-5 );
 		color: var( --color-error );
-		font-size: $font-body-extra-small;
+		font-size: $font-body-small;
 		line-height: 24px;
 		margin-top: 18px;
 		padding-top: 18px;

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -296,7 +296,7 @@
 		}
 	}
 
-	.email-plan-mailboxes-list__mailbox-list-item-warning {
+	.email-mailbox-warnings__warning {
 		border-top: 1px solid var( --color-neutral-5 );
 		color: var( --color-error );
 		font-size: $font-body-extra-small;
@@ -321,8 +321,9 @@
 		}
 	}
 
-	.email-plan-mailboxes-list__mailbox-list-item-action {
+	.email-mailbox-warnings__action {
 		margin-top: 12px;
+
 		@include break-xlarge {
 			flex: 0.75;
 			margin-top: 0;

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -290,9 +290,9 @@
 		display: none;
 
 		@include break-xlarge {
-			align-self: center;
 			display: unset;
 			margin-left: 10px;
+			margin-top: 3px;
 		}
 	}
 
@@ -329,6 +329,10 @@
 			margin-top: 0;
 			margin-left: auto;
 			text-align: right;
+		}
+
+		> .button > .gridicons-external {
+			margin-left: 6px;
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR refactors the mailbox-level warnings into a new `EmailMailboxWarnings` component, and leverages `mailbox.warnings` to drive warning messages.
* The PR maintains the existing structure and CSS for warnings that were added for email forwards in #52169 and #52750, but makes it cleaner to drop additional warnings in should we need to do so.
* The PR also increases the size of the warning text slightly, and adjusts the vertical alignment of the Admin badge
* The PR implements fairly special handling for cases where the the account-level Google terms of service haven't been accepted. We then show _all_ mailboxes as "Pending", without a CTA and without the ellipsis menu.

#### Testing instructions

* Run this branch locally or access it via the [live branch](https://calypso.live/?branch=add/google-mailbox-warnings-to-email-plan-page).
* Open the email home page for a site that includes a Google subscription where one or more mailboxes (or users) still need to accept the ToS.
* Verify that each of the admin users that hasn't accepted the ToS yet has an "Action required" notice next to it, as well as a "Finish setup" button.
* Verify that clicking on the "Finish setup" button attempts to log you into GMail with the correct details filled in.
* Switch to an account where the account-level ToS haven't been accepted yet.
* Verify that all mailboxes show "Pending", and don't display the ellipsis menu.
* Adjust the screen width to check the layout at various widths to make sure it continues to look good.

#### Screenshots

| Before | After |
| -------|------|
| <img width="863" alt="Screenshot 2021-05-19 at 22 28 38" src="https://user-images.githubusercontent.com/3376401/118880117-c7951f00-b8f1-11eb-8fd5-d9537845604b.png"> | <img width="852" alt="Screenshot 2021-05-19 at 22 38 51" src="https://user-images.githubusercontent.com/3376401/118881603-91f13580-b8f3-11eb-8af1-d249c0eecf55.png"> |

##### Account-level ToS haven't been accepted

Note that the correct CTA for this is being added in #53068.
<img width="1092" alt="Screenshot 2021-05-21 at 19 55 06" src="https://user-images.githubusercontent.com/3376401/119179587-62ffce80-ba6f-11eb-8a7e-dfbcd507c55e.png">
