### PR TITLE
Emails: Update Add New Mailboxes/Users pages with section header

### DIFF
--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -40,6 +40,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE, GSUITE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
 import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
@@ -253,37 +254,51 @@ class GSuiteAddUsers extends React.Component {
 	}
 
 	render() {
-		const { currentRoute, isNewAccount, productType, translate, selectedDomainName, selectedSite } = this.props;
+		const {
+			currentRoute,
+			isNewAccount,
+			productType,
+			translate,
+			selectedDomainName,
+			selectedSite,
+		} = this.props;
 
 		const analyticsPath = isNewAccount
-			? emailManagementNewGSuiteAccount( ':site', ':domain', ':productType' )
-			: emailManagementAddGSuiteUsers( ':site', selectedDomainName ? ':domain' : undefined );
+			? emailManagementNewGSuiteAccount( ':site', ':domain', ':productType', currentRoute )
+			: emailManagementAddGSuiteUsers(
+					':site',
+					selectedDomainName ? ':domain' : undefined,
+					':productType',
+					currentRoute
+			  );
 
 		const googleMailServiceFamily = getGoogleMailServiceFamily( getProductSlug( productType ) );
 
 		return (
 			<>
-				<PageViewTracker path={ analyticsPath } title="Email Management > Add New Users" />
+				<PageViewTracker path={ analyticsPath } title="Email Management > Add Google Users" />
 
 				{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 
 				{ selectedSite && <QueryGSuiteUsers siteId={ selectedSite.ID } /> }
 
-				<DocumentHead title={ translate( 'Add New Users' ) } />
+				<Main wideLayout={ true }>
+					<DocumentHead title={ translate( 'Add New Users' ) } />
 
-				<EmailHeader currentRoute={ currentRoute } selectedSite={ selectedSite } />
+					<EmailHeader currentRoute={ currentRoute } selectedSite={ selectedSite } />
 
-				<HeaderCake onClick={ this.handleBack }>{ translate( 'Add new users' ) }</HeaderCake>
+					<HeaderCake onClick={ this.goToEmail }>{ translate( 'Add new users' ) }</HeaderCake>
 
-				<EmailVerificationGate
-					noticeText={ translate( 'You must verify your email to purchase %(productFamily)s.', {
-						args: { productFamily: googleMailServiceFamily },
-						comment: '%(productFamily)s can be either "G Suite" or "Google Workspace"',
-					} ) }
-					noticeStatus="is-info"
-				>
-					{ this.renderAddGSuite() }
-				</EmailVerificationGate>
+					<EmailVerificationGate
+						noticeText={ translate( 'You must verify your email to purchase %(productFamily)s.', {
+							args: { productFamily: googleMailServiceFamily },
+							comment: '%(productFamily)s can be either "G Suite" or "Google Workspace"',
+						} ) }
+						noticeStatus="is-info"
+					>
+						{ this.renderAddGSuite() }
+					</EmailVerificationGate>
+				</Main>
 			</>
 		);
 	}

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -14,7 +14,8 @@ import { withShoppingCart } from '@automattic/shopping-cart';
  */
 import AddEmailAddressesCardPlaceholder from './add-users-placeholder';
 import { Button, Card } from '@automattic/components';
-import DomainManagementHeader from 'calypso/my-sites/domains/domain-management/components/header';
+import DocumentHead from 'calypso/components/data/document-head';
+import EmailHeader from 'calypso/my-sites/email/email-header';
 import {
 	emailManagementAddGSuiteUsers,
 	emailManagementNewGSuiteAccount,
@@ -38,7 +39,7 @@ import {
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE, GSUITE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
-import Main from 'calypso/components/main';
+import HeaderCake from 'calypso/components/header-cake';
 import Notice from 'calypso/components/notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
@@ -252,7 +253,7 @@ class GSuiteAddUsers extends React.Component {
 	}
 
 	render() {
-		const { isNewAccount, productType, translate, selectedDomainName, selectedSite } = this.props;
+		const { currentRoute, isNewAccount, productType, translate, selectedDomainName, selectedSite } = this.props;
 
 		const analyticsPath = isNewAccount
 			? emailManagementNewGSuiteAccount( ':site', ':domain', ':productType' )
@@ -261,31 +262,29 @@ class GSuiteAddUsers extends React.Component {
 		const googleMailServiceFamily = getGoogleMailServiceFamily( getProductSlug( productType ) );
 
 		return (
-			<Fragment>
-				<PageViewTracker path={ analyticsPath } title="Domain Management > Add G Suite Users" />
+			<>
+				<PageViewTracker path={ analyticsPath } title="Email Management > Add New Users" />
 
 				{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
+
 				{ selectedSite && <QueryGSuiteUsers siteId={ selectedSite.ID } /> }
 
-				<Main>
-					<DomainManagementHeader
-						onClick={ this.goToEmail }
-						selectedDomainName={ selectedDomainName }
-					>
-						{ googleMailServiceFamily }
-					</DomainManagementHeader>
+				<DocumentHead title={ translate( 'Add New Users' ) } />
 
-					<EmailVerificationGate
-						noticeText={ translate( 'You must verify your email to purchase %(productFamily)s.', {
-							args: { productFamily: googleMailServiceFamily },
-							comment: '%(productFamily)s can be either "G Suite" or "Google Workspace"',
-						} ) }
-						noticeStatus="is-info"
-					>
-						{ this.renderAddGSuite() }
-					</EmailVerificationGate>
-				</Main>
-			</Fragment>
+				<EmailHeader currentRoute={ currentRoute } selectedSite={ selectedSite } />
+
+				<HeaderCake onClick={ this.handleBack }>{ translate( 'Add new users' ) }</HeaderCake>
+
+				<EmailVerificationGate
+					noticeText={ translate( 'You must verify your email to purchase %(productFamily)s.', {
+						args: { productFamily: googleMailServiceFamily },
+						comment: '%(productFamily)s can be either "G Suite" or "Google Workspace"',
+					} ) }
+					noticeStatus="is-info"
+				>
+					{ this.renderAddGSuite() }
+				</EmailVerificationGate>
+			</>
 		);
 	}
 }

--- a/client/my-sites/email/titan-mail-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-mail-add-mailboxes/index.jsx
@@ -278,7 +278,7 @@ class TitanMailAddMailboxes extends React.Component {
 
 				{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 
-				<Main>
+				<Main wideLayout={ true }>
 					<DocumentHead title={ pageTitle } />
 
 					<EmailHeader currentRoute={ currentRoute } selectedSite={ selectedSite } />

--- a/client/my-sites/email/titan-mail-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-mail-add-mailboxes/index.jsx
@@ -19,8 +19,8 @@ import {
 	transformMailboxForCart,
 } from 'calypso/lib/titan/new-mailbox';
 import { Button, Card } from '@automattic/components';
-import DomainManagementHeader from 'calypso/my-sites/domains/domain-management/components/header';
-import SectionHeader from 'calypso/components/section-header';
+import DocumentHead from 'calypso/components/data/document-head';
+import EmailHeader from 'calypso/my-sites/email/email-header';
 import {
 	emailManagement,
 	emailManagementManageTitanAccount,
@@ -43,6 +43,7 @@ import { getDomainsWithForwards } from 'calypso/state/selectors/get-email-forwar
 import { getProductBySlug, getProductsList } from 'calypso/state/products-list/selectors';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -52,12 +53,12 @@ import {
 	TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL,
 	TITAN_MAIL_MONTHLY_SLUG,
 } from 'calypso/lib/titan/constants';
+import SectionHeader from 'calypso/components/section-header';
 import TitanExistingForwardsNotice from 'calypso/my-sites/email/titan-mail-add-mailboxes/titan-existing-forwards-notice';
 import TitanMailboxPricingNotice from 'calypso/my-sites/email/titan-mail-add-mailboxes/titan-mailbox-pricing-notice';
 import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
 import TitanNewMailboxList from 'calypso/my-sites/email/titan-mail-add-mailboxes/titan-new-mailbox-list';
 import TitanUnusedMailboxesNotice from 'calypso/my-sites/email/titan-mail-add-mailboxes/titan-unused-mailbox-notice';
-
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 
 /**
@@ -266,6 +267,7 @@ class TitanMailAddMailboxes extends React.Component {
 		}
 
 		const analyticsPath = emailManagementNewTitanAccount( ':site', ':domain', currentRoute );
+		const pageTitle = getTitanProductName() + ': ' + selectedDomainName;
 		const finishSetupLinkIsExternal = ! isEnabled( 'titan/iframe-control-panel' );
 
 		return (
@@ -277,12 +279,11 @@ class TitanMailAddMailboxes extends React.Component {
 				{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 
 				<Main>
-					<DomainManagementHeader
-						onClick={ this.goToEmail }
-						selectedDomainName={ selectedDomainName }
-					>
-						{ getTitanProductName() + ': ' + selectedDomainName }
-					</DomainManagementHeader>
+					<DocumentHead title={ pageTitle } />
+
+					<EmailHeader currentRoute={ currentRoute } selectedSite={ selectedSite } />
+
+					<HeaderCake onClick={ this.goToEmail }>{ pageTitle }</HeaderCake>
 
 					<TitanExistingForwardsNotice domainsWithForwards={ domainsWithForwards } />
 					{ selectedDomain && (

--- a/client/my-sites/email/titan-mail-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-mail-add-mailboxes/index.jsx
@@ -24,6 +24,7 @@ import SectionHeader from 'calypso/components/section-header';
 import {
 	emailManagement,
 	emailManagementManageTitanAccount,
+	emailManagementNewTitanAccount,
 	emailManagementTitanControlPanelRedirect,
 } from 'calypso/my-sites/email/paths';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
@@ -43,6 +44,7 @@ import { getProductBySlug, getProductsList } from 'calypso/state/products-list/s
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
@@ -247,13 +249,14 @@ class TitanMailAddMailboxes extends React.Component {
 
 	render() {
 		const {
+			currentRoute,
 			domainsWithForwards,
+			isLoadingDomains,
+			isSelectedDomainNameValid,
+			maxTitanMailboxCount,
 			selectedDomain,
 			selectedDomainName,
 			selectedSite,
-			isSelectedDomainNameValid,
-			isLoadingDomains,
-			maxTitanMailboxCount,
 			titanMonthlyProduct,
 		} = this.props;
 
@@ -262,10 +265,13 @@ class TitanMailAddMailboxes extends React.Component {
 			return null;
 		}
 
+		const analyticsPath = emailManagementNewTitanAccount( ':site', ':domain', currentRoute );
 		const finishSetupLinkIsExternal = ! isEnabled( 'titan/iframe-control-panel' );
 
 		return (
 			<>
+				<PageViewTracker path={ analyticsPath } title="Email Management > Add Titan Mailboxes" />
+
 				<QueryProductsList />
 
 				{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes a few changes to the respective "Add mailboxes" for Google and Titan:

##### Changes to the Google "Add new users" page
 * The page now uses the Email section header
 * The page view tracking has been fixed to specify the product type as `':productType'` instead of `undefined`, and include the current route
 * The existing `Main` wrapper component now has the `wideLayout` prop enabled

##### Changes to the Titan "Add mailboxes" page
 * The page now uses the Email section header
 * The page now includes a `PageViewTracker` for tracking page views
 * The existing `Main` component now has the `wideLayout` prop enabled

#### Testing instructions

* Run this branch locally or via the [live branch](https://calypso.live/?branch=update/add-new-mailboxes-page)
* Navigate to Upgrades -> Emails for a site that has a Google Workspace or G Suite subscription
* Click on the row for your subscription
* Ensure your browser network tab is open
* Click on "Add new mailbox"
* Verify that the page displays with the Email section header
* Verify that the page displays a wide layout (which is up to 1040px wide)
* Verify that a page view event is sent including `:productType`
* Click on the Back button and verify you're returned to the email subscription page
* Navigate to Upgrades -> Emails for a site with an existing Professional Email subscription
* Click on the row for the domain with Professional Email
* Ensure your browser network tab is open
* Click on "Add new mailbox"
* Verify that the page displays with the Email section header
* Verify that the page displays a wide layout (which is up to 1040px wide)
* Verify that a page view event is sent to the server
* Click on the Back button and verify you're returned to the email subscription page

#### Screenshots

##### Google Add New Users page

| Before | After |
| ------ | ------|
| <img width="1164" alt="Screenshot 2021-05-21 at 16 40 23" src="https://user-images.githubusercontent.com/3376401/119155252-45bd0700-ba53-11eb-905e-4aad8d605e83.png"> | <img width="1164" alt="Screenshot 2021-05-21 at 16 39 47" src="https://user-images.githubusercontent.com/3376401/119155274-48b7f780-ba53-11eb-96ed-6801542a57d0.png"> |

##### Titan Add Mailboxes page

| Before | After |
| ------ | ------|
| <img width="1164" alt="Screenshot 2021-05-21 at 16 31 46" src="https://user-images.githubusercontent.com/3376401/119154106-25d91380-ba52-11eb-8ef5-37d7c5a60cc6.png"> | <img width="1164" alt="Screenshot 2021-05-21 at 16 31 15" src="https://user-images.githubusercontent.com/3376401/119154126-296c9a80-ba52-11eb-8f69-36b9adaeb41e.png"> |