### PR TITLE
Block patterns: adding blockTypes to FSE patterns

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -133,6 +133,7 @@ class Block_Patterns_From_API {
 					$viewport_width = isset( $pattern['pattern_meta']['viewport_width'] ) ? intval( $pattern['pattern_meta']['viewport_width'] ) : 1280;
 					$viewport_width = $viewport_width < 320 ? 320 : $viewport_width;
 					$pattern_name   = self::PATTERN_NAMESPACE . $pattern['name'];
+					$block_types    = $this->utils->maybe_get_pattern_block_types_from_pattern_meta( $pattern );
 
 					$results[ $pattern_name ] = register_block_pattern(
 						$pattern_name,
@@ -145,6 +146,7 @@ class Block_Patterns_From_API {
 								$pattern['categories']
 							),
 							'isPremium'     => $is_premium,
+							'blockTypes'    => $block_types,
 						)
 					);
 				}

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-utils.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-utils.php
@@ -86,4 +86,33 @@ class Block_Patterns_Utils {
 		$language = function_exists( 'get_blog_lang_code' ) ? get_blog_lang_code() : get_locale();
 		return \A8C\FSE\Common\get_iso_639_locale( $language );
 	}
+
+	/**
+	 * Check for block type values in the pattern_meta tag.
+	 * When tags have a prefix of `block_type_`, we expect the remaining suffix to be a blockType value.
+	 * We'll add these values to the `(array) blockType` options property when registering the pattern
+	 * via `register_block_pattern`.
+	 *
+	 * @param array $pattern A pattern with a 'pattern_meta' array.
+	 *
+	 * @return array         An array of block types defined in pattern meta.
+	 */
+	public function maybe_get_pattern_block_types_from_pattern_meta( $pattern ) {
+		$block_types = array();
+
+		if ( ! isset( $pattern['pattern_meta'] ) || empty( $pattern['pattern_meta'] ) ) {
+			return $block_types;
+		}
+
+		foreach ( $pattern['pattern_meta'] as $pattern_meta => $value ) {
+			// Match against tags starting with `block_type_`.
+			$split_slug = preg_split( '/^block_type_/', $pattern_meta );
+
+			if ( isset( $split_slug[1] ) ) {
+				$block_types[] = $split_slug[1];
+			}
+		}
+
+		return $block_types;
+	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
@@ -1,7 +1,9 @@
 <?php
 /**
- * Coming Soon Tests File
- * Run: yarn run test:php --testsuite block-patterns
+ * Block patterns API tests
+ * Run:
+ * cd apps/editing-toolkit
+ * yarn run test:php --testsuite block-patterns
  *
  * @package full-site-editing-plugin
  */
@@ -19,14 +21,14 @@ class Block_Patterns_From_Api_Test extends TestCase {
 	/**
 	 * PHPUnit_Framework_MockObject_MockObject.
 	 *
-	 * @var string
+	 * @var object
 	 */
 	protected $utils_mock;
 
 	/**
 	 * Representation of a Pattern as returned by the API.
 	 *
-	 * @var string
+	 * @var array
 	 */
 	protected $pattern_mock_object;
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-utils-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-utils-test.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Block patterns Utils tests
+ * Run:
+ * cd apps/editing-toolkit
+ * yarn run test:php --testsuite block-patterns
+ *
+ * @package full-site-editing-plugin
+ */
+
+namespace A8C\FSE;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../class-block-patterns-utils.php';
+
+/**
+ * Class Coming_Soon_Test
+ */
+class Block_Patterns_Utils_Test extends TestCase {
+	/**
+	 * Block_Patterns_Utils
+	 *
+	 * @var object
+	 */
+	protected $utils;
+
+	/**
+	 * Pre-test setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->utils = new Block_Patterns_Utils();
+	}
+
+	/**
+	 *  Tests that we receive an empty block_types array where there are no block types in pattern_meta
+	 */
+	public function test_should_return_empty_array_from_block_types_check() {
+		$test_pattern = $this->get_test_pattern();
+		$block_types  = $this->utils->maybe_get_pattern_block_types_from_pattern_meta( $test_pattern );
+
+		$this->assertEmpty( $block_types );
+	}
+
+	/**
+	 *  Tests that we can parse block types from pattern_meta.
+	 */
+	public function test_should_return_block_types_from_patterns_meta() {
+		$test_pattern = $this->get_test_pattern(
+			array(
+				'pattern_meta' => array(
+					'block_type_core/template-part/footer' => true,
+				),
+			)
+		);
+		$block_types  = $this->utils->maybe_get_pattern_block_types_from_pattern_meta( $test_pattern );
+
+		$this->assertEquals( array( 'core/template-part/footer' ), $block_types );
+	}
+
+	/**
+	 * Util function from grabbing a test pattern.
+	 *
+	 * @param  array $new_pattern_values Values to merge into the default array.
+	 * @return array                     A test pattern.
+	 */
+	private function get_test_pattern( $new_pattern_values = array() ) {
+		$default_pattern = array(
+			'ID'            => '1',
+			'site_id'       => '2',
+			'title'         => 'test title',
+			'name'          => 'test pattern name',
+			'description'   => 'test description',
+			'html'          => '<p>test</p>',
+			'source_url'    => 'http;//test',
+			'modified_date' => 'dd:mm:YY',
+			'categories'    => array(
+				array(
+					'title' => 'test-category',
+				),
+			),
+			'pattern_meta'  => array(
+				'is_web' => true,
+			),
+		);
+
+		return array_merge( $default_pattern, $new_pattern_values );
+	}
+}


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR checks a pattern's `pattern_meta` for block type values and adds them to the options array when registering blocks with `register_block_pattern`. WOOT!

This PR was brought to you by Yorkshire Gold Tea!

## Testing instructions

Enable a block-based theme, e.g., TT1 blocks

Add a new Header block to a template in the Site Editor. In the "Template Part" dialogue, click "New template part"

A default pattern should appear. These patterns are fetched from the source site dotcomfsepatterns.

![block-types-testing](https://user-images.githubusercontent.com/6458278/119301952-a3955d00-bca6-11eb-899c-65adb38dbf39.gif)

Check that other header/footer patterns load as well:

<img width="1584" alt="Screen Shot 2021-05-25 at 12 23 43 pm" src="https://user-images.githubusercontent.com/6458278/119430425-1b6d9100-bd54-11eb-92a7-ee3f44bfd2e8.png">


Unit tests:

```
cd apps/editing-toolkit
yarn run test:php --testsuite block-patterns
```


Related to https://github.com/Automattic/view-design/issues/111
