### PR TITLE
Update/52927 atomic upload theme tracks events

### DIFF
--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -14,11 +14,7 @@ import { connectOptions } from './theme-options';
 import { translate } from 'i18n-calypso';
 import { trackClick } from './helpers';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import {
-	getSelectedSiteId,
-	getSelectedSiteSlug,
-	getSelectedSite,
-} from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isJetpackSiteMultiSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { Button } from '@automattic/components';
@@ -81,15 +77,14 @@ const InstallThemeButton = connectOptions(
 
 const mapStateToProps = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
-	const selectedSite = getSelectedSite( state );
 	return {
-		allMySites: ! selectedSite,
+		allMySites: ! selectedSiteId,
 		siteSlug: getSelectedSiteSlug( state ),
 		isLoggedIn: isUserLoggedIn( state ),
 		isMultisite: isJetpackSiteMultiSite( state, selectedSiteId ),
 		jetpackSite: Boolean( isJetpackSite( state, selectedSiteId ) ),
 		canUploadThemesOrPlugins: siteCanUploadThemesOrPlugins( state, selectedSiteId ),
-		atomicSite: Boolean( isAtomicSite( selectedSite ) ),
+		atomicSite: Boolean( isAtomicSite( state, selectedSiteId ) ),
 	};
 };
 

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -39,6 +39,7 @@ function getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) {
 
 const InstallThemeButton = connectOptions(
 	( {
+		selectedSiteId,
 		isMultisite,
 		jetpackSite,
 		isLoggedIn,
@@ -59,6 +60,7 @@ const InstallThemeButton = connectOptions(
 					is_all_my_sites: allMySites,
 					is_atomic: atomicSite,
 					is_jetpack_connected: jetpackSite,
+					site_id: selectedSiteId,
 				},
 			} );
 		};
@@ -78,6 +80,7 @@ const InstallThemeButton = connectOptions(
 const mapStateToProps = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
+		selectedSiteId,
 		allMySites: ! selectedSiteId,
 		siteSlug: getSelectedSiteSlug( state ),
 		isLoggedIn: isUserLoggedIn( state ),

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -39,7 +39,6 @@ function getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) {
 
 const InstallThemeButton = connectOptions(
 	( {
-		selectedSiteId,
 		isMultisite,
 		jetpackSite,
 		isLoggedIn,
@@ -60,7 +59,6 @@ const InstallThemeButton = connectOptions(
 					is_all_my_sites: allMySites,
 					is_atomic: atomicSite,
 					is_jetpack_connected: jetpackSite,
-					site_id: selectedSiteId,
 				},
 			} );
 		};
@@ -80,7 +78,6 @@ const InstallThemeButton = connectOptions(
 const mapStateToProps = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
-		selectedSiteId,
 		allMySites: ! selectedSiteId,
 		siteSlug: getSelectedSiteSlug( state ),
 		isLoggedIn: isUserLoggedIn( state ),

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -20,7 +20,7 @@ import {
 	getSelectedSite,
 } from 'calypso/state/ui/selectors';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
+import { isJetpackSiteMultiSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { Button } from '@automattic/components';
 import { isATEnabled } from 'calypso/lib/automated-transfer';
 
@@ -44,11 +44,13 @@ function getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) {
 const InstallThemeButton = connectOptions(
 	( {
 		isMultisite,
+		jetpackSite,
 		isLoggedIn,
 		siteSlug,
 		dispatchTracksEvent,
 		canUploadThemesOrPlugins,
 		ATEnabled,
+		allMySites,
 	} ) => {
 		if ( ! isLoggedIn || isMultisite ) {
 			return null;
@@ -58,7 +60,9 @@ const InstallThemeButton = connectOptions(
 			trackClick( 'upload theme' );
 			dispatchTracksEvent( {
 				tracksEventProps: {
+					is_all_my_sites: allMySites,
 					is_atomic: ATEnabled,
+					is_jetpack_connected: jetpackSite,
 				},
 			} );
 		};
@@ -79,11 +83,13 @@ const mapStateToProps = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const selectedSite = getSelectedSite( state );
 	return {
+		allMySites: ! selectedSite,
 		siteSlug: getSelectedSiteSlug( state ),
 		isLoggedIn: isUserLoggedIn( state ),
 		isMultisite: isJetpackSiteMultiSite( state, selectedSiteId ),
+		jetpackSite: Boolean( isJetpackSite( state, selectedSiteId ) ),
 		canUploadThemesOrPlugins: siteCanUploadThemesOrPlugins( state, selectedSiteId ),
-		ATEnabled: isATEnabled( selectedSite ),
+		ATEnabled: Boolean( isATEnabled( selectedSite ) ),
 	};
 };
 

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -22,7 +22,7 @@ import {
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isJetpackSiteMultiSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { Button } from '@automattic/components';
-import { isATEnabled } from 'calypso/lib/automated-transfer';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 
 /**
  * Style dependencies
@@ -49,7 +49,7 @@ const InstallThemeButton = connectOptions(
 		siteSlug,
 		dispatchTracksEvent,
 		canUploadThemesOrPlugins,
-		ATEnabled,
+		atomicSite,
 		allMySites,
 	} ) => {
 		if ( ! isLoggedIn || isMultisite ) {
@@ -61,7 +61,7 @@ const InstallThemeButton = connectOptions(
 			dispatchTracksEvent( {
 				tracksEventProps: {
 					is_all_my_sites: allMySites,
-					is_atomic: ATEnabled,
+					is_atomic: atomicSite,
 					is_jetpack_connected: jetpackSite,
 				},
 			} );
@@ -89,7 +89,7 @@ const mapStateToProps = ( state ) => {
 		isMultisite: isJetpackSiteMultiSite( state, selectedSiteId ),
 		jetpackSite: Boolean( isJetpackSite( state, selectedSiteId ) ),
 		canUploadThemesOrPlugins: siteCanUploadThemesOrPlugins( state, selectedSiteId ),
-		ATEnabled: Boolean( isATEnabled( selectedSite ) ),
+		atomicSite: Boolean( isAtomicSite( selectedSite ) ),
 	};
 };
 

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -78,13 +78,13 @@ const InstallThemeButton = connectOptions(
 const mapStateToProps = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
-		allMySites: ! selectedSiteId,
+		allMySites: selectedSiteId === null,
 		siteSlug: getSelectedSiteSlug( state ),
 		isLoggedIn: isUserLoggedIn( state ),
 		isMultisite: isJetpackSiteMultiSite( state, selectedSiteId ),
-		jetpackSite: Boolean( isJetpackSite( state, selectedSiteId ) ),
+		jetpackSite: isJetpackSite( state, selectedSiteId ),
 		canUploadThemesOrPlugins: siteCanUploadThemesOrPlugins( state, selectedSiteId ),
-		atomicSite: Boolean( isAtomicSite( state, selectedSiteId ) ),
+		atomicSite: isAtomicSite( state, selectedSiteId ),
 	};
 };
 

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -46,7 +46,6 @@ const InstallThemeButton = connectOptions(
 		dispatchTracksEvent,
 		canUploadThemesOrPlugins,
 		atomicSite,
-		allMySites,
 	} ) => {
 		if ( ! isLoggedIn || isMultisite ) {
 			return null;
@@ -56,7 +55,6 @@ const InstallThemeButton = connectOptions(
 			trackClick( 'upload theme' );
 			dispatchTracksEvent( {
 				tracksEventProps: {
-					is_all_my_sites: allMySites,
 					is_atomic: atomicSite,
 					is_jetpack_connected: jetpackSite,
 				},
@@ -78,7 +76,6 @@ const InstallThemeButton = connectOptions(
 const mapStateToProps = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
-		allMySites: selectedSiteId === null,
 		siteSlug: getSelectedSiteSlug( state ),
 		isLoggedIn: isUserLoggedIn( state ),
 		isMultisite: isJetpackSiteMultiSite( state, selectedSiteId ),

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -58,6 +58,8 @@ const InstallThemeButton = connectOptions(
 			siteType = 'jetpack';
 		} else if ( siteSlug ) {
 			siteType = 'simple';
+		} else if ( ! isLoggedIn ) {
+			siteType = 'logged_out';
 		}
 
 		const clickHandler = () => {

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -58,8 +58,6 @@ const InstallThemeButton = connectOptions(
 			siteType = 'jetpack';
 		} else if ( siteSlug ) {
 			siteType = 'simple';
-		} else if ( ! isLoggedIn ) {
-			siteType = 'logged_out';
 		}
 
 		const clickHandler = () => {

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -52,14 +52,14 @@ const InstallThemeButton = connectOptions(
 		}
 
 		let siteType = null;
-		if ( atomicSite ) {
+		if ( ! isLoggedIn ) {
+			siteType = 'logged_out';
+		} else if ( atomicSite ) {
 			siteType = 'atomic';
 		} else if ( jetpackSite ) {
 			siteType = 'jetpack';
 		} else if ( siteSlug ) {
 			siteType = 'simple';
-		} else if ( ! isLoggedIn ) {
-			siteType = 'logged_out';
 		}
 
 		const clickHandler = () => {

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -51,12 +51,20 @@ const InstallThemeButton = connectOptions(
 			return null;
 		}
 
+		let siteType = null;
+		if ( atomicSite ) {
+			siteType = 'atomic';
+		} else if ( jetpackSite ) {
+			siteType = 'jetpack';
+		} else if ( siteSlug ) {
+			siteType = 'simple';
+		}
+
 		const clickHandler = () => {
 			trackClick( 'upload theme' );
 			dispatchTracksEvent( {
 				tracksEventProps: {
-					is_atomic: atomicSite,
-					is_jetpack_connected: jetpackSite,
+					site_type: siteType,
 				},
 			} );
 		};


### PR DESCRIPTION
When a user clicks the "Install Theme" button, we should track what type of site this was done from.

#### Testing instructions

**Given** an atomic site,
**When** you navigate to wordpress.com/themes/SITE_SLUG page and click the 'Install Theme' button,
**Then** a `calypso_click_theme_upload` tracks event should be created with `site_type` as `atomic`

**Given** a simple-site site,
**When** you navigate to wordpress.com/themes/SITE_SLUG page and click the 'Install Theme' button,
**Then** a `calypso_click_theme_upload` tracks event should be created with `site_type` as `simple`

**Given** a jetpack-connected, self-hosted site,
**When** you navigate to wordpress.com/themes/SITE_SLUG page and click the 'Install Theme' button,
**Then** a `calypso_click_theme_upload` tracks event should be created with `site_type` as `jetpack`

**Given** you are logged out
**When** you navigate to wordpress.com/themes page
**Then** you should not see the 'Install Theme' button.

#### Notes

- If the first page you load is SSR rendered, such as /themes (instead of /themes/SITE_SLUG), onClick events won't work. 
It's not due to the PR. 

#### Context

Related to #52927