### PR TITLE
Theme Showcase: Update language around homepage switching

### DIFF
--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -176,7 +176,7 @@ class AutoLoadingHomepageModal extends Component {
 							value="keep_current_homepage"
 							checked={ 'keep_current_homepage' === this.state.homepageAction }
 							onChange={ this.handleHomepageAction }
-							label={ translate( 'Use %(themeName)s without changing my homepage content.', {
+							label={ translate( 'Use %(themeName)s without changing my homepage.', {
 								args: { themeName },
 							} ) }
 						/>
@@ -187,7 +187,7 @@ class AutoLoadingHomepageModal extends Component {
 							checked={ 'use_new_homepage' === this.state.homepageAction }
 							onChange={ this.handleHomepageAction }
 							label={ translate(
-								"Use %(themeName)s's homepage content and make my existing homepage a draft.",
+								"Use %(themeName)s's homepage for my site and make my existing homepage a draft.",
 								{
 									args: { themeName },
 								}

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -176,7 +176,7 @@ class AutoLoadingHomepageModal extends Component {
 							value="keep_current_homepage"
 							checked={ 'keep_current_homepage' === this.state.homepageAction }
 							onChange={ this.handleHomepageAction }
-							label={ translate( 'Use %(themeName)s without changing my homepage.', {
+							label={ translate( 'Switch to %(themeName)s without changing the homepage content.', {
 								args: { themeName },
 							} ) }
 						/>
@@ -187,7 +187,7 @@ class AutoLoadingHomepageModal extends Component {
 							checked={ 'use_new_homepage' === this.state.homepageAction }
 							onChange={ this.handleHomepageAction }
 							label={ translate(
-								"Use %(themeName)s's homepage for my site and make my existing homepage a draft.",
+								'Replace the homepage content with the %(themeName)s demo content. The existing homepage will be saved as a draft under Pages → Drafts.',
 								{
 									args: { themeName },
 								}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update Autoloading Homepage modal copy to be clearer about switching between themes that have blog homepage vs. static homepage content. Ref: https://github.com/Automattic/wp-calypso/issues/52799#issuecomment-845320841
* Caveat: I'm not sure this language is clearer. :) What do you think @ianstewart @michaeldcain ?

**Before**

<img width="523" alt="Screen Shot 2021-05-21 at 11 52 25 AM" src="https://user-images.githubusercontent.com/2124984/119164999-05499300-ba2b-11eb-9099-e3a1a4add264.png">

**After**

<img width="499" alt="Screen Shot 2021-05-25 at 1 35 06 PM" src="https://user-images.githubusercontent.com/2124984/119549601-617f2080-bd65-11eb-8c3a-7bb2abb4c246.png">

#### Testing instructions

* Switch to this PR, navigate to `/themes`
* Activate one of the Recommended themes on your site; you should see the auto-loading homepage modal, like above.
* Note copy changes.

Related to #52799