### PR TITLE
Search: enable Jetpack Search section in Jetpack Cloud

### DIFF
--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -22,7 +22,6 @@ import QueryScanState from 'calypso/components/data/query-jetpack-scan';
 import ScanBadge from 'calypso/components/jetpack/scan-badge';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
 export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 	const translate = useTranslate();
@@ -90,19 +89,17 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 					<ScanBadge progress={ scanProgress } numberOfThreatsFound={ scanThreats?.length ?? 0 } />
 				</SidebarItem>
 			) }
-			{ ! isJetpackCloud() && (
-				<SidebarItem
-					tipTarget="jetpack-search"
-					icon={ showIcons ? 'search' : undefined }
-					label={ translate( 'Search', {
-						comment: 'Jetpack sidebar menu item',
-					} ) }
-					link={ `/jetpack-search/${ siteSlug }` }
-					onNavigate={ onNavigate( tracksEventNames.activityClicked ) }
-					selected={ currentPathMatches( `/jetpack-search/${ siteSlug }` ) }
-					expandSection={ expandSection }
-				/>
-			) }
+			<SidebarItem
+				tipTarget="jetpack-search"
+				icon={ showIcons ? 'search' : undefined }
+				label={ translate( 'Search', {
+					comment: 'Jetpack sidebar menu item',
+				} ) }
+				link={ `/jetpack-search/${ siteSlug }` }
+				onNavigate={ onNavigate( tracksEventNames.activityClicked ) }
+				selected={ currentPathMatches( `/jetpack-search/${ siteSlug }` ) }
+				expandSection={ expandSection }
+			/>
 		</>
 	);
 };

--- a/client/my-sites/jetpack-search/controller.js
+++ b/client/my-sites/jetpack-search/controller.js
@@ -6,7 +6,19 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import IsJetpackDisconnectedSwitch from 'calypso/components/jetpack/is-jetpack-disconnected-switch';
 import JetpackSearchMain from './main';
+import JetpackSearchDisconnected from './disconnected';
+
+export function showJetpackIsDisconnected( context, next ) {
+	context.primary = (
+		<IsJetpackDisconnectedSwitch
+			trueComponent={ <JetpackSearchDisconnected /> }
+			falseComponent={ context.primary }
+		/>
+	);
+	next();
+}
 
 /* handles /jetpack-search/:site, see `jetpackSearchMainPath` */
 export function jetpackSearchMain( context, next ) {

--- a/client/my-sites/jetpack-search/disconnected.tsx
+++ b/client/my-sites/jetpack-search/disconnected.tsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import DocumentHead from 'calypso/components/data/document-head';
+import Main from 'calypso/components/main';
+import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import JetpackDisconnected from 'calypso/components/jetpack/jetpack-disconnected';
+import JetpackDisconnectedWPCOM from 'calypso/components/jetpack/jetpack-disconnected-wpcom';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+
+export default function JetpackSearchDisconnected(): ReactElement {
+	const isCloud = isJetpackCloud();
+	return (
+		<Main className="jetpack-search">
+			<DocumentHead title="Jetpack Search" />
+			<SidebarNavigation />
+			<PageViewTracker path="/jetpack-search/:site" title="Jetpack Search" />
+			<div className="jetpack-search__disconnected">
+				{ isCloud ? <JetpackDisconnected /> : <JetpackDisconnectedWPCOM /> }
+			</div>
+		</Main>
+	);
+}

--- a/client/my-sites/jetpack-search/footer.tsx
+++ b/client/my-sites/jetpack-search/footer.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement, Fragment } from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
+
+export default function JetpackSearchFooter(): ReactElement {
+	const siteId = useSelector( getSelectedSiteId );
+	const isWPCOM = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
+	const isCloud = isJetpackCloud();
+
+	// Don't display this footer in Jetpack Cloud or for non-WordPress.com sites
+	if ( isCloud || ! isWPCOM ) {
+		return null;
+	}
+
+	return (
+		<Fragment>
+			<WhatIsJetpack />
+		</Fragment>
+	);
+}

--- a/client/my-sites/jetpack-search/index.js
+++ b/client/my-sites/jetpack-search/index.js
@@ -21,6 +21,7 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+
 	/* handles /jetpack-search, see `jetpackSearchMainPath` */
 	page( jetpackSearchMainPath(), siteSelection, sites, makeLayout, clientRender );
 }

--- a/client/my-sites/jetpack-search/index.js
+++ b/client/my-sites/jetpack-search/index.js
@@ -6,7 +6,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { jetpackSearchMain } from 'calypso/my-sites/jetpack-search/controller';
+import {
+	jetpackSearchMain,
+	showJetpackIsDisconnected,
+} from 'calypso/my-sites/jetpack-search/controller';
 import { jetpackSearchMainPath } from './paths';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
@@ -18,6 +21,7 @@ export default function () {
 		siteSelection,
 		navigation,
 		jetpackSearchMain,
+		showJetpackIsDisconnected,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/jetpack-search/logo.tsx
+++ b/client/my-sites/jetpack-search/logo.tsx
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement } from 'react';
+
+/**
+ * Asset dependencies
+ */
+import JetpackSearchSVG from 'calypso/assets/images/illustrations/jetpack-search.svg';
+
+export default function JetpackSearchLogo(): ReactElement {
+	return (
+		<div className="jetpack-search__logo">
+			<img src={ JetpackSearchSVG } alt="Search logo" />
+		</div>
+	);
+}

--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -23,15 +23,14 @@ import {
 } from 'calypso/state/ui/selectors';
 import getSiteSetting from 'calypso/state/selectors/get-site-setting';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
-import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import JetpackSearchUpsell from './upsell';
 import JetpackSearchPlaceholder from './placeholder';
+import JetpackSearchFooter from './footer';
 import { isJetpackSearch, planHasJetpackSearch } from '@automattic/calypso-products';
 import {
 	getSitePurchases,
 	hasLoadedSitePurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
-import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 
 /**
  * Asset dependencies
@@ -51,7 +50,6 @@ export default function JetpackSearchMain(): ReactElement {
 		sitePurchases.find( checkForSearchProduct ) || planHasJetpackSearch( site?.plan?.product_slug );
 	const hasLoadedSitePurchases = useSelector( hasLoadedSitePurchasesFromServer );
 	const onSettingsClick = useTrackCallback( undefined, 'calypso_jetpack_search_settings' );
-	const isWPCOM = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
 
 	if ( ! hasLoadedSitePurchases ) {
 		return <JetpackSearchPlaceholder siteId={ siteId } />;
@@ -102,7 +100,7 @@ export default function JetpackSearchMain(): ReactElement {
 				/>
 			</PromoCard>
 
-			{ isWPCOM && <WhatIsJetpack /> }
+			<JetpackSearchFooter />
 		</Main>
 	);
 }

--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -65,8 +65,11 @@ export default function JetpackSearchMain(): ReactElement {
 		getSiteSetting( state, siteId, 'jetpack_search_enabled' )
 	);
 	const isSearchEnabled = isJetpack ? isJetpackSearchModuleActive : isJetpackSearchSettingEnabled;
+	const isRelevantSettingLoaded = isJetpack
+		? !! jetpackModules
+		: siteSettings && 'jetpack_search_enabled' in siteSettings;
 
-	if ( ! hasLoadedSitePurchases || ! ( siteSettings || jetpackModules ) ) {
+	if ( ! hasLoadedSitePurchases || ! isRelevantSettingLoaded ) {
 		return <JetpackSearchPlaceholder siteId={ siteId } />;
 	}
 

--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -36,11 +36,8 @@ import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-act
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSiteSettings } from 'calypso/state/site-settings/selectors';
 import getJetpackModules from 'calypso/state/selectors/get-jetpack-modules';
-
-/**
- * Asset dependencies
- */
-import JetpackSearchSVG from 'calypso/assets/images/illustrations/jetpack-search.svg';
+import Upsell from 'calypso/components/jetpack/upsell';
+import JetpackSearchLogo from './logo';
 
 export default function JetpackSearchMain(): ReactElement {
 	const site = useSelector( getSelectedSite );
@@ -91,39 +88,22 @@ export default function JetpackSearchMain(): ReactElement {
 			<PageViewTracker path="/jetpack-search/:site" title="Jetpack Search" />
 			<QuerySiteSettings siteId={ siteId } />
 
-			<FormattedHeader
-				headerText={ translate( 'Jetpack Search' ) }
-				id="jetpack-search-header"
-				align="left"
-				brandFont
-			/>
-
-			<PromoCard
-				title={
+			<Upsell
+				headerText={
 					isSearchEnabled
 						? translate( 'Jetpack Search is enabled on your site.' )
 						: translate( 'Jetpack Search is disabled on your site.' )
 				}
-				image={ { path: JetpackSearchSVG } }
-				isPrimary
-			>
-				<p className="jetpack-search__text">
-					{ isSearchEnabled
+				bodyText={
+					isSearchEnabled
 						? translate( 'Your visitors are getting our fastest search experience.' )
-						: translate( 'Enable it to ensure your visitors get our fastest search experience.' ) }
-				</p>
-
-				<PromoCardCTA
-					cta={ {
-						text: translate( 'Settings' ),
-						action: {
-							url: settingsUrl,
-							onClick: onSettingsClick,
-							selfTarget: true,
-						},
-					} }
-				/>
-			</PromoCard>
+						: translate( 'Enable it to ensure your visitors get our fastest search experience.' )
+				}
+				buttonLink={ settingsUrl }
+				buttonText={ translate( 'Settings' ) }
+				onClick={ onSettingsClick }
+				iconComponent={ <JetpackSearchLogo /> }
+			/>
 
 			<JetpackSearchFooter />
 		</Main>

--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -31,6 +31,7 @@ import {
 	getSitePurchases,
 	hasLoadedSitePurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
 /**
  * Asset dependencies
@@ -58,6 +59,13 @@ export default function JetpackSearchMain(): ReactElement {
 	if ( ! hasSearchProduct ) {
 		return <JetpackSearchUpsell />;
 	}
+
+	const isCloud = isJetpackCloud();
+
+	// Send Jetpack Cloud users to wp-admin settings and everyone else to Calypso blue
+	const settingsUrl = isCloud
+		? `${ site.options.admin_url }admin.php?page=jetpack#/performance`
+		: `/settings/performance/${ siteSlug }`;
 
 	return (
 		<Main className="jetpack-search">
@@ -92,7 +100,7 @@ export default function JetpackSearchMain(): ReactElement {
 					cta={ {
 						text: translate( 'Settings' ),
 						action: {
-							url: `/settings/performance/${ siteSlug }`,
+							url: settingsUrl,
 							onClick: onSettingsClick,
 							selfTarget: true,
 						},

--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -84,7 +84,7 @@ export default function JetpackSearchMain(): ReactElement {
 				image={ { path: JetpackSearchSVG } }
 				isPrimary
 			>
-				<p>
+				<p className="jetpack-search__text">
 					{ isSearchEnabled
 						? translate( 'Your visitors are getting our fastest search experience.' )
 						: translate( 'Enable it to ensure your visitors get our fastest search experience.' ) }

--- a/client/my-sites/jetpack-search/placeholder.tsx
+++ b/client/my-sites/jetpack-search/placeholder.tsx
@@ -17,6 +17,8 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import Upsell from 'calypso/components/jetpack/upsell';
+import JetpackSearchLogo from './logo';
 
 /**
  * Style dependencies
@@ -44,17 +46,17 @@ export default function JetpackSearchPlaceholder( { siteId }: Props ): ReactElem
 			<DocumentHead title="Jetpack Search" />
 			<SidebarNavigation />
 
-			<FormattedHeader
-				headerText={ translate( 'Jetpack Search' ) }
-				id="jetpack-search-header"
-				align="left"
-				brandFont
+			<Upsell
+				headerText={ translate( 'Finely-tuned search for your site.' ) }
+				bodyText={ translate(
+					'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.'
+				) }
+				buttonLink={ null }
+				buttonText={ translate( 'Upgrade to Jetpack Search' ) }
+				className="jetpack_search__placeholder"
+				onClick={ () => {} }
+				iconComponent={ <JetpackSearchLogo /> }
 			/>
-
-			<PromoCard title={ 'Placeholder' } image={ { path: JetpackSearchSVG } } isPrimary>
-				<p className="jetpack-search__placeholder-description">Placeholder</p>
-				<button className="jetpack-search__placeholder-button">Placeholder</button>
-			</PromoCard>
 		</Main>
 	);
 }

--- a/client/my-sites/jetpack-search/placeholder.tsx
+++ b/client/my-sites/jetpack-search/placeholder.tsx
@@ -3,6 +3,7 @@
  */
 import React, { ReactElement } from 'react';
 import { translate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -13,6 +14,9 @@ import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import FormattedHeader from 'calypso/components/formatted-header';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import QuerySiteSettings from 'calypso/components/data/query-site-settings';
+import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 
 /**
  * Style dependencies
@@ -29,9 +33,14 @@ interface Props {
 }
 
 export default function JetpackSearchPlaceholder( { siteId }: Props ): ReactElement {
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+
 	return (
 		<Main className="jetpack-search__placeholder">
 			<QuerySitePurchases siteId={ siteId } />
+			<QuerySiteSettings siteId={ siteId } />
+			{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }
+
 			<DocumentHead title="Jetpack Search" />
 			<SidebarNavigation />
 

--- a/client/my-sites/jetpack-search/style.scss
+++ b/client/my-sites/jetpack-search/style.scss
@@ -3,3 +3,7 @@
 		@include placeholder( --color-neutral-10 );
 	}
 }
+
+.jetpack-search__text {
+	font-size: 1rem;
+}

--- a/client/my-sites/jetpack-search/style.scss
+++ b/client/my-sites/jetpack-search/style.scss
@@ -7,3 +7,7 @@
 .jetpack-search__text {
 	font-size: 1rem;
 }
+
+.jetpack-search__disconnected {
+	padding-top: 40px; // to match Backup and Scan
+}

--- a/client/my-sites/jetpack-search/style.scss
+++ b/client/my-sites/jetpack-search/style.scss
@@ -8,6 +8,10 @@
 	font-size: 1rem;
 }
 
-.jetpack-search__disconnected {
+.jetpack-search__logo {
 	padding-top: 40px; // to match Backup and Scan
+	img {
+		height: 72px;
+		width: auto;
+	}
 }

--- a/client/my-sites/jetpack-search/upsell.tsx
+++ b/client/my-sites/jetpack-search/upsell.tsx
@@ -17,7 +17,7 @@ import PromoCard from 'calypso/components/promo-section/promo-card';
 import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
+import JetpackSearchFooter from './footer';
 
 /**
  * Asset dependencies
@@ -47,7 +47,7 @@ export default function JetpackSearchUpsell(): ReactElement {
 				image={ { path: JetpackSearchSVG } }
 				isPrimary
 			>
-				<p>
+				<p className="jetpack-search__text">
 					{ translate(
 						'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.'
 					) }
@@ -68,7 +68,7 @@ export default function JetpackSearchUpsell(): ReactElement {
 				/>
 			</PromoCard>
 
-			<WhatIsJetpack />
+			<JetpackSearchFooter />
 		</Main>
 	);
 }

--- a/client/my-sites/jetpack-search/upsell.tsx
+++ b/client/my-sites/jetpack-search/upsell.tsx
@@ -18,6 +18,8 @@ import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import JetpackSearchFooter from './footer';
+import Upsell from 'calypso/components/jetpack/upsell';
+import JetpackSearchLogo from './logo';
 
 /**
  * Asset dependencies
@@ -28,6 +30,10 @@ export default function JetpackSearchUpsell(): ReactElement {
 	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_search_upsell' );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate();
+	const upgradeUrl =
+		'/checkout/' +
+		siteSlug +
+		'/jetpack_search_monthly?utm_campaign=my-sites-jetpack-search&utm_source=calypso';
 
 	return (
 		<Main className="jetpack-search">
@@ -35,38 +41,16 @@ export default function JetpackSearchUpsell(): ReactElement {
 			<SidebarNavigation />
 			<PageViewTracker path="/jetpack-search/:site" title="Jetpack Search" />
 
-			<FormattedHeader
-				headerText={ translate( 'Jetpack Search' ) }
-				id="jetpack-search-header"
-				align="left"
-				brandFont
+			<Upsell
+				headerText={ translate( 'Finely-tuned search for your site.' ) }
+				bodyText={ translate(
+					'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.'
+				) }
+				buttonLink={ upgradeUrl }
+				buttonText={ translate( 'Upgrade to Jetpack Search' ) }
+				onClick={ onUpgradeClick }
+				iconComponent={ <JetpackSearchLogo /> }
 			/>
-
-			<PromoCard
-				title={ translate( 'Finely-tuned search for your site.' ) }
-				image={ { path: JetpackSearchSVG } }
-				isPrimary
-			>
-				<p className="jetpack-search__text">
-					{ translate(
-						'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.'
-					) }
-				</p>
-
-				<PromoCardCTA
-					cta={ {
-						text: translate( 'Upgrade to Jetpack Search' ),
-						action: {
-							url:
-								'/checkout/' +
-								siteSlug +
-								'/jetpack_search_monthly?utm_campaign=my-sites-jetpack-search&utm_source=calypso',
-							onClick: onUpgradeClick,
-							selfTarget: true,
-						},
-					} }
-				/>
-			</PromoCard>
 
 			<JetpackSearchFooter />
 		</Main>

--- a/client/state/selectors/get-site-setting.js
+++ b/client/state/selectors/get-site-setting.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
 
 /**

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -67,8 +67,9 @@
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud": true,
-		"scan": true,
-		"jetpack-connect": true
+		"jetpack-connect": true,
+		"jetpack-search": true,
+		"scan": true
 	},
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -62,8 +62,9 @@
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud": true,
-		"scan": true,
-		"jetpack-connect": true
+		"jetpack-connect": true,
+		"jetpack-search": true,
+		"scan": true
 	},
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud"

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -62,6 +62,7 @@
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud": true,
+		"jetpack-search": true,
 		"scan": true
 	},
 	"site_filter": [ "jetpack" ],

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -65,8 +65,9 @@
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud": true,
-		"scan": true,
-		"jetpack-connect": true
+		"jetpack-connect": true,
+		"jetpack-search": true,
+		"scan": true
 	},
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the 'Search' menu item to Jetpack Cloud. This section shows the same information as Jetpack > Search in Calypso blue.

<img width="782" alt="Screen Shot 2021-05-21 at 15 48 36" src="https://user-images.githubusercontent.com/17325/119079341-06d78300-ba4c-11eb-92e9-c5644e644ec7.png">

##### Context

In https://github.com/Automattic/wp-calypso/pull/47879 we hid the 'Search' menu item in Jetpack Cloud because the search section was 404ing. Turns out just we needed to enable the `jetpack-search` section in the Cloud configs!

#### Testing instructions

1. Run locally with `CALYPSO_ENV=jetpack-cloud-development yarn start` and map `jetpack.cloud.localhost` to 127.0.0.1 in your “hosts” file.
2. Visit http://jetpack.cloud.localhost:3000/ and choose the 'Search' item in the sidebar.
3. Try to access a site that is disconnected from Jetpack (like an old jurassic.ninja site). It should look like this:

<img width="769" alt="Screen Shot 2021-05-24 at 16 00 17" src="https://user-images.githubusercontent.com/17325/119295009-e278e200-bca9-11eb-9b72-84e125fdf2d8.png">

4. Stop Calypso and restart with the regular environment (`yarn start`) and access via http://calypso.localhost:3000.
5. Visit the same sites in Calypso blue via Jetpack > Search and ensure the experience is consistent.

#### Todo

- [x] Tune font sizing
- [x] Always hide 'What is Jetpack' footer in Cloud
- [x] Check Jetpack is connected
- [ ] Fix 'flash of disabled' when actually enabled - show placeholder until we know
- [x] Fix Settings link for Jetpack sites
- [x] Match styling of Backup and Scan sections in Jetpack Cloud (different fonts and sizes, no container box)
- [ ] Handle missing site (410 Gone) like a deleted jurassic.ninja
- [ ] Adjust styles for placeholder
