### PR TITLE
ETK Block patterns: Adding extra checks for array values before we use them to avoid PHP

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -252,7 +252,10 @@ class Block_Patterns_From_API {
 				// Gutenberg registers patterns with varying prefixes, but categorizes them using `core/*` in a blockTypes array.
 				// This will ensure we remove `query/*` blocks for example.
 				// TODO: We need to revisit our usage or $pattern['blockTypes']: they are currently an experimental feature and not guaranteed to reference `core/*` blocks.
-				$pattern_block_type_or_name = ! empty( $pattern['blockTypes'][0] ) ? $pattern['blockTypes'][0] : $pattern['name'];
+				$pattern_block_type_or_name =
+					isset( $pattern['blockTypes'] ) && is_array( $pattern['blockTypes'] ) && ! empty( $pattern['blockTypes'][0] )
+					? $pattern['blockTypes'][0]
+					: $pattern['name'];
 				if ( 'core/' === substr( $pattern_block_type_or_name, 0, 5 ) ) {
 					unregister_block_pattern( $pattern['name'] );
 				}
@@ -275,8 +278,11 @@ class Block_Patterns_From_API {
 	private function update_core_patterns_with_wpcom_categories() {
 		if ( class_exists( 'WP_Block_Patterns_Registry' ) ) {
 			foreach ( \WP_Block_Patterns_Registry::get_instance()->get_all_registered() as $pattern ) {
-				$wpcom_categories = $this->core_to_wpcom_categories_dictionary[ $pattern['name'] ];
-				if ( isset( $wpcom_categories ) ) {
+				$wpcom_categories =
+					$pattern['name'] && isset( $this->core_to_wpcom_categories_dictionary[ $pattern['name'] ] )
+					? $this->core_to_wpcom_categories_dictionary[ $pattern['name'] ]
+					: null;
+				if ( $wpcom_categories ) {
 					unregister_block_pattern( $pattern['name'] );
 					$pattern_properties = array_merge(
 						$pattern,

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -253,7 +253,7 @@ class Block_Patterns_From_API {
 				// This will ensure we remove `query/*` blocks for example.
 				// TODO: We need to revisit our usage or $pattern['blockTypes']: they are currently an experimental feature and not guaranteed to reference `core/*` blocks.
 				$pattern_block_type_or_name =
-					isset( $pattern['blockTypes'] ) && is_array( $pattern['blockTypes'] ) && ! empty( $pattern['blockTypes'][0] )
+					isset( $pattern['blockTypes'] ) && ! empty( $pattern['blockTypes'][0] )
 					? $pattern['blockTypes'][0]
 					: $pattern['name'];
 				if ( 'core/' === substr( $pattern_block_type_or_name, 0, 5 ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

In [this commit ](https://github.com/Automattic/wp-calypso/commit/47d8b66a7a4b589485258e8baa154d2133ff2da8#diff-d44c36e7354f0d5126e432970464208fc3001be6077ffcb29e485d04713ca81aR278) we added a method to update core pattern categories. 

Great. 🕺 

Sad news is, the `$this->core_to_wpcom_categories_dictionary[ $pattern['name'] ]` is not robust enough and is causing PHP warnings. ⚠️ 

This PR tightens a couple of array checks, and hopefully restores our goodwill among those who keep our logs.


### Testing instructions

Apply this patch to your sandbox and testing using a sandboxed site:

`install-plugin.sh etk fix/etk-block-patterns-add-check-before-accessing-categories-array`

Follow the testing instructions in https://github.com/Automattic/wp-calypso/pull/52656

Generally, the editor and the patterns in the patterns inserter should have no regressions and patterns should load without any errors.


