### PR TITLE
ci(e2e): Revert #52910

### DIFF
--- a/test/e2e/lib/components/shopping-cart-widget-component.js
+++ b/test/e2e/lib/components/shopping-cart-widget-component.js
@@ -48,10 +48,6 @@ export default class ShoppingCartWidgetComponent extends AsyncBaseContainer {
 		return this.remove( 'domain_reg', domain );
 	}
 
-	async removeDomainMapping( domain ) {
-		return this.remove( 'domain_map', domain );
-	}
-
 	async remove( type, name ) {
 		const cartBadgeLocator = by.css( '.cart__count-badge' );
 

--- a/test/e2e/lib/components/shopping-cart-widget-component.js
+++ b/test/e2e/lib/components/shopping-cart-widget-component.js
@@ -43,27 +43,4 @@ export default class ShoppingCartWidgetComponent extends AsyncBaseContainer {
 			}
 		}
 	}
-
-	async removeDomainRegistraion( domain ) {
-		return this.remove( 'domain_reg', domain );
-	}
-
-	async remove( type, name ) {
-		const cartBadgeLocator = by.css( '.cart__count-badge' );
-
-		const present = await driverHelper.isElementLocated( this.driver, cartBadgeLocator );
-		if ( present ) {
-			await this.open();
-			await driverHelper.clickWhenClickable(
-				this.driver,
-				by.xpath(
-					// Find an element X with class=.cart-item
-					//    that contains an element with data-e2e-product-slug=`type`
-					//    and a sibling with class="product-domain" and text=`name`
-					// and then select an element inside X that matches class=cart__remove-item
-					`//*[@class="cart-item"][.//*[@data-e2e-product-slug="${ type }"]/following-sibling::*[@class="product-domain"][text()="${ name }"]]//*[@class="cart__remove-item"]`
-				)
-			);
-		}
-	}
 }

--- a/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
@@ -110,9 +110,9 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 			await DomainsPage.Expect( this.driver );
 			try {
 				const shoppingCartWidgetComponent = await ShoppingCartWidgetComponent.Expect( this.driver );
-				await shoppingCartWidgetComponent.removeDomainRegistraion( expectedDomainName );
+				await shoppingCartWidgetComponent.empty();
 			} catch {
-				console.log( `Can't clean up domain registration for ${ expectedDomainName } from cart` );
+				console.log( 'Cart already empty' );
 			}
 		} );
 	} );

--- a/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
@@ -198,7 +198,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 			await DomainsPage.Expect( this.driver );
 			try {
 				const shoppingCartWidgetComponent = await ShoppingCartWidgetComponent.Expect( this.driver );
-				await shoppingCartWidgetComponent.removeDomainMapping( blogName );
+				await shoppingCartWidgetComponent.empty();
 			} catch {
 				console.log( 'Cart already empty' );
 			}


### PR DESCRIPTION
#### Background

In #52910 we introduced a change to selectively remove the domains from the shopping cart that were introduced in a test run (as oposed to just empty the cart). This want meant to help with parallelization.

For some reason (yet to be investigated) it doesn't correctly clear the shopping cart, which keeps growing and growing, adding some delays to the checkout screen and causing a timeout in other e2e tests (see p1621828983019700-slack-C1A1EKDGQ )

#### Changes proposed in this Pull Request

* Manually reverts #52910

#### Testing instructions

Verify e2e tests pass.