### PR TITLE
Editor: Hide Launch button from top bar on small screens

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/styles.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 // Added to body to allow general overrides
 .editor-gutenberg-launch__fse-overrides {
 	// Override 'Save' button to have tertiary styles.
@@ -16,6 +19,13 @@
 }
 
 .editor-gutenberg-launch__launch-button {
+	// Hide button on screen widths < 480px because there's not enough horizontal space
+	// in the header.
+	display: none;
 	padding: 0 12px;
 	margin: 0 12px 0 3px;
+
+	@include break-mobile {
+		display: block;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Temporary fix for the issue described in #50758 by hiding Launch button on smaller screens.

#### Testing instructions

* Apply patch
* Sandbox an unlaunched site
* Open page/post editor on a viewport less than 480px wide
* There should be no "Launch" button

#### Screenshots (Iphone SE)
**Before**

<img width="320" alt="Screenshot 2021-05-22 at 07 59 25" src="https://user-images.githubusercontent.com/14192054/119215035-c58ab600-bad3-11eb-99de-e6741c5c8eb4.png">

**After**

<img width="319" alt="Screenshot 2021-05-22 at 07 59 41" src="https://user-images.githubusercontent.com/14192054/119215033-c28fc580-bad3-11eb-9297-6726dfc8d74a.png">

Related to #50758
