### PR TITLE
General: Remove unused imports and vars

### DIFF
--- a/client/blocks/stats-sparkline/index.jsx
+++ b/client/blocks/stats-sparkline/index.jsx
@@ -3,7 +3,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
+import React from 'react';
 import classnames from 'classnames';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';

--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -3,7 +3,7 @@
  */
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
-import React, { ChangeEvent, Fragment, FunctionComponent, useState } from 'react';
+import React, { ChangeEvent, FunctionComponent, useState } from 'react';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 
 /**

--- a/client/components/jetpack/backup-card/index.tsx
+++ b/client/components/jetpack/backup-card/index.tsx
@@ -33,9 +33,6 @@ import cloudIcon from 'calypso/components/jetpack/daily-backup-status/status-car
  */
 import type { Activity } from 'calypso/state/activity-log/types';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
-
 type Props = {
 	activity: Activity;
 	subActivities?: Activity[];

--- a/client/components/jetpack/threat-description/index.tsx
+++ b/client/components/jetpack/threat-description/index.tsx
@@ -97,7 +97,7 @@ class ThreatDescription extends React.PureComponent< Props > {
 	}
 
 	render() {
-		const { children, status, problem, fix, diff, rows, context, filename } = this.props;
+		const { children, problem, fix, diff, rows, context, filename } = this.props;
 
 		return (
 			<div className="threat-description">

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -33,7 +33,6 @@ import {
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
 } from '@automattic/calypso-products';
-import { MembershipSubscription, MembershipSubscriptionsSite } from 'calypso/lib/purchases/types';
 import { errorNotice } from 'calypso/state/notices/actions';
 
 const debug = debugFactory( 'calypso:purchases' );
@@ -80,8 +79,8 @@ function getPurchasesBySite( purchases, sites ) {
 /**
  * Returns an array of sites objects, each of which contains an array of subscriptions.
  *
- * @param {MembershipSubscription[]} subscriptions An array of subscription objects.
- * @returns {MembershipSubscriptionsSite[]} An array of sites with subscriptions attached.
+ * @param {import('calypso/lib/purchases/types').MembershipSubscription[]} subscriptions An array of subscription objects.
+ * @returns {import('calypso/lib/purchases/types').MembershipSubscriptionsSite[]} An array of sites with subscriptions attached.
  */
 function getSubscriptionsBySite( subscriptions ) {
 	return subscriptions

--- a/client/lib/site/timezone.js
+++ b/client/lib/site/timezone.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import moment, { MomentInput, Moment } from 'moment-timezone';
+import moment from 'moment-timezone';
 
 /**
  * A collection of parameters for applying a site's timezone or UTC offset to
@@ -26,10 +26,10 @@ import moment, { MomentInput, Moment } from 'moment-timezone';
  * Accepts (optional) timezone and offset and applies one to the provided date, preferring the
  * timezone. If neither are provided, creates a default moment.js object in local timezone.
  *
- * @param  {MomentInput}  input Valid input for moment (string, timestamp, moment.js object)
+ * @param  {import('moment-timezone').MomentInput}  input Valid input for moment (string, timestamp, moment.js object)
  *                        to which timezone or offset will be applied.
  * @param  {OffsetParams} params Parameters
- * @returns {Moment}       Moment with timezone applied if provided.
+ * @returns {import('moment-timezone').Moment}       Moment with timezone applied if provided.
  *                        Moment with gmtOffset applied if no timezone is provided.
  *                        If neither is provided, the original moment is returned.
  */

--- a/client/state/selectors/get-site-scan-history.js
+++ b/client/state/selectors/get-site-scan-history.js
@@ -6,7 +6,6 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { Threat } from 'calypso/components/jetpack/threat-item/types';
 import 'calypso/state/data-layer/wpcom/sites/scan';
 
 /**
@@ -15,7 +14,7 @@ import 'calypso/state/data-layer/wpcom/sites/scan';
  *
  * @param  {object}   state    Global state tree
  * @param  {number}   siteId   The ID of the site we're querying
- * @returns {Threat[]}         Array of threats found
+ * @returns {import('calypso/components/jetpack/threat-item/types').Threat[]} Array of threats found
  */
 export default function getSiteScanHistory( state, siteId ) {
 	return get( state, [ 'jetpackScan', 'history', 'data', siteId, 'threats' ], [] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I've noticed there are a few places where we import modules or declare variables / constants only for the sake of inline documentation, or have simply left unused code by mistake. This PR removes some of those instances.

#### Testing instructions

* Go through each instance and verify we're removing only unused code, and that docs changes make sense. 

#### Notes

There are a couple of pre-existing errors in one of the affected files, this PR is consciously staying away from addressing them. 