### PR TITLE
Checkout: Add isBusy to Google Pay and Apple Pay button while submitting

### DIFF
--- a/packages/wpcom-checkout/src/payment-request-button.tsx
+++ b/packages/wpcom-checkout/src/payment-request-button.tsx
@@ -42,7 +42,7 @@ export default function PaymentRequestButton( {
 
 	if ( formStatus === FormStatus.SUBMITTING ) {
 		return (
-			<Button disabled fullWidth>
+			<Button isBusy disabled fullWidth>
 				{ __( 'Completing your purchase' ) }
 			</Button>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the busy button loading animation to the button rendered by the Google Pay and Apple Pay payment methods while the form is submitting.

#### Testing instructions

- Enter checkout with a product in the cart.
- Pay using Google Pay (you must be using Chrome and have a card saved in your Google Pay wallet to see this option).
- Verify that the submit button is animated during the processing step.