### PR TITLE
E2E: Ensure plan is removed in secure checkout

### DIFF
--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -433,13 +433,16 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 	}
 
 	async removeBusinessPlan() {
-		const productSlug = this.businessPlanSlug;
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css(
-				`button.cart__remove-item,.checkout-line-item[data-e2e-product-slug="${ productSlug }"] button.checkout-line-item__remove-product`
-			)
+		const trashButtonLocator = By.css(
+			`.checkout-line-item[data-e2e-product-slug="${ this.businessPlanSlug }"] button.checkout-line-item__remove-product`
 		);
+		const confirmButtonLocator = driverHelper.createTextLocator(
+			By.css( '.checkout-modal .checkout-button' ),
+			'Continue'
+		);
+
+		await driverHelper.clickWhenClickable( this.driver, trashButtonLocator );
+		await driverHelper.clickWhenClickable( this.driver, confirmButtonLocator );
 	}
 
 	async cartTotalDisplayed() {

--- a/test/e2e/specs/specs-calypso/wp-plan-purchase__viewing-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-plan-purchase__viewing-spec.js
@@ -28,17 +28,17 @@ describe( `[${ host }] Plans - Viewing: (${ screenSize }) @parallel @jetpack`, f
 		return await driverManager.ensureNotLoggedIn( this.driver );
 	} );
 
-	it( 'Login and Select My Site', async function () {
+	it( 'Login and select my site', async function () {
 		loginFlow = new LoginFlow( this.driver );
 		return await loginFlow.loginAndSelectMySite();
 	} );
 
-	it( 'Can Select Plans', async function () {
+	it( 'Select plans', async function () {
 		const sideBarComponent = await SidebarComponent.Expect( this.driver );
 		return await sideBarComponent.selectPlans();
 	} );
 
-	it( 'Can Compare Plans', async function () {
+	it( 'Compare plans', async function () {
 		const plansPage = await PlansPage.Expect( this.driver );
 		await plansPage.openPlansTab();
 		if ( host === 'WPCOM' ) {
@@ -47,20 +47,20 @@ describe( `[${ host }] Plans - Viewing: (${ screenSize }) @parallel @jetpack`, f
 		return await plansPage.waitForComparison();
 	} );
 
-	it( 'Select Business Plan', async function () {
+	it( 'Select Business plan', async function () {
 		const plansPage = await PlansPage.Expect( this.driver );
 		return await plansPage.selectPaidPlan();
 	} );
 
 	it( 'Remove any existing coupon', async function () {
-		const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
+		const securePaymentComponent = await SecurePaymentComponent.Expect( this.this.driver );
 
 		if ( await securePaymentComponent.hasCouponApplied() ) {
 			await securePaymentComponent.removeCoupon();
 		}
 	} );
 
-	it( 'Can Correctly Apply Coupon', async function () {
+	it( 'Apply coupon', async function () {
 		const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 
 		await securePaymentComponent.toggleCartSummary();
@@ -75,7 +75,7 @@ describe( `[${ host }] Plans - Viewing: (${ screenSize }) @parallel @jetpack`, f
 		assert.strictEqual( newCartAmount, expectedCartAmount, 'Coupon not applied properly' );
 	} );
 
-	it( 'Can Remove Coupon', async function () {
+	it( 'Remove coupon', async function () {
 		const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 
 		await securePaymentComponent.removeCoupon();
@@ -84,9 +84,13 @@ describe( `[${ host }] Plans - Viewing: (${ screenSize }) @parallel @jetpack`, f
 		assert.strictEqual( removedCouponAmount, originalCartAmount, 'Coupon not removed properly' );
 	} );
 
-	it( 'Remove from cart', async function () {
+	it( 'Remove Business plan', async function () {
 		const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 
 		return await securePaymentComponent.removeBusinessPlan();
+	} );
+
+	it( 'Redirect back to Plans page', async function () {
+		await PlansPage.Expect( this.driver ); // Redirect means the plan was successfully removed
 	} );
 } );

--- a/test/e2e/specs/specs-calypso/wp-plan-purchase__viewing-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-plan-purchase__viewing-spec.js
@@ -53,7 +53,7 @@ describe( `[${ host }] Plans - Viewing: (${ screenSize }) @parallel @jetpack`, f
 	} );
 
 	it( 'Remove any existing coupon', async function () {
-		const securePaymentComponent = await SecurePaymentComponent.Expect( this.this.driver );
+		const securePaymentComponent = await SecurePaymentComponent.Expect( this.driver );
 
 		if ( await securePaymentComponent.hasCouponApplied() ) {
 			await securePaymentComponent.removeCoupon();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Ensure plan is removed in secure checkout
  - The plan removal confirmation was not being accepted so the plan was never being removed
  - There was no validation of whether the plan was actually removed or not. Removing the plan takes us back to the Plans page so that's what we're checking as a validation now.

#### Testing instructions

All tests should pass.