### PR TITLE
Checkout: Do not try to add FRESHPACK for renewals

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
@@ -25,13 +25,19 @@ const useMaybeJetpackIntroCouponCode = (
 		if ( isCouponApplied ) {
 			return undefined;
 		}
-		const includesJetpackItems = products
-			.map( ( p ) => p.product_slug )
-			.some( ( slug ) => isJetpackProductSlug( slug ) || isJetpackPlanSlug( slug ) );
+		const jetpackProducts = products.filter(
+			( product ) =>
+				isJetpackProductSlug( product.product_slug ) || isJetpackPlanSlug( product.product_slug )
+		);
 
 		// Only apply FRESHPACK if there's a Jetpack
 		// product or plan present in the cart
-		if ( ! includesJetpackItems ) {
+		if ( jetpackProducts.length < 1 ) {
+			return undefined;
+		}
+
+		// Only apply FRESHPACK for new purchases, not renewals.
+		if ( jetpackProducts.some( ( product ) => product.extra.purchaseType === 'renewal' ) ) {
 			return undefined;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This prevents automatically adding the `FRESHPACK` coupon for renewals.

#### Testing instructions

Visit checkout with a Jetpack plan renewal in your cart, and verify there is no coupon auto-applied.