### PR TITLE
Site editor: prevent crashing with Blank Canvas Blocks design

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -52,7 +52,8 @@ registerPlugin( 'wpcom-block-editor-nux', {
 
 		// Open patterns panel before Welcome Tour if necessary (e.g. when using Blank Canvas theme)
 		// Do this only when Welcome Tour is not manually opened.
-		if ( variant === BLANK_CANVAS_VARIANT && ! isManuallyOpened ) {
+		// NOTE: at the moment, 'starter-page-templates' assets are not loaded on /site-editor/ page so 'setOpenState' may be undefined
+		if ( variant === BLANK_CANVAS_VARIANT && ! isManuallyOpened && setOpenState ) {
 			setOpenState( 'OPEN_FOR_BLANK_CANVAS' );
 			return null;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Because 'starter-page-templates' [assets are not loaded](https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php#L132-L135) on `/site-editor/` page, opening it for Blank Canvas (added in https://github.com/Automattic/wp-calypso/pull/52288) crashes the editor.

#### Testing instructions
For setup, run `cd apps/editing-toolkit && yarn dev --sync`

1. Go to https://horizon.wordpress.com/new?flags=gutenboarding/site-editor
2. Pick the Blank Canvas design.
3. Pick a paid plan => you'll get redirected to /checkout [NOTE: this step is just to allow sandboxing]
4. Sandbox the new site
5. Close checkout screen (top-left X button)
6. Editor should load without crashing

Fixed paYE8P-Tg-p2#comment-786