### PR TITLE
My Home: remove old stats card copy now that translations are complete

### DIFF
--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { useEffect } from 'react';
 import { connect, useDispatch } from 'react-redux';
-import i18nCalypso, { numberFormat, useTranslate } from 'i18n-calypso';
+import { numberFormat, useTranslate } from 'i18n-calypso';
 import { Card } from '@automattic/components';
 import { times } from 'lodash';
 import moment from 'moment';
@@ -70,24 +70,16 @@ export const StatsV2 = ( {
 		}
 	}, [ isSiteUnlaunched ] );
 
-	const newSiteCopy =
-		[ 'en', 'en-gb' ].includes( i18nCalypso.getLocaleSlug() ) ||
-		i18nCalypso.hasTranslation(
-			'No stats to display yet. Publish or share a post to get some traffic to your site.'
-		)
-			? preventWidows(
-					translate(
-						'No stats to display yet. Publish or share a post to get some traffic to your site.'
-					),
-					4
-			  )
-			: translate( "No traffic yet, but you'll get there!" );
-
 	const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
 	const siteOlderThanAWeek = Date.now() - new Date( siteCreatedAt ).getTime() > WEEK_IN_MS;
 	const statsPlaceholderMessage = siteOlderThanAWeek
 		? translate( "No traffic this week, but don't give up!" )
-		: newSiteCopy;
+		: preventWidows(
+				translate(
+					'No stats to display yet. Publish or share a post to get some traffic to your site.'
+				),
+				4
+		  );
 
 	return (
 		<div className="stats">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

New copy was introduced to the stats card in #52702
Now that [translations are complete](https://translate.wordpress.com/deliverables/overview/5893199), the old fallback copy can be removed.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test using a site that
  * is less than a week old
  * is launched
  * has had no traffic
* Test the stats card should say `No stats to display yet. Publish or share a post to get some traffic to your site.`
* Change language and check the copy is translated correctly (Google translate can help)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

