### PR TITLE
ci(e2e): Fix relative path for Jetpack tests

### DIFF
--- a/test/e2e/specs/specs-jetpack/wp-jetpack-connect-spec.js
+++ b/test/e2e/specs/specs-jetpack/wp-jetpack-connect-spec.js
@@ -8,31 +8,31 @@ import config from 'config';
  * Internal dependencies
  */
 
-import LoginFlow from '../lib/flows/login-flow';
-import SignUpFlow from '../lib/flows/sign-up-flow';
+import LoginFlow from '../../lib/flows/login-flow';
+import SignUpFlow from '../../lib/flows/sign-up-flow';
 
-import JetpackAuthorizePage from '../lib/pages/jetpack-authorize-page';
-import PickAPlanPage from '../lib/pages/signup/pick-a-plan-page';
-import WPAdminJetpackPage from '../lib/pages/wp-admin/wp-admin-jetpack-page.js';
-import WPAdminDashboardPage from '../lib/pages/wp-admin/wp-admin-dashboard-page';
-import WPAdminNewUserPage from '../lib/pages/wp-admin/wp-admin-new-user-page';
-import WPAdminLogonPage from '../lib/pages/wp-admin/wp-admin-logon-page';
-import WPAdminSidebar from '../lib/pages/wp-admin/wp-admin-sidebar.js';
-import JetpackConnectFlow from '../lib/flows/jetpack-connect-flow';
-import JetpackConnectPage from '../lib/pages/jetpack/jetpack-connect-page';
-import LoginPage from '../lib/pages/login-page';
-import JetpackComPage from '../lib/pages/external/jetpackcom-page';
-import JetpackComFeaturesDesignPage from '../lib/pages/external/jetpackcom-features-design-page';
+import JetpackAuthorizePage from '../../lib/pages/jetpack-authorize-page';
+import PickAPlanPage from '../../lib/pages/signup/pick-a-plan-page';
+import WPAdminJetpackPage from '../../lib/pages/wp-admin/wp-admin-jetpack-page.js';
+import WPAdminDashboardPage from '../../lib/pages/wp-admin/wp-admin-dashboard-page';
+import WPAdminNewUserPage from '../../lib/pages/wp-admin/wp-admin-new-user-page';
+import WPAdminLogonPage from '../../lib/pages/wp-admin/wp-admin-logon-page';
+import WPAdminSidebar from '../../lib/pages/wp-admin/wp-admin-sidebar.js';
+import JetpackConnectFlow from '../../lib/flows/jetpack-connect-flow';
+import JetpackConnectPage from '../../lib/pages/jetpack/jetpack-connect-page';
+import LoginPage from '../../lib/pages/login-page';
+import JetpackComPage from '../../lib/pages/external/jetpackcom-page';
+import JetpackComFeaturesDesignPage from '../../lib/pages/external/jetpackcom-features-design-page';
 
-import * as driverManager from '../lib/driver-manager';
-import * as driverHelper from '../lib/driver-helper';
-import * as dataHelper from '../lib/data-helper';
-import JetpackComPricingPage from '../lib/pages/external/jetpackcom-pricing-page';
-import SecurePaymentComponent from '../lib/components/secure-payment-component';
-import WPHomePage from '../lib/pages/wp-home-page';
-import ThankYouModalComponent from '../lib/components/thank-you-modal-component';
-import MyPlanPage from '../lib/pages/my-plan-page';
-import WPAdminInPlaceApprovePage from '../lib/pages/wp-admin/wp-admin-in-place-approve-page';
+import * as driverManager from '../../lib/driver-manager';
+import * as driverHelper from '../../lib/driver-helper';
+import * as dataHelper from '../../lib/data-helper';
+import JetpackComPricingPage from '../../lib/pages/external/jetpackcom-pricing-page';
+import SecurePaymentComponent from '../../lib/components/secure-payment-component';
+import WPHomePage from '../../lib/pages/wp-home-page';
+import ThankYouModalComponent from '../../lib/components/thank-you-modal-component';
+import MyPlanPage from '../../lib/pages/my-plan-page';
+import WPAdminInPlaceApprovePage from '../../lib/pages/wp-admin/wp-admin-in-place-approve-page';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();

--- a/test/e2e/specs/specs-jetpack/wp-jetpack-plans-spec.js
+++ b/test/e2e/specs/specs-jetpack/wp-jetpack-plans-spec.js
@@ -6,24 +6,24 @@ import config from 'config';
 /**
  * Internal dependencies
  */
-import * as driverManager from '../lib/driver-manager';
-import * as driverHelper from '../lib/driver-helper';
-import * as dataHelper from '../lib/data-helper';
+import * as driverManager from '../../lib/driver-manager';
+import * as driverHelper from '../../lib/driver-helper';
+import * as dataHelper from '../../lib/data-helper';
 
-import LoginFlow from '../lib/flows/login-flow';
+import LoginFlow from '../../lib/flows/login-flow';
 
-import PlansPage from '../lib/pages/plans-page';
-import WPAdminJetpackPage from '../lib/pages/wp-admin/wp-admin-jetpack-page';
+import PlansPage from '../../lib/pages/plans-page';
+import WPAdminJetpackPage from '../../lib/pages/wp-admin/wp-admin-jetpack-page';
 
-import ReaderPage from '../lib/pages/reader-page.js';
-import SecurePaymentComponent from '../lib/components/secure-payment-component.js';
-import ShoppingCartWidgetComponent from '../lib/components/shopping-cart-widget-component.js';
-import SidebarComponent from '../lib/components/sidebar-component.js';
-import NavBarComponent from '../lib/components/nav-bar-component.js';
+import ReaderPage from '../../lib/pages/reader-page.js';
+import SecurePaymentComponent from '../../lib/components/secure-payment-component.js';
+import ShoppingCartWidgetComponent from '../../lib/components/shopping-cart-widget-component.js';
+import SidebarComponent from '../../lib/components/sidebar-component.js';
+import NavBarComponent from '../../lib/components/nav-bar-component.js';
 
-import WPAdminSidebar from '../lib/pages/wp-admin/wp-admin-sidebar';
+import WPAdminSidebar from '../../lib/pages/wp-admin/wp-admin-sidebar';
 
-import WPAdminLogonPage from '../lib/pages/wp-admin/wp-admin-logon-page';
+import WPAdminLogonPage from '../../lib/pages/wp-admin/wp-admin-logon-page';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();

--- a/test/e2e/specs/specs-jetpack/wp-jetpack-settings-writing-media-spec.js
+++ b/test/e2e/specs/specs-jetpack/wp-jetpack-settings-writing-media-spec.js
@@ -7,12 +7,12 @@ import config from 'config';
 /**
  * Internal dependencies
  */
-import * as driverManager from '../lib/driver-manager';
-import * as dataHelper from '../lib/data-helper';
+import * as driverManager from '../../lib/driver-manager';
+import * as dataHelper from '../../lib/data-helper';
 
-import SettingsPage from '../lib/pages/settings-page';
+import SettingsPage from '../../lib/pages/settings-page';
 
-import LoginFlow from '../lib/flows/login-flow';
+import LoginFlow from '../../lib/flows/login-flow';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();


### PR DESCRIPTION
#### Background

Jetpack tests are failing with

```
  [ERROR] [Mocha Plugin] [
04:01:53
    'Could not capture mocha tests. To debug, run the following command:\n' +
04:01:53
      'MOCHA_CAPTURE_PATH=%s %s %s',
04:01:53
    '/home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/test/e2e/temp/get_mocha_tests.json',
04:01:53
    '/home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/node_modules/mocha/bin/mocha',
04:01:53
    '--reporter-options tags=jetpack --reporter /home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/packages/magellan-mocha-plugin/lib/suite_capture.js specs/specs-calypso specs/specs-jetpack'
04:01:53
  ]
```

Running that commands locally shows the problem:

```
/Users/sergio/src/automattic/wp-calypso/test/e2e/specs/specs-jetpack/wp-jetpack-connect-spec.js:1
Error: Cannot find module '../lib/flows/login-flow'
Require stack:
- /Users/sergio/src/automattic/wp-calypso/test/e2e/specs/specs-jetpack/wp-jetpack-connect-spec.js
- /Users/sergio/src/automattic/wp-calypso/node_modules/mocha/lib/esm-utils.js
- /Users/sergio/src/automattic/wp-calypso/node_modules/mocha/lib/mocha.js
- /Users/sergio/src/automattic/wp-calypso/node_modules/mocha/lib/cli/one-and-dones.js
- /Users/sergio/src/automattic/wp-calypso/node_modules/mocha/lib/cli/options.js
- /Users/sergio/src/automattic/wp-calypso/node_modules/mocha/lib/cli/cli.js
    at Object.<anonymous> (/Users/sergio/src/automattic/wp-calypso/test/e2e/specs/specs-jetpack/wp-jetpack-connect-spec.js:1)
    at Generator.next (<anonymous>)
    at Object.exports.requireOrImport (/Users/sergio/src/automattic/wp-calypso/node_modules/mocha/lib/esm-utils.js:20:12)
    at Object.exports.loadFilesAsync (/Users/sergio/src/automattic/wp-calypso/node_modules/mocha/lib/esm-utils.js:33:34)
    at process.runNextTicks [as _tickCallback] (internal/process/task_queues.js:58:5)
    at internal/main/run_main_module.js:17:47
    at async singleRun (/Users/sergio/src/automattic/wp-calypso/node_modules/mocha/lib/cli/run-helpers.js:156:3)
    at async Object.exports.handler (/Users/sergio/src/automattic/wp-calypso/node_modules/mocha/lib/cli/run.js:366:5)
```


#### Changes proposed in this Pull Request

* Fixes relative imports from `specs/specs-jetpack`

#### Testing instructions

Run Jetpack tests in e2e and check the error above is gone.