### PR TITLE
plugin: do not hide `Back` button

### DIFF
--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -106,8 +106,8 @@ class SinglePlugin extends React.Component {
 		return ! shouldUseHistoryBack ? '/plugins/manage/' + ( siteUrl || '' ) : null;
 	};
 
-	displayHeader( calypsoify ) {
-		if ( ! this.props.selectedSite || calypsoify ) {
+	displayHeader() {
+		if ( ! this.props.selectedSite ) {
 			return <Card className="plugins__installed-header" />;
 		}
 
@@ -287,7 +287,7 @@ class SinglePlugin extends React.Component {
 				<PluginNotices pluginId={ plugin.id } sites={ this.props.sites } plugins={ [ plugin ] } />
 
 				<div className="plugin__page">
-					{ this.displayHeader( calypsoify ) }
+					{ this.displayHeader() }
 					<PluginMeta
 						plugin={ plugin }
 						siteUrl={ this.props.siteUrl }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR restore the back button for all sites

Fixes https://github.com/Automattic/wp-calypso/issues/52540

#### Testing instructions

Test with a Simple site

before | after
-----|-----
<img width="549" alt="Screen Shot 2021-05-20 at 9 14 01 AM" src="https://user-images.githubusercontent.com/77539/118976831-db6d6f00-b94b-11eb-80fb-cb6119be6449.png"> | <img width="551" alt="Screen Shot 2021-05-20 at 9 14 24 AM" src="https://user-images.githubusercontent.com/77539/118976822-d90b1500-b94b-11eb-92c2-4251dce3ae5b.png">


