### PR TITLE
Cloudflare: do not show banner for sites with jetack_free

### DIFF
--- a/client/my-sites/stats/cloudflare.js
+++ b/client/my-sites/stats/cloudflare.js
@@ -22,7 +22,7 @@ const Cloudflare = () => {
 	const showCloudflare = config.isEnabled( 'cloudflare' );
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) || 0;
 	const sitePlan = useSelector( ( state ) => getSitePlanSlug( state, siteId ) );
-	const showUpsell = [ 'personal-bundle', 'free_plan' ].includes( sitePlan );
+	const showUpsell = [ 'personal-bundle', 'free_plan', 'jetpack_free' ].includes( sitePlan );
 
 	if ( ! showCloudflare ) return null;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Do not show the Cloudflare banner for sites with `jetpack_free` plan. 

#### Testing instructions

* Test with an Atomic site with a `Free` plan
* Go to stats page

before | after
-----|-----
![image](https://user-images.githubusercontent.com/77539/118999071-56d91b80-b960-11eb-8c1e-db9231dea708.png) | ![image](https://user-images.githubusercontent.com/77539/118998497-e0d4b480-b95f-11eb-8cc9-23b2d261598f.png)
_Cloudflare banner as default_ | _Another banner_


Related to https://github.com/Automattic/wp-calypso/issues/51822
Fixes https://github.com/Automattic/wp-calypso/issues/51822
