### PR TITLE
Gutenboarding: Fix invalid shopping cart submissions

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -87,10 +87,12 @@ export default function useOnSiteCreation(): void {
 				} );
 				const go = async () => {
 					const cart: ResponseCart = await wpcom.getCart( newSite.site_slug );
-					await wpcom.setCart( newSite.blogid, {
-						...cart,
-						products: [ ...cart.products, planProduct, domainProduct ],
-					} );
+					if ( planProduct || domainProduct ) {
+						await wpcom.setCart( newSite.blogid, {
+							...cart,
+							products: [ ...cart.products, planProduct, domainProduct ].filter( Boolean ),
+						} );
+					}
 					resetOnboardStore();
 					clearLastNonEditorRoute();
 					setSelectedSite( newSite.blogid );

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -61,20 +61,27 @@ export default function useOnSiteCreation(): void {
 		if ( newSite && ! isRedirecting ) {
 			setIsRedirecting( true );
 
-			if ( selectedPlan && ! selectedPlan?.isFree ) {
+			if (
+				selectedPlan &&
+				! selectedPlan?.isFree &&
+				planProductSource &&
+				domain &&
+				domain.product_id &&
+				domain.product_slug
+			) {
 				const planProduct: RequestCartProduct = createRequestCartProduct( {
-					product_id: planProductSource?.productId,
-					product_slug: planProductSource?.storeSlug,
+					product_id: planProductSource.productId,
+					product_slug: planProductSource.storeSlug,
 					extra: {
 						source: 'gutenboarding',
 					},
 				} );
 				const domainProduct: RequestCartProduct = createRequestCartProduct( {
-					meta: domain?.domain_name,
-					product_id: domain?.product_id,
+					meta: domain.domain_name,
+					product_id: domain.product_id,
+					product_slug: domain.product_slug,
 					extra: {
-						privacy_available: domain?.supports_privacy,
-						privacy: domain?.supports_privacy,
+						privacy: domain.supports_privacy,
 						source: 'gutenboarding',
 					},
 				} );

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -3,6 +3,8 @@
  */
 import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { createRequestCartProduct } from '@automattic/shopping-cart';
+import type { RequestCartProduct } from '@automattic/shopping-cart';
 import wp from '../../../lib/wp';
 
 /**
@@ -88,14 +90,14 @@ export default function useOnSiteCreation(): void {
 			setIsRedirecting( true );
 
 			if ( selectedPlan && ! selectedPlan?.isFree ) {
-				const planProduct = {
+				const planProduct: RequestCartProduct = createRequestCartProduct( {
 					product_id: planProductSource?.productId,
 					product_slug: planProductSource?.storeSlug,
 					extra: {
 						source: 'gutenboarding',
 					},
-				};
-				const domainProduct = {
+				} );
+				const domainProduct: RequestCartProduct = createRequestCartProduct( {
 					meta: domain?.domain_name,
 					product_id: domain?.product_id,
 					extra: {
@@ -103,7 +105,7 @@ export default function useOnSiteCreation(): void {
 						privacy: domain?.supports_privacy,
 						source: 'gutenboarding',
 					},
-				};
+				} );
 				const go = async () => {
 					const cart: Cart = await wpcom.getCart( newSite.site_slug );
 					await wpcom.setCart( newSite.blogid, {

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -86,8 +86,8 @@ export default function useOnSiteCreation(): void {
 					},
 				} );
 				const go = async () => {
-					const cart: ResponseCart = await wpcom.getCart( newSite.site_slug );
 					if ( planProduct || domainProduct ) {
+						const cart: ResponseCart = await wpcom.getCart( newSite.site_slug );
 						await wpcom.setCart( newSite.blogid, {
 							...cart,
 							products: [ ...cart.products, planProduct, domainProduct ].filter( Boolean ),

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createRequestCartProduct } from '@automattic/shopping-cart';
-import type { RequestCartProduct } from '@automattic/shopping-cart';
+import type { RequestCartProduct, ResponseCart } from '@automattic/shopping-cart';
 import wp from '../../../lib/wp';
 
 /**
@@ -20,37 +20,6 @@ import { clearLastNonEditorRoute } from '../lib/clear-last-non-editor-route';
 import { useOnboardingFlow } from '../path';
 
 const wpcom = wp.undocumented();
-
-interface Cart {
-	blog_id: number;
-	cart_key: number;
-	coupon: string;
-	coupon_discounts: unknown[];
-	coupon_discounts_integer: unknown[];
-	is_coupon_applied: boolean;
-	has_bundle_credit: boolean;
-	next_domain_is_free: boolean;
-	next_domain_condition: string;
-	products: unknown[];
-	total_cost: number;
-	currency: string;
-	total_cost_display: string;
-	total_cost_integer: number;
-	temporary: boolean;
-	tax: unknown;
-	sub_total: number;
-	sub_total_display: string;
-	sub_total_integer: number;
-	total_tax: number;
-	total_tax_display: string;
-	total_tax_integer: number;
-	credits: number;
-	credits_display: string;
-	credits_integer: number;
-	allowed_payment_methods: unknown[];
-	create_new_blog: boolean;
-	messages: Record< 'errors' | 'success', unknown >;
-}
 
 /**
  * After a new site has been created there are 3 scenarios to cover:
@@ -107,7 +76,7 @@ export default function useOnSiteCreation(): void {
 					},
 				} );
 				const go = async () => {
-					const cart: Cart = await wpcom.getCart( newSite.site_slug );
+					const cart: ResponseCart = await wpcom.getCart( newSite.site_slug );
 					await wpcom.setCart( newSite.blogid, {
 						...cart,
 						products: [ ...cart.products, planProduct, domainProduct ],

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -131,6 +131,8 @@ export default function useOnSiteCreation(): void {
 			window.location.href = destination;
 		}
 	}, [
+		flow,
+		planProductSource,
 		domain,
 		selectedPlan,
 		isRedirecting,

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -46,12 +46,15 @@ export default function useOnSiteCreation(): void {
 	const flow = useOnboardingFlow();
 
 	const { resetOnboardStore, setIsRedirecting, setSelectedSite } = useDispatch( ONBOARD_STORE );
-	const flowCompleteTrackingParams = {
-		isNewSite: !! newSite,
-		isNewUser: !! newUser,
-		blogId: newSite?.blogid,
-		hasCartItems: false,
-	};
+	const flowCompleteTrackingParams = React.useMemo(
+		() => ( {
+			isNewSite: !! newSite,
+			isNewUser: !! newUser,
+			blogId: newSite?.blogid,
+			hasCartItems: false,
+		} ),
+		[ newSite, newUser ]
+	);
 
 	React.useEffect( () => {
 		// isRedirecting check this is needed to make sure we don't overwrite the first window.location.replace() call

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -61,14 +61,7 @@ export default function useOnSiteCreation(): void {
 		if ( newSite && ! isRedirecting ) {
 			setIsRedirecting( true );
 
-			if (
-				selectedPlan &&
-				! selectedPlan?.isFree &&
-				planProductSource &&
-				domain &&
-				domain.product_id &&
-				domain.product_slug
-			) {
+			if ( selectedPlan && ! selectedPlan?.isFree && planProductSource ) {
 				const planProduct: RequestCartProduct = createRequestCartProduct( {
 					product_id: planProductSource.productId,
 					product_slug: planProductSource.storeSlug,
@@ -76,15 +69,20 @@ export default function useOnSiteCreation(): void {
 						source: 'gutenboarding',
 					},
 				} );
-				const domainProduct: RequestCartProduct = createRequestCartProduct( {
-					meta: domain.domain_name,
-					product_id: domain.product_id,
-					product_slug: domain.product_slug,
-					extra: {
-						privacy: domain.supports_privacy,
-						source: 'gutenboarding',
-					},
-				} );
+
+				let domainProduct: RequestCartProduct | null = null;
+				if ( domain?.product_id && domain?.product_slug ) {
+					domainProduct = createRequestCartProduct( {
+						meta: domain.domain_name,
+						product_id: domain.product_id,
+						product_slug: domain.product_slug,
+						extra: {
+							privacy: domain.supports_privacy,
+							source: 'gutenboarding',
+						},
+					} );
+				}
+
 				const go = async () => {
 					if ( planProduct || domainProduct ) {
 						const cart: ResponseCart = await wpcom.getCart( newSite.site_slug );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `useOnSiteCreation()` hook in Gutenboarding adds products to the cart, but it allows invalid cart products and doesn't handle the errors that result. Because it tries to add products with no `product_id`, the shopping-cart endpoint fails. We get lots of errors on the server from this source, but it's unclear to me if users see this error or not. 

There are several bugs in the hook, even though it's written in TypeScript, because it manually interacts with the shopping-cart endpoint rather than going through the `@automattic/shopping-cart` package. That said, the existing TS did make it considerably easier to fix.

We could eventually convert this to use the `ShoppingCartProvider` like the rest of calypso, but I'm not sure if Gutenboarding is somehow not able to access the rest of the calypso codebase for some reason so I'll leave it as-is for now.

I believe this bug was introduced in https://github.com/Automattic/wp-calypso/pull/40045

This PR attempts to clean up these issues.

#### Testing instructions

I'm actually not sure how to test this. Suggestions are welcome.