### PR TITLE
Revert "My Home: Remove Visit Site Button"

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -10,17 +10,20 @@ import { flowRight } from 'lodash';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
 import { preventWidows } from 'calypso/lib/formatting';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { canCurrentUserUseCustomerHome } from 'calypso/state/sites/selectors';
+import { canCurrentUserUseCustomerHome, getSiteOption } from 'calypso/state/sites/selectors';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteChecklist from 'calypso/components/data/query-site-checklist';
 import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import QueryHomeLayout from 'calypso/components/data/query-home-layout';
 import { getHomeLayout } from 'calypso/state/selectors/get-home-layout';
 import Primary from 'calypso/my-sites/customer-home/locations/primary';
@@ -40,6 +43,7 @@ const Home = ( {
 	layout,
 	site,
 	siteId,
+	trackViewSiteAction,
 	noticeType,
 	shuffleViews,
 } ) => {
@@ -73,6 +77,22 @@ const Home = ( {
 		);
 	}
 
+	const header = (
+		<div className="customer-home__heading">
+			<FormattedHeader
+				brandFont
+				headerText={ translate( 'My Home' ) }
+				subHeaderText={ translate( 'Your hub for posting, editing, and growing your site.' ) }
+				align="left"
+			/>
+			<div className="customer-home__view-site-button">
+				<Button href={ site.URL } onClick={ trackViewSiteAction }>
+					{ translate( 'Visit site' ) }
+				</Button>
+			</div>
+		</div>
+	);
+
 	return (
 		<Main wideLayout className="customer-home__main">
 			<PageViewTracker path={ `/home/:site` } title={ translate( 'My Home' ) } />
@@ -87,13 +107,7 @@ const Home = ( {
 				/>
 			) }
 			<SidebarNavigation />
-			<FormattedHeader
-				brandFont
-				className="customer-home__heading"
-				headerText={ translate( 'My Home' ) }
-				subHeaderText={ translate( 'Your hub for posting, editing, and growing your site.' ) }
-				align="left"
-			/>
+			{ header }
 			{ layout ? (
 				<>
 					<Primary cards={ layout.primary } />
@@ -116,25 +130,51 @@ const Home = ( {
 Home.propTypes = {
 	canUserUseCustomerHome: PropTypes.bool.isRequired,
 	isDev: PropTypes.bool,
+	isStaticHomePage: PropTypes.bool.isRequired,
 	forcedView: PropTypes.string,
 	layout: PropTypes.object,
 	site: PropTypes.object.isRequired,
 	siteId: PropTypes.number.isRequired,
+	trackViewSiteAction: PropTypes.func.isRequired,
 	shuffleViews: PropTypes.bool,
 };
 
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
+	const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
 	const layout = getHomeLayout( state, siteId );
 
 	return {
 		site: getSelectedSite( state ),
 		siteId,
 		canUserUseCustomerHome: canCurrentUserUseCustomerHome( state, siteId ),
+		isStaticHomePage:
+			! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' ),
 		layout,
 	};
 };
 
-const connectHome = connect( mapStateToProps );
+const trackViewSiteAction = ( isStaticHomePage ) =>
+	composeAnalytics(
+		recordTracksEvent( 'calypso_customer_home_my_site_view_site_click', {
+			is_static_home_page: isStaticHomePage,
+		} ),
+		bumpStat( 'calypso_customer_home', 'my_site_view_site' )
+	);
+
+const mapDispatchToProps = {
+	trackViewSiteAction,
+};
+
+const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+	const { isStaticHomePage } = stateProps;
+	return {
+		...ownProps,
+		...stateProps,
+		trackViewSiteAction: () => dispatchProps.trackViewSiteAction( isStaticHomePage ),
+	};
+};
+
+const connectHome = connect( mapStateToProps, mapDispatchToProps, mergeProps );
 
 export default flowRight( connectHome, withTrackingTool( 'HotJar' ) )( Home );

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -19,8 +19,30 @@
 	grid-column: $col-start / span $span;
 }
 
-.customer-home__heading .formatted-header__subtitle {
-	margin: 0;
+.customer-home__heading {
+	display: flex;
+
+	@include breakpoint-deprecated( '<660px' ) {
+		padding-right: 16px;
+	}
+
+	.formatted-header {
+		margin-right: 12px;
+	}
+
+	.formatted-header__subtitle {
+		margin: 0;
+	}
+
+	.customer-home__view-site-button {
+		margin: auto;
+		margin-right: 0;
+
+		.button {
+			text-align: center;
+			white-space: nowrap;
+		}
+	}
 }
 
 .customer-home__layout {


### PR DESCRIPTION
Reverts #52830 following https://github.com/Automattic/wp-calypso/pull/52830#issuecomment-845970030.

This should be fairly straight-forward to test; just verify that the "Visit Site" button appears again on My Home.

<img width="1239" alt="Screenshot 2021-05-21 at 15 03 47" src="https://user-images.githubusercontent.com/43215253/119149807-c1b05280-ba45-11eb-97f7-4fe654f2bc03.png">

Analytics should also work fine, but you might need to manually remove the link before clicking the button to verify this.

<img width="1222" alt="Screenshot 2021-05-21 at 15 05 48" src="https://user-images.githubusercontent.com/43215253/119150113-0c31cf00-ba46-11eb-8c45-e4ad0e89b0ab.png">
