### PR TITLE
Add support for the verify email task on My Home

### DIFF
--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -30,3 +30,4 @@ export const TASK_WEBINARS = 'home-task-webinars';
 export const TASK_WP_COURSES = 'home-task-wp-courses';
 export const TASK_CLOUDFLARE = 'home-task-cloudflare';
 export const TASK_UPSELL_TITAN = 'home-task-upsell-titan';
+export const TASK_VERIFY_EMAIL = 'home-task-verify-email';

--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -43,6 +43,7 @@ const Task = ( {
 	illustration,
 	isLoading: forceIsLoading = false,
 	isUrgent = false,
+	showSkip = true,
 	enableSkipOptions = true,
 	scary,
 	siteId,
@@ -146,15 +147,17 @@ const Task = ( {
 				<p className="task__description">{ description }</p>
 				<div className="task__actions">
 					{ renderAction() }
-					<Button
-						className="task__skip is-link"
-						ref={ skipButtonRef }
-						onClick={ () => ( enableSkipOptions ? setSkipOptionsVisible( true ) : skipTask() ) }
-					>
-						{ enableSkipOptions ? translate( 'Hide this' ) : translate( 'Dismiss' ) }
-						{ enableSkipOptions && <Gridicon icon="dropdown" size={ 18 } /> }
-					</Button>
-					{ enableSkipOptions && areSkipOptionsVisible && (
+					{ showSkip && (
+						<Button
+							className="task__skip is-link"
+							ref={ skipButtonRef }
+							onClick={ () => ( enableSkipOptions ? setSkipOptionsVisible( true ) : skipTask() ) }
+						>
+							{ enableSkipOptions ? translate( 'Hide this' ) : translate( 'Dismiss' ) }
+							{ enableSkipOptions && <Gridicon icon="dropdown" size={ 18 } /> }
+						</Button>
+					) }
+					{ showSkip && enableSkipOptions && areSkipOptionsVisible && (
 						<PopoverMenu
 							context={ skipButtonRef.current }
 							isVisible={ areSkipOptionsVisible }

--- a/client/my-sites/customer-home/cards/tasks/verify-email/index.tsx
+++ b/client/my-sites/customer-home/cards/tasks/verify-email/index.tsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
+import { verifyEmail } from 'calypso/state/current-user/email-verification/actions';
+import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
+
+const VerifyEmail = (): React.ReactElement => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const userEmail = useSelector( getCurrentUserEmail );
+
+	return (
+		<Task
+			title={ translate( 'Confirm your email address' ) }
+			description={ translate(
+				'Please click the link in the email we sent to %(email)s. ' +
+					'Typo in your email address? {{changeButton}}Change it here{{/changeButton}}.',
+				{
+					args: {
+						email: userEmail,
+					},
+					components: {
+						changeButton: <a href="/me/account" />,
+					},
+				}
+			) }
+			actionText={ translate( 'Resend email' ) }
+			actionOnClick={ () => dispatch( verifyEmail( { showGlobalNotices: true } ) ) }
+			badgeText={ translate( 'Action required' ) }
+			showSkip={ false }
+		/>
+	);
+};
+
+export default VerifyEmail;

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -19,6 +19,7 @@ import TitanBanner from 'calypso/my-sites/customer-home/cards/tasks/titan-banner
 import Webinars from 'calypso/my-sites/customer-home/cards/tasks/webinars';
 import WPCourses from 'calypso/my-sites/customer-home/cards/tasks/wp-courses';
 import Cloudflare from 'calypso/my-sites/customer-home/cards/tasks/cloudflare';
+import VerifyEmail from 'calypso/my-sites/customer-home/cards/tasks/verify-email';
 import CelebrateSiteCreation from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-creation';
 import CelebrateSiteLaunch from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-launch';
 import CelebrateSiteMigration from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-migration';
@@ -41,6 +42,7 @@ import {
 	TASK_SITE_SETUP_CHECKLIST_ECOMMERCE,
 	TASK_SITE_SETUP_CHECKLIST,
 	TASK_UPSELL_TITAN,
+	TASK_VERIFY_EMAIL,
 	TASK_WEBINARS,
 	TASK_WP_COURSES,
 } from 'calypso/my-sites/customer-home/cards/constants';
@@ -68,6 +70,7 @@ const cardComponents = {
 	[ TASK_WEBINARS ]: Webinars,
 	[ TASK_WP_COURSES ]: WPCourses,
 	[ TASK_CLOUDFLARE ]: Cloudflare,
+	[ TASK_VERIFY_EMAIL ]: VerifyEmail,
 };
 
 const Primary = ( { cards, trackCards } ) => {


### PR DESCRIPTION
The `/home/layout` endpoint may now return a `TASK_VERIFY_EMAIL` task in the primary location (after D61639-code). The task should be shown for users who have completed the site checklist, but never verified their address (somehow, this _shouldn't_ be possible). This PR quickly puts together a card to display for that case, and if it turns out to be a higher number than we expect we can do a better job of the card.

The text is copied from the task in the site setup checklist so translations will already exist.

We should be able to monitor the `calypso_customer_home_card_impression` tracks event to see how many users this affects.

![May-20-2021 16-05-01](https://user-images.githubusercontent.com/1500769/118917530-33749780-b985-11eb-9ec5-d2eaa2076853.gif)

(the card doesn't disappear after sending the email, which would be a nice touch, but I think something we could fix after seeing whether anyone even sees this card)

#### Changes proposed in this Pull Request

* Allow task cards to be not skippable
* Create a new `<VerifyEmail>` task using the `<Task>` component
* Display `<VerifyEmail>` in the primary location when the `/home/layout` endpoint returns `TASK_VERIFY_EMAIL`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply diff D61639-code to sandbox and proxy public-api
* Force My Home to show the card using the `?dev=true&view=VIEW_UNVERIFIED_EMAIL`
* To test a real unverified user
  * Create a new user and complete site creation flow
  * Land on My Home with the site checklist visible
  * In sandbox run this to force the setup checklist to be completed before verifying your address
   ```
   wp --url=yourtestsite.wordpress.com option update onboarding_checklist_completed `date +%s`
   ```
  * Next refresh of My Home you should see the verify email task

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #52991