### PR TITLE
Notifications: Add custom html support for notification body.

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -124,6 +124,10 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 			break;
 		case 'button':
 			new_classes.push( 'is-primary' );
+		case 'custom-html':
+			new_container = document.createElement( 'div' );
+			new_container.innerHTML = range_info.content;
+			break;
 		default:
 			// Most range types fall here
 			if ( ( options.links && range_info.url ) || range_info_type === 'a' ) {


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR adds custom html support for notification body.
For now, this is used to insert embeddable content on notification body.

When the `range_type` of `custom-html` is detected, it will just output the html that is stored in the `range_info.content`.

The reason why for a `custom-html` type instead of specific types like `youtube` or `iframe` etc. is because the html content provided by the different embed services are varied.

This PR complements the phab patch D61784-code.
 
## Testing instructions

* Apply phab patch D61784-code.
* Sandbox `public-api.wordpress.com`.
* You'll need 2 users, say Tom & Harry.
* As Tom, go to Harry's blog and create a comment with the a comment containing YouTube shortcode, here's an example:
```
Hello, this is a test comment. 
[youtube url="https://www.youtube.com/watch?v=CJcciG-m79g"]
Hope you'll like this video above.
```
* As Harry, go to `calypso.localhost:3000` and open the Notifications panel.
* You should see the YouTube video rendered.

## Screenshot

![2021-05-24_16-56-17](https://user-images.githubusercontent.com/1287077/119370639-cbd88800-bcb5-11eb-85f3-a682a1327638.jpg)

Related to #45208