### PR TITLE
Checkout: Enable Google Pay in production

### DIFF
--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -33,7 +33,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
-		"checkout/google-pay": true,
+		"checkout/google-pay": false,
 		"dev/preferences-helper": true,
 		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -31,7 +31,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
-		"checkout/google-pay": true,
+		"checkout/google-pay": false,
 		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,
 		"jetpack-cloud/connect": false,

--- a/config/production.json
+++ b/config/production.json
@@ -25,7 +25,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": true,
-		"checkout/google-pay": false,
+		"checkout/google-pay": true,
 		"desktop-promo": true,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,

--- a/config/test.json
+++ b/config/test.json
@@ -36,7 +36,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": true,
-		"checkout/google-pay": false,
+		"checkout/google-pay": true,
 		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This enables Google Pay support in production.

#### Testing instructions

There's no way to test this since all the testing environments already have Google Pay enabled.