### PR TITLE
Make the shopping-cart-widget more robust

### DIFF
--- a/test/e2e/lib/components/shopping-cart-widget-component.js
+++ b/test/e2e/lib/components/shopping-cart-widget-component.js
@@ -56,7 +56,7 @@ export default class ShoppingCartWidgetComponent extends AsyncBaseContainer {
 		}
 	}
 
-	async removeDomainRegistraion( domain ) {
+	async removeDomainRegistration( domain ) {
 		return this.remove( 'domain_reg', domain );
 	}
 

--- a/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
@@ -110,7 +110,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function 
 			await DomainsPage.Expect( this.driver );
 			try {
 				const shoppingCartWidgetComponent = await ShoppingCartWidgetComponent.Expect( this.driver );
-				await shoppingCartWidgetComponent.removeDomainRegistraion( expectedDomainName );
+				await shoppingCartWidgetComponent.removeDomainRegistration( expectedDomainName );
 			} catch {
 				console.log( `Can't clean up domain registration for ${ expectedDomainName } from cart` );
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Make the helper for Shopping Cart widget more robust:

* Wait for the badge to appear before trying to open it
* Wait for the popover to be rendered before returning from `open()`
* Ensure it is expanded before trying to locate specific items

#### Testing instructions

N/A