### PR TITLE
Add source info to `calypso_jetpack_pricing_page_visit` event

### DIFF
--- a/client/my-sites/plans/jetpack-plans/get-view-tracker-path.ts
+++ b/client/my-sites/plans/jetpack-plans/get-view-tracker-path.ts
@@ -1,8 +1,8 @@
 const sitePattern = /\/:site\??/;
 const siteSegment = '/:site';
 
-export default function getViewTrackerPath( path: string, siteId?: number | null ): string {
-	if ( siteId ) {
+export default function getViewTrackerPath( path: string, siteSlug?: string ): string {
+	if ( siteSlug ) {
 		if ( ! path.match( sitePattern ) ) {
 			return path + siteSegment;
 		}

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -56,8 +56,13 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
 
 	useEffect( () => {
-		dispatch( recordTracksEvent( 'calypso_jetpack_pricing_page_visit', { site: siteSlug } ) );
-	}, [ dispatch, siteSlug ] );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_pricing_page_visit', {
+				site: siteSlug,
+				rootPath: rootUrl,
+			} )
+		);
+	}, [ dispatch, rootUrl, siteSlug ] );
 
 	useEffect( () => {
 		setDuration( defaultDuration );

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -54,7 +54,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	const siteSlugState = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const siteSlug = siteSlugProp || siteSlugState;
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
-	const viewTrackerPath = getViewTrackerPath( rootUrl, siteId );
+	const viewTrackerPath = getViewTrackerPath( rootUrl, siteSlugProp );
 	const viewTrackerProps = siteId ? { site: siteSlug } : {};
 
 	useEffect( () => {

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -54,15 +54,18 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	const siteSlugState = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const siteSlug = siteSlugProp || siteSlugState;
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
+	const viewTrackerPath = getViewTrackerPath( rootUrl, siteId );
+	const viewTrackerProps = siteId ? { site: siteSlug } : {};
 
 	useEffect( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_pricing_page_visit', {
 				site: siteSlug,
-				rootPath: rootUrl,
+				path: viewTrackerPath,
+				root_path: rootUrl,
 			} )
 		);
-	}, [ dispatch, rootUrl, siteSlug ] );
+	}, [ dispatch, rootUrl, siteSlug, viewTrackerPath ] );
 
 	useEffect( () => {
 		setDuration( defaultDuration );
@@ -152,9 +155,6 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 		);
 		setDuration( selectedDuration );
 	};
-
-	const viewTrackerPath = getViewTrackerPath( rootUrl, siteId );
-	const viewTrackerProps = siteId ? { site: siteSlug } : {};
 
 	return (
 		<Main className="selector__main" wideLayout>


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds the `path` and `root_path` properties to the `calypso_jetpack_pricing_page_visit` tracking event. The former is required to set the `blogid` property, and the latter makes it easier to tell from where the pricing page is seen.

### Testing instructions

#### Prerequisites
- Download the PR and run both Calypso and cloud
- Make sure you have a Jetpack site available
- Make sure you know how to see tracked events in the console or the network panel

#### Cloud
- Visit `/pricing`. Make sure `calypso_jetpack_pricing_page_visit` is triggered once, and has the properties `path: "/pricing"` , and `"/pricing/:site?"`.
- Visit `/pricing/:site`. Make sure the same event is triggered once, and has the properties `blog_id: xxxxxxxxx`, `path: "/pricing/:site"`, and `root_path: "/pricing/:site?"`.

#### Calypso
- Visit `/plans/:site`. Make sure the same event is triggered once, and has the properties `blog_id: xxxxxxxxx`, `path: "/plans/:site"`, and `root_path: "/plans"`.
- Visit `/jetpack/connect/store`. Make sure the same event is triggered once, and has the properties `blog_id: xxxxxxxxx`, `path: "/jetpack/connect/store"`, and `root_path: "/jetpack/connect/store"`.