### PR TITLE
Fix how we handle unsupported premium domain searches

### DIFF
--- a/client/components/domains/register-domain-step/utility.js
+++ b/client/components/domains/register-domain-step/utility.js
@@ -68,6 +68,14 @@ export function isUnknownSuggestion( suggestion ) {
 	return suggestion.status === domainAvailability.UNKNOWN;
 }
 
+export function isUnsupportedPremiumSuggestion( suggestion ) {
+	return (
+		domainAvailability.AVAILABLE_PREMIUM === suggestion.status &&
+		suggestion.hasOwnProperty( 'is_supported_premium_domain' ) &&
+		suggestion?.is_supported_premium_domain === false
+	);
+}
+
 export function isMissingVendor( suggestion ) {
 	return ! ( 'vendor' in suggestion );
 }


### PR DESCRIPTION
Sometimes our domain suggestion engine returns premium domain suggestions even when we don't support the TLD if you enter an exact premium domain search string. However we also do an explicit availability check for that domain so we can safely discard the domain suggestion record from the results.

#### Changes proposed in this Pull Request

* When a premium domain is entered and if the same is returned from the domain suggestion engine we should discard that because we already know it's premium.

<img width="400" alt="Screenshot 2021-05-21 at 17 13 53" src="https://user-images.githubusercontent.com/1355045/119151552-2e344d00-ba58-11eb-87e9-5b0e81a87b46.png"> | <img width="400" alt="Screenshot 2021-05-21 at 17 14 21" src="https://user-images.githubusercontent.com/1355045/119151562-3096a700-ba58-11eb-9923-e07acdef622c.png">
-------|-----
before | after


#### Testing instructions

* Open up the live branch and try searching for a premium domain like `wa.wedding` - without this PR you would see `Sorry, wa.wedding is a premium domain. We don't support purchasing this premium domain on WordPress.com, but if you purchase the domain elsewhere, you can map it to your site.` notice but also you'll see `wa.wedding` as first result in the suggested domains. With this PR you should only see the notice and the domain should be removed from the suggestions below.
* Please also test searching for .blog premium domains and make sure they work as they were before