### PR TITLE
Revert "`?shuffle` param on My Home will request shuffled views"

### DIFF
--- a/client/components/data/query-home-layout/index.js
+++ b/client/components/data/query-home-layout/index.js
@@ -9,10 +9,10 @@ import { useDispatch } from 'react-redux';
  */
 import { requestHomeLayout } from 'calypso/state/home/actions';
 
-export default function QueryHomeLayout( { isDev, forcedView, siteId, shuffle } ) {
+export default function QueryHomeLayout( { isDev, forcedView, siteId } ) {
 	const dispatch = useDispatch();
 	React.useEffect( () => {
-		dispatch( requestHomeLayout( siteId, isDev, forcedView, shuffle ) );
+		dispatch( requestHomeLayout( siteId, isDev, forcedView ) );
 	}, [ dispatch, siteId ] );
 
 	return null;

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -18,7 +18,6 @@ export default async function ( context, next ) {
 	const isDev = context.query.dev === 'true';
 	const forcedView = context.query.view;
 	const noticeType = context.query.notice;
-	const shuffle = context.query.hasOwnProperty( 'shuffle' );
 
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {
@@ -31,7 +30,6 @@ export default async function ( context, next ) {
 			isDev={ isDev }
 			forcedView={ forcedView }
 			noticeType={ noticeType }
-			shuffleViews={ shuffle }
 		/>
 	);
 

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -45,7 +45,6 @@ const Home = ( {
 	siteId,
 	trackViewSiteAction,
 	noticeType,
-	shuffleViews,
 } ) => {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
@@ -98,14 +97,7 @@ const Home = ( {
 			<PageViewTracker path={ `/home/:site` } title={ translate( 'My Home' ) } />
 			<DocumentHead title={ translate( 'My Home' ) } />
 			{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
-			{ siteId && (
-				<QueryHomeLayout
-					siteId={ siteId }
-					isDev={ isDev }
-					forcedView={ forcedView }
-					shuffle={ shuffleViews }
-				/>
-			) }
+			{ siteId && <QueryHomeLayout siteId={ siteId } isDev={ isDev } forcedView={ forcedView } /> }
 			<SidebarNavigation />
 			{ header }
 			{ layout ? (
@@ -136,7 +128,6 @@ Home.propTypes = {
 	site: PropTypes.object.isRequired,
 	siteId: PropTypes.number.isRequired,
 	trackViewSiteAction: PropTypes.func.isRequired,
-	shuffleViews: PropTypes.bool,
 };
 
 const mapStateToProps = ( state ) => {

--- a/client/state/data-layer/wpcom/sites/home/layout/index.js
+++ b/client/state/data-layer/wpcom/sites/home/layout/index.js
@@ -10,7 +10,6 @@ import config from '@automattic/calypso-config';
 
 const requestLayout = ( action ) => {
 	const isDev = config.isEnabled( 'home/layout-dev' ) || action.isDev;
-
 	return http(
 		{
 			method: 'GET',
@@ -19,7 +18,6 @@ const requestLayout = ( action ) => {
 			query: {
 				...( isDev && { dev: true } ),
 				...( isDev && action.forcedView && { view: action.forcedView } ),
-				...( action.shuffle && { shuffle: true } ),
 			},
 		},
 		action

--- a/client/state/home/actions.js
+++ b/client/state/home/actions.js
@@ -12,17 +12,11 @@ import {
 import 'calypso/state/data-layer/wpcom/sites/home/layout';
 import 'calypso/state/home/init';
 
-export const requestHomeLayout = (
-	siteId,
-	isDev = false,
-	forcedView = null,
-	shuffle = false
-) => ( {
+export const requestHomeLayout = ( siteId, isDev = false, forcedView = null ) => ( {
 	type: HOME_LAYOUT_REQUEST,
 	siteId,
 	isDev,
 	forcedView,
-	shuffle,
 } );
 
 export const skipCurrentViewHomeLayout = ( siteId, reminder = null ) => ( {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#52802

Timeline:
- The shuffle parameter was added D61325-code, the default was `?shuffle=false`
- The ability to opt-in to shuffle in Calypso was added in #52802
- D61401-code changed the default to `?shuffle=true`, making it visible to all users

Since a12s no longer need the ability to opt-in to shuffle (since we all see it anyway) the ability can be tidied from Calypso