### PR TITLE
Update the domain management header to show the selected domain

### DIFF
--- a/client/my-sites/domains/domain-management/components/header/index.jsx
+++ b/client/my-sites/domains/domain-management/components/header/index.jsx
@@ -21,8 +21,14 @@ import { isUnderDomainManagementAll } from 'calypso/my-sites/domains/paths';
 import './style.scss';
 
 const DomainManagementHeader = ( props ) => {
-	const { isManagingAllDomains, onClick, backHref, children } = props;
+	const { selectedDomainName, isManagingAllDomains, onClick, backHref, children } = props;
 	const translate = useTranslate();
+	let formattedHeaderText = selectedDomainName;
+	if ( ! selectedDomainName ) {
+		formattedHeaderText = isManagingAllDomains
+			? translate( 'All Domains' )
+			: translate( 'Site Domains' );
+	}
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -30,9 +36,7 @@ const DomainManagementHeader = ( props ) => {
 			<FormattedHeader
 				brandFont
 				className="stats__section-header"
-				headerText={
-					isManagingAllDomains ? translate( 'All Domains' ) : translate( 'Site Domains' )
-				}
+				headerText={ formattedHeaderText }
 				align="left"
 			/>
 			<HeaderCake className="domain-management-header" onClick={ onClick } backHref={ backHref }>

--- a/client/my-sites/domains/domain-management/edit/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/index.jsx
@@ -43,10 +43,7 @@ class Edit extends React.Component {
 
 		return (
 			<Main>
-				<Header
-					onClick={ this.goToDomainManagement }
-					selectedDomainName={ this.props.selectedDomainName }
-				>
+				<Header onClick={ this.goToDomainManagement }>
 					{ this.props.translate( '%(domainType)s Settings', {
 						args: {
 							domainType: this.getDomainTypeText( domain ),


### PR DESCRIPTION
Managing domain settings can be confusing when you have multiple domains because you might not be sure which domain you're managing. In order to make that clearer we've decided to show the domain name instead of the fixed "Site domains"/"All domains" header so it's always clear which domain settings you're editing

#### Changes proposed in this Pull Request

* Show the selected domain name in the domain management header text

Here's how it looks:
<img width="764" alt="Screenshot 2021-05-24 at 18 26 44" src="https://user-images.githubusercontent.com/1355045/119370297-cbdc8600-bcbd-11eb-85fb-19c4c7f92c19.png">
<img width="768" alt="Screenshot 2021-05-24 at 18 27 00" src="https://user-images.githubusercontent.com/1355045/119370300-cd0db300-bcbd-11eb-8144-4e1cd59ccdb6.png">
<img width="755" alt="Screenshot 2021-05-24 at 18 27 34" src="https://user-images.githubusercontent.com/1355045/119370304-cda64980-bcbd-11eb-94c6-f35beea4e8e6.png">

#### Testing instructions

* Open up the live branch or spin up local calypso and then click on any domain you have from Upgrades > Domains
* You should see the domain name as page header instead of "Site domains" or "All domains"
