### PR TITLE
Fix adding domain and plan to cart in signup flow

### DIFF
--- a/client/lib/signup/cart.js
+++ b/client/lib/signup/cart.js
@@ -8,7 +8,7 @@ import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 
 function addProductsToCart( cart, newCartItems ) {
 	const productsData = productsList.get();
-	const newProducts = Object.entries( newCartItems ).map( function ( [ , cartItem ] ) {
+	const newProducts = newCartItems.map( function ( cartItem ) {
 		cartItem.extra = { ...cartItem.extra, context: 'signup' };
 		return fillInSingleCartItemAttributes( cartItem, productsData );
 	} );

--- a/client/lib/signup/cart.js
+++ b/client/lib/signup/cart.js
@@ -8,7 +8,7 @@ import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 
 function addProductsToCart( cart, newCartItems ) {
 	const productsData = productsList.get();
-	const newProducts = newCartItems.map( function ( cartItem ) {
+	const newProducts = Object.entries( newCartItems ).map( function ( [ , cartItem ] ) {
 		cartItem.extra = { ...cartItem.extra, context: 'signup' };
 		return fillInSingleCartItemAttributes( cartItem, productsData );
 	} );

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { defer, difference, get, includes, isEmpty, omitBy, pick, startsWith } from 'lodash';
+import { defer, difference, get, includes, isEmpty, pick, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -90,9 +90,8 @@ export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 
 		SignupCart.createCart(
 			siteId,
-			omitBy(
-				pick( dependencies, 'domainItem', 'privacyItem', 'cartItem' ),
-				( dep ) => dep === null
+			[ dependencies.domainItem, dependencies.privacyItem, dependencies.cartItem ].filter(
+				Boolean
 			),
 			( error ) => {
 				callback( error, providedDependencies );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixing a bug introduced in https://github.com/Automattic/wp-calypso/pull/52355 related to adding products to the signup flow when there is no site selected.
* It looks like `newCartItems` is an object, so `map` won't work there.

This shows how to replicate the error:

![2021-05-21 15 35 05](https://user-images.githubusercontent.com/1379730/119191741-0b506b80-ba4d-11eb-8360-aadef22be585.gif)

#### Testing instructions

Without a specific site selected, go to the /domains/manage page
Select "Add a domain"
Enter some query text
Select a domain
Select "Existing WordPress.com Site"
Select a site
Select a plan
Make sure that you end up on the shopping cart page after a moment
Check the console to make sure there are no errors like "Uncaught TypeError: newCartItems.map is not a function"

