### PR TITLE
Enable email/centralized-home flag in horizon, staging, and production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -37,7 +37,7 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"email/centralized-home": false,
+		"email/centralized-home": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/production.json
+++ b/config/production.json
@@ -36,7 +36,7 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"email/centralized-home": false,
+		"email/centralized-home": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -39,7 +39,7 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"email/centralized-home": false,
+		"email/centralized-home": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR enables the `email/centralized-home` flag in the horizon, staging, and production environments

#### Testing instructions

* Given that the feature flag was already enabled in the development and wpcalypso environments, I don't think it's possible to really test this beyond code inspection.