### PR TITLE
Add two status checks to email plan header

### DIFF
--- a/client/lib/emails/email-provider-constants.js
+++ b/client/lib/emails/email-provider-constants.js
@@ -5,4 +5,5 @@ export const EMAIL_TYPE_FORWARD = 'email_forward';
 export const EMAIL_USER_ROLE_ADMIN = 'admin';
 export const EMAIL_WARNING_SLUG_GOOGLE_ACCOUNT_TOS = 'google_pending_tos_acceptance';
 export const EMAIL_WARNING_SLUG_UNUSED_MAILBOXES = 'unused_mailboxes';
+export const EMAIL_WARNING_SLUG_UNVERIFIED_FORWARDS = 'unverified_forwards';
 export const EMAIL_WARNING_TYPE_ACTION_REQUIRED = 'action_required';

--- a/client/lib/emails/has-unverified-email-forward.js
+++ b/client/lib/emails/has-unverified-email-forward.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import { EMAIL_WARNING_SLUG_UNVERIFIED_FORWARDS } from './email-provider-constants';
+
+/**
+ * Indicates whether the supplied email account has an unverified email forward warning
+ * for any of its mailboxes.
+ *
+ * @param {Object} emailAccount - Email account object returned from the server.
+ * @returns {boolean} - Returns whether an email for the email account has an unverified email warning.
+ */
+export function hasUnverifiedEmailForward( emailAccount ) {
+	if ( ! emailAccount?.emails?.length ) {
+		return false;
+	}
+
+	return emailAccount.emails.some( ( email ) => {
+		if ( ! email?.warnings?.length ) {
+			return false;
+		}
+
+		return email.warnings.some(
+			( warning ) => warning?.warning_slug === EMAIL_WARNING_SLUG_UNVERIFIED_FORWARDS
+		);
+	} );
+}

--- a/client/lib/emails/index.js
+++ b/client/lib/emails/index.js
@@ -1,6 +1,7 @@
 export { getEmailForwardAddress } from './get-email-forward-address';
 export { hasGoogleAccountTOSWarning } from './has-google-account-t-o-s-warning';
 export { hasUnusedMailboxWarning } from './has-unused-mailbox-warning';
+export { hasUnverifiedEmailForward } from './has-unverified-email-forward';
 export { isEmailForward } from './is-email-forward';
 export { isEmailForwardVerified } from './is-email-forward-verified';
 export { isEmailUserAdmin } from './is-email-user-admin';

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -29,3 +29,4 @@ export { hasGSuiteWithUs } from './has-gsuite-with-us';
 export { hasPendingGSuiteUsers } from './has-pending-gsuite-users';
 export { getGoogleMailServiceFamily } from './get-google-mail-service-family';
 export { getProductSlug, getProductType } from './gsuite-product-type';
+export { isPendingGSuiteTOSAcceptance } from './is-pending-gsuite-tos-acceptance';

--- a/client/lib/gsuite/is-pending-gsuite-tos-acceptance.js
+++ b/client/lib/gsuite/is-pending-gsuite-tos-acceptance.js
@@ -1,0 +1,10 @@
+/**
+ * Does a domain have a G Suite account where the terms of service
+ * need to be accepted.
+ *
+ * @param {object} domain - domain object
+ * @returns {boolean} - Does domain have a G Suite account pending ToS acceptance
+ */
+export function isPendingGSuiteTOSAcceptance( domain ) {
+	return domain?.googleAppsSubscription?.pendingTosAcceptance ?? false;
+}

--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -22,7 +22,11 @@ import {
 } from 'calypso/lib/titan';
 import { getEmailForwardsCount, hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
-import { hasGoogleAccountTOSWarning, hasUnusedMailboxWarning, hasUnverifiedEmailForward } from 'calypso/lib/emails';
+import {
+	hasGoogleAccountTOSWarning,
+	hasUnusedMailboxWarning,
+	hasUnverifiedEmailForward,
+} from 'calypso/lib/emails';
 
 export function getNumberOfMailboxesText( domain ) {
 	if ( hasGSuiteWithUs( domain ) ) {
@@ -115,7 +119,10 @@ export function resolveEmailPlanStatus( domain, emailAccount, isLoadingEmails ) 
 
 	if ( hasGSuiteWithUs( domain ) ) {
 		// Check for pending TOS acceptance warnings at the account level
-		if ( isPendingGSuiteTOSAcceptance( domain ) || ( emailAccount && hasGoogleAccountTOSWarning( emailAccount ) ) ) {
+		if (
+			isPendingGSuiteTOSAcceptance( domain ) ||
+			( emailAccount && hasGoogleAccountTOSWarning( emailAccount ) )
+		) {
 			return defaultWarningStatus;
 		}
 

--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -11,6 +11,7 @@ import {
 	getGSuiteSubscriptionId,
 	hasGSuiteWithUs,
 	hasPendingGSuiteUsers,
+	isPendingGSuiteTOSAcceptance,
 } from 'calypso/lib/gsuite';
 import {
 	getConfiguredTitanMailboxCount,
@@ -21,7 +22,7 @@ import {
 } from 'calypso/lib/titan';
 import { getEmailForwardsCount, hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
-import { hasUnusedMailboxWarning, hasGoogleAccountTOSWarning } from 'calypso/lib/emails';
+import { hasGoogleAccountTOSWarning, hasUnusedMailboxWarning, hasUnverifiedEmailForward } from 'calypso/lib/emails';
 
 export function getNumberOfMailboxesText( domain ) {
 	if ( hasGSuiteWithUs( domain ) ) {
@@ -114,7 +115,7 @@ export function resolveEmailPlanStatus( domain, emailAccount, isLoadingEmails ) 
 
 	if ( hasGSuiteWithUs( domain ) ) {
 		// Check for pending TOS acceptance warnings at the account level
-		if ( hasGoogleAccountTOSWarning( emailAccount ) ) {
+		if ( isPendingGSuiteTOSAcceptance( domain ) || ( emailAccount && hasGoogleAccountTOSWarning( emailAccount ) ) ) {
 			return defaultWarningStatus;
 		}
 
@@ -151,6 +152,12 @@ export function resolveEmailPlanStatus( domain, emailAccount, isLoadingEmails ) 
 		}
 
 		return defaultActiveStatus;
+	}
+
+	if ( hasEmailForwards( domain ) && emailAccount ) {
+		if ( hasUnverifiedEmailForward( emailAccount ) ) {
+			return defaultWarningStatus;
+		}
 	}
 
 	return defaultActiveStatus;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds two checks to the logic for email plan status:
* We now check whether the account-level Google ToS have been accepted as per the `domain` data
   - Due to the data being on the `domain` object, we can show this in the email home page listing
   - It is also worth noting that we already had a check for pending users, so this check may not catch too many additional cases
* We now check whether an email forward account has any mailboxes with unverified forwarding email addresses
   - This is currently available only in the email plan page - we need to wire in additional data to the email home page to fully support this check in that context

#### Testing instructions

* Run this branch locally or via the [live branch](https://calypso.live/?branch=update/email-plan-status-checks)
* Navigate to Upgrades -> Emails for a site where you have a Google Workspace or G Suite subscription where the account-level ToS haven't been accepted yet
* Verify that the domain with that Google subscription has an "Action required" warning next to it
* Click on the domain for an email forwarding configuration that has one or more unverified email forwards.
* Verify that the email plan header shows an "Action required" notice once the mailbox data has been loaded.
