### PR TITLE
E2E: Make sure promises are awaited before being returned

### DIFF
--- a/test/e2e/lib/components/find-a-domain-component.js
+++ b/test/e2e/lib/components/find-a-domain-component.js
@@ -21,16 +21,10 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 	async waitForResults() {
 		const driver = this.driver;
 		const resultsLoadingLocator = By.css( '.domain-suggestion.is-placeholder' );
-		await driver.wait(
-			function () {
-				return driverHelper
-					.isElementLocated( driver, resultsLoadingLocator )
-					.then( function ( present ) {
-						return ! present;
-					} );
-			},
-			this.explicitWaitMS * 2,
-			'The domain results loading element was still present when it should have disappeared by now.'
+		await driverHelper.waitUntilElementNotLocated(
+			driver,
+			resultsLoadingLocator,
+			this.explicitWaitMS * 2
 		);
 		return await this.checkForUnknownABTestKeys();
 	}
@@ -128,8 +122,8 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 		}
 	}
 
-	selectPreviousStep() {
-		return driverHelper.clickWhenClickable(
+	async selectPreviousStep() {
+		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( 'a.previous-step' ),
 			this.explicitWaitMS

--- a/test/e2e/lib/components/inline-help-popover-component.js
+++ b/test/e2e/lib/components/inline-help-popover-component.js
@@ -15,7 +15,10 @@ class InlineHelpPopoverComponent extends AsyncBaseContainer {
 	}
 
 	async waitForToggleNotToBePresent() {
-		return driverHelper.waitUntilElementNotLocated( this.driver, By.css( '.inline-help__button' ) );
+		return await driverHelper.waitUntilElementNotLocated(
+			this.driver,
+			By.css( '.inline-help__button' )
+		);
 	}
 
 	async isToggleVisible() {

--- a/test/e2e/lib/components/nav-bar-component.js
+++ b/test/e2e/lib/components/nav-bar-component.js
@@ -42,8 +42,8 @@ export default class NavBarComponent extends AsyncBaseContainer {
 		const mySitesLocator = by.css( 'header.masterbar a.masterbar__item' );
 		await driverHelper.clickWhenClickable( this.driver, mySitesLocator );
 	}
-	hasUnreadNotifications() {
-		return this.driver
+	async hasUnreadNotifications() {
+		return await this.driver
 			.findElement( by.css( '.masterbar__item-notifications' ) )
 			.getAttribute( 'class' )
 			.then( ( classNames ) => {
@@ -55,7 +55,7 @@ export default class NavBarComponent extends AsyncBaseContainer {
 		const notificationsLocator = by.css( '.masterbar__item-notifications' );
 		const classNames = await driver.findElement( notificationsLocator ).getAttribute( 'class' );
 		if ( classNames.includes( 'is-active' ) === false ) {
-			return driverHelper.clickWhenClickable( driver, notificationsLocator );
+			return await driverHelper.clickWhenClickable( driver, notificationsLocator );
 		}
 		await driver.sleep( 400 ); // Wait for menu animation to complete
 	}

--- a/test/e2e/lib/components/notifications-component.js
+++ b/test/e2e/lib/components/notifications-component.js
@@ -37,7 +37,7 @@ export default class NotificationsComponent extends AsyncBaseContainer {
 			by.css( '.wpnc__excerpt' ),
 			commentText
 		);
-		return driverHelper.clickWhenClickable( this.driver, commentLocator );
+		return await driverHelper.clickWhenClickable( this.driver, commentLocator );
 	}
 
 	async trashComment() {

--- a/test/e2e/lib/components/revisions-modal-component.js
+++ b/test/e2e/lib/components/revisions-modal-component.js
@@ -28,6 +28,9 @@ export default class RevisionsModalComponent extends AsyncBaseContainer {
 		await this.driver.executeScript( 'arguments[0].click()', firstRevision );
 		await this.driver.executeScript( 'arguments[0].click()', loadButton );
 
-		return driverHelper.waitUntilElementNotLocated( this.driver, this.expectedElementLocator );
+		return await driverHelper.waitUntilElementNotLocated(
+			this.driver,
+			this.expectedElementLocator
+		);
 	}
 }

--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -29,7 +29,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 	}
 
 	async isCompositeCheckout() {
-		return driverHelper.isElementLocated( this.driver, By.css( '.composite-checkout' ) );
+		return await driverHelper.isElementLocated( this.driver, By.css( '.composite-checkout' ) );
 	}
 
 	async _postInit() {
@@ -154,7 +154,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 			this.driver,
 			By.css( `#country-selector option[value="${ cardCountryCode }"]` )
 		);
-		return driverHelper.clickWhenClickable(
+		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( 'button[aria-label="Continue with the entered contact details"]' )
 		);
@@ -349,23 +349,23 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 	async hasCouponApplied() {
 		const isCompositeCheckout = await this.isCompositeCheckout();
 		if ( isCompositeCheckout ) {
-			return driverHelper.isElementLocated(
+			return await driverHelper.isElementLocated(
 				this.driver,
 				By.css( '#checkout-line-item-coupon-line-item' )
 			);
 		}
-		return driverHelper.isElementLocated( this.driver, By.css( '.cart__remove-link' ) );
+		return await driverHelper.isElementLocated( this.driver, By.css( '.cart__remove-link' ) );
 	}
 
 	async waitForCouponToBeApplied() {
 		const isCompositeCheckout = await this.isCompositeCheckout();
 		if ( isCompositeCheckout ) {
-			return driverHelper.waitUntilElementLocatedAndVisible(
+			return await driverHelper.waitUntilElementLocatedAndVisible(
 				this.driver,
 				By.css( '.checkout-review-order.is-summary #checkout-line-item-coupon-line-item' )
 			);
 		}
-		return driverHelper.waitUntilElementLocatedAndVisible(
+		return await driverHelper.waitUntilElementLocatedAndVisible(
 			this.driver,
 			By.css( '.cart__remove-link' )
 		);

--- a/test/e2e/lib/components/site-preview-component.js
+++ b/test/e2e/lib/components/site-preview-component.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { By, until } from 'selenium-webdriver';
-import config from 'config';
+import { By } from 'selenium-webdriver';
 
 /**
  * Internal dependencies
@@ -25,18 +24,13 @@ class SitePreviewComponent extends AsyncBaseContainer {
 
 	async enterSitePreview() {
 		const iFrameLocator = By.css( '.web-preview__frame' );
-		const explicitWaitMS = config.get( 'explicitWaitMS' );
 
 		await this.driver.switchTo().defaultContent();
 		await driverHelper.waitUntilElementLocatedAndVisible(
 			this.driver,
 			By.css( '.web-preview__inner.is-visible.is-loaded' )
 		);
-		return this.driver.wait(
-			until.ableToSwitchToFrame( iFrameLocator ),
-			explicitWaitMS,
-			'Could not switch to web preview iFrame'
-		);
+		return await driverHelper.waitUntilAbleToSwitchToFrame( this.driver, iFrameLocator );
 	}
 
 	async leaveSitePreview() {

--- a/test/e2e/lib/components/support-search-component.js
+++ b/test/e2e/lib/components/support-search-component.js
@@ -33,7 +33,7 @@ class SupportSearchComponent extends AsyncBaseContainer {
 			'.inline-help__results-placeholder, .help-search__results-placeholder'
 		);
 
-		return driverHelper.waitUntilElementNotLocated(
+		return await driverHelper.waitUntilElementNotLocated(
 			driver,
 			resultsLoadingLocator,
 			this.explicitWaitMS * 2
@@ -57,7 +57,7 @@ class SupportSearchComponent extends AsyncBaseContainer {
 	}
 
 	async waitForDefaultResultsNotToBePresent() {
-		return driverHelper.waitUntilElementNotLocated( this.driver, defaultResultsLocators );
+		return await driverHelper.waitUntilElementNotLocated( this.driver, defaultResultsLocators );
 	}
 
 	async getErrorResults() {
@@ -70,7 +70,7 @@ class SupportSearchComponent extends AsyncBaseContainer {
 	}
 
 	async waitForErrorResultsNotToBePresent() {
-		return driverHelper.waitUntilElementNotLocated( this.driver, errorResultsLocators );
+		return await driverHelper.waitUntilElementNotLocated( this.driver, errorResultsLocators );
 	}
 
 	async getSearchResults() {
@@ -83,7 +83,7 @@ class SupportSearchComponent extends AsyncBaseContainer {
 	}
 
 	async waitForSearchResultsNotToBePresent() {
-		return driverHelper.waitUntilElementNotLocated( this.driver, searchResultsLocators );
+		return await driverHelper.waitUntilElementNotLocated( this.driver, searchResultsLocators );
 	}
 
 	async getAdminSearchResults() {
@@ -96,7 +96,7 @@ class SupportSearchComponent extends AsyncBaseContainer {
 	}
 
 	async waitForAdminResultsNotToBePresent() {
-		return driverHelper.waitUntilElementNotLocated( this.driver, adminSearchResultsLocators );
+		return await driverHelper.waitUntilElementNotLocated( this.driver, adminSearchResultsLocators );
 	}
 
 	async searchFor( query = '' ) {

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -353,7 +353,7 @@ export async function ensureNotLoggedIn( driver ) {
 		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com;SameSite=None;Secure"'
 	);
 
-	return driver.sleep( 500 );
+	await driver.sleep( 500 );
 }
 
 /**

--- a/test/e2e/lib/flows/create-site-flow.js
+++ b/test/e2e/lib/flows/create-site-flow.js
@@ -32,7 +32,7 @@ export default class CreateSiteFlow {
 			By.css( '.signup-processing-screen__title' ),
 			/your site will be ready shortly/i
 		);
-		await driverHelper.waitUntilElementLocated( this.driver, hoorayTitleLocator );
+		await driverHelper.waitUntilElementLocatedAndVisible( this.driver, hoorayTitleLocator );
 		/**
 		 * Let's give the create request enough time to finish. Sometimes it takes
 		 * way more than the default 20 seconds, and the cost of waiting a bit
@@ -45,6 +45,6 @@ export default class CreateSiteFlow {
 		);
 
 		const myHomePage = await MyHomePage.Expect( this.driver );
-		return myHomePage.siteSetupListExists();
+		return await myHomePage.siteSetupListExists();
 	}
 }

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -109,7 +109,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async enterTitle( title ) {
 		const titleLocator = By.css( '.editor-post-title__input' );
-		return driverHelper.setWhenSettable( this.driver, titleLocator, title );
+		return await driverHelper.setWhenSettable( this.driver, titleLocator, title );
 	}
 
 	async getTitle() {
@@ -220,19 +220,19 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await this.exitCodeEditor();
 	}
 
-	blockDisplayedInEditor( dataTypeLocatorVal ) {
-		return driverHelper.isElementEventuallyLocatedAndVisible(
+	async blockDisplayedInEditor( dataTypeLocatorVal ) {
+		return await driverHelper.isElementEventuallyLocatedAndVisible(
 			this.driver,
 			By.css( `[data-type="${ dataTypeLocatorVal }"]` )
 		);
 	}
 
-	contactFormDisplayedInEditor() {
-		return this.blockDisplayedInEditor( 'jetpack/contact-form' );
+	async contactFormDisplayedInEditor() {
+		return await this.blockDisplayedInEditor( 'jetpack/contact-form' );
 	}
 
 	async errorDisplayed() {
-		return driverHelper.isElementEventuallyLocatedAndVisible(
+		return await driverHelper.isElementEventuallyLocatedAndVisible(
 			this.driver,
 			By.css( '.editor-error-boundary' )
 		);
@@ -294,7 +294,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	 * @returns {string[]} Array of block titles (i.e ['Open Table', 'Paypal']);
 	 */
 	async getShownBlockInserterItems() {
-		return this.driver
+		return await this.driver
 			.findElements(
 				By.css(
 					'.edit-post-layout__inserter-panel .block-editor-block-types-list span.block-editor-block-types-list__item-title'
@@ -420,7 +420,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.clickWhenClickable( this.driver, inserterBlockItemLocator );
 		await driverHelper.waitUntilElementLocatedAndVisible( this.driver, insertedBlockLocator );
 
-		return this.driver.findElement( insertedBlockLocator ).getAttribute( 'id' );
+		return await this.driver.findElement( insertedBlockLocator ).getAttribute( 'id' );
 	}
 
 	/**

--- a/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -26,7 +26,7 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 		);
 		await driverHelper.scrollIntoView( this.driver, by );
 		await driverHelper.clickWhenClickable( this.driver, by );
-		return driverHelper.waitUntilElementLocatedAndVisible(
+		return await driverHelper.waitUntilElementLocatedAndVisible(
 			this.driver,
 			By.css( '.components-panel' )
 		);

--- a/test/e2e/lib/pages/accept-invite-page.js
+++ b/test/e2e/lib/pages/accept-invite-page.js
@@ -14,8 +14,8 @@ export default class AcceptInvitePage extends AsyncBaseContainer {
 		super( driver, By.css( '.invite-accept' ) );
 	}
 
-	getEmailPreFilled() {
-		return this.driver.findElement( By.css( '#email' ) ).getAttribute( 'value' );
+	async getEmailPreFilled() {
+		return await this.driver.findElement( By.css( '#email' ) ).getAttribute( 'value' );
 	}
 
 	async enterUsernameAndPasswordAndSignUp( username, password ) {

--- a/test/e2e/lib/pages/account/account-settings-page.js
+++ b/test/e2e/lib/pages/account/account-settings-page.js
@@ -21,8 +21,8 @@ export default class AccountSettingsPage extends AsyncBaseContainer {
 		return await driverHelper.clickWhenClickable( this.driver, closeAccountLocator );
 	}
 
-	getUsername() {
-		return this.driver.wait(
+	async getUsername() {
+		return await this.driver.wait(
 			new Condition( 'for username to be available', async () => {
 				try {
 					const element = await this.driver.findElement( By.css( 'input#user_login' ) );

--- a/test/e2e/lib/pages/account/close-account-page.js
+++ b/test/e2e/lib/pages/account/close-account-page.js
@@ -47,7 +47,10 @@ export default class CloseAccountPage extends AsyncBaseContainer {
 			this.driver,
 			by.css( '.dialog button.is-scary[disabled]' )
 		);
-		return driverHelper.clickWhenClickable( this.driver, by.css( '.dialog button.is-scary' ) );
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			by.css( '.dialog button.is-scary' )
+		);
 	}
 
 	async confirmAccountHasBeenClosed() {
@@ -55,7 +58,10 @@ export default class CloseAccountPage extends AsyncBaseContainer {
 			by.css( '.empty-content__title' ),
 			'Your account has been closed'
 		);
-		await driverHelper.waitUntilElementLocated( this.driver, messageLocator );
-		return driverHelper.clickWhenClickable( this.driver, by.css( 'button.empty-content__action' ) );
+		await driverHelper.waitUntilElementLocatedAndVisible( this.driver, messageLocator );
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			by.css( 'button.empty-content__action' )
+		);
 	}
 }

--- a/test/e2e/lib/pages/comments-page.js
+++ b/test/e2e/lib/pages/comments-page.js
@@ -18,16 +18,6 @@ export default class CommentsPage extends AsyncBaseContainer {
 	async waitForComments() {
 		const driver = this.driver;
 		const resultsLoadingLocator = By.css( '.comment .is-placeholder' );
-		return await driver.wait(
-			function () {
-				return driverHelper
-					.isElementLocated( driver, resultsLoadingLocator )
-					.then( function ( present ) {
-						return ! present;
-					} );
-			},
-			this.explicitWaitMS,
-			'The comments placeholder element was still present when it should have disappeared by now.'
-		);
+		return await driverHelper.waitUntilElementNotLocated( driver, resultsLoadingLocator );
 	}
 }

--- a/test/e2e/lib/pages/domains-page.js
+++ b/test/e2e/lib/pages/domains-page.js
@@ -16,7 +16,7 @@ export default class DomainsPage extends AsyncBaseContainer {
 	}
 
 	async clickAddDomain() {
-		return driverHelper.clickWhenClickable( this.driver, By.css( '.add-domain-button' ) );
+		return await driverHelper.clickWhenClickable( this.driver, By.css( '.add-domain-button' ) );
 	}
 
 	async clickPopoverItem( name ) {
@@ -24,11 +24,14 @@ export default class DomainsPage extends AsyncBaseContainer {
 			By.css( '.popover__menu-item' ),
 			name
 		);
-		return driverHelper.clickWhenClickable( this.driver, actionItemLocator );
+		return await driverHelper.clickWhenClickable( this.driver, actionItemLocator );
 	}
 
 	async popOverMenuDisplayed() {
 		const popOverMenuLocator = By.css( '.popover__menu' );
-		return driverHelper.isElementEventuallyLocatedAndVisible( this.driver, popOverMenuLocator );
+		return await driverHelper.isElementEventuallyLocatedAndVisible(
+			this.driver,
+			popOverMenuLocator
+		);
 	}
 }

--- a/test/e2e/lib/pages/gutenboarding/new-page.js
+++ b/test/e2e/lib/pages/gutenboarding/new-page.js
@@ -35,7 +35,7 @@ export default class NewPage extends AsyncBaseContainer {
 	}
 
 	async waitForBlock() {
-		return driverHelper.isElementEventuallyLocatedAndVisible(
+		return await driverHelper.isElementEventuallyLocatedAndVisible(
 			this.driver,
 			by.css( '[data-type="automattic/onboarding"]' )
 		);

--- a/test/e2e/lib/pages/invite-error-page.js
+++ b/test/e2e/lib/pages/invite-error-page.js
@@ -8,14 +8,14 @@ import { By } from 'selenium-webdriver';
  */
 import AsyncBaseContainer from '../async-base-container';
 
-import * as DriverHelper from '../driver-helper.js';
+import * as driverHelper from '../driver-helper.js';
 
 export default class InviteErrorPage extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.empty-content__illustration' ) );
 	}
 
-	inviteErrorTitleDisplayed() {
-		return DriverHelper.isElementLocated( this.driver, By.css( '.empty-content__title' ) );
+	async inviteErrorTitleDisplayed() {
+		return await driverHelper.isElementLocated( this.driver, By.css( '.empty-content__title' ) );
 	}
 }

--- a/test/e2e/lib/pages/login-page.js
+++ b/test/e2e/lib/pages/login-page.js
@@ -72,7 +72,7 @@ export default class LoginPage extends AsyncBaseContainer {
 		await driverHelper.waitUntilElementNotLocated( driver, userNameLocator );
 	}
 
-	use2FAMethod( twoFAMethod ) {
+	async use2FAMethod( twoFAMethod ) {
 		let actionLocator;
 
 		if ( twoFAMethod === 'sms' ) {
@@ -84,13 +84,7 @@ export default class LoginPage extends AsyncBaseContainer {
 		}
 
 		if ( actionLocator ) {
-			return driverHelper
-				.isElementLocated( this.driver, actionLocator )
-				.then( ( actionAvailable ) => {
-					if ( actionAvailable ) {
-						return driverHelper.clickWhenClickable( this.driver, actionLocator );
-					}
-				} );
+			return await driverHelper.clickIfPresent( this.driver, actionLocator );
 		}
 	}
 

--- a/test/e2e/lib/pages/pages-page.js
+++ b/test/e2e/lib/pages/pages-page.js
@@ -18,17 +18,7 @@ export default class PagesPage extends AsyncBaseContainer {
 	async waitForPages() {
 		const driver = this.driver;
 		const resultsLoadingLocator = By.css( '.pages__page-list .is-placeholder:not(.page)' );
-		return await driver.wait(
-			function () {
-				return driverHelper
-					.isElementLocated( driver, resultsLoadingLocator )
-					.then( function ( present ) {
-						return ! present;
-					} );
-			},
-			this.explicitWaitMS,
-			'The page results loading element was still present when it should have disappeared by now.'
-		);
+		return await driverHelper.waitUntilElementNotLocated( driver, resultsLoadingLocator );
 	}
 
 	async editPageWithTitle( title ) {

--- a/test/e2e/lib/pages/plans-page.js
+++ b/test/e2e/lib/pages/plans-page.js
@@ -72,7 +72,10 @@ export default class PlansPage extends AsyncBaseContainer {
 			selector = `.is-${ planName }-plan`;
 		}
 
-		return driverHelper.isElementEventuallyLocatedAndVisible( this.driver, by.css( selector ) );
+		return await driverHelper.isElementEventuallyLocatedAndVisible(
+			this.driver,
+			by.css( selector )
+		);
 	}
 
 	async planTypesShown( planType ) {

--- a/test/e2e/lib/pages/pressable/pressable-site-settings-page.js
+++ b/test/e2e/lib/pages/pressable/pressable-site-settings-page.js
@@ -17,9 +17,9 @@ export default class PressableSiteSettingsPage extends AsyncBaseContainer {
 		super( driver, By.css( '.site-show-sections' ) );
 	}
 
-	waitForJetpackPremium() {
+	async waitForJetpackPremium() {
 		const loadingLocator = By.css( '.activating img.loading-image' );
-		return driverHelper.waitUntilElementNotLocated(
+		return await driverHelper.waitUntilElementNotLocated(
 			this.driver,
 			loadingLocator,
 			explicitWaitMS * 4

--- a/test/e2e/lib/pages/profile-page.js
+++ b/test/e2e/lib/pages/profile-page.js
@@ -30,13 +30,13 @@ export default class ProfilePage extends AsyncBaseContainer {
 		await driverHelper.waitUntilElementNotLocated( this.driver, buttonLocator );
 	}
 
-	chooseManagePurchases() {
+	async chooseManagePurchases() {
 		const itemLocator = By.css( '.sidebar a[href$="purchases"]' );
-		return driverHelper.clickWhenClickable( this.driver, itemLocator );
+		return await driverHelper.clickWhenClickable( this.driver, itemLocator );
 	}
 
-	chooseAccountSettings() {
+	async chooseAccountSettings() {
 		const itemLocator = By.css( '.sidebar a[href$="account"]' );
-		return driverHelper.clickWhenClickable( this.driver, itemLocator );
+		return await driverHelper.clickWhenClickable( this.driver, itemLocator );
 	}
 }

--- a/test/e2e/lib/pages/reader-page.js
+++ b/test/e2e/lib/pages/reader-page.js
@@ -44,7 +44,7 @@ export default class ReaderPage extends AsyncBaseContainer {
 
 		async function clickAndOpenShareModal() {
 			await driverHelper.clickWhenClickable( this.driver, shareButtonLocator );
-			return driverHelper.clickWhenClickable(
+			return await driverHelper.clickWhenClickable(
 				this.driver,
 				By.css( '.site-selector__sites .site__content' )
 			);
@@ -68,15 +68,15 @@ export default class ReaderPage extends AsyncBaseContainer {
 			By.css( '.comments__form textarea' ),
 			comment
 		);
-		return driverHelper.clickWhenClickable( this.driver, By.css( '.comments__form button' ) );
+		return await driverHelper.clickWhenClickable( this.driver, By.css( '.comments__form button' ) );
 	}
 
-	waitForCommentToAppear( comment ) {
+	async waitForCommentToAppear( comment ) {
 		const commentLocator = driverHelper.createTextLocator(
 			By.css( '.comments__comment-content' ),
 			comment
 		);
-		return driverHelper.waitUntilElementLocated( this.driver, commentLocator );
+		return await driverHelper.waitUntilElementLocatedAndVisible( this.driver, commentLocator );
 	}
 
 	static getReaderURL() {

--- a/test/e2e/lib/pages/signup/checkout-page.js
+++ b/test/e2e/lib/pages/signup/checkout-page.js
@@ -75,7 +75,7 @@ export default class CheckOutPage extends AsyncBaseContainer {
 	}
 
 	async isCompositeCheckout() {
-		return driverHelper.isElementLocated( this.driver, By.css( '.composite-checkout' ) );
+		return await driverHelper.isElementLocated( this.driver, By.css( '.composite-checkout' ) );
 	}
 
 	async submitForm() {

--- a/test/e2e/lib/pages/view-post-page.js
+++ b/test/e2e/lib/pages/view-post-page.js
@@ -82,12 +82,8 @@ export default class ViewPostPage extends AsyncBaseContainer {
 		);
 	}
 
-	async imageDisplayed( fileDetails ) {
-		return await this.driver
-			.findElement( By.css( `img[alt='${ fileDetails.imageName }']` ) )
-			.then( ( imageElement ) => {
-				return driverHelper.isImageVisible( this.driver, imageElement );
-			} );
+	async imageDisplayed( { imageName } ) {
+		return await driverHelper.isImageVisible( this.driver, By.css( `img[alt='${ imageName }']` ) );
 	}
 
 	async leaveAComment( comment ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Make sure promises are awaited before being returned.

Returning an awaited promise can make sense for better stack trace information as well as for consistent error handling (returned promises will not be caught in an async function try/catch).
See:
- https://github.com/eslint/eslint/issues/11878#issuecomment-505363819
- https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/return-await.md

#### Testing instructions

All tests should pass.