### PR TITLE
Remove Launch button from editor top bar

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
@@ -76,27 +76,14 @@ function enqueue_launch_button_script_and_style( $site_launch_options ) {
  * @param array $site_launch_options Site launch options.
  */
 function enqueue_launch_flow_script_and_style( $site_launch_options ) {
-
-	$launch_flow = $site_launch_options['launch_flow'];
-
-	// Determine script name by launch flow.
-	// We are avoiding string concatenation for security reasons.
-	switch ( $launch_flow ) {
-		case 'gutenboarding-launch':
-			$script_name = 'gutenboarding-launch';
-			break;
-		case 'focused-launch':
-			$script_name = 'focused-launch';
-			break;
-		default:
-			// For redirect or invalid flows, skip & exit early.
-			return;
-	}
-
-	// @TODO: remove this once $launch_flow value is 'focused-launch' for AnchorFM sites
 	$anchor_podcast = $site_launch_options['anchor_podcast'];
+
 	if ( ! empty( $anchor_podcast ) ) {
+		// AnchorFM flow runs on focused-launch.
 		$script_name = 'focused-launch';
+	} else {
+		// For redirect or non-AnchorFM sites, skip & exit early.
+		return;
 	}
 
 	$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/' . $script_name . '.asset.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
@@ -12,7 +12,7 @@ import '@wordpress/editor';
  * Internal dependencies
  */
 import { inIframe } from '../../../block-inserter-modifications/contextual-tips/utils';
-import { GUTENBOARDING_LAUNCH_FLOW, FOCUSED_LAUNCH_FLOW, SITE_LAUNCH_FLOW } from '../constants';
+import { GUTENBOARDING_LAUNCH_FLOW } from '../constants';
 import './styles.scss';
 
 let handled = false;
@@ -40,7 +40,14 @@ domReady( () => {
 			return;
 		}
 
-		const { launchUrl, launchFlow, isGutenboarding, anchorFmPodcastId } = siteLaunchOptions;
+		const { launchFlow, isGutenboarding, anchorFmPodcastId } = siteLaunchOptions;
+		// Enable anchor-flavoured features (the launch button works immediately).
+		const isAnchorFm = !! anchorFmPodcastId;
+
+		// Display the Launch button only for the AnchorFM flow
+		if ( launchFlow !== GUTENBOARDING_LAUNCH_FLOW || ! isAnchorFm ) {
+			return;
+		}
 
 		// Wrap 'Launch' button link to control launch flow.
 		const launchButton = document.createElement( 'button' );
@@ -55,8 +62,6 @@ domReady( () => {
 				is_in_iframe: inIframe(),
 			} );
 
-			// Enable anchor-flavoured features (the launch button works immediately).
-			const isAnchorFm = !! anchorFmPodcastId;
 			if ( isAnchorFm ) {
 				dispatch( 'automattic/launch' ).enableAnchorFm();
 			}
@@ -74,18 +79,6 @@ domReady( () => {
 					// Save post in the background while step-by-step flow opens
 					dispatch( 'automattic/launch' ).openSidebar();
 					delayedSavePost();
-					break;
-				case FOCUSED_LAUNCH_FLOW:
-					// Save post in the background while focused launch flow opens
-					dispatch( 'automattic/launch' ).openFocusedLaunch();
-					delayedSavePost();
-					break;
-				case SITE_LAUNCH_FLOW:
-					// Save post first before redirecting to launch url
-					( async () => {
-						await savePost();
-						window.top.location.href = launchUrl;
-					} )();
 					break;
 			}
 		} );

--- a/apps/editing-toolkit/typings/index.d.ts
+++ b/apps/editing-toolkit/typings/index.d.ts
@@ -4,7 +4,6 @@ declare module 'a8c-fse-common-data-stores' {}
 
 interface Window {
 	wpcomEditorSiteLaunch?: {
-		launchUrl: string;
 		launchFlow: string;
 		// property does not exist when not isGutenboarding
 		// property holds the value '1' when isGutenboarding


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove Launch button from editor for all sites except AnchorFm.

#### Testing instructions

* Create a site with `/new`
* Do the same with `/start`
* Sandbox the two sites
* In both cases, when opening the editor, Launch button shouldn't be displayed as it is in production.

**Follow up**
- [x] Create an issue to handle proper code cleanup https://github.com/Automattic/wp-calypso/issues/53118

Fixes https://github.com/Automattic/wp-calypso/issues/53109
