### PR TITLE
Add onboarding checklist options to jetpack whitelist

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -342,3 +342,11 @@ function load_error_reporting() {
 	require_once __DIR__ . '/error-reporting/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_error_reporting' );
+
+/**
+ * Enhancements to support wpcom onboarding checklist tasks
+ */
+function load_wpcom_tasks() {
+	require_once __DIR__ . '/wpcom-tasks/index.php';
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_tasks' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-tasks/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-tasks/index.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Atomic support for WPCOM onboarding checklist tasks.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE\WPCOMTasks;
+
+/**
+ * Add onboarding checklist task options
+ *
+ * @param [ string ] $options incoming options to filter.
+ *
+ * @return [ string ]
+ */
+function wpcom_tasks_jetpack_options_whitelist( $options ) {
+	$options[] = 'onboarding_checklist_task_front_page_updated';
+	return $options;
+}
+
+/**
+ * Returns whether or not the site loading ETK is in the WoA env.
+ *
+ * @return bool
+ */
+function is_atomic() {
+	return defined( 'IS_ATOMIC' ) && IS_ATOMIC;
+}
+
+if ( is_atomic() ) {
+	add_filter( 'jetpack_options_whitelist', __NAMESPACE__ . '\\wpcom_tasks_jetpack_options_whitelist' );
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-tasks/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-tasks/index.php
@@ -8,6 +8,28 @@
 namespace A8C\FSE\WPCOMTasks;
 
 /**
+ * This logic is duplicated from Onboarding_Checklist\Blog
+ */
+function page_post_saved( $post_ID, $post, $update ) {
+	if ( get_option( 'show_on_front' ) === 'page' && (int) get_option( 'page_on_front' ) === $post_ID ) {
+		set_option( 'onboarding_checklist_task_front_page_updated', true );
+	}
+}
+add_action( 'save_post_page', __NAMESPACE__ . '\\page_post_saved', 10, 3 );
+
+/**
+ * This logic is duplicated from Onboarding_Checklist\Blog
+ */
+function update_option_page_on_front( $old_value, $new_value ) {
+	if ( $old_value === $new_value ) {
+		return;
+	}
+
+	set_option( 'onboarding_checklist_task_front_page_updated', true );
+}
+add_action( 'update_option_page_on_front', __NAMESPACE__ . '\\update_option_page_on_front', 10, 3 );
+
+/**
  * Add onboarding checklist task options
  *
  * @param [ string ] $options incoming options to filter.
@@ -15,6 +37,7 @@ namespace A8C\FSE\WPCOMTasks;
  * @return [ string ]
  */
 function wpcom_tasks_jetpack_options_whitelist( $options ) {
+	$options[] = 'onboarding_checklist_initialized';
 	$options[] = 'onboarding_checklist_task_front_page_updated';
 	return $options;
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-tasks/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-tasks/index.php
@@ -12,7 +12,7 @@ namespace A8C\FSE\WPCOMTasks;
  */
 function page_post_saved( $post_ID, $post, $update ) {
 	if ( get_option( 'show_on_front' ) === 'page' && (int) get_option( 'page_on_front' ) === $post_ID ) {
-		set_option( 'onboarding_checklist_task_front_page_updated', true );
+		update_option( 'onboarding_checklist_task_front_page_updated', true );
 	}
 }
 add_action( 'save_post_page', __NAMESPACE__ . '\\page_post_saved', 10, 3 );
@@ -25,7 +25,7 @@ function update_option_page_on_front( $old_value, $new_value ) {
 		return;
 	}
 
-	set_option( 'onboarding_checklist_task_front_page_updated', true );
+	update_option( 'onboarding_checklist_task_front_page_updated', true );
 }
 add_action( 'update_option_page_on_front', __NAMESPACE__ . '\\update_option_page_on_front', 10, 3 );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-tasks/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-tasks/index.php
@@ -8,28 +8,6 @@
 namespace A8C\FSE\WPCOMTasks;
 
 /**
- * This logic is duplicated from Onboarding_Checklist\Blog
- */
-function page_post_saved( $post_ID, $post, $update ) {
-	if ( get_option( 'show_on_front' ) === 'page' && (int) get_option( 'page_on_front' ) === $post_ID ) {
-		update_option( 'onboarding_checklist_task_front_page_updated', true );
-	}
-}
-add_action( 'save_post_page', __NAMESPACE__ . '\\page_post_saved', 10, 3 );
-
-/**
- * This logic is duplicated from Onboarding_Checklist\Blog
- */
-function update_option_page_on_front( $old_value, $new_value ) {
-	if ( $old_value === $new_value ) {
-		return;
-	}
-
-	update_option( 'onboarding_checklist_task_front_page_updated', true );
-}
-add_action( 'update_option_page_on_front', __NAMESPACE__ . '\\update_option_page_on_front', 10, 3 );
-
-/**
  * Add onboarding checklist task options
  *
  * @param [ string ] $options incoming options to filter.
@@ -41,16 +19,33 @@ function wpcom_tasks_jetpack_options_whitelist( $options ) {
 	$options[] = 'onboarding_checklist_task_front_page_updated';
 	return $options;
 }
+add_filter( 'jetpack_options_whitelist', __NAMESPACE__ . '\\wpcom_tasks_jetpack_options_whitelist' );
 
-/**
- * Returns whether or not the site loading ETK is in the WoA env.
- *
- * @return bool
- */
-function is_atomic() {
-	return defined( 'IS_ATOMIC' ) && IS_ATOMIC;
-}
+if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+	/**
+	 * This logic is duplicated from Onboarding_Checklist\Blog
+	 *
+	 * @param [ int | Page ] $post_ID the post that has been saved.
+	 */
+	function page_post_saved( $post_ID ) {
+		if ( get_option( 'show_on_front' ) === 'page' && (int) get_option( 'page_on_front' ) === $post_ID ) {
+			update_option( 'onboarding_checklist_task_front_page_updated', true );
+		}
+	}
+	add_action( 'save_post_page', __NAMESPACE__ . '\\page_post_saved', 10, 1 );
 
-if ( is_atomic() ) {
-	add_filter( 'jetpack_options_whitelist', __NAMESPACE__ . '\\wpcom_tasks_jetpack_options_whitelist' );
+	/**
+	 * This logic is duplicated from Onboarding_Checklist\Blog
+	 *
+	 * @param [ int ] $old_value Post ID of page_on_front it was updated.
+	 * @param [ int ] $new_value Post ID front page_on_front is now.
+	 */
+	function update_option_page_on_front( $old_value, $new_value ) {
+		if ( $old_value === $new_value ) {
+			return;
+		}
+
+		update_option( 'onboarding_checklist_task_front_page_updated', true );
+	}
+	add_action( 'update_option_page_on_front', __NAMESPACE__ . '\\update_option_page_on_front', 10, 2 );
 }


### PR DESCRIPTION
#### WIP

This PR adds the syncing logic for the `front_page_updated` checklist task for atomic sites.

Fixes #52705


#### Testing instructions

1. cd wp-calypso/apps/editing-toolkit
2. zip -r editing-toolkit-plugin.zip editing-toolkit-plugin
3. upload the plugin to your atomic site (navigate to your-atomic-site.com/wp-admin/plugin-install.php?tab=upload) and activate it

